### PR TITLE
Fix providers dev gate (ty-clean under --extra dev, SDK-free config check)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,14 @@ openai = ["openai>=1.40"]
 bedrock = ["boto3>=1.34"]
 otel = ["opentelemetry-proto>=1.24"]
 config = ["tomli-w>=1.0"]  # writing .wmh/config.toml (stdlib tomllib reads)
-dev = ["pytest>=8.0", "ruff>=0.5", "ty>=0.0.1a1", "tomli-w>=1.0"]
+# dev pulls in every backend SDK so `ty check` and the full test suite resolve over the whole
+# project (the providers import anthropic/openai/boto3 lazily, but type-checking needs them present).
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.5",
+    "ty>=0.0.1a1",
+    "world-model-harness[anthropic,openai,bedrock,otel,config]",
+]
 
 [project.scripts]
 wmh = "wmh.cli:app"

--- a/uv.lock
+++ b/uv.lock
@@ -897,6 +897,10 @@ config = [
     { name = "tomli-w" },
 ]
 dev = [
+    { name = "anthropic" },
+    { name = "boto3" },
+    { name = "openai" },
+    { name = "opentelemetry-proto" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "tomli-w" },
@@ -923,9 +927,9 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "tomli-w", marker = "extra == 'config'", specifier = ">=1.0" },
-    { name = "tomli-w", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.29" },
+    { name = "world-model-harness", extras = ["anthropic", "openai", "bedrock", "otel", "config"], marker = "extra == 'dev'" },
 ]
 provides-extras = ["anthropic", "openai", "bedrock", "otel", "config", "dev"]

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -32,13 +32,17 @@ class AzureOpenAIProvider:
         # Lazy: construct on first use. api_key + endpoint default to AZURE_OPENAI_API_KEY /
         # AZURE_OPENAI_ENDPOINT from the environment; api_version must be supplied by config.
         if self._client is None:
-            from openai import AzureOpenAI
-
+            # Validate config before reaching for the SDK, so a config error doesn't depend on the
+            # optional `openai` extra being installed.
             if self.config.api_version is None:
                 raise ValueError("AzureOpenAIProvider requires config.api_version to be set.")
+            endpoint = self.config.endpoint or _require_endpoint()
+
+            from openai import AzureOpenAI
+
             self._client = AzureOpenAI(
                 api_version=self.config.api_version,
-                azure_endpoint=self.config.endpoint or _require_endpoint(),
+                azure_endpoint=endpoint,
             )
         return self._client
 


### PR DESCRIPTION
Two issues introduced by the providers PR (#4) that surface only under the **documented** `uv sync --extra dev` workflow from AGENTS.md. They were masked in #4 because I'd installed the optional SDK extras in the worktree — so the gate I actually ran wasn't the documented one. Both are mine; this corrects them.

## 1. `ty check` not clean under `--extra dev` (was 11 diagnostics)
The provider files import `anthropic`/`openai`/`boto3` (lazily at runtime, but `ty` needs them present to resolve the `TYPE_CHECKING` imports). Those SDKs live in separate optional extras, so `uv sync --extra dev` didn't install them and `ty` reported 11 `unresolved-import` diagnostics across all four provider files.

**Fix:** `dev` now self-references the backend extras — `world-model-harness[anthropic,openai,bedrock,otel,config]` — so the documented sync installs everything type-checking and the full test suite need.

## 2. `test_get_client_requires_api_version` hard-failed without the `openai` extra
`_get_client()` did `from openai import AzureOpenAI` *before* the `api_version` config check, so in a minimal env the test raised `ModuleNotFoundError: openai` instead of exercising the guard.

**Fix:** validate config (and resolve the endpoint) *before* importing the SDK. A config-validation error shouldn't depend on an optional dependency being installed — better altitude than an `importorskip` guard, and the test now passes in the minimal env.

## Verification (documented workflow only)
```
uv sync --extra dev
uv run ruff check .   # clean
uv run ty check       # All checks passed!  (was 11 diagnostics)
uv run pytest -q      # 42 passed, 4 skipped  (4 = env-gated live smoke tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)