### PR TITLE
CLAUDE.md: point to Notion Eng Docs for project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 See [AGENTS.md](./AGENTS.md) for project conventions and rules. They apply here in full.
+
+## Docs
+
+Project docs live in Notion under Eng Docs → [world-model-harness](https://app.notion.com/p/38e0f8b3f5918087b6b7fc883178dc5e) (page ID `38e0f8b3-f591-8087-b6b7-fc883178dc5e`), accessible via the Notion MCP server (`notion-search` / `notion-fetch`). Store new project docs there.


### PR DESCRIPTION
Adds a Docs section to CLAUDE.md pointing at the Notion Eng Docs → world-model-harness page (with page ID), reachable via the Notion MCP server, so future sessions know where project docs live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)