### PR TITLE
Embedding adapter provider + run tracking (time/cost/tokens)

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -1,0 +1,60 @@
+# Embeddings (phi for retrieval)
+
+Retrieval (DreamGym top-k) ranks past steps by cosine similarity of an embedding `phi(state,
+action)`. The embedder that produces `phi` is chosen by `HarnessConfig.embed_provider` (an
+`EmbedderKind`) and sized by `HarnessConfig.embed_dim`.
+
+## Choosing an embedder
+
+| `embed_provider` | What runs | Needs | Notes |
+|---|---|---|---|
+| `hashing` (default) | `HashingEmbedder` | nothing | Offline hashed char-trigram vector, L2-normalized. Lexical, not semantic. Zero config. |
+| `bedrock` | Amazon Titan text embeddings | AWS creds + region | `embed_model` defaults to `amazon.titan-embed-text-v2:0`. |
+| `openai` | OpenAI embeddings | `OPENAI_API_KEY` | Set `embed_model` (e.g. `text-embedding-3-small`). |
+| `azure_openai` | Azure OpenAI embedding deployment | Azure creds + endpoint | `embed_model` is the **deployment name**, not the base model id. |
+
+Anthropic has no embeddings API, so there is no `anthropic` embedder kind — use one of the above (or
+`hashing`) for `phi` while serving the world model on Anthropic/Bedrock for *generation*.
+
+## How `embed_model` is configured per provider
+
+`embed_model` lives on the **`ProviderConfig`** for the backing provider (the one whose `kind`
+matches `embed_provider`). It is independent of the completion `model`:
+
+- **Bedrock** — `embed_model` is the Titan model id (`amazon.titan-embed-text-v2:0`). Optional; the
+  provider defaults to titan-embed-text-v2 when unset.
+- **OpenAI** — `embed_model` is the embeddings model id (`text-embedding-3-small`/`-large`).
+  Required for `embed()`.
+- **Azure OpenAI** — `embed_model` is the **embedding deployment name** (same role `deployment`
+  plays for completions). Required for `embed()`.
+
+`get_embedder(config)` (in `wmh.retrieval.embedders`) resolves all of this: for `hashing` it builds
+`HashingEmbedder(dim=embed_dim)`; otherwise it constructs the backing provider via the registry and
+stamps `embed_dim` onto its `ProviderConfig` so the backend requests a vector of exactly that size.
+
+## Dimensions must match
+
+The persisted index and the query embedder must agree on dimensionality, or cosine similarity is a
+shape error. `embed_dim` is the single knob:
+
+- For `hashing`, `embed_dim` is the literal vector length.
+- For Bedrock Titan v2 and OpenAI `text-embedding-3-*`, `embed_dim` is sent as the API's
+  `dimensions` parameter, so the model returns exactly that width. (Leave `embed_dim` unset on a
+  provider to accept the model's native dimension.)
+
+`EmbeddingRetriever.topk` keeps a runtime guard: if the query embedder's dimension differs from the
+indexed matrix, it raises a clear error telling you to load the same `embed_dim` used at build time —
+never a raw numpy mismatch.
+
+## Verifying the embed path
+
+`wmh providers verify` pings each provider's completion path and, when `embed_provider` is not
+`hashing`, also embeds one tiny string through the configured embed provider and reports `ok` + the
+produced `dim` (or the failure detail). It never raises — a missing key or wrong model comes back as
+`fail`.
+
+## Wiring at build time
+
+`wmh build --embed-provider <kind> [--embed-model <id>] [--embed-dim N]` constructs the embedder via
+`get_embedder` and passes it into the build, so the index is built with the same `phi` that
+`WorldModel.load` will reconstruct at serve time.

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -11,7 +11,8 @@ import typer
 from rich.console import Console
 
 from wmh.config import ARTIFACT_DIR, HarnessConfig, load_config
-from wmh.providers import ProviderConfig, ProviderKind, verify_all
+from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
+from wmh.providers.base import EmbedderKind
 
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
 providers_app = typer.Typer(help="Manage and verify LLM providers.")
@@ -21,11 +22,19 @@ _console = Console()
 
 @providers_app.command("verify")
 def providers_verify(root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir.")) -> None:
-    """Ping every configured provider (Anthropic/Bedrock/Azure/OpenAI) and report status."""
+    """Ping every configured provider (completion + embed path) and report status."""
     config = load_config(root)
     for result in verify_all(config.providers):
         mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
         _console.print(f"{mark} {result.kind.value} ({result.model}) {result.detail}")
+    # Verify the phi embed path too, unless it's the offline (creds-free) hashing embedder.
+    if config.embed_provider is not EmbedderKind.HASHING:
+        embed_cfg = config.provider_config(config.embed_provider.provider_kind()).model_copy(
+            update={"embed_dim": config.embed_dim}
+        )
+        result = verify_embedder(embed_cfg)
+        mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
+        _console.print(f"{mark} embed:{result.kind.value} ({result.model}) {result.detail}")
 
 
 @app.command("build")
@@ -37,6 +46,11 @@ def build(
     model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     gepa_budget: int = typer.Option(50, help="GEPA rollout budget."),
+    embed_provider: str = typer.Option(
+        "hashing", help="phi embedder: hashing (offline) | bedrock | openai | azure_openai."
+    ),
+    embed_model: str = typer.Option(None, help="Embeddings model id / Azure embedding deployment."),
+    embed_dim: int = typer.Option(512, help="phi dimensionality (index + query must agree)."),
 ) -> None:
     """Ingest traces (file upload or vendor SDK pull) and build the `.wmh/` artifact.
 
@@ -45,15 +59,37 @@ def build(
     """
     from wmh.engine.build import build as run_build
     from wmh.ingest import VendorPull
+    from wmh.retrieval import get_embedder
 
     serve_provider = ProviderKind(provider)
+    embed_kind = EmbedderKind(embed_provider)
+    providers = [ProviderConfig(kind=serve_provider, model=model, region=region)]
+    # A provider-backed embedder needs its own ProviderConfig (creds/model). Reuse the serve config
+    # when it's the same backend; otherwise add a minimal one carrying the embed model + region.
+    if embed_kind is not EmbedderKind.HASHING and embed_kind.provider_kind() != serve_provider:
+        providers.append(
+            ProviderConfig(
+                kind=embed_kind.provider_kind(),
+                model=embed_model or "",
+                embed_model=embed_model,
+                region=region,
+            )
+        )
+    elif embed_kind is not EmbedderKind.HASHING:
+        providers[0] = providers[0].model_copy(update={"embed_model": embed_model})
     config = HarnessConfig(
-        providers=[ProviderConfig(kind=serve_provider, model=model, region=region)],
+        providers=providers,
         serve_provider=serve_provider,
+        embed_provider=embed_kind,
+        embed_dim=embed_dim,
         gepa_budget=gepa_budget,
     )
     result = run_build(
-        config, file=file, vendor=VendorPull() if vendor else None, root=root
+        config,
+        file=file,
+        vendor=VendorPull() if vendor else None,
+        root=root,
+        embedder=get_embedder(config),
     )
     _console.print(
         f"[green]built[/green] {root}: held_out_accuracy="

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -57,9 +57,14 @@ def build(
     Creates `.wmh/` if absent, then: ingest -> normalize -> split(train/test) -> embed/index ->
     GEPA optimize -> write the artifact.
     """
+    import uuid
+
+    from wmh.config import ArtifactPaths
     from wmh.engine.build import build as run_build
     from wmh.ingest import VendorPull
+    from wmh.providers import get_provider
     from wmh.retrieval import get_embedder
+    from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
     serve_provider = ProviderKind(provider)
     embed_kind = EmbedderKind(embed_provider)
@@ -84,18 +89,44 @@ def build(
         embed_dim=embed_dim,
         gepa_budget=gepa_budget,
     )
-    result = run_build(
-        config,
-        file=file,
-        vendor=VendorPull() if vendor else None,
-        root=root,
-        embedder=get_embedder(config),
+    # Meter the build at the provider boundary: the one serve provider drives GEPA rollouts,
+    # reflection, and the judge, so wrapping it captures all build LLM cost/tokens without touching
+    # the optimizer. `classify_build_call` splits judge vs GEPA by system prompt.
+    tracker = RunTracker(run_id=uuid.uuid4().hex, kind="build")
+    metered = MeteredProvider(
+        get_provider(config.serve_provider_config()),
+        tracker,
+        classify=classify_build_call,
     )
+    with tracker.timed():
+        result = run_build(
+            config,
+            file=file,
+            vendor=VendorPull() if vendor else None,
+            root=root,
+            serve_provider=metered,
+            embedder=get_embedder(config),
+        )
+    record = tracker.record_summary()
+    save_run(record, ArtifactPaths(root).runs)
+
     _console.print(
         f"[green]built[/green] {root}: held_out_accuracy="
         f"{result.metrics.held_out_accuracy:.3f}, frontier={len(result.frontier)}, "
         f"rollouts={result.metrics.rollouts_used}"
     )
+    _console.print(
+        f"[bold]run[/bold] {record.run_id[:8]}: {record.duration_seconds:.1f}s, "
+        f"{record.total.total_tokens} tokens, ${record.total.cost_usd:.4f} "
+        f"({record.total.calls} calls)"
+    )
+    for phase in (Phase.GEPA, Phase.JUDGE):
+        bucket = record.by_phase.get(phase)
+        if bucket is not None:
+            _console.print(
+                f"  {phase.value}: {bucket.total_tokens} tokens, "
+                f"${bucket.cost_usd:.4f} ({bucket.calls} calls)"
+            )
 
 
 @app.command("serve")

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -66,8 +66,24 @@ def build(
     from wmh.retrieval import get_embedder
     from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
-    serve_provider = ProviderKind(provider)
-    embed_kind = EmbedderKind(embed_provider)
+    try:
+        serve_provider = ProviderKind(provider)
+    except ValueError:
+        kinds = ", ".join(k.value for k in ProviderKind)
+        raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
+    try:
+        embed_kind = EmbedderKind(embed_provider)
+    except ValueError:
+        kinds = ", ".join(k.value for k in EmbedderKind)
+        raise typer.BadParameter(
+            f"unknown embed provider {embed_provider!r}; choose one of: {kinds}"
+        ) from None
+    # A provider-backed embedder needs an embeddings model; fail fast, not deep inside embed().
+    if embed_kind is not EmbedderKind.HASHING and not embed_model:
+        raise typer.BadParameter(
+            f"--embed-provider {embed_kind.value} requires --embed-model "
+            "(the embeddings model id / Azure embedding deployment)"
+        )
     providers = [ProviderConfig(kind=serve_provider, model=model, region=region)]
     # A provider-backed embedder needs its own ProviderConfig (creds/model). Reuse the serve config
     # when it's the same backend; otherwise add a minimal one carrying the embed model + region.
@@ -75,7 +91,7 @@ def build(
         providers.append(
             ProviderConfig(
                 kind=embed_kind.provider_kind(),
-                model=embed_model or "",
+                model=embed_model,
                 embed_model=embed_model,
                 region=region,
             )

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -11,7 +11,7 @@ import typer
 from rich.console import Console
 
 from wmh.config import ARTIFACT_DIR, HarnessConfig, load_config
-from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
+from wmh.providers import ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import EmbedderKind
 
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
@@ -29,10 +29,7 @@ def providers_verify(root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir."
         _console.print(f"{mark} {result.kind.value} ({result.model}) {result.detail}")
     # Verify the phi embed path too, unless it's the offline (creds-free) hashing embedder.
     if config.embed_provider is not EmbedderKind.HASHING:
-        embed_cfg = config.provider_config(config.embed_provider.provider_kind()).model_copy(
-            update={"embed_dim": config.embed_dim}
-        )
-        result = verify_embedder(embed_cfg)
+        result = verify_embedder(config.embed_provider_config())
         mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
         _console.print(f"{mark} embed:{result.kind.value} ({result.model}) {result.detail}")
 
@@ -84,24 +81,13 @@ def build(
             f"--embed-provider {embed_kind.value} requires --embed-model "
             "(the embeddings model id / Azure embedding deployment)"
         )
-    providers = [ProviderConfig(kind=serve_provider, model=model, region=region)]
-    # A provider-backed embedder needs its own ProviderConfig (creds/model). Reuse the serve config
-    # when it's the same backend; otherwise add a minimal one carrying the embed model + region.
-    if embed_kind is not EmbedderKind.HASHING and embed_kind.provider_kind() != serve_provider:
-        providers.append(
-            ProviderConfig(
-                kind=embed_kind.provider_kind(),
-                model=embed_model,
-                embed_model=embed_model,
-                region=region,
-            )
-        )
-    elif embed_kind is not EmbedderKind.HASHING:
-        providers[0] = providers[0].model_copy(update={"embed_model": embed_model})
-    config = HarnessConfig(
-        providers=providers,
+    # Provider wiring (reuse-vs-separate embed config) lives in HarnessConfig.for_build, not here.
+    config = HarnessConfig.for_build(
         serve_provider=serve_provider,
+        serve_model=model,
+        region=region,
         embed_provider=embed_kind,
+        embed_model=embed_model,
         embed_dim=embed_dim,
         gepa_budget=gepa_budget,
     )

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -73,6 +73,11 @@ class ArtifactPaths:
         return self.root / "index"
 
     @property
+    def runs(self) -> Path:
+        """Directory of persisted run records (build + serve), one JSON per run."""
+        return self.root / "runs"
+
+    @property
     def base_prompt(self) -> Path:
         return self.root / "prompts" / "base.txt"
 

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -53,6 +53,59 @@ class HarnessConfig(BaseModel):
         """The ProviderConfig that serves the live world model."""
         return self.provider_config(self.serve_provider)
 
+    def embed_provider_config(self) -> ProviderConfig:
+        """The ProviderConfig backing phi retrieval, with `embed_dim` stamped on.
+
+        Stamping `embed_dim` makes the backend request vectors of exactly the persisted dimension,
+        so the index and query embedders agree. Raises for `EmbedderKind.HASHING` (the offline
+        embedder has no provider) — guard with `embed_provider is EmbedderKind.HASHING` first.
+        """
+        config = self.provider_config(self.embed_provider.provider_kind())
+        return config.model_copy(update={"embed_dim": self.embed_dim})
+
+    @classmethod
+    def for_build(
+        cls,
+        *,
+        serve_provider: ProviderKind,
+        serve_model: str,
+        region: str | None,
+        embed_provider: EmbedderKind,
+        embed_model: str | None,
+        embed_dim: int,
+        gepa_budget: int,
+    ) -> HarnessConfig:
+        """Assemble a build config from the choices `wmh build` collects.
+
+        Owns the one piece of provider wiring: a provider-backed embedder either **reuses** the
+        serve provider's config (same backend — just add `embed_model`) or gets **its own**
+        `ProviderConfig`. Keeping this here (not in the CLI) makes it unit-testable and gives every
+        entry point one place to construct a build config. Callers must already have validated that
+        a non-hashing embedder has an `embed_model`.
+        """
+        serve = ProviderConfig(kind=serve_provider, model=serve_model, region=region)
+        providers = [serve]
+        if embed_provider is not EmbedderKind.HASHING:
+            embed_kind = embed_provider.provider_kind()
+            if embed_kind == serve_provider:
+                providers[0] = serve.model_copy(update={"embed_model": embed_model})
+            else:
+                providers.append(
+                    ProviderConfig(
+                        kind=embed_kind,
+                        model=embed_model or "",
+                        embed_model=embed_model,
+                        region=region,
+                    )
+                )
+        return cls(
+            providers=providers,
+            serve_provider=serve_provider,
+            embed_provider=embed_provider,
+            embed_dim=embed_dim,
+            gepa_budget=gepa_budget,
+        )
+
 
 class ArtifactPaths:
     """Resolves the files under `.wmh/`."""

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -12,7 +12,7 @@ import tomli_w
 from pydantic import BaseModel, Field, JsonValue, ValidationError
 
 from wmh.core.types import JsonObject
-from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.base import EmbedderKind, ProviderConfig, ProviderKind
 
 ARTIFACT_DIR = ".wmh"
 
@@ -30,8 +30,10 @@ class HarnessConfig(BaseModel):
 
     providers: list[ProviderConfig] = Field(default_factory=list)
     serve_provider: ProviderKind = ProviderKind.ANTHROPIC  # serves the live world model
-    embed_provider: ProviderKind = ProviderKind.OPENAI  # supplies phi for retrieval
-    embed_dim: int = 512  # phi dimensionality; the offline HashingEmbedder's vector size
+    # Which embedder supplies phi for retrieval. Defaults to the offline HashingEmbedder (no creds);
+    # set to a provider-backed kind (bedrock/openai/azure_openai) for semantic phi.
+    embed_provider: EmbedderKind = EmbedderKind.HASHING
+    embed_dim: int = 512  # phi dimensionality; index + query embedder must agree on this
     top_k: int = 5  # demos retrieved per step (DreamGym k)
     train_split: float = 0.8  # train/held-out ratio for GEPA
     gepa_budget: int = 50  # rollout budget for prompt evolution

--- a/wmh/config/config_test.py
+++ b/wmh/config/config_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from wmh.config.config import HarnessConfig, load_config, save_config
-from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.base import EmbedderKind, ProviderConfig, ProviderKind
 
 
 def test_save_then_load_round_trips(tmp_path: Path) -> None:
@@ -18,13 +18,15 @@ def test_save_then_load_round_trips(tmp_path: Path) -> None:
                 kind=ProviderKind.AZURE_OPENAI,
                 model="gpt-5.5",
                 embed_model="text-embedding-3-large",
+                embed_dim=1024,
                 endpoint="https://example.openai.azure.com",
                 deployment="gpt-55",
                 api_version="2024-02-01",
             ),
         ],
         serve_provider=ProviderKind.ANTHROPIC,
-        embed_provider=ProviderKind.AZURE_OPENAI,
+        embed_provider=EmbedderKind.AZURE_OPENAI,
+        embed_dim=1024,
         top_k=8,
         train_split=0.7,
         gepa_budget=120,

--- a/wmh/config/config_test.py
+++ b/wmh/config/config_test.py
@@ -101,3 +101,63 @@ def test_provider_config_missing_kind_raises() -> None:
     config = HarnessConfig(providers=[], serve_provider=ProviderKind.BEDROCK)
     with pytest.raises(ValueError, match="no provider config for bedrock"):
         config.serve_provider_config()
+
+
+def test_embed_provider_config_stamps_embed_dim() -> None:
+    config = HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.OPENAI, model="gpt", embed_model="te3")],
+        embed_provider=EmbedderKind.OPENAI,
+        embed_dim=256,
+    )
+    embed_cfg = config.embed_provider_config()
+    assert embed_cfg.embed_model == "te3"
+    assert embed_cfg.embed_dim == 256  # stamped from HarnessConfig.embed_dim
+
+
+def test_for_build_reuses_serve_config_when_embed_backend_matches() -> None:
+    # Bedrock serves AND embeds -> one provider config carrying both model + embed_model.
+    config = HarnessConfig.for_build(
+        serve_provider=ProviderKind.BEDROCK,
+        serve_model="us.anthropic.claude-opus-4-8",
+        region="us-east-1",
+        embed_provider=EmbedderKind.BEDROCK,
+        embed_model="amazon.titan-embed-text-v2:0",
+        embed_dim=256,
+        gepa_budget=10,
+    )
+    assert len(config.providers) == 1
+    only = config.providers[0]
+    assert only.model == "us.anthropic.claude-opus-4-8"
+    assert only.embed_model == "amazon.titan-embed-text-v2:0"
+    assert config.embed_dim == 256
+
+
+def test_for_build_adds_separate_config_for_cross_backend_embedder() -> None:
+    # Bedrock serves, OpenAI embeds -> two provider configs.
+    config = HarnessConfig.for_build(
+        serve_provider=ProviderKind.BEDROCK,
+        serve_model="opus",
+        region=None,
+        embed_provider=EmbedderKind.OPENAI,
+        embed_model="text-embedding-3-small",
+        embed_dim=512,
+        gepa_budget=10,
+    )
+    kinds = {pc.kind for pc in config.providers}
+    assert kinds == {ProviderKind.BEDROCK, ProviderKind.OPENAI}
+    openai_cfg = config.provider_config(ProviderKind.OPENAI)
+    assert openai_cfg.embed_model == "text-embedding-3-small"
+
+
+def test_for_build_hashing_embedder_needs_no_embed_provider_config() -> None:
+    config = HarnessConfig.for_build(
+        serve_provider=ProviderKind.BEDROCK,
+        serve_model="opus",
+        region=None,
+        embed_provider=EmbedderKind.HASHING,
+        embed_model=None,
+        embed_dim=512,
+        gepa_budget=10,
+    )
+    assert [pc.kind for pc in config.providers] == [ProviderKind.BEDROCK]
+    assert config.embed_provider is EmbedderKind.HASHING

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -70,7 +70,14 @@ class WorldModel:
         return session
 
     def session_usage(self, session_id: str) -> RunRecord:
-        """Return the running token/cost/time record for `session_id` (DreamGym serve metering)."""
+        """Return the running token/cost/time record for `session_id` (DreamGym serve metering).
+
+        The tracker is started at `new_session` and intentionally left running for the life of the
+        session (serve sessions have no explicit end), so `duration_seconds` is live wall-clock
+        since the session was created — not just time spent inside `step`. Raises `KeyError` if
+        `session_id` is unknown (callers that take session ids from clients should validate first,
+        as the serving API does).
+        """
         return self._trackers[session_id].record_summary()
 
     def get_session(self, session_id: str) -> Session:

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -14,6 +14,7 @@ from wmh.core.types import Action, EnvState, Observation, Session, Step
 from wmh.engine.prompts import BASE_ENV_PROMPT, build_env_prompt
 from wmh.providers.base import Embedder, Message, Provider
 from wmh.retrieval import EmbeddingRetriever, Retriever
+from wmh.tracking import Phase, RunRecord, RunTracker
 
 
 class WorldModel:
@@ -29,6 +30,9 @@ class WorldModel:
         self._env_prompt = env_prompt
         self._top_k = top_k
         self._sessions: dict[str, Session] = {}
+        # Per-session token/cost/time accounting (serve-time observability). One tracker per
+        # session, started when the session is created; `session_usage` exposes running totals.
+        self._trackers: dict[str, RunTracker] = {}
 
     @classmethod
     def load(
@@ -60,7 +64,14 @@ class WorldModel:
     def new_session(self, task: str | None = None, seed_state: EnvState | None = None) -> Session:
         session = Session(id=uuid.uuid4().hex, task=task, state=seed_state or EnvState())
         self._sessions[session.id] = session
+        tracker = RunTracker(run_id=session.id, kind="serve")
+        tracker.start()
+        self._trackers[session.id] = tracker
         return session
+
+    def session_usage(self, session_id: str) -> RunRecord:
+        """Return the running token/cost/time record for `session_id` (DreamGym serve metering)."""
+        return self._trackers[session_id].record_summary()
 
     def get_session(self, session_id: str) -> Session:
         return self._sessions[session_id]
@@ -90,6 +101,11 @@ class WorldModel:
         system, user = build_env_prompt(self._env_prompt, session, action, demos)
         completion = self._provider.complete(system, [_user_message(user)])
         observation = parse_observation(completion.text)
+
+        # serve-time metering: attribute this call's tokens/cost to the session
+        tracker = self._trackers.get(session_id)
+        if tracker is not None:
+            tracker.record(Phase.SERVE, self._provider.config.model, completion.usage)
 
         # (4) advance session: append step, update structured state + scratchpad, enrich buffer
         step = Step(

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -37,11 +37,11 @@ class WorldModel:
         """Construct from a built `.wmh/` artifact (optimized prompt + indexed replay buffer).
 
         `provider` serves the live world model (generation). `embedder` supplies phi for retrieval;
-        when omitted we use the offline `HashingEmbedder` (the default build embedder), so loading
-        needs no embedding credentials.
+        when omitted we reconstruct the configured embedder (`embed_provider` + `embed_dim`), which
+        defaults to the offline `HashingEmbedder` so loading needs no embedding credentials.
         """
         from wmh.config import ArtifactPaths, load_config
-        from wmh.retrieval.embedders import HashingEmbedder
+        from wmh.retrieval.embedders import get_embedder
 
         config = load_config(artifact_dir)
         paths = ArtifactPaths(artifact_dir)
@@ -50,9 +50,9 @@ class WorldModel:
             if paths.optimized_prompt.exists()
             else BASE_ENV_PROMPT
         )
-        # Reconstruct the *same* embedder the build used (dim is persisted in config), so the
+        # Reconstruct the *same* embedder the build used (provider + dim persisted in config), so
         # query vectors match the stored matrix. A caller-supplied embedder overrides.
-        retriever = EmbeddingRetriever(embedder or HashingEmbedder(dim=config.embed_dim))
+        retriever = EmbeddingRetriever(embedder or get_embedder(config))
         if paths.index.exists():
             retriever.load(paths.index)
         return cls(provider, retriever, env_prompt=env_prompt, top_k=config.top_k)

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -11,6 +11,7 @@ from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 def test_world_model_new_session_works() -> None:
     wm = WorldModel.__new__(WorldModel)
     wm._sessions = {}
+    wm._trackers = {}
     session = WorldModel.new_session(wm, task="hi")
     assert session.id
     assert WorldModel.get_session(wm, session.id) is session
@@ -87,6 +88,42 @@ def test_step_marks_errors_and_enriches_buffer() -> None:
     assert obs.is_error is True
     # The freshly produced step was added to the buffer (online enrichment).
     assert len(retriever._steps) == 1
+
+
+class _UsageProvider(FakeProvider):
+    """FakeProvider that also reports token usage, for serve-metering assertions."""
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        from wmh.providers.base import TokenUsage
+
+        self.last_system = system
+        self.last_user = messages[0].content
+        return Completion(text=self._reply, usage=TokenUsage(input_tokens=120, output_tokens=30))
+
+
+def test_step_meters_usage_per_session() -> None:
+    provider = _UsageProvider('{"output": "ok", "is_error": false}')
+    provider.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="claude-opus-4-8")
+    wm = WorldModel(provider, _retriever_with([]), top_k=1)
+    session = wm.new_session(task="t")
+
+    wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="f", arguments={}))
+    wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="f", arguments={}))
+
+    usage = wm.session_usage(session.id)
+    assert usage.kind == "serve"
+    assert usage.total.calls == 2
+    assert usage.total.input_tokens == 240
+    assert usage.total.output_tokens == 60
+    # 240*5/1e6 + 60*25/1e6 = 0.0012 + 0.0015 = 0.0027
+    assert usage.total.cost_usd == 0.0027
 
 
 def test_load_reads_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
 from wmh.engine.world_model import WorldModel
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
@@ -122,8 +124,8 @@ def test_step_meters_usage_per_session() -> None:
     assert usage.total.calls == 2
     assert usage.total.input_tokens == 240
     assert usage.total.output_tokens == 60
-    # 240*5/1e6 + 60*25/1e6 = 0.0012 + 0.0015 = 0.0027
-    assert usage.total.cost_usd == 0.0027
+    # 240*5/1e6 + 60*25/1e6 = 0.0012 + 0.0015 = 0.0027 (float division → approx)
+    assert usage.total.cost_usd == pytest.approx(0.0027)
 
 
 def test_load_reads_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture

--- a/wmh/providers/__init__.py
+++ b/wmh/providers/__init__.py
@@ -6,21 +6,24 @@ verified on startup with a cheap ping. Built fresh for this repo; no external cl
 
 from wmh.providers.base import (
     Completion,
+    EmbedderKind,
     Message,
     Provider,
     ProviderConfig,
     ProviderKind,
     VerifyResult,
 )
-from wmh.providers.registry import get_provider, verify_all
+from wmh.providers.registry import get_provider, verify_all, verify_embedder
 
 __all__ = [
     "Provider",
     "ProviderConfig",
     "ProviderKind",
+    "EmbedderKind",
     "Completion",
     "Message",
     "VerifyResult",
     "get_provider",
     "verify_all",
+    "verify_embedder",
 ]

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -26,7 +26,9 @@ class _ChatCompletions(Protocol):
 
 
 class _Embeddings(Protocol):
-    def create(self, *, model: str, input: list[str]) -> CreateEmbeddingResponse: ...
+    def create(
+        self, *, model: str, input: list[str], dimensions: int = ...
+    ) -> CreateEmbeddingResponse: ...
 
 
 def to_messages(system: str, messages: list[Message]) -> list[ChatCompletionMessageParam]:
@@ -70,7 +72,17 @@ def complete(
     return Completion(text=text, usage=token_usage)
 
 
-def embed(embeddings: _Embeddings, model: str, texts: list[str]) -> list[list[float]]:
-    """Embed `texts` against `model` (an OpenAI model id, or an Azure embedding deployment)."""
-    response = embeddings.create(model=model, input=texts)
+def embed(
+    embeddings: _Embeddings, model: str, texts: list[str], dim: int | None = None
+) -> list[list[float]]:
+    """Embed `texts` against `model` (an OpenAI model id, or an Azure embedding deployment).
+
+    `dim`, when set, requests a specific output dimension via the `dimensions` param (supported by
+    text-embedding-3-* and their Azure deployments) so the index and query vectors match.
+    """
+    response = (
+        embeddings.create(model=model, input=texts, dimensions=dim)
+        if dim is not None
+        else embeddings.create(model=model, input=texts)
+    )
     return [item.embedding for item in response.data]

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -65,7 +65,9 @@ class AzureOpenAIProvider:
         # embedding model, not a base OpenAI model id, or the call 404s.
         if self.config.embed_model is None:
             raise ValueError("AzureOpenAIProvider.embed requires config.embed_model (deployment).")
-        return _openai_common.embed(self._get_client().embeddings, self.config.embed_model, texts)
+        return _openai_common.embed(
+            self._get_client().embeddings, self.config.embed_model, texts, self.config.embed_dim
+        )
 
     def verify(self) -> VerifyResult:
         return verify_via_ping(self)

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -15,6 +15,26 @@ class ProviderKind(StrEnum):
     OPENAI = "openai"  # GPT 5.5 direct
 
 
+class EmbedderKind(StrEnum):
+    """Which embedder supplies phi for retrieval.
+
+    `HASHING` is the offline, zero-config default (no creds, no network). The other three map 1:1 to
+    the same-named `ProviderKind` and use that backend's embeddings API. Anthropic is intentionally
+    absent — it has no embeddings API; configure `BEDROCK`/`OPENAI`/`AZURE_OPENAI` (or `HASHING`).
+    """
+
+    HASHING = "hashing"  # offline HashingEmbedder (default)
+    BEDROCK = "bedrock"  # Titan on AWS Bedrock
+    OPENAI = "openai"  # OpenAI embeddings
+    AZURE_OPENAI = "azure_openai"  # Azure OpenAI embedding deployment
+
+    def provider_kind(self) -> ProviderKind:
+        """The ProviderKind backing this embedder. Raises for `HASHING` (no provider)."""
+        if self is EmbedderKind.HASHING:
+            raise ValueError("HASHING is the offline embedder; it has no backing provider")
+        return ProviderKind(self.value)
+
+
 Role = Literal["user", "assistant"]
 
 
@@ -49,7 +69,8 @@ class ProviderConfig(BaseModel):
 
     kind: ProviderKind
     model: str
-    embed_model: str | None = None
+    embed_model: str | None = None  # embeddings model id / Azure embedding deployment
+    embed_dim: int | None = None  # requested embedding dimension (Titan v2, text-embedding-3-*)
     # Backend knobs (only some apply per kind):
     endpoint: str | None = None  # Azure OpenAI / custom base URL
     region: str | None = None  # AWS Bedrock region

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, TypedDict, cast
 
+from wmh.core.types import JsonValue
 from wmh.providers.base import (
     Completion,
     Message,
@@ -20,6 +21,9 @@ if TYPE_CHECKING:
 # Bedrock speaks the same Anthropic Messages schema as the direct API, pinned by this version tag.
 _ANTHROPIC_BEDROCK_VERSION = "bedrock-2023-05-31"
 
+# Default Titan text-embeddings model (confirmed reachable; v2 supports `dimensions` 256/512/1024).
+_DEFAULT_EMBED_MODEL = "amazon.titan-embed-text-v2:0"
+
 
 class _ContentBlock(TypedDict):
     type: str
@@ -34,6 +38,10 @@ class _Usage(TypedDict):
 class _BedrockResponse(TypedDict):
     content: list[_ContentBlock]
     usage: _Usage
+
+
+class _TitanEmbedResponse(TypedDict):
+    embedding: list[float]
 
 
 class BedrockProvider:
@@ -77,11 +85,24 @@ class BedrockProvider:
         return Completion(text=text, usage=usage)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        # Embeddings on Bedrock (Titan / Cohere) are a separate model surface, not yet wired up;
-        # use an OpenAI embed provider for retrieval (phi) in the meantime.
-        raise NotImplementedError(
-            "BedrockProvider embeddings are not implemented; use an OpenAI embed provider."
-        )
+        """Embed via Amazon Titan text embeddings on Bedrock (phi for retrieval).
+
+        Titan's InvokeModel embeds one text per call (no batch input), so we loop. `embed_model`
+        selects the Titan model (defaults to titan-embed-text-v2); `embed_dim`, when set, requests a
+        specific output dimension (v2 supports 256/512/1024) so the index and query vectors match.
+        """
+        model = self.config.embed_model or _DEFAULT_EMBED_MODEL
+        client = self._get_client()
+        vectors: list[list[float]] = []
+        for text in texts:
+            body: dict[str, JsonValue] = {"inputText": text}
+            if self.config.embed_dim is not None:
+                body["dimensions"] = self.config.embed_dim
+                body["normalize"] = True
+            raw = client.invoke_model(modelId=model, body=json.dumps(body))
+            data = cast("_TitanEmbedResponse", json.loads(raw["body"].read()))
+            vectors.append(data["embedding"])
+        return vectors
 
     def verify(self) -> VerifyResult:
         return verify_via_ping(self)

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -47,7 +47,9 @@ class OpenAIProvider:
     def embed(self, texts: list[str]) -> list[list[float]]:
         if self.config.embed_model is None:
             raise ValueError("OpenAIProvider.embed requires config.embed_model to be set.")
-        return _openai_common.embed(self._get_client().embeddings, self.config.embed_model, texts)
+        return _openai_common.embed(
+            self._get_client().embeddings, self.config.embed_model, texts, self.config.embed_dim
+        )
 
     def verify(self) -> VerifyResult:
         return verify_via_ping(self)

--- a/wmh/providers/registry.py
+++ b/wmh/providers/registry.py
@@ -52,5 +52,11 @@ def verify_embedder(config: ProviderConfig) -> VerifyResult:
         vectors = get_provider(config).embed(["ping"])
     except Exception as exc:  # noqa: BLE001 - verification must not crash startup
         return VerifyResult(ok=False, kind=config.kind, model=embed_model, detail=str(exc))
-    dim = len(vectors[0]) if vectors and vectors[0] else 0
+    # A successful call must return one non-empty vector; an empty result or a zero-width vector
+    # means the embed path didn't actually produce usable phi — report that as a failure, not ok.
+    dim = len(vectors[0]) if vectors else 0
+    if dim == 0:
+        return VerifyResult(
+            ok=False, kind=config.kind, model=embed_model, detail="embed returned no vector"
+        )
     return VerifyResult(ok=True, kind=config.kind, model=embed_model, detail=f"dim={dim}")

--- a/wmh/providers/registry.py
+++ b/wmh/providers/registry.py
@@ -38,3 +38,19 @@ def verify_all(configs: list[ProviderConfig]) -> list[VerifyResult]:
         except Exception as exc:  # noqa: BLE001 - verification must not crash startup
             results.append(VerifyResult(ok=False, kind=cfg.kind, model=cfg.model, detail=str(exc)))
     return results
+
+
+def verify_embedder(config: ProviderConfig) -> VerifyResult:
+    """Embed one tiny string to confirm the embeddings path (creds + model) works.
+
+    Mirrors `verify_via_ping` for the embed half: never raises — a failure (missing creds, no
+    embeddings API, wrong model) comes back as `ok=False` with the detail. The reported `model` is
+    the embeddings model (`embed_model`), falling back to the completion model when unset.
+    """
+    embed_model = config.embed_model or config.model
+    try:
+        vectors = get_provider(config).embed(["ping"])
+    except Exception as exc:  # noqa: BLE001 - verification must not crash startup
+        return VerifyResult(ok=False, kind=config.kind, model=embed_model, detail=str(exc))
+    dim = len(vectors[0]) if vectors and vectors[0] else 0
+    return VerifyResult(ok=True, kind=config.kind, model=embed_model, detail=f"dim={dim}")

--- a/wmh/providers/tests/bedrock_test.py
+++ b/wmh/providers/tests/bedrock_test.py
@@ -62,9 +62,52 @@ def test_complete_builds_anthropic_body_and_parses(monkeypatch: pytest.MonkeyPat
     assert "temperature" not in body  # Claude 4.8 rejects sampling params
 
 
-def test_embed_not_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="OpenAI embed provider"):
-        BedrockProvider(_config()).embed(["x"])
+class _FakeEmbedClient:
+    """Fakes bedrock-runtime for Titan embeddings: one invoke_model call per input text."""
+
+    def __init__(self, vector: list[float]) -> None:
+        self._vector = vector
+        self.calls: list[dict[str, object]] = []
+
+    def invoke_model(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        return {"body": _FakeBody({"embedding": self._vector})}
+
+
+def test_embed_invokes_titan_per_text_and_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeEmbedClient([0.1, 0.2, 0.3])
+    config = ProviderConfig(
+        kind=ProviderKind.BEDROCK,
+        model="us.anthropic.claude-opus-4-8",
+        embed_model="amazon.titan-embed-text-v2:0",
+        embed_dim=3,
+        region="us-east-1",
+    )
+    provider = BedrockProvider(config)
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    vectors = provider.embed(["a", "b"])
+
+    assert vectors == [[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]
+    assert len(fake.calls) == 2  # Titan embeds one text per call
+    assert fake.calls[0]["modelId"] == "amazon.titan-embed-text-v2:0"
+    body = json.loads(cast("str", fake.calls[0]["body"]))
+    assert body == {"inputText": "a", "dimensions": 3, "normalize": True}
+
+
+def test_embed_defaults_model_and_omits_dimensions_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeEmbedClient([1.0])
+    # No embed_model / embed_dim: default Titan model, and no `dimensions` (model's native size).
+    provider = BedrockProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.embed(["x"])
+
+    assert fake.calls[0]["modelId"] == "amazon.titan-embed-text-v2:0"
+    body = json.loads(cast("str", fake.calls[0]["body"]))
+    assert body == {"inputText": "x"}  # no dimensions/normalize when embed_dim is unset
 
 
 def test_verify_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -100,3 +143,27 @@ def test_live_verify() -> None:  # pragma: no cover - network
         )
     )
     assert provider.verify().ok is True
+
+
+@pytest.mark.skipif(
+    "AWS_REGION" not in __import__("os").environ,
+    reason="no AWS_REGION; skipping live Titan embeddings test",
+)
+def test_live_titan_embed() -> None:  # pragma: no cover - network
+    import os
+
+    # Real Titan embeddings: returns one 256-dim L2-normalized vector per input text.
+    provider = BedrockProvider(
+        ProviderConfig(
+            kind=ProviderKind.BEDROCK,
+            model="us.anthropic.claude-opus-4-8",
+            embed_model="amazon.titan-embed-text-v2:0",
+            embed_dim=256,
+            region=os.environ["AWS_REGION"],
+        )
+    )
+    vectors = provider.embed(["hello world", "a different sentence"])
+    assert len(vectors) == 2
+    assert all(len(v) == 256 for v in vectors)
+    # Distinct inputs should not produce identical embeddings.
+    assert vectors[0] != vectors[1]

--- a/wmh/providers/tests/openai_test.py
+++ b/wmh/providers/tests/openai_test.py
@@ -111,6 +111,21 @@ def test_embed_uses_embed_model(monkeypatch: pytest.MonkeyPatch) -> None:
     assert vectors == [[0.1, 0.2], [0.3, 0.4]]
     assert embeddings.last_kwargs["model"] == "text-embed-3"
     assert embeddings.last_kwargs["input"] == ["a", "b"]
+    assert "dimensions" not in embeddings.last_kwargs  # omitted when embed_dim unset
+
+
+def test_embed_threads_embed_dim_as_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    embeddings = _FakeEmbeddings(_FakeEmbeddingResponse([[0.1, 0.2, 0.3]]))
+    config = ProviderConfig(
+        kind=ProviderKind.OPENAI, model="gpt-5.5", embed_model="text-embed-3", embed_dim=3
+    )
+    provider = OpenAIProvider(config)
+    chat = _FakeChatCompletions(_FakeChatResponse("", _FakeUsage(0, 0)))
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat, embeddings))
+
+    provider.embed(["a"])
+
+    assert embeddings.last_kwargs["dimensions"] == 3  # embed_dim -> dimensions param
 
 
 def test_embed_requires_embed_model() -> None:

--- a/wmh/providers/tests/registry_test.py
+++ b/wmh/providers/tests/registry_test.py
@@ -60,9 +60,18 @@ def test_verify_embedder_ok_reports_dim(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_verify_embedder_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
     config = ProviderConfig(kind=ProviderKind.BEDROCK, model="opus")
-    monkeypatch.setattr(
-        "wmh.providers.registry.get_provider", lambda cfg: _BoomEmbedProvider(cfg)
-    )
+    monkeypatch.setattr("wmh.providers.registry.get_provider", lambda cfg: _BoomEmbedProvider(cfg))
     result = verify_embedder(config)
     assert result.ok is False
     assert "no creds" in result.detail
+
+
+def test_verify_embedder_empty_vector_is_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A call that returns a zero-width vector ([[]]) didn't actually produce usable phi.
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="opus", embed_model="titan")
+    monkeypatch.setattr(
+        "wmh.providers.registry.get_provider", lambda cfg: _FakeEmbedProvider(cfg, [])
+    )
+    result = verify_embedder(config)
+    assert result.ok is False
+    assert "no vector" in result.detail

--- a/wmh/providers/tests/registry_test.py
+++ b/wmh/providers/tests/registry_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from wmh.providers import ProviderConfig, ProviderKind, get_provider
+from wmh.providers import ProviderConfig, ProviderKind, get_provider, verify_embedder
 from wmh.providers.base import Provider
 
 
@@ -22,3 +22,47 @@ def test_verify_never_raises_and_reports_failure(monkeypatch: pytest.MonkeyPatch
     result = provider.verify()
     assert result.ok is False
     assert result.kind is ProviderKind.ANTHROPIC
+
+
+class _FakeEmbedProvider:
+    """Minimal Embedder: returns a fixed-width vector per text."""
+
+    def __init__(self, config: ProviderConfig, vector: list[float]) -> None:
+        self.config = config
+        self._vector = vector
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [list(self._vector) for _ in texts]
+
+
+class _BoomEmbedProvider:
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise RuntimeError("no creds")
+
+
+def test_verify_embedder_ok_reports_dim(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A working embed path reports ok=True with the produced dimension and the embed_model.
+    config = ProviderConfig(
+        kind=ProviderKind.BEDROCK, model="opus", embed_model="amazon.titan-embed-text-v2:0"
+    )
+    monkeypatch.setattr(
+        "wmh.providers.registry.get_provider",
+        lambda cfg: _FakeEmbedProvider(cfg, [0.0, 1.0, 2.0]),
+    )
+    result = verify_embedder(config)
+    assert result.ok is True
+    assert result.model == "amazon.titan-embed-text-v2:0"
+    assert result.detail == "dim=3"
+
+
+def test_verify_embedder_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="opus")
+    monkeypatch.setattr(
+        "wmh.providers.registry.get_provider", lambda cfg: _BoomEmbedProvider(cfg)
+    )
+    result = verify_embedder(config)
+    assert result.ok is False
+    assert "no creds" in result.detail

--- a/wmh/retrieval/__init__.py
+++ b/wmh/retrieval/__init__.py
@@ -1,6 +1,6 @@
 """Retrieval over the trace replay buffer (DreamGym Eq. 4)."""
 
-from wmh.retrieval.embedders import HashingEmbedder
+from wmh.retrieval.embedders import HashingEmbedder, get_embedder
 from wmh.retrieval.retriever import EmbeddingRetriever, Retriever
 
-__all__ = ["EmbeddingRetriever", "HashingEmbedder", "Retriever"]
+__all__ = ["EmbeddingRetriever", "HashingEmbedder", "Retriever", "get_embedder"]

--- a/wmh/retrieval/embedders.py
+++ b/wmh/retrieval/embedders.py
@@ -79,6 +79,5 @@ def get_embedder(config: HarnessConfig) -> Embedder:
 
     from wmh.providers import get_provider
 
-    provider_config = config.provider_config(config.embed_provider.provider_kind())
-    # Stamp the requested embedding dimension onto the provider config so the backend asks for it.
-    return get_provider(provider_config.model_copy(update={"embed_dim": config.embed_dim}))
+    # `embed_provider_config` resolves the backing provider and stamps `embed_dim` on it.
+    return get_provider(config.embed_provider_config())

--- a/wmh/retrieval/embedders.py
+++ b/wmh/retrieval/embedders.py
@@ -1,20 +1,29 @@
-"""Local, dependency-free embedders for retrieval (phi).
+"""Embedders for retrieval (phi), and the factory that picks one from config.
 
-Bedrock's `embed` is intentionally not wired up (see `wmh.providers.bedrock`), and we don't require
-an OpenAI key just to retrieve. `HashingEmbedder` provides a deterministic, offline phi so the whole
-build/serve loop runs on completions alone: it is a classic hashed-bag-of-character-ngrams vector
-(the "hashing trick"), L2-normalized. It captures lexical overlap between (state, action) renderings
-— enough for top-k similarity over a trace replay buffer — without a model or network.
+Two flavors of phi:
 
-It implements the `embed` half of the `Provider` protocol; the world model uses a real completion
-provider (e.g. Bedrock Opus) for generation and a `HashingEmbedder` for retrieval.
+* `HashingEmbedder` — the offline, zero-config default. A deterministic hashed-bag-of-character-
+  trigrams vector (the "hashing trick"), L2-normalized. Lexical, not semantic, but needs no creds or
+  network, so the whole build/serve loop runs on completions alone.
+* A real provider's embeddings API (Bedrock Titan / OpenAI / Azure OpenAI) — semantic phi. Selected
+  by setting `embed_provider` (an `EmbedderKind`) + the backend's credentials.
+
+Both satisfy the `wmh.providers.base.Embedder` protocol, so `EmbeddingRetriever` and the world model
+consume either interchangeably. `get_embedder` is the single place this choice is resolved.
 """
 
 from __future__ import annotations
 
 import hashlib
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+from wmh.providers.base import EmbedderKind
+
+if TYPE_CHECKING:
+    from wmh.config import HarnessConfig
+    from wmh.providers.base import Embedder
 
 DEFAULT_DIM = 512
 _NGRAM = 3
@@ -52,3 +61,24 @@ class HashingEmbedder:
         if norm > 0:
             vec /= norm
         return vec.tolist()
+
+
+def get_embedder(config: HarnessConfig) -> Embedder:
+    """Resolve the configured phi embedder from a `HarnessConfig`.
+
+    `embed_provider == HASHING` (the default) returns the offline `HashingEmbedder` sized to
+    `config.embed_dim` — no credentials, no network. Any other kind constructs the matching backend
+    provider (via the registry) with `embed_dim` threaded through, so the provider requests vectors
+    of exactly the persisted dimension and the index/query vectors line up.
+
+    The registry import is deferred to keep `wmh.retrieval` free of a hard dependency on the
+    provider backends (retrieval only needs the `Embedder` protocol).
+    """
+    if config.embed_provider is EmbedderKind.HASHING:
+        return HashingEmbedder(dim=config.embed_dim)
+
+    from wmh.providers import get_provider
+
+    provider_config = config.provider_config(config.embed_provider.provider_kind())
+    # Stamp the requested embedding dimension onto the provider config so the backend asks for it.
+    return get_provider(provider_config.model_copy(update={"embed_dim": config.embed_dim}))

--- a/wmh/retrieval/embedders_test.py
+++ b/wmh/retrieval/embedders_test.py
@@ -1,4 +1,4 @@
-"""Tests for the offline HashingEmbedder."""
+"""Tests for the offline HashingEmbedder and the get_embedder factory."""
 
 from __future__ import annotations
 
@@ -6,7 +6,9 @@ import math
 
 import pytest
 
-from wmh.retrieval.embedders import HashingEmbedder
+from wmh.config import HarnessConfig
+from wmh.providers.base import EmbedderKind, ProviderConfig, ProviderKind
+from wmh.retrieval.embedders import HashingEmbedder, get_embedder
 
 
 def _cosine(a: list[float], b: list[float]) -> float:
@@ -43,3 +45,52 @@ def test_batch_matches_individual() -> None:
 def test_rejects_nonpositive_dim() -> None:
     with pytest.raises(ValueError, match="positive"):
         HashingEmbedder(dim=0)
+
+
+# --- get_embedder factory ------------------------------------------------------------------------
+
+
+def test_get_embedder_defaults_to_hashing_sized_to_embed_dim() -> None:
+    embedder = get_embedder(HarnessConfig(embed_dim=77))  # default embed_provider is HASHING
+    assert isinstance(embedder, HashingEmbedder)
+    assert len(embedder.embed(["x"])[0]) == 77
+
+
+def test_get_embedder_builds_provider_with_embed_dim_threaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, ProviderConfig] = {}
+
+    def fake_get_provider(config: ProviderConfig) -> object:
+        captured["config"] = config
+        return object()  # the factory returns whatever the registry builds
+
+    # The factory imports get_provider from wmh.providers lazily; patch it there.
+    import wmh.providers as providers_pkg
+
+    monkeypatch.setattr(providers_pkg, "get_provider", fake_get_provider)
+
+    config = HarnessConfig(
+        providers=[
+            ProviderConfig(
+                kind=ProviderKind.BEDROCK,
+                model="us.anthropic.claude-opus-4-8",
+                embed_model="amazon.titan-embed-text-v2:0",
+            )
+        ],
+        embed_provider=EmbedderKind.BEDROCK,
+        embed_dim=256,
+    )
+    get_embedder(config)
+
+    built = captured["config"]
+    assert built.kind is ProviderKind.BEDROCK
+    assert built.embed_model == "amazon.titan-embed-text-v2:0"
+    assert built.embed_dim == 256  # embed_dim stamped onto the provider config
+
+
+def test_get_embedder_missing_provider_config_raises() -> None:
+    # embed_provider points at OPENAI but no OpenAI ProviderConfig is registered.
+    config = HarnessConfig(embed_provider=EmbedderKind.OPENAI)
+    with pytest.raises(ValueError, match="no provider config for openai"):
+        get_embedder(config)

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from wmh.core.types import Action, EnvState, Observation, Session
 from wmh.engine.world_model import WorldModel
+from wmh.tracking import RunRecord
 
 
 class NewSessionRequest(BaseModel):
@@ -66,6 +67,12 @@ def create_app(artifact_dir: str = ".wmh", world_model: WorldModel | None = None
     @app.get("/sessions/{session_id}", response_model=Session)
     def get_session(session_id: str) -> Session:
         return _session_or_404(session_id)
+
+    @app.get("/sessions/{session_id}/usage", response_model=RunRecord)
+    def session_usage(session_id: str) -> RunRecord:
+        """Per-session token/cost/time so far (serve-time observability)."""
+        _session_or_404(session_id)
+        return wm.session_usage(session_id)
 
     @app.post("/sessions/{session_id}/step", response_model=StepResponse)
     def step(session_id: str, req: StepRequest) -> StepResponse:

--- a/wmh/tracking/__init__.py
+++ b/wmh/tracking/__init__.py
@@ -1,0 +1,36 @@
+"""Run tracking: time + cost + tokens across the harness lifecycle.
+
+Instrument at the provider boundary (`MeteredProvider`) so the world model, GEPA, and the judge are
+all metered without changes to those modules. `RunTracker` aggregates `UsageEvent`s into
+`UsageTotals` (priced via `wmh.tracking.pricing`) plus a wall-clock duration from an injectable
+`Clock`; `RunRecord`s persist under `.wmh/runs/`.
+"""
+
+from wmh.tracking.clock import Clock, SystemClock
+from wmh.tracking.metered import MeteredProvider, classify_build_call
+from wmh.tracking.pricing import ModelPrice, cost_usd, price_for
+from wmh.tracking.store import load_runs, save_run
+from wmh.tracking.tracker import (
+    Phase,
+    RunRecord,
+    RunTracker,
+    UsageEvent,
+    UsageTotals,
+)
+
+__all__ = [
+    "Clock",
+    "SystemClock",
+    "MeteredProvider",
+    "classify_build_call",
+    "ModelPrice",
+    "cost_usd",
+    "price_for",
+    "load_runs",
+    "save_run",
+    "Phase",
+    "RunRecord",
+    "RunTracker",
+    "UsageEvent",
+    "UsageTotals",
+]

--- a/wmh/tracking/clock.py
+++ b/wmh/tracking/clock.py
@@ -1,0 +1,24 @@
+"""Injectable clock so run-tracking durations are deterministic in tests.
+
+Production uses `SystemClock` (real `time.monotonic`). Tests pass a `FakeClock` with scripted ticks
+so cost/time assertions don't depend on wall-clock timing.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    def monotonic(self) -> float:
+        """Seconds from an arbitrary epoch; only differences are meaningful (for durations)."""
+        ...
+
+
+class SystemClock:
+    """Default clock backed by `time.monotonic` (monotonic, unaffected by wall-clock changes)."""
+
+    def monotonic(self) -> float:
+        return time.monotonic()

--- a/wmh/tracking/metered.py
+++ b/wmh/tracking/metered.py
@@ -1,0 +1,89 @@
+"""`MeteredProvider`: a Provider wrapper that records every call onto a RunTracker.
+
+Instrumenting at the provider boundary means the optimizer, the judge, and the world model are all
+metered without any of them knowing about tracking — we don't edit `gepa.py` or the judge. The
+wrapper forwards `complete`/`embed`/`verify`/`config` to the wrapped provider unchanged and records
+a `UsageEvent` per call.
+
+Phase attribution: build and serve share one provider, and within build the *same* provider serves
+GEPA rollouts, GEPA reflection, and the judge. We tell them apart by the system prompt each path
+uses (a stable, boundary-visible signal), defaulting `complete` to whatever base phase the wrapper
+was constructed with. Callers that want exact control can pass their own `classify`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from wmh.providers.base import (
+    Completion,
+    Message,
+    Provider,
+    ProviderConfig,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.tracking.tracker import Phase, RunTracker
+
+# System-prompt fingerprints of the build-time call sites (see judge.py / gepa.py).
+_JUDGE_MARKER = "grade a world model"
+_REFLECTION_MARKER = "improve the system prompt"
+
+
+def classify_build_call(system: str) -> Phase:
+    """Default phase classifier for a build-time `complete`: judge vs GEPA (rollout/reflection)."""
+    if _JUDGE_MARKER in system:
+        return Phase.JUDGE
+    # GEPA rollouts (env-sim) and reflection both belong to the optimization phase.
+    return Phase.GEPA
+
+
+class MeteredProvider:
+    """Wraps a `Provider`, recording token usage + cost per call onto a `RunTracker`.
+
+    `base_phase` is the phase for `complete` calls when no `classify` is given (e.g. `Phase.SERVE`
+    for the live world model). For build, pass `classify=classify_build_call` to split judge from
+    GEPA.
+    """
+
+    def __init__(
+        self,
+        provider: Provider,
+        tracker: RunTracker,
+        *,
+        base_phase: Phase = Phase.OTHER,
+        classify: Callable[[str], Phase] | None = None,
+    ) -> None:
+        self._provider = provider
+        self._tracker = tracker
+        self._base_phase = base_phase
+        self._classify = classify
+
+    @property
+    def config(self) -> ProviderConfig:
+        return self._provider.config
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        completion = self._provider.complete(
+            system, messages, temperature=temperature, max_tokens=max_tokens
+        )
+        phase = self._classify(system) if self._classify is not None else self._base_phase
+        self._tracker.record(phase, self._provider.config.model, completion.usage)
+        return completion
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        # Embeddings carry no token usage from our providers; record a zero-usage event for the
+        # call count so EMBED still shows up in the breakdown.
+        vectors = self._provider.embed(texts)
+        self._tracker.record(Phase.EMBED, self._provider.config.model, TokenUsage())
+        return vectors
+
+    def verify(self) -> VerifyResult:
+        return self._provider.verify()

--- a/wmh/tracking/metered.py
+++ b/wmh/tracking/metered.py
@@ -80,9 +80,11 @@ class MeteredProvider:
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         # Embeddings carry no token usage from our providers; record a zero-usage event for the
-        # call count so EMBED still shows up in the breakdown.
+        # call count so EMBED shows up in the breakdown. Attribute it to the embeddings model
+        # (`embed_model`), not the completion model, so any future embed pricing is keyed right.
         vectors = self._provider.embed(texts)
-        self._tracker.record(Phase.EMBED, self._provider.config.model, TokenUsage())
+        embed_model = self._provider.config.embed_model or self._provider.config.model
+        self._tracker.record(Phase.EMBED, embed_model, TokenUsage())
         return vectors
 
     def verify(self) -> VerifyResult:

--- a/wmh/tracking/metered_test.py
+++ b/wmh/tracking/metered_test.py
@@ -77,6 +77,22 @@ def test_embed_is_recorded_under_embed_phase() -> None:
     assert tracker.by_phase()[Phase.EMBED].calls == 1
 
 
+def test_embed_event_is_attributed_to_embed_model_not_completion_model() -> None:
+    provider = FakeProvider()
+    provider.config = ProviderConfig(
+        kind=ProviderKind.BEDROCK,
+        model="claude-opus-4-8",
+        embed_model="amazon.titan-embed-text-v2:0",
+    )
+    tracker = RunTracker(run_id="r", kind="build")
+    MeteredProvider(provider, tracker).embed(["a"])
+
+    # The EMBED event must carry the embeddings model, not the completion model.
+    embed_events = [e for e in tracker.events if e.phase is Phase.EMBED]
+    assert len(embed_events) == 1
+    assert embed_events[0].model == "amazon.titan-embed-text-v2:0"
+
+
 def test_config_is_forwarded() -> None:
     provider = FakeProvider()
     metered = MeteredProvider(provider, RunTracker(run_id="r", kind="serve"))

--- a/wmh/tracking/metered_test.py
+++ b/wmh/tracking/metered_test.py
@@ -1,0 +1,83 @@
+"""Tests for MeteredProvider: every call is recorded with the right phase + usage. No network."""
+
+from __future__ import annotations
+
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, TokenUsage
+from wmh.tracking.metered import MeteredProvider, classify_build_call
+from wmh.tracking.tracker import Phase, RunTracker
+
+
+class FakeProvider:
+    """Returns canned usage; mimics the build-time call sites by branching on the system prompt."""
+
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="claude-opus-4-8")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        if "grade a world model" in system:
+            return Completion(text="judged", usage=TokenUsage(input_tokens=40, output_tokens=10))
+        return Completion(text="rolled", usage=TokenUsage(input_tokens=100, output_tokens=20))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0, 1.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def test_complete_records_usage_with_base_phase() -> None:
+    tracker = RunTracker(run_id="r", kind="serve")
+    metered = MeteredProvider(FakeProvider(), tracker, base_phase=Phase.SERVE)
+
+    completion = metered.complete("anything", [Message(role="user", content="hi")])
+
+    assert completion.text == "rolled"  # forwarded unchanged
+    total = tracker.totals()
+    assert total.calls == 1
+    assert total.input_tokens == 100
+    assert total.output_tokens == 20
+    assert tracker.by_phase()[Phase.SERVE].calls == 1
+
+
+def test_classify_build_call_splits_judge_from_gepa() -> None:
+    tracker = RunTracker(run_id="r", kind="build")
+    metered = MeteredProvider(FakeProvider(), tracker, classify=classify_build_call)
+
+    # A GEPA env-sim rollout (any non-judge system) and a judge call.
+    metered.complete("You simulate an environment", [Message(role="user", content="x")])
+    metered.complete("You grade a world model ...", [Message(role="user", content="y")])
+
+    by_phase = tracker.by_phase()
+    assert by_phase[Phase.GEPA].calls == 1
+    assert by_phase[Phase.GEPA].input_tokens == 100
+    assert by_phase[Phase.JUDGE].calls == 1
+    assert by_phase[Phase.JUDGE].input_tokens == 40
+
+
+def test_classify_build_call_marker() -> None:
+    assert classify_build_call("You grade a world model") is Phase.JUDGE
+    assert classify_build_call("You improve the system prompt") is Phase.GEPA
+    assert classify_build_call("env simulator") is Phase.GEPA
+
+
+def test_embed_is_recorded_under_embed_phase() -> None:
+    tracker = RunTracker(run_id="r", kind="build")
+    metered = MeteredProvider(FakeProvider(), tracker)
+
+    vectors = metered.embed(["a", "b"])
+
+    assert vectors == [[0.0, 1.0], [0.0, 1.0]]  # forwarded unchanged
+    assert tracker.by_phase()[Phase.EMBED].calls == 1
+
+
+def test_config_is_forwarded() -> None:
+    provider = FakeProvider()
+    metered = MeteredProvider(provider, RunTracker(run_id="r", kind="serve"))
+    assert metered.config is provider.config

--- a/wmh/tracking/pricing.py
+++ b/wmh/tracking/pricing.py
@@ -1,0 +1,73 @@
+"""Per-model token pricing → USD cost.
+
+Provider-agnostic: prices are keyed by a normalized model id (provider prefixes like Bedrock's
+`us.anthropic.` are stripped before lookup), so the same Opus 4.8 row covers the direct API and
+Bedrock. Prices are USD per 1M tokens; an unknown model costs 0.0 and is flagged so callers can
+surface "cost unavailable" rather than silently under-reporting.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from wmh.providers.base import TokenUsage
+
+
+class ModelPrice(BaseModel):
+    """USD per 1,000,000 tokens, split by input/output."""
+
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+# Keyed by normalized model id (see `_normalize`). USD / 1M tokens.
+# Sources: Claude API pricing (Opus 4.8 $5/$25, Sonnet 4.6 $3/$15, Haiku 4.5 $1/$5); OpenAI
+# GPT-5.x and embedding list prices; Bedrock Titan v2 embeddings.
+_PRICES: dict[str, ModelPrice] = {
+    "claude-opus-4-8": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-7": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-6": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-sonnet-4-6": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
+    "claude-haiku-4-5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
+    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "gpt-5.2": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "gpt-5.1": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "gpt-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    # Embeddings (output tokens are always 0 for embed calls).
+    "text-embedding-3-small": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),
+    "text-embedding-3-large": ModelPrice(input_per_mtok=0.13, output_per_mtok=0.0),
+    "amazon.titan-embed-text-v2:0": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),
+}
+
+
+def _normalize(model: str) -> str:
+    """Strip provider/region routing prefixes so one row covers a model across providers.
+
+    Bedrock ids look like `us.anthropic.claude-opus-4-8`; the direct API uses `claude-opus-4-8`.
+    We drop a leading region segment (`us.`/`eu.`/...) and an `anthropic.` vendor segment, but keep
+    `amazon.titan-...` (its `amazon.` is part of the canonical model id, not a routing prefix).
+    """
+    normalized = model.strip()
+    region_prefixes = ("us.", "eu.", "apac.", "us-gov.")
+    for prefix in region_prefixes:
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    if normalized.startswith("anthropic."):
+        normalized = normalized[len("anthropic.") :]
+    return normalized
+
+
+def price_for(model: str) -> ModelPrice | None:
+    """Return the price row for `model` (after normalization), or None if unknown."""
+    return _PRICES.get(_normalize(model))
+
+
+def cost_usd(model: str, usage: TokenUsage) -> float:
+    """USD cost of `usage` on `model`. Unknown models cost 0.0 (see `price_for` to detect that)."""
+    price = price_for(model)
+    if price is None:
+        return 0.0
+    return (
+        usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+    ) / 1_000_000

--- a/wmh/tracking/pricing.py
+++ b/wmh/tracking/pricing.py
@@ -20,20 +20,31 @@ class ModelPrice(BaseModel):
     output_per_mtok: float
 
 
-# Keyed by normalized model id (see `_normalize`). USD / 1M tokens.
-# Sources: Claude API pricing (Opus 4.8 $5/$25, Sonnet 4.6 $3/$15, Haiku 4.5 $1/$5); OpenAI
-# GPT-5.x and embedding list prices; Bedrock Titan v2 embeddings.
+# Keyed by normalized model id (see `_normalize`). USD per 1M tokens.
+#
+# Completion prices verified 2026-06-25 against the live vendor pricing pages:
+#   - Claude: platform.claude.com/docs/en/about-claude/models/overview
+#   - OpenAI GPT-5.x: developers.openai.com/api/docs/pricing (Standard tier, short context)
+# Embedding prices are long-stable list prices NOT re-fetched in that pass (the OpenAI pricing
+# page no longer surfaces them); treat as approximate and re-verify if embed cost matters.
 _PRICES: dict[str, ModelPrice] = {
+    # --- Anthropic / Bedrock (Claude) ---
+    "claude-fable-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
+    "claude-mythos-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
     "claude-opus-4-8": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
     "claude-opus-4-7": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
     "claude-opus-4-6": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-1": ModelPrice(input_per_mtok=15.0, output_per_mtok=75.0),
     "claude-sonnet-4-6": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
     "claude-haiku-4-5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
-    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "gpt-5.2": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "gpt-5.1": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "gpt-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    # Embeddings (output tokens are always 0 for embed calls).
+    # --- OpenAI / Azure OpenAI (GPT-5.x; Azure deployments reuse the base model's price) ---
+    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=30.0),
+    "gpt-5.5-pro": ModelPrice(input_per_mtok=30.0, output_per_mtok=180.0),
+    "gpt-5.4": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0),
+    "gpt-5.4-mini": ModelPrice(input_per_mtok=0.75, output_per_mtok=4.5),
+    "gpt-5.4-nano": ModelPrice(input_per_mtok=0.2, output_per_mtok=1.25),
+    # --- Embeddings (output tokens are always 0 for embed calls) ---
     "text-embedding-3-small": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),
     "text-embedding-3-large": ModelPrice(input_per_mtok=0.13, output_per_mtok=0.0),
     "amazon.titan-embed-text-v2:0": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),

--- a/wmh/tracking/pricing_test.py
+++ b/wmh/tracking/pricing_test.py
@@ -2,21 +2,23 @@
 
 from __future__ import annotations
 
+import pytest
+
 from wmh.providers.base import TokenUsage
 from wmh.tracking.pricing import cost_usd, price_for
 
 
 def test_opus_4_8_cost_is_5_in_25_out_per_mtok() -> None:
-    # 1M input + 1M output on Opus 4.8 = $5 + $25.
+    # 1M input + 1M output on Opus 4.8 = $5 + $25. (approx: float division, not exact arithmetic)
     cost = cost_usd("claude-opus-4-8", TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000))
-    assert cost == 30.0
+    assert cost == pytest.approx(30.0)
 
 
 def test_bedrock_prefix_normalizes_to_same_price() -> None:
     # The Bedrock-prefixed id prices identically to the direct id.
     usage = TokenUsage(input_tokens=1_000_000, output_tokens=0)
     assert cost_usd("us.anthropic.claude-opus-4-8", usage) == cost_usd("claude-opus-4-8", usage)
-    assert cost_usd("us.anthropic.claude-opus-4-8", usage) == 5.0
+    assert cost_usd("us.anthropic.claude-opus-4-8", usage) == pytest.approx(5.0)
 
 
 def test_gpt_5_5_output_is_30_per_mtok() -> None:
@@ -45,4 +47,4 @@ def test_unknown_model_is_zero_and_flagged() -> None:
 def test_partial_usage_is_prorated() -> None:
     # 500k input + 200k output on Opus 4.8 = 0.5*5 + 0.2*25 = 2.5 + 5.0 = 7.5.
     cost = cost_usd("claude-opus-4-8", TokenUsage(input_tokens=500_000, output_tokens=200_000))
-    assert cost == 7.5
+    assert cost == pytest.approx(7.5)

--- a/wmh/tracking/pricing_test.py
+++ b/wmh/tracking/pricing_test.py
@@ -1,0 +1,35 @@
+"""Tests for the token→cost pricing table."""
+
+from __future__ import annotations
+
+from wmh.providers.base import TokenUsage
+from wmh.tracking.pricing import cost_usd, price_for
+
+
+def test_opus_4_8_cost_is_5_in_25_out_per_mtok() -> None:
+    # 1M input + 1M output on Opus 4.8 = $5 + $25.
+    cost = cost_usd("claude-opus-4-8", TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000))
+    assert cost == 30.0
+
+
+def test_bedrock_prefix_normalizes_to_same_price() -> None:
+    # The Bedrock-prefixed id prices identically to the direct id.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0)
+    assert cost_usd("us.anthropic.claude-opus-4-8", usage) == cost_usd("claude-opus-4-8", usage)
+    assert cost_usd("us.anthropic.claude-opus-4-8", usage) == 5.0
+
+
+def test_titan_embedding_keeps_amazon_prefix() -> None:
+    # `amazon.` is part of the Titan model id, not a routing prefix — it must still resolve.
+    assert price_for("amazon.titan-embed-text-v2:0") is not None
+
+
+def test_unknown_model_is_zero_and_flagged() -> None:
+    assert price_for("totally-made-up-model") is None
+    assert cost_usd("totally-made-up-model", TokenUsage(input_tokens=999, output_tokens=999)) == 0.0
+
+
+def test_partial_usage_is_prorated() -> None:
+    # 500k input + 200k output on Opus 4.8 = 0.5*5 + 0.2*25 = 2.5 + 5.0 = 7.5.
+    cost = cost_usd("claude-opus-4-8", TokenUsage(input_tokens=500_000, output_tokens=200_000))
+    assert cost == 7.5

--- a/wmh/tracking/pricing_test.py
+++ b/wmh/tracking/pricing_test.py
@@ -19,6 +19,19 @@ def test_bedrock_prefix_normalizes_to_same_price() -> None:
     assert cost_usd("us.anthropic.claude-opus-4-8", usage) == 5.0
 
 
+def test_gpt_5_5_output_is_30_per_mtok() -> None:
+    # Verified 2026-06-25 against OpenAI's live pricing page: gpt-5.5 is $5 in / $30 out.
+    price = price_for("gpt-5.5")
+    assert price is not None
+    assert (price.input_per_mtok, price.output_per_mtok) == (5.0, 30.0)
+
+
+def test_fable_5_is_10_in_50_out() -> None:
+    price = price_for("claude-fable-5")
+    assert price is not None
+    assert (price.input_per_mtok, price.output_per_mtok) == (10.0, 50.0)
+
+
 def test_titan_embedding_keeps_amazon_prefix() -> None:
     # `amazon.` is part of the Titan model id, not a routing prefix — it must still resolve.
     assert price_for("amazon.titan-embed-text-v2:0") is not None

--- a/wmh/tracking/store.py
+++ b/wmh/tracking/store.py
@@ -1,0 +1,31 @@
+"""Persist + list run records under `.wmh/runs/`.
+
+One JSON file per run (`<run_id>.json`). Kept tiny and dependency-free so `wmh build`/`serve` can
+write a record without pulling in the rest of the harness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmh.tracking.tracker import RunRecord
+
+
+def save_run(record: RunRecord, runs_dir: str | Path) -> Path:
+    """Write `record` to `<runs_dir>/<run_id>.json`, creating the directory if needed."""
+    path = Path(runs_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    out = path / f"{record.run_id}.json"
+    out.write_text(record.model_dump_json(indent=2), encoding="utf-8")
+    return out
+
+
+def load_runs(runs_dir: str | Path) -> list[RunRecord]:
+    """Load all run records from `runs_dir` (empty list if the directory doesn't exist)."""
+    path = Path(runs_dir)
+    if not path.exists():
+        return []
+    return [
+        RunRecord.model_validate_json(p.read_text(encoding="utf-8"))
+        for p in sorted(path.glob("*.json"))
+    ]

--- a/wmh/tracking/store_test.py
+++ b/wmh/tracking/store_test.py
@@ -1,0 +1,41 @@
+"""Tests for run-record persistence under .wmh/runs/."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmh.tracking.store import load_runs, save_run
+from wmh.tracking.tracker import Phase, RunRecord, UsageTotals
+
+
+def _record(run_id: str) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        kind="build",
+        duration_seconds=2.5,
+        total=UsageTotals(calls=2, input_tokens=300, output_tokens=50, cost_usd=0.01),
+        by_phase={Phase.GEPA: UsageTotals(calls=2, input_tokens=300, output_tokens=50)},
+    )
+
+
+def test_save_then_load_round_trips(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    save_run(_record("abc"), runs)
+
+    loaded = load_runs(runs)
+    assert len(loaded) == 1
+    assert loaded[0].run_id == "abc"
+    assert loaded[0].total.input_tokens == 300
+    assert loaded[0].by_phase[Phase.GEPA].calls == 2
+
+
+def test_load_missing_dir_returns_empty(tmp_path: Path) -> None:
+    assert load_runs(tmp_path / "does-not-exist") == []
+
+
+def test_save_writes_one_file_per_run(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    save_run(_record("r1"), runs)
+    save_run(_record("r2"), runs)
+    assert {p.stem for p in runs.glob("*.json")} == {"r1", "r2"}
+    assert len(load_runs(runs)) == 2

--- a/wmh/tracking/tracker.py
+++ b/wmh/tracking/tracker.py
@@ -1,0 +1,145 @@
+"""Run tracking: aggregate tokens → cost + wall-clock across the harness lifecycle.
+
+A `RunTracker` collects `UsageEvent`s (one per LLM call, tagged by phase) and rolls them up into
+`UsageTotals` (tokens, USD, calls) plus a wall-clock duration measured off an injectable `Clock`.
+`RunRecord` is the persisted artifact (`.wmh/runs/<run_id>.json`).
+
+The tracker is provider-agnostic: it records `(model, TokenUsage)` and prices via
+`wmh.tracking.pricing`. It's fed at the provider boundary by `MeteredProvider` (so GEPA, the judge,
+and the world model are all captured without touching the optimizer), and directly by the world
+model's serve `step`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from wmh.providers.base import TokenUsage
+from wmh.tracking.clock import Clock, SystemClock
+from wmh.tracking.pricing import cost_usd
+
+
+class Phase(StrEnum):
+    """Lifecycle phase a usage event is attributed to."""
+
+    BUILD = "build"  # world-model build (overall)
+    GEPA = "gepa"  # GEPA rollouts + reflection during optimization
+    JUDGE = "judge"  # LLM-judge scoring
+    SERVE = "serve"  # live world-model step calls
+    EMBED = "embed"  # embedding calls (phi)
+    OTHER = "other"
+
+
+class UsageEvent(BaseModel):
+    """One metered LLM call."""
+
+    phase: Phase
+    model: str
+    usage: TokenUsage = Field(default_factory=TokenUsage)
+    cost_usd: float = 0.0
+
+
+class UsageTotals(BaseModel):
+    """Rolled-up usage: tokens, cost, and call count."""
+
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+    def _add(self, event: UsageEvent) -> None:
+        self.calls += 1
+        self.input_tokens += event.usage.input_tokens
+        self.output_tokens += event.usage.output_tokens
+        self.cost_usd += event.cost_usd
+
+
+class RunRecord(BaseModel):
+    """Persisted summary of one run (build or serve session)."""
+
+    run_id: str
+    kind: str  # "build" | "serve" | ... (free-form label for the run)
+    duration_seconds: float = 0.0
+    total: UsageTotals = Field(default_factory=UsageTotals)
+    by_phase: dict[Phase, UsageTotals] = Field(default_factory=dict)
+
+
+class RunTracker:
+    """Accumulates usage events and the wall-clock of a run.
+
+    Duration is measured between `start()` and `stop()` off the injected `Clock`, so tests can pass
+    a `FakeClock` and assert exact seconds. `record` is the single entry point for a metered call.
+    """
+
+    def __init__(self, run_id: str, kind: str, clock: Clock | None = None) -> None:
+        self._run_id = run_id
+        self._kind = kind
+        self._clock = clock or SystemClock()
+        self._events: list[UsageEvent] = []
+        self._started_at: float | None = None
+        self._elapsed: float = 0.0
+
+    def start(self) -> None:
+        self._started_at = self._clock.monotonic()
+
+    def stop(self) -> None:
+        if self._started_at is not None:
+            self._elapsed = self._clock.monotonic() - self._started_at
+            self._started_at = None
+
+    @contextmanager
+    def timed(self) -> Iterator[RunTracker]:
+        """Time a run: `with tracker.timed(): ...` brackets start()/stop() even on error."""
+        self.start()
+        try:
+            yield self
+        finally:
+            self.stop()
+
+    def record(self, phase: Phase, model: str, usage: TokenUsage) -> UsageEvent:
+        """Record one metered LLM call, pricing it via the model pricing table."""
+        event = UsageEvent(
+            phase=phase, model=model, usage=usage, cost_usd=cost_usd(model, usage)
+        )
+        self._events.append(event)
+        return event
+
+    @property
+    def events(self) -> list[UsageEvent]:
+        return list(self._events)
+
+    def totals(self) -> UsageTotals:
+        total = UsageTotals()
+        for event in self._events:
+            total._add(event)
+        return total
+
+    def by_phase(self) -> dict[Phase, UsageTotals]:
+        buckets: dict[Phase, UsageTotals] = defaultdict(UsageTotals)
+        for event in self._events:
+            buckets[event.phase]._add(event)
+        return dict(buckets)
+
+    def duration_seconds(self) -> float:
+        """Elapsed seconds; live (since start) if still running, else the frozen final span."""
+        if self._started_at is not None:
+            return self._clock.monotonic() - self._started_at
+        return self._elapsed
+
+    def record_summary(self) -> RunRecord:
+        return RunRecord(
+            run_id=self._run_id,
+            kind=self._kind,
+            duration_seconds=self.duration_seconds(),
+            total=self.totals(),
+            by_phase=self.by_phase(),
+        )

--- a/wmh/tracking/tracker.py
+++ b/wmh/tracking/tracker.py
@@ -107,9 +107,7 @@ class RunTracker:
 
     def record(self, phase: Phase, model: str, usage: TokenUsage) -> UsageEvent:
         """Record one metered LLM call, pricing it via the model pricing table."""
-        event = UsageEvent(
-            phase=phase, model=model, usage=usage, cost_usd=cost_usd(model, usage)
-        )
+        event = UsageEvent(phase=phase, model=model, usage=usage, cost_usd=cost_usd(model, usage))
         self._events.append(event)
         return event
 

--- a/wmh/tracking/tracker_test.py
+++ b/wmh/tracking/tracker_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from wmh.providers.base import TokenUsage
 from wmh.tracking.tracker import Phase, RunTracker
 
@@ -29,8 +31,8 @@ def test_totals_sum_tokens_and_cost_across_events() -> None:
     assert total.input_tokens == 1500
     assert total.output_tokens == 300
     assert total.total_tokens == 1800
-    # 1500*5/1e6 + 300*25/1e6 = 0.0075 + 0.0075 = 0.015
-    assert total.cost_usd == 0.015
+    # 1500*5/1e6 + 300*25/1e6 = 0.0075 + 0.0075 = 0.015 (float division → approx)
+    assert total.cost_usd == pytest.approx(0.015)
 
 
 def test_by_phase_buckets_events() -> None:

--- a/wmh/tracking/tracker_test.py
+++ b/wmh/tracking/tracker_test.py
@@ -1,0 +1,81 @@
+"""Tests for RunTracker aggregation + deterministic timing via a fake clock."""
+
+from __future__ import annotations
+
+from wmh.providers.base import TokenUsage
+from wmh.tracking.tracker import Phase, RunTracker
+
+
+class FakeClock:
+    """Scripted monotonic clock: each `monotonic()` returns the next value in `ticks`."""
+
+    def __init__(self, ticks: list[float]) -> None:
+        self._ticks = ticks
+        self._i = 0
+
+    def monotonic(self) -> float:
+        value = self._ticks[self._i]
+        self._i += 1
+        return value
+
+
+def test_totals_sum_tokens_and_cost_across_events() -> None:
+    tracker = RunTracker(run_id="r", kind="build")
+    tracker.record(Phase.GEPA, "claude-opus-4-8", TokenUsage(input_tokens=1000, output_tokens=200))
+    tracker.record(Phase.JUDGE, "claude-opus-4-8", TokenUsage(input_tokens=500, output_tokens=100))
+
+    total = tracker.totals()
+    assert total.calls == 2
+    assert total.input_tokens == 1500
+    assert total.output_tokens == 300
+    assert total.total_tokens == 1800
+    # 1500*5/1e6 + 300*25/1e6 = 0.0075 + 0.0075 = 0.015
+    assert total.cost_usd == 0.015
+
+
+def test_by_phase_buckets_events() -> None:
+    tracker = RunTracker(run_id="r", kind="build")
+    tracker.record(Phase.GEPA, "claude-opus-4-8", TokenUsage(input_tokens=1000, output_tokens=0))
+    tracker.record(Phase.GEPA, "claude-opus-4-8", TokenUsage(input_tokens=1000, output_tokens=0))
+    tracker.record(Phase.JUDGE, "claude-opus-4-8", TokenUsage(input_tokens=400, output_tokens=0))
+
+    by_phase = tracker.by_phase()
+    assert by_phase[Phase.GEPA].calls == 2
+    assert by_phase[Phase.GEPA].input_tokens == 2000
+    assert by_phase[Phase.JUDGE].calls == 1
+
+
+def test_duration_is_measured_off_injected_clock() -> None:
+    clock = FakeClock([100.0, 105.5])  # start, stop
+    tracker = RunTracker(run_id="r", kind="build", clock=clock)
+    tracker.start()
+    tracker.stop()
+    assert tracker.duration_seconds() == 5.5
+
+
+def test_timed_contextmanager_brackets_start_stop() -> None:
+    clock = FakeClock([10.0, 13.0])
+    tracker = RunTracker(run_id="r", kind="serve", clock=clock)
+    with tracker.timed():
+        pass
+    assert tracker.record_summary().duration_seconds == 3.0
+
+
+def test_duration_is_live_while_running() -> None:
+    clock = FakeClock([0.0, 2.0])  # start, then a live read
+    tracker = RunTracker(run_id="r", kind="serve", clock=clock)
+    tracker.start()
+    assert tracker.duration_seconds() == 2.0  # not yet stopped → measured live
+
+
+def test_record_summary_carries_id_kind_and_breakdown() -> None:
+    clock = FakeClock([0.0, 1.0])
+    tracker = RunTracker(run_id="abc", kind="build", clock=clock)
+    with tracker.timed():
+        tracker.record(Phase.GEPA, "claude-opus-4-8", TokenUsage(input_tokens=10, output_tokens=2))
+    record = tracker.record_summary()
+    assert record.run_id == "abc"
+    assert record.kind == "build"
+    assert record.duration_seconds == 1.0
+    assert record.total.calls == 1
+    assert Phase.GEPA in record.by_phase


### PR DESCRIPTION
Two connected pieces on top of `feat/retrieval-optimize`. (RAG-aware GEPA — the third piece — was implemented separately on `feat/retrieval-optimize` itself; this branch deliberately doesn't touch `wmh/optimize/gepa.py` or `wmh/engine/build.py`.)

## 1. Embedding adapter provider — real semantic phi

Retrieval `phi` was offline-only (`HashingEmbedder`, lexical). Now a user sets `embed_provider` + creds and gets semantic embeddings, with `HashingEmbedder` as the zero-config default.

- **`EmbedderKind`** enum (`hashing` | `bedrock` | `openai` | `azure_openai`); Anthropic excluded (no embeddings API). `HarnessConfig.embed_provider` is now an `EmbedderKind` defaulting to `HASHING`, so config honestly drives behavior (previously it defaulted to `OPENAI` but was ignored).
- **Bedrock Titan** (`BedrockProvider.embed`): `amazon.titan-embed-text-v2:0`, one `InvokeModel` per text; `embed_dim` → Titan `dimensions` (+`normalize`).
- **`ProviderConfig.embed_dim`** threads the requested dimension; OpenAI/Azure pass it as the `dimensions` param so index and query vectors match. The existing `EmbeddingRetriever` dim-guard stays as the backstop.
- **`get_embedder(config)`** factory resolves hashing vs provider-backed; wired into `WorldModel.load` and `wmh build` (`--embed-provider/-model/-dim`). Uses the existing injectable `embedder` hook on `build()` — no edit to `build.py`.
- **`wmh providers verify`** now also verifies the embed path (`verify_embedder`: embeds one string, reports `dim`; never raises).
- `docs/embeddings.md` documents how `embed_model` is configured per provider + the dimension rule.

**Live-verified** against real Bedrock Titan (`AWS_REGION`-gated `test_live_titan_embed`): two distinct 256-dim vectors.

## 2. Run tracking — time + cost + tokens

New `wmh/tracking/` package; provider-agnostic observability across the lifecycle.

- **`pricing.py`** — per-model USD table (Opus 4.8 $5/$25, …); normalizes provider prefixes so `us.anthropic.claude-opus-4-8` prices like `claude-opus-4-8`. Unknown model → 0.0, detectable via `price_for(...) is None`.
- **`tracker.py`** — `RunTracker` aggregates `UsageEvent`s → `UsageTotals` (tokens, cost, calls) + by-phase breakdown, with wall-clock from an **injectable `Clock`** (so tests assert exact seconds, never real time). `RunRecord` is the persisted summary.
- **`metered.py`** — `MeteredProvider` wraps a `Provider` and records each `complete()`/`embed()` onto a tracker. **Instrumented at the provider boundary** so GEPA rollouts, reflection, and the judge are all metered without editing the optimizer; `classify_build_call` splits judge vs GEPA by system prompt.
- **`store.py`** — persist/load `RunRecord`s under `.wmh/runs/`.

Wiring (my files only):
- `WorldModel.step` meters serve-time calls per session; new `session_usage()` + `GET /sessions/{id}/usage`.
- `wmh build` wraps the serve provider in a `MeteredProvider`, times the build, persists a run record, and prints totals + GEPA/judge breakdown.

Deterministic tests (fake provider with known usage + `FakeClock`, no network) cover pricing, aggregation/timing, phase attribution, store round-trip, and per-session serve metering.

## Verification
`uv sync --extra dev` → `ruff check .` ✓, `ty check` ✓, `pytest -q` → **127 passed / 6 skipped** (skips are creds-gated live smoke tests). Verified on a clean checkout of the branch HEAD, independent of the shared worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)