### PR TITLE
AGENTS.md: add process rules 8-13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,47 @@ uv run pytest -q
 7. **Route reusable workflows through `wmh`.** Avoid parallel top-level scripts for harness actions.
    If a workflow is generally useful outside one example dataset, implement it in `wmh/` and expose
    it through the CLI.
+
+8. **Design every public surface from the perspective of a dev using it.** Before implementing a
+   feature, write the call site first — the Python snippet or CLI invocation an outside developer
+   would type — and judge it: is it obvious, minimal, and hard to misuse? Public surfaces (the
+   `wmh` Python API, CLI commands, pydantic models) stay small, composable, and explicitly typed.
+   Extend via the existing seam for that concern (a new `TraceAdapter`, provider, retriever, eval
+   scorer) rather than flags and special cases on existing functions. Error messages are part of
+   the interface: a failure a user can hit must say what went wrong *and* what to do about it.
+
+9. **Tests and evals come before functionality.** Write the failing test (for harness code) or the
+   eval (for world-model behavior, under `examples/<task>/evals/`) first, then implement until it
+   passes. Bug fixes are no exception: first write a test that reproduces the bug and fails, then
+   fix it — a fix without a captured repro can silently regress. Treat failures as a coevolution
+   loop: a failing test means the test *or* the implementation is wrong. Tests go stale — if the
+   implementation's behavior is correct and the test encodes an outdated expectation, fix or delete
+   the test, stating why. But never weaken a test merely to get green, and never mark work done on
+   a test you haven't watched fail first. New behavior without a test or eval that would catch its
+   regression is not done.
+
+10. **Verify end-to-end before claiming done.** Unit tests passing is necessary, not sufficient.
+    For anything with a runtime surface, actually drive it — run the CLI command, hit the served
+    endpoint, render the figure — and confirm the observed behavior, not just the exit code.
+
+11. **Improve automated components by inspecting their actual outputs.** Anything automated — an
+    LLM judge, a retriever, an optimizer, a scorer — is tuned against real data, not intuition.
+    Pull a sample of its actual inputs and outputs, read them, ask "do I agree with what it did
+    here?", and tweak based on the disagreements. A judge prompt is validated by reading its
+    scores on real predictions; a retriever by reading what it retrieved. Never declare an
+    automated component improved without looking at concrete before/after examples.
+
+12. **Build for now, not for the future.** No speculative generality, no unused hooks, no
+    backwards compatibility — this is a pre-1.0 open-source project, so make breaking changes
+    freely and delete deprecated paths outright instead of shimming them. When behavior changes,
+    migrate every caller in the same change and keep exactly one way to do each thing. The
+    cleanest codebase is the one with the least code.
+
+13. **All visuals follow the brand system.** Research figures, README/docs images, frontends, and
+    any UI must look clean and minimal — Vercel/Notion/Apple-like: white background, generous
+    whitespace, no chartjunk, left-aligned titles, hairline grids. All accents come from the brand
+    palette; do not introduce ad-hoc colors:
+    - Ink (text/titles): `#0a0a0a` · Grid/hairlines: `#ececec` · Background: white
+    - Accents, in order of use: `#0070f3` (primary blue), `#7928ca` purple, `#f5a623` amber,
+      `#ee0000` red, `#50e3c2` teal
+    `scripts/plot_trace_scaling.py` is the reference implementation for matplotlib figures.


### PR DESCRIPTION
## Summary

Extends AGENTS.md beyond structure rules (1-7) with six process rules that until now had to be re-typed every session:

- **8 — Interface design from the consuming dev's perspective.** Write the call site first; extend via existing seams (TraceAdapter, providers, retrievers, scorers); error messages are part of the interface.
- **9 — Tests and evals before functionality.** Failing test/eval first, bug fixes start with a failing repro, and the test↔implementation coevolution loop: a failing test may mean the *test* is stale — fix or delete it with stated reason, but never weaken one just to go green.
- **10 — Verify end-to-end.** Drive the CLI/endpoint/figure; exit codes aren't evidence.
- **11 — Improve automation empirically.** Judges, retrievers, optimizers, scorers get tuned by reading their real inputs/outputs and disagreeing with concrete examples, not by intuition.
- **12 — Build for now.** No speculative generality, no backwards compat pre-1.0; delete deprecated paths, migrate all callers in the same change.
- **13 — Brand system for all visuals.** White/minimal Vercel-Notion-Apple aesthetic; palette codified from `scripts/plot_trace_scaling.py` (ink #0a0a0a, grid #ececec, accents #0070f3 → #7928ca → #f5a623 → #ee0000 → #50e3c2), which is named the reference implementation.

## Test plan

- [x] `uv run ruff check .` and `uv run ty check` pass (docs-only change; whole-project gate per rule 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)