### PR TITLE
ICL arm: policy agent + critique memory vs the tau WM; OpenAI provider custom endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ demos/
 logs/
 
 .wmh-fixed/
+
+# dev-run artifacts of the RL arms (official rows are committed deliberately under results/)
+examples/tau-bench/rl/*.results.jsonl
+examples/tau-bench/rl/icl_memory.jsonl

--- a/examples/tau-bench/.gitignore
+++ b/examples/tau-bench/.gitignore
@@ -4,3 +4,6 @@ tau2-bench/
 .venv/
 data/
 *.json
+
+# the RL arms' pinned tool inventory is committed (see rl/pin_scenarios.py)
+!rl/tools.json

--- a/examples/tau-bench/rl/icl.py
+++ b/examples/tau-bench/rl/icl.py
@@ -1,0 +1,403 @@
+"""The ICL arm of BENCH-B: in-context learning against the tau-bench world model.
+
+The no-gradient control every trained arm (SFT/PPO/REINFORCE++/GRPO/SDPO) is compared against.
+A policy LLM proposes tau tool calls; the world model answers; the episode-end reward judge
+scores the rollout and its `critique` is what gets learned — injected back into the policy's
+context instead of into its weights.
+
+Modes (`--mode`):
+- `base`     no memory, one attempt per scenario. With the Qwen policy this IS the base-model row.
+- `single`   k attempts per scenario; each retry sees the judge critiques of ITS OWN prior
+             attempts (within-scenario self-correction). Reported row = final attempt.
+- `collect`  run the TRAIN scenarios once each and write the cross-task memory JSONL
+             (task outcome + critique per scenario) that `multi` consumes.
+- `multi`    one attempt per scenario with the frozen cross-task memory from `collect`
+             injected (the CLaaS paper's ICL arm shape).
+
+Scenario files are the PINNED sets (scenarios_train.jsonl / scenarios_eval.jsonl — see
+pin_scenarios.py); rows key on scenario provenance. Policy backends: `bedrock:<model-id>`
+(dev stand-in) or `vllm:<model>@<base-url>` (Qwen3.5-9B on the wake/sleep server's vLLM).
+
+Examples:
+    uv run python examples/tau-bench/rl/icl.py --mode base --scenarios eval --limit 2
+    uv run python examples/tau-bench/rl/icl.py --mode collect --scenarios train --wm haiku
+    uv run python examples/tau-bench/rl/icl.py --mode multi --scenarios eval --wm gpt-5.5 \
+        --policy vllm:Qwen/Qwen3.5-9B@http://localhost:8001/v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from pydantic import BaseModel, Field, ValidationError
+
+from wmh.config import load_config
+from wmh.core.parsing import extract_json_object
+from wmh.core.render import render_action
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Step, Trace
+from wmh.engine import ingest, split_traces_3way
+from wmh.engine.world_model import WorldModel
+from wmh.env import DONE_SIGNAL, WorldModelEnv, run_episode
+from wmh.optimize.reward import EpisodeScore
+from wmh.providers.base import Message, Provider, ProviderConfig, ProviderKind
+from wmh.providers.registry import get_provider
+
+_HERE = Path(__file__).resolve().parent
+_MODEL_DIR = _HERE.parent / "models" / "tau-bench"
+_TRACES_PATH = _HERE.parent / "traces.otel.jsonl"
+_SCENARIO_FILES = {"train": _HERE / "scenarios_train.jsonl", "eval": _HERE / "scenarios_eval.jsonl"}
+
+HAIKU = "us.anthropic.claude-haiku-4-5-20251001-v1:0"  # dated profile id (undated is rejected)
+OPUS = "us.anthropic.claude-opus-4-8"  # eval reward judge: third family vs both WM backends
+REGION = "us-east-1"
+MAX_STEPS = 12
+OBS_CHARS = 800  # observation excerpt per history line in the policy prompt
+MEMORY_RECORDS = 8  # most-recent cross-task records injected in `multi`
+
+AGENT_SYSTEM = """You are a customer-service agent operating {domain} tools.
+Work the task step by step: one tool call at a time, read the result, then decide the next call.
+
+Available tools (name: argument keys):
+{tools}
+
+Reply with ONLY one JSON object per turn:
+  {{"tool": "<name>", "arguments": {{...}}}}         to call a tool
+  {{"done": true, "summary": "<what you did>"}}      when the task is complete or impossible
+{memory}"""
+
+
+class PinnedScenario(BaseModel):
+    """One line of a pinned scenario file (see pin_scenarios.py)."""
+
+    task: str
+    provenance: list[str]
+    domain: str = "unknown"
+
+
+class MemoryRecord(BaseModel):
+    """What one finished episode teaches the next ones."""
+
+    scenario_id: str  # first provenance trace_id
+    domain: str
+    success: bool
+    reward: float
+    critique: str
+
+
+class RowResult(BaseModel):
+    """One eval row entry: a scored episode on one scenario."""
+
+    scenario_id: str
+    domain: str
+    attempt: int
+    steps: int
+    stop_reason: str
+    reward: float
+    success: bool
+    critique: str
+    wm_cost_usd: float | None = None
+    seconds: float = 0.0
+
+
+class _ToolCall(BaseModel):
+    tool: str
+    arguments: JsonObject = Field(default_factory=dict)
+
+
+class _Done(BaseModel):
+    done: bool
+    summary: str = ""
+
+
+class PolicyAgent:
+    """wmh `Agent`: an LLM proposing tau tool calls from task + episode history (+ ICL memory)."""
+
+    def __init__(
+        self,
+        provider: Provider,
+        tools_block: str,
+        domain: str,
+        memory_block: str = "",
+        temperature: float = 0.7,
+    ) -> None:
+        self._provider = provider
+        self._system = AGENT_SYSTEM.format(
+            domain=domain,
+            tools=tools_block,
+            memory=f"\n{memory_block}" if memory_block else "",
+        )
+        self._temperature = temperature
+
+    def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
+        lines = [f"TASK:\n{task or '(none)'}", "", "EPISODE SO FAR:"]
+        if not history:
+            lines.append("(no steps yet)")
+        for i, step in enumerate(history, start=1):
+            observation = step.observation.content[:OBS_CHARS]
+            flag = " [ERROR]" if step.observation.is_error else ""
+            lines.append(f"{i}. {render_action(step.action)}\n   -> {flag}{observation}")
+        lines.append("\nYour next JSON:")
+        completion = self._provider.complete(
+            self._system,
+            [Message(role="user", content="\n".join(lines))],
+            temperature=self._temperature,
+            max_tokens=1024,
+        )
+        return _parse_action(completion.text)
+
+
+def _parse_action(text: str) -> Action:
+    raw = extract_json_object(text)
+    if raw is not None:
+        try:
+            call = _ToolCall.model_validate_json(raw)
+            return Action(kind=ActionKind.TOOL_CALL, name=call.tool, arguments=call.arguments)
+        except ValidationError:
+            pass
+        try:
+            done = _Done.model_validate_json(raw)
+            if done.done:
+                return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+        except ValidationError:
+            pass
+    # Unparseable replies end the episode rather than feeding garbage to the world model.
+    return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+
+
+def _tool_inventory(train: list[Trace]) -> dict[str, str]:
+    """domain -> 'name: arg, arg' lines, derived from the TRAIN split only (leak-free)."""
+    tools: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for trace in train:
+        domain = str(trace.metadata.get("domain") or "unknown")
+        for step in trace.steps:
+            if step.action.kind is ActionKind.TOOL_CALL and step.action.name:
+                tools[domain][step.action.name].update(step.action.arguments)
+    blocks: dict[str, str] = {}
+    for domain, by_name in tools.items():
+        lines = [
+            f"- {name}: {', '.join(sorted(args)) or '(no args)'}"
+            for name, args in sorted(by_name.items())
+        ]
+        blocks[domain] = "\n".join(lines)
+    return blocks
+
+
+def _memory_block(records: list[MemoryRecord], domain: str) -> str:
+    """Cross-task learnings: same-domain records first, most recent first, capped."""
+    ranked = [r for r in records if r.domain == domain] + [r for r in records if r.domain != domain]
+    picked = ranked[:MEMORY_RECORDS]
+    if not picked:
+        return ""
+    lines = ["== Learnings from prior tasks (use them; do not repeat mistakes) =="]
+    for r in picked:
+        outcome = "SUCCEEDED" if r.success else "FAILED"
+        lines.append(f"[{outcome} r={r.reward:.2f} {r.domain}] {r.critique}")
+    return "\n".join(lines)
+
+
+def _self_critique_block(prior: list[RowResult]) -> str:
+    if not prior:
+        return ""
+    lines = ["== Feedback on YOUR previous attempts at THIS task =="]
+    for r in prior:
+        lines.append(f"[attempt {r.attempt}: reward={r.reward:.2f}] {r.critique}")
+    return "\n".join(lines)
+
+
+def _build_wm(kind: str) -> WorldModel:
+    """The environment: haiku (training WM) or gpt-5.5 (pinned eval WM). Judge rides along."""
+    if kind == "haiku":
+        env_provider = get_provider(
+            ProviderConfig(kind=ProviderKind.BEDROCK, model=HAIKU, region=REGION)
+        )
+        judge = env_provider  # cheap critiques while collecting memory / dev
+    elif kind == "gpt-5.5":
+        env_provider = get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5"))
+        judge = get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=OPUS, region=REGION))
+    else:
+        raise SystemExit(f"unknown --wm {kind!r}; use haiku or gpt-5.5")
+    return WorldModel.load(str(_MODEL_DIR), env_provider, reward_provider=judge)
+
+
+def _build_policy(spec: str) -> Provider:
+    """--policy bedrock:<model-id> | vllm:<model>@<base-url> | openai:<model>."""
+    scheme, _, rest = spec.partition(":")
+    if scheme == "bedrock":
+        return get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=rest, region=REGION))
+    if scheme == "vllm":
+        model, _, url = rest.partition("@")
+        if not url:
+            raise SystemExit("vllm policy needs vllm:<model>@<base-url>")
+        return get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=model, endpoint=url))
+    if scheme == "openai":
+        return get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=rest))
+    raise SystemExit(f"unknown policy spec {spec!r}")
+
+
+def _episode(
+    wm: WorldModel,
+    policy: Provider,
+    scenario: PinnedScenario,
+    tools: dict[str, str],
+    memory_block: str,
+    temperature: float,
+    attempt: int,
+) -> RowResult:
+    agent = PolicyAgent(
+        policy,
+        tools.get(scenario.domain, tools.get("unknown", "(tools unknown)")),
+        scenario.domain,
+        memory_block=memory_block,
+        temperature=temperature,
+    )
+    env = WorldModelEnv(wm, score_on_close=True)
+    started = time.monotonic()
+    result = run_episode(env, agent, task=scenario.task, max_steps=MAX_STEPS)
+    score: EpisodeScore = env.last_score
+    usage = env.usage
+    return RowResult(
+        scenario_id=scenario.provenance[0],
+        domain=scenario.domain,
+        attempt=attempt,
+        steps=len(result.steps),
+        stop_reason=str(result.stop_reason),
+        reward=score.reward,
+        success=score.success,
+        critique=score.critique,
+        wm_cost_usd=usage.total.cost_usd if usage else None,
+        seconds=round(time.monotonic() - started, 1),
+    )
+
+
+def _summarize(rows: list[RowResult]) -> str:
+    if not rows:
+        return "no rows"
+    by_domain: dict[str, list[RowResult]] = defaultdict(list)
+    for r in rows:
+        by_domain[r.domain].append(r)
+    success = sum(1 for r in rows if r.success) / len(rows)
+    reward = sum(r.reward for r in rows) / len(rows)
+    cost = sum(r.wm_cost_usd or 0.0 for r in rows)
+    parts = [f"n={len(rows)} success={success:.2%} mean_reward={reward:.3f} wm_cost=${cost:.2f}"]
+    for domain, group in sorted(by_domain.items()):
+        ds = sum(1 for r in group if r.success) / len(group)
+        parts.append(f"  {domain}: n={len(group)} success={ds:.2%}")
+    return "\n".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["base", "single", "collect", "multi"], required=True)
+    parser.add_argument("--scenarios", choices=["train", "eval"], required=True)
+    parser.add_argument("--wm", default="haiku", help="haiku (training WM) | gpt-5.5 (eval WM)")
+    parser.add_argument(
+        "--policy", default=f"bedrock:{HAIKU}", help="bedrock:<id> | vllm:<m>@<url>"
+    )
+    parser.add_argument("--limit", type=int, default=0, help="cap scenarios (0 = all)")
+    parser.add_argument("--attempts", type=int, default=2, help="attempts per scenario (single)")
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--memory", type=Path, default=_HERE / "icl_memory.jsonl")
+    parser.add_argument("--out", type=Path, default=None, help="results JSONL (default: derived)")
+    parser.add_argument("--wandb", action="store_true", help="log rows to wandb wmh-rl-transfer")
+    args = parser.parse_args()
+
+    scenario_path = _SCENARIO_FILES[args.scenarios]
+    scenarios = [
+        PinnedScenario.model_validate_json(line)
+        for line in scenario_path.read_text().splitlines()
+        if line.strip()
+    ]
+    if args.limit:
+        scenarios = scenarios[: args.limit]
+
+    config = load_config(str(_MODEL_DIR))
+    train, _val, _test = split_traces_3way(ingest(config, file=str(_TRACES_PATH)), 0.8, 0.1)
+    tools = _tool_inventory(train)
+    wm = _build_wm(args.wm)
+    policy = _build_policy(args.policy)
+
+    memory: list[MemoryRecord] = []
+    if args.mode == "multi":
+        if not args.memory.exists():
+            raise SystemExit(f"--mode multi needs {args.memory} (run --mode collect first)")
+        memory = [
+            MemoryRecord.model_validate_json(line)
+            for line in args.memory.read_text().splitlines()
+            if line.strip()
+        ]
+
+    run = None
+    if args.wandb:
+        import wandb  # example-local optional dep: uv run --with wandb ...
+
+        run = wandb.init(
+            project="wmh-rl-transfer",
+            name=f"icl-{args.mode}-{args.scenarios}-wm_{args.wm}",
+            config={k: str(v) for k, v in vars(args).items()},
+        )
+
+    rows: list[RowResult] = []
+    collected: list[MemoryRecord] = []
+    for i, scenario in enumerate(scenarios, start=1):
+        attempts = args.attempts if args.mode == "single" else 1
+        prior: list[RowResult] = []
+        for attempt in range(1, attempts + 1):
+            if args.mode == "multi":
+                block = _memory_block(memory, scenario.domain)
+            elif args.mode == "single":
+                block = _self_critique_block(prior)
+            else:
+                block = ""
+            row = _episode(wm, policy, scenario, tools, block, args.temperature, attempt)
+            prior.append(row)
+            print(
+                f"[{i}/{len(scenarios)} a{attempt}] {scenario.domain} "
+                f"reward={row.reward:.2f} success={row.success} steps={row.steps} "
+                f"({row.seconds}s)"
+            )
+        final = prior[-1]
+        rows.append(final)
+        if run is not None:
+            run.log(
+                {
+                    "reward": final.reward,
+                    "success": int(final.success),
+                    "steps": final.steps,
+                    "wm_cost_usd": final.wm_cost_usd or 0.0,
+                    "scenario_index": i,
+                }
+            )
+        if args.mode == "collect":
+            collected.append(
+                MemoryRecord(
+                    scenario_id=final.scenario_id,
+                    domain=final.domain,
+                    success=final.success,
+                    reward=final.reward,
+                    critique=final.critique,
+                )
+            )
+
+    out = args.out or _HERE / f"icl_{args.mode}_{args.scenarios}_wm-{args.wm}.results.jsonl"
+    out.write_text("\n".join(r.model_dump_json() for r in rows) + "\n", encoding="utf-8")
+    if args.mode == "collect":
+        args.memory.write_text(
+            "\n".join(r.model_dump_json() for r in collected) + "\n", encoding="utf-8"
+        )
+        print(f"memory -> {args.memory} ({len(collected)} records)")
+    print(f"\n== icl --mode {args.mode} --scenarios {args.scenarios} --wm {args.wm} ==")
+    print(_summarize(rows))
+    print(f"rows -> {out}")
+    if run is not None:
+        run.summary["success_rate"] = sum(1 for r in rows if r.success) / len(rows)
+        run.summary["mean_reward"] = sum(r.reward for r in rows) / len(rows)
+        run.finish()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/tau-bench/rl/icl.py
+++ b/examples/tau-bench/rl/icl.py
@@ -10,13 +10,19 @@ Modes (`--mode`):
 - `single`   k attempts per scenario; each retry sees the judge critiques of ITS OWN prior
              attempts (within-scenario self-correction). Reported row = final attempt.
 - `collect`  run the TRAIN scenarios once each and write the cross-task memory JSONL
-             (task outcome + critique per scenario) that `multi` consumes.
+             (task outcome + critique per scenario) that `multi` consumes. Train scenarios
+             only — collecting on eval scenarios would leak judge feedback about the eval
+             tasks into the eval row, so the script refuses.
 - `multi`    one attempt per scenario with the frozen cross-task memory from `collect`
              injected (the CLaaS paper's ICL arm shape).
 
-Scenario files are the PINNED sets (scenarios_train.jsonl / scenarios_eval.jsonl — see
-pin_scenarios.py); rows key on scenario provenance. Policy backends: `bedrock:<model-id>`
-(dev stand-in) or `vllm:<model>@<base-url>` (Qwen3.5-9B on the wake/sleep server's vLLM).
+Everything an arm consumes is PINNED (see pin_scenarios.py): the scenario sets AND the
+per-domain tool inventory (tools.json) — nothing is re-derived from the corpus at run time.
+Rows key on scenario provenance and are appended to the results file as each scenario
+completes, so a mid-run failure keeps every finished row. Policy backends:
+`bedrock:<model-id>` (dev stand-in; NOTE Bedrock drops sampling params, so --temperature has
+no effect there) or `vllm:<model>@<base-url>` (Qwen3.5-9B on the wake/sleep server's vLLM,
+which does honor --temperature).
 
 Examples:
     uv run python examples/tau-bench/rl/icl.py --mode base --scenarios eval --limit 2
@@ -35,21 +41,19 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field, ValidationError
 
-from wmh.config import load_config
 from wmh.core.parsing import extract_json_object
 from wmh.core.render import render_action
-from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Step, Trace
-from wmh.engine import ingest, split_traces_3way
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Step
 from wmh.engine.world_model import WorldModel
-from wmh.env import DONE_SIGNAL, WorldModelEnv, run_episode
+from wmh.env import DONE_SIGNAL, Scenario, WorldModelEnv, run_episode
 from wmh.optimize.reward import EpisodeScore
 from wmh.providers.base import Message, Provider, ProviderConfig, ProviderKind
 from wmh.providers.registry import get_provider
 
 _HERE = Path(__file__).resolve().parent
 _MODEL_DIR = _HERE.parent / "models" / "tau-bench"
-_TRACES_PATH = _HERE.parent / "traces.otel.jsonl"
 _SCENARIO_FILES = {"train": _HERE / "scenarios_train.jsonl", "eval": _HERE / "scenarios_eval.jsonl"}
+_TOOLS_PATH = _HERE / "tools.json"
 
 HAIKU = "us.anthropic.claude-haiku-4-5-20251001-v1:0"  # dated profile id (undated is rejected)
 OPUS = "us.anthropic.claude-opus-4-8"  # eval reward judge: third family vs both WM backends
@@ -69,12 +73,15 @@ Reply with ONLY one JSON object per turn:
   {{"done": true, "summary": "<what you did>"}}      when the task is complete or impossible
 {memory}"""
 
+_REPARSE_NUDGE = (
+    "Your previous reply was not one valid JSON object of the two allowed shapes. "
+    "Reply again with ONLY the JSON."
+)
 
-class PinnedScenario(BaseModel):
-    """One line of a pinned scenario file (see pin_scenarios.py)."""
 
-    task: str
-    provenance: list[str]
+class PinnedScenario(Scenario):
+    """One line of a pinned scenario file: a `Scenario` plus its tau domain."""
+
     domain: str = "unknown"
 
 
@@ -99,6 +106,8 @@ class RowResult(BaseModel):
     reward: float
     success: bool
     critique: str
+    parse_failures: int = 0  # policy replies that were not valid action JSON
+    error: str | None = None  # infra failure (env error / judge failure); row is NOT a score
     wm_cost_usd: float | None = None
     seconds: float = 0.0
 
@@ -114,7 +123,12 @@ class _Done(BaseModel):
 
 
 class PolicyAgent:
-    """wmh `Agent`: an LLM proposing tau tool calls from task + episode history (+ ICL memory)."""
+    """wmh `Agent`: an LLM proposing tau tool calls from task + episode history (+ ICL memory).
+
+    A malformed policy reply gets ONE re-ask with a terse nudge; a second failure ends the
+    episode (never feed garbage to the world model). `parse_failures` counts both, so rows
+    where the parser — not the policy's decisions — shaped the outcome are identifiable.
+    """
 
     def __init__(
         self,
@@ -131,8 +145,20 @@ class PolicyAgent:
             memory=f"\n{memory_block}" if memory_block else "",
         )
         self._temperature = temperature
+        self.parse_failures = 0
 
     def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
+        user = self._render_turn(task, history)
+        action = self._propose(user)
+        if action is None:
+            self.parse_failures += 1
+            action = self._propose(f"{user}\n\n{_REPARSE_NUDGE}")
+        if action is None:
+            self.parse_failures += 1
+            return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+        return action
+
+    def _render_turn(self, task: str | None, history: list[Step]) -> str:
         lines = [f"TASK:\n{task or '(none)'}", "", "EPISODE SO FAR:"]
         if not history:
             lines.append("(no steps yet)")
@@ -141,55 +167,51 @@ class PolicyAgent:
             flag = " [ERROR]" if step.observation.is_error else ""
             lines.append(f"{i}. {render_action(step.action)}\n   -> {flag}{observation}")
         lines.append("\nYour next JSON:")
+        return "\n".join(lines)
+
+    def _propose(self, user: str) -> Action | None:
         completion = self._provider.complete(
             self._system,
-            [Message(role="user", content="\n".join(lines))],
+            [Message(role="user", content=user)],
             temperature=self._temperature,
             max_tokens=1024,
         )
         return _parse_action(completion.text)
 
 
-def _parse_action(text: str) -> Action:
+def _parse_action(text: str) -> Action | None:
+    """One of the two allowed reply shapes, or None if the reply matches neither."""
     raw = extract_json_object(text)
-    if raw is not None:
-        try:
-            call = _ToolCall.model_validate_json(raw)
-            return Action(kind=ActionKind.TOOL_CALL, name=call.tool, arguments=call.arguments)
-        except ValidationError:
-            pass
-        try:
-            done = _Done.model_validate_json(raw)
-            if done.done:
-                return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
-        except ValidationError:
-            pass
-    # Unparseable replies end the episode rather than feeding garbage to the world model.
-    return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+    if raw is None:
+        return None
+    try:
+        call = _ToolCall.model_validate_json(raw)
+        return Action(kind=ActionKind.TOOL_CALL, name=call.tool, arguments=call.arguments)
+    except ValidationError:
+        pass
+    try:
+        done = _Done.model_validate_json(raw)
+    except ValidationError:
+        return None
+    return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL) if done.done else None
 
 
-def _tool_inventory(train: list[Trace]) -> dict[str, str]:
-    """domain -> 'name: arg, arg' lines, derived from the TRAIN split only (leak-free)."""
-    tools: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
-    for trace in train:
-        domain = str(trace.metadata.get("domain") or "unknown")
-        for step in trace.steps:
-            if step.action.kind is ActionKind.TOOL_CALL and step.action.name:
-                tools[domain][step.action.name].update(step.action.arguments)
-    blocks: dict[str, str] = {}
-    for domain, by_name in tools.items():
-        lines = [
-            f"- {name}: {', '.join(sorted(args)) or '(no args)'}"
-            for name, args in sorted(by_name.items())
-        ]
-        blocks[domain] = "\n".join(lines)
-    return blocks
+def _load_tools() -> dict[str, str]:
+    """The pinned per-domain tool inventory, rendered as prompt blocks."""
+    inventory: dict[str, dict[str, list[str]]] = json.loads(_TOOLS_PATH.read_text(encoding="utf-8"))
+    return {
+        domain: "\n".join(
+            f"- {name}: {', '.join(args) or '(no args)'}" for name, args in by_name.items()
+        )
+        for domain, by_name in inventory.items()
+    }
 
 
 def _memory_block(records: list[MemoryRecord], domain: str) -> str:
-    """Cross-task learnings: same-domain records first, most recent first, capped."""
-    ranked = [r for r in records if r.domain == domain] + [r for r in records if r.domain != domain]
-    picked = ranked[:MEMORY_RECORDS]
+    """Cross-task learnings: same-domain first, most recent first, capped at MEMORY_RECORDS."""
+    same = [r for r in reversed(records) if r.domain == domain]
+    other = [r for r in reversed(records) if r.domain != domain]
+    picked = (same + other)[:MEMORY_RECORDS]
     if not picked:
         return ""
     lines = ["== Learnings from prior tasks (use them; do not repeat mistakes) =="]
@@ -247,9 +269,10 @@ def _episode(
     temperature: float,
     attempt: int,
 ) -> RowResult:
+    """One scored episode. Infra failures come back as an `error` row, never an exception."""
     agent = PolicyAgent(
         policy,
-        tools.get(scenario.domain, tools.get("unknown", "(tools unknown)")),
+        tools.get(scenario.domain, "(tools unknown)"),
         scenario.domain,
         memory_block=memory_block,
         temperature=temperature,
@@ -257,8 +280,16 @@ def _episode(
     env = WorldModelEnv(wm, score_on_close=True)
     started = time.monotonic()
     result = run_episode(env, agent, task=scenario.task, max_steps=MAX_STEPS)
-    score: EpisodeScore = env.last_score
     usage = env.usage
+    try:
+        score: EpisodeScore = env.last_score
+    except RuntimeError as exc:
+        # Judge failed during the scoring close (throttle/network); the session was still
+        # freed. Record an error row so the batch continues and the row is excluded upstream.
+        score = EpisodeScore(reward=0.0, success=False, critique="")
+        error = f"scoring failed: {exc.__cause__ or exc}"
+    else:
+        error = result.error and f"{result.stop_reason}: {result.error}"
     return RowResult(
         scenario_id=scenario.provenance[0],
         domain=scenario.domain,
@@ -268,6 +299,8 @@ def _episode(
         reward=score.reward,
         success=score.success,
         critique=score.critique,
+        parse_failures=agent.parse_failures,
+        error=error,
         wm_cost_usd=usage.total.cost_usd if usage else None,
         seconds=round(time.monotonic() - started, 1),
     )
@@ -276,13 +309,21 @@ def _episode(
 def _summarize(rows: list[RowResult]) -> str:
     if not rows:
         return "no rows"
+    scored = [r for r in rows if r.error is None]
+    errored = len(rows) - len(scored)
+    if not scored:
+        return f"no scored rows ({errored} infra errors)"
     by_domain: dict[str, list[RowResult]] = defaultdict(list)
-    for r in rows:
+    for r in scored:
         by_domain[r.domain].append(r)
-    success = sum(1 for r in rows if r.success) / len(rows)
-    reward = sum(r.reward for r in rows) / len(rows)
+    success = sum(1 for r in scored if r.success) / len(scored)
+    reward = sum(r.reward for r in scored) / len(scored)
     cost = sum(r.wm_cost_usd or 0.0 for r in rows)
-    parts = [f"n={len(rows)} success={success:.2%} mean_reward={reward:.3f} wm_cost=${cost:.2f}"]
+    parse_failures = sum(r.parse_failures for r in rows)
+    parts = [
+        f"n={len(scored)} success={success:.2%} mean_reward={reward:.3f} wm_cost=${cost:.2f}"
+        f" infra_errors={errored} parse_failures={parse_failures}"
+    ]
     for domain, group in sorted(by_domain.items()):
         ds = sum(1 for r in group if r.success) / len(group)
         parts.append(f"  {domain}: n={len(group)} success={ds:.2%}")
@@ -299,24 +340,45 @@ def main() -> int:
     )
     parser.add_argument("--limit", type=int, default=0, help="cap scenarios (0 = all)")
     parser.add_argument("--attempts", type=int, default=2, help="attempts per scenario (single)")
-    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument(
+        "--temperature", type=float, default=0.7, help="policy sampling (vllm/openai only)"
+    )
     parser.add_argument("--memory", type=Path, default=_HERE / "icl_memory.jsonl")
     parser.add_argument("--out", type=Path, default=None, help="results JSONL (default: derived)")
     parser.add_argument("--wandb", action="store_true", help="log rows to wandb wmh-rl-transfer")
     args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be >= 1")
+    if args.limit < 0:
+        parser.error("--limit must be >= 0")
+    if args.mode == "collect" and args.scenarios != "train":
+        parser.error(
+            "--mode collect only runs on --scenarios train: memory collected from eval "
+            "scenarios would leak judge feedback about the eval tasks into the multi row"
+        )
+
+    run = None
+    if args.wandb:
+        # Fail fast (before any WM/provider setup) if wandb isn't installed:
+        # examples are gate-excluded, so this is an opt-in extra (uv run --with wandb ...).
+        import wandb
+
+        run = wandb.init(
+            project="wmh-rl-transfer",
+            name=f"icl-{args.mode}-{args.scenarios}-wm_{args.wm}",
+            config={k: str(v) for k, v in vars(args).items()},
+        )
 
     scenario_path = _SCENARIO_FILES[args.scenarios]
     scenarios = [
         PinnedScenario.model_validate_json(line)
-        for line in scenario_path.read_text().splitlines()
+        for line in scenario_path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
     if args.limit:
         scenarios = scenarios[: args.limit]
 
-    config = load_config(str(_MODEL_DIR))
-    train, _val, _test = split_traces_3way(ingest(config, file=str(_TRACES_PATH)), 0.8, 0.1)
-    tools = _tool_inventory(train)
+    tools = _load_tools()
     wm = _build_wm(args.wm)
     policy = _build_policy(args.policy)
 
@@ -326,64 +388,59 @@ def main() -> int:
             raise SystemExit(f"--mode multi needs {args.memory} (run --mode collect first)")
         memory = [
             MemoryRecord.model_validate_json(line)
-            for line in args.memory.read_text().splitlines()
+            for line in args.memory.read_text(encoding="utf-8").splitlines()
             if line.strip()
         ]
 
-    run = None
-    if args.wandb:
-        import wandb  # example-local optional dep: uv run --with wandb ...
-
-        run = wandb.init(
-            project="wmh-rl-transfer",
-            name=f"icl-{args.mode}-{args.scenarios}-wm_{args.wm}",
-            config={k: str(v) for k, v in vars(args).items()},
-        )
-
+    out = args.out or _HERE / f"icl_{args.mode}_{args.scenarios}_wm-{args.wm}.results.jsonl"
+    attempts = args.attempts if args.mode == "single" else 1
     rows: list[RowResult] = []
     collected: list[MemoryRecord] = []
-    for i, scenario in enumerate(scenarios, start=1):
-        attempts = args.attempts if args.mode == "single" else 1
-        prior: list[RowResult] = []
-        for attempt in range(1, attempts + 1):
-            if args.mode == "multi":
-                block = _memory_block(memory, scenario.domain)
-            elif args.mode == "single":
-                block = _self_critique_block(prior)
-            else:
-                block = ""
-            row = _episode(wm, policy, scenario, tools, block, args.temperature, attempt)
-            prior.append(row)
-            print(
-                f"[{i}/{len(scenarios)} a{attempt}] {scenario.domain} "
-                f"reward={row.reward:.2f} success={row.success} steps={row.steps} "
-                f"({row.seconds}s)"
-            )
-        final = prior[-1]
-        rows.append(final)
-        if run is not None:
-            run.log(
-                {
-                    "reward": final.reward,
-                    "success": int(final.success),
-                    "steps": final.steps,
-                    "wm_cost_usd": final.wm_cost_usd or 0.0,
-                    "scenario_index": i,
-                }
-            )
-        if args.mode == "collect":
-            collected.append(
-                MemoryRecord(
-                    scenario_id=final.scenario_id,
-                    domain=final.domain,
-                    success=final.success,
-                    reward=final.reward,
-                    critique=final.critique,
+    with out.open("w", encoding="utf-8") as sink:  # rows land as they finish, not at the end
+        for i, scenario in enumerate(scenarios, start=1):
+            prior: list[RowResult] = []
+            for attempt in range(1, attempts + 1):
+                if args.mode == "multi":
+                    block = _memory_block(memory, scenario.domain)
+                elif args.mode == "single":
+                    block = _self_critique_block(prior)
+                else:
+                    block = ""
+                row = _episode(wm, policy, scenario, tools, block, args.temperature, attempt)
+                prior.append(row)
+                note = f" ERROR={row.error}" if row.error else ""
+                print(
+                    f"[{i}/{len(scenarios)} a{attempt}] {scenario.domain} "
+                    f"reward={row.reward:.2f} success={row.success} steps={row.steps} "
+                    f"({row.seconds}s){note}"
                 )
-            )
+            final = prior[-1]
+            rows.append(final)
+            sink.write(final.model_dump_json() + "\n")
+            sink.flush()
+            if run is not None:
+                run.log(
+                    {
+                        "reward": final.reward,
+                        "success": int(final.success),
+                        "steps": final.steps,
+                        "parse_failures": final.parse_failures,
+                        "infra_error": int(final.error is not None),
+                        "wm_cost_usd": final.wm_cost_usd or 0.0,
+                        "scenario_index": i,
+                    }
+                )
+            if args.mode == "collect" and final.error is None:
+                collected.append(
+                    MemoryRecord(
+                        scenario_id=final.scenario_id,
+                        domain=final.domain,
+                        success=final.success,
+                        reward=final.reward,
+                        critique=final.critique,
+                    )
+                )
 
-    out = args.out or _HERE / f"icl_{args.mode}_{args.scenarios}_wm-{args.wm}.results.jsonl"
-    out.write_text("\n".join(r.model_dump_json() for r in rows) + "\n", encoding="utf-8")
     if args.mode == "collect":
         args.memory.write_text(
             "\n".join(r.model_dump_json() for r in collected) + "\n", encoding="utf-8"
@@ -393,8 +450,11 @@ def main() -> int:
     print(_summarize(rows))
     print(f"rows -> {out}")
     if run is not None:
-        run.summary["success_rate"] = sum(1 for r in rows if r.success) / len(rows)
-        run.summary["mean_reward"] = sum(r.reward for r in rows) / len(rows)
+        scored = [r for r in rows if r.error is None]
+        if scored:
+            run.summary["success_rate"] = sum(1 for r in scored if r.success) / len(scored)
+            run.summary["mean_reward"] = sum(r.reward for r in scored) / len(scored)
+        run.summary["infra_errors"] = len(rows) - len(scored)
         run.finish()
     return 0
 

--- a/examples/tau-bench/rl/icl.py
+++ b/examples/tau-bench/rl/icl.py
@@ -58,7 +58,8 @@ _TOOLS_PATH = _HERE / "tools.json"
 HAIKU = "us.anthropic.claude-haiku-4-5-20251001-v1:0"  # dated profile id (undated is rejected)
 OPUS = "us.anthropic.claude-opus-4-8"  # eval reward judge: third family vs both WM backends
 REGION = "us-east-1"
-MAX_STEPS = 12
+MAX_STEPS = 20  # shared eval protocol (DECISIONS.md D30)
+POLICY_MAX_TOKENS = 6000  # room for Qwen3.5 reasoning + tool call (D30/D31)
 OBS_CHARS = 800  # observation excerpt per history line in the policy prompt
 MEMORY_RECORDS = 8  # most-recent cross-task records injected in `multi`
 
@@ -174,7 +175,7 @@ class PolicyAgent:
             self._system,
             [Message(role="user", content=user)],
             temperature=self._temperature,
-            max_tokens=1024,
+            max_tokens=POLICY_MAX_TOKENS,
         )
         return _parse_action(completion.text)
 
@@ -341,7 +342,16 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=0, help="cap scenarios (0 = all)")
     parser.add_argument("--attempts", type=int, default=2, help="attempts per scenario (single)")
     parser.add_argument(
-        "--temperature", type=float, default=0.7, help="policy sampling (vllm/openai only)"
+        "--temperature",
+        type=float,
+        default=1.0,  # shared eval protocol (D30); vllm/openai only — bedrock drops it
+        help="policy sampling (vllm/openai only)",
+    )
+    parser.add_argument(
+        "--episodes-per-scenario",
+        type=int,
+        default=1,
+        help="episodes per eval scenario (shared protocol D30 uses 2 for official rows)",
     )
     parser.add_argument("--memory", type=Path, default=_HERE / "icl_memory.jsonl")
     parser.add_argument("--out", type=Path, default=None, help="results JSONL (default: derived)")
@@ -377,6 +387,9 @@ def main() -> int:
     ]
     if args.limit:
         scenarios = scenarios[: args.limit]
+    if args.episodes_per_scenario < 1:
+        parser.error("--episodes-per-scenario must be >= 1")
+    scenarios = [s for s in scenarios for _ in range(args.episodes_per_scenario)]
 
     tools = _load_tools()
     wm = _build_wm(args.wm)

--- a/examples/tau-bench/rl/pin_scenarios.py
+++ b/examples/tau-bench/rl/pin_scenarios.py
@@ -12,6 +12,9 @@ re-derive (a corpus append would silently shift a re-derived list).
 - eval scenarios: EVERY test-split scenario (no sampling — the eval set must never look chosen)
 - identity: each line carries `provenance` (source trace_ids); consumers key on provenance,
   never on line number
+- tools.json: the per-domain tool inventory (name -> argument keys) derived from the TRAIN
+  split only, pinned for the same reason the scenarios are — every arm's agent must see the
+  same tool list, and a corpus append must not silently change it
 
 Run from the repo root:  uv run python examples/tau-bench/rl/pin_scenarios.py
 Idempotent: re-running on the same corpus rewrites byte-identical files.
@@ -25,7 +28,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from wmh.config import load_config
-from wmh.core.types import Trace
+from wmh.core.types import ActionKind, Trace
 from wmh.engine import ingest, split_traces_3way
 from wmh.env import Scenario, scenarios_from_traces
 
@@ -37,6 +40,21 @@ SEED = 4405  # the repo's benchmark-convention seed (D12 lineage)
 
 TRAIN_OUT = _HERE / "scenarios_train.jsonl"
 EVAL_OUT = _HERE / "scenarios_eval.jsonl"
+TOOLS_OUT = _HERE / "tools.json"
+
+
+def _tool_inventory(train: list[Trace]) -> dict[str, dict[str, list[str]]]:
+    """domain -> {tool name -> sorted argument keys}, from the TRAIN split only (leak-free)."""
+    tools: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for trace in train:
+        domain = _domain(trace)
+        for step in trace.steps:
+            if step.action.kind is ActionKind.TOOL_CALL and step.action.name:
+                tools[domain][step.action.name].update(step.action.arguments)
+    return {
+        domain: {name: sorted(args) for name, args in sorted(by_name.items())}
+        for domain, by_name in sorted(tools.items())
+    }
 
 
 def _domain(trace: Trace) -> str:
@@ -100,6 +118,9 @@ def main() -> int:
 
     _write(TRAIN_OUT, train_scenarios, by_trace)
     _write(EVAL_OUT, eval_scenarios, by_trace)
+    TOOLS_OUT.write_text(
+        json.dumps(_tool_inventory(train), indent=1, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
     def _counts(scenarios: list[Scenario]) -> dict[str, int]:
         counts: dict[str, int] = defaultdict(int)
@@ -111,7 +132,7 @@ def main() -> int:
     print(f"corpus: {len(traces)} traces -> {split_note}")
     print(f"train scenarios: {len(train_scenarios)} (cap {TRAIN_CAP}) {_counts(train_scenarios)}")
     print(f"eval scenarios:  {len(eval_scenarios)} (ALL of test) {_counts(eval_scenarios)}")
-    print(f"wrote {TRAIN_OUT.name}, {EVAL_OUT.name}")
+    print(f"wrote {TRAIN_OUT.name}, {EVAL_OUT.name}, {TOOLS_OUT.name}")
     return 0
 
 

--- a/examples/tau-bench/rl/tools.json
+++ b/examples/tau-bench/rl/tools.json
@@ -1,0 +1,182 @@
+{
+ "airline": {
+  "book_reservation": [
+   "cabin",
+   "destination",
+   "flight_type",
+   "flights",
+   "insurance",
+   "nonfree_baggages",
+   "origin",
+   "passengers",
+   "payment_methods",
+   "total_baggages",
+   "user_id"
+  ],
+  "calculate": [
+   "expression"
+  ],
+  "cancel_reservation": [
+   "reservation_id"
+  ],
+  "get_flight_status": [
+   "date",
+   "flight_number"
+  ],
+  "get_reservation_details": [
+   "reservation_id"
+  ],
+  "get_user_details": [
+   "user_id"
+  ],
+  "search_direct_flight": [
+   "date",
+   "destination",
+   "origin"
+  ],
+  "search_onestop_flight": [
+   "date",
+   "destination",
+   "origin"
+  ],
+  "transfer_to_human_agents": [
+   "summary"
+  ],
+  "update_reservation_baggages": [
+   "nonfree_baggages",
+   "payment_id",
+   "reservation_id",
+   "total_baggages"
+  ],
+  "update_reservation_flights": [
+   "cabin",
+   "flights",
+   "payment_id",
+   "reservation_id"
+  ],
+  "update_reservation_passengers": [
+   "passengers",
+   "reservation_id"
+  ]
+ },
+ "retail": {
+  "calculate": [
+   "expression"
+  ],
+  "cancel_pending_order": [
+   "order_id",
+   "reason"
+  ],
+  "exchange_delivered_order_items": [
+   "item_ids",
+   "new_item_ids",
+   "order_id",
+   "payment_method_id"
+  ],
+  "find_user_id_by_email": [
+   "email"
+  ],
+  "find_user_id_by_name_zip": [
+   "first_name",
+   "last_name",
+   "zip"
+  ],
+  "get_item_details": [
+   "item_id"
+  ],
+  "get_order_details": [
+   "order_id"
+  ],
+  "get_product_details": [
+   "product_id"
+  ],
+  "get_user_details": [
+   "user_id"
+  ],
+  "modify_pending_order_address": [
+   "address1",
+   "address2",
+   "city",
+   "country",
+   "order_id",
+   "state",
+   "zip"
+  ],
+  "modify_pending_order_items": [
+   "item_ids",
+   "new_item_ids",
+   "order_id",
+   "payment_method_id"
+  ],
+  "modify_user_address": [
+   "address1",
+   "address2",
+   "city",
+   "country",
+   "state",
+   "user_id",
+   "zip"
+  ],
+  "return_delivered_order_items": [
+   "item_ids",
+   "order_id",
+   "payment_method_id"
+  ],
+  "transfer_to_human_agents": [
+   "summary"
+  ]
+ },
+ "telecom": {
+  "can_send_mms": [],
+  "check_apn_settings": [],
+  "check_data_restriction_status": [],
+  "check_network_status": [],
+  "check_status_bar": [],
+  "check_vpn_status": [],
+  "enable_roaming": [
+   "customer_id",
+   "line_id"
+  ],
+  "get_bills_for_customer": [
+   "customer_id"
+  ],
+  "get_customer_by_id": [
+   "customer_id"
+  ],
+  "get_customer_by_phone": [
+   "phone_number"
+  ],
+  "get_data_usage": [
+   "customer_id",
+   "line_id"
+  ],
+  "get_details_by_id": [
+   "id"
+  ],
+  "grant_app_permission": [
+   "app_name",
+   "permission"
+  ],
+  "refuel_data": [
+   "customer_id",
+   "gb_amount",
+   "line_id"
+  ],
+  "resume_line": [
+   "customer_id",
+   "line_id"
+  ],
+  "run_speed_test": [],
+  "send_payment_request": [
+   "bill_id",
+   "customer_id"
+  ],
+  "set_network_mode_preference": [
+   "mode"
+  ],
+  "toggle_airplane_mode": [],
+  "transfer_to_human_agents": [
+   "summary"
+  ]
+ }
+}

--- a/wmh/env/base.py
+++ b/wmh/env/base.py
@@ -60,6 +60,7 @@ class WorldModelEnv:
         self._session_id: str | None = None
         self._usage: RunRecord | None = None
         self._last_score: EpisodeScore | None = None
+        self._score_error: Exception | None = None
 
     @property
     def session_id(self) -> str:
@@ -79,8 +80,13 @@ class WorldModelEnv:
         """The episode score captured by the most recent scoring `close`.
 
         Raises if no scored episode has completed yet — either the env was built without
-        `score_on_close=True`, or `close` hasn't run.
+        `score_on_close=True`, or `close` hasn't run. If the judge call itself failed during
+        `close` (throttle, network), the ORIGINAL failure is re-raised here: `run_episode`
+        deliberately swallows teardown errors, and a batch caller must see the real cause
+        instead of a misleading "no scored episode".
         """
+        if self._score_error is not None:
+            raise RuntimeError("scoring failed during close; see cause") from self._score_error
         if self._last_score is None:
             raise RuntimeError(
                 "no scored episode yet; construct WorldModelEnv(wm, score_on_close=True) "
@@ -98,8 +104,18 @@ class WorldModelEnv:
         return self._world_model.step(self.session_id, action)
 
     def close(self) -> None:
-        if self._session_id is not None:
+        if self._session_id is None:
+            return
+        try:
             if self._score_on_close:
-                self._last_score = self._world_model.score_session(self._session_id)
+                self._last_score = None
+                self._score_error = None
+                try:
+                    self._last_score = self._world_model.score_session(self._session_id)
+                except Exception as exc:  # noqa: BLE001 - preserved and re-raised by last_score
+                    # A judge failure must not leak the session or masquerade as "unscored";
+                    # the session still ends below and last_score re-raises this cause.
+                    self._score_error = exc
+        finally:
             self._usage = self._world_model.end_session(self._session_id)
             self._session_id = None

--- a/wmh/env/base_test.py
+++ b/wmh/env/base_test.py
@@ -153,3 +153,36 @@ def test_close_without_score_on_close_does_not_judge() -> None:
     env.close()
     with pytest.raises(RuntimeError):
         _ = env.last_score
+
+
+def test_judge_failure_during_scoring_close_ends_session_and_surfaces_cause() -> None:
+    """A throttled judge must not leak the session or masquerade as 'no scored episode'."""
+
+    class ExplodingJudge(FakeProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            raise ConnectionError("throttled")
+
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=64))
+    wm = WorldModel(
+        FakeProvider('{"output": "ok", "is_error": false}'),
+        retriever,
+        top_k=1,
+        reward_provider=ExplodingJudge("unused"),
+    )
+    env = WorldModelEnv(wm, score_on_close=True)
+    env.reset(task="t")
+    session_id = env.session_id
+    env.step(Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={}))
+    env.close()  # must not raise (run_episode swallows teardown), must still end the session
+    with pytest.raises(KeyError):
+        wm.get_session(session_id)  # session freed despite the judge failure
+    with pytest.raises(RuntimeError, match="scoring failed") as excinfo:
+        _ = env.last_score
+    assert isinstance(excinfo.value.__cause__, ConnectionError)

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -22,6 +22,7 @@ class _ChatCompletions(Protocol):
         model: str,
         messages: list[ChatCompletionMessageParam],
         max_completion_tokens: int,
+        temperature: float = ...,
     ) -> ChatCompletion: ...
 
 
@@ -46,18 +47,27 @@ def complete(
     system: str,
     messages: list[Message],
     max_tokens: int,
+    temperature: float | None = None,
 ) -> Completion:
     """Run one chat completion and map it onto our `Completion`.
 
-    `max_completion_tokens` (not the deprecated `max_tokens`) and no `temperature` keeps this
-    compatible with GPT 5.5, whose reasoning models reject the legacy field and non-default
-    sampling params.
+    `max_completion_tokens` (not the deprecated `max_tokens`) keeps this compatible with GPT 5.5.
+    `temperature` is sent ONLY when given: GPT 5.5's reasoning models reject non-default sampling
+    params (callers pass None), while OpenAI-compatible servers (vLLM policies) need it.
     """
-    response = chat_completions.create(
-        model=model,
-        messages=to_messages(system, messages),
-        max_completion_tokens=max_tokens,
-    )
+    if temperature is None:
+        response = chat_completions.create(
+            model=model,
+            messages=to_messages(system, messages),
+            max_completion_tokens=max_tokens,
+        )
+    else:
+        response = chat_completions.create(
+            model=model,
+            messages=to_messages(system, messages),
+            max_completion_tokens=max_tokens,
+            temperature=temperature,
+        )
     if not response.choices:
         # Content filtering (and some error modes) can return zero choices; surface it clearly
         # rather than letting choices[0] raise a bare IndexError.

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -28,9 +28,19 @@ class OpenAIProvider:
     def _get_client(self) -> OpenAI:
         # Lazy: don't import the SDK or read OPENAI_API_KEY until first use.
         if self._client is None:
+            import os
+
             from openai import OpenAI
 
-            self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
+            if self.config.endpoint:
+                # OpenAI-compatible server (vLLM, llama.cpp, a proxy). Such servers usually
+                # ignore auth, but the SDK insists on *a* key — fall back to a placeholder.
+                self._client = OpenAI(
+                    base_url=self.config.endpoint,
+                    api_key=os.environ.get("OPENAI_API_KEY") or "not-needed",
+                )
+            else:
+                self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
         return self._client
 
     def complete(

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -1,7 +1,14 @@
-"""OpenAI direct provider (GPT 5.5). Reads OPENAI_API_KEY from the environment."""
+"""OpenAI direct provider (GPT 5.5). Reads OPENAI_API_KEY from the environment.
+
+With `ProviderConfig.endpoint` set, the same provider speaks to any OpenAI-compatible server
+(vLLM, llama.cpp, a proxy) instead: the endpoint becomes the client's base_url, auth comes from
+`WMH_ENDPOINT_API_KEY` (never `OPENAI_API_KEY` — the real key must not leak to arbitrary hosts),
+and `temperature` IS forwarded (self-hosted servers accept sampling params; GPT 5.5 rejects them).
+"""
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from wmh.providers import _openai_common
@@ -26,18 +33,17 @@ class OpenAIProvider:
         self._client: OpenAI | None = None
 
     def _get_client(self) -> OpenAI:
-        # Lazy: don't import the SDK or read OPENAI_API_KEY until first use.
+        # Lazy: don't import the SDK or read the key env vars until first use.
         if self._client is None:
-            import os
-
             from openai import OpenAI
 
             if self.config.endpoint:
-                # OpenAI-compatible server (vLLM, llama.cpp, a proxy). Such servers usually
-                # ignore auth, but the SDK insists on *a* key — fall back to a placeholder.
+                # OpenAI-compatible server. Auth comes from WMH_ENDPOINT_API_KEY; NEVER send
+                # the real OPENAI_API_KEY to an arbitrary base_url. Most self-hosted servers
+                # ignore auth, but the SDK insists on *a* key — hence the placeholder.
                 self._client = OpenAI(
                     base_url=self.config.endpoint,
-                    api_key=os.environ.get("OPENAI_API_KEY") or "not-needed",
+                    api_key=os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed",
                 )
             else:
                 self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
@@ -52,7 +58,14 @@ class OpenAIProvider:
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         return _openai_common.complete(
-            self._get_client().chat.completions, self.config.model, system, messages, max_tokens
+            self._get_client().chat.completions,
+            self.config.model,
+            system,
+            messages,
+            max_tokens,
+            # Self-hosted OpenAI-compatible servers honor sampling params (a policy being
+            # trained NEEDS temperature diversity); real OpenAI GPT-5.5 rejects them.
+            temperature=temperature if self.config.endpoint else None,
         )
 
     def embed(self, texts: list[str]) -> list[list[float]]:

--- a/wmh/providers/tests/openai_test.py
+++ b/wmh/providers/tests/openai_test.py
@@ -169,31 +169,57 @@ def test_live_verify() -> None:  # pragma: no cover - network
     assert provider.verify().ok is True
 
 
-def test_custom_endpoint_reaches_the_client(monkeypatch) -> None:  # noqa: ANN001
-    """ProviderConfig.endpoint must become the client's base_url (vLLM / OpenAI-compatible)."""
-    from wmh.providers.base import ProviderKind
-    from wmh.providers.openai import OpenAIProvider
-
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    provider = OpenAIProvider(
+def _endpoint_provider() -> OpenAIProvider:
+    return OpenAIProvider(
         ProviderConfig(
             kind=ProviderKind.OPENAI, model="qwen3.5-9b", endpoint="http://localhost:8001/v1"
         )
     )
-    client = provider._get_client()
+
+
+def test_custom_endpoint_reaches_the_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ProviderConfig.endpoint must become the client's base_url (vLLM / OpenAI-compatible)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    client = _endpoint_provider()._get_client()
     assert str(client.base_url).rstrip("/") == "http://localhost:8001/v1"
 
 
-def test_custom_endpoint_needs_no_openai_key(monkeypatch) -> None:  # noqa: ANN001
-    """A self-hosted OpenAI-compatible server (vLLM) has no real key; loading must not raise."""
-    from wmh.providers.base import ProviderKind
-    from wmh.providers.openai import OpenAIProvider
+def test_custom_endpoint_never_receives_the_real_openai_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENAI_API_KEY must not be sent as a Bearer token to an arbitrary custom endpoint."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-secret")
+    monkeypatch.delenv("WMH_ENDPOINT_API_KEY", raising=False)
+    client = _endpoint_provider()._get_client()
+    assert client.api_key != "sk-real-openai-secret"
 
+
+def test_custom_endpoint_uses_dedicated_key_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An authenticated OpenAI-compatible server takes its key from WMH_ENDPOINT_API_KEY."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real-openai-secret")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    client = _endpoint_provider()._get_client()
+    assert client.api_key == "endpoint-token"
+
+
+def test_custom_endpoint_needs_no_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A self-hosted OpenAI-compatible server (vLLM) has no real key; loading must not raise."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    provider = OpenAIProvider(
-        ProviderConfig(
-            kind=ProviderKind.OPENAI, model="qwen3.5-9b", endpoint="http://localhost:8001/v1"
-        )
-    )
-    client = provider._get_client()
+    monkeypatch.delenv("WMH_ENDPOINT_API_KEY", raising=False)
+    client = _endpoint_provider()._get_client()
     assert client.api_key  # placeholder key, not an exception
+
+
+def test_custom_endpoint_forwards_temperature_but_openai_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Self-hosted servers get the sampling param; real OpenAI (GPT-5.5) must not (rejects it)."""
+    for endpoint, expects_temperature in [("http://localhost:8001/v1", True), (None, False)]:
+        provider = OpenAIProvider(
+            ProviderConfig(kind=ProviderKind.OPENAI, model="m", endpoint=endpoint)
+        )
+        chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(1, 1)))
+        fake = _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([[0.0]])))
+        monkeypatch.setattr(provider, "_get_client", lambda fake=fake: fake)
+        provider.complete("sys", [Message(role="user", content="hi")], temperature=0.3)
+        assert ("temperature" in chat.last_kwargs) is expects_temperature

--- a/wmh/providers/tests/openai_test.py
+++ b/wmh/providers/tests/openai_test.py
@@ -167,3 +167,33 @@ def test_verify_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch)
 def test_live_verify() -> None:  # pragma: no cover - network
     provider = OpenAIProvider(_config())
     assert provider.verify().ok is True
+
+
+def test_custom_endpoint_reaches_the_client(monkeypatch) -> None:  # noqa: ANN001
+    """ProviderConfig.endpoint must become the client's base_url (vLLM / OpenAI-compatible)."""
+    from wmh.providers.base import ProviderKind
+    from wmh.providers.openai import OpenAIProvider
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider = OpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.OPENAI, model="qwen3.5-9b", endpoint="http://localhost:8001/v1"
+        )
+    )
+    client = provider._get_client()
+    assert str(client.base_url).rstrip("/") == "http://localhost:8001/v1"
+
+
+def test_custom_endpoint_needs_no_openai_key(monkeypatch) -> None:  # noqa: ANN001
+    """A self-hosted OpenAI-compatible server (vLLM) has no real key; loading must not raise."""
+    from wmh.providers.base import ProviderKind
+    from wmh.providers.openai import OpenAIProvider
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = OpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.OPENAI, model="qwen3.5-9b", endpoint="http://localhost:8001/v1"
+        )
+    )
+    client = provider._get_client()
+    assert client.api_key  # placeholder key, not an exception


### PR DESCRIPTION
The no-gradient control arm of BENCH-B, plus the provider fix it needs for the Qwen policy.

- **`examples/tau-bench/rl/icl.py`** — PolicyAgent (LLM proposes tau tool calls from task + episode history + a tool inventory derived from the train split only), judge-critique memory in three shapes: `base` (none — the base-model row when the policy is Qwen), `single` (within-scenario self-correction across attempts), `collect`/`multi` (frozen cross-task memory built on the pinned train scenarios, injected at eval). Pinned scenario files only, rows keyed by provenance, per-row WM cost, optional wandb.
- **`OpenAIProvider` honors `ProviderConfig.endpoint`** (base_url + placeholder-key fallback) — wmh can now call any OpenAI-compatible server, i.e. the Qwen3.5-9B vLLM policy endpoint on h100-dev-box-8. Tests written first (both failed, then passed).
- Dev-run artifacts gitignored.

## Verification (rule 11/12)
All four modes driven live against the haiku-backed tau WM: base 2 episodes ($0.04), single retry lifted 0.95→1.00 with the critique injected, collect wrote 3 memory records, multi ran with memory. Judge critiques read by hand — specific and grounded (budget arithmetic, membership tier, missed steps). Gate: ruff/ty clean, 330 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)