### PR TITLE
RL seam: episode reward judge, session scoring API, scenarios from traces + 5-method smoke harness

### DIFF
--- a/examples/tau-bench/rl/README.md
+++ b/examples/tau-bench/rl/README.md
@@ -1,0 +1,116 @@
+# RL smoke harness (tau-bench)
+
+`smoke.py` exercises every wmh-side data path each downstream training chat will consume
+end-to-end against the real tau-bench world model on Bedrock, at tiny scale (~30 haiku calls,
+`max_steps=3`, 2 scenarios). It exists so we find interface problems in the RL seam here
+before the transfer prompts spawn four training chats that would each hit the same wall.
+
+## What it checks
+
+Six paths, each independently PASS/FAIL:
+
+1. **ICL** — one closed-loop episode via `run_episode(WorldModelEnv(wm), agent, task)`, then a
+   scored follow-up rollout so we can build the augmented next-episode prompt that folds the
+   reward-judge critique back in. This is the whole ICL story: no gradient, just critique-in-prompt.
+2. **SFT** — chat-format dataset builder over two recorded train traces, one JSON example per
+   step: `{messages: [system, user], completion: "<recorded tool call JSON>"}`. Shape only; no
+   training.
+3. **PPO / REINFORCE++** — n=1 rollout per scenario stepped directly against the WM
+   (`new_session -> agent loop -> score_session -> end_session`), producing a batch of
+   `{task_id, rollout_steps, reward, success, step_rewards}`.
+4. **GRPO** — n=2 rollouts per scenario, grouped by `task_id`; group-relative advantages
+   (`reward - group_mean`) computed and printed.
+5. **SDPO** — one scored rollout emitted as a `{task, rollout, critique, reward}` feedback record
+   where `critique` is `EpisodeScore.critique` (SDPO's tokenized teacher signal).
+6. **HTTP** — the FastAPI seam claas-verl will actually call: `create_app` + `TestClient` in
+   process, driving `session -> step -> score -> delete`.
+
+## Run
+
+```bash
+uv run python examples/tau-bench/rl/smoke.py   # from repo root; AWS default profile, us-east-1
+```
+
+The script loads `examples/tau-bench/models/tau-bench/` (built config + retrieval index + optimized
+prompt) but overrides the runtime provider to Bedrock haiku
+(`us.anthropic.claude-haiku-4-5-20251001-v1:0`) for BOTH the serve model and the reward judge, so a
+smoke doesn't cost Opus money. All 6 paths must PASS.
+
+## Verified output
+
+```
+wmh RL smoke: loading tau-bench world model with Bedrock haiku (us-east-1)...
+  loaded wm + 822 train traces + 2 scenarios (0.2s)
+
+--- 1_ICL ---
+scenario.task[:120]: '{"domain": "airline", "known_info": "You are Anya Garcia.\n\nYour user id is: anya_garcia_5901.\n\nYour confirmation num'
+  stop_reason=max_steps steps=3
+  scored followup rollout: reward=0.10 success=False
+  critique[:200]: 'You retrieved user details but failed to complete the task. ...'
+[PASS] 1_ICL: episode steps=3, follow-up reward=0.10, critique injected
+
+--- 2_SFT ---
+  dataset size: 9 examples
+[PASS] 2_SFT: 9 SFT examples built from 2 train traces
+
+--- 3_PPO_REINFORCE ---
+  rollout: {'task_id': 'f9203b81...', 'rollout_steps': 3, 'reward': 0.6, 'step_rewards': [0.8, 0.9, 1.0]}
+  rollout: {'task_id': '0af7f822...', 'rollout_steps': 3, 'reward': 0.3, 'step_rewards': [0.4, 0.3, 0.3]}
+[PASS] 3_PPO_REINFORCE: 2 single-rollout PPO/R++ examples
+
+--- 4_GRPO ---
+  group f9203b81...: mean_reward=0.300
+    rollout 0: reward=0.30 adv=+0.000
+    rollout 1: reward=0.30 adv=+0.000
+  group 0af7f822...: mean_reward=0.150
+    rollout 0: reward=0.15 adv=+0.000
+    rollout 1: reward=0.15 adv=+0.000
+[PASS] 4_GRPO: 2 groups, 4 rollouts, group-relative advantages computed
+
+--- 5_SDPO ---
+  SDPO record (critique[:200]): 'You gathered relevant information but failed to complete the task as instructed. ...'
+  rollout_steps=3 reward=0.20
+[PASS] 5_SDPO: 1 SDPO feedback record built (rollout_steps=3)
+
+--- 6_HTTP ---
+  session_id=cc154e34b4a24d11bec122fbc44aef49
+  step observation.content[:200]: '```json\n{\n  "output": {\n    "reservation_id": "EHGLP3", ...'
+  score: reward=1.00 success=True
+  final usage: {'total': {'calls': 2, 'input_tokens': 4118, 'output_tokens': 574, 'cost_usd': 0.006988}, ...}
+[PASS] 6_HTTP: HTTP session cc154e34 ok (reward=1.00)
+
+=============================
+SMOKE SUMMARY
+=============================
+  1_ICL             PASS   episode steps=3, follow-up reward=0.10, critique injected
+  2_SFT             PASS   9 SFT examples built from 2 train traces
+  3_PPO_REINFORCE   PASS   2 single-rollout PPO/R++ examples
+  4_GRPO            PASS   2 groups, 4 rollouts, group-relative advantages computed
+  5_SDPO            PASS   1 SDPO feedback record built (rollout_steps=3)
+  6_HTTP            PASS   HTTP session cc154e34 ok (reward=1.00)
+=============================
+```
+
+## Notes for the transfer-prompt chats
+
+- **`run_episode` vs `WorldModel.score_session`.** `run_episode` opens its OWN session inside
+  the `WorldModelEnv` and closes it on return, so you cannot call `wm.score_session(session.id)`
+  on that same session afterwards. RL rollouts that need `score_session` should step the WM
+  directly instead: `new_session -> agent.act loop -> score_session -> end_session`. That
+  pattern is `_rollout_direct` in `smoke.py`. `run_episode` is still the right primitive for
+  offline eval (compare against the real env) — just not for reward collection.
+- **`_reward_provider` is currently module-private on `WorldModel`.** `WorldModel.load` only
+  accepts one `provider`; if you want the reward judge on a different (cheaper) model you have to
+  poke `wm._reward_provider` after loading. Consider promoting this to a `WorldModel.load(...,
+  reward_provider=...)` kwarg before the training chats start; today's smoke works around it.
+- **Bedrock model ids need the dated suffix on inference profiles.** `us.anthropic.claude-haiku-
+  4-5` alone returns `ValidationException`; the full profile id
+  `us.anthropic.claude-haiku-4-5-20251001-v1:0` works. `wmh.tracking.pricing` already strips the
+  suffix for the price lookup, so cost accounting still works.
+- **Identical GRPO rollouts under temperature=0.** The default `provider.complete` is deterministic,
+  so both rollouts in a group land on identical outputs and advantages collapse to 0. That is fine
+  for wiring smoke; real GRPO training must pass a non-zero temperature (or top_p) so the group
+  actually varies.
+- **`scenarios_from_traces` first-seen order.** For a tau-bench train split it picks whatever
+  trace hashed lowest first. If a downstream chat wants a specific scenario, filter/sort by
+  `provenance` rather than assuming index 0 is stable across runs.

--- a/examples/tau-bench/rl/smoke.py
+++ b/examples/tau-bench/rl/smoke.py
@@ -1,0 +1,483 @@
+"""Smoke-test all 5 RL-method data paths + the HTTP training seam against the tau-bench WM.
+
+Each downstream training chat (SFT + PPO + REINFORCE++, GRPO + SDPO, ICL) will consume the same
+wmh-side machinery this script exercises end-to-end at tiny scale:
+
+    1. ICL       -- closed-loop episode via `run_episode` + `WorldModelEnv`, plus
+                    prior-episode critique injection into the next-episode agent prompt.
+    2. SFT       -- chat-format dataset builder over recorded train traces
+                    (one JSON example per step: {messages, completion}).
+    3. PPO / R++ -- single-rollout batch: n=1 rollout per scenario, scored by
+                    `WorldModel.score_session` (reward, step_rewards).
+    4. GRPO      -- group-relative advantages: n=2 rollouts per scenario, grouped by
+                    task_id; advantage = reward - group_mean.
+    5. SDPO      -- one rollout scored, then the {task, rollout, critique} feedback
+                    record (critique = EpisodeScore.critique).
+
+Finally we hit the FastAPI serving layer in-process with `TestClient` and drive
+session -> step -> score -> delete, since claas-verl and other training scaffolds will
+talk to that HTTP surface, not the Python objects.
+
+Budget: <~30 Bedrock haiku calls, max_steps=3, 2 scenarios. Under `examples/` so it's
+excluded from the ruff/ty gate but we keep it clean. Run with:
+
+    uv run python examples/tau-bench/rl/smoke.py
+
+from the repo root. AWS creds come from `~/.aws` (default profile), region us-east-1.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from fastapi.testclient import TestClient
+
+from wmh.config import load_config
+from wmh.core.parsing import extract_json_object
+from wmh.core.render import render_action, render_demo
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Step, Trace
+from wmh.engine import ingest, split_traces_3way
+from wmh.engine.world_model import WorldModel
+from wmh.env import DONE_SIGNAL, WorldModelEnv, run_episode
+from wmh.env.scenarios import Scenario, scenarios_from_traces
+from wmh.optimize.reward import EpisodeScore
+from wmh.providers import get_provider
+from wmh.providers.base import Message, Provider, ProviderConfig, ProviderKind
+from wmh.serving.server import create_app
+
+# --- config ---------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODEL_DIR = _REPO_ROOT / "examples" / "tau-bench" / "models" / "tau-bench"
+_TRACES_PATH = _REPO_ROOT / "examples" / "tau-bench" / "traces.otel.jsonl"
+
+# Haiku is cheap and honours all Bedrock knobs; we override the model's built-in Opus so a
+# ~30-call smoke doesn't cost Opus money. WorldModel.load reads the artifact index + prompt
+# unchanged; only the *runtime* provider swaps.
+# The Bedrock inference-profile id needs the dated version suffix (undated `us.anthropic.
+# claude-haiku-4-5` returns ValidationException). Pricing strips the suffix, so cost still
+# lines up with the `claude-haiku-4-5` price row.
+_HAIKU_MODEL = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+_REGION = "us-east-1"
+
+MAX_STEPS = 3
+NUM_SCENARIOS = 2
+GRPO_ROLLOUTS_PER_SCENARIO = 2
+WORLD_MODEL_NAME = "tau-bench"
+
+
+# --- result plumbing ------------------------------------------------------
+
+
+@dataclass
+class MethodResult:
+    name: str
+    passed: bool
+    detail: str = ""
+    error: str = ""
+
+
+@dataclass
+class Report:
+    results: list[MethodResult] = field(default_factory=list)
+
+    def record(self, r: MethodResult) -> None:
+        self.results.append(r)
+        icon = "PASS" if r.passed else "FAIL"
+        print(f"\n[{icon}] {r.name}: {r.detail or r.error}")
+
+    def summary(self) -> str:
+        width = max(len(r.name) for r in self.results)
+        lines = ["", "=" * (width + 14), "SMOKE SUMMARY", "=" * (width + 14)]
+        for r in self.results:
+            status = "PASS" if r.passed else "FAIL"
+            lines.append(f"  {r.name.ljust(width)}   {status}   {r.detail or r.error}")
+        lines.append("=" * (width + 14))
+        return "\n".join(lines)
+
+
+def _run(report: Report, name: str, fn: Callable[[], str]) -> None:
+    """Run one path; on any exception, mark FAIL and keep going so we see every method's status."""
+    print(f"\n--- {name} ---")
+    try:
+        detail = fn()
+        report.record(MethodResult(name=name, passed=True, detail=detail))
+    except Exception as exc:  # noqa: BLE001 - smoke reports rather than crashes on first failure
+        tb = traceback.format_exc()
+        report.record(MethodResult(name=name, passed=False, error=f"{type(exc).__name__}: {exc}"))
+        print(tb)
+
+
+# --- world model + agent construction ------------------------------------
+
+
+def _load_wm_with_haiku() -> tuple[WorldModel, Provider]:
+    """Load the built tau-bench WM but swap in Bedrock haiku for BOTH serve and reward providers."""
+    config = load_config(str(_MODEL_DIR))  # read stored embed_dim, top_k, artifact layout
+    _ = config  # config is consumed inside WorldModel.load; we override the provider only
+    haiku_cfg = ProviderConfig(kind=ProviderKind.BEDROCK, model=_HAIKU_MODEL, region=_REGION)
+    provider = get_provider(haiku_cfg)
+    wm = WorldModel.load(str(_MODEL_DIR), provider)
+    # score_session judges with `_reward_provider`; default is the serve provider, but the seam
+    # allows a different reward model. For smoke we deliberately use the same haiku for both.
+    wm._reward_provider = provider  # noqa: SLF001 - smoke; production would take a kwarg
+    return wm, provider
+
+
+def _load_scenarios() -> tuple[list[Trace], list[Trace], list[Scenario]]:
+    """Ingest the tau-bench corpus and split 80/10/10 (train / val / test).
+
+    We only need a couple of scenarios, but running through the full split proves the whole
+    train/test surface still works after the RL seam landed.
+    """
+    config = load_config(str(_MODEL_DIR))
+    traces = ingest(config, file=str(_TRACES_PATH))
+    train, _val, _test = split_traces_3way(traces, 0.8, 0.1)
+    scenarios = scenarios_from_traces(train)[:NUM_SCENARIOS]
+    if len(scenarios) < NUM_SCENARIOS:
+        raise RuntimeError(
+            f"need >= {NUM_SCENARIOS} scenarios from the train split; got {len(scenarios)}"
+        )
+    return train, _test, scenarios
+
+
+# --- an agent that talks to the WM ---------------------------------------
+
+
+class HaikuToolCallAgent:
+    """Ask haiku for one tool call per step; fall back to a MESSAGE action on parse failure.
+
+    Same shape as `wmh.engine.demo._propose_action`: JSON-only tool-call reply, temperature 0.
+    """
+
+    def __init__(self, provider: Provider, examples: list[Step]) -> None:
+        self._provider = provider
+        self._examples = examples
+
+    def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
+        # Feed the model the task and (very brief) history — enough for a smoke tool call.
+        history_text = "\n".join(
+            f"step {i + 1} ACTION: {render_action(s.action)}\n"
+            f"step {i + 1} OBSERVATION: {s.observation.content[:200]}"
+            for i, s in enumerate(history[-3:])
+        ) or "(no prior steps)"
+        example_block = "\n\n".join(render_demo(e) for e in self._examples[:2]) or "(no examples)"
+        user = (
+            "You role-play a tau-bench airline/retail/telecom customer-service agent. Emit one "
+            "next tool call as a JSON object and nothing else:\n"
+            '{"name": "<tool>", "arguments": {<json>}}\n\n'
+            "If you believe the task is complete, instead return exactly the string <DONE>.\n\n"
+            f"TASK:\n{task}\n\n"
+            f"HISTORY:\n{history_text}\n\n"
+            f"REFERENCE EXAMPLES:\n{example_block}\n\n"
+            "Your single tool call (JSON only) or <DONE>:"
+        )
+        completion = self._provider.complete(
+            "You role-play an agent. Reply with JSON only or <DONE>.",
+            [Message(role="user", content=user)],
+        )
+        text = completion.text.strip()
+        if text == DONE_SIGNAL:
+            return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+        raw = extract_json_object(text)
+        if raw is not None:
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict) and "name" in obj:
+                    args = obj.get("arguments") or {}
+                    if isinstance(args, dict):
+                        return Action(
+                            kind=ActionKind.TOOL_CALL,
+                            name=str(obj["name"]),
+                            arguments=_as_json_object(args),
+                        )
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return Action(kind=ActionKind.MESSAGE, content=text[:500])
+
+
+def _as_json_object(d: dict) -> JsonObject:
+    return {str(k): v for k, v in d.items()}
+
+
+# --- helper: step the WM manually (used by PPO/GRPO/SDPO) ----------------
+
+
+def _rollout_direct(
+    wm: WorldModel, agent: HaikuToolCallAgent, task: str, max_steps: int
+) -> tuple[str, list[Step], EpisodeScore]:
+    """New WM session, agent loop, score, return (session_id, steps, score).
+
+    `run_episode` uses its own session inside a WorldModelEnv (opened at reset, closed at return),
+    so it isn't usable when we need `wm.score_session(session_id)` on the SAME session afterwards.
+    This helper is the pattern PPO/GRPO/SDPO batches will use: new_session -> loop -> score ->
+    end_session, keeping the reward tracker's SERVE/JUDGE split intact.
+    """
+    session = wm.new_session(task=task)
+    for _ in range(max_steps):
+        try:
+            action = agent.act(task, session.state, session.history)
+        except Exception as exc:  # noqa: BLE001 - one bad agent call kills only this rollout
+            print(f"  agent.act raised: {type(exc).__name__}: {exc}")
+            break
+        if action.kind is ActionKind.MESSAGE and action.content == DONE_SIGNAL:
+            break
+        try:
+            wm.step(session.id, action)
+        except Exception as exc:  # noqa: BLE001 - env exceptions become episode-end, not test-end
+            print(f"  wm.step raised: {type(exc).__name__}: {exc}")
+            break
+    score = wm.score_session(session.id)
+    steps = list(session.history)
+    wm.end_session(session.id)
+    return session.id, steps, score
+
+
+# --- method 1: ICL --------------------------------------------------------
+
+
+def _method_icl(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) -> str:
+    """Closed-loop episode via `run_episode`; then show critique injection into a next-episode prompt."""
+    scenario = scenarios[0]
+    print(f"scenario.task[:120]: {scenario.task[:120]!r}")
+    examples = wm.sample_steps(2)
+    agent = HaikuToolCallAgent(provider, examples)
+    env = WorldModelEnv(wm)
+    result = run_episode(env, agent, scenario.task, max_steps=MAX_STEPS)
+    print(f"  stop_reason={result.stop_reason.value} steps={len(result.steps)}")
+    if not result.steps:
+        raise RuntimeError("ICL: episode produced 0 steps; agent likely errored on step 1")
+    # Now score the *just-completed* run by hand-building the same score call. run_episode
+    # closed its env session, so we spin one up over the recorded steps to score - or simpler:
+    # rebuild a session, replay steps into history (no LLM calls) and score. To keep this
+    # smoke honest and cheap, we score a FRESH one-step rollout that reuses the agent instead.
+    _sid, _steps, score = _rollout_direct(wm, agent, scenario.task, max_steps=1)
+    print(f"  scored followup rollout: reward={score.reward:.2f} success={score.success}")
+    print(f"  critique[:200]: {score.critique[:200]!r}")
+
+    # ICL's whole point: fold the critique into the NEXT-episode prompt so the agent learns
+    # in-context. Build the augmented prompt string and print — no second episode needed.
+    augmented = (
+        f"TASK:\n{scenario.task}\n\n"
+        f"PREVIOUS ATTEMPT CRITIQUE (from the reward judge, use as guidance):\n{score.critique}\n\n"
+        f"Take a fresh next tool call reflecting the critique."
+    )
+    print(f"  augmented next-episode prompt (first 300 chars):\n    {augmented[:300]!r}")
+    return (
+        f"episode steps={len(result.steps)}, follow-up reward={score.reward:.2f}, "
+        f"critique injected"
+    )
+
+
+# --- method 2: SFT --------------------------------------------------------
+
+
+def _method_sft(train_traces: list[Trace]) -> str:
+    """Build a chat-format SFT dataset from the first 2 train traces: one example per step."""
+    if len(train_traces) < 2:
+        raise RuntimeError("SFT: need >= 2 train traces")
+    dataset: list[dict] = []
+    for trace in train_traces[:2]:
+        task = _first_task(trace)
+        for i, step in enumerate(trace.steps):
+            prior = trace.steps[:i]
+            history_lines = []
+            for j, ps in enumerate(prior[-3:], start=1):
+                history_lines.append(f"turn {j} action: {render_action(ps.action)}")
+                history_lines.append(f"turn {j} observation: {ps.observation.content[:200]}")
+            user_content = (
+                f"TASK: {task}\n\n"
+                f"PRIOR TURNS:\n{chr(10).join(history_lines) or '(none)'}\n\n"
+                "Emit the next agent tool call as JSON:"
+            )
+            completion = json.dumps(
+                {"name": step.action.name, "arguments": step.action.arguments},
+                sort_keys=True,
+            )
+            dataset.append(
+                {
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "You are a tau-bench customer-service agent.",
+                        },
+                        {"role": "user", "content": user_content},
+                    ],
+                    "completion": completion,
+                }
+            )
+    print(f"  dataset size: {len(dataset)} examples")
+    print("  example[0]:")
+    print(json.dumps(dataset[0], indent=2)[:600])
+    return f"{len(dataset)} SFT examples built from 2 train traces"
+
+
+def _first_task(trace: Trace) -> str:
+    for step in trace.steps:
+        if step.task:
+            return step.task
+    return "(no task recorded)"
+
+
+# --- method 3: PPO / REINFORCE++ -----------------------------------------
+
+
+def _method_ppo(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) -> str:
+    """n=1 rollout per scenario, WM-scored. Reports the per-scenario batch record."""
+    examples = wm.sample_steps(2)
+    agent = HaikuToolCallAgent(provider, examples)
+    batch = []
+    for scenario in scenarios:
+        _sid, steps, score = _rollout_direct(wm, agent, scenario.task, max_steps=MAX_STEPS)
+        entry = {
+            "task_id": scenario.provenance[0] if scenario.provenance else "?",
+            "task": scenario.task[:80],
+            "rollout_steps": len(steps),
+            "reward": score.reward,
+            "success": score.success,
+            "step_rewards": score.step_rewards,
+        }
+        batch.append(entry)
+        print(f"  rollout: {entry}")
+    return f"{len(batch)} single-rollout PPO/R++ examples"
+
+
+# --- method 4: GRPO -------------------------------------------------------
+
+
+def _method_grpo(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) -> str:
+    """n=2 rollouts per scenario; group-relative advantages = reward - group_mean."""
+    examples = wm.sample_steps(2)
+    agent = HaikuToolCallAgent(provider, examples)
+    groups: dict[str, list[dict]] = {}
+    for scenario in scenarios:
+        task_id = scenario.provenance[0] if scenario.provenance else "?"
+        group = groups.setdefault(task_id, [])
+        for k in range(GRPO_ROLLOUTS_PER_SCENARIO):
+            _sid, steps, score = _rollout_direct(wm, agent, scenario.task, max_steps=MAX_STEPS)
+            group.append(
+                {
+                    "rollout_index": k,
+                    "reward": score.reward,
+                    "step_rewards": score.step_rewards,
+                    "steps": len(steps),
+                }
+            )
+    for task_id, group in groups.items():
+        mean = sum(r["reward"] for r in group) / max(len(group), 1)
+        for r in group:
+            r["advantage"] = r["reward"] - mean
+        print(f"  group {task_id}: mean_reward={mean:.3f}")
+        for r in group:
+            print(f"    rollout {r['rollout_index']}: reward={r['reward']:.2f} adv={r['advantage']:+.3f}")
+    n_rollouts = sum(len(g) for g in groups.values())
+    return f"{len(groups)} groups, {n_rollouts} rollouts, group-relative advantages computed"
+
+
+# --- method 5: SDPO -------------------------------------------------------
+
+
+def _method_sdpo(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) -> str:
+    """One scored rollout -> {task, rollout, critique} feedback record (SDPO's teacher signal)."""
+    scenario = scenarios[0]
+    examples = wm.sample_steps(2)
+    agent = HaikuToolCallAgent(provider, examples)
+    _sid, steps, score = _rollout_direct(wm, agent, scenario.task, max_steps=MAX_STEPS)
+    record = {
+        "task": scenario.task,
+        "rollout": [
+            {
+                "action": {
+                    "kind": s.action.kind.value,
+                    "name": s.action.name,
+                    "arguments": s.action.arguments,
+                    "content": s.action.content,
+                },
+                "observation": {
+                    "content": s.observation.content[:200],
+                    "is_error": s.observation.is_error,
+                },
+            }
+            for s in steps
+        ],
+        "critique": score.critique,
+        "reward": score.reward,
+    }
+    print(f"  SDPO record (critique[:200]): {record['critique'][:200]!r}")
+    print(f"  rollout_steps={len(record['rollout'])} reward={record['reward']:.2f}")
+    return f"1 SDPO feedback record built (rollout_steps={len(steps)})"
+
+
+# --- HTTP smoke via TestClient -------------------------------------------
+
+
+def _method_http(wm: WorldModel) -> str:
+    """Serve the wm via `create_app` and drive session -> step -> score -> delete over HTTP."""
+    app = create_app(world_models={WORLD_MODEL_NAME: wm})
+    client = TestClient(app)
+
+    resp = client.post(
+        f"/world_models/{WORLD_MODEL_NAME}/sessions",
+        json={"task": "Look up reservation EHGLP3 for emma_kim_9957."},
+    )
+    assert resp.status_code == 200, resp.text
+    session_id = resp.json()["session_id"]
+    print(f"  session_id={session_id}")
+
+    action = {
+        "kind": "tool_call",
+        "name": "get_reservation_details",
+        "arguments": {"reservation_id": "EHGLP3"},
+        "content": None,
+    }
+    resp = client.post(
+        f"/world_models/{WORLD_MODEL_NAME}/sessions/{session_id}/step",
+        json={"action": action},
+    )
+    assert resp.status_code == 200, resp.text
+    obs = resp.json()["observation"]
+    print(f"  step observation.content[:200]: {obs['content'][:200]!r}")
+
+    resp = client.post(f"/world_models/{WORLD_MODEL_NAME}/sessions/{session_id}/score")
+    assert resp.status_code == 200, resp.text
+    score = resp.json()
+    print(f"  score: reward={score['reward']:.2f} success={score['success']}")
+    print(f"  critique[:200]: {score['critique'][:200]!r}")
+
+    resp = client.delete(f"/world_models/{WORLD_MODEL_NAME}/sessions/{session_id}")
+    assert resp.status_code == 200, resp.text
+    usage = resp.json()
+    print(f"  final usage: {usage}")
+
+    return f"HTTP session {session_id[:8]} ok (reward={score['reward']:.2f})"
+
+
+# --- main -----------------------------------------------------------------
+
+
+def main() -> int:
+    print("wmh RL smoke: loading tau-bench world model with Bedrock haiku (us-east-1)...")
+    t0 = time.monotonic()
+    wm, provider = _load_wm_with_haiku()
+    train, _test, scenarios = _load_scenarios()
+    print(f"  loaded wm + {len(train)} train traces + {len(scenarios)} scenarios ({time.monotonic() - t0:.1f}s)")
+
+    report = Report()
+    _run(report, "1_ICL", lambda: _method_icl(wm, provider, scenarios))
+    _run(report, "2_SFT", lambda: _method_sft(train))
+    _run(report, "3_PPO_REINFORCE", lambda: _method_ppo(wm, provider, scenarios))
+    _run(report, "4_GRPO", lambda: _method_grpo(wm, provider, scenarios))
+    _run(report, "5_SDPO", lambda: _method_sdpo(wm, provider, scenarios))
+    _run(report, "6_HTTP", lambda: _method_http(wm))
+
+    print(report.summary())
+    return 0 if all(r.passed for r in report.results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -15,11 +15,12 @@ from wmh.config import ArtifactPaths, load_config
 from wmh.core.parsing import parse_observation
 from wmh.core.types import Action, EnvState, Observation, Session, Step
 from wmh.engine.prompts import BASE_ENV_PROMPT, build_env_prompt
+from wmh.optimize.reward import EpisodeRewardJudge, EpisodeScore
 from wmh.providers.base import Embedder, Message, Provider
 from wmh.retrieval import EmbeddingRetriever, Retriever
 from wmh.retrieval.embedders import get_embedder
 from wmh.telemetry import capture
-from wmh.tracking import Phase, RunRecord, RunTracker
+from wmh.tracking import MeteredProvider, Phase, RunRecord, RunTracker
 
 
 class WorldModel:
@@ -30,6 +31,7 @@ class WorldModel:
         env_prompt: str = BASE_ENV_PROMPT,
         top_k: int = 5,
         telemetry_root: str | Path = ".wmh",
+        reward_provider: Provider | None = None,
     ) -> None:
         self._provider = provider
         self._retriever = retriever
@@ -40,6 +42,9 @@ class WorldModel:
         # Per-session token/cost/time accounting (serve-time observability). One tracker per
         # session, started when the session is created; `session_usage` exposes running totals.
         self._trackers: dict[str, RunTracker] = {}
+        # Reward judging (`score_session`) defaults to the serve provider; pass `reward_provider`
+        # to judge with a different model than the one simulating the environment.
+        self._reward_provider = reward_provider or provider
 
     @classmethod
     def load(
@@ -117,6 +122,31 @@ class WorldModel:
     def sample_steps(self, n: int) -> list[Step]:
         """Return up to `n` steps from the replay buffer (used to seed the demo agent)."""
         return self._retriever.sample(n)
+
+    def score_session(self, session_id: str) -> EpisodeScore:
+        """Judge the session's rollout so far: episode reward, per-step rewards, and a critique.
+
+        This is the RL reward signal. The reward judge sees the session's task and its full step
+        history — never a gold trace — and returns everything the algorithms need in one call:
+        scalar reward/success (GRPO, PPO, REINFORCE++), `step_rewards` (dense diagnostics), and
+        `critique` (SDPO's teacher feedback). Raises `KeyError` for an unknown session id.
+
+        Judge usage is metered onto the session's tracker under `Phase.JUDGE`, so `session_usage`
+        keeps reward cost separate from the world model's SERVE cost.
+        """
+        session = self._sessions[session_id]
+        tracker = self._trackers.get(session_id)
+        provider = (
+            MeteredProvider(self._reward_provider, tracker, base_phase=Phase.JUDGE)
+            if tracker is not None
+            else self._reward_provider
+        )
+        score = EpisodeRewardJudge(provider).score(session.task, session.history)
+        # The scalar rides the final observation too, so replay-buffer consumers that read
+        # Observation.reward (DreamGym-style terminal r) see the same number the API returned.
+        if session.history:
+            session.history[-1].observation.reward = score.reward
+        return score
 
     def render_step_prompt(self, session_id: str, action: Action) -> str:
         """Assemble the exact (system + user) env prompt `step` would send, without calling the LLM.

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -12,7 +12,14 @@ from wmh.config import ArtifactPaths, HarnessConfig, save_config
 from wmh.config.settings import set_telemetry_enabled
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
 from wmh.engine.world_model import WorldModel
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, TokenUsage
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+    VerifyResult,
+)
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
 
@@ -232,3 +239,52 @@ def test_load_named_model_uses_project_root_for_telemetry_opt_out(
 
     assert wm._telemetry_root == project_root
     assert calls == []
+
+
+def test_score_session_meters_judge_separately_from_serve() -> None:
+    """Reward-judge tokens land under Phase.JUDGE on the session tracker, not SERVE (D12 split)."""
+    from wmh.optimize.reward import EpisodeScore
+    from wmh.tracking import Phase
+
+    class JudgeReply:
+        def __init__(self) -> None:
+            self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="judge-m")
+
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            return Completion(
+                text='{"success": false, "reward": 0.2, "step_rewards": [0.2], "critique": "c"}',
+                usage=TokenUsage(input_tokens=10, output_tokens=5),
+            )
+
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] for _ in texts]
+
+        def verify(self) -> VerifyResult:
+            raise NotImplementedError
+
+    env_provider = FakeProvider('{"output": "found u1", "is_error": false}')
+    retriever = _retriever_with(
+        [
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={}),
+                observation=Observation(content="found u1"),
+            )
+        ]
+    )
+    wm = WorldModel(env_provider, retriever, top_k=1, reward_provider=JudgeReply())
+    session = wm.new_session(task="do the thing")
+    wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={}))
+    score = wm.score_session(session.id)
+    assert isinstance(score, EpisodeScore)
+    assert score.reward == 0.2
+    assert session.history[-1].observation.reward == 0.2
+    usage = wm.session_usage(session.id)
+    assert usage.by_phase[Phase.JUDGE].input_tokens == 10  # judge cost split out (D12)
+    assert Phase.SERVE in usage.by_phase  # the step call stays attributed to SERVE

--- a/wmh/env/__init__.py
+++ b/wmh/env/__init__.py
@@ -7,13 +7,16 @@ byte-identical against either side.
 
 from wmh.env.base import Env, WorldModelEnv
 from wmh.env.episode import DONE_SIGNAL, Agent, EpisodeResult, StopReason, run_episode
+from wmh.env.scenarios import Scenario, scenarios_from_traces
 
 __all__ = [
     "DONE_SIGNAL",
     "Agent",
     "Env",
     "EpisodeResult",
+    "Scenario",
     "StopReason",
     "WorldModelEnv",
     "run_episode",
+    "scenarios_from_traces",
 ]

--- a/wmh/env/scenarios.py
+++ b/wmh/env/scenarios.py
@@ -1,0 +1,52 @@
+"""Scenarios: the task prompts an agent trains and is evaluated on, derived from traces.
+
+v1 scenario creation is deliberately minimal (the prompts already recorded in the corpus's traces
+ARE the scenarios): `scenarios_from_traces` extracts one `Scenario` per unique task from the given
+traces. Callers control leakage by choosing which traces to pass — extract training scenarios from
+the train split and held-out scenarios from the test split, and the two can never overlap because
+the whole-trace split already separated them.
+
+Principled scenario *generation* (coverage, difficulty calibration, counterfactuals) is a later
+layer that will produce the same `Scenario` type.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from wmh.core.types import Trace
+
+
+class Scenario(BaseModel):
+    """One task an agent can attempt against an environment."""
+
+    task: str  # the prompt handed to the agent (and to Env.reset)
+    provenance: list[str] = Field(default_factory=list)  # trace_ids this scenario came from
+
+
+def scenarios_from_traces(traces: list[Trace]) -> list[Scenario]:
+    """Extract the unique task prompts from `traces`, in first-seen order.
+
+    Traces without a task (or with a whitespace-only one) are skipped: a scenario is exactly "a
+    prompt we can hand to an agent", and an empty prompt isn't one. Duplicate tasks collapse into
+    a single scenario whose `provenance` lists every contributing trace.
+    """
+    by_task: dict[str, Scenario] = {}
+    for trace in traces:
+        task = _trace_task(trace)
+        if task is None:
+            continue
+        scenario = by_task.get(task)
+        if scenario is None:
+            by_task[task] = Scenario(task=task, provenance=[trace.trace_id])
+        elif trace.trace_id not in scenario.provenance:
+            scenario.provenance.append(trace.trace_id)
+    return list(by_task.values())
+
+
+def _trace_task(trace: Trace) -> str | None:
+    """The trace's task prompt: first non-empty per-step task (steps carry it in this corpus)."""
+    for step in trace.steps:
+        if step.task and step.task.strip():
+            return step.task.strip()
+    return None

--- a/wmh/env/scenarios_test.py
+++ b/wmh/env/scenarios_test.py
@@ -1,0 +1,38 @@
+"""Tests for scenario extraction from traces."""
+
+from __future__ import annotations
+
+from wmh.core.types import Action, ActionKind, Observation, Step, Trace
+from wmh.env.scenarios import Scenario, scenarios_from_traces
+
+
+def _trace(trace_id: str, task: str | None) -> Trace:
+    step = Step(
+        action=Action(kind=ActionKind.TOOL_CALL, name="t", arguments={}),
+        observation=Observation(content="ok"),
+        task=task,
+    )
+    return Trace(trace_id=trace_id, steps=[step])
+
+
+def test_extracts_unique_tasks_with_provenance() -> None:
+    traces = [
+        _trace("a", "book a flight"),
+        _trace("b", "cancel order 7"),
+        _trace("c", "book a flight"),  # duplicate task -> same scenario, extra provenance
+    ]
+    scenarios = scenarios_from_traces(traces)
+    assert scenarios == [
+        Scenario(task="book a flight", provenance=["a", "c"]),
+        Scenario(task="cancel order 7", provenance=["b"]),
+    ]
+
+
+def test_skips_traces_without_a_task() -> None:
+    traces = [_trace("a", None), _trace("b", "   "), _trace("c", "real task")]
+    scenarios = scenarios_from_traces(traces)
+    assert [s.task for s in scenarios] == ["real task"]
+
+
+def test_empty_input_gives_empty_output() -> None:
+    assert scenarios_from_traces([]) == []

--- a/wmh/optimize/__init__.py
+++ b/wmh/optimize/__init__.py
@@ -3,8 +3,11 @@
 from wmh.optimize.gepa import GEPAOptimizer, OptimizeMetrics, Optimizer, OptimizeResult
 from wmh.optimize.judge import Judge, JudgeResult, LLMJudge, RubricJudge
 from wmh.optimize.numeric import NumericJudge
+from wmh.optimize.reward import EpisodeRewardJudge, EpisodeScore
 
 __all__ = [
+    "EpisodeRewardJudge",
+    "EpisodeScore",
     "GEPAOptimizer",
     "OptimizeMetrics",
     "OptimizeResult",

--- a/wmh/optimize/reward.py
+++ b/wmh/optimize/reward.py
@@ -1,0 +1,129 @@
+"""Episode reward judging: the RL-side reward signal served by the harness.
+
+An `EpisodeRewardJudge` scores one finished rollout (task + the steps the agent took against the
+world model) in a single LLM call, returning every signal the RL algorithms need at once:
+
+- `reward` / `success` — the scalar episode outcome (GRPO group advantages, PPO/REINFORCE++ returns)
+- `critique` — natural-language feedback (SDPO's tokenized teacher signal)
+- `step_rewards` — per-step progress scores (dense credit assignment / diagnostics)
+
+One call per rollout keeps reward cheap and internally consistent (the same judgement produces the
+scalar and the per-step breakdown). The judge sees ONLY the task and the rollout — never a gold
+trace — so alternative strategies that accomplish the task score well.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, Field, ValidationError
+
+from wmh.core.parsing import extract_json_object
+from wmh.core.render import render_action
+from wmh.core.types import Step
+from wmh.providers.base import Message, Provider
+
+REWARD_JUDGE_SYSTEM = """You are a strict evaluator of agent rollouts in a simulated environment.
+You are given a TASK and the sequence of steps an agent took (each step: the agent's action and
+the environment's response). Judge whether the agent accomplished the task.
+
+Score honestly and strictly:
+- An agent that reached the goal state through ANY valid strategy succeeds.
+- An agent that claims success without the environment confirming it does NOT succeed.
+- Errors the agent recovered from should reduce step scores, not the episode score.
+
+Reply with ONLY a JSON object:
+{"success": <bool: did the rollout accomplish the task>,
+ "reward": <float 0..1: graded task completion>,
+ "step_rewards": [<float 0..1 per step, in order: did this step make progress toward the task>],
+ "critique": "<2-4 sentences: what the agent did well / where it went wrong / what it should have
+ done instead. Written as feedback TO the agent.>"}
+The step_rewards array must have exactly one entry per step shown."""
+
+
+class EpisodeScore(BaseModel):
+    """Everything the reward judge extracts from one rollout, in one call."""
+
+    reward: float  # graded episode-level task completion, 0..1
+    success: bool  # binary task completion (GRPO/REINFORCE++ binary reward)
+    critique: str  # feedback to the agent; SDPO's tokenized teacher signal
+    step_rewards: list[float] = Field(default_factory=list)  # per-step progress, 0..1 each
+
+
+class _RawEpisodeScore(BaseModel):
+    """Lenient view of the judge's JSON before clamping/normalization."""
+
+    reward: float
+    success: bool
+    critique: str = ""
+    step_rewards: list[float] = Field(default_factory=list)
+
+
+class EpisodeRewardJudge:
+    """Scores finished rollouts with a single judge-LLM call. See module docstring."""
+
+    def __init__(self, provider: Provider) -> None:
+        self._provider = provider
+
+    def score(self, task: str | None, steps: list[Step]) -> EpisodeScore:
+        """Judge one rollout; robust to malformed judge replies (flagged zero score, never raises).
+
+        `steps` is the episode in order (e.g. `EpisodeResult.steps` from `run_episode`, or a served
+        session's history). An empty rollout scores 0 without calling the LLM.
+        """
+        if not steps:
+            return EpisodeScore(
+                reward=0.0, success=False, critique="Empty rollout: no steps to judge."
+            )
+        user = _build_reward_prompt(task, steps)
+        completion = self._provider.complete(
+            REWARD_JUDGE_SYSTEM, [Message(role="user", content=user)], temperature=0.0
+        )
+        return _parse_episode_score(completion.text, n_steps=len(steps))
+
+
+def _build_reward_prompt(task: str | None, steps: list[Step]) -> str:
+    """Render the rollout for the judge: task, then each action -> observation in order."""
+    lines = [f"TASK: {task or '(none given)'}", "", f"ROLLOUT ({len(steps)} steps):"]
+    for i, step in enumerate(steps, start=1):
+        observation = step.observation
+        flag = " [ERROR]" if observation.is_error else ""
+        lines.append(f"--- step {i} ---")
+        lines.append(f"ACTION: {render_action(step.action)}")
+        if step.action.arguments:
+            lines.append(f"ARGUMENTS: {json.dumps(step.action.arguments, sort_keys=True)}")
+        lines.append(f"OBSERVATION{flag}: {observation.content}")
+    return "\n".join(lines)
+
+
+def _parse_episode_score(text: str, n_steps: int) -> EpisodeScore:
+    """Parse the judge reply; normalize step_rewards to exactly `n_steps` entries.
+
+    Malformed replies become a flagged zero score rather than raising, so one bad judge reply
+    can't abort a training batch. Missing/short step_rewards are padded with 0.0; extras dropped.
+    """
+    raw = extract_json_object(text)
+    if raw is not None:
+        try:
+            parsed = _RawEpisodeScore.model_validate_json(raw)
+        except ValidationError:
+            parsed = None
+        if parsed is not None:
+            step_rewards = [_clamp(r) for r in parsed.step_rewards[:n_steps]]
+            step_rewards += [0.0] * (n_steps - len(step_rewards))
+            return EpisodeScore(
+                reward=_clamp(parsed.reward),
+                success=parsed.success,
+                critique=parsed.critique.strip(),
+                step_rewards=step_rewards,
+            )
+    return EpisodeScore(
+        reward=0.0,
+        success=False,
+        critique=f"Unparseable reward-judge reply; treated as failure. Raw: {text.strip()[:200]}",
+        step_rewards=[0.0] * n_steps,
+    )
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))

--- a/wmh/optimize/reward_test.py
+++ b/wmh/optimize/reward_test.py
@@ -1,0 +1,96 @@
+"""Tests for the episode reward judge."""
+
+from __future__ import annotations
+
+import json
+
+from wmh.core.types import Action, ActionKind, Observation, Step
+from wmh.optimize.reward import EpisodeRewardJudge, EpisodeScore, _build_reward_prompt
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+
+
+def _step(content: str = "ok", is_error: bool = False) -> Step:
+    return Step(
+        action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u1"}),
+        observation=Observation(content=content, is_error=is_error),
+    )
+
+
+class FakeProvider:
+    """Returns a canned completion text; records the prompts it saw."""
+
+    def __init__(self, reply: str) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model="m")
+        self._reply = reply
+        self.calls: list[tuple[str, str]] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.calls.append((system, messages[0].content))
+        return Completion(text=self._reply)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def test_scores_parse_clamp_and_truncate() -> None:
+    reply = json.dumps(
+        {"success": True, "reward": 1.7, "step_rewards": [0.5, 2.0, -1.0, 0.9], "critique": "good"}
+    )
+    judge = EpisodeRewardJudge(FakeProvider(reply))
+    score = judge.score("book a flight", [_step(), _step()])
+    assert score.success is True
+    assert score.reward == 1.0  # clamped
+    assert score.step_rewards == [0.5, 1.0]  # clamped + truncated to n_steps
+    assert score.critique == "good"
+
+
+def test_short_step_rewards_are_padded() -> None:
+    reply = json.dumps({"success": False, "reward": 0.3, "step_rewards": [0.3], "critique": "meh"})
+    judge = EpisodeRewardJudge(FakeProvider(reply))
+    score = judge.score("task", [_step(), _step(), _step()])
+    assert score.step_rewards == [0.3, 0.0, 0.0]
+
+
+def test_unparseable_reply_is_flagged_zero_not_raise() -> None:
+    judge = EpisodeRewardJudge(FakeProvider("the agent did great, five stars"))
+    score = judge.score("task", [_step()])
+    assert score.reward == 0.0
+    assert score.success is False
+    assert "Unparseable" in score.critique
+    assert score.step_rewards == [0.0]
+
+
+def test_empty_rollout_scores_zero_without_llm_call() -> None:
+    provider = FakeProvider("{}")
+    score = EpisodeRewardJudge(provider).score("task", [])
+    expected = EpisodeScore(reward=0.0, success=False, critique="Empty rollout: no steps to judge.")
+    assert score == expected
+    assert provider.calls == []
+
+
+def test_prompt_shows_task_actions_observations_and_error_flags() -> None:
+    prompt = _build_reward_prompt("find the reservation", [_step("not found", is_error=True)])
+    assert "TASK: find the reservation" in prompt
+    assert "get_user" in prompt
+    assert '"id": "u1"' in prompt
+    assert "[ERROR]" in prompt
+    assert "not found" in prompt
+
+
+def test_judge_never_sees_gold_trace() -> None:
+    """The prompt must contain only task + rollout — no reference/gold observation channel."""
+    provider = FakeProvider(json.dumps({"success": True, "reward": 1.0, "critique": ""}))
+    EpisodeRewardJudge(provider).score("task", [_step()])
+    _system, user = provider.calls[0]
+    assert "gold" not in user.lower()
+    assert "reference" not in user.lower()

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -3,6 +3,11 @@
 Routes are namespaced by world model name (`/world_models/{name}/...`) so one backend can serve
 several named models at once. Each route is a thin transport over an in-process `WorldModel`; the
 CLI and the API share the same code path.
+
+The backend is also the *reward* server for RL training: `POST .../sessions/{id}/score` judges the
+session's rollout (task + history) with `EpisodeRewardJudge`, returning the scalar episode reward
+(GRPO/PPO/REINFORCE++), per-step rewards, and a critique string (SDPO's teacher feedback) — so a
+training scaffold gets environment and reward behind one API.
 """
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ from pydantic import BaseModel
 
 from wmh.core.types import Action, EnvState, Observation, Session
 from wmh.engine.world_model import WorldModel
+from wmh.optimize.reward import EpisodeScore
 from wmh.tracking import RunRecord
 
 
@@ -118,5 +124,22 @@ def create_app(
         _session_or_404(wm, session_id)
         observation = wm.step(session_id, req.action)
         return StepResponse(observation=observation)
+
+    @app.post(
+        "/world_models/{world_model_name}/sessions/{session_id}/score",
+        response_model=EpisodeScore,
+    )
+    def score_session(world_model_name: str, session_id: str) -> EpisodeScore:
+        """Judge the session's rollout so far: episode reward + per-step rewards + critique."""
+        wm = _model_or_404(world_model_name)
+        _session_or_404(wm, session_id)
+        return wm.score_session(session_id)
+
+    @app.delete("/world_models/{world_model_name}/sessions/{session_id}", response_model=RunRecord)
+    def end_session(world_model_name: str, session_id: str) -> RunRecord:
+        """End the session (free its memory + metering) and return its final usage record."""
+        wm = _model_or_404(world_model_name)
+        _session_or_404(wm, session_id)
+        return wm.end_session(session_id)
 
     return app

--- a/wmh/serving/server_test.py
+++ b/wmh/serving/server_test.py
@@ -106,3 +106,60 @@ def test_sessions_are_isolated_between_named_models() -> None:
     # A session created on `airline` is not visible under `retail`.
     miss = client.get(f"/world_models/retail/sessions/{session_id}")
     assert miss.status_code == 404
+
+
+class RewardJudgeProvider(FakeProvider):
+    """Replies like the reward judge (JSON episode score) instead of an env observation."""
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        return Completion(
+            text='{"success": true, "reward": 0.8, "step_rewards": [0.6], "critique": "solid"}'
+        )
+
+
+def _rewarded_world_model() -> WorldModel:
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
+    return WorldModel(FakeProvider(), retriever, top_k=3, reward_provider=RewardJudgeProvider())
+
+
+def test_score_session_returns_episode_score_and_stamps_final_reward() -> None:
+    wm = _rewarded_world_model()
+    client = TestClient(create_app(world_models={"airline": wm}))
+    session_id = client.post(
+        "/world_models/airline/sessions", json={"task": "find user u1"}
+    ).json()["session_id"]
+    client.post(
+        f"/world_models/airline/sessions/{session_id}/step",
+        json={"action": {"kind": "tool_call", "name": "get_user", "arguments": {"id": "u1"}}},
+    )
+    response = client.post(f"/world_models/airline/sessions/{session_id}/score")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["reward"] == 0.8
+    assert body["step_rewards"] == [0.6]
+    assert body["critique"] == "solid"
+    # the scalar also lands on the final step's observation (replay-buffer visibility)
+    session = client.get(f"/world_models/airline/sessions/{session_id}").json()
+    assert session["history"][-1]["observation"]["reward"] == 0.8
+
+
+def test_score_unknown_session_is_404() -> None:
+    client = _client()
+    assert client.post("/world_models/airline/sessions/nope/score").status_code == 404
+
+
+def test_end_session_returns_usage_and_frees_the_session() -> None:
+    client = _client()
+    session_id = client.post("/world_models/airline/sessions", json={}).json()["session_id"]
+    response = client.delete(f"/world_models/airline/sessions/{session_id}")
+    assert response.status_code == 200
+    assert "events" in response.json() or "run_id" in response.json()
+    assert client.get(f"/world_models/airline/sessions/{session_id}").status_code == 404


### PR DESCRIPTION
The base interfaces for BENCH-B (RL transfer: 6 training methods vs a wmh world model). Everything a training scaffold needs — environment AND reward — behind one API.

## What's new

- **`wmh/optimize/reward.py` — `EpisodeRewardJudge`**: one judge call per finished rollout → `EpisodeScore{reward: 0..1, success: bool, step_rewards: [per step], critique: str}`. Scalar for GRPO/PPO/REINFORCE++, critique text for SDPO's teacher feedback, per-step rewards for dense credit/diagnostics. The judge sees the task + rollout only — never a gold trace — so valid alternative strategies score. Malformed judge replies become flagged zero scores (a batch never aborts on one bad reply).
- **`WorldModel.score_session(session_id)`**: judges the session history; judge usage metered under `Phase.JUDGE` on the session tracker, separate from `SERVE` (the D12 target-vs-judge cost split); the scalar is also stamped on the final step's `Observation.reward`. Optional `reward_provider` decouples the judge model from the env model.
- **Serving**: `POST /world_models/{name}/sessions/{id}/score` → EpisodeScore; `DELETE /world_models/{name}/sessions/{id}` → final usage (frees session memory — batch rollouts open thousands).
- **`wmh/env/scenarios.py`**: `Scenario` + `scenarios_from_traces` — v1 scenario creation (the task prompts already in the corpus; leakage controlled by which split the caller passes).
- **`examples/tau-bench/rl/smoke.py`**: drives all 5 method data paths (ICL, SFT dataset build, PPO/R++ single rollouts, GRPO n-rollout groups + advantages, SDPO critique records) plus the HTTP session→step→score→delete path end-to-end against the real tau WM on Bedrock haiku. All 6 PASS; verified output in the README.

## Verification
- `ruff check` + `ty check` + `pytest -q` clean over the whole repo (324 passed / 4 skipped)
- Smoke harness run live against Bedrock (`uv run python examples/tau-bench/rl/smoke.py`)

Context: DECISIONS.md D20–D23; plan `wmh-plan/plans/bench-b.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)