### PR TITLE
Post-merge review: pin judge cost-marker, ASCII tool names, architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ reconstructed from your own OpenTelemetry traces. No sandbox, no live services, 
 
 Inspired by **Qwen-AgentWorld** (LLM-as-environment), **GEPA** (reflective prompt evolution), and
 **DreamGym** (retrieval over a trace replay buffer) — but with **zero training**: we get there with
-prompt optimization on a frontier model. See [`DESIGN.md`](./DESIGN.md) for the full design.
+prompt optimization on a frontier model. See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for how
+the pieces fit (and where to plug in a new provider, adapter, or embedder).
 
 ## How it works
 
@@ -25,6 +26,7 @@ wmh providers verify                       # confirm Anthropic / Bedrock / Azure
 wmh build                                  # guided creation wizard (prompts for name, traces, provider…)
 wmh build --name airline --file traces.jsonl   # …or fully scriptable with flags -> .wmh/models/airline/
 wmh list                                   # show every built world model
+wmh eval traces.jsonl                      # score reconstruction fidelity (replay + LLM judge)
 wmh serve                                  # local backend on :8000 (serves all built models)
 wmh demo                                   # watch an LLM agent step against the world model
 wmh play                                   # step into the environment yourself (interactive REPL)
@@ -42,10 +44,13 @@ is optional.
 
 ```python
 from wmh import WorldModel, Action, ActionKind
-from wmh.providers import get_provider, ProviderConfig, ProviderKind
+from wmh.config.store import WorldModelStore
+from wmh.engine.loader import load_world_model
 
-provider = get_provider(ProviderConfig(kind=ProviderKind.ANTHROPIC, model="claude-opus-4-8"))
-wm = WorldModel.load(".wmh", provider)
+# Resolve a named model under the project root (.wmh/models/<name>/) and load it with the
+# serve provider + embedder it was built with — no need to reconstruct the provider yourself.
+model_dir = WorldModelStore(".wmh").resolve("airline")
+wm, _provider = load_world_model(model_dir)
 
 session = wm.new_session(task="check out the cart")
 obs = wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="add_to_cart",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architecture
+
+World Model Harness turns a frontier LLM into the *environment* your agent steps against,
+reconstructed from your own OpenTelemetry traces. This doc is the map: how the packages fit, the
+data that flows between them, and where to plug in new pieces.
+
+## The shape
+
+Packages are layered; arrows point "depends on". `core` depends on nothing, the CLI sits on top.
+
+```
+                      cli  ──────────────┐
+                       │                 │
+        ┌──────────────┼─────────────┐   │
+     serving         engine          │   │
+        │           │  │  │  │        │   │
+        └───────────┘  │  │  └────────┴───┤
+                  optimize retrieval      │
+                       │     │            │
+                    ingest   │            │
+                       └──────┴──────┬─────┘
+                              core ◄──┘  providers  config  tracking
+```
+
+- **`core`** — the vocabulary. `types.py` (`Trace`/`Step`/`Action`/`Observation`/`EnvState`/
+  `Session`), `render.py` (the one canonical (state, action)→text rendering, shared by retrieval,
+  GEPA, and the engine so an embedded step and a shown demo describe a step *identically*), and
+  `parsing.py` (robust JSON / observation-contract parsing). Depends on nothing.
+- **`providers`** — one `Provider` protocol (`complete`/`embed`/`verify`), four backends
+  (Anthropic, Bedrock, Azure OpenAI, OpenAI) behind `get_provider`. `Embedder` is the narrower
+  embed-only capability retrieval needs.
+- **`config`** — `HarnessConfig` (persisted to `config.toml`), `ArtifactPaths` (the on-disk layout
+  of one model), and `WorldModelStore` (named models under `.wmh/models/<name>/`).
+- **`ingest`** — `TraceAdapter` protocol + a registry; the OTel GenAI adapter normalizes spans into
+  `Trace`s. New trace sources register here.
+- **`retrieval`** — the DreamGym replay buffer. `EmbeddingRetriever` (cosine top-k over phi),
+  pluggable `Embedder`s (`embedders.py`, incl. the offline `HashingEmbedder`), and `leakfree.py`
+  (`DemoRetriever` — train-only, never-own-trace retrieval shared by GEPA and eval).
+- **`optimize`** — `LLMJudge` (the fitness signal) and `GEPAOptimizer` (drives the `gepa` package
+  to evolve the env prompt). Provider-only, so it never imports `engine` (avoids a cycle).
+- **`engine`** — the heart. `WorldModel` (`step`: retrieve → assemble prompt → predict → parse →
+  advance → enrich), `build` (the ingest→split→index→GEPA→persist pipeline), `loader` (the one
+  artifact-dir→live-model path), and the operator flows `replay`/`eval`, `demo`, `play`.
+- **`serving`** — a thin FastAPI transport over in-process `WorldModel`s, namespaced by model name.
+- **`tracking`** — `MeteredProvider` wraps any `Provider` at the boundary to record time/tokens/cost
+  per phase (build / GEPA / judge / serve) onto a `RunTracker`. Transparent: nothing it wraps knows.
+- **`cli`** — `build / list / eval / serve / demo / play / providers verify`. Each command is thin:
+  it parses flags and delegates to an `engine` function.
+
+## The two lifecycles
+
+**Build** (`wmh build` → `engine.build.build`):
+`ingest` traces → `split_traces` (deterministic train/held-out) → `EmbeddingRetriever.index` →
+`GEPAOptimizer.optimize` (replays held-out steps with leak-free RAG, scores with `LLMJudge`,
+reflects to mutate the prompt) → persist prompt + frontier + index + metrics under
+`.wmh/models/<name>/`.
+
+**Serve / step** (`wmh serve` | `play` | `demo` → `loader.load_world_model` → `WorldModel.step`):
+retrieve top-k similar past steps (phi) → assemble the env prompt (`core.render.build_env_prompt`,
+the *same* assembly GEPA optimized against) → `provider.complete` → `parse_observation` → advance
+the session (history + scratchpad) → enrich the buffer.
+
+## Where to extend
+
+- **A new LLM backend** → implement the `Provider` protocol in `wmh/providers/`, register it in
+  `providers/registry.py`, add its env vars to `config.PROVIDER_ENV_VARS`.
+- **A new embedding model (phi)** → implement `Embedder` (`embed(texts) -> list[list[float]]`) in
+  `wmh/retrieval/embedders.py`; wire it into `get_embedder`. Set `embed_provider` / `embed_dim` in
+  config; the persisted dim must match at load (guarded with a clear error).
+- **A new trace source / format** → implement the `TraceAdapter` protocol in `wmh/ingest/`, register
+  it; select it via `config.trace_adapter`.
+- **A different fitness signal** → implement the `Judge` protocol in `wmh/optimize/judge.py`.
+- **A new CLI command** → add a thin command in `wmh/cli/app.py` that delegates to an `engine`
+  function; keep the logic in `engine` so it stays testable without the CLI.
+
+## Conventions
+
+See [AGENTS.md](../AGENTS.md): inline `*_test.py` tests, `ruff` + `ty` clean over the whole project
+before commit, no `Any`/bare `dict` (use pydantic + `JsonValue`), deep package structure with a
+small CLI surface.

--- a/docs/tau2_runbook.md
+++ b/docs/tau2_runbook.md
@@ -58,13 +58,13 @@ models/tau2-airline/
 ## 2. Load the stored model and step against it
 
 ```python
-from wmh.engine.world_model import WorldModel
+from wmh.config.store import WorldModelStore
 from wmh.core.types import Action, ActionKind
-from wmh.providers import get_provider, ProviderConfig, ProviderKind
+from wmh.engine.loader import load_world_model
 
-provider = get_provider(ProviderConfig(
-    kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8", region="us-east-1"))
-wm = WorldModel.load("/tmp/tau2_wmh", provider)
+# Resolve the named model under the project root and load it with the provider it was built on.
+model_dir = WorldModelStore("/tmp/tau2_wmh").resolve("tau2-airline")
+wm, _provider = load_world_model(model_dir)
 
 s = wm.new_session(task="Customer request: I am Katherine Johnson (u_kath). Look up my account.")
 print(wm.step(s.id, Action(kind=ActionKind.TOOL_CALL, name="bash",

--- a/wmh/engine/play.py
+++ b/wmh/engine/play.py
@@ -65,8 +65,15 @@ def play_turn(world_model: WorldModel, session_id: str, action: Action) -> PlayT
 
 
 def _looks_like_tool_name(token: str) -> bool:
-    """A tool name is an identifier-ish token: letters/digits/._- starting with a letter."""
-    return bool(token) and token[0].isalpha() and all(c.isalnum() or c in "._-" for c in token)
+    """A tool name is an ASCII identifier-ish token: [A-Za-z][A-Za-z0-9._-]*.
+
+    ASCII-only on purpose: `str.isalpha()`/`isalnum()` accept Unicode letters/digits, so without
+    this a non-ASCII first word (e.g. "café ..." or "日本 ...") would be misread as a tool call
+    instead of a prose message.
+    """
+    if not token or not ("a" <= token[0].lower() <= "z"):
+        return False
+    return all(c.isascii() and (c.isalnum() or c in "._-") for c in token)
 
 
 def _parse_arguments(rest: str) -> JsonObject:

--- a/wmh/engine/play_test.py
+++ b/wmh/engine/play_test.py
@@ -67,6 +67,15 @@ def test_parse_action_rejects_empty_and_bad_json() -> None:
         parse_action('get_user ["not", "an", "object"]')
 
 
+def test_parse_action_non_ascii_first_word_is_a_message() -> None:
+    # Tool names are ASCII identifiers; a non-ASCII first word is prose, not a tool call
+    # (str.isalpha() would otherwise accept Unicode letters and misread it).
+    action = parse_action("café {}")
+    assert action.kind == ActionKind.MESSAGE
+    action2 = parse_action("日本 hello")
+    assert action2.kind == ActionKind.MESSAGE
+
+
 def test_play_turn_steps_and_evolves_scratchpad() -> None:
     retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
     retriever.index(

--- a/wmh/optimize/judge.py
+++ b/wmh/optimize/judge.py
@@ -15,6 +15,11 @@ from wmh.core.parsing import extract_json_object
 from wmh.core.types import Observation, Step
 from wmh.providers.base import Message, Provider
 
+# A stable substring of JUDGE_SYSTEM used to recognize judge calls when attributing run cost
+# (wmh.tracking.metered). Kept as a named constant so the prompt and the classifier never drift:
+# JUDGE_SYSTEM must always contain JUDGE_MARKER (pinned by judge_test.py).
+JUDGE_MARKER = "grade a world model"
+
 JUDGE_SYSTEM = """You grade a world model that simulates an environment for an AI agent.
 Given the agent's action, the ACTUAL observation the real environment returned, and a PREDICTED
 observation the world model generated, judge whether the prediction is *functionally equivalent* to

--- a/wmh/optimize/judge_test.py
+++ b/wmh/optimize/judge_test.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 from wmh.core.types import Action, ActionKind, Observation, Step
-from wmh.optimize.judge import Judge, JudgeResult, LLMJudge, _parse_judgement
+from wmh.optimize.judge import (
+    JUDGE_MARKER,
+    JUDGE_SYSTEM,
+    Judge,
+    JudgeResult,
+    LLMJudge,
+    _parse_judgement,
+)
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+
+
+def test_judge_system_contains_marker() -> None:
+    # Run-cost attribution (wmh.tracking.metered.classify_build_call) recognizes judge calls by
+    # JUDGE_MARKER. If the prompt is edited to no longer contain it, judge cost is silently
+    # misattributed to GEPA — pin the coupling here.
+    assert JUDGE_MARKER in JUDGE_SYSTEM
 
 
 class FakeProvider:

--- a/wmh/tracking/metered.py
+++ b/wmh/tracking/metered.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from wmh.optimize.judge import JUDGE_MARKER
 from wmh.providers.base import (
     Completion,
     Message,
@@ -25,16 +26,15 @@ from wmh.providers.base import (
 )
 from wmh.tracking.tracker import Phase, RunTracker
 
-# System-prompt fingerprints of the build-time call sites (see judge.py / gepa.py).
-_JUDGE_MARKER = "grade a world model"
-_REFLECTION_MARKER = "improve the system prompt"
-
 
 def classify_build_call(system: str) -> Phase:
-    """Default phase classifier for a build-time `complete`: judge vs GEPA (rollout/reflection)."""
-    if _JUDGE_MARKER in system:
+    """Default phase classifier for a build-time `complete`: judge vs GEPA (rollout/reflection).
+
+    The judge is recognized by `JUDGE_MARKER` (owned by judge.py, so the prompt and this classifier
+    can't drift). Everything else during build — GEPA rollouts (env-sim) and reflection — is GEPA.
+    """
+    if JUDGE_MARKER in system:
         return Phase.JUDGE
-    # GEPA rollouts (env-sim) and reflection both belong to the optimization phase.
     return Phase.GEPA
 
 


### PR DESCRIPTION
Whole-repo readability/extensibility review after #3, #8, #9 landed in `main`. Reviewed as a
maintainer building a clean, extensible OSS repo. The merged codebase is in good shape (verified
the full pipeline end-to-end on Bedrock — build → list → resolve-by-name → load → step; ruff/ty
clean; 180 tests pass), so this is a focused set of real fixes, not churn.

## Correctness / maintainability
- **Judge cost-marker drift.** Run-cost attribution split judge vs GEPA by the literal
  `"grade a world model"` hardcoded in `tracking/metered.py`, duplicating a substring of the judge
  prompt. Editing the prompt would silently misattribute judge cost to GEPA with no test catching
  it. Now `judge.py` owns `JUDGE_MARKER`, `metered.py` imports it, and a test pins
  `JUDGE_MARKER ⊂ JUDGE_SYSTEM`.
- **Unicode tool-name parse in `play`.** `parse_action` used `str.isalpha()`/`isalnum()` (which
  accept Unicode), so `"café {}"` / `"日本 ..."` were misread as tool calls. Restricted to ASCII
  identifiers; added tests.

## Docs / OSS onboarding
- **`docs/ARCHITECTURE.md`** (new): the package layering map, the two lifecycles (build / serve+step),
  and a "where to extend" guide (new provider / embedder / trace adapter / judge / CLI command).
- **README**: added `wmh eval` to the Quickstart; fixed the broken `DESIGN.md` link (it's gitignored)
  → ARCHITECTURE.md; fixed the **stale API example** — `WorldModel.load(".wmh")` no longer works now
  that models live under `.wmh/models/<name>/`, replaced with `WorldModelStore.resolve` +
  `load_world_model`. Both rewritten examples were executed to confirm they run.
- **tau2_runbook.md**: same named-model load fix.

## Deliberately NOT changed (surfaced, left as-is)
- **No LICENSE file** and no `license` field in `pyproject.toml` — that's an IP decision for the
  maintainer to make, not something to assume. Recommend adding one before public release.
- A `CONTRIBUTING.md` and committing/replacing the gitignored `DESIGN.md` would help adoption but
  are out of scope here.

ruff ✅ · ty ✅ · 180 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)