### PR TITLE
AGENTS.md: allow web/ (rule 5 exception, own tsc/eslint gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ uv run pytest -q
    suite definitions belong under `examples/<task>/evals/`; generated eval results belong under the
    local `.wmh/evals/` artifact root. Built models normally belong under `.wmh/models/`;
    intentional prebuilt example artifacts belong under `examples/<task>/models/`.
+   Exception: `web/` — the project website (Next.js/TypeScript). It is excluded from the Python
+   gate (ruff/ty/pytest never touch it) and carries its own gate instead: `npm run lint` and
+   `npx tsc --noEmit` from `web/` must be clean before every commit that touches it.
 
 6. **Keep dataset-specific logic inside examples.** SWE-bench, tau-bench, terminal-task, and similar
    dataset-specific launch or conversion logic belongs under `examples/<task>/`. A standard example

--- a/wmh/providers/tests/bedrock_test.py
+++ b/wmh/providers/tests/bedrock_test.py
@@ -149,7 +149,7 @@ def test_live_verify() -> None:  # pragma: no cover - network
     provider = BedrockProvider(
         ProviderConfig(
             kind=ProviderKind.BEDROCK,
-            model="anthropic.claude-opus-4-8",
+            model="us.anthropic.claude-opus-4-8",
             region=os.environ["AWS_REGION"],
         )
     )


### PR DESCRIPTION
Per the coordination plan (DECISIONS.md D2, owner WS-B1): the project website lives at `web/` inside world-model-harness. This amends AGENTS.md rule 5 accordingly — `web/` is excluded from the python gate and carries its own gate (`npm run lint` + `npx tsc --noEmit`).

Also fixes the pre-existing `test_live_verify` failure hit while running the whole-repo gate: it used bare `anthropic.claude-opus-4-8`, which Bedrock rejects for on-demand throughput; switched to the `us.` inference-profile id used everywhere else.

Gate: ruff ✓ ty ✓ pytest 265 passed / 4 skipped ✓ (was 1 failed before the model-id fix).

WS-B1 plan: `~/Desktop/Projects/wmh-plan/plans/ws-b1.md`; decisions logged as D15–D17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)