### PR TITLE
[codex] Add anonymous PostHog telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,7 @@ uv run pytest -q
 7. **Route reusable workflows through `wmh`.** Avoid parallel top-level scripts for harness actions.
    If a workflow is generally useful outside one example dataset, implement it in `wmh/` and expose
    it through the CLI.
+
+8. **Keep imports explicit and fail-fast.** Put imports at module scope unless moving them is
+   required to break a real circular dependency. Do not use lazy imports for optional convenience,
+   and do not catch `ImportError`/`ModuleNotFoundError` to silently fall back to alternate behavior.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ uv run wmh serve                  # local HTTP backend on :8000
 
 Example-local prebuilt models live under `examples/<task>/models/`; pass `--root examples/<task>` to `wmh list`, `wmh demo`, `wmh play`, or `wmh serve` to use one without rebuilding.
 
+## Usage telemetry
+
+`wmh` sends anonymous PostHog usage telemetry so we can understand whether the harness is useful:
+build/eval metadata, generated world-model session counts, and generated world-model step counts.
+Telemetry is strictly metadata. It never includes prompts, traces, actions, observations, file paths,
+model names, provider credentials, or raw user content.
+
+Telemetry is enabled by default. To opt out for a project:
+
+```bash
+uv run wmh config telemetry disable
+```
+
+This writes `.wmh/settings.toml`. You can re-enable it with `uv run wmh config telemetry enable`,
+check the current setting with `uv run wmh config telemetry status`, or disable it for a process
+with `DO_NOT_TRACK=1` or `WMH_TELEMETRY=0`.
+
 ## Use it as an API
 
 ```python

--- a/README.md
+++ b/README.md
@@ -38,23 +38,6 @@ uv run wmh serve                  # local HTTP backend on :8000
 
 Example-local prebuilt models live under `examples/<task>/models/`; pass `--root examples/<task>` to `wmh list`, `wmh demo`, `wmh play`, or `wmh serve` to use one without rebuilding.
 
-## Usage telemetry
-
-`wmh` sends anonymous PostHog usage telemetry so we can understand whether the harness is useful:
-build/eval metadata, generated world-model session counts, and generated world-model step counts.
-Telemetry is strictly metadata. It never includes prompts, traces, actions, observations, file paths,
-model names, provider credentials, or raw user content.
-
-Telemetry is enabled by default. To opt out for a project:
-
-```bash
-uv run wmh config telemetry disable
-```
-
-This writes `.wmh/settings.toml`. You can re-enable it with `uv run wmh config telemetry enable`,
-check the current setting with `uv run wmh config telemetry status`, or disable it for a process
-with `DO_NOT_TRACK=1` or `WMH_TELEMETRY=0`.
-
 ## Use it as an API
 
 ```python
@@ -95,3 +78,20 @@ uv run ruff format .     # format
 uv run ty check          # type check
 uv run pytest -q         # tests
 ```
+
+## Usage telemetry
+
+`wmh` sends anonymous PostHog usage telemetry so we can understand whether the harness is useful:
+build/eval metadata, generated world-model session counts, and generated world-model step counts.
+Telemetry is strictly metadata. It never includes prompts, traces, actions, observations, file paths,
+model names, provider credentials, or raw user content.
+
+Telemetry is enabled by default. To opt out for a project:
+
+```bash
+uv run wmh config telemetry disable
+```
+
+This writes `.wmh/settings.toml`. You can re-enable it with `uv run wmh config telemetry enable`,
+check the current setting with `uv run wmh config telemetry status`, or disable it for a process
+with `DO_NOT_TRACK=1` or `WMH_TELEMETRY=0`.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ uv run pytest -q         # tests
 
 ## Usage telemetry
 
-`wmh` sends anonymous PostHog usage telemetry so we can understand whether the harness is useful:
-build/eval metadata, generated world-model session counts, and generated world-model step counts.
+`wmh` uses anonymous usage telemetry to track the volume of usage.
 Telemetry is strictly metadata. It never includes prompts, traces, actions, observations, file paths,
 model names, provider credentials, or raw user content.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "rich>=13.7",
     "gepa>=0.1.1",
     "tomli-w>=1.0",  # writing .wmh/config.toml (stdlib tomllib reads); every `wmh build` needs it
+    "posthog>=7.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
@@ -91,6 +100,95 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -518,6 +616,21 @@ wheels = [
 ]
 
 [[package]]
+name = "posthog"
+version = "7.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/d4/91b88c706264cba1c73cb761c319bc833240273b258c25de89208c5c33f4/posthog-7.21.2.tar.gz", hash = "sha256:26460ab3589445e969cef51074198685ea27439fc3def6612a9ce1841685acce", size = 309338, upload-time = "2026-07-01T07:44:21.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/d2/f7d062da696fd8cdfe2992f832547b2b2feb237a350785163f77d6230f6b/posthog-7.21.2-py3-none-any.whl", hash = "sha256:8672d5b6dd10713abbe31c58668a6094f2929ffc8618c6f52744a63f2f192623", size = 371320, upload-time = "2026-07-01T07:44:19.233Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +797,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -890,6 +1018,7 @@ dependencies = [
     { name = "httpx" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "posthog" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "tomli-w" },
@@ -930,6 +1059,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.40" },
     { name = "opentelemetry-proto", marker = "extra == 'otel'", specifier = ">=1.24" },
+    { name = "posthog", specifier = ">=7.0" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rich", specifier = ">=13.7" },

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -29,12 +29,15 @@ from wmh.providers.base import EmbedderKind
 
 if TYPE_CHECKING:
     from wmh.engine.eval import EvalReport
+    from wmh.engine.reporting import BuildReporter
 
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
 providers_app = typer.Typer(help="Manage and verify LLM providers.")
 examples_app = typer.Typer(help="List and launch self-contained task examples.")
+config_app = typer.Typer(help="Manage local harness config.")
 app.add_typer(providers_app, name="providers")
 app.add_typer(examples_app, name="examples")
+app.add_typer(config_app, name="config")
 _console = Console()
 _CHECK = "[green]✓[/green]"
 
@@ -55,6 +58,69 @@ class _EvalOptions:
     sample_turns: str
     seed: int
     top_k: int
+
+
+@dataclass
+class _BuildTelemetryStats:
+    input_trace_count: int = 0
+    input_step_count: int = 0
+    train_trace_count: int = 0
+    heldout_trace_count: int = 0
+    indexed_step_count: int = 0
+    frontier_size: int = 0
+    rollouts_used: int = 0
+
+
+class _TelemetryBuildReporter:
+    def __init__(self, inner: BuildReporter, stats: _BuildTelemetryStats) -> None:
+        self._inner = inner
+        self._stats = stats
+
+    def ingest_done(self, traces: int, steps: int) -> None:
+        self._stats.input_trace_count = traces
+        self._stats.input_step_count = steps
+        self._inner.ingest_done(traces, steps)
+
+    def split_done(self, train: int, test: int) -> None:
+        self._stats.train_trace_count = train
+        self._stats.heldout_trace_count = test
+        self._inner.split_done(train, test)
+
+    def index_done(self, steps: int) -> None:
+        self._stats.indexed_step_count = steps
+        self._inner.index_done(steps)
+
+    def optimize_start(self, budget: int) -> None:
+        self._inner.optimize_start(budget)
+
+    def rollout(self, done: int, budget: int, score: float | None) -> None:
+        self._inner.rollout(done, budget, score)
+
+    def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
+        self._stats.frontier_size = frontier_size
+        self._stats.rollouts_used = rollouts
+        self._inner.optimize_done(held_out_accuracy, frontier_size, rollouts)
+
+
+@config_app.command("telemetry")
+def config_telemetry(
+    action: str = typer.Argument("status", help="status | enable | disable"),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding local settings."),
+) -> None:
+    """View or change project-local usage telemetry settings."""
+    from wmh.config import load_settings, set_telemetry_enabled, settings_path
+
+    normalized = action.lower()
+    if normalized == "status":
+        settings = load_settings(root)
+    elif normalized == "enable":
+        settings = set_telemetry_enabled(True, root)
+    elif normalized == "disable":
+        settings = set_telemetry_enabled(False, root)
+    else:
+        raise typer.BadParameter("action must be one of: status, enable, disable")
+    state = "enabled" if settings.telemetry.enabled else "disabled"
+    _console.print(f"telemetry {state} ({settings_path(root)})")
 
 
 @providers_app.command("verify")
@@ -179,6 +245,7 @@ def build(
     from wmh.ingest import VendorPull
     from wmh.providers import get_provider
     from wmh.retrieval import get_embedder
+    from wmh.telemetry import capture
     from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
     # Decide whether to run the wizard: explicit flag wins; otherwise auto when at a TTY and the
@@ -253,18 +320,39 @@ def build(
         tracker,
         classify=classify_build_call,
     )
+    build_stats = _BuildTelemetryStats()
     with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
-        run_build(
+        result = run_build(
             config,
             file=params.file,
             vendor=VendorPull() if params.vendor else None,
             root=model_dir,
             serve_provider=metered,
             embedder=get_embedder(config),
-            reporter=reporter,
+            reporter=_TelemetryBuildReporter(reporter, build_stats),
         )
     record = tracker.record_summary()
     save_run(record, ArtifactPaths(model_dir).runs)
+    capture(
+        "wmh build completed",
+        {
+            "success": True,
+            "input_trace_count": build_stats.input_trace_count,
+            "input_step_count": build_stats.input_step_count,
+            "train_trace_count": build_stats.train_trace_count,
+            "heldout_trace_count": build_stats.heldout_trace_count,
+            "indexed_step_count": build_stats.indexed_step_count,
+            "gepa_budget": params.gepa_budget,
+            "rollouts_used": result.metrics.rollouts_used,
+            "frontier_size": len(result.frontier),
+            "duration_seconds": round(record.duration_seconds, 3),
+            "llm_call_count": record.total.calls,
+            "input_tokens": record.total.input_tokens,
+            "output_tokens": record.total.output_tokens,
+            "cost_usd": round(record.total.cost_usd, 6),
+        },
+        root=root,
+    )
 
     _console.print(build_summary_panel(store.info(params.name), model_dir))
     _console.print(
@@ -463,6 +551,13 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     _print_eval_report(report)
     if out:
         _write_ad_hoc_eval_report(Path(out), report)
+    _capture_eval_completed(
+        mode="ad_hoc",
+        file_count=len(args),
+        report=report,
+        options=options,
+        root=ARTIFACT_DIR,
+    )
 
 
 def _eval_list(examples_root: str) -> None:
@@ -601,6 +696,13 @@ def _eval_run_suite(
     }
     destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     _console.print(f"wrote eval result -> {destination}")
+    _capture_eval_completed(
+        mode="suite",
+        file_count=len(files),
+        report=report,
+        options=options,
+        root=_settings_root_from_results_root(results_root),
+    )
 
 
 def _eval_options(
@@ -705,6 +807,38 @@ def _write_ad_hoc_eval_report(path: Path, report: EvalReport) -> None:
     _console.print(f"wrote full report -> {path}")
 
 
+def _capture_eval_completed(
+    *,
+    mode: str,
+    file_count: int,
+    report: EvalReport,
+    options: _EvalOptions,
+    root: str | Path,
+) -> None:
+    from wmh.telemetry import capture
+
+    capture(
+        "wmh eval completed",
+        {
+            "success": True,
+            "eval_mode": mode,
+            "file_count": file_count,
+            "scored_step_count": report.total_steps,
+            "rag_enabled": options.use_rag,
+            "judge_mode": options.judge,
+            "sample_turns": options.sample_turns,
+            "train_split": options.train_split,
+            "top_k": options.top_k,
+        },
+        root=root,
+    )
+
+
+def _settings_root_from_results_root(results_root: str) -> Path:
+    path = Path(results_root)
+    return path.parent if path.name == "evals" else Path(ARTIFACT_DIR)
+
+
 def _eval_report_payload(report: EvalReport) -> dict[str, object]:
     return {
         "overall_fidelity": report.overall_fidelity,
@@ -802,7 +936,9 @@ def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, nam
 
     store = WorldModelStore(root)
     resolved_name = _resolve_name(store, name)
-    world_model, provider = load_world_model(store.resolve(resolved_name))
+    world_model, provider = load_world_model(
+        store.resolve(resolved_name), telemetry_root=store.root
+    )
     return world_model, resolved_name, provider
 
 

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -8,28 +8,67 @@ models are named (`--name`), stored under `<root>/models/<name>/`, and listed wi
 
 from __future__ import annotations
 
+import json
+import subprocess
+import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import typer
+import uvicorn
 from rich.console import Console
+from rich.table import Table
 
+import wmh.providers as providers
+from wmh.cli.ui import (
+    BuildParams,
+    RichBuildReporter,
+    build_summary_panel,
+    models_table,
+    run_build_wizard,
+    run_play_repl,
+    select_model,
+)
 from wmh.config import (
     ARTIFACT_DIR,
     DEFAULT_MODEL_NAME,
     PROVIDER_ENV_VARS,
+    ArtifactPaths,
     HarnessConfig,
     WorldModelStore,
     load_config,
+    load_settings,
+    set_telemetry_enabled,
+    settings_path,
     validate_name,
 )
+from wmh.engine.build import build as run_build
+from wmh.engine.demo import run_demo
+from wmh.engine.eval import EvalReport, evaluate_files
+from wmh.engine.eval_suites import (
+    discover_eval_suites,
+    list_eval_results,
+    resolve_eval_suite,
+    result_path,
+)
+from wmh.engine.loader import load_world_model
+from wmh.engine.prompts import BASE_ENV_PROMPT
+from wmh.ingest import VendorPull
+from wmh.optimize.judge import LLMJudge, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import EmbedderKind
-
-if TYPE_CHECKING:
-    from wmh.engine.eval import EvalReport
-    from wmh.engine.reporting import BuildReporter
+from wmh.retrieval import HashingEmbedder, get_embedder
+from wmh.serving.server import create_app
+from wmh.telemetry import (
+    BuildTelemetryStats,
+    TelemetryBuildReporter,
+    capture_build_completed,
+    capture_eval_completed,
+    settings_root_from_results_root,
+)
+from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
 app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
 providers_app = typer.Typer(help="Manage and verify LLM providers.")
@@ -60,56 +99,12 @@ class _EvalOptions:
     top_k: int
 
 
-@dataclass
-class _BuildTelemetryStats:
-    input_trace_count: int = 0
-    input_step_count: int = 0
-    train_trace_count: int = 0
-    heldout_trace_count: int = 0
-    indexed_step_count: int = 0
-    frontier_size: int = 0
-    rollouts_used: int = 0
-
-
-class _TelemetryBuildReporter:
-    def __init__(self, inner: BuildReporter, stats: _BuildTelemetryStats) -> None:
-        self._inner = inner
-        self._stats = stats
-
-    def ingest_done(self, traces: int, steps: int) -> None:
-        self._stats.input_trace_count = traces
-        self._stats.input_step_count = steps
-        self._inner.ingest_done(traces, steps)
-
-    def split_done(self, train: int, test: int) -> None:
-        self._stats.train_trace_count = train
-        self._stats.heldout_trace_count = test
-        self._inner.split_done(train, test)
-
-    def index_done(self, steps: int) -> None:
-        self._stats.indexed_step_count = steps
-        self._inner.index_done(steps)
-
-    def optimize_start(self, budget: int) -> None:
-        self._inner.optimize_start(budget)
-
-    def rollout(self, done: int, budget: int, score: float | None) -> None:
-        self._inner.rollout(done, budget, score)
-
-    def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
-        self._stats.frontier_size = frontier_size
-        self._stats.rollouts_used = rollouts
-        self._inner.optimize_done(held_out_accuracy, frontier_size, rollouts)
-
-
 @config_app.command("telemetry")
 def config_telemetry(
     action: str = typer.Argument("status", help="status | enable | disable"),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding local settings."),
 ) -> None:
     """View or change project-local usage telemetry settings."""
-    from wmh.config import load_settings, set_telemetry_enabled, settings_path
-
     normalized = action.lower()
     if normalized == "status":
         settings = load_settings(root)
@@ -195,8 +190,6 @@ def examples_run(
     name: str = typer.Argument(..., help="Example task name."),
 ) -> None:
     """Run an example's local launcher, forwarding any extra args after `--`."""
-    import subprocess
-
     example_dir = _resolve_example(name)
     runner = example_dir / "run.sh"
     if not runner.exists():
@@ -237,17 +230,6 @@ def build(
     With no `--name`/`--file` on an interactive terminal, this launches a guided creation wizard;
     pass `--no-interactive` (or any of those flags) to stay fully scriptable.
     """
-    import uuid
-
-    from wmh.cli.ui import BuildParams, RichBuildReporter, build_summary_panel, run_build_wizard
-    from wmh.config import ArtifactPaths
-    from wmh.engine.build import build as run_build
-    from wmh.ingest import VendorPull
-    from wmh.providers import get_provider
-    from wmh.retrieval import get_embedder
-    from wmh.telemetry import capture
-    from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
-
     # Decide whether to run the wizard: explicit flag wins; otherwise auto when at a TTY and the
     # essential inputs (a name and a trace source) were not supplied.
     needs_input = name is None or (file is None and vendor is None)
@@ -316,11 +298,11 @@ def build(
     # the optimizer. `classify_build_call` splits judge vs GEPA by system prompt.
     tracker = RunTracker(run_id=uuid.uuid4().hex, kind="build")
     metered = MeteredProvider(
-        get_provider(config.serve_provider_config()),
+        providers.get_provider(config.serve_provider_config()),
         tracker,
         classify=classify_build_call,
     )
-    build_stats = _BuildTelemetryStats()
+    build_stats = BuildTelemetryStats()
     with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
         result = run_build(
             config,
@@ -329,28 +311,16 @@ def build(
             root=model_dir,
             serve_provider=metered,
             embedder=get_embedder(config),
-            reporter=_TelemetryBuildReporter(reporter, build_stats),
+            reporter=TelemetryBuildReporter(reporter, build_stats),
         )
     record = tracker.record_summary()
     save_run(record, ArtifactPaths(model_dir).runs)
-    capture(
-        "wmh build completed",
-        {
-            "success": True,
-            "input_trace_count": build_stats.input_trace_count,
-            "input_step_count": build_stats.input_step_count,
-            "train_trace_count": build_stats.train_trace_count,
-            "heldout_trace_count": build_stats.heldout_trace_count,
-            "indexed_step_count": build_stats.indexed_step_count,
-            "gepa_budget": params.gepa_budget,
-            "rollouts_used": result.metrics.rollouts_used,
-            "frontier_size": len(result.frontier),
-            "duration_seconds": round(record.duration_seconds, 3),
-            "llm_call_count": record.total.calls,
-            "input_tokens": record.total.input_tokens,
-            "output_tokens": record.total.output_tokens,
-            "cost_usd": round(record.total.cost_usd, 6),
-        },
+    capture_build_completed(
+        stats=build_stats,
+        gepa_budget=params.gepa_budget,
+        rollouts_used=result.metrics.rollouts_used,
+        frontier_size=len(result.frontier),
+        record=record,
         root=root,
     )
 
@@ -416,8 +386,6 @@ def _verify_or_abort(config: HarnessConfig) -> None:
 @app.command("list")
 def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list.")) -> None:
     """List every world model built under the project dir."""
-    from wmh.cli.ui import models_table
-
     infos = WorldModelStore(root).list_info()
     if not infos:
         _console.print("[yellow]no world models built yet[/yellow]; run `wmh build --name <name>`")
@@ -438,10 +406,6 @@ def serve(
     Serves every built model by default, or just the `--name` ones. Routes are namespaced:
     `/world_models/{name}/sessions` and `.../step`.
     """
-    import uvicorn
-
-    from wmh.serving.server import create_app
-
     names = list(name) if name else None
     uvicorn.run(create_app(root, names=names), host="127.0.0.1", port=port)
 
@@ -551,20 +515,20 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     _print_eval_report(report)
     if out:
         _write_ad_hoc_eval_report(Path(out), report)
-    _capture_eval_completed(
+    capture_eval_completed(
         mode="ad_hoc",
         file_count=len(args),
-        report=report,
-        options=options,
+        scored_step_count=report.total_steps,
+        rag_enabled=options.use_rag,
+        judge_mode=options.judge,
+        sample_turns=options.sample_turns,
+        train_split=options.train_split,
+        top_k=options.top_k,
         root=ARTIFACT_DIR,
     )
 
 
 def _eval_list(examples_root: str) -> None:
-    from rich.table import Table
-
-    from wmh.engine.eval_suites import discover_eval_suites
-
     suites = discover_eval_suites(examples_root)
     if not suites:
         _console.print("[yellow]no eval suites found[/yellow]")
@@ -593,10 +557,6 @@ def _eval_results(
     *,
     limit: int,
 ) -> None:
-    from rich.table import Table
-
-    from wmh.engine.eval_suites import list_eval_results, resolve_eval_suite
-
     resolved_suite = suite_filter
     if suite_filter is not None:
         try:
@@ -646,12 +606,6 @@ def _eval_run_suite(
     top_k: int | None,
     out: str | None,
 ) -> None:
-    import json
-    from datetime import UTC, datetime
-    from uuid import uuid4
-
-    from wmh.engine.eval_suites import resolve_eval_suite, result_path
-
     suite = resolve_eval_suite(selector, examples_root)
     suite_prompt = suite.resolve_prompt()
     options = _eval_options(
@@ -696,12 +650,16 @@ def _eval_run_suite(
     }
     destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     _console.print(f"wrote eval result -> {destination}")
-    _capture_eval_completed(
+    capture_eval_completed(
         mode="suite",
         file_count=len(files),
-        report=report,
-        options=options,
-        root=_settings_root_from_results_root(results_root),
+        scored_step_count=report.total_steps,
+        rag_enabled=options.use_rag,
+        judge_mode=options.judge,
+        sample_turns=options.sample_turns,
+        train_split=options.train_split,
+        top_k=options.top_k,
+        root=settings_root_from_results_root(results_root),
     )
 
 
@@ -753,12 +711,6 @@ def _run_eval_files(
     model: str,
     region: str | None,
 ) -> EvalReport:
-    from wmh.engine.eval import evaluate_files
-    from wmh.engine.prompts import BASE_ENV_PROMPT
-    from wmh.optimize.judge import LLMJudge, RubricJudge
-    from wmh.providers import ProviderConfig, get_provider
-    from wmh.retrieval import HashingEmbedder
-
     for path in files:
         if not path.exists():
             raise typer.BadParameter(f"trace file not found: {path}")
@@ -767,7 +719,7 @@ def _run_eval_files(
     except ValueError:
         kinds = ", ".join(k.value for k in ProviderKind)
         raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
-    llm = get_provider(ProviderConfig(kind=serve_provider, model=model, region=region))
+    llm = providers.get_provider(ProviderConfig(kind=serve_provider, model=model, region=region))
     prompt = (
         Path(options.prompt_file).read_text(encoding="utf-8")
         if options.prompt_file
@@ -798,45 +750,11 @@ def _print_eval_report(report: EvalReport) -> None:
 
 
 def _write_ad_hoc_eval_report(path: Path, report: EvalReport) -> None:
-    import json
-
     path.write_text(
         json.dumps({n: r.model_dump(mode="json") for n, r in report.per_file.items()}, indent=2),
         encoding="utf-8",
     )
     _console.print(f"wrote full report -> {path}")
-
-
-def _capture_eval_completed(
-    *,
-    mode: str,
-    file_count: int,
-    report: EvalReport,
-    options: _EvalOptions,
-    root: str | Path,
-) -> None:
-    from wmh.telemetry import capture
-
-    capture(
-        "wmh eval completed",
-        {
-            "success": True,
-            "eval_mode": mode,
-            "file_count": file_count,
-            "scored_step_count": report.total_steps,
-            "rag_enabled": options.use_rag,
-            "judge_mode": options.judge,
-            "sample_turns": options.sample_turns,
-            "train_split": options.train_split,
-            "top_k": options.top_k,
-        },
-        root=root,
-    )
-
-
-def _settings_root_from_results_root(results_root: str) -> Path:
-    path = Path(results_root)
-    return path.parent if path.name == "evals" else Path(ARTIFACT_DIR)
 
 
 def _eval_report_payload(report: EvalReport) -> dict[str, object]:
@@ -854,8 +772,6 @@ def demo(
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
 ) -> None:
     """Demo the harness: an LLM agent makes a tool call vs the world model; show prompt+output."""
-    from wmh.engine.demo import run_demo
-
     wm, _resolved_name, provider = _load_model(name, root)
     # Seed the demo agent from whatever steps the index holds.
     examples = wm.sample_steps(3)
@@ -872,8 +788,6 @@ def play(
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
 ) -> None:
     """Step into the environment yourself: type actions, the world model returns observations."""
-    from wmh.cli.ui import run_play_repl
-
     wm, resolved_name, _provider = _load_model(name, root)
     run_play_repl(_console, wm, resolved_name, task)
 
@@ -893,8 +807,6 @@ def _resolve_name(store: WorldModelStore, name: str | None) -> str:
         # Only enumerate full model summaries when we actually need the picker (>1 model on a TTY).
         # `list_names` is cheap (a dir scan); `list_info` reads every config/metrics/frontier file.
         if _console.is_terminal and len(store.list_names()) > 1:
-            from wmh.cli.ui import select_model
-
             return select_model(_console, store.list_info())
         return store.resolve(None).name
     except (FileNotFoundError, ValueError) as exc:
@@ -932,8 +844,6 @@ def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, nam
     Returns `(world_model, resolved_name, provider)` so callers can reuse the provider without
     re-reading config / reconstructing it.
     """
-    from wmh.engine import load_world_model
-
     store = WorldModelStore(root)
     resolved_name = _resolve_name(store, name)
     world_model, provider = load_world_model(

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -126,6 +126,24 @@ def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names
     assert "examples" in group_names
+    assert "config" in group_names
+
+
+def test_config_telemetry_command_manages_project_settings(tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+
+    disabled = runner.invoke(app, ["config", "telemetry", "disable", "--root", str(root)])
+    assert disabled.exit_code == 0, disabled.output
+    assert "telemetry disabled" in disabled.output
+    assert "enabled = false" in (root / "settings.toml").read_text(encoding="utf-8")
+
+    status = runner.invoke(app, ["config", "telemetry", "--root", str(root)])
+    assert status.exit_code == 0, status.output
+    assert "telemetry disabled" in status.output
+
+    enabled = runner.invoke(app, ["config", "telemetry", "enable", "--root", str(root)])
+    assert enabled.exit_code == 0, enabled.output
+    assert "telemetry enabled" in enabled.output
 
 
 def test_examples_list_shows_task_folders() -> None:

--- a/wmh/config/__init__.py
+++ b/wmh/config/__init__.py
@@ -8,6 +8,15 @@ from wmh.config.config import (
     load_config,
     save_config,
 )
+from wmh.config.settings import (
+    ProjectSettings,
+    TelemetrySettings,
+    ensure_telemetry_anonymous_id,
+    load_settings,
+    save_settings,
+    set_telemetry_enabled,
+    settings_path,
+)
 from wmh.config.store import (
     DEFAULT_MODEL_NAME,
     ModelInfo,
@@ -22,8 +31,15 @@ __all__ = [
     "ArtifactPaths",
     "HarnessConfig",
     "ModelInfo",
+    "ProjectSettings",
+    "TelemetrySettings",
     "WorldModelStore",
+    "ensure_telemetry_anonymous_id",
     "load_config",
+    "load_settings",
     "save_config",
+    "save_settings",
+    "set_telemetry_enabled",
+    "settings_path",
     "validate_name",
 ]

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -1,0 +1,71 @@
+"""Project-local settings stored under the selected harness root."""
+
+from __future__ import annotations
+
+import tomllib
+import uuid
+from pathlib import Path
+
+import tomli_w
+from pydantic import BaseModel, Field, ValidationError
+
+from wmh.config.config import ARTIFACT_DIR
+
+SETTINGS_FILENAME = "settings.toml"
+
+
+class TelemetrySettings(BaseModel):
+    """Usage telemetry preferences for this harness project."""
+
+    enabled: bool = True
+    anonymous_id: str | None = None
+
+
+class ProjectSettings(BaseModel):
+    """Settings that are local to one harness project root."""
+
+    telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
+
+
+def settings_path(root: str | Path = ARTIFACT_DIR) -> Path:
+    return Path(root) / SETTINGS_FILENAME
+
+
+def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
+    path = settings_path(root)
+    if not path.exists():
+        return ProjectSettings()
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{path} is not valid TOML ({exc})") from exc
+    try:
+        return ProjectSettings.model_validate(data)
+    except ValidationError as exc:
+        raise ValueError(f"{path} does not match the current settings schema ({exc})") from exc
+
+
+def save_settings(settings: ProjectSettings, root: str | Path = ARTIFACT_DIR) -> None:
+    path = settings_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = settings.model_dump(mode="json", exclude_none=True)
+    tmp = path.with_name(f"{path.name}.tmp")
+    with tmp.open("wb") as fh:
+        tomli_w.dump(data, fh)
+    tmp.replace(path)
+
+
+def set_telemetry_enabled(enabled: bool, root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
+    settings = load_settings(root)
+    settings.telemetry.enabled = enabled
+    save_settings(settings, root)
+    return settings
+
+
+def ensure_telemetry_anonymous_id(root: str | Path = ARTIFACT_DIR) -> str:
+    settings = load_settings(root)
+    if settings.telemetry.anonymous_id is None:
+        settings.telemetry.anonymous_id = uuid.uuid4().hex
+        save_settings(settings, root)
+    return settings.telemetry.anonymous_id

--- a/wmh/config/settings_test.py
+++ b/wmh/config/settings_test.py
@@ -1,0 +1,52 @@
+"""Tests for project-local settings under .wmh/settings.toml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.config.settings import (
+    ProjectSettings,
+    ensure_telemetry_anonymous_id,
+    load_settings,
+    save_settings,
+    set_telemetry_enabled,
+    settings_path,
+)
+
+
+def test_missing_settings_defaults_to_telemetry_enabled(tmp_path: Path) -> None:
+    settings = load_settings(tmp_path / ".wmh")
+    assert settings.telemetry.enabled is True
+    assert settings.telemetry.anonymous_id is None
+
+
+def test_save_then_load_settings_round_trips(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(ProjectSettings(), root)
+    loaded = load_settings(root)
+    assert loaded.telemetry.enabled is True
+
+
+def test_set_telemetry_enabled_writes_project_settings(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    set_telemetry_enabled(False, root)
+    assert load_settings(root).telemetry.enabled is False
+    assert "enabled = false" in settings_path(root).read_text(encoding="utf-8")
+
+
+def test_ensure_telemetry_anonymous_id_persists_value(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    first = ensure_telemetry_anonymous_id(root)
+    second = ensure_telemetry_anonymous_id(root)
+    assert first == second
+    assert len(first) == 32
+
+
+def test_load_corrupt_settings_raises_friendly_error(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    root.mkdir()
+    settings_path(root).write_text("not = = toml", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid TOML"):
+        load_settings(root)

--- a/wmh/engine/loader.py
+++ b/wmh/engine/loader.py
@@ -15,7 +15,9 @@ from wmh.providers import get_provider
 from wmh.providers.base import Provider
 
 
-def load_world_model(model_dir: str | Path) -> tuple[WorldModel, Provider]:
+def load_world_model(
+    model_dir: str | Path, *, telemetry_root: str | Path | None = None
+) -> tuple[WorldModel, Provider]:
     """Load the world model under `model_dir`, returning it with the serve provider it was built on.
 
     The provider is returned alongside so callers that also need it (e.g. `wmh demo`, which runs an
@@ -23,4 +25,4 @@ def load_world_model(model_dir: str | Path) -> tuple[WorldModel, Provider]:
     """
     config = load_config(str(model_dir))
     provider = get_provider(config.serve_provider_config())
-    return WorldModel.load(str(model_dir), provider), provider
+    return WorldModel.load(str(model_dir), provider, telemetry_root=telemetry_root), provider

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -7,7 +7,9 @@ session — including the env's free-text scratchpad "database" — to stay cons
 
 from __future__ import annotations
 
+import time
 import uuid
+from pathlib import Path
 
 from wmh.core.parsing import parse_observation
 from wmh.core.types import Action, EnvState, Observation, Session, Step
@@ -24,11 +26,13 @@ class WorldModel:
         retriever: Retriever,
         env_prompt: str = BASE_ENV_PROMPT,
         top_k: int = 5,
+        telemetry_root: str | Path = ".wmh",
     ) -> None:
         self._provider = provider
         self._retriever = retriever
         self._env_prompt = env_prompt
         self._top_k = top_k
+        self._telemetry_root = Path(telemetry_root)
         self._sessions: dict[str, Session] = {}
         # Per-session token/cost/time accounting (serve-time observability). One tracker per
         # session, started when the session is created; `session_usage` exposes running totals.
@@ -36,7 +40,11 @@ class WorldModel:
 
     @classmethod
     def load(
-        cls, artifact_dir: str, provider: Provider, embedder: Embedder | None = None
+        cls,
+        artifact_dir: str,
+        provider: Provider,
+        embedder: Embedder | None = None,
+        telemetry_root: str | Path | None = None,
     ) -> WorldModel:
         """Construct from a built `.wmh/` artifact (optimized prompt + indexed replay buffer).
 
@@ -59,14 +67,27 @@ class WorldModel:
         retriever = EmbeddingRetriever(embedder or get_embedder(config))
         if paths.index.exists():
             retriever.load(paths.index)
-        return cls(provider, retriever, env_prompt=env_prompt, top_k=config.top_k)
+        return cls(
+            provider,
+            retriever,
+            env_prompt=env_prompt,
+            top_k=config.top_k,
+            telemetry_root=telemetry_root or artifact_dir,
+        )
 
     def new_session(self, task: str | None = None, seed_state: EnvState | None = None) -> Session:
+        from wmh.telemetry import capture
+
         session = Session(id=uuid.uuid4().hex, task=task, state=seed_state or EnvState())
         self._sessions[session.id] = session
         tracker = RunTracker(run_id=session.id, kind="serve")
         tracker.start()
         self._trackers[session.id] = tracker
+        capture(
+            "wmh generated trace started",
+            {"generated_trace_count": 1},
+            root=getattr(self, "_telemetry_root", ".wmh"),
+        )
         return session
 
     def session_usage(self, session_id: str) -> RunRecord:
@@ -99,6 +120,9 @@ class WorldModel:
 
     def step(self, session_id: str, action: Action) -> Observation:
         """Predict the observation for `action` and advance the session. DreamGym Eq. (4)."""
+        from wmh.telemetry import capture
+
+        started = time.monotonic()
         session = self._sessions[session_id]
 
         # (1) retrieve top-k similar past steps conditioned on the latest state + action
@@ -106,13 +130,26 @@ class WorldModel:
 
         # (2) assemble the env prompt and (3) predict the observation
         system, user = build_env_prompt(self._env_prompt, session, action, demos)
-        completion = self._provider.complete(system, [_user_message(user)])
+        try:
+            completion = self._provider.complete(system, [_user_message(user)])
+        except Exception:
+            capture(
+                "wmh generated step failed",
+                {
+                    "success": False,
+                    "duration_seconds": round(time.monotonic() - started, 3),
+                },
+                root=self._telemetry_root,
+            )
+            raise
         observation = parse_observation(completion.text)
 
         # serve-time metering: attribute this call's tokens/cost to the session
+        usage_cost_usd: float | None = None
         tracker = self._trackers.get(session_id)
         if tracker is not None:
-            tracker.record(Phase.SERVE, self._provider.config.model, completion.usage)
+            usage_event = tracker.record(Phase.SERVE, self._provider.config.model, completion.usage)
+            usage_cost_usd = usage_event.cost_usd
 
         # (4) advance session: append step, update structured state + scratchpad, enrich buffer
         step = Step(
@@ -121,6 +158,19 @@ class WorldModel:
         session.history.append(step)
         self._update_state(session, step)
         self._retriever.add(step)
+        capture(
+            "wmh generated step completed",
+            {
+                "success": True,
+                "generated_step_count": 1,
+                "session_step_count": len(session.history),
+                "duration_seconds": round(time.monotonic() - started, 3),
+                "input_tokens": completion.usage.input_tokens,
+                "output_tokens": completion.usage.output_tokens,
+                "cost_usd": round(usage_cost_usd, 6) if usage_cost_usd is not None else None,
+            },
+            root=self._telemetry_root,
+        )
         return observation
 
     def _update_state(self, session: Session, step: Step) -> None:

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -11,11 +11,14 @@ import time
 import uuid
 from pathlib import Path
 
+from wmh.config import ArtifactPaths, load_config
 from wmh.core.parsing import parse_observation
 from wmh.core.types import Action, EnvState, Observation, Session, Step
 from wmh.engine.prompts import BASE_ENV_PROMPT, build_env_prompt
 from wmh.providers.base import Embedder, Message, Provider
 from wmh.retrieval import EmbeddingRetriever, Retriever
+from wmh.retrieval.embedders import get_embedder
+from wmh.telemetry import capture
 from wmh.tracking import Phase, RunRecord, RunTracker
 
 
@@ -52,9 +55,6 @@ class WorldModel:
         when omitted we reconstruct the configured embedder (`embed_provider` + `embed_dim`), which
         defaults to the offline `HashingEmbedder` so loading needs no embedding credentials.
         """
-        from wmh.config import ArtifactPaths, load_config
-        from wmh.retrieval.embedders import get_embedder
-
         config = load_config(artifact_dir)
         paths = ArtifactPaths(artifact_dir)
         env_prompt = (
@@ -76,8 +76,6 @@ class WorldModel:
         )
 
     def new_session(self, task: str | None = None, seed_state: EnvState | None = None) -> Session:
-        from wmh.telemetry import capture
-
         session = Session(id=uuid.uuid4().hex, task=task, state=seed_state or EnvState())
         self._sessions[session.id] = session
         tracker = RunTracker(run_id=session.id, kind="serve")
@@ -120,8 +118,6 @@ class WorldModel:
 
     def step(self, session_id: str, action: Action) -> Observation:
         """Predict the observation for `action` and advance the session. DreamGym Eq. (4)."""
-        from wmh.telemetry import capture
-
         started = time.monotonic()
         session = self._sessions[session_id]
 

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -72,7 +72,7 @@ class WorldModel:
             retriever,
             env_prompt=env_prompt,
             top_k=config.top_k,
-            telemetry_root=telemetry_root or artifact_dir,
+            telemetry_root=telemetry_root or _default_telemetry_root(artifact_dir),
         )
 
     def new_session(self, task: str | None = None, seed_state: EnvState | None = None) -> Session:
@@ -84,7 +84,7 @@ class WorldModel:
         capture(
             "wmh generated trace started",
             {"generated_trace_count": 1},
-            root=getattr(self, "_telemetry_root", ".wmh"),
+            root=self._telemetry_root,
         )
         return session
 
@@ -184,3 +184,10 @@ class WorldModel:
 
 def _user_message(text: str) -> Message:
     return Message(role="user", content=text)
+
+
+def _default_telemetry_root(artifact_dir: str | Path) -> Path:
+    path = Path(artifact_dir)
+    if path.parent.name == "models":
+        return path.parent.parent
+    return path

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import httpx
 import pytest
 
+import wmh.telemetry as telemetry
+from wmh.config import ArtifactPaths, HarnessConfig, save_config
+from wmh.config.settings import set_telemetry_enabled
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
 from wmh.engine.world_model import WorldModel
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, TokenUsage
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
 
 def test_world_model_new_session_works() -> None:
     wm = WorldModel.__new__(WorldModel)
+    wm._telemetry_root = Path(".wmh")
     wm._sessions = {}
     wm._trackers = {}
     session = WorldModel.new_session(wm, task="hi")
@@ -107,8 +110,6 @@ class _UsageProvider(FakeProvider):
         temperature: float = 0.7,
         max_tokens: int = 8192,
     ) -> Completion:
-        from wmh.providers.base import TokenUsage
-
         self.last_system = system
         self.last_user = messages[0].content
         return Completion(text=self._reply, usage=TokenUsage(input_tokens=120, output_tokens=30))
@@ -137,11 +138,19 @@ def test_step_telemetry_counts_steps_without_content(
 ) -> None:
     calls: list[object] = []
 
-    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
-        calls.append(json)
-        return httpx.Response(200)
+    class FakePosthog:
+        def __init__(self, project_api_key: str, **kwargs: object) -> None:
+            pass
 
-    monkeypatch.setattr(httpx, "post", fake_post)
+        def capture(self, event: str, **kwargs: object) -> str:
+            calls.append({"event": event, **kwargs})
+            return "message-id"
+
+        def shutdown(self) -> None:
+            pass
+
+    telemetry._CLIENTS.clear()
+    monkeypatch.setattr(telemetry, "Posthog", FakePosthog)
     monkeypatch.setenv("WMH_TELEMETRY", "1")
     monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
 
@@ -166,8 +175,6 @@ def test_step_telemetry_counts_steps_without_content(
 
 
 def test_load_reads_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture
-    from wmh.config import ArtifactPaths, HarnessConfig, save_config
-
     root = tmp_path / ".wmh"
     # embed_dim must match the embedder the index was built with (64 here), or load() rebuilds a
     # mismatched query embedder. This is the contract WorldModel.load relies on.
@@ -193,3 +200,35 @@ def test_load_reads_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture
         EnvState(), Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "x"}), k=1
     )
     assert len(restored) == 1 and restored[0].observation.content == "ok"
+
+
+def test_load_named_model_uses_project_root_for_telemetry_opt_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[object] = []
+
+    class FakePosthog:
+        def __init__(self, project_api_key: str, **kwargs: object) -> None:
+            pass
+
+        def capture(self, event: str, **kwargs: object) -> str:
+            calls.append({"event": event, **kwargs})
+            return "message-id"
+
+        def shutdown(self) -> None:
+            pass
+
+    project_root = tmp_path / ".wmh"
+    model_dir = project_root / "models" / "demo"
+    save_config(HarnessConfig(top_k=2, embed_dim=64), model_dir)
+    set_telemetry_enabled(False, project_root)
+    telemetry._CLIENTS.clear()
+    monkeypatch.setattr(telemetry, "Posthog", FakePosthog)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    wm = WorldModel.load(str(model_dir), FakeProvider("{}"))
+    wm.new_session(task="should respect project opt-out")
+
+    assert wm._telemetry_root == project_root
+    assert calls == []

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import httpx
 import pytest
 
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
@@ -126,6 +130,39 @@ def test_step_meters_usage_per_session() -> None:
     assert usage.total.output_tokens == 60
     # 240*5/1e6 + 60*25/1e6 = 0.0012 + 0.0015 = 0.0027 (float division → approx)
     assert usage.total.cost_usd == pytest.approx(0.0027)
+
+
+def test_step_telemetry_counts_steps_without_content(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[object] = []
+
+    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
+        calls.append(json)
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setenv("WMH_TELEMETRY", "1")
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    provider = _UsageProvider('{"output": "secret observation", "is_error": false}')
+    provider.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="claude-opus-4-8")
+    wm = WorldModel(provider, _retriever_with([]), top_k=1, telemetry_root=tmp_path / ".wmh")
+    session = wm.new_session(task="secret task")
+    wm.step(
+        session.id,
+        Action(kind=ActionKind.TOOL_CALL, name="secret_tool", arguments={"secret": "value"}),
+    )
+
+    serialized = json.dumps(calls)
+    assert "wmh generated trace started" in serialized
+    assert "wmh generated step completed" in serialized
+    assert "generated_trace_count" in serialized
+    assert "generated_step_count" in serialized
+    assert "secret task" not in serialized
+    assert "secret_tool" not in serialized
+    assert "secret observation" not in serialized
+    assert "value" not in serialized
 
 
 def test_load_reads_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -49,7 +49,7 @@ def _load_named_models(artifact_dir: str, names: list[str] | None) -> dict[str, 
         )
     models: dict[str, WorldModel] = {}
     for name in chosen:
-        world_model, _provider = load_world_model(store.resolve(name))
+        world_model, _provider = load_world_model(store.resolve(name), telemetry_root=store.root)
         models[name] = world_model
     return models
 

--- a/wmh/telemetry.py
+++ b/wmh/telemetry.py
@@ -172,7 +172,7 @@ def _enabled(root: str | Path) -> bool:
         return False
     try:
         return load_settings(root).telemetry.enabled
-    except ValueError:
+    except (OSError, ValueError):
         return False
 
 

--- a/wmh/telemetry.py
+++ b/wmh/telemetry.py
@@ -1,0 +1,90 @@
+"""Best-effort anonymous usage telemetry."""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import httpx
+
+from wmh.config import ARTIFACT_DIR
+from wmh.config.settings import ensure_telemetry_anonymous_id, load_settings
+
+POSTHOG_PROJECT_API_KEY = "phc_rPFfCufWpxyctR7duEZTTXovP4k5kbHqSqzd4Z4MQJdL"
+POSTHOG_HOST = "https://us.i.posthog.com"
+
+TelemetryValue = str | int | float | bool | None
+TelemetryProperties = dict[str, TelemetryValue]
+
+_FALSE_VALUES = {"0", "false", "off", "no"}
+_TRUE_VALUES = {"1", "true", "on", "yes"}
+
+
+def capture(
+    event: str,
+    properties: TelemetryProperties | None = None,
+    *,
+    root: str | Path = ARTIFACT_DIR,
+) -> bool:
+    """Send one anonymous metadata-only event. Returns False when skipped or failed."""
+    if not _enabled(root):
+        return False
+    api_key = os.getenv("WMH_POSTHOG_PROJECT_API_KEY", POSTHOG_PROJECT_API_KEY).strip()
+    if not api_key:
+        return False
+    host = os.getenv("WMH_POSTHOG_HOST", POSTHOG_HOST).rstrip("/")
+    try:
+        distinct_id = ensure_telemetry_anonymous_id(root)
+        event_properties: TelemetryProperties = {
+            "$process_person_profile": False,
+            "wmh_version": _wmh_version(),
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+            **(properties or {}),
+        }
+        # Never log prompts, traces, actions, observations, paths, models, credentials, or text.
+        response = httpx.post(
+            f"{host}/i/v0/e/",
+            json={
+                "api_key": api_key,
+                "event": event,
+                "distinct_id": distinct_id,
+                "properties": event_properties,
+            },
+            timeout=0.5,
+        )
+        return 200 <= response.status_code < 300
+    except (httpx.HTTPError, OSError, ValueError):
+        return False
+
+
+def _enabled(root: str | Path) -> bool:
+    if _env_truthy("DO_NOT_TRACK"):
+        return False
+    env = os.getenv("WMH_TELEMETRY")
+    if env is not None:
+        return env.strip().lower() in _TRUE_VALUES
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return False
+    try:
+        return load_settings(root).telemetry.enabled
+    except ValueError:
+        return False
+
+
+def _env_truthy(name: str) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    if normalized in _FALSE_VALUES:
+        return False
+    return bool(normalized)
+
+
+def _wmh_version() -> str:
+    try:
+        return version("world-model-harness")
+    except PackageNotFoundError:
+        return "0+local"

--- a/wmh/telemetry.py
+++ b/wmh/telemetry.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import os
 import sys
-from importlib.metadata import PackageNotFoundError, version
+from dataclasses import dataclass
+from importlib.metadata import version
 from pathlib import Path
 
 import httpx
 
 from wmh.config import ARTIFACT_DIR
 from wmh.config.settings import ensure_telemetry_anonymous_id, load_settings
+from wmh.engine.reporting import BuildReporter
+from wmh.tracking import RunRecord
 
 POSTHOG_PROJECT_API_KEY = "phc_rPFfCufWpxyctR7duEZTTXovP4k5kbHqSqzd4Z4MQJdL"
 POSTHOG_HOST = "https://us.i.posthog.com"
@@ -20,6 +23,44 @@ TelemetryProperties = dict[str, TelemetryValue]
 
 _FALSE_VALUES = {"0", "false", "off", "no"}
 _TRUE_VALUES = {"1", "true", "on", "yes"}
+
+
+@dataclass
+class BuildTelemetryStats:
+    input_trace_count: int = 0
+    input_step_count: int = 0
+    train_trace_count: int = 0
+    heldout_trace_count: int = 0
+    indexed_step_count: int = 0
+
+
+class TelemetryBuildReporter:
+    def __init__(self, inner: BuildReporter, stats: BuildTelemetryStats) -> None:
+        self._inner = inner
+        self._stats = stats
+
+    def ingest_done(self, traces: int, steps: int) -> None:
+        self._stats.input_trace_count = traces
+        self._stats.input_step_count = steps
+        self._inner.ingest_done(traces, steps)
+
+    def split_done(self, train: int, test: int) -> None:
+        self._stats.train_trace_count = train
+        self._stats.heldout_trace_count = test
+        self._inner.split_done(train, test)
+
+    def index_done(self, steps: int) -> None:
+        self._stats.indexed_step_count = steps
+        self._inner.index_done(steps)
+
+    def optimize_start(self, budget: int) -> None:
+        self._inner.optimize_start(budget)
+
+    def rollout(self, done: int, budget: int, score: float | None) -> None:
+        self._inner.rollout(done, budget, score)
+
+    def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
+        self._inner.optimize_done(held_out_accuracy, frontier_size, rollouts)
 
 
 def capture(
@@ -59,6 +100,71 @@ def capture(
         return False
 
 
+def capture_build_completed(
+    *,
+    stats: BuildTelemetryStats,
+    gepa_budget: int,
+    rollouts_used: int,
+    frontier_size: int,
+    record: RunRecord,
+    root: str | Path,
+) -> None:
+    capture(
+        "wmh build completed",
+        {
+            "success": True,
+            "input_trace_count": stats.input_trace_count,
+            "input_step_count": stats.input_step_count,
+            "train_trace_count": stats.train_trace_count,
+            "heldout_trace_count": stats.heldout_trace_count,
+            "indexed_step_count": stats.indexed_step_count,
+            "gepa_budget": gepa_budget,
+            "rollouts_used": rollouts_used,
+            "frontier_size": frontier_size,
+            "duration_seconds": round(record.duration_seconds, 3),
+            "llm_call_count": record.total.calls,
+            "input_tokens": record.total.input_tokens,
+            "output_tokens": record.total.output_tokens,
+            "cost_usd": round(record.total.cost_usd, 6),
+        },
+        root=root,
+    )
+
+
+def capture_eval_completed(
+    *,
+    mode: str,
+    file_count: int,
+    scored_step_count: int,
+    rag_enabled: bool,
+    judge_mode: str,
+    sample_turns: str,
+    train_split: float,
+    top_k: int,
+    root: str | Path,
+) -> None:
+    capture(
+        "wmh eval completed",
+        {
+            "success": True,
+            "eval_mode": mode,
+            "file_count": file_count,
+            "scored_step_count": scored_step_count,
+            "rag_enabled": rag_enabled,
+            "judge_mode": judge_mode,
+            "sample_turns": sample_turns,
+            "train_split": train_split,
+            "top_k": top_k,
+        },
+        root=root,
+    )
+
+
+def settings_root_from_results_root(results_root: str) -> Path:
+    path = Path(results_root)
+    return path.parent if path.name == "evals" else Path(ARTIFACT_DIR)
+
+
 def _enabled(root: str | Path) -> bool:
     if _env_truthy("DO_NOT_TRACK"):
         return False
@@ -84,7 +190,4 @@ def _env_truthy(name: str) -> bool:
 
 
 def _wmh_version() -> str:
-    try:
-        return version("world-model-harness")
-    except PackageNotFoundError:
-        return "0+local"
+    return version("world-model-harness")

--- a/wmh/telemetry.py
+++ b/wmh/telemetry.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import os
 import sys
+from atexit import register
 from dataclasses import dataclass
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-import httpx
+from posthog import Posthog
 
 from wmh.config import ARTIFACT_DIR
 from wmh.config.settings import ensure_telemetry_anonymous_id, load_settings
@@ -23,6 +24,7 @@ TelemetryProperties = dict[str, TelemetryValue]
 
 _FALSE_VALUES = {"0", "false", "off", "no"}
 _TRUE_VALUES = {"1", "true", "on", "yes"}
+_CLIENTS: dict[tuple[str, str], Posthog] = {}
 
 
 @dataclass
@@ -85,18 +87,13 @@ def capture(
             **(properties or {}),
         }
         # Never log prompts, traces, actions, observations, paths, models, credentials, or text.
-        response = httpx.post(
-            f"{host}/i/v0/e/",
-            json={
-                "api_key": api_key,
-                "event": event,
-                "distinct_id": distinct_id,
-                "properties": event_properties,
-            },
-            timeout=0.5,
+        message_id = _posthog_client(api_key, host).capture(
+            event,
+            distinct_id=distinct_id,
+            properties=event_properties,
         )
-        return 200 <= response.status_code < 300
-    except (httpx.HTTPError, OSError, ValueError):
+        return message_id is not None
+    except (OSError, ValueError):
         return False
 
 
@@ -190,4 +187,23 @@ def _env_truthy(name: str) -> bool:
 
 
 def _wmh_version() -> str:
-    return version("world-model-harness")
+    try:
+        return version("world-model-harness")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _posthog_client(api_key: str, host: str) -> Posthog:
+    key = (api_key, host)
+    client = _CLIENTS.get(key)
+    if client is None:
+        client = Posthog(
+            api_key,
+            host=host,
+            flush_interval=1.0,
+            max_retries=1,
+            timeout=0.5,
+        )
+        _CLIENTS[key] = client
+        register(client.shutdown)
+    return client

--- a/wmh/telemetry_test.py
+++ b/wmh/telemetry_test.py
@@ -74,6 +74,23 @@ def test_capture_respects_project_opt_out(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert clients == []
 
 
+def test_capture_skips_when_settings_file_cannot_be_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clients = _install_fake_posthog(monkeypatch)
+
+    def unreadable_settings(root: str | Path) -> object:
+        raise PermissionError
+
+    monkeypatch.setattr(telemetry, "load_settings", unreadable_settings)
+    monkeypatch.delenv("WMH_TELEMETRY", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    assert capture("wmh test event", root=tmp_path / ".wmh") is False
+    assert clients == []
+
+
 def test_do_not_track_wins_over_env_enable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     clients = _install_fake_posthog(monkeypatch)
 

--- a/wmh/telemetry_test.py
+++ b/wmh/telemetry_test.py
@@ -1,0 +1,73 @@
+"""Tests for anonymous PostHog telemetry capture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import httpx
+import pytest
+
+from wmh.config.settings import set_telemetry_enabled
+from wmh.telemetry import capture
+
+
+def test_capture_posts_anonymous_metadata_event(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, object, float]] = []
+
+    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
+        calls.append((url, json, timeout))
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setenv("WMH_TELEMETRY", "1")
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    assert capture("wmh test event", {"generated_step_count": 1}, root=tmp_path / ".wmh")
+
+    assert len(calls) == 1
+    url, raw_payload, timeout = calls[0]
+    payload = cast(dict[str, object], raw_payload)
+    properties = cast(dict[str, object], payload["properties"])
+    assert url == "https://us.i.posthog.com/i/v0/e/"
+    assert timeout == 0.5
+    assert payload["api_key"] == "phc_test"
+    assert payload["event"] == "wmh test event"
+    assert isinstance(payload["distinct_id"], str)
+    assert properties["$process_person_profile"] is False
+    assert properties["generated_step_count"] == 1
+
+
+def test_capture_respects_project_opt_out(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[object] = []
+
+    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
+        calls.append((url, json, timeout))
+        return httpx.Response(200)
+
+    root = tmp_path / ".wmh"
+    set_telemetry_enabled(False, root)
+    monkeypatch.delenv("WMH_TELEMETRY", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    assert capture("wmh test event", root=root) is False
+    assert calls == []
+
+
+def test_do_not_track_wins_over_env_enable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[object] = []
+
+    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
+        calls.append((url, json, timeout))
+        return httpx.Response(200)
+
+    monkeypatch.setenv("WMH_TELEMETRY", "1")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    assert capture("wmh test event", root=tmp_path / ".wmh") is False
+    assert calls == []

--- a/wmh/telemetry_test.py
+++ b/wmh/telemetry_test.py
@@ -5,69 +5,100 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
-import httpx
 import pytest
 
+import wmh.telemetry as telemetry
 from wmh.config.settings import set_telemetry_enabled
 from wmh.telemetry import capture
+
+
+class _FakePosthog:
+    instances: list[_FakePosthog] = []
+
+    def __init__(self, project_api_key: str, **kwargs: object) -> None:
+        self.project_api_key = project_api_key
+        self.kwargs = kwargs
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.shutdown_called = False
+        self.instances.append(self)
+
+    def capture(self, event: str, **kwargs: object) -> str:
+        self.calls.append((event, kwargs))
+        return "message-id"
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def _install_fake_posthog(monkeypatch: pytest.MonkeyPatch) -> list[_FakePosthog]:
+    _FakePosthog.instances = []
+    telemetry._CLIENTS.clear()
+    monkeypatch.setattr(telemetry, "Posthog", _FakePosthog)
+    return _FakePosthog.instances
 
 
 def test_capture_posts_anonymous_metadata_event(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[str, object, float]] = []
+    clients = _install_fake_posthog(monkeypatch)
 
-    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
-        calls.append((url, json, timeout))
-        return httpx.Response(200)
-
-    monkeypatch.setattr(httpx, "post", fake_post)
     monkeypatch.setenv("WMH_TELEMETRY", "1")
     monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
 
     assert capture("wmh test event", {"generated_step_count": 1}, root=tmp_path / ".wmh")
 
-    assert len(calls) == 1
-    url, raw_payload, timeout = calls[0]
-    payload = cast(dict[str, object], raw_payload)
-    properties = cast(dict[str, object], payload["properties"])
-    assert url == "https://us.i.posthog.com/i/v0/e/"
-    assert timeout == 0.5
-    assert payload["api_key"] == "phc_test"
-    assert payload["event"] == "wmh test event"
-    assert isinstance(payload["distinct_id"], str)
+    assert len(clients) == 1
+    client = clients[0]
+    assert client.project_api_key == "phc_test"
+    assert client.kwargs["host"] == "https://us.i.posthog.com"
+    assert client.kwargs["timeout"] == 0.5
+    assert len(client.calls) == 1
+    event, kwargs = client.calls[0]
+    properties = cast(dict[str, object], kwargs["properties"])
+    assert event == "wmh test event"
+    assert isinstance(kwargs["distinct_id"], str)
     assert properties["$process_person_profile"] is False
     assert properties["generated_step_count"] == 1
 
 
 def test_capture_respects_project_opt_out(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    calls: list[object] = []
-
-    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
-        calls.append((url, json, timeout))
-        return httpx.Response(200)
+    clients = _install_fake_posthog(monkeypatch)
 
     root = tmp_path / ".wmh"
     set_telemetry_enabled(False, root)
     monkeypatch.delenv("WMH_TELEMETRY", raising=False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
-    monkeypatch.setattr(httpx, "post", fake_post)
 
     assert capture("wmh test event", root=root) is False
-    assert calls == []
+    assert clients == []
 
 
 def test_do_not_track_wins_over_env_enable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    calls: list[object] = []
-
-    def fake_post(url: str, *, json: object, timeout: float) -> httpx.Response:
-        calls.append((url, json, timeout))
-        return httpx.Response(200)
+    clients = _install_fake_posthog(monkeypatch)
 
     monkeypatch.setenv("WMH_TELEMETRY", "1")
     monkeypatch.setenv("DO_NOT_TRACK", "1")
-    monkeypatch.setattr(httpx, "post", fake_post)
 
     assert capture("wmh test event", root=tmp_path / ".wmh") is False
-    assert calls == []
+    assert clients == []
+
+
+def test_capture_uses_unknown_version_when_distribution_metadata_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clients = _install_fake_posthog(monkeypatch)
+
+    def missing_version(distribution_name: str) -> str:
+        raise telemetry.PackageNotFoundError(distribution_name)
+
+    monkeypatch.setattr(telemetry, "version", missing_version)
+    monkeypatch.setenv("WMH_TELEMETRY", "1")
+    monkeypatch.setenv("WMH_POSTHOG_PROJECT_API_KEY", "phc_test")
+
+    assert capture("wmh test event", root=tmp_path / ".wmh")
+
+    assert len(clients) == 1
+    _event, kwargs = clients[0].calls[0]
+    properties = cast(dict[str, object], kwargs["properties"])
+    assert properties["wmh_version"] == "unknown"


### PR DESCRIPTION
## Summary
- Add project-local `.wmh/settings.toml` support for telemetry preferences and anonymous install ids.
- Add best-effort PostHog capture for build/eval metadata plus generated world-model trace/session and step counts.
- Add `wmh config telemetry status|enable|disable` and README docs for metadata-only telemetry and opt-out paths.

## Privacy
Telemetry payloads intentionally exclude prompts, traces, actions, observations, file paths, model names, provider credentials, and raw user content. The generated-step instrumentation is covered by a regression test that asserts secret task/action/observation strings are not posted.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check wmh/cli/app.py wmh/cli/app_test.py wmh/config/__init__.py wmh/config/settings.py wmh/config/settings_test.py wmh/engine/loader.py wmh/engine/world_model.py wmh/engine/world_model_test.py wmh/serving/server.py wmh/telemetry.py wmh/telemetry_test.py`
- `uv run ty check`
- `uv run pytest -q`

Note: full `uv run ruff format --check .` still reports pre-existing formatting issues in `scripts/plot_trace_scaling.py` and `wmh/research/trace_scaling_test.py`, so I kept formatting checks scoped to the files changed in this PR.