### PR TITLE
Make empty judge predictions explicit

### DIFF
--- a/wmh/optimize/judge.py
+++ b/wmh/optimize/judge.py
@@ -29,6 +29,9 @@ outcomes, flipped success/error status, and missing or fabricated salient facts.
 The observations are encoded as JSON strings. If `content` is `""` and `content_length` is `0`, the
 observation is the empty string; do not infer or fill in missing content from the action or actual
 observation.
+An empty predicted observation is also marked with `empty_sentinel: "<EMPTY_PREDICTION>"`.
+If the predicted observation is empty and the actual observation is non-empty, assign a very low
+score because the prediction omitted the environment's response.
 
 Respond with ONLY a JSON object, no prose around it:
 {"score": <float 0..1>, "critique": "<one or two sentences: what matched, what diverged, and how \
@@ -76,8 +79,8 @@ class LLMJudge:
 def _build_judge_prompt(predicted: Observation, actual: Observation, context: Step) -> str:
     action = context.action
     action_desc = action.name or action.content or "(none)"
-    actual_payload = _observation_payload(actual)
-    predicted_payload = _observation_payload(predicted)
+    actual_payload = _observation_payload(actual, empty_sentinel="<EMPTY_ACTUAL_OBSERVATION>")
+    predicted_payload = _observation_payload(predicted, empty_sentinel="<EMPTY_PREDICTION>")
     return (
         f"AGENT ACTION ({action.kind.value}): {action_desc}\n"
         f"ACTION ARGUMENTS: {json.dumps(action.arguments, sort_keys=True, default=str)}\n\n"
@@ -88,12 +91,13 @@ def _build_judge_prompt(predicted: Observation, actual: Observation, context: St
     )
 
 
-def _observation_payload(observation: Observation) -> dict[str, object]:
+def _observation_payload(observation: Observation, *, empty_sentinel: str) -> dict[str, object]:
     return {
         "is_error": observation.is_error,
         "content_length": len(observation.content),
         "content": observation.content,
         "empty_content": observation.content == "",
+        "empty_sentinel": empty_sentinel if observation.content == "" else None,
     }
 
 

--- a/wmh/optimize/judge_test.py
+++ b/wmh/optimize/judge_test.py
@@ -86,6 +86,11 @@ def test_judge_prompt_makes_empty_prediction_explicit() -> None:
     assert '"content": ""' in prompt
     assert '"content_length": 0' in prompt
     assert '"empty_content": true' in prompt
+    assert '"empty_sentinel": "<EMPTY_PREDICTION>"' in prompt
+    assert "<EMPTY_ACTUAL_OBSERVATION>" not in prompt
+    assert "If the predicted observation is empty and the actual observation is non-empty" in (
+        JUDGE_SYSTEM
+    )
     assert "PREDICTED OBSERVATION JSON" in prompt
 
 


### PR DESCRIPTION
## Summary
- Mark empty predicted observations with the literal sentinel `<EMPTY_PREDICTION>` in the judge payload.
- Mark empty actual observations separately as `<EMPTY_ACTUAL_OBSERVATION>`.
- Tell the LLM judge explicitly to assign a very low score when prediction is empty and actual is non-empty.

## Checks
- `PYTHONPATH=/Users/admin/Documents/experientiallabs/world-model-harness-empty-prediction-fix /Users/admin/Documents/experientiallabs/_codex_worktrees/world-model-harness-separate-rag-optimization/.venv/bin/python -m pytest wmh/optimize/judge_test.py`
- `/Users/admin/Documents/experientiallabs/_codex_worktrees/world-model-harness-separate-rag-optimization/.venv/bin/ruff check wmh/optimize/judge.py wmh/optimize/judge_test.py`
- `/Users/admin/Documents/experientiallabs/_codex_worktrees/world-model-harness-separate-rag-optimization/.venv/bin/ty check wmh/optimize/judge.py wmh/optimize/judge_test.py`

Note: this PR intentionally does not include the Qwen AgentWorld benchmark runner or stale benchmark results from PR #25.
