### PR TITLE
Benchmarks as first-class objects: definitions, runner, persistence, leaderboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,9 @@ dist/
 .ty_cache/
 .DS_Store
 
+# Benchmark run outputs (the leaderboard reads these). Definitions (benchmark.toml) are committed;
+# the per-run JSON scorecards are reproducible artifacts, so they stay out of the tree.
+benchmarks/*/results/
+
 # Local-only design notes; not committed.
 DESIGN.md

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ wmh build                                  # guided creation wizard (prompts for
 wmh build --name airline --file traces.jsonl   # …or fully scriptable with flags -> .wmh/models/airline/
 wmh list                                   # show every built world model
 wmh eval traces.jsonl                      # score reconstruction fidelity (replay + LLM judge)
+wmh bench run tau-bench                     # score a prompt against a committed benchmark (mean ± std)
+wmh bench                                   # leaderboard across all persisted benchmark runs
 wmh serve                                  # local backend on :8000 (serves all built models)
 wmh demo                                   # watch an LLM agent step against the world model
 wmh play                                   # step into the environment yourself (interactive REPL)

--- a/benchmarks/tau-bench/benchmark.toml
+++ b/benchmarks/tau-bench/benchmark.toml
@@ -1,0 +1,32 @@
+# tau-bench — open-loop reconstruction-fidelity benchmark.
+#
+# A committed, versioned benchmark definition ("filesystem as DB"). `wmh bench run tau-bench` replays
+# the held-out steps of the trace(s) below teacher-forced, has the world model predict each
+# observation, and scores it against the recorded one with the pinned judge. Results land in
+# `benchmarks/tau-bench/results/` and surface on `wmh bench`.
+#
+# Trace paths are resolved relative to this directory. They point at the shared corpus under
+# `examples/` (owned by the benchmark-infra chat) so there is one source of truth; the infra chat's
+# richer tau2-bench capture drops in by replacing that file — no change here.
+
+version = "1"
+description = "tau2-bench airline/retail tool transitions; reconstruction fidelity (open-loop)."
+traces = ["../../examples/tau2-bench.otel.jsonl"]
+
+[eval]
+# "all" scores every held-out step; "sampled" uses Qwen-AgentWorld's 5-turn protocol.
+sample_turns = "all"
+# Multiple world-model samples per step; with temperature > 0 this yields a score distribution
+# (reported as mean ± std). Kept at 1/0.0 here so the committed default run is deterministic and
+# cheap; raise both to measure variance.
+rollouts = 1
+temperature = 0.0
+seeds = [0]
+train_split = 0.7
+top_k = 5
+
+[eval.judge]
+# Reference-grounded multi-dimension LLM judge. Pinned for reproducibility (Bedrock Opus 4.8).
+provider = "bedrock"
+model = "us.anthropic.claude-opus-4-8"
+region = "us-east-1"

--- a/benchmarks/tau-bench/benchmark.toml
+++ b/benchmarks/tau-bench/benchmark.toml
@@ -14,11 +14,11 @@ description = "tau2-bench airline/retail tool transitions; reconstruction fideli
 traces = ["../../examples/tau2-bench.otel.jsonl"]
 
 [eval]
-# "all" scores every held-out step; "sampled" uses Qwen-AgentWorld's 5-turn protocol.
-sample_turns = "all"
-# Multiple world-model samples per step; with temperature > 0 this yields a score distribution
-# (reported as mean ± std). Kept at 1/0.0 here so the committed default run is deterministic and
-# cheap; raise both to measure variance.
+# "all" scores every held-out step; "sampled" uses Qwen-AgentWorld's 5-turn protocol (cheaper,
+# and what the committed reference fidelity ~0.47 was measured with).
+sample_turns = "sampled"
+# Rollouts/temperature are a reserved variance knob — the scorer is deterministic until the
+# providers forward a sampling temperature, so 1/0.0 keeps the committed run reproducible and cheap.
 rollouts = 1
 temperature = 0.0
 seeds = [0]
@@ -26,7 +26,8 @@ train_split = 0.7
 top_k = 5
 
 [eval.judge]
-# Reference-grounded multi-dimension LLM judge. Pinned for reproducibility (Bedrock Opus 4.8).
+# Reference-grounded 5-dimension rubric judge (wmh.optimize.judge.RubricJudge). Pinned for
+# reproducibility (Bedrock Opus 4.8).
 provider = "bedrock"
 model = "us.anthropic.claude-opus-4-8"
 region = "us-east-1"

--- a/benchmarks/terminal-tasks/benchmark.toml
+++ b/benchmarks/terminal-tasks/benchmark.toml
@@ -1,0 +1,32 @@
+# terminal-tasks — open-loop reconstruction-fidelity benchmark.
+#
+# A committed, versioned benchmark definition ("filesystem as DB"). `wmh bench run terminal-tasks`
+# replays the held-out steps of the trace below teacher-forced, has the world model predict each
+# observation, and scores it against the recorded one with the pinned rubric judge. Results land in
+# `benchmarks/terminal-tasks/results/` and surface on `wmh bench`.
+#
+# Trace paths resolve relative to this directory; they point at the shared corpus under `examples/`
+# (owned by the benchmark-infra capture pipeline) so there is one source of truth.
+
+version = "1"
+description = "terminal-tasks bash/tool transitions; reconstruction fidelity (open-loop)."
+traces = ["../../examples/terminal-tasks.otel.jsonl"]
+
+[eval]
+# "sampled" uses Qwen-AgentWorld's 5-turn protocol (the committed reference fidelity ~0.62 was
+# measured with it); "all" scores every held-out step.
+sample_turns = "sampled"
+# Reserved variance knob — inert until the providers forward a sampling temperature; 1/0.0 keeps the
+# committed run reproducible and cheap.
+rollouts = 1
+temperature = 0.0
+seeds = [0]
+train_split = 0.7
+top_k = 5
+
+[eval.judge]
+# Reference-grounded 5-dimension rubric judge (wmh.optimize.judge.RubricJudge). Pinned for
+# reproducibility (Bedrock Opus 4.8).
+provider = "bedrock"
+model = "us.anthropic.claude-opus-4-8"
+region = "us-east-1"

--- a/docs/benchmark_reporting.md
+++ b/docs/benchmark_reporting.md
@@ -51,7 +51,7 @@ trace-capture pipeline) so there is one source of truth.
 ```bash
 wmh bench list                      # every committed benchmark + its eval config
 wmh bench run tau-bench             # score the bundled BASE_ENV_PROMPT
-wmh bench run tau-bench --model airline   # score a built model's optimized prompt
+wmh bench run tau-bench --model tau-bench  # score a model's optimized prompt (bundled or built)
 wmh bench run tau-bench --prompt my_prompt.txt
 wmh bench                           # leaderboard over all persisted runs
 ```
@@ -60,6 +60,11 @@ wmh bench                           # leaderboard over all persisted runs
 benchmark-level **mean ± std**, and writes a `BenchRun` JSON under `benchmarks/<name>/results/`.
 Runs are comparable over time; the leaderboard shows the *latest* run per (benchmark, prompt),
 ranked by fidelity.
+
+`--model` resolves through `WorldModelStore`, which searches both the writable project root
+(`.wmh/models/<name>/`, where `wmh build` writes) and the committed bundled `world-models/<name>/`
+(canonical example models shipped with the repo) — so `--model tau-bench` scores the bundled
+canonical model with no extra flags.
 
 ## Aggregation
 

--- a/docs/benchmark_reporting.md
+++ b/docs/benchmark_reporting.md
@@ -6,9 +6,9 @@ benchmark, persists the result, and `wmh bench` renders a leaderboard over every
 
 This sits on top of the open-loop eval scorer (`wmh.engine.eval`): for each held-out step it feeds
 the recorded `(state, action)` teacher-forced, has the world model predict the observation, and
-scores it against the *real* recorded observation with a reference-grounded LLM judge. Because the
-world model runs at temperature > 0, a step yields a distribution of scores across rollouts — we
-report **mean ± std**.
+scores it against the *real* recorded observation with the reference-grounded 5-dimension
+`RubricJudge`. We report **mean ± std** — across seeds, and (once a sampling temperature is
+plumbed through the providers) across rollouts.
 
 ## The definition ("filesystem as DB")
 
@@ -29,14 +29,14 @@ description = "tau2-bench tool transitions; reconstruction fidelity (open-loop).
 traces = ["../../examples/tau2-bench.otel.jsonl"]   # resolved relative to this dir
 
 [eval]
-sample_turns = "all"   # "all" | "sampled" (Qwen-AgentWorld's 5-turn protocol)
-rollouts = 1           # world-model samples per scored turn -> mean ± std
-temperature = 0.0      # raise with rollouts to measure variance
-seeds = [0]            # one scoring pass per seed (across-seed std = reproducibility)
+sample_turns = "sampled"  # "all" | "sampled" (Qwen-AgentWorld's 5-turn protocol)
+rollouts = 1              # reserved variance knob (inert until temperature is plumbed)
+temperature = 0.0         # reserved; the scorer is deterministic today
+seeds = [0]               # one scoring pass per seed (across-seed std = reproducibility)
 train_split = 0.7
 top_k = 5
 
-[eval.judge]           # pinned grader, for reproducibility
+[eval.judge]              # pinned RubricJudge grader, for reproducibility
 provider = "bedrock"
 model = "us.anthropic.claude-opus-4-8"
 region = "us-east-1"
@@ -56,14 +56,16 @@ wmh bench run tau-bench --prompt my_prompt.txt
 wmh bench                           # leaderboard over all persisted runs
 ```
 
-`bench run` scores once per seed (the scorer draws `rollouts` samples per step internally),
-aggregates to a benchmark-level **mean ± std**, and writes a `BenchRun` JSON under
-`benchmarks/<name>/results/`. Runs are comparable over time; the leaderboard shows the *latest* run
-per (benchmark, prompt), ranked by fidelity.
+`bench run` scores once per seed (looping `rollouts` samples per pass), aggregates to a
+benchmark-level **mean ± std**, and writes a `BenchRun` JSON under `benchmarks/<name>/results/`.
+Runs are comparable over time; the leaderboard shows the *latest* run per (benchmark, prompt),
+ranked by fidelity.
 
 ## Aggregation
 
-- **Within a seed**: mean ± std over the seed's rollouts (the scorer's rollout distribution).
+- **Within a seed**: mean ± std over the seed's `rollouts`. The scorer is deterministic today (no
+  sampling temperature is plumbed through the providers), so this std is 0 until temperature lands;
+  the loop is wired so it becomes a real distribution the moment it does.
 - **Across seeds**: the benchmark `fidelity_mean` is the step-weighted mean of per-seed means;
   `fidelity_std` is the population std of the per-seed means — a seed-to-seed reproducibility signal
   distinct from the within-seed rollout std.

--- a/docs/benchmark_reporting.md
+++ b/docs/benchmark_reporting.md
@@ -1,0 +1,76 @@
+# Benchmarks + leaderboard
+
+A **benchmark** is a first-class, committed, reproducible object: a named set of recorded trace
+files plus the eval config that scores them. `wmh bench run` scores a world-model prompt against a
+benchmark, persists the result, and `wmh bench` renders a leaderboard over every persisted run.
+
+This sits on top of the open-loop eval scorer (`wmh.engine.eval`): for each held-out step it feeds
+the recorded `(state, action)` teacher-forced, has the world model predict the observation, and
+scores it against the *real* recorded observation with a reference-grounded LLM judge. Because the
+world model runs at temperature > 0, a step yields a distribution of scores across rollouts — we
+report **mean ± std**.
+
+## The definition ("filesystem as DB")
+
+Each benchmark is a directory under `benchmarks/<name>/`:
+
+```
+benchmarks/
+  tau-bench/
+    benchmark.toml      # the versioned definition (committed)
+    results/            # persisted run scorecards (generated; gitignored)
+```
+
+`benchmark.toml`:
+
+```toml
+version = "1"
+description = "tau2-bench tool transitions; reconstruction fidelity (open-loop)."
+traces = ["../../examples/tau2-bench.otel.jsonl"]   # resolved relative to this dir
+
+[eval]
+sample_turns = "all"   # "all" | "sampled" (Qwen-AgentWorld's 5-turn protocol)
+rollouts = 1           # world-model samples per scored turn -> mean ± std
+temperature = 0.0      # raise with rollouts to measure variance
+seeds = [0]            # one scoring pass per seed (across-seed std = reproducibility)
+train_split = 0.7
+top_k = 5
+
+[eval.judge]           # pinned grader, for reproducibility
+provider = "bedrock"
+model = "us.anthropic.claude-opus-4-8"
+region = "us-east-1"
+```
+
+Trace paths resolve relative to the benchmark directory, so a checked-out benchmark is
+self-contained. The bundled `tau-bench` points at the shared `examples/` corpus (owned by the
+trace-capture pipeline) so there is one source of truth.
+
+## Running
+
+```bash
+wmh bench list                      # every committed benchmark + its eval config
+wmh bench run tau-bench             # score the bundled BASE_ENV_PROMPT
+wmh bench run tau-bench --model airline   # score a built model's optimized prompt
+wmh bench run tau-bench --prompt my_prompt.txt
+wmh bench                           # leaderboard over all persisted runs
+```
+
+`bench run` scores once per seed (the scorer draws `rollouts` samples per step internally),
+aggregates to a benchmark-level **mean ± std**, and writes a `BenchRun` JSON under
+`benchmarks/<name>/results/`. Runs are comparable over time; the leaderboard shows the *latest* run
+per (benchmark, prompt), ranked by fidelity.
+
+## Aggregation
+
+- **Within a seed**: mean ± std over the seed's rollouts (the scorer's rollout distribution).
+- **Across seeds**: the benchmark `fidelity_mean` is the step-weighted mean of per-seed means;
+  `fidelity_std` is the population std of the per-seed means — a seed-to-seed reproducibility signal
+  distinct from the within-seed rollout std.
+
+## How it layers
+
+`wmh/bench/` is the benchmark domain: `definition.py` (load/discover `benchmark.toml`), `runner.py`
+(seed sweep → `BenchRun`), `scoring.py` (the one binding to `wmh.engine.eval`), `results.py`
+(persist/aggregate), `leaderboard.py` (rank persisted runs). The CLI commands are thin wrappers;
+the rich tables live in `wmh.cli.ui`.

--- a/wmh/bench/__init__.py
+++ b/wmh/bench/__init__.py
@@ -1,0 +1,49 @@
+"""Benchmarks as first-class, persisted objects on top of the open-loop eval scorer.
+
+A *benchmark* is a committed, versioned definition (`benchmarks/<name>/benchmark.toml`): a named set
+of recorded trace files plus an eval config (sample-turns, rollouts, seeds, judge). `wmh bench run`
+scores a world-model prompt against it reproducibly — per seed, aggregating the rollout distribution
+as MEAN + STD — and persists the result under `benchmarks/<name>/results/` ("filesystem as DB").
+`wmh bench` / `wmh bench list` render a leaderboard over those persisted runs.
+
+The scoring unit itself (replay a held-out trace teacher-forced, judge predicted vs. real
+observation) lives in the eval layer (`wmh.engine.eval`); this package never reimplements it — it
+calls it once per rollout and aggregates.
+"""
+
+from wmh.bench.definition import (
+    BenchmarkDef,
+    EvalConfig,
+    JudgeConfig,
+    discover_benchmarks,
+    load_benchmark,
+)
+from wmh.bench.leaderboard import LeaderboardRow, build_leaderboard
+from wmh.bench.results import (
+    BenchRun,
+    SeedResult,
+    load_runs,
+    results_dir_for,
+    save_run,
+)
+from wmh.bench.runner import RolloutScore, ScoreOnce, run_benchmark
+from wmh.bench.scoring import evaluate_files_once
+
+__all__ = [
+    "BenchmarkDef",
+    "EvalConfig",
+    "JudgeConfig",
+    "discover_benchmarks",
+    "load_benchmark",
+    "LeaderboardRow",
+    "build_leaderboard",
+    "BenchRun",
+    "SeedResult",
+    "load_runs",
+    "results_dir_for",
+    "save_run",
+    "RolloutScore",
+    "ScoreOnce",
+    "run_benchmark",
+    "evaluate_files_once",
+]

--- a/wmh/bench/_stats.py
+++ b/wmh/bench/_stats.py
@@ -1,0 +1,17 @@
+"""Shared aggregation helpers for the bench package.
+
+One definition of "population std over a sample" so the within-seed rollout std (`scoring.py`) and
+the across-seed std (`results.py`) can never drift apart. Thin wrapper over stdlib
+`statistics.pstdev` with the harness's "< 2 values -> 0.0" convention (a single observation has no
+spread, and `pstdev` raises on an empty list).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from statistics import pstdev
+
+
+def pop_std(values: Sequence[float]) -> float:
+    """Population standard deviation; 0.0 for fewer than two values."""
+    return pstdev(values) if len(values) >= 2 else 0.0

--- a/wmh/bench/_stats_test.py
+++ b/wmh/bench/_stats_test.py
@@ -1,0 +1,21 @@
+"""Tests for the shared population-std helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.bench._stats import pop_std
+
+
+def test_empty_and_single_have_no_spread() -> None:
+    assert pop_std([]) == 0.0
+    assert pop_std([0.9]) == 0.0
+
+
+def test_population_std_of_two_values() -> None:
+    # Population std of [1.0, 0.0] around mean 0.5 is 0.5.
+    assert pop_std([1.0, 0.0]) == 0.5
+
+
+def test_matches_known_spread() -> None:
+    assert pop_std([0.2, 0.8]) == pytest.approx(0.3)

--- a/wmh/bench/definition.py
+++ b/wmh/bench/definition.py
@@ -1,0 +1,130 @@
+"""Benchmark definitions: the committed, versioned `benchmark.toml` ("filesystem as DB").
+
+A benchmark lives in its own directory under `benchmarks/<name>/`:
+
+    benchmarks/
+      tau-bench/
+        benchmark.toml      <- the definition (this module loads it)
+        results/            <- persisted runs (wmh.bench.results)
+
+`benchmark.toml` names the recorded trace files to score and the eval knobs that make a run
+reproducible — which turns to sample ("all" or Qwen-AgentWorld's 5-turn "sampled"), how many
+world-model rollouts to draw per turn, the seeds to sweep, and which judge model grades. Trace
+paths resolve relative to the benchmark directory so a checked-out benchmark is self-contained.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+# How many held-out turns to score per trace. Matches the eval scorer's contract
+# (`wmh.engine.replay`): "all" scores every step; "sampled" takes Qwen-AgentWorld's 5-turn protocol
+# (first, last, and 3 uniformly-spaced middle turns) for a fixed, cheaper turn budget.
+SampleTurns = Literal["all", "sampled"]
+
+# The benchmark.toml file name inside each benchmark directory.
+BENCHMARK_FILE = "benchmark.toml"
+
+
+class JudgeConfig(BaseModel):
+    """Which model grades predicted-vs-real observations. Pinned in the definition for repro."""
+
+    provider: str = "bedrock"
+    model: str = "us.anthropic.claude-opus-4-8"
+    region: str | None = None
+
+
+class EvalConfig(BaseModel):
+    """The reproducibility knobs of a benchmark, passed through to the open-loop scorer.
+
+    `sample_turns` is `"all"` or `"sampled"` (Qwen-AgentWorld's 5-turn protocol). `rollouts` is how
+    many world-model samples to draw per scored turn — with `temperature` > 0 each rollout yields a
+    different score, so we report mean + std over them. `seeds` is the sweep: one scoring pass per
+    seed, so a benchmark can report variance across seeds as well as across rollouts.
+    """
+
+    sample_turns: SampleTurns = "all"
+    rollouts: int = Field(default=1, ge=1)
+    temperature: float = Field(default=0.0, ge=0.0)
+    seeds: list[int] = Field(default_factory=lambda: [0], min_length=1)
+    train_split: float = Field(default=0.7, gt=0.0, lt=1.0)
+    top_k: int = Field(default=5, ge=0)
+    no_rag: bool = False
+    embed_dim: int = Field(default=512, ge=1)
+    judge: JudgeConfig = Field(default_factory=JudgeConfig)
+
+
+class BenchmarkDef(BaseModel):
+    """A loaded benchmark definition. `dir`/`name` come from the file location, not the TOML."""
+
+    name: str
+    version: str = "0"
+    description: str = ""
+    traces: list[str] = Field(default_factory=list)  # paths relative to the benchmark dir
+    eval: EvalConfig = Field(default_factory=EvalConfig)
+    dir: Path = Field(exclude=True)  # the benchmark directory; not serialized back to TOML
+
+    def trace_files(self) -> list[Path]:
+        """Resolve the configured trace paths against the benchmark directory."""
+        return [self._resolve(t) for t in self.traces]
+
+    def _resolve(self, trace: str) -> Path:
+        path = Path(trace)
+        return path if path.is_absolute() else (self.dir / path)
+
+    def missing_traces(self) -> list[Path]:
+        """Configured trace files that don't exist on disk (a definition can reference fixtures
+        produced by another chat that haven't landed yet)."""
+        return [p for p in self.trace_files() if not p.exists()]
+
+
+def load_benchmark(path: str | Path) -> BenchmarkDef:
+    """Load a benchmark from its directory or its `benchmark.toml` file.
+
+    Accepts either `benchmarks/tau-bench/` or `benchmarks/tau-bench/benchmark.toml`. The benchmark
+    name defaults to the directory name unless the TOML overrides `name`.
+    """
+    toml_path, bench_dir = _locate(path)
+    try:
+        with toml_path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{toml_path} is not valid TOML ({exc})") from exc
+
+    data.setdefault("name", bench_dir.name)
+    data["dir"] = bench_dir
+    try:
+        return BenchmarkDef.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(f"{toml_path} does not match the benchmark schema ({exc})") from exc
+
+
+def discover_benchmarks(root: str | Path) -> list[BenchmarkDef]:
+    """Load every benchmark under `root` (each `<root>/<name>/benchmark.toml`), sorted by name.
+
+    Returns an empty list if `root` doesn't exist. Subdirectories without a `benchmark.toml` are
+    skipped, so `results/` and other artifacts never look like benchmarks.
+    """
+    base = Path(root)
+    if not base.exists():
+        return []
+    defs = [
+        load_benchmark(child)
+        for child in sorted(base.iterdir())
+        if child.is_dir() and (child / BENCHMARK_FILE).exists()
+    ]
+    return defs
+
+
+def _locate(path: str | Path) -> tuple[Path, Path]:
+    """Resolve `path` to `(benchmark.toml, benchmark_dir)`, accepting either as input."""
+    p = Path(path)
+    if p.is_dir():
+        return p / BENCHMARK_FILE, p
+    if p.name == BENCHMARK_FILE:
+        return p, p.parent
+    raise FileNotFoundError(f"{p} is not a benchmark directory or a {BENCHMARK_FILE} file")

--- a/wmh/bench/definition.py
+++ b/wmh/bench/definition.py
@@ -19,7 +19,7 @@ import tomllib
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 # How many held-out turns to score per trace. Matches the eval scorer's contract
 # (`wmh.engine.replay`): "all" scores every step; "sampled" takes Qwen-AgentWorld's 5-turn protocol
@@ -67,6 +67,15 @@ class BenchmarkDef(BaseModel):
     traces: list[str] = Field(default_factory=list)  # paths relative to the benchmark dir
     eval: EvalConfig = Field(default_factory=EvalConfig)
     dir: Path = Field(exclude=True)  # the benchmark directory; not serialized back to TOML
+
+    @field_validator("traces")
+    @classmethod
+    def _non_blank_traces(cls, traces: list[str]) -> list[str]:
+        # A blank path resolves to the benchmark dir itself, which exists — so `missing_traces`
+        # would not flag it and the benchmark would silently score nothing. Reject it at load.
+        if any(not t.strip() for t in traces):
+            raise ValueError("trace paths must be non-empty")
+        return traces
 
     def trace_files(self) -> list[Path]:
         """Resolve the configured trace paths against the benchmark directory."""

--- a/wmh/bench/definition_test.py
+++ b/wmh/bench/definition_test.py
@@ -82,6 +82,14 @@ def test_rejects_invalid_sample_turns(tmp_path) -> None:  # noqa: ANN001
         load_benchmark(bench_dir)
 
 
+def test_rejects_blank_trace_path(tmp_path) -> None:  # noqa: ANN001
+    # A blank path would resolve to the benchmark dir itself (which exists), so missing_traces()
+    # would not flag it — reject it at load instead of silently scoring nothing.
+    bench_dir = _write_benchmark(tmp_path, "tau", 'traces = ["", "a.jsonl"]\n')
+    with pytest.raises(ValueError, match="schema"):
+        load_benchmark(bench_dir)
+
+
 def test_rejects_malformed_toml(tmp_path) -> None:  # noqa: ANN001
     bench_dir = _write_benchmark(tmp_path, "tau", "this is = = not toml\n")
     with pytest.raises(ValueError, match="not valid TOML"):

--- a/wmh/bench/definition_test.py
+++ b/wmh/bench/definition_test.py
@@ -1,0 +1,101 @@
+"""Tests for benchmark definition loading + discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.bench.definition import discover_benchmarks, load_benchmark
+
+
+def _write_benchmark(tmp_path, name: str, body: str) -> str:  # noqa: ANN001 - pytest path
+    bench_dir = tmp_path / name
+    bench_dir.mkdir(parents=True)
+    (bench_dir / "benchmark.toml").write_text(body, encoding="utf-8")
+    return str(bench_dir)
+
+
+def test_loads_definition_with_defaults(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(
+        tmp_path,
+        "tau",
+        'version = "2"\ntraces = ["a.jsonl"]\n',
+    )
+    bench = load_benchmark(bench_dir)
+    assert bench.name == "tau"  # defaulted from the directory name
+    assert bench.version == "2"
+    assert bench.eval.sample_turns == "all"
+    assert bench.eval.rollouts == 1
+    assert bench.eval.seeds == [0]
+    # Trace paths resolve relative to the benchmark dir.
+    assert bench.trace_files()[0] == tmp_path / "tau" / "a.jsonl"
+
+
+def test_loads_full_eval_and_judge_config(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(
+        tmp_path,
+        "retail",
+        "\n".join(
+            [
+                'traces = ["t.jsonl"]',
+                "[eval]",
+                'sample_turns = "sampled"',
+                "rollouts = 3",
+                "temperature = 0.7",
+                "seeds = [1, 2, 3]",
+                "[eval.judge]",
+                'provider = "bedrock"',
+                'model = "us.anthropic.claude-opus-4-8"',
+            ]
+        ),
+    )
+    bench = load_benchmark(bench_dir)
+    assert bench.eval.sample_turns == "sampled"
+    assert bench.eval.rollouts == 3
+    assert bench.eval.temperature == 0.7
+    assert bench.eval.seeds == [1, 2, 3]
+    assert bench.eval.judge.model == "us.anthropic.claude-opus-4-8"
+
+
+def test_accepts_toml_path_directly(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(tmp_path, "tau", 'traces = ["a.jsonl"]\n')
+    bench = load_benchmark(f"{bench_dir}/benchmark.toml")
+    assert bench.name == "tau"
+
+
+def test_missing_traces_reports_absent_files(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(tmp_path, "tau", 'traces = ["nope.jsonl"]\n')
+    bench = load_benchmark(bench_dir)
+    missing = bench.missing_traces()
+    assert len(missing) == 1
+    assert missing[0].name == "nope.jsonl"
+
+
+def test_rejects_empty_seeds(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(tmp_path, "tau", "traces = []\n[eval]\nseeds = []\n")
+    with pytest.raises(ValueError, match="schema"):
+        load_benchmark(bench_dir)
+
+
+def test_rejects_invalid_sample_turns(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(tmp_path, "tau", '[eval]\nsample_turns = "first-five"\n')
+    with pytest.raises(ValueError, match="schema"):
+        load_benchmark(bench_dir)
+
+
+def test_rejects_malformed_toml(tmp_path) -> None:  # noqa: ANN001
+    bench_dir = _write_benchmark(tmp_path, "tau", "this is = = not toml\n")
+    with pytest.raises(ValueError, match="not valid TOML"):
+        load_benchmark(bench_dir)
+
+
+def test_discover_skips_non_benchmark_dirs(tmp_path) -> None:  # noqa: ANN001
+    _write_benchmark(tmp_path, "tau", 'traces = ["a.jsonl"]\n')
+    _write_benchmark(tmp_path, "retail", 'traces = ["b.jsonl"]\n')
+    # A stray directory without a benchmark.toml (e.g. a results/ sibling) is ignored.
+    (tmp_path / "results").mkdir()
+    found = discover_benchmarks(tmp_path)
+    assert [b.name for b in found] == ["retail", "tau"]  # sorted by name
+
+
+def test_discover_missing_root_is_empty(tmp_path) -> None:  # noqa: ANN001
+    assert discover_benchmarks(tmp_path / "nope") == []

--- a/wmh/bench/leaderboard.py
+++ b/wmh/bench/leaderboard.py
@@ -1,0 +1,71 @@
+"""Leaderboard aggregation: persisted `BenchRun`s -> ranked rows.
+
+Pure data shaping, no rich — the CLI (`wmh.cli.ui.leaderboard_table`) renders these rows into a
+table. For each (benchmark, prompt) pair we surface the *latest* run (runs are comparable over time,
+and the newest reflects the current prompt), then rank by fidelity. Keeping this headless makes the
+ranking testable without a terminal.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from wmh.bench.results import BenchRun
+
+
+class LeaderboardRow(BaseModel):
+    """One row: a prompt's latest score on a benchmark, with rollout/seed provenance to read it."""
+
+    benchmark: str
+    benchmark_version: str = "0"
+    prompt_label: str
+    fidelity_mean: float = 0.0
+    fidelity_std: float = 0.0
+    sample_turns: str = "all"
+    rollouts: int = 1
+    n_seeds: int = 0
+    total_steps: int = 0
+    run_id: str = ""
+    created_at: str = ""
+
+
+def build_leaderboard(runs: list[BenchRun]) -> list[LeaderboardRow]:
+    """Collapse runs to the latest per (benchmark, prompt), sorted for display.
+
+    Sort order: benchmark name, then fidelity (desc) so the best prompt leads each benchmark, then
+    prompt label for a stable tie-break. "Latest" is decided by `created_at` then `run_id`, so an
+    unstamped run never shadows a stamped one.
+    """
+    latest: dict[tuple[str, str], BenchRun] = {}
+    for run in runs:
+        key = (run.benchmark, run.prompt_label)
+        current = latest.get(key)
+        if current is None or _newer(run, current):
+            latest[key] = run
+
+    rows = [_row(run) for run in latest.values()]
+    rows.sort(key=lambda r: (r.benchmark, -r.fidelity_mean, r.prompt_label))
+    return rows
+
+
+def _newer(candidate: BenchRun, current: BenchRun) -> bool:
+    return (candidate.created_at, candidate.run_id) > (current.created_at, current.run_id)
+
+
+def _row(run: BenchRun) -> LeaderboardRow:
+    return LeaderboardRow(
+        benchmark=run.benchmark,
+        benchmark_version=run.benchmark_version,
+        prompt_label=run.prompt_label,
+        fidelity_mean=run.fidelity_mean,
+        fidelity_std=run.fidelity_std,
+        sample_turns=run.sample_turns,
+        rollouts=run.rollouts,
+        n_seeds=len(run.seeds),
+        total_steps=run.total_steps,
+        run_id=run.run_id,
+        created_at=run.created_at,
+    )
+
+
+__all__ = ["LeaderboardRow", "build_leaderboard"]

--- a/wmh/bench/leaderboard_test.py
+++ b/wmh/bench/leaderboard_test.py
@@ -1,0 +1,68 @@
+"""Tests for leaderboard aggregation over persisted runs."""
+
+from __future__ import annotations
+
+from wmh.bench.leaderboard import build_leaderboard
+from wmh.bench.results import BenchRun, SeedResult
+
+
+def _run(
+    benchmark: str,
+    prompt: str,
+    mean: float,
+    *,
+    run_id: str,
+    created_at: str = "",
+) -> BenchRun:
+    return BenchRun.aggregate(
+        benchmark=benchmark,
+        benchmark_version="1",
+        prompt_label=prompt,
+        sample_turns="all",
+        rollouts=1,
+        seeds=[SeedResult(seed=0, fidelity_mean=mean, n_steps=10)],
+        run_id=run_id,
+        created_at=created_at,
+    )
+
+
+def test_ranks_prompts_by_fidelity_within_benchmark() -> None:
+    rows = build_leaderboard(
+        [
+            _run("tau", "base", 0.5, run_id="r1"),
+            _run("tau", "optimized", 0.9, run_id="r2"),
+        ]
+    )
+    assert [r.prompt_label for r in rows] == ["optimized", "base"]
+
+
+def test_keeps_only_latest_run_per_prompt() -> None:
+    rows = build_leaderboard(
+        [
+            _run("tau", "base", 0.5, run_id="old", created_at="2026-01-01T00:00:00+00:00"),
+            _run("tau", "base", 0.8, run_id="new", created_at="2026-06-01T00:00:00+00:00"),
+        ]
+    )
+    assert len(rows) == 1
+    assert rows[0].run_id == "new"
+    assert rows[0].fidelity_mean == 0.8
+
+
+def test_groups_by_benchmark_then_fidelity() -> None:
+    rows = build_leaderboard(
+        [
+            _run("retail", "base", 0.7, run_id="r1"),
+            _run("tau", "base", 0.6, run_id="r2"),
+            _run("tau", "opt", 0.95, run_id="r3"),
+        ]
+    )
+    # Sorted by benchmark name, then fidelity desc.
+    assert [(r.benchmark, r.prompt_label) for r in rows] == [
+        ("retail", "base"),
+        ("tau", "opt"),
+        ("tau", "base"),
+    ]
+
+
+def test_empty_runs_yield_no_rows() -> None:
+    assert build_leaderboard([]) == []

--- a/wmh/bench/results.py
+++ b/wmh/bench/results.py
@@ -9,10 +9,11 @@ harness.
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 
 from pydantic import BaseModel, Field
+
+from wmh.bench._stats import pop_std
 
 RESULTS_DIRNAME = "results"
 
@@ -87,7 +88,7 @@ class BenchRun(BaseModel):
             sample_turns=sample_turns,
             rollouts=rollouts,
             fidelity_mean=mean,
-            fidelity_std=_pop_std([s.fidelity_mean for s in seeds]),
+            fidelity_std=pop_std([s.fidelity_mean for s in seeds]),
             total_steps=total_steps,
             seeds=seeds,
         )
@@ -116,15 +117,6 @@ def load_runs(results_dir: str | Path) -> list[BenchRun]:
         BenchRun.model_validate_json(p.read_text(encoding="utf-8"))
         for p in sorted(path.glob("*.json"))
     ]
-
-
-def _pop_std(values: list[float]) -> float:
-    """Population standard deviation; 0.0 for fewer than two values."""
-    if len(values) < 2:
-        return 0.0
-    mean = sum(values) / len(values)
-    variance = sum((v - mean) ** 2 for v in values) / len(values)
-    return math.sqrt(variance)
 
 
 __all__ = [

--- a/wmh/bench/results.py
+++ b/wmh/bench/results.py
@@ -1,0 +1,137 @@
+"""Persisted benchmark runs ("filesystem as DB"): one JSON per run in `benchmarks/<name>/results`.
+
+A `BenchRun` is the comparable-over-time record of scoring one prompt against one benchmark: the
+per-seed fidelities (each already a rollout mean + std) and the across-seed aggregate. Runs persist
+so the leaderboard can compare prompts and seeds historically without rerunning. The layout mirrors
+`wmh.tracking.store` (one JSON file per record, dependency-light) so it reads like the rest of the
+harness.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+RESULTS_DIRNAME = "results"
+
+
+class SeedResult(BaseModel):
+    """One seed's fidelity, aggregated over that seed's world-model rollouts."""
+
+    seed: int
+    fidelity_mean: float = 0.0
+    fidelity_std: float = 0.0  # std across the seed's rollouts
+    rollouts: int = 1
+    n_steps: int = 0
+
+
+class BenchRun(BaseModel):
+    """One persisted scoring of a prompt against a benchmark, aggregated across seeds.
+
+    `fidelity_mean` is the step-weighted mean of the per-seed means; `fidelity_std` is the
+    (population) std across seed means — a reproducibility signal distinct from within-seed rollout
+    std. `run_id` and `created_at` are stamped by the caller (no implicit clock here) so runs sort
+    and dedupe deterministically.
+    """
+
+    run_id: str
+    created_at: str = ""  # ISO-8601, stamped by the caller; "" if unknown
+    benchmark: str
+    benchmark_version: str = "0"
+    prompt_label: str
+    sample_turns: str = "all"
+    rollouts: int = 1
+    fidelity_mean: float = 0.0
+    fidelity_std: float = 0.0
+    total_steps: int = 0
+    seeds: list[SeedResult] = Field(default_factory=list)
+
+    @property
+    def seed_values(self) -> list[int]:
+        return [s.seed for s in self.seeds]
+
+    @classmethod
+    def aggregate(
+        cls,
+        *,
+        benchmark: str,
+        benchmark_version: str,
+        prompt_label: str,
+        sample_turns: str,
+        rollouts: int,
+        seeds: list[SeedResult],
+        run_id: str = "",
+        created_at: str = "",
+    ) -> BenchRun:
+        """Roll per-seed results into a benchmark-level mean + across-seed std.
+
+        The mean is step-weighted (a seed that scored more held-out steps counts proportionally) so
+        the overall figure matches what the scorer would report over the pooled steps. The std is
+        the population std of the per-seed means, capturing seed-to-seed reproducibility.
+        """
+        total_steps = sum(s.n_steps for s in seeds)
+        if total_steps:
+            mean = sum(s.fidelity_mean * s.n_steps for s in seeds) / total_steps
+        elif seeds:
+            mean = sum(s.fidelity_mean for s in seeds) / len(seeds)
+        else:
+            mean = 0.0
+        return cls(
+            run_id=run_id,
+            created_at=created_at,
+            benchmark=benchmark,
+            benchmark_version=benchmark_version,
+            prompt_label=prompt_label,
+            sample_turns=sample_turns,
+            rollouts=rollouts,
+            fidelity_mean=mean,
+            fidelity_std=_pop_std([s.fidelity_mean for s in seeds]),
+            total_steps=total_steps,
+            seeds=seeds,
+        )
+
+
+def results_dir_for(benchmark_dir: str | Path) -> Path:
+    """The results directory for a benchmark (`<benchmark_dir>/results/`)."""
+    return Path(benchmark_dir) / RESULTS_DIRNAME
+
+
+def save_run(run: BenchRun, results_dir: str | Path) -> Path:
+    """Write `run` to `<results_dir>/<run_id>.json`, creating the directory if needed."""
+    path = Path(results_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    out = path / f"{run.run_id}.json"
+    out.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+    return out
+
+
+def load_runs(results_dir: str | Path) -> list[BenchRun]:
+    """Load all persisted runs from `results_dir` (empty if the directory doesn't exist)."""
+    path = Path(results_dir)
+    if not path.exists():
+        return []
+    return [
+        BenchRun.model_validate_json(p.read_text(encoding="utf-8"))
+        for p in sorted(path.glob("*.json"))
+    ]
+
+
+def _pop_std(values: list[float]) -> float:
+    """Population standard deviation; 0.0 for fewer than two values."""
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((v - mean) ** 2 for v in values) / len(values)
+    return math.sqrt(variance)
+
+
+__all__ = [
+    "BenchRun",
+    "SeedResult",
+    "RESULTS_DIRNAME",
+    "results_dir_for",
+    "save_run",
+    "load_runs",
+]

--- a/wmh/bench/results_test.py
+++ b/wmh/bench/results_test.py
@@ -1,0 +1,84 @@
+"""Tests for benchmark run persistence + cross-seed aggregation."""
+
+from __future__ import annotations
+
+from wmh.bench.results import BenchRun, SeedResult, load_runs, save_run
+
+
+def _seed(seed: int, mean: float, n_steps: int = 10, std: float = 0.0) -> SeedResult:
+    return SeedResult(seed=seed, fidelity_mean=mean, fidelity_std=std, n_steps=n_steps)
+
+
+def test_aggregate_step_weights_the_mean() -> None:
+    run = BenchRun.aggregate(
+        benchmark="tau",
+        benchmark_version="1",
+        prompt_label="base",
+        sample_turns="all",
+        rollouts=1,
+        seeds=[_seed(0, 0.8, n_steps=10), _seed(1, 0.6, n_steps=30)],
+    )
+    # Step-weighted: (0.8*10 + 0.6*30) / 40 = 0.65, not the unweighted 0.7.
+    assert run.fidelity_mean == 0.65
+    assert run.total_steps == 40
+
+
+def test_aggregate_reports_across_seed_std() -> None:
+    run = BenchRun.aggregate(
+        benchmark="tau",
+        benchmark_version="1",
+        prompt_label="base",
+        sample_turns="all",
+        rollouts=1,
+        seeds=[_seed(0, 1.0), _seed(1, 0.0)],
+    )
+    # Population std of [1.0, 0.0] around mean 0.5 is 0.5.
+    assert run.fidelity_std == 0.5
+
+
+def test_aggregate_single_seed_has_zero_std() -> None:
+    run = BenchRun.aggregate(
+        benchmark="tau",
+        benchmark_version="1",
+        prompt_label="base",
+        sample_turns="all",
+        rollouts=1,
+        seeds=[_seed(0, 0.9)],
+    )
+    assert run.fidelity_std == 0.0
+
+
+def test_aggregate_no_steps_falls_back_to_seed_mean() -> None:
+    run = BenchRun.aggregate(
+        benchmark="tau",
+        benchmark_version="1",
+        prompt_label="base",
+        sample_turns="all",
+        rollouts=1,
+        seeds=[_seed(0, 0.4, n_steps=0), _seed(1, 0.6, n_steps=0)],
+    )
+    assert run.fidelity_mean == 0.5  # unweighted when no steps were scored
+    assert run.total_steps == 0
+
+
+def test_save_then_load_round_trips(tmp_path) -> None:  # noqa: ANN001
+    run = BenchRun.aggregate(
+        benchmark="tau",
+        benchmark_version="1",
+        prompt_label="base",
+        sample_turns="all",
+        rollouts=2,
+        seeds=[_seed(0, 0.8)],
+        run_id="abc123",
+        created_at="2026-06-26T00:00:00+00:00",
+    )
+    save_run(run, tmp_path / "results")
+    loaded = load_runs(tmp_path / "results")
+    assert len(loaded) == 1
+    assert loaded[0].run_id == "abc123"
+    assert loaded[0].fidelity_mean == 0.8
+    assert loaded[0].seed_values == [0]
+
+
+def test_load_missing_dir_is_empty(tmp_path) -> None:  # noqa: ANN001
+    assert load_runs(tmp_path / "nope") == []

--- a/wmh/bench/runner.py
+++ b/wmh/bench/runner.py
@@ -1,0 +1,107 @@
+"""Run a benchmark reproducibly and aggregate the rollout distribution as MEAN + STD.
+
+The scoring unit — replay a held-out trace teacher-forced and judge predicted vs. real observation —
+belongs to the open-loop eval scorer (`wmh.engine.eval`). This runner sits on top: for each seed in
+the benchmark's `EvalConfig`, it scores the prompt once (the scorer draws `rollouts` world-model
+samples internally and returns their mean + std), then rolls the per-seed results into one
+`SeedResult` apiece. `wmh.bench.results.BenchRun` is the persisted aggregate over all seeds.
+
+`ScoreOnce` is the thin seam over the scorer so this module stays testable with a fake and so the
+real `evaluate` API can drop in at one place. See `wmh.bench.scoring` for the production binding.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel
+
+from wmh.bench.definition import BenchmarkDef, SampleTurns
+from wmh.bench.results import BenchRun, SeedResult
+
+
+class RolloutScore(BaseModel):
+    """One seed's fidelity, already aggregated over the seed's `rollouts` world-model samples.
+
+    `fidelity_mean`/`fidelity_std` summarize the rollout distribution (std is 0 when `rollouts == 1`
+    or the scorer doesn't yet expose per-rollout scores). `n_steps` is the count of held-out steps
+    scored, used to step-weight the benchmark overall.
+    """
+
+    fidelity_mean: float = 0.0
+    fidelity_std: float = 0.0
+    n_steps: int = 0
+    rollouts: int = 1
+
+
+class ScoreOnce(Protocol):
+    """Score one prompt against a set of trace files for a single seed.
+
+    The implementation draws `rollouts` world-model samples per scored turn and returns their
+    aggregate. `sample_turns` is `"all"` or the per-trace turn cap (Qwen-AgentWorld uses 5).
+    """
+
+    def __call__(
+        self,
+        files: list[Path],
+        prompt: str,
+        *,
+        sample_turns: SampleTurns,
+        rollouts: int,
+        temperature: float,
+        seed: int,
+    ) -> RolloutScore: ...
+
+
+# A hook called after each seed is scored, for progress reporting (seed, index, total).
+SeedCallback = Callable[[int, int, int], None]
+
+
+def run_benchmark(
+    bench: BenchmarkDef,
+    prompt: str,
+    prompt_label: str,
+    score_once: ScoreOnce,
+    *,
+    on_seed: SeedCallback | None = None,
+) -> BenchRun:
+    """Execute `bench` against `prompt`, scoring once per configured seed, into a `BenchRun`.
+
+    `prompt_label` names the scored prompt in the persisted result (e.g. a model name or prompt
+    file). Trace paths are resolved relative to the benchmark dir. The overall fidelity is the
+    step-weighted mean of the per-seed means; the across-seed std measures reproducibility.
+    """
+    files = bench.trace_files()
+    cfg = bench.eval
+    seeds: list[SeedResult] = []
+    for i, seed in enumerate(cfg.seeds):
+        score = score_once(
+            files,
+            prompt,
+            sample_turns=cfg.sample_turns,
+            rollouts=cfg.rollouts,
+            temperature=cfg.temperature,
+            seed=seed,
+        )
+        seeds.append(
+            SeedResult(
+                seed=seed,
+                fidelity_mean=score.fidelity_mean,
+                fidelity_std=score.fidelity_std,
+                rollouts=score.rollouts,
+                n_steps=score.n_steps,
+            )
+        )
+        if on_seed is not None:
+            on_seed(seed, i + 1, len(cfg.seeds))
+
+    return BenchRun.aggregate(
+        benchmark=bench.name,
+        benchmark_version=bench.version,
+        prompt_label=prompt_label,
+        sample_turns=cfg.sample_turns,
+        rollouts=cfg.rollouts,
+        seeds=seeds,
+    )

--- a/wmh/bench/runner_test.py
+++ b/wmh/bench/runner_test.py
@@ -1,0 +1,69 @@
+"""Tests for the benchmark runner: one scoring pass per seed, aggregated into a BenchRun."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.bench.definition import BenchmarkDef, EvalConfig
+from wmh.bench.runner import RolloutScore, run_benchmark
+
+
+def _bench(tmp_path, seeds: list[int]) -> BenchmarkDef:  # noqa: ANN001 - pytest path
+    return BenchmarkDef(
+        name="tau",
+        version="1",
+        traces=["a.jsonl"],
+        eval=EvalConfig(seeds=seeds, rollouts=2, temperature=0.7),
+        dir=tmp_path,
+    )
+
+
+def test_runs_one_score_pass_per_seed() -> None:
+    seen: list[int] = []
+
+    def score_once(files, prompt, *, sample_turns, rollouts, temperature, seed):  # noqa: ANN001, ANN202
+        seen.append(seed)
+        # Echo the knobs back so we can assert they flow through from the config.
+        assert rollouts == 2
+        assert temperature == 0.7
+        assert sample_turns == "all"
+        return RolloutScore(fidelity_mean=0.8, fidelity_std=0.1, n_steps=10, rollouts=rollouts)
+
+    bench = _bench(Path("/tmp"), seeds=[0, 1, 7])
+    run = run_benchmark(bench, "PROMPT", "base", score_once)
+
+    assert seen == [0, 1, 7]
+    assert run.benchmark == "tau"
+    assert run.prompt_label == "base"
+    assert run.rollouts == 2
+    assert run.fidelity_mean == 0.8  # all seeds equal -> mean 0.8
+    assert run.fidelity_std == pytest.approx(0.0)  # no spread across seeds
+    assert run.total_steps == 30
+    assert run.seed_values == [0, 1, 7]
+
+
+def test_aggregates_across_seed_variance() -> None:
+    scores = {0: 1.0, 1: 0.0}
+
+    def score_once(files, prompt, *, sample_turns, rollouts, temperature, seed):  # noqa: ANN001, ANN202
+        return RolloutScore(fidelity_mean=scores[seed], n_steps=10, rollouts=rollouts)
+
+    bench = _bench(Path("/tmp"), seeds=[0, 1])
+    run = run_benchmark(bench, "PROMPT", "base", score_once)
+    assert run.fidelity_mean == 0.5
+    assert run.fidelity_std == 0.5  # population std of [1.0, 0.0]
+
+
+def test_on_seed_callback_fires_per_seed() -> None:
+    progress: list[tuple[int, int, int]] = []
+
+    def score_once(files, prompt, *, sample_turns, rollouts, temperature, seed):  # noqa: ANN001, ANN202
+        return RolloutScore(fidelity_mean=0.5, n_steps=5, rollouts=rollouts)
+
+    bench = _bench(Path("/tmp"), seeds=[3, 4])
+    run_benchmark(
+        bench, "PROMPT", "base", score_once, on_seed=lambda s, d, t: progress.append((s, d, t))
+    )
+    assert progress == [(3, 1, 2), (4, 2, 2)]

--- a/wmh/bench/scoring.py
+++ b/wmh/bench/scoring.py
@@ -1,0 +1,95 @@
+"""Production binding of the `ScoreOnce` seam to the open-loop eval scorer.
+
+This is the ONE place that touches the scorer API, so when the eval-scorer chat's open-loop
+`evaluate_files(..., rollouts, temperature, sample_turns, seed)` lands we collapse this to a single
+call here and nowhere else. On `main` today `evaluate_files` doesn't yet take those knobs, so we
+draw `rollouts` independent samples ourselves and aggregate their overall fidelity as mean + std —
+exactly the rollout distribution the benchmark reports. `sample_turns`/`seed` are part of the
+reproducible contract and flow through unchanged until that scorer merges.
+
+    # TODO: replace with the open-loop wmh.engine.eval.evaluate_files once chat 1 (eval scorer)
+    # merges. Its EvalReport already exposes the rollout aggregate, so this whole loop collapses to:
+    #   report = evaluate_files(files, prompt, provider, judge, embedder=embedder,
+    #                           train_split=..., top_k=..., rollouts=rollouts,
+    #                           temperature=temperature, sample_turns=sample_turns, seed=seed)
+    #   return RolloutScore(fidelity_mean=report.overall_fidelity,
+    #                       fidelity_std=report.overall_std, n_steps=report.total_steps,
+    #                       rollouts=report.rollouts)
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from wmh.bench.definition import JudgeConfig, SampleTurns
+from wmh.bench.runner import RolloutScore
+from wmh.engine.eval import evaluate_files
+from wmh.optimize.judge import LLMJudge
+from wmh.providers import ProviderConfig, ProviderKind, get_provider
+from wmh.retrieval import HashingEmbedder
+
+
+def evaluate_files_once(
+    files: list[Path],
+    prompt: str,
+    judge_config: JudgeConfig,
+    *,
+    sample_turns: SampleTurns,
+    rollouts: int,
+    temperature: float,
+    seed: int,
+    train_split: float = 0.7,
+    top_k: int = 5,
+    no_rag: bool = False,
+    embed_dim: int = 512,
+) -> RolloutScore:
+    """Score `prompt` against `files` for one seed, aggregating `rollouts` samples as mean + std.
+
+    Builds the judge/serve provider from `judge_config` (the benchmark pins the grader for
+    reproducibility), then replays the held-out steps once per rollout. At `temperature` > 0 each
+    rollout's overall fidelity differs, so we report the mean and population std over them.
+    `sample_turns`/`seed` ride along for the open-loop scorer (see the module TODO).
+    """
+    provider = get_provider(
+        ProviderConfig(
+            kind=ProviderKind(judge_config.provider),
+            model=judge_config.model,
+            region=judge_config.region,
+        )
+    )
+    judge = LLMJudge(provider)
+    embedder = None if no_rag else HashingEmbedder(dim=embed_dim)
+
+    fidelities: list[float] = []
+    total_steps = 0
+    for _ in range(max(1, rollouts)):
+        report = evaluate_files(
+            files,
+            prompt,
+            provider,
+            judge,
+            embedder=embedder,
+            train_split=train_split,
+            top_k=top_k,
+        )
+        fidelities.append(report.overall_fidelity)
+        total_steps = report.total_steps  # stable across rollouts (same held-out split)
+
+    _ = (sample_turns, temperature, seed)  # forwarded to the open-loop scorer on merge (see TODO)
+    return RolloutScore(
+        fidelity_mean=sum(fidelities) / len(fidelities),
+        fidelity_std=_pop_std(fidelities),
+        n_steps=total_steps,
+        rollouts=len(fidelities),
+    )
+
+
+def _pop_std(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return math.sqrt(sum((v - mean) ** 2 for v in values) / len(values))
+
+
+__all__ = ["evaluate_files_once"]

--- a/wmh/bench/scoring.py
+++ b/wmh/bench/scoring.py
@@ -1,20 +1,15 @@
 """Production binding of the `ScoreOnce` seam to the open-loop eval scorer.
 
-This is the ONE place that touches the scorer API, so when the eval-scorer chat's open-loop
-`evaluate_files(..., rollouts, temperature, sample_turns, seed)` lands we collapse this to a single
-call here and nowhere else. On `main` today `evaluate_files` doesn't yet take those knobs, so we
-draw `rollouts` independent samples ourselves and aggregate their overall fidelity as mean + std —
-exactly the rollout distribution the benchmark reports. `sample_turns`/`seed` are part of the
-reproducible contract and flow through unchanged until that scorer merges.
+This is the ONE place the benchmark layer touches the scorer API. It builds the reference-grounded
+`RubricJudge` (the open-loop fidelity grader — five dimensions, mean as the headline score) and
+replays the held-out steps via `wmh.engine.eval.evaluate_files`, which returns an `EvalReport` whose
+`overall_fidelity`/`overall_std`/`total_steps` we read directly.
 
-    # TODO: replace with the open-loop wmh.engine.eval.evaluate_files once chat 1 (eval scorer)
-    # merges. Its EvalReport already exposes the rollout aggregate, so this whole loop collapses to:
-    #   report = evaluate_files(files, prompt, provider, judge, embedder=embedder,
-    #                           train_split=..., top_k=..., rollouts=rollouts,
-    #                           temperature=temperature, sample_turns=sample_turns, seed=seed)
-    #   return RolloutScore(fidelity_mean=report.overall_fidelity,
-    #                       fidelity_std=report.overall_std, n_steps=report.total_steps,
-    #                       rollouts=report.rollouts)
+`rollouts`/`temperature` are reproducibility knobs reserved for when the providers forward a
+sampling temperature: `evaluate_files` is deterministic today (no temperature plumbing), so extra
+rollouts reproduce identical scores. We still loop `rollouts` times so the mean±std machinery is
+wired end-to-end — at the committed `rollouts=1` that is a single call, and the per-seed std is 0
+until either `rollouts` > 1 with temperature support, or multiple `seeds` produce a spread.
 """
 
 from __future__ import annotations
@@ -25,7 +20,7 @@ from wmh.bench._stats import pop_std
 from wmh.bench.definition import JudgeConfig, SampleTurns
 from wmh.bench.runner import RolloutScore
 from wmh.engine.eval import evaluate_files
-from wmh.optimize.judge import LLMJudge
+from wmh.optimize.judge import RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, get_provider
 from wmh.retrieval import HashingEmbedder
 
@@ -46,10 +41,11 @@ def evaluate_files_once(
 ) -> RolloutScore:
     """Score `prompt` against `files` for one seed, aggregating `rollouts` samples as mean + std.
 
-    Builds the judge/serve provider from `judge_config` (the benchmark pins the grader for
-    reproducibility), then replays the held-out steps once per rollout. At `temperature` > 0 each
-    rollout's overall fidelity differs, so we report the mean and population std over them.
-    `sample_turns`/`seed` ride along for the open-loop scorer (see the module TODO).
+    Builds the serve provider + `RubricJudge` from `judge_config` (the benchmark pins the grader
+    for reproducibility), then replays the held-out steps once per rollout, forwarding
+    `sample_turns` and `seed` to the scorer. `temperature` is accepted for forward-compatibility but
+    inert until the providers forward a sampling temperature (see the module docstring), so rollouts
+    currently reproduce identical scores.
     """
     provider = get_provider(
         ProviderConfig(
@@ -58,7 +54,7 @@ def evaluate_files_once(
             region=judge_config.region,
         )
     )
-    judge = LLMJudge(provider)
+    judge = RubricJudge(provider)
     embedder = None if no_rag else HashingEmbedder(dim=embed_dim)
 
     fidelities: list[float] = []
@@ -72,11 +68,13 @@ def evaluate_files_once(
             embedder=embedder,
             train_split=train_split,
             top_k=top_k,
+            sample_turns=sample_turns,
+            seed=seed,
         )
         fidelities.append(report.overall_fidelity)
         total_steps = report.total_steps  # stable across rollouts (same held-out split)
 
-    _ = (sample_turns, temperature, seed)  # forwarded to the open-loop scorer on merge (see TODO)
+    _ = temperature  # reserved; inert until the providers forward a sampling temperature
     return RolloutScore(
         fidelity_mean=sum(fidelities) / len(fidelities),
         fidelity_std=pop_std(fidelities),

--- a/wmh/bench/scoring.py
+++ b/wmh/bench/scoring.py
@@ -19,9 +19,9 @@ reproducible contract and flow through unchanged until that scorer merges.
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 
+from wmh.bench._stats import pop_std
 from wmh.bench.definition import JudgeConfig, SampleTurns
 from wmh.bench.runner import RolloutScore
 from wmh.engine.eval import evaluate_files
@@ -79,17 +79,10 @@ def evaluate_files_once(
     _ = (sample_turns, temperature, seed)  # forwarded to the open-loop scorer on merge (see TODO)
     return RolloutScore(
         fidelity_mean=sum(fidelities) / len(fidelities),
-        fidelity_std=_pop_std(fidelities),
+        fidelity_std=pop_std(fidelities),
         n_steps=total_steps,
         rollouts=len(fidelities),
     )
-
-
-def _pop_std(values: list[float]) -> float:
-    if len(values) < 2:
-        return 0.0
-    mean = sum(values) / len(values)
-    return math.sqrt(sum((v - mean) ** 2 for v in values) / len(values))
 
 
 __all__ = ["evaluate_files_once"]

--- a/wmh/bench/scoring_test.py
+++ b/wmh/bench/scoring_test.py
@@ -20,7 +20,7 @@ def test_aggregates_rollouts_as_mean_and_std(monkeypatch) -> None:  # noqa: ANN0
         return EvalReport(overall_fidelity=next(fidelities), total_steps=12)
 
     monkeypatch.setattr(scoring, "get_provider", lambda config: object())
-    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(scoring, "RubricJudge", lambda provider: object())
     monkeypatch.setattr(scoring, "evaluate_files", fake_evaluate)
 
     score = evaluate_files_once(
@@ -40,7 +40,7 @@ def test_aggregates_rollouts_as_mean_and_std(monkeypatch) -> None:  # noqa: ANN0
 
 def test_single_rollout_has_zero_std(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(scoring, "get_provider", lambda config: object())
-    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(scoring, "RubricJudge", lambda provider: object())
     monkeypatch.setattr(
         scoring,
         "evaluate_files",
@@ -67,7 +67,7 @@ def test_no_rag_skips_embedder(monkeypatch) -> None:  # noqa: ANN001
         return EvalReport(overall_fidelity=0.5, total_steps=3)
 
     monkeypatch.setattr(scoring, "get_provider", lambda config: object())
-    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(scoring, "RubricJudge", lambda provider: object())
     monkeypatch.setattr(scoring, "evaluate_files", fake_evaluate)
 
     evaluate_files_once(

--- a/wmh/bench/scoring_test.py
+++ b/wmh/bench/scoring_test.py
@@ -1,0 +1,83 @@
+"""Tests for the ScoreOnce binding to the eval scorer (fake scorer + provider, no network)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import wmh.bench.scoring as scoring
+from wmh.bench.definition import JudgeConfig
+from wmh.bench.scoring import evaluate_files_once
+from wmh.engine.eval import EvalReport
+
+
+def test_aggregates_rollouts_as_mean_and_std(monkeypatch) -> None:  # noqa: ANN001
+    # The scorer returns a different overall fidelity per rollout; the binding should mean+std them.
+    fidelities = iter([0.2, 0.8])
+
+    def fake_evaluate(files, prompt, provider, judge, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        return EvalReport(overall_fidelity=next(fidelities), total_steps=12)
+
+    monkeypatch.setattr(scoring, "get_provider", lambda config: object())
+    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(scoring, "evaluate_files", fake_evaluate)
+
+    score = evaluate_files_once(
+        [Path("a.jsonl")],
+        "PROMPT",
+        JudgeConfig(),
+        sample_turns="all",
+        rollouts=2,
+        temperature=0.7,
+        seed=0,
+    )
+    assert score.rollouts == 2
+    assert score.fidelity_mean == 0.5  # mean(0.2, 0.8)
+    assert score.fidelity_std == pytest.approx(0.3)  # population std around 0.5
+    assert score.n_steps == 12
+
+
+def test_single_rollout_has_zero_std(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(scoring, "get_provider", lambda config: object())
+    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(
+        scoring,
+        "evaluate_files",
+        lambda *a, **k: EvalReport(overall_fidelity=0.9, total_steps=5),
+    )
+    score = evaluate_files_once(
+        [Path("a.jsonl")],
+        "PROMPT",
+        JudgeConfig(),
+        sample_turns="all",
+        rollouts=1,
+        temperature=0.0,
+        seed=0,
+    )
+    assert score.fidelity_mean == 0.9
+    assert score.fidelity_std == 0.0
+
+
+def test_no_rag_skips_embedder(monkeypatch) -> None:  # noqa: ANN001
+    captured: dict[str, object] = {}
+
+    def fake_evaluate(files, prompt, provider, judge, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        captured["embedder"] = kwargs.get("embedder")
+        return EvalReport(overall_fidelity=0.5, total_steps=3)
+
+    monkeypatch.setattr(scoring, "get_provider", lambda config: object())
+    monkeypatch.setattr(scoring, "LLMJudge", lambda provider: object())
+    monkeypatch.setattr(scoring, "evaluate_files", fake_evaluate)
+
+    evaluate_files_once(
+        [Path("a.jsonl")],
+        "PROMPT",
+        JudgeConfig(),
+        sample_turns="all",
+        rollouts=1,
+        temperature=0.0,
+        seed=0,
+        no_rag=True,
+    )
+    assert captured["embedder"] is None

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -26,11 +26,19 @@ from wmh.providers.base import EmbedderKind
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
 providers_app = typer.Typer(help="Manage and verify LLM providers.")
 app.add_typer(providers_app, name="providers")
+bench_app = typer.Typer(
+    help="Run benchmarks (open-loop fidelity) and view the leaderboard.",
+    invoke_without_command=True,
+)
+app.add_typer(bench_app, name="bench")
 _console = Console()
 _CHECK = "[green]✓[/green]"
 
 # Module-level singleton: a typer.Argument call can't be a default inline (ruff B008).
 _EVAL_FILES = typer.Argument(..., help="OTel trace files to score (one corpus each).")
+
+# Where committed benchmark definitions live ("filesystem as DB"); shared with the infra chat.
+BENCHMARKS_DIR = "benchmarks"
 
 
 @providers_app.command("verify")
@@ -388,6 +396,165 @@ def play(
 
     wm, resolved_name, _provider = _load_model(name, root)
     run_play_repl(_console, wm, resolved_name, task)
+
+
+@bench_app.callback()
+def bench(
+    ctx: typer.Context,
+    benchmarks: str = typer.Option(BENCHMARKS_DIR, "--benchmarks", help="Benchmark defs dir."),
+) -> None:
+    """With no subcommand, render the leaderboard over all persisted benchmark runs."""
+    if ctx.invoked_subcommand is not None:
+        return
+    from wmh.bench import build_leaderboard, discover_benchmarks, load_runs, results_dir_for
+    from wmh.cli.ui import leaderboard_table
+
+    defs = discover_benchmarks(benchmarks)
+    if not defs:
+        _console.print(
+            f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
+            "add one as benchmarks/<name>/benchmark.toml"
+        )
+        return
+    runs = [run for d in defs for run in load_runs(results_dir_for(d.dir))]
+    rows = build_leaderboard(runs)
+    if not rows:
+        _console.print(
+            "[yellow]no benchmark runs yet[/yellow]; score one with `wmh bench run <name>`"
+        )
+        return
+    _console.print(leaderboard_table(rows))
+
+
+@bench_app.command("list")
+def bench_list(
+    benchmarks: str = typer.Option(BENCHMARKS_DIR, "--benchmarks", help="Benchmark defs dir."),
+) -> None:
+    """List every committed benchmark definition and its eval config."""
+    from wmh.bench import discover_benchmarks
+    from wmh.cli.ui import benchmarks_table
+
+    defs = discover_benchmarks(benchmarks)
+    if not defs:
+        _console.print(
+            f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
+            "add one as benchmarks/<name>/benchmark.toml"
+        )
+        return
+    _console.print(benchmarks_table(defs))
+
+
+@bench_app.command("run")
+def bench_run(
+    name: str = typer.Argument(..., help="Benchmark name (benchmarks/<name>/benchmark.toml)."),
+    model: str = typer.Option(
+        None, "--model", help="Built world model whose optimized prompt to score (under --root)."
+    ),
+    prompt_file: str = typer.Option(None, "--prompt", help="Prompt file to score; default=BASE."),
+    benchmarks: str = typer.Option(BENCHMARKS_DIR, "--benchmarks", help="Benchmark defs dir."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (for --model)."),
+) -> None:
+    """Score a world-model prompt against a benchmark, persist the run, and print mean±std.
+
+    The prompt comes from `--model` (a built model's optimized prompt), `--prompt` (a file), or the
+    bundled `BASE_ENV_PROMPT`. The benchmark's own `benchmark.toml` fixes the eval config — sample
+    turns, rollouts, seeds, judge — so a run is reproducible. Results land under
+    `benchmarks/<name>/results/` for the leaderboard.
+    """
+    import uuid
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    from wmh.bench import (
+        BenchmarkDef,
+        evaluate_files_once,
+        load_benchmark,
+        results_dir_for,
+        run_benchmark,
+        save_run,
+    )
+
+    bench_dir = Path(benchmarks) / name
+    try:
+        bench_def: BenchmarkDef = load_benchmark(bench_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    missing = bench_def.missing_traces()
+    if missing:
+        raise typer.BadParameter(
+            f"benchmark {name!r} references missing trace files: "
+            + ", ".join(str(p) for p in missing)
+        )
+
+    prompt, prompt_label = _resolve_prompt(model, prompt_file, root)
+
+    def on_seed(seed: int, done: int, total: int) -> None:
+        _console.print(f"  [dim]scored seed {seed} ({done}/{total})[/dim]")
+
+    _console.print(
+        f"[bold]running[/bold] {name} (v{bench_def.version}) "
+        f"against [cyan]{prompt_label}[/cyan]: "
+        f"{len(bench_def.eval.seeds)} seed(s) × {bench_def.eval.rollouts} rollout(s)"
+    )
+
+    def score_once(  # noqa: ANN202 - returns wmh.bench.RolloutScore; signature matches ScoreOnce
+        files,  # noqa: ANN001
+        prompt: str,
+        *,
+        sample_turns,  # noqa: ANN001
+        rollouts: int,
+        temperature: float,
+        seed: int,
+    ):
+        return evaluate_files_once(
+            files,
+            prompt,
+            bench_def.eval.judge,
+            sample_turns=sample_turns,
+            rollouts=rollouts,
+            temperature=temperature,
+            seed=seed,
+            train_split=bench_def.eval.train_split,
+            top_k=bench_def.eval.top_k,
+            no_rag=bench_def.eval.no_rag,
+            embed_dim=bench_def.eval.embed_dim,
+        )
+
+    run = run_benchmark(bench_def, prompt, prompt_label, score_once, on_seed=on_seed)
+    run.run_id = uuid.uuid4().hex
+    run.created_at = datetime.now(UTC).isoformat(timespec="seconds")
+    out = save_run(run, results_dir_for(bench_def.dir))
+
+    _console.print(
+        f"[bold]{name}[/bold] fidelity={run.fidelity_mean:.3f} ± {run.fidelity_std:.3f} "
+        f"over {len(run.seeds)} seed(s), {run.total_steps} held-out steps"
+    )
+    _console.print(f"[dim]wrote run {run.run_id[:8]} -> {out}[/dim]")
+
+
+def _resolve_prompt(model: str | None, prompt_file: str | None, root: str) -> tuple[str, str]:
+    """Resolve the prompt to score + a human label, from --model, --prompt, or the base prompt."""
+    from pathlib import Path
+
+    from wmh.config import ArtifactPaths
+    from wmh.engine.prompts import BASE_ENV_PROMPT
+
+    if model is not None and prompt_file is not None:
+        raise typer.BadParameter("pass at most one of --model / --prompt")
+    if model is not None:
+        store = WorldModelStore(root)
+        try:
+            model_dir = store.resolve(model)
+        except (FileNotFoundError, ValueError) as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        optimized = ArtifactPaths(model_dir).optimized_prompt
+        if not optimized.exists():
+            raise typer.BadParameter(f"model {model!r} has no optimized prompt at {optimized}")
+        return optimized.read_text(encoding="utf-8"), model
+    if prompt_file is not None:
+        return Path(prompt_file).read_text(encoding="utf-8"), Path(prompt_file).stem
+    return BASE_ENV_PROMPT, "base"
 
 
 def _resolve_name(store: WorldModelStore, name: str | None) -> str:

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -523,7 +523,9 @@ def bench_run(
 
     run = run_benchmark(bench_def, prompt, prompt_label, score_once, on_seed=on_seed)
     run.run_id = uuid.uuid4().hex
-    run.created_at = datetime.now(UTC).isoformat(timespec="seconds")
+    # Microsecond precision so two runs of the same prompt seconds apart still order by recency on
+    # the leaderboard (created_at is the primary "latest" key; see wmh.bench.leaderboard._newer).
+    run.created_at = datetime.now(UTC).isoformat(timespec="microseconds")
     out = save_run(run, results_dir_for(bench_def.dir))
 
     _console.print(

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -124,6 +124,11 @@ def test_providers_subcommand_is_registered() -> None:
     assert "providers" in group_names
 
 
+def test_bench_subcommand_is_registered() -> None:
+    group_names = {group.name for group in app.registered_groups}
+    assert "bench" in group_names
+
+
 def test_build_then_list_shows_named_model(patched_provider, tmp_path) -> None:  # noqa: ANN001
     root = tmp_path / ".wmh"
     _build(root, "tau2-airline", tmp_path)
@@ -287,3 +292,82 @@ def test_providers_verify_reports_built_model_provider(patched_provider, tmp_pat
     assert result.exit_code == 0, result.output
     # The bedrock provider configured at build time shows up in the verify report.
     assert "bedrock" in result.output
+
+
+# --- bench commands ------------------------------------------------------------------------------
+
+
+def _benchmark(benchmarks_root, name: str, tmp_path) -> None:  # noqa: ANN001 - pytest paths
+    """Write a benchmark definition under <benchmarks_root>/<name>/ pointing at a real trace."""
+    bench_dir = benchmarks_root / name
+    bench_dir.mkdir(parents=True)
+    trace = _traces_file(tmp_path)
+    (bench_dir / "benchmark.toml").write_text(
+        f'version = "1"\ntraces = ["{trace}"]\n[eval]\nseeds = [0]\n', encoding="utf-8"
+    )
+
+
+def test_bench_list_shows_definitions(tmp_path) -> None:  # noqa: ANN001
+    benchmarks = tmp_path / "benchmarks"
+    _benchmark(benchmarks, "tau-bench", tmp_path)
+    result = runner.invoke(app, ["bench", "list", "--benchmarks", str(benchmarks)])
+    assert result.exit_code == 0, result.output
+    assert "tau-bench" in result.output
+
+
+def test_bench_list_empty_is_friendly(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["bench", "list", "--benchmarks", str(tmp_path / "benchmarks")])
+    assert result.exit_code == 0
+    assert "no benchmarks" in result.output
+
+
+def test_bench_leaderboard_empty_is_friendly(tmp_path) -> None:  # noqa: ANN001
+    benchmarks = tmp_path / "benchmarks"
+    _benchmark(benchmarks, "tau-bench", tmp_path)
+    # Defined but never run: bare `wmh bench` reports no runs yet.
+    result = runner.invoke(app, ["bench", "--benchmarks", str(benchmarks)])
+    assert result.exit_code == 0, result.output
+    assert "no benchmark runs yet" in result.output
+
+
+def test_bench_run_then_leaderboard(monkeypatch, tmp_path) -> None:  # noqa: ANN001
+    import wmh.bench as bench_pkg
+    from wmh.bench.runner import RolloutScore
+
+    # Fake the scorer so the run does no LLM work; the runner + persistence + leaderboard are real.
+    def fake_score(files, prompt, judge_config, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        return RolloutScore(fidelity_mean=0.75, fidelity_std=0.05, n_steps=4, rollouts=1)
+
+    monkeypatch.setattr(bench_pkg, "evaluate_files_once", fake_score)
+
+    benchmarks = tmp_path / "benchmarks"
+    _benchmark(benchmarks, "tau-bench", tmp_path)
+
+    run = runner.invoke(app, ["bench", "run", "tau-bench", "--benchmarks", str(benchmarks)])
+    assert run.exit_code == 0, run.output
+    assert "0.750" in run.output
+    # The run persisted under the benchmark's results/ dir.
+    assert list((benchmarks / "tau-bench" / "results").glob("*.json"))
+
+    board = runner.invoke(app, ["bench", "--benchmarks", str(benchmarks)])
+    assert board.exit_code == 0, board.output
+    assert "tau-bench" in board.output
+    assert "0.750" in board.output
+
+
+def test_bench_run_unknown_benchmark_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app, ["bench", "run", "ghost", "--benchmarks", str(tmp_path / "benchmarks")]
+    )
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, (FileNotFoundError, ValueError))
+
+
+def test_bench_run_missing_trace_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    benchmarks = tmp_path / "benchmarks"
+    bench_dir = benchmarks / "tau-bench"
+    bench_dir.mkdir(parents=True)
+    (bench_dir / "benchmark.toml").write_text('traces = ["gone.jsonl"]\n', encoding="utf-8")
+    result = runner.invoke(app, ["bench", "run", "tau-bench", "--benchmarks", str(benchmarks)])
+    assert result.exit_code != 0
+    assert "missing" in result.output

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -34,6 +34,8 @@ from rich.progress import (
 )
 from rich.table import Table
 
+from wmh.bench.definition import BenchmarkDef
+from wmh.bench.leaderboard import LeaderboardRow
 from wmh.config import PROVIDER_ENV_VARS, ModelInfo, validate_name
 from wmh.core.types import Action, ActionKind, Session
 from wmh.engine.play import PlayTurn, parse_action, play_turn
@@ -370,6 +372,56 @@ def build_summary_panel(info: ModelInfo, root: str) -> Panel:
         subtitle="serve it with `wmh serve` or step into it with `wmh play`",
         border_style="green",
     )
+
+
+def benchmarks_table(defs: list[BenchmarkDef]) -> Table:
+    """A table of committed benchmark definitions (for `wmh bench list`)."""
+    table = Table(title="benchmarks")
+    table.add_column("name", style="bold")
+    table.add_column("version", justify="right")
+    table.add_column("traces", justify="right")
+    table.add_column("sample", justify="right")
+    table.add_column("rollouts", justify="right")
+    table.add_column("seeds", justify="right")
+    table.add_column("judge")
+    for d in defs:
+        n_traces = len(d.traces)
+        missing = len(d.missing_traces())
+        traces_cell = str(n_traces) if not missing else f"[red]{n_traces} ({missing} missing)[/red]"
+        sample = "all" if d.eval.sample_turns == "all" else str(d.eval.sample_turns)
+        table.add_row(
+            d.name,
+            d.version,
+            traces_cell,
+            sample,
+            str(d.eval.rollouts),
+            str(len(d.eval.seeds)),
+            d.eval.judge.model,
+        )
+    return table
+
+
+def leaderboard_table(rows: list[LeaderboardRow]) -> Table:
+    """The leaderboard: each prompt's latest fidelity per benchmark (for bare `wmh bench`)."""
+    table = Table(title="leaderboard (open-loop fidelity)")
+    table.add_column("benchmark", style="bold")
+    table.add_column("prompt")
+    table.add_column("fidelity", justify="right")
+    table.add_column("sample", justify="right")
+    table.add_column("rollouts", justify="right")
+    table.add_column("seeds", justify="right")
+    table.add_column("steps", justify="right")
+    for r in rows:
+        table.add_row(
+            r.benchmark,
+            r.prompt_label,
+            f"{r.fidelity_mean:.3f} ± {r.fidelity_std:.3f}",
+            r.sample_turns,
+            str(r.rollouts),
+            str(r.n_seeds),
+            str(r.total_steps),
+        )
+    return table
 
 
 def models_table(infos: list[ModelInfo]) -> Table:


### PR DESCRIPTION
## What

Adds `wmh/bench/` — a benchmark domain layered on the open-loop eval scorer — and the `wmh bench` CLI. A **benchmark** becomes a first-class, committed, reproducible object: a named set of recorded trace files + an eval config, scored against a world-model prompt, with results persisted ("filesystem as DB") and surfaced on a leaderboard.

The scoring unit (replay a held-out step teacher-forced, judge predicted vs. real observation) belongs to `wmh.engine.eval` — this package never reimplements it. It calls it once per rollout and aggregates as **mean ± std** (the world model runs at temperature > 0, so a step yields a score distribution).

## Surface

- `wmh bench run <name>` — score a prompt against a benchmark (`--model <built>` / `--prompt <file>` / bundled base), per seed, aggregate to mean ± std, persist a `BenchRun`.
- `wmh bench list` — every committed benchmark + its eval config.
- `wmh bench` — leaderboard (rich table) over all persisted runs: latest run per (benchmark, prompt), ranked by fidelity.

## Layout

- `wmh/bench/definition.py` — `benchmarks/<name>/benchmark.toml` load/discover (sample_turns `all`|`sampled`, rollouts, temperature, seeds, pinned judge); relative trace resolution.
- `wmh/bench/runner.py` — seed sweep over a thin `ScoreOnce` seam → `BenchRun`.
- `wmh/bench/scoring.py` — the ONE binding to `wmh.engine.eval.evaluate_files`.
- `wmh/bench/results.py` — persist/load run JSON under `benchmarks/<name>/results/` (gitignored); step-weighted mean + across-seed std.
- `wmh/bench/leaderboard.py` — rank persisted runs.
- Canonical `benchmarks/tau-bench/benchmark.toml` pointing at the shared `examples/` corpus.
- Tables in `wmh/cli/ui.py`; thin commands in `wmh/cli/app.py`.

## Coordination (I merge last; consumes the other three chats)

- **`wmh/bench/` is shared with the benchmark-infra chat** (capture half). Files are disjoint except `__init__.py` — on rebase, merge the two export lists. `BenchmarkDef` (mine) ≠ `BenchmarkSpec` (theirs).
- **Eval scorer (chat 1) already ships the open-loop `evaluate_files(..., rollouts, temperature, sample_turns, seed)`.** This branch is based on the older main, so `scoring.py` keeps a manual rollout loop with a `# TODO` to collapse to one `evaluate_files` call on rebase. `sample_turns` literal matches theirs (`all`|`sampled`).
- GEPA chat's canonical model lands under `world-models/tau-bench/`; `bench run --model` resolves via `WorldModelStore` — point `--root` there (or add a path option on reconcile).

## Verification

`uv run ruff check .` ✓ · `uv run ty check` ✓ · `uv run pytest -q` → 212 passed, 6 skipped. End-to-end `bench run` → persist → `bench` leaderboard exercised with a fake scorer (no network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)