### PR TITLE
tau-bench: grow trace corpus to ~1000 across airline/retail/telecom

### DIFF
--- a/examples/tau-bench/README.md
+++ b/examples/tau-bench/README.md
@@ -68,6 +68,31 @@ export TAU2_DATA_DIR="$PWD/tau2-bench/data" AWS_REGION=us-east-1 AWS_REGION_NAME
 # -> tau2-bench/data/simulations/airline_capture/results.json
 ```
 
+## Bulk capture: the committed ~1000-trace corpus
+
+`traces.otel.jsonl` here holds **~1000 distinct traces** across all three tau2 domains —
+airline (50 tasks) + retail (114) + telecom (the bulk, from its 2285-task `full` split). Two helper
+scripts capture and merge it; both are idempotent/resumable:
+
+```bash
+# airline + retail + telecom (single-model), then convert + merge -> traces.otel.jsonl
+./capture_corpus.sh
+
+# telecom at scale, sharded across THREE Opus models to beat per-model Bedrock throttling
+TAU2_DATA_DIR="$PWD/tau2-bench/data" AWS_REGION=us-east-1 \
+  .venv/bin/python capture_telecom_multimodel.py --total 990 --concurrency 3
+```
+
+Why two scripts: a **single** Opus model on Bedrock throttles hard under telecom's long,
+call-heavy trajectories (litellm `ServiceUnavailableError` — a single-model run salvaged only
+~180/980 telecom sims). `capture_telecom_multimodel.py` shards the telecom task list across
+`opus-4-6-v1` / `opus-4-7` / `opus-4-8` — each its own per-model quota — lifting that to ~850+ with
+near-zero throttling. Disjoint round-robin slices per model (`--offset` for top-ups) keep traces
+unique. All valid sims are kept (reward rides along in metadata), so ~80% are reward-1.0 and the
+rest are real partial trajectories. Bedrock model ids (default AWS profile, us-east-1):
+`us.anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-6-v1` (the `-v1` suffix is required),
+`us.anthropic.claude-opus-4-8`.
+
 ## Convert to the wmh corpus
 
 ```bash

--- a/examples/tau-bench/capture_corpus.sh
+++ b/examples/tau-bench/capture_corpus.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Capture a multi-domain tau2-bench trace corpus across airline + retail + telecom, then convert and
+# merge into one wmh OTel corpus. This is how `examples/tau-bench/traces.otel.jsonl` was grown to
+# ~1000 traces for the trace-scaling-law experiment (docs/trace_scaling.md).
+#
+#   examples/tau-bench/capture_corpus.sh
+#
+# Distinct-task budget per domain (1 trial each, so every trace is a different task — no repeats):
+#   airline   50  (all tasks)
+#   retail   114  (all tasks)
+#   telecom  ~880 (of 2285 in the `full` split) -> ~1000 distinct total
+# Reward < 1.0 sims are KEPT (the recorded tool results are real either way; reward rides along in
+# trace metadata for later filtering). Only infrastructure errors and tool-call-free chats drop out.
+#
+# NOTE: telecom on a single Opus model throttles hard on Bedrock (see capture_telecom_multimodel.py,
+# which shards telecom across 4.6/4.7/4.8 and is how the committed telecom traces were captured).
+# This script's telecom leg is the simple single-model path; prefer the multimodel one at scale.
+#
+# Resumable: a domain whose results.json already exists is skipped, so a re-run only fills gaps.
+# Live on Bedrock (the default AWS profile has Bedrock access).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Concurrency is deliberately LOW (3): Opus 4.8 on Bedrock throttles
+# (litellm ServiceUnavailableError) under sustained parallel load, and telecom's longer trajectories
+# make more LLM calls per task — at concurrency 8 ~80% of telecom sims failed permanently. Lower
+# concurrency + task-level retries trades wall-clock for a reliable yield.
+CONCURRENCY="${CONCURRENCY:-3}"
+MAX_RETRIES="${MAX_RETRIES:-5}"     # tau2 task-level retries for failed sims (default 3)
+RETRY_DELAY="${RETRY_DELAY:-5.0}"   # seconds between task retries (default 1.0)
+AGENT_LLM="bedrock/us.anthropic.claude-opus-4-8"
+USER_LLM="bedrock/us.anthropic.claude-opus-4-8"
+OUT="${OUT:-./traces.otel.jsonl}"
+
+export TAU2_DATA_DIR="$PWD/tau2-bench/data"
+export AWS_REGION="${AWS_REGION:-us-east-1}" AWS_REGION_NAME="${AWS_REGION_NAME:-us-east-1}"
+
+# domain : task-split : num-tasks. The default "base" split exposes only airline 50 / retail 114 /
+# telecom 114; telecom's "full" split unlocks 2285 tasks, so we draw the bulk from there. num-tasks
+# is over-budgeted (esp. telecom) to absorb sims that still fail after retries and chats with no tool
+# call, and still clear ~1000 distinct: airline ~47 + retail ~74 + telecom ~880.
+DOMAINS=("airline:base:50" "retail:base:114" "telecom:full:980")
+
+# --auto-resume makes a re-run RETRY only the failed/missing tasks in an existing save dir (keeping
+# the ones that already succeeded), so re-running this script tops up a throttled run rather than
+# starting over or skipping wholesale. Idempotent: when a domain is fully captured, the resume is a
+# no-op and it moves on.
+run_domain() {
+  local domain="$1" split="$2" n="$3" save="capture_${1}"
+  echo "=== ${domain}: capturing/resuming ${n} tasks (split=${split}) @ concurrency ${CONCURRENCY} ==="
+  .venv/bin/tau2 run \
+    --domain "$domain" \
+    --agent-llm "$AGENT_LLM" --agent-llm-args '{}' \
+    --user-llm  "$USER_LLM"  --user-llm-args '{}' \
+    --task-split-name "$split" \
+    --num-trials 1 --num-tasks "$n" --max-concurrency "$CONCURRENCY" \
+    --max-retries "$MAX_RETRIES" --retry-delay "$RETRY_DELAY" \
+    --auto-resume \
+    --save-to "$save"
+}
+
+for spec in "${DOMAINS[@]}"; do
+  IFS=":" read -r d s n <<< "$spec"
+  run_domain "$d" "$s" "$n"
+done
+
+# Convert each domain's results into its own OTel shard, then concatenate into the merged corpus.
+# (convert_to_wmh.py infers a single domain per results.json, so convert per-domain and cat.)
+echo "=== converting + merging -> ${OUT} ==="
+: > "$OUT"
+total=0
+for spec in "${DOMAINS[@]}"; do
+  domain="${spec%%:*}"
+  res="tau2-bench/data/simulations/capture_${domain}/results.json"
+  shard="/tmp/tau2_${domain}.otel.jsonl"
+  .venv/bin/python convert_to_wmh.py "$res" --out "$shard" --benchmark tau2-bench
+  cat "$shard" >> "$OUT"
+done
+# Report distinct trace count in the merged corpus.
+total=$(python3 -c "
+import json
+ids=set()
+for line in open('$OUT'):
+    line=line.strip()
+    if line: ids.add(json.loads(line)['traceId'])
+print(len(ids))
+")
+echo "=== merged corpus: ${total} distinct traces -> ${OUT} ==="

--- a/examples/tau-bench/capture_telecom_multimodel.py
+++ b/examples/tau-bench/capture_telecom_multimodel.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Capture telecom tau2 traces across MULTIPLE Opus models to beat the per-model Bedrock quota.
+
+A single Opus model on Bedrock throttles (litellm ServiceUnavailableError) under sustained load — a
+concurrency-8 telecom run lost ~80% of sims, and dropping concurrency didn't help because the wall
+is a per-model account quota, not jitter. Telecom is the worst case (longest trajectories + a
+tool-calling user simulator => most LLM calls per task).
+
+Fix: shard the telecom task list across several Opus models (4.6 / 4.7 / 4.8), each its own
+per-model quota, run them concurrently. Each shard is a DISJOINT slice of the full task list (so no
+task is captured twice) and writes to its own save dir; `--auto-resume` makes a re-run retry only
+that shard's still-failed tasks. Merge the shards afterward with convert_to_wmh.py + cat (see
+capture_corpus.sh / the README).
+
+This runs in the ISOLATED tau2 venv (Python 3.13, `tau2` installed); it imports `tau2`, never `wmh`.
+
+    TAU2_DATA_DIR=$PWD/tau2-bench/data AWS_REGION=us-east-1 \
+      .venv/bin/python capture_telecom_multimodel.py --total 980 --concurrency 3
+
+-> data/simulations/capture_telecom_<modeltag>/results.json  (one per model)
+Convert each like any other domain shard, then cat into examples/tau-bench/traces.otel.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import threading
+from pathlib import Path
+
+from tau2.run import run_tasks
+from tau2.runner.helpers import get_tasks
+
+# Persist each shard as data/simulations/<name>/results.json — the same layout the CLI's --save-to
+# produces and convert_to_wmh.py expects. The deprecated run_tasks(save_to=) treats save_to as a
+# literal path (NOT relative to data/simulations like the CLI), so we build the absolute path here.
+_SIM_DIR = Path(os.environ["TAU2_DATA_DIR"]) / "simulations"
+
+# The Opus inference-profile IDs that invoke on this account (verified ACTIVE). Each is a separate
+# per-model quota, so sharding across them multiplies effective throughput. litellm's Bedrock route
+# wants the `bedrock/` prefix.
+DEFAULT_MODELS = [
+    "bedrock/us.anthropic.claude-opus-4-6-v1",
+    "bedrock/us.anthropic.claude-opus-4-7",
+    "bedrock/us.anthropic.claude-opus-4-8",
+]
+
+
+def _model_tag(model: str) -> str:
+    """A filesystem-safe tag from a model id, e.g. '...opus-4-7' -> 'opus-4-7'."""
+    return model.split("/")[-1].replace("us.anthropic.claude-", "").replace(":", "_")
+
+
+def _run_shard(
+    model: str, tasks: list, concurrency: int, retries: int, delay: float, suffix: str = ""
+) -> None:
+    save_path = _SIM_DIR / f"capture_telecom_{_model_tag(model)}{suffix}" / "results.json"
+    print(f"[{model}] {len(tasks)} tasks -> {save_path}", flush=True)
+    run_tasks(
+        domain="telecom",
+        tasks=tasks,
+        agent="llm_agent",
+        user="user_simulator",
+        llm_agent=model,
+        llm_args_agent={},
+        llm_user=model,
+        llm_args_user={},
+        num_trials=1,
+        max_concurrency=concurrency,
+        max_retries=retries,
+        retry_delay=delay,
+        auto_resume=True,
+        save_to=str(save_path),
+        console_display=False,
+    )
+    print(f"[{model}] done", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--total", type=int, default=980, help="Total telecom tasks across shards.")
+    parser.add_argument(
+        "--offset", type=int, default=0, help="Skip this many tasks first (for disjoint top-ups)."
+    )
+    parser.add_argument("--concurrency", type=int, default=3, help="Per-model concurrency.")
+    parser.add_argument("--retries", type=int, default=5, help="tau2 task-level retries.")
+    parser.add_argument("--delay", type=float, default=5.0, help="Seconds between task retries.")
+    parser.add_argument("--split", default="full", help="Telecom task split (full = 2285 tasks).")
+    parser.add_argument(
+        "--models", default=",".join(DEFAULT_MODELS), help="Comma-separated litellm model ids."
+    )
+    parser.add_argument(
+        "--suffix", default="", help="Save-dir suffix to isolate a top-up run from prior shards."
+    )
+    args = parser.parse_args()
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    all_tasks = get_tasks("telecom", task_split_name=args.split)[args.offset : args.offset + args.total]
+    print(
+        f"telecom '{args.split}': tasks [{args.offset}:{args.offset + args.total}] "
+        f"({len(all_tasks)}), sharding across {len(models)} models"
+    )
+
+    # Round-robin the tasks into disjoint shards so each model gets a contiguous-free, even slice and
+    # no task is run twice. Round-robin (not contiguous blocks) keeps task-type mix even per model.
+    shards: list[list] = [[] for _ in models]
+    for i, task in enumerate(all_tasks):
+        shards[i % len(models)].append(task)
+
+    threads = [
+        threading.Thread(
+            target=_run_shard,
+            args=(model, shard, args.concurrency, args.retries, args.delay, args.suffix),
+        )
+        for model, shard in zip(models, shards, strict=True)
+        if shard
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    print("all shards complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Replaces `examples/tau-bench/traces.otel.jsonl` (was 66 traces / 866 spans) with a **~1000-trace corpus** captured live from Sierra's real tau²-bench across all three domains:

| Domain | Traces |
|---|---|
| airline | 47 |
| retail | 74 |
| telecom | 912 |
| **Total** | **1033** (5289 steps) |

All traces carry gold metadata. All valid sims kept (reward in `Trace.metadata`) → ~80% reward 1.0, rest real partial trajectories. The `tau-bench` eval suite (`evals/default.toml → ../traces.otel.jsonl`) picks it up unchanged — verified it resolves to 1033 traces through the new `eval_suites` structure.

## Why

The trace-scaling-law experiment needs a real substrate. On the old 66-trace corpus the fixed-test split was train pool 45 / valid 11 / test 10; on this one it's **train pool ~648 / valid ~176 / test ~209** — enough to sweep training-trace counts 10 → ~640 against a fixed test set.

## Capture tooling (added under `examples/tau-bench/`, gate-excluded, never imported by wmh)

- **`capture_corpus.sh`** — airline + retail + telecom end to end. Telecom needs `--task-split-name full` (the default `base` split exposes only 114 telecom tasks vs. 2285 in `full`).
- **`capture_telecom_multimodel.py`** — the key to scale. A **single** Opus model throttles hard on Bedrock under telecom's long, call-heavy trajectories (litellm `ServiceUnavailableError` — a single-model run salvaged only ~180/980). Sharding the task list across **three Opus models (4.6 / 4.7 / 4.8)**, each its own per-model quota, lifts that to ~850+ with near-zero throttling. Disjoint round-robin slices per model (`--offset` for top-ups) keep traces unique.

README documents the bulk-capture path and the throttling lesson.

## Verification

`uv run ruff check .` ✓ · `uv run ty check` ✓ · `uv run pytest -q` → 228 passed / 6 skipped. tau-bench eval suite resolves to the 1033-trace corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)