### PR TITLE
cli: dash-join whitespace in model names instead of rejecting

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -40,6 +40,7 @@ from wmh.config import (
     WorldModelStore,
     load_config,
     load_settings,
+    normalize_name,
     set_telemetry_enabled,
     settings_path,
     validate_name,
@@ -258,6 +259,8 @@ def build(
     elif name is None and file is None and vendor is None:
         raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
 
+    # Flag-supplied names get the same whitespace-to-dash normalization as the wizard.
+    params.name = normalize_name(params.name)
     try:
         validate_name(params.name)
     except ValueError as err:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -141,7 +141,7 @@ def test_bare_invocation_shows_help(args: list[str]) -> None:
 def test_build_rejects_invalid_name_flag_with_friendly_error(tmp_path) -> None:  # noqa: ANN001
     result = runner.invoke(
         app,
-        ["build", "--name", "tau bench", "--file", _traces_file(tmp_path), "--no-interactive"],
+        ["build", "--name", "tau/bench", "--file", _traces_file(tmp_path), "--no-interactive"],
     )
     assert result.exit_code == 2  # usage error, not a ValueError traceback
     assert "invalid world model name" in result.output

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -35,7 +35,7 @@ from rich.progress import (
 )
 from rich.table import Table
 
-from wmh.config import PROVIDER_ENV_VARS, ModelInfo, validate_name
+from wmh.config import PROVIDER_ENV_VARS, ModelInfo, normalize_name, validate_name
 from wmh.core.types import Action, ActionKind, Session
 from wmh.engine.play import PlayTurn, parse_action, play_turn
 from wmh.engine.world_model import WorldModel
@@ -116,20 +116,25 @@ def run_build_wizard(
         )
     )
 
-    # An unsafe name (spaces, path separators, ...) re-prompts with the validation message
-    # rather than escaping as a ValueError traceback. An invalid name arriving via --name is
+    # Whitespace is dash-joined ('tau bench' -> 'tau-bench') rather than rejected; a name
+    # that is still unsafe (path separators, ...) re-prompts with the validation message
+    # instead of escaping as a ValueError traceback. An invalid name arriving via --name is
     # dropped from the suggested default — otherwise Enter would re-offer it forever.
     try:
-        name_default = validate_name(defaults.name)
+        name_default = validate_name(normalize_name(defaults.name))
     except ValueError:
         name_default = None
     while True:
-        name = _prompt_text(console, ask, "Name this world model", name_default)
+        raw_name = _prompt_text(console, ask, "Name this world model", name_default)
+        name = normalize_name(raw_name)
         try:
             validate_name(name)
-            break
         except ValueError as err:
             console.print(f"[red]{escape(str(err))}[/red]")
+            continue
+        if name != raw_name:
+            console.print(f"  [dim]using[/dim] {escape(name)}")
+        break
 
     file = defaults.file
     vendor = defaults.vendor

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -204,24 +204,44 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     assert params.embed_provider == "hashing"  # default embedder, no embed-model prompt
 
 
+def test_build_wizard_dashes_spaces_in_name() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    # Whitespace is dash-joined rather than rejected: typing "tau bench" quietly becomes
+    # "tau-bench", with a dim note showing the name actually used.
+    reader = _scripted_reader(["tau bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.name == "tau-bench"
+    assert "using tau-bench" in console.export_text()
+
+
 def test_build_wizard_reprompts_on_invalid_name() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    # An unsafe name ("tau bench" has a space) must re-prompt with the friendly validation
-    # message, not escape as a ValueError traceback; the retry answers the same prompt.
-    reader = _scripted_reader(["tau bench", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    # A name normalization can't rescue ("tau/bench" has a path separator) must re-prompt with
+    # the friendly validation message, not escape as a ValueError traceback.
+    reader = _scripted_reader(["tau/bench", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
     assert params.name == "tau-bench"
     assert "invalid world model name" in console.export_text()
 
 
-def test_build_wizard_drops_invalid_flag_name_from_default() -> None:
+def test_build_wizard_normalizes_flag_name_in_default() -> None:
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    # An invalid --name flag must not become the bracketed Enter-default (it could never be
-    # accepted); blank input then means "no name yet" and re-prompts until a valid one arrives.
-    reader = _scripted_reader(["", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    # A whitespace-y --name flag becomes the normalized bracketed default, acceptable via Enter
+    # on the first prompt (no validation error, no re-prompt).
+    reader = _scripted_reader(["", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(console, BuildParams(name="tau bench"), reader=reader)
     assert params.name == "tau-bench"
-    assert "[tau bench]" not in console.export_text()
+    assert "invalid world model name" not in console.export_text()
+
+
+def test_build_wizard_drops_invalid_flag_name_from_default() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    # An unrescuable --name flag must not become the bracketed Enter-default (it could never be
+    # accepted); blank input then means "no name yet" and re-prompts until a valid one arrives.
+    reader = _scripted_reader(["", "tau-bench", "/tmp/t.jsonl", "", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="tau/bench"), reader=reader)
+    assert params.name == "tau-bench"
+    assert "[tau/bench]" not in console.export_text()
 
 
 def test_build_wizard_aborts_cleanly_on_eof() -> None:

--- a/wmh/config/__init__.py
+++ b/wmh/config/__init__.py
@@ -21,6 +21,7 @@ from wmh.config.store import (
     DEFAULT_MODEL_NAME,
     ModelInfo,
     WorldModelStore,
+    normalize_name,
     validate_name,
 )
 
@@ -37,6 +38,7 @@ __all__ = [
     "ensure_telemetry_anonymous_id",
     "load_config",
     "load_settings",
+    "normalize_name",
     "save_config",
     "save_settings",
     "set_telemetry_enabled",

--- a/wmh/config/store.py
+++ b/wmh/config/store.py
@@ -43,6 +43,11 @@ def validate_name(name: str) -> str:
     return name
 
 
+def normalize_name(name: str) -> str:
+    """Dash-join whitespace: 'tau bench' -> 'tau-bench'. Validity stays validate_name's call."""
+    return re.sub(r"\s+", "-", name.strip())
+
+
 class ModelInfo(BaseModel):
     """A one-line summary of a built world model, for `wmh list`."""
 

--- a/wmh/config/store_test.py
+++ b/wmh/config/store_test.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from wmh.config import ArtifactPaths, HarnessConfig, save_config
-from wmh.config.store import DEFAULT_MODEL_NAME, WorldModelStore, validate_name
+from wmh.config.store import DEFAULT_MODEL_NAME, WorldModelStore, normalize_name, validate_name
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 
@@ -33,6 +33,14 @@ def test_validate_name_accepts_safe_names_and_rejects_traversal() -> None:
     for bad in ["../escape", "a/b", ".", "", ".hidden", "with space"]:
         with pytest.raises(ValueError, match="invalid world model name"):
             validate_name(bad)
+
+
+def test_normalize_name_dash_joins_whitespace() -> None:
+    assert normalize_name("tau bench") == "tau-bench"
+    assert normalize_name("  tau   bench  ") == "tau-bench"
+    assert normalize_name("tau-bench") == "tau-bench"  # already safe: unchanged
+    with pytest.raises(ValueError, match="invalid world model name"):
+        validate_name(normalize_name("tau/bench"))  # normalization never rescues separators
 
 
 def test_list_names_and_info(tmp_path) -> None:  # noqa: ANN001 - pytest fixture


### PR DESCRIPTION
'tau bench' now quietly becomes 'tau-bench' — in the wizard (with a dim `using tau-bench` note), in the wizard's suggested default from an unvalidated `--name`, and on the `wmh build --name` flag path. Names normalization can't rescue (path separators) still re-prompt / usage-error as before. Full suite green (353 passed); driven live. Per user request, merged directly without the /ready-for-merge gate.