### PR TITLE
[codex] Make replay eval open-loop multi-turn

### DIFF
--- a/wmh/engine/replay.py
+++ b/wmh/engine/replay.py
@@ -1,11 +1,11 @@
 """Open-loop reconstruction-fidelity evaluation by replaying held-out steps ("open replay").
 
-Replay is TEACHER-FORCED and so perfectly repeatable per step: for each held-out step we feed the
-*real recorded* `(state_before, action)` and have the world model predict the observation, then
-score it against the *real recorded* observation. Nothing the model generates feeds forward, so a
-bad prediction at one step never contaminates another — the score isolates per-step fidelity. (The
-closed-loop counterpart, where predictions feed forward, is a future direction: see
-docs/closed_loop.md.)
+Replay is TEACHER-FORCED and so perfectly repeatable per step: for each held-out step we feed
+all *real recorded* prior same-trace steps plus the step's `(state_before, action)`, have the world
+model predict the observation, then score it against the *real recorded* observation. Nothing the
+model generates feeds forward, so a bad prediction at one step never contaminates another — the
+score isolates per-step fidelity. (The closed-loop counterpart, where predictions feed forward, is a
+future direction: see docs/closed_loop.md.)
 
 The judge is pluggable; `RubricJudge` (the Qwen-AgentWorld-style 5-dimension scorer) is the default
 for evaluation, and the report carries per-step scores plus their mean ± std across steps.
@@ -96,20 +96,23 @@ def replay(
     rng = random.Random(seed)
     results: list[StepResult] = []
     for trace in held_out:
-        for step in _select_steps(trace, sample_turns, rng):
-            results.append(_score_step(prompt, trace.trace_id, step, provider, judge, demos))
+        for step_index in _select_step_indices(trace, sample_turns, rng):
+            step = trace.steps[step_index]
+            history = trace.steps[:step_index]
+            results.append(
+                _score_step(prompt, trace.trace_id, step, provider, judge, demos, history)
+            )
     return _aggregate(results)
 
 
-def _select_steps(trace: Trace, sample_turns: str, rng: random.Random) -> list[Step]:
+def _select_step_indices(trace: Trace, sample_turns: str, rng: random.Random) -> list[int]:
     """Pick which steps of `trace` to score. 'all' = every step; 'sampled' = first/last/3 middle."""
     steps = trace.steps
     if sample_turns != "sampled" or len(steps) <= SAMPLED_TURNS:
-        return steps
+        return list(range(len(steps)))
     middle = list(range(1, len(steps) - 1))
     picks = sorted(rng.sample(middle, SAMPLED_TURNS - 2))
-    indices = [0, *picks, len(steps) - 1]
-    return [steps[i] for i in indices]
+    return [0, *picks, len(steps) - 1]
 
 
 def _score_step(
@@ -119,11 +122,13 @@ def _score_step(
     provider: Provider,
     judge: Judge,
     demos: DemoRetriever,
+    history: list[Step],
 ) -> StepResult:
     """Predict the observation for one step and score it against the recorded observation."""
     predicted = predict_observation(
         provider, prompt, step.task, step.state_before, step.action,
         demos=demos.demos_for(trace_id, step),
+        history=history,
     )
     verdict = judge.score(predicted, step.observation, step)
     return StepResult(

--- a/wmh/engine/replay_test.py
+++ b/wmh/engine/replay_test.py
@@ -77,6 +77,17 @@ def test_replay_scores_and_aggregates() -> None:
     assert report.results[0].actual == "real-0"
 
 
+def test_replay_includes_all_prior_teacher_forced_history_by_default() -> None:
+    provider = FakeProvider('{"output": "real-2", "is_error": false}')
+    report = replay("BASE", [_trace("h", n=3)], provider, FakeJudge(1.0))
+
+    assert report.n_steps == 3
+    user_prompt = provider.last_user or ""
+    assert "OBSERVATION (is_error=False): real-0" in user_prompt
+    assert "OBSERVATION (is_error=False): real-1" in user_prompt
+    assert "OBSERVATION (is_error=False): real-2" not in user_prompt
+
+
 def test_replay_tracks_error_flag_mismatch() -> None:
     # Model predicts an error, but the actual observation is not an error -> flag mismatch.
     provider = FakeProvider('{"output": "boom", "is_error": true}')
@@ -124,17 +135,43 @@ def test_replay_carries_rubric_dimensions() -> None:
 
 def test_replay_sampled_turns_scores_five_for_long_traces() -> None:
     judge = FakeJudge(0.5)
-    report = replay("BASE", [_trace("h", n=10)], FakeProvider('{"output": "x"}'),
-                    judge, sample_turns="sampled", seed=0)
+    report = replay(
+        "BASE",
+        [_trace("h", n=10)],
+        FakeProvider('{"output": "x"}'),
+        judge,
+        sample_turns="sampled",
+        seed=0,
+    )
     assert report.n_steps == 5  # first, last, 3 middle
     # Deterministic under a fixed seed.
     judge2 = FakeJudge(0.5)
-    report2 = replay("BASE", [_trace("h", n=10)], FakeProvider('{"output": "x"}'),
-                     judge2, sample_turns="sampled", seed=0)
+    report2 = replay(
+        "BASE",
+        [_trace("h", n=10)],
+        FakeProvider('{"output": "x"}'),
+        judge2,
+        sample_turns="sampled",
+        seed=0,
+    )
     assert [r.action for r in report.results] == [r.action for r in report2.results]
 
 
+def test_replay_sampled_turns_history_uses_original_trace_prefix() -> None:
+    provider = FakeProvider('{"output": "x"}')
+    replay("BASE", [_trace("h", n=10)], provider, FakeJudge(0.5), sample_turns="sampled", seed=0)
+
+    user_prompt = provider.last_user or ""
+    assert "OBSERVATION (is_error=False): real-8" in user_prompt
+    assert "OBSERVATION (is_error=False): real-9" not in user_prompt
+
+
 def test_replay_sample_turns_all_scores_every_step() -> None:
-    report = replay("BASE", [_trace("h", n=10)], FakeProvider('{"output": "x"}'),
-                    FakeJudge(0.5), sample_turns="all")
+    report = replay(
+        "BASE",
+        [_trace("h", n=10)],
+        FakeProvider('{"output": "x"}'),
+        FakeJudge(0.5),
+        sample_turns="all",
+    )
     assert report.n_steps == 10

--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -80,6 +80,7 @@ def predict_observation(
     state: EnvState,
     action: Action,
     demos: list[Step],
+    history: list[Step] | None = None,
 ) -> Observation:
     """Predict the observation for (state, action) under `prompt`, using only a Provider.
 
@@ -92,7 +93,7 @@ def predict_observation(
     temperature is forwarded. A temperature sweep is parked until a sampling-capable provider exists
     (see docs/research_directions.md).
     """
-    system, user = build_env_prompt(prompt, task, state, action, demos=demos)
+    system, user = build_env_prompt(prompt, task, state, action, history=history, demos=demos)
     completion = provider.complete(
         system, [Message(role="user", content=user)], temperature=0.0, max_tokens=1024
     )

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -31,6 +31,7 @@ class FakeProvider:
         self._mutation = mutation
         self.reflection_calls = 0
         self.rollout_calls = 0
+        self.last_rollout_user: str | None = None
 
     def complete(
         self,
@@ -44,6 +45,7 @@ class FakeProvider:
             self.reflection_calls += 1
             return Completion(text=self._mutation)
         self.rollout_calls += 1
+        self.last_rollout_user = messages[0].content
         return Completion(text=self._prediction)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
@@ -89,6 +91,21 @@ def test_predict_observation_uses_provider() -> None:
         demos=[],
     )
     assert obs.content == "the cart now has 1 item"
+
+
+def test_predict_observation_can_include_history() -> None:
+    provider = FakeProvider(prediction="next")
+    predict_observation(
+        provider,
+        "PROMPT",
+        task="t",
+        state=EnvState(),
+        action=Action(kind=ActionKind.MESSAGE, content="continue"),
+        demos=[],
+        history=[_trace("hist", n=1).steps[0]],
+    )
+
+    assert "OBSERVATION (is_error=False): real-0" in (provider.last_rollout_user or "")
 
 
 def test_optimizer_satisfies_protocol() -> None:


### PR DESCRIPTION
## Summary
- keep replay/eval open-loop and teacher-forced, but include all prior real same-trace steps in the prompt for each scored step
- preserve sampled-turn scoring while building history from the original trace prefix, not just sampled steps
- thread optional history through the shared provider-only rollout helper without changing existing GEPA callers

## Tests
- UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q wmh/engine/replay_test.py wmh/optimize/gepa_test.py wmh/engine/eval_test.py wmh/research/pipeline_test.py
- UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q
- UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check .
- UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run ty check
- git diff --check