### PR TITLE
Named world models, namespaced serving API, interactive play, animated build UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,22 @@ prompt optimization on a frontier model. See [`DESIGN.md`](./DESIGN.md) for the 
 
 ```bash
 uv sync
-wmh providers verify                # confirm Anthropic / Bedrock / Azure OpenAI / OpenAI creds
-wmh build --file traces.jsonl       # ingest + index + GEPA optimize -> .wmh/ artifact
-                                    #   (or: wmh build --vendor <vendor>; build creates .wmh/ itself)
-wmh serve                           # local backend on :8000
-wmh demo                            # watch an LLM agent step against the world model
+wmh providers verify                       # confirm Anthropic / Bedrock / Azure OpenAI / OpenAI creds
+wmh build                                  # guided creation wizard (prompts for name, traces, provider…)
+wmh build --name airline --file traces.jsonl   # …or fully scriptable with flags -> .wmh/models/airline/
+wmh list                                   # show every built world model
+wmh serve                                  # local backend on :8000 (serves all built models)
+wmh demo                                   # watch an LLM agent step against the world model
+wmh play                                   # step into the environment yourself (interactive REPL)
 ```
+
+`wmh build` with no flags launches a **creation wizard** on an interactive terminal; pass `--file`
+(and friends) or `--no-interactive` to stay scriptable. Commands that run a model (`play`/`serve`/
+`demo`) take `--name`; omit it and — if several models exist — you get an interactive **picker**.
+
+World models are **named** and stored under `.wmh/models/<name>/`, so one project can hold several
+(e.g. `airline`, `retail`). Commands that read a model take `--name`; if only one is built, `--name`
+is optional.
 
 ## Use it as an API
 
@@ -43,7 +53,8 @@ obs = wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="add_to_cart",
 print(obs.content)
 ```
 
-Or over HTTP (same code path): `POST /sessions`, then `POST /sessions/{id}/step`.
+Or over HTTP (same code path), namespaced by model name: `GET /world_models` to list, then
+`POST /world_models/{name}/sessions` and `POST /world_models/{name}/sessions/{id}/step`.
 
 ## Providers
 
@@ -74,6 +85,6 @@ Conventions live in [AGENTS.md](./AGENTS.md). Tests are inline next to the code 
 
 ## Status
 
-This is a **skeleton**: interfaces, types, CLI, and HTTP routes are wired and importable; the heavy
-internals (embedding/index, GEPA loop, judge prompts, provider request mapping, vendor pulls) are
-stubbed with `NotImplementedError`.
+The full pipeline works end-to-end: ingest → split → index → GEPA optimize → persist → serve/step,
+verified on real Bedrock Opus 4.8 (see [`docs/tau2_runbook.md`](./docs/tau2_runbook.md)). Vendor SDK
+pulls are the main stub remaining.

--- a/docs/tau2_runbook.md
+++ b/docs/tau2_runbook.md
@@ -22,27 +22,37 @@ the committed `examples/` corpus is the reusable artifact.
 
 ```bash
 AWS_REGION=us-east-1 uv run wmh build \
+  --name tau2-airline \
   --file examples/tau2-bench.otel.jsonl \
   --root /tmp/tau2_wmh \
   --provider bedrock --model us.anthropic.claude-opus-4-8 --region us-east-1 \
   --gepa-budget 6
 ```
 
+The build renders a guided, animated pipeline (ingest → split → index → a live GEPA rollout
+progress bar with the running held-out score → a summary panel). When piped to a file it degrades to
+one plain line per stage, so captured logs stay legible.
+
 Observed (budget 6): `held_out_accuracy=0.562, frontier=2, rollouts=14`. GEPA improved the held-out
 judge score from the base prompt's ~0.40 to **0.562** within the budget. The evolved prompt is
 genuinely specialized — it inferred the environment is a Unix shell/tool sandbox and even captured
 the exact JSON schemas the tau2 tools emit (e.g. the `get_user` record shape and key ordering).
 
+`wmh list --root /tmp/tau2_wmh` shows every model built under the project dir.
+
 ### Artifact layout (`/tmp/tau2_wmh`)
 
+World models are named and stored under `models/<name>/`; each is a self-contained artifact:
+
 ```
-config.toml              # HarnessConfig (serve provider, embed_dim, top_k, ...)
-prompts/base.txt         # the un-evolved BASE_ENV_PROMPT
-prompts/optimized.txt    # GEPA winner (what serve uses)
-prompts/frontier.json    # Pareto frontier of candidate prompts
-metrics.json             # held_out_accuracy, rollouts_used
-index/embeddings.npy     # phi(s,a) matrix for the replay buffer
-index/steps.jsonl        # the parallel Steps
+models/tau2-airline/
+  config.toml              # HarnessConfig (serve provider, embed_dim, top_k, ...)
+  prompts/base.txt         # the un-evolved BASE_ENV_PROMPT
+  prompts/optimized.txt    # GEPA winner (what serve uses)
+  prompts/frontier.json    # Pareto frontier of candidate prompts
+  metrics.json             # held_out_accuracy, rollouts_used
+  index/embeddings.npy     # phi(s,a) matrix for the replay buffer
+  index/steps.jsonl        # the parallel Steps
 ```
 
 ## 2. Load the stored model and step against it
@@ -67,13 +77,34 @@ Observed:
 - `get_reservation r_999` → `Error: reservation r_999 not found`, `is_error=True` — the model
   *simulates* environment behavior (errors on a missing id) rather than echoing a demo.
 
-## 3. Serve it over HTTP (same code path)
+## 4. Play it yourself (interactive REPL)
+
+Step into the reconstructed environment as the agent — type tool calls, the world model answers,
+and the session scratchpad evolves so later turns stay consistent:
+
+```bash
+AWS_REGION=us-east-1 uv run wmh play --root /tmp/tau2_wmh --name tau2-airline \
+  --task "Look up user u_kath."
+# agent> get_user {"command": "get_user u_kath"}
+#   -> observation panel with the env's JSON reply
+# agent> :state     # show the task, turn count, and scratchpad "database"
+# agent> :quit
+```
+
+Verified on 2026-06-25 against real Bedrock Opus 4.8: typing `bash {"command": "get_user u_kath"}`
+returned the silver-membership user record, and a follow-up missing-id lookup returned a simulated
+`not found` error — the scratchpad accumulated the state notes across turns.
+
+## 5. Serve it over HTTP (same code path)
 
 ```bash
 AWS_REGION=us-east-1 uv run wmh serve --root /tmp/tau2_wmh
-# POST /sessions  ->  {"session_id": ...}
-# POST /sessions/{id}/step  with {"action": {"kind": "tool_call", "name": "bash", ...}}
+# GET  /world_models                                 ->  {"world_models": ["tau2-airline"]}
+# POST /world_models/tau2-airline/sessions           ->  {"session_id": ...}
+# POST /world_models/tau2-airline/sessions/{id}/step  with {"action": {"kind": "tool_call", ...}}
 ```
+
+`wmh serve` serves every built model by default; pass `--name` (repeatable) to serve a subset.
 
 ## Reproducing the verification automatically
 

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -1,8 +1,9 @@
 """`wmh` CLI — ingestion UI and operator console for the harness.
 
 Deliberately small. The lifecycle is:
-    providers verify -> build -> serve / demo
-`build` creates the `.wmh/` artifact directory itself, so there is no separate init step.
+    providers verify -> build -> list -> serve / demo / play
+`build` creates the project artifact directory itself, so there is no separate init step. World
+models are named (`--name`), stored under `<root>/models/<name>/`, and listed with `wmh list`.
 """
 
 from __future__ import annotations
@@ -10,8 +11,15 @@ from __future__ import annotations
 import typer
 from rich.console import Console
 
-from wmh.config import ARTIFACT_DIR, HarnessConfig, load_config
-from wmh.providers import ProviderKind, verify_all, verify_embedder
+from wmh.config import (
+    ARTIFACT_DIR,
+    DEFAULT_MODEL_NAME,
+    HarnessConfig,
+    WorldModelStore,
+    load_config,
+    validate_name,
+)
+from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import EmbedderKind
 
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
@@ -24,24 +32,63 @@ _EVAL_FILES = typer.Argument(..., help="OTel trace files to score (one corpus ea
 
 
 @providers_app.command("verify")
-def providers_verify(root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir.")) -> None:
-    """Ping every configured provider (completion + embed path) and report status."""
-    config = load_config(root)
-    for result in verify_all(config.providers):
+def providers_verify(
+    name: str = typer.Option(None, "--name", help="Verify one model's providers (default: all)."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+) -> None:
+    """Ping every configured provider (completion + embed path) and report status.
+
+    Gathers provider configs from the built world models (one `--name`, or all of them, deduped by
+    kind+model), so a brand-new project with nothing built yet has nothing to verify. The phi embed
+    path of each model is checked too, unless it is the offline (creds-free) hashing embedder.
+    """
+    store = WorldModelStore(root)
+    names = [name] if name is not None else store.list_names()
+    if not names:
+        _console.print("[yellow]no world models built yet[/yellow]; run `wmh build --name <name>`")
+        return
+    configs: list[HarnessConfig] = []
+    for model_name in names:
+        try:
+            model_dir = str(store.resolve(model_name))
+        except (FileNotFoundError, ValueError) as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        configs.append(load_config(model_dir))
+
+    # Dedup completion providers by kind+model across all selected models.
+    seen: set[tuple[str, str]] = set()
+    providers: list[ProviderConfig] = []
+    for config in configs:
+        for pc in config.providers:
+            key = (pc.kind.value, pc.model)
+            if key not in seen:
+                seen.add(key)
+                providers.append(pc)
+    for result in verify_all(providers):
         mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
         _console.print(f"{mark} {result.kind.value} ({result.model}) {result.detail}")
-    # Verify the phi embed path too, unless it's the offline (creds-free) hashing embedder.
-    if config.embed_provider is not EmbedderKind.HASHING:
-        result = verify_embedder(config.embed_provider_config())
+
+    # Verify each distinct provider-backed embed path (skip the offline hashing embedder).
+    embed_seen: set[tuple[str, str]] = set()
+    for config in configs:
+        if config.embed_provider is EmbedderKind.HASHING:
+            continue
+        embed_config = config.embed_provider_config()
+        key = (embed_config.kind.value, embed_config.model)
+        if key in embed_seen:
+            continue
+        embed_seen.add(key)
+        result = verify_embedder(embed_config)
         mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
         _console.print(f"{mark} embed:{result.kind.value} ({result.model}) {result.detail}")
 
 
 @app.command("build")
 def build(
+    name: str = typer.Option(None, "--name", help="Name for this world model."),
     file: str = typer.Option(None, "--file", help="Path to exported traces (OTLP-JSON / JSONL)."),
     vendor: str = typer.Option(None, "--vendor", help="Vendor name to pull traces via SDK."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir to create/write."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
     provider: str = typer.Option("bedrock", "--provider", help="Provider that serves the model."),
     model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
@@ -51,14 +98,23 @@ def build(
     ),
     embed_model: str = typer.Option(None, help="Embeddings model id / Azure embedding deployment."),
     embed_dim: int = typer.Option(512, help="phi dimensionality (index + query must agree)."),
+    interactive: bool = typer.Option(
+        None,
+        "--interactive/--no-interactive",
+        help="Guided creation wizard. Default: on at a TTY when inputs are missing.",
+    ),
 ) -> None:
-    """Ingest traces (file upload or vendor SDK pull) and build the `.wmh/` artifact.
+    """Ingest traces (file upload or vendor SDK pull) and build a named world model.
 
-    Creates `.wmh/` if absent, then: ingest -> normalize -> split(train/test) -> embed/index ->
-    GEPA optimize -> write the artifact.
+    Stores the artifact under `<root>/models/<name>/`: ingest -> normalize -> split(train/test) ->
+    embed/index -> GEPA optimize -> write. Re-running with the same `--name` rebuilds it.
+
+    With no `--name`/`--file` on an interactive terminal, this launches a guided creation wizard;
+    pass `--no-interactive` (or any of those flags) to stay fully scriptable.
     """
     import uuid
 
+    from wmh.cli.ui import BuildParams, RichBuildReporter, build_summary_panel, run_build_wizard
     from wmh.config import ArtifactPaths
     from wmh.engine.build import build as run_build
     from wmh.ingest import VendorPull
@@ -66,33 +122,61 @@ def build(
     from wmh.retrieval import get_embedder
     from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
+    # Decide whether to run the wizard: explicit flag wins; otherwise auto when at a TTY and the
+    # essential inputs (a name and a trace source) were not supplied.
+    needs_input = name is None or (file is None and vendor is None)
+    use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
+
+    params = BuildParams(
+        name=name or DEFAULT_MODEL_NAME,
+        file=file,
+        vendor=vendor,
+        provider=provider,
+        model=model,
+        region=region,
+        gepa_budget=gepa_budget,
+        embed_provider=embed_provider,
+        embed_model=embed_model,
+        embed_dim=embed_dim,
+    )
+    if use_wizard:
+        params = run_build_wizard(_console, params)
+    elif name is None and file is None and vendor is None:
+        raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
+
+    validate_name(params.name)
     try:
-        serve_provider = ProviderKind(provider)
+        serve_provider = ProviderKind(params.provider)
     except ValueError:
         kinds = ", ".join(k.value for k in ProviderKind)
-        raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
+        raise typer.BadParameter(
+            f"unknown provider {params.provider!r}; choose one of: {kinds}"
+        ) from None
     try:
-        embed_kind = EmbedderKind(embed_provider)
+        embed_kind = EmbedderKind(params.embed_provider)
     except ValueError:
         kinds = ", ".join(k.value for k in EmbedderKind)
         raise typer.BadParameter(
-            f"unknown embed provider {embed_provider!r}; choose one of: {kinds}"
+            f"unknown embed provider {params.embed_provider!r}; choose one of: {kinds}"
         ) from None
     # A provider-backed embedder needs an embeddings model; fail fast, not deep inside embed().
-    if embed_kind is not EmbedderKind.HASHING and not embed_model:
+    if embed_kind is not EmbedderKind.HASHING and not params.embed_model:
         raise typer.BadParameter(
             f"--embed-provider {embed_kind.value} requires --embed-model "
             "(the embeddings model id / Azure embedding deployment)"
         )
+
+    store = WorldModelStore(root)
+    model_dir = str(store.model_dir(params.name))
     # Provider wiring (reuse-vs-separate embed config) lives in HarnessConfig.for_build, not here.
     config = HarnessConfig.for_build(
         serve_provider=serve_provider,
-        serve_model=model,
-        region=region,
+        serve_model=params.model,
+        region=params.region,
         embed_provider=embed_kind,
-        embed_model=embed_model,
-        embed_dim=embed_dim,
-        gepa_budget=gepa_budget,
+        embed_model=params.embed_model,
+        embed_dim=params.embed_dim,
+        gepa_budget=params.gepa_budget,
     )
     # Meter the build at the provider boundary: the one serve provider drives GEPA rollouts,
     # reflection, and the judge, so wrapping it captures all build LLM cost/tokens without touching
@@ -103,23 +187,20 @@ def build(
         tracker,
         classify=classify_build_call,
     )
-    with tracker.timed():
-        result = run_build(
+    with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
+        run_build(
             config,
-            file=file,
-            vendor=VendorPull() if vendor else None,
-            root=root,
+            file=params.file,
+            vendor=VendorPull() if params.vendor else None,
+            root=model_dir,
             serve_provider=metered,
             embedder=get_embedder(config),
+            reporter=reporter,
         )
     record = tracker.record_summary()
-    save_run(record, ArtifactPaths(root).runs)
+    save_run(record, ArtifactPaths(model_dir).runs)
 
-    _console.print(
-        f"[green]built[/green] {root}: held_out_accuracy="
-        f"{result.metrics.held_out_accuracy:.3f}, frontier={len(result.frontier)}, "
-        f"rollouts={result.metrics.rollouts_used}"
-    )
+    _console.print(build_summary_panel(store.info(params.name), model_dir))
     _console.print(
         f"[bold]run[/bold] {record.run_id[:8]}: {record.duration_seconds:.1f}s, "
         f"{record.total.total_tokens} tokens, ${record.total.cost_usd:.4f} "
@@ -134,17 +215,37 @@ def build(
             )
 
 
+@app.command("list")
+def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list.")) -> None:
+    """List every world model built under the project dir."""
+    from wmh.cli.ui import models_table
+
+    infos = WorldModelStore(root).list_info()
+    if not infos:
+        _console.print("[yellow]no world models built yet[/yellow]; run `wmh build --name <name>`")
+        return
+    _console.print(models_table(infos))
+
+
 @app.command("serve")
 def serve(
+    name: list[str] = typer.Option(  # noqa: B008 - typer reads option defaults at definition time
+        None, "--name", help="World model(s) to serve. Repeatable; default: all built ones."
+    ),
     port: int = typer.Option(8000, help="Port for the local backend."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir to serve."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir to serve from."),
 ) -> None:
-    """Run the local FastAPI backend so agents can step against the world model over HTTP."""
+    """Run the local FastAPI backend so agents can step against world models over HTTP.
+
+    Serves every built model by default, or just the `--name` ones. Routes are namespaced:
+    `/world_models/{name}/sessions` and `.../step`.
+    """
     import uvicorn
 
     from wmh.serving.server import create_app
 
-    uvicorn.run(create_app(root), host="127.0.0.1", port=port)
+    names = list(name) if name else None
+    uvicorn.run(create_app(root, names=names), host="127.0.0.1", port=port)
 
 
 @app.command("eval")
@@ -203,22 +304,70 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
 
 
 @app.command("demo")
-def demo(root: str = typer.Option(ARTIFACT_DIR, help="Artifact dir to demo against.")) -> None:
+def demo(
+    name: str = typer.Option(None, "--name", help="World model to demo (default: the only one)."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+) -> None:
     """Demo the harness: an LLM agent makes a tool call vs the world model; show prompt+output."""
-    from wmh.config import load_config as _load
     from wmh.engine.demo import run_demo
-    from wmh.engine.world_model import WorldModel
-    from wmh.providers import get_provider
 
-    config = _load(root)
-    provider = get_provider(config.serve_provider_config())
-    wm = WorldModel.load(root, provider)
+    wm, _resolved_name, provider = _load_model(name, root)
     # Seed the demo agent from whatever steps the index holds.
     examples = wm.sample_steps(3)
     result = run_demo(wm, provider, examples)
     _console.print(f"[bold]agent action[/bold]: {result.agent_action.model_dump()}")
     _console.print(f"[bold]env prompt[/bold]:\n{result.env_prompt}")
     _console.print(f"[bold]observation[/bold]: {result.observation.model_dump()}")
+
+
+@app.command("play")
+def play(
+    name: str = typer.Option(None, "--name", help="World model to play (default: the only one)."),
+    task: str = typer.Option(None, "--task", help="Task to seed the session with."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+) -> None:
+    """Step into the environment yourself: type actions, the world model returns observations."""
+    from wmh.cli.ui import run_play_repl
+
+    wm, resolved_name, _provider = _load_model(name, root)
+    run_play_repl(_console, wm, resolved_name, task)
+
+
+def _resolve_name(store: WorldModelStore, name: str | None) -> str:
+    """Resolve which model to run: explicit `--name`, an interactive picker, or the sole model.
+
+    With `--name`, validate it exists. Otherwise, when several models are built on an interactive
+    terminal, show a numbered picker; on a non-TTY (or a single model) defer to `store.resolve`,
+    which returns the lone model or raises a helpful "pass --name" error. Store errors
+    (unknown/ambiguous name) are turned into a clean `typer.BadParameter` rather than a traceback.
+    """
+    try:
+        if name is not None:
+            store.resolve(name)  # validates existence, raising a friendly error if missing
+            return name
+        # Only enumerate full model summaries when we actually need the picker (>1 model on a TTY).
+        # `list_names` is cheap (a dir scan); `list_info` reads every config/metrics/frontier file.
+        if _console.is_terminal and len(store.list_names()) > 1:
+            from wmh.cli.ui import select_model
+
+            return select_model(_console, store.list_info())
+        return store.resolve(None).name
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, name, Provider)
+    """Resolve + load a named world model (or the single built one) with its serve provider.
+
+    Returns `(world_model, resolved_name, provider)` so callers can reuse the provider without
+    re-reading config / reconstructing it.
+    """
+    from wmh.engine import load_world_model
+
+    store = WorldModelStore(root)
+    resolved_name = _resolve_name(store, name)
+    world_model, provider = load_world_model(store.model_dir(resolved_name))
+    return world_model, resolved_name, provider
 
 
 if __name__ == "__main__":

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -1,15 +1,220 @@
-"""Tests for the CLI command surface."""
+"""Tests for the CLI: command surface + build/list/play driven via CliRunner (fake provider)."""
 
 from __future__ import annotations
 
+import json
+
+import pytest
+from typer.testing import CliRunner
+
 from wmh.cli import app
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+
+runner = CliRunner()
+
+
+class FakeProvider:
+    """Canned world-model JSON for rollouts/steps; a fixed prompt for GEPA reflection."""
+
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="opus")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        if "improve the system prompt" in system:
+            return Completion(text="IMPROVED ENV PROMPT")
+        if "grade a world model" in system:
+            return Completion(text='{"score": 0.5, "critique": "be more specific"}')
+        return Completion(text='{"output": "user u1 found", "is_error": false}')
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def _traces_file(tmp_path) -> str:  # noqa: ANN001 - pytest fixture path
+    span_llm = {
+        "traceId": "a" * 32,
+        "spanId": "s1",
+        "name": "chat",
+        "startTimeUnixNano": 1,
+        "attributes": [
+            {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+            {"key": "gen_ai.tool.name", "value": {"stringValue": "get_user"}},
+            {"key": "gen_ai.tool.call.arguments", "value": {"stringValue": '{"id": "u1"}'}},
+            {"key": "gen_ai.prompt", "value": {"stringValue": "look up u1"}},
+        ],
+    }
+    span_tool = {
+        "traceId": "a" * 32,
+        "spanId": "s2",
+        "name": "execute_tool",
+        "startTimeUnixNano": 2,
+        "attributes": [
+            {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+            {"key": "gen_ai.tool.message", "value": {"stringValue": "found u1"}},
+        ],
+    }
+    path = tmp_path / "traces.jsonl"
+    path.write_text(json.dumps(span_llm) + "\n" + json.dumps(span_tool) + "\n", encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture
+def patched_provider(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
+    """Swap the real provider registry for the fake everywhere the CLI constructs one.
+
+    Each module binds `get_provider` at its own import time (build.py for the build pipeline,
+    loader.py for serve/demo/play), so patch every module-level name plus the registry the lazy
+    imports read.
+    """
+    import sys
+
+    import wmh.providers as providers_pkg
+
+    fake = FakeProvider()
+    # `wmh.engine.__init__` rebinds the name `build` to the function, shadowing the submodule
+    # attribute, so reach module objects through sys.modules rather than attribute access.
+    for module_name in ("wmh.engine.build", "wmh.engine.loader"):
+        monkeypatch.setattr(sys.modules[module_name], "get_provider", lambda config: fake)
+    monkeypatch.setattr(providers_pkg, "get_provider", lambda config: fake)
+
+
+def _build(root, name: str, tmp_path) -> None:  # noqa: ANN001 - pytest fixture paths
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            name,
+            "--file",
+            _traces_file(tmp_path),
+            "--root",
+            str(root),
+            "--provider",
+            "bedrock",
+            "--gepa-budget",
+            "4",
+        ],
+    )
+    assert result.exit_code == 0, result.output
 
 
 def test_cli_exposes_the_small_command_set() -> None:
     names = {cmd.name for cmd in app.registered_commands}
-    assert names == {"build", "serve", "demo", "eval"}
+    assert names == {"build", "list", "serve", "demo", "eval", "play"}
 
 
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names
+
+
+def test_build_then_list_shows_named_model(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    _build(root, "tau2-airline", tmp_path)
+
+    # The artifact lands under <root>/models/<name>/.
+    assert (root / "models" / "tau2-airline" / "config.toml").exists()
+
+    listed = runner.invoke(app, ["list", "--root", str(root)])
+    assert listed.exit_code == 0, listed.output
+    assert "tau2-airline" in listed.output
+
+
+def test_list_empty_project_is_friendly(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["list", "--root", str(tmp_path / ".wmh")])
+    assert result.exit_code == 0
+    assert "no world models" in result.output
+
+
+def test_play_repl_steps_and_quits(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    _build(root, "default", tmp_path)
+
+    # Feed one tool call then quit; the world model's canned observation should surface.
+    result = runner.invoke(
+        app,
+        ["play", "--root", str(root), "--task", "look up users"],
+        input='get_user {"id": "u1"}\n:quit\n',
+    )
+    assert result.exit_code == 0, result.output
+    assert "user u1 found" in result.output
+
+
+def test_build_interactive_wizard_creates_model(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    # --interactive forces the wizard even under CliRunner (non-TTY); feed each answer line in
+    # prompt order: name, file, provider, model, region, budget, embedder, embed_dim (the offline
+    # 'hashing' embedder skips the embed-model prompt).
+    answers = "\n".join(
+        [
+            "wizard-built",
+            _traces_file(tmp_path),
+            "bedrock",
+            "opus",
+            "us-east-1",
+            "4",
+            "hashing",
+            "64",
+        ]
+    )
+    result = runner.invoke(
+        app, ["build", "--interactive", "--root", str(root)], input=answers + "\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert (root / "models" / "wizard-built" / "config.toml").exists()
+
+
+def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa: ANN001
+    # No --file/--vendor and --no-interactive: should fail fast rather than hang on input.
+    result = runner.invoke(app, ["build", "--no-interactive", "--root", str(tmp_path / ".wmh")])
+    assert result.exit_code != 0
+
+
+def test_play_unknown_model_errors(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["play", "--name", "nope", "--root", str(tmp_path / ".wmh")])
+    assert result.exit_code != 0
+    # A clean usage error, not an uncaught FileNotFoundError traceback.
+    assert not isinstance(result.exception, FileNotFoundError)
+    assert "nope" in result.output
+
+
+def test_demo_unknown_model_is_clean_error(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    _build(root, "airline", tmp_path)
+    result = runner.invoke(app, ["demo", "--name", "ghost", "--root", str(root)])
+    assert result.exit_code != 0
+    # Resolved through _load_model -> _resolve_name; must surface as a usage error, not a traceback.
+    assert not isinstance(result.exception, (FileNotFoundError, ValueError))
+
+
+def test_providers_verify_unknown_model_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app, ["providers", "verify", "--name", "ghost", "--root", str(tmp_path / ".wmh")]
+    )
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, FileNotFoundError)
+
+
+def test_providers_verify_empty_project_is_friendly(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["providers", "verify", "--root", str(tmp_path / ".wmh")])
+    assert result.exit_code == 0
+    assert "no world models built yet" in result.output
+
+
+def test_providers_verify_reports_built_model_provider(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    _build(root, "airline", tmp_path)
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+    assert result.exit_code == 0, result.output
+    # The bedrock provider configured at build time shows up in the verify report.
+    assert "bedrock" in result.output

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -1,0 +1,406 @@
+"""Terminal UX for the `wmh` CLI: guided creation/selection flows, an animated build pipeline, and
+the interactive play REPL.
+
+Everything that talks to `rich` lives here so the engine stays headless. Responsibilities:
+
+- `run_build_wizard` interactively fills in any missing `wmh build` inputs (name, traces, provider,
+  region, budget), so a bare `wmh build` becomes a guided creation flow.
+- `select_model` shows a numbered picker so a user can choose which built world model to run when
+  `--name` is omitted and several exist.
+- `RichBuildReporter` implements `wmh.engine.reporting.BuildReporter`, turning build events into a
+  guided, animated pipeline (stage lines + a live GEPA rollout progress bar) on a TTY, and into
+  plain one-line-per-event output when piped (non-TTY), so logs stay legible.
+- `run_play_repl` drives the human-in-the-loop demo: the user types actions, the world model
+  answers, and the evolving session state (scratchpad + history) is rendered each turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import BaseModel
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from rich.table import Table
+
+from wmh.config import ModelInfo, validate_name
+from wmh.core.types import Action, ActionKind, Session
+from wmh.engine.play import PlayTurn, parse_action, play_turn
+from wmh.engine.world_model import WorldModel
+
+# A reader takes a fully-rendered prompt string and returns the user's typed line.
+PromptReader = Callable[[str], str]
+
+# Stage glyphs reused by the animated and plain reporters.
+_CHECK = "[green]✓[/green]"
+
+# Provider-specific defaults the creation wizard suggests.
+_DEFAULT_MODELS: dict[str, str] = {
+    "bedrock": "us.anthropic.claude-opus-4-8",
+    "anthropic": "claude-opus-4-8",
+    "openai": "gpt-5.5",
+    "azure_openai": "gpt-5.5",
+}
+_DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
+
+
+class BuildParams(BaseModel):
+    """The fully-resolved inputs for a build, as collected by the creation wizard."""
+
+    name: str
+    file: str | None = None
+    vendor: str | None = None
+    provider: str = "bedrock"
+    model: str = "us.anthropic.claude-opus-4-8"
+    region: str | None = None
+    gepa_budget: int = 50
+    embed_provider: str = "hashing"
+    embed_model: str | None = None
+    embed_dim: int = 512
+
+
+def run_build_wizard(
+    console: Console, defaults: BuildParams, reader: PromptReader | None = None
+) -> BuildParams:
+    """Guided creation flow: prompt for each build input, pre-filled with `defaults`.
+
+    Returns a resolved `BuildParams`. Any value already set in `defaults` (i.e. passed as a flag)
+    becomes the suggested default the user can accept with Enter. Raises `ValueError` if no trace
+    source (file or vendor) is provided.
+    """
+    ask = reader if reader is not None else (lambda text: console.input(text))
+    console.print(
+        Panel(
+            "Let's create a world model. Press Enter to accept the [dim]default[/dim] in brackets.",
+            title="[bold cyan]wmh build[/bold cyan]",
+            border_style="cyan",
+        )
+    )
+
+    name = _prompt_text(console, ask, "Name this world model", defaults.name)
+    validate_name(name)
+
+    file = defaults.file
+    vendor = defaults.vendor
+    if not file and not vendor:
+        file = _prompt_text(console, ask, "Path to exported traces (OTLP-JSON / JSONL)", None)
+        if not file:
+            raise ValueError("a traces file is required to build (or pass --vendor)")
+
+    provider = _prompt_text(console, ask, "Serve provider", defaults.provider)
+    model_default = defaults.model or _DEFAULT_MODELS.get(provider, defaults.model)
+    model = _prompt_text(console, ask, "Serve model id", model_default)
+    region_default = defaults.region or _DEFAULT_REGIONS.get(provider)
+    region = _prompt_text(console, ask, "Region (blank for default)", region_default) or None
+    gepa_budget = _prompt_int(console, ask, "GEPA rollout budget", defaults.gepa_budget)
+
+    # Retrieval phi embedder: default offline hashing (no creds). A provider-backed embedder needs
+    # a model id, prompted only when the user picks one.
+    embed_label = "Embedder (hashing | bedrock | openai | azure_openai)"
+    embed_provider = _prompt_text(console, ask, embed_label, defaults.embed_provider)
+    embed_model = defaults.embed_model
+    if embed_provider != "hashing":
+        embed_model = _prompt_text(console, ask, "Embeddings model id", embed_model) or None
+    embed_dim = _prompt_int(console, ask, "phi dimensionality", defaults.embed_dim)
+
+    return BuildParams(
+        name=name,
+        file=file,
+        vendor=vendor,
+        provider=provider,
+        model=model,
+        region=region,
+        gepa_budget=gepa_budget,
+        embed_provider=embed_provider,
+        embed_model=embed_model,
+        embed_dim=embed_dim,
+    )
+
+
+def select_model(
+    console: Console, infos: list[ModelInfo], reader: PromptReader | None = None
+) -> str:
+    """Show a numbered picker and return the chosen model name.
+
+    Re-prompts on invalid input. With a single model it returns that name without prompting.
+    """
+    if len(infos) == 1:
+        return infos[0].name
+    ask = reader if reader is not None else (lambda text: console.input(text))
+    console.print("[bold]Select a world model:[/bold]")
+    for i, info in enumerate(infos, start=1):
+        acc = info.held_out_accuracy
+        score = "" if acc is None else f"  [dim](held-out {acc:.2f})[/dim]"
+        console.print(f"  [cyan]{i}[/cyan]. {info.name}{score}")
+    while True:
+        raw = ask("> ").strip()
+        choice = _parse_int(raw)
+        if choice is not None and 1 <= choice <= len(infos):
+            return infos[choice - 1].name
+        # Allow typing the name directly too.
+        for info in infos:
+            if raw == info.name:
+                return info.name
+        console.print(f"[red]pick 1-{len(infos)} or a model name[/red]")
+
+
+def _prompt_text(console: Console, ask: PromptReader, label: str, default: str | None) -> str:
+    suffix = f" [dim][{default}][/dim]" if default else ""
+    value = ask(f"[bold]{label}[/bold]{suffix}: ").strip()
+    return value or (default or "")
+
+
+def _prompt_int(console: Console, ask: PromptReader, label: str, default: int) -> int:
+    while True:
+        raw = ask(f"[bold]{label}[/bold] [dim][{default}][/dim]: ").strip()
+        if not raw:
+            return default
+        value = _parse_int(raw)
+        if value is not None and value >= 0:
+            return value
+        console.print("[red]enter a non-negative whole number[/red]")
+
+
+def _parse_int(raw: str) -> int | None:
+    """Parse a base-10 integer, or None. Unlike `str.isdigit`, this rejects unicode digit
+    characters (e.g. superscripts) that `isdigit()` accepts but `int()` rejects with ValueError."""
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+class RichBuildReporter:
+    """A `BuildReporter` that renders the build as a guided pipeline.
+
+    On a TTY it shows stage lines and a live progress bar for GEPA rollouts (with the running
+    held-out score). When output is piped (`console.is_terminal` is false) it degrades to a single
+    plain line per event — no spinners, no carriage returns — so captured logs stay readable.
+    """
+
+    def __init__(self, console: Console, model_name: str) -> None:
+        self._console = console
+        self._name = model_name
+        self._tty = console.is_terminal
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+
+    def ingest_done(self, traces: int, steps: int) -> None:
+        self._stage(f"ingested {traces} traces → normalized {steps} steps")
+
+    def split_done(self, train: int, test: int) -> None:
+        self._stage(f"split {train} train / {test} held-out traces")
+
+    def index_done(self, steps: int) -> None:
+        self._stage(f"indexed {steps} steps into the replay buffer")
+
+    def optimize_start(self, budget: int) -> None:
+        self._stage(f"optimizing env prompt with GEPA (budget {budget} rollouts)")
+        if self._tty and budget > 0:
+            self._progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                TaskProgressColumn(),
+                TextColumn("{task.fields[score]}"),
+                TimeElapsedColumn(),
+                console=self._console,
+                transient=True,
+            )
+            self._progress.start()
+            self._task_id = self._progress.add_task(
+                "GEPA rollouts", total=budget, score="score n/a"
+            )
+
+    def rollout(self, done: int, budget: int, score: float | None) -> None:
+        label = f"best held-out {score:.3f}" if score is not None else "score n/a"
+        if self._progress is not None and self._task_id is not None:
+            self._progress.update(self._task_id, completed=min(done, budget), score=label)
+        elif not self._tty:
+            # Non-TTY: emit a sparse heartbeat so long runs still show life without flooding logs.
+            if done == 1 or done % 10 == 0 or done >= budget:
+                self._console.print(f"  rollout {done}/{budget} ({label})")
+
+    def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+            self._progress = None
+            self._task_id = None
+        self._stage(
+            f"GEPA done: held-out {held_out_accuracy:.3f}, "
+            f"{frontier_size} frontier candidates, {rollouts} rollouts used"
+        )
+
+    def _stage(self, message: str) -> None:
+        self._console.print(f"{_CHECK} {message}")
+
+    def close(self) -> None:
+        """Stop the live progress bar if it is still running (e.g. the build raised mid-GEPA)."""
+        if self._progress is not None:
+            self._progress.stop()
+            self._progress = None
+            self._task_id = None
+
+    def __enter__(self) -> RichBuildReporter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        # Always tear down the live Progress so an exception during the build doesn't leave a
+        # spinning bar that corrupts the terminal.
+        self.close()
+
+
+def build_summary_panel(info: ModelInfo, root: str) -> Panel:
+    """A tidy panel summarizing a freshly built world model (shown after `wmh build`)."""
+    table = Table.grid(padding=(0, 2))
+    table.add_column(justify="right", style="bold")
+    table.add_column()
+    table.add_row("name", info.name)
+    table.add_row("artifact", root)
+    table.add_row("serve provider", f"{info.serve_provider} ({info.serve_model})")
+    if info.held_out_accuracy is not None:
+        table.add_row("held-out accuracy", f"{info.held_out_accuracy:.3f}")
+    if info.rollouts_used is not None:
+        table.add_row("rollouts used", str(info.rollouts_used))
+    if info.frontier_size is not None:
+        table.add_row("frontier candidates", str(info.frontier_size))
+    return Panel(
+        table,
+        title=f"[bold green]world model ready: {info.name}[/bold green]",
+        subtitle="serve it with `wmh serve` or step into it with `wmh play`",
+        border_style="green",
+    )
+
+
+def models_table(infos: list[ModelInfo]) -> Table:
+    """A table of every built world model (for `wmh list`)."""
+    table = Table(title="world models")
+    table.add_column("name", style="bold")
+    table.add_column("serve provider")
+    table.add_column("held-out", justify="right")
+    table.add_column("rollouts", justify="right")
+    table.add_column("frontier", justify="right")
+    for info in infos:
+        table.add_row(
+            info.name,
+            f"{info.serve_provider} ({info.serve_model})",
+            "-" if info.held_out_accuracy is None else f"{info.held_out_accuracy:.3f}",
+            "-" if info.rollouts_used is None else str(info.rollouts_used),
+            "-" if info.frontier_size is None else str(info.frontier_size),
+        )
+    return table
+
+
+# --- interactive play REPL -----------------------------------------------------------------------
+
+_PLAY_HELP = (
+    "[bold]You are the agent.[/bold] Type an action and the world model answers:\n"
+    '  [cyan]get_user {"id": "u1"}[/cyan]   a tool call with JSON arguments\n'
+    "  [cyan]list_flights[/cyan]            a tool call with no arguments\n"
+    "  [cyan]say I am stuck[/cyan]          a free-text message to the environment\n"
+    "Commands: [cyan]:state[/cyan] show session state  ·  [cyan]:help[/cyan]  ·  "
+    "[cyan]:quit[/cyan] (or Ctrl-D) to exit"
+)
+
+
+_AGENT_PROMPT = "[bold]agent>[/bold] "
+
+
+def run_play_repl(
+    console: Console,
+    world_model: WorldModel,
+    model_name: str,
+    task: str | None,
+    reader: PromptReader | None = None,
+) -> None:
+    """Run the human-in-the-loop demo against `world_model`.
+
+    `reader` is an optional `PromptReader` (`(prompt_text) -> line`) used to source input — injected
+    in tests, defaults to the console's prompt. The loop ends on `:quit`, EOF, or KeyboardInterrupt.
+    """
+    ask = reader if reader is not None else console.input
+    session = world_model.new_session(task=task)
+    console.print(
+        Panel(
+            _PLAY_HELP,
+            title=f"[bold]playing[/bold] {model_name}",
+            subtitle=f"task: {task}" if task else "no task set",
+            border_style="cyan",
+        )
+    )
+
+    while True:
+        try:
+            line = ask(_AGENT_PROMPT)
+        except (EOFError, KeyboardInterrupt):
+            console.print("\n[dim]bye[/dim]")
+            return
+        line = line.strip()
+        if not line:
+            continue
+        if line in {":quit", ":q", ":exit"}:
+            console.print("[dim]bye[/dim]")
+            return
+        if line in {":help", ":h"}:
+            console.print(_PLAY_HELP)
+            continue
+        if line == ":state":
+            _render_state(console, world_model.get_session(session.id))
+            continue
+        _handle_action(console, world_model, session.id, line)
+
+
+def _handle_action(console: Console, world_model: WorldModel, session_id: str, line: str) -> None:
+    """Parse + step one typed action, rendering the observation (or a friendly error).
+
+    A failed step (e.g. a provider/network error) is reported and swallowed so the REPL keeps the
+    session alive instead of crashing the whole interactive run.
+    """
+    try:
+        action = parse_action(line)
+    except ValueError as exc:
+        console.print(f"[red]parse error[/red]: {exc}")
+        return
+    try:
+        with console.status("[dim]world model thinking…[/dim]", spinner="dots"):
+            turn = play_turn(world_model, session_id, action)
+    except Exception as exc:  # noqa: BLE001 - keep the REPL alive; surface the failure to the user
+        console.print(f"[red]step failed[/red]: {exc}")
+        return
+    _render_turn(console, turn)
+
+
+def _render_turn(console: Console, turn: PlayTurn) -> None:
+    console.print(f"[bold cyan]→ you[/bold cyan]: {_action_text(turn.action)}")
+    style = "red" if turn.observation.is_error else "green"
+    label = "error" if turn.observation.is_error else "observation"
+    console.print(
+        Panel(
+            turn.observation.content or "[dim](empty)[/dim]",
+            title=f"[bold]{label}[/bold]",
+            border_style=style,
+        )
+    )
+
+
+def _render_state(console: Console, session: Session) -> None:
+    scratchpad = session.state.scratchpad or "[dim](empty)[/dim]"
+    body = f"[bold]task[/bold]: {session.task or '(none)'}\n"
+    body += f"[bold]turns[/bold]: {len(session.history)}\n\n"
+    body += f"[bold]scratchpad[/bold]:\n{scratchpad}"
+    console.print(Panel(body, title="session state", border_style="blue"))
+
+
+def _action_text(action: Action) -> str:
+    if action.kind == ActionKind.TOOL_CALL:
+        return f"{action.name}({action.arguments})"
+    return f'message: "{action.content}"'

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -1,0 +1,238 @@
+"""Tests for the terminal UX: the non-TTY build reporter and the play REPL (injected I/O)."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from wmh.cli.ui import (
+    BuildParams,
+    RichBuildReporter,
+    models_table,
+    run_build_wizard,
+    run_play_repl,
+    select_model,
+)
+from wmh.config import ModelInfo
+from wmh.core.types import Action, ActionKind, Observation, Step, Trace
+from wmh.engine.world_model import WorldModel
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+def _scripted_reader(answers: list[str]):  # noqa: ANN202 - returns a PromptReader
+    """A PromptReader that returns successive `answers`, ignoring the rendered prompt text."""
+    it = iter(answers)
+    return lambda _prompt: next(it)
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        return Completion(
+            text='{"output": "found u1", "is_error": false, "state_note": "looked up u1"}'
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def _world_model() -> WorldModel:
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
+    retriever.index(
+        [
+            Trace(
+                trace_id="t",
+                steps=[
+                    Step(
+                        action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={}),
+                        observation=Observation(content="found u0"),
+                    )
+                ],
+            )
+        ]
+    )
+    return WorldModel(FakeProvider(), retriever, top_k=3)
+
+
+def test_reporter_degrades_to_plain_lines_when_not_a_tty() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    reporter = RichBuildReporter(console, "airline")
+    with console.capture() as cap:
+        reporter.ingest_done(3, 9)
+        reporter.split_done(2, 1)
+        reporter.index_done(9)
+        reporter.optimize_start(20)
+        reporter.rollout(1, 20, 0.4)
+        reporter.rollout(10, 20, 0.6)
+        reporter.optimize_done(0.6, 2, 20)
+    out = cap.get()
+    assert "ingested 3 traces" in out
+    assert "normalized 9 steps" in out
+    assert "2 train / 1 held-out" in out
+    assert "rollout 1/20" in out  # non-TTY heartbeat
+    assert "rollout 10/20" in out
+    assert "held-out 0.600" in out
+
+
+def test_models_table_renders_names() -> None:
+    console = Console(force_terminal=False, no_color=True, width=120)
+    table = models_table([ModelInfo(name="airline", serve_provider="bedrock", serve_model="opus")])
+    with console.capture() as cap:
+        console.print(table)
+    assert "airline" in cap.get()
+
+
+def test_play_repl_renders_observation_and_state_then_quits() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    reader = _scripted_reader(['get_user {"id": "u1"}', ":state", ":quit"])
+    with console.capture() as cap:
+        run_play_repl(console, _world_model(), "airline", task="look up users", reader=reader)
+    out = cap.get()
+    assert "found u1" in out  # observation rendered
+    assert "looked up u1" in out  # scratchpad updated and shown by :state
+    assert "bye" in out
+
+
+def test_play_repl_reports_parse_errors_without_crashing() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    reader = _scripted_reader(['get_user ["bad"]', ":quit"])
+    with console.capture() as cap:
+        run_play_repl(console, _world_model(), "airline", task=None, reader=reader)
+    assert "parse error" in cap.get()
+
+
+def test_play_repl_exits_cleanly_on_eof() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+
+    def eof(_prompt: str) -> str:
+        raise EOFError
+
+    with console.capture() as cap:
+        run_play_repl(console, _world_model(), "airline", task=None, reader=eof)
+    assert "bye" in cap.get()
+
+
+# --- creation wizard -----------------------------------------------------------------------------
+
+
+def test_build_wizard_collects_all_inputs() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    # Prompts in order: name, file, provider, model, region, budget, embedder, embed_dim.
+    # (embed model is skipped because the embedder is the offline 'hashing' default.)
+    reader = _scripted_reader(
+        [
+            "tau2-airline",
+            "/tmp/traces.jsonl",
+            "bedrock",
+            "us.anthropic.claude-opus-4-8",
+            "us-east-1",
+            "8",
+            "hashing",
+            "512",
+        ]
+    )
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.name == "tau2-airline"
+    assert params.file == "/tmp/traces.jsonl"
+    assert params.provider == "bedrock"
+    assert params.region == "us-east-1"
+    assert params.gepa_budget == 8
+    assert params.embed_provider == "hashing"
+
+
+def test_build_wizard_collects_provider_embedder() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    # Picking a provider-backed embedder adds an embeddings-model prompt.
+    reader = _scripted_reader(
+        ["m", "/tmp/t.jsonl", "bedrock", "opus", "us-east-1", "8", "bedrock", "titan-v2", "1024"]
+    )
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.embed_provider == "bedrock"
+    assert params.embed_model == "titan-v2"
+    assert params.embed_dim == 1024
+
+
+def test_build_wizard_accepts_defaults_with_blank_input() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    # File provided (so that prompt is skipped); press Enter (blank) for every remaining prompt
+    # (name/provider/model/region/budget/embedder/embed_dim) to accept the suggested defaults.
+    reader = _scripted_reader(["", "", "", "", "", "", ""])
+    defaults = BuildParams(name="seeded", file="/tmp/t.jsonl", provider="bedrock", gepa_budget=50)
+    params = run_build_wizard(console, defaults, reader=reader)
+    assert params.name == "seeded"  # blank kept the default
+    assert params.provider == "bedrock"
+    assert params.gepa_budget == 50
+    assert params.region == "us-east-1"  # bedrock default suggested + accepted
+    assert params.embed_provider == "hashing"  # default embedder, no embed-model prompt
+
+
+def test_build_wizard_requires_a_trace_source() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    reader = _scripted_reader(["mymodel", ""])  # name, then blank file
+    with pytest.raises(ValueError, match="traces file is required"):
+        run_build_wizard(console, BuildParams(name="default"), reader=reader)
+
+
+# --- selection picker ----------------------------------------------------------------------------
+
+
+def test_select_model_single_returns_without_prompting() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    info = ModelInfo(name="only", serve_provider="bedrock", serve_model="opus")
+    # No reader needed: a single model is returned directly.
+    assert select_model(console, [info]) == "only"
+
+
+def test_select_model_picks_by_number() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    infos = [
+        ModelInfo(name="airline", serve_provider="bedrock", serve_model="opus"),
+        ModelInfo(name="retail", serve_provider="bedrock", serve_model="opus"),
+    ]
+    assert select_model(console, infos, reader=_scripted_reader(["2"])) == "retail"
+
+
+def test_select_model_reprompts_then_accepts_name() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    infos = [
+        ModelInfo(name="airline", serve_provider="bedrock", serve_model="opus"),
+        ModelInfo(name="retail", serve_provider="bedrock", serve_model="opus"),
+    ]
+    # First an out-of-range number (re-prompts), then the model name directly.
+    chosen = select_model(console, infos, reader=_scripted_reader(["9", "airline"]))
+    assert chosen == "airline"
+
+
+def test_select_model_survives_unicode_digit_input() -> None:
+    # '²' (superscript two): str.isdigit() is True but int() raises ValueError. The picker must
+    # treat it as invalid and re-prompt, not crash.
+    console = Console(force_terminal=False, no_color=True, width=100)
+    infos = [
+        ModelInfo(name="airline", serve_provider="bedrock", serve_model="opus"),
+        ModelInfo(name="retail", serve_provider="bedrock", serve_model="opus"),
+    ]
+    chosen = select_model(console, infos, reader=_scripted_reader(["²", "1"]))
+    assert chosen == "airline"
+
+
+def test_build_wizard_reprompts_on_unicode_digit_budget() -> None:
+    # Same unicode-digit footgun in the int prompt: must re-ask, not crash. With file provided the
+    # prompts are name/provider/model/region/budget/embedder/embed_dim; blanks accept defaults,
+    # '²' is a bad budget that must be rejected and re-asked.
+    console = Console(force_terminal=False, no_color=True, width=100)
+    reader = _scripted_reader(["", "", "", "", "²", "7", "", ""])
+    params = run_build_wizard(console, BuildParams(name="m", file="/tmp/t.jsonl"), reader=reader)
+    assert params.gepa_budget == 7

--- a/wmh/config/__init__.py
+++ b/wmh/config/__init__.py
@@ -8,12 +8,22 @@ from wmh.config.config import (
     load_config,
     save_config,
 )
+from wmh.config.store import (
+    DEFAULT_MODEL_NAME,
+    ModelInfo,
+    WorldModelStore,
+    validate_name,
+)
 
 __all__ = [
     "ARTIFACT_DIR",
+    "DEFAULT_MODEL_NAME",
     "PROVIDER_ENV_VARS",
     "ArtifactPaths",
     "HarnessConfig",
+    "ModelInfo",
+    "WorldModelStore",
     "load_config",
     "save_config",
+    "validate_name",
 ]

--- a/wmh/config/store.py
+++ b/wmh/config/store.py
@@ -1,0 +1,143 @@
+"""Named world models on disk.
+
+The project root (`.wmh/` by default) holds many named world models under `models/<name>/`. Each
+model directory is a self-contained artifact in the layout `ArtifactPaths` already understands
+(config.toml, prompts/, index/, metrics.json). The store turns names into directories, lists what
+has been built, and reads a small summary for `wmh list`.
+
+    .wmh/
+      models/
+        tau2-airline/   <- one artifact (config.toml, prompts/, index/, metrics.json)
+        retail-bench/   <- another
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, JsonValue
+
+from wmh.config.config import ARTIFACT_DIR, ArtifactPaths, HarnessConfig
+
+# The implicit model name used when the user does not pass `--name`.
+DEFAULT_MODEL_NAME = "default"
+
+# A safe, filesystem-friendly model name: no path separators, traversal, or leading dot.
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def validate_name(name: str) -> str:
+    """Return `name` if it is a safe single path segment, else raise a friendly ValueError."""
+    if not _NAME_RE.match(name) or name in {".", ".."} or "/" in name or "\\" in name:
+        raise ValueError(
+            f"invalid world model name {name!r}: use letters, digits, '.', '_', '-' "
+            "(must start with a letter or digit, no path separators)"
+        )
+    return name
+
+
+class ModelInfo(BaseModel):
+    """A one-line summary of a built world model, for `wmh list`."""
+
+    name: str
+    serve_provider: str
+    serve_model: str
+    held_out_accuracy: float | None = None
+    rollouts_used: int | None = None
+    frontier_size: int | None = None
+
+
+class WorldModelStore:
+    """Resolves and enumerates named world models under a project root."""
+
+    def __init__(self, root: str | Path = ARTIFACT_DIR) -> None:
+        self.root = Path(root)
+
+    @property
+    def models_dir(self) -> Path:
+        return self.root / "models"
+
+    def model_dir(self, name: str) -> Path:
+        """The artifact directory for `name` (not guaranteed to exist)."""
+        return self.models_dir / validate_name(name)
+
+    def exists(self, name: str) -> bool:
+        return ArtifactPaths(self.model_dir(name)).config.exists()
+
+    def list_names(self) -> list[str]:
+        """Sorted names of every built model (a directory containing a config.toml)."""
+        if not self.models_dir.exists():
+            return []
+        names = [
+            d.name for d in self.models_dir.iterdir() if d.is_dir() and (d / "config.toml").exists()
+        ]
+        return sorted(names)
+
+    def resolve(self, name: str | None) -> Path:
+        """Resolve `name` to a built model's artifact dir for read commands (serve/demo/play).
+
+        With an explicit `name`, require it to exist. With `name=None`, fall back to the single
+        built model if there is exactly one; otherwise raise, listing the choices.
+        """
+        if name is not None:
+            if not self.exists(name):
+                available = self.list_names()
+                hint = f" (have: {', '.join(available)})" if available else ""
+                raise FileNotFoundError(
+                    f"no world model named {name!r} under {self.models_dir}{hint}; "
+                    "run `wmh build --name <name>` first"
+                )
+            return self.model_dir(name)
+
+        names = self.list_names()
+        if not names:
+            raise FileNotFoundError(
+                f"no world models built under {self.models_dir}; "
+                "run `wmh build --name <name>` first"
+            )
+        if len(names) > 1:
+            raise ValueError(
+                f"multiple world models built ({', '.join(names)}); pass --name to choose one"
+            )
+        return self.model_dir(names[0])
+
+    def info(self, name: str) -> ModelInfo:
+        """Read a model's config + metrics into a summary (for `wmh list`)."""
+        paths = ArtifactPaths(self.model_dir(name))
+        with paths.config.open("rb") as fh:
+            config = HarnessConfig.model_validate(tomllib.load(fh))
+        accuracy: float | None = None
+        rollouts: int | None = None
+        if paths.metrics.exists():
+            metrics = json.loads(paths.metrics.read_text(encoding="utf-8"))
+            accuracy = _as_float(metrics.get("held_out_accuracy"))
+            rollouts = _as_int(metrics.get("rollouts_used"))
+        frontier_size: int | None = None
+        if paths.frontier.exists():
+            frontier = json.loads(paths.frontier.read_text(encoding="utf-8"))
+            if isinstance(frontier, list):
+                frontier_size = len(frontier)
+        serve = config.serve_provider_config()
+        return ModelInfo(
+            name=name,
+            serve_provider=serve.kind.value,
+            serve_model=serve.model,
+            held_out_accuracy=accuracy,
+            rollouts_used=rollouts,
+            frontier_size=frontier_size,
+        )
+
+    def list_info(self) -> list[ModelInfo]:
+        return [self.info(name) for name in self.list_names()]
+
+
+def _as_float(value: JsonValue) -> float | None:
+    # bool is an int subclass; exclude it so a stray `true` doesn't read as 1.0.
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _as_int(value: JsonValue) -> int | None:
+    return int(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None

--- a/wmh/config/store_test.py
+++ b/wmh/config/store_test.py
@@ -1,0 +1,76 @@
+"""Tests for the named-world-model store (resolution, listing, summaries)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from wmh.config import ArtifactPaths, HarnessConfig, save_config
+from wmh.config.store import DEFAULT_MODEL_NAME, WorldModelStore, validate_name
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+
+def _build_fake_model(store: WorldModelStore, name: str, accuracy: float = 0.5) -> None:
+    """Write a minimal but valid artifact (config + metrics + frontier) for `name`."""
+    root = store.model_dir(name)
+    config = HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="opus")],
+        serve_provider=ProviderKind.BEDROCK,
+    )
+    save_config(config, root)
+    paths = ArtifactPaths(root)
+    paths.metrics.write_text(
+        json.dumps({"held_out_accuracy": accuracy, "rollouts_used": 7}), encoding="utf-8"
+    )
+    paths.frontier.parent.mkdir(parents=True, exist_ok=True)
+    paths.frontier.write_text(json.dumps(["a", "b"]), encoding="utf-8")
+
+
+def test_validate_name_accepts_safe_names_and_rejects_traversal() -> None:
+    assert validate_name("tau2-airline") == "tau2-airline"
+    assert validate_name("retail.v2") == "retail.v2"
+    for bad in ["../escape", "a/b", ".", "", ".hidden", "with space"]:
+        with pytest.raises(ValueError, match="invalid world model name"):
+            validate_name(bad)
+
+
+def test_list_names_and_info(tmp_path) -> None:  # noqa: ANN001 - pytest fixture
+    store = WorldModelStore(tmp_path / ".wmh")
+    assert store.list_names() == []
+    _build_fake_model(store, "beta", accuracy=0.4)
+    _build_fake_model(store, "alpha", accuracy=0.9)
+
+    assert store.list_names() == ["alpha", "beta"]  # sorted
+    info = store.info("alpha")
+    assert info.serve_provider == "bedrock"
+    assert info.serve_model == "opus"
+    assert info.held_out_accuracy == 0.9
+    assert info.rollouts_used == 7
+    assert info.frontier_size == 2
+
+
+def test_resolve_explicit_and_singleton_and_ambiguous(tmp_path) -> None:  # noqa: ANN001
+    store = WorldModelStore(tmp_path / ".wmh")
+
+    # No models yet: resolve(None) errors helpfully.
+    with pytest.raises(FileNotFoundError, match="no world models built"):
+        store.resolve(None)
+
+    _build_fake_model(store, DEFAULT_MODEL_NAME)
+    # Exactly one model: resolve(None) picks it.
+    assert store.resolve(None) == store.model_dir(DEFAULT_MODEL_NAME)
+    # Explicit name resolves to its dir.
+    assert store.resolve(DEFAULT_MODEL_NAME) == store.model_dir(DEFAULT_MODEL_NAME)
+
+    _build_fake_model(store, "second")
+    # Two models: resolve(None) is ambiguous.
+    with pytest.raises(ValueError, match="multiple world models"):
+        store.resolve(None)
+
+
+def test_resolve_unknown_name_lists_available(tmp_path) -> None:  # noqa: ANN001
+    store = WorldModelStore(tmp_path / ".wmh")
+    _build_fake_model(store, "alpha")
+    with pytest.raises(FileNotFoundError, match="alpha"):
+        store.resolve("nope")

--- a/wmh/core/parsing.py
+++ b/wmh/core/parsing.py
@@ -81,9 +81,7 @@ def parse_observation(text: str) -> Observation:
             metadata: JsonObject = {}
             if parsed.state_note:
                 metadata["state_note"] = parsed.state_note
-            return Observation(
-                content=parsed.output, is_error=parsed.is_error, metadata=metadata
-            )
+            return Observation(content=parsed.output, is_error=parsed.is_error, metadata=metadata)
     return Observation(content=text.strip())
 
 

--- a/wmh/engine/__init__.py
+++ b/wmh/engine/__init__.py
@@ -1,8 +1,11 @@
-"""The world-model engine: prompt assembly, the WorldModel, the build pipeline, and the demo."""
+"""The world-model engine: prompt assembly, the WorldModel, the build pipeline, eval, demo, play."""
 
 from wmh.engine.build import build, ingest, split_traces
 from wmh.engine.demo import DemoResult, run_demo
 from wmh.engine.eval import EvalReport, evaluate_files
+from wmh.engine.loader import load_world_model
+from wmh.engine.play import PlayTurn, parse_action, play_turn
+from wmh.engine.reporting import BuildReporter, NullReporter
 from wmh.engine.world_model import WorldModel
 
 __all__ = [
@@ -13,5 +16,11 @@ __all__ = [
     "run_demo",
     "EvalReport",
     "evaluate_files",
+    "load_world_model",
+    "PlayTurn",
+    "parse_action",
+    "play_turn",
+    "BuildReporter",
+    "NullReporter",
     "WorldModel",
 ]

--- a/wmh/engine/build.py
+++ b/wmh/engine/build.py
@@ -12,11 +12,16 @@ import json
 from wmh.config import ArtifactPaths, HarnessConfig, save_config
 from wmh.core.types import Trace
 from wmh.engine.prompts import BASE_ENV_PROMPT
+from wmh.engine.reporting import BuildReporter, NullReporter
 from wmh.ingest import VendorPull, get_adapter
 from wmh.optimize import GEPAOptimizer, LLMJudge, OptimizeResult
 from wmh.providers import get_provider
 from wmh.providers.base import Embedder, Provider
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+def _count_steps(traces: list[Trace]) -> int:
+    return sum(len(trace.steps) for trace in traces)
 
 
 def ingest(
@@ -55,18 +60,24 @@ def build(
     root: str = ".wmh",
     serve_provider: Provider | None = None,
     embedder: Embedder | None = None,
+    reporter: BuildReporter | None = None,
 ) -> OptimizeResult:
     """Ingest traces and run the full build, creating + persisting the artifact under `root`.
 
     `serve_provider` / `embedder` are injectable for testing; in production they are constructed
     from `config` (serve provider via the registry, embedder = offline HashingEmbedder sized to
-    `config.embed_dim`). Returns the GEPA OptimizeResult (also persisted).
+    `config.embed_dim`). `reporter` receives progress events (defaults to a no-op). Returns the
+    GEPA OptimizeResult (also persisted).
     """
+    report = reporter or NullReporter()
     paths = ArtifactPaths(root)
     traces = ingest(config, file=file, vendor=vendor)
     if not traces:
         raise ValueError("no traces ingested; nothing to build")
+    report.ingest_done(len(traces), _count_steps(traces))
+
     train, test = split_traces(traces, config.train_split)
+    report.split_done(len(train), len(test))
 
     provider = serve_provider or get_provider(config.serve_provider_config())
     embed = embedder or HashingEmbedder(dim=config.embed_dim)
@@ -74,12 +85,27 @@ def build(
     # Serving index over the full corpus: at serve time we retrieve from everything we have seen.
     retriever = EmbeddingRetriever(embed)
     retriever.index(traces)
+    report.index_done(_count_steps(traces))
 
     # GEPA evolves the env prompt under serving conditions: it retrieves demos the same way the
     # world model will, but from a SEPARATE retriever it re-indexes over train-only (so held-out
     # steps never retrieve themselves). The embedder is stateless, so it's safe to share.
-    optimizer = GEPAOptimizer(provider, LLMJudge(provider), retriever=EmbeddingRetriever(embed))
+    report.optimize_start(config.gepa_budget)
+    budget = config.gepa_budget
+
+    def _on_rollout(done: int, score: float | None) -> None:
+        report.rollout(done, budget, score)
+
+    optimizer = GEPAOptimizer(
+        provider,
+        LLMJudge(provider),
+        retriever=EmbeddingRetriever(embed),
+        on_rollout=_on_rollout,
+    )
     result = optimizer.optimize(train, test or train, BASE_ENV_PROMPT, config.gepa_budget)
+    report.optimize_done(
+        result.metrics.held_out_accuracy, len(result.frontier), result.metrics.rollouts_used
+    )
 
     _persist(paths, config, retriever, result)
     return result

--- a/wmh/engine/integration_test.py
+++ b/wmh/engine/integration_test.py
@@ -46,9 +46,7 @@ _SPANS = [
             {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
             {
                 "key": "gen_ai.tool.message",
-                "value": {
-                    "stringValue": '{"membership": "silver", "name": "Katherine Johnson"}'
-                },
+                "value": {"stringValue": '{"membership": "silver", "name": "Katherine Johnson"}'},
             },
         ],
     },

--- a/wmh/engine/loader.py
+++ b/wmh/engine/loader.py
@@ -1,0 +1,26 @@
+"""Load a built world model from its artifact directory.
+
+One place owns the "artifact dir -> live WorldModel" sequence (read config -> construct the serve
+provider -> `WorldModel.load`). The CLI and the serving layer both call this so the loading path
+stays identical no matter how the model was selected (by name, by picker, or served in bulk).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmh.config import load_config
+from wmh.engine.world_model import WorldModel
+from wmh.providers import get_provider
+from wmh.providers.base import Provider
+
+
+def load_world_model(model_dir: str | Path) -> tuple[WorldModel, Provider]:
+    """Load the world model under `model_dir`, returning it with the serve provider it was built on.
+
+    The provider is returned alongside so callers that also need it (e.g. `wmh demo`, which runs an
+    LLM agent against the same provider) don't re-read the config or reconstruct it.
+    """
+    config = load_config(str(model_dir))
+    provider = get_provider(config.serve_provider_config())
+    return WorldModel.load(str(model_dir), provider), provider

--- a/wmh/engine/play.py
+++ b/wmh/engine/play.py
@@ -1,0 +1,85 @@
+"""`wmh play`: a human drives the agent inside the reconstructed environment.
+
+This is the interactive sibling of `wmh demo`. Instead of an LLM-as-agent proposing one tool call,
+a *person* types actions — `tool_name {json args}` or a free-text message — and the world model
+returns the observation, advancing the session (history + scratchpad "database") exactly as a real
+agent would experience it.
+
+The engine here is UI-agnostic: it parses a typed line into an `Action` and steps the world model,
+returning the observation alongside the exact env prompt that produced it. The REPL loop, prompts,
+and rendering live in the CLI (`wmh.cli.ui`); this module is what the CLI and its tests call.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, JsonValue
+
+from wmh.core.parsing import extract_json_object
+from wmh.core.types import Action, ActionKind, JsonObject, Observation
+from wmh.engine.world_model import WorldModel
+
+
+class PlayTurn(BaseModel):
+    """The outcome of one human turn: the action taken, the observation, and the env prompt sent."""
+
+    action: Action
+    observation: Observation
+    env_prompt: str
+
+
+def parse_action(line: str) -> Action:
+    """Parse a typed REPL line into an `Action`.
+
+    Grammar (forgiving, human-first):
+      - `get_user {"id": "u1"}`  -> tool call `get_user` with JSON arguments
+      - `list_flights`           -> tool call `list_flights` with no arguments
+      - `say hello there`        -> free-text message "hello there"
+      - anything else            -> a free-text message (so the env can react to plain prose)
+
+    A bare first token is treated as a tool name when it looks like an identifier; otherwise the
+    whole line is a message. The `say ` prefix forces a message even when it looks tool-like.
+    """
+    text = line.strip()
+    if not text:
+        raise ValueError("empty action")
+
+    if text.startswith("say "):
+        return Action(kind=ActionKind.MESSAGE, content=text[4:].strip())
+
+    head, _, rest = text.partition(" ")
+    rest = rest.strip()
+    # A tool call is a bare identifier (`list_flights`) or `name {json args}`. A trailing tail not
+    # starting with a JSON bracket means prose (e.g. "what is the weather?") -> treat as a message.
+    if _looks_like_tool_name(head) and (not rest or rest.startswith(("{", "["))):
+        return Action(kind=ActionKind.TOOL_CALL, name=head, arguments=_parse_arguments(rest))
+    return Action(kind=ActionKind.MESSAGE, content=text)
+
+
+def play_turn(world_model: WorldModel, session_id: str, action: Action) -> PlayTurn:
+    """Render the env prompt for `action`, step the world model, and return the full turn."""
+    env_prompt = world_model.render_step_prompt(session_id, action)
+    observation = world_model.step(session_id, action)
+    return PlayTurn(action=action, observation=observation, env_prompt=env_prompt)
+
+
+def _looks_like_tool_name(token: str) -> bool:
+    """A tool name is an identifier-ish token: letters/digits/._- starting with a letter."""
+    return bool(token) and token[0].isalpha() and all(c.isalnum() or c in "._-" for c in token)
+
+
+def _parse_arguments(rest: str) -> JsonObject:
+    """Parse the argument tail into a JSON object; empty tail -> no arguments."""
+    if not rest:
+        return {}
+    raw = extract_json_object(rest)
+    if raw is None:
+        raise ValueError(
+            f"could not read tool arguments from {rest!r}; pass a JSON object like "
+            '{"id": "u1"} (or omit it for no arguments)'
+        )
+    parsed: JsonValue = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError('tool arguments must be a JSON object, e.g. {"id": "u1"}')
+    return parsed

--- a/wmh/engine/play_test.py
+++ b/wmh/engine/play_test.py
@@ -1,0 +1,95 @@
+"""Tests for the interactive play engine: line parsing and a human-driven turn (no network)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.core.types import Action, ActionKind, Observation, Step, Trace
+from wmh.engine.play import parse_action, play_turn
+from wmh.engine.world_model import WorldModel
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        return Completion(
+            text='{"output": "user u1 found", "is_error": false, "state_note": "looked up u1"}'
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def test_parse_action_tool_call_with_json_args() -> None:
+    action = parse_action('get_user {"id": "u1"}')
+    assert action.kind == ActionKind.TOOL_CALL
+    assert action.name == "get_user"
+    assert action.arguments == {"id": "u1"}
+
+
+def test_parse_action_bare_tool_name_has_no_args() -> None:
+    action = parse_action("list_flights")
+    assert action.kind == ActionKind.TOOL_CALL
+    assert action.name == "list_flights"
+    assert action.arguments == {}
+
+
+def test_parse_action_say_prefix_forces_message() -> None:
+    action = parse_action("say hello there")
+    assert action.kind == ActionKind.MESSAGE
+    assert action.content == "hello there"
+
+
+def test_parse_action_prose_is_a_message() -> None:
+    action = parse_action("what is the weather?")
+    assert action.kind == ActionKind.MESSAGE
+    assert action.content == "what is the weather?"
+
+
+def test_parse_action_rejects_empty_and_bad_json() -> None:
+    with pytest.raises(ValueError, match="empty action"):
+        parse_action("   ")
+    with pytest.raises(ValueError, match="JSON object"):
+        parse_action('get_user ["not", "an", "object"]')
+
+
+def test_play_turn_steps_and_evolves_scratchpad() -> None:
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
+    retriever.index(
+        [
+            Trace(
+                trace_id="t",
+                steps=[
+                    Step(
+                        action=Action(
+                            kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u0"}
+                        ),
+                        observation=Observation(content="found u0"),
+                    )
+                ],
+            )
+        ]
+    )
+    wm = WorldModel(FakeProvider(), retriever, top_k=3)
+    session = wm.new_session(task="look up users")
+
+    turn = play_turn(wm, session.id, parse_action('get_user {"id": "u1"}'))
+    assert turn.observation.content == "user u1 found"
+    assert "get_user" in turn.env_prompt
+    # The state note folds into the session scratchpad so later turns stay consistent.
+    assert "looked up u1" in wm.get_session(session.id).state.scratchpad
+    assert len(wm.get_session(session.id).history) == 1

--- a/wmh/engine/prompts.py
+++ b/wmh/engine/prompts.py
@@ -82,9 +82,7 @@ def build_env_prompt(
 
 def build_demo_agent_prompt(task: str, examples: list[Step]) -> str:
     """Prompt for the throwaway LLM-as-agent used by `wmh demo` (no GEPA, just examples)."""
-    example_block = (
-        "\n\n".join(render_demo(e) for e in examples) if examples else "(no examples)"
-    )
+    example_block = "\n\n".join(render_demo(e) for e in examples) if examples else "(no examples)"
     return (
         "You are role-playing the agent in a traced environment. Based on the task and the example "
         "interactions below, emit a SINGLE next tool call as a JSON object and nothing else:\n"

--- a/wmh/engine/reporting.py
+++ b/wmh/engine/reporting.py
@@ -1,0 +1,53 @@
+"""Progress reporting for the build pipeline.
+
+The build emits coarse lifecycle events (ingest, split, index, optimize, persist) plus fine-grained
+GEPA rollout events to a `BuildReporter`. The engine depends only on this protocol — never on rich —
+so the pipeline stays headless and testable. The CLI supplies a rich-backed reporter
+(`wmh.cli.ui.RichBuildReporter`); everything else uses `NullReporter`.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class BuildReporter(Protocol):
+    """Sink for build-pipeline progress events. All methods are best-effort and side-effecting."""
+
+    def ingest_done(self, traces: int, steps: int) -> None:
+        """Called once after traces are ingested + normalized."""
+        ...
+
+    def split_done(self, train: int, test: int) -> None:
+        """Called once after the train/held-out split (counts are traces)."""
+        ...
+
+    def index_done(self, steps: int) -> None:
+        """Called once after the retrieval index is built over the replay buffer."""
+        ...
+
+    def optimize_start(self, budget: int) -> None:
+        """Called once before GEPA begins, with the rollout budget."""
+        ...
+
+    def rollout(self, done: int, budget: int, score: float | None) -> None:
+        """Called as GEPA consumes its rollout budget. `score` is the best held-out score so far."""
+        ...
+
+    def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
+        """Called once after GEPA finishes."""
+        ...
+
+
+class NullReporter:
+    """A reporter that does nothing — the default for library/test callers."""
+
+    def ingest_done(self, traces: int, steps: int) -> None: ...
+    def split_done(self, train: int, test: int) -> None: ...
+    def index_done(self, steps: int) -> None: ...
+    def optimize_start(self, budget: int) -> None: ...
+    def rollout(self, done: int, budget: int, score: float | None) -> None: ...
+
+    def optimize_done(
+        self, held_out_accuracy: float, frontier_size: int, rollouts: int
+    ) -> None: ...

--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -18,7 +18,7 @@ against what is actually deployed.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
@@ -36,6 +36,9 @@ from wmh.retrieval.leakfree import DemoRetriever
 
 # The single named component GEPA evolves: the specialized env (system) prompt.
 ENV_PROMPT_COMPONENT = "env_prompt"
+
+# Called once per judged rollout: (rollouts_done, best_score_so_far). Used to drive build progress.
+RolloutCallback = Callable[[int, float | None], None]
 
 
 class OptimizeMetrics(BaseModel):
@@ -126,9 +129,14 @@ class WorldModelGEPAAdapter(GEPAAdapter[_EvalStep, _StepTrajectory, Observation]
     precomputed once (see `GEPAOptimizer._eval_steps`) and reused across every candidate.
     """
 
-    def __init__(self, provider: Provider, judge: Judge) -> None:
+    def __init__(
+        self, provider: Provider, judge: Judge, on_rollout: RolloutCallback | None = None
+    ) -> None:
         self._provider = provider
         self._judge = judge
+        self._on_rollout = on_rollout
+        self._rollouts = 0
+        self._best_score: float | None = None
 
     def evaluate(
         self,
@@ -158,6 +166,7 @@ class WorldModelGEPAAdapter(GEPAAdapter[_EvalStep, _StepTrajectory, Observation]
                 score, critique = 0.0, f"Rollout failed: {exc}"
             outputs.append(predicted)
             scores.append(score)
+            self._note_rollout(score)
             if trajectories is not None:
                 trajectories.append(
                     _StepTrajectory(step=step, predicted=predicted, score=score, critique=critique)
@@ -189,6 +198,14 @@ class WorldModelGEPAAdapter(GEPAAdapter[_EvalStep, _StepTrajectory, Observation]
             )
         # GEPA only ever asks us to update the components it selected; we own a single one.
         return {component: records for component in components_to_update}
+
+    def _note_rollout(self, score: float) -> None:
+        """Tick the rollout counter + running best score and notify the callback, if any."""
+        self._rollouts += 1
+        if self._best_score is None or score > self._best_score:
+            self._best_score = score
+        if self._on_rollout is not None:
+            self._on_rollout(self._rollouts, self._best_score)
 
 
 # --- reflection LM adapter -----------------------------------------------------------------------
@@ -233,12 +250,17 @@ class GEPAOptimizer:
     """Reflective prompt evolution against the held-out trace split (drives the `gepa` engine)."""
 
     def __init__(
-        self, provider: Provider, judge: Judge, retriever: Retriever | None = None
+        self,
+        provider: Provider,
+        judge: Judge,
+        retriever: Retriever | None = None,
+        on_rollout: RolloutCallback | None = None,
     ) -> None:
         self._provider = provider
         self._judge = judge
         # Optional retriever for RAG-aware evaluation. When None, GEPA evaluates zero-shot.
         self._retriever = retriever
+        self._on_rollout = on_rollout
 
     def optimize(
         self, train: list[Trace], test: list[Trace], base_prompt: str, budget: int
@@ -257,7 +279,7 @@ class GEPAOptimizer:
         demos = DemoRetriever(self._retriever, train_src)
         trainset = _eval_steps(train_src, demos)
         valset = _eval_steps(val_src, demos)
-        adapter = WorldModelGEPAAdapter(self._provider, self._judge)
+        adapter = WorldModelGEPAAdapter(self._provider, self._judge, self._on_rollout)
         result = gepa.optimize(
             seed_candidate={ENV_PROMPT_COMPONENT: base_prompt},
             trainset=trainset,

--- a/wmh/retrieval/leakfree.py
+++ b/wmh/retrieval/leakfree.py
@@ -32,9 +32,7 @@ class DemoRetriever:
     is empty, it yields no demos (zero-shot) — callers get the same interface either way.
     """
 
-    def __init__(
-        self, retriever: Retriever | None, corpus: list[Trace], *, top_k: int = 5
-    ) -> None:
+    def __init__(self, retriever: Retriever | None, corpus: list[Trace], *, top_k: int = 5) -> None:
         self._retriever = retriever
         self._top_k = top_k
         self._enabled = retriever is not None and any(t.steps for t in corpus)
@@ -42,9 +40,7 @@ class DemoRetriever:
             assert retriever is not None  # for type-checkers; guarded by _enabled
             retriever.index(corpus)
             # id(step) -> originating trace_id, to exclude a query's own trace from its demos.
-            self._origin: dict[int, str] = {
-                id(s): t.trace_id for t in corpus for s in t.steps
-            }
+            self._origin: dict[int, str] = {id(s): t.trace_id for t in corpus for s in t.steps}
 
     def demos_for(self, trace_id: str, step: Step) -> list[Step]:
         """Return up to top_k demos for `step`, excluding any from `trace_id`'s own trace."""

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -1,6 +1,8 @@
 """Local FastAPI backend — the live environment agents call over HTTP.
 
-Thin transport over an in-process `WorldModel`; the CLI and the API share the same code path.
+Routes are namespaced by world model name (`/world_models/{name}/...`) so one backend can serve
+several named models at once. Each route is a thin transport over an in-process `WorldModel`; the
+CLI and the API share the same code path.
 """
 
 from __future__ import annotations
@@ -30,26 +32,51 @@ class StepResponse(BaseModel):
     observation: Observation
 
 
-def _load_world_model(artifact_dir: str) -> WorldModel:
-    """Load the served WorldModel from `.wmh/` using the configured serve provider."""
-    from wmh.config import load_config
-    from wmh.providers import get_provider
-
-    config = load_config(artifact_dir)
-    provider = get_provider(config.serve_provider_config())
-    return WorldModel.load(artifact_dir, provider)
+class ModelsResponse(BaseModel):
+    world_models: list[str]
 
 
-def create_app(artifact_dir: str = ".wmh", world_model: WorldModel | None = None) -> FastAPI:
-    """Build the FastAPI app bound to a loaded WorldModel.
+def _load_named_models(artifact_dir: str, names: list[str] | None) -> dict[str, WorldModel]:
+    """Load the requested world models (or all built ones) from `artifact_dir` by name."""
+    from wmh.config import WorldModelStore
+    from wmh.engine import load_world_model
 
-    The WorldModel is loaded from `artifact_dir` on construction (so the first request is fast), or
-    injected directly via `world_model` for testing.
+    store = WorldModelStore(artifact_dir)
+    chosen = names if names is not None else store.list_names()
+    if not chosen:
+        raise FileNotFoundError(
+            f"no world models built under {store.models_dir}; run `wmh build --name <name>` first"
+        )
+    models: dict[str, WorldModel] = {}
+    for name in chosen:
+        world_model, _provider = load_world_model(store.resolve(name))
+        models[name] = world_model
+    return models
+
+
+def create_app(
+    artifact_dir: str = ".wmh",
+    names: list[str] | None = None,
+    world_models: dict[str, WorldModel] | None = None,
+) -> FastAPI:
+    """Build the FastAPI app serving one or more named WorldModels.
+
+    Models are either injected directly via `world_models` (name -> model, for tests), or loaded
+    from `artifact_dir` with `names` selecting which to serve (default: all built ones).
     """
     app = FastAPI(title="World Model Harness")
-    wm = world_model or _load_world_model(artifact_dir)
+    models = world_models if world_models is not None else _load_named_models(artifact_dir, names)
 
-    def _session_or_404(session_id: str) -> Session:
+    def _model_or_404(name: str) -> WorldModel:
+        try:
+            return models[name]
+        except KeyError:
+            available = ", ".join(sorted(models)) or "(none)"
+            raise HTTPException(
+                status_code=404, detail=f"no world model {name!r}; have: {available}"
+            ) from None
+
+    def _session_or_404(wm: WorldModel, session_id: str) -> Session:
         try:
             return wm.get_session(session_id)
         except KeyError:
@@ -59,24 +86,36 @@ def create_app(artifact_dir: str = ".wmh", world_model: WorldModel | None = None
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
 
-    @app.post("/sessions", response_model=NewSessionResponse)
-    def new_session(req: NewSessionRequest) -> NewSessionResponse:
+    @app.get("/world_models", response_model=ModelsResponse)
+    def list_world_models() -> ModelsResponse:
+        return ModelsResponse(world_models=sorted(models))
+
+    @app.post("/world_models/{world_model_name}/sessions", response_model=NewSessionResponse)
+    def new_session(world_model_name: str, req: NewSessionRequest) -> NewSessionResponse:
+        wm = _model_or_404(world_model_name)
         session = wm.new_session(task=req.task, seed_state=req.seed_state)
         return NewSessionResponse(session_id=session.id)
 
-    @app.get("/sessions/{session_id}", response_model=Session)
-    def get_session(session_id: str) -> Session:
-        return _session_or_404(session_id)
+    @app.get("/world_models/{world_model_name}/sessions/{session_id}", response_model=Session)
+    def get_session(world_model_name: str, session_id: str) -> Session:
+        wm = _model_or_404(world_model_name)
+        return _session_or_404(wm, session_id)
 
-    @app.get("/sessions/{session_id}/usage", response_model=RunRecord)
-    def session_usage(session_id: str) -> RunRecord:
+    @app.get(
+        "/world_models/{world_model_name}/sessions/{session_id}/usage", response_model=RunRecord
+    )
+    def session_usage(world_model_name: str, session_id: str) -> RunRecord:
         """Per-session token/cost/time so far (serve-time observability)."""
-        _session_or_404(session_id)
+        wm = _model_or_404(world_model_name)
+        _session_or_404(wm, session_id)
         return wm.session_usage(session_id)
 
-    @app.post("/sessions/{session_id}/step", response_model=StepResponse)
-    def step(session_id: str, req: StepRequest) -> StepResponse:
-        _session_or_404(session_id)
+    @app.post(
+        "/world_models/{world_model_name}/sessions/{session_id}/step", response_model=StepResponse
+    )
+    def step(world_model_name: str, session_id: str, req: StepRequest) -> StepResponse:
+        wm = _model_or_404(world_model_name)
+        _session_or_404(wm, session_id)
         observation = wm.step(session_id, req.action)
         return StepResponse(observation=observation)
 

--- a/wmh/serving/server_test.py
+++ b/wmh/serving/server_test.py
@@ -1,4 +1,4 @@
-"""Tests for the FastAPI serving layer, with an injected in-process WorldModel (no network)."""
+"""Tests for the FastAPI serving layer, with injected in-process WorldModels (no network)."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ class FakeProvider:
         raise NotImplementedError
 
 
-def _client() -> TestClient:
+def _world_model() -> WorldModel:
     retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
     retriever.index(
         [
@@ -49,36 +49,60 @@ def _client() -> TestClient:
             )
         ]
     )
-    wm = WorldModel(FakeProvider(), retriever, top_k=3)
-    return TestClient(create_app(world_model=wm))
+    return WorldModel(FakeProvider(), retriever, top_k=3)
+
+
+def _client(world_models: dict[str, WorldModel] | None = None) -> TestClient:
+    models = world_models or {"airline": _world_model()}
+    return TestClient(create_app(world_models=models))
 
 
 def test_healthz() -> None:
     assert _client().get("/healthz").json() == {"status": "ok"}
 
 
-def test_session_lifecycle_and_step() -> None:
+def test_lists_world_models_by_name() -> None:
+    client = _client({"airline": _world_model(), "retail": _world_model()})
+    assert client.get("/world_models").json() == {"world_models": ["airline", "retail"]}
+
+
+def test_session_lifecycle_and_step_are_namespaced() -> None:
     client = _client()
-    resp = client.post("/sessions", json={"task": "look up a user"})
+    resp = client.post("/world_models/airline/sessions", json={"task": "look up a user"})
     assert resp.status_code == 200
     session_id = resp.json()["session_id"]
 
     step = client.post(
-        f"/sessions/{session_id}/step",
+        f"/world_models/airline/sessions/{session_id}/step",
         json={"action": {"kind": "tool_call", "name": "get_user", "arguments": {"id": "u2"}}},
     )
     assert step.status_code == 200
     assert step.json()["observation"]["content"] == "user found"
 
-    got = client.get(f"/sessions/{session_id}")
+    got = client.get(f"/world_models/airline/sessions/{session_id}")
     assert got.status_code == 200
     assert len(got.json()["history"]) == 1
+
+
+def test_unknown_world_model_is_404() -> None:
+    client = _client()
+    resp = client.post("/world_models/nope/sessions", json={"task": "x"})
+    assert resp.status_code == 404
 
 
 def test_step_on_missing_session_is_404() -> None:
     client = _client()
     resp = client.post(
-        "/sessions/nope/step",
+        "/world_models/airline/sessions/nope/step",
         json={"action": {"kind": "message", "content": "hi"}},
     )
     assert resp.status_code == 404
+
+
+def test_sessions_are_isolated_between_named_models() -> None:
+    client = _client({"airline": _world_model(), "retail": _world_model()})
+    created = client.post("/world_models/airline/sessions", json={"task": "x"})
+    session_id = created.json()["session_id"]
+    # A session created on `airline` is not visible under `retail`.
+    miss = client.get(f"/world_models/retail/sessions/{session_id}")
+    assert miss.status_code == 404


### PR DESCRIPTION
Rebased onto main after PR #3 and #8 squash-merged (the old base `feat/retrieval-optimize` was deleted, which auto-closed PR #6 — this is its successor, reconciled with main's `eval` command, embeddings adapter, and run tracking).

## What this adds
- **Named world models** under `<root>/models/<name>/`, with `WorldModelStore` + `wmh list`. Single-model commands default `--name`; with several built, read commands show an interactive picker (TTY) or ask for `--name` (piped).
- **Serving API namespaced by name**: `GET /world_models`, `/world_models/{name}/sessions[/{id}][/step]`, and `/world_models/{name}/sessions/{id}/usage` (main's per-session token/cost/time, now namespaced).
- **`wmh play`**: human-in-the-loop REPL — type tool calls/messages, the world model answers, the session scratchpad evolves. Engine in `wmh/engine/play.py`, REPL in `wmh/cli/ui.py`.
- **Animated build UI** via a headless `BuildReporter` protocol + `RichBuildReporter` (stage lines, live GEPA rollout bar, summary panel; degrades to plain lines off-TTY).
- **Creation wizard** (bare `wmh build`) + selection picker. The wizard now also prompts for the embedder (main's `--embed-provider/--embed-model/--embed-dim`).
- **Shared `wmh/engine/loader.py:load_world_model`** used by both CLI and serving.

## Reconciled with main (kept main's behavior, replayed mine on top)
- `wmh build` keeps main's embeddings config (`HarnessConfig.for_build`, `get_embedder`) **and** run tracking (`MeteredProvider` + `save_run`, now written under `models/<name>/runs/`), wrapped in the animated reporter.
- `wmh eval` is preserved untouched; command set is now `{build, list, serve, demo, eval, play}` (the `app_test.py` assertion was updated to include all six).
- `providers verify` gathers + dedupes providers across built models and verifies each distinct embed path.

## Verified
- Full gate green locally (no CI): `ruff check .`, `ty check`, `pytest -q` → 178 passed, 6 skipped.
- Live on Bedrock Opus 4.8: merged `wmh build` (held-out 0.70, run summary `66s / 20410 tokens / $0.19` with gepa/judge breakdown, run record persisted under the model dir) and `wmh play` (grounded observations, scratchpad accumulating across turns).

Supersedes #6 (closed as history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)