### PR TITLE
RL seam composability: score_on_close, public reward_provider, dated haiku model id

### DIFF
--- a/examples/tau-bench/rl/smoke.py
+++ b/examples/tau-bench/rl/smoke.py
@@ -122,10 +122,7 @@ def _load_wm_with_haiku() -> tuple[WorldModel, Provider]:
     _ = config  # config is consumed inside WorldModel.load; we override the provider only
     haiku_cfg = ProviderConfig(kind=ProviderKind.BEDROCK, model=_HAIKU_MODEL, region=_REGION)
     provider = get_provider(haiku_cfg)
-    wm = WorldModel.load(str(_MODEL_DIR), provider)
-    # score_session judges with `_reward_provider`; default is the serve provider, but the seam
-    # allows a different reward model. For smoke we deliberately use the same haiku for both.
-    wm._reward_provider = provider  # noqa: SLF001 - smoke; production would take a kwarg
+    wm = WorldModel.load(str(_MODEL_DIR), provider, reward_provider=provider)
     return wm, provider
 
 
@@ -161,11 +158,14 @@ class HaikuToolCallAgent:
 
     def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
         # Feed the model the task and (very brief) history — enough for a smoke tool call.
-        history_text = "\n".join(
-            f"step {i + 1} ACTION: {render_action(s.action)}\n"
-            f"step {i + 1} OBSERVATION: {s.observation.content[:200]}"
-            for i, s in enumerate(history[-3:])
-        ) or "(no prior steps)"
+        history_text = (
+            "\n".join(
+                f"step {i + 1} ACTION: {render_action(s.action)}\n"
+                f"step {i + 1} OBSERVATION: {s.observation.content[:200]}"
+                for i, s in enumerate(history[-3:])
+            )
+            or "(no prior steps)"
+        )
         example_block = "\n\n".join(render_demo(e) for e in self._examples[:2]) or "(no examples)"
         user = (
             "You role-play a tau-bench airline/retail/telecom customer-service agent. Emit one "
@@ -269,8 +269,7 @@ def _method_icl(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) -
     )
     print(f"  augmented next-episode prompt (first 300 chars):\n    {augmented[:300]!r}")
     return (
-        f"episode steps={len(result.steps)}, follow-up reward={score.reward:.2f}, "
-        f"critique injected"
+        f"episode steps={len(result.steps)}, follow-up reward={score.reward:.2f}, critique injected"
     )
 
 
@@ -374,7 +373,9 @@ def _method_grpo(wm: WorldModel, provider: Provider, scenarios: list[Scenario]) 
             r["advantage"] = r["reward"] - mean
         print(f"  group {task_id}: mean_reward={mean:.3f}")
         for r in group:
-            print(f"    rollout {r['rollout_index']}: reward={r['reward']:.2f} adv={r['advantage']:+.3f}")
+            print(
+                f"    rollout {r['rollout_index']}: reward={r['reward']:.2f} adv={r['advantage']:+.3f}"
+            )
     n_rollouts = sum(len(g) for g in groups.values())
     return f"{len(groups)} groups, {n_rollouts} rollouts, group-relative advantages computed"
 
@@ -465,7 +466,9 @@ def main() -> int:
     t0 = time.monotonic()
     wm, provider = _load_wm_with_haiku()
     train, _test, scenarios = _load_scenarios()
-    print(f"  loaded wm + {len(train)} train traces + {len(scenarios)} scenarios ({time.monotonic() - t0:.1f}s)")
+    print(
+        f"  loaded wm + {len(train)} train traces + {len(scenarios)} scenarios ({time.monotonic() - t0:.1f}s)"
+    )
 
     report = Report()
     _run(report, "1_ICL", lambda: _method_icl(wm, provider, scenarios))

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -49,7 +49,12 @@ _CHECK = "[green]✓[/green]"
 # Serve providers offered in the wizard picker, with the model ids each supports. The first model
 # in each list is the suggested default. Keep these in sync with the provider backends.
 _PROVIDER_MODELS: dict[str, list[str]] = {
-    "bedrock": ["us.anthropic.claude-opus-4-8", "us.anthropic.claude-opus-4-7"],
+    "bedrock": [
+        "us.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4-7",
+        # haiku needs the dated inference-profile id; the undated alias is rejected by Bedrock
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ],
     "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
     "openai_responses": ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4"],

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -53,12 +53,15 @@ class WorldModel:
         provider: Provider,
         embedder: Embedder | None = None,
         telemetry_root: str | Path | None = None,
+        reward_provider: Provider | None = None,
     ) -> WorldModel:
         """Construct from a built `.wmh/` artifact (optimized prompt + indexed replay buffer).
 
         `provider` serves the live world model (generation). `embedder` supplies phi for retrieval;
         when omitted we reconstruct the configured embedder (`embed_provider` + `embed_dim`), which
         defaults to the offline `HashingEmbedder` so loading needs no embedding credentials.
+        `reward_provider` backs `score_session` (defaults to `provider`) — pass it to judge with a
+        different model than the one simulating the environment.
         """
         config = load_config(artifact_dir)
         paths = ArtifactPaths(artifact_dir)
@@ -78,6 +81,7 @@ class WorldModel:
             env_prompt=env_prompt,
             top_k=config.top_k,
             telemetry_root=telemetry_root or _default_telemetry_root(artifact_dir),
+            reward_provider=reward_provider,
         )
 
     def new_session(self, task: str | None = None, seed_state: EnvState | None = None) -> Session:

--- a/wmh/env/base.py
+++ b/wmh/env/base.py
@@ -12,6 +12,7 @@ from typing import Protocol, runtime_checkable
 
 from wmh.core.types import Action, EnvState, Observation
 from wmh.engine.world_model import WorldModel
+from wmh.optimize.reward import EpisodeScore
 from wmh.tracking import RunRecord
 
 
@@ -43,12 +44,22 @@ class WorldModelEnv:
     Each `reset` opens a new session (ending any previous one); `step` delegates to
     `WorldModel.step`. `close` ends the session in the world model — freeing its history and
     metering — and keeps the final token/cost record available as `usage`.
+
+    RL rollouts need the episode judged before the session's history is freed, and `run_episode`
+    closes the env in its `finally` — so with `score_on_close=True`, `close` scores the session
+    (`WorldModel.score_session`) right before ending it and keeps the result as `last_score`:
+
+        env = WorldModelEnv(wm, score_on_close=True)
+        result = run_episode(env, agent, task)
+        reward = env.last_score.reward  # scalar for GRPO/PPO/REINFORCE++; .critique for SDPO
     """
 
-    def __init__(self, world_model: WorldModel) -> None:
+    def __init__(self, world_model: WorldModel, *, score_on_close: bool = False) -> None:
         self._world_model = world_model
+        self._score_on_close = score_on_close
         self._session_id: str | None = None
         self._usage: RunRecord | None = None
+        self._last_score: EpisodeScore | None = None
 
     @property
     def session_id(self) -> str:
@@ -63,6 +74,20 @@ class WorldModelEnv:
             return self._world_model.session_usage(self._session_id)
         return self._usage
 
+    @property
+    def last_score(self) -> EpisodeScore:
+        """The episode score captured by the most recent scoring `close`.
+
+        Raises if no scored episode has completed yet — either the env was built without
+        `score_on_close=True`, or `close` hasn't run.
+        """
+        if self._last_score is None:
+            raise RuntimeError(
+                "no scored episode yet; construct WorldModelEnv(wm, score_on_close=True) "
+                "and complete an episode (run_episode closes — and thus scores — for you)"
+            )
+        return self._last_score
+
     def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
         self.close()  # a leftover session would otherwise leak in the world model
         session = self._world_model.new_session(task=task, seed_state=seed_state)
@@ -74,5 +99,7 @@ class WorldModelEnv:
 
     def close(self) -> None:
         if self._session_id is not None:
+            if self._score_on_close:
+                self._last_score = self._world_model.score_session(self._session_id)
             self._usage = self._world_model.end_session(self._session_id)
             self._session_id = None

--- a/wmh/env/base_test.py
+++ b/wmh/env/base_test.py
@@ -116,3 +116,40 @@ def test_recorded_history_snapshots_state_per_step() -> None:
     assert history[0].state_before.scratchpad == ""  # state BEFORE the first action
     assert history[1].state_before.scratchpad == "- did a thing"
     assert history[0].state_before is not history[1].state_before
+
+
+def test_score_on_close_captures_episode_score_before_session_ends() -> None:
+    """RL rollouts: run_episode closes the env, so scoring must happen inside close()."""
+    from wmh.optimize.reward import EpisodeScore
+
+    env_reply = '{"output": "found u1", "is_error": false}'
+    judge_reply = '{"success": true, "reward": 0.7, "step_rewards": [0.7], "critique": "nice"}'
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=64))
+    wm = WorldModel(
+        FakeProvider(env_reply), retriever, top_k=1, reward_provider=FakeProvider(judge_reply)
+    )
+    env = WorldModelEnv(wm, score_on_close=True)
+    env.reset(task="find u1")
+    session_id = env.session_id
+    env.step(Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u1"}))
+    env.close()
+    assert isinstance(env.last_score, EpisodeScore)
+    assert env.last_score.reward == 0.7
+    assert env.last_score.critique == "nice"
+    # the session is gone (memory freed) but the score survived
+    with pytest.raises(KeyError):
+        wm.get_session(session_id)
+
+
+def test_last_score_raises_before_any_scored_episode() -> None:
+    env = WorldModelEnv(_world_model("{}"), score_on_close=True)
+    with pytest.raises(RuntimeError, match="no scored episode"):
+        _ = env.last_score
+
+
+def test_close_without_score_on_close_does_not_judge() -> None:
+    env = WorldModelEnv(_world_model("{}"))
+    env.reset(task="t")
+    env.close()
+    with pytest.raises(RuntimeError):
+        _ = env.last_score


### PR DESCRIPTION
Follow-up to #58, fixing the three sharp edges the live smoke run surfaced before the RL training chats inherit them:

- **`WorldModelEnv(wm, score_on_close=True)`** — `close()` now scores the session (`score_session`) right before ending it, keeping the result as `.last_score`. `run_episode` closes the env in its `finally`, which previously freed the session before it could be judged — RL rollouts had to bypass `run_episode` entirely. Now: `run_episode(env, agent, task)` then `env.last_score.reward`.
- **`WorldModel.load(..., reward_provider=...)`** — the reward-judge model is a public constructor arg end to end (smoke.py previously poked `wm._reward_provider`).
- **CLI bedrock suggestions** include the dated haiku inference-profile id `us.anthropic.claude-haiku-4-5-20251001-v1:0` — the undated alias is rejected by Bedrock with `ValidationException`.

Verification: smoke harness re-run live against Bedrock (all 6 paths PASS); whole-repo gate green (327 passed / 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)