### PR TITLE
hygiene: opt-out generic path markers for observations (recover appworld file-system tasks → 90/90)

### DIFF
--- a/environment-capture/appworld/README.md
+++ b/environment-capture/appworld/README.md
@@ -70,25 +70,31 @@ dynamics.
 
 ## Results (2026-07-02, corpus as captured)
 
-- **Corpus**: 74 fresh real Bedrock runs over the train split (40 on
-  `us.anthropic.claude-opus-4-8`, 34 on `-4-7`), covering 74 of the 90 train tasks, 827 recorded
-  `execute_python` transitions, mean reward **0.981** (93% of tasks fully solved by AppWorld's own
-  tests). Hygiene audit `scan_spans_jsonl(...) == {}` (clean).
-  - The 16 uncaptured train tasks are the split's **file-system** tasks (e.g. *"export … into
-    `~/backups/spotify_library.csv`"*): AppWorld's *simulated* file system uses `~/`-rooted paths,
-    which trip the shared hygiene detector's `~/` observation marker, so `partition_contained` drops
-    those (legitimate) trajectories. This is a benchmark-specific false positive — AppWorld's own
-    execution sandbox (SafetyGuard) blocks `os.listdir` / `subprocess` / `open`, so real host escape
-    is not possible through `world.execute` (though `os.path.expanduser("~")` still echoes the real
-    home, which the hygiene runtime markers correctly catch). Kept as the safe default rather than
-    weakening the shared gate; a benchmark-specific containment keyed on real host identity would
-    recover them.
+- **Corpus**: 90 fresh real Bedrock runs over the train split (50 on
+  `us.anthropic.claude-opus-4-8`, 40 on `-4-7`), covering all 90 train tasks, 1,058 recorded
+  `execute_python` transitions, mean reward **0.983** (93% of tasks fully solved by AppWorld's own
+  tests). Real-host-identity audit is clean (0 trajectories).
 - **Open-loop fidelity** (suite `appworld/default`, seed 0, Opus 4.8 target + rubric judge, run via
   `uv run wmh eval run appworld/default --examples-root environment-capture`): mean fidelity
-  **0.793 ± 0.209**, error-flag accuracy **0.962**, n=210 held-out steps. AppWorld's structured JSON
-  API observations reconstruct better than financebench's document excerpts (0.581) but below
-  bird-sql's fully structured sqlite rows (0.864) — the residual is opaque per-world identifiers and
-  values (song ids, tokens, amounts) the model cannot infer from the request alone.
+  **0.802 ± 0.208**, error-flag accuracy **0.957**, n=280 held-out steps. AppWorld's structured JSON API
+  observations reconstruct better than financebench's document excerpts (0.581) but below bird-sql's
+  fully structured sqlite rows (0.864) — the residual is opaque per-world identifiers and values
+  (song ids, tokens, amounts) the model cannot infer from the request alone.
+
+### Hygiene: benchmark-scoped host-escape checks
+
+AppWorld executes agent code in its OWN sandbox (SafetyGuard blocks `os.listdir` / `subprocess` /
+`open`), and its *simulated* file system legitimately uses `~/`- and `/home/`-rooted paths as
+environment content (e.g. *"export … into `~/backups/spotify_library.csv`"*). The shared hygiene
+detector's generic path markers (`~/`, `/home/`, …) would drop those legitimate file-system
+trajectories as false host-escapes. So capture passes `partition_contained(...,
+generic_path_markers=False)`: the generic path markers are skipped **for observations only**, while
+(a) all command-level checks and (b) the runtime IDENTITY markers (this machine's real username and
+home path) stay active unconditionally. That still catches a genuine leak — `os.path.expanduser("~")`
+does echo the real home through AppWorld's sandbox — so a trajectory that touches the real account is
+dropped whole (this happens occasionally; the corpus above is the retained, identity-clean set). The
+emitted corpus therefore contains simulated `~/` paths by design; a strict `scan_spans_jsonl` (which
+uses the generic markers) flags exactly those, but the identity audit is empty.
 
 ## License — read before redistributing
 

--- a/environment-capture/appworld/capture.py
+++ b/environment-capture/appworld/capture.py
@@ -68,7 +68,12 @@ def _capture_shard(
     result = run_capture(adapter, agent, split=split, tasks=tasks)
     for failure in result.failures:
         print(f"[skip] {failure.task_id} on {model_id}: {failure.error}", file=sys.stderr)
-    contained, flagged = partition_contained(result.trajectories)
+    # generic_path_markers=False: AppWorld executes in its own sandbox (SafetyGuard blocks
+    # os.listdir/subprocess/open), and its SIMULATED file system legitimately uses ~/ and /home
+    # paths as environment content — the generic path markers would drop those (real) trajectories
+    # as false positives. The runtime identity markers (real username + home) still catch a genuine
+    # leak (e.g. os.path.expanduser echoing the account), and command-level checks stay active.
+    contained, flagged = partition_contained(result.trajectories, generic_path_markers=False)
     for trajectory in flagged:
         print(f"[drop] {trajectory.task.task_id}: host-escape content", file=sys.stderr)
     originals = {t.task_id: t for t in tasks}

--- a/environment-capture/environment_capture/hygiene.py
+++ b/environment-capture/environment_capture/hygiene.py
@@ -74,7 +74,9 @@ class HygieneFinding:
     excerpt: str
 
 
-def _check_text(field: str, text: str) -> list[HygieneFinding]:
+def _check_text(
+    field: str, text: str, *, generic_path_markers: bool = True
+) -> list[HygieneFinding]:
     findings: list[HygieneFinding] = []
     if field == "command":
         match = _CMD_ESCAPE_RE.search(text)
@@ -83,7 +85,11 @@ def _check_text(field: str, text: str) -> list[HygieneFinding]:
                 HygieneFinding(field=field, marker=match.group(1).strip(), excerpt=text[:120])
             )
         return findings
-    for marker in _OBS_MARKERS + _RUNTIME_MARKERS:
+    # The generic path markers can be a false positive when the benchmark's OWN environment uses
+    # host-shaped paths as legitimate content; the runtime identity markers (real username + real
+    # home) always run so an actual account leak is never missed.
+    markers = (_OBS_MARKERS + _RUNTIME_MARKERS) if generic_path_markers else _RUNTIME_MARKERS
+    for marker in markers:
         index = text.find(marker)
         if index != -1:
             findings.append(
@@ -95,25 +101,43 @@ def _check_text(field: str, text: str) -> list[HygieneFinding]:
     return findings
 
 
-def host_escape_findings(trajectory: Trajectory) -> list[HygieneFinding]:
-    """Every host-escape signal in a trajectory's commands and observations."""
+def host_escape_findings(
+    trajectory: Trajectory, *, generic_path_markers: bool = True
+) -> list[HygieneFinding]:
+    """Every host-escape signal in a trajectory's commands and observations.
+
+    Command-level checks always run. Set ``generic_path_markers=False`` to skip the generic path
+    markers (``~/``, ``/home/``, ``/root``, ...) FOR OBSERVATIONS ONLY — for a benchmark whose own
+    environment legitimately emits such paths as content (e.g. AppWorld's simulated file system).
+    The runtime identity markers (real username + real home) still run unconditionally.
+    """
     findings: list[HygieneFinding] = []
     for step in trajectory.steps:
         for value in step.action.arguments.values():
             if isinstance(value, str):
                 findings.extend(_check_text("command", value))
-        findings.extend(_check_text("output", step.output))
+        findings.extend(
+            _check_text("output", step.output, generic_path_markers=generic_path_markers)
+        )
     return findings
 
 
 def partition_contained(
-    trajectories: list[Trajectory],
+    trajectories: list[Trajectory], *, generic_path_markers: bool = True
 ) -> tuple[list[Trajectory], list[Trajectory]]:
-    """Split trajectories into (workspace-contained, flagged), preserving order."""
+    """Split trajectories into (workspace-contained, flagged), preserving order.
+
+    ``generic_path_markers`` is forwarded to :func:`host_escape_findings`.
+    """
     clean: list[Trajectory] = []
     flagged: list[Trajectory] = []
     for trajectory in trajectories:
-        (flagged if host_escape_findings(trajectory) else clean).append(trajectory)
+        target = (
+            flagged
+            if host_escape_findings(trajectory, generic_path_markers=generic_path_markers)
+            else clean
+        )
+        target.append(trajectory)
     return clean, flagged
 
 

--- a/environment-capture/environment_capture/hygiene_test.py
+++ b/environment-capture/environment_capture/hygiene_test.py
@@ -82,6 +82,46 @@ def test_partition_contained_splits_and_preserves_order() -> None:
     assert flagged == [dirty]
 
 
+def test_generic_path_markers_false_allows_simulated_paths_in_observations() -> None:
+    """A benchmark whose OWN environment uses ~/ or /home paths as content (e.g. AppWorld's
+    simulated file system) can opt out of the generic path markers for observations."""
+    sim = _trajectory(
+        "print(apis.file_system.show_file(path='~/documents/report.txt'))",
+        "wrote 3 rows to ~/documents/report.txt (see /home/appuser/documents)",
+    )
+    # By default the simulated ~/ path is treated as a host marker and flagged...
+    assert host_escape_findings(sim)
+    # ...but with generic_path_markers=False the observation path markers are skipped.
+    assert host_escape_findings(sim, generic_path_markers=False) == []
+
+
+def test_generic_path_markers_false_still_flags_real_identity_leak() -> None:
+    """Opting out of GENERIC path markers must NOT disable the runtime identity markers: a real
+    username / home leak (e.g. os.path.expanduser echoing the account) is still caught."""
+    import getpass
+
+    user = getpass.getuser()
+    leak = _trajectory("print(os.path.expanduser('~'))", f"home is {str(Path.home())} for {user}")
+    findings = host_escape_findings(leak, generic_path_markers=False)
+    assert findings and findings[0].field == "output"
+    assert findings[0].marker in (user, str(Path.home()))
+
+
+def test_generic_path_markers_false_still_flags_commands() -> None:
+    """Command-level host targeting is checked unconditionally, regardless of the flag."""
+    dirty = _trajectory("cat /Users/someone/.ssh/config", "ok")
+    findings = host_escape_findings(dirty, generic_path_markers=False)
+    assert findings and findings[0].field == "command"
+
+
+def test_partition_contained_respects_generic_path_markers() -> None:
+    sim = _trajectory("print('save')", "saved to ~/documents/out.csv")
+    clean, flagged = partition_contained([sim])
+    assert flagged == [sim]  # default: flagged
+    clean, flagged = partition_contained([sim], generic_path_markers=False)
+    assert clean == [sim] and flagged == []
+
+
 def test_scan_spans_jsonl_maps_trace_ids_to_findings(tmp_path: Path) -> None:
     def span(trace_id: str, key: str, value: str) -> dict[str, object]:
         return {


### PR DESCRIPTION
## What

Adds a keyword-only opt-out to the shared hygiene checks so a benchmark whose OWN environment emits host-shaped paths as legitimate content isn't dropped as a false host-escape — and uses it to recover AppWorld's file-system tasks to **full 90/90 train coverage**.

## Hygiene change (shared, principled, no weakening for other benchmarks)

- `host_escape_findings(trajectory, *, generic_path_markers: bool = True)`, threaded through `partition_contained(..., generic_path_markers=True)`.
- When `False`: the **generic path markers** (`~/`, `/home/`, `/root`, …) are skipped **for observations only**. **Unchanged and always active**: all command-level checks, and the runtime **identity** markers (this machine's real username + real home path).
- Default stays `True`, so bird-sql / financebench / dabstep behavior is identical.
- Tests (TDD): a simulated `~/documents/...` observation passes with the flag off; a real username/home leak still fails; command targeting still flags; `partition_contained` respects the flag.

## AppWorld usage

`appworld/capture.py` passes `generic_path_markers=False`, justified in-code and in the README: AppWorld's SafetyGuard sandboxes real FS access (`os.listdir`/`subprocess`/`open` blocked) and its *simulated* file system legitimately uses `~/` paths as environment content, while a genuine identity leak (`os.path.expanduser` echoing the account) is still caught by the runtime markers.

## Corpus + fidelity (local, gitignored per AppWorld license)

- Recovered the 16 file-system tasks (9–11, 33–38, 43, 48–50, 66–68) → **90/90 train tasks**, 90 traces, 1,058 `execute_python` steps, mean reward **0.983**, 50 opus-4-8 / 40 opus-4-7.
- **Real-host-identity audit: clean (0 trajectories).** The emitted corpus now contains simulated `~/` paths by design; a strict `scan_spans_jsonl` (generic markers) flags exactly those, while the identity audit is empty.
- The flag correctly preserves the safety property: task 43 was dropped on a run where the agent's exploration hit a real `expanduser`-style home leak, then recovered on a clean re-run.
- **Open-loop fidelity 0.802 ± 0.208** (was 0.793 on the 74-trace corpus), error-flag accuracy **0.957**, n=280 held-out steps — recovering the file-system dynamics held fidelity steady while completing coverage.

## Gate

Whole-repo gate green: `ruff` + `ty` clean, `pytest` 406 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)