### PR TITLE
[codex] add OTel trace source providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,19 @@ AZURE_OPENAI_ENDPOINT=
 
 # OpenAI direct (GPT 5.5)
 OPENAI_API_KEY=
+
+# Trace sources (optional; used by `wmh build --vendor ...`)
+
+# Generic OTLP-compatible query endpoint
+WMH_OTLP_QUERY_ENDPOINT=
+WMH_OTLP_API_KEY=
+
+# Braintrust BTQL
+BRAINTRUST_API_URL=https://api.braintrust.dev
+BRAINTRUST_API_KEY=
+BRAINTRUST_PROJECT=
+
+# Arize Phoenix
+PHOENIX_BASE_URL=http://localhost:6006
+PHOENIX_API_KEY=
+PHOENIX_PROJECT_ID=

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ the pieces fit (and where to plug in a new provider, adapter, or embedder).
 
 ## How it works
 
-1. **Build** from your agent's OTel traces (file export or vendor SDK): ingest → normalize → split
-   train/held-out → index a replay buffer → evolve the env prompt with GEPA against the held-out split.
+1. **Build** from your agent's OTel traces (file export or provider query API): ingest → normalize
+   → split train/held-out → index a replay buffer → evolve the env prompt with GEPA against the
+   held-out split.
 2. **Serve**: agents call `WorldModel.step(action)` (in-process or via the local HTTP backend). Each
    step retrieves the most similar past `(state, action) → observation` examples and predicts the
    next observation.
@@ -25,6 +26,8 @@ uv sync
 wmh providers verify                       # confirm Anthropic / Bedrock / Azure OpenAI / OpenAI creds
 wmh build                                  # guided creation wizard (prompts for name, traces, provider…)
 wmh build --name airline --file traces.jsonl   # …or fully scriptable with flags -> .wmh/models/airline/
+wmh build --name airline --vendor braintrust --trace-project prod-airline
+wmh build --name airline --vendor phoenix --trace-project default
 wmh list                                   # show every built world model
 wmh eval traces.jsonl                      # score reconstruction fidelity (replay + LLM judge)
 wmh serve                                  # local backend on :8000 (serves all built models)
@@ -39,6 +42,31 @@ wmh play                                   # step into the environment yourself 
 World models are **named** and stored under `.wmh/models/<name>/`, so one project can hold several
 (e.g. `airline`, `retail`). Commands that read a model take `--name`; if only one is built, `--name`
 is optional.
+
+## Import traces
+
+Local exports remain the simplest path:
+
+```bash
+wmh build --name airline --file traces.otel.jsonl
+```
+
+Provider-backed imports use `--vendor` plus source-specific flags/env vars. All sources feed the
+same `otel-genai` adapter, so they may return either OTLP JSON (`resourceSpans`) or span rows with
+`trace_id`/`span_id` plus `attributes` containing OTel GenAI keys such as `gen_ai.tool.name`.
+
+| Source | Command | Credentials / config |
+|---|---|---|
+| Generic OTLP HTTP | `--vendor otlp --trace-endpoint <url>` | `WMH_OTLP_QUERY_ENDPOINT`, `WMH_OTLP_API_KEY` |
+| Braintrust BTQL | `--vendor braintrust --trace-project <project>` | `BRAINTRUST_API_KEY`, optional `BRAINTRUST_API_URL`, `BRAINTRUST_PROJECT` |
+| Arize Phoenix | `--vendor phoenix --trace-project <project>` | `PHOENIX_BASE_URL`, `PHOENIX_API_KEY`, `PHOENIX_PROJECT_ID` |
+
+Common filters: `--trace-since`, `--trace-until`, `--trace-limit`. Braintrust also accepts
+`--trace-query` for a custom BTQL query when the default `project_logs(..., shape => 'traces')`
+query does not match your workspace layout.
+
+Phoenix defaults to `GET /v1/projects/{project}/spans/otlpv1` under `PHOENIX_BASE_URL`; pass
+`--trace-endpoint` to target a custom Phoenix-compatible spans route directly.
 
 ## Use it as an API
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uv sync
 wmh providers verify                       # confirm Anthropic / Bedrock / Azure OpenAI / OpenAI creds
 wmh build                                  # guided creation wizard (prompts for name, traces, provider…)
 wmh build --name airline --file traces.jsonl   # …or fully scriptable with flags -> .wmh/models/airline/
-wmh build --name airline --vendor braintrust --trace-project prod-airline
+wmh build --name airline --vendor braintrust --trace-project prod-airline --trace-since 2026-06-01T00:00:00Z
 wmh build --name airline --vendor phoenix --trace-project default
 wmh list                                   # show every built world model
 wmh eval traces.jsonl                      # score reconstruction fidelity (replay + LLM judge)
@@ -58,12 +58,13 @@ same `otel-genai` adapter, so they may return either OTLP JSON (`resourceSpans`)
 | Source | Command | Credentials / config |
 |---|---|---|
 | Generic OTLP HTTP | `--vendor otlp --trace-endpoint <url>` | `WMH_OTLP_QUERY_ENDPOINT`, `WMH_OTLP_API_KEY` |
-| Braintrust BTQL | `--vendor braintrust --trace-project <project>` | `BRAINTRUST_API_KEY`, optional `BRAINTRUST_API_URL`, `BRAINTRUST_PROJECT` |
+| Braintrust BTQL | `--vendor braintrust --trace-project <project> --trace-since <iso-time>` | `BRAINTRUST_API_KEY`, optional `BRAINTRUST_API_URL`, `BRAINTRUST_PROJECT` |
 | Arize Phoenix | `--vendor phoenix --trace-project <project>` | `PHOENIX_BASE_URL`, `PHOENIX_API_KEY`, `PHOENIX_PROJECT_ID` |
 
-Common filters: `--trace-since`, `--trace-until`, `--trace-limit`. Braintrust also accepts
-`--trace-query` for a custom BTQL query when the default `project_logs(..., shape => 'traces')`
-query does not match your workspace layout.
+Common filters: `--trace-since`, `--trace-until`, `--trace-limit`. Braintrust default BTQL imports
+require `--trace-since` so `project_logs(..., shape => 'traces')` stays range-bounded; Braintrust
+also accepts `--trace-query` for a custom BTQL query when the default query does not match your
+workspace layout.
 
 Phoenix defaults to `GET /v1/projects/{project}/spans/otlpv1` under `PHOENIX_BASE_URL`; pass
 `--trace-endpoint` to target a custom Phoenix-compatible spans route directly.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,8 +34,9 @@ Packages are layered; arrows point "depends on". `core` depends on nothing, the 
   writable-first: the user's `.wmh/models/<name>/` (where builds write) and a read-only bundled
   `world-models/<name>/` of canonical example models committed to the repo (e.g. `tau-bench`); a
   writable model shadows a bundled one of the same name. `WMH_BUNDLED_DIR` overrides/disables it.
-- **`ingest`** — `TraceAdapter` protocol + a registry; the OTel GenAI adapter normalizes spans into
-  `Trace`s. New trace sources register here.
+- **`ingest`** — `TraceSource` protocol + registry for transport (file, generic OTLP HTTP,
+  Braintrust, Phoenix) and `TraceAdapter` protocol + registry for schema normalization. The OTel
+  GenAI adapter maps fetched payloads into `Trace`s.
 - **`retrieval`** — the DreamGym replay buffer. `EmbeddingRetriever` (cosine top-k over phi),
   pluggable `Embedder`s (`embedders.py`, incl. the offline `HashingEmbedder`), and `leakfree.py`
   (`DemoRetriever` — train-only, never-own-trace retrieval shared by GEPA and eval).
@@ -58,7 +59,7 @@ Packages are layered; arrows point "depends on". `core` depends on nothing, the 
 ## The two lifecycles
 
 **Build** (`wmh build` → `engine.build.build`):
-`ingest` traces → `split_traces` (deterministic train/held-out) → `EmbeddingRetriever.index` →
+load traces from a `TraceSource` → normalize via `TraceAdapter` → `split_traces` (deterministic train/held-out) → `EmbeddingRetriever.index` →
 `GEPAOptimizer.optimize` (replays held-out steps with leak-free RAG, scores with `LLMJudge`,
 reflects to mutate the prompt) → persist prompt + frontier + index + metrics under
 `.wmh/models/<name>/`.
@@ -75,8 +76,11 @@ the session (history + scratchpad) → enrich the buffer.
 - **A new embedding model (phi)** → implement `Embedder` (`embed(texts) -> list[list[float]]`) in
   `wmh/retrieval/embedders.py`; wire it into `get_embedder`. Set `embed_provider` / `embed_dim` in
   config; the persisted dim must match at load (guarded with a clear error).
-- **A new trace source / format** → implement the `TraceAdapter` protocol in `wmh/ingest/`, register
-  it; select it via `config.trace_adapter`.
+- **A new trace transport** → implement the `TraceSource` protocol in `wmh/ingest/trace_source.py`
+  and register it. Use this when the payload is still OTLP / OTel GenAI but the fetch/query API is
+  provider-specific.
+- **A new trace schema** → implement the `TraceAdapter` protocol in `wmh/ingest/`, register it, and
+  select it via `config.trace_adapter`.
 - **A different fitness signal** → implement the `Judge` protocol in `wmh/optimize/judge.py`.
 - **A new CLI command** → add a thin command in `wmh/cli/app.py` that delegates to an `engine`
   function; keep the logic in `engine` so it stays testable without the CLI.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -37,6 +37,22 @@ Traces are stored as one-span-per-line OTel-GenAI JSONL that `wmh.ingest.otel_ge
 per-step state and trace metadata travel as optional `wmh.state.*` / `wmh.trace.metadata` span
 attributes — a strict superset of the OTel GenAI semconv, so any trace that omits them still parses.
 
+## Trace sources
+
+The OTel GenAI parser is schema-only. Transport is handled by `TraceSource` implementations:
+
+- `file` — local OTLP JSON / JSONL exports (`wmh build --file traces.otel.jsonl`).
+- `otlp` — a generic HTTP query endpoint returning OTLP JSON (`WMH_OTLP_QUERY_ENDPOINT` or
+  `--trace-endpoint`).
+- `braintrust` — Braintrust BTQL (`BRAINTRUST_API_KEY`, `BRAINTRUST_PROJECT`, optional
+  `--trace-query`).
+- `phoenix` — Arize Phoenix OTLP spans (`GET /v1/projects/{project}/spans/otlpv1` under
+  `PHOENIX_BASE_URL`, with `PHOENIX_API_KEY` / `PHOENIX_PROJECT_ID`).
+
+Provider sources should return either OTLP JSON directly or rows with `trace_id`/`span_id` and an
+`attributes` object containing the same `gen_ai.*` keys the file parser accepts. The adapter then
+groups by `trace_id`, sorts spans by start time, and emits one `Step` per recorded action.
+
 ## How tau²-bench is captured
 
 The pipeline lives in [`tools/tau2-capture/`](../tools/tau2-capture/README.md) and is deliberately

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -44,8 +44,8 @@ The OTel GenAI parser is schema-only. Transport is handled by `TraceSource` impl
 - `file` — local OTLP JSON / JSONL exports (`wmh build --file traces.otel.jsonl`).
 - `otlp` — a generic HTTP query endpoint returning OTLP JSON (`WMH_OTLP_QUERY_ENDPOINT` or
   `--trace-endpoint`).
-- `braintrust` — Braintrust BTQL (`BRAINTRUST_API_KEY`, `BRAINTRUST_PROJECT`, optional
-  `--trace-query`).
+- `braintrust` — Braintrust BTQL (`BRAINTRUST_API_KEY`, `BRAINTRUST_PROJECT`,
+  `--trace-since` for the default range-bounded query, or `--trace-query`).
 - `phoenix` — Arize Phoenix OTLP spans (`GET /v1/projects/{project}/spans/otlpv1` under
   `PHOENIX_BASE_URL`, with `PHOENIX_API_KEY` / `PHOENIX_PROJECT_ID`).
 

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -119,9 +119,10 @@ def build(
         "--trace-until",
         help="Trace source upper time bound (ISO-8601; provider support varies).",
     ),
-    trace_limit: int = typer.Option(
+    trace_limit: int | None = typer.Option(
         None,
         "--trace-limit",
+        min=1,
         help="Maximum traces to import after source normalization.",
     ),
     trace_query: str = typer.Option(
@@ -145,7 +146,7 @@ def build(
         help="Guided creation wizard. Default: on at a TTY when inputs are missing.",
     ),
 ) -> None:
-    """Ingest traces (file upload or vendor SDK pull) and build a named world model.
+    """Ingest traces (file upload or provider trace source) and build a named world model.
 
     Stores the artifact under `<root>/models/<name>/`: ingest -> normalize -> split(train/test) ->
     embed/index -> GEPA optimize -> write. Re-running with the same `--name` rebuilds it.

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -89,7 +89,46 @@ def providers_verify(
 def build(
     name: str = typer.Option(None, "--name", help="Name for this world model."),
     file: str = typer.Option(None, "--file", help="Path to exported traces (OTLP-JSON / JSONL)."),
-    vendor: str = typer.Option(None, "--vendor", help="Vendor name to pull traces via SDK."),
+    vendor: str = typer.Option(
+        None,
+        "--vendor",
+        help="Trace source to pull from instead of --file: braintrust, phoenix, or otlp.",
+    ),
+    trace_endpoint: str = typer.Option(
+        None,
+        "--trace-endpoint",
+        help="Trace source endpoint/base URL override.",
+    ),
+    trace_api_key: str = typer.Option(
+        None,
+        "--trace-api-key",
+        help="Trace source API key override; otherwise source-specific env vars are used.",
+    ),
+    trace_project: str = typer.Option(
+        None,
+        "--trace-project",
+        help="Trace source project/workspace id or name.",
+    ),
+    trace_since: str = typer.Option(
+        None,
+        "--trace-since",
+        help="Trace source lower time bound (ISO-8601; provider support varies).",
+    ),
+    trace_until: str = typer.Option(
+        None,
+        "--trace-until",
+        help="Trace source upper time bound (ISO-8601; provider support varies).",
+    ),
+    trace_limit: int = typer.Option(
+        None,
+        "--trace-limit",
+        help="Maximum traces to import after source normalization.",
+    ),
+    trace_query: str = typer.Option(
+        None,
+        "--trace-query",
+        help="Provider-native query override, currently used by Braintrust BTQL.",
+    ),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
     provider: str = typer.Option("bedrock", "--provider", help="Provider that serves the model."),
     model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
@@ -119,7 +158,7 @@ def build(
     from wmh.cli.ui import BuildParams, RichBuildReporter, build_summary_panel, run_build_wizard
     from wmh.config import ArtifactPaths
     from wmh.engine.build import build as run_build
-    from wmh.ingest import VendorPull
+    from wmh.ingest import TraceSourceConfig, trace_source_kind
     from wmh.providers import get_provider
     from wmh.retrieval import get_embedder
     from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
@@ -133,6 +172,13 @@ def build(
         name=name or DEFAULT_MODEL_NAME,
         file=file,
         vendor=vendor,
+        trace_endpoint=trace_endpoint,
+        trace_api_key=trace_api_key,
+        trace_project=trace_project,
+        trace_since=trace_since,
+        trace_until=trace_until,
+        trace_limit=trace_limit,
+        trace_query=trace_query,
         provider=provider,
         model=model,
         region=region,
@@ -145,6 +191,24 @@ def build(
         params = run_build_wizard(_console, params)
     elif name is None and file is None and vendor is None:
         raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
+    if params.file is not None and params.vendor is not None:
+        raise typer.BadParameter("pass either --file or --vendor, not both")
+    source = None
+    if params.vendor is not None:
+        try:
+            source_kind = trace_source_kind(params.vendor)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        source = TraceSourceConfig(
+            kind=source_kind,
+            endpoint=params.trace_endpoint,
+            api_key=params.trace_api_key,
+            project=params.trace_project,
+            since=params.trace_since,
+            until=params.trace_until,
+            limit=params.trace_limit,
+            query=params.trace_query,
+        )
 
     validate_name(params.name)
     try:
@@ -198,7 +262,7 @@ def build(
         run_build(
             config,
             file=params.file,
-            vendor=VendorPull() if params.vendor else None,
+            source=source,
             root=model_dir,
             serve_provider=metered,
             embedder=get_embedder(config),

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -254,6 +254,28 @@ def test_build_rejects_unknown_trace_source(tmp_path) -> None:  # noqa: ANN001
     assert "unknown trace source" in result.output
 
 
+def test_build_rejects_non_positive_trace_limit(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--vendor",
+            "otlp",
+            "--trace-endpoint",
+            "https://otel.example/query",
+            "--trace-limit",
+            "0",
+            "--root",
+            str(tmp_path / ".wmh"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "trace-limit" in result.output
+
+
 def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None:  # noqa: ANN001
     """A missing SDK must abort the build before any rollouts, with the `uv sync` extra hint.
 

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -216,6 +216,44 @@ def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa:
     assert result.exit_code != 0
 
 
+def test_build_rejects_file_and_vendor_together(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            _traces_file(tmp_path),
+            "--vendor",
+            "braintrust",
+            "--root",
+            str(tmp_path / ".wmh"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "either --file or --vendor" in result.output
+
+
+def test_build_rejects_unknown_trace_source(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--vendor",
+            "not-a-source",
+            "--root",
+            str(tmp_path / ".wmh"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown trace source" in result.output
+
+
 def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None:  # noqa: ANN001
     """A missing SDK must abort the build before any rollouts, with the `uv sync` extra hint.
 

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -72,6 +72,13 @@ class BuildParams(BaseModel):
     name: str
     file: str | None = None
     vendor: str | None = None
+    trace_endpoint: str | None = None
+    trace_api_key: str | None = None
+    trace_project: str | None = None
+    trace_since: str | None = None
+    trace_until: str | None = None
+    trace_limit: int | None = None
+    trace_query: str | None = None
     provider: str = "bedrock"
     model: str = "us.anthropic.claude-opus-4-8"
     region: str | None = None
@@ -150,6 +157,13 @@ def run_build_wizard(
         name=name,
         file=file,
         vendor=vendor,
+        trace_endpoint=defaults.trace_endpoint,
+        trace_api_key=defaults.trace_api_key,
+        trace_project=defaults.trace_project,
+        trace_since=defaults.trace_since,
+        trace_until=defaults.trace_until,
+        trace_limit=defaults.trace_limit,
+        trace_query=defaults.trace_query,
         provider=provider,
         model=model,
         region=region,

--- a/wmh/engine/build.py
+++ b/wmh/engine/build.py
@@ -13,7 +13,7 @@ from wmh.config import ArtifactPaths, HarnessConfig, save_config
 from wmh.core.types import Trace
 from wmh.engine.prompts import BASE_ENV_PROMPT
 from wmh.engine.reporting import BuildReporter, NullReporter
-from wmh.ingest import VendorPull, get_adapter
+from wmh.ingest import TraceSourceConfig, TraceSourceKind, get_adapter, load_traces
 from wmh.optimize import GEPAOptimizer, LLMJudge, OptimizeResult
 from wmh.providers import get_provider
 from wmh.providers.base import Embedder, Provider
@@ -25,15 +25,18 @@ def _count_steps(traces: list[Trace]) -> int:
 
 
 def ingest(
-    config: HarnessConfig, *, file: str | None = None, vendor: VendorPull | None = None
+    config: HarnessConfig,
+    *,
+    file: str | None = None,
+    source: TraceSourceConfig | None = None,
 ) -> list[Trace]:
-    """Load + normalize traces from a file upload or a vendor SDK pull into `Trace` objects."""
+    """Load + normalize traces from a file upload or provider-backed source."""
     adapter = get_adapter(config.trace_adapter)
     if file is not None:
-        return adapter.from_file(file)
-    if vendor is not None:
-        return adapter.from_vendor(vendor)
-    raise ValueError("ingest needs either a file path or a vendor pull")
+        return load_traces(TraceSourceConfig(kind=TraceSourceKind.FILE, path=file), adapter)
+    if source is not None:
+        return load_traces(source, adapter)
+    raise ValueError("ingest needs either a file path or a trace source")
 
 
 def split_traces(traces: list[Trace], train_split: float) -> tuple[list[Trace], list[Trace]]:
@@ -56,7 +59,7 @@ def build(
     config: HarnessConfig,
     *,
     file: str | None = None,
-    vendor: VendorPull | None = None,
+    source: TraceSourceConfig | None = None,
     root: str = ".wmh",
     serve_provider: Provider | None = None,
     embedder: Embedder | None = None,
@@ -71,7 +74,7 @@ def build(
     """
     report = reporter or NullReporter()
     paths = ArtifactPaths(root)
-    traces = ingest(config, file=file, vendor=vendor)
+    traces = ingest(config, file=file, source=source)
     if not traces:
         raise ValueError("no traces ingested; nothing to build")
     report.ingest_done(len(traces), _count_steps(traces))

--- a/wmh/ingest/__init__.py
+++ b/wmh/ingest/__init__.py
@@ -1,11 +1,33 @@
-"""Trace ingestion: vendor SDK pulls and file uploads -> normalized `Trace` objects.
+"""Trace ingestion: trace sources + schema adapters -> normalized `Trace` objects.
 
-A `TraceAdapter` turns one source's spans into the generic `Trace` schema. One concrete adapter
-ships (official OTel GenAI semconv); others register behind the same protocol.
+A `TraceSource` loads raw telemetry from file / provider query APIs. A `TraceAdapter` turns that
+payload into the generic `Trace` schema. One concrete adapter ships (official OTel GenAI semconv);
+other schemas can register behind the same protocol.
 """
 
 # Import for the registration side effect so `get_adapter("otel-genai")` works on package import.
 from wmh.ingest import otel_genai as otel_genai  # noqa: F401
-from wmh.ingest.adapter import TraceAdapter, VendorPull, get_adapter, register_adapter
+from wmh.ingest import trace_source as trace_source  # noqa: F401
+from wmh.ingest.adapter import TraceAdapter, get_adapter, register_adapter
+from wmh.ingest.trace_source import (
+    TraceSource,
+    TraceSourceConfig,
+    TraceSourceKind,
+    get_trace_source,
+    load_traces,
+    register_trace_source,
+    trace_source_kind,
+)
 
-__all__ = ["TraceAdapter", "VendorPull", "get_adapter", "register_adapter"]
+__all__ = [
+    "TraceAdapter",
+    "TraceSource",
+    "TraceSourceConfig",
+    "TraceSourceKind",
+    "get_adapter",
+    "get_trace_source",
+    "load_traces",
+    "register_adapter",
+    "register_trace_source",
+    "trace_source_kind",
+]

--- a/wmh/ingest/adapter.py
+++ b/wmh/ingest/adapter.py
@@ -1,25 +1,17 @@
 """TraceAdapter protocol + a small registry.
 
-Sources differ in two ways: *transport* (file vs. vendor SDK) and *schema* (which OTel semantic
-convention the spans follow). An adapter owns both: it pulls/reads raw spans and normalizes them.
+Sources differ in two ways: *transport* (file, Braintrust, Phoenix, ... query APIs) and *schema*
+(which OTel semantic convention the spans follow). A `TraceAdapter` owns only the schema mapping:
+raw payloads -> normalized traces. Transport lives in `trace_source.py`.
 """
 
 from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from pydantic import BaseModel
+from pydantic import JsonValue
 
 from wmh.core.types import Trace
-
-
-class VendorPull(BaseModel):
-    """Parameters for pulling traces from an observability vendor's API."""
-
-    api_key: str | None = None  # falls back to the vendor's env var when None
-    project: str | None = None  # vendor project / workspace to pull from
-    since: str | None = None  # ISO-8601 lower bound on trace start time
-    limit: int | None = None  # max traces to pull
 
 
 @runtime_checkable
@@ -32,8 +24,8 @@ class TraceAdapter(Protocol):
         """Read traces from an exported file (OTLP-JSON / vendor JSONL)."""
         ...
 
-    def from_vendor(self, pull: VendorPull) -> list[Trace]:
-        """Pull traces via a vendor SDK/API."""
+    def from_payload(self, payload: JsonValue, *, source: str) -> list[Trace]:
+        """Normalize an already-fetched trace payload."""
         ...
 
 

--- a/wmh/ingest/otel_genai.py
+++ b/wmh/ingest/otel_genai.py
@@ -35,14 +35,12 @@ observation for `(state_before, action)` against the recorded one.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
-import httpx
 from pydantic import BaseModel, Field, JsonValue
 
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step, Trace
-from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.adapter import register_adapter
 
 # `gen_ai.operation.name` values, per the OTel GenAI semantic conventions.
 _LLM_OPS = frozenset({"chat", "text_completion", "invoke_agent", "generate_content"})
@@ -76,12 +74,6 @@ _TOOL_OUTPUT_KEYS = (
 _STATE_STRUCTURED_KEY = "wmh.state.structured"
 _STATE_SCRATCHPAD_KEY = "wmh.state.scratchpad"
 _TRACE_METADATA_KEY = "wmh.trace.metadata"
-
-# Env vars the (placeholder) vendor pull reads. The real query semantics are vendor-specific; see
-# the TODO in `from_vendor`.
-VENDOR_ENDPOINT_ENV = "WMH_OTLP_QUERY_ENDPOINT"
-VENDOR_API_KEY_ENV = "WMH_OTLP_API_KEY"
-
 
 class _ParsedSpan(BaseModel):
     """A flattened OTLP span with its attributes already decoded to plain JSON values."""
@@ -426,6 +418,10 @@ def _spans_to_traces(spans: list[_ParsedSpan], source: str) -> list[Trace]:
 class OtelGenAIAdapter:
     name = "otel-genai"
 
+    def from_payload(self, payload: JsonValue, *, source: str) -> list[Trace]:
+        """Normalize an already-loaded OTLP / OTel-GenAI payload."""
+        return _spans_to_traces(_collect_spans(payload), source=source)
+
     def from_file(self, path: str) -> list[Trace]:
         text = Path(path).read_text(encoding="utf-8")
         spans: list[_ParsedSpan] = []
@@ -446,44 +442,6 @@ class OtelGenAIAdapter:
         else:
             spans = _collect_spans(payload)
         return _spans_to_traces(spans, source=f"file:{path}")
-
-    def from_vendor(self, pull: VendorPull) -> list[Trace]:
-        """Pull OTLP-JSON spans from an OTLP-compatible query backend.
-
-        OTLP itself is push-only, so "pulling" traces is inherently vendor-specific (Grafana Tempo,
-        Jaeger, Honeycomb, ... each expose their own query API and auth). This implementation does a
-        best-effort generic OTLP-JSON fetch and reuses the same span->Step mapping as `from_file`.
-
-        TODO: implement the vendor-specific query protocol and auth. Today we:
-          - read the query URL from ``$WMH_OTLP_QUERY_ENDPOINT``;
-          - send ``pull.api_key`` (or ``$WMH_OTLP_API_KEY``) as a Bearer token;
-          - pass project/since/limit as query params (real backends name these differently).
-        """
-        endpoint = os.environ.get(VENDOR_ENDPOINT_ENV)
-        if not endpoint:
-            raise ValueError(
-                f"set ${VENDOR_ENDPOINT_ENV} to an OTLP-compatible query URL to pull traces "
-                "(vendor-specific query support is not yet implemented; use from_file meanwhile)"
-            )
-        api_key = pull.api_key or os.environ.get(VENDOR_API_KEY_ENV)
-        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-        # TODO: these param names are placeholders; map to the target backend's query schema.
-        params: dict[str, str] = {}
-        if pull.project is not None:
-            params["project"] = pull.project
-        if pull.since is not None:
-            params["since"] = pull.since
-        if pull.limit is not None:
-            params["limit"] = str(pull.limit)
-        response = httpx.get(endpoint, headers=headers, params=params, timeout=30.0)
-        response.raise_for_status()
-        spans = _collect_spans(response.json())
-        traces = _spans_to_traces(spans, source=f"vendor:{pull.project or endpoint}")
-        # The `limit` query param is a placeholder a real backend may ignore; enforce it locally
-        # so the `VendorPull.limit` contract holds regardless of what the backend honors.
-        if pull.limit is not None:
-            traces = traces[: pull.limit]
-        return traces
 
 
 register_adapter(OtelGenAIAdapter())

--- a/wmh/ingest/otel_genai_test.py
+++ b/wmh/ingest/otel_genai_test.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
 
 from wmh.core.types import ActionKind
 from wmh.ingest import get_adapter
-from wmh.ingest.adapter import VendorPull
-from wmh.ingest.otel_genai import VENDOR_ENDPOINT_ENV, OtelGenAIAdapter
+from wmh.ingest.otel_genai import OtelGenAIAdapter
 
 _TESTDATA = Path(__file__).parent / "testdata"
 # `wmh/ingest/otel_genai_test.py` -> repo root is parents[2].
@@ -75,6 +73,37 @@ def test_from_file_parses_jsonl_with_multiple_traces() -> None:
     assert second.steps[0].action.name == "search"
     assert second.steps[0].action.arguments == {"q": "otel"}
     assert second.steps[0].observation.content == "3 results"
+
+
+def test_from_payload_parses_bare_span_list() -> None:
+    payload = [
+        {
+            "traceId": "cccc",
+            "spanId": "01",
+            "name": "chat",
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.tool.name", "value": {"stringValue": "search"}},
+                {"key": "gen_ai.tool.call.arguments", "value": {"stringValue": '{"q": "otel"}'}},
+            ],
+        },
+        {
+            "traceId": "cccc",
+            "spanId": "02",
+            "name": "execute_tool",
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                {"key": "gen_ai.tool.message", "value": {"stringValue": "3 results"}},
+            ],
+        },
+    ]
+
+    traces = OtelGenAIAdapter().from_payload(payload, source="unit")
+
+    assert len(traces) == 1
+    assert traces[0].source == "unit"
+    assert traces[0].steps[0].action.name == "search"
+    assert traces[0].steps[0].observation.content == "3 results"
 
 
 def test_from_file_skips_corrupt_jsonl_lines(tmp_path: Path) -> None:
@@ -212,13 +241,3 @@ def test_committed_terminal_tasks_corpus_satisfies_the_replay_contract() -> None
             assert step.action.name  # the real tool name (bash)
             assert step.task  # the originating task instruction
     assert n_steps > 0
-
-
-def test_from_vendor_without_endpoint_raises_friendly_error() -> None:
-    saved = os.environ.pop(VENDOR_ENDPOINT_ENV, None)
-    try:
-        with pytest.raises(ValueError, match=VENDOR_ENDPOINT_ENV):
-            OtelGenAIAdapter().from_vendor(VendorPull(project="demo"))
-    finally:
-        if saved is not None:
-            os.environ[VENDOR_ENDPOINT_ENV] = saved

--- a/wmh/ingest/trace_source.py
+++ b/wmh/ingest/trace_source.py
@@ -1,0 +1,569 @@
+"""Trace source transports for OTel ingestion.
+
+The harness has two separate extension points:
+
+- `TraceSource`: fetch/load raw telemetry from a place (file, Braintrust, Phoenix, generic OTLP).
+- `TraceAdapter`: normalize that payload into `Trace` objects.
+
+Keeping transport here lets the OTel GenAI adapter remain a pure schema parser while vendor query
+semantics live behind small, testable source implementations.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol, cast, runtime_checkable
+from urllib.parse import quote, urljoin
+
+import httpx
+from pydantic import BaseModel, JsonValue
+
+from wmh.core.types import JsonObject, Trace
+from wmh.ingest.adapter import TraceAdapter
+
+OTLP_ENDPOINT_ENV = "WMH_OTLP_QUERY_ENDPOINT"
+OTLP_API_KEY_ENV = "WMH_OTLP_API_KEY"
+
+BRAINTRUST_API_URL_ENV = "BRAINTRUST_API_URL"
+BRAINTRUST_API_KEY_ENV = "BRAINTRUST_API_KEY"
+BRAINTRUST_PROJECT_ENV = "BRAINTRUST_PROJECT"
+BRAINTRUST_DEFAULT_API_URL = "https://api.braintrust.dev"
+
+PHOENIX_BASE_URL_ENV = "PHOENIX_BASE_URL"
+PHOENIX_API_KEY_ENV = "PHOENIX_API_KEY"
+PHOENIX_PROJECT_ENV = "PHOENIX_PROJECT_ID"
+PHOENIX_DEFAULT_BASE_URL = "http://localhost:6006"
+
+
+class TraceSourceKind(StrEnum):
+    """Built-in trace source transports."""
+
+    FILE = "file"
+    OTLP = "otlp"
+    BRAINTRUST = "braintrust"
+    PHOENIX = "phoenix"
+
+
+class TraceSourceConfig(BaseModel):
+    """Resolved inputs for loading raw telemetry before adapter normalization."""
+
+    kind: TraceSourceKind
+    path: str | None = None
+    endpoint: str | None = None
+    api_key: str | None = None
+    project: str | None = None
+    since: str | None = None
+    until: str | None = None
+    limit: int | None = None
+    query: str | None = None
+
+
+@runtime_checkable
+class TraceSource(Protocol):
+    """Fetch raw telemetry and normalize it with the requested adapter."""
+
+    name: str
+
+    def load(self, config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+        """Return normalized traces."""
+        ...
+
+
+_SOURCE_ALIASES = {
+    "arize": TraceSourceKind.PHOENIX.value,
+    "arize-phoenix": TraceSourceKind.PHOENIX.value,
+    "arize_phoenix": TraceSourceKind.PHOENIX.value,
+    "generic": TraceSourceKind.OTLP.value,
+    "generic-otlp": TraceSourceKind.OTLP.value,
+    "generic_otlp": TraceSourceKind.OTLP.value,
+    "http": TraceSourceKind.OTLP.value,
+    "otlp-http": TraceSourceKind.OTLP.value,
+    "otlp_http": TraceSourceKind.OTLP.value,
+}
+_SOURCES: dict[str, TraceSource] = {}
+
+
+def trace_source_kind(value: str) -> TraceSourceKind:
+    """Resolve user-facing source names and aliases to a built-in source kind."""
+    normalized = value.strip().lower()
+    normalized = _SOURCE_ALIASES.get(normalized, normalized)
+    try:
+        return TraceSourceKind(normalized)
+    except ValueError:
+        choices = ", ".join(k.value for k in TraceSourceKind)
+        aliases = ", ".join(sorted(_SOURCE_ALIASES))
+        raise ValueError(
+            f"unknown trace source {value!r}; choose one of: {choices} ({aliases})"
+        ) from None
+
+
+def register_trace_source(source: TraceSource) -> None:
+    _SOURCES[source.name] = source
+
+
+def get_trace_source(kind: TraceSourceKind | str) -> TraceSource:
+    key = trace_source_kind(kind).value if isinstance(kind, str) else kind.value
+    if key not in _SOURCES:
+        raise ValueError(f"no trace source registered for {key!r}; have {list(_SOURCES)}")
+    return _SOURCES[key]
+
+
+def load_traces(config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+    """Fetch telemetry through a registered source, then normalize with `adapter`."""
+    return get_trace_source(config.kind).load(config, adapter)
+
+
+def _required(value: str | None, message: str) -> str:
+    if value:
+        return value
+    raise ValueError(message)
+
+
+def _auth_headers(api_key: str | None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+
+def _json_response(response: httpx.Response) -> JsonValue:
+    response.raise_for_status()
+    return cast(JsonValue, response.json())
+
+
+def _get_json(
+    endpoint: str, *, api_key: str | None, params: dict[str, str] | None = None
+) -> JsonValue:
+    response = httpx.get(
+        endpoint,
+        headers=_auth_headers(api_key),
+        params=params or {},
+        timeout=30.0,
+    )
+    return _json_response(response)
+
+
+def _post_json(endpoint: str, *, api_key: str | None, body: JsonObject) -> JsonValue:
+    response = httpx.post(endpoint, headers=_auth_headers(api_key), json=body, timeout=30.0)
+    return _json_response(response)
+
+
+class FileTraceSource:
+    name = TraceSourceKind.FILE.value
+
+    def load(self, config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+        path = _required(config.path, "file trace source requires a path")
+        return adapter.from_file(path)
+
+
+class GenericOtlpTraceSource:
+    name = TraceSourceKind.OTLP.value
+
+    def load(self, config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+        endpoint = config.endpoint or os.environ.get(OTLP_ENDPOINT_ENV)
+        endpoint = _required(
+            endpoint,
+            f"set ${OTLP_ENDPOINT_ENV} or pass --trace-endpoint for the generic OTLP source",
+        )
+        api_key = config.api_key or os.environ.get(OTLP_API_KEY_ENV)
+        params = _query_params(config)
+        payload = _get_json(endpoint, api_key=api_key, params=params)
+        return _limit_traces(adapter.from_payload(payload, source=f"otlp:{endpoint}"), config.limit)
+
+
+class BraintrustTraceSource:
+    """Fetch Braintrust logs via BTQL and normalize span rows into OTLP-like spans."""
+
+    name = TraceSourceKind.BRAINTRUST.value
+
+    def load(self, config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+        base_url = config.endpoint or os.environ.get(BRAINTRUST_API_URL_ENV)
+        if base_url is None:
+            base_url = BRAINTRUST_DEFAULT_API_URL
+        endpoint = (
+            base_url if base_url.endswith("/btql") else urljoin(f"{base_url.rstrip('/')}/", "btql")
+        )
+        api_key = config.api_key or os.environ.get(BRAINTRUST_API_KEY_ENV)
+        project = config.project or os.environ.get(BRAINTRUST_PROJECT_ENV)
+        query = config.query or _braintrust_default_query(project, config)
+        payload = _post_json(endpoint, api_key=api_key, body={"query": query})
+        normalized = _payload_or_vendor_spans(payload, _vendor_record_to_span)
+        label = project or endpoint
+        traces = adapter.from_payload(normalized, source=f"braintrust:{label}")
+        return _limit_traces(traces, config.limit)
+
+
+class PhoenixTraceSource:
+    """Fetch Arize Phoenix spans from its REST API and normalize them into OTLP-like spans."""
+
+    name = TraceSourceKind.PHOENIX.value
+
+    def load(self, config: TraceSourceConfig, adapter: TraceAdapter) -> list[Trace]:
+        project = config.project or os.environ.get(PHOENIX_PROJECT_ENV)
+        endpoint = config.endpoint
+        if endpoint is None:
+            endpoint = _phoenix_spans_endpoint(
+                _required(
+                    project,
+                    f"set ${PHOENIX_PROJECT_ENV}, pass --trace-project, "
+                    "or pass --trace-endpoint",
+                )
+            )
+        api_key = config.api_key or os.environ.get(PHOENIX_API_KEY_ENV)
+        params = _phoenix_params(config, include_project=config.endpoint is not None)
+        payloads: list[JsonValue] = []
+        next_cursor: str | None = None
+        while True:
+            page_params = dict(params)
+            if next_cursor is not None:
+                page_params["cursor"] = next_cursor
+            page = _get_json(endpoint, api_key=api_key, params=page_params)
+            payloads.append(page)
+            records = _extract_records(page)
+            if config.limit is not None and records is not None and len(records) >= config.limit:
+                break
+            next_cursor = _next_cursor(page)
+            if next_cursor is None:
+                break
+        normalized = _payloads_or_vendor_spans(payloads, _vendor_record_to_span)
+        label = project or endpoint
+        traces = adapter.from_payload(normalized, source=f"phoenix:{label}")
+        return _limit_traces(traces, config.limit)
+
+
+def _query_params(config: TraceSourceConfig) -> dict[str, str]:
+    params: dict[str, str] = {}
+    if config.project is not None:
+        params["project"] = config.project
+    if config.since is not None:
+        params["since"] = config.since
+    if config.until is not None:
+        params["until"] = config.until
+    if config.limit is not None:
+        params["limit"] = str(config.limit)
+    return params
+
+
+def _braintrust_default_query(project: str | None, config: TraceSourceConfig) -> str:
+    project = _required(
+        project,
+        f"set ${BRAINTRUST_PROJECT_ENV}, pass --trace-project, or pass --trace-query",
+    )
+    query = f"select * from project_logs('{_btql_quote(project)}', shape => 'traces')"
+    clauses: list[str] = []
+    if config.since is not None:
+        clauses.append(f"created >= '{_btql_quote(config.since)}'")
+    if config.until is not None:
+        clauses.append(f"created <= '{_btql_quote(config.until)}'")
+    if clauses:
+        query = f"{query} where {' and '.join(clauses)}"
+    if config.limit is not None:
+        query = f"{query} limit {config.limit}"
+    return query
+
+
+def _btql_quote(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _phoenix_spans_endpoint(project: str) -> str:
+    base_url = os.environ.get(PHOENIX_BASE_URL_ENV, PHOENIX_DEFAULT_BASE_URL)
+    escaped_project = quote(project, safe="")
+    return urljoin(f"{base_url.rstrip('/')}/", f"v1/projects/{escaped_project}/spans/otlpv1")
+
+
+def _phoenix_params(config: TraceSourceConfig, *, include_project: bool) -> dict[str, str]:
+    params: dict[str, str] = {}
+    project = config.project or os.environ.get(PHOENIX_PROJECT_ENV)
+    if include_project and project is not None:
+        params["project_id"] = project
+    if config.since is not None:
+        params["start_time"] = config.since
+    if config.until is not None:
+        params["end_time"] = config.until
+    if config.limit is not None:
+        params["limit"] = str(config.limit)
+    return params
+
+
+def _payloads_or_vendor_spans(
+    payloads: list[JsonValue], converter: VendorSpanConverter
+) -> JsonValue:
+    if len(payloads) == 1:
+        return _payload_or_vendor_spans(payloads[0], converter)
+    spans: list[JsonValue] = []
+    for payload in payloads:
+        converted = _payload_or_vendor_spans(payload, converter)
+        if isinstance(converted, list):
+            spans.extend(converted)
+        else:
+            spans.append(converted)
+    return spans
+
+
+class VendorSpanConverter(Protocol):
+    def __call__(self, record: JsonObject) -> JsonValue | None:
+        ...
+
+
+def _payload_or_vendor_spans(payload: JsonValue, converter: VendorSpanConverter) -> JsonValue:
+    if _looks_like_otlp(payload):
+        return payload
+    records = _extract_records(payload)
+    if records is None:
+        return payload
+    spans: list[JsonValue] = []
+    for record in records:
+        obj = _as_object(record)
+        if obj is None:
+            continue
+        if _looks_like_otlp(obj):
+            spans.append(obj)
+            continue
+        span = converter(obj)
+        if span is not None:
+            spans.append(span)
+    return spans
+
+
+def _looks_like_otlp(payload: JsonValue) -> bool:
+    if isinstance(payload, dict):
+        return "resourceSpans" in payload or "traceId" in payload
+    if isinstance(payload, list):
+        return all(_looks_like_otlp(item) for item in payload if isinstance(item, dict))
+    return False
+
+
+def _extract_records(payload: JsonValue) -> list[JsonValue] | None:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return None
+    for key in ("spans", "data", "rows", "records", "results", "items", "traces"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+    return None
+
+
+def _next_cursor(payload: JsonValue) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    for key in ("next_cursor", "nextCursor", "cursor", "next"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _vendor_record_to_span(record: JsonObject) -> JsonValue | None:
+    attrs = _record_attributes(record)
+    trace_id = _first_str(record, "trace_id", "traceId") or _first_str(attrs, "trace_id", "traceId")
+    if trace_id is None:
+        return None
+    span_id = (
+        _first_str(record, "span_id", "spanId", "id")
+        or _first_str(attrs, "span_id", "spanId", "id")
+        or trace_id
+    )
+    span: JsonObject = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "parentSpanId": _first_str(record, "parent_span_id", "parentSpanId", "parent_id")
+        or _first_str(attrs, "parent_span_id", "parentSpanId", "parent_id")
+        or "",
+        "name": _first_str(record, "name", "span_name")
+        or _first_str(attrs, "name", "span_name")
+        or "",
+        "startTimeUnixNano": _time_nanos(
+            _first_value(
+                record,
+                "startTimeUnixNano",
+                "start_time_unix_nano",
+                "start_time",
+            )
+            or _nested_value(record, "metrics", "start")
+            or _nested_value(record, "metrics", "start_time")
+        ),
+        "endTimeUnixNano": _time_nanos(
+            _first_value(
+                record,
+                "endTimeUnixNano",
+                "end_time_unix_nano",
+                "end_time",
+            )
+            or _nested_value(record, "metrics", "end")
+            or _nested_value(record, "metrics", "end_time")
+        ),
+        "attributes": _record_attributes_to_otlp(record, attrs),
+        "status": _status(record),
+    }
+    return span
+
+
+def _record_attributes(record: JsonObject) -> JsonObject:
+    for key in ("attributes", "span_attributes", "spanAttributes"):
+        value = record.get(key)
+        obj = _as_object(value)
+        if obj is not None:
+            return obj
+    return {}
+
+
+def _record_attributes_to_otlp(record: JsonObject, attrs: JsonObject) -> list[JsonObject]:
+    raw = record.get("attributes")
+    if isinstance(raw, list):
+        normalized: list[JsonObject] = []
+        for item in raw:
+            obj = _as_object(item)
+            if obj is None:
+                continue
+            key = obj.get("key")
+            value = obj.get("value")
+            if isinstance(key, str):
+                normalized.append({"key": key, "value": _normalize_any_value(value)})
+        return normalized
+    return _attributes_to_otlp(attrs)
+
+
+def _as_object(value: JsonValue) -> JsonObject | None:
+    return value if isinstance(value, dict) else None
+
+
+def _first_value(record: JsonObject, *keys: str) -> JsonValue | None:
+    for key in keys:
+        value = record.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _nested_value(record: JsonObject, parent: str, key: str) -> JsonValue | None:
+    obj = _as_object(record.get(parent))
+    if obj is None:
+        return None
+    return obj.get(key)
+
+
+def _first_str(record: JsonObject, *keys: str) -> str | None:
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _time_nanos(value: JsonValue | None) -> int:
+    if value is None or isinstance(value, bool):
+        return 0
+    if isinstance(value, int | float):
+        numeric = float(value)
+        absolute = abs(numeric)
+        if absolute >= 1e17:
+            return int(numeric)
+        if absolute >= 1e12:
+            return int(numeric * 1_000_000)
+        if absolute >= 1e9:
+            return int(numeric * 1_000_000_000)
+        return int(numeric)
+    if isinstance(value, str):
+        try:
+            return _time_nanos(float(value))
+        except ValueError:
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return 0
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return int(parsed.timestamp() * 1_000_000_000)
+    return 0
+
+
+def _attributes_to_otlp(attrs: JsonObject) -> list[JsonObject]:
+    out: list[JsonObject] = []
+    for key, value in attrs.items():
+        if value is None:
+            continue
+        out.append({"key": key, "value": _any_value(value)})
+    return out
+
+
+def _any_value(value: JsonValue) -> JsonObject:
+    if isinstance(value, bool):
+        return {"boolValue": value}
+    if isinstance(value, int):
+        return {"intValue": value}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    if isinstance(value, str):
+        return {"stringValue": value}
+    if isinstance(value, list):
+        return {"arrayValue": {"values": [_any_value(item) for item in value]}}
+    if isinstance(value, dict):
+        return {
+            "kvlistValue": {
+                "values": [
+                    {"key": key, "value": _any_value(nested)}
+                    for key, nested in value.items()
+                    if nested is not None
+                ]
+            }
+        }
+    return {"stringValue": ""}
+
+
+def _normalize_any_value(value: JsonValue | None) -> JsonObject:
+    if not isinstance(value, dict):
+        return _any_value(value)
+    mapping = {
+        "string_value": "stringValue",
+        "int_value": "intValue",
+        "double_value": "doubleValue",
+        "bool_value": "boolValue",
+        "array_value": "arrayValue",
+        "kvlist_value": "kvlistValue",
+    }
+    out: JsonObject = {}
+    for key, nested in value.items():
+        mapped = mapping.get(key, key)
+        if nested is None:
+            continue
+        if mapped == "arrayValue" and isinstance(nested, dict):
+            values = nested.get("values")
+            if isinstance(values, list):
+                out[mapped] = {"values": [_normalize_any_value(item) for item in values]}
+                continue
+        if mapped == "kvlistValue" and isinstance(nested, dict):
+            values = nested.get("values")
+            if isinstance(values, list):
+                out[mapped] = {"values": values}
+                continue
+        out[mapped] = nested
+    return out or {"stringValue": ""}
+
+
+def _status(record: JsonObject) -> JsonObject:
+    existing = _as_object(record.get("status"))
+    if existing is not None:
+        code = existing.get("code")
+        if code in {"ERROR", "STATUS_CODE_ERROR"}:
+            return {"code": "STATUS_CODE_ERROR"}
+        if code == 2:
+            return {"code": 2}
+        return existing
+    status = _first_str(record, "status_code", "statusCode", "status")
+    if status is not None and status.lower() in {"error", "errored", "failed"}:
+        return {"code": "STATUS_CODE_ERROR"}
+    if record.get("error") is True:
+        return {"code": "STATUS_CODE_ERROR"}
+    return {"code": "STATUS_CODE_OK"}
+
+
+def _limit_traces(traces: list[Trace], limit: int | None) -> list[Trace]:
+    return traces[:limit] if limit is not None else traces
+
+
+register_trace_source(FileTraceSource())
+register_trace_source(GenericOtlpTraceSource())
+register_trace_source(BraintrustTraceSource())
+register_trace_source(PhoenixTraceSource())

--- a/wmh/ingest/trace_source.py
+++ b/wmh/ingest/trace_source.py
@@ -18,7 +18,7 @@ from typing import Protocol, cast, runtime_checkable
 from urllib.parse import quote, urljoin
 
 import httpx
-from pydantic import BaseModel, JsonValue
+from pydantic import BaseModel, Field, JsonValue
 
 from wmh.core.types import JsonObject, Trace
 from wmh.ingest.adapter import TraceAdapter
@@ -56,7 +56,7 @@ class TraceSourceConfig(BaseModel):
     project: str | None = None
     since: str | None = None
     until: str | None = None
-    limit: int | None = None
+    limit: int | None = Field(default=None, gt=0)
     query: str | None = None
 
 
@@ -212,6 +212,7 @@ class PhoenixTraceSource:
         params = _phoenix_params(config, include_project=config.endpoint is not None)
         payloads: list[JsonValue] = []
         next_cursor: str | None = None
+        fetched_records = 0
         while True:
             page_params = dict(params)
             if next_cursor is not None:
@@ -219,7 +220,13 @@ class PhoenixTraceSource:
             page = _get_json(endpoint, api_key=api_key, params=page_params)
             payloads.append(page)
             records = _extract_records(page)
-            if config.limit is not None and records is not None and len(records) >= config.limit:
+            if records is not None:
+                fetched_records += len(records)
+            if (
+                config.limit is not None
+                and records is not None
+                and fetched_records >= config.limit
+            ):
                 break
             next_cursor = _next_cursor(page)
             if next_cursor is None:
@@ -248,10 +255,12 @@ def _braintrust_default_query(project: str | None, config: TraceSourceConfig) ->
         project,
         f"set ${BRAINTRUST_PROJECT_ENV}, pass --trace-project, or pass --trace-query",
     )
+    since = _required(
+        config.since,
+        "Braintrust default queries require --trace-since; pass --trace-query for custom SQL",
+    )
     query = f"select * from project_logs('{_btql_quote(project)}', shape => 'traces')"
-    clauses: list[str] = []
-    if config.since is not None:
-        clauses.append(f"created >= '{_btql_quote(config.since)}'")
+    clauses = [f"created >= '{_btql_quote(since)}'"]
     if config.until is not None:
         clauses.append(f"created <= '{_btql_quote(config.until)}'")
     if clauses:
@@ -357,7 +366,9 @@ def _next_cursor(payload: JsonValue) -> str | None:
 
 def _vendor_record_to_span(record: JsonObject) -> JsonValue | None:
     attrs = _record_attributes(record)
-    trace_id = _first_str(record, "trace_id", "traceId") or _first_str(attrs, "trace_id", "traceId")
+    trace_id = _first_str(record, "trace_id", "traceId", "root_span_id") or _first_str(
+        attrs, "trace_id", "traceId", "root_span_id"
+    )
     if trace_id is None:
         return None
     span_id = (
@@ -368,9 +379,7 @@ def _vendor_record_to_span(record: JsonObject) -> JsonValue | None:
     span: JsonObject = {
         "traceId": trace_id,
         "spanId": span_id,
-        "parentSpanId": _first_str(record, "parent_span_id", "parentSpanId", "parent_id")
-        or _first_str(attrs, "parent_span_id", "parentSpanId", "parent_id")
-        or "",
+        "parentSpanId": _parent_span_id(record, attrs),
         "name": _first_str(record, "name", "span_name")
         or _first_str(attrs, "name", "span_name")
         or "",
@@ -450,6 +459,22 @@ def _first_str(record: JsonObject, *keys: str) -> str | None:
         if isinstance(value, str) and value:
             return value
     return None
+
+
+def _parent_span_id(record: JsonObject, attrs: JsonObject) -> str:
+    parent = _first_str(record, "parent_span_id", "parentSpanId", "parent_id")
+    if parent is not None:
+        return parent
+    parent = _first_str(attrs, "parent_span_id", "parentSpanId", "parent_id")
+    if parent is not None:
+        return parent
+    for source in (record, attrs):
+        span_parents = source.get("span_parents")
+        if isinstance(span_parents, list):
+            for candidate in reversed(span_parents):
+                if isinstance(candidate, str) and candidate:
+                    return candidate
+    return ""
 
 
 def _time_nanos(value: JsonValue | None) -> int:
@@ -554,7 +579,8 @@ def _status(record: JsonObject) -> JsonObject:
     status = _first_str(record, "status_code", "statusCode", "status")
     if status is not None and status.lower() in {"error", "errored", "failed"}:
         return {"code": "STATUS_CODE_ERROR"}
-    if record.get("error") is True:
+    error = record.get("error")
+    if error not in (None, False, ""):
         return {"code": "STATUS_CODE_ERROR"}
     return {"code": "STATUS_CODE_OK"}
 

--- a/wmh/ingest/trace_source_test.py
+++ b/wmh/ingest/trace_source_test.py
@@ -152,7 +152,11 @@ def test_braintrust_source_posts_btql_and_normalizes_rows(monkeypatch) -> None: 
 
     monkeypatch.setattr(module.httpx, "post", fake_post)
     traces = load_traces(
-        TraceSourceConfig(kind=TraceSourceKind.BRAINTRUST, limit=4),
+        TraceSourceConfig(
+            kind=TraceSourceKind.BRAINTRUST,
+            since="2026-06-01T00:00:00Z",
+            limit=4,
+        ),
         OtelGenAIAdapter(),
     )
 
@@ -161,16 +165,30 @@ def test_braintrust_source_posts_btql_and_normalizes_rows(monkeypatch) -> None: 
     body = seen["body"]
     assert isinstance(body, dict)
     assert "project_logs('customer-support'" in str(body["query"])
+    assert "created >= '2026-06-01T00:00:00Z'" in str(body["query"])
     assert traces[0].source == "braintrust:customer-support"
     assert traces[0].steps[0].action.name == "search"
     assert traces[0].steps[0].action.arguments == {"q": "otel"}
     assert traces[0].steps[0].observation.content == "3 docs"
 
 
+def test_braintrust_default_query_requires_since(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setenv(BRAINTRUST_PROJECT_ENV, "customer-support")
+    with pytest.raises(ValueError, match="require --trace-since"):
+        load_traces(
+            TraceSourceConfig(kind=TraceSourceKind.BRAINTRUST),
+            OtelGenAIAdapter(),
+        )
+
+
 def test_phoenix_source_fetches_spans_endpoint_and_normalizes_rows(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setenv(PHOENIX_BASE_URL_ENV, "https://phoenix.example")
     monkeypatch.setenv(PHOENIX_API_KEY_ENV, "px-key")
-    seen: dict[str, JsonValue] = {}
+    calls: list[tuple[str, dict[str, str], dict[str, str], float]] = []
+    pages = [
+        {"data": _phoenix_otlp_rows()[:1], "next_cursor": "next-page"},
+        {"data": _phoenix_otlp_rows()[1:], "next_cursor": "ignored"},
+    ]
 
     def fake_get(
         endpoint: str,
@@ -179,11 +197,8 @@ def test_phoenix_source_fetches_spans_endpoint_and_normalizes_rows(monkeypatch) 
         params: dict[str, str],
         timeout: float,
     ) -> httpx.Response:
-        seen["endpoint"] = endpoint
-        seen["headers"] = headers
-        seen["params"] = params
-        seen["timeout"] = timeout
-        return _response(endpoint, {"data": _phoenix_otlp_rows(), "next_cursor": None})
+        calls.append((endpoint, headers, params, timeout))
+        return _response(endpoint, pages[len(calls) - 1])
 
     import wmh.ingest.trace_source as module
 
@@ -194,18 +209,21 @@ def test_phoenix_source_fetches_spans_endpoint_and_normalizes_rows(monkeypatch) 
             project="42",
             since="2026-06-01T00:00:00Z",
             until="2026-06-02T00:00:00Z",
-            limit=4,
+            limit=2,
         ),
         OtelGenAIAdapter(),
     )
 
-    assert seen["endpoint"] == "https://phoenix.example/v1/projects/42/spans/otlpv1"
-    assert seen["headers"] == {"Authorization": "Bearer px-key"}
-    assert seen["params"] == {
+    assert len(calls) == 2
+    endpoint, headers, params, _timeout = calls[0]
+    assert endpoint == "https://phoenix.example/v1/projects/42/spans/otlpv1"
+    assert headers == {"Authorization": "Bearer px-key"}
+    assert params == {
         "start_time": "2026-06-01T00:00:00Z",
         "end_time": "2026-06-02T00:00:00Z",
-        "limit": "4",
+        "limit": "2",
     }
+    assert calls[1][2] == {**params, "cursor": "next-page"}
     assert traces[0].source == "phoenix:42"
     assert traces[0].steps[0].observation.content == "3 docs"
 
@@ -220,7 +238,7 @@ def test_trace_source_aliases() -> None:
 def _vendor_rows() -> list[JsonValue]:
     return [
         {
-            "trace_id": "vendor-trace",
+            "root_span_id": "vendor-trace",
             "span_id": "a",
             "name": "chat",
             "start_time": "2026-06-01T00:00:00Z",
@@ -232,8 +250,9 @@ def _vendor_rows() -> list[JsonValue]:
             },
         },
         {
-            "trace_id": "vendor-trace",
+            "root_span_id": "vendor-trace",
             "span_id": "b",
+            "span_parents": ["a"],
             "name": "execute_tool search",
             "start_time": "2026-06-01T00:00:01Z",
             "attributes": {

--- a/wmh/ingest/trace_source_test.py
+++ b/wmh/ingest/trace_source_test.py
@@ -1,0 +1,278 @@
+"""Tests for trace-source transports feeding the OTel adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import JsonValue
+
+from wmh.ingest.otel_genai import OtelGenAIAdapter
+from wmh.ingest.trace_source import (
+    BRAINTRUST_API_KEY_ENV,
+    BRAINTRUST_PROJECT_ENV,
+    PHOENIX_API_KEY_ENV,
+    PHOENIX_BASE_URL_ENV,
+    TraceSourceConfig,
+    TraceSourceKind,
+    load_traces,
+    trace_source_kind,
+)
+
+
+def _span(
+    trace_id: str,
+    span_id: str,
+    name: str,
+    attrs: list[dict[str, JsonValue]],
+    *,
+    start: int = 1,
+) -> dict[str, JsonValue]:
+    return {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": name,
+        "startTimeUnixNano": start,
+        "attributes": attrs,
+    }
+
+
+def _attr(key: str, value: JsonValue) -> dict[str, JsonValue]:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _otel_payload() -> list[JsonValue]:
+    return [
+        _span(
+            "trace-1",
+            "s1",
+            "chat",
+            [
+                _attr("gen_ai.operation.name", "chat"),
+                _attr("gen_ai.prompt", "find docs"),
+                _attr("gen_ai.tool.name", "search"),
+                _attr("gen_ai.tool.call.arguments", '{"q": "otel"}'),
+            ],
+            start=1,
+        ),
+        _span(
+            "trace-1",
+            "s2",
+            "execute_tool search",
+            [
+                _attr("gen_ai.operation.name", "execute_tool"),
+                _attr("gen_ai.tool.name", "search"),
+                _attr("gen_ai.tool.message", "3 docs"),
+            ],
+            start=2,
+        ),
+    ]
+
+
+def _response(endpoint: str, payload: JsonValue) -> httpx.Response:
+    return httpx.Response(200, json=payload, request=httpx.Request("GET", endpoint))
+
+
+def test_file_source_loads_exported_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "traces.jsonl"
+    path.write_text("\n".join(json.dumps(span) for span in _otel_payload()), encoding="utf-8")
+
+    traces = load_traces(
+        TraceSourceConfig(kind=TraceSourceKind.FILE, path=str(path)),
+        OtelGenAIAdapter(),
+    )
+
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "search"
+    assert traces[0].steps[0].observation.content == "3 docs"
+
+
+def test_generic_otlp_source_fetches_endpoint(monkeypatch) -> None:  # noqa: ANN001
+    seen: dict[str, JsonValue] = {}
+
+    def fake_get(
+        endpoint: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, str],
+        timeout: float,
+    ) -> httpx.Response:
+        seen["endpoint"] = endpoint
+        seen["headers"] = headers
+        seen["params"] = params
+        seen["timeout"] = timeout
+        return _response(endpoint, _otel_payload())
+
+    import wmh.ingest.trace_source as module
+
+    monkeypatch.setattr(module.httpx, "get", fake_get)
+    traces = load_traces(
+        TraceSourceConfig(
+            kind=TraceSourceKind.OTLP,
+            endpoint="https://otel.example/query",
+            api_key="secret",
+            project="proj",
+            since="2026-06-01T00:00:00Z",
+            limit=1,
+        ),
+        OtelGenAIAdapter(),
+    )
+
+    assert seen["endpoint"] == "https://otel.example/query"
+    assert seen["headers"] == {"Authorization": "Bearer secret"}
+    assert seen["params"] == {
+        "project": "proj",
+        "since": "2026-06-01T00:00:00Z",
+        "limit": "1",
+    }
+    assert traces[0].source == "otlp:https://otel.example/query"
+
+
+def test_braintrust_source_posts_btql_and_normalizes_rows(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setenv(BRAINTRUST_API_KEY_ENV, "bt-key")
+    monkeypatch.setenv(BRAINTRUST_PROJECT_ENV, "customer-support")
+    seen: dict[str, JsonValue] = {}
+
+    def fake_post(
+        endpoint: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, JsonValue],
+        timeout: float,
+    ) -> httpx.Response:
+        seen["endpoint"] = endpoint
+        seen["headers"] = headers
+        seen["body"] = json
+        seen["timeout"] = timeout
+        return _response(endpoint, {"rows": _vendor_rows()})
+
+    import wmh.ingest.trace_source as module
+
+    monkeypatch.setattr(module.httpx, "post", fake_post)
+    traces = load_traces(
+        TraceSourceConfig(kind=TraceSourceKind.BRAINTRUST, limit=4),
+        OtelGenAIAdapter(),
+    )
+
+    assert seen["endpoint"] == "https://api.braintrust.dev/btql"
+    assert seen["headers"] == {"Authorization": "Bearer bt-key"}
+    body = seen["body"]
+    assert isinstance(body, dict)
+    assert "project_logs('customer-support'" in str(body["query"])
+    assert traces[0].source == "braintrust:customer-support"
+    assert traces[0].steps[0].action.name == "search"
+    assert traces[0].steps[0].action.arguments == {"q": "otel"}
+    assert traces[0].steps[0].observation.content == "3 docs"
+
+
+def test_phoenix_source_fetches_spans_endpoint_and_normalizes_rows(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setenv(PHOENIX_BASE_URL_ENV, "https://phoenix.example")
+    monkeypatch.setenv(PHOENIX_API_KEY_ENV, "px-key")
+    seen: dict[str, JsonValue] = {}
+
+    def fake_get(
+        endpoint: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, str],
+        timeout: float,
+    ) -> httpx.Response:
+        seen["endpoint"] = endpoint
+        seen["headers"] = headers
+        seen["params"] = params
+        seen["timeout"] = timeout
+        return _response(endpoint, {"data": _phoenix_otlp_rows(), "next_cursor": None})
+
+    import wmh.ingest.trace_source as module
+
+    monkeypatch.setattr(module.httpx, "get", fake_get)
+    traces = load_traces(
+        TraceSourceConfig(
+            kind=TraceSourceKind.PHOENIX,
+            project="42",
+            since="2026-06-01T00:00:00Z",
+            until="2026-06-02T00:00:00Z",
+            limit=4,
+        ),
+        OtelGenAIAdapter(),
+    )
+
+    assert seen["endpoint"] == "https://phoenix.example/v1/projects/42/spans/otlpv1"
+    assert seen["headers"] == {"Authorization": "Bearer px-key"}
+    assert seen["params"] == {
+        "start_time": "2026-06-01T00:00:00Z",
+        "end_time": "2026-06-02T00:00:00Z",
+        "limit": "4",
+    }
+    assert traces[0].source == "phoenix:42"
+    assert traces[0].steps[0].observation.content == "3 docs"
+
+
+def test_trace_source_aliases() -> None:
+    assert trace_source_kind("arize") is TraceSourceKind.PHOENIX
+    assert trace_source_kind("generic-otlp") is TraceSourceKind.OTLP
+    with pytest.raises(ValueError, match="unknown trace source"):
+        trace_source_kind("unknown")
+
+
+def _vendor_rows() -> list[JsonValue]:
+    return [
+        {
+            "trace_id": "vendor-trace",
+            "span_id": "a",
+            "name": "chat",
+            "start_time": "2026-06-01T00:00:00Z",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.prompt": "find docs",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.call.arguments": '{"q": "otel"}',
+            },
+        },
+        {
+            "trace_id": "vendor-trace",
+            "span_id": "b",
+            "name": "execute_tool search",
+            "start_time": "2026-06-01T00:00:01Z",
+            "attributes": {
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "search",
+                "gen_ai.tool.message": "3 docs",
+            },
+        },
+    ]
+
+
+def _phoenix_otlp_rows() -> list[JsonValue]:
+    return [
+        {
+            "trace_id": "phoenix-trace",
+            "span_id": "a",
+            "name": "chat",
+            "start_time_unix_nano": 1,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"string_value": "chat"}},
+                {"key": "gen_ai.prompt", "value": {"string_value": "find docs"}},
+                {"key": "gen_ai.tool.name", "value": {"string_value": "search"}},
+                {
+                    "key": "gen_ai.tool.call.arguments",
+                    "value": {"string_value": '{"q": "otel"}'},
+                },
+            ],
+            "status": {"code": 1},
+        },
+        {
+            "trace_id": "phoenix-trace",
+            "span_id": "b",
+            "name": "execute_tool search",
+            "start_time_unix_nano": 2,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"string_value": "execute_tool"}},
+                {"key": "gen_ai.tool.name", "value": {"string_value": "search"}},
+                {"key": "gen_ai.tool.message", "value": {"string_value": "3 docs"}},
+            ],
+            "status": {"code": 1},
+        },
+    ]


### PR DESCRIPTION
## Summary

- split trace ingestion into schema adapters and transport-level trace sources
- add built-in trace sources for local files, generic OTLP HTTP, Braintrust BTQL, and Arize Phoenix OTLP spans
- wire `wmh build --vendor ...` with trace source flags/env vars and document the import paths

## Notes

The existing `otel-genai` adapter now stays focused on normalization. Provider-specific fetch/query behavior lives behind `TraceSource`, with Phoenix defaulting to `GET /v1/projects/{project}/spans/otlpv1` and Braintrust accepting a custom `--trace-query` when a workspace needs custom BTQL.

## Validation

- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ty check`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q`
