### PR TITLE
README: simplify to launch-post style, embed demo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,44 @@
 # World Model Harness
 
-> **Docker as an LLM.** Simulate an agent environment from traces instead of standing up a sandbox.
+`wmh` makes it easy to go from agent traces to faithful replication of your production environment where your agents run.
 
-A frontier LLM acts as the environment your agent steps against, reconstructed from OpenTelemetry
-traces. The harness ingests recorded `(state, action) -> observation` steps, builds a retrieval index,
-evolves the base environment prompt with GEPA, and serves the resulting world model locally.
+Basically, an LLM pretends to be a virtual machine executing instructions — but it's 5x faster than a real sandbox.
 
-## How It Works
-
-1. **Build** from OTel traces: ingest, normalize, split train/held-out, index the replay buffer, and
-   optimize the environment prompt.
-2. **Serve or play** the built model: agents call `WorldModel.step(action)` in-process or through the
-   local HTTP backend.
-3. **Evaluate** reconstruction fidelity with `wmh eval` against trace files.
-
-## Quickstart
+Just:
 
 ```bash
+git clone https://github.com/experientiallabs/world-model-harness
+cd world-model-harness
 uv sync
-wmh providers verify
-wmh build --name airline --file examples/tau-bench/traces.otel.jsonl
-wmh list
-wmh eval examples/tau-bench/traces.otel.jsonl
-wmh eval list
-wmh eval run tau-bench
-wmh eval results
-wmh examples list
-wmh examples run tau-bench -- --trace 0
-wmh serve
-wmh demo --name airline
-wmh play --name airline
+uv run wmh build
 ```
 
-`wmh build` with no flags launches a guided creation wizard on an interactive terminal. Pass
-`--file` and related flags, or `--no-interactive`, for scriptable runs.
+The `build` command opens a wizard that walks you through creating your own world model from your traces.
 
-World models are named and stored under `.wmh/models/<name>/`. `wmh list`, `wmh serve`, `wmh demo`,
-and `wmh play` only use models built locally in that directory.
+Below is a comparison running 8 SWE-bench tasks: real sandboxes on the left, a world model acting as the sandbox on the right.
 
-## CLI Reference
+![world-model-harness demo](./assets/demo.gif)
 
-| Command | What it does |
-|---|---|
-| `wmh build` | Builds a named world model from OTel traces or a vendor trace pull. It ingests traces, normalizes them, splits train/held-out data, builds the retrieval index, runs GEPA prompt optimization, and writes the artifact to `.wmh/models/<name>/`. With no required inputs on a TTY, it opens the guided wizard. |
-| `wmh list` | Lists world models found under the selected root's `models/` directory, including provider, held-out score, rollout count, and frontier size when those metrics exist. By default, the selected root is `.wmh/`, so plain `wmh list` does not read committed example artifacts. |
-| `wmh eval <trace files...>` | Scores reconstruction fidelity on one or more OTel trace files. It performs a deterministic train/held-out split, replays held-out steps through the base or supplied prompt, grades predicted observations against recorded observations, and prints per-file plus overall fidelity. |
-| `wmh eval list` | Lists named eval suites from `examples/<task>/evals/*.toml`. Suites are example-local definitions for repeatable reconstruction-fidelity runs. |
-| `wmh eval run <suite>` | Runs a named eval suite, using its configured trace files and split/scoring settings. Results are written as local JSON under `.wmh/evals/<task>/<suite>/` unless `--out` is supplied. The default suite for an example can be selected by task name, e.g. `wmh eval run tau-bench`. |
-| `wmh eval results [suite]` | Summarizes locally saved named eval results from `.wmh/evals/`. These are generated artifacts and should not be committed. |
-| `wmh serve` | Starts the local FastAPI backend on `127.0.0.1:8000` by default. It serves all locally built models, or only the repeated `--name` selections, through `/world_models/...` HTTP routes. |
-| `wmh demo` | Runs a short demo against a built model. A throwaway LLM agent proposes an action from sampled trace examples, the world model predicts the environment observation, and the CLI prints the action, environment prompt, and observation. |
-| `wmh play` | Opens an interactive REPL for a built model. You type tool calls or free-text actions, and the world model returns observations while maintaining session state and history. |
-| `wmh providers verify` | Checks provider connectivity for locally built models. It verifies configured completion providers and any provider-backed embedder paths, skipping the offline hashing embedder. |
-| `wmh examples list` | Lists self-contained task examples under `examples/<task>/` that include a `traces.otel.jsonl` corpus or `run.sh` launcher. |
-| `wmh examples run <task> -- <args>` | Runs the selected example's local `run.sh` launcher and forwards all arguments after `--`. This is the standard entrypoint for dataset-specific example helpers. |
+## How it works
 
-## Examples
+A frontier LLM acts as the *environment* your agent steps against, reconstructed from your own OpenTelemetry traces. Inspired by **Qwen-AgentWorld** (LLM-as-environment), **GEPA** (reflective prompt evolution), and **DreamGym** (retrieval over a trace replay buffer) — but with **zero training**: we get there with prompt optimization on a frontier model.
 
-Dataset-specific logic lives only under `examples/`. Each task folder is self-contained:
+1. **Build** from your OTel traces: ingest → normalize → split train/held-out → index a replay buffer → evolve the env prompt with GEPA against the held-out split.
+2. **Serve**: agents call `WorldModel.step(action)` (in-process or via the local HTTP backend). Each step retrieves the most similar past `(state, action) → observation` examples and predicts the next observation.
 
-- `examples/swe-bench/traces.otel.jsonl`
-- `examples/tau-bench/traces.otel.jsonl`
-- `examples/terminal-tasks/traces.otel.jsonl`
+## Try it
 
-Each example folder may include task-local capture or launch helpers. Launch them through
-`wmh examples run <task> -- <args>`. Reusable harness behavior belongs in `wmh/` and should be
-exposed through the `wmh` CLI.
+```bash
+uv run wmh examples list          # swe-bench, tau-bench, terminal-tasks
+uv run wmh eval list              # eval suites shipped with the examples
+uv run wmh eval run tau-bench     # replay + score reconstruction fidelity
+uv run wmh play                   # step into the environment yourself
+uv run wmh serve                  # local HTTP backend on :8000
+```
 
-Repeatable eval suite definitions live under `examples/<task>/evals/*.toml`. They point at
-example-local trace files and configure replay options such as train split, sampling, RAG, and
-judge. Generated eval results stay local under `.wmh/evals/`.
+Example-local prebuilt models live under `examples/<task>/models/`; pass `--root examples/<task>` to `wmh list`, `wmh demo`, `wmh play`, or `wmh serve` to use one without rebuilding.
 
-Example-local prebuilt artifacts live under `examples/<task>/models/<name>/`; pass
-`--root examples/<task>` to `wmh list`, `wmh demo`, `wmh play`, or `wmh serve` to use one without
-copying it into `.wmh/`.
-
-## Python API
+## Use it as an API
 
 ```python
 from wmh import Action, ActionKind
@@ -86,21 +49,18 @@ model_dir = WorldModelStore(".wmh").resolve("airline")
 wm, _provider = load_world_model(model_dir)
 
 session = wm.new_session(task="check out the cart")
-obs = wm.step(
-    session.id,
-    Action(kind=ActionKind.TOOL_CALL, name="add_to_cart", arguments={"sku": "A1"}),
-)
+obs = wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="add_to_cart",
+                                 arguments={"sku": "A1"}))
 print(obs.content)
 ```
 
-Over HTTP, use `GET /world_models`, then `POST /world_models/{name}/sessions` and
-`POST /world_models/{name}/sessions/{id}/step`.
+Or over HTTP (same code path), namespaced by model name: `GET /world_models`, then `POST /world_models/{name}/sessions` and `POST /world_models/{name}/sessions/{id}/step`.
 
 ## Providers
 
-Credentials are read from the environment.
+One interface, four backends, verified on startup. Credentials are read from the environment:
 
-| Provider | Default model family | Env vars |
+| Provider | Model | Env vars |
 |---|---|---|
 | Anthropic | Claude Opus | `ANTHROPIC_API_KEY` |
 | AWS Bedrock | Claude Opus | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` |
@@ -109,13 +69,12 @@ Credentials are read from the environment.
 
 ## Development
 
-```bash
-uv sync --extra dev
-uv run ruff check .
-uv run ruff format .
-uv run ty check
-uv run pytest -q
-```
+Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).
 
-Conventions live in `AGENTS.md`. Tests are inline next to the code they cover
-(`foo.py` -> `foo_test.py`) under `wmh/`.
+```bash
+uv sync --extra dev      # env + dev tools
+uv run ruff check .      # lint
+uv run ruff format .     # format
+uv run ty check          # type check
+uv run pytest -q         # tests
+```


### PR DESCRIPTION
## Summary
- Rewrite the README around the launch-post hook (`wmh` makes it easy to go from agent traces to faithful replication of your production environment; an LLM pretends to be a VM, 5x faster than a real sandbox).
- Lead with the 3-step clone → `uv sync` → `uv run wmh build` quickstart.
- Embed a compressed **640×360 · 8fps · ~4.7MB** demo gif at `assets/demo.gif` showing the 8-SWE-bench-tasks comparison (real sandboxes vs the world model).
- Drop the long CLI reference table and Examples deep-dive; keep only Try it / Python API / Providers / Development.

Net effect: 122 → 80 lines, README loads with the pitch and the visual instead of a wall of prose.

## Test plan
- [ ] Open the PR on GitHub and confirm the gif renders inline at a reasonable size.
- [ ] `uv run wmh examples list`, `uv run wmh eval list`, `uv run wmh eval run tau-bench` still match what the "Try it" block claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)