### PR TITLE
Wizard pickers + credential checks; fail fast when a provider can't be reached

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from wmh.config import (
     ARTIFACT_DIR,
     DEFAULT_MODEL_NAME,
+    PROVIDER_ENV_VARS,
     HarnessConfig,
     WorldModelStore,
     load_config,
@@ -26,6 +27,7 @@ app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's
 providers_app = typer.Typer(help="Manage and verify LLM providers.")
 app.add_typer(providers_app, name="providers")
 _console = Console()
+_CHECK = "[green]✓[/green]"
 
 # Module-level singleton: a typer.Argument call can't be a default inline (ruff B008).
 _EVAL_FILES = typer.Argument(..., help="OTel trace files to score (one corpus each).")
@@ -178,6 +180,11 @@ def build(
         embed_dim=params.embed_dim,
         gepa_budget=params.gepa_budget,
     )
+    # Fail fast: ping the serve provider (and the embed path, if provider-backed) before spending
+    # any rollouts. A missing SDK or bad creds otherwise surfaces only deep inside GEPA, which
+    # silently swallows it and "succeeds" with a useless held-out-0.0 model.
+    _verify_or_abort(config)
+
     # Meter the build at the provider boundary: the one serve provider drives GEPA rollouts,
     # reflection, and the judge, so wrapping it captures all build LLM cost/tokens without touching
     # the optimizer. `classify_build_call` splits judge vs GEPA by system prompt.
@@ -213,6 +220,50 @@ def build(
                 f"  {phase.value}: {bucket.total_tokens} tokens, "
                 f"${bucket.cost_usd:.4f} ({bucket.calls} calls)"
             )
+
+
+# The `uv sync` extra that installs each provider's SDK, surfaced when a verify ping fails with a
+# missing module so the fix is one copy-paste away.
+_PROVIDER_EXTRA: dict[ProviderKind, str] = {
+    ProviderKind.ANTHROPIC: "anthropic",
+    ProviderKind.BEDROCK: "bedrock",
+    ProviderKind.OPENAI: "openai",
+    ProviderKind.AZURE_OPENAI: "openai",
+}
+
+
+def _verify_or_abort(config: HarnessConfig) -> None:
+    """Ping the serve provider (and any provider-backed embedder) and abort on failure.
+
+    Runs before any rollouts so a missing SDK or bad creds fails loudly and immediately, instead of
+    being swallowed inside GEPA and yielding a useless model. Raises `typer.Exit(1)` with an
+    actionable hint (the `uv sync` extra for a missing SDK; "check creds / model id" otherwise).
+    """
+    checks = [(config.serve_provider_config(), False)]
+    if config.embed_provider is not EmbedderKind.HASHING:
+        checks.append((config.embed_provider_config(), True))
+
+    failed = False
+    for cfg, is_embed in checks:
+        label = f"embed:{cfg.kind.value}" if is_embed else cfg.kind.value
+        _console.print(f"verifying {label}…")
+        result = verify_embedder(cfg) if is_embed else verify_all([cfg])[0]
+        if result.ok:
+            _console.print(f"  {_CHECK} {label} ({result.model}) reachable")
+            continue
+        failed = True
+        _console.print(f"  [red]✗ {label} ({result.model}) failed[/red]: {result.detail}")
+        if "No module named" in result.detail:
+            extra = _PROVIDER_EXTRA.get(cfg.kind, cfg.kind.value)
+            _console.print(f"    [yellow]run `uv sync --extra {extra}` to install the SDK[/yellow]")
+        else:
+            envs = ", ".join(PROVIDER_ENV_VARS.get(cfg.kind, []))
+            hint = f" ({envs})" if envs else ""
+            _console.print(
+                f"    [yellow]check the model id and that your credentials are set{hint}[/yellow]"
+            )
+    if failed:
+        raise typer.Exit(1)
 
 
 @app.command("list")

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from wmh.cli import app
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, verify_via_ping
 
 runner = CliRunner()
 
@@ -37,7 +37,9 @@ class FakeProvider:
         return [[0.0] for _ in texts]
 
     def verify(self):  # noqa: ANN201
-        raise NotImplementedError
+        # The pre-build verify guard pings through this; delegate to the shared ping so the fake
+        # reports ok without hitting a real backend.
+        return verify_via_ping(self)
 
 
 def _traces_file(tmp_path) -> str:  # noqa: ANN001 - pytest fixture path
@@ -79,6 +81,7 @@ def patched_provider(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
     import sys
 
     import wmh.providers as providers_pkg
+    import wmh.providers.registry as registry
 
     fake = FakeProvider()
     # `wmh.engine.__init__` rebinds the name `build` to the function, shadowing the submodule
@@ -86,6 +89,9 @@ def patched_provider(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
     for module_name in ("wmh.engine.build", "wmh.engine.loader"):
         monkeypatch.setattr(sys.modules[module_name], "get_provider", lambda config: fake)
     monkeypatch.setattr(providers_pkg, "get_provider", lambda config: fake)
+    # The pre-build verify guard pings via verify_all/verify_embedder, which construct providers
+    # through the registry's own get_provider — patch that too so the guard sees the fake.
+    monkeypatch.setattr(registry, "get_provider", lambda config: fake)
 
 
 def _build(root, name: str, tmp_path) -> None:  # noqa: ANN001 - pytest fixture paths
@@ -183,18 +189,18 @@ def test_play_loads_bundled_only_model(patched_provider, monkeypatch, tmp_path) 
 def test_build_interactive_wizard_creates_model(patched_provider, tmp_path) -> None:  # noqa: ANN001
     root = tmp_path / ".wmh"
     # --interactive forces the wizard even under CliRunner (non-TTY); feed each answer line in
-    # prompt order: name, file, provider, model, region, budget, embedder, embed_dim (the offline
-    # 'hashing' embedder skips the embed-model prompt).
+    # prompt order: name, file, provider (select), model (select), region (bedrock only), budget,
+    # embedder (select). The offline 'hashing' embedder skips the embed-model prompt; phi dim isn't
+    # prompted. Provider/model/embedder are picked by index against their option lists.
     answers = "\n".join(
         [
             "wizard-built",
             _traces_file(tmp_path),
-            "bedrock",
-            "opus",
+            "1",  # provider: bedrock
+            "1",  # model: us.anthropic.claude-opus-4-8
             "us-east-1",
-            "4",
-            "hashing",
-            "64",
+            "4",  # gepa budget
+            "1",  # embedder: hashing
         ]
     )
     result = runner.invoke(
@@ -208,6 +214,39 @@ def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa:
     # No --file/--vendor and --no-interactive: should fail fast rather than hang on input.
     result = runner.invoke(app, ["build", "--no-interactive", "--root", str(tmp_path / ".wmh")])
     assert result.exit_code != 0
+
+
+def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None:  # noqa: ANN001
+    """A missing SDK must abort the build before any rollouts, with the `uv sync` extra hint.
+
+    Regression: previously the ModuleNotFoundError was swallowed inside GEPA and the build
+    "succeeded" with a useless held-out-0.0 model.
+    """
+    import sys
+
+    from wmh.providers.base import VerifyResult
+
+    appmod = sys.modules["wmh.cli.app"]
+    monkeypatch.setattr(
+        appmod,
+        "verify_all",
+        lambda configs: [
+            VerifyResult(
+                ok=False,
+                kind=configs[0].kind,
+                model=configs[0].model,
+                detail="No module named 'boto3'",
+            )
+        ],
+    )
+    root = tmp_path / ".wmh"
+    result = runner.invoke(
+        app, ["build", "--name", "x", "--file", _traces_file(tmp_path), "--root", str(root)]
+    )
+    assert result.exit_code == 1
+    assert "uv sync --extra bedrock" in result.output
+    # Aborted before building: no artifact written.
+    assert not (root / "models" / "x" / "config.toml").exists()
 
 
 def test_play_unknown_model_errors(tmp_path) -> None:  # noqa: ANN001

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -16,6 +16,7 @@ Everything that talks to `rich` lives here so the engine stays headless. Respons
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 
 from pydantic import BaseModel
@@ -33,10 +34,11 @@ from rich.progress import (
 )
 from rich.table import Table
 
-from wmh.config import ModelInfo, validate_name
+from wmh.config import PROVIDER_ENV_VARS, ModelInfo, validate_name
 from wmh.core.types import Action, ActionKind, Session
 from wmh.engine.play import PlayTurn, parse_action, play_turn
 from wmh.engine.world_model import WorldModel
+from wmh.providers.base import ProviderKind
 
 # A reader takes a fully-rendered prompt string and returns the user's typed line.
 PromptReader = Callable[[str], str]
@@ -44,14 +46,24 @@ PromptReader = Callable[[str], str]
 # Stage glyphs reused by the animated and plain reporters.
 _CHECK = "[green]✓[/green]"
 
-# Provider-specific defaults the creation wizard suggests.
-_DEFAULT_MODELS: dict[str, str] = {
-    "bedrock": "us.anthropic.claude-opus-4-8",
-    "anthropic": "claude-opus-4-8",
-    "openai": "gpt-5.5",
-    "azure_openai": "gpt-5.5",
+# Serve providers offered in the wizard picker, with the model ids each supports. The first model
+# in each list is the suggested default. Keep these in sync with the provider backends.
+_PROVIDER_MODELS: dict[str, list[str]] = {
+    "bedrock": ["us.anthropic.claude-opus-4-8", "us.anthropic.claude-opus-4-7"],
+    "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
+    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
+    "azure_openai": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
+
+# Embedders offered in the wizard, with the embeddings-model ids each provider-backed one supports
+# (None = the offline hashing embedder, no model). First entry is the suggested default.
+_EMBEDDERS: dict[str, list[str] | None] = {
+    "hashing": None,
+    "bedrock": ["amazon.titan-embed-text-v2:0"],
+    "openai": ["text-embedding-3-small", "text-embedding-3-large"],
+    "azure_openai": ["text-embedding-3-small", "text-embedding-3-large"],
+}
 
 
 class BuildParams(BaseModel):
@@ -105,21 +117,34 @@ def run_build_wizard(
             if not file:
                 console.print("[red]a traces path is required (or pass --vendor)[/red]")
 
-    provider = _prompt_text(console, ask, "Serve provider", defaults.provider)
-    model_default = defaults.model or _DEFAULT_MODELS.get(provider, defaults.model)
-    model = _prompt_text(console, ask, "Serve model id", model_default)
-    region_default = defaults.region or _DEFAULT_REGIONS.get(provider)
-    region = _prompt_text(console, ask, "Region (blank for default)", region_default) or None
-    gepa_budget = _prompt_int(console, ask, "GEPA rollout budget", defaults.gepa_budget)
+    # Serve provider: pick from the list, then show which credentials it expects so a missing one
+    # is surfaced here (an offline check) rather than as an opaque failure mid-build.
+    provider = _select(console, ask, "Serve provider", list(_PROVIDER_MODELS), defaults.provider)
+    _report_credentials(console, provider)
+    model = _select(console, ask, "Serve model id", _PROVIDER_MODELS[provider], defaults.model)
 
-    # Retrieval phi embedder: default offline hashing (no creds). A provider-backed embedder needs
-    # a model id, prompted only when the user picks one.
-    embed_label = "Embedder (hashing | bedrock | openai | azure_openai)"
-    embed_provider = _prompt_text(console, ask, embed_label, defaults.embed_provider)
+    region = None
+    if provider == "bedrock":
+        region_default = defaults.region or _DEFAULT_REGIONS.get(provider)
+        region = _prompt_text(console, ask, "AWS region", region_default) or None
+
+    gepa_budget = _prompt_int(
+        console,
+        ask,
+        "GEPA rollout budget (more rollouts = better prompt, higher cost/time)",
+        defaults.gepa_budget,
+    )
+
+    # Retrieval phi embedder: default offline hashing (no creds). A provider-backed embedder is
+    # picked from the list and prompts for its embeddings-model id; phi dimensionality keeps its
+    # default (the index and query embedders must agree, so it is not a wizard knob).
+    embed_provider = _select(console, ask, "Embedder", list(_EMBEDDERS), defaults.embed_provider)
     embed_model = defaults.embed_model
-    if embed_provider != "hashing":
-        embed_model = _prompt_text(console, ask, "Embeddings model id", embed_model) or None
-    embed_dim = _prompt_int(console, ask, "phi dimensionality", defaults.embed_dim)
+    embed_models = _EMBEDDERS[embed_provider]
+    if embed_models is not None:
+        if embed_provider != provider:
+            _report_credentials(console, embed_provider)
+        embed_model = _select(console, ask, "Embeddings model id", embed_models, embed_model)
 
     return BuildParams(
         name=name,
@@ -131,8 +156,50 @@ def run_build_wizard(
         gepa_budget=gepa_budget,
         embed_provider=embed_provider,
         embed_model=embed_model,
-        embed_dim=embed_dim,
+        embed_dim=defaults.embed_dim,
     )
+
+
+def _select(
+    console: Console, ask: PromptReader, label: str, options: list[str], default: str | None
+) -> str:
+    """Prompt the user to pick one of `options` by number (or name), defaulting to `default`.
+
+    The default is whichever of `default`/`options[0]` is present in `options`; Enter accepts it.
+    Re-prompts on invalid input. Returns the chosen option string.
+    """
+    chosen_default = default if default in options else options[0]
+    console.print(f"[bold]{label}[/bold]:")
+    for i, opt in enumerate(options, start=1):
+        marker = "  [dim](default)[/dim]" if opt == chosen_default else ""
+        console.print(f"  [cyan]{i}[/cyan]. {escape(opt)}{marker}")
+    while True:
+        raw = ask(f"[dim]\\[{escape(chosen_default)}][/dim] > ").strip()
+        if not raw:
+            return chosen_default
+        choice = _parse_int(raw)
+        if choice is not None and 1 <= choice <= len(options):
+            return options[choice - 1]
+        if raw in options:  # allow typing the option name directly
+            return raw
+        console.print(f"[red]pick 1-{len(options)} or an option name[/red]")
+
+
+def _report_credentials(console: Console, provider: str) -> None:
+    """Print which env vars the chosen provider reads, flagging any that are unset.
+
+    An offline presence check only — it does not validate the value. The live ping that confirms
+    the creds actually work happens once before the build (see `wmh build`).
+    """
+    try:
+        env_vars = PROVIDER_ENV_VARS[ProviderKind(provider)]
+    except (ValueError, KeyError):
+        return
+    for var in env_vars:
+        if os.environ.get(var):
+            console.print(f"  {_CHECK} {var} is set")
+        else:
+            console.print(f"  [yellow]make sure {var} is set[/yellow]")
 
 
 def select_model(

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -129,8 +129,8 @@ def test_play_repl_exits_cleanly_on_eof() -> None:
 
 def test_build_wizard_collects_all_inputs() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
-    # Prompts in order: name, file, provider, model, region, budget, embedder, embed_dim.
-    # (embed model is skipped because the embedder is the offline 'hashing' default.)
+    # Prompts in order: name, file, provider (select), model (select), region (bedrock only),
+    # budget, embedder (select). No embed-model (hashing default) and no phi-dim prompt.
     reader = _scripted_reader(
         [
             "tau2-airline",
@@ -140,7 +140,6 @@ def test_build_wizard_collects_all_inputs() -> None:
             "us-east-1",
             "8",
             "hashing",
-            "512",
         ]
     )
     params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
@@ -152,23 +151,35 @@ def test_build_wizard_collects_all_inputs() -> None:
     assert params.embed_provider == "hashing"
 
 
+def test_build_wizard_select_by_number() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    # Provider/model/embedder are numbered pickers; choosing by index must work. Pick anthropic (2),
+    # its second model, no region prompt (not bedrock), budget 8, hashing embedder (1).
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "2", "2", "8", "1"])
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.provider == "anthropic"
+    assert params.model == "claude-opus-4-7"  # second anthropic model
+    assert params.region is None  # region only prompted for bedrock
+    assert params.embed_provider == "hashing"
+
+
 def test_build_wizard_collects_provider_embedder() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
-    # Picking a provider-backed embedder adds an embeddings-model prompt.
+    # A provider-backed embedder adds an embeddings-model picker; phi dim keeps its default.
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "bedrock", "opus", "us-east-1", "8", "bedrock", "titan-v2", "1024"]
+        ["m", "/tmp/t.jsonl", "openai", "gpt-5.5", "8", "openai", "text-embedding-3-large"]
     )
     params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
-    assert params.embed_provider == "bedrock"
-    assert params.embed_model == "titan-v2"
-    assert params.embed_dim == 1024
+    assert params.embed_provider == "openai"
+    assert params.embed_model == "text-embedding-3-large"
+    assert params.embed_dim == 512  # default, no longer prompted
 
 
 def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # File provided (so that prompt is skipped); press Enter (blank) for every remaining prompt
-    # (name/provider/model/region/budget/embedder/embed_dim) to accept the suggested defaults.
-    reader = _scripted_reader(["", "", "", "", "", "", ""])
+    # (name/provider/model/region/budget/embedder) to accept the suggested defaults.
+    reader = _scripted_reader(["", "", "", "", "", ""])
     defaults = BuildParams(name="seeded", file="/tmp/t.jsonl", provider="bedrock", gepa_budget=50)
     params = run_build_wizard(console, defaults, reader=reader)
     assert params.name == "seeded"  # blank kept the default
@@ -180,12 +191,25 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
 
 def test_build_wizard_reprompts_on_blank_trace_source() -> None:
     # A blank traces path must re-ask, not crash. After a name, blank the file once, then give a
-    # real path; remaining prompts (provider/model/region/budget/embedder/embed_dim) take defaults.
+    # real path; remaining prompts (provider/model/region/budget/embedder) take defaults.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["mymodel", "", "/tmp/t.jsonl", "", "", "", "", "", ""])
+    reader = _scripted_reader(["mymodel", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
     assert params.name == "mymodel"
     assert params.file == "/tmp/t.jsonl"
+
+
+def test_build_wizard_reports_missing_credentials(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
+    # The wizard flags an unset provider env var (offline presence check) so the user sees it
+    # before the build. With AWS creds cleared, bedrock should warn for each.
+    for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    console = Console(force_terminal=False, no_color=True, width=100)
+    with console.capture() as cap:
+        reader = _scripted_reader(["m", "/tmp/t.jsonl", "bedrock", "", "us-east-1", "8", "hashing"])
+        run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    out = cap.get()
+    assert "make sure AWS_ACCESS_KEY_ID is set" in out
 
 
 # --- selection picker ----------------------------------------------------------------------------
@@ -232,9 +256,9 @@ def test_select_model_survives_unicode_digit_input() -> None:
 
 def test_build_wizard_reprompts_on_unicode_digit_budget() -> None:
     # Same unicode-digit footgun in the int prompt: must re-ask, not crash. With file provided the
-    # prompts are name/provider/model/region/budget/embedder/embed_dim; blanks accept defaults,
-    # '²' is a bad budget that must be rejected and re-asked.
+    # prompts are name/provider/model/region/budget/embedder; blanks accept defaults, '²' is a bad
+    # budget that must be rejected and re-asked.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["", "", "", "", "²", "7", "", ""])
+    reader = _scripted_reader(["", "", "", "", "²", "7", ""])
     params = run_build_wizard(console, BuildParams(name="m", file="/tmp/t.jsonl"), reader=reader)
     assert params.gepa_budget == 7


### PR DESCRIPTION
## Summary
Polishes the `wmh build` wizard and makes provider problems fail loudly instead of silently producing a dead model.

### Wizard UX
- **Serve provider / model id / embedder are numbered selects** now, not free-text prompts — pick from valid options instead of typing a string.
- **Credential presence check**: after picking a provider the wizard prints which env vars are set (✓) vs missing (`make sure AWS_ACCESS_KEY_ID is set`). Offline check only — the live ping happens before the build.
- **Region** is only prompted for bedrock.
- **GEPA budget** label now explains the tradeoff: `GEPA rollout budget (more rollouts = better prompt, higher cost/time)`.
- **phi dimensionality prompt removed** — the index and query embedders must agree on it, so it was never a safe per-build knob; keeps the default.

### Fail-fast verify guard
`wmh build` now pings the serve provider (and any provider-backed embedder) **before** running GEPA and aborts on failure with an actionable hint:
- missing SDK → `run \`uv sync --extra bedrock\` to install the SDK`
- creds/model error → `check the model id and that your credentials are set (AWS_REGION, ...)`

**Why:** in the reported run, `boto3` was missing, every GEPA reflection raised `ModuleNotFoundError`, the optimizer swallowed it, and the build "succeeded" with held-out **0.000** after burning all 52 rollouts. Now it stops immediately.

## Test plan
- `uv run pytest -q` → 214 passed, 6 skipped
- `uv run ruff check .` → clean
- `uv run --extra dev ty check` → clean
- New tests: wizard select-by-index, missing-credential reporting, and build-aborts-on-missing-SDK (asserts no artifact written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)