### PR TITLE
environment-capture: benchmark adapter contract + OTel GenAI capture package (WS-B2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,13 @@ uv run pytest -q
    Exception: `web/` — the project website (Next.js/TypeScript). It is excluded from the Python
    gate (ruff/ty/pytest never touch it) and carries its own gate instead: `npm run lint` and
    `npx tsc --noEmit` from `web/` must be clean before every commit that touches it.
+   Exception: `environment-capture/` — a uv workspace member that runs benchmarks for real and
+   records agent-environment transitions as OTel GenAI JSONL (extraction-ready: its
+   `environment_capture` package never imports `wmh`, except the one round-trip test pinning the
+   wire format). It IS part of the Python gate. Per-benchmark data dirs inside it
+   (`environment-capture/<benchmark>/`) follow the examples/ pattern: committed
+   `traces.otel.jsonl` + provenance README + thin scripts; heavy deps and cloned upstreams stay
+   in local, gitignored venvs.
 
 6. **Keep dataset-specific logic inside examples.** SWE-bench, tau-bench, terminal-task, and similar
    dataset-specific launch or conversion logic belongs under `examples/<task>/`. A standard example

--- a/environment-capture/README.md
+++ b/environment-capture/README.md
@@ -1,0 +1,51 @@
+# environment-capture
+
+Run benchmarks **for real** and record every agent-environment transition as
+OTel GenAI JSONL — the wmh trace wire format. This is the capture side of the harness: adapters
+stand up a real benchmark environment, an agent acts in it, and the real `(action → observation)`
+pairs become the trace corpus a world model is built from.
+
+It is a uv workspace member (`environment_capture` package) designed to be extraction-ready: the
+package never imports `wmh` (one round-trip test pins the wire format against wmh's ingest and
+moves across the boundary if this is ever split out to its own repo).
+
+## The contract
+
+```python
+from environment_capture import (
+    BenchmarkAdapter,   # tasks(split) / open_env(task) / grade(task, submission)
+    CommandEnv,         # execute(command) -> ExecResult(output, returncode); close()
+    run_capture,        # drive an agent over a split against the REAL env -> [Trajectory]
+    trajectory_to_spans, write_spans_jsonl,   # Trajectory -> OTel GenAI JSONL
+)
+```
+
+- **`CommandEnv.execute` is the world-model seam.** A real adapter executes commands in a real
+  workspace; swap in a world-model-backed implementation and the identical agent loop runs
+  against the WM. That is what "replace the benchmark with a world model" means mechanically.
+- **Graders are deterministic.** `grade(task, submission) -> float` must not call an LLM, so
+  WM-vs-real comparisons are judged by the same fixed function.
+- **Observations are never synthesized.** A corpus comes from `run_capture` against the real
+  environment (or a conversion of someone else's REAL runs, with provenance). No hand-written or
+  model-imagined observations, ever.
+
+## Layout
+
+```
+environment-capture/
+  environment_capture/        # the package: contract + emitter + converters (+ inline *_test.py)
+  <benchmark>/                # one dir per benchmark: committed traces.otel.jsonl,
+                              # provenance README, task data, thin capture/convert scripts
+```
+
+Per-benchmark dirs follow the `examples/` discipline: only traces, small task data, and thin
+scripts are committed; cloned upstreams, venvs, and raw run output stay local and gitignored.
+
+## Adding a benchmark
+
+1. Implement a `BenchmarkAdapter` in `environment_capture/benchmarks/<name>.py` — fresh code
+   against the benchmark's real upstream dataset (tests inline).
+2. Create `environment-capture/<name>/` with the task data (license-checked) and a capture or
+   conversion script that writes `traces.otel.jsonl`.
+3. Verify the corpus round-trips: `wmh build --file environment-capture/<name>/traces.otel.jsonl`
+   must ingest every trace, then eval it under the repo's reporting conventions.

--- a/environment-capture/environment_capture/__init__.py
+++ b/environment-capture/environment_capture/__init__.py
@@ -1,0 +1,31 @@
+"""Run benchmarks for real and record agent-environment transitions as OTel GenAI JSONL."""
+
+from environment_capture.adapter import (
+    AgentRun,
+    BenchmarkAdapter,
+    CaptureAgent,
+    CommandEnv,
+    ExecResult,
+    run_capture,
+)
+from environment_capture.otel import trace_id_for, trajectory_to_spans, write_spans_jsonl
+from environment_capture.sib_cache import load_sib_cache
+from environment_capture.trajectory import JsonValue, StepRecord, Task, ToolCall, Trajectory
+
+__all__ = [
+    "AgentRun",
+    "BenchmarkAdapter",
+    "CaptureAgent",
+    "CommandEnv",
+    "ExecResult",
+    "JsonValue",
+    "StepRecord",
+    "Task",
+    "ToolCall",
+    "Trajectory",
+    "load_sib_cache",
+    "run_capture",
+    "trace_id_for",
+    "trajectory_to_spans",
+    "write_spans_jsonl",
+]

--- a/environment-capture/environment_capture/adapter.py
+++ b/environment-capture/environment_capture/adapter.py
@@ -1,0 +1,93 @@
+"""The benchmark adapter contract and the capture driver.
+
+An adapter stands up ONE real benchmark: it lists tasks per split, opens a real environment for a
+task (a workspace the agent's commands actually execute in), and grades a submission
+deterministically. ``run_capture`` drives an agent through every task and assembles graded
+Trajectories — the only sanctioned way to produce a trace corpus (real runs, never synthesized
+observations).
+
+The ``CommandEnv.execute`` seam is deliberately the smallest possible surface: swap in an
+implementation backed by a world model and the same agent loop runs against the WM instead of the
+real environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from environment_capture.trajectory import StepRecord, Task, Trajectory
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """What the environment returned for one command."""
+
+    output: str
+    returncode: int
+
+
+@runtime_checkable
+class CommandEnv(Protocol):
+    """A live environment for one task: execute commands, then release resources."""
+
+    def execute(self, command: str) -> ExecResult: ...
+
+    def close(self) -> None: ...
+
+
+@runtime_checkable
+class BenchmarkAdapter(Protocol):
+    """One real benchmark: tasks per split, a real env per task, a deterministic grader."""
+
+    @property
+    def name(self) -> str: ...
+
+    def tasks(self, split: str) -> list[Task]: ...
+
+    def open_env(self, task: Task) -> CommandEnv: ...
+
+    def grade(self, task: Task, submission: str) -> float: ...
+
+
+@dataclass(frozen=True)
+class AgentRun:
+    """What an agent produced on one task: the real steps taken and its final answer."""
+
+    steps: list[StepRecord]
+    final_answer: str
+    model: str
+
+
+class CaptureAgent(Protocol):
+    """Anything that can drive a CommandEnv through one task."""
+
+    def run(self, task: Task, env: CommandEnv) -> AgentRun: ...
+
+
+def run_capture(
+    adapter: BenchmarkAdapter,
+    agent: CaptureAgent,
+    *,
+    split: str,
+    limit: int | None = None,
+) -> list[Trajectory]:
+    """Run the agent over the split's tasks against the real environment; return graded runs."""
+    trajectories: list[Trajectory] = []
+    for task in adapter.tasks(split)[:limit]:
+        env = adapter.open_env(task)
+        try:
+            run = agent.run(task, env)
+        finally:
+            env.close()
+        trajectories.append(
+            Trajectory(
+                task=task,
+                steps=run.steps,
+                final_answer=run.final_answer,
+                reward=adapter.grade(task, run.final_answer),
+                model=run.model,
+                split=split,
+            )
+        )
+    return trajectories

--- a/environment-capture/environment_capture/adapter_test.py
+++ b/environment-capture/environment_capture/adapter_test.py
@@ -1,0 +1,85 @@
+"""Tests for the BenchmarkAdapter protocol and the run_capture driver."""
+
+from __future__ import annotations
+
+from environment_capture.adapter import (
+    AgentRun,
+    BenchmarkAdapter,
+    CommandEnv,
+    ExecResult,
+    run_capture,
+)
+from environment_capture.trajectory import StepRecord, Task, ToolCall
+
+
+class _EchoEnv:
+    """Deterministic env: echoes the command back; records close()."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def execute(self, command: str) -> ExecResult:
+        return ExecResult(output=f"ran:{command}", returncode=0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeAdapter:
+    name = "echo-bench"
+
+    def __init__(self) -> None:
+        self.envs: list[_EchoEnv] = []
+
+    def tasks(self, split: str) -> list[Task]:
+        return [Task(task_id=f"{split}-{i}", prompt=f"say {i}", data={}) for i in range(3)]
+
+    def open_env(self, task: Task) -> CommandEnv:
+        env = _EchoEnv()
+        self.envs.append(env)
+        return env
+
+    def grade(self, task: Task, submission: str) -> float:
+        return 1.0 if submission == task.prompt.removeprefix("say ") else 0.0
+
+
+class _OneShotAgent:
+    """Runs one command through the env, then answers with the task's digit."""
+
+    def run(self, task: Task, env: CommandEnv) -> AgentRun:
+        result = env.execute(f"echo {task.task_id}")
+        step = StepRecord(
+            action=ToolCall(name="bash", arguments={"command": f"echo {task.task_id}"}),
+            output=result.output,
+            is_error=result.returncode != 0,
+        )
+        return AgentRun(steps=[step], final_answer=task.prompt.removeprefix("say "), model="fake")
+
+
+def test_run_capture_grades_and_assembles_trajectories() -> None:
+    adapter = _FakeAdapter()
+    assert isinstance(adapter, BenchmarkAdapter)
+    trajectories = run_capture(adapter, _OneShotAgent(), split="train")
+    assert [t.task.task_id for t in trajectories] == ["train-0", "train-1", "train-2"]
+    assert all(t.reward == 1.0 for t in trajectories)
+    assert all(t.split == "train" for t in trajectories)
+    assert trajectories[0].steps[0].output == "ran:echo train-0"
+    assert all(env.closed for env in adapter.envs)
+
+
+def test_run_capture_limit_and_env_closed_on_agent_error() -> None:
+    adapter = _FakeAdapter()
+
+    class _BoomAgent:
+        def run(self, task: Task, env: CommandEnv) -> AgentRun:
+            raise RuntimeError("agent crashed")
+
+    try:
+        run_capture(adapter, _BoomAgent(), split="train", limit=1)
+    except RuntimeError:
+        pass
+    assert len(adapter.envs) == 1
+    assert adapter.envs[0].closed  # env released even when the agent dies
+
+    trajectories = run_capture(adapter, _OneShotAgent(), split="train", limit=2)
+    assert len(trajectories) == 2

--- a/environment-capture/environment_capture/otel.py
+++ b/environment-capture/environment_capture/otel.py
@@ -1,0 +1,104 @@
+"""Emit trajectories as OTel GenAI JSONL — the wmh trace wire format.
+
+One OTLP-JSON span object per line. Per step: a `chat` action span (tool name + JSON arguments;
+the first one also carries the task prompt as ``gen_ai.prompt`` and the trace metadata as
+``wmh.trace.metadata``) followed by an `execute_tool` observation span (real output as
+``gen_ai.tool.message``, error flag via span status). The final answer is NOT emitted as a span —
+it produces no environment observation — and rides in ``wmh.trace.metadata`` instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from environment_capture.trajectory import JsonValue, Trajectory
+
+_SpanAttr = dict[str, "JsonValue"]
+Span = dict[str, "JsonValue"]
+
+
+def trace_id_for(benchmark: str, task_id: str) -> str:
+    """Deterministic 32-hex trace id so re-conversion never duplicates traces."""
+    return hashlib.sha256(f"{benchmark}|{task_id}".encode()).hexdigest()[:32]
+
+
+def _attr(key: str, value: str) -> _SpanAttr:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _trace_metadata(trajectory: Trajectory, benchmark: str) -> dict[str, JsonValue]:
+    metadata: dict[str, JsonValue] = {
+        "benchmark": benchmark,
+        "task_id": trajectory.task.task_id,
+    }
+    if trajectory.model:
+        metadata["model"] = trajectory.model
+    if trajectory.split:
+        metadata["split"] = trajectory.split
+    if trajectory.reward is not None:
+        metadata["reward"] = trajectory.reward
+    if trajectory.final_answer:
+        metadata["final_answer"] = trajectory.final_answer
+    metadata.update(trajectory.metadata)
+    return metadata
+
+
+def trajectory_to_spans(trajectory: Trajectory, *, benchmark: str) -> list[Span]:
+    """Emit ordered action/observation span pairs for one trajectory."""
+    trace_id = trace_id_for(benchmark, trajectory.task.task_id)
+    spans: list[Span] = []
+    for ordinal, step in enumerate(trajectory.steps):
+        action_attrs = [
+            _attr("gen_ai.operation.name", "chat"),
+            _attr("gen_ai.request.model", trajectory.model or benchmark),
+            _attr("gen_ai.tool.name", step.action.name),
+            _attr("gen_ai.tool.call.arguments", json.dumps(step.action.arguments)),
+        ]
+        if ordinal == 0:
+            if trajectory.task.prompt:
+                action_attrs.append(_attr("gen_ai.prompt", trajectory.task.prompt))
+            action_attrs.append(
+                _attr("wmh.trace.metadata", json.dumps(_trace_metadata(trajectory, benchmark)))
+            )
+        spans.append(
+            {
+                "traceId": trace_id,
+                "spanId": f"{trace_id[:12]}{ordinal:04x}a",
+                "parentSpanId": "",
+                "name": f"chat {benchmark}",
+                "startTimeUnixNano": ordinal * 10,
+                "endTimeUnixNano": ordinal * 10 + 1,
+                "status": {"code": "STATUS_CODE_OK"},
+                "attributes": action_attrs,
+            }
+        )
+        spans.append(
+            {
+                "traceId": trace_id,
+                "spanId": f"{trace_id[:12]}{ordinal:04x}b",
+                "parentSpanId": "",
+                "name": f"execute_tool {benchmark}",
+                "startTimeUnixNano": ordinal * 10 + 2,
+                "endTimeUnixNano": ordinal * 10 + 3,
+                "status": {"code": "STATUS_CODE_ERROR" if step.is_error else "STATUS_CODE_OK"},
+                "attributes": [
+                    _attr("gen_ai.operation.name", "execute_tool"),
+                    _attr("gen_ai.tool.name", step.action.name),
+                    _attr("gen_ai.tool.message", step.output),
+                ],
+            }
+        )
+    return spans
+
+
+def write_spans_jsonl(spans: Iterable[Span], path: Path, *, append: bool = False) -> int:
+    """Write spans one-JSON-object-per-line; returns the number written."""
+    count = 0
+    with path.open("a" if append else "w", encoding="utf-8") as out:
+        for span in spans:
+            out.write(json.dumps(span, ensure_ascii=False) + "\n")
+            count += 1
+    return count

--- a/environment-capture/environment_capture/otel_test.py
+++ b/environment-capture/environment_capture/otel_test.py
@@ -1,0 +1,101 @@
+"""Tests for the OTel GenAI JSONL emitter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from environment_capture.otel import Span, trace_id_for, trajectory_to_spans, write_spans_jsonl
+from environment_capture.trajectory import StepRecord, Task, ToolCall, Trajectory
+
+
+def _trajectory() -> Trajectory:
+    return Trajectory(
+        task=Task(
+            task_id="fb-train-0", prompt="What is 3M's FY2018 capex?", data={"stratum": "easy"}
+        ),
+        steps=[
+            StepRecord(
+                action=ToolCall(name="bash", arguments={"command": "ls docs"}),
+                output="a.txt\nb.txt",
+                is_error=False,
+            ),
+            StepRecord(
+                action=ToolCall(name="bash", arguments={"command": "cat missing.txt"}),
+                output="cat: missing.txt: No such file or directory",
+                is_error=True,
+            ),
+        ],
+        final_answer="$1577.00",
+        reward=1.0,
+        model="gpt-5.4",
+        split="train",
+        metadata={"passed": True},
+    )
+
+
+def test_trace_id_is_deterministic_and_distinct() -> None:
+    assert trace_id_for("financebench", "fb-train-0") == trace_id_for("financebench", "fb-train-0")
+    assert trace_id_for("financebench", "fb-train-0") != trace_id_for("financebench", "fb-train-1")
+    assert len(trace_id_for("financebench", "fb-train-0")) == 32
+
+
+def test_trajectory_to_spans_emits_action_observation_pairs() -> None:
+    spans = trajectory_to_spans(_trajectory(), benchmark="financebench")
+    assert len(spans) == 4  # 2 steps x (action span + tool span)
+
+    action0, tool0, action1, tool1 = spans
+    trace_id = trace_id_for("financebench", "fb-train-0")
+    assert all(s["traceId"] == trace_id for s in spans)
+    assert len({s["spanId"] for s in spans}) == 4
+    # Spans are ordered by start time so ingestion reconstructs the step order.
+    starts = [s["startTimeUnixNano"] for s in spans]
+    assert starts == sorted(starts)
+
+    def attrs(span: Span) -> dict[str, str]:
+        raw = span["attributes"]
+        assert isinstance(raw, list)
+        out: dict[str, str] = {}
+        for attribute in raw:
+            assert isinstance(attribute, dict)
+            value = attribute["value"]
+            assert isinstance(value, dict)
+            key, string_value = attribute["key"], value["stringValue"]
+            assert isinstance(key, str) and isinstance(string_value, str)
+            out[key] = string_value
+        return out
+
+    a0 = attrs(action0)
+    assert a0["gen_ai.operation.name"] == "chat"
+    assert a0["gen_ai.tool.name"] == "bash"
+    assert json.loads(a0["gen_ai.tool.call.arguments"]) == {"command": "ls docs"}
+    # Task prompt + trace metadata ride only on the first action span.
+    assert a0["gen_ai.prompt"] == "What is 3M's FY2018 capex?"
+    metadata = json.loads(a0["wmh.trace.metadata"])
+    assert metadata["benchmark"] == "financebench"
+    assert metadata["task_id"] == "fb-train-0"
+    assert metadata["model"] == "gpt-5.4"
+    assert metadata["reward"] == 1.0
+    assert metadata["passed"] is True
+    a1 = attrs(action1)
+    assert "gen_ai.prompt" not in a1
+    assert "wmh.trace.metadata" not in a1
+
+    t0 = attrs(tool0)
+    assert t0["gen_ai.operation.name"] == "execute_tool"
+    assert t0["gen_ai.tool.message"] == "a.txt\nb.txt"
+    assert tool0["status"] == {"code": "STATUS_CODE_OK"}
+    assert tool1["status"] == {"code": "STATUS_CODE_ERROR"}
+
+
+def test_write_spans_jsonl_round_trips(tmp_path: Path) -> None:
+    spans = trajectory_to_spans(_trajectory(), benchmark="financebench")
+    out = tmp_path / "traces.otel.jsonl"
+    n = write_spans_jsonl(spans, out)
+    assert n == 4
+    lines = out.read_text().splitlines()
+    assert [json.loads(line)["spanId"] for line in lines] == [s["spanId"] for s in spans]
+    # Append mode extends rather than truncates.
+    n2 = write_spans_jsonl(spans, out, append=True)
+    assert n2 == 4
+    assert len(out.read_text().splitlines()) == 8

--- a/environment-capture/environment_capture/otel_wmh_roundtrip_test.py
+++ b/environment-capture/environment_capture/otel_wmh_roundtrip_test.py
@@ -1,0 +1,58 @@
+"""Round-trip test: emitted spans must parse through wmh's real OTel GenAI ingest adapter.
+
+This is the one test in the package allowed to import wmh — it pins the wire format against its
+actual consumer. If environment-capture is ever extracted to its own repo, this test moves to the
+wmh side of the boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from environment_capture.otel import trajectory_to_spans, write_spans_jsonl
+from environment_capture.trajectory import StepRecord, Task, ToolCall, Trajectory
+from wmh.ingest.otel_genai import OtelGenAIAdapter
+
+
+def test_emitted_spans_ingest_as_the_same_steps(tmp_path: Path) -> None:
+    trajectory = Trajectory(
+        task=Task(task_id="fb-train-0", prompt="What is 3M's FY2018 capex?", data={}),
+        steps=[
+            StepRecord(
+                action=ToolCall(name="bash", arguments={"command": "ls docs"}),
+                output="a.txt",
+                is_error=False,
+            ),
+            StepRecord(
+                action=ToolCall(name="bash", arguments={"command": "cat gone"}),
+                output="cat: gone: No such file or directory",
+                is_error=True,
+            ),
+        ],
+        final_answer="$1577.00",
+        reward=1.0,
+        model="gpt-5.4",
+        split="train",
+    )
+    path = tmp_path / "traces.otel.jsonl"
+    write_spans_jsonl(trajectory_to_spans(trajectory, benchmark="financebench"), path)
+
+    traces = OtelGenAIAdapter().from_file(str(path))
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.metadata["benchmark"] == "financebench"
+    assert trace.metadata["task_id"] == "fb-train-0"
+    assert trace.metadata["reward"] == 1.0
+    assert len(trace.steps) == 2
+
+    first, second = trace.steps
+    assert first.task == "What is 3M's FY2018 capex?"
+    assert first.action.name == "bash"
+    arguments = first.action.arguments
+    if isinstance(arguments, str):  # ingest may keep arguments as the raw JSON string
+        arguments = json.loads(arguments)
+    assert arguments["command"] == "ls docs"
+    assert first.observation.content == "a.txt"
+    assert first.observation.is_error is False
+    assert second.observation.is_error is True

--- a/environment-capture/environment_capture/sib_cache.py
+++ b/environment-capture/environment_capture/sib_cache.py
@@ -1,0 +1,91 @@
+"""Load trajectories from a SIB baseline-cache directory (data-only reuse, DECISIONS.md D21).
+
+The cache is a directory of REAL benchmark runs: ``manifest.json`` (per-task reward + the model
+that produced the run), ``tasks/<task_id>.json`` (the agent-visible task), and
+``traces/<task_id>.json`` (the native trajectory: a ``messages`` list where each assistant turn
+carries exactly one fenced ``sib_bash`` command and the following user turn carries the real
+``<returncode>``/``<output>`` the environment returned). This module parses that DATA format;
+no SIB code is imported or vendored.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from environment_capture.trajectory import JsonValue, StepRecord, Task, ToolCall, Trajectory
+
+_FENCE_RE = re.compile(r"```sib_bash\s*\n(.*?)```", re.DOTALL)
+_RETURNCODE_RE = re.compile(r"<returncode>(-?\d+)</returncode>")
+_OUTPUT_RE = re.compile(r"<output>\n?(.*?)\n?</output>\s*\Z", re.DOTALL)
+
+
+def _parse_observation(content: str, *, task_id: str) -> tuple[str, int]:
+    rc_match = _RETURNCODE_RE.search(content)
+    out_match = _OUTPUT_RE.search(content)
+    if rc_match is None or out_match is None:
+        raise ValueError(
+            f"{task_id}: expected <returncode>/<output> markers in observation, got: "
+            f"{content[:120]!r}. The cache trace format may have changed — update sib_cache.py."
+        )
+    return out_match.group(1), int(rc_match.group(1))
+
+
+def _steps_from_messages(messages: list[dict[str, str]], *, task_id: str) -> list[StepRecord]:
+    steps: list[StepRecord] = []
+    for index, message in enumerate(messages):
+        if message.get("role") != "assistant":
+            continue
+        fence = _FENCE_RE.search(message.get("content", ""))
+        if fence is None:
+            continue  # a final free-text turn issues no command -> no environment transition
+        command = fence.group(1).strip()
+        follow = messages[index + 1] if index + 1 < len(messages) else None
+        if follow is None or follow.get("role") != "user":
+            continue  # command with no recorded observation (run cut off) -> not a transition
+        output, returncode = _parse_observation(follow.get("content", ""), task_id=task_id)
+        steps.append(
+            StepRecord(
+                action=ToolCall(name="bash", arguments={"command": command}),
+                output=output,
+                is_error=returncode != 0,
+            )
+        )
+    return steps
+
+
+def load_sib_cache(cache_dir: Path) -> list[Trajectory]:
+    """Parse every task in a baseline-cache directory into Trajectories, in manifest order."""
+    manifest = json.loads((cache_dir / "manifest.json").read_text(encoding="utf-8"))
+    model = str(manifest.get("model", ""))
+    split = str(manifest.get("split", ""))
+
+    trajectories: list[Trajectory] = []
+    for entry in manifest["tasks"]:
+        task_id = str(entry["task_id"])
+        task_raw = json.loads((cache_dir / "tasks" / f"{task_id}.json").read_text(encoding="utf-8"))
+        trace_raw = json.loads(
+            (cache_dir / "traces" / f"{task_id}.json").read_text(encoding="utf-8")
+        )
+        metadata: dict[str, JsonValue] = {
+            "source_format": "sib-baseline-cache",
+            "passed": bool(entry.get("passed", False)),
+            "exit_status": str(trace_raw.get("exit_status", "")),
+        }
+        trajectories.append(
+            Trajectory(
+                task=Task(
+                    task_id=task_id,
+                    prompt=str(task_raw.get("prompt", "")),
+                    data=task_raw.get("data", {}),
+                ),
+                steps=_steps_from_messages(trace_raw.get("messages", []), task_id=task_id),
+                final_answer=str(trace_raw.get("submission", "")),
+                reward=float(entry["reward"]) if entry.get("reward") is not None else None,
+                model=model,
+                split=split,
+                metadata=metadata,
+            )
+        )
+    return trajectories

--- a/environment-capture/environment_capture/sib_cache_test.py
+++ b/environment-capture/environment_capture/sib_cache_test.py
@@ -1,0 +1,92 @@
+"""Tests for loading SIB baseline-cache trajectories (data-only reuse, DECISIONS.md D21)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from environment_capture.sib_cache import load_sib_cache
+
+_ASSISTANT_0 = "I'll list the docs first.\n```sib_bash\nls docs && grep -in capex docs/*.txt\n```"
+_USER_0 = "<returncode>0</returncode>\n<output>\na.txt\nb.txt\n</output>"
+_ASSISTANT_1 = "Submitting.\n```sib_bash\nprintf 'SIB_SUBMIT\\n$1577.00\\n'\n```"
+_USER_1 = "<returncode>0</returncode>\n<output>\nSIB_SUBMIT\n$1577.00\n</output>"
+
+
+def _write_cache(root: Path) -> Path:
+    (root / "tasks").mkdir(parents=True)
+    (root / "traces").mkdir()
+    manifest = {
+        "benchmark": "financebench",
+        "split": "train",
+        "model": "gpt-5.4",
+        "n": 2,
+        "mean_reward": 0.5,
+        "pass_rate": 0.5,
+        "tasks": [
+            {"task_id": "fb-train-0", "passed": True, "reward": 1.0, "exit_status": "Submitted"},
+            {"task_id": "fb-train-1", "passed": False, "reward": 0.0, "exit_status": "Submitted"},
+        ],
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest))
+    for task_id, rc in (("fb-train-0", 0), ("fb-train-1", 1)):
+        task_payload = {
+            "task_id": task_id,
+            "prompt": f"Question for {task_id}?",
+            "data": {"stratum": "easy"},
+        }
+        (root / "tasks" / f"{task_id}.json").write_text(json.dumps(task_payload))
+        user_0 = _USER_0 if rc == 0 else f"<returncode>{rc}</returncode>\n<output>\nboom\n</output>"
+        trace = {
+            "submission": "$1577.00",
+            "exit_status": "Submitted",
+            "steps": 2,
+            "cost_usd": 0.01,
+            "tokens": 1000,
+            "messages": [
+                {"role": "system", "content": "You are an agent."},
+                {"role": "user", "content": f"Question for {task_id}?"},
+                {"role": "assistant", "content": _ASSISTANT_0},
+                {"role": "user", "content": user_0},
+                {"role": "assistant", "content": _ASSISTANT_1},
+                {"role": "user", "content": _USER_1},
+            ],
+        }
+        (root / "traces" / f"{task_id}.json").write_text(json.dumps(trace))
+    return root
+
+
+def test_load_sib_cache_parses_commands_and_observations(tmp_path: Path) -> None:
+    trajectories = load_sib_cache(_write_cache(tmp_path))
+    assert [t.task.task_id for t in trajectories] == ["fb-train-0", "fb-train-1"]
+
+    ok = trajectories[0]
+    assert ok.model == "gpt-5.4"
+    assert ok.split == "train"
+    assert ok.reward == 1.0
+    assert ok.final_answer == "$1577.00"
+    assert ok.metadata["passed"] is True
+    assert ok.task.prompt == "Question for fb-train-0?"
+    assert len(ok.steps) == 2
+    first = ok.steps[0]
+    assert first.action.name == "bash"
+    assert first.action.arguments == {"command": "ls docs && grep -in capex docs/*.txt"}
+    assert first.output == "a.txt\nb.txt"
+    assert first.is_error is False
+
+    failed = trajectories[1]
+    assert failed.reward == 0.0
+    assert failed.steps[0].is_error is True
+    assert failed.steps[0].output == "boom"
+
+
+def test_load_sib_cache_rejects_malformed_observation(tmp_path: Path) -> None:
+    root = _write_cache(tmp_path)
+    trace_path = root / "traces" / "fb-train-0.json"
+    trace = json.loads(trace_path.read_text())
+    trace["messages"][3]["content"] = "no markers here"
+    trace_path.write_text(json.dumps(trace))
+    with pytest.raises(ValueError, match="fb-train-0"):
+        load_sib_cache(root)

--- a/environment-capture/environment_capture/trajectory.py
+++ b/environment-capture/environment_capture/trajectory.py
@@ -1,0 +1,51 @@
+"""Core record types: one real benchmark run = one Trajectory of (action -> observation) steps.
+
+Stdlib-only (dataclasses, no pydantic) so the package stays dependency-free and shareable with
+non-wmh consumers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+JsonValue: TypeAlias = "str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]"
+
+
+@dataclass(frozen=True)
+class Task:
+    """One benchmark task as the agent sees it (gold answers live elsewhere)."""
+
+    task_id: str
+    prompt: str
+    data: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """The agent's action: a named tool invocation with JSON arguments."""
+
+    name: str
+    arguments: dict[str, JsonValue]
+
+
+@dataclass(frozen=True)
+class StepRecord:
+    """One real transition: the action taken and the observation the environment returned."""
+
+    action: ToolCall
+    output: str
+    is_error: bool = False
+
+
+@dataclass(frozen=True)
+class Trajectory:
+    """A full agent run on one task: ordered steps plus the graded outcome."""
+
+    task: Task
+    steps: list[StepRecord]
+    final_answer: str = ""
+    reward: float | None = None
+    model: str = ""
+    split: str = ""
+    metadata: dict[str, JsonValue] = field(default_factory=dict)

--- a/environment-capture/pyproject.toml
+++ b/environment-capture/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "environment-capture"
+version = "0.1.0"
+description = "Run benchmarks for real and record agent-environment transitions as OTel GenAI JSONL."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+bedrock = ["boto3>=1.34"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["environment_capture"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dev = [
     "ruff>=0.5",
     "ty>=0.0.1a1",
     "world-model-harness[anthropic,openai,bedrock,otel,viz]",
+    # Workspace member: benchmark adapters + real-run trace capture (environment-capture/).
+    "environment-capture[bedrock]",
 ]
 
 [project.scripts]
@@ -43,10 +45,16 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["wmh"]
 
+[tool.uv.workspace]
+members = ["environment-capture"]
+
+[tool.uv.sources]
+environment-capture = { workspace = true }
+
 [tool.pytest.ini_options]
 # Tests live inline next to the modules they cover (foo.py -> foo_test.py).
 python_files = ["*_test.py"]
-testpaths = ["wmh"]
+testpaths = ["wmh", "environment-capture"]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,12 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+members = [
+    "environment-capture",
+    "world-model-harness",
+]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -328,6 +334,20 @@ sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
+
+[[package]]
+name = "environment-capture"
+version = "0.1.0"
+source = { editable = "environment-capture" }
+
+[package.optional-dependencies]
+bedrock = [
+    { name = "boto3" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" }]
+provides-extras = ["bedrock"]
 
 [[package]]
 name = "fastapi"
@@ -1543,6 +1563,7 @@ bedrock = [
 dev = [
     { name = "anthropic" },
     { name = "boto3" },
+    { name = "environment-capture", extra = ["bedrock"] },
     { name = "matplotlib" },
     { name = "openai" },
     { name = "opentelemetry-proto" },
@@ -1566,6 +1587,7 @@ viz = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.39" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
+    { name = "environment-capture", extras = ["bedrock"], marker = "extra == 'dev'", editable = "environment-capture" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gepa", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## What

Top-level `environment-capture/` uv workspace member — the scaffold for WS-B2 (SIB × world models, `plans/ws-b2.md`, DECISIONS.md D20–D24):

- **`BenchmarkAdapter` protocol** (`tasks(split)` / `open_env(task)` / `grade(task, submission)`) with **`CommandEnv.execute(command) -> (output, returncode)` as the world-model seam**: swap the real env for a WM-backed one and the identical agent loop runs against the world model.
- **`run_capture` driver**: agent × real env → graded `Trajectory` list (observations never synthesized).
- **OTel GenAI JSONL emitter** matching the wmh wire format — a round-trip test pins it against `wmh.ingest.OtelGenAIAdapter` (the one place the package touches wmh; moves across the boundary if the package is ever extracted).
- **SIB baseline-cache loader** (data-only reuse per D21; no SIB code/paths). Verified against the real financebench cache: 121/121 trajectories parse, mean reward reproduces the manifest exactly (0.2893).
- AGENTS.md rule-5 exception for `environment-capture/` (same mechanism as `web/`); the package IS inside the python gate (workspace member; pytest testpaths extended).

## Why in-repo (not a separate package)

User decision 2026-07-02 (D20): shared-capture code lives inside wmh for now, extraction-ready (stdlib-only package, no wmh imports), possibly shared with SIB post-release.

## Next (stacked)

financebench end-to-end: converted 121-trace corpus + fresh Bedrock capture top-up → `wmh build` → D12 fidelity eval → WM-replacement reward-agreement demo.

Gate: ruff + ty + pytest whole-repo green (320 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)