### PR TITLE
[codex] add concurrent sandbox benchmark eval

### DIFF
--- a/tools/swe-bench-capture/run.sh
+++ b/tools/swe-bench-capture/run.sh
@@ -3,7 +3,8 @@
 # environment (build from scratch on native x86_64, else pull the prebuilt image) and run the
 # recorded scenario, streaming all stdout. One command.
 #
-#   tools/swe-bench-capture/run.sh [--trace N] [--mode build|pull|auto] [--warm] [--cache] [--keep-image] [...]
+#   tools/swe-bench-capture/run.sh [--trace N] [--scenarios N] [--concurrency N]
+#                                    [--mode build|pull|auto] [--warm] [--cache] [...]
 #
 # The whole thing — Python venv creation, `swebench` install, the Docker standup (a from-scratch
 # conda/pip build on x86_64, or a multi-GB prebuilt-image pull under emulation), and the recorded
@@ -14,6 +15,10 @@
 # skips. Re-runs reuse the venv; pass --warm (optionally with --cache) to reuse existing images /
 # build layers for a faster repeat run. After the run the stood-up image(s) are wound down in the
 # background (multi-GB; a cold run rebuilds them) — pass --keep-image to keep them.
+# For multi-scenario runs, run_real_scenario.py streams each child runner with a trace prefix and
+# forces --warm --cache to avoid concurrent runners deleting Docker images from under each other.
+# Docker Desktop / remote daemons can lag the local CLI API; pin a compatible API unless the user
+# deliberately overrides it.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -26,5 +31,6 @@ if ! .venv/bin/python -c 'import swebench' >/dev/null 2>&1; then
 fi
 
 export AWS_REGION="${AWS_REGION:-us-east-1}" AWS_REGION_NAME="${AWS_REGION_NAME:-us-east-1}"
+export DOCKER_API_VERSION="${DOCKER_API_VERSION:-1.41}"
 echo "=== running the real swe-bench scenario (stand up env + exec) ==="
 exec .venv/bin/python run_real_scenario.py "$@"

--- a/tools/swe-bench-capture/run_real_scenario.py
+++ b/tools/swe-bench-capture/run_real_scenario.py
@@ -56,16 +56,23 @@ def _attr_map(span: dict[str, Any]) -> dict[str, str]:
 
 
 def _load_traces(corpus: Path) -> "list[dict[str, Any]]":
-    """Group the OTel spans into ordered traces: [{trace_id, instance_id, commands:[...]}]."""
+    """Group the OTel spans into ordered traces: [{trace_id, instance_id, commands:[...]}].
+
+    Traces are ordered by their earliest span's (startTimeUnixNano, spanId) — IDENTICAL to the wmh
+    adapter (wmh/ingest/otel_genai.py), NOT by first appearance in the file. `--trace N` must select
+    the SAME scenario index on both sides; ordering by file position would silently diverge from the
+    world-model side whenever the corpus is not already start-time sorted.
+    """
     spans = [json.loads(line) for line in corpus.read_text(encoding="utf-8").splitlines() if line]
-    order: list[str] = []
     by_trace: dict[str, list[dict[str, Any]]] = {}
     for span in spans:
-        tid = span["traceId"]
-        if tid not in by_trace:
-            by_trace[tid] = []
-            order.append(tid)
-        by_trace[tid].append(span)
+        by_trace.setdefault(span["traceId"], []).append(span)
+
+    def _span_key(span: dict[str, Any]) -> tuple[int, str]:
+        return (int(span.get("startTimeUnixNano") or 0), str(span.get("spanId") or ""))
+
+    # Earliest span per trace = its sort key; matches otel_genai's group[0] inter-trace ordering.
+    order = sorted(by_trace, key=lambda tid: _span_key(min(by_trace[tid], key=_span_key)))
 
     traces: list[dict[str, Any]] = []
     for tid in order:
@@ -235,9 +242,11 @@ def _run_many(
     args: argparse.Namespace, selected: list[tuple[int, dict[str, Any]]], *, pool_name: str
 ) -> int:
     """Run several single-scenario invocations concurrently and summarize their timings."""
-    workers = args.concurrency or args.scenarios
-    if workers < 1:
+    # `args.concurrency or args.scenarios` would treat an explicit --concurrency 0 as unset; reject
+    # it before defaulting.
+    if args.concurrency is not None and args.concurrency < 1:
         raise SystemExit("--concurrency must be at least 1")
+    workers = args.concurrency or args.scenarios
     warm = args.warm
     cache = args.cache
     if not warm or not cache:
@@ -325,9 +334,25 @@ def _run_many(
     batch_start = time.monotonic()
     results: list[dict[str, Any]] = []
     with cf.ThreadPoolExecutor(max_workers=workers) as ex:
-        futures = {ex.submit(run_child, item): item[0] for item in selected}
+        futures = {ex.submit(run_child, item): item for item in selected}
         for fut in cf.as_completed(futures):
-            result = fut.result()
+            trace_i, trace = futures[fut]
+            try:
+                result = fut.result()
+            except Exception as exc:  # noqa: BLE001 - record a failed child, keep the batch going
+                # e.g. the child failed to even spawn (bad interpreter, fd exhaustion). Record it as
+                # a failure rather than aborting the batch and orphaning sibling children.
+                result = {
+                    "trace_index": trace_i,
+                    "trace_id": trace["trace_id"],
+                    "instance_id": trace["instance_id"],
+                    "commands": len(trace["commands"]),
+                    "returncode": 1,
+                    "seconds": 0.0,
+                }
+                print(f"[done] trace {trace_i} {trace['instance_id']}: failed to run: {exc}")
+                results.append(result)
+                continue
             results.append(result)
             status = "ok" if result["returncode"] == 0 else f"exit {result['returncode']}"
             print(

--- a/tools/swe-bench-capture/run_real_scenario.py
+++ b/tools/swe-bench-capture/run_real_scenario.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run ONE real SWE-bench scenario against the real Docker sandbox — BUILT FROM SCRATCH — + timing.
+"""Run real SWE-bench scenario(s) against the real Docker sandbox, with timing.
 
 The **real-environment** half of the scenario comparison. `wmh bench scenario swe-bench --trace N`
 reconstructs a held-out scenario with the world model (no container, just LLM calls); this runs the
@@ -17,8 +17,9 @@ for a faster repeat run.
 Needs the swebench `.venv` from this directory's README (it imports `swebench` to get the official
 Dockerfiles + setup scripts) and a running local Docker daemon. It never imports `wmh`; it reads the
 committed `examples/swe-bench.otel.jsonl` and re-implements the harness's deterministic blake2b
-held-out split inline so `--trace N` selects the SAME scenario the world-model side does (default 0;
-pass -1 for the simplest = fewest commands).
+held-out split inline so `--trace N` selects the SAME scenario the world-model side does. If a demo
+batch is larger than the held-out pool but fits in the full corpus, it switches both sides to the
+full corpus so 8-way demos can run from the same trace indexes.
 
 By default the stood-up image(s) are wound down in the background after the run (they are multi-GB
 and a cold run re-creates them); pass `--keep-image` to keep them.
@@ -27,16 +28,21 @@ Usage (from tools/swe-bench-capture/, in the swebench venv):
     .venv/bin/python run_real_scenario.py                          # trace 0, truly cold, then clean up
     .venv/bin/python run_real_scenario.py --warm --cache           # reuse existing image/layers
     .venv/bin/python run_real_scenario.py --trace 2 --keep-image   # a specific trace, keep the image
+    .venv/bin/python run_real_scenario.py --trace 0 --scenarios 8 --concurrency 8
 """
 
 from __future__ import annotations
 
 import argparse
+import concurrent.futures as cf
 import hashlib
 import json
+import os
 import platform
 import subprocess
+import sys
 import tempfile
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -86,7 +92,7 @@ def _holdout(traces: list[dict[str, Any]], train_split: float) -> list[dict[str,
         fraction = int.from_bytes(digest, "big") / 2**64
         if fraction >= train_split:
             held.append(trace)
-    return held or traces  # tiny corpora: no held-out -> fall back to all (matches the wmh side)
+    return held
 
 
 def _docker_build(
@@ -200,12 +206,183 @@ def _default_mode() -> str:
     return "build" if platform.machine().lower() in ("x86_64", "amd64") else "pull"
 
 
+def _select_traces(
+    pool: list[dict[str, Any]], trace_index: int, scenarios: int, *, pool_name: str
+) -> list[tuple[int, dict[str, Any]]]:
+    """Select traces by the same semantics as the world-model side."""
+    if scenarios < 1:
+        raise SystemExit("--scenarios must be at least 1")
+    if trace_index == -1:
+        selected = sorted(enumerate(pool), key=lambda item: len(item[1]["commands"]))[:scenarios]
+    elif 0 <= trace_index < len(pool):
+        end = trace_index + scenarios
+        if end > len(pool):
+            raise SystemExit(
+                f"--trace {trace_index} with --scenarios {scenarios} exceeds "
+                f"{len(pool)} {pool_name} trace(s)"
+            )
+        selected = [(i, pool[i]) for i in range(trace_index, end)]
+    else:
+        raise SystemExit(f"--trace {trace_index} out of range; {len(pool)} {pool_name} trace(s)")
+    if len(selected) < scenarios:
+        raise SystemExit(
+            f"requested {scenarios} scenario(s), but only {len(selected)} {pool_name} trace(s) exist"
+        )
+    return selected
+
+
+def _run_many(
+    args: argparse.Namespace, selected: list[tuple[int, dict[str, Any]]], *, pool_name: str
+) -> int:
+    """Run several single-scenario invocations concurrently and summarize their timings."""
+    workers = args.concurrency or args.scenarios
+    if workers < 1:
+        raise SystemExit("--concurrency must be at least 1")
+    warm = args.warm
+    cache = args.cache
+    if not warm or not cache:
+        # A cold single run purges the whole swebench image family. Running that concurrently would
+        # make children delete images from under each other, so batch mode uses warm cached semantics.
+        warm = True
+        cache = True
+        print(
+            "=== multi-scenario run: forcing --warm --cache to avoid concurrent image purges ==="
+        )
+
+    def child_cmd(trace_i: int) -> list[str]:
+        cmd = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--corpus",
+            str(args.corpus),
+            "--trace",
+            str(trace_i),
+            "--trace-pool",
+            pool_name,
+            "--train-split",
+            str(args.train_split),
+            "--dataset",
+            str(args.dataset),
+            "--mode",
+            str(args.mode),
+            "--exec-timeout",
+            str(args.exec_timeout),
+        ]
+        if warm:
+            cmd.append("--warm")
+        if cache:
+            cmd.append("--cache")
+        if args.keep_image:
+            cmd.append("--keep-image")
+        return cmd
+
+    print_lock = threading.Lock()
+
+    def stream(pipe, prefix: str) -> None:  # noqa: ANN001 - subprocess pipe object
+        try:
+            for line in pipe:
+                with print_lock:
+                    print(f"{prefix}{line}", end="", flush=True)
+        finally:
+            pipe.close()
+
+    def run_child(item: tuple[int, dict[str, Any]]) -> dict[str, Any]:
+        trace_i, trace = item
+        start = time.monotonic()
+        proc = subprocess.Popen(
+            child_cmd(trace_i),
+            cwd=Path(__file__).resolve().parent,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        stdout_thread = threading.Thread(
+            target=stream, args=(proc.stdout, f"[trace {trace_i} out] "), daemon=True
+        )
+        stderr_thread = threading.Thread(
+            target=stream, args=(proc.stderr, f"[trace {trace_i} err] "), daemon=True
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = proc.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+        seconds = time.monotonic() - start
+        return {
+            "trace_index": trace_i,
+            "trace_id": trace["trace_id"],
+            "instance_id": trace["instance_id"],
+            "commands": len(trace["commands"]),
+            "returncode": returncode,
+            "seconds": seconds,
+        }
+
+    print(
+        f"REAL sandbox batch: {len(selected)} SWE-bench scenario(s) from {pool_name}, "
+        f"concurrency={workers}\n"
+    )
+    batch_start = time.monotonic()
+    results: list[dict[str, Any]] = []
+    with cf.ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(run_child, item): item[0] for item in selected}
+        for fut in cf.as_completed(futures):
+            result = fut.result()
+            results.append(result)
+            status = "ok" if result["returncode"] == 0 else f"exit {result['returncode']}"
+            print(
+                f"[done] trace {result['trace_index']} {result['instance_id']} "
+                f"({result['commands']} commands): {status}, {result['seconds']:.1f}s"
+            )
+
+    batch_wall = time.monotonic() - batch_start
+    ok = sum(1 for r in results if r["returncode"] == 0)
+    work = sum(float(r["seconds"]) for r in results)
+    print(
+        f"\ndone (REAL sandbox batch): {ok}/{len(results)} ok, "
+        f"batch wall {batch_wall:.1f}s, summed runner wall {work:.1f}s"
+    )
+    for result in sorted(results, key=lambda r: r["trace_index"]):
+        status = "ok" if result["returncode"] == 0 else f"exit {result['returncode']}"
+        print(
+            f"  trace {result['trace_index']}: {result['instance_id']} "
+            f"{result['commands']} commands, {status}, {result['seconds']:.1f}s"
+        )
+        if result["returncode"] != 0:
+            print(f"    see streamed trace {result['trace_index']} output above")
+    return 0 if ok == len(results) else 1
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--corpus", default=str(_DEFAULT_CORPUS), help="swe-bench OTel JSONL corpus.")
     parser.add_argument(
         "--trace", type=int, default=0,
-        help="Held-out trace to replay (default: 0). Pass -1 for the simplest = fewest commands.",
+        help=(
+            "Trace index to replay (default: 0). Uses held-out indexes when possible; switches to "
+            "all traces for larger demo batches. Pass -1 for the simplest = fewest commands."
+        ),
+    )
+    parser.add_argument(
+        "--scenarios",
+        type=int,
+        default=1,
+        help=(
+            "Number of scenarios to run. With --trace N, runs N consecutive indexes; with "
+            "--trace -1, runs the simplest N traces."
+        ),
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help="Concurrent scenario runners. Default: --scenarios.",
+    )
+    parser.add_argument(
+        "--trace-pool",
+        choices=("auto", "held-out", "all"),
+        default="auto",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--train-split", type=float, default=0.7, help="Train/holdout ratio.")
     parser.add_argument(
@@ -245,18 +422,35 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+    # Docker Desktop/remote daemons can support an older API than the locally installed Docker CLI.
+    # Pin the client API unless the caller deliberately chose a different value.
+    os.environ.setdefault("DOCKER_API_VERSION", "1.41")
 
     traces = _load_traces(Path(args.corpus))
-    pool = _holdout(traces, args.train_split)
+    heldout = _holdout(traces, args.train_split)
+    if args.trace_pool == "all":
+        pool = traces
+        pool_name = "all"
+    elif args.trace_pool == "held-out":
+        pool = heldout
+        pool_name = "held-out"
+    else:
+        pool = heldout or traces
+        pool_name = "held-out" if heldout else "all"
+    requested_end = args.trace + args.scenarios if args.trace >= 0 else args.scenarios
+    if args.trace_pool == "auto" and heldout and requested_end > len(pool) and requested_end <= len(traces):
+        print(
+            f"=== requested {args.scenarios} scenario(s) from trace {args.trace}, but only "
+            f"{len(pool)} held-out traces exist; using all {len(traces)} traces instead ==="
+        )
+        pool = traces
+        pool_name = "all"
     if not pool:
         raise SystemExit(f"no traces in {args.corpus}; nothing to run")
-    if args.trace == -1:
-        # The simplest scenario — fewest recorded commands (matches the wmh side's `min` default).
-        trace = min(pool, key=lambda t: len(t["commands"]))
-    elif 0 <= args.trace < len(pool):
-        trace = pool[args.trace]
-    else:
-        raise SystemExit(f"--trace {args.trace} out of range; {len(pool)} held-out trace(s)")
+    selected = _select_traces(pool, args.trace, args.scenarios, pool_name=pool_name)
+    if args.scenarios > 1:
+        raise SystemExit(_run_many(args, selected, pool_name=pool_name))
+    trace = selected[0][1]
     instance_id, commands = trace["instance_id"], trace["commands"]
     if not instance_id:
         raise SystemExit(f"trace {trace['trace_id'][:8]} has no instance_id in metadata")

--- a/wmh/bench/__init__.py
+++ b/wmh/bench/__init__.py
@@ -29,6 +29,12 @@ from wmh.bench.results import (
 from wmh.bench.runner import RolloutScore, ScoreOnce, run_benchmark
 from wmh.bench.scenario import ScenarioReport, ScenarioStep, run_scenario
 from wmh.bench.scoring import evaluate_files_once
+from wmh.bench.side_by_side import (
+    RealSandboxResult,
+    RealSandboxSpec,
+    real_sandbox_spec,
+    run_real_sandbox,
+)
 
 __all__ = [
     "BenchmarkDef",
@@ -41,6 +47,10 @@ __all__ = [
     "ScenarioReport",
     "ScenarioStep",
     "run_scenario",
+    "RealSandboxResult",
+    "RealSandboxSpec",
+    "real_sandbox_spec",
+    "run_real_sandbox",
     "BenchRun",
     "SeedResult",
     "load_runs",

--- a/wmh/bench/side_by_side.py
+++ b/wmh/bench/side_by_side.py
@@ -1,0 +1,151 @@
+"""Real-sandbox runner helpers for side-by-side benchmark demos."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class RealSandboxSpec(BaseModel):
+    """How to run the real-environment half of a benchmark scenario demo."""
+
+    benchmark: str
+    label: str
+    command: list[str]
+    cwd: Path
+
+    def display_command(self) -> str:
+        return " ".join(self.command)
+
+
+class RealSandboxResult(BaseModel):
+    """Captured output and timing from a real sandbox runner."""
+
+    spec: RealSandboxSpec
+    returncode: int | None
+    seconds: float
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0 and not self.timed_out and self.error is None
+
+    def summary(self) -> str:
+        if self.timed_out:
+            return f"timed out after {self.seconds:.1f}s"
+        if self.error is not None:
+            return f"failed before launch: {self.error}"
+        status = "ok" if self.returncode == 0 else f"exit {self.returncode}"
+        return f"{status}, wall {self.seconds:.1f}s"
+
+
+_RUNNERS: dict[str, tuple[str, str, str | None]] = {
+    # benchmark name -> (display label, tool directory, trace arg for default/simplest scenario)
+    "tau-bench": ("real tau2 environment", "tools/tau2-capture", None),
+    "tau2-bench": ("real tau2 environment", "tools/tau2-capture", None),
+    "swe-bench": (
+        "real SWE-bench sandbox replaying mini-SWE-agent commands",
+        "tools/swe-bench-capture",
+        "-1",
+    ),
+    "terminal-tasks": ("real terminal sandbox", "tools/terminal-tasks-capture", None),
+}
+
+
+def real_sandbox_spec(
+    benchmark: str,
+    *,
+    trace_index: int | None,
+    train_split: float,
+    extra_args: list[str] | None = None,
+    repo_root: Path | None = None,
+) -> RealSandboxSpec:
+    """Build the matching `tools/<benchmark>-capture/run.sh` invocation.
+
+    A `None` trace means "the simplest held-out scenario" on the world-model side. Most real
+    runners use that as their default too; SWE-bench uses `--trace -1` for the same selection.
+    """
+    root = repo_root or Path(__file__).resolve().parents[2]
+    try:
+        label, tool_dir, simplest_trace = _RUNNERS[benchmark]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_RUNNERS))
+        raise ValueError(
+            f"benchmark {benchmark!r} has no real sandbox runner; supported: {supported}"
+        ) from exc
+
+    cwd = root / tool_dir
+    runner = cwd / "run.sh"
+    if not runner.exists():
+        raise FileNotFoundError(f"missing real sandbox runner: {runner}")
+
+    command = [str(runner)]
+    if trace_index is not None:
+        command.extend(["--trace", str(trace_index)])
+    elif simplest_trace is not None:
+        command.extend(["--trace", simplest_trace])
+    command.extend(["--train-split", str(train_split)])
+    command.extend(extra_args or [])
+    return RealSandboxSpec(benchmark=benchmark, label=label, command=command, cwd=cwd)
+
+
+def run_real_sandbox(
+    spec: RealSandboxSpec,
+    *,
+    timeout_seconds: float | None = None,
+) -> RealSandboxResult:
+    """Run the real sandbox command, capturing stdout/stderr for side-by-side rendering."""
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            spec.command,
+            cwd=spec.cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return RealSandboxResult(
+            spec=spec,
+            returncode=None,
+            seconds=time.monotonic() - start,
+            stdout=_coerce_text(exc.stdout),
+            stderr=_coerce_text(exc.stderr),
+            timed_out=True,
+        )
+    except OSError as exc:
+        return RealSandboxResult(
+            spec=spec,
+            returncode=None,
+            seconds=time.monotonic() - start,
+            error=str(exc),
+        )
+    return RealSandboxResult(
+        spec=spec,
+        returncode=proc.returncode,
+        seconds=time.monotonic() - start,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
+
+
+def _coerce_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
+__all__ = [
+    "RealSandboxResult",
+    "RealSandboxSpec",
+    "real_sandbox_spec",
+    "run_real_sandbox",
+]

--- a/wmh/bench/side_by_side.py
+++ b/wmh/bench/side_by_side.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 from pydantic import BaseModel
 
@@ -45,17 +46,41 @@ class RealSandboxResult(BaseModel):
         return f"{status}, wall {self.seconds:.1f}s"
 
 
-_RUNNERS: dict[str, tuple[str, str, str | None]] = {
-    # benchmark name -> (display label, tool directory, trace arg for default/simplest scenario)
-    "tau-bench": ("real tau2 environment", "tools/tau2-capture", None),
-    "tau2-bench": ("real tau2 environment", "tools/tau2-capture", None),
-    "swe-bench": (
+class _Runner(NamedTuple):
+    """How one benchmark's real sandbox runner is invoked."""
+
+    label: str  # display label
+    tool_dir: str  # directory under the repo holding run.sh
+    simplest_trace: str | None  # --trace value selecting the simplest scenario (None = its default)
+    supports_trace_pool: bool  # runner accepts `--trace-pool` to pin which pool an index refers to
+    concurrent_purges_images: bool  # concurrent cold runs delete shared images -> force warm+cache
+
+
+_RUNNERS: dict[str, _Runner] = {
+    "tau-bench": _Runner("real tau2 environment", "tools/tau2-capture", None, False, False),
+    "tau2-bench": _Runner("real tau2 environment", "tools/tau2-capture", None, False, False),
+    "swe-bench": _Runner(
         "real SWE-bench sandbox replaying mini-SWE-agent commands",
         "tools/swe-bench-capture",
         "-1",
+        supports_trace_pool=True,
+        concurrent_purges_images=True,
     ),
-    "terminal-tasks": ("real terminal sandbox", "tools/terminal-tasks-capture", None),
+    "terminal-tasks": _Runner(
+        "real terminal sandbox", "tools/terminal-tasks-capture", None, False, False
+    ),
 }
+
+
+def runner_info(benchmark: str) -> _Runner:
+    """Return the real sandbox runner metadata for `benchmark`, or raise for an unsupported one."""
+    try:
+        return _RUNNERS[benchmark]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_RUNNERS))
+        raise ValueError(
+            f"benchmark {benchmark!r} has no real sandbox runner; supported: {supported}"
+        ) from exc
 
 
 def real_sandbox_spec(
@@ -63,6 +88,7 @@ def real_sandbox_spec(
     *,
     trace_index: int | None,
     train_split: float,
+    trace_pool: str | None = None,
     extra_args: list[str] | None = None,
     repo_root: Path | None = None,
 ) -> RealSandboxSpec:
@@ -70,17 +96,16 @@ def real_sandbox_spec(
 
     A `None` trace means "the simplest held-out scenario" on the world-model side. Most real
     runners use that as their default too; SWE-bench uses `--trace -1` for the same selection.
+
+    `trace_pool` pins which pool the index refers to ("held-out" or "all"), so a caller that
+    resolved its index against the full corpus selects the SAME trace on the real side. It is
+    forwarded only to runners that accept `--trace-pool`; passing it to one that does not is an
+    error, since silently dropping it would let the two sides replay different scenarios.
     """
     root = repo_root or Path(__file__).resolve().parents[2]
-    try:
-        label, tool_dir, simplest_trace = _RUNNERS[benchmark]
-    except KeyError as exc:
-        supported = ", ".join(sorted(_RUNNERS))
-        raise ValueError(
-            f"benchmark {benchmark!r} has no real sandbox runner; supported: {supported}"
-        ) from exc
+    info = runner_info(benchmark)
 
-    cwd = root / tool_dir
+    cwd = root / info.tool_dir
     runner = cwd / "run.sh"
     if not runner.exists():
         raise FileNotFoundError(f"missing real sandbox runner: {runner}")
@@ -88,11 +113,18 @@ def real_sandbox_spec(
     command = [str(runner)]
     if trace_index is not None:
         command.extend(["--trace", str(trace_index)])
-    elif simplest_trace is not None:
-        command.extend(["--trace", simplest_trace])
+    elif info.simplest_trace is not None:
+        command.extend(["--trace", info.simplest_trace])
     command.extend(["--train-split", str(train_split)])
+    if trace_pool is not None:
+        if not info.supports_trace_pool:
+            raise ValueError(
+                f"benchmark {benchmark!r} runner does not support --trace-pool; cannot pin the "
+                f"index to the {trace_pool!r} pool, so the real side may replay a different trace"
+            )
+        command.extend(["--trace-pool", trace_pool])
     command.extend(extra_args or [])
-    return RealSandboxSpec(benchmark=benchmark, label=label, command=command, cwd=cwd)
+    return RealSandboxSpec(benchmark=benchmark, label=info.label, command=command, cwd=cwd)
 
 
 def run_real_sandbox(
@@ -148,4 +180,5 @@ __all__ = [
     "RealSandboxSpec",
     "real_sandbox_spec",
     "run_real_sandbox",
+    "runner_info",
 ]

--- a/wmh/bench/side_by_side_test.py
+++ b/wmh/bench/side_by_side_test.py
@@ -1,0 +1,51 @@
+"""Tests for real-sandbox runner specs/capture used by the side-by-side demo."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from wmh.bench.side_by_side import RealSandboxSpec, real_sandbox_spec, run_real_sandbox
+
+
+def test_real_sandbox_spec_maps_swe_default_to_simplest_trace() -> None:
+    spec = real_sandbox_spec(
+        "swe-bench", trace_index=None, train_split=0.7, repo_root=_repo_root()
+    )
+
+    assert spec.cwd.name == "swe-bench-capture"
+    assert spec.label == "real SWE-bench sandbox replaying mini-SWE-agent commands"
+    assert spec.command[-4:] == ["--trace", "-1", "--train-split", "0.7"]
+
+
+def test_real_sandbox_spec_passes_explicit_trace_and_extra_args() -> None:
+    spec = real_sandbox_spec(
+        "tau-bench",
+        trace_index=2,
+        train_split=0.8,
+        extra_args=["--x", "y"],
+        repo_root=_repo_root(),
+    )
+
+    assert spec.cwd.name == "tau2-capture"
+    assert spec.command[-6:] == ["--trace", "2", "--train-split", "0.8", "--x", "y"]
+
+
+def test_run_real_sandbox_captures_output(tmp_path) -> None:  # noqa: ANN001 - pytest fixture
+    spec = RealSandboxSpec(
+        benchmark="fake",
+        label="fake real env",
+        command=[sys.executable, "-c", "print('REAL OUTPUT')"],
+        cwd=tmp_path,
+    )
+
+    result = run_real_sandbox(spec)
+
+    assert result.ok
+    assert result.returncode == 0
+    assert "REAL OUTPUT" in result.stdout
+    assert "wall" in result.summary()
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -9,7 +9,10 @@ models are named (`--name`), stored under `<root>/models/<name>/`, and listed wi
 from __future__ import annotations
 
 import typer
+from rich.columns import Columns
 from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
 
 from wmh.config import (
     ARTIFACT_DIR,
@@ -576,32 +579,65 @@ def bench_scenario(
             "model's configured serve model."
         ),
     ),
+    serve_region: str = typer.Option(
+        None,
+        "--serve-region",
+        help="Override the provider region for the served world model, e.g. us-west-2 for Bedrock.",
+    ),
     trace_index: int = typer.Option(
-        None, "--trace", help="Held-out trace to replay (default: the simplest = fewest steps)."
+        None,
+        "--trace",
+        help=(
+            "Trace index to replay (default: the simplest = fewest steps). Uses held-out indexes "
+            "when possible; larger demo batches switch to all traces. Pass -1 for the simplest."
+        ),
+    ),
+    scenarios: int = typer.Option(
+        1,
+        "--scenarios",
+        help=(
+            "Number of scenarios to run. With no --trace, picks the simplest N indexes; with "
+            "--trace, runs N consecutive indexes."
+        ),
+    ),
+    concurrency: int = typer.Option(
+        None,
+        "--concurrency",
+        help="Concurrent world-model workers. Default: --scenarios.",
     ),
     benchmarks: str = typer.Option(BENCHMARKS_DIR, "--benchmarks", help="Benchmark defs dir."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir (for --model)."),
 ) -> None:
     """Open-loop replay one recorded scenario through the world model, timing + costing each step.
 
-    The world-model half of the scenario comparison. Picks a held-out trace from the benchmark's
-    corpus — by default the SIMPLEST (fewest recorded steps), so the demo scenario is short; pass
-    `--trace N` for a specific one — and predicts each recorded step **teacher-forced, exactly as
-    `wmh eval` does** (from the recorded state + history + leak-free demos from the train split; a
-    step never sees the model's own prior predictions), printing each predicted observation as it
-    lands. Ends with total time, tokens, cost, and fidelity. Run the SAME scenario against the real
-    environment with the matching `tools/<benchmark>-capture/` runner (closed-loop) and compare.
+    The world-model half of the scenario comparison. Picks held-out traces when possible; for demo
+    batches larger than the held-out pool, it switches to the full corpus so it can line up with the
+    real sandbox runner. It predicts each recorded step **teacher-forced, exactly as `wmh eval`
+    does** (from the recorded state + history + leak-free demos from the train split; a step never
+    sees the model's own prior predictions), printing each predicted observation as it lands. Ends
+    with total time, tokens, cost, and fidelity. Run the SAME scenario against the real environment
+    with the matching `tools/<benchmark>-capture/` runner (closed-loop) and compare.
     """
+    import concurrent.futures as cf
+    import threading
+    import time
     from pathlib import Path
 
-    from wmh.bench import ScenarioStep, load_benchmark, run_scenario
+    from wmh.bench import ScenarioReport, ScenarioStep, load_benchmark, run_scenario
     from wmh.config import ArtifactPaths, load_config
+    from wmh.core.types import Trace
     from wmh.engine.build import split_traces
     from wmh.engine.prompts import BASE_ENV_PROMPT
     from wmh.ingest import get_adapter
     from wmh.providers import get_provider
     from wmh.retrieval import EmbeddingRetriever, get_embedder
     from wmh.retrieval.leakfree import DemoRetriever
+
+    if scenarios < 1:
+        raise typer.BadParameter("--scenarios must be at least 1")
+    workers = concurrency or scenarios
+    if workers < 1:
+        raise typer.BadParameter("--concurrency must be at least 1")
 
     bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
     try:
@@ -623,17 +659,40 @@ def bench_scenario(
         raise typer.BadParameter(f"benchmark {name!r} ingested no traces")
     train, holdout = split_traces(traces, bench_def.eval.train_split)
     pool = holdout or traces  # tiny corpora may have no held-out trace; fall back to all
-    kind = "held-out" if holdout else "(no held-out split; all)"
-    if trace_index is None:
-        # Default: the simplest scenario — the held-out trace with the fewest recorded steps (ties
-        # broken by corpus order). Keeps the demo short without the user hunting for a small trace.
-        trace = min(pool, key=lambda t: len(t.steps))
+    kind = "held-out" if holdout else "all"
+    requested_end = (
+        trace_index + scenarios if trace_index is not None and trace_index >= 0 else scenarios
+    )
+    if holdout and requested_end > len(pool) and requested_end <= len(traces):
+        _console.print(
+            f"[yellow]requested {scenarios} scenario(s) from "
+            f"{'trace ' + str(trace_index) if trace_index is not None else 'the simplest traces'}, "
+            f"but {name!r} only has {len(pool)} held-out trace(s); using all "
+            f"{len(traces)} traces instead[/yellow]"
+        )
+        pool = traces
+        kind = "all"
+    if trace_index is None or trace_index == -1:
+        # Default: the simplest scenario(s) — the held-out traces with the fewest recorded steps
+        # (ties broken by corpus order). Keeps the demo short without hunting for small traces.
+        selected = sorted(enumerate(pool), key=lambda item: len(item[1].steps))[:scenarios]
     else:
         if not 0 <= trace_index < len(pool):
             raise typer.BadParameter(
                 f"--trace {trace_index} out of range; {name!r} has {len(pool)} {kind} trace(s)"
             )
-        trace = pool[trace_index]
+        end = trace_index + scenarios
+        if end > len(pool):
+            raise typer.BadParameter(
+                f"--trace {trace_index} with --scenarios {scenarios} exceeds {name!r}'s "
+                f"{len(pool)} {kind} trace(s)"
+            )
+        selected = [(i, pool[i]) for i in range(trace_index, end)]
+    if len(selected) < scenarios:
+        raise typer.BadParameter(
+            f"requested {scenarios} scenario(s), but {name!r} only has {len(selected)} "
+            f"available {kind} trace(s)"
+        )
 
     # Resolve the model dir (default: the benchmark name -> the bundled canonical model), then load
     # its serve provider + optimized prompt + embedder — the exact pieces the eval path uses.
@@ -650,47 +709,480 @@ def bench_scenario(
         else BASE_ENV_PROMPT
     )
     serve_config = config.serve_provider_config()
+    serve_updates: dict[str, str] = {}
     if serve_model:
         # Swap only the LLM id, keeping the same provider backend + the model's prompt/demos — so we
         # can measure a cheaper/faster model (Haiku, Sonnet) against the same scenario and prompt.
-        serve_config = serve_config.model_copy(update={"model": serve_model})
-    provider = get_provider(serve_config)
-    # Leak-free demos from the TRAIN split only (never the query's own trace), identical to eval.
-    retriever = EmbeddingRetriever(get_embedder(config))
-    demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
+        serve_updates["model"] = serve_model
+    if serve_region:
+        serve_updates["region"] = serve_region
+    if serve_updates:
+        serve_config = serve_config.model_copy(update=serve_updates)
 
-    n_steps = len(trace.steps)
-    _console.print(
-        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of {name} "
-        f"scenario [cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps), no environment to stand up"
-    )
-    # The task the agent was pursuing (the recorded instruction), shown briefly for context.
-    task = trace.steps[0].task if trace.steps else None
-    if task:
-        _console.print(f"[bold]task[/bold] [dim]{_clip(task, 240)}[/dim]\n")
+    output_lock = threading.Lock()
 
-    def on_step(step: ScenarioStep) -> None:
-        # Light live-fidelity signal: error flag agreed and a non-empty prediction landed.
+    def render_step(step: ScenarioStep) -> None:
+        """Live per-step rendering for the single-scenario terminal demo."""
         ok = step.is_error_predicted == step.is_error_actual and bool(step.predicted.strip())
         mark = "[green]✓[/green]" if ok else "[yellow]≈[/yellow]"
         err = " [red](error)[/red]" if step.is_error_predicted else ""
-        # Show the agent's CALL to the environment, then the world model's OBSERVATION back.
         _console.print(
             f"{mark} [dim]step {step.index} ({step.seconds:.2f}s)[/dim]\n"
             f"  [bold blue]agent →[/bold blue] {_clip(step.action, 200)}\n"
             f"  [bold green]world model →[/bold green]{err} {_clip(step.predicted)}"
         )
 
-    report = run_scenario(
-        provider, env_prompt, trace, demos, benchmark=name, model=(model or name), on_step=on_step
+    def render_batch_step(pool_index: int, step: ScenarioStep) -> None:
+        """Live per-step rendering for concurrent demo batches, with stable trace prefixes."""
+        ok = step.is_error_predicted == step.is_error_actual and bool(step.predicted.strip())
+        mark = "[green]✓[/green]" if ok else "[yellow]≈[/yellow]"
+        err = " [red](error)[/red]" if step.is_error_predicted else ""
+        with output_lock:
+            _console.print(
+                f"[cyan]trace {pool_index}[/cyan] {mark} "
+                f"[dim]step {step.index} ({step.seconds:.2f}s)[/dim]\n"
+                f"  [bold blue]agent →[/bold blue] {_clip(step.action, 180)}\n"
+                f"  [bold green]world model →[/bold green]{err} {_clip(step.predicted, 260)}"
+            )
+
+    def run_one(
+        pool_index: int, scenario_trace: Trace, *, live: bool = False, stream_steps: bool = False
+    ) -> tuple[int, ScenarioReport]:
+        provider = get_provider(serve_config)
+        # Leak-free demos from TRAIN only, never the query's own trace; identical to eval.
+        retriever = EmbeddingRetriever(get_embedder(config))
+        demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
+        on_step = render_step if live else None
+        if stream_steps:
+            def on_batch_step(step: ScenarioStep) -> None:
+                render_batch_step(pool_index, step)
+
+            on_step = on_batch_step
+        report = run_scenario(
+            provider,
+            env_prompt,
+            scenario_trace,
+            demos,
+            benchmark=name,
+            model=(model or name),
+            on_step=on_step,
+        )
+        return pool_index, report
+
+    if len(selected) == 1:
+        _pool_index, trace = selected[0]
+        n_steps = len(trace.steps)
+        _console.print(
+            f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of "
+            f"{name} scenario [cyan]{trace.trace_id[:8]}[/cyan] ({n_steps} steps), "
+            "no environment to stand up"
+        )
+        task = trace.steps[0].task if trace.steps else None
+        if task:
+            _console.print(f"[bold]task[/bold] [dim]{_clip(task, 240)}[/dim]\n")
+        try:
+            _idx, report = run_one(_pool_index, trace, live=True)
+        except Exception as exc:  # noqa: BLE001 - surface provider/setup failures cleanly
+            _console.print(
+                f"[red]failed trace {_pool_index}: {_clip(_format_exception(exc), 320)}[/red]"
+            )
+            raise typer.Exit(1) from None
+        _console.print(f"\n[bold]done[/bold]: {report.summary()}")
+        return
+
+    _console.print(
+        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — open-loop replay of "
+        f"{len(selected)} {name} scenarios with concurrency {workers}, no environments to stand up"
     )
-    _console.print(f"\n[bold]done[/bold]: {report.summary()}")
+    started = time.monotonic()
+    reports: dict[int, ScenarioReport] = {}
+    failures: dict[int, str] = {}
+    with cf.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(run_one, pool_index, trace, stream_steps=True): pool_index
+            for pool_index, trace in selected
+        }
+        for future in cf.as_completed(futures):
+            fallback_index = futures[future]
+            try:
+                pool_index, report = future.result()
+            except Exception as exc:  # noqa: BLE001 - keep demo batch output concise
+                failures[fallback_index] = _format_exception(exc)
+                with output_lock:
+                    _console.print(
+                        f"  [red]failed trace {fallback_index}: "
+                        f"{_clip(failures[fallback_index], 320)}[/red]"
+                    )
+                continue
+            reports[pool_index] = report
+            with output_lock:
+                _console.print(
+                    f"  [dim]done trace {pool_index}: {report.trace_id[:8]} "
+                    f"({len(report.steps)} steps, {report.total_seconds:.1f}s model work)[/dim]"
+                )
+    wall = time.monotonic() - started
+
+    total_work = sum(r.total_seconds for r in reports.values())
+    total_tokens = sum(r.tokens for r in reports.values())
+    total_cost = sum(r.cost_usd for r in reports.values())
+    total_steps = sum(len(r.steps) for r in reports.values())
+    matches = sum(
+        1
+        for report in reports.values()
+        for step in report.steps
+        if step.is_error_predicted == step.is_error_actual
+    )
+    fidelity = matches / total_steps if total_steps else 0.0
+    _console.print(
+        f"\n[bold]done[/bold]: {len(reports)}/{len(selected)} scenarios ok, "
+        f"batch wall {wall:.1f}s, "
+        f"summed model work {total_work:.1f}s, {total_tokens} tokens, ${total_cost:.4f}, "
+        f"fidelity {fidelity:.0%}"
+    )
+    table = Table(title="world-model scenario batch")
+    table.add_column("trace", justify="right")
+    table.add_column("id")
+    table.add_column("steps", justify="right")
+    table.add_column("result")
+    for pool_index, trace in selected:
+        report = reports.get(pool_index)
+        result = report.summary() if report is not None else failures.get(pool_index, "failed")
+        table.add_row(str(pool_index), trace.trace_id[:8], str(len(trace.steps)), result)
+    _console.print(table)
+    if failures:
+        raise typer.Exit(1)
+
+
+@bench_app.command("side-by-side")
+def bench_side_by_side(
+    name: str = typer.Argument(..., help="Benchmark name (benchmarks/<name>/benchmark.toml)."),
+    model: str = typer.Option(
+        None, "--model", help="Built world model to serve (default: the benchmark name)."
+    ),
+    serve_model: str = typer.Option(
+        None,
+        "--serve-model",
+        help=(
+            "Override the LLM that plays the environment, keeping the model's prompt + demos. "
+            "Default: the model's configured serve model."
+        ),
+    ),
+    serve_region: str = typer.Option(
+        None,
+        "--serve-region",
+        help="Override the provider region for the served world model, e.g. us-west-2 for Bedrock.",
+    ),
+    trace_index: int = typer.Option(
+        None,
+        "--trace",
+        help=(
+            "Trace index to replay (default: the simplest = fewest steps). Uses held-out indexes "
+            "when possible; larger demo batches switch to all traces. Pass -1 for the simplest."
+        ),
+    ),
+    scenarios: int = typer.Option(
+        1,
+        "--scenarios",
+        help=(
+            "Number of scenarios to run. With no --trace, picks the simplest N indexes; with "
+            "--trace, runs N consecutive indexes."
+        ),
+    ),
+    concurrency: int = typer.Option(
+        None,
+        "--concurrency",
+        help="Concurrent workers per side. Default: --scenarios.",
+    ),
+    benchmarks: str = typer.Option(BENCHMARKS_DIR, "--benchmarks", help="Benchmark defs dir."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (for --model)."),
+    real_arg: list[str] = typer.Option(  # noqa: B008 - typer reads option defaults at definition
+        None,
+        "--real-arg",
+        help="Extra argument passed to the real sandbox runner; repeat, e.g. --real-arg=--cache.",
+    ),
+    real_timeout: float = typer.Option(
+        None, "--real-timeout", help="Abort the real sandbox runner after this many seconds."
+    ),
+) -> None:
+    """Demo one scenario through the world model and the matching real sandbox, side by side."""
+    import concurrent.futures as cf
+    import time
+    from pathlib import Path
+
+    from wmh.bench import ScenarioReport, ScenarioStep, load_benchmark, run_scenario
+    from wmh.bench.side_by_side import RealSandboxResult, real_sandbox_spec, run_real_sandbox
+    from wmh.config import ArtifactPaths, load_config
+    from wmh.core.types import Trace
+    from wmh.engine.build import split_traces
+    from wmh.engine.prompts import BASE_ENV_PROMPT
+    from wmh.ingest import get_adapter
+    from wmh.providers import get_provider
+    from wmh.retrieval import EmbeddingRetriever, get_embedder
+    from wmh.retrieval.leakfree import DemoRetriever
+
+    if scenarios < 1:
+        raise typer.BadParameter("--scenarios must be at least 1")
+    workers = concurrency or scenarios
+    if workers < 1:
+        raise typer.BadParameter("--concurrency must be at least 1")
+
+    bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
+    try:
+        bench_def = load_benchmark(bench_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    missing = bench_def.missing_traces()
+    if missing:
+        raise typer.BadParameter(
+            f"benchmark {name!r} references missing trace files: "
+            + ", ".join(str(p) for p in missing)
+        )
+
+    adapter = get_adapter("otel-genai")
+    traces = [t for f in bench_def.trace_files() for t in adapter.from_file(str(f))]
+    if not traces:
+        raise typer.BadParameter(f"benchmark {name!r} ingested no traces")
+    train, holdout = split_traces(traces, bench_def.eval.train_split)
+    pool = holdout or traces
+    kind = "held-out" if holdout else "all"
+    requested_end = (
+        trace_index + scenarios if trace_index is not None and trace_index >= 0 else scenarios
+    )
+    if holdout and requested_end > len(pool) and requested_end <= len(traces):
+        _console.print(
+            f"[yellow]requested {scenarios} scenario(s) from "
+            f"{'trace ' + str(trace_index) if trace_index is not None else 'the simplest traces'}, "
+            f"but {name!r} only has {len(pool)} held-out trace(s); using all "
+            f"{len(traces)} traces instead[/yellow]"
+        )
+        pool = traces
+        kind = "all"
+    if trace_index is None or trace_index == -1:
+        selected = sorted(enumerate(pool), key=lambda item: len(item[1].steps))[:scenarios]
+    else:
+        if not 0 <= trace_index < len(pool):
+            raise typer.BadParameter(
+                f"--trace {trace_index} out of range; {name!r} has {len(pool)} {kind} trace(s)"
+            )
+        end = trace_index + scenarios
+        if end > len(pool):
+            raise typer.BadParameter(
+                f"--trace {trace_index} with --scenarios {scenarios} exceeds {name!r}'s "
+                f"{len(pool)} {kind} trace(s)"
+            )
+        selected = [(i, pool[i]) for i in range(trace_index, end)]
+    if len(selected) < scenarios:
+        raise typer.BadParameter(
+            f"requested {scenarios} scenario(s), but {name!r} only has {len(selected)} "
+            f"available {kind} trace(s)"
+        )
+
+    store = WorldModelStore(root)
+    try:
+        model_dir = store.resolve(model or name)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    config = load_config(str(model_dir))
+    paths = ArtifactPaths(model_dir)
+    env_prompt = (
+        paths.optimized_prompt.read_text(encoding="utf-8")
+        if paths.optimized_prompt.exists()
+        else BASE_ENV_PROMPT
+    )
+    serve_config = config.serve_provider_config()
+    serve_updates: dict[str, str] = {}
+    if serve_model:
+        serve_updates["model"] = serve_model
+    if serve_region:
+        serve_updates["region"] = serve_region
+    if serve_updates:
+        serve_config = serve_config.model_copy(update=serve_updates)
+
+    real_args = list(real_arg or [])
+    if name == "swe-bench" and scenarios > 1 and "--warm" not in real_args:
+        real_args.append("--warm")
+    if name == "swe-bench" and scenarios > 1 and "--cache" not in real_args:
+        real_args.append("--cache")
+    if name == "swe-bench" and scenarios > 1:
+        _console.print(
+            "[yellow]multi-scenario SWE-bench run: adding --warm --cache to avoid concurrent "
+            "global image purges[/yellow]"
+        )
+
+    def run_world(pool_index: int, scenario_trace: Trace) -> tuple[int, ScenarioReport, list[str]]:
+        world_lines: list[str] = []
+
+        def on_step(step: ScenarioStep) -> None:
+            err = " (error)" if step.is_error_predicted else ""
+            world_lines.append(
+                f"step {step.index} ({step.seconds:.2f}s)\n"
+                f"agent -> {_clip(step.action, 180)}\n"
+                f"world model ->{err} {_clip(step.predicted, 260)}"
+            )
+
+        provider = get_provider(serve_config)
+        retriever = EmbeddingRetriever(get_embedder(config))
+        demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
+        report = run_scenario(
+            provider,
+            env_prompt,
+            scenario_trace,
+            demos,
+            benchmark=name,
+            model=(model or name),
+            on_step=on_step,
+        )
+        return pool_index, report, world_lines
+
+    def run_real(pool_index: int) -> tuple[int, RealSandboxResult]:
+        spec = real_sandbox_spec(
+            name,
+            trace_index=pool_index,
+            train_split=bench_def.eval.train_split,
+            extra_args=real_args,
+        )
+        return pool_index, run_real_sandbox(spec, timeout_seconds=real_timeout)
+
+    _console.print(
+        f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — replaying "
+        f"{len(selected)} {name} scenario(s) with concurrency {workers}"
+    )
+    world_started = time.monotonic()
+    world_results: dict[int, ScenarioReport] = {}
+    world_lines_by_index: dict[int, list[str]] = {}
+    with cf.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(run_world, pool_index, trace) for pool_index, trace in selected]
+        for future in cf.as_completed(futures):
+            pool_index, report, lines = future.result()
+            world_results[pool_index] = report
+            world_lines_by_index[pool_index] = lines
+    world_wall = time.monotonic() - world_started
+
+    try:
+        real_specs = {
+            pool_index: real_sandbox_spec(
+                name,
+                trace_index=pool_index,
+                train_split=bench_def.eval.train_split,
+                extra_args=real_args,
+            )
+            for pool_index, _trace in selected
+        }
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    real_spec = next(iter(real_specs.values()))
+    _console.print(
+        f"[bold]{real_spec.label}[/bold] — running {len(selected)} scenario(s) with concurrency "
+        f"{workers}"
+    )
+    real_started = time.monotonic()
+    real_results: dict[int, RealSandboxResult] = {}
+    with cf.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(run_real, pool_index) for pool_index, _trace in selected]
+        for future in cf.as_completed(futures):
+            pool_index, result = future.result()
+            real_results[pool_index] = result
+    real_wall = time.monotonic() - real_started
+
+    summary = Table(title="side-by-side scenario summary")
+    summary.add_column("side", style="bold")
+    summary.add_column("scenarios", justify="right")
+    summary.add_column("concurrency", justify="right")
+    summary.add_column("batch wall", justify="right")
+    summary.add_column("summed work", justify="right")
+    summary.add_column("status")
+    world_total = sum(r.total_seconds for r in world_results.values())
+    world_tokens = sum(r.tokens for r in world_results.values())
+    world_cost = sum(r.cost_usd for r in world_results.values())
+    world_steps = sum(len(r.steps) for r in world_results.values())
+    world_matches = sum(
+        1
+        for report in world_results.values()
+        for step in report.steps
+        if step.is_error_predicted == step.is_error_actual
+    )
+    fidelity = (world_matches / world_steps) if world_steps else 0.0
+    real_total = sum(r.seconds for r in real_results.values())
+    real_ok = sum(1 for r in real_results.values() if r.ok)
+    summary.add_row(
+        "world model",
+        str(len(selected)),
+        str(workers),
+        f"{world_wall:.1f}s",
+        f"{world_total:.1f}s",
+        f"{world_tokens} tokens, ${world_cost:.4f}, fidelity {fidelity:.0%}",
+    )
+    summary.add_row(
+        real_spec.label,
+        str(len(selected)),
+        str(workers),
+        f"{real_wall:.1f}s",
+        f"{real_total:.1f}s",
+        f"{real_ok}/{len(selected)} ok",
+    )
+    _console.print(summary)
+
+    details = Table(title="per-scenario results")
+    details.add_column("trace", justify="right")
+    details.add_column("id")
+    details.add_column("steps", justify="right")
+    details.add_column("world model", justify="right")
+    details.add_column(real_spec.label)
+    for pool_index, trace in selected:
+        world_report = world_results[pool_index]
+        real_result = real_results[pool_index]
+        details.add_row(
+            str(pool_index),
+            trace.trace_id[:8],
+            str(len(trace.steps)),
+            world_report.summary(),
+            real_result.summary(),
+        )
+    _console.print(details)
+
+    if len(selected) != 1:
+        return
+
+    pool_index, _trace = selected[0]
+    world_text = "\n\n".join(world_lines_by_index[pool_index]) or "(no world-model steps)"
+    real_result = real_results[pool_index]
+    real_text = real_result.stdout.strip() or "(no stdout)"
+    if real_result.stderr.strip():
+        real_text = f"{real_text}\n\n[stderr]\n{real_result.stderr.strip()}"
+    if real_result.error:
+        real_text = f"{real_text}\n\n[error]\n{real_result.error}"
+    if real_result.timed_out:
+        real_text = f"{real_text}\n\n[timed out]"
+
+    _console.print(
+        Columns(
+            [
+                Panel(
+                    world_text,
+                    title="[bold green]world model[/bold green]",
+                    border_style="green",
+                ),
+                Panel(
+                    real_text,
+                    title=f"[bold blue]{real_spec.label}[/bold blue]",
+                    border_style="blue",
+                ),
+            ],
+            equal=True,
+            expand=True,
+        )
+    )
 
 
 def _clip(text: str, limit: int = 160) -> str:
     """One-line clip of an observation for the live scenario view."""
     flat = " ".join(text.split())
     return flat if len(flat) <= limit else flat[: limit - 1] + "…"
+
+
+def _format_exception(exc: BaseException) -> str:
+    return f"{type(exc).__name__}: {exc}"
 
 
 def _resolve_prompt(model: str | None, prompt_file: str | None, root: str) -> tuple[str, str]:

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -635,9 +635,11 @@ def bench_scenario(
 
     if scenarios < 1:
         raise typer.BadParameter("--scenarios must be at least 1")
-    workers = concurrency or scenarios
-    if workers < 1:
+    # `concurrency or scenarios` would treat an explicit --concurrency 0 as unset, so validate the
+    # raw option before defaulting it.
+    if concurrency is not None and concurrency < 1:
         raise typer.BadParameter("--concurrency must be at least 1")
+    workers = concurrency or scenarios
 
     bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
     try:
@@ -719,6 +721,13 @@ def bench_scenario(
     if serve_updates:
         serve_config = serve_config.model_copy(update=serve_updates)
 
+    # Build the leak-free demo retriever ONCE and share it across workers: index() embeds the whole
+    # train split (expensive), and it is read-only during replay (topk never mutates, add() is never
+    # called), so a per-scenario rebuild would re-embed the train split N times.
+    shared_demos = DemoRetriever(
+        EmbeddingRetriever(get_embedder(config)), train or traces, top_k=config.top_k
+    )
+
     output_lock = threading.Lock()
 
     def render_step(step: ScenarioStep) -> None:
@@ -748,10 +757,6 @@ def bench_scenario(
     def run_one(
         pool_index: int, scenario_trace: Trace, *, live: bool = False, stream_steps: bool = False
     ) -> tuple[int, ScenarioReport]:
-        provider = get_provider(serve_config)
-        # Leak-free demos from TRAIN only, never the query's own trace; identical to eval.
-        retriever = EmbeddingRetriever(get_embedder(config))
-        demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
         on_step = render_step if live else None
         if stream_steps:
             def on_batch_step(step: ScenarioStep) -> None:
@@ -759,10 +764,10 @@ def bench_scenario(
 
             on_step = on_batch_step
         report = run_scenario(
-            provider,
+            get_provider(serve_config),
             env_prompt,
             scenario_trace,
-            demos,
+            shared_demos,
             benchmark=name,
             model=(model or name),
             on_step=on_step,
@@ -910,7 +915,13 @@ def bench_side_by_side(
     from pathlib import Path
 
     from wmh.bench import ScenarioReport, ScenarioStep, load_benchmark, run_scenario
-    from wmh.bench.side_by_side import RealSandboxResult, real_sandbox_spec, run_real_sandbox
+    from wmh.bench.side_by_side import (
+        RealSandboxResult,
+        RealSandboxSpec,
+        real_sandbox_spec,
+        run_real_sandbox,
+        runner_info,
+    )
     from wmh.config import ArtifactPaths, load_config
     from wmh.core.types import Trace
     from wmh.engine.build import split_traces
@@ -922,14 +933,19 @@ def bench_side_by_side(
 
     if scenarios < 1:
         raise typer.BadParameter("--scenarios must be at least 1")
-    workers = concurrency or scenarios
-    if workers < 1:
+    if concurrency is not None and concurrency < 1:
         raise typer.BadParameter("--concurrency must be at least 1")
+    workers = concurrency or scenarios
 
     bench_dir = Path(_resolve_benchmarks_dir(benchmarks)) / name
     try:
         bench_def = load_benchmark(bench_dir)
     except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    # Fail before any work if there is no real runner for this benchmark (the real half needs one).
+    try:
+        runner_info(name)
+    except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
     missing = bench_def.missing_traces()
     if missing:
@@ -998,16 +1014,30 @@ def bench_side_by_side(
     if serve_updates:
         serve_config = serve_config.model_copy(update=serve_updates)
 
+    # Pin the real runner to the SAME pool the world-model side resolved against. Only the fallback
+    # case (held-out existed but was too small, so we switched to "all") diverges from the child's
+    # own default of held-out-when-present; forwarding "all" keeps both sides on one trace.
+    real_trace_pool = "all" if (kind == "all" and holdout) else None
+
     real_args = list(real_arg or [])
-    if name == "swe-bench" and scenarios > 1 and "--warm" not in real_args:
-        real_args.append("--warm")
-    if name == "swe-bench" and scenarios > 1 and "--cache" not in real_args:
-        real_args.append("--cache")
-    if name == "swe-bench" and scenarios > 1:
-        _console.print(
-            "[yellow]multi-scenario SWE-bench run: adding --warm --cache to avoid concurrent "
-            "global image purges[/yellow]"
-        )
+    # Concurrent cold runs of some runners purge a shared image family, deleting images from under
+    # each other; force warm+cache for those so a multi-scenario batch is safe. Keyed off the runner
+    # registry, not a hardcoded benchmark name.
+    if workers > 1 and runner_info(name).concurrent_purges_images:
+        added = [flag for flag in ("--warm", "--cache") if flag not in real_args]
+        real_args.extend(added)
+        if added:
+            _console.print(
+                f"[yellow]concurrent {name} run: adding {' '.join(added)} to avoid concurrent "
+                "global image purges[/yellow]"
+            )
+
+    # Build the leak-free demo retriever ONCE and share it across workers: it indexes (embeds) the
+    # whole train split, which is expensive, and it is read-only during replay (topk never mutates;
+    # add() is never called), so re-embedding per scenario would be N× wasted work.
+    shared_demos = DemoRetriever(
+        EmbeddingRetriever(get_embedder(config)), train or traces, top_k=config.top_k
+    )
 
     def run_world(pool_index: int, scenario_trace: Trace) -> tuple[int, ScenarioReport, list[str]]:
         world_lines: list[str] = []
@@ -1020,28 +1050,36 @@ def bench_side_by_side(
                 f"world model ->{err} {_clip(step.predicted, 260)}"
             )
 
-        provider = get_provider(serve_config)
-        retriever = EmbeddingRetriever(get_embedder(config))
-        demos = DemoRetriever(retriever, train or traces, top_k=config.top_k)
         report = run_scenario(
-            provider,
+            get_provider(serve_config),
             env_prompt,
             scenario_trace,
-            demos,
+            shared_demos,
             benchmark=name,
             model=(model or name),
             on_step=on_step,
         )
         return pool_index, report, world_lines
 
-    def run_real(pool_index: int) -> tuple[int, RealSandboxResult]:
-        spec = real_sandbox_spec(
+    def make_real_spec(pool_index: int) -> RealSandboxSpec:
+        return real_sandbox_spec(
             name,
             trace_index=pool_index,
             train_split=bench_def.eval.train_split,
+            trace_pool=real_trace_pool,
             extra_args=real_args,
         )
-        return pool_index, run_real_sandbox(spec, timeout_seconds=real_timeout)
+
+    def run_real(pool_index: int) -> tuple[int, RealSandboxResult]:
+        result = run_real_sandbox(make_real_spec(pool_index), timeout_seconds=real_timeout)
+        return pool_index, result
+
+    # Build one spec up front: validates the runner exists (clean error before any work) and gives
+    # the table headers a label. run_real rebuilds per index inside its worker.
+    try:
+        real_spec = make_real_spec(selected[0][0])
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
     _console.print(
         f"\n[bold]world model[/bold] [cyan]{model or name}[/cyan] — replaying "
@@ -1050,28 +1088,27 @@ def bench_side_by_side(
     world_started = time.monotonic()
     world_results: dict[int, ScenarioReport] = {}
     world_lines_by_index: dict[int, list[str]] = {}
+    world_failures: dict[int, str] = {}
     with cf.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = [executor.submit(run_world, pool_index, trace) for pool_index, trace in selected]
+        futures = {
+            executor.submit(run_world, pool_index, trace): pool_index
+            for pool_index, trace in selected
+        }
         for future in cf.as_completed(futures):
-            pool_index, report, lines = future.result()
+            fallback_index = futures[future]
+            try:
+                pool_index, report, lines = future.result()
+            except Exception as exc:  # noqa: BLE001 - record per-trace failure, keep the batch going
+                world_failures[fallback_index] = _format_exception(exc)
+                _console.print(
+                    f"  [red]failed trace {fallback_index}: "
+                    f"{_clip(world_failures[fallback_index], 320)}[/red]"
+                )
+                continue
             world_results[pool_index] = report
             world_lines_by_index[pool_index] = lines
     world_wall = time.monotonic() - world_started
 
-    try:
-        real_specs = {
-            pool_index: real_sandbox_spec(
-                name,
-                trace_index=pool_index,
-                train_split=bench_def.eval.train_split,
-                extra_args=real_args,
-            )
-            for pool_index, _trace in selected
-        }
-    except (FileNotFoundError, ValueError) as exc:
-        raise typer.BadParameter(str(exc)) from exc
-
-    real_spec = next(iter(real_specs.values()))
     _console.print(
         f"[bold]{real_spec.label}[/bold] — running {len(selected)} scenario(s) with concurrency "
         f"{workers}"
@@ -1079,9 +1116,19 @@ def bench_side_by_side(
     real_started = time.monotonic()
     real_results: dict[int, RealSandboxResult] = {}
     with cf.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = [executor.submit(run_real, pool_index) for pool_index, _trace in selected]
+        futures = {executor.submit(run_real, pool_index): pool_index for pool_index, _t in selected}
         for future in cf.as_completed(futures):
-            pool_index, result = future.result()
+            fallback_index = futures[future]
+            try:
+                pool_index, result = future.result()
+            except Exception as exc:  # noqa: BLE001 - surface runner launch failures, keep going
+                real_results[fallback_index] = RealSandboxResult(
+                    spec=real_spec,
+                    returncode=None,
+                    seconds=0.0,
+                    error=_format_exception(exc),
+                )
+                continue
             real_results[pool_index] = result
     real_wall = time.monotonic() - real_started
 
@@ -1103,6 +1150,7 @@ def bench_side_by_side(
         if step.is_error_predicted == step.is_error_actual
     )
     fidelity = (world_matches / world_steps) if world_steps else 0.0
+    world_ok = len(world_results)
     real_total = sum(r.seconds for r in real_results.values())
     real_ok = sum(1 for r in real_results.values() if r.ok)
     summary.add_row(
@@ -1111,7 +1159,8 @@ def bench_side_by_side(
         str(workers),
         f"{world_wall:.1f}s",
         f"{world_total:.1f}s",
-        f"{world_tokens} tokens, ${world_cost:.4f}, fidelity {fidelity:.0%}",
+        f"{world_ok}/{len(selected)} ok, {world_tokens} tokens, ${world_cost:.4f}, "
+        f"fidelity {fidelity:.0%}",
     )
     summary.add_row(
         real_spec.label,
@@ -1130,26 +1179,41 @@ def bench_side_by_side(
     details.add_column("world model", justify="right")
     details.add_column(real_spec.label)
     for pool_index, trace in selected:
-        world_report = world_results[pool_index]
-        real_result = real_results[pool_index]
+        world_report = world_results.get(pool_index)
+        world_cell = (
+            world_report.summary()
+            if world_report is not None
+            else f"failed: {_clip(world_failures.get(pool_index, 'no result'), 60)}"
+        )
+        real_result = real_results.get(pool_index)
+        real_cell = real_result.summary() if real_result is not None else "no result"
         details.add_row(
             str(pool_index),
             trace.trace_id[:8],
             str(len(trace.steps)),
-            world_report.summary(),
-            real_result.summary(),
+            world_cell,
+            real_cell,
         )
     _console.print(details)
 
     if len(selected) != 1:
+        if world_failures:
+            raise typer.Exit(1)
         return
 
     pool_index, _trace = selected[0]
-    world_text = "\n\n".join(world_lines_by_index[pool_index]) or "(no world-model steps)"
-    real_result = real_results[pool_index]
-    real_text = real_result.stdout.strip() or "(no stdout)"
+    world_text = "\n\n".join(world_lines_by_index.get(pool_index, [])) or (
+        f"(world model failed: {world_failures.get(pool_index, 'no result')})"
+    )
+    real_result = real_results.get(pool_index)
+    if real_result is None:
+        raise typer.Exit(1)
+    # Cap the real runner's transcript: a cold SWE-bench build streams thousands of lines, which
+    # would flood the side-by-side panel and dwarf the (clipped) world-model column. Keep the TAIL
+    # (where the result lands) and preserve newlines so the panel stays readable.
+    real_text = _tail(real_result.stdout.strip(), 4000) or "(no stdout)"
     if real_result.stderr.strip():
-        real_text = f"{real_text}\n\n[stderr]\n{real_result.stderr.strip()}"
+        real_text = f"{real_text}\n\n[stderr]\n{_tail(real_result.stderr.strip(), 1000)}"
     if real_result.error:
         real_text = f"{real_text}\n\n[error]\n{real_result.error}"
     if real_result.timed_out:
@@ -1179,6 +1243,13 @@ def _clip(text: str, limit: int = 160) -> str:
     """One-line clip of an observation for the live scenario view."""
     flat = " ".join(text.split())
     return flat if len(flat) <= limit else flat[: limit - 1] + "…"
+
+
+def _tail(text: str, limit: int) -> str:
+    """Keep the last `limit` chars of a long transcript (newlines preserved), marking the cut."""
+    if len(text) <= limit:
+        return text
+    return "…[earlier output truncated]…\n" + text[-limit:]
 
 
 def _format_exception(exc: BaseException) -> str:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -67,6 +68,41 @@ def _traces_file(tmp_path) -> str:  # noqa: ANN001 - pytest fixture path
     }
     path = tmp_path / "traces.jsonl"
     path.write_text(json.dumps(span_llm) + "\n" + json.dumps(span_tool) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _multi_traces_file(tmp_path, trace_ids: list[str]) -> str:  # noqa: ANN001 - pytest fixture path
+    lines: list[str] = []
+    for i, trace_id in enumerate(trace_ids):
+        span_llm = {
+            "traceId": trace_id,
+            "spanId": f"s{i}a",
+            "name": "chat",
+            "startTimeUnixNano": i * 10,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.tool.name", "value": {"stringValue": "get_user"}},
+                {
+                    "key": "gen_ai.tool.call.arguments",
+                    "value": {"stringValue": json.dumps({"id": f"u{i}"})},
+                },
+                {"key": "gen_ai.prompt", "value": {"stringValue": f"look up u{i}"}},
+            ],
+        }
+        span_tool = {
+            "traceId": trace_id,
+            "spanId": f"s{i}b",
+            "name": "execute_tool",
+            "startTimeUnixNano": i * 10 + 1,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                {"key": "gen_ai.tool.message", "value": {"stringValue": f"found u{i}"}},
+            ],
+        }
+        lines.append(json.dumps(span_llm))
+        lines.append(json.dumps(span_tool))
+    path = tmp_path / "multi_traces.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return str(path)
 
 
@@ -307,6 +343,14 @@ def _benchmark(benchmarks_root, name: str, tmp_path) -> None:  # noqa: ANN001 - 
     )
 
 
+def _benchmark_with_trace(benchmarks_root, name: str, trace: str) -> None:  # noqa: ANN001
+    bench_dir = benchmarks_root / name
+    bench_dir.mkdir(parents=True)
+    (bench_dir / "benchmark.toml").write_text(
+        f'version = "1"\ntraces = ["{trace}"]\n[eval]\nseeds = [0]\n', encoding="utf-8"
+    )
+
+
 def test_bench_list_shows_definitions(tmp_path) -> None:  # noqa: ANN001
     benchmarks = tmp_path / "benchmarks"
     _benchmark(benchmarks, "tau-bench", tmp_path)
@@ -371,6 +415,166 @@ def test_bench_scenario_replays_through_the_model(patched_provider, tmp_path) ->
     # The fake provider's canned observation shows up as the live prediction, and the run finishes.
     assert "user u1 found" in result.output
     assert "done" in result.output
+
+
+def test_bench_scenario_runs_multiple_replays_concurrently(
+    patched_provider: object, tmp_path: Path
+) -> None:
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    trace = _multi_traces_file(tmp_path, ["a" * 32, "b" * 32])
+    _benchmark_with_trace(benchmarks, "scen", trace)
+
+    result = runner.invoke(
+        app,
+        [
+            "bench",
+            "scenario",
+            "scen",
+            "--scenarios",
+            "2",
+            "--concurrency",
+            "2",
+            "--benchmarks",
+            str(benchmarks),
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2 scen scenarios" in result.output
+    assert "trace 0 ✓ step 0" in result.output
+    assert "world model →" in result.output
+    assert "world-model scenario batch" in result.output
+    assert "fidelity 100%" in result.output
+
+
+def test_bench_scenario_demo_batch_falls_back_to_all_traces(
+    patched_provider: object, tmp_path: Path
+) -> None:
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    # "a" is held out at train_split=0.7; "c" is train. Requesting two scenarios from trace 0
+    # exceeds the one-trace held-out pool but fits in the full corpus, matching the 8-way demo path.
+    trace = _multi_traces_file(tmp_path, ["a" * 32, "c" * 32])
+    _benchmark_with_trace(benchmarks, "scen", trace)
+
+    result = runner.invoke(
+        app,
+        [
+            "bench",
+            "scenario",
+            "scen",
+            "--trace",
+            "0",
+            "--scenarios",
+            "2",
+            "--concurrency",
+            "2",
+            "--benchmarks",
+            str(benchmarks),
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "using all 2 traces instead" in result.output
+    assert "2 scen scenarios" in result.output
+
+
+def test_bench_side_by_side_runs_world_model_and_real_runner(
+    patched_provider: object, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import wmh.bench.side_by_side as side_by_side
+    from wmh.bench.side_by_side import RealSandboxResult
+
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    _benchmark(benchmarks, "swe-bench", tmp_path)
+
+    def fake_run(spec, *, timeout_seconds=None):  # noqa: ANN001, ANN202
+        return RealSandboxResult(
+            spec=spec,
+            returncode=0,
+            seconds=1.2,
+            stdout="REAL OUTPUT",
+        )
+
+    monkeypatch.setattr(side_by_side, "run_real_sandbox", fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "bench",
+            "side-by-side",
+            "swe-bench",
+            "--model",
+            "scen",
+            "--benchmarks",
+            str(benchmarks),
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "side-by-side scenario summary" in result.output
+    assert "mini-SWE-agent" in result.output
+    assert "user u1 found" in result.output
+    assert "REAL OUTPUT" in result.output
+
+
+def test_bench_side_by_side_runs_multiple_scenarios_concurrently(
+    patched_provider: object, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import wmh.bench.side_by_side as side_by_side
+    from wmh.bench.side_by_side import RealSandboxResult
+
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    trace = _multi_traces_file(tmp_path, ["a" * 32, "b" * 32])
+    _benchmark_with_trace(benchmarks, "swe-bench", trace)
+    seen: list[list[str]] = []
+
+    def fake_run(spec, *, timeout_seconds=None):  # noqa: ANN001, ANN202
+        seen.append(spec.command)
+        return RealSandboxResult(spec=spec, returncode=0, seconds=1.2, stdout="REAL OUTPUT")
+
+    monkeypatch.setattr(side_by_side, "run_real_sandbox", fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "bench",
+            "side-by-side",
+            "swe-bench",
+            "--model",
+            "scen",
+            "--scenarios",
+            "2",
+            "--concurrency",
+            "2",
+            "--benchmarks",
+            str(benchmarks),
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "adding --warm" in result.output
+    assert "2" in result.output
+    assert len(seen) == 2
+    assert all("--warm" in command for command in seen)
+    assert all("--cache" in command for command in seen)
+    assert any(command[command.index("--trace") + 1] == "0" for command in seen)
+    assert any(command[command.index("--trace") + 1] == "1" for command in seen)
 
 
 def test_bench_scenario_unknown_benchmark_is_clean_error(tmp_path) -> None:  # noqa: ANN001

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -577,6 +577,60 @@ def test_bench_side_by_side_runs_multiple_scenarios_concurrently(
     assert any(command[command.index("--trace") + 1] == "1" for command in seen)
 
 
+def test_bench_side_by_side_forwards_trace_pool_on_full_corpus_fallback(
+    patched_provider: object, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # When the world side outgrows the held-out pool and switches to the full corpus, the real
+    # runner must be told (--trace-pool all) so it resolves the SAME index against the full corpus.
+    import wmh.bench.side_by_side as side_by_side
+    from wmh.bench.side_by_side import RealSandboxResult
+
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    # "a" is held out at split 0.7; "c" is train -> 1 held-out, 2 total. Two scenarios from trace 0
+    # exceed the held-out pool but fit the full corpus, triggering the fallback.
+    trace = _multi_traces_file(tmp_path, ["a" * 32, "c" * 32])
+    _benchmark_with_trace(benchmarks, "swe-bench", trace)
+    seen: list[list[str]] = []
+
+    def fake_run(spec, *, timeout_seconds=None):  # noqa: ANN001, ANN202
+        seen.append(spec.command)
+        return RealSandboxResult(spec=spec, returncode=0, seconds=1.0, stdout="REAL OUTPUT")
+
+    monkeypatch.setattr(side_by_side, "run_real_sandbox", fake_run)
+
+    result = runner.invoke(
+        app,
+        ["bench", "side-by-side", "swe-bench", "--model", "scen", "--trace", "0",
+         "--scenarios", "2", "--concurrency", "2", "--benchmarks", str(benchmarks),
+         "--root", str(root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "using all 2 traces instead" in result.output
+    assert len(seen) == 2
+    assert all("--trace-pool" in command for command in seen)
+    assert all(command[command.index("--trace-pool") + 1] == "all" for command in seen)
+
+
+def test_bench_side_by_side_rejects_zero_concurrency(
+    patched_provider: object, tmp_path: Path
+) -> None:
+    # An explicit --concurrency 0 must be rejected, not silently treated as unset.
+    root = tmp_path / ".wmh"
+    _build(root, "scen", tmp_path)
+    benchmarks = tmp_path / "benchmarks"
+    _benchmark(benchmarks, "swe-bench", tmp_path)
+    result = runner.invoke(
+        app,
+        ["bench", "side-by-side", "swe-bench", "--model", "scen", "--concurrency", "0",
+         "--benchmarks", str(benchmarks), "--root", str(root)],
+    )
+    assert result.exit_code != 0
+    assert "at least 1" in result.output
+
+
 def test_bench_scenario_unknown_benchmark_is_clean_error(tmp_path) -> None:  # noqa: ANN001
     result = runner.invoke(
         app, ["bench", "scenario", "ghost", "--benchmarks", str(tmp_path / "benchmarks")]


### PR DESCRIPTION
## Summary

Adds the concurrent sandbox benchmark eval path used for the 8-sandbox demo run.

- adds real-sandbox side-by-side runner helpers under `wmh.bench`
- extends `wmh bench scenario` and `wmh bench side-by-side` with `--scenarios` / `--concurrency`
- updates the SWE-bench real scenario script to run multiple sandbox scenarios concurrently and keep trace selection aligned with the world-model side
- covers the new concurrent CLI and runner behavior with tests

## Validation

- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ruff check wmh/bench/__init__.py wmh/bench/side_by_side.py wmh/bench/side_by_side_test.py wmh/cli/app.py wmh/cli/app_test.py`
- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev python -m py_compile tools/swe-bench-capture/run_real_scenario.py`
- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev pytest wmh/bench/side_by_side_test.py wmh/cli/app_test.py`
- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ty check`