### PR TITLE
appworld: stateful multi-app adapter + Python-REPL capture agent (corpus local-only per license)

### DIFF
--- a/environment-capture/appworld/.gitignore
+++ b/environment-capture/appworld/.gitignore
@@ -1,0 +1,8 @@
+# AppWorld's engine and protected dataset (Apache 2.0 with an encrypted-redistribution restriction
+# on the data and its derivatives — see README). NONE of it, nor any capture derived from it, may be
+# committed in plain text.
+.venv/
+data/
+experiments/
+runs/
+traces.otel.jsonl

--- a/environment-capture/appworld/README.md
+++ b/environment-capture/appworld/README.md
@@ -1,0 +1,116 @@
+# appworld
+
+A **stateful** multi-app world. AppWorld drops an agent into a simulated world of nine apps (Amazon,
+Gmail, Venmo, Spotify, phone, file system, Splitwise, Todoist, SimpleNote) plus a `supervisor` app
+for the account, behind 450+ real Python APIs. A task is a natural-language request — e.g. *"what is
+the title of the most-liked song in my Spotify playlists"* — and the agent completes it by writing
+Python that calls `apis.<app>.<endpoint>(...)` against a **live, mutable world**, signalling
+completion with `apis.supervisor.complete_task(...)`. This is the first adapter whose world state
+carries across steps (variables and world mutations persist), which is exactly the world-model
+dynamics this benchmark exists to exercise — see
+`environment_capture/benchmarks/appworld.py`.
+
+## Architecture: the engine runs out-of-process
+
+The `appworld` engine is Python-3.11-only, pulls a large dependency tree, and ships its data as
+encrypted `.bundle` files — so it lives in a **benchmark-local venv** (`./.venv`, gitignored) and the
+gate-checked `environment_capture.benchmarks.appworld` module never imports it. Instead:
+
+- `AppWorldAdapter.open_env(task)` launches `backend/world_backend.py serve <appworld_id> <exp>` under
+  that venv. The subprocess boots ONE live `AppWorld` for the task and speaks a line-delimited JSON
+  protocol on stdio; `AppWorldEnv` is the client. Each agent action — the `CommandEnv.execute` seam —
+  is a block of Python run against that live world, so state persists across steps.
+- `AppWorldAgent` (Bedrock, in the gate module, appworld-free) is the capture agent: its only
+  environment action is the `execute_python` tool, faithful to AppWorld's real action space.
+- `grade` shells out to `backend/world_backend.py grade`, which runs AppWorld's **own deterministic
+  evaluation tests** over the final world state; reward is the fraction of those tests that pass. No
+  LLM judging.
+
+Swapping `AppWorldEnv` for a world-model-backed `CommandEnv` runs the identical agent loop against a
+world model instead of the real engine — the point of the harness.
+
+## Contents
+
+- `capture.py` — fresh real-run capture against this adapter (Bedrock Python-REPL agent, sharded
+  across models). Writes `traces.otel.jsonl` (gitignored, see License).
+- `backend/` — the venv-only side (imports `appworld`; excluded from the repo type gate):
+  - `fetch_data.py` — `appworld install` + `appworld download data`, then materialize
+    `data/train.jsonl`.
+  - `world_backend.py` — the `serve` / `grade` engine subprocess.
+  - `smoke.py` — end-to-end plumbing check against a real world (no Bedrock).
+- `evals/default.toml` — the open-loop fidelity replay suite.
+- `data/` (gitignored) — AppWorld's downloaded data + the materialized `data/train.jsonl`
+  (`{task_id: "aw-train-<i>", prompt, data: {appworld_id}}`).
+
+## Getting the data
+
+Python 3.11 is required by `appworld`. Create the benchmark-local venv, install the engine, and
+materialize the task index (all gitignored):
+
+```bash
+cd environment-capture/appworld
+uv venv --python 3.11 .venv
+VIRTUAL_ENV=.venv uv pip install appworld
+./.venv/bin/python backend/fetch_data.py   # runs `appworld install` + `download data`, writes data/train.jsonl
+```
+
+Then, from the repo root, smoke-test the plumbing and capture:
+
+```bash
+uv run python environment-capture/appworld/backend/smoke.py            # real world, no model
+uv run python environment-capture/appworld/capture.py --split train \
+    --models us.anthropic.claude-opus-4-8,us.anthropic.claude-opus-4-7
+```
+
+## Splits
+
+Only the `train` split (90 tasks) is materialized and captured. AppWorld's hidden test splits
+(`test_normal`, `test_challenge`) are **never** captured, so the world model can't absorb their
+dynamics.
+
+## Results (2026-07-02, corpus as captured)
+
+- **Corpus**: 74 fresh real Bedrock runs over the train split (40 on
+  `us.anthropic.claude-opus-4-8`, 34 on `-4-7`), covering 74 of the 90 train tasks, 827 recorded
+  `execute_python` transitions, mean reward **0.981** (93% of tasks fully solved by AppWorld's own
+  tests). Hygiene audit `scan_spans_jsonl(...) == {}` (clean).
+  - The 16 uncaptured train tasks are the split's **file-system** tasks (e.g. *"export … into
+    `~/backups/spotify_library.csv`"*): AppWorld's *simulated* file system uses `~/`-rooted paths,
+    which trip the shared hygiene detector's `~/` observation marker, so `partition_contained` drops
+    those (legitimate) trajectories. This is a benchmark-specific false positive — AppWorld's own
+    execution sandbox (SafetyGuard) blocks `os.listdir` / `subprocess` / `open`, so real host escape
+    is not possible through `world.execute` (though `os.path.expanduser("~")` still echoes the real
+    home, which the hygiene runtime markers correctly catch). Kept as the safe default rather than
+    weakening the shared gate; a benchmark-specific containment keyed on real host identity would
+    recover them.
+- **Open-loop fidelity** (suite `appworld/default`, seed 0, Opus 4.8 target + rubric judge, run via
+  `uv run wmh eval run appworld/default --examples-root environment-capture`): mean fidelity
+  **0.793 ± 0.209**, error-flag accuracy **0.962**, n=210 held-out steps. AppWorld's structured JSON
+  API observations reconstruct better than financebench's document excerpts (0.581) but below
+  bird-sql's fully structured sqlite rows (0.864) — the residual is opaque per-world identifiers and
+  values (song ids, tokens, amounts) the model cannot infer from the request alone.
+
+## License — read before redistributing
+
+**AppWorld dual-licenses, and its data has an encrypted-redistribution restriction that this corpus
+respects by staying uncommitted.**
+
+- The **public** portion (agent baselines, evaluation utilities) is plain **Apache 2.0**.
+- The **protected** portion — API documentation and implementation, task data, solutions, and
+  evaluation tests — ships in encrypted `.bundle` files under **Apache 2.0 with an additional
+  requirement that any public redistribution of it (or of its derivatives) be done in an encrypted
+  format**. AppWorld additionally requests that extracted/derived data not be posted online in plain
+  text. There is an explicit exemption: *"Training language models and serving their outputs do not
+  constitute redistribution."*
+
+A captured trace embeds task instructions and app-API observations, which are **derivatives** of that
+protected data. So, unlike `bird-sql` (CC BY-SA 4.0) or `financebench`, **`traces.otel.jsonl` is NOT
+committed** — it is gitignored along with `data/` and `experiments/`, and is reproduced locally with
+`capture.py`. Building and serving a world model from a locally-captured corpus falls under the
+training exemption; committing the plaintext corpus to this public repo would not, so we don't.
+
+- **Upstream**: AppWorld (Stony Brook NLP / AI2) — <https://github.com/StonyBrookNLP/appworld>;
+  paper *"AppWorld: A Controllable World of Apps and People for Benchmarking Interactive Coding
+  Agents"* (ACL 2024), <https://arxiv.org/abs/2407.18901>. Package `appworld` (PyPI), Apache 2.0.
+- **Adapter/agent/backend code here is fresh**, written against AppWorld's public API
+  (`load_task_ids`, `AppWorld`, `world.execute`, `world.evaluate` / `evaluate_task`).

--- a/environment-capture/appworld/backend/fetch_data.py
+++ b/environment-capture/appworld/backend/fetch_data.py
@@ -1,0 +1,71 @@
+"""Materialize the real AppWorld dataset into this benchmark's on-disk shape (run under the venv).
+
+AppWorld ships its apps + task data as encrypted ``.bundle`` files inside the ``appworld`` pip
+package. This script unpacks and downloads them into the benchmark-local directory, then writes the
+agent-visible task index the gate-checked adapter reads:
+
+  - ``appworld install`` unpacks the app/engine source into the venv.
+  - ``appworld download data`` fetches ``data/`` (apps' base databases, per-task specs + gold).
+  - ``data/train.jsonl`` — one row per train task:
+    ``{task_id: "aw-train-<i>", prompt: <instruction>, data: {appworld_id: <upstream id>}}``. The
+    instruction comes straight from the task's ``specs.json`` (no world boot needed); the upstream
+    id is what the adapter passes to the backend.
+
+Only the ``train`` split is materialized: AppWorld's hidden test splits (``test_normal`` /
+``test_challenge``) are never captured, so the world model can't absorb their dynamics. NOTHING here
+is committed — the downloaded ``data/`` and this ``data/train.jsonl`` are AppWorld's protected data
+(see the README's license note) and stay gitignored.
+
+Usage (from this directory, under the venv):
+    ./.venv/bin/python backend/fetch_data.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from appworld import load_task_ids
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_data() -> None:
+    """Unpack the engine and download AppWorld's data into this directory if not already present."""
+    if not (_ROOT / "data" / "tasks").is_dir():
+        subprocess.run([sys.executable, "-m", "appworld.cli", "install"], check=True)
+        subprocess.run(
+            [sys.executable, "-m", "appworld.cli", "download", "data", "--root", str(_ROOT)],
+            check=True,
+        )
+
+
+def _instruction(appworld_id: str) -> str:
+    specs = json.loads(
+        (_ROOT / "data" / "tasks" / appworld_id / "specs.json").read_text(encoding="utf-8")
+    )
+    return str(specs["instruction"]).strip()
+
+
+def main() -> None:
+    _ensure_data()
+    rows: list[str] = []
+    for index, appworld_id in enumerate(load_task_ids("train")):
+        rows.append(
+            json.dumps(
+                {
+                    "task_id": f"aw-train-{index}",
+                    "prompt": _instruction(appworld_id),
+                    "data": {"appworld_id": appworld_id},
+                }
+            )
+        )
+    out = _ROOT / "data" / "train.jsonl"
+    out.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    print(f"materialized {len(rows)} train tasks -> {out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/environment-capture/appworld/backend/smoke.py
+++ b/environment-capture/appworld/backend/smoke.py
@@ -1,0 +1,40 @@
+"""End-to-end smoke check of the AppWorld adapter against a REAL world (no Bedrock, no model cost).
+
+Runs under the MAIN workspace interpreter (``uv run``): the adapter is appworld-free and launches
+the real ``backend/world_backend.py`` under the benchmark venv. A tiny scripted "agent" does a task
+by hand — authenticate, answer, ``complete_task`` — then the adapter grades it via AppWorld's own
+tests. This validates the serve/execute/grade plumbing before a capture run.
+
+    uv run python environment-capture/appworld/backend/smoke.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from environment_capture.benchmarks.appworld import AppWorldAdapter
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    adapter = AppWorldAdapter(_ROOT, experiment_prefix="smoke")
+    task = adapter.tasks("train")[0]
+    print(f"task {task.task_id} ({task.data['appworld_id']}): {task.prompt}")
+
+    env = adapter.open_env(task)
+    try:
+        # A minimal real interaction: read the supervisor's own info, then complete the task.
+        info = env.execute("print(apis.supervisor.show_profile())")
+        print("profile head:", info.output[:120].replace("\n", " "))
+        done = env.execute("apis.supervisor.complete_task(answer='smoke test answer')")
+        print("completed flag after complete_task:", env.completed, "| error:", done.returncode)
+    finally:
+        env.close()
+
+    reward = adapter.grade(task, "smoke test answer")
+    print(f"grade reward = {reward}")
+
+
+if __name__ == "__main__":
+    main()

--- a/environment-capture/appworld/backend/world_backend.py
+++ b/environment-capture/appworld/backend/world_backend.py
@@ -1,0 +1,104 @@
+"""Out-of-process AppWorld engine, run under the benchmark-local venv (Python 3.11 + ``appworld``).
+
+The gate-checked ``environment_capture.benchmarks.appworld`` module never imports the heavy
+``appworld`` engine; it shells out to this script instead. Two subcommands:
+
+* ``serve <task_id> <experiment_name>`` boots ONE live ``AppWorld`` for the task and speaks a
+  line-delimited JSON protocol on stdio — one ``{"op": ...}`` request per line in, one response per
+  line out — keeping the world stateful across many ``execute`` calls (the whole point of AppWorld):
+    - ``{"op": "execute", "code": "<python>"}`` -> ``{"output", "error", "completed"}``
+    - ``{"op": "close"}`` -> shuts the world down and exits.
+  AppWorld chatters on real stdout during boot/execution, so this process redirects the engine's
+  stdout to stderr and writes the protocol JSON to the original stdout fd, keeping it clean.
+
+* ``grade <task_id> <experiment_name>`` runs AppWorld's own deterministic evaluation tests over the
+  world the agent left behind and prints ``{"reward", "success", "num_tests"}`` — reward is the
+  fraction of tests that pass (no LLM).
+
+This file imports ``appworld`` and is excluded from the repo's type gate (like other heavy-dep
+scripts); it is exercised end-to-end by ``backend/smoke.py`` under the venv.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# AppWorld prints setup/usage banners to stdout; move its stdout to stderr and keep the ORIGINAL
+# stdout as the clean protocol channel before importing/booting anything.
+_PROTOCOL_OUT = sys.stdout
+sys.stdout = sys.stderr
+
+from appworld import AppWorld, evaluate_task  # noqa: E402  (after the stdout redirect above)
+
+_EXECUTION_ERROR_MARKER = "Execution failed"
+
+
+def _emit(payload: dict[str, object]) -> None:
+    _PROTOCOL_OUT.write(json.dumps(payload) + "\n")
+    _PROTOCOL_OUT.flush()
+
+
+def _serve(task_id: str, experiment_name: str) -> None:
+    try:
+        world = AppWorld(task_id=task_id, experiment_name=experiment_name)
+        world.__enter__()
+    except Exception as error:  # noqa: BLE001 - report boot failure over the protocol, then exit
+        _emit({"ready": False, "error": f"{type(error).__name__}: {error}"})
+        return
+    _emit({"ready": True})
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        op = request.get("op")
+        if op == "close":
+            break
+        if op == "execute":
+            code = str(request.get("code", ""))
+            try:
+                output = world.execute(code)
+            except Exception as error:  # noqa: BLE001 - a shell error is a normal observation
+                output = f"{_EXECUTION_ERROR_MARKER}. {type(error).__name__}: {error}"
+            _emit(
+                {
+                    "output": output,
+                    "error": output.startswith(_EXECUTION_ERROR_MARKER),
+                    "completed": bool(world.task_completed()),
+                }
+            )
+            continue
+        _emit({"output": f"unknown op: {op!r}", "error": True, "completed": False})
+
+    world.close()
+    world.__exit__(None, None, None)
+
+
+def _grade(task_id: str, experiment_name: str) -> None:
+    tracker = evaluate_task(
+        task_id=task_id,
+        experiment_name=experiment_name,
+        suppress_errors=True,
+        save_report=False,
+    )
+    report = tracker.to_dict()
+    num_tests = int(report["num_tests"])
+    reward = (len(report["passes"]) / num_tests) if num_tests else 0.0
+    _emit({"reward": reward, "success": bool(report["success"]), "num_tests": num_tests})
+
+
+def main() -> None:
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+    if command == "serve" and len(sys.argv) == 4:
+        _serve(sys.argv[2], sys.argv[3])
+    elif command == "grade" and len(sys.argv) == 4:
+        _grade(sys.argv[2], sys.argv[3])
+    else:
+        sys.stderr.write("usage: world_backend.py {serve|grade} <task_id> <experiment_name>\n")
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/environment-capture/appworld/capture.py
+++ b/environment-capture/appworld/capture.py
@@ -1,0 +1,161 @@
+"""Capture fresh REAL AppWorld runs on Bedrock and append them to the trace corpus.
+
+Runs under the MAIN workspace interpreter: the ``AppWorldAgent`` (Bedrock) drives the appworld-free
+``AppWorldAdapter``, which launches the real ``appworld`` engine out-of-process under this
+benchmark's venv (``backend/world_backend.py``). Every ``execute_python`` transition is recorded
+from execution against a LIVE, stateful world, and each task is graded by AppWorld's own tests.
+
+Tasks are sharded round-robin across the given Bedrock model ids (one thread per model — the
+established pattern for beating per-model throttling; keep to 2 while other captures share Bedrock).
+Each emitted trace carries a run-suffixed task id (``aw-train-3#opus48-r1``) so the deterministic
+trace id never collides across models or repeated passes; the base task id and reward ride in the
+trace metadata. Each shard uses its run tag as the AppWorld ``experiment_prefix`` so the per-task
+world states two shards write never collide. Raw graded trajectories are also written to ``runs/``
+as JSONL (gitignored) so a capture can be inspected and resumed without re-running.
+
+The resulting ``traces.otel.jsonl`` is NOT committed: AppWorld's dataset license forbids plaintext
+public redistribution of its data or derivatives (see README). It stays gitignored and is
+reproducible with this script.
+
+Usage (from the repo root; data must be materialized first — see backend/fetch_data.py):
+    uv run python environment-capture/appworld/capture.py \
+        --split train --limit 8 \
+        --models us.anthropic.claude-opus-4-8,us.anthropic.claude-opus-4-7 \
+        --out environment-capture/appworld/traces.otel.jsonl --append
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from environment_capture import (
+    Task,
+    Trajectory,
+    partition_contained,
+    run_capture,
+    trajectory_to_spans,
+    write_spans_jsonl,
+)
+from environment_capture.benchmarks.appworld import AppWorldAdapter, AppWorldAgent
+
+_HERE = Path(__file__).parent
+_BENCHMARK = "appworld"
+
+
+def _short_model(model_id: str) -> str:
+    """A compact tag for a Bedrock model id, e.g. us.anthropic.claude-opus-4-8 -> opus48."""
+    tail = model_id.rsplit(".", 1)[-1].removeprefix("claude-")
+    return tail.replace("-", "").replace("v1", "")
+
+
+def _capture_shard(
+    model_id: str,
+    tasks: list[Task],
+    split: str,
+    max_steps: int,
+    run_tag: str,
+) -> list[Trajectory]:
+    # Each shard's run tag doubles as the AppWorld experiment prefix, so two models grading the same
+    # task write to disjoint experiment directories.
+    adapter = AppWorldAdapter(_HERE, experiment_prefix=run_tag)
+    agent = AppWorldAgent(model_id, max_steps=max_steps)
+    result = run_capture(adapter, agent, split=split, tasks=tasks)
+    for failure in result.failures:
+        print(f"[skip] {failure.task_id} on {model_id}: {failure.error}", file=sys.stderr)
+    contained, flagged = partition_contained(result.trajectories)
+    for trajectory in flagged:
+        print(f"[drop] {trajectory.task.task_id}: host-escape content", file=sys.stderr)
+    originals = {t.task_id: t for t in tasks}
+    tagged: list[Trajectory] = []
+    for trajectory in contained:
+        original = originals[trajectory.task.task_id]
+        suffixed = dataclasses.replace(original, task_id=f"{original.task_id}#{run_tag}")
+        tagged.append(
+            dataclasses.replace(
+                trajectory,
+                task=suffixed,
+                metadata={**trajectory.metadata, "base_task_id": original.task_id},
+            )
+        )
+    return tagged
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--split", default="train", choices=["train"])
+    parser.add_argument("--limit", type=int, default=None, help="Cap the number of tasks")
+    parser.add_argument("--skip", type=int, default=0, help="Skip the first N tasks (resume)")
+    parser.add_argument(
+        "--models",
+        default="us.anthropic.claude-opus-4-8,us.anthropic.claude-opus-4-7",
+        help="Comma-separated Bedrock model ids; tasks are sharded round-robin across them",
+    )
+    parser.add_argument("--runs", type=int, default=1, help="Passes over the split (run-suffixed)")
+    parser.add_argument(
+        "--run-start",
+        type=int,
+        default=1,
+        help="First run number for tag suffixes; bump past prior waves so ids never collide",
+    )
+    parser.add_argument("--max-steps", type=int, default=30)
+    parser.add_argument("--out", default=str(_HERE / "traces.otel.jsonl"))
+    parser.add_argument("--append", action="store_true", help="Append to --out (default: refuse)")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    if out.exists() and not args.append:
+        raise SystemExit(f"{out} exists; pass --append to extend it")
+
+    adapter = AppWorldAdapter(_HERE)
+    model_ids = [m.strip() for m in args.models.split(",") if m.strip()]
+    tasks = adapter.tasks(args.split)[args.skip :]
+    if args.limit is not None:
+        tasks = tasks[: args.limit]
+
+    started = time.time()
+    all_trajectories: list[Trajectory] = []
+    for run_index in range(args.runs):
+        shards = [tasks[i :: len(model_ids)] for i in range(len(model_ids))]
+        jobs = [
+            (model_id, shard, f"{_short_model(model_id)}-r{args.run_start + run_index}")
+            for model_id, shard in zip(model_ids, shards, strict=True)
+        ]
+        with ThreadPoolExecutor(max_workers=len(model_ids)) as pool:
+            shard_results = list(
+                pool.map(
+                    lambda job: _capture_shard(job[0], job[1], args.split, args.max_steps, job[2]),
+                    jobs,
+                )
+            )
+        all_trajectories.extend(t for shard in shard_results for t in shard)
+
+    runs_dir = _HERE / "runs"
+    runs_dir.mkdir(exist_ok=True)
+    raw_path = runs_dir / f"capture-{int(started)}.jsonl"
+    with raw_path.open("w", encoding="utf-8") as raw:
+        for trajectory in all_trajectories:
+            raw.write(json.dumps(dataclasses.asdict(trajectory), ensure_ascii=False) + "\n")
+
+    kept = [t for t in all_trajectories if t.steps]
+    n_spans = 0
+    for index, trajectory in enumerate(kept):
+        spans = trajectory_to_spans(trajectory, benchmark=_BENCHMARK)
+        n_spans += write_spans_jsonl(spans, out, append=args.append or index > 0)
+
+    rewards = [t.reward or 0.0 for t in all_trajectories]
+    mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
+    print(
+        f"captured {len(all_trajectories)} runs ({len(kept)} with transitions, "
+        f"{sum(len(t.steps) for t in kept)} steps, {n_spans} spans, mean reward {mean_reward:.3f}) "
+        f"in {time.time() - started:.0f}s -> {out} (raw: {raw_path})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/environment-capture/appworld/evals/default.toml
+++ b/environment-capture/appworld/evals/default.toml
@@ -1,0 +1,7 @@
+title = "AppWorld default replay"
+description = "Open-loop reconstruction fidelity over the appworld trace corpus (train-split real runs)."
+files = ["../traces.otel.jsonl"]
+train_split = 0.7
+sample_turns = "all"
+seed = 0
+judge = "rubric"

--- a/environment-capture/environment_capture/benchmarks/appworld.py
+++ b/environment-capture/environment_capture/benchmarks/appworld.py
@@ -1,0 +1,424 @@
+"""AppWorld adapter: a stateful multi-app world driven by real Python-API calls.
+
+Upstream: AppWorld (StonyBrookNLP; github.com/StonyBrookNLP/appworld). AppWorld drops an agent into
+a simulated world of nine apps (Amazon, Gmail, Venmo, Spotify, phone, file system, ...) behind 450+
+real Python APIs and asks it to complete a multi-step request — e.g. "what is the title of the
+most-liked song in my Spotify playlists". The agent acts by writing Python that calls
+``apis.<app>.<endpoint>(...)`` against a LIVE, MUTABLE world; it signals completion by calling
+``apis.supervisor.complete_task(...)``. This is the first STATEFUL adapter in the harness: world
+state carries across steps, which is exactly the world-model dynamics this benchmark exists to
+exercise.
+
+The heavy ``appworld`` engine (Python 3.11, its own encrypted data bundles) lives in a
+benchmark-local venv, so THIS module — part of the whole-repo gate — never imports it. It drives
+the engine OUT OF PROCESS instead: :meth:`AppWorldAdapter.open_env` launches a
+``backend/world_backend.py serve`` subprocess under that venv which boots one live ``AppWorld`` for
+the task and speaks a line-delimited JSON protocol on stdio (:class:`AppWorldEnv` is the client).
+Each agent action is a block of Python executed against that live world — the ``CommandEnv.execute``
+seam whose observations a world model reconstructs. Grading shells out to
+``backend/world_backend.py grade``, which runs AppWorld's own deterministic evaluation tests over
+the final world state; reward is the fraction of those tests that pass (no LLM judging).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from botocore.exceptions import ClientError, ConnectTimeoutError, ReadTimeoutError
+
+from environment_capture.adapter import AgentRun, CommandEnv, ExecResult
+from environment_capture.agent import ConverseClient, make_bedrock_client
+from environment_capture.trajectory import JsonValue, StepRecord, Task, ToolCall
+
+# The line-delimited JSON stdio protocol spoken with backend/world_backend.py serve. Requests and
+# responses are one compact JSON object per line (AppWorld output rides as an escaped string value,
+# so a multi-line observation is still a single physical line).
+_READY_TIMEOUT_S = 180.0  # first boot loads every app + the task's database
+_ERROR_MARKER = "Execution failed"  # how AppWorld's world.execute reports a raised/invalid snippet
+
+
+class AppWorldError(RuntimeError):
+    """The world backend subprocess failed to boot or died mid-episode."""
+
+
+@dataclass(frozen=True)
+class _Reply:
+    output: str
+    error: bool
+    completed: bool
+
+
+class AppWorldEnv:
+    """CommandEnv over one live AppWorld world: ``execute(code)`` runs Python against it.
+
+    The ``command`` a caller passes is a block of Python executed in the world's stateful shell
+    (variables and world mutations persist across calls, exactly as in real AppWorld). Output is the
+    printed/return text the shell produced; a non-zero return code flags a raised or syntactically
+    invalid snippet. ``completed`` tracks whether the agent has called ``complete_task`` yet.
+    """
+
+    def __init__(self, command: list[str], *, cwd: Path, timeout_s: int = 120) -> None:
+        """Launch the backend subprocess for one task and wait for its readiness handshake."""
+        self.timeout_s = timeout_s
+        self.completed = False
+        self._process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        self._await_ready()
+
+    def _await_ready(self) -> None:
+        line = self._read_line(timeout_s=int(_READY_TIMEOUT_S))
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as error:
+            self.close()
+            raise AppWorldError(f"world backend sent no readiness handshake: {line!r}") from error
+        if not payload.get("ready"):
+            self.close()
+            raise AppWorldError(f"world backend failed to boot: {payload.get('error', line)!r}")
+
+    def _read_line(self, *, timeout_s: int) -> str:
+        assert self._process.stdout is not None
+        deadline = time.monotonic() + timeout_s
+        while True:
+            line = self._process.stdout.readline()
+            if line:
+                return line
+            if self._process.poll() is not None:
+                stderr = self._process.stderr.read() if self._process.stderr else ""
+                raise AppWorldError(
+                    f"world backend exited (code {self._process.returncode}): {stderr}"
+                )
+            if time.monotonic() > deadline:
+                raise AppWorldError(f"world backend timed out after {timeout_s}s")
+            time.sleep(0.02)
+
+    def _request(self, payload: dict[str, JsonValue]) -> _Reply:
+        assert self._process.stdin is not None
+        self._process.stdin.write(json.dumps(payload) + "\n")
+        self._process.stdin.flush()
+        reply = json.loads(self._read_line(timeout_s=self.timeout_s))
+        return _Reply(
+            output=str(reply.get("output", "")),
+            error=bool(reply.get("error", False)),
+            completed=bool(reply.get("completed", False)),
+        )
+
+    def execute(self, command: str) -> ExecResult:
+        """Run one block of Python against the live world; return its output and error status."""
+        if self._process.poll() is not None:
+            return ExecResult(output="world backend is no longer running", returncode=1)
+        try:
+            reply = self._request({"op": "execute", "code": command})
+        except (AppWorldError, json.JSONDecodeError, OSError) as error:
+            return ExecResult(output=f"world backend error: {error}", returncode=1)
+        self.completed = self.completed or reply.completed
+        return ExecResult(output=reply.output, returncode=1 if reply.error else 0)
+
+    def close(self) -> None:
+        if self._process.poll() is None and self._process.stdin is not None:
+            try:
+                self._process.stdin.write(json.dumps({"op": "close"}) + "\n")
+                self._process.stdin.flush()
+            except OSError:
+                pass
+        try:
+            self._process.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+
+
+class AppWorldAdapter:
+    """BenchmarkAdapter over a materialized AppWorld data directory, driven via the venv backend.
+
+    ``root`` is the benchmark-local directory holding ``data/{split}.jsonl`` (materialized by
+    ``backend/fetch_data.py``), the downloaded AppWorld ``data/`` and ``experiments/`` trees, the
+    ``.venv`` with the ``appworld`` engine, and ``backend/world_backend.py``. Every AppWorld
+    operation runs as a subprocess under ``.venv`` so this gate-checked module stays appworld-free.
+    """
+
+    name = "appworld"
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        experiment_prefix: str = "wmh-cap",
+        venv_python: Path | None = None,
+        backend: Path | None = None,
+        timeout_s: int = 120,
+    ) -> None:
+        self.root = root
+        self.experiment_prefix = experiment_prefix
+        self.venv_python = venv_python or root / ".venv" / "bin" / "python"
+        self.backend = backend or root / "backend" / "world_backend.py"
+        self.timeout_s = timeout_s
+
+    def tasks(self, split: str) -> list[Task]:
+        path = self.root / "data" / f"{split}.jsonl"
+        tasks: list[Task] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            raw = json.loads(line)
+            tasks.append(
+                Task(task_id=raw["task_id"], prompt=raw["prompt"], data=raw.get("data", {}))
+            )
+        return tasks
+
+    def _appworld_id(self, task: Task) -> str:
+        appworld_id = task.data.get("appworld_id")
+        if not isinstance(appworld_id, str) or not appworld_id:
+            raise ValueError(f"task {task.task_id} is missing a string data.appworld_id")
+        return appworld_id
+
+    def _experiment(self, task: Task) -> str:
+        """A per-(capture-run, task) AppWorld experiment name so states never collide.
+
+        ``experiment_prefix`` carries the capture's run tag (model + pass), so two shards grading
+        the same AppWorld task write to disjoint experiment directories.
+        """
+        return f"{self.experiment_prefix}--{self._appworld_id(task)}"
+
+    def open_env(self, task: Task) -> AppWorldEnv:
+        command = [
+            str(self.venv_python),
+            str(self.backend),
+            "serve",
+            self._appworld_id(task),
+            self._experiment(task),
+        ]
+        return AppWorldEnv(command, cwd=self.root, timeout_s=self.timeout_s)
+
+    def grade(self, task: Task, submission: str) -> float:
+        """Run AppWorld's own evaluation tests over the final world state; reward = pass fraction.
+
+        The submission text is irrelevant to AppWorld (grading is state-based), so it is ignored;
+        the grader reads the world the agent left behind under this task's experiment directory.
+        """
+        del submission
+        result = subprocess.run(
+            [
+                str(self.venv_python),
+                str(self.backend),
+                "grade",
+                self._appworld_id(task),
+                self._experiment(task),
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            timeout=self.timeout_s,
+        )
+        if result.returncode != 0:
+            raise AppWorldError(f"grade failed for {task.task_id}: {result.stderr.strip()}")
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        return float(payload["reward"])
+
+
+# --------------------------------------------------------------------------- capture agent
+
+_SYSTEM_PROMPT = """You are an autonomous agent operating AppWorld, a simulated world of nine apps
+(Amazon, Gmail, Venmo, Spotify, phone, file system, Splitwise, Todoist, SimpleNote) plus a
+`supervisor` app for your account. You act ONLY by writing Python code with the `execute_python`
+tool: each call runs your code in a STATEFUL Python shell where `apis` is preloaded, so variables
+and world changes persist across calls. Start by exploring: read the task, then discover and read
+the relevant API docs with `apis.api_docs.show_api_descriptions(app_name=...)` and
+`apis.api_docs.show_api_doc(app_name=..., api_name=...)`. Authenticate via
+`apis.supervisor.show_account_passwords()` and each app's login endpoint before calling protected
+APIs. Inspect results before assuming them, and take one focused step per call. When — and only
+when — the request is fully carried out, call `apis.supervisor.complete_task()` (pass
+`answer=<value>` if the task asks a question), then call the `finish` tool to end. If you get
+stuck, still call `finish` rather than looping."""
+
+_INSTRUCTIONS = (
+    "\n\nComplete this request in the AppWorld Python shell using the `execute_python` tool. "
+    "Explore the APIs, authenticate, act, then call apis.supervisor.complete_task(...) and finish."
+)
+
+_TOOL_CONFIG: dict[str, JsonValue] = {
+    "tools": [
+        {
+            "toolSpec": {
+                "name": "execute_python",
+                "description": "Run one block of Python in the stateful AppWorld shell (the `apis` "
+                "object is preloaded); returns the real printed output or error traceback.",
+                "inputSchema": {
+                    "json": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    }
+                },
+            }
+        },
+        {
+            "toolSpec": {
+                "name": "finish",
+                "description": "End the task after you have called apis.supervisor.complete_task.",
+                "inputSchema": {
+                    "json": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                        "required": [],
+                    }
+                },
+            }
+        },
+    ]
+}
+
+_THROTTLE_CODES = {"ThrottlingException", "TooManyRequestsException", "ServiceUnavailableException"}
+_MAX_RETRIES = 6
+
+
+def task_prompt_with_instructions(task: Task) -> str:
+    """The task prompt plus the how-to-act framing (mirrors bird-sql's SQL framing)."""
+    return task.prompt + _INSTRUCTIONS
+
+
+class AppWorldAgent:
+    """CaptureAgent that drives an AppWorldEnv through Bedrock converse tool-use.
+
+    Faithful to AppWorld's real action space: the model's only environment action is a block of
+    Python (the ``execute_python`` tool) run against the live world; it ends by calling ``finish``
+    after signalling completion in-world with ``apis.supervisor.complete_task``. Throttling is
+    retried with linear backoff; other errors propagate so ``run_capture`` can isolate the task.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        *,
+        client: ConverseClient | None = None,
+        region: str = "us-east-1",
+        max_steps: int = 20,
+        max_tokens: int = 2048,
+        retry_backoff_s: float = 5.0,
+    ) -> None:
+        self.model_id = model_id
+        self._client = client if client is not None else make_bedrock_client(region)
+        self.max_steps = max_steps
+        self.max_tokens = max_tokens
+        self.retry_backoff_s = retry_backoff_s
+
+    def _converse(self, messages: list[JsonValue]) -> dict[str, JsonValue]:
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                return self._client.converse(
+                    modelId=self.model_id,
+                    messages=messages,
+                    system=[{"text": _SYSTEM_PROMPT}],
+                    toolConfig=_TOOL_CONFIG,
+                    inferenceConfig={"maxTokens": self.max_tokens},
+                )
+            except (ReadTimeoutError, ConnectTimeoutError):
+                if attempt == _MAX_RETRIES:
+                    raise
+                time.sleep(self.retry_backoff_s * (attempt + 1))
+            except ClientError as error:
+                code = error.response.get("Error", {}).get("Code", "")
+                if code not in _THROTTLE_CODES or attempt == _MAX_RETRIES:
+                    raise
+                time.sleep(self.retry_backoff_s * (attempt + 1))
+        raise RuntimeError("unreachable")
+
+    def run(self, task: Task, env: CommandEnv) -> AgentRun:
+        """Drive the world until the agent finishes, answers in text, or hits max_steps."""
+        messages: list[JsonValue] = [
+            {"role": "user", "content": [{"text": task_prompt_with_instructions(task)}]}
+        ]
+        steps: list[StepRecord] = []
+        final_answer = ""
+
+        while len(steps) < self.max_steps:
+            response = self._converse(messages)
+            output = response.get("output")
+            assert isinstance(output, dict)
+            message = output.get("message")
+            assert isinstance(message, dict)
+            messages.append(message)
+
+            tool_uses = _tool_uses(message)
+            if not tool_uses:
+                final_answer = _text_content(message)
+                break
+
+            tool_results: list[JsonValue] = []
+            finished = False
+            for tool_use_id, name, tool_input in tool_uses:
+                if name == "finish":
+                    answer = tool_input.get("answer", "")
+                    final_answer = answer if isinstance(answer, str) else str(answer)
+                    finished = True
+                    break
+
+                code = tool_input.get("code", "")
+                code_text = code if isinstance(code, str) else str(code)
+                result = env.execute(code_text)
+                steps.append(
+                    StepRecord(
+                        action=ToolCall(name="execute_python", arguments={"code": code_text}),
+                        output=result.output,
+                        is_error=result.returncode != 0,
+                    )
+                )
+                tool_results.append(
+                    {
+                        "toolResult": {
+                            "toolUseId": tool_use_id,
+                            "content": [{"text": result.output or "(no output)"}],
+                            "status": "error" if result.returncode != 0 else "success",
+                        }
+                    }
+                )
+                if len(steps) >= self.max_steps:
+                    break
+
+            if finished:
+                break
+            messages.append({"role": "user", "content": tool_results})
+
+        return AgentRun(steps=steps, final_answer=final_answer, model=self.model_id)
+
+
+def _tool_uses(message: dict[str, JsonValue]) -> list[tuple[str, str, dict[str, JsonValue]]]:
+    """Every (id, name, input) tool-use block in the message, in order."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    uses: list[tuple[str, str, dict[str, JsonValue]]] = []
+    for block in content:
+        if isinstance(block, dict) and isinstance(block.get("toolUse"), dict):
+            tool_use = block["toolUse"]
+            assert isinstance(tool_use, dict)
+            tool_use_id = tool_use.get("toolUseId", "")
+            name = tool_use.get("name", "")
+            tool_input = tool_use.get("input", {})
+            assert isinstance(tool_use_id, str) and isinstance(name, str)
+            assert isinstance(tool_input, dict)
+            uses.append((tool_use_id, name, tool_input))
+    return uses
+
+
+def _text_content(message: dict[str, JsonValue]) -> str:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts = [
+        block["text"]
+        for block in content
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    ]
+    return "\n".join(str(p) for p in parts).strip()

--- a/environment-capture/environment_capture/benchmarks/appworld_test.py
+++ b/environment-capture/environment_capture/benchmarks/appworld_test.py
@@ -1,0 +1,211 @@
+"""Tests for the AppWorld adapter, env, and capture agent.
+
+The real ``appworld`` engine lives in a separate venv, so these tests never touch it: a tiny
+stdlib ``fake_backend.py`` written into ``tmp_path`` speaks the same stdio JSON protocol as
+``backend/world_backend.py`` (proving statefulness and the serve/grade wiring), and a stub converse
+client drives the agent through a scripted tool-use sequence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from environment_capture.adapter import ExecResult
+from environment_capture.benchmarks.appworld import (
+    AppWorldAdapter,
+    AppWorldAgent,
+    AppWorldError,
+)
+from environment_capture.trajectory import JsonValue, Task
+
+# A stand-in for backend/world_backend.py: stdlib-only, keeps world state across execute calls
+# (returns a growing step count), marks completion when the code contains COMPLETE, and grades from
+# an env-name-encoded reward, so the adapter's serve/grade wiring can be checked without appworld.
+_FAKE_BACKEND = """\
+import json, sys
+def main():
+    op = sys.argv[1]
+    if op == "serve":
+        print(json.dumps({"ready": True}), flush=True)
+        history = []
+        for line in sys.stdin:
+            req = json.loads(line)
+            if req.get("op") == "close":
+                break
+            code = req.get("code", "")
+            history.append(code)
+            if code == "BOOM":
+                print(json.dumps({"output": "Execution failed. boom", "error": True,
+                                  "completed": False}), flush=True)
+            else:
+                print(json.dumps({"output": "steps=%d" % len(history),
+                                  "error": False, "completed": "COMPLETE" in code}), flush=True)
+    elif op == "grade":
+        experiment_name = sys.argv[3]
+        reward = float(experiment_name.split("--", 1)[0].rsplit("-", 1)[-1])
+        print(json.dumps({"reward": reward, "success": reward >= 1.0, "num_tests": 2}))
+main()
+"""
+
+
+@pytest.fixture()
+def root(tmp_path: Path) -> Path:
+    backend = tmp_path / "backend"
+    backend.mkdir()
+    (backend / "fake_backend.py").write_text(_FAKE_BACKEND, encoding="utf-8")
+    data = tmp_path / "data"
+    data.mkdir()
+    tasks = [
+        {"task_id": "aw-train-0", "prompt": "Do a thing.", "data": {"appworld_id": "abc_1"}},
+        {"task_id": "aw-train-1", "prompt": "Do another.", "data": {"appworld_id": "abc_2"}},
+    ]
+    (data / "train.jsonl").write_text(
+        "\n".join(json.dumps(t) for t in tasks) + "\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _adapter(root: Path, *, experiment_prefix: str = "reward-1.0") -> AppWorldAdapter:
+    return AppWorldAdapter(
+        root,
+        experiment_prefix=experiment_prefix,
+        venv_python=Path("python3"),
+        backend=root / "backend" / "fake_backend.py",
+    )
+
+
+def test_tasks_parses_split(root: Path) -> None:
+    tasks = _adapter(root).tasks("train")
+    assert [t.task_id for t in tasks] == ["aw-train-0", "aw-train-1"]
+    assert tasks[0].data["appworld_id"] == "abc_1"
+
+
+def test_open_env_state_persists_across_calls(root: Path) -> None:
+    adapter = _adapter(root)
+    env = adapter.open_env(adapter.tasks("train")[0])
+    try:
+        # The growing step count proves the world is the SAME process across execute calls.
+        assert env.execute("x = 1").output == "steps=1"
+        assert env.execute("y = 2").output == "steps=2"
+        assert not env.completed
+        result = env.execute("apis.supervisor.complete_task()  # COMPLETE")
+        assert result.returncode == 0
+        assert env.completed
+    finally:
+        env.close()
+
+
+def test_execute_flags_errors(root: Path) -> None:
+    adapter = _adapter(root)
+    env = adapter.open_env(adapter.tasks("train")[0])
+    try:
+        result = env.execute("BOOM")
+        assert result.returncode == 1
+        assert "Execution failed" in result.output
+    finally:
+        env.close()
+
+
+def test_grade_reads_backend_reward(root: Path) -> None:
+    adapter = _adapter(root, experiment_prefix="reward-1.0")
+    assert adapter.grade(adapter.tasks("train")[0], "ignored") == 1.0
+    half = _adapter(root, experiment_prefix="reward-0.5")
+    assert half.grade(half.tasks("train")[0], "ignored") == 0.5
+
+
+def test_open_env_raises_on_missing_appworld_id(root: Path) -> None:
+    adapter = _adapter(root)
+    with pytest.raises(ValueError, match="appworld_id"):
+        adapter.open_env(Task(task_id="x", prompt="p", data={}))
+
+
+def test_env_raises_when_backend_cannot_start(root: Path) -> None:
+    adapter = AppWorldAdapter(
+        root, venv_python=Path("python3"), backend=root / "backend" / "does_not_exist.py"
+    )
+    with pytest.raises((AppWorldError, OSError)):
+        adapter.open_env(adapter.tasks("train")[0])
+
+
+# --------------------------------------------------------------------------- agent
+
+
+class _ScriptedClient:
+    """A ConverseClient stub that replays a fixed list of assistant messages, in order."""
+
+    def __init__(self, messages: list[dict[str, JsonValue]]) -> None:
+        self._messages = messages
+        self.calls = 0
+
+    def converse(
+        self,
+        *,
+        modelId: str,  # noqa: N803 - matches the boto3 converse signature
+        messages: list[JsonValue],
+        system: list[JsonValue],
+        toolConfig: JsonValue,  # noqa: N803
+        inferenceConfig: JsonValue,  # noqa: N803
+    ) -> dict[str, JsonValue]:
+        message = self._messages[self.calls]
+        self.calls += 1
+        return {"output": {"message": message}}
+
+
+class _FakeEnv:
+    """Minimal AppWorldEnv stand-in recording the code the agent runs."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.completed = False
+
+    def execute(self, command: str) -> ExecResult:
+        self.executed.append(command)
+        self.completed = "complete_task" in command
+        return ExecResult(output=f"ran: {command}", returncode=0)
+
+    def close(self) -> None:
+        pass
+
+
+def _tool_use_msg(name: str, arguments: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    return {"content": [{"toolUse": {"toolUseId": f"tu-{name}", "name": name, "input": arguments}}]}
+
+
+def test_agent_runs_python_then_finishes() -> None:
+    client = _ScriptedClient(
+        [
+            _tool_use_msg("execute_python", {"code": "apis.supervisor.complete_task(answer='42')"}),
+            _tool_use_msg("finish", {"answer": "42"}),
+        ]
+    )
+    agent = AppWorldAgent("test-model", client=client)
+    env = _FakeEnv()
+    run = agent.run(Task(task_id="aw-train-0", prompt="Answer 42."), env)
+
+    assert env.executed == ["apis.supervisor.complete_task(answer='42')"]
+    assert run.final_answer == "42"
+    assert run.model == "test-model"
+    assert len(run.steps) == 1
+    assert run.steps[0].action.name == "execute_python"
+    assert run.steps[0].action.arguments["code"] == "apis.supervisor.complete_task(answer='42')"
+
+
+def test_agent_stops_at_max_steps() -> None:
+    looping = [_tool_use_msg("execute_python", {"code": f"step_{i}"}) for i in range(10)]
+    agent = AppWorldAgent("test-model", client=_ScriptedClient(looping), max_steps=3)
+    env = _FakeEnv()
+    run = agent.run(Task(task_id="aw-train-0", prompt="Loop."), env)
+    assert len(run.steps) == 3
+    assert [s.action.arguments["code"] for s in run.steps] == ["step_0", "step_1", "step_2"]
+
+
+def test_agent_ends_on_plain_text() -> None:
+    agent = AppWorldAgent(
+        "test-model", client=_ScriptedClient([{"content": [{"text": "I give up."}]}])
+    )
+    run = agent.run(Task(task_id="aw-train-0", prompt="x"), _FakeEnv())
+    assert run.final_answer == "I give up."
+    assert run.steps == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,11 @@ python-version = "3.11"
 [tool.ty.src]
 # `plot_trace_scaling.py` is a one-off research figure that imports matplotlib ephemerally
 # (`uv run --with matplotlib`), not a project dependency — exclude it from the type gate.
-exclude = ["examples/", "scripts/plot_trace_scaling.py"]
+# The appworld `backend/` scripts import the heavy `appworld` engine, which lives only in that
+# benchmark's local venv (not a project dependency) — exclude them like the figure script above.
+exclude = [
+    "examples/",
+    "scripts/plot_trace_scaling.py",
+    "environment-capture/appworld/backend/world_backend.py",
+    "environment-capture/appworld/backend/fetch_data.py",
+]


### PR DESCRIPTION
## What

The first **stateful** `environment-capture` adapter: **AppWorld** (StonyBrookNLP) — nine simulated apps (Amazon, Gmail, Venmo, Spotify, phone, file system, Splitwise, Todoist, SimpleNote) behind 450+ real Python APIs, with world state that carries across steps. The agent acts by writing Python that calls `apis.<app>.<endpoint>(...)` against a live, mutable world and completes via `apis.supervisor.complete_task(...)`; grading runs AppWorld's own deterministic tests over the final world state (no LLM).

## Architecture (heavy engine out-of-process)

`appworld` is Python-3.11-only, pulls a large dep tree, and ships encrypted data bundles, so it lives in a benchmark-local venv (gitignored) and the gate-checked `environment_capture.benchmarks.appworld` module never imports it:

- `AppWorldEnv` (the `CommandEnv` seam) drives the engine via `backend/world_backend.py serve` — a line-delimited JSON stdio protocol over one live `AppWorld` per task. Each action is a block of Python run against the live, stateful world (AppWorld's real action space).
- `AppWorldAgent` is a Bedrock converse loop whose only environment tool is `execute_python`.
- `grade` shells to `backend/world_backend.py grade` → AppWorld's own evaluation tests; reward = pass fraction.
- Inline tests (`appworld_test.py`) use a stdlib fake backend (proving statefulness + serve/grade wiring) and a stub converse client. `backend/*.py` (the only appworld-importing files) are added to the `ty` exclude, like `plot_trace_scaling.py`.

## License finding — corpus is NOT committed

AppWorld dual-licenses: public code is plain Apache 2.0, but the **protected dataset** (task data, API docs/impl, solutions, eval tests) ships in encrypted `.bundle` files under Apache 2.0 **plus** a requirement that *any public redistribution of it or its derivatives be done in an encrypted format* (training/serving models is explicitly exempt). A captured trace embeds task instructions + API observations = **derivatives**, so — unlike bird-sql (CC BY-SA 4.0) — **`traces.otel.jsonl` is gitignored** (along with `data/` and `experiments/`) and reproduced locally with `capture.py`. This repo carries adapter + tests + backend + README + reported numbers only. (Mirrors the GAIA data policy, DECISIONS D31/D43. The sibling SIB repo hit the same wall and shipped a synthetic stand-in; this wave uses the real engine locally.)

## Results (local capture)

- **Corpus**: 74 real Bedrock traces / 74 of 90 train tasks (40 opus-4-8, 34 opus-4-7), 827 `execute_python` steps, mean reward **0.981** (93% fully solved). Hygiene audit `scan_spans_jsonl == {}`.
- **Open-loop fidelity** (`appworld/default`, Opus 4.8 target + rubric judge): **0.793 ± 0.209**, error-flag accuracy **0.962**, n=210 held-out steps — between financebench's document excerpts (0.581) and bird-sql's structured sqlite (0.864); residual is opaque per-world ids/values.

## Hygiene note

AppWorld's SafetyGuard blocks `os.listdir`/`subprocess`/`open`, but `os.path.expanduser("~")` still echoes the real home, so the shared hygiene runtime markers are needed. Separately, AppWorld's *simulated* file system uses `~/` paths, which trip the generic `~/` observation marker → `partition_contained` drops the 16 file-system train tasks as false positives (emitted corpus still audits `== {}`). Kept as the safe default rather than weakening the shared gate; a benchmark-specific containment keyed on real host identity would recover them.

## Gate

Whole-repo gate green: `ruff check` + `ruff format` clean, `ty check` clean, `pytest` 400 passed / 3 skipped. Real end-to-end validated via `backend/smoke.py` and the capture runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)