### PR TITLE
Add OpenAI Responses provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ uv run ty check
 uv run pytest -q
 ```
 
+## Python
+
+- Every Python file must have a module docstring.
+- Write Google-style docstrings for all classes and functions with significant logic. Use plain
+  one-line docstrings for simple/self-explanatory classes and functions.
+
 ## Rules
 
 1. **Clean tree before every commit.** Run `uv run ruff check .` and `uv run ty check` over the

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -52,6 +52,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "bedrock": ["us.anthropic.claude-opus-4-8", "us.anthropic.claude-opus-4-7"],
     "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
+    "openai_responses": ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4"],
     "azure_openai": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -22,6 +22,7 @@ PROVIDER_ENV_VARS: dict[ProviderKind, list[str]] = {
     ProviderKind.BEDROCK: ["AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
     ProviderKind.AZURE_OPENAI: ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
     ProviderKind.OPENAI: ["OPENAI_API_KEY"],
+    ProviderKind.OPENAI_RESPONSES: ["OPENAI_API_KEY"],
 }
 
 

--- a/wmh/providers/__init__.py
+++ b/wmh/providers/__init__.py
@@ -1,7 +1,7 @@
 """Unified LLM provider layer.
 
-One interface (`Provider`), four backends, one entry point (`get_provider`). All four can be
-verified on startup with a cheap ping. Built fresh for this repo; no external client framework.
+One interface (`Provider`), multiple backends, one entry point (`get_provider`). All can be verified
+on startup with a cheap ping. Built fresh for this repo; no external client framework.
 """
 
 from wmh.providers.base import (

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -13,6 +13,7 @@ class ProviderKind(StrEnum):
     BEDROCK = "bedrock"  # Claude 4.8 via AWS
     AZURE_OPENAI = "azure_openai"  # GPT 5.5 via Azure
     OPENAI = "openai"  # GPT 5.5 direct
+    OPENAI_RESPONSES = "openai_responses"  # GPT 5.x direct via the Responses API
 
 
 class EmbedderKind(StrEnum):
@@ -79,6 +80,7 @@ class ProviderConfig(BaseModel):
     region: str | None = None  # AWS Bedrock region
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version
+    reasoning_effort: str | None = None  # OpenAI Responses reasoning.effort
 
 
 @runtime_checkable

--- a/wmh/providers/openai_responses.py
+++ b/wmh/providers/openai_responses.py
@@ -1,0 +1,177 @@
+"""OpenAI direct provider using the Responses API. Reads OPENAI_API_KEY from the environment."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, cast
+
+from wmh.providers import _openai_common
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    Completion,
+    Message,
+    ProviderConfig,
+    TokenUsage,
+    VerifyResult,
+)
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+    from openai.types.responses.response_input_param import ResponseInputParam
+    from openai.types.shared_params.reasoning import Reasoning
+
+
+class OpenAIResponsesProvider:
+    """GPT 5.x via OpenAI's Responses API."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+        self._client: OpenAI | None = None
+
+    def _get_client(self) -> OpenAI:
+        """Create and cache the OpenAI SDK client on first use."""
+        # Lazy: don't import the SDK or read OPENAI_API_KEY until first use.
+        if self._client is None:
+            from openai import OpenAI
+
+            self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
+        return self._client
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        """Generate a completion through the Responses API.
+
+        Args:
+            system: System prompt to send as the first Responses input item.
+            messages: Conversation messages following the system prompt.
+            temperature: Accepted for provider interface compatibility; not forwarded because the
+                benchmark path keeps Responses-model sampling at provider defaults.
+            max_tokens: Maximum number of output tokens to request.
+
+        Returns:
+            Completion text and token usage parsed from the Responses API response.
+        """
+        # GPT-5.x Responses models reject non-default sampling in this benchmark path.
+        del temperature
+        response_input = cast("ResponseInputParam", _responses_input(system, messages))
+        responses = self._get_client().responses
+        if self.config.reasoning_effort:
+            response = responses.create(
+                model=self.config.model,
+                input=response_input,
+                max_output_tokens=max_tokens,
+                store=False,
+                reasoning=cast("Reasoning", {"effort": self.config.reasoning_effort}),
+            )
+        else:
+            response = responses.create(
+                model=self.config.model,
+                input=response_input,
+                max_output_tokens=max_tokens,
+                store=False,
+            )
+        return Completion(text=_response_text(response), usage=_usage_from_response(response))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed text through OpenAI's embeddings API.
+
+        Args:
+            texts: Text strings to embed.
+
+        Returns:
+            One embedding vector per input text.
+
+        Raises:
+            ValueError: If `ProviderConfig.embed_model` is unset.
+        """
+        if self.config.embed_model is None:
+            raise ValueError("OpenAIResponsesProvider.embed requires config.embed_model to be set.")
+        return _openai_common.embed(
+            self._get_client().embeddings, self.config.embed_model, texts, self.config.embed_dim
+        )
+
+    def verify(self) -> VerifyResult:
+        """Run a cheap completion request and report provider availability."""
+        try:
+            self.complete(
+                "",
+                [Message(role="user", content="Reply with exactly: ok")],
+                max_tokens=256,
+            )
+        except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
+            return VerifyResult(
+                ok=False,
+                kind=self.config.kind,
+                model=self.config.model,
+                detail=str(exc),
+            )
+        return VerifyResult(ok=True, kind=self.config.kind, model=self.config.model)
+
+
+def _responses_input(system: str, messages: list[Message]) -> list[dict[str, str]]:
+    """Convert the provider message shape into Responses API input items."""
+    out: list[dict[str, str]] = []
+    if system:
+        out.append({"role": "system", "content": system})
+    out.extend({"role": message.role, "content": message.content} for message in messages)
+    return out
+
+
+def _get(value: object, key: str) -> object:
+    """Read a field from either an SDK object or mapping."""
+    if isinstance(value, Mapping):
+        return cast("Mapping[str, object]", value).get(key)
+    return getattr(value, key, None)
+
+
+def _as_int(value: object) -> int:
+    """Coerce numeric SDK usage fields into integers, defaulting invalid values to zero."""
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _response_text(response: object) -> str:
+    """Extract generated text from direct or nested Responses SDK shapes."""
+    direct = _get(response, "output_text")
+    if isinstance(direct, str) and direct:
+        return direct
+
+    chunks: list[str] = []
+    output = _get(response, "output")
+    if isinstance(output, list):
+        for item in output:
+            content = _get(item, "content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                text = _get(block, "text")
+                if isinstance(text, str):
+                    chunks.append(text)
+    return "".join(chunks)
+
+
+def _usage_from_response(response: object) -> TokenUsage:
+    """Extract token usage from a Responses SDK object or mapping."""
+    usage = _get(response, "usage")
+    if usage is None:
+        return TokenUsage()
+    return TokenUsage(
+        input_tokens=_as_int(_get(usage, "input_tokens")),
+        output_tokens=_as_int(_get(usage, "output_tokens")),
+    )

--- a/wmh/providers/openai_responses_test.py
+++ b/wmh/providers/openai_responses_test.py
@@ -1,0 +1,193 @@
+"""Unit tests for OpenAIResponsesProvider. No network: the SDK client is faked."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, ProviderConfig, ProviderKind
+from wmh.providers.openai_responses import OpenAIResponsesProvider
+
+
+class _FakeUsage:
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class _FakeResponsesResponse:
+    def __init__(
+        self,
+        output_text: str,
+        usage: _FakeUsage | None,
+        output: list[object] | None = None,
+    ) -> None:
+        self.output_text = output_text
+        self.usage = usage
+        self.output = output or []
+
+
+class _FakeResponses:
+    def __init__(self, response: _FakeResponsesResponse) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> _FakeResponsesResponse:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeEmbeddingItem:
+    def __init__(self, embedding: list[float]) -> None:
+        self.embedding = embedding
+
+
+class _FakeEmbeddingResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.data = [_FakeEmbeddingItem(v) for v in vectors]
+
+
+class _FakeEmbeddings:
+    def __init__(self, response: _FakeEmbeddingResponse) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> _FakeEmbeddingResponse:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeClient:
+    def __init__(self, responses: _FakeResponses, embeddings: _FakeEmbeddings) -> None:
+        self.responses = responses
+        self.embeddings = embeddings
+
+
+def _config() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.OPENAI_RESPONSES,
+        model="gpt-5.4-mini",
+        embed_model="text-embedding-3-small",
+        reasoning_effort="low",
+    )
+
+
+def test_complete_uses_responses_api_and_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses(_FakeResponsesResponse("ok", _FakeUsage(11, 7)))
+    provider = OpenAIResponsesProvider(_config())
+    fake = _FakeClient(responses, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    completion = provider.complete(
+        "be exact",
+        [Message(role="user", content="ping")],
+        max_tokens=64,
+    )
+
+    assert completion.text == "ok"
+    assert completion.usage.input_tokens == 11
+    assert completion.usage.output_tokens == 7
+    sent = responses.last_kwargs
+    assert sent["model"] == "gpt-5.4-mini"
+    assert sent["max_output_tokens"] == 64
+    assert sent["store"] is False
+    assert sent["reasoning"] == {"effort": "low"}
+    assert "temperature" not in sent
+    assert sent["input"] == [
+        {"role": "system", "content": "be exact"},
+        {"role": "user", "content": "ping"},
+    ]
+
+
+def test_complete_default_max_tokens_is_8k(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = _FakeResponses(_FakeResponsesResponse("ok", _FakeUsage(1, 2)))
+    provider = OpenAIResponsesProvider(_config())
+    fake = _FakeClient(responses, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("", [Message(role="user", content="ping")])
+
+    assert responses.last_kwargs["max_output_tokens"] == DEFAULT_MAX_TOKENS
+
+
+def test_complete_parses_nested_output_when_output_text_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _FakeResponsesResponse(
+        "",
+        None,
+        output=[{"content": [{"type": "output_text", "text": "hello"}, {"text": " world"}]}],
+    )
+    responses = _FakeResponses(response)
+    provider = OpenAIResponsesProvider(_config())
+    fake = _FakeClient(responses, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    completion = provider.complete("", [Message(role="user", content="ping")])
+
+    assert completion.text == "hello world"
+    assert completion.usage.input_tokens == 0
+    assert completion.usage.output_tokens == 0
+
+
+def test_reasoning_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = _FakeResponses(_FakeResponsesResponse("ok", _FakeUsage(1, 2)))
+    config = ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="gpt-5.5")
+    provider = OpenAIResponsesProvider(config)
+    fake = _FakeClient(responses, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete("", [Message(role="user", content="ping")])
+
+    assert "reasoning" not in responses.last_kwargs
+
+
+def test_embed_uses_openai_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+    embeddings = _FakeEmbeddings(_FakeEmbeddingResponse([[0.1, 0.2]]))
+    config = _config().model_copy(update={"embed_dim": 2})
+    provider = OpenAIResponsesProvider(config)
+    responses = _FakeResponses(_FakeResponsesResponse("", _FakeUsage(0, 0)))
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(responses, embeddings))
+
+    vectors = provider.embed(["a"])
+
+    assert vectors == [[0.1, 0.2]]
+    assert embeddings.last_kwargs["model"] == "text-embedding-3-small"
+    assert embeddings.last_kwargs["input"] == ["a"]
+    assert embeddings.last_kwargs["dimensions"] == 2
+
+
+def test_embed_requires_embed_model() -> None:
+    provider = OpenAIResponsesProvider(
+        ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="gpt-5.5")
+    )
+    with pytest.raises(ValueError, match="embed_model"):
+        provider.embed(["x"])
+
+
+def test_verify_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        def create(self, **kwargs: object) -> object:
+            raise RuntimeError("401")
+
+    fake = type("C", (), {"responses": _Boom()})()
+    provider = OpenAIResponsesProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    result = provider.verify()
+
+    assert result.ok is False
+    assert result.kind is ProviderKind.OPENAI_RESPONSES
+    assert "401" in result.detail
+
+
+@pytest.mark.skipif(
+    "OPENAI_API_KEY" not in __import__("os").environ,
+    reason="no OPENAI_API_KEY; skipping live smoke test",
+)
+def test_live_verify() -> None:  # pragma: no cover - network
+    provider = OpenAIResponsesProvider(
+        ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="gpt-5.4-mini")
+    )
+    assert provider.verify().ok is True

--- a/wmh/providers/registry.py
+++ b/wmh/providers/registry.py
@@ -11,12 +11,14 @@ from wmh.providers.azure_openai import AzureOpenAIProvider
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind, VerifyResult
 from wmh.providers.bedrock import BedrockProvider
 from wmh.providers.openai import OpenAIProvider
+from wmh.providers.openai_responses import OpenAIResponsesProvider
 
 _BACKENDS = {
     ProviderKind.ANTHROPIC: AnthropicProvider,
     ProviderKind.BEDROCK: BedrockProvider,
     ProviderKind.AZURE_OPENAI: AzureOpenAIProvider,
     ProviderKind.OPENAI: OpenAIProvider,
+    ProviderKind.OPENAI_RESPONSES: OpenAIResponsesProvider,
 }
 
 


### PR DESCRIPTION
## Summary
- add an `openai_responses` provider kind backed by `OpenAI().responses.create`
- wire the provider into config env checks, provider registry, and CLI model suggestions
- add inline unit coverage next to `wmh/providers/openai_responses.py` for request shape, default 8k output cap, nested response parsing, embeddings, verify failure, and optional live verify
- update `AGENTS.md` to explicitly require Python module docstrings and Google-style docstrings for public/non-trivial logic

## Verification
- `PYTHONPATH=. UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ruff check .`
- `PYTHONPATH=. UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev ty check`
- `PYTHONPATH=. UV_NO_SYSTEM_CONFIG=1 UV_CACHE_DIR=/tmp/.uv-cache uv run --extra dev pytest -q` -> `262 passed, 7 skipped`