### PR TITLE
swe-bench: default world model to Haiku 4.5; drop serve-LLM from scenario header

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -661,8 +661,7 @@ def bench_scenario(
 
     n_steps = len(trace.steps)
     _console.print(
-        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] "
-        f"[dim](LLM: {serve_config.model})[/dim] — open-loop replay of {name} "
+        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of {name} "
         f"scenario [cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps), no environment to stand up"
     )
     # The task the agent was pursuing (the recorded instruction), shown briefly for context.

--- a/world-models/swe-bench/config.toml
+++ b/world-models/swe-bench/config.toml
@@ -1,5 +1,5 @@
 providers = [
-    { kind = "bedrock", model = "us.anthropic.claude-opus-4-8", region = "us-east-1" },
+    { kind = "bedrock", model = "us.anthropic.claude-haiku-4-5-20251001-v1:0", region = "us-east-1" },
 ]
 serve_provider = "bedrock"
 embed_provider = "hashing"


### PR DESCRIPTION
- **`world-models/swe-bench/config.toml`**: serve **Haiku 4.5** by default instead of Opus 4.8. On the swe-bench astropy scenario it matches Opus's 100% error-flag fidelity at **~31s / $0.09** vs **~52s / $0.54** — ~1.6× faster, ~6× cheaper, so it's the better default backend here. Override per-run with `--serve-model`.
- **`bench scenario`**: drop the `(LLM: ...)` serve-model annotation from the header line (cleaner output).

### verification
- `uv run ruff check .` ✓ · `uv run ty check` ✓
- `wmh bench scenario swe-bench` (no flag) now runs on Haiku: ~31s, $0.0885, fidelity 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)