### PR TITLE
[codex] Separate GEPA RAG corpus from optimization splits

### DIFF
--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -60,7 +60,13 @@ class OptimizeResult(BaseModel):
 @runtime_checkable
 class Optimizer(Protocol):
     def optimize(
-        self, train: list[Trace], test: list[Trace], base_prompt: str, budget: int
+        self,
+        train: list[Trace],
+        test: list[Trace],
+        base_prompt: str,
+        budget: int,
+        *,
+        rag_corpus: list[Trace] | None = None,
     ) -> OptimizeResult: ...
 
 
@@ -272,8 +278,23 @@ class GEPAOptimizer:
         self._seed = seed
 
     def optimize(
-        self, train: list[Trace], test: list[Trace], base_prompt: str, budget: int
+        self,
+        train: list[Trace],
+        test: list[Trace],
+        base_prompt: str,
+        budget: int,
+        *,
+        rag_corpus: list[Trace] | None = None,
     ) -> OptimizeResult:
+        """Run GEPA over optimization splits, optionally retrieving demos from another corpus.
+
+        `train`/`test` are GEPA's optimization data: minibatch examples and validation examples.
+        `rag_corpus`, when supplied, is the replay-buffer corpus used for retrieved demos during
+        those GEPA evaluations. Keeping it separate lets callers optimize a prompt on a dev split
+        while using an independently chosen RAG/index split, instead of forcing the GEPA trainset to
+        double as the retrieval corpus. When omitted, the historical behavior is preserved: demos
+        come from the GEPA train source.
+        """
         train_steps = [step for trace in train for step in trace.steps]
         val_steps = [step for trace in test for step in trace.steps]
         # GEPA samples minibatches from the trainset; fall back to val when train is empty.
@@ -283,9 +304,11 @@ class GEPAOptimizer:
             # Nothing to optimize against (or no budget): the base prompt is the only candidate.
             return OptimizeResult(prompt=base_prompt, frontier=[base_prompt])
 
-        # RAG-aware, leak-free: retrieve demos from the train corpus only, never a step's own trace.
+        # RAG-aware, leak-free: retrieve demos from the configured RAG corpus only, never a step's
+        # own trace. By default, preserve the original behavior and use GEPA's train source.
         # Built once and reused for both splits (retrieval is independent of the candidate prompt).
-        demos = DemoRetriever(self._retriever, train_src)
+        demo_src = train_src if rag_corpus is None else rag_corpus
+        demos = DemoRetriever(self._retriever, demo_src)
         trainset = _eval_steps(train_src, demos)
         valset = _eval_steps(val_src, demos)
         adapter = WorldModelGEPAAdapter(self._provider, self._judge, self._on_rollout)

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -115,6 +115,44 @@ def test_optimize_runs_bounded_loop_and_returns_valid_frontier() -> None:
     assert judge.calls > 0
 
 
+def test_optimize_can_retrieve_from_separate_rag_corpus() -> None:
+    from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+    class PromptRecordingProvider(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.rollout_user_messages: list[str] = []
+
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 2048,
+        ) -> Completion:
+            if "improve the system prompt" not in system:
+                self.rollout_user_messages.append(messages[0].content)
+            return super().complete(
+                system, messages, temperature=temperature, max_tokens=max_tokens
+            )
+
+    provider = PromptRecordingProvider()
+    dev = _trace("dev", n=1)
+    rag = _trace("rag", n=1)
+    rag.steps[0].observation.content = "rag-only-observation"
+    rag.steps[0].action.arguments = {"source": "rag-only"}
+
+    result = GEPAOptimizer(
+        provider, FakeJudge(), retriever=EmbeddingRetriever(HashingEmbedder(dim=64))
+    ).optimize([dev], [dev], "BASE", budget=1, rag_corpus=[rag])
+
+    assert result.prompt
+    prompt_text = "\n".join(provider.rollout_user_messages)
+    assert "rag-only-observation" in prompt_text
+    assert "real-0" not in prompt_text
+
+
 def test_optimize_with_zero_budget_returns_base_prompt() -> None:
     result = GEPAOptimizer(FakeProvider(), FakeJudge()).optimize(
         [_trace("tr1")], [_trace("te1")], "BASE", budget=0

--- a/wmh/optimize/judge.py
+++ b/wmh/optimize/judge.py
@@ -26,6 +26,9 @@ observation the world model generated, judge whether the prediction is *function
 the actual one — i.e. it conveys the same outcome, errors, and salient data the agent would act on.
 Ignore cosmetic differences (wording, formatting, ordering, incidental ids). Penalize wrong
 outcomes, flipped success/error status, and missing or fabricated salient facts.
+The observations are encoded as JSON strings. If `content` is `""` and `content_length` is `0`, the
+observation is the empty string; do not infer or fill in missing content from the action or actual
+observation.
 
 Respond with ONLY a JSON object, no prose around it:
 {"score": <float 0..1>, "critique": "<one or two sentences: what matched, what diverged, and how \
@@ -73,12 +76,25 @@ class LLMJudge:
 def _build_judge_prompt(predicted: Observation, actual: Observation, context: Step) -> str:
     action = context.action
     action_desc = action.name or action.content or "(none)"
+    actual_payload = _observation_payload(actual)
+    predicted_payload = _observation_payload(predicted)
     return (
         f"AGENT ACTION ({action.kind.value}): {action_desc}\n"
         f"ACTION ARGUMENTS: {json.dumps(action.arguments, sort_keys=True, default=str)}\n\n"
-        f"ACTUAL OBSERVATION (is_error={actual.is_error}):\n{actual.content}\n\n"
-        f"PREDICTED OBSERVATION (is_error={predicted.is_error}):\n{predicted.content}\n"
+        "ACTUAL OBSERVATION JSON:\n"
+        f"{json.dumps(actual_payload, ensure_ascii=False, sort_keys=True)}\n\n"
+        "PREDICTED OBSERVATION JSON:\n"
+        f"{json.dumps(predicted_payload, ensure_ascii=False, sort_keys=True)}\n"
     )
+
+
+def _observation_payload(observation: Observation) -> dict[str, object]:
+    return {
+        "is_error": observation.is_error,
+        "content_length": len(observation.content),
+        "content": observation.content,
+        "empty_content": observation.content == "",
+    }
 
 
 def _parse_judgement(text: str) -> JudgeResult:

--- a/wmh/optimize/judge_test.py
+++ b/wmh/optimize/judge_test.py
@@ -14,6 +14,7 @@ from wmh.optimize.judge import (
     JudgeResult,
     LLMJudge,
     RubricJudge,
+    _build_judge_prompt,
     _parse_judgement,
 )
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
@@ -74,6 +75,18 @@ def test_score_parses_bare_json() -> None:
     # The judge actually saw both observations in its prompt.
     assert provider.last_user is not None
     assert "pred" in provider.last_user and "actual" in provider.last_user
+
+
+def test_judge_prompt_makes_empty_prediction_explicit() -> None:
+    prompt = _build_judge_prompt(
+        Observation(content="", is_error=False),
+        Observation(content="HTTP 200\n", is_error=False),
+        _ctx(),
+    )
+    assert '"content": ""' in prompt
+    assert '"content_length": 0' in prompt
+    assert '"empty_content": true' in prompt
+    assert "PREDICTED OBSERVATION JSON" in prompt
 
 
 def test_parse_handles_fenced_json() -> None:


### PR DESCRIPTION
## Summary
- add an optional `rag_corpus` keyword to `GEPAOptimizer.optimize`
- keep existing behavior when `rag_corpus` is omitted
- add regression coverage proving GEPA can optimize on one corpus while retrieving demos from another

## Validation
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ty check`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q`