### PR TITLE
cli: show help when invoked without a command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.12",
+    "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)
     "fastapi>=0.110",
     "uvicorn>=0.29",
     "pydantic>=2.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1520,6 +1520,7 @@ name = "world-model-harness"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "fastapi" },
     { name = "gepa" },
     { name = "httpx" },
@@ -1566,6 +1567,7 @@ viz = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.39" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
+    { name = "click", specifier = ">=8.2" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gepa", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27" },

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -70,10 +70,15 @@ from wmh.telemetry import (
 )
 from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
-app = typer.Typer(help="World Model Harness: a frontier LLM acts as your agent's environment.")
-providers_app = typer.Typer(help="Manage and verify LLM providers.")
-examples_app = typer.Typer(help="List and launch self-contained task examples.")
-config_app = typer.Typer(help="Manage local harness config.")
+app = typer.Typer(
+    help="World Model Harness: a frontier LLM acts as your agent's environment.",
+    no_args_is_help=True,
+)
+providers_app = typer.Typer(help="Manage and verify LLM providers.", no_args_is_help=True)
+examples_app = typer.Typer(
+    help="List and launch self-contained task examples.", no_args_is_help=True
+)
+config_app = typer.Typer(help="Manage local harness config.", no_args_is_help=True)
 app.add_typer(providers_app, name="providers")
 app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -128,6 +128,9 @@ def test_bare_invocation_shows_help(args: list[str]) -> None:
     assert "Missing command" not in result.output
     assert "Usage:" in result.output
     assert "--help" in result.output
+    # Bare invocation keeps the usage-error exit code (click >=8.2), unlike explicit --help
+    # which exits 0 — scripts can still tell "asked for help" from "forgot the command".
+    assert result.exit_code == 2
 
 
 def test_providers_subcommand_is_registered() -> None:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -122,6 +122,14 @@ def test_cli_exposes_the_small_command_set() -> None:
     assert names == {"build", "list", "serve", "demo", "eval", "play"}
 
 
+@pytest.mark.parametrize("args", [[], ["providers"], ["examples"], ["config"]])
+def test_bare_invocation_shows_help(args: list[str]) -> None:
+    result = runner.invoke(app, args)
+    assert "Missing command" not in result.output
+    assert "Usage:" in result.output
+    assert "--help" in result.output
+
+
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names


### PR DESCRIPTION
Bare `uv run wmh` previously exited with a terse 'Missing command' error box, which reads as "nothing happened". Now the top-level app and the `providers`/`examples`/`config` sub-apps print their full help screen when invoked without a command (`no_args_is_help=True`).

Tested: bare `wmh` prints the help screen; `ruff check`/`format` clean; `pytest wmh/cli/` 35 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)