### PR TITLE
swe-bench: cold pull standup by default

### DIFF
--- a/tools/swe-bench-capture/run.sh
+++ b/tools/swe-bench-capture/run.sh
@@ -8,8 +8,10 @@
 # The whole thing — Python venv creation, `swebench` install, the Docker standup (a from-scratch
 # conda/pip build on x86_64, or a multi-GB prebuilt-image pull under emulation), and the recorded
 # commands — runs and prints here, so the total wall-clock is the true cost of standing up + running
-# the real environment cold. That is the cost the world model side (`wmh bench scenario swe-bench`)
-# skips. Re-runs reuse the venv; pass --cache to also reuse Docker build layers.
+# the real environment cold. The standup is cold by default (build with --no-cache; pull after
+# removing any cached image, so the multi-GB download is actually paid) — that is the cost the world
+# model side (`wmh bench scenario swe-bench`) skips. Re-runs reuse the venv; pass --cache to also
+# reuse the Docker build layers / the already-pulled image.
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/tools/swe-bench-capture/run_real_scenario.py
+++ b/tools/swe-bench-capture/run_real_scenario.py
@@ -111,16 +111,24 @@ def _exists(image: str) -> bool:
     ).returncode == 0
 
 
-def _pull_image(instance_id: str, platform_str: str) -> str:
+def _pull_image(instance_id: str, platform_str: str, *, no_cache: bool) -> str:
     """`docker pull` the official prebuilt per-instance image, streaming progress; return its tag.
 
     The standup for the `pull` mode: a multi-GB image download (the environment + its installed
     dependencies, prebuilt) — a real, timed cost, just not a from-scratch compile. This is the path
     that works under emulation (the from-scratch `build` mode's `apt`/conda steps fail under qemu on
     non-x86 hosts). Raises on a failed pull.
+
+    Cold by default (`no_cache=True`): a locally-cached image makes `docker pull` a no-op (~0.5s
+    "up to date" check), which would silently hide the real download cost the comparison is about —
+    so we remove it first, mirroring the build path's `--no-cache`. Pass `--cache` to reuse it.
     """
     compat = instance_id.replace("__", "_1776_")
     image = f"docker.io/swebench/sweb.eval.x86_64.{compat}:latest".lower()
+    if no_cache and _exists(image):
+        print(f"--- removing cached image for a cold pull (pass --cache to reuse): {image} ---")
+        subprocess.run(["docker", "rmi", "-f", image], stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL)
     cmd = ["docker", "pull", "--platform", platform_str, image]
     print(f"$ {' '.join(cmd)}")
     rc = subprocess.run(cmd).returncode
@@ -206,11 +214,11 @@ def main() -> None:
         f"[mode={mode}], then exec'ing the recorded commands\n"
     )
     start = time.monotonic()
+    no_cache = not args.cache  # cold by default: build with --no-cache, pull after removing cache
 
     if mode == "build":
         # base image -> env image (the real conda/pip dependency install) -> instance image (clone
         # repo + checkout + install). Each streams its build log and counts toward the clock.
-        no_cache = not args.cache
         layers = [
             ("base", spec.base_image_key, spec.base_dockerfile, {}),
             (
@@ -236,7 +244,7 @@ def main() -> None:
         run_image = spec.instance_image_key
     else:  # pull
         print("=== pulling the prebuilt instance image (multi-GB download — this is the standup) ===")
-        run_image = _pull_image(instance_id, spec.platform)
+        run_image = _pull_image(instance_id, spec.platform, no_cache=no_cache)
         print()
     build_done = time.monotonic()
     print(f"[environment stood up ({mode}) in {build_done - start:.1f}s]\n")


### PR DESCRIPTION
On arm64 (Apple Silicon), `swe-bench` `run.sh` resolves to `--mode pull` because the from-scratch build's apt/conda steps fail under qemu. But a previously-pulled image made `docker pull` a no-op:

```
Status: Image is up to date for swebench/sweb.eval...astropy-14508:latest
[environment stood up (pull) in 0.6s]
```

That 0.6s is the "is it up to date?" check, **not** the multi-GB download — so the pull side was silently warm while the build side was cold (`--no-cache`) every run. The two weren't measuring the same standup.

Fix: make `pull` cold by default too — `docker rmi` the cached image before pulling unless `--cache` is passed (mirrors the build path's `--no-cache`). Now both modes report a true cold standup. `--cache` reuses the already-pulled image / build layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)