### PR TITLE
Pluggable trace ingestion: observability providers + chat/tool-call conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A frontier LLM acts as the *environment* your agent steps against, reconstructed
 1. **Build** from your OTel traces: ingest → normalize → split train/held-out → index a replay buffer → evolve the env prompt with GEPA against the held-out split.
 2. **Serve**: agents call `WorldModel.step(action)` (in-process or via the local HTTP backend). Each step retrieves the most similar past `(state, action) → observation` examples and predicts the next observation.
 
+Already have traces in **Braintrust, Arize Phoenix, Langfuse, LangSmith, PostHog, or Mastra** — or just chat/tool-call logs? Pick the source right in `wmh build` (`--source <name>` with `--file` or `--pull`, or choose it in the wizard); it's normalized into the harness's trace format via one pluggable interface, no separate step. See [`docs/ingest.md`](./docs/ingest.md).
+
 ## Try it
 
 ```bash

--- a/docs/ingest.braintrust.md
+++ b/docs/ingest.braintrust.md
@@ -1,0 +1,81 @@
+# Ingesting Braintrust traces
+
+The `braintrust` adapter turns a [Braintrust](https://www.braintrust.dev) span-row export into the
+normalized `Trace` shape the harness builds world models from. Braintrust does **not** emit OTLP
+spans — it logs **spans as rows** in an experiment or project log, where a *trace* is the set of rows
+that share a `root_span_id` — so this adapter overrides `spans_from_payload` and re-emits each row in
+OTel-GenAI vocabulary for the shared normalizer (`wmh/ingest/normalize.py`).
+
+## The shape
+
+`GET /v1/project_logs/{id}/fetch` (or `/v1/experiment/{id}/fetch`, or the SDK) returns one row per
+span, roughly:
+
+```json
+{
+  "span_id": "s1",
+  "root_span_id": "r1",
+  "span_parents": [],
+  "span_attributes": {"name": "agent", "type": "llm"},
+  "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+  "output": {"role": "assistant",
+             "tool_calls": [{"id": "c1",
+                "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]},
+  "metadata": {"model": "gpt-4o"},
+  "created": "2026-01-01T00:00:01Z",
+  "error": null
+}
+```
+
+Each row's `span_attributes.type` (commonly `llm | tool | function | task | score`) classifies it.
+The adapter maps rows so:
+
+- An **llm / task / function / chain** row whose `output` carries OpenAI-style `tool_calls` becomes a
+  `chat` **action** span (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`), one per call. Its
+  result is the sibling `tool` row.
+- A **tool** row (or an unknown-typed, tool-like row with I/O) becomes an `execute_tool` **result**
+  span (`gen_ai.tool.message`), also carrying name/args so a standalone tool row still pairs.
+- An **llm / task / function** row with no tool call becomes a plain `chat` message action with no
+  observation.
+- Rows with no usable output and no tool semantics (e.g. `score`/`eval`) are ignored.
+- A non-null `error` marks the row's step as an error.
+
+Rows are grouped by `root_span_id` (the trace key; `span_id` is the per-span key) and ordered by the
+`created` ISO-8601 timestamp (-> a monotonic ordinal; list index when absent). The first user message
+in `input` becomes the step `task` (`gen_ai.prompt`), and the row `metadata` round-trips via
+`wmh.trace.metadata`. The Braintrust ids are used as-is as grouping keys (they need not be 32-hex).
+
+## Export from Braintrust
+
+```bash
+# Project logs ({"events": [...]} — the adapter accepts this directly):
+curl -s -H "Authorization: Bearer $BRAINTRUST_API_KEY" \
+  "https://api.braintrust.dev/v1/project_logs/$PROJECT_ID/fetch" > braintrust_export.json
+
+# An experiment's spans:
+curl -s -H "Authorization: Bearer $BRAINTRUST_API_KEY" \
+  "https://api.braintrust.dev/v1/experiment/$EXPERIMENT_ID/fetch" > braintrust_export.json
+```
+
+Accepted file shapes: a single span row, a JSON array of rows, an API page wrapper
+(`{"events": [...]}` or `{"data": [...]}`), or JSONL (one row per line).
+
+## Run
+
+```bash
+uv run wmh build --name braintrust-demo --source braintrust --file braintrust_export.json
+```
+
+See `examples/ingest/braintrust_to_wmh.sh` for the end-to-end script.
+
+## Caveats
+
+- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
+  first. (The Braintrust SDK would be lazy-imported in `_pull_payloads` if/when pull is added.)
+- The richest pairing comes from OpenAI-style `tool_calls` on an llm row's `output`. Custom output
+  shapes that don't carry `tool_calls` fall back to a plain message step.
+- A tool row's `input` is used as the call arguments only when the preceding llm action lacked them
+  (the normalizer backfills name/args from the tool span).
+- Field names follow the Braintrust fetch export (`span_id`, `root_span_id`, `span_attributes.type`,
+  `created`, `error`). If your export differs (e.g. a flattened SDK dump), the `root_span_id`/
+  `span_id`/`span_attributes` keys are what drive grouping and classification.

--- a/docs/ingest.langfuse.md
+++ b/docs/ingest.langfuse.md
@@ -1,0 +1,80 @@
+# Ingesting Langfuse traces
+
+The `langfuse` adapter turns a [Langfuse](https://langfuse.com) trace export into the normalized
+`Trace` shape the harness builds world models from. Langfuse does **not** emit OTLP spans — it models
+a *trace* with a flat list of nested *observations* — so this adapter overrides `spans_from_payload`
+and re-emits the observations in OTel-GenAI vocabulary for the shared normalizer
+(`wmh/ingest/normalize.py`).
+
+## The shape
+
+`GET /api/public/traces/{id}` (or the SDK) returns roughly:
+
+```json
+{
+  "id": "lf-trace-abc123",
+  "name": "weather-agent",
+  "input": "what's the weather in Paris?",
+  "metadata": {"benchmark": "demo"},
+  "observations": [
+    {"id": "o1", "type": "GENERATION", "startTime": "2026-01-01T00:00:01Z",
+     "output": {"tool_calls": [{"id": "c1",
+                "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]}},
+    {"id": "o2", "type": "TOOL", "name": "get_weather", "startTime": "2026-01-01T00:00:02Z",
+     "input": {"city": "Paris"}, "output": "18C and sunny", "level": "DEFAULT"}
+  ]
+}
+```
+
+Each observation has a `type` of `SPAN | GENERATION | EVENT | TOOL`. The adapter maps them so:
+
+- A **GENERATION** whose `output` carries OpenAI-style `tool_calls` becomes a `chat` **action** span
+  (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`). Its result is the sibling tool observation.
+- A **TOOL** (or a tool-like **SPAN** with `output`/`input`) becomes an `execute_tool` **result**
+  span (`gen_ai.tool.message`), also carrying name/args so a standalone tool observation still pairs.
+- A **GENERATION** with no tool call becomes a plain `chat` message action with no observation.
+- **EVENT** (and non-actionable) observations are ignored.
+- `level == "ERROR"` marks the observation's step as an error (`ObservationLevel` is
+  DEBUG | DEFAULT | WARNING | ERROR). `statusMessage` is NOT an error signal — Langfuse sets it on
+  any level — so its presence alone does not flag an error.
+
+Observations are ordered by `startTime` (ISO-8601 -> a monotonic ordinal; list index when absent).
+The trace `input` becomes the step `task` (`gen_ai.prompt`), and trace `metadata` round-trips via
+`wmh.trace.metadata`. The Langfuse trace id is used as-is as the grouping key (it need not be 32-hex).
+
+## Export from Langfuse
+
+```bash
+# A single trace by id:
+curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+  "$LANGFUSE_HOST/api/public/traces/$TRACE_ID" > langfuse_export.json
+
+# A page of recent traces ({"data": [...]} — the adapter accepts this directly). NOTE: the LIST
+# endpoint returns each trace's `observations` as ID *strings* only, so a list page yields no steps —
+# fetch each trace by id (loop the ids from this page) to get full observation objects:
+curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+  "$LANGFUSE_HOST/api/public/traces?limit=50" > langfuse_traces_page.json
+```
+
+Accepted file shapes: a single trace object, a JSON array of traces, an API list page
+(`{"data": [...]}`), or JSONL (one trace per line). For a list page to produce steps, each element
+must carry full `observations` objects (fetch traces by id), not observation-id strings. For
+framework traces where tool calls are separate child observations, Langfuse's native OTLP endpoint
+(`POST /api/public/otel/v1/traces`) with `--source otel-genai` is often the cleaner route.
+
+## Run
+
+```bash
+uv run wmh build --name langfuse-demo --source langfuse --file langfuse_export.json
+```
+
+See `examples/ingest/langfuse_to_wmh.sh` for the end-to-end script.
+
+## Caveats
+
+- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
+  first. (The Langfuse SDK would be lazy-imported in `_pull_payloads` if/when pull is added.)
+- The richest pairing comes from the OpenAI-style `tool_calls` on a GENERATION `output`. Custom
+  output shapes that don't carry `tool_calls` fall back to a plain message step.
+- A tool observation's `input` is used as the call arguments only when the preceding GENERATION
+  action lacked them (the normalizer backfills name/args from the tool span).

--- a/docs/ingest.langsmith.md
+++ b/docs/ingest.langsmith.md
@@ -1,0 +1,87 @@
+# Ingesting LangSmith runs
+
+The `langsmith` adapter turns a [LangSmith](https://smith.langchain.com) (LangChain) run export into
+the normalized `Trace` shape the harness builds world models from. LangSmith does **not** emit OTLP
+spans — it models a trace as a tree of *runs* — so this adapter overrides `spans_from_payload` and
+re-emits the runs in OTel-GenAI vocabulary for the shared normalizer (`wmh/ingest/normalize.py`).
+
+## The shape
+
+`Client.list_runs` (or `POST /api/v1/runs/query` — the list endpoint is a POST with a JSON filter
+body, not a GET) returns runs that look roughly like:
+
+```json
+[
+  {"id": "11...", "trace_id": "tt...", "parent_run_id": null, "run_type": "chain",
+   "name": "AgentExecutor", "inputs": {"input": "what's the weather in Paris?"},
+   "outputs": {"output": "It's 18C and sunny in Paris."},
+   "start_time": "2026-01-01T00:00:00", "error": null},
+  {"id": "22...", "trace_id": "tt...", "run_type": "llm", "name": "ChatOpenAI",
+   "outputs": {"generations": [{"message": {"kwargs": {"tool_calls": [
+       {"id": "call_1", "name": "get_weather", "args": {"city": "Paris"}}]}}}]},
+   "start_time": "2026-01-01T00:00:01", "error": null},
+  {"id": "33...", "trace_id": "tt...", "run_type": "tool", "name": "get_weather",
+   "outputs": {"output": "18C and sunny"}, "start_time": "2026-01-01T00:00:03", "error": null}
+]
+```
+
+Each run is typed by `run_type`. The adapter maps them so:
+
+- An **`llm`** run whose `outputs` carry tool calls becomes one `chat` **action** span per call
+  (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`). Its result is the sibling `tool` run.
+- An **`llm`** run with no tool call becomes a plain `chat` **message** action (`gen_ai.completion`),
+  with no observation.
+- A **`tool`** run becomes an `execute_tool` **result** span (`gen_ai.tool.message`).
+- **`chain` / `retriever`** (and unknown) runs are not directly actionable and are skipped.
+- A non-null `error` marks that run's step as an error.
+
+Tool calls are dug out of the common (version-dependent) LangChain locations, best-effort:
+`outputs.generations[].message.kwargs.tool_calls`, the same under `additional_kwargs.tool_calls`
+(OpenAI shape), nested list-of-lists generations, and flatter `outputs.tool_calls` /
+`outputs.message.kwargs.tool_calls`. A tool-call entry is either the LangChain-normalized
+`{"name", "args": {...}}` or the OpenAI `{"function": {"name", "arguments": "<json str>"}}` shape;
+both are handled. A run that can't be interpreted is skipped rather than crashing the ingest.
+
+Runs are ordered by `start_time` (ISO-8601 -> a monotonic ordinal; list index when absent), grouped
+by `trace_id` (falling back to the run `id` for a root run that omits it). The first human/user
+input (dug from a run's `inputs`) becomes the step `task` (`gen_ai.prompt`).
+
+## Export from LangSmith
+
+```bash
+# REST API — runs in a project (filter to one trace by id):
+curl -s -X POST "${LANGCHAIN_ENDPOINT:-https://api.smith.langchain.com}/api/v1/runs/query" \
+  -H "x-api-key: $LANGCHAIN_API_KEY" -H "Content-Type: application/json" \
+  -d '{"session": ["<project-uuid>"], "limit": 100}' \
+  | python -c 'import sys,json; print(json.dumps(json.load(sys.stdin)["runs"]))' > langsmith_export.json
+
+# SDK (Python):
+uv run python -c '
+import json, sys
+from langsmith import Client
+runs = Client().list_runs(project_name="my-project")
+json.dump([r.dict() for r in runs], sys.stdout, default=str)' > langsmith_export.json
+```
+
+Accepted file shapes: a single run object, a JSON array of runs, a `{"runs": [...]}` wrapper, or
+JSONL (one run per line).
+
+## Run
+
+```bash
+uv run wmh build --name langsmith-demo --source langsmith --file langsmith_export.json
+```
+
+See `examples/ingest/langsmith_to_wmh.sh` for the end-to-end script.
+
+## Caveats
+
+- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
+  first. (The `langsmith` SDK would be lazy-imported in `_pull_payloads` if/when pull is added, so
+  the config gate stays SDK-free.)
+- **Tool-call paths are version-dependent.** LangChain's run-output shape varies across versions;
+  the adapter digs the common locations but a custom/unusual dump that doesn't carry `tool_calls`
+  falls back to a plain message step.
+- Pairing assumes the `tool` run follows its issuing `llm` run by `start_time` (the normalizer pairs
+  each action with the nearest following `execute_tool` span). Deeply parallel tool calls within one
+  LLM turn pair in start-time order.

--- a/docs/ingest.mastra.md
+++ b/docs/ingest.mastra.md
@@ -1,0 +1,44 @@
+# Ingesting Mastra traces
+
+The `mastra` adapter turns a [Mastra](https://mastra.ai) AI-tracing export into the normalized
+`Trace` shape the harness builds world models from. Mastra (a TypeScript agent framework) records
+agent runs as **AI-tracing spans** (`ExportedSpan`) typed by `type`, which this adapter maps into the
+OTel-GenAI vocabulary for the shared normalizer (`wmh/ingest/normalize.py`). The span id field is
+`id`, and spans order by `startTime`. (Mastra renamed its LLM spans to "model" spans in the 2025-11
+release; the adapter still accepts the pre-rename aliases — `spanType`, `llm_generation`, `spanId`,
+`startedAt` — so older exports keep working.)
+
+## The shape
+
+Spans sharing a `traceId`, each with a `type`:
+
+- **`model_generation`** (pre-rename: `llm_generation`) — an LLM call. `input` is the messages,
+  `output` the completion. A completion that issues a tool call carries it as the AI-SDK `toolCalls`
+  (`{toolCallId, toolName, input}` on AI SDK v5; `args` on v4) or the OpenAI `tool_calls`
+  (`{id, function:{name, arguments}}`) shape.
+- **`tool_call`** / **`mcp_tool_call`** — a tool execution: `name` (tool), `input` (args),
+  `output` (result).
+- **`agent_run`** / **`workflow_*`** / **`model_chunk`** / **`model_step`** / **`generic`** —
+  container/streaming spans; no standalone step. An `agent_run`/`model_generation` `input` supplies
+  the trace task.
+- An `errorInfo`/`error` (or error status) marks the step errored.
+
+Each `model_generation` tool call becomes an Action, paired with the sibling `tool_call` span's
+result; a standalone `tool_call` span becomes a complete step on its own.
+
+## Build from it
+
+```bash
+# From a running Mastra server (fetches {base}/api/observability/traces):
+uv run wmh build --name mastra-demo --source mastra --pull --project http://localhost:4111
+
+# Or from an exported spans file (a single span, a JSON array, a {"spans"|"traces": [...]} wrapper,
+# or JSONL):
+uv run wmh build --name mastra-demo --source mastra --file mastra_spans.json
+```
+
+- **Server URL**: pass the Mastra server base URL as `--project` (or set `$MASTRA_URL`), e.g.
+  `http://localhost:4111`. `--api-key` is sent as a bearer token if your server requires auth.
+- **File export**: dump Mastra's stored AI spans (from its storage / the observability API) to JSON.
+
+See `examples/ingest/mastra_to_wmh.sh` for a runnable script.

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -1,0 +1,193 @@
+# Ingesting traces from anywhere
+
+The harness builds a world model from **recorded agent traces**. Ingestion is part of `wmh build`,
+not a separate step: you pick a **source** and `build` turns traces from whatever you already have —
+an observability provider, an OTLP export, or a plain chat/tool-call log — into the normalized
+`wmh.core.types.Trace` shape and runs the pipeline.
+
+Everything plugs into **one interface** (`TraceAdapter`) and **one normalizer**
+(`wmh.ingest.normalize`), so adding a source is a thin adapter, never a rewrite.
+
+## Quickstart
+
+```bash
+wmh build --name m --source <name> --file <export>          # build from a file export
+wmh build --name m --source <name> --pull --project <p>     # build from a live vendor pull
+wmh build                                                   # or pick the source in the wizard
+```
+
+`--source` is a registered adapter (`otel-genai`, `chat-json`, `braintrust`, `phoenix`, `langfuse`,
+`langsmith`, `posthog`, `mastra`); `--file` reads an export, `--pull` fetches live (with
+`--project`/`--api-key`) for
+sources that support it. On an interactive terminal, `wmh build` with no source launches a wizard
+that lists the sources and prompts for file-or-pull.
+
+Under the hood the chosen adapter normalizes to OTel-GenAI span JSONL — the same format the bundled
+`examples/*.otel.jsonl` use — so a source is interchangeable with any other corpus the harness reads.
+
+## Sources
+
+| `--source` | What it reads | File | Live pull |
+|---|---|---|---|
+| `otel-genai` | OTLP-JSON spans (OTel GenAI semconv) | ✅ | ✅ (generic OTLP query backend) |
+| `chat-json` | recorded OpenAI/LangChain-style chat + tool-call conversations | ✅ | — |
+| `phoenix` | Arize Phoenix / OpenInference spans | ✅ | provider-dependent |
+| `langfuse` | Langfuse trace + observation tree | ✅ | provider-dependent |
+| `langsmith` | LangSmith run tree | ✅ | provider-dependent |
+| `braintrust` | Braintrust span/log rows | ✅ | ✅ (REST fetch API) |
+| `posthog` | PostHog LLM-observability `$ai_*` events | ✅ | ✅ (HogQL query API) |
+| `mastra` | Mastra AI-tracing spans (`type` = model_generation/tool_call/…) | ✅ | ✅ (server API) |
+
+Per-provider export instructions, payload shapes, and caveats:
+[Phoenix](./ingest.phoenix.md) · [Langfuse](./ingest.langfuse.md) ·
+[LangSmith](./ingest.langsmith.md) · [Braintrust](./ingest.braintrust.md) ·
+[PostHog](./ingest.posthog.md) · [Mastra](./ingest.mastra.md). Runnable examples live in
+[`examples/ingest/`](../examples/ingest/).
+
+### Already OTel-native? Use `otel-genai` (no dedicated adapter needed)
+
+A dedicated adapter only exists where a provider emits its OWN non-OTLP shape (Langfuse's
+observation tree, LangSmith's run tree, Braintrust/PostHog rows, Phoenix's OpenInference dataframe,
+Mastra's AI-tracing spans). Platforms that already export **OTel GenAI spans** need no adapter — point
+them at a file or an OTLP query backend and use `--source otel-genai`:
+
+- **Traceloop / OpenLLMetry**, **Opik** (Comet), **Logfire** (Pydantic), **Laminar**, **Datadog LLM
+  Observability**, **MLflow Tracing**, **Honeycomb**, **New Relic**, **Grafana/Tempo**, **SigNoz** —
+  all speak OTLP GenAI natively.
+- **Helicone** (LLM gateway/proxy) can forward its logged traffic as OTLP; use `otel-genai` against
+  that export. If you only have Helicone's native request/response logs (not OTLP), that's a small
+  dedicated adapter — open an issue.
+- **Langfuse** and **Mastra** ALSO expose OTLP endpoints; for framework traces where tool calls are
+  separate child spans, `otel-genai` against their OTLP export is often cleaner than the native
+  adapter (which reads the provider's own tree/span shape).
+
+If a provider isn't listed and doesn't emit OTLP, it's a ~30-line adapter (see below) — open an issue
+or add one.
+
+### Databases and other stores
+
+There is no bespoke database adapter — instead, **point your store at OpenTelemetry** and ingest with
+`--source otel-genai`. If your agent runs are in a SQL table, a warehouse, or a custom log, the clean
+hook-up is to emit OTel GenAI spans (most agent frameworks and the OTel GenAI instrumentations do
+this out of the box) and either export them to a file (`--file spans.otlp.json`) or serve them from
+an OTLP-compatible query backend and `--pull`. One OTel format, any store behind it — no per-database
+code to maintain.
+
+**File vs. pull.** Every adapter supports `--file` (an export you already have); `--pull` (live from
+the vendor API) is opt-in per adapter and errors with a clear "export to a file" message when a
+source hasn't implemented it. File ingestion needs **no** vendor SDK — the provider adapters parse
+the export as JSON. The optional `pip install 'world-model-harness[phoenix]'` (etc.) extras install a
+provider's own SDK only if you want to drive its export tooling yourself; nothing in `wmh` imports
+them.
+
+## The chat / tool-call converter (`chat-json`)
+
+If you don't use an observability vendor, the most universal trace is a list of chat messages with
+tool calls — the OpenAI Chat Completions shape (which LangChain, the Anthropic SDK, and most agent
+frameworks can emit). Drop it in a file and ingest it:
+
+```json
+{"messages": [
+  {"role": "user", "content": "what's the weather in Paris?"},
+  {"role": "assistant", "tool_calls": [{"id": "c1",
+     "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]},
+  {"role": "tool", "tool_call_id": "c1", "content": "18C and sunny"},
+  {"role": "assistant", "content": "It's 18C and sunny in Paris."}
+]}
+```
+
+```bash
+wmh build --name my-model --source chat-json --file conversation.json
+```
+
+Each assistant tool call becomes an Action paired with its `role:"tool"` result (the Observation);
+a trailing assistant message becomes a final message step. Accepts one conversation object, a JSON
+array of them, JSONL (one per line), or a bare message list. See `wmh/ingest/messages.py`.
+
+## The trace contract (what an adapter produces)
+
+A `Trace` is `{trace_id, steps, source, metadata}`. Each `Step` is one
+`(state_before, action) → observation`:
+
+- `action` — a tool call (`name` + `arguments`) or a free-text message.
+- `observation` — what the environment returned (`content`, `is_error`).
+- `state_before` — optional env-state snapshot (most provider traces leave it empty; open-loop
+  replay reconstructs state from action + history).
+- `task` — the originating instruction.
+
+`metadata` carries provenance and anything a source wants to thread through. Open-loop replay scores
+a predicted observation for `(state_before, action)` against the recorded one, so faithful `action`
+and `observation` are what matter most.
+
+## How the pieces fit
+
+```
+                                  ┌─ from_file(path)  ─┐
+  raw export / vendor API ──▶ adapter                  ├─▶ list[SpanRecord] ──▶ spans_to_traces ──▶ list[Trace]
+                                  └─ from_vendor(pull) ─┘        (wmh.ingest.normalize: the ONE normalizer)
+```
+
+- `wmh/ingest/adapter.py` — the `TraceAdapter` protocol + the registry (`register_adapter`,
+  `get_adapter`, `list_adapters`).
+- `wmh/ingest/base.py` — `BaseTraceAdapter`: file/JSONL loading + vendor plumbing, so a concrete
+  adapter only implements `spans_from_payload` (and optionally `_pull_payloads`).
+- `wmh/ingest/normalize.py` — the shared span→Trace core. Understands **both** the OTel GenAI
+  (`gen_ai.*`) and **OpenInference** (`openinference.span.kind`, `tool.name`, `input.value` /
+  `output.value`, `llm.*`) vocabularies, pairs each action span with its following tool span, and
+  honors optional `wmh.*` enrichments.
+- `wmh/ingest/otel_writer.py` — the inverse: `Trace` → OTel-GenAI span JSONL (used to persist a
+  corpus; round-trips losslessly through `otel-genai`).
+
+## Add a new source in ~30 lines
+
+Most providers export spans that are already OTLP or OpenInference, so a new adapter is small:
+
+```python
+# wmh/ingest/myprovider.py
+from __future__ import annotations
+
+from wmh.ingest.adapter import register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord
+
+
+class MyProviderAdapter(BaseTraceAdapter):
+    name = "myprovider"
+
+    def spans_from_payload(self, payload):  # one decoded JSON payload -> SpanRecords
+        # If the export is OTLP/OpenInference JSON, the BaseTraceAdapter default already works —
+        # you don't even need this method. Override it only when the export is a custom shape:
+        spans: list[SpanRecord] = []
+        for row in payload.get("events", []):
+            spans.append(SpanRecord(
+                trace_id=row["trace"], span_id=row["id"], start_nano=row["ts"],
+                attributes={                      # emit in GenAI vocab; the normalizer pairs them
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.tool.name": row["tool"],
+                    "gen_ai.tool.call.arguments": row["args"],   # JSON string or object
+                },
+            ))
+            spans.append(SpanRecord(
+                trace_id=row["trace"], span_id=row["id"] + "-r", start_nano=row["ts"] + 1,
+                status_error=bool(row.get("error")),
+                attributes={"gen_ai.operation.name": "execute_tool",
+                            "gen_ai.tool.message": row["result"]},
+            ))
+        return spans
+
+
+register_adapter(MyProviderAdapter())
+```
+
+Then import it in `wmh/ingest/__init__.py` (for registration on package import), add an inline
+`myprovider_test.py` with a recorded fixture payload (no network), and `wmh build --source myprovider`
+picks it up. To support `--pull`, implement `_pull_payloads(pull)` returning raw payloads from the
+vendor API (use `httpx`; lazy-import the vendor SDK only if needed). To surface it in the build
+wizard's source picker, add it to `_SOURCES` in `wmh/cli/ui.py`. Mirror the four bundled provider
+adapters for reference.
+
+## Conventions
+
+Adapters live in `wmh/ingest/`, are typed (no `Any`/bare `dict`; use `wmh.core.types`
+`JsonValue`/`JsonObject`), and are tested inline with fixtures — never the network. Vendor SDKs are
+optional extras, imported lazily; file ingestion works with none installed.

--- a/docs/ingest.phoenix.md
+++ b/docs/ingest.phoenix.md
@@ -1,0 +1,62 @@
+# Ingesting Arize Phoenix traces
+
+[Arize Phoenix](https://github.com/Arize-ai/phoenix) stores **OpenInference** spans. The `phoenix`
+adapter normalizes a Phoenix span export into the harness's OTel-JSONL, reusing the shared
+OpenInference classifier (`openinference.span.kind`, `tool.name`, `input.value`, `output.value`,
+`llm.input_messages`, `llm.model_name`).
+
+## Export from Phoenix
+
+Phoenix has no stable file-export CLI, so dump spans with the Phoenix client against your instance:
+
+```python
+import phoenix as px
+
+df = px.Client().get_spans_dataframe()          # optionally filter / limit
+df.reset_index().to_json("phoenix_export.json", orient="records")
+```
+
+The Phoenix UI's per-trace **Export** also produces a JSON array of span objects. Both work.
+
+## Shapes the adapter accepts
+
+1. **Phoenix native span dicts** — flat objects where ids live under `context` and timestamps are
+   ISO strings:
+
+   ```json
+   {
+     "name": "agent_step",
+     "context": {"trace_id": "f1e2...", "span_id": "aaaa...0001"},
+     "parent_id": null,
+     "start_time": "2024-01-01T00:00:00.000000+00:00",
+     "status_code": "OK",
+     "attributes": {"openinference.span.kind": "LLM", "tool.name": "get_user", "...": "..."}
+   }
+   ```
+
+   A single object, a JSON array, or one object per line (JSONL) are all accepted.
+
+2. **OTLP envelope** — standard `{"resourceSpans": [...]}` OTLP-JSON (or bare OTLP spans with
+   `traceId`). These delegate to the shared OTLP collector.
+
+The adapter maps Phoenix's field names (`context.trace_id`, `context.span_id`, `parent_id`,
+`start_time`, `status_code`) into the normalizer's span records; ISO timestamps are parsed to epoch
+nanoseconds for ordering, falling back to array index when missing/unparseable (ordering only needs
+to be monotonic within a trace). LLM/AGENT spans become Actions and the following TOOL span becomes
+the Observation, mirroring an agent's `(action) -> observation` step.
+
+## Run it
+
+```bash
+uv run wmh build --name phoenix-demo --source phoenix --file phoenix_export.json
+```
+
+See `examples/ingest/phoenix_to_wmh.sh` for a runnable script.
+
+## Caveats
+
+- **Live pull is not implemented.** Phoenix's query SDK surface is version-dependent, so the adapter
+  leaves `--pull` as the friendly "export to a file" error rather than guess an endpoint. Export to
+  a file and use `--file`.
+- The adapter is **SDK-free**: it parses the export as JSON and needs no `phoenix`/`arize` package
+  installed.

--- a/docs/ingest.posthog.md
+++ b/docs/ingest.posthog.md
@@ -1,0 +1,47 @@
+# Ingesting PostHog LLM traces
+
+The `posthog` adapter turns [PostHog LLM observability](https://posthog.com/docs/ai-engineering) data
+into the normalized `Trace` shape the harness builds world models from. PostHog captures LLM traces
+as analytics **events** (not OTLP spans), so this adapter maps the `$ai_*` events into the OTel-GenAI
+vocabulary for the shared normalizer (`wmh/ingest/normalize.py`).
+
+## The shape
+
+Per agent run, PostHog emits events sharing `properties.$ai_trace_id`:
+
+- **`$ai_generation`** — one LLM call. Prompt in `properties.$ai_input` (a messages list), completion
+  in `properties.$ai_output_choices`. In PostHog's NORMALIZED shape a tool call is a `content` part
+  (`{"type": "function", "function": {"name", "arguments"}}`, with `arguments` a JSON object) and
+  assistant text is a `[{"type": "text", "text"}]` parts list; the adapter also accepts a raw-OpenAI
+  top-level `tool_calls` array (string `arguments`) for setups that forward the provider payload
+  unnormalized.
+- **`$ai_span`** — a non-LLM step (often a tool execution): `properties.$ai_span_name` (tool name),
+  `properties.$ai_input_state` (args), `properties.$ai_output_state` (result).
+- **`$ai_trace`** — a trace-root summary; no standalone step.
+- **`$ai_is_error`** (bool) on any event marks that step errored.
+
+The adapter maps each `$ai_generation` tool call to an Action, pairs it with the sibling `$ai_span`
+result, and turns a plain generation into a message step. Events order by `timestamp`.
+
+## Build from it
+
+```bash
+# From a live PostHog project (HogQL query over $ai_* events):
+uv run wmh build --name posthog-demo --source posthog --pull \
+  --project "$POSTHOG_PROJECT_ID" --api-key "$POSTHOG_API_KEY"
+
+# Or from an exported events file (a single event, a JSON array, JSONL, or a {"results": [...]}
+# HogQL query result):
+uv run wmh build --name posthog-demo --source posthog --file events.json
+```
+
+- **API key**: a PostHog *personal API key* (Settings → Personal API keys), passed via `--api-key`
+  or `$POSTHOG_API_KEY`.
+- **Host**: set `$POSTHOG_HOST` for your region (`https://us.posthog.com` default, or
+  `https://eu.posthog.com` / a self-hosted URL).
+- **Project**: the numeric PostHog project id.
+
+The pull runs `select event, properties, timestamp from events where event like '$ai_%'` via the
+HogQL query API and normalizes the rows.
+
+See `examples/ingest/posthog_to_wmh.sh` for a runnable script.

--- a/examples/ingest/braintrust_to_wmh.sh
+++ b/examples/ingest/braintrust_to_wmh.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Ingest Braintrust traces into a world model, end to end.
+#
+# Braintrust logs SPANS AS ROWS in an experiment/project log (not OTLP spans). A trace is the set of
+# rows sharing a `root_span_id`. Export the rows via the fetch API (or the SDK), then let the
+# `braintrust` adapter normalize them into the OTel-GenAI JSONL that `wmh build` consumes.
+set -euo pipefail
+
+EXPORT="${1:-braintrust_export.json}"
+MODEL="${2:-braintrust-demo}"
+
+# 1) Export from Braintrust (pick one). The adapter accepts a single span row, a JSON array of rows,
+#    an API page wrapper ({"events": [...]} or {"data": [...]}), or JSONL (one row per line).
+#
+#    Fetch API — project logs ({"events": [...]}); BRAINTRUST_API_KEY is your org key:
+#      curl -s -H "Authorization: Bearer $BRAINTRUST_API_KEY" \
+#        "https://api.braintrust.dev/v1/project_logs/$PROJECT_ID/fetch" > "$EXPORT"
+#
+#    Fetch API — an experiment's spans:
+#      curl -s -H "Authorization: Bearer $BRAINTRUST_API_KEY" \
+#        "https://api.braintrust.dev/v1/experiment/$EXPERIMENT_ID/fetch" > "$EXPORT"
+#
+#    SDK (Python): braintrust.api.* / dataset iteration -> dump each span row to JSON/JSONL.
+
+# 2) Build directly from the Braintrust export — `--source braintrust` ingests it as part of build.
+uv run wmh build --name "$MODEL" --source braintrust --file "$EXPORT" --no-interactive
+
+echo "Built world model '$MODEL' from $EXPORT."

--- a/examples/ingest/langfuse_to_wmh.sh
+++ b/examples/ingest/langfuse_to_wmh.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Ingest Langfuse traces into a world model, end to end.
+#
+# Langfuse exports a TRACE as an observation tree (not OTLP spans). Grab one (or a page) via the
+# public API or the SDK, then let the `langfuse` adapter normalize it into the OTel-GenAI JSONL that
+# `wmh build` consumes.
+set -euo pipefail
+
+EXPORT="${1:-langfuse_export.json}"
+MODEL="${2:-langfuse-demo}"
+
+# 1) Export from Langfuse (pick one). The adapter accepts a single trace object, a JSON array of
+#    traces, an API list page ({"data": [...]}), or JSONL (one trace per line).
+#
+#    Public API — a single trace by id (LANGFUSE_* keys are your project credentials):
+#      curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+#        "$LANGFUSE_HOST/api/public/traces/$TRACE_ID" > "$EXPORT"
+#
+#    Public API — a page of recent traces (newest first):
+#      curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+#        "$LANGFUSE_HOST/api/public/traces?limit=50" > "$EXPORT"
+#
+#    SDK (Python): langfuse.api.trace.get(trace_id).dict() -> dump to JSON.
+
+# 2) Build directly from the Langfuse export — `--source langfuse` ingests it as part of build.
+uv run wmh build --name "$MODEL" --source langfuse --file "$EXPORT" --no-interactive
+
+echo "Built world model '$MODEL' from $EXPORT."

--- a/examples/ingest/langsmith_to_wmh.sh
+++ b/examples/ingest/langsmith_to_wmh.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Ingest LangSmith runs into a world model, end to end.
+#
+# LangSmith (LangChain) exports a trace as a tree of RUNS (not OTLP spans). Pull the runs for a
+# trace (or a project page) via the API or the SDK, then let the `langsmith` adapter normalize the
+# run tree into the OTel-GenAI JSONL that `wmh build` consumes.
+set -euo pipefail
+
+EXPORT="${1:-langsmith_export.json}"
+MODEL="${2:-langsmith-demo}"
+
+# 1) Export from LangSmith (pick one). The adapter accepts a single run, a JSON array of runs, a
+#    {"runs": [...]} wrapper, or JSONL (one run per line).
+#
+#    REST API — runs in a project (LANGCHAIN_API_KEY is your key; filter to one trace by id):
+#      curl -s -X POST "${LANGCHAIN_ENDPOINT:-https://api.smith.langchain.com}/api/v1/runs/query" \
+#        -H "x-api-key: $LANGCHAIN_API_KEY" -H "Content-Type: application/json" \
+#        -d '{"session": ["<project-uuid>"], "limit": 100}' \
+#        | python -c 'import sys,json; print(json.dumps(json.load(sys.stdin)["runs"]))' > "$EXPORT"
+#
+#    SDK (Python): dump runs to a JSON array (one trace, or a whole project):
+#      uv run python - <<'PY' > "$EXPORT"
+#      import json
+#      from langsmith import Client
+#      runs = Client().list_runs(project_name="my-project")  # or trace_id=<uuid>
+#      json.dump([r.dict() for r in runs], sys.stdout, default=str)
+#      PY
+
+# 2) Build directly from the LangSmith export — `--source langsmith` ingests it as part of build.
+uv run wmh build --name "$MODEL" --source langsmith --file "$EXPORT" --no-interactive
+
+echo "Built world model '$MODEL' from $EXPORT."

--- a/examples/ingest/mastra_to_wmh.sh
+++ b/examples/ingest/mastra_to_wmh.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build a world model from Mastra AI-tracing spans, end to end.
+#
+# Mastra records agent runs as AI-tracing spans typed by `type` (model_generation / tool_call / ...).
+# Pull them live from a running Mastra server, or ingest an exported spans file.
+set -euo pipefail
+
+MODEL="${1:-mastra-demo}"
+
+# Option A — pull live from a running Mastra server (fetches {base}/api/observability/traces).
+#   MASTRA_URL defaults to Mastra's dev server; --api-key is sent as a bearer token if needed.
+MASTRA_URL="${MASTRA_URL:-http://localhost:4111}"
+uv run wmh build --name "$MODEL" --source mastra --pull --project "$MASTRA_URL" --no-interactive
+
+# Option B — build from an exported spans file instead (single span / array / {"spans": [...]} /
+# {"traces": [...]} / JSONL):
+#   uv run wmh build --name "$MODEL" --source mastra --file mastra_spans.json --no-interactive
+
+echo "Built world model '$MODEL' from Mastra AI-tracing spans."

--- a/examples/ingest/phoenix_to_wmh.sh
+++ b/examples/ingest/phoenix_to_wmh.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Ingest Arize Phoenix traces into a world model.
+#
+# Phoenix stores OpenInference spans. Export them to a file, then let the `phoenix` adapter
+# normalize them into the OTel-JSONL the rest of the pipeline consumes.
+set -euo pipefail
+
+# 1) Export spans from Phoenix to a JSON file. Phoenix has no stable file-export CLI, so dump the
+#    spans dataframe with the Phoenix client (run against your Phoenix instance):
+#
+#      python - <<'PY'
+#      import phoenix as px
+#      df = px.Client().get_spans_dataframe()           # all spans (optionally filter/limit)
+#      df.reset_index().to_json("phoenix_export.json", orient="records")
+#      PY
+#
+#    The Phoenix UI's per-trace "Export" also yields a JSON array of span objects. Either shape
+#    works: flat OpenInference span dicts (context.trace_id / start_time / attributes) OR an OTLP
+#    `resourceSpans` envelope.
+EXPORT="${1:-phoenix_export.json}"
+MODEL="${2:-phoenix-demo}"
+
+# 2) Build directly from the Phoenix export — `--source phoenix` ingests it as part of build.
+uv run wmh build --name "$MODEL" --source phoenix --file "${EXPORT}" --no-interactive
+
+echo "Built world model '$MODEL' from $EXPORT."

--- a/examples/ingest/posthog_to_wmh.sh
+++ b/examples/ingest/posthog_to_wmh.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build a world model from PostHog LLM-observability traces, end to end.
+#
+# PostHog captures LLM traces as `$ai_*` analytics events (not OTLP spans). Pull them live with the
+# `posthog` adapter (HogQL query over the events table), or ingest an exported events file.
+set -euo pipefail
+
+MODEL="${1:-posthog-demo}"
+
+# Credentials (a PostHog PERSONAL API key + your region host + numeric project id):
+#   export POSTHOG_API_KEY=phx_...           # Settings -> Personal API keys
+#   export POSTHOG_HOST=https://us.posthog.com   # or https://eu.posthog.com / self-hosted
+#   export POSTHOG_PROJECT_ID=12345
+
+# Option A — pull live from PostHog (build ingests via HogQL: event like '$ai_%'):
+uv run wmh build --name "$MODEL" --source posthog --pull \
+  --project "${POSTHOG_PROJECT_ID:?set POSTHOG_PROJECT_ID}" --no-interactive
+
+# Option B — build from an exported events file instead (single event / JSON array / JSONL /
+# a {"results": [...]} HogQL result):
+#   uv run wmh build --name "$MODEL" --source posthog --file events.json --no-interactive
+
+echo "Built world model '$MODEL' from PostHog LLM events."

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -65,7 +65,7 @@ from wmh.engine.eval_suites import (
 )
 from wmh.engine.prompts import BASE_ENV_PROMPT
 from wmh.engine.world_model import WorldModel
-from wmh.ingest import VendorPull
+from wmh.ingest import VendorPull, list_adapters
 from wmh.optimize.judge import LLMJudge, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import EmbedderKind
@@ -220,8 +220,23 @@ def examples_run(
 @app.command("build")
 def build(
     name: str = typer.Option(None, "--name", help="Name for this world model."),
-    file: str = typer.Option(None, "--file", help="Path to exported traces (OTLP-JSON / JSONL)."),
-    vendor: str = typer.Option(None, "--vendor", help="Vendor name to pull traces via SDK."),
+    source: str = typer.Option(
+        "otel-genai",
+        "--source",
+        help="Trace source adapter: otel-genai, chat-json, braintrust, phoenix, langfuse, "
+        "langsmith, posthog, mastra.",
+    ),
+    file: str = typer.Option(None, "--file", help="Path to an exported traces file for --source."),
+    pull: bool = typer.Option(
+        False, "--pull", help="Pull traces live from the source's vendor API (instead of --file)."
+    ),
+    project: str = typer.Option(None, "--project", help="Vendor project/workspace id (--pull)."),
+    api_key: str = typer.Option(None, "--api-key", help="Vendor API key (else env var)."),
+    since: str = typer.Option(None, "--since", help="Only pull traces since this ISO timestamp."),
+    limit: int = typer.Option(None, "--limit", help="Max number of traces to pull."),
+    vendor: str = typer.Option(
+        None, "--vendor", help="[deprecated] alias for --source <name> --pull."
+    ),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
     provider: str = typer.Option(
         None, "--provider", help="Provider that serves the model (default: bedrock)."
@@ -254,15 +269,26 @@ def build(
     With no `--name`/`--file` on an interactive terminal, this launches a guided creation wizard;
     pass `--no-interactive` (or any of those flags) to stay fully scriptable.
     """
+    # `--vendor <name>` is the deprecated alias for `--source <name> --pull`: it names the source
+    # adapter and implies a live pull.
+    if vendor:
+        source = vendor
+        pull = True
+
     # Decide whether to run the wizard: explicit flag wins; otherwise auto when at a TTY and the
-    # essential inputs (a name and a trace source) were not supplied.
-    needs_input = name is None or (file is None and vendor is None)
+    # essential inputs (a name and a trace source — a file or a live pull) were not supplied.
+    needs_input = name is None or (file is None and not pull)
     use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
 
     params = BuildParams(
         name=name or DEFAULT_MODEL_NAME,
+        source=source,
         file=file,
-        vendor=vendor,
+        pull=pull,
+        project=project,
+        api_key=api_key,
+        since=since,
+        limit=limit,
         provider=provider,
         model=model,
         region=region,
@@ -275,8 +301,16 @@ def build(
     )
     if use_wizard:
         params = run_build_wizard(_console, params)
-    elif name is None and file is None and vendor is None:
-        raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
+    elif name is None and file is None and not pull:
+        raise typer.BadParameter(
+            "provide --file <export> or --pull (with --source), or run `wmh build` interactively"
+        )
+    if params.file and params.pull:
+        raise typer.BadParameter("pass either --file or --pull, not both")
+    if params.source not in list_adapters():
+        raise typer.BadParameter(
+            f"unknown --source {params.source!r}; choose one of: {', '.join(list_adapters())}"
+        )
     # The wizard always resolves a provider; the flag path keeps its historical default.
     params.provider = params.provider or "bedrock"
 
@@ -320,6 +354,7 @@ def build(
         gepa_budget=params.gepa_budget,
         train_split=params.train_split,
         judge_model=params.judge_model or judge_model_default(params.provider, params.model),
+        trace_adapter=params.source,
     )
     # Fail fast: ping the serve provider (and the embed path, if provider-backed) before spending
     # any rollouts. A missing SDK or bad creds otherwise surfaces only deep inside GEPA, which
@@ -347,8 +382,17 @@ def build(
     with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
         result = run_build(
             config,
-            file=params.file,
-            vendor=VendorPull() if params.vendor else None,
+            file=None if params.pull else params.file,
+            vendor=(
+                VendorPull(
+                    api_key=params.api_key,
+                    project=params.project,
+                    since=params.since,
+                    limit=params.limit,
+                )
+                if params.pull
+                else None
+            ),
             root=model_dir,
             serve_provider=metered,
             judge_provider=metered_judge,

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -422,12 +422,13 @@ def test_build_interactive_wizard_creates_model(
     for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
         monkeypatch.setenv(var, "test-cred")  # creds present: no interactive key prompts
     # --interactive forces the wizard even under CliRunner (non-TTY); feed each answer line in
-    # prompt order: name, file, provider (select), model (select), region (bedrock only),
-    # judge model (select), budget, embedder (select). The offline 'hashing' embedder skips
-    # the embed-model prompt; phi dim isn't prompted. Provider/model/embedder pick by index.
+    # prompt order: name, trace source (select), file, provider (select), model (select), region
+    # (bedrock only), judge model (select), budget, embedder (select). The offline 'hashing'
+    # embedder skips the embed-model prompt; phi dim isn't prompted. Selects pick by index.
     answers = "\n".join(
         [
             "wizard-built",
+            "",  # trace source: accept the default (otel-genai)
             _traces_file(tmp_path),
             "3",  # provider: bedrock (order: openai, anthropic, bedrock, azure, ...)
             "1",  # model: us.anthropic.claude-opus-4-8

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -109,7 +109,18 @@ class BuildParams(BaseModel):
     """The fully-resolved inputs for a build, as collected by the creation wizard."""
 
     name: str
+    # Trace source: which adapter ingests, and where the traces come from. `source` is a registered
+    # adapter name (otel-genai, chat-json, braintrust, phoenix, langfuse, langsmith, posthog,
+    # mastra). A source is read from a `file` export or `pull`ed live from its vendor API
+    # (`project`/`api_key`, optionally windowed by `since`/`limit`).
+    source: str = "otel-genai"
     file: str | None = None
+    pull: bool = False
+    project: str | None = None
+    api_key: str | None = None
+    since: str | None = None
+    limit: int | None = None
+    # Deprecated alias for `--source <name> --pull`; kept so old invocations keep working.
     vendor: str | None = None
     # None = not chosen yet: the wizard suggests the first provider with credentials present,
     # and the non-interactive path falls back to bedrock.
@@ -123,6 +134,81 @@ class BuildParams(BaseModel):
     embed_provider: str = "hashing"
     embed_model: str | None = None
     embed_dim: int = 512
+
+
+# Trace sources offered in the build wizard: name -> (label, can-pull-live). File-only sources
+# (otel-genai/chat-json) read an export; the rest can also pull live from a vendor API. Any adapter
+# registered in `wmh.ingest` is usable via `--source` even if it isn't surfaced here.
+_SOURCES: dict[str, tuple[str, bool]] = {
+    "otel-genai": ("OpenTelemetry GenAI spans (file)", False),
+    "chat-json": ("Chat / tool-call log, OpenAI-style (file)", False),
+    "braintrust": ("Braintrust", True),
+    "phoenix": ("Arize Phoenix", True),
+    "langfuse": ("Langfuse", True),
+    "langsmith": ("LangSmith", True),
+    "posthog": ("PostHog", True),
+    "mastra": ("Mastra", True),
+}
+
+
+def _collect_source(
+    console: Console,
+    ask: PromptReader,
+    ask_secret: PromptReader,
+    defaults: BuildParams,
+    interactive: bool,
+) -> tuple[str, str | None, bool, str | None, str | None]:
+    """Pick the trace source and where its traces come from.
+
+    Returns `(source, file, pull, project, api_key)`. The source is a registered adapter; traces
+    are read from a `file` export or pulled live (`pull`, with `project` + a masked `api_key`). A
+    source/file/pull already supplied via flags is honored without re-prompting.
+    """
+    # A source supplied entirely via flags (a file, a pull, or a non-default --source) is accepted
+    # as-is; otherwise prompt for the adapter.
+    source = defaults.source
+    if source == "otel-genai" and not defaults.file and not defaults.pull:
+        names = list(_SOURCES)
+        labels = [_SOURCES[n][0] for n in names]
+        chosen = _select(
+            console, ask, "Trace source", labels, _SOURCES[source][0], interactive=interactive
+        )
+        source = names[labels.index(chosen)]
+
+    can_pull = _SOURCES.get(source, ("", False))[1]
+    file = defaults.file
+    pull = defaults.pull
+    project = defaults.project
+    api_key = defaults.api_key
+
+    # A pull-capable vendor with no file already given: offer file-vs-pull.
+    if can_pull and not file and not pull:
+        mode = _select(
+            console, ask, "Read traces from", ["exported file", "live API pull"], None,
+            interactive=interactive,
+        )
+        pull = mode == "live API pull"
+
+    if pull:
+        if not project:
+            project = _prompt_text(console, ask, f"{source} project / workspace", None) or None
+        # Read the key without echo (it's a secret); blank falls back to the source's env var.
+        if not api_key:
+            api_key = ask_secret(f"{source} API key (blank = use env var): ").strip() or None
+        return source, None, True, project, api_key
+
+    # File source: require a path, re-prompting on empty input rather than erroring out.
+    while not file:
+        file = _prompt_text(
+            console,
+            ask,
+            f"Path to the {source} export to ingest",
+            None,
+            example="examples/tau-bench/traces.otel.jsonl",
+        )
+        if not file:
+            console.print("[red]a trace export path is required[/red]")
+    return source, file, False, project, api_key
 
 
 def select_provider_and_model(
@@ -252,20 +338,12 @@ def run_build_wizard(
             console.print(f"  [dim]using[/dim] {escape(name)}")
         break
 
-    file = defaults.file
-    vendor = defaults.vendor
-    if not file and not vendor:
-        # A trace source is required, so re-prompt on empty input rather than erroring out.
-        while not file:
-            file = _prompt_text(
-                console,
-                ask,
-                "Path to exported traces (OTLP-JSON / JSONL)",
-                None,
-                example="examples/tau-bench/traces.otel.jsonl",
-            )
-            if not file:
-                console.print("[red]a traces path is required (or pass --vendor)[/red]")
+    # Trace source: pick which adapter ingests, then where its traces come from — a file export or a
+    # live pull from the vendor's API (with project + masked API key). A source already supplied via
+    # flags (--file/--pull/--source) is kept without re-prompting.
+    source, file, pull, project, api_key = _collect_source(
+        console, ask, ask_secret, defaults, interactive
+    )
 
     provider, model, region = select_provider_and_model(
         console,
@@ -366,8 +444,13 @@ def run_build_wizard(
 
     return BuildParams(
         name=name,
+        source=source,
         file=file,
-        vendor=vendor,
+        pull=pull,
+        project=project,
+        api_key=api_key,
+        since=defaults.since,
+        limit=defaults.limit,
         provider=provider,
         model=model,
         judge_model=judge_model,

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -239,11 +239,12 @@ def test_step_selection_navigates_wraps_and_accepts() -> None:
 
 def test_build_wizard_collects_all_inputs() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
-    # Prompts in order: name, file, provider (select), model (select), region (bedrock only),
-    # budget, embedder (select). No embed-model (hashing default) and no phi-dim prompt.
+    # Prompts in order: name, trace source (select), file, provider (select), model (select),
+    # region (bedrock only), budget, embedder (select). No embed-model (hashing) or phi-dim prompt.
     reader = _scripted_reader(
         [
             "tau2-airline",
+            "",  # trace source: accept the default (otel-genai)
             "/tmp/traces.jsonl",
             "bedrock",
             "us.anthropic.claude-opus-4-8",
@@ -275,7 +276,7 @@ def test_build_wizard_select_by_number() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # Provider/model/embedder are numbered pickers; choosing by index must work. Pick anthropic (2),
     # its second model, no region prompt (not bedrock), budget 8, hashing embedder (1).
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "2", "2", "", "8", "1"])
+    reader = _scripted_reader(["m", "", "/tmp/t.jsonl", "2", "2", "", "8", "1"])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -294,7 +295,7 @@ def test_build_wizard_collects_provider_embedder() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # A provider-backed embedder adds an embeddings-model picker; phi dim keeps its default.
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "openai", "gpt-5.5", "", "8", "openai", "text-embedding-3-large"]
+        ["m", "", "/tmp/t.jsonl", "openai", "gpt-5.5", "", "8", "openai", "text-embedding-3-large"]
     )
     params = run_build_wizard(
         console,
@@ -385,7 +386,7 @@ def test_build_wizard_dashes_spaces_in_name() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     # Whitespace is dash-joined rather than rejected: typing "tau bench" quietly becomes
     # "tau-bench", with a dim note showing the name actually used.
-    reader = _scripted_reader(["tau bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["tau bench", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -401,7 +402,7 @@ def test_build_wizard_reprompts_on_invalid_name() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     # A name normalization can't rescue ("tau/bench" has a path separator) must re-prompt with
     # the friendly validation message, not escape as a ValueError traceback.
-    reader = _scripted_reader(["tau/bench", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["tau/bench", "tau-bench", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -417,7 +418,7 @@ def test_build_wizard_normalizes_flag_name_in_default() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     # A whitespace-y --name flag becomes the normalized bracketed default, acceptable via Enter
     # on the first prompt (no validation error, no re-prompt).
-    reader = _scripted_reader(["", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="tau bench"),
@@ -433,7 +434,7 @@ def test_build_wizard_drops_invalid_flag_name_from_default() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     # An unrescuable --name flag must not become the bracketed Enter-default (it could never be
     # accepted); blank input then means "no name yet" and re-prompts until a valid one arrives.
-    reader = _scripted_reader(["", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["", "tau-bench", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="tau/bench"),
@@ -458,10 +459,11 @@ def test_build_wizard_aborts_cleanly_on_eof() -> None:
 
 
 def test_build_wizard_reprompts_on_blank_trace_source() -> None:
-    # A blank traces path must re-ask, not crash. After a name, blank the file once, then give a
-    # real path; remaining prompts (provider/model/region/budget/embedder) take defaults.
+    # A blank traces path must re-ask, not crash. After a name and the trace-source select, blank
+    # the file once, then give a real path; remaining prompts (provider/model/region/budget/
+    # embedder) take defaults.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["mymodel", "", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["mymodel", "", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -484,9 +486,9 @@ def test_build_wizard_prompts_for_missing_credentials_and_saves(
     monkeypatch.chdir(tmp_path)
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     reader = _scripted_reader(
-        # name, file, provider, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (skip),
-        # model, region, budget, embedder
-        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "test-key-id", "", "1", "", "", "8", "1"]
+        # name, trace source, file, provider, AWS_REGION, AWS_ACCESS_KEY_ID,
+        # AWS_SECRET_ACCESS_KEY (skip), model, region, budget, embedder
+        ["m", "", "/tmp/t.jsonl", "bedrock", "us-east-1", "test-key-id", "", "1", "", "", "8", "1"]
     )
     params = run_build_wizard(
         console,
@@ -519,7 +521,7 @@ def test_build_wizard_keeps_session_creds_when_persistence_fails(
     monkeypatch.setattr(ui_module, "upsert_env_var", refuse)
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "key-id", "secret", "1", "", "", "8", "1"]
+        ["m", "", "/tmp/t.jsonl", "bedrock", "us-east-1", "key-id", "secret", "1", "", "", "8", "1"]
     )
     params = run_build_wizard(
         console,
@@ -544,7 +546,7 @@ def test_build_wizard_verifies_provider_and_retries_on_failure() -> None:
         return VerifyResult(ok=ok, kind=cfg.kind, model=cfg.model, detail="" if ok else "bad key")
 
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "anthropic", "", "", "", ""])
+    reader = _scripted_reader(["m", "", "/tmp/t.jsonl", "openai", "", "anthropic", "", "", "", ""])
     params = run_build_wizard(
         console, BuildParams(name="default"), reader=reader, verify=flaky, verify_embed=_ok_verify
     )
@@ -565,7 +567,7 @@ def test_build_wizard_verifies_embedder_with_embed_config() -> None:
 
     console = Console(force_terminal=False, no_color=True, width=100)
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "openai", "", "", "", "openai", "text-embedding-3-large"]
+        ["m", "", "/tmp/t.jsonl", "openai", "", "", "", "openai", "text-embedding-3-large"]
     )
     run_build_wizard(
         console,
@@ -584,7 +586,7 @@ def test_build_wizard_defaults_to_first_provider_with_creds(monkeypatch) -> None
     # bedrock, azure order) whose creds are present — here anthropic, once openai's key is gone.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "", "", "", "", ""])
+    reader = _scripted_reader(["m", "", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -600,7 +602,7 @@ def test_build_wizard_annotates_providers_that_have_keys(monkeypatch) -> None:  
     # Providers whose creds are present are labeled in the picker; cleared ones are not.
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "", "", ""])
+    reader = _scripted_reader(["m", "", "/tmp/t.jsonl", "openai", "", "", "", ""])
     run_build_wizard(
         console,
         BuildParams(name="default"),

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -80,6 +80,7 @@ class HarnessConfig(BaseModel):
         gepa_budget: int,
         train_split: float = 0.8,
         judge_model: str | None = None,
+        trace_adapter: str = "otel-genai",
     ) -> HarnessConfig:
         """Assemble a build config from the choices `wmh build` collects.
 
@@ -112,6 +113,7 @@ class HarnessConfig(BaseModel):
             gepa_budget=gepa_budget,
             train_split=train_split,
             judge_model=judge_model,
+            trace_adapter=trace_adapter,
         )
 
 

--- a/wmh/ingest/__init__.py
+++ b/wmh/ingest/__init__.py
@@ -1,11 +1,44 @@
-"""Trace ingestion: vendor SDK pulls and file uploads -> normalized `Trace` objects.
+"""Trace ingestion: file uploads and vendor pulls -> normalized `Trace` objects.
 
-A `TraceAdapter` turns one source's spans into the generic `Trace` schema. One concrete adapter
-ships (official OTel GenAI semconv); others register behind the same protocol.
+A `TraceAdapter` turns one source's telemetry into the generic `Trace` schema. Adapters register
+themselves on import and are looked up by name (`get_adapter`) or listed (`list_adapters`). The
+span-based adapters share one normalizer (`wmh.ingest.normalize`) and the `BaseTraceAdapter`
+scaffolding, so adding a new source is transport + attribute-mapping, not a rewrite. See
+`docs/ingest.md`.
+
+Bundled adapters:
+  - `otel-genai`  : OTLP-JSON spans following the OTel GenAI semantic conventions (file or pull).
+  - `chat-json`   : recorded OpenAI-style chat/tool-call conversations (file).
+Provider adapters (Braintrust, Phoenix/Arize, Langfuse, LangSmith) register when their module is
+imported; their heavy SDKs are optional extras, imported lazily inside the adapter.
 """
 
-# Import for the registration side effect so `get_adapter("otel-genai")` works on package import.
+# Import for the registration side effect so `get_adapter(...)` works on package import. The
+# provider adapters are SDK-free (they parse exports as JSON and pull over httpx), so importing them
+# here is cheap and brings no heavy dependency — their optional extras only matter if a user drives
+# the provider's own SDK alongside `wmh ingest`.
+from wmh.ingest import braintrust as braintrust  # noqa: F401
+from wmh.ingest import langfuse as langfuse  # noqa: F401
+from wmh.ingest import langsmith as langsmith  # noqa: F401
+from wmh.ingest import mastra as mastra  # noqa: F401
+from wmh.ingest import messages as messages  # noqa: F401
 from wmh.ingest import otel_genai as otel_genai  # noqa: F401
-from wmh.ingest.adapter import TraceAdapter, VendorPull, get_adapter, register_adapter
+from wmh.ingest import phoenix as phoenix  # noqa: F401
+from wmh.ingest import posthog as posthog  # noqa: F401
+from wmh.ingest.adapter import (
+    TraceAdapter,
+    VendorPull,
+    get_adapter,
+    list_adapters,
+    register_adapter,
+)
+from wmh.ingest.base import BaseTraceAdapter
 
-__all__ = ["TraceAdapter", "VendorPull", "get_adapter", "register_adapter"]
+__all__ = [
+    "BaseTraceAdapter",
+    "TraceAdapter",
+    "VendorPull",
+    "get_adapter",
+    "list_adapters",
+    "register_adapter",
+]

--- a/wmh/ingest/adapter.py
+++ b/wmh/ingest/adapter.py
@@ -48,3 +48,8 @@ def get_adapter(name: str) -> TraceAdapter:
     if name not in _ADAPTERS:
         raise ValueError(f"no trace adapter registered for {name!r}; have {list(_ADAPTERS)}")
     return _ADAPTERS[name]
+
+
+def list_adapters() -> list[str]:
+    """Names of all registered trace adapters, sorted (what the build source picker shows)."""
+    return sorted(_ADAPTERS)

--- a/wmh/ingest/base.py
+++ b/wmh/ingest/base.py
@@ -1,0 +1,102 @@
+"""`BaseTraceAdapter` — shared scaffolding so a new source is transport + mapping, not a rewrite.
+
+A span-based provider adapter only needs to answer two questions:
+  1. how do I get raw bytes/objects? (a file path, or a vendor API/SDK pull)
+  2. how do I turn one raw payload into `SpanRecord`s? (the provider's export shape)
+Everything after that — JSON/JSONL loading, grouping spans into `Trace`s, honoring `wmh.*`
+enrichments — is shared (`wmh.ingest.normalize`). `BaseTraceAdapter` wires (1) and (2) together so
+a concrete adapter is typically ~30 lines: set `name`, implement `spans_from_payload`, and (if it
+supports live pulls) `_pull_payloads`.
+
+Subclasses override:
+  - `name`: the registry key (e.g. "phoenix").
+  - `spans_from_payload(payload) -> list[SpanRecord]`: map ONE decoded JSON payload to spans. The
+    default delegates to `wmh.ingest.normalize.collect_spans` (OTLP/OpenInference-JSON); override it
+    when the provider's export is not OTLP-shaped.
+  - `_pull_payloads(pull) -> list[JsonValue]`: yield raw payloads from the vendor API/SDK. The
+    default raises a friendly "not implemented" — so `from_file` works with no override, and
+    `from_vendor` is opt-in.
+
+`from_file` accepts a single JSON document (object or array) OR JSONL (one payload per line), and
+skips a single corrupt JSONL line rather than aborting the whole ingest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from wmh.core.types import Trace
+from wmh.ingest.adapter import VendorPull
+from wmh.ingest.normalize import SpanRecord, collect_spans, spans_to_traces
+
+
+class BaseTraceAdapter:
+    """Default file+vendor plumbing around the shared span normalizer."""
+
+    name: str = "base"
+
+    # --- mapping hook (override for non-OTLP export shapes) -----------------------------------
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Map ONE decoded payload to `SpanRecord`s. Default: OTLP/OpenInference-JSON collection."""
+        return collect_spans(payload)
+
+    # --- transport hooks ----------------------------------------------------------------------
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch raw payloads from the vendor API/SDK. Override to support live pulls."""
+        raise ValueError(
+            f"{self.name!r} does not support live vendor pulls yet; export traces to a file and "
+            f"use `from_file` (or `wmh ingest run --source {self.name} --file <export>`)"
+        )
+
+    # --- public API (rarely overridden) -------------------------------------------------------
+
+    def _load_payloads(self, text: str) -> list[JsonValue]:
+        """Parse a whole-document JSON payload, or per-line JSONL on a top-level decode failure."""
+        try:
+            return [json.loads(text)]
+        except json.JSONDecodeError:
+            payloads: list[JsonValue] = []
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    payloads.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    continue  # tolerate a truncated/corrupt line; keep the rest
+            return payloads
+
+    def _collect_all(self, payloads: list[JsonValue]) -> list[SpanRecord]:
+        """Map every payload to spans and re-stamp `span_id` globally unique in emission order.
+
+        Adapters assign `span_id`/`start_nano` per payload, so a trace split across payloads (e.g.
+        one row/observation/run per JSONL line) would otherwise emit colliding ids and identical
+        `start_nano`. `spans_to_traces` sorts by `(start_nano, span_id)`, so the collision scrambles
+        the action/observation pairing. Stamping a globally monotonic `span_id` makes equal-time
+        spans (the row-adapter case, all `start_nano=0`) order by emission, while real timestamps
+        (e.g. Phoenix) still dominate the sort. Uniqueness is owned here so adapters can't get it
+        wrong individually.
+        """
+        spans: list[SpanRecord] = []
+        for payload in payloads:
+            for span in self.spans_from_payload(payload):
+                span.span_id = f"{len(spans):012d}-{span.span_id}"
+                spans.append(span)
+        return spans
+
+    def from_file(self, path: str) -> list[Trace]:
+        text = Path(path).read_text(encoding="utf-8")
+        spans = self._collect_all(self._load_payloads(text))
+        return spans_to_traces(spans, source=f"{self.name}:{path}")
+
+    def from_vendor(self, pull: VendorPull) -> list[Trace]:
+        spans = self._collect_all(self._pull_payloads(pull))
+        traces = spans_to_traces(spans, source=f"{self.name}:{pull.project or 'vendor'}")
+        if pull.limit is not None:
+            traces = traces[: pull.limit]
+        return traces

--- a/wmh/ingest/base_test.py
+++ b/wmh/ingest/base_test.py
@@ -1,0 +1,181 @@
+"""Tests for BaseTraceAdapter + the shared normalizer's OpenInference handling.
+
+Proves a provider adapter that only sets `name` + (optionally) `spans_from_payload` gets correct
+file/JSONL loading and span->Trace normalization for free — including OpenInference-vocabulary spans
+(`openinference.span.kind`, `tool.name`, `output.value`), which providers like Phoenix/Langfuse use.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from wmh.core.types import ActionKind, JsonObject
+from wmh.ingest.adapter import VendorPull
+from wmh.ingest.base import BaseTraceAdapter
+
+
+def _oi_span(
+    span_id: str, kind: str, attrs: JsonObject, *, start: int, name: str = ""
+) -> JsonObject:
+    """An OpenInference-style OTLP span with a FLAT attribute map (provider export shape)."""
+    return {
+        "traceId": "oitrace0000000000000000000000000",
+        "spanId": span_id,
+        "name": name,
+        "startTimeUnixNano": start,
+        "attributes": {"openinference.span.kind": kind, **attrs},
+    }
+
+
+def _otlp(spans: list[JsonObject]) -> JsonObject:
+    return {"resourceSpans": [{"scopeSpans": [{"spans": spans}]}]}
+
+
+class _DefaultAdapter(BaseTraceAdapter):
+    name = "test-default"
+
+
+def test_base_from_file_normalizes_openinference_spans(tmp_path: Path) -> None:
+    # LLM span issues a tool call (OpenInference: tool.name + input.value); TOOL span has output.
+    spans = [
+        _oi_span(
+            "a1",
+            "LLM",
+            {"tool.name": "get_user", "input.value": '{"id": "u1"}', "input": "look up u1"},
+            start=1,
+        ),
+        _oi_span("t1", "TOOL", {"tool.name": "get_user", "output.value": "found u1"}, start=2),
+    ]
+    path = tmp_path / "oi.json"
+    path.write_text(json.dumps(_otlp(spans)), encoding="utf-8")
+
+    traces = _DefaultAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    assert traces[0].source.startswith("test-default:")
+    step = traces[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "get_user"
+    assert step.action.arguments == {"id": "u1"}
+    assert step.observation.content == "found u1"
+
+
+def test_base_from_file_handles_jsonl_and_skips_corrupt_lines(tmp_path: Path) -> None:
+    good = json.dumps(_otlp([_oi_span("a1", "LLM", {"llm.model_name": "gpt"}, start=1)]))
+    path = tmp_path / "spans.jsonl"
+    path.write_text(f"{good}\n{{truncated\n{good}\n", encoding="utf-8")
+
+    traces = _DefaultAdapter().from_file(str(path))
+    # Two valid lines -> two payloads -> same trace id grouped into one trace; corrupt line skipped.
+    assert len(traces) == 1
+
+
+def test_base_vendor_pull_unsupported_is_friendly() -> None:
+    try:
+        _DefaultAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "does not support live vendor pulls" in str(exc)
+        assert "test-default" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_subclass_can_override_spans_from_payload(tmp_path: Path) -> None:
+    """A provider whose export is NOT OTLP maps its own shape via spans_from_payload."""
+    from wmh.ingest.normalize import SpanRecord
+
+    class CustomAdapter(BaseTraceAdapter):
+        name = "custom"
+
+        def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+            # payload is {"events": [{"call": "...", "result": "..."}]}
+            spans: list[SpanRecord] = []
+            events = payload.get("events", []) if isinstance(payload, dict) else []
+            if not isinstance(events, list):
+                return spans
+            for i, ev in enumerate(events):
+                if not isinstance(ev, dict):
+                    continue
+                spans.append(
+                    SpanRecord(
+                        trace_id="c" * 32,
+                        span_id=f"a{i}",
+                        start_nano=i * 2,
+                        attributes={
+                            "gen_ai.operation.name": "chat",
+                            "gen_ai.tool.name": ev["call"],
+                            "gen_ai.tool.call.arguments": "{}",
+                        },
+                    )
+                )
+                spans.append(
+                    SpanRecord(
+                        trace_id="c" * 32,
+                        span_id=f"t{i}",
+                        start_nano=i * 2 + 1,
+                        attributes={
+                            "gen_ai.operation.name": "execute_tool",
+                            "gen_ai.tool.message": ev["result"],
+                        },
+                    )
+                )
+            return spans
+
+    path = tmp_path / "custom.json"
+    path.write_text(json.dumps({"events": [{"call": "ping", "result": "pong"}]}), encoding="utf-8")
+
+    traces = CustomAdapter().from_file(str(path))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "ping"
+    assert traces[0].steps[0].observation.content == "pong"
+
+
+def test_multi_step_trace_split_across_jsonl_lines_keeps_order(tmp_path: Path) -> None:
+    """A trace whose spans arrive one-per-JSONL-line must not collide on span_id / start_nano.
+
+    Row-shaped adapters assign per-payload ordinals (0,1,...). With one row per JSONL line, every
+    payload restarts at 0, so without globally-unique span ids the action/observation spans would
+    share `start_nano=0` and the same span_id, scrambling the pairing (regression guard).
+    """
+    from wmh.ingest.normalize import SpanRecord
+
+    class RowAdapter(BaseTraceAdapter):
+        name = "row"
+
+        def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+            # Each payload (one JSONL line) is a single {kind, tool, content} row -> one span,
+            # always at the per-payload ordinal 0 (the collision-prone case).
+            if not isinstance(payload, dict):
+                return []
+            tool = payload.get("tool")
+            is_tool = payload.get("kind") == "tool"
+            attrs: JsonObject = {
+                "gen_ai.operation.name": "execute_tool" if is_tool else "chat",
+                "gen_ai.tool.name": tool if isinstance(tool, str) else "",
+            }
+            if is_tool:
+                attrs["gen_ai.tool.message"] = payload.get("content", "")
+            else:
+                attrs["gen_ai.tool.call.arguments"] = "{}"
+            return [SpanRecord(trace_id="t" * 32, span_id="x0", start_nano=0, attributes=attrs)]
+
+    # Two steps (callA->resultA, callB->resultB), four JSONL lines, all one trace.
+    lines = [
+        {"kind": "llm", "tool": "callA"},
+        {"kind": "tool", "tool": "callA", "content": "resultA"},
+        {"kind": "llm", "tool": "callB"},
+        {"kind": "tool", "tool": "callB", "content": "resultB"},
+    ]
+    path = tmp_path / "rows.jsonl"
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+
+    traces = RowAdapter().from_file(str(path))
+    assert len(traces) == 1
+    steps = traces[0].steps
+    assert [(s.action.name, s.observation.content) for s in steps] == [
+        ("callA", "resultA"),
+        ("callB", "resultB"),
+    ]

--- a/wmh/ingest/braintrust.py
+++ b/wmh/ingest/braintrust.py
@@ -1,0 +1,364 @@
+"""Braintrust adapter: turn a Braintrust span-row export into `Trace`s.
+
+Braintrust does NOT export OTLP spans. It logs **spans as rows** in an experiment or project log;
+the export API (`GET /v1/project_logs/{id}/fetch`, `GET /v1/experiment/{id}/fetch`) and the SDK
+return one row per span, where a *trace* is the set of rows sharing a `root_span_id`:
+
+    {"span_id": "s2", "root_span_id": "r1", "span_parents": ["s1"],
+     "span_attributes": {"name": "llm", "type": "llm"},
+     "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+     "output": {"role": "assistant",
+                "tool_calls": [{"id": "c1",
+                    "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]},
+     "metadata": {"model": "gpt-4o"}, "created": "2026-01-01T00:00:01.000Z", "error": null}
+
+Because this is not an OTLP/OpenInference span shape, the adapter overrides `spans_from_payload`
+(like `wmh.ingest.langfuse`) and re-emits each row in the **OTel-GenAI vocabulary** so the shared
+classifier/normalizer (`wmh.ingest.normalize`) does the pairing/state/metadata work:
+
+  - The row's `span_attributes.type` classifies it. A row of type `llm`/`task`/`function`/`chain`
+    whose `output` carries OpenAI-style `tool_calls` becomes one `chat` **action** span per call
+    (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`).
+  - A row of type `tool` (or a tool-like row carrying `output`) becomes an `execute_tool` **result**
+    span (`gen_ai.tool.message`), also carrying name/args so a standalone tool row still pairs.
+  - An `llm`/`task`/`function` row with no tool call becomes a plain `chat` message span
+    (`gen_ai.completion`).
+  - A non-null `error` marks the row's step as an error (`status_error=True`).
+
+Rows are grouped by `root_span_id` (the trace key; `span_id` is the per-span key) and ordered by the
+`created` ISO-8601 timestamp -> a monotonic ordinal (list index when absent). Only monotonicity
+within a trace matters — the normalizer sorts by `start_nano`. The first user message in the first
+row's `input` becomes the step `task` (`gen_ai.prompt`); the row-level `metadata` round-trips via
+`wmh.trace.metadata`.
+
+Accepted file shapes (`from_file`): a single span row, a JSON array of rows, an API page wrapper
+(`{"events": [...]}` or `{"data": [...]}`), or JSONL (one row per line).
+
+Pull: live pull via the Braintrust SDK is not implemented; export to a file and use `from_file`. The
+`BaseTraceAdapter` default raises a friendly error pointing at `--file`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+# Braintrust REST API. The fetch endpoint returns `{"events": [span rows]}`; the project list
+# resolves a human project name to its id. Overridable for self-hosted deployments.
+_API_BASE = os.environ.get("BRAINTRUST_API_URL", "https://api.braintrust.dev").rstrip("/")
+_API_KEY_ENV = "BRAINTRUST_API_KEY"
+
+# Row types (`span_attributes.type`) that represent a model/agent turn (a potential action), vs a
+# tool execution (a result). Braintrust's common types are: "llm", "tool", "function", "task",
+# "score", "eval". We treat anything tool-like as a result and the rest of the "thinking" types as
+# llm-ish; unknown types fall back to a content-based guess.
+_LLM_TYPES = frozenset({"llm", "task", "function", "chain", "agent"})
+_TOOL_TYPES = frozenset({"tool"})
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _looks_like_uuid(value: str) -> bool:
+    """True if `value` is a canonical UUID (Braintrust project ids), so we skip the name lookup."""
+    import uuid
+
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _start_ordinal(row: JsonObject, fallback: int) -> int:
+    """Monotonic ordering key from the row's `created` timestamp (shared helper; UTC-safe)."""
+    return iso_to_ordinal(row.get("created"), fallback)
+
+
+def _row_type(row: JsonObject) -> str:
+    """The span type from `span_attributes.type` (Braintrust's row kind)."""
+    attrs = row.get("span_attributes")
+    if isinstance(attrs, dict):
+        value = attrs.get("type")
+        if isinstance(value, str):
+            return value.lower()
+    return ""
+
+
+def _row_name(row: JsonObject) -> str:
+    """A display/tool name from `span_attributes.name` (or top-level `name`)."""
+    attrs = row.get("span_attributes")
+    if isinstance(attrs, dict):
+        value = attrs.get("name")
+        if isinstance(value, str) and value:
+            return value
+    name = row.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _is_error(row: JsonObject) -> bool:
+    """A non-null/non-empty `error` marks the row as a failed step."""
+    error = row.get("error")
+    if error is None:
+        return False
+    if isinstance(error, str):
+        return bool(error.strip())
+    return bool(error)
+
+
+def _tool_calls(output: JsonValue) -> list[JsonObject]:
+    """Extract OpenAI-style tool calls from an `output` (a message object or a message list)."""
+    if isinstance(output, dict):
+        raw = output.get("tool_calls")
+        if isinstance(raw, list):
+            return [tc for tc in raw if isinstance(tc, dict)]
+    if isinstance(output, list):
+        calls: list[JsonObject] = []
+        for message in output:
+            if isinstance(message, dict):
+                raw = message.get("tool_calls")
+                if isinstance(raw, list):
+                    calls.extend(tc for tc in raw if isinstance(tc, dict))
+        return calls
+    return []
+
+
+def _call_name_args(tool_call: JsonObject) -> tuple[str, str]:
+    """(name, raw-arguments-json) from a tool call in OpenAI-nested or flattened shape."""
+    fn = tool_call.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:
+        name = tool_call.get("name")
+        args = tool_call.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _first_user_text(value: JsonValue) -> str | None:
+    """The first user message text from an `input` (message list), else the input rendered as text.
+
+    Braintrust `input` is commonly a list of chat messages; the task is the first user turn. When
+    `input` is not a message list, the whole input (rendered) stands in as the task.
+    """
+    if isinstance(value, list):
+        for message in value:
+            if isinstance(message, dict) and message.get("role") == "user":
+                return as_text(message.get("content"))
+        return None
+    if value is None:
+        return None
+    return as_text(value)
+
+
+def _completion_text(output: JsonValue) -> str:
+    """Render an llm `output` to text: an assistant message's `content`, else the whole output."""
+    if isinstance(output, dict):
+        content = output.get("content")
+        if content is not None:
+            return as_text(content)
+    return as_text(output)
+
+
+class BraintrustAdapter(BaseTraceAdapter):
+    """Map a Braintrust span-row export into normalized `Trace`s. No SDK."""
+
+    name = "braintrust"
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch span rows live from the Braintrust REST API.
+
+        `pull.project` is a project name or id; `pull.api_key` (else `$BRAINTRUST_API_KEY`) auths.
+        Resolves a name to an id via `/v1/project`, then fetches `/v1/project_logs/{id}/fetch`,
+        whose `{"events": [...]}` body is handed straight to `spans_from_payload`.
+        """
+        api_key = pull.api_key or os.environ.get(_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(
+                f"braintrust pull needs an API key: pass --api-key or set ${_API_KEY_ENV}"
+            )
+        if not pull.project:
+            raise ValueError("braintrust pull needs --project (a project name or id)")
+        headers = {"Authorization": f"Bearer {api_key}"}
+        project_id = self._resolve_project_id(pull.project, headers)
+        params: dict[str, str] = {}
+        if pull.limit is not None:
+            params["limit"] = str(pull.limit)
+        resp = httpx.get(
+            f"{_API_BASE}/v1/project_logs/{project_id}/fetch",
+            headers=headers,
+            params=params,
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        return [resp.json()]
+
+    def _resolve_project_id(self, project: str, headers: dict[str, str]) -> str:
+        """Resolve a project name to its id (a UUID-shaped `project` is used as the id directly).
+
+        Filters by `project_name` server-side rather than listing+scanning, so it does not miss
+        projects past an arbitrary page limit.
+        """
+        if _looks_like_uuid(project):
+            return project
+        resp = httpx.get(
+            f"{_API_BASE}/v1/project",
+            headers=headers,
+            params={"project_name": project, "limit": "100"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        objects = body.get("objects", []) if isinstance(body, dict) else []
+        for obj in objects:
+            if isinstance(obj, dict) and obj.get("name") == project:
+                pid = obj.get("id")
+                if isinstance(pid, str):
+                    return pid
+        raise ValueError(f"braintrust project {project!r} not found for this API key")
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Map a Braintrust export (a row, a list, or a page wrapper) to `SpanRecord`s."""
+        rows = self._rows(payload)
+        # Group rows by their trace key (`root_span_id`), preserving first-seen order of traces.
+        by_trace: dict[str, list[JsonObject]] = {}
+        for row in rows:
+            by_trace.setdefault(self._trace_id(row), []).append(row)
+        spans: list[SpanRecord] = []
+        for trace_id, trace_rows in by_trace.items():
+            spans.extend(self._spans_for_trace(trace_id, trace_rows))
+        return spans
+
+    def _rows(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a flat list of Braintrust span-row objects.
+
+        Accepts a single row, a bare list of rows, or an API page wrapper (`{"events": [...]}` /
+        `{"data": [...]}` as returned by the fetch endpoints).
+        """
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._rows(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        for wrapper_key in ("events", "data"):
+            inner = payload.get(wrapper_key)
+            if isinstance(inner, list):
+                out = []
+                for item in inner:
+                    out.extend(self._rows(item))
+                return out
+        # A bare span row is identified by its grouping/identity keys.
+        if any(key in payload for key in ("root_span_id", "span_id", "span_attributes")):
+            return [payload]
+        return []
+
+    def _trace_id(self, row: JsonObject) -> str:
+        """The trace grouping key: `root_span_id`, then `span_id`, else a hash (stable fallback)."""
+        for key in ("root_span_id", "span_id"):
+            value = row.get(key)
+            if isinstance(value, str) and value:
+                return value
+        import hashlib
+
+        return hashlib.sha256(as_text(row).encode()).hexdigest()[:32]
+
+    def _spans_for_trace(self, trace_id: str, rows: list[JsonObject]) -> list[SpanRecord]:
+        # Order by `created`; ties (or absent timestamps) keep input order via the index fallback.
+        indexed = list(enumerate(rows))
+        indexed.sort(key=lambda pair: (_start_ordinal(pair[1], pair[0]), pair[0]))
+
+        # The task is the first user message across the trace's rows (in time order).
+        task: str | None = None
+        for _, row in indexed:
+            task = _first_user_text(row.get("input"))
+            if task is not None:
+                break
+        # Trace metadata: the first row's metadata object (in time order).
+        meta_obj: JsonObject = {}
+        for _, row in indexed:
+            meta = row.get("metadata")
+            if isinstance(meta, dict) and meta:
+                meta_obj = meta
+                break
+
+        spans: list[SpanRecord] = []
+        ordinal = 0
+
+        def emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+            nonlocal ordinal
+            if ordinal == 0:
+                if task is not None:
+                    attrs.setdefault("gen_ai.prompt", task)
+                if meta_obj:
+                    attrs.setdefault("wmh.trace.metadata", json.dumps(meta_obj))
+            spans.append(
+                SpanRecord(
+                    trace_id=trace_id,
+                    span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                    name="execute_tool" if tool else "chat",
+                    start_nano=ordinal,
+                    attributes={
+                        "gen_ai.operation.name": "execute_tool" if tool else "chat",
+                        **attrs,
+                    },
+                    status_error=error,
+                )
+            )
+            ordinal += 1
+
+        for _, row in indexed:
+            rtype = _row_type(row)
+            error = _is_error(row)
+            output = row.get("output")
+            calls = _tool_calls(output) if rtype not in _TOOL_TYPES else []
+            if calls:
+                # An llm/task/function row that issued tool calls: one `chat` action span per call.
+                # The RESULT comes from the sibling `tool` row below (the normalizer pairs the
+                # nearest following execute_tool span), so we do NOT synthesize a result here.
+                for tool_call in calls:
+                    name, args = _call_name_args(tool_call)
+                    emit(
+                        {"gen_ai.tool.name": name, "gen_ai.tool.call.arguments": args},
+                        tool=False,
+                        error=error,
+                    )
+            elif rtype in _TOOL_TYPES or (rtype not in _LLM_TYPES and self._is_tool_like(row)):
+                # A `tool` row (or an unknown-typed tool-like row) = a tool execution: an
+                # `execute_tool` result span. We carry name/args too so a standalone tool row (no
+                # preceding llm action) still pairs; the normalizer backfills the action otherwise.
+                emit(
+                    {
+                        "gen_ai.tool.name": _row_name(row),
+                        "gen_ai.tool.call.arguments": as_text(row.get("input")),
+                        "gen_ai.tool.message": as_text(output),
+                    },
+                    tool=True,
+                    error=error,
+                )
+            elif rtype in _LLM_TYPES or output is not None:
+                # A plain llm/task turn (no tool call): a message action, no observation.
+                emit({"gen_ai.completion": _completion_text(output)}, tool=False, error=error)
+            # Rows with no usable output and no tool semantics (e.g. score/eval) are ignored.
+        return spans
+
+    def _is_tool_like(self, row: JsonObject) -> bool:
+        """An unknown-typed row is a tool execution when it has a name and I/O (input/output)."""
+        if row.get("output") is None and row.get("input") is None:
+            return False
+        return bool(_row_name(row))
+
+
+register_adapter(BraintrustAdapter())

--- a/wmh/ingest/braintrust_test.py
+++ b/wmh/ingest/braintrust_test.py
@@ -1,0 +1,210 @@
+"""Tests for the Braintrust span-row -> Trace adapter (braintrust).
+
+Fixture-based, no network: a hand-authored Braintrust export with an `llm` span that issues a tool
+call, the sibling `tool` span carrying the result, and a second `tool` span in an error state — all
+sharing one `root_span_id` so they group into a single trace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.adapter import VendorPull
+from wmh.ingest.braintrust import BraintrustAdapter
+
+# A realistic Braintrust fetch export: rows sharing `root_span_id` "r1" form one trace. An llm row
+# emits a tool call; a `tool` row returns the result; a second `tool` row errors.
+_ROWS = [
+    {
+        "span_id": "s1",
+        "root_span_id": "r1",
+        "span_parents": [],
+        "span_attributes": {"name": "agent", "type": "llm"},
+        "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+        "output": {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'}}
+            ],
+        },
+        "metadata": {"model": "gpt-4o", "benchmark": "demo"},
+        "created": "2026-01-01T00:00:01.000Z",
+        "error": None,
+    },
+    {
+        "span_id": "s2",
+        "root_span_id": "r1",
+        "span_parents": ["s1"],
+        "span_attributes": {"name": "get_weather", "type": "tool"},
+        "input": {"city": "Paris"},
+        "output": "18C and sunny",
+        "created": "2026-01-01T00:00:02.000Z",
+        "error": None,
+    },
+    {
+        "span_id": "s3",
+        "root_span_id": "r1",
+        "span_parents": ["s1"],
+        "span_attributes": {"name": "get_forecast", "type": "tool"},
+        "input": {"city": "Paris"},
+        "output": "forecast service unavailable",
+        "created": "2026-01-01T00:00:03.000Z",
+        "error": "ServiceUnavailable: 503",
+    },
+]
+
+
+def test_braintrust_adapter_is_registered() -> None:
+    assert get_adapter("braintrust").name == "braintrust"
+
+
+def test_llm_tool_call_pairs_with_tool_row_and_groups_into_one_trace(tmp_path: Path) -> None:
+    path = tmp_path / "export.json"
+    path.write_text(json.dumps(_ROWS), encoding="utf-8")
+
+    traces = BraintrustAdapter().from_file(str(path))
+
+    # All three rows share root_span_id "r1" -> exactly ONE trace.
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.trace_id == "r1"
+    assert trace.metadata == {"model": "gpt-4o", "benchmark": "demo"}
+    # The llm tool call pairs with the s2 tool result; the s3 error tool row pairs alone.
+    assert len(trace.steps) == 2
+
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "get_weather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.observation.is_error is False
+    assert call.task == "what's the weather in Paris?"
+
+    err = trace.steps[1]
+    assert err.action.kind == ActionKind.TOOL_CALL
+    assert err.action.name == "get_forecast"
+    assert err.action.arguments == {"city": "Paris"}
+    assert err.observation.content == "forecast service unavailable"
+    assert err.observation.is_error is True
+
+
+def test_plain_llm_row_becomes_message_step(tmp_path: Path) -> None:
+    rows = [
+        {
+            "span_id": "s1",
+            "root_span_id": "r2",
+            "span_attributes": {"name": "agent", "type": "llm"},
+            "input": [{"role": "user", "content": "say hi"}],
+            "output": {"role": "assistant", "content": "hello there"},
+            "created": "2026-01-01T00:00:01.000Z",
+            "error": None,
+        }
+    ]
+    path = tmp_path / "msg.json"
+    path.write_text(json.dumps(rows), encoding="utf-8")
+
+    step = BraintrustAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.kind == ActionKind.MESSAGE
+    assert step.action.content is not None
+    assert "hello there" in step.action.content
+    assert step.observation.content == ""
+
+
+def test_events_wrapper_and_ordering_by_created(tmp_path: Path) -> None:
+    # `{"events": [...]}` page wrapper; rows deliberately out of `created` order.
+    page = {
+        "events": [
+            {
+                "span_id": "t1",
+                "root_span_id": "r3",
+                "span_attributes": {"name": "ls", "type": "tool"},
+                "input": {},
+                "output": "a.txt\nb.txt",
+                "created": "2026-01-01T00:00:05.000Z",
+            },
+            {
+                "span_id": "g1",
+                "root_span_id": "r3",
+                "span_attributes": {"name": "agent", "type": "llm"},
+                "input": [{"role": "user", "content": "list files"}],
+                "output": {
+                    "tool_calls": [{"id": "x", "function": {"name": "ls", "arguments": "{}"}}]
+                },
+                "created": "2026-01-01T00:00:04.000Z",
+            },
+        ]
+    }
+    path = tmp_path / "page.json"
+    path.write_text(json.dumps(page), encoding="utf-8")
+
+    traces = BraintrustAdapter().from_file(str(path))
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    # Ordered by `created`: the llm row (04s) precedes the tool result (05s) and they pair.
+    assert step.action.name == "ls"
+    assert step.observation.content == "a.txt\nb.txt"
+
+
+def test_jsonl_multiple_traces(tmp_path: Path) -> None:
+    other = {
+        "span_id": "z1",
+        "root_span_id": "r4",
+        "span_attributes": {"name": "agent", "type": "llm"},
+        "input": [{"role": "user", "content": "ping"}],
+        "output": {"content": "pong"},
+        "created": "2026-01-01T00:00:01.000Z",
+    }
+    path = tmp_path / "rows.jsonl"
+    # One JSON array line (the r1 trace) + one bare-row line (the r4 trace).
+    path.write_text(json.dumps(_ROWS) + "\n" + json.dumps(other) + "\n", encoding="utf-8")
+
+    traces = BraintrustAdapter().from_file(str(path))
+    assert len(traces) == 2
+
+
+def test_vendor_pull_without_key_is_friendly(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
+    try:
+        BraintrustAdapter().from_vendor(VendorPull(project="p"))
+    except ValueError as exc:
+        assert "API key" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_vendor_pull_without_project_is_friendly() -> None:
+    try:
+        BraintrustAdapter().from_vendor(VendorPull(api_key="k"))
+    except ValueError as exc:
+        assert "project" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_vendor_pull_resolves_project_and_fetches(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    """Live-pull path with httpx mocked: resolve project name -> id, fetch logs, normalize."""
+    import wmh.ingest.braintrust as bt
+
+    def fake_get(url, headers=None, params=None, timeout=None):  # noqa: ANN001, ANN202 - test stub
+        class _Resp:
+            def raise_for_status(self) -> None: ...
+
+            def __init__(self, payload: dict) -> None:
+                self._payload = payload
+
+            def json(self) -> dict:
+                return self._payload
+
+        if url.endswith("/v1/project"):
+            return _Resp({"objects": [{"id": "pid-1", "name": "Demo"}]})
+        assert "/v1/project_logs/pid-1/fetch" in url  # resolved the name to the id
+        assert headers == {"Authorization": "Bearer k"}
+        return _Resp({"events": _ROWS})
+
+    monkeypatch.setattr(bt.httpx, "get", fake_get)
+    traces = BraintrustAdapter().from_vendor(VendorPull(api_key="k", project="Demo"))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "get_weather"

--- a/wmh/ingest/langfuse.py
+++ b/wmh/ingest/langfuse.py
@@ -1,0 +1,250 @@
+"""Langfuse adapter: turn a Langfuse trace export (observation tree) into `Trace`s.
+
+Langfuse does NOT export OTLP spans. Its public API (`GET /api/public/traces/{id}`) and SDK return
+a **trace** object with a flat list of nested **observations**, each typed
+`SPAN | GENERATION | EVENT | TOOL`:
+
+    {"id": "<traceId>", "name": "...", "input": <task>, "output": ...,
+     "observations": [
+        {"id": "o1", "type": "GENERATION", "name": "llm",
+         "input": [{"role": "user", "content": "..."}], "output": {...},
+         "startTime": "2026-01-01T00:00:00.000Z", "model": "gpt-4o",
+         # a GENERATION that issues a tool call carries it in output.tool_calls (OpenAI shape)
+         "output": {"role": "assistant", "tool_calls": [{"id": "c1",
+                    "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}}]}},
+        {"id": "o2", "type": "TOOL", "name": "get_weather",
+         "input": {"city": "Paris"}, "output": "18C and sunny",
+         "startTime": "...", "level": "DEFAULT"},
+        {"id": "o3", "type": "SPAN", "name": "...", "level": "ERROR", ...}
+     ]}
+
+Because this is not an OTLP/OpenInference span shape, the adapter overrides `spans_from_payload`
+(like `wmh.ingest.messages`) and emits `SpanRecord`s in the **OTel-GenAI vocabulary** so the shared
+classifier/normalizer (`wmh.ingest.normalize`) does the pairing/state/metadata work:
+
+  - A tool-producing observation (a GENERATION whose `output` carries `tool_calls`, or any
+    TOOL/SPAN named like a tool) becomes a `chat` action span with
+    `{"gen_ai.tool.name", "gen_ai.tool.call.arguments"}`.
+  - A tool result (a TOOL/SPAN observation's `output`) becomes an `execute_tool` span with
+    `{"gen_ai.tool.message": <output text>}`; a GENERATION's own `tool_calls` are paired with a
+    synthesized result span from the call id (when the result is a sibling TOOL observation, the
+    normalizer pairs the nearest following execute_tool span).
+  - A GENERATION with no tool call becomes a plain `chat` message span (`gen_ai.completion`).
+  - `level == "ERROR"` sets `status_error=True` (ObservationLevel = DEBUG|DEFAULT|WARNING|ERROR).
+
+Observations are ordered by `startTime` (ISO-8601 -> a monotonic ordinal); when absent, list index
+is used. The trace `input` is carried as `gen_ai.prompt` on the first emitted span (the task), and
+the trace-level `metadata` is carried as `wmh.trace.metadata` so it round-trips.
+
+Export the FULL trace: `GET /api/public/traces/{traceId}` (`TraceWithFullDetails`) returns
+`observations` as full objects. The LIST endpoint `GET /api/public/traces` returns each trace's
+`observations` as ID *strings* only, so such a page yields no steps — fetch each trace by id (or use
+Langfuse's native OTLP endpoint `POST /api/public/otel/v1/traces` and the `otel-genai` source, which
+is the better route for framework traces where tool calls are separate child observations).
+
+Pull: live pull via the Langfuse SDK is not implemented; export to a file and use `from_file`. The
+`BaseTraceAdapter` default raises a friendly error pointing at `--file`.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _start_ordinal(observation: JsonObject, fallback: int) -> int:
+    """Monotonic ordering key from the observation's `startTime` (shared helper; UTC-safe)."""
+    return iso_to_ordinal(observation.get("startTime"), fallback)
+
+
+def _is_error(observation: JsonObject) -> bool:
+    """An observation errored iff its `level` is ERROR.
+
+    Langfuse's `ObservationLevel` is DEBUG | DEFAULT | WARNING | ERROR. `statusMessage` is NOT an
+    error signal — it is generic context Langfuse sets on any level — so we must not treat its
+    presence as an error (that misclassified successful observations).
+    """
+    return _as_str(observation.get("level")).upper() == "ERROR"
+
+
+def _tool_calls(output: JsonValue) -> list[JsonObject]:
+    """Extract OpenAI-style tool calls from a GENERATION `output` (object or message list)."""
+    if isinstance(output, dict):
+        raw = output.get("tool_calls")
+        if isinstance(raw, list):
+            return [tc for tc in raw if isinstance(tc, dict)]
+    if isinstance(output, list):
+        calls: list[JsonObject] = []
+        for message in output:
+            if isinstance(message, dict):
+                raw = message.get("tool_calls")
+                if isinstance(raw, list):
+                    calls.extend(tc for tc in raw if isinstance(tc, dict))
+        return calls
+    return []
+
+
+def _call_name_args(tool_call: JsonObject) -> tuple[str, str]:
+    """(name, raw-arguments-json) from a tool call in OpenAI-nested or flattened shape."""
+    fn = tool_call.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:
+        name = tool_call.get("name")
+        args = tool_call.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _observation_tool_name(observation: JsonObject) -> str:
+    """A tool name for a TOOL/SPAN observation (explicit field, else the observation name)."""
+    for key in ("toolName", "tool_name", "name"):
+        value = observation.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+class LangfuseAdapter(BaseTraceAdapter):
+    """Map a Langfuse trace export (observation tree) into normalized `Trace`s. No SDK."""
+
+    name = "langfuse"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Map one Langfuse trace (or a list/`{data:[...]}` page of them) to `SpanRecord`s."""
+        spans: list[SpanRecord] = []
+        for trace in self._traces(payload):
+            spans.extend(self._spans_for_trace(trace))
+        return spans
+
+    def _traces(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a list of Langfuse trace objects.
+
+        Accepts a single trace object, a bare list of traces, or an API list page (`{"data": [...]}`
+        as returned by `GET /api/public/traces`).
+        """
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._traces(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        data = payload.get("data")
+        if isinstance(data, list) and "observations" not in payload:
+            out = []
+            for item in data:
+                out.extend(self._traces(item))
+            return out
+        if "observations" in payload or "id" in payload:
+            return [payload]
+        return []
+
+    def _spans_for_trace(self, trace: JsonObject) -> list[SpanRecord]:
+        trace_id = self._trace_id(trace)
+        metadata = trace.get("metadata")
+        meta_obj: JsonObject = metadata if isinstance(metadata, dict) else {}
+        task = trace.get("input")
+
+        observations = trace.get("observations")
+        obs_list: list[JsonObject] = (
+            [o for o in observations if isinstance(o, dict)]
+            if isinstance(observations, list)
+            else []
+        )
+        # Order by startTime; ties (or absent timestamps) keep input order via the index fallback.
+        indexed = list(enumerate(obs_list))
+        indexed.sort(key=lambda pair: (_start_ordinal(pair[1], pair[0]), pair[0]))
+
+        spans: list[SpanRecord] = []
+        ordinal = 0
+
+        def emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+            nonlocal ordinal
+            if ordinal == 0:
+                if task is not None:
+                    attrs.setdefault("gen_ai.prompt", as_text(task))
+                if meta_obj:
+                    attrs.setdefault("wmh.trace.metadata", json.dumps(meta_obj))
+            spans.append(
+                SpanRecord(
+                    trace_id=trace_id,
+                    span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                    name="execute_tool" if tool else "chat",
+                    start_nano=ordinal,
+                    attributes={
+                        "gen_ai.operation.name": "execute_tool" if tool else "chat",
+                        **attrs,
+                    },
+                    status_error=error,
+                )
+            )
+            ordinal += 1
+
+        for _, obs in indexed:
+            otype = _as_str(obs.get("type")).upper()
+            error = _is_error(obs)
+            calls = _tool_calls(obs.get("output")) if otype == "GENERATION" else []
+            if calls:
+                # A GENERATION that issued tool calls: emit a `chat` action span per call. The tool
+                # RESULT comes from the sibling TOOL/SPAN observation below (the normalizer pairs
+                # the nearest following execute_tool span), so we do NOT synthesize a result here.
+                for tool_call in calls:
+                    name, args = _call_name_args(tool_call)
+                    emit(
+                        {"gen_ai.tool.name": name, "gen_ai.tool.call.arguments": args},
+                        tool=False,
+                        error=error,
+                    )
+            elif otype == "TOOL" or (otype == "SPAN" and self._span_is_tool(obs)):
+                # A TOOL/SPAN observation = a tool execution: an `execute_tool` result span. Its
+                # `output` is the observation; the normalizer pairs it with the preceding action
+                # span (the GENERATION's tool call), backfilling name/args from here if the action
+                # lacked them. We carry name/args too so a standalone TOOL (no GENERATION) pairs.
+                emit(
+                    {
+                        "gen_ai.tool.name": _observation_tool_name(obs),
+                        "gen_ai.tool.call.arguments": as_text(obs.get("input")),
+                        "gen_ai.tool.message": as_text(obs.get("output")),
+                    },
+                    tool=True,
+                    error=error,
+                )
+            elif otype == "GENERATION":
+                # A plain LLM turn (no tool call): a message action, no observation.
+                emit({"gen_ai.completion": as_text(obs.get("output"))}, tool=False, error=error)
+            # EVENT (and other non-actionable) observations are ignored.
+        return spans
+
+    def _span_is_tool(self, observation: JsonObject) -> bool:
+        """A SPAN observation is a tool execution when it has output or a tool name/field."""
+        if observation.get("output") is not None:
+            return True
+        for key in ("toolName", "tool_name", "input"):
+            if observation.get(key) is not None:
+                return True
+        return False
+
+    def _trace_id(self, trace: JsonObject) -> str:
+        """A stable grouping key. Langfuse ids are not 32-hex; that's fine (it's just a key)."""
+        tid = trace.get("id")
+        if isinstance(tid, str) and tid:
+            return tid
+        import hashlib
+
+        return hashlib.sha256(as_text(trace).encode()).hexdigest()[:32]
+
+
+register_adapter(LangfuseAdapter())

--- a/wmh/ingest/langfuse_test.py
+++ b/wmh/ingest/langfuse_test.py
@@ -1,0 +1,190 @@
+"""Tests for the Langfuse observation-tree -> Trace adapter (langfuse).
+
+Fixture-based, no network: a hand-authored Langfuse trace export with a GENERATION that issues a
+tool call, the sibling TOOL observation carrying the result, and an ERROR tool observation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.langfuse import LangfuseAdapter
+
+# A realistic Langfuse `GET /api/public/traces/{id}` export: a trace with nested observations.
+_TRACE = {
+    "id": "lf-trace-abc123",
+    "name": "weather-agent",
+    "input": "what's the weather in Paris?",
+    "output": "It's 18C and sunny in Paris.",
+    "metadata": {"benchmark": "demo", "env": "prod"},
+    "observations": [
+        {
+            "id": "o1",
+            "type": "GENERATION",
+            "name": "llm",
+            "startTime": "2026-01-01T00:00:01.000Z",
+            "model": "gpt-4o",
+            "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+            "output": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    }
+                ],
+            },
+            "level": "DEFAULT",
+        },
+        {
+            "id": "o2",
+            "type": "TOOL",
+            "name": "get_weather",
+            "startTime": "2026-01-01T00:00:02.000Z",
+            "input": {"city": "Paris"},
+            "output": "18C and sunny",
+            "level": "DEFAULT",
+        },
+        {
+            "id": "o3",
+            "type": "TOOL",
+            "name": "get_forecast",
+            "startTime": "2026-01-01T00:00:03.000Z",
+            "input": {"city": "Paris"},
+            "output": "forecast service unavailable",
+            "level": "ERROR",
+        },
+    ],
+}
+
+
+def test_langfuse_adapter_is_registered() -> None:
+    assert get_adapter("langfuse").name == "langfuse"
+
+
+def test_generation_tool_call_pairs_with_tool_observation(tmp_path: Path) -> None:
+    path = tmp_path / "trace.json"
+    path.write_text(json.dumps(_TRACE), encoding="utf-8")
+
+    traces = LangfuseAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.trace_id == "lf-trace-abc123"
+    assert trace.metadata == {"benchmark": "demo", "env": "prod"}
+    # The GENERATION's tool call pairs with the o2 TOOL result; the o3 ERROR TOOL pairs alone.
+    assert len(trace.steps) == 2
+
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "get_weather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.observation.is_error is False
+    assert call.task == "what's the weather in Paris?"
+
+    err = trace.steps[1]
+    assert err.action.kind == ActionKind.TOOL_CALL
+    assert err.action.name == "get_forecast"
+    assert err.action.arguments == {"city": "Paris"}
+    assert err.observation.content == "forecast service unavailable"
+    assert err.observation.is_error is True
+
+
+def test_plain_generation_becomes_message_step(tmp_path: Path) -> None:
+    trace = {
+        "id": "lf-2",
+        "input": "say hi",
+        "observations": [
+            {
+                "id": "g1",
+                "type": "GENERATION",
+                "startTime": "2026-01-01T00:00:01.000Z",
+                "output": {"role": "assistant", "content": "hello there"},
+            }
+        ],
+    }
+    path = tmp_path / "msg.json"
+    path.write_text(json.dumps(trace), encoding="utf-8")
+
+    step = LangfuseAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.kind == ActionKind.MESSAGE
+    assert step.action.content is not None
+    assert "hello there" in step.action.content
+    assert step.observation.content == ""
+
+
+def test_api_list_page_and_ordering_by_start_time(tmp_path: Path) -> None:
+    # API list shape `{"data": [...]}`; observations are deliberately out of start-time order.
+    page = {
+        "data": [
+            {
+                "id": "lf-3",
+                "input": "list files",
+                "observations": [
+                    {
+                        "id": "t1",
+                        "type": "TOOL",
+                        "name": "ls",
+                        "startTime": "2026-01-01T00:00:05.000Z",
+                        "input": {},
+                        "output": "a.txt\nb.txt",
+                    },
+                    {
+                        "id": "gen",
+                        "type": "GENERATION",
+                        "startTime": "2026-01-01T00:00:04.000Z",
+                        "output": {
+                            "tool_calls": [
+                                {"id": "x", "function": {"name": "ls", "arguments": "{}"}}
+                            ]
+                        },
+                    },
+                ],
+            }
+        ]
+    }
+    path = tmp_path / "page.json"
+    path.write_text(json.dumps(page), encoding="utf-8")
+
+    traces = LangfuseAdapter().from_file(str(path))
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    # Ordered by startTime: the GENERATION (04s) precedes the TOOL result (05s) and they pair.
+    assert step.action.name == "ls"
+    assert step.observation.content == "a.txt\nb.txt"
+
+
+def test_jsonl_multiple_traces(tmp_path: Path) -> None:
+    other = {
+        "id": "lf-4",
+        "input": "ping",
+        "observations": [
+            {
+                "id": "g",
+                "type": "GENERATION",
+                "startTime": "2026-01-01T00:00:01.000Z",
+                "output": "pong",
+            }
+        ],
+    }
+    path = tmp_path / "traces.jsonl"
+    path.write_text(json.dumps(_TRACE) + "\n" + json.dumps(other) + "\n", encoding="utf-8")
+
+    traces = LangfuseAdapter().from_file(str(path))
+    assert len(traces) == 2
+
+
+def test_vendor_pull_unsupported_is_friendly() -> None:
+    from wmh.ingest.adapter import VendorPull
+
+    try:
+        LangfuseAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "does not support live vendor pulls" in str(exc)
+        assert "langfuse" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")

--- a/wmh/ingest/langsmith.py
+++ b/wmh/ingest/langsmith.py
@@ -1,0 +1,378 @@
+"""LangSmith adapter: turn a LangSmith run-tree export into `Trace`s.
+
+LangSmith (LangChain's tracing product) does NOT export OTLP spans. It models a trace as a tree of
+**runs**, where each run is a node typed by `run_type`
+(`tool | chain | llm | retriever | embedding | prompt | parser`). An exported run (from
+`POST /api/v1/runs/query` — the list endpoint is a POST with a JSON filter body, NOT a GET — or the
+SDK `Client.list_runs`) looks roughly like:
+
+    {"id": "<run uuid>", "trace_id": "<trace grouping uuid>", "parent_run_id": "<uuid|null>",
+     "run_type": "llm" | "tool" | "chain" | "retriever" | "embedding" | "prompt" | "parser",
+     "name": "ChatOpenAI",
+     "inputs": {...}, "outputs": {...},
+     "start_time": "2026-01-01T00:00:00.000000", "end_time": "...",
+     "error": null | "<traceback str>", "extra": {...}}
+
+Because this is not an OTLP/OpenInference span shape, the adapter overrides `spans_from_payload`
+(like `wmh.ingest.messages` / `wmh.ingest.langfuse`) and emits `SpanRecord`s in the **OTel-GenAI
+vocabulary** so the shared classifier/normalizer (`wmh.ingest.normalize`) does the pairing /
+state / metadata work. Each run maps to zero or more spans:
+
+  - `run_type == "llm"`: if the outputs carry tool calls, emit one `chat` ACTION span per call with
+    `{"gen_ai.tool.name", "gen_ai.tool.call.arguments"}`; otherwise emit one plain `chat` message
+    span with `{"gen_ai.completion": <text>}`.
+  - `run_type == "tool"`: emit one `execute_tool` RESULT span with
+    `{"gen_ai.operation.name": "execute_tool", "gen_ai.tool.name": <name>,
+      "gen_ai.tool.message": <outputs as text>}`.  The normalizer pairs it with the preceding action
+    span (the llm run's tool call), backfilling name/args from here if the action lacked them.
+  - `run_type in {"chain", "retriever", ...}`: skipped (not directly actionable). A run we cannot
+    interpret is skipped rather than crashing the ingest.
+
+Where LangChain hides tool calls (these paths are version-dependent and best-effort; we dig all of
+them and degrade gracefully):
+  - `outputs["generations"][i]["message"]["kwargs"]["tool_calls"]`  (LCEL ChatGeneration dump)
+  - `outputs["generations"][i]["message"]["kwargs"]["additional_kwargs"]["tool_calls"]`  (OpenAI)
+  - `outputs["generations"][i][j]["message"]...`  (nested list-of-lists generations)
+  - `outputs["tool_calls"]` / `outputs["message"]...`  (flatter dumps)
+A LangChain `tool_calls` entry is either the normalized shape `{"name", "args": {...}, "id"}` or the
+OpenAI shape `{"id", "function": {"name", "arguments": "<json str>"}}`; both are handled.
+
+The LLM completion text is dug from `generations[i].text`, `generations[i].message.kwargs.content`,
+or `outputs["output"|"content"|"text"]`. A tool run's output is dug from
+`outputs["output"]`, else the whole `outputs`. The task (`gen_ai.prompt`) is the first human/user
+input, dug from a run's `inputs` (chat `messages`, a `messages` list, or `inputs["input"]`).
+
+Ordering: runs are ordered by `start_time` (ISO-8601 -> epoch microseconds); only monotonicity
+within a trace matters (the normalizer sorts by `start_nano`), so an absent/unparseable timestamp
+degrades to the run's list index.
+
+Accepted file shapes (`from_file`): a single run object, a JSON array of runs, a `{"runs": [...]}`
+wrapper, or JSONL (one run per line). Grouping is by `trace_id` (falling back to `id` for a root
+run that omits it).
+
+Pull: a live pull via the `langsmith` SDK is not implemented here; export to a file and use
+`from_file`. The `BaseTraceAdapter` default raises a friendly error pointing at `--file`, so the
+config gate stays SDK-free.
+"""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _is_error(run: JsonObject) -> bool:
+    """A non-null/non-empty `error` marks the run as failed; an empty string is NOT an error.
+
+    Some LangSmith dumps set `error: ""` on a successful run, so a bare `is not None` check would
+    misclassify it as a failure.
+    """
+    error = run.get("error")
+    if error is None:
+        return False
+    if isinstance(error, str):
+        return bool(error.strip())
+    return bool(error)
+
+
+def _start_ordinal(run: JsonObject, fallback: int) -> int:
+    """Monotonic ordering key from the run's `start_time` (shared helper; UTC-safe)."""
+    return iso_to_ordinal(run.get("start_time"), fallback)
+
+
+def _generations(outputs: JsonObject) -> list[JsonObject]:
+    """Flatten `outputs["generations"]` (a list, or a list-of-lists) into generation dicts."""
+    raw = outputs.get("generations")
+    if not isinstance(raw, list):
+        return []
+    flat: list[JsonObject] = []
+    for item in raw:
+        if isinstance(item, dict):
+            flat.append(item)
+        elif isinstance(item, list):  # list-of-lists (one inner list per prompt)
+            flat.extend(g for g in item if isinstance(g, dict))
+    return flat
+
+
+def _message_kwargs(generation: JsonObject) -> JsonObject:
+    """The `message.kwargs` dict of a ChatGeneration dump (empty when absent)."""
+    message = generation.get("message")
+    if isinstance(message, dict):
+        kwargs = message.get("kwargs")
+        if isinstance(kwargs, dict):
+            return kwargs
+    return {}
+
+
+def _tool_calls_in(container: JsonObject) -> list[JsonObject]:
+    """Pull `tool_calls` from a dict, checking `tool_calls` then `additional_kwargs.tool_calls`."""
+    calls: list[JsonObject] = []
+    raw = container.get("tool_calls")
+    if isinstance(raw, list):
+        calls.extend(tc for tc in raw if isinstance(tc, dict))
+    extra = container.get("additional_kwargs")
+    if isinstance(extra, dict):
+        raw_extra = extra.get("tool_calls")
+        if isinstance(raw_extra, list):
+            calls.extend(tc for tc in raw_extra if isinstance(tc, dict))
+    return calls
+
+
+def _llm_tool_calls(outputs: JsonObject) -> list[JsonObject]:
+    """Dig tool calls out of an llm run's `outputs`, across the common LangChain locations."""
+    calls: list[JsonObject] = []
+    for generation in _generations(outputs):
+        calls.extend(_tool_calls_in(_message_kwargs(generation)))
+    # Flatter dumps: outputs.tool_calls or outputs.message.kwargs.tool_calls.
+    calls.extend(_tool_calls_in(outputs))
+    message = outputs.get("message")
+    if isinstance(message, dict):
+        kwargs = message.get("kwargs")
+        if isinstance(kwargs, dict):
+            calls.extend(_tool_calls_in(kwargs))
+    return calls
+
+
+def _call_name_args(tool_call: JsonObject) -> tuple[str, str]:
+    """(name, raw-arguments-json) from a LangChain-normalized or OpenAI-shaped tool call."""
+    fn = tool_call.get("function")
+    if isinstance(fn, dict):  # OpenAI shape: {"function": {"name", "arguments": "<json str>"}}
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:  # LangChain-normalized shape: {"name", "args": {...}, "id"}
+        name = tool_call.get("name")
+        args = tool_call.get("args")
+        if args is None:
+            args = tool_call.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _llm_completion(outputs: JsonObject) -> str:
+    """Dig the assistant text out of an llm run's `outputs` (best-effort across dump shapes)."""
+    for generation in _generations(outputs):
+        text = generation.get("text")
+        if isinstance(text, str) and text:
+            return text
+        content = _message_kwargs(generation).get("content")
+        if isinstance(content, str) and content:
+            return content
+    for key in ("output", "content", "text"):
+        value = outputs.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return as_text(outputs)
+
+
+def _tool_output_text(outputs: JsonValue) -> str:
+    """A tool run's result text: `outputs["output"]` if present, else the whole outputs."""
+    if isinstance(outputs, dict):
+        value = outputs.get("output")
+        if value is not None:
+            return as_text(value)
+    return as_text(outputs)
+
+
+def _tool_run_name(run: JsonObject) -> str:
+    """A tool name for a `tool` run: explicit fields first, else the run name."""
+    for key in ("tool_name", "name"):
+        value = run.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _first_user_text(inputs: JsonValue) -> str | None:
+    """Dig the first human/user input out of a run's `inputs` (the trace task)."""
+    if isinstance(inputs, str):
+        return inputs or None
+    if not isinstance(inputs, dict):
+        return None
+    messages = inputs.get("messages")
+    text = _first_user_in_messages(messages)
+    if text is not None:
+        return text
+    for key in ("input", "question", "query", "text"):
+        value = inputs.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _first_user_in_messages(messages: JsonValue) -> str | None:
+    """First human/user message content in a (possibly nested) LangChain messages list."""
+    if not isinstance(messages, list):
+        return None
+    for message in messages:
+        # Nested list-of-lists (one inner list per prompt) — recurse.
+        if isinstance(message, list):
+            found = _first_user_in_messages(message)
+            if found is not None:
+                return found
+            continue
+        if not isinstance(message, dict):
+            continue
+        role = _message_role(message)
+        content = _message_content(message)
+        if role in {"human", "user"} and content:
+            return content
+    return None
+
+
+def _message_role(message: JsonObject) -> str:
+    """Role of a LangChain/OpenAI message dict (`role`, `type`, or a serialized class id)."""
+    for key in ("role", "type"):
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value.lower()
+    # Serialized LangChain message: {"id": [..., "HumanMessage"], "kwargs": {...}}.
+    cid = message.get("id")
+    if isinstance(cid, list) and cid:
+        last = cid[-1]
+        if isinstance(last, str):
+            return last.lower().removesuffix("message")
+    return ""
+
+
+def _message_content(message: JsonObject) -> str:
+    """Text content of a LangChain/OpenAI message dict (top-level or under `kwargs`)."""
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        return content
+    kwargs = message.get("kwargs")
+    if isinstance(kwargs, dict):
+        nested = kwargs.get("content")
+        if isinstance(nested, str) and nested:
+            return nested
+    return ""
+
+
+class LangSmithAdapter(BaseTraceAdapter):
+    """Map a LangSmith run-tree export into normalized `Trace`s. No SDK; pure JSON."""
+
+    name = "langsmith"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Map one payload (single run, list, `{runs:[...]}`) to ordered `SpanRecord`s by trace."""
+        runs = self._runs(payload)
+        # Group by trace_id so we can assign a per-trace monotonic ordinal and set the task once.
+        by_trace: dict[str, list[JsonObject]] = {}
+        for run in runs:
+            by_trace.setdefault(self._trace_id(run), []).append(run)
+
+        spans: list[SpanRecord] = []
+        for trace_id, trace_runs in by_trace.items():
+            spans.extend(self._spans_for_trace(trace_id, trace_runs))
+        return spans
+
+    def _runs(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a flat list of run objects.
+
+        Accepts a single run, a bare list of runs, or a `{"runs": [...]}` wrapper.
+        """
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._runs(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        wrapped = payload.get("runs")
+        if isinstance(wrapped, list) and "run_type" not in payload:
+            out = []
+            for item in wrapped:
+                out.extend(self._runs(item))
+            return out
+        # A run object: it has an id (and usually run_type). Be permissive.
+        if "id" in payload or "run_type" in payload:
+            return [payload]
+        return []
+
+    def _spans_for_trace(self, trace_id: str, runs: list[JsonObject]) -> list[SpanRecord]:
+        # Order by start_time; ties (or absent timestamps) keep input order via the index fallback.
+        indexed = list(enumerate(runs))
+        indexed.sort(key=lambda pair: (_start_ordinal(pair[1], pair[0]), pair[0]))
+
+        task = self._trace_task([run for _, run in indexed])
+
+        spans: list[SpanRecord] = []
+        ordinal = 0
+
+        def emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+            nonlocal ordinal
+            if ordinal == 0 and task is not None:
+                attrs.setdefault("gen_ai.prompt", task)
+            spans.append(
+                SpanRecord(
+                    trace_id=trace_id,
+                    span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                    name="execute_tool" if tool else "chat",
+                    start_nano=ordinal,
+                    attributes={
+                        "gen_ai.operation.name": "execute_tool" if tool else "chat",
+                        **attrs,
+                    },
+                    status_error=error,
+                )
+            )
+            ordinal += 1
+
+        for _, run in indexed:
+            run_type = _as_str(run.get("run_type")).lower()
+            error = _is_error(run)
+            outputs = run.get("outputs")
+            out_obj: JsonObject = outputs if isinstance(outputs, dict) else {}
+
+            if run_type == "llm":
+                calls = _llm_tool_calls(out_obj)
+                if calls:
+                    for tool_call in calls:
+                        name, args = _call_name_args(tool_call)
+                        emit(
+                            {"gen_ai.tool.name": name, "gen_ai.tool.call.arguments": args},
+                            tool=False,
+                            error=error,
+                        )
+                else:
+                    emit({"gen_ai.completion": _llm_completion(out_obj)}, tool=False, error=error)
+            elif run_type == "tool":
+                emit(
+                    {
+                        "gen_ai.tool.name": _tool_run_name(run),
+                        "gen_ai.tool.message": _tool_output_text(outputs),
+                    },
+                    tool=True,
+                    error=error,
+                )
+            # chain / retriever / unknown run types are not directly actionable -> skipped.
+        return spans
+
+    def _trace_task(self, runs: list[JsonObject]) -> str | None:
+        """First human/user input across a trace's runs (ordered) -> the task text."""
+        for run in runs:
+            text = _first_user_text(run.get("inputs"))
+            if text is not None:
+                return text
+        return None
+
+    def _trace_id(self, run: JsonObject) -> str:
+        """Grouping key: `trace_id`, else the run's own `id` (a root run may omit trace_id)."""
+        for key in ("trace_id", "id"):
+            value = run.get(key)
+            if isinstance(value, str) and value:
+                return value
+        import hashlib
+
+        return hashlib.sha256(as_text(run).encode()).hexdigest()[:32]
+
+
+register_adapter(LangSmithAdapter())

--- a/wmh/ingest/langsmith_test.py
+++ b/wmh/ingest/langsmith_test.py
@@ -1,0 +1,262 @@
+"""Tests for the LangSmith run-tree -> Trace adapter (langsmith).
+
+Fixture-based, no network: a hand-authored set of LangSmith runs sharing one `trace_id` — an `llm`
+run whose `outputs` carry a tool call (in the LCEL `generations[].message.kwargs.tool_calls`
+location), a `tool` run carrying the result, and an `llm` run that errored. Asserts the action
+name/args, the observation content, the error flag, and that everything groups into ONE trace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.langsmith import LangSmithAdapter
+
+# A realistic `Client.list_runs` / `GET /api/v1/runs` export: a flat list of runs in one trace.
+_RUNS = [
+    {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "trace_id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
+        "parent_run_id": None,
+        "run_type": "chain",
+        "name": "AgentExecutor",
+        "inputs": {"input": "what's the weather in Paris?"},
+        "outputs": {"output": "It's 18C and sunny in Paris."},
+        "start_time": "2026-01-01T00:00:00.000000",
+        "end_time": "2026-01-01T00:00:05.000000",
+        "error": None,
+    },
+    {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "trace_id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
+        "parent_run_id": "11111111-1111-1111-1111-111111111111",
+        "run_type": "llm",
+        "name": "ChatOpenAI",
+        "inputs": {
+            "messages": [
+                [
+                    {
+                        "id": ["langchain", "schema", "HumanMessage"],
+                        "kwargs": {"content": "what's the weather in Paris?"},
+                    },
+                ]
+            ]
+        },
+        "outputs": {
+            "generations": [
+                {
+                    "text": "",
+                    "message": {
+                        "kwargs": {
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "name": "get_weather",
+                                    "args": {"city": "Paris"},
+                                }
+                            ],
+                        }
+                    },
+                }
+            ]
+        },
+        "start_time": "2026-01-01T00:00:01.000000",
+        "end_time": "2026-01-01T00:00:02.000000",
+        "error": None,
+    },
+    {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "trace_id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
+        "parent_run_id": "11111111-1111-1111-1111-111111111111",
+        "run_type": "tool",
+        "name": "get_weather",
+        "inputs": {"city": "Paris"},
+        "outputs": {"output": "18C and sunny"},
+        "start_time": "2026-01-01T00:00:03.000000",
+        "end_time": "2026-01-01T00:00:03.500000",
+        "error": None,
+    },
+    {
+        "id": "44444444-4444-4444-4444-444444444444",
+        "trace_id": "tttttttt-tttt-tttt-tttt-tttttttttttt",
+        "parent_run_id": "11111111-1111-1111-1111-111111111111",
+        "run_type": "tool",
+        "name": "get_forecast",
+        "inputs": {"city": "Paris"},
+        "outputs": {"output": "forecast service unavailable"},
+        "start_time": "2026-01-01T00:00:04.000000",
+        "end_time": "2026-01-01T00:00:04.500000",
+        "error": "ToolException: service unavailable",
+    },
+]
+
+
+def test_langsmith_adapter_is_registered() -> None:
+    assert get_adapter("langsmith").name == "langsmith"
+
+
+def test_llm_tool_call_pairs_with_tool_run(tmp_path: Path) -> None:
+    path = tmp_path / "runs.json"
+    path.write_text(json.dumps(_RUNS), encoding="utf-8")
+
+    traces = LangSmithAdapter().from_file(str(path))
+
+    # All four runs share one trace_id -> ONE trace.
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.trace_id == "tttttttt-tttt-tttt-tttt-tttttttttttt"
+
+    # The llm tool call pairs with the tool run's result.
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "get_weather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.observation.is_error is False
+    # The first human input becomes the task.
+    assert call.task == "what's the weather in Paris?"
+
+    # The errored tool run becomes a step whose observation is flagged as an error.
+    err = trace.steps[-1]
+    assert err.action.name == "get_forecast"
+    assert err.observation.content == "forecast service unavailable"
+    assert err.observation.is_error is True
+
+
+def test_openai_shaped_tool_call_and_runs_wrapper(tmp_path: Path) -> None:
+    # The {"runs": [...]} wrapper + the OpenAI tool-call shape (function.name/arguments str)
+    # under additional_kwargs.
+    payload = {
+        "runs": [
+            {
+                "id": "a",
+                "trace_id": "tr-openai",
+                "run_type": "llm",
+                "inputs": {"messages": [{"role": "user", "content": "list files"}]},
+                "outputs": {
+                    "generations": [
+                        {
+                            "message": {
+                                "kwargs": {
+                                    "additional_kwargs": {
+                                        "tool_calls": [
+                                            {
+                                                "id": "c1",
+                                                "function": {"name": "ls", "arguments": "{}"},
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                "start_time": "2026-01-01T00:00:01.000000",
+                "error": None,
+            },
+            {
+                "id": "b",
+                "trace_id": "tr-openai",
+                "run_type": "tool",
+                "name": "ls",
+                "outputs": {"output": "a.txt\nb.txt"},
+                "start_time": "2026-01-01T00:00:02.000000",
+                "error": None,
+            },
+        ]
+    }
+    path = tmp_path / "wrap.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    traces = LangSmithAdapter().from_file(str(path))
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    assert step.action.name == "ls"
+    assert step.action.arguments == {}
+    assert step.observation.content == "a.txt\nb.txt"
+    assert step.task == "list files"
+
+
+def test_plain_llm_run_becomes_message_step(tmp_path: Path) -> None:
+    run = {
+        "id": "solo",
+        "trace_id": "tr-msg",
+        "run_type": "llm",
+        "inputs": {"messages": [{"role": "user", "content": "say hi"}]},
+        "outputs": {"generations": [{"text": "hello there"}]},
+        "start_time": "2026-01-01T00:00:01.000000",
+        "error": None,
+    }
+    path = tmp_path / "msg.json"
+    path.write_text(json.dumps(run), encoding="utf-8")
+
+    step = LangSmithAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.kind == ActionKind.MESSAGE
+    assert step.action.content is not None
+    assert "hello there" in step.action.content
+    assert step.observation.content == ""
+
+
+def test_jsonl_and_chain_runs_skipped(tmp_path: Path) -> None:
+    # JSONL (one run per line); the lone chain run produces no actionable step.
+    chain = {
+        "id": "c",
+        "trace_id": "tr-chain",
+        "run_type": "chain",
+        "inputs": {"input": "noop"},
+        "outputs": {"output": "noop"},
+        "start_time": "2026-01-01T00:00:01.000000",
+        "error": None,
+    }
+    llm = {
+        "id": "l",
+        "trace_id": "tr-llm",
+        "run_type": "llm",
+        "inputs": {"messages": [{"role": "user", "content": "ping"}]},
+        "outputs": {"generations": [{"text": "pong"}]},
+        "start_time": "2026-01-01T00:00:01.000000",
+        "error": None,
+    }
+    path = tmp_path / "runs.jsonl"
+    path.write_text(json.dumps(chain) + "\n" + json.dumps(llm) + "\n", encoding="utf-8")
+
+    traces = LangSmithAdapter().from_file(str(path))
+    by_id = {t.trace_id: t for t in traces}
+    # The chain-only trace yields no actionable spans, so it produces no Trace at all; the llm
+    # trace has one message step.
+    assert "tr-chain" not in by_id
+    assert by_id["tr-llm"].steps[0].action.content is not None
+
+
+def test_vendor_pull_unsupported_is_friendly() -> None:
+    from wmh.ingest.adapter import VendorPull
+
+    try:
+        LangSmithAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "does not support live vendor pulls" in str(exc)
+        assert "langsmith" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_empty_string_error_is_not_an_error(tmp_path: Path) -> None:
+    """Some LangSmith dumps set error="" on a successful run; it must NOT mark the step errored."""
+    run = {
+        "id": "r1",
+        "trace_id": "t-empty-err",
+        "run_type": "tool",
+        "name": "lookup",
+        "outputs": {"output": "ok"},
+        "error": "",  # empty string, not a real error
+        "start_time": "2026-01-01T00:00:00",
+    }
+    path = tmp_path / "run.json"
+    path.write_text(json.dumps(run), encoding="utf-8")
+
+    trace = LangSmithAdapter().from_file(str(path))[0]
+    assert trace.steps[0].observation.is_error is False

--- a/wmh/ingest/mastra.py
+++ b/wmh/ingest/mastra.py
@@ -1,0 +1,330 @@
+"""Mastra adapter: turn a Mastra AI-tracing export into `Trace`s.
+
+[Mastra](https://mastra.ai) (a TypeScript agent framework) records agent runs as **AI-tracing
+spans** (`ExportedSpan`), typed by `type`, that share a `traceId`. The span id field is `id`, times
+are `startTime`/`endTime`, and errors ride on a structured `errorInfo` object:
+
+    {"traceId": "t1", "id": "s2", "parentSpanId": "s1",
+     "name": "modelGeneration", "type": "model_generation",
+     "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+     "output": {"role": "assistant",
+                "toolCalls": [{"toolCallId": "c1", "toolName": "getWeather",
+                               "input": {"city": "Paris"}}]},  # AI SDK v5 uses `input` (v4: `args`)
+     "attributes": {"model": "gpt-4o"}, "startTime": "2026-01-01T00:00:01.000Z"}
+    {"traceId": "t1", "id": "s3", "name": "getWeather", "type": "tool_call",
+     "input": {"city": "Paris"}, "output": "18C and sunny", "startTime": "..."}
+
+Because this is not an OTLP/OpenInference span shape, the adapter overrides `spans_from_payload`
+(like `wmh.ingest.langfuse`) and emits `SpanRecord`s in the **OTel-GenAI vocabulary** so the shared
+classifier/normalizer (`wmh.ingest.normalize`) does the pairing/state/metadata work:
+
+  - a `model_generation` span (or the pre-rename `llm_generation`) whose `output` carries tool calls
+    -> one `chat` action span per call (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`). Mastra
+    exposes tool calls as either the AI SDK `toolCalls` (`{toolCallId, toolName, input}` on v5;
+    `args` on v4) or the OpenAI `tool_calls` (`{id, function:{name, arguments}}`); both are handled.
+    (Tool calls may instead appear only as separate `tool_call` spans — that case is covered below.)
+  - a `tool_call` / `mcp_tool_call` span -> an `execute_tool` result span (`gen_ai.tool.message`
+    from `output`), also carrying name/args (from `name`/`input`) so a standalone tool span still
+    pairs; the normalizer backfills the action's name/args from here if the model span lacked them.
+  - a `model_generation` with no tool call -> a plain `chat` message span (`gen_ai.completion`).
+  - `agent_run` / `workflow_*` / `model_chunk` / `model_step` / `generic` container/noise spans are
+    skipped (no `(action) -> observation` step); an `agent_run`/`model_generation` input supplies
+    the task.
+  - a span with an `errorInfo` (or an error status) sets `status_error=True`.
+
+Spans order by `startTime`/`startedAt` (ISO-8601 or datetime -> a monotonic ordinal, index if none).
+
+Accepted file shapes (`from_file`): a single span, a JSON array of spans, a wrapper
+(`{"spans": [...]}` / `{"traces": [...]}` / `{"data": [...]}`), or JSONL. Grouping is by `traceId`.
+
+Pull: `_pull_payloads` fetches from a running Mastra server's observability API
+(`{base}/api/observability/traces`), with the base URL passed as `--project` (or `$MASTRA_URL`). The
+response is handed to the same flexible span extractor, so it tolerates the server's wrapper shape.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+# Mastra self-hosts, so the "vendor" is a server base URL (dev default http://localhost:4111).
+_MASTRA_URL_ENV = "MASTRA_URL"
+
+# `type` values (normalized lowercase). LLM/agent turns vs tool executions; the rest are
+# containers/noise that carry no standalone step. Mastra renamed LLM spans to "model" spans
+# (changelog 2025-11-01): `model_generation` is current, `llm_generation` is the pre-rename name we
+# still accept. `model_chunk`/`model_step`/`agent_run`/`workflow_*`/`generic` are not steps.
+_LLM_TYPES = frozenset({"model_generation", "llm_generation"})
+_TOOL_TYPES = frozenset({"tool_call", "mcp_tool_call"})
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _span_type(span: JsonObject) -> str:
+    for key in ("spanType", "span_type", "type"):
+        value = span.get(key)
+        if isinstance(value, str) and value:
+            return value.lower()
+    return ""
+
+
+def _start_ordinal(span: JsonObject, fallback: int) -> int:
+    """Monotonic ordering key from the span's start time (shared helper; UTC-safe)."""
+    for key in ("startTime", "startedAt", "start_time"):
+        value = span.get(key)
+        if value is not None:
+            return iso_to_ordinal(value, fallback)
+    return fallback
+
+
+def _is_error(span: JsonObject) -> bool:
+    """A non-empty `errorInfo`/`error`, or an error status, marks the span as failed."""
+    for key in ("errorInfo", "error"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+        if isinstance(value, dict) and value:
+            return True
+    status = span.get("status")
+    return isinstance(status, str) and status.upper() in {"ERROR", "FAILED"}
+
+
+def _tool_calls(output: JsonValue) -> list[JsonObject]:
+    """Extract tool calls from an llm span `output` (AI SDK `toolCalls` or OpenAI `tool_calls`)."""
+    calls: list[JsonObject] = []
+    candidates: list[JsonValue] = [output]
+    if isinstance(output, dict):
+        # Mastra may nest the assistant message under output.message / output.response.
+        for key in ("message", "response"):
+            nested = output.get(key)
+            if nested is not None:
+                candidates.append(nested)
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            for key in ("toolCalls", "tool_calls"):
+                raw = candidate.get(key)
+                if isinstance(raw, list):
+                    calls.extend(tc for tc in raw if isinstance(tc, dict))
+        elif isinstance(candidate, list):
+            for message in candidate:
+                if isinstance(message, dict):
+                    for key in ("toolCalls", "tool_calls"):
+                        raw = message.get(key)
+                        if isinstance(raw, list):
+                            calls.extend(tc for tc in raw if isinstance(tc, dict))
+    return calls
+
+
+def _call_name_args(tool_call: JsonObject) -> tuple[str, str]:
+    """(name, raw-arguments-json) from a Mastra AI-SDK or OpenAI-shaped tool call."""
+    fn = tool_call.get("function")
+    if isinstance(fn, dict):  # OpenAI shape: {"function": {"name", "arguments": "<json str>"}}
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:  # AI SDK shape: v5 {"toolName", "input": {...}, "toolCallId"}; v4 used "args".
+        name = tool_call.get("toolName") or tool_call.get("name")
+        args = tool_call.get("input")  # AI SDK v5
+        if args is None:
+            args = tool_call.get("args")  # AI SDK v4
+        if args is None:
+            args = tool_call.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _tool_span_name(span: JsonObject) -> str:
+    """A tool name for a tool_call span: explicit attribute first, else the span name."""
+    attributes = span.get("attributes")
+    if isinstance(attributes, dict):
+        for key in ("toolName", "tool_name"):
+            value = attributes.get(key)
+            if isinstance(value, str) and value:
+                return value
+    name = span.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _first_user_text(value: JsonValue) -> str | None:
+    """First user message text from a span `input` (a messages list), else the input as text."""
+    if isinstance(value, list):
+        for message in value:
+            if isinstance(message, dict) and _as_str(message.get("role")).lower() in {
+                "user",
+                "human",
+            }:
+                content = message.get("content")
+                if content is not None:
+                    return as_text(content)
+        return None
+    if isinstance(value, dict):
+        for key in ("prompt", "input", "query", "message"):
+            inner = value.get(key)
+            if isinstance(inner, str) and inner:
+                return inner
+        return None
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _completion_text(output: JsonValue) -> str:
+    """Render an llm span `output` to text: an assistant message content, else the whole output."""
+    if isinstance(output, dict):
+        for key in ("text", "content"):
+            value = output.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return as_text(output)
+
+
+class MastraAdapter(BaseTraceAdapter):
+    """Map a Mastra AI-tracing export into normalized `Trace`s. No SDK."""
+
+    name = "mastra"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        raw_spans = self._spans(payload)
+        by_trace: dict[str, list[JsonObject]] = {}
+        for span in raw_spans:
+            by_trace.setdefault(self._trace_id(span), []).append(span)
+        spans: list[SpanRecord] = []
+        for trace_id, trace_spans in by_trace.items():
+            spans.extend(self._spans_for_trace(trace_id, trace_spans))
+        return spans
+
+    def _spans(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a flat list of Mastra span objects.
+
+        Accepts a single span, a bare list, or a wrapper (`{"spans"|"traces"|"data": [...]}`). A
+        wrapper item may itself be a trace object holding its own `spans`, so we recurse.
+        """
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._spans(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        for wrapper_key in ("spans", "traces", "data"):
+            inner = payload.get(wrapper_key)
+            if isinstance(inner, list):
+                out = []
+                for item in inner:
+                    out.extend(self._spans(item))
+                return out
+        # A bare span carries a trace id and a type (Mastra's span id field is `id`).
+        if any(key in payload for key in ("traceId", "type", "spanType", "id", "spanId")):
+            return [payload]
+        return []
+
+    def _trace_id(self, span: JsonObject) -> str:
+        for key in ("traceId", "trace_id"):
+            value = span.get(key)
+            if isinstance(value, str) and value:
+                return value
+        sid = span.get("id") or span.get("spanId") or span.get("span_id")
+        if isinstance(sid, str) and sid:
+            return sid
+        import hashlib
+
+        return hashlib.sha256(as_text(span).encode()).hexdigest()[:32]
+
+    def _spans_for_trace(self, trace_id: str, raw_spans: list[JsonObject]) -> list[SpanRecord]:
+        indexed = list(enumerate(raw_spans))
+        indexed.sort(key=lambda pair: (_start_ordinal(pair[1], pair[0]), pair[0]))
+
+        task: str | None = None
+        for _, span in indexed:
+            task = _first_user_text(span.get("input"))
+            if task is not None:
+                break
+
+        spans: list[SpanRecord] = []
+        ordinal = 0
+
+        def emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+            nonlocal ordinal
+            if ordinal == 0 and task is not None:
+                attrs.setdefault("gen_ai.prompt", task)
+            spans.append(
+                SpanRecord(
+                    trace_id=trace_id,
+                    span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                    name="execute_tool" if tool else "chat",
+                    start_nano=ordinal,
+                    attributes={
+                        "gen_ai.operation.name": "execute_tool" if tool else "chat",
+                        **attrs,
+                    },
+                    status_error=error,
+                )
+            )
+            ordinal += 1
+
+        for _, span in indexed:
+            stype = _span_type(span)
+            error = _is_error(span)
+            if stype in _LLM_TYPES:
+                calls = _tool_calls(span.get("output"))
+                if calls:
+                    for tool_call in calls:
+                        name, args = _call_name_args(tool_call)
+                        emit(
+                            {"gen_ai.tool.name": name, "gen_ai.tool.call.arguments": args},
+                            tool=False,
+                            error=error,
+                        )
+                else:
+                    emit(
+                        {"gen_ai.completion": _completion_text(span.get("output"))},
+                        tool=False,
+                        error=error,
+                    )
+            elif stype in _TOOL_TYPES:
+                emit(
+                    {
+                        "gen_ai.tool.name": _tool_span_name(span),
+                        "gen_ai.tool.call.arguments": as_text(span.get("input")),
+                        "gen_ai.tool.message": as_text(span.get("output")),
+                    },
+                    tool=True,
+                    error=error,
+                )
+            # agent_run / workflow_* / llm_chunk / generic -> no standalone step.
+        return spans
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch AI-tracing spans from a running Mastra server's observability API.
+
+        `pull.project` (else `$MASTRA_URL`) is the Mastra server base URL, e.g.
+        `http://localhost:4111`. Fetches `{base}/api/observability/traces` and hands the response to
+        the flexible span extractor (which tolerates the server's `{traces|spans: [...]}` wrapper).
+        """
+        base = (pull.project or os.environ.get(_MASTRA_URL_ENV) or "").rstrip("/")
+        if not base:
+            raise ValueError(
+                f"mastra pull needs the server URL: pass --project <base-url> or set "
+                f"${_MASTRA_URL_ENV}"
+            )
+        headers = {"Authorization": f"Bearer {pull.api_key}"} if pull.api_key else {}
+        params: dict[str, str] = {}
+        if pull.limit is not None:
+            params["perPage"] = str(pull.limit)
+        resp = httpx.get(
+            f"{base}/api/observability/traces", headers=headers, params=params, timeout=60.0
+        )
+        resp.raise_for_status()
+        return [resp.json()]
+
+
+register_adapter(MastraAdapter())

--- a/wmh/ingest/mastra_test.py
+++ b/wmh/ingest/mastra_test.py
@@ -1,0 +1,217 @@
+"""Tests for the Mastra AI-tracing -> Trace adapter (mastra).
+
+Fixture-based, no network. The primary fixture uses Mastra's CURRENT `ExportedSpan` shape (post the
+2025-11 "model" rename): span id field `id`, span kind `type`, `model_generation` for LLM turns,
+`startTime` for ordering, and AI-SDK-v5 tool calls (`{toolName, input}`). A `model_generation` span
+issues the tool call, the sibling `tool_call` span carries the result, and a final model span holds
+the assistant message — all under one `traceId`.
+`test_legacy_prerename_span_shape` covers the pre-rename aliases we still accept.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.adapter import VendorPull
+from wmh.ingest.mastra import MastraAdapter
+
+_SPANS = [
+    {
+        "traceId": "t1",
+        "id": "s1",
+        "type": "agent_run",
+        "name": "weatherAgent",
+        "input": [{"role": "user", "content": "what's the weather in Paris?"}],
+        "startTime": "2026-01-01T00:00:00.000Z",
+    },
+    {
+        "traceId": "t1",
+        "id": "s2",
+        "parentSpanId": "s1",
+        "type": "model_generation",
+        "name": "modelGeneration",
+        "output": {
+            "role": "assistant",
+            # AI SDK v5 tool call: `toolName` + `input` (not v4's `args`).
+            "toolCalls": [
+                {"toolCallId": "c1", "toolName": "getWeather", "input": {"city": "Paris"}}
+            ],
+        },
+        "attributes": {"model": "gpt-4o"},
+        "startTime": "2026-01-01T00:00:01.000Z",
+    },
+    {
+        "traceId": "t1",
+        "id": "s3",
+        "parentSpanId": "s1",
+        "type": "tool_call",
+        "name": "getWeather",
+        "input": {"city": "Paris"},
+        "output": "18C and sunny",
+        "startTime": "2026-01-01T00:00:02.000Z",
+    },
+    {
+        "traceId": "t1",
+        "id": "s4",
+        "parentSpanId": "s1",
+        "type": "model_generation",
+        "name": "modelGeneration",
+        "output": {"text": "It's 18C and sunny in Paris."},
+        "startTime": "2026-01-01T00:00:03.000Z",
+    },
+]
+
+
+def test_mastra_adapter_is_registered() -> None:
+    assert get_adapter("mastra").name == "mastra"
+
+
+def test_converts_llm_tool_call_and_result(tmp_path: Path) -> None:
+    path = tmp_path / "spans.json"
+    path.write_text(json.dumps(_SPANS), encoding="utf-8")
+
+    traces = MastraAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    trace = traces[0]
+    # getWeather tool call (paired with its tool_call span result) + the final assistant message.
+    assert len(trace.steps) == 2
+
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "getWeather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.task == "what's the weather in Paris?"  # from the agent_run input
+
+    final = trace.steps[1]
+    assert final.action.kind == ActionKind.MESSAGE
+    assert final.action.content == "It's 18C and sunny in Paris."
+
+
+def test_openai_tool_call_shape_and_error(tmp_path: Path) -> None:
+    spans = [
+        {
+            "traceId": "t2",
+            "spanId": "a",
+            "spanType": "llm_generation",
+            "output": {
+                "tool_calls": [{"id": "x", "function": {"name": "charge", "arguments": "{}"}}]
+            },
+            "startedAt": "2026-01-01T00:00:00Z",
+        },
+        {
+            "traceId": "t2",
+            "spanId": "b",
+            "spanType": "tool_call",
+            "name": "charge",
+            "output": "declined",
+            "errorInfo": {"message": "card declined"},
+            "startedAt": "2026-01-01T00:00:01Z",
+        },
+    ]
+    path = tmp_path / "e.json"
+    path.write_text(json.dumps(spans), encoding="utf-8")
+
+    step = MastraAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.name == "charge"  # OpenAI-shaped tool call parsed
+    assert step.observation.content == "declined"
+    assert step.observation.is_error is True
+
+
+def test_legacy_prerename_span_shape(tmp_path: Path) -> None:
+    """Pre-2025-11 exports (still accepted): `spanId`/`spanType`/`startedAt`, the `llm_generation`
+    kind, and an AI-SDK-v4 `args` tool call."""
+    spans = [
+        {
+            "traceId": "t4",
+            "spanId": "s1",
+            "spanType": "llm_generation",
+            "output": {
+                "toolCalls": [{"toolCallId": "c", "toolName": "getWeather", "args": {"city": "SF"}}]
+            },
+            "startedAt": "2026-01-01T00:00:00Z",
+        },
+        {
+            "traceId": "t4",
+            "spanId": "s2",
+            "spanType": "tool_call",
+            "name": "getWeather",
+            "output": "60F and foggy",
+            "startedAt": "2026-01-01T00:00:01Z",
+        },
+    ]
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps(spans), encoding="utf-8")
+
+    step = MastraAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "getWeather"
+    assert step.action.arguments == {"city": "SF"}
+    assert step.observation.content == "60F and foggy"
+
+
+def test_standalone_tool_span_is_self_contained(tmp_path: Path) -> None:
+    # A tool_call span with no preceding llm_generation still becomes a complete step.
+    spans = [
+        {
+            "traceId": "t3",
+            "spanId": "only",
+            "spanType": "mcp_tool_call",
+            "name": "search",
+            "input": {"q": "otel"},
+            "output": "3 results",
+        }
+    ]
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps(spans), encoding="utf-8")
+
+    step = MastraAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.name == "search"
+    assert step.action.arguments == {"q": "otel"}
+    assert step.observation.content == "3 results"
+
+
+def test_spans_wrapper_and_jsonl(tmp_path: Path) -> None:
+    # A {"spans": [...]} wrapper works, and so does one span per JSONL line (same trace grouped).
+    path = tmp_path / "w.jsonl"
+    lines = [json.dumps({"spans": _SPANS[:2]}), json.dumps(_SPANS[2]), json.dumps(_SPANS[3])]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    traces = MastraAdapter().from_file(str(path))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "getWeather"
+    assert traces[0].steps[0].observation.content == "18C and sunny"
+
+
+def test_pull_without_url_is_friendly(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    monkeypatch.delenv("MASTRA_URL", raising=False)
+    try:
+        MastraAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "server URL" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_pull_fetches_observability_traces(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    """Live-pull path with httpx mocked: fetch the observability API, normalize the spans."""
+    import wmh.ingest.mastra as ms
+
+    def fake_get(url, headers=None, params=None, timeout=None):  # noqa: ANN001, ANN202 - stub
+        class _Resp:
+            def raise_for_status(self) -> None: ...
+
+            def json(self) -> dict:
+                return {"traces": [{"spans": _SPANS}]}
+
+        assert url == "http://localhost:4111/api/observability/traces"
+        return _Resp()
+
+    monkeypatch.setattr(ms.httpx, "get", fake_get)
+    traces = MastraAdapter().from_vendor(VendorPull(project="http://localhost:4111/"))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "getWeather"

--- a/wmh/ingest/messages.py
+++ b/wmh/ingest/messages.py
@@ -1,0 +1,200 @@
+"""Chat / tool-call converter: turn recorded LLM conversations into `Trace`s (no SDK, no spans).
+
+Not every source is a span exporter. The most universal trace people already have is a list of chat
+messages with tool calls — the OpenAI Chat Completions shape, which LangChain, the Anthropic SDK
+(after a light dump), and most agent frameworks can emit:
+
+    {"messages": [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {"role": "assistant", "content": "let me check",
+         "tool_calls": [{"id": "c1", "function": {"name": "get_weather",
+                                                  "arguments": "{\"city\": \"Paris\"}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "18C and sunny"},
+        {"role": "assistant", "content": "It's 18C and sunny in Paris."}
+    ]}
+
+This adapter maps each assistant **tool call** to an Action and the matching `role:"tool"` message
+(by `tool_call_id`, else the next tool message in order) to its Observation — exactly the
+`(action) -> observation` step the harness scores. A trailing assistant message with no tool call
+becomes a final message Step with an empty observation. The first user message is the trace `task`.
+
+It builds `SpanRecord`s in the OTel-GenAI vocabulary and hands them to the shared normalizer, so it
+reuses the same pairing/state/metadata logic as every other adapter rather than re-implementing it.
+
+Accepted file shapes (`from_file`):
+  - a single conversation object `{"messages": [...]}` (optionally `{"id"/"trace_id", "metadata"}`)
+  - a JSON array of such conversation objects
+  - JSONL: one conversation object per line
+  - a bare list of messages `[{"role": ...}, ...]` (treated as one conversation)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject, Trace
+from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.normalize import SpanRecord, as_text, spans_to_traces
+
+
+def _hash_id(*parts: str) -> str:
+    import hashlib
+
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()[:32]
+
+
+def _tool_calls(message: JsonObject) -> list[JsonObject]:
+    raw = message.get("tool_calls")
+    if not isinstance(raw, list):
+        return []
+    return [tc for tc in raw if isinstance(tc, dict)]
+
+
+def _call_name_args(tc: JsonObject) -> tuple[str, str]:
+    """Extract (name, raw-arguments-json) from a tool call in OpenAI or flattened shape."""
+    fn = tc.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:  # flattened {"name":..., "arguments":...}
+        name = tc.get("name")
+        args = tc.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    # arguments is usually a JSON *string* (OpenAI) but may be an object; normalize to a string the
+    # span carries, and let the normalizer's _tool_args re-parse it.
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _spans_for_conversation(
+    messages: list[JsonValue], trace_id: str, metadata: JsonObject
+) -> list[SpanRecord]:
+    """Build ordered action/observation SpanRecords (GenAI vocab) for one conversation."""
+    # Index tool results by tool_call_id; fall back to consumption in order for results lacking one.
+    results_by_id: dict[str, str] = {}
+    ordered_results: list[str] = []
+    task: str | None = None
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        if role == "user" and task is None:
+            task = as_text(m.get("content"))
+        if role == "tool":
+            content = as_text(m.get("content"))
+            tcid = m.get("tool_call_id")
+            if isinstance(tcid, str):
+                results_by_id[tcid] = content
+            ordered_results.append(content)
+
+    spans: list[SpanRecord] = []
+    ordinal = 0
+    unmatched = list(ordered_results)
+
+    def _emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+        nonlocal ordinal
+        if ordinal == 0 and task is not None:
+            attrs.setdefault("gen_ai.prompt", task)
+        if ordinal == 0 and metadata:
+            attrs.setdefault("wmh.trace.metadata", json.dumps(metadata))
+        spans.append(
+            SpanRecord(
+                trace_id=trace_id,
+                span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                name="execute_tool" if tool else "chat",
+                start_nano=ordinal,
+                attributes={"gen_ai.operation.name": "execute_tool" if tool else "chat", **attrs},
+                status_error=error,
+            )
+        )
+        ordinal += 1
+
+    for m in messages:
+        if not isinstance(m, dict) or m.get("role") != "assistant":
+            continue
+        calls = _tool_calls(m)
+        if calls:
+            for tc in calls:
+                name, args = _call_name_args(tc)
+                _emit({"gen_ai.tool.name": name, "gen_ai.tool.call.arguments": args}, tool=False)
+                tcid = tc.get("id")
+                if isinstance(tcid, str) and tcid in results_by_id:
+                    result = results_by_id[tcid]
+                    if result in unmatched:
+                        unmatched.remove(result)
+                elif unmatched:
+                    result = unmatched.pop(0)
+                else:
+                    result = ""
+                _emit({"gen_ai.tool.message": result}, tool=True)
+        else:
+            # A plain assistant message turn (e.g. the final answer): a message Action, no tool obs.
+            content = m.get("content")
+            if content is not None:
+                _emit({"gen_ai.completion": as_text(content)}, tool=False)
+    return spans
+
+
+def _conversation_records(payload: JsonValue) -> list[tuple[str, list[JsonValue], JsonObject]]:
+    """Normalize a payload into a list of (trace_id, messages, metadata) conversations."""
+    out: list[tuple[str, list[JsonValue], JsonObject]] = []
+    if isinstance(payload, list):
+        # Either a list of conversation objects, or a bare message list (one conversation).
+        if payload and all(isinstance(x, dict) and "role" in x for x in payload):
+            out.append((_hash_id(as_text(payload)), payload, {}))
+            return out
+        for item in payload:
+            out.extend(_conversation_records(item))
+        return out
+    if not isinstance(payload, dict):
+        return out
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return out
+    tid = payload.get("trace_id") or payload.get("id")
+    trace_id = tid if isinstance(tid, str) and tid else _hash_id(as_text(messages))
+    # 32-hex normalize so trace ids are uniform regardless of source id format.
+    if len(trace_id) != 32 or any(c not in "0123456789abcdef" for c in trace_id.lower()):
+        trace_id = _hash_id(trace_id)
+    meta = payload.get("metadata")
+    metadata: JsonObject = meta if isinstance(meta, dict) else {}
+    out.append((trace_id, messages, metadata))
+    return out
+
+
+class ChatMessagesAdapter:
+    """Convert recorded chat/tool-call conversations (OpenAI-style) into `Trace`s. No SDK."""
+
+    name = "chat-json"
+
+    def from_file(self, path: str) -> list[Trace]:
+        text = Path(path).read_text(encoding="utf-8")
+        payloads: list[JsonValue] = []
+        try:
+            payloads.append(json.loads(text))
+        except json.JSONDecodeError:
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    payloads.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    continue
+        spans: list[SpanRecord] = []
+        for payload in payloads:
+            for trace_id, messages, metadata in _conversation_records(payload):
+                spans.extend(_spans_for_conversation(messages, trace_id, metadata))
+        return spans_to_traces(spans, source=f"chat-json:{path}")
+
+    def from_vendor(self, pull: VendorPull) -> list[Trace]:
+        raise ValueError(
+            "chat-json converts local conversation files; it has no vendor API. "
+            "Use `from_file` with an exported messages JSON/JSONL."
+        )
+
+
+register_adapter(ChatMessagesAdapter())

--- a/wmh/ingest/messages_test.py
+++ b/wmh/ingest/messages_test.py
@@ -1,0 +1,139 @@
+"""Tests for the chat/tool-call -> Trace converter (chat-json adapter)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.messages import ChatMessagesAdapter
+
+_CONVO = {
+    "id": "conv-1",
+    "metadata": {"benchmark": "demo"},
+    "messages": [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "18C and sunny"},
+        {"role": "assistant", "content": "It's 18C and sunny in Paris."},
+    ],
+}
+
+
+def test_chat_json_adapter_is_registered() -> None:
+    assert get_adapter("chat-json").name == "chat-json"
+
+
+def test_converts_tool_call_and_final_message(tmp_path: Path) -> None:
+    path = tmp_path / "convo.json"
+    path.write_text(json.dumps(_CONVO), encoding="utf-8")
+
+    traces = ChatMessagesAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.metadata == {"benchmark": "demo"}
+    # 2 steps: the get_weather tool call (paired with its result) + the final assistant message.
+    assert len(trace.steps) == 2
+
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "get_weather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.task == "what's the weather in Paris?"
+
+    final = trace.steps[1]
+    assert final.action.kind == ActionKind.MESSAGE
+    assert final.action.content == "It's 18C and sunny in Paris."
+    assert final.observation.content == ""
+
+
+def test_tool_result_matched_by_order_when_no_id(tmp_path: Path) -> None:
+    convo = {
+        "messages": [
+            {"role": "user", "content": "list files"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "ls", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "a.txt\nb.txt"},  # no tool_call_id -> matched in order
+        ]
+    }
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps(convo), encoding="utf-8")
+
+    traces = ChatMessagesAdapter().from_file(str(path))
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    assert step.action.name == "ls"
+    assert step.observation.content == "a.txt\nb.txt"
+
+
+def test_jsonl_multiple_conversations(tmp_path: Path) -> None:
+    c2 = {
+        "id": "conv-2",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    }
+    path = tmp_path / "convos.jsonl"
+    path.write_text(json.dumps(_CONVO) + "\n" + json.dumps(c2) + "\n", encoding="utf-8")
+
+    traces = ChatMessagesAdapter().from_file(str(path))
+    assert len(traces) == 2
+
+
+def test_bare_message_list_is_one_conversation(tmp_path: Path) -> None:
+    path = tmp_path / "bare.json"
+    path.write_text(json.dumps(_CONVO["messages"]), encoding="utf-8")
+
+    traces = ChatMessagesAdapter().from_file(str(path))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "get_weather"
+
+
+def test_flattened_tool_call_shape(tmp_path: Path) -> None:
+    # Some frameworks flatten the call (no nested "function").
+    convo = {
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "tool_calls": [{"id": "x", "name": "f", "arguments": {"a": 1}}]},
+            {"role": "tool", "tool_call_id": "x", "content": "ok"},
+        ]
+    }
+    path = tmp_path / "flat.json"
+    path.write_text(json.dumps(convo), encoding="utf-8")
+
+    step = ChatMessagesAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.name == "f"
+    assert step.action.arguments == {"a": 1}  # arguments object re-parsed by the normalizer
+    assert step.observation.content == "ok"
+
+
+def test_empty_tool_arguments_become_empty_dict(tmp_path: Path) -> None:
+    """A tool call with no/blank arguments yields {} args, not a junk {"value": ""}."""
+    convo = {
+        "messages": [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "tool_calls": [{"id": "c1", "function": {"name": "noop"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "done"},
+        ]
+    }
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps(convo), encoding="utf-8")
+
+    step = ChatMessagesAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.name == "noop"
+    assert step.action.arguments == {}

--- a/wmh/ingest/normalize.py
+++ b/wmh/ingest/normalize.py
@@ -1,0 +1,501 @@
+"""Shared span-to-`Trace` normalizer — the one core every span-based adapter reuses.
+
+Most agent-observability providers (Arize/Phoenix, Langfuse, LangSmith, Braintrust) export spans
+that follow either the OpenTelemetry **GenAI** semantic conventions (`gen_ai.*`) or the
+**OpenInference** conventions (`llm.*`, `tool.*`, `input.value`/`output.value`, `openinference.span.
+kind`). Rather than write a bespoke parser per provider, an adapter normalizes its raw export into a
+flat list of `SpanRecord`s and calls `spans_to_traces()` here. The attribute *keys* differ across
+conventions, so the field extractors below look in both vocabularies (GenAI first, OpenInference as
+fallback).
+
+Pipeline:
+  raw OTLP/OpenInference payload --(collect_spans / a provider's own transform)--> list[SpanRecord]
+  list[SpanRecord] --(spans_to_traces)--> list[Trace]
+
+`spans_to_traces` groups by `trace_id`, orders each group by start time, and pairs each LLM/agent
+span (an Action) with the following tool/execution span (its Observation), mirroring how a real
+agent step reads: `(state, action) -> observation`. The optional `wmh.*` enrichment attributes
+(`wmh.state.*` -> `Step.state_before`, `wmh.trace.metadata` -> `Trace.metadata`) are honored on any
+span, so a faithfully captured trace round-trips for open-loop replay.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field, JsonValue
+
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step, Trace
+
+# --- attribute vocabularies (GenAI semconv first, OpenInference fallback) ---------------------
+
+# Operation/kind markers.
+_LLM_OPS = frozenset({"chat", "text_completion", "invoke_agent", "generate_content"})
+_TOOL_OPS = frozenset({"execute_tool"})
+# OpenInference span kinds (attribute `openinference.span.kind`).
+_OI_LLM_KINDS = frozenset({"LLM", "AGENT", "CHAIN"})
+_OI_TOOL_KINDS = frozenset({"TOOL"})
+
+# A tool call's name, in priority order across conventions.
+_TOOL_NAME_KEYS = ("gen_ai.tool.name", "tool.name", "tool_call.function.name")
+# A tool call's serialized arguments, in priority order.
+_TOOL_ARG_KEYS = (
+    "gen_ai.tool.call.arguments",
+    "gen_ai.tool.arguments",
+    "gen_ai.tool.input",
+    "gen_ai.request.arguments",
+    "tool_call.function.arguments",
+    "input.value",
+    "input",
+)
+# A tool execution's output, in priority order.
+_TOOL_OUTPUT_KEYS = (
+    "gen_ai.tool.message",
+    "gen_ai.tool.output",
+    "gen_ai.tool.call.result",
+    "gen_ai.tool.result",
+    "gen_ai.completion",
+    "output.value",
+    "output",
+)
+# The originating prompt / task, in priority order.
+_PROMPT_KEYS = ("gen_ai.prompt", "input.value", "llm.input_messages")
+# An LLM message completion, in priority order.
+_COMPLETION_KEYS = ("gen_ai.completion", "output.value", "llm.output_messages")
+# Presence of any of these marks a span as an LLM/agent span when no explicit op/kind is set.
+_LLM_PRESENCE_KEYS = (
+    "gen_ai.request.model",
+    "gen_ai.completion",
+    "gen_ai.prompt",
+    "llm.model_name",
+    "llm.input_messages",
+)
+
+# Optional `wmh.*` enrichment keys (a strict superset of any semconv).
+_STATE_STRUCTURED_KEY = "wmh.state.structured"
+_STATE_SCRATCHPAD_KEY = "wmh.state.scratchpad"
+_TRACE_METADATA_KEY = "wmh.trace.metadata"
+
+
+class SpanRecord(BaseModel):
+    """A flattened span with attributes decoded to plain JSON — the normalizer's input unit.
+
+    Adapters either build these directly (from a provider's own event shape) or via
+    `collect_spans` (from an OTLP/OpenInference-JSON payload).
+    """
+
+    trace_id: str
+    span_id: str = ""
+    parent_span_id: str = ""
+    name: str = ""
+    start_nano: int = 0
+    end_nano: int = 0
+    attributes: JsonObject = Field(default_factory=dict)
+    status_error: bool = False
+
+
+# --- value coercion ---------------------------------------------------------------------------
+
+
+def iso_to_ordinal(value: object, fallback: int) -> int:
+    """Map an ISO-8601 timestamp (or a `datetime`) to epoch microseconds; `fallback` if unusable.
+
+    Accepts a string OR a `datetime`/pandas `Timestamp` (Phoenix's `get_spans_dataframe` yields
+    datetimes, not ISO strings). A naive value (no tz offset — e.g. LangSmith's `2026-01-01T00:00`)
+    is treated as **UTC**, not the machine's local zone, so ordering is reproducible across hosts.
+    Only monotonicity within a trace matters (spans_to_traces sorts by start_nano), so microsecond
+    precision and a list-index fallback are plenty. Shared by every row adapter's timestamp order.
+    """
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value:
+        text = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return fallback
+    else:
+        return fallback
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    try:
+        return int(parsed.timestamp() * 1_000_000)
+    except (ValueError, OverflowError, OSError):
+        return fallback
+
+
+def to_int(value: JsonValue) -> int:
+    """Coerce an OTLP numeric/string to int; bool (an int subclass) is treated as non-numeric."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def as_text(value: JsonValue) -> str:
+    """Render a value as a JSON-clean string: strings pass through, else compact JSON (no repr)."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+# --- OTLP / OpenInference AnyValue decoding ---------------------------------------------------
+
+
+def any_value(value: JsonValue) -> JsonValue:
+    """Decode an OTLP `AnyValue` (`{"stringValue": ...}` etc.) to a plain JSON value."""
+    if not isinstance(value, dict):
+        return value
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "intValue" in value:
+        return to_int(value["intValue"])
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "arrayValue" in value:
+        arr = value["arrayValue"]
+        values = arr.get("values") if isinstance(arr, dict) else None
+        return [any_value(v) for v in values] if isinstance(values, list) else []
+    if "kvlistValue" in value:
+        kv = value["kvlistValue"]
+        values = kv.get("values") if isinstance(kv, dict) else None
+        return attrs_to_dict(values) if isinstance(values, list) else {}
+    return value
+
+
+def attrs_to_dict(attrs: JsonValue) -> JsonObject:
+    """Turn an OTLP attribute list (`[{"key", "value": <AnyValue>}, ...]`) into a flat dict.
+
+    Also accepts an already-flat `{key: value}` mapping (some providers export that shape), in which
+    case values are returned as-is.
+    """
+    out: JsonObject = {}
+    if isinstance(attrs, dict):
+        for key, val in attrs.items():
+            if isinstance(key, str):
+                out[key] = val
+        return out
+    if not isinstance(attrs, list):
+        return out
+    for attr in attrs:
+        if isinstance(attr, dict):
+            key = attr.get("key")
+            if isinstance(key, str):
+                out[key] = any_value(attr.get("value"))
+    return out
+
+
+def parse_span(raw: JsonValue) -> SpanRecord | None:
+    """Parse one OTLP-JSON span object into a `SpanRecord` (None if it lacks a trace id)."""
+    if not isinstance(raw, dict):
+        return None
+    trace_id = raw.get("traceId")
+    if not isinstance(trace_id, str) or not trace_id:
+        return None
+    status = raw.get("status")
+    status_error = False
+    if isinstance(status, dict):
+        code = status.get("code")
+        status_error = code in (2, "STATUS_CODE_ERROR")
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=_as_str(raw.get("spanId")),
+        parent_span_id=_as_str(raw.get("parentSpanId")),
+        name=_as_str(raw.get("name")),
+        start_nano=to_int(raw.get("startTimeUnixNano")),
+        end_nano=to_int(raw.get("endTimeUnixNano")),
+        attributes=attrs_to_dict(raw.get("attributes")),
+        status_error=status_error,
+    )
+
+
+def collect_spans(obj: JsonValue) -> list[SpanRecord]:
+    """Walk an OTLP-JSON payload, a list of payloads/spans, or a bare span into `SpanRecord`s."""
+    spans: list[SpanRecord] = []
+    if isinstance(obj, list):
+        for item in obj:
+            spans.extend(collect_spans(item))
+        return spans
+    if not isinstance(obj, dict):
+        return spans
+    if "resourceSpans" in obj:
+        resource_spans = obj["resourceSpans"]
+        if isinstance(resource_spans, list):
+            for resource_span in resource_spans:
+                spans.extend(_spans_in_resource(resource_span))
+        return spans
+    parsed = parse_span(obj)
+    if parsed is not None:
+        spans.append(parsed)
+    return spans
+
+
+def _spans_in_resource(resource_span: JsonValue) -> list[SpanRecord]:
+    spans: list[SpanRecord] = []
+    if not isinstance(resource_span, dict):
+        return spans
+    scope_spans = resource_span.get("scopeSpans")
+    if not isinstance(scope_spans, list):
+        return spans
+    for scope_span in scope_spans:
+        if not isinstance(scope_span, dict):
+            continue
+        raw_spans = scope_span.get("spans")
+        if not isinstance(raw_spans, list):
+            continue
+        for raw in raw_spans:
+            parsed = parse_span(raw)
+            if parsed is not None:
+                spans.append(parsed)
+    return spans
+
+
+# --- classification + field extraction --------------------------------------------------------
+
+
+def _first(attrs: JsonObject, keys: tuple[str, ...]) -> JsonValue:
+    for key in keys:
+        value = attrs.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _operation(span: SpanRecord) -> str:
+    op = span.attributes.get("gen_ai.operation.name")
+    return op if isinstance(op, str) else ""
+
+
+def _oi_kind(span: SpanRecord) -> str:
+    kind = span.attributes.get("openinference.span.kind")
+    return kind if isinstance(kind, str) else ""
+
+
+def is_tool_span(span: SpanRecord) -> bool:
+    op = _operation(span)
+    if op in _TOOL_OPS:
+        return True
+    if op in _LLM_OPS:
+        return False
+    kind = _oi_kind(span)
+    if kind in _OI_TOOL_KINDS:
+        return True
+    if kind in _OI_LLM_KINDS:
+        return False
+    return span.name.startswith("execute_tool")
+
+
+def is_llm_span(span: SpanRecord) -> bool:
+    op = _operation(span)
+    if op in _LLM_OPS:
+        return True
+    if op in _TOOL_OPS:
+        return False
+    kind = _oi_kind(span)
+    if kind in _OI_LLM_KINDS:
+        return True
+    if kind in _OI_TOOL_KINDS:
+        return False
+    return any(span.attributes.get(key) is not None for key in _LLM_PRESENCE_KEYS)
+
+
+def _coerce_args(raw: JsonValue) -> JsonObject:
+    """Coerce a tool call's arguments (a dict, a JSON string, or a scalar) to an arguments dict."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        if not raw.strip():
+            return {}  # empty/blank serialized args (e.g. a no-arg tool call) -> no arguments
+        try:
+            parsed: JsonValue = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"value": raw}
+        return parsed if isinstance(parsed, dict) else {"value": parsed}
+    return {"value": raw}
+
+
+def _tool_args(attrs: JsonObject) -> JsonObject:
+    return _coerce_args(_first(attrs, _TOOL_ARG_KEYS))
+
+
+# OpenInference flattens an LLM-emitted tool call across INDEXED attribute keys, e.g.
+#   llm.output_messages.0.message.tool_calls.0.tool_call.function.name      = "get_user"
+#   llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments = '{"id": "u1"}'
+# so the tool call lives on the LLM span itself, not a static `tool.name` key.
+_OI_TOOL_NAME_SUFFIX = ".tool_call.function.name"
+_OI_TOOL_ARGS_SUFFIX = ".tool_call.function.arguments"
+
+
+def _openinference_tool_call(attrs: JsonObject) -> tuple[str, JsonValue] | None:
+    """The lowest-indexed OpenInference tool call `(name, raw_args)` on an LLM span, if any."""
+    name_keys = sorted(k for k in attrs if k.endswith(_OI_TOOL_NAME_SUFFIX))
+    for name_key in name_keys:
+        name = attrs.get(name_key)
+        if isinstance(name, str) and name:
+            args_key = name_key[: -len(_OI_TOOL_NAME_SUFFIX)] + _OI_TOOL_ARGS_SUFFIX
+            return name, attrs.get(args_key)
+    return None
+
+
+def action_from_llm_span(span: SpanRecord) -> Action:
+    attrs = span.attributes
+    tool_name = _first(attrs, _TOOL_NAME_KEYS)
+    if isinstance(tool_name, str) and tool_name:
+        return Action(kind=ActionKind.TOOL_CALL, name=tool_name, arguments=_tool_args(attrs))
+    oi_call = _openinference_tool_call(attrs)
+    if oi_call is not None:
+        name, raw_args = oi_call
+        return Action(kind=ActionKind.TOOL_CALL, name=name, arguments=_coerce_args(raw_args))
+    completion = _first(attrs, _COMPLETION_KEYS)
+    content = _first(attrs, _PROMPT_KEYS) if completion is None else completion
+    return Action(kind=ActionKind.MESSAGE, content=as_text(content))
+
+
+def tool_call_action_from_tool_span(span: SpanRecord) -> Action:
+    name = _first(span.attributes, _TOOL_NAME_KEYS)
+    return Action(
+        kind=ActionKind.TOOL_CALL,
+        name=name if isinstance(name, str) and name else None,
+        arguments=_tool_args(span.attributes),
+    )
+
+
+def observation_from_tool_span(span: SpanRecord) -> Observation:
+    content = as_text(_first(span.attributes, _TOOL_OUTPUT_KEYS))
+    return Observation(content=content, is_error=span.status_error)
+
+
+def _trace_task(spans: list[SpanRecord]) -> str | None:
+    for span in spans:
+        prompt = _first(span.attributes, _PROMPT_KEYS)
+        if prompt is not None:
+            return as_text(prompt)
+    return None
+
+
+def _state_before(span: SpanRecord) -> EnvState:
+    """Read an optional `wmh.state.*` snapshot off a span (empty when absent)."""
+    attrs = span.attributes
+    structured = attrs.get(_STATE_STRUCTURED_KEY)
+    if isinstance(structured, str):
+        try:
+            decoded: JsonValue = json.loads(structured)
+        except json.JSONDecodeError:
+            decoded = {}
+        structured = decoded
+    scratchpad = attrs.get(_STATE_SCRATCHPAD_KEY)
+    return EnvState(
+        structured=structured if isinstance(structured, dict) else {},
+        scratchpad=scratchpad if isinstance(scratchpad, str) else "",
+    )
+
+
+def _trace_metadata(spans: list[SpanRecord]) -> JsonObject:
+    """First `wmh.trace.metadata` object across a trace's spans."""
+    for span in spans:
+        raw = span.attributes.get(_TRACE_METADATA_KEY)
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                decoded: JsonValue = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(decoded, dict):
+                return decoded
+    return {}
+
+
+def _build_steps(spans: list[SpanRecord]) -> list[Step]:
+    """Pair ordered Action spans with their following Observation spans into Steps."""
+    task = _trace_task(spans)
+    steps: list[Step] = []
+    pending: Action | None = None
+    pending_ids: list[str] = []
+    pending_state = EnvState()
+
+    def flush(
+        action: Action, observation: Observation, span_ids: list[str], state: EnvState
+    ) -> None:
+        steps.append(
+            Step(
+                action=action,
+                observation=observation,
+                state_before=state,
+                task=task,
+                raw_span_ids=span_ids,
+            )
+        )
+
+    for span in spans:
+        if is_tool_span(span):
+            observation = observation_from_tool_span(span)
+            if pending is None:
+                action = tool_call_action_from_tool_span(span)
+                flush(action, observation, [span.span_id], _state_before(span))
+            else:
+                # The LLM span usually carries the call's name/args; backfill from the tool span
+                # only when it didn't. Derive the tool-span action once to avoid re-parsing.
+                if pending.kind == ActionKind.TOOL_CALL and (
+                    not pending.arguments or pending.name is None
+                ):
+                    from_tool = tool_call_action_from_tool_span(span)
+                    if not pending.arguments:
+                        pending.arguments = from_tool.arguments
+                    if pending.name is None:
+                        pending.name = from_tool.name
+                flush(pending, observation, [*pending_ids, span.span_id], pending_state)
+            pending, pending_ids, pending_state = None, [], EnvState()
+        elif is_llm_span(span):
+            if pending is not None:
+                flush(pending, Observation(content=""), pending_ids, pending_state)
+            pending, pending_ids = action_from_llm_span(span), [span.span_id]
+            pending_state = _state_before(span)
+        # Non-agent spans are ignored.
+
+    if pending is not None:
+        flush(pending, Observation(content=""), pending_ids, pending_state)
+    return steps
+
+
+def spans_to_traces(spans: list[SpanRecord], *, source: str) -> list[Trace]:
+    """Group spans by trace id, order each group by start time, and build `Trace`s.
+
+    This is the shared tail every span-based adapter calls after producing `SpanRecord`s.
+    """
+    by_trace: dict[str, list[SpanRecord]] = {}
+    for span in spans:
+        by_trace.setdefault(span.trace_id, []).append(span)
+    # Sorting each group by (start_nano, span_id) leaves group[0] as that trace's earliest span, so
+    # we reuse it as the inter-trace sort key rather than re-scanning.
+    ordered: list[tuple[int, Trace]] = []
+    for group in by_trace.values():
+        group.sort(key=lambda s: (s.start_nano, s.span_id))
+        trace = Trace(
+            trace_id=group[0].trace_id,
+            steps=_build_steps(group),
+            source=source,
+            metadata=_trace_metadata(group),
+        )
+        ordered.append((group[0].start_nano, trace))
+    ordered.sort(key=lambda pair: pair[0])
+    return [trace for _, trace in ordered]

--- a/wmh/ingest/normalize_test.py
+++ b/wmh/ingest/normalize_test.py
@@ -1,0 +1,29 @@
+"""Tests for the shared normalizer helpers (the pieces every adapter relies on)."""
+
+from __future__ import annotations
+
+from wmh.ingest.normalize import iso_to_ordinal
+
+
+def test_iso_to_ordinal_naive_timestamp_is_utc_not_local() -> None:
+    """A naive timestamp (no tz) must be read as UTC, so ordinals are machine-independent.
+
+    Regression: `datetime.fromisoformat("...").timestamp()` on a naive value uses the machine's
+    local timezone, which would reorder spans differently across machines. `iso_to_ordinal` pins
+    naive timestamps to UTC, so a naive value and its explicit-UTC form map to the same ordinal.
+    """
+    naive = iso_to_ordinal("2026-01-01T00:00:00", fallback=-1)
+    explicit_utc = iso_to_ordinal("2026-01-01T00:00:00+00:00", fallback=-1)
+    zulu = iso_to_ordinal("2026-01-01T00:00:00Z", fallback=-1)
+    assert naive == explicit_utc == zulu
+    assert naive > 0
+
+
+def test_iso_to_ordinal_orders_and_falls_back() -> None:
+    earlier = iso_to_ordinal("2026-01-01T00:00:00Z", fallback=0)
+    later = iso_to_ordinal("2026-01-01T00:00:01Z", fallback=0)
+    assert earlier < later
+    # Absent/unparseable/non-string -> the caller's fallback (a list index), not a crash.
+    assert iso_to_ordinal(None, fallback=7) == 7
+    assert iso_to_ordinal("not-a-date", fallback=9) == 9
+    assert iso_to_ordinal("", fallback=3) == 3

--- a/wmh/ingest/otel_writer.py
+++ b/wmh/ingest/otel_writer.py
@@ -1,0 +1,98 @@
+"""Write normalized `Trace`s back out as OTel-GenAI span JSONL — the inverse of `normalize`.
+
+`wmh ingest` normalizes any source into `Trace`s, then persists them with this writer so the rest of
+the pipeline (`wmh build`, `wmh eval`) reads them through the existing `otel-genai` file adapter.
+Writing in the same span vocabulary the normalizer reads makes a `Trace -> file -> Trace` round-trip
+lossless for everything the harness uses (action, observation+error, state_before, task, metadata).
+
+One span per JSONL line: each `Step` becomes a `chat` (action) span plus, when it has an
+observation, an `execute_tool` span. The first step's action span also carries the trace `task`
+(`gen_ai.prompt`) and `wmh.trace.metadata`. Timestamps are deterministic ordinals (no wall clock),
+so re-writing the same trace is byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind, JsonObject, JsonValue, Step, Trace
+
+
+def _attr(key: str, value: str) -> JsonObject:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _action_attrs(
+    step: Step, *, ordinal: int, task: str | None, metadata: JsonObject
+) -> list[JsonValue]:
+    attrs: list[JsonValue] = [_attr("gen_ai.operation.name", "chat")]
+    action = step.action
+    if action.kind == ActionKind.TOOL_CALL:
+        attrs.append(_attr("gen_ai.tool.name", action.name or ""))
+        attrs.append(_attr("gen_ai.tool.call.arguments", json.dumps(action.arguments)))
+    else:
+        attrs.append(_attr("gen_ai.completion", action.content or ""))
+    if ordinal == 0 and task is not None:
+        attrs.append(_attr("gen_ai.prompt", task))
+    if ordinal == 0 and metadata:
+        attrs.append(_attr("wmh.trace.metadata", json.dumps(metadata)))
+    if step.state_before.structured:
+        attrs.append(_attr("wmh.state.structured", json.dumps(step.state_before.structured)))
+    if step.state_before.scratchpad:
+        attrs.append(_attr("wmh.state.scratchpad", step.state_before.scratchpad))
+    return attrs
+
+
+def trace_to_spans(trace: Trace) -> list[JsonObject]:
+    """Project one `Trace` into ordered OTLP-JSON action/observation span dicts."""
+    spans: list[JsonObject] = []
+    task = trace.steps[0].task if trace.steps else None
+    prefix = (trace.trace_id or "trace")[:12]
+    for i, step in enumerate(trace.steps):
+        spans.append(
+            {
+                "traceId": trace.trace_id,
+                "spanId": f"{prefix}{i:06x}a",
+                "parentSpanId": "",
+                "name": "chat",
+                "startTimeUnixNano": i * 10,
+                "endTimeUnixNano": i * 10 + 1,
+                "status": {"code": "STATUS_CODE_OK"},
+                "attributes": _action_attrs(step, ordinal=i, task=task, metadata=trace.metadata),
+            }
+        )
+        # A final message turn (empty observation, message action) has nothing to pair; skip the
+        # observation span so it round-trips as an unpaired action exactly as the normalizer emits.
+        obs = step.observation
+        if step.action.kind == ActionKind.MESSAGE and not obs.content and not obs.is_error:
+            continue
+        spans.append(
+            {
+                "traceId": trace.trace_id,
+                "spanId": f"{prefix}{i:06x}b",
+                "parentSpanId": "",
+                "name": "execute_tool",
+                "startTimeUnixNano": i * 10 + 2,
+                "endTimeUnixNano": i * 10 + 3,
+                "status": {"code": "STATUS_CODE_ERROR" if obs.is_error else "STATUS_CODE_OK"},
+                "attributes": [
+                    _attr("gen_ai.operation.name", "execute_tool"),
+                    _attr("gen_ai.tool.name", step.action.name or "tool"),
+                    _attr("gen_ai.tool.message", obs.content),
+                ],
+            }
+        )
+    return spans
+
+
+def write_traces_jsonl(traces: list[Trace], path: Path) -> int:
+    """Write traces as one-span-per-line OTel-GenAI JSONL. Returns the number of spans written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n = 0
+    with path.open("w", encoding="utf-8") as f:
+        for trace in traces:
+            for span in trace_to_spans(trace):
+                f.write(json.dumps(span) + "\n")
+                n += 1
+    return n

--- a/wmh/ingest/otel_writer_test.py
+++ b/wmh/ingest/otel_writer_test.py
@@ -1,0 +1,72 @@
+"""Round-trip tests: Trace -> otel_writer JSONL -> otel-genai adapter -> Trace (lossless)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+from wmh.ingest.otel_genai import OtelGenAIAdapter
+from wmh.ingest.otel_writer import trace_to_spans, write_traces_jsonl
+
+
+def _trace() -> Trace:
+    return Trace(
+        trace_id="a" * 32,
+        source="test",
+        metadata={"benchmark": "demo", "gold": {"answer": "42"}},
+        steps=[
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u1"}),
+                observation=Observation(content="found u1", is_error=False),
+                state_before=EnvState(structured={"cart": ["a"]}, scratchpad="logged in"),
+                task="look up u1",
+            ),
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="rm", arguments={"p": "/x"}),
+                observation=Observation(content="permission denied", is_error=True),
+                task="look up u1",
+            ),
+            Step(
+                action=Action(kind=ActionKind.MESSAGE, content="done"),
+                observation=Observation(content=""),
+                task="look up u1",
+            ),
+        ],
+    )
+
+
+def test_roundtrip_preserves_steps_state_and_metadata(tmp_path: Path) -> None:
+    out = tmp_path / "rt.otel.jsonl"
+    n_spans = write_traces_jsonl([_trace()], out)
+    # 2 paired steps (action+obs) + 1 trailing message (action only) = 5 spans.
+    assert n_spans == 5
+
+    reloaded = OtelGenAIAdapter().from_file(str(out))
+    assert len(reloaded) == 1
+    rt = reloaded[0]
+    assert rt.trace_id == "a" * 32
+    assert rt.metadata == {"benchmark": "demo", "gold": {"answer": "42"}}
+    assert len(rt.steps) == 3
+
+    s0 = rt.steps[0]
+    assert s0.action.name == "get_user"
+    assert s0.action.arguments == {"id": "u1"}
+    assert s0.observation.content == "found u1"
+    assert s0.observation.is_error is False
+    assert s0.state_before.structured == {"cart": ["a"]}
+    assert s0.state_before.scratchpad == "logged in"
+    assert s0.task == "look up u1"
+
+    s1 = rt.steps[1]
+    assert s1.action.name == "rm"
+    assert s1.observation.is_error is True
+
+    s2 = rt.steps[2]
+    assert s2.action.kind == ActionKind.MESSAGE
+    assert s2.action.content == "done"
+    assert s2.observation.content == ""
+
+
+def test_writer_is_deterministic() -> None:
+    # No wall-clock: the same trace serializes byte-identically across calls.
+    assert trace_to_spans(_trace()) == trace_to_spans(_trace())

--- a/wmh/ingest/phoenix.py
+++ b/wmh/ingest/phoenix.py
@@ -1,0 +1,150 @@
+"""Arize Phoenix adapter — OpenInference spans, in Phoenix's native export shape.
+
+Phoenix (https://github.com/Arize-ai/phoenix) stores **OpenInference** spans: each span carries a
+flat `attributes` dict using OpenInference keys (`openinference.span.kind`, `tool.name`,
+`input.value`, `output.value`, `llm.input_messages`, `llm.model_name`, ...). The shared normalizer
+(`wmh.ingest.normalize`) already classifies those keys, so this adapter is almost entirely about
+*transport + field naming*: turning Phoenix's exported span objects into `SpanRecord`s.
+
+Phoenix exports spans in two shapes, both handled here:
+
+  1. **OTLP envelope** — `{"resourceSpans": [...]}` (or a JSON array of bare OTLP spans with
+     `traceId`/`spanId`/`startTimeUnixNano`). This is standard OTLP-JSON, so we hand it straight to
+     `collect_spans`.
+
+  2. **Phoenix native span dicts** — what `px.Client().get_spans_dataframe(...)` /
+     the Phoenix UI "export" produce. Two flavours are handled:
+       - Nested (UI/JSON export): ids under a `context` object, `attributes` a nested dict.
+       - FLAT (the dataframe: `get_spans_dataframe().reset_index().to_dict("records")`): the id and
+         attributes are **dotted top-level columns** — `context.trace_id`, `context.span_id`,
+         `attributes.openinference.span.kind`, `attributes.llm.output_messages.0...` — and
+         `start_time`/`end_time` are pandas `Timestamp`/`datetime`, not ISO strings.
+
+         {
+           "name": "agent",
+           "context.trace_id": "abc123...", "context.span_id": "def456...",
+           "parent_id": null, "status_code": "OK",
+           "start_time": Timestamp("2024-01-01T00:00:00Z"),
+           "attributes.openinference.span.kind": "LLM",
+           "attributes.llm.output_messages.0.message.tool_calls.0.tool_call.function.name": "get"
+         }
+
+     `collect_spans` -> `parse_span` looks for OTLP `traceId`/`spanId`, which these dicts lack, so
+     it would drop them. `_phoenix_span` reads `context.<field>` from either shape and rebuilds
+     `attributes` from both a nested dict and the flat `attributes.*` columns; the shared classifier
+     (which understands OpenInference indexed tool-call keys) does the rest. `start_time`/`end_time`
+     accept an ISO string OR a datetime; a missing/unparseable one falls back to the array index,
+     which only needs to be monotonic within a trace.
+
+Optional `wmh.*` enrichments (`wmh.state.*`, `wmh.trace.metadata`) are honored by the shared
+normalizer if present in a span's attributes.
+
+Live pull: Phoenix's query API/SDK is left as the `BaseTraceAdapter` default (a friendly
+"export to a file" error). Phoenix's recommended export path is a file (or a pandas dataframe dumped
+to JSON), and the SDK surface is version-dependent; we prefer correctness over a guessed endpoint.
+Export from Phoenix to a file and use `from_file` / `wmh ingest run --source phoenix --file ...`.
+"""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, attrs_to_dict, collect_spans, iso_to_ordinal
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _ctx_field(span: JsonObject, field: str) -> str:
+    """Read `context.<field>` whether `context` is a NESTED dict (Phoenix UI export) or a FLAT
+    dotted column `context.<field>` (`get_spans_dataframe().reset_index().to_dict("records")`)."""
+    context = span.get("context")
+    if isinstance(context, dict):
+        value = context.get(field)
+        if isinstance(value, str) and value:
+            return value
+    flat = span.get(f"context.{field}")
+    if isinstance(flat, str) and flat:
+        return flat
+    bare = span.get(field)
+    return bare if isinstance(bare, str) else ""
+
+
+def _phoenix_attributes(span: JsonObject) -> JsonObject:
+    """Reconstruct a span's attributes from a nested `attributes` dict AND/OR flat `attributes.*`
+    dotted columns (the dataframe flattens attributes to top-level `attributes.<key>` cols)."""
+    attrs = attrs_to_dict(span.get("attributes"))
+    for key, value in span.items():
+        if isinstance(key, str) and key.startswith("attributes."):
+            attrs[key[len("attributes.") :]] = value
+    return attrs
+
+
+def _phoenix_span(raw: JsonValue, ordinal: int) -> SpanRecord | None:
+    """Map ONE Phoenix native span dict to a `SpanRecord` (None if it carries no trace id)."""
+    if not isinstance(raw, dict):
+        return None
+    trace_id = _ctx_field(raw, "trace_id")
+    if not trace_id:
+        return None
+    status = _as_str(raw.get("status_code")).upper()
+    return SpanRecord(
+        trace_id=trace_id,
+        span_id=_ctx_field(raw, "span_id"),
+        parent_span_id=_as_str(raw.get("parent_id")),
+        name=_as_str(raw.get("name")),
+        # `start_time`/`end_time` may be ISO strings (UI export) or datetimes (dataframe records).
+        start_nano=iso_to_ordinal(raw.get("start_time"), ordinal),
+        end_nano=iso_to_ordinal(raw.get("end_time"), ordinal),
+        attributes=_phoenix_attributes(raw),
+        status_error=status in ("ERROR", "STATUS_CODE_ERROR"),
+    )
+
+
+def _phoenix_spans(payload: JsonValue) -> list[SpanRecord]:
+    """Map Phoenix native span dicts (a single dict or an array) to `SpanRecord`s."""
+    items = payload if isinstance(payload, list) else [payload]
+    spans: list[SpanRecord] = []
+    for ordinal, item in enumerate(items):
+        parsed = _phoenix_span(item, ordinal)
+        if parsed is not None:
+            spans.append(parsed)
+    return spans
+
+
+def _is_otlp(payload: JsonValue) -> bool:
+    """True when the payload is an OTLP envelope or a bare OTLP span (has `traceId`)."""
+    if isinstance(payload, dict):
+        return "resourceSpans" in payload or "traceId" in payload
+    if isinstance(payload, list):
+        return any(_is_otlp(item) for item in payload)
+    return False
+
+
+class PhoenixAdapter(BaseTraceAdapter):
+    """Normalize Arize Phoenix OpenInference span exports into `Trace`s. SDK-free."""
+
+    name = "phoenix"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Phoenix native span dicts -> SpanRecords; OTLP envelopes delegate to `collect_spans`.
+
+        A list may mix shapes, so route per item rather than all-or-nothing — otherwise a single
+        OTLP-shaped element would send the whole list to `collect_spans`, silently dropping the
+        native dicts (which lack `traceId`).
+        """
+        if isinstance(payload, list):
+            spans: list[SpanRecord] = []
+            for item in payload:
+                spans.extend(self.spans_from_payload(item))
+            return spans
+        if _is_otlp(payload):
+            return collect_spans(payload)
+        return _phoenix_spans(payload)
+
+
+register_adapter(PhoenixAdapter())

--- a/wmh/ingest/phoenix_test.py
+++ b/wmh/ingest/phoenix_test.py
@@ -1,0 +1,213 @@
+"""Tests for the Arize Phoenix adapter against realistic Phoenix span exports.
+
+Phoenix exports flat OpenInference span dicts whose ids live under `context` and whose timestamps
+are ISO strings (NOT OTLP `traceId`/`startTimeUnixNano`), so these fixtures exercise the adapter's
+own field mapping plus the shared OpenInference classifier. No network; file fixtures only.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest.adapter import VendorPull, get_adapter
+from wmh.ingest.normalize import spans_to_traces
+from wmh.ingest.phoenix import PhoenixAdapter
+
+# A small, realistic Phoenix span export: an AGENT/LLM span issuing a tool call (OpenInference
+# `tool.name` + `input.value`), followed by the TOOL span carrying the tool's `output.value`.
+_PHOENIX_SPANS = [
+    {
+        "name": "agent_step",
+        "context": {
+            "trace_id": "f1e2d3c4b5a6978800112233445566aa",
+            "span_id": "aaaa000000000001",
+        },
+        "parent_id": None,
+        "start_time": "2024-01-01T00:00:00.000000+00:00",
+        "end_time": "2024-01-01T00:00:00.500000+00:00",
+        "status_code": "OK",
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "llm.model_name": "gpt-4o",
+            # An LLM span's prompt lives under llm.input_messages (a real OpenInference key); the
+            # structured tool-call args ride on the following TOOL span's input.value.
+            "llm.input_messages": "look up user u1",
+            "tool.name": "get_user",
+        },
+    },
+    {
+        "name": "get_user",
+        "context": {
+            "trace_id": "f1e2d3c4b5a6978800112233445566aa",
+            "span_id": "aaaa000000000002",
+        },
+        "parent_id": "aaaa000000000001",
+        "start_time": "2024-01-01T00:00:00.600000+00:00",
+        "end_time": "2024-01-01T00:00:00.800000+00:00",
+        "status_code": "OK",
+        "attributes": {
+            "openinference.span.kind": "TOOL",
+            "tool.name": "get_user",
+            "input.value": '{"id": "u1"}',
+            "output.value": "user u1: Ada Lovelace",
+        },
+    },
+]
+
+
+def test_from_file_maps_phoenix_native_spans(tmp_path: Path) -> None:
+    path = tmp_path / "phoenix_spans.json"
+    path.write_text(json.dumps(_PHOENIX_SPANS), encoding="utf-8")
+
+    traces = PhoenixAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    assert traces[0].trace_id == "f1e2d3c4b5a6978800112233445566aa"
+    assert traces[0].source.startswith("phoenix:")
+    assert len(traces[0].steps) == 1
+    step = traces[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "get_user"
+    # The LLM span had no args; the normalizer backfills from the TOOL span's input.value.
+    assert step.action.arguments == {"id": "u1"}
+    assert step.observation.content == "user u1: Ada Lovelace"
+    assert step.observation.is_error is False
+
+
+def test_from_file_handles_jsonl_and_error_status(tmp_path: Path) -> None:
+    # One span per line (JSONL), and a TOOL span flagged with an ERROR status_code.
+    llm_span = {
+        "name": "agent_step",
+        "context": {"trace_id": "e" * 32, "span_id": "bbbb000000000001"},
+        "start_time": "2024-02-02T00:00:00.000000+00:00",
+        "status_code": "OK",
+        "attributes": {"openinference.span.kind": "LLM", "tool.name": "get_user"},
+    }
+    tool_span = {
+        "name": "get_user",
+        "context": {"trace_id": "e" * 32, "span_id": "bbbb000000000002"},
+        "start_time": "2024-02-02T00:00:01.000000+00:00",
+        "status_code": "ERROR",
+        "attributes": {
+            "openinference.span.kind": "TOOL",
+            "input.value": '{"id": "u1"}',
+            "output.value": "not found",
+        },
+    }
+    path = tmp_path / "phoenix_spans.jsonl"
+    path.write_text(f"{json.dumps(llm_span)}\n{json.dumps(tool_span)}\n", encoding="utf-8")
+
+    traces = PhoenixAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    assert step.observation.is_error is True
+    assert step.observation.content == "not found"
+
+
+def test_from_file_accepts_otlp_envelope(tmp_path: Path) -> None:
+    # Phoenix can also export standard OTLP spans; those delegate to the shared collect_spans.
+    otlp = {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "0a0b0c0d0e0f00112233445566778899",
+                                "spanId": "1111000000000001",
+                                "name": "chat",
+                                "startTimeUnixNano": 1,
+                                "attributes": {
+                                    "openinference.span.kind": "LLM",
+                                    "tool.name": "search",
+                                    "input.value": '{"q": "hi"}',
+                                },
+                            },
+                            {
+                                "traceId": "0a0b0c0d0e0f00112233445566778899",
+                                "spanId": "1111000000000002",
+                                "name": "search",
+                                "startTimeUnixNano": 2,
+                                "attributes": {
+                                    "openinference.span.kind": "TOOL",
+                                    "output.value": "1 result",
+                                },
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    path = tmp_path / "phoenix_otlp.json"
+    path.write_text(json.dumps(otlp), encoding="utf-8")
+
+    traces = PhoenixAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    assert step.action.name == "search"
+    assert step.action.arguments == {"q": "hi"}
+    assert step.observation.content == "1 result"
+
+
+def test_dataframe_records_flat_columns_indexed_tool_calls() -> None:
+    """The REAL `get_spans_dataframe().reset_index().to_dict("records")` shape: ids and attributes
+    are FLAT dotted columns (`context.trace_id`, `attributes.<key>`), the tool call rides on the LLM
+    span as INDEXED OpenInference keys (`...output_messages.0.message.tool_calls.0...`), and
+    `start_time` is a `datetime` object, not an ISO string. Passed in-memory (a dataframe can't
+    round-trip a datetime through JSON), which is how the SDK export is actually consumed."""
+    tc = "attributes.llm.output_messages.0.message.tool_calls.0.tool_call.function"
+    records = [
+        {
+            "name": "llm",
+            "context.trace_id": "d" * 32,
+            "context.span_id": "cccc000000000001",
+            "parent_id": None,
+            "start_time": datetime(2024, 3, 3, tzinfo=UTC),
+            "status_code": "OK",
+            "attributes.openinference.span.kind": "LLM",
+            "attributes.llm.model_name": "gpt-4o",
+            f"{tc}.name": "get_user",
+            f"{tc}.arguments": '{"id": "u1"}',
+        },
+        {
+            "name": "get_user",
+            "context.trace_id": "d" * 32,
+            "context.span_id": "cccc000000000002",
+            "parent_id": "cccc000000000001",
+            "start_time": datetime(2024, 3, 3, 0, 0, 1, tzinfo=UTC),
+            "status_code": "OK",
+            "attributes.openinference.span.kind": "TOOL",
+            "attributes.output.value": "user u1: Ada Lovelace",
+        },
+    ]
+
+    adapter = PhoenixAdapter()
+    traces = spans_to_traces(adapter._collect_all([records]), source="phoenix:df")
+
+    assert len(traces) == 1
+    assert traces[0].trace_id == "d" * 32
+    step = traces[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "get_user"
+    assert step.action.arguments == {"id": "u1"}
+    assert step.observation.content == "user u1: Ada Lovelace"
+
+
+def test_registered_under_phoenix() -> None:
+    assert get_adapter("phoenix").name == "phoenix"
+
+
+def test_vendor_pull_left_as_friendly_default() -> None:
+    try:
+        PhoenixAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "does not support live vendor pulls" in str(exc)
+        assert "phoenix" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")

--- a/wmh/ingest/posthog.py
+++ b/wmh/ingest/posthog.py
@@ -1,0 +1,334 @@
+"""PostHog adapter: turn PostHog LLM-observability events into `Trace`s.
+
+PostHog captures LLM traces as analytics **events** (not OTLP spans). Its LLM-observability schema
+emits, per agent run, a set of events sharing `properties.$ai_trace_id`:
+
+  - `$ai_generation` — one LLM call. Prompt in `properties.$ai_input` (a messages list), completion
+    in `properties.$ai_output_choices` (a list of choice messages). A choice message that issues a
+    tool call carries it OpenAI-style in `tool_calls`.
+  - `$ai_span` — a non-LLM step (often a tool execution). Its input is `properties.$ai_input_state`
+    and its result `properties.$ai_output_state`; the tool name is `properties.$ai_span_name`.
+  - `$ai_trace` — a trace-root summary event (its `$ai_input`/`$ai_output_state` may hold the
+    overall task/result); it carries no step of its own.
+  - `$ai_is_error` (bool) on any event marks that step as an error.
+
+Because this is not an OTLP/OpenInference span shape, the adapter overrides `spans_from_payload`
+(like `wmh.ingest.langfuse`) and emits `SpanRecord`s in the **OTel-GenAI vocabulary** so the shared
+classifier/normalizer (`wmh.ingest.normalize`) does the pairing/state/metadata work:
+
+  - a `$ai_generation` whose output choices carry tool calls -> one `chat` action span per call
+    (`gen_ai.tool.name` + `gen_ai.tool.call.arguments`); the result is paired with the sibling
+    `$ai_span` tool event by the normalizer.
+  - a `$ai_generation` with no tool call -> a plain `chat` message span (`gen_ai.completion`).
+  - a tool-like `$ai_span` -> an `execute_tool` span (`gen_ai.tool.message` from the
+    `$ai_output_state`), also carrying name/args so a standalone tool event still pairs.
+
+Events are ordered by `timestamp` (ISO-8601 -> a monotonic ordinal, list index when absent). The
+first user message across the trace's `$ai_input`s becomes the task (`gen_ai.prompt`).
+
+Accepted file shapes (`from_file`): a single event, a JSON array of events, a query-result wrapper
+(`{"results": [...]}` from the HogQL/events API), or JSONL (one event per line). Grouping is by
+`properties.$ai_trace_id` (falling back to `$ai_span_id`/event id).
+
+Pull: live pull via the PostHog query API is implemented in `_pull_payloads` (HogQL over `events`);
+export to a file and use `from_file` if you prefer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+# PostHog API. `$AI_*` events are queried via HogQL over the `events` table. Host is region-specific
+# (US: us.posthog.com, EU: eu.posthog.com), so it is configurable.
+_API_HOST = os.environ.get("POSTHOG_HOST", "https://us.posthog.com").rstrip("/")
+_API_KEY_ENV = "POSTHOG_API_KEY"
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _props(event: JsonObject) -> JsonObject:
+    """An event's `properties` dict (PostHog nests the $ai_* fields there)."""
+    props = event.get("properties")
+    return props if isinstance(props, dict) else {}
+
+
+def _start_ordinal(event: JsonObject, fallback: int) -> int:
+    """Monotonic ordering key from the event `timestamp` (shared helper; UTC-safe)."""
+    return iso_to_ordinal(event.get("timestamp"), fallback)
+
+
+def _event_name(event: JsonObject) -> str:
+    name = event.get("event")
+    return name if isinstance(name, str) else ""
+
+
+def _is_error(props: JsonObject) -> bool:
+    flag = props.get("$ai_is_error")
+    if isinstance(flag, bool):
+        return flag
+    error = props.get("$ai_error")
+    if isinstance(error, str):
+        return bool(error.strip())
+    return bool(error)
+
+
+def _tool_calls(choices: JsonValue) -> list[JsonObject]:
+    """Tool calls from `$ai_output_choices` (a list of choice messages).
+
+    PostHog's NORMALIZED format puts a tool call as a `content` PART `{"type": "function",
+    "function": {"name", "arguments"}}` (arguments is a JSON object, not a string), NOT in a
+    `tool_calls` array. We collect both: content-parts with `type == "function"` (the normalized
+    shape) and a `tool_calls` array (raw-OpenAI passthrough). `_call_name_args` handles either.
+    """
+    calls: list[JsonObject] = []
+    if not isinstance(choices, list):
+        return calls
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        raw = choice.get("tool_calls")
+        if isinstance(raw, list):
+            calls.extend(tc for tc in raw if isinstance(tc, dict))
+        content = choice.get("content")
+        if isinstance(content, list):
+            calls.extend(
+                part
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "function"
+            )
+    return calls
+
+
+def _call_name_args(tool_call: JsonObject) -> tuple[str, str]:
+    """(name, raw-arguments-json) from a tool call in OpenAI-nested or flattened shape."""
+    fn = tool_call.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        args = fn.get("arguments")
+    else:
+        name = tool_call.get("name")
+        args = tool_call.get("arguments")
+    name_s = name if isinstance(name, str) else ""
+    args_s = args if isinstance(args, str) else as_text(args)
+    return name_s, args_s
+
+
+def _content_text(content: JsonValue) -> str:
+    """Assistant text from a choice `content`: a plain string, or a parts list where text lives in
+    `{"type": "text", "text": ...}` parts (PostHog's normalized multi-part shape). Non-text parts
+    (e.g. `type == "function"` tool calls) are skipped."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    texts.append(text)
+        return "\n".join(texts)
+    return ""
+
+
+def _choices_text(choices: JsonValue) -> str:
+    """Assistant text from `$ai_output_choices` (first choice's content), else the whole list."""
+    if isinstance(choices, list):
+        for choice in choices:
+            if isinstance(choice, dict):
+                text = _content_text(choice.get("content"))
+                if text:
+                    return text
+    return as_text(choices)
+
+
+def _first_user_text(messages: JsonValue) -> str | None:
+    """First user/human message content in an `$ai_input` messages list."""
+    if not isinstance(messages, list):
+        return None
+    for message in messages:
+        if isinstance(message, dict) and _as_str(message.get("role")).lower() in {"user", "human"}:
+            content = message.get("content")
+            if content is not None:
+                return as_text(content)
+    return None
+
+
+class PostHogAdapter(BaseTraceAdapter):
+    """Map PostHog LLM-observability events into normalized `Trace`s."""
+
+    name = "posthog"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        events = self._events(payload)
+        by_trace: dict[str, list[JsonObject]] = {}
+        for event in events:
+            by_trace.setdefault(self._trace_id(event), []).append(event)
+        spans: list[SpanRecord] = []
+        for trace_id, trace_events in by_trace.items():
+            spans.extend(self._spans_for_trace(trace_id, trace_events))
+        return spans
+
+    def _events(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a flat list of PostHog event objects.
+
+        Accepts a single event, a bare list, or a query wrapper (`{"results": [...]}`).
+        """
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._events(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        for wrapper_key in ("results", "events"):
+            inner = payload.get(wrapper_key)
+            if isinstance(inner, list):
+                out = []
+                for item in inner:
+                    out.extend(self._events(item))
+                return out
+        if "event" in payload or "properties" in payload:
+            return [payload]
+        return []
+
+    def _trace_id(self, event: JsonObject) -> str:
+        props = _props(event)
+        for key in ("$ai_trace_id", "$ai_span_id"):
+            value = props.get(key)
+            if isinstance(value, str) and value:
+                return value
+        eid = event.get("id") or event.get("uuid")
+        if isinstance(eid, str) and eid:
+            return eid
+        import hashlib
+
+        return hashlib.sha256(as_text(event).encode()).hexdigest()[:32]
+
+    def _spans_for_trace(self, trace_id: str, events: list[JsonObject]) -> list[SpanRecord]:
+        indexed = list(enumerate(events))
+        indexed.sort(key=lambda pair: (_start_ordinal(pair[1], pair[0]), pair[0]))
+
+        task: str | None = None
+        for _, event in indexed:
+            task = _first_user_text(_props(event).get("$ai_input"))
+            if task is not None:
+                break
+
+        spans: list[SpanRecord] = []
+        ordinal = 0
+
+        def emit(attrs: JsonObject, *, tool: bool, error: bool = False) -> None:
+            nonlocal ordinal
+            if ordinal == 0 and task is not None:
+                attrs.setdefault("gen_ai.prompt", task)
+            spans.append(
+                SpanRecord(
+                    trace_id=trace_id,
+                    span_id=f"{trace_id[:12]}{ordinal:06x}{'t' if tool else 'a'}",
+                    name="execute_tool" if tool else "chat",
+                    start_nano=ordinal,
+                    attributes={
+                        "gen_ai.operation.name": "execute_tool" if tool else "chat",
+                        **attrs,
+                    },
+                    status_error=error,
+                )
+            )
+            ordinal += 1
+
+        for _, event in indexed:
+            name = _event_name(event)
+            props = _props(event)
+            error = _is_error(props)
+            if name == "$ai_generation":
+                calls = _tool_calls(props.get("$ai_output_choices"))
+                if calls:
+                    for tool_call in calls:
+                        tool_name, args = _call_name_args(tool_call)
+                        emit(
+                            {"gen_ai.tool.name": tool_name, "gen_ai.tool.call.arguments": args},
+                            tool=False,
+                            error=error,
+                        )
+                else:
+                    emit(
+                        {"gen_ai.completion": _choices_text(props.get("$ai_output_choices"))},
+                        tool=False,
+                        error=error,
+                    )
+            elif name == "$ai_span" and self._span_is_tool(props):
+                emit(
+                    {
+                        "gen_ai.tool.name": _as_str(props.get("$ai_span_name")),
+                        "gen_ai.tool.call.arguments": as_text(props.get("$ai_input_state")),
+                        "gen_ai.tool.message": as_text(props.get("$ai_output_state")),
+                    },
+                    tool=True,
+                    error=error,
+                )
+            # $ai_trace (root summary) and other events carry no standalone step.
+        return spans
+
+    def _span_is_tool(self, props: JsonObject) -> bool:
+        """An `$ai_span` is a tool execution when it has an output/input state or a span name."""
+        return (
+            props.get("$ai_output_state") is not None
+            or props.get("$ai_input_state") is not None
+            or bool(_as_str(props.get("$ai_span_name")))
+        )
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Query PostHog for `$ai_*` events via HogQL and return them for normalization.
+
+        `pull.project` is the PostHog project id; `pull.api_key` (else `$POSTHOG_API_KEY`) is a
+        personal API key. Host is `$POSTHOG_HOST` (region-specific). Fetches recent `$ai_*` events.
+        """
+        api_key = pull.api_key or os.environ.get(_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(
+                f"posthog pull needs an API key: pass --api-key or set ${_API_KEY_ENV}"
+            )
+        if not pull.project:
+            raise ValueError("posthog pull needs --project (the PostHog project id)")
+        limit = pull.limit if pull.limit is not None else 1000
+        query = (
+            "select event, properties, timestamp from events "
+            "where event like '$ai_%' order by timestamp asc limit " + str(int(limit))
+        )
+        # Trailing slash required: PostHog's DRF router 301-redirects `/query` -> `/query/`, and the
+        # redirect drops the POST body (httpx follows as a GET), so hit the canonical URL directly.
+        resp = httpx.post(
+            f"{_API_HOST}/api/projects/{pull.project}/query/",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"query": {"kind": "HogQLQuery", "query": query}},
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        # HogQL returns {"results": [[event, properties, timestamp], ...], "columns": [...]}.
+        results = body.get("results", []) if isinstance(body, dict) else []
+        events: list[JsonValue] = []
+        for row in results:
+            if isinstance(row, list) and len(row) >= 3:
+                props = row[1]
+                if isinstance(props, str):
+                    try:
+                        props = json.loads(props)
+                    except json.JSONDecodeError:
+                        props = {}
+                events.append({"event": row[0], "properties": props, "timestamp": row[2]})
+        return [events]
+
+
+register_adapter(PostHogAdapter())

--- a/wmh/ingest/posthog_test.py
+++ b/wmh/ingest/posthog_test.py
@@ -1,0 +1,189 @@
+"""Tests for the PostHog LLM-observability events -> Trace adapter (posthog).
+
+Fixture-based, no network: hand-authored $ai_generation / $ai_span events sharing one $ai_trace_id —
+a generation that issues a tool call, the sibling $ai_span carrying the result, and an errored span.
+
+The primary fixture uses PostHog's NORMALIZED output shape (what its LLM-observability integrations
+actually emit): a tool call is a `content` PART `{"type": "function", "function": {...}}` with
+`arguments` as a JSON object, and assistant text is a `[{"type": "text", "text": ...}]` parts list —
+NOT a top-level `tool_calls` array. `test_raw_openai_tool_calls_passthrough` covers the raw-OpenAI
+shape we ALSO accept.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest import get_adapter
+from wmh.ingest.adapter import VendorPull
+from wmh.ingest.posthog import PostHogAdapter
+
+_EVENTS = [
+    {
+        "event": "$ai_generation",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "properties": {
+            "$ai_trace_id": "t1",
+            "$ai_input": [{"role": "user", "content": "what's the weather in Paris?"}],
+            # Normalized shape: the tool call is a content PART, arguments is an object.
+            "$ai_output_choices": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": {"city": "Paris"}},
+                        }
+                    ],
+                }
+            ],
+        },
+    },
+    {
+        "event": "$ai_span",
+        "timestamp": "2026-01-01T00:00:01.000Z",
+        "properties": {
+            "$ai_trace_id": "t1",
+            "$ai_span_name": "get_weather",
+            "$ai_input_state": {"city": "Paris"},
+            "$ai_output_state": "18C and sunny",
+        },
+    },
+    {
+        "event": "$ai_generation",
+        "timestamp": "2026-01-01T00:00:02.000Z",
+        "properties": {
+            "$ai_trace_id": "t1",
+            # Normalized shape: assistant text is a list of `text` parts.
+            "$ai_output_choices": [
+                {"role": "assistant", "content": [{"type": "text", "text": "It's 18C and sunny."}]}
+            ],
+        },
+    },
+]
+
+
+def test_posthog_adapter_is_registered() -> None:
+    assert get_adapter("posthog").name == "posthog"
+
+
+def test_converts_generation_tool_call_and_result(tmp_path: Path) -> None:
+    path = tmp_path / "events.json"
+    path.write_text(json.dumps(_EVENTS), encoding="utf-8")
+
+    traces = PostHogAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    trace = traces[0]
+    # get_weather tool call (paired with its result span) + the final assistant message.
+    assert len(trace.steps) == 2
+
+    call = trace.steps[0]
+    assert call.action.kind == ActionKind.TOOL_CALL
+    assert call.action.name == "get_weather"
+    assert call.action.arguments == {"city": "Paris"}
+    assert call.observation.content == "18C and sunny"
+    assert call.task == "what's the weather in Paris?"
+
+    final = trace.steps[1]
+    assert final.action.kind == ActionKind.MESSAGE
+    assert final.action.content == "It's 18C and sunny."
+
+
+def test_raw_openai_tool_calls_passthrough(tmp_path: Path) -> None:
+    """We ALSO accept the raw-OpenAI shape: a top-level `tool_calls` array with a string-JSON
+    `arguments` (some setups forward the provider payload unnormalized)."""
+    events = [
+        {
+            "event": "$ai_generation",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "properties": {
+                "$ai_trace_id": "t3",
+                "$ai_output_choices": [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {"function": {"name": "get_weather", "arguments": '{"city": "Paris"}'}}
+                        ],
+                    }
+                ],
+            },
+        }
+    ]
+    path = tmp_path / "raw.json"
+    path.write_text(json.dumps(events), encoding="utf-8")
+
+    step = PostHogAdapter().from_file(str(path))[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "get_weather"
+    assert step.action.arguments == {"city": "Paris"}
+
+
+def test_query_results_wrapper_and_error_flag(tmp_path: Path) -> None:
+    events = [
+        {
+            "event": "$ai_span",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "properties": {
+                "$ai_trace_id": "t2",
+                "$ai_span_name": "charge",
+                "$ai_output_state": "declined",
+                "$ai_is_error": True,
+            },
+        }
+    ]
+    path = tmp_path / "q.json"
+    path.write_text(json.dumps({"results": events}), encoding="utf-8")
+
+    trace = PostHogAdapter().from_file(str(path))[0]
+    assert trace.steps[0].action.name == "charge"
+    assert trace.steps[0].observation.is_error is True
+
+
+def test_pull_without_key_is_friendly(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    try:
+        PostHogAdapter().from_vendor(VendorPull(project="1"))
+    except ValueError as exc:
+        assert "API key" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_pull_queries_hogql_and_normalizes(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    """Live-pull path with httpx mocked: HogQL results (row tuples) -> events -> Trace."""
+    import wmh.ingest.posthog as ph
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: ANN001, ANN202, A002 - stub
+        class _Resp:
+            def raise_for_status(self) -> None: ...
+
+            def json(self) -> dict:
+                # HogQL returns rows as [event, properties, timestamp].
+                return {
+                    "results": [
+                        [
+                            "$ai_span",
+                            {
+                                "$ai_trace_id": "t9",
+                                "$ai_span_name": "lookup",
+                                "$ai_output_state": "ok",
+                            },
+                            "2026-01-01T00:00:00Z",
+                        ]
+                    ],
+                    "columns": ["event", "properties", "timestamp"],
+                }
+
+        # Trailing slash is required (PostHog 301-redirects `/query` and drops the POST body).
+        assert url.endswith("/api/projects/42/query/")
+        assert headers == {"Authorization": "Bearer k"}
+        return _Resp()
+
+    monkeypatch.setattr(ph.httpx, "post", fake_post)
+    traces = PostHogAdapter().from_vendor(VendorPull(api_key="k", project="42"))
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "lookup"
+    assert traces[0].steps[0].observation.content == "ok"


### PR DESCRIPTION
## What

Bring traces into the harness from **wherever you already have them** — Braintrust, Arize Phoenix,
Langfuse, LangSmith, an OTLP export, or a plain chat/tool-call log — through **one pluggable
interface**. Adding a source is a ~30-line adapter, never a rewrite.

## The foundation (extends the existing `TraceAdapter` seam, doesn't reinvent it)

- **`wmh/ingest/normalize.py`** — the one shared span→`Trace` core (extracted from `otel_genai`).
  Understands **both** OTel GenAI (`gen_ai.*`) and **OpenInference** (`openinference.span.kind`,
  `tool.name`, `input.value`/`output.value`, `llm.*`) vocabularies; pairs each action span with its
  following tool span; honors optional `wmh.*` state/metadata enrichments. `otel_genai.py` is now a
  thin transport over it.
- **`wmh/ingest/base.py`** — `BaseTraceAdapter`: file/JSONL loading + vendor plumbing, so a concrete
  adapter only implements `spans_from_payload` (and optionally `_pull_payloads`).
- **`wmh/ingest/messages.py`** (`chat-json`) — converts recorded OpenAI/LangChain-style
  chat+tool-call conversations into `Trace`s, no SDK.
- **`wmh/ingest/otel_writer.py`** — the inverse (`Trace` → OTel-GenAI span JSONL); lossless
  round-trip, so `wmh ingest` output feeds `build`/`eval` unchanged.

## Provider adapters (fanned out, each thin + tested)

`phoenix`, `langfuse`, `langsmith`, `braintrust` — each maps its export shape into `SpanRecord`s and
reuses the shared normalizer. **SDK-free** (parse exports as JSON; live pull would use `httpx`), so
the gate needs no vendor SDK. Each ships inline **fixture tests** (no network), a runnable
`examples/ingest/<provider>_to_wmh.sh`, and a `docs/ingest.<provider>.md` section.

## CLI

```bash
wmh ingest list                                                  # every registered source
wmh ingest run --source langfuse --file export.json --out traces.otel.jsonl
wmh build --file traces.otel.jsonl --name my-model
```

Top-level command set unchanged (`ingest` is a sub-typer, like `bench`/`providers`).

## Docs & extras

`docs/ingest.md` documents the interface, file-vs-pull modes, the chat converter, the source table,
and the **"add a new source in ~30 lines"** recipe. Per-provider optional extras in `pyproject`
(`[phoenix]` / `[langfuse]` / `[langsmith]` / `[braintrust]`) — optional, since adapters are SDK-free.

## Gate

`uv run ruff check .`, `uv run ty check`, `uv run pytest -q` all green (308 passed, 6 pre-existing
creds-gated skips). End-to-end verified: a Langfuse export ingests → OTel JSONL → re-reads with
faithful action/args/observation/task/metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)