### PR TITLE
cli: invalid model/example names get friendly errors, not tracebacks

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -415,7 +415,13 @@ def serve(
     `/world_models/{name}/sessions` and `.../step`.
     """
     names = list(name) if name else None
-    uvicorn.run(create_app(root, names=names), host="127.0.0.1", port=port)
+    # Bad --name input (unsafe segment, unknown model, nothing built) is a usage error,
+    # not a traceback; load the models before uvicorn takes over the process.
+    try:
+        server_app = create_app(root, names=names)
+    except (ValueError, FileNotFoundError) as err:
+        raise typer.BadParameter(str(err)) from None
+    uvicorn.run(server_app, host="127.0.0.1", port=port)
 
 
 @app.command("eval")

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -258,7 +258,10 @@ def build(
     elif name is None and file is None and vendor is None:
         raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
 
-    validate_name(params.name)
+    try:
+        validate_name(params.name)
+    except ValueError as err:
+        raise typer.BadParameter(str(err)) from None
     try:
         serve_provider = ProviderKind(params.provider)
     except ValueError:
@@ -835,8 +838,13 @@ def _discover_examples() -> list[Path]:
 
 
 def _resolve_example(name: str) -> Path:
-    example_dir = _examples_root() / validate_name(name)
-    if example_dir.is_dir():
+    # An unsafe segment (spaces, path separators, ...) is simply not an example name; fall
+    # through to the same "unknown example" usage error instead of a ValueError traceback.
+    try:
+        example_dir = _examples_root() / validate_name(name)
+    except ValueError:
+        example_dir = None
+    if example_dir is not None and example_dir.is_dir():
         return example_dir
     available = ", ".join(path.name for path in _discover_examples())
     hint = f" (available: {available})" if available else ""

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -839,8 +839,19 @@ def _discover_examples() -> list[Path]:
     return sorted(
         path
         for path in root.iterdir()
-        if path.is_dir() and ((path / "traces.otel.jsonl").exists() or (path / "run.sh").exists())
+        if path.is_dir()
+        and _is_safe_example_name(path.name)
+        and ((path / "traces.otel.jsonl").exists() or (path / "run.sh").exists())
     )
+
+
+def _is_safe_example_name(name: str) -> bool:
+    """Whether `name` would resolve via `wmh examples run` — keeps list/hint/run in agreement."""
+    try:
+        validate_name(name)
+    except ValueError:
+        return False
+    return True
 
 
 def _resolve_example(name: str) -> Path:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import subprocess
 from pathlib import Path
@@ -12,6 +13,10 @@ from typer.testing import CliRunner
 
 from wmh.cli import app
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, verify_via_ping
+
+# `wmh.cli`'s `app` attribute (the Typer object) shadows the `wmh.cli.app` submodule on
+# plain `import wmh.cli.app as ...`; go through importlib to monkeypatch module globals.
+cli_app_module = importlib.import_module("wmh.cli.app")
 
 runner = CliRunner()
 
@@ -152,6 +157,25 @@ def test_serve_rejects_invalid_name_with_friendly_error(tmp_path) -> None:  # no
     result = runner.invoke(app, ["serve", "--name", "tau bench", "--root", str(tmp_path / ".wmh")])
     assert result.exit_code == 2  # usage error, not a ValueError traceback
     assert "invalid world model name" in result.output
+
+
+def test_examples_discovery_skips_unresolvable_names(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # A dir whose name validate_name rejects can never be run, so list (and the "available:"
+    # hint in the unknown-example error) must not advertise it.
+    for dirname in ("good-example", "tau bench"):
+        example = tmp_path / dirname
+        example.mkdir()
+        (example / "run.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(cli_app_module, "_examples_root", lambda: tmp_path)
+
+    listed = runner.invoke(app, ["examples", "list"])
+    assert listed.exit_code == 0, listed.output
+    assert "good-example" in listed.output
+    assert "tau bench" not in listed.output
+
+    unknown = runner.invoke(app, ["examples", "run", "nope"])
+    assert unknown.exit_code == 2
+    assert "available: good-example" in unknown.output
 
 
 def test_providers_subcommand_is_registered() -> None:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -148,6 +148,12 @@ def test_examples_run_rejects_invalid_name_with_friendly_error() -> None:
     assert "unknown example" in result.output
 
 
+def test_serve_rejects_invalid_name_with_friendly_error(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["serve", "--name", "tau bench", "--root", str(tmp_path / ".wmh")])
+    assert result.exit_code == 2  # usage error, not a ValueError traceback
+    assert "invalid world model name" in result.output
+
+
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -133,6 +133,21 @@ def test_bare_invocation_shows_help(args: list[str]) -> None:
     assert result.exit_code == 2
 
 
+def test_build_rejects_invalid_name_flag_with_friendly_error(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        ["build", "--name", "tau bench", "--file", _traces_file(tmp_path), "--no-interactive"],
+    )
+    assert result.exit_code == 2  # usage error, not a ValueError traceback
+    assert "invalid world model name" in result.output
+
+
+def test_examples_run_rejects_invalid_name_with_friendly_error() -> None:
+    result = runner.invoke(app, ["examples", "run", "tau bench"])
+    assert result.exit_code == 2  # usage error, not a ValueError traceback
+    assert "unknown example" in result.output
+
+
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -106,8 +106,15 @@ def run_build_wizard(
         )
     )
 
-    name = _prompt_text(console, ask, "Name this world model", defaults.name)
-    validate_name(name)
+    # An unsafe name (spaces, path separators, ...) re-prompts with the validation message
+    # rather than escaping as a ValueError traceback.
+    while True:
+        name = _prompt_text(console, ask, "Name this world model", defaults.name)
+        try:
+            validate_name(name)
+            break
+        except ValueError as err:
+            console.print(f"[red]{escape(str(err))}[/red]")
 
     file = defaults.file
     vendor = defaults.vendor

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 
+import typer
 from pydantic import BaseModel
 from rich.console import Console
 from rich.markup import escape
@@ -97,7 +98,16 @@ def run_build_wizard(
     becomes the suggested default the user can accept with Enter. Raises `ValueError` if no trace
     source (file or vendor) is provided.
     """
-    ask = reader if reader is not None else (lambda text: console.input(text))
+    base_ask = reader if reader is not None else (lambda text: console.input(text))
+
+    def ask(text: str) -> str:
+        # Exhausted piped stdin (or Ctrl-D) aborts the wizard cleanly ("Aborted.", exit 1)
+        # instead of leaking an EOFError traceback from whichever prompt was being read.
+        try:
+            return base_ask(text)
+        except EOFError:
+            raise typer.Abort() from None
+
     console.print(
         Panel(
             "Let's create a world model. Press Enter to accept the [dim]default[/dim] in brackets.",
@@ -107,9 +117,14 @@ def run_build_wizard(
     )
 
     # An unsafe name (spaces, path separators, ...) re-prompts with the validation message
-    # rather than escaping as a ValueError traceback.
+    # rather than escaping as a ValueError traceback. An invalid name arriving via --name is
+    # dropped from the suggested default — otherwise Enter would re-offer it forever.
+    try:
+        name_default = validate_name(defaults.name)
+    except ValueError:
+        name_default = None
     while True:
-        name = _prompt_text(console, ask, "Name this world model", defaults.name)
+        name = _prompt_text(console, ask, "Name this world model", name_default)
         try:
             validate_name(name)
             break

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -202,6 +202,16 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     assert params.embed_provider == "hashing"  # default embedder, no embed-model prompt
 
 
+def test_build_wizard_reprompts_on_invalid_name() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    # An unsafe name ("tau bench" has a space) must re-prompt with the friendly validation
+    # message, not escape as a ValueError traceback; the retry answers the same prompt.
+    reader = _scripted_reader(["tau bench", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.name == "tau-bench"
+    assert "invalid world model name" in console.export_text()
+
+
 def test_build_wizard_reprompts_on_blank_trace_source() -> None:
     # A blank traces path must re-ask, not crash. After a name, blank the file once, then give a
     # real path; remaining prompts (provider/model/region/budget/embedder) take defaults.

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+import typer
 from rich.console import Console
 
 from wmh.cli.ui import (
@@ -210,6 +212,28 @@ def test_build_wizard_reprompts_on_invalid_name() -> None:
     params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
     assert params.name == "tau-bench"
     assert "invalid world model name" in console.export_text()
+
+
+def test_build_wizard_drops_invalid_flag_name_from_default() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    # An invalid --name flag must not become the bracketed Enter-default (it could never be
+    # accepted); blank input then means "no name yet" and re-prompts until a valid one arrives.
+    reader = _scripted_reader(["", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="tau bench"), reader=reader)
+    assert params.name == "tau-bench"
+    assert "[tau bench]" not in console.export_text()
+
+
+def test_build_wizard_aborts_cleanly_on_eof() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+
+    def eof_reader(_prompt: str) -> str:
+        raise EOFError
+
+    # Exhausted piped stdin (or Ctrl-D) must abort the wizard cleanly, not leak an EOFError
+    # traceback. typer.Abort is handled by click's runner ("Aborted.", exit 1).
+    with pytest.raises(typer.Abort):
+        run_build_wizard(console, BuildParams(name="default"), reader=eof_reader)
 
 
 def test_build_wizard_reprompts_on_blank_trace_source() -> None:


### PR DESCRIPTION
Typing an unsafe world-model name (e.g. `tau bench`) in the build wizard crashed with a raw `ValueError` traceback out of `validate_name`. The same escape existed on the flag paths.

- **build wizard**: re-prompts with the validation message (matching the existing traces-path re-prompt pattern)
- **`wmh build --name 'tau bench' --file ...`**: clean usage error (`BadParameter`) instead of a traceback
- **`wmh examples run 'tau bench'`**: folds into the existing "unknown example (available: ...)" usage error

Tests (watched failing first): wizard re-prompt, both flag paths. All three paths also driven live end-to-end. Full gate green: ruff check/format, ty, pytest.