### PR TITLE
[codex] default provider outputs to 8k tokens

### DIFF
--- a/wmh/bench/scenario_test.py
+++ b/wmh/bench/scenario_test.py
@@ -21,7 +21,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         self.calls += 1
         return Completion(text='{"output": "predicted obs", "is_error": false}')
@@ -121,7 +121,7 @@ class MeteredProvider(FakeProvider):
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         self.calls += 1
         return Completion(

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -25,7 +25,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" in system:
             return Completion(text="IMPROVED ENV PROMPT")

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -35,7 +35,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         return Completion(
             text='{"output": "found u1", "is_error": false, "state_note": "looked up u1"}'

--- a/wmh/engine/build_test.py
+++ b/wmh/engine/build_test.py
@@ -23,7 +23,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" in system:
             return Completion(text="IMPROVED ENV PROMPT")

--- a/wmh/engine/demo_test.py
+++ b/wmh/engine/demo_test.py
@@ -21,7 +21,7 @@ class ScriptedProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "role-play an agent" in system:
             return Completion(text='{"name": "get_user", "arguments": {"id": "u1"}}')

--- a/wmh/engine/eval_test.py
+++ b/wmh/engine/eval_test.py
@@ -22,7 +22,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         return Completion(text=self._reply)
 

--- a/wmh/engine/play_test.py
+++ b/wmh/engine/play_test.py
@@ -21,7 +21,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         return Completion(
             text='{"output": "user u1 found", "is_error": false, "state_note": "looked up u1"}'

--- a/wmh/engine/replay_test.py
+++ b/wmh/engine/replay_test.py
@@ -21,7 +21,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         self.last_user = messages[0].content
         return Completion(text=self._reply)

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -34,7 +34,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         self.last_system = system
         self.last_user = messages[0].content
@@ -101,7 +101,7 @@ class _UsageProvider(FakeProvider):
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         from wmh.providers.base import TokenUsage
 

--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -30,7 +30,7 @@ from wmh.core.parsing import parse_observation
 from wmh.core.render import build_env_prompt, encode_state_action
 from wmh.core.types import Action, EnvState, JsonValue, Observation, Step, Trace
 from wmh.optimize.judge import Judge
-from wmh.providers.base import Message, Provider
+from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, Provider
 from wmh.retrieval import Retriever
 from wmh.retrieval.leakfree import DemoRetriever
 
@@ -95,7 +95,7 @@ def predict_observation(
     """
     system, user = build_env_prompt(prompt, task, state, action, history=history, demos=demos)
     completion = provider.complete(
-        system, [Message(role="user", content=user)], temperature=0.0, max_tokens=1024
+        system, [Message(role="user", content=user)], temperature=0.0, max_tokens=DEFAULT_MAX_TOKENS
     )
     return parse_observation(completion.text)
 
@@ -243,7 +243,7 @@ def _reflection_lm(provider: Provider):  # noqa: ANN202 - returns gepa's Languag
             _REFLECTION_SYSTEM,
             [Message(role="user", content=text)],
             temperature=1.0,
-            max_tokens=2048,
+            max_tokens=DEFAULT_MAX_TOKENS,
         )
         return completion.text
 

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -19,7 +19,7 @@ from wmh.optimize.gepa import (
     predict_observation,
 )
 from wmh.optimize.judge import JudgeResult
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import DEFAULT_MAX_TOKENS, Completion, Message, ProviderConfig, ProviderKind
 
 
 class FakeProvider:
@@ -32,6 +32,7 @@ class FakeProvider:
         self.reflection_calls = 0
         self.rollout_calls = 0
         self.last_rollout_user: str | None = None
+        self.last_rollout_max_tokens: int | None = None
 
     def complete(
         self,
@@ -39,13 +40,14 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" in system:
             self.reflection_calls += 1
             return Completion(text=self._mutation)
         self.rollout_calls += 1
         self.last_rollout_user = messages[0].content
+        self.last_rollout_max_tokens = max_tokens
         return Completion(text=self._prediction)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
@@ -91,6 +93,7 @@ def test_predict_observation_uses_provider() -> None:
         demos=[],
     )
     assert obs.content == "the cart now has 1 item"
+    assert provider.last_rollout_max_tokens == DEFAULT_MAX_TOKENS
 
 
 def test_predict_observation_can_include_history() -> None:
@@ -146,7 +149,7 @@ def test_optimize_can_retrieve_from_separate_rag_corpus() -> None:
             messages: list[Message],
             *,
             temperature: float = 0.7,
-            max_tokens: int = 2048,
+            max_tokens: int = 8192,
         ) -> Completion:
             if "improve the system prompt" not in system:
                 self.rollout_user_messages.append(messages[0].content)
@@ -203,7 +206,7 @@ class _TempRecordingProvider(FakeProvider):
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" not in system:
             self.rollout_temps.append(temperature)

--- a/wmh/optimize/judge_test.py
+++ b/wmh/optimize/judge_test.py
@@ -42,7 +42,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         self.last_system = system
         self.last_user = messages[0].content

--- a/wmh/providers/__init__.py
+++ b/wmh/providers/__init__.py
@@ -5,6 +5,7 @@ verified on startup with a cheap ping. Built fresh for this repo; no external cl
 """
 
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     EmbedderKind,
     Message,
@@ -20,6 +21,7 @@ __all__ = [
     "ProviderConfig",
     "ProviderKind",
     "EmbedderKind",
+    "DEFAULT_MAX_TOKENS",
     "Completion",
     "Message",
     "VerifyResult",

--- a/wmh/providers/anthropic.py
+++ b/wmh/providers/anthropic.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     ProviderConfig,
@@ -40,7 +41,7 @@ class AnthropicProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         # Opus 4.8 takes `system` as a top-level arg and rejects sampling params, so temperature
         # is intentionally not forwarded; adaptive thinking is the default.

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from wmh.providers import _openai_common
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     ProviderConfig,
@@ -58,7 +59,7 @@ class AzureOpenAIProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         return _openai_common.complete(
             self._get_client().chat.completions, self._deployment(), system, messages, max_tokens

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -53,6 +53,9 @@ class Completion(BaseModel):
     usage: TokenUsage = Field(default_factory=TokenUsage)
 
 
+DEFAULT_MAX_TOKENS = 8192
+
+
 class VerifyResult(BaseModel):
     ok: bool
     kind: ProviderKind
@@ -101,7 +104,7 @@ class Provider(Protocol):
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         """Generate a completion. Used by the world model, GEPA, the judge, and the demo agent."""
         ...

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypedDict, cast
 
 from wmh.core.types import JsonValue
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     ProviderConfig,
@@ -66,7 +67,7 @@ class BedrockProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         # Claude 4.8 rejects sampling params, so temperature is intentionally not forwarded.
         body = {

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from wmh.providers import _openai_common
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     ProviderConfig,
@@ -38,7 +39,7 @@ class OpenAIProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         return _openai_common.complete(
             self._get_client().chat.completions, self.config.model, system, messages, max_tokens

--- a/wmh/providers/tests/bedrock_test.py
+++ b/wmh/providers/tests/bedrock_test.py
@@ -8,7 +8,7 @@ from typing import cast
 
 import pytest
 
-from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, ProviderConfig, ProviderKind
 from wmh.providers.bedrock import BedrockProvider
 
 
@@ -60,6 +60,17 @@ def test_complete_builds_anthropic_body_and_parses(monkeypatch: pytest.MonkeyPat
     assert body["system"] == "sys"
     assert body["messages"] == [{"role": "user", "content": "hi"}]
     assert "temperature" not in body  # Claude 4.8 rejects sampling params
+
+
+def test_complete_default_max_tokens_is_8k(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(_payload())
+    provider = BedrockProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("sys", [Message(role="user", content="hi")])
+
+    body = json.loads(cast("str", fake.last_kwargs["body"]))
+    assert body["max_tokens"] == DEFAULT_MAX_TOKENS
 
 
 class _FakeEmbedClient:

--- a/wmh/providers/tests/openai_test.py
+++ b/wmh/providers/tests/openai_test.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, ProviderConfig, ProviderKind
 from wmh.providers.openai import OpenAIProvider
 
 
@@ -97,6 +97,17 @@ def test_complete_folds_system_and_uses_max_completion_tokens(
         {"role": "system", "content": "be nice"},
         {"role": "user", "content": "yo"},
     ]
+
+
+def test_complete_default_max_tokens_is_8k(monkeypatch: pytest.MonkeyPatch) -> None:
+    chat = _FakeChatCompletions(_FakeChatResponse("hi there", _FakeUsage(9, 4)))
+    provider = OpenAIProvider(_config())
+    fake = _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("be nice", [Message(role="user", content="yo")])
+
+    assert chat.last_kwargs["max_completion_tokens"] == DEFAULT_MAX_TOKENS
 
 
 def test_embed_uses_embed_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/research/pipeline_test.py
+++ b/wmh/research/pipeline_test.py
@@ -21,7 +21,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" in system:
             return Completion(text="IMPROVED")

--- a/wmh/research/seed_stability_test.py
+++ b/wmh/research/seed_stability_test.py
@@ -19,7 +19,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "improve the system prompt" in system:
             return Completion(text="IMPROVED")

--- a/wmh/retrieval/retriever_test.py
+++ b/wmh/retrieval/retriever_test.py
@@ -26,7 +26,7 @@ class FakeEmbedProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         return Completion(text="")
 

--- a/wmh/serving/server_test.py
+++ b/wmh/serving/server_test.py
@@ -21,7 +21,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         return Completion(text='{"output": "user found", "is_error": false}')
 

--- a/wmh/tracking/metered.py
+++ b/wmh/tracking/metered.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 
 from wmh.optimize.judge import JUDGE_MARKER
 from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     Provider,
@@ -69,7 +70,7 @@ class MeteredProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         completion = self._provider.complete(
             system, messages, temperature=temperature, max_tokens=max_tokens

--- a/wmh/tracking/metered_test.py
+++ b/wmh/tracking/metered_test.py
@@ -19,7 +19,7 @@ class FakeProvider:
         messages: list[Message],
         *,
         temperature: float = 0.7,
-        max_tokens: int = 2048,
+        max_tokens: int = 8192,
     ) -> Completion:
         if "grade a world model" in system:
             return Completion(text="judged", usage=TokenUsage(input_tokens=40, output_tokens=10))


### PR DESCRIPTION
## Summary

Raises the default provider completion budget to 8k output tokens.

- adds `DEFAULT_MAX_TOKENS = 8192` to the provider contract
- wires OpenAI, Azure OpenAI, Anthropic, Bedrock, metered provider, and GEPA call paths to the shared default
- updates test fakes and assertions so stale 1k/2k defaults do not silently reappear

## Validation

- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ruff check wmh/providers wmh/optimize/gepa.py wmh/optimize/gepa_test.py wmh/tracking/metered.py`
- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev pytest wmh/providers/tests/openai_test.py wmh/providers/tests/bedrock_test.py wmh/optimize/gepa_test.py wmh/tracking/metered_test.py`
- `UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ty check`
- `rg -n "max_tokens: int = (1024|2048)|max_tokens=(1024|2048)|max_completion_tokens=(1024|2048)" wmh scripts || true`