### PR TITLE
bench scenario: --serve-model override + Bedrock dated-id pricing + swe-bench image wind-down

### DIFF
--- a/tools/swe-bench-capture/run.sh
+++ b/tools/swe-bench-capture/run.sh
@@ -3,7 +3,7 @@
 # environment (build from scratch on native x86_64, else pull the prebuilt image) and run the
 # recorded scenario, streaming all stdout. One command.
 #
-#   tools/swe-bench-capture/run.sh [--trace N] [--mode build|pull|auto] [--cache] [...]
+#   tools/swe-bench-capture/run.sh [--trace N] [--mode build|pull|auto] [--cache] [--keep-image] [...]
 #
 # The whole thing — Python venv creation, `swebench` install, the Docker standup (a from-scratch
 # conda/pip build on x86_64, or a multi-GB prebuilt-image pull under emulation), and the recorded
@@ -11,7 +11,8 @@
 # the real environment cold. The standup is cold by default (build with --no-cache; pull after
 # removing any cached image, so the multi-GB download is actually paid) — that is the cost the world
 # model side (`wmh bench scenario swe-bench`) skips. Re-runs reuse the venv; pass --cache to also
-# reuse the Docker build layers / the already-pulled image.
+# reuse the Docker build layers / the already-pulled image. After the run the stood-up image(s) are
+# wound down in the background (multi-GB; a cold run rebuilds them) — pass --keep-image to keep them.
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/tools/swe-bench-capture/run_real_scenario.py
+++ b/tools/swe-bench-capture/run_real_scenario.py
@@ -17,9 +17,13 @@ Dockerfiles + setup scripts) and a running local Docker daemon. It never imports
 committed `examples/swe-bench.otel.jsonl` and re-implements the harness's deterministic blake2b
 held-out split inline so `--trace N` selects the SAME scenario the world-model side does.
 
+By default the stood-up image(s) are wound down in the background after the run (they are multi-GB
+and a cold run re-creates them); pass `--keep-image` to keep them, or `--cache` to reuse them.
+
 Usage (from tools/swe-bench-capture/, in the swebench venv):
-    .venv/bin/python run_real_scenario.py --trace 0            # cold build (default)
-    .venv/bin/python run_real_scenario.py --trace 0 --cache    # reuse cached layers
+    .venv/bin/python run_real_scenario.py --trace 0               # cold build (default), then clean up
+    .venv/bin/python run_real_scenario.py --trace 0 --cache       # reuse cached layers, keep image
+    .venv/bin/python run_real_scenario.py --trace 0 --keep-image  # cold, but keep the image
 """
 
 from __future__ import annotations
@@ -137,6 +141,26 @@ def _pull_image(instance_id: str, platform_str: str, *, no_cache: bool) -> str:
     return image
 
 
+def _wind_down(images: list[str]) -> None:
+    """Remove the stood-up images in a detached background process; return immediately.
+
+    These instance images are multi-GB and a cold run re-creates them anyway, so we don't leave them
+    filling the disk. Detached (`Popen`, no wait) so the cleanup doesn't add to the reported run
+    time — `docker rmi` can take a moment to unwind layers. `--keep-image` skips this.
+    """
+    if not images:
+        return
+    # `docker rmi -f` each image; `|| true` so a missing/shared image doesn't abort the rest.
+    script = " ; ".join(f"docker rmi -f {img} >/dev/null 2>&1 || true" for img in images)
+    subprocess.Popen(  # noqa: S602 - fixed command, image tags are derived from the dataset spec
+        ["bash", "-c", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    print(f"[winding down {len(images)} image(s) in the background: {', '.join(images)}]")
+
+
 def _default_mode() -> str:
     """`build` from scratch on a native x86_64 host, else `pull` the prebuilt image.
 
@@ -174,6 +198,14 @@ def main() -> None:
         help="Reuse cached Docker layers (skip already-built images). Default: cold --no-cache.",
     )
     parser.add_argument("--exec-timeout", type=int, default=600, help="Per-command timeout (s).")
+    parser.add_argument(
+        "--keep-image",
+        action="store_true",
+        help=(
+            "Keep the stood-up Docker image(s) after the run. Default: wind them down in the "
+            "background (these images are multi-GB; a cold run re-creates them anyway)."
+        ),
+    )
     args = parser.parse_args()
 
     traces = _load_traces(Path(args.corpus))
@@ -215,6 +247,7 @@ def main() -> None:
     )
     start = time.monotonic()
     no_cache = not args.cache  # cold by default: build with --no-cache, pull after removing cache
+    created: list[str] = []  # images this run stood up (for the wind-down cleanup)
 
     if mode == "build":
         # base image -> env image (the real conda/pip dependency install) -> instance image (clone
@@ -240,11 +273,13 @@ def main() -> None:
                 continue
             print(f"=== building {label}: {tag} ===")
             _docker_build(tag, dockerfile, scripts, spec.platform, no_cache=no_cache)
+            created.append(tag)
             print()
         run_image = spec.instance_image_key
     else:  # pull
         print("=== pulling the prebuilt instance image (multi-GB download — this is the standup) ===")
         run_image = _pull_image(instance_id, spec.platform, no_cache=no_cache)
+        created.append(run_image)
         print()
     build_done = time.monotonic()
     print(f"[environment stood up ({mode}) in {build_done - start:.1f}s]\n")
@@ -284,6 +319,11 @@ def main() -> None:
         f"done (REAL sandbox): standup {build_done - start:.1f}s + "
         f"{len(commands)} commands, {total:.1f}s total{note}"
     )
+
+    # Wind-down: drop the multi-GB image(s) this run stood up, in the background (after timing, so it
+    # never counts against the clock). `--keep-image` or `--cache` (you want to reuse it) opt out.
+    if not args.keep_image and not args.cache:
+        _wind_down(created)
 
 
 if __name__ == "__main__":

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -567,6 +567,15 @@ def bench_scenario(
     model: str = typer.Option(
         None, "--model", help="World model to serve (default: the benchmark name)."
     ),
+    serve_model: str = typer.Option(
+        None,
+        "--serve-model",
+        help=(
+            "Override the LLM that plays the environment, keeping the model's prompt + demos "
+            "(e.g. a Bedrock id like us.anthropic.claude-haiku-4-5-20251001-v1:0). Default: the "
+            "model's configured serve model."
+        ),
+    ),
     trace_index: int = typer.Option(
         None, "--trace", help="Held-out trace to replay (default: the simplest = fewest steps)."
     ),
@@ -640,14 +649,20 @@ def bench_scenario(
         if paths.optimized_prompt.exists()
         else BASE_ENV_PROMPT
     )
-    provider = get_provider(config.serve_provider_config())
+    serve_config = config.serve_provider_config()
+    if serve_model:
+        # Swap only the LLM id, keeping the same provider backend + the model's prompt/demos — so we
+        # can measure a cheaper/faster model (Haiku, Sonnet) against the same scenario and prompt.
+        serve_config = serve_config.model_copy(update={"model": serve_model})
+    provider = get_provider(serve_config)
     # Leak-free demos from the TRAIN split only (never the query's own trace), identical to eval.
     retriever = EmbeddingRetriever(get_embedder(config))
     demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
 
     n_steps = len(trace.steps)
     _console.print(
-        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of {name} "
+        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] "
+        f"[dim](LLM: {serve_config.model})[/dim] — open-loop replay of {name} "
         f"scenario [cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps), no environment to stand up"
     )
     # The task the agent was pursuing (the recorded instruction), shown briefly for context.

--- a/wmh/tracking/pricing.py
+++ b/wmh/tracking/pricing.py
@@ -8,9 +8,16 @@ surface "cost unavailable" rather than silently under-reporting.
 
 from __future__ import annotations
 
+import re
+
 from pydantic import BaseModel
 
 from wmh.providers.base import TokenUsage
+
+# Bedrock appends a snapshot date and/or version to the model id, e.g.
+# `claude-haiku-4-5-20251001-v1:0` or `claude-opus-4-6-v1`. Strip them so the lookup key matches the
+# undated table rows (`claude-haiku-4-5`). Only applied to `claude-*` ids.
+_BEDROCK_SUFFIX = re.compile(r"(-\d{8})?(-v\d+)?(:\d+)?$")
 
 
 class ModelPrice(BaseModel):
@@ -66,6 +73,10 @@ def _normalize(model: str) -> str:
             break
     if normalized.startswith("anthropic."):
         normalized = normalized[len("anthropic.") :]
+    if normalized.startswith("claude-"):
+        # Drop a trailing Bedrock snapshot date / version (`-20251001-v1:0`, `-v1`) so dated
+        # inference-profile ids match the undated table rows.
+        normalized = _BEDROCK_SUFFIX.sub("", normalized)
     return normalized
 
 

--- a/wmh/tracking/pricing_test.py
+++ b/wmh/tracking/pricing_test.py
@@ -21,6 +21,16 @@ def test_bedrock_prefix_normalizes_to_same_price() -> None:
     assert cost_usd("us.anthropic.claude-opus-4-8", usage) == pytest.approx(5.0)
 
 
+def test_bedrock_dated_inference_profile_id_normalizes() -> None:
+    # Bedrock inference-profile ids carry a snapshot date + version, e.g.
+    # `us.anthropic.claude-haiku-4-5-20251001-v1:0`; they must price like the undated row.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0)
+    assert price_for("us.anthropic.claude-haiku-4-5-20251001-v1:0") is not None
+    assert cost_usd("us.anthropic.claude-haiku-4-5-20251001-v1:0", usage) == pytest.approx(1.0)
+    # The `-v1` version suffix alone is also stripped.
+    assert cost_usd("anthropic.claude-opus-4-6-v1", usage) == pytest.approx(5.0)
+
+
 def test_gpt_5_5_output_is_30_per_mtok() -> None:
     # Verified 2026-06-25 against OpenAI's live pricing page: gpt-5.5 is $5 in / $30 out.
     price = price_for("gpt-5.5")


### PR DESCRIPTION
### `--serve-model` for `bench scenario`
Swap the LLM that *plays the environment* while keeping the world model's prompt + demos, so you can measure a cheaper/faster model on the same scenario:

```
uv run wmh bench scenario swe-bench --serve-model us.anthropic.claude-haiku-4-5-20251001-v1:0
```

Measured on the swe-bench astropy scenario (9 steps), same 100% error-flag fidelity:

| serve LLM | total | cost |
|---|---|---|
| Opus 4.8 (default) | ~52s | $0.54 |
| Haiku 4.5 | ~31s | $0.09 |

~1.6× faster, ~6× cheaper, no fidelity drop on this scenario. (Reasoning is already off on the Bedrock path — no `thinking` param is sent.) The intro line now prints the serve LLM id.

### Bedrock dated-id pricing fix
Bedrock inference-profile ids carry a snapshot date / version (`...claude-haiku-4-5-20251001-v1:0`, `...-opus-4-6-v1`). `_normalize` now strips them so they match the undated price-table rows — without this, Haiku reported **$0.00**. Regression test added. (Opus 4.8 was unaffected because its configured id has no date suffix.)

### swe-bench image wind-down
The real runner now drops the multi-GB image(s) it stood up, in a **detached background process after timing** (never counts against the clock). Only removes images this run created; `--keep-image` or `--cache` opt out.

### verification
- `uv run ruff check .` ✓ · `uv run ty check` ✓ · `uv run pytest -q` → 268 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)