### PR TITLE
bench: resolve benchmarks/ from any cwd; swe-bench pull mode; scenario output + review fixes

### DIFF
--- a/benchmarks/swe-bench/benchmark.toml
+++ b/benchmarks/swe-bench/benchmark.toml
@@ -3,8 +3,8 @@
 # A committed, versioned benchmark definition ("filesystem as DB"). `wmh bench run swe-bench` replays
 # the held-out steps of the trace(s) below teacher-forced, has the world model predict each
 # observation, and scores it against the recorded one with the pinned rubric judge. Results land in
-# `benchmarks/swe-bench/results/` and surface on `wmh bench`. `wmh bench race swe-bench` replays one
-# recorded scenario live and times it (the sandbox-vs-world-model demo).
+# `benchmarks/swe-bench/results/` and surface on `wmh bench`. `wmh bench scenario swe-bench` replays
+# one recorded scenario open-loop and times it (the sandbox-vs-world-model demo).
 #
 # Trace paths resolve relative to this directory; they point at the shared corpus under `examples/`
 # (captured from real SWE-bench Verified via tools/swe-bench-capture/) so there is one source of

--- a/tools/swe-bench-capture/run.sh
+++ b/tools/swe-bench-capture/run.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
-# End-to-end REAL swe-bench scenario: set up the venv + deps (timed standup), then build the
-# environment from scratch and run the recorded scenario, streaming all stdout. One command.
+# End-to-end REAL swe-bench scenario: set up the venv + deps (timed standup), then stand up the
+# environment (build from scratch on native x86_64, else pull the prebuilt image) and run the
+# recorded scenario, streaming all stdout. One command.
 #
-#   tools/swe-bench-capture/run.sh [--trace N] [--cache] [...]
+#   tools/swe-bench-capture/run.sh [--trace N] [--mode build|pull|auto] [--cache] [...]
 #
-# The whole thing — Python venv creation, `swebench` install, the base/env/instance Docker build
-# (real conda/pip dependency install), and the recorded commands — runs and prints here, so the
-# total wall-clock is the true cost of standing up + running the real environment cold. That is the
-# cost the world model side (`wmh bench scenario swe-bench`) skips. Re-runs reuse the venv; pass
-# --cache to also reuse Docker layers.
+# The whole thing — Python venv creation, `swebench` install, the Docker standup (a from-scratch
+# conda/pip build on x86_64, or a multi-GB prebuilt-image pull under emulation), and the recorded
+# commands — runs and prints here, so the total wall-clock is the true cost of standing up + running
+# the real environment cold. That is the cost the world model side (`wmh bench scenario swe-bench`)
+# skips. Re-runs reuse the venv; pass --cache to also reuse Docker build layers.
 set -euo pipefail
 cd "$(dirname "$0")"
 
-if [ ! -x .venv/bin/python ]; then
+# Guard on the package actually importing, not just the venv dir existing — a half-finished prior
+# setup (venv created, pip install interrupted) must re-run the install, not skip it.
+if ! .venv/bin/python -c 'import swebench' >/dev/null 2>&1; then
   echo "=== setting up the swebench venv (one-time; counts as standup) ==="
   uv venv --python 3.12 .venv
   uv pip install --python .venv swebench boto3
 fi
 
 export AWS_REGION="${AWS_REGION:-us-east-1}" AWS_REGION_NAME="${AWS_REGION_NAME:-us-east-1}"
-echo "=== running the real swe-bench scenario (build from scratch + exec) ==="
+echo "=== running the real swe-bench scenario (stand up env + exec) ==="
 exec .venv/bin/python run_real_scenario.py "$@"

--- a/tools/swe-bench-capture/run_real_scenario.py
+++ b/tools/swe-bench-capture/run_real_scenario.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import platform
 import subprocess
 import tempfile
 import time
@@ -82,7 +83,7 @@ def _holdout(traces: list[dict[str, Any]], train_split: float) -> list[dict[str,
 
 
 def _docker_build(
-    tag: str, dockerfile: str, scripts: dict[str, str], platform: str, *, no_cache: bool
+    tag: str, dockerfile: str, scripts: dict[str, str], platform_str: str, *, no_cache: bool
 ) -> None:
     """Write a build context (Dockerfile + setup scripts) and `docker build` it, streaming output.
 
@@ -94,7 +95,7 @@ def _docker_build(
         (ctx_dir / "Dockerfile").write_text(dockerfile, encoding="utf-8")
         for name, body in scripts.items():
             (ctx_dir / name).write_text(body, encoding="utf-8")
-        cmd = ["docker", "build", "-t", tag, "--platform", platform]
+        cmd = ["docker", "build", "-t", tag, "--platform", platform_str]
         if no_cache:
             cmd.append("--no-cache")
         cmd.append(str(ctx_dir))
@@ -110,6 +111,34 @@ def _exists(image: str) -> bool:
     ).returncode == 0
 
 
+def _pull_image(instance_id: str, platform_str: str) -> str:
+    """`docker pull` the official prebuilt per-instance image, streaming progress; return its tag.
+
+    The standup for the `pull` mode: a multi-GB image download (the environment + its installed
+    dependencies, prebuilt) — a real, timed cost, just not a from-scratch compile. This is the path
+    that works under emulation (the from-scratch `build` mode's `apt`/conda steps fail under qemu on
+    non-x86 hosts). Raises on a failed pull.
+    """
+    compat = instance_id.replace("__", "_1776_")
+    image = f"docker.io/swebench/sweb.eval.x86_64.{compat}:latest".lower()
+    cmd = ["docker", "pull", "--platform", platform_str, image]
+    print(f"$ {' '.join(cmd)}")
+    rc = subprocess.run(cmd).returncode
+    if rc != 0:
+        raise SystemExit(f"docker pull failed for {image} (exit {rc})")
+    return image
+
+
+def _default_mode() -> str:
+    """`build` from scratch on a native x86_64 host, else `pull` the prebuilt image.
+
+    SWE-bench's base/env Dockerfiles run `apt`/conda steps that fail under qemu emulation (the apt
+    GPG "invalid signature" error) on Apple-Silicon/arm64 hosts, so building from scratch only works
+    natively. Everywhere else, pulling the prebuilt image is the robust real-environment standup.
+    """
+    return "build" if platform.machine().lower() in ("x86_64", "amd64") else "pull"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--corpus", default=str(_DEFAULT_CORPUS), help="swe-bench OTel JSONL corpus.")
@@ -122,6 +151,16 @@ def main() -> None:
         "--dataset", default="SWE-bench/SWE-bench_Verified", help="HF dataset for the build spec."
     )
     parser.add_argument(
+        "--mode",
+        choices=("auto", "build", "pull"),
+        default="auto",
+        help=(
+            "How to stand up the env: 'build' compiles base/env/instance from scratch (native "
+            "x86_64/Linux only — apt/conda fail under qemu emulation); 'pull' downloads the prebuilt "
+            "multi-GB image (works under emulation). 'auto' (default): build on x86_64, else pull."
+        ),
+    )
+    parser.add_argument(
         "--cache",
         action="store_true",
         help="Reuse cached Docker layers (skip already-built images). Default: cold --no-cache.",
@@ -131,6 +170,8 @@ def main() -> None:
 
     traces = _load_traces(Path(args.corpus))
     pool = _holdout(traces, args.train_split)
+    if not pool:
+        raise SystemExit(f"no traces in {args.corpus}; nothing to run")
     if args.trace is None:
         # Default: the simplest scenario — fewest recorded commands (matches the wmh side's default).
         trace = min(pool, key=lambda t: len(t["commands"]))
@@ -142,81 +183,98 @@ def main() -> None:
     if not instance_id:
         raise SystemExit(f"trace {trace['trace_id'][:8]} has no instance_id in metadata")
 
+    mode = _default_mode() if args.mode == "auto" else args.mode
+
+    print(f"=== resolving SWE-bench dataset spec for {instance_id} (first run downloads it) ===")
     # Official SWE-bench build spec: the real base/env/instance Dockerfiles + setup scripts.
     try:
         from swebench.harness.test_spec.test_spec import make_test_spec
         from swebench.harness.utils import load_swebench_dataset
     except ImportError as exc:  # pragma: no cover - depends on the isolated venv
         raise SystemExit(
-            "swebench is not importable; run this from tools/swe-bench-capture/ in the .venv "
-            "(see this directory's README). Docker must be running."
+            "swebench is not importable; run via ./run.sh (it sets up the .venv) or install "
+            "swebench in tools/swe-bench-capture/.venv. Docker must be running."
         ) from exc
 
     ds = load_swebench_dataset(args.dataset, "test", instance_ids=[instance_id])
     if not ds:
         raise SystemExit(f"instance {instance_id} not found in {args.dataset}")
     spec = make_test_spec(ds[0])
-    no_cache = not args.cache
 
     print(
-        f"REAL sandbox: {instance_id} ({len(commands)} commands) — building the environment from "
-        f"scratch (base -> env deps -> instance), then exec'ing the recorded commands"
-        f"{' [--no-cache]' if no_cache else ' [cached]'}\n"
+        f"\nREAL sandbox: {instance_id} ({len(commands)} commands) — standing up the env "
+        f"[mode={mode}], then exec'ing the recorded commands\n"
     )
     start = time.monotonic()
 
-    # 1) base image, 2) env image (the real conda/pip dependency install), 3) instance image
-    #    (clone repo + checkout + install). Each streams its build log and counts toward the clock.
-    layers = [
-        ("base", spec.base_image_key, spec.base_dockerfile, {}),
-        (
-            "env (dependency install)",
-            spec.env_image_key,
-            spec.env_dockerfile,
-            {"setup_env.sh": spec.setup_env_script},
-        ),
-        (
-            "instance (repo + install)",
-            spec.instance_image_key,
-            spec.instance_dockerfile,
-            {"setup_repo.sh": spec.install_repo_script},
-        ),
-    ]
-    for label, tag, dockerfile, scripts in layers:
-        if args.cache and _exists(tag):
-            print(f"--- {label}: {tag} already built (cached) ---\n")
-            continue
-        print(f"--- building {label}: {tag} ---")
-        _docker_build(tag, dockerfile, scripts, spec.platform, no_cache=no_cache)
+    if mode == "build":
+        # base image -> env image (the real conda/pip dependency install) -> instance image (clone
+        # repo + checkout + install). Each streams its build log and counts toward the clock.
+        no_cache = not args.cache
+        layers = [
+            ("base", spec.base_image_key, spec.base_dockerfile, {}),
+            (
+                "env (dependency install)",
+                spec.env_image_key,
+                spec.env_dockerfile,
+                {"setup_env.sh": spec.setup_env_script},
+            ),
+            (
+                "instance (repo + install)",
+                spec.instance_image_key,
+                spec.instance_dockerfile,
+                {"setup_repo.sh": spec.install_repo_script},
+            ),
+        ]
+        for label, tag, dockerfile, scripts in layers:
+            if args.cache and _exists(tag):
+                print(f"--- {label}: {tag} already built (cached) ---\n")
+                continue
+            print(f"=== building {label}: {tag} ===")
+            _docker_build(tag, dockerfile, scripts, spec.platform, no_cache=no_cache)
+            print()
+        run_image = spec.instance_image_key
+    else:  # pull
+        print("=== pulling the prebuilt instance image (multi-GB download — this is the standup) ===")
+        run_image = _pull_image(instance_id, spec.platform)
         print()
     build_done = time.monotonic()
-    print(f"[environment built from scratch in {build_done - start:.1f}s]\n")
+    print(f"[environment stood up ({mode}) in {build_done - start:.1f}s]\n")
 
-    # Run the recorded scenario in a fresh container off the just-built instance image.
+    # Run the recorded scenario in a fresh container off the stood-up instance image.
     container = f"wmh-real-{uuid.uuid4().hex[:8]}"
     rc = subprocess.run(
         ["docker", "run", "-d", "--name", container, "--platform", spec.platform,
-         "-w", "/testbed", "--rm", spec.instance_image_key, "sleep", "2h"],
+         "-w", "/testbed", "--rm", run_image, "sleep", "2h"],
         stdout=subprocess.DEVNULL,
     ).returncode
     if rc != 0:
         raise SystemExit(f"failed to start container (docker run exit {rc})")
+    failures = 0
     try:
         for i, command in enumerate(commands):
             print(f"--- step {i} ---\n$ {command}")
-            subprocess.run(
-                ["docker", "exec", "-w", "/testbed", container, "bash", "-lc", command],
-                timeout=args.exec_timeout,
-            )
+            try:
+                proc = subprocess.run(
+                    ["docker", "exec", "-w", "/testbed", container, "bash", "-lc", command],
+                    timeout=args.exec_timeout,
+                )
+                if proc.returncode != 0:
+                    failures += 1
+                    print(f"[exit {proc.returncode}]")
+            except subprocess.TimeoutExpired:
+                failures += 1
+                print(f"[timed out after {args.exec_timeout}s]")
             print()
     finally:
         subprocess.run(["docker", "rm", "-f", container], stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL)
 
     total = time.monotonic() - start
+    note = "" if failures == 0 else f" ({failures} command(s) errored/timed out)"
     print(
-        f"done (REAL sandbox): build {build_done - start:.1f}s + "
-        f"{len(commands)} commands, {total:.1f}s total"
+        f"done (REAL sandbox): standup {build_done - start:.1f}s + "
+        f"{len(commands)} commands, {total:.1f}s total{note}"
     )
 
 

--- a/tools/tau2-capture/run.sh
+++ b/tools/tau2-capture/run.sh
@@ -12,9 +12,16 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-if [ ! -x .venv/bin/python ]; then
+# Guard on tau2 actually importing, not just the venv dir existing — a half-finished prior setup
+# (venv created, pip install interrupted) must re-run, not skip.
+if ! .venv/bin/python -c 'import tau2' >/dev/null 2>&1; then
   echo "=== setting up the tau2 venv + data (one-time; counts as standup) ==="
-  [ -d tau2-bench ] || git clone --depth 1 https://github.com/sierra-research/tau2-bench.git
+  # A complete clone has the package's pyproject.toml; a partial/interrupted clone gets removed and
+  # retried rather than silently used.
+  if [ ! -f tau2-bench/pyproject.toml ]; then
+    rm -rf tau2-bench
+    git clone --depth 1 https://github.com/sierra-research/tau2-bench.git
+  fi
   uv venv --python 3.13 .venv
   # audioop-lts: backport of the audioop module removed from 3.13 stdlib (tau2 imports it).
   uv pip install --python .venv ./tau2-bench audioop-lts boto3

--- a/tools/tau2-capture/run_real_scenario.py
+++ b/tools/tau2-capture/run_real_scenario.py
@@ -89,6 +89,8 @@ def main() -> None:
 
     traces = _load_traces(Path(args.corpus))
     pool = _holdout(traces, args.train_split)
+    if not pool:
+        raise SystemExit(f"no traces in {args.corpus}; nothing to run")
     if args.trace is None:
         # Default: the simplest scenario — fewest recorded tool calls (matches the wmh side).
         trace = min(pool, key=lambda t: len(t["calls"]))

--- a/tools/terminal-tasks-capture/run_real_scenario.py
+++ b/tools/terminal-tasks-capture/run_real_scenario.py
@@ -130,6 +130,8 @@ def main() -> None:
 
     traces = _load_traces(Path(args.corpus))
     pool = _holdout(traces, args.train_split)
+    if not pool:
+        raise SystemExit(f"no traces in {args.corpus}; nothing to run")
     if args.trace is None:
         # Default: the simplest scenario — fewest recorded commands (matches the wmh side's default).
         trace = min(pool, key=lambda t: len(t["commands"]))

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -433,10 +433,11 @@ def bench(
     from wmh.bench import build_leaderboard, discover_benchmarks, load_runs, results_dir_for
     from wmh.cli.ui import leaderboard_table
 
-    defs = discover_benchmarks(_resolve_benchmarks_dir(benchmarks))
+    resolved = _resolve_benchmarks_dir(benchmarks)
+    defs = discover_benchmarks(resolved)
     if not defs:
         _console.print(
-            f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
+            f"[yellow]no benchmarks under {resolved}/[/yellow]; "
             "add one as benchmarks/<name>/benchmark.toml"
         )
         return
@@ -458,10 +459,11 @@ def bench_list(
     from wmh.bench import discover_benchmarks
     from wmh.cli.ui import benchmarks_table
 
-    defs = discover_benchmarks(_resolve_benchmarks_dir(benchmarks))
+    resolved = _resolve_benchmarks_dir(benchmarks)
+    defs = discover_benchmarks(resolved)
     if not defs:
         _console.print(
-            f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
+            f"[yellow]no benchmarks under {resolved}/[/yellow]; "
             "add one as benchmarks/<name>/benchmark.toml"
         )
         return
@@ -645,23 +647,30 @@ def bench_scenario(
 
     n_steps = len(trace.steps)
     _console.print(
-        f"[bold]world model[/bold] {model or name}: open-loop replay of {name} scenario "
-        f"[cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps) — no environment to stand up"
+        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of {name} "
+        f"scenario [cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps), no environment to stand up"
     )
+    # The task the agent was pursuing (the recorded instruction), shown briefly for context.
+    task = trace.steps[0].task if trace.steps else None
+    if task:
+        _console.print(f"[bold]task[/bold] [dim]{_clip(task, 240)}[/dim]\n")
 
     def on_step(step: ScenarioStep) -> None:
         # Light live-fidelity signal: error flag agreed and a non-empty prediction landed.
         ok = step.is_error_predicted == step.is_error_actual and bool(step.predicted.strip())
         mark = "[green]✓[/green]" if ok else "[yellow]≈[/yellow]"
+        err = " [red](error)[/red]" if step.is_error_predicted else ""
+        # Show the agent's CALL to the environment, then the world model's OBSERVATION back.
         _console.print(
-            f"  {mark} [{step.seconds:5.2f}s] {step.action}\n"
-            f"      [dim]predicted[/dim] {_clip(step.predicted)}"
+            f"{mark} [dim]step {step.index} ({step.seconds:.2f}s)[/dim]\n"
+            f"  [bold blue]agent →[/bold blue] {_clip(step.action, 200)}\n"
+            f"  [bold green]world model →[/bold green]{err} {_clip(step.predicted)}"
         )
 
     report = run_scenario(
         provider, env_prompt, trace, demos, benchmark=name, model=(model or name), on_step=on_step
     )
-    _console.print(f"[bold]done[/bold]: {report.summary()}")
+    _console.print(f"\n[bold]done[/bold]: {report.summary()}")
 
 
 def _clip(text: str, limit: int = 160) -> str:

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -41,6 +41,25 @@ _EVAL_FILES = typer.Argument(..., help="OTel trace files to score (one corpus ea
 BENCHMARKS_DIR = "benchmarks"
 
 
+def _resolve_benchmarks_dir(benchmarks: str) -> str:
+    """Resolve the benchmarks dir, tolerant of the current working directory.
+
+    `--benchmarks` defaults to the relative `"benchmarks"`, which only exists at the repo root — so
+    running `wmh bench …` from a subdir (e.g. `tools/<bench>-capture/`) would miss it. When the
+    given path doesn't exist as-is but the repo's committed `benchmarks/` does, fall back to that
+    (located relative to this package, like `default_bundled_dir` does for `world-models/`). An
+    explicit `--benchmarks <path>` that exists is always honored.
+    """
+    from pathlib import Path
+
+    if Path(benchmarks).exists():
+        return benchmarks
+    repo_root_benchmarks = Path(__file__).resolve().parent.parent.parent / BENCHMARKS_DIR
+    if benchmarks == BENCHMARKS_DIR and repo_root_benchmarks.is_dir():
+        return str(repo_root_benchmarks)
+    return benchmarks  # leave as-is; the caller surfaces a clear "not found" error
+
+
 @providers_app.command("verify")
 def providers_verify(
     name: str = typer.Option(None, "--name", help="Verify one model's providers (default: all)."),
@@ -414,7 +433,7 @@ def bench(
     from wmh.bench import build_leaderboard, discover_benchmarks, load_runs, results_dir_for
     from wmh.cli.ui import leaderboard_table
 
-    defs = discover_benchmarks(benchmarks)
+    defs = discover_benchmarks(_resolve_benchmarks_dir(benchmarks))
     if not defs:
         _console.print(
             f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
@@ -439,7 +458,7 @@ def bench_list(
     from wmh.bench import discover_benchmarks
     from wmh.cli.ui import benchmarks_table
 
-    defs = discover_benchmarks(benchmarks)
+    defs = discover_benchmarks(_resolve_benchmarks_dir(benchmarks))
     if not defs:
         _console.print(
             f"[yellow]no benchmarks under {benchmarks}/[/yellow]; "
@@ -479,7 +498,7 @@ def bench_run(
         save_run,
     )
 
-    bench_dir = Path(benchmarks) / name
+    bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
     try:
         bench_def: BenchmarkDef = load_benchmark(bench_dir)
     except (FileNotFoundError, ValueError) as exc:
@@ -573,7 +592,7 @@ def bench_scenario(
     from wmh.retrieval import EmbeddingRetriever, get_embedder
     from wmh.retrieval.leakfree import DemoRetriever
 
-    bench_dir = Path(benchmarks) / name
+    bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
     try:
         bench_def = load_benchmark(bench_dir)
     except (FileNotFoundError, ValueError) as exc:


### PR DESCRIPTION
Builds on the merged #22 scenario-comparison work. Two threads:

### benchmarks-root resolution (original PR)
`wmh bench` / `bench list` / `bench run` / `bench scenario` resolve the default `benchmarks/` dir relative to the repo root, so they work from any cwd (e.g. `tools/swe-bench-capture/`), not only the repo root. Empty-set messages now report the *resolved* path.

### review fixes + two follow-ups (code-review xhigh --fix)
- **swe-bench `--mode auto|build|pull`.** From-scratch build's apt/conda steps fail under qemu emulation on arm64 (apt GPG "invalid signature"), so `auto` pulls the prebuilt multi-GB image off-x86 (still a real, timed standup) and builds natively on x86_64. Progress banners + HF logs stay visible (no more silent pauses).
- **`bench scenario` output.** Prints the task briefly, then each step as the agent's CALL to the environment and the world model's OBSERVATION back, with an explicit `(error)` marker.
- swe-bench runner surfaces non-zero exec exit codes / timeouts per-step and in the summary.
- Empty-corpus guard before `min()` in all three `run_real_scenario.py`.
- `run.sh` (swe-bench, tau2) guard on the package *importing*, not just the venv dir existing; tau2 re-clones a partial checkout.
- `benchmark.toml` stale `bench race` → `bench scenario`.

### verification
- `uv run ruff check .` ✓ · `uv run ty check` ✓ · `uv run pytest -q` → 267 passed, 6 skipped
- SIB grep returns zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)