### PR TITLE
Fix wmh build: tomli-w dependency, wizard defaults, and trace-path UX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.27",
     "rich>=13.7",
     "gepa>=0.1.1",
+    "tomli-w>=1.0",  # writing .wmh/config.toml (stdlib tomllib reads); every `wmh build` needs it
 ]
 
 [project.optional-dependencies]
@@ -20,14 +21,13 @@ anthropic = ["anthropic>=0.39"]
 openai = ["openai>=1.40"]
 bedrock = ["boto3>=1.34"]
 otel = ["opentelemetry-proto>=1.24"]
-config = ["tomli-w>=1.0"]  # writing .wmh/config.toml (stdlib tomllib reads)
 # dev pulls in every backend SDK so `ty check` and the full test suite resolve over the whole
 # project (the providers import anthropic/openai/boto3 lazily, but type-checking needs them present).
 dev = [
     "pytest>=8.0",
     "ruff>=0.5",
     "ty>=0.0.1a1",
-    "world-model-harness[anthropic,openai,bedrock,otel,config]",
+    "world-model-harness[anthropic,openai,bedrock,otel]",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -892,6 +892,7 @@ dependencies = [
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pydantic" },
     { name = "rich" },
+    { name = "tomli-w" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -903,9 +904,6 @@ anthropic = [
 bedrock = [
     { name = "boto3" },
 ]
-config = [
-    { name = "tomli-w" },
-]
 dev = [
     { name = "anthropic" },
     { name = "boto3" },
@@ -913,7 +911,6 @@ dev = [
     { name = "opentelemetry-proto" },
     { name = "pytest" },
     { name = "ruff" },
-    { name = "tomli-w" },
     { name = "ty" },
 ]
 openai = [
@@ -937,10 +934,10 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rich", specifier = ">=13.7" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
-    { name = "tomli-w", marker = "extra == 'config'", specifier = ">=1.0" },
+    { name = "tomli-w", specifier = ">=1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.29" },
-    { name = "world-model-harness", extras = ["anthropic", "openai", "bedrock", "otel", "config"], marker = "extra == 'dev'" },
+    { name = "world-model-harness", extras = ["anthropic", "openai", "bedrock", "otel"], marker = "extra == 'dev'" },
 ]
-provides-extras = ["anthropic", "openai", "bedrock", "otel", "config", "dev"]
+provides-extras = ["anthropic", "openai", "bedrock", "otel", "dev"]

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 
 from pydantic import BaseModel
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
@@ -92,9 +93,17 @@ def run_build_wizard(
     file = defaults.file
     vendor = defaults.vendor
     if not file and not vendor:
-        file = _prompt_text(console, ask, "Path to exported traces (OTLP-JSON / JSONL)", None)
-        if not file:
-            raise ValueError("a traces file is required to build (or pass --vendor)")
+        # A trace source is required, so re-prompt on empty input rather than erroring out.
+        while not file:
+            file = _prompt_text(
+                console,
+                ask,
+                "Path to exported traces (OTLP-JSON / JSONL)",
+                None,
+                example="examples/tau2-bench.otel.jsonl",
+            )
+            if not file:
+                console.print("[red]a traces path is required (or pass --vendor)[/red]")
 
     provider = _prompt_text(console, ask, "Serve provider", defaults.provider)
     model_default = defaults.model or _DEFAULT_MODELS.get(provider, defaults.model)
@@ -153,15 +162,30 @@ def select_model(
         console.print(f"[red]pick 1-{len(infos)} or a model name[/red]")
 
 
-def _prompt_text(console: Console, ask: PromptReader, label: str, default: str | None) -> str:
-    suffix = f" [dim][{default}][/dim]" if default else ""
+def _prompt_text(
+    console: Console,
+    ask: PromptReader,
+    label: str,
+    default: str | None,
+    *,
+    example: str | None = None,
+) -> str:
+    # Escape interpolated values: "default" or anything with [...] is valid rich markup and would
+    # otherwise be swallowed (rendered invisibly) instead of shown. A prompt with no default can
+    # carry a grey `example` hint so the user sees the expected shape of the answer.
+    if default:
+        suffix = f" [dim]\\[{escape(default)}][/dim]"
+    elif example:
+        suffix = f" [dim](e.g. {escape(example)})[/dim]"
+    else:
+        suffix = ""
     value = ask(f"[bold]{label}[/bold]{suffix}: ").strip()
     return value or (default or "")
 
 
 def _prompt_int(console: Console, ask: PromptReader, label: str, default: int) -> int:
     while True:
-        raw = ask(f"[bold]{label}[/bold] [dim][{default}][/dim]: ").strip()
+        raw = ask(f"[bold]{label}[/bold] [dim]\\[{default}][/dim]: ").strip()
         if not raw:
             return default
         value = _parse_int(raw)

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 from rich.console import Console
 
 from wmh.cli.ui import (
@@ -179,11 +178,14 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     assert params.embed_provider == "hashing"  # default embedder, no embed-model prompt
 
 
-def test_build_wizard_requires_a_trace_source() -> None:
+def test_build_wizard_reprompts_on_blank_trace_source() -> None:
+    # A blank traces path must re-ask, not crash. After a name, blank the file once, then give a
+    # real path; remaining prompts (provider/model/region/budget/embedder/embed_dim) take defaults.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["mymodel", ""])  # name, then blank file
-    with pytest.raises(ValueError, match="traces file is required"):
-        run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    reader = _scripted_reader(["mymodel", "", "/tmp/t.jsonl", "", "", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.name == "mymodel"
+    assert params.file == "/tmp/t.jsonl"
 
 
 # --- selection picker ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes three issues hit while running `wmh build` interactively.

- **`tomli-w` crash on plain sync.** `wmh.config.config` imports `tomli_w` at module top and every `wmh build` writes `config.toml`, but it was declared only in the optional `config` extra — so a base `uv sync` left `wmh` unable to start (`ModuleNotFoundError: No module named 'tomli_w'`). Moved it into base `dependencies` and dropped the now-empty `config` extra.
- **Default name rendered invisibly.** The wizard's suggested default `default` (and anything containing `[...]`) is valid rich markup, so `[default]` was parsed as a style and shown as empty brackets. Defaults are now escaped.
- **Blank traces path crashed.** Pressing Enter at the traces prompt raised `ValueError` instead of re-asking. It now re-prompts, and shows a grey example hint (`e.g. examples/tau2-bench.otel.jsonl`) so the expected input is clear.

## Test plan
- `uv sync` (base, no extras) → `wmh --help` loads
- `uv run pytest wmh/cli/ -q` → 27 passed
- `uv run ruff check` → clean
- Updated the wizard test to cover the blank-path re-prompt instead of the removed raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)