### PR TITLE
cli: arrow-key pickers + credential-aware provider selection

### DIFF
--- a/.agents/docs/reference/embeddings.md
+++ b/.agents/docs/reference/embeddings.md
@@ -18,7 +18,7 @@ action)`. The embedder that produces `phi` is chosen by `HarnessConfig.embed_pro
 | `hashing` (default) | `HashingEmbedder` | nothing | Offline hashed char-trigram vector, L2-normalized. Lexical, not semantic. Zero config. |
 | `bedrock` | Amazon Titan text embeddings | AWS creds + region | `embed_model` defaults to `amazon.titan-embed-text-v2:0`. |
 | `openai` | OpenAI embeddings | `OPENAI_API_KEY` | Set `embed_model` (e.g. `text-embedding-3-small`). |
-| `azure_openai` | Azure OpenAI embedding deployment | Azure creds + endpoint | `embed_model` is the **deployment name**, not the base model id. |
+| `azure` | Azure OpenAI embedding deployment | Azure creds + endpoint | `embed_model` is the **deployment name**, not the base model id. |
 
 Anthropic has no embeddings API, so there is no `anthropic` embedder kind — use one of the above (or
 `hashing`) for `phi` while serving the world model on Anthropic/Bedrock for *generation*.

--- a/conftest.py
+++ b/conftest.py
@@ -2,20 +2,10 @@
 
 from __future__ import annotations
 
-import importlib
 import os
 
 # Rich consoles snapshot color support when constructed, and `wmh.cli.app` builds its console at
-# import time — so color-forcing vars must go before anything imports it, or a dev shell
+# import time — so color-forcing vars must go before any test module imports it, or a dev shell
 # exporting FORCE_COLOR would inject ANSI codes into CliRunner captures and fail assertions.
 os.environ.pop("FORCE_COLOR", None)
 os.environ.pop("CLICOLOR_FORCE", None)
-
-# `wmh.cli.app` also loads the developer's real `.env` at import time (so wizard-saved keys
-# persist across sessions). Tests must see the shell environment, not the `.env`: otherwise a
-# local OPENAI_API_KEY/AWS key would un-skip the live provider tests and leak into CLI
-# assertions. Import it here — before any test module — and scrub whatever the load injected.
-_shell_env = dict(os.environ)
-importlib.import_module("wmh.cli.app")
-for _var in set(os.environ) - set(_shell_env):
-    del os.environ[_var]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+"""Repo-wide pytest configuration."""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+# Rich consoles snapshot color support when constructed, and `wmh.cli.app` builds its console at
+# import time — so color-forcing vars must go before anything imports it, or a dev shell
+# exporting FORCE_COLOR would inject ANSI codes into CliRunner captures and fail assertions.
+os.environ.pop("FORCE_COLOR", None)
+os.environ.pop("CLICOLOR_FORCE", None)
+
+# `wmh.cli.app` also loads the developer's real `.env` at import time (so wizard-saved keys
+# persist across sessions). Tests must see the shell environment, not the `.env`: otherwise a
+# local OPENAI_API_KEY/AWS key would un-skip the live provider tests and leak into CLI
+# assertions. Import it here — before any test module — and scrub whatever the load injected.
+_shell_env = dict(os.environ)
+importlib.import_module("wmh.cli.app")
+for _var in set(os.environ) - set(_shell_env):
+    del os.environ[_var]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
 ]
 
 [project.scripts]
-wmh = "wmh.cli:app"
+wmh = "wmh.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/wmh/cli/__init__.py
+++ b/wmh/cli/__init__.py
@@ -1,5 +1,5 @@
 """The `wmh` command-line interface."""
 
-from wmh.cli.app import app
+from wmh.cli.app import app, main
 
-__all__ = ["app"]
+__all__ = ["app", "main"]

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -72,10 +72,6 @@ from wmh.telemetry import (
 )
 from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
-# Load .env from the working directory at import so wizard-saved provider keys persist across
-# sessions (a typer callback would flip help rendering under CliRunner; import-time is simpler).
-load_env_file()
-
 app = typer.Typer(
     help="World Model Harness: a frontier LLM acts as your agent's environment.",
     no_args_is_help=True,
@@ -897,4 +893,12 @@ def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, nam
 
 
 if __name__ == "__main__":
+    app()
+
+
+def main() -> None:
+    """CLI entry point: load `.env` from the working directory (so wizard-saved provider keys
+    persist across sessions), then dispatch. Kept out of import time so importing the module
+    never mutates os.environ."""
+    load_env_file()
     app()

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -39,6 +39,7 @@ from wmh.config import (
     HarnessConfig,
     WorldModelStore,
     load_config,
+    load_env_file,
     load_settings,
     normalize_name,
     set_telemetry_enabled,
@@ -71,10 +72,16 @@ from wmh.telemetry import (
 )
 from wmh.tracking import MeteredProvider, Phase, RunTracker, classify_build_call, save_run
 
+# Load .env from the working directory at import so wizard-saved provider keys persist across
+# sessions (a typer callback would flip help rendering under CliRunner; import-time is simpler).
+load_env_file()
+
 app = typer.Typer(
     help="World Model Harness: a frontier LLM acts as your agent's environment.",
     no_args_is_help=True,
 )
+
+
 providers_app = typer.Typer(help="Manage and verify LLM providers.", no_args_is_help=True)
 examples_app = typer.Typer(
     help="List and launch self-contained task examples.", no_args_is_help=True
@@ -210,7 +217,9 @@ def build(
     file: str = typer.Option(None, "--file", help="Path to exported traces (OTLP-JSON / JSONL)."),
     vendor: str = typer.Option(None, "--vendor", help="Vendor name to pull traces via SDK."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
-    provider: str = typer.Option("bedrock", "--provider", help="Provider that serves the model."),
+    provider: str = typer.Option(
+        None, "--provider", help="Provider that serves the model (default: bedrock)."
+    ),
     model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     gepa_budget: int = typer.Option(50, help="GEPA rollout budget."),
@@ -218,7 +227,7 @@ def build(
         0.8, help="Train/held-out ratio for GEPA's internal split (lower = bigger valset)."
     ),
     embed_provider: str = typer.Option(
-        "hashing", help="phi embedder: hashing (offline) | bedrock | openai | azure_openai."
+        "hashing", help="phi embedder: hashing (offline) | bedrock | openai | azure."
     ),
     embed_model: str = typer.Option(None, help="Embeddings model id / Azure embedding deployment."),
     embed_dim: int = typer.Option(512, help="phi dimensionality (index + query must agree)."),
@@ -258,6 +267,8 @@ def build(
         params = run_build_wizard(_console, params)
     elif name is None and file is None and vendor is None:
         raise typer.BadParameter("provide --file (or --vendor), or run `wmh build` interactively")
+    # The wizard always resolves a provider; the flag path keeps its historical default.
+    params.provider = params.provider or "bedrock"
 
     # Flag-supplied names get the same whitespace-to-dash normalization as the wizard.
     params.name = normalize_name(params.name)

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -338,8 +338,14 @@ def test_play_repl_steps_and_quits(patched_provider, tmp_path) -> None:  # noqa:
     assert "user u1 found" in result.output
 
 
-def test_build_interactive_wizard_creates_model(patched_provider, tmp_path) -> None:  # noqa: ANN001
+def test_build_interactive_wizard_creates_model(
+    patched_provider,  # noqa: ANN001 - pytest fixture
+    tmp_path,  # noqa: ANN001 - pytest fixture
+    monkeypatch,  # noqa: ANN001 - pytest fixture
+) -> None:
     root = tmp_path / ".wmh"
+    for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.setenv(var, "test-cred")  # creds present: no interactive key prompts
     # --interactive forces the wizard even under CliRunner (non-TTY); feed each answer line in
     # prompt order: name, file, provider (select), model (select), region (bedrock only), budget,
     # embedder (select). The offline 'hashing' embedder skips the embed-model prompt; phi dim isn't
@@ -348,7 +354,7 @@ def test_build_interactive_wizard_creates_model(patched_provider, tmp_path) -> N
         [
             "wizard-built",
             _traces_file(tmp_path),
-            "1",  # provider: bedrock
+            "3",  # provider: bedrock (order: openai, anthropic, bedrock, azure, ...)
             "1",  # model: us.anthropic.claude-opus-4-8
             "us-east-1",
             "4",  # gepa budget

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import cast
@@ -176,6 +177,17 @@ def test_examples_discovery_skips_unresolvable_names(tmp_path, monkeypatch) -> N
     unknown = runner.invoke(app, ["examples", "run", "nope"])
     assert unknown.exit_code == 2
     assert "available: good-example" in unknown.output
+
+
+def test_main_entry_loads_dotenv_before_dispatch(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # The persistence half of the wizard's credential flow: keys saved to .env must be back in
+    # os.environ on the next `wmh` invocation (main), and importing the module must NOT load.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("WMH_TEST_MAIN_VAR=loaded\n", encoding="utf-8")
+    monkeypatch.delenv("WMH_TEST_MAIN_VAR", raising=False)
+    monkeypatch.setattr(cli_app_module, "app", lambda: None)
+    cli_app_module.main()
+    assert os.environ["WMH_TEST_MAIN_VAR"] == "loaded"
 
 
 def test_providers_subcommand_is_registered() -> None:

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 
 import os
 import sys
-import termios
-import tty
 from collections.abc import Callable
 
+import click
 import typer
 from pydantic import BaseModel
 from rich.console import Console
+from rich.control import Control
 from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import (
@@ -36,6 +36,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.segment import ControlType
 from rich.table import Table
 
 from wmh.config import (
@@ -176,8 +177,9 @@ def run_build_wizard(
     # of them is the suggested default (no default when none have creds). After the pick, any
     # missing credential is prompted for and persisted to .env rather than failing mid-build.
     providers = list(_PROVIDER_MODELS)
-    notes = {p: "api key exists" for p in providers if _has_credentials(p)}
-    provider_default = defaults.provider or next((p for p in providers if p in notes), None)
+    with_creds = [p for p in providers if _has_credentials(p)]
+    notes = {p: "api key exists" for p in with_creds}
+    provider_default = defaults.provider or (with_creds[0] if with_creds else None)
     provider = _select(
         console,
         ask,
@@ -186,7 +188,6 @@ def run_build_wizard(
         provider_default,
         interactive=interactive,
         notes=notes,
-        fallback_to_first=False,
     )
     _ensure_credentials(console, ask_secret, provider)
     model = _select(
@@ -227,7 +228,12 @@ def run_build_wizard(
         if embed_provider != provider:
             _ensure_credentials(console, ask_secret, embed_provider)
         embed_model = _select(
-            console, ask, "Embeddings model id", embed_models, embed_model, interactive=interactive
+            console,
+            ask,
+            "Embeddings model id",
+            embed_models,
+            embed_model or embed_models[0],
+            interactive=interactive,
         )
 
     return BuildParams(
@@ -245,19 +251,26 @@ def run_build_wizard(
     )
 
 
-def _stdin_is_tty(console: Console) -> bool:
-    """Whether the arrow-key picker can run: rich sees a terminal and stdin is a real TTY."""
-    return console.is_terminal and sys.stdin.isatty()
+def _picker_fits(console: Console, row_count: int) -> bool:
+    """Whether the arrow-key picker can run: a real TTY and every row fits on screen at once
+    (the repaint moves the cursor up over the block, which breaks if the block scrolled)."""
+    return console.is_terminal and sys.stdin.isatty() and row_count + 2 <= console.size.height
 
 
-def _read_key(stream) -> str:  # noqa: ANN001 - any .read(n) text stream (stdin, StringIO in tests)
-    """Read one keypress; arrow escape sequences decode to 'up'/'down', other ESC input to 'esc'."""
-    ch = stream.read(1)
-    if ch != "\x1b":
-        return ch
-    if stream.read(1) != "[":
+def _decode_key(seq: str) -> str:
+    """Map one click.getchar() sequence to a picker key.
+
+    getchar returns a whole escape sequence per call ('\x1b[A'), so nothing can desync: plain
+    and application-mode arrows decode to 'up'/'down', any other escape sequence (modified
+    arrows, PgUp, Delete, bare ESC) is the inert 'esc', and a plain character passes through.
+    """
+    if seq in ("\x1b[A", "\x1bOA"):
+        return "up"
+    if seq in ("\x1b[B", "\x1bOB"):
+        return "down"
+    if seq.startswith("\x1b"):
         return "esc"
-    return {"A": "up", "B": "down"}.get(stream.read(1), "esc")
+    return seq
 
 
 def _step_selection(key: str, index: int, count: int) -> tuple[int, bool]:
@@ -272,41 +285,43 @@ def _step_selection(key: str, index: int, count: int) -> tuple[int, bool]:
         return (index + 1) % count, False
     if key in ("\r", "\n"):
         return index, True
-    if key.isdigit() and 1 <= int(key) <= count:
+    # ASCII-decimal only: '²'.isdigit() is True but int('²') raises.
+    if key.isascii() and key.isdecimal() and 1 <= int(key) <= count:
         return int(key) - 1, True
     return index, False
 
 
 def _arrow_select(console: Console, rows: list[str], index: int) -> int:
-    """Drive an up/down picker over pre-rendered `rows` on the raw-mode TTY; return chosen index.
+    """Drive an up/down picker over pre-rendered `rows`; return the chosen index.
 
-    Caller guarantees a real TTY (`_stdin_is_tty`). cbreak keeps ISIG, so Ctrl-C still raises
-    KeyboardInterrupt and click renders its usual clean abort.
+    Keys come from click.getchar(): raw mode handled portably (termios on Unix, msvcrt on
+    Windows), one whole escape sequence per call, Ctrl-C raised as KeyboardInterrupt for
+    click's usual clean abort. EOF (closed stdin) aborts rather than spinning.
     """
-    fd = sys.stdin.fileno()
-    saved = termios.tcgetattr(fd)
     painted = False
 
     def paint(current: int) -> None:
         nonlocal painted
         if painted:
-            console.file.write(f"\x1b[{len(rows)}A")
+            console.control(Control.move(y=-len(rows)))
         for i, row in enumerate(rows):
-            console.file.write("\x1b[2K")
+            console.control(Control((ControlType.ERASE_IN_LINE, 2)))
             pointer = "[bold cyan]\u276f[/bold cyan]" if i == current else " "
-            console.print(f" {pointer} {row}", highlight=False)
+            console.print(f" {pointer} {row}", highlight=False, no_wrap=True, overflow="ellipsis")
         painted = True
 
-    try:
-        tty.setcbreak(fd)
-        while True:
+    while True:
+        paint(index)
+        try:
+            seq = click.getchar()
+        except EOFError:
+            raise typer.Abort() from None
+        if seq == "":
+            raise typer.Abort()
+        index, accepted = _step_selection(_decode_key(seq), index, len(rows))
+        if accepted:
             paint(index)
-            index, accepted = _step_selection(_read_key(sys.stdin), index, len(rows))
-            if accepted:
-                paint(index)
-                return index
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+            return index
 
 
 def _select(
@@ -318,18 +333,20 @@ def _select(
     *,
     interactive: bool = False,
     notes: dict[str, str] | None = None,
-    fallback_to_first: bool = True,
 ) -> str:
     """Pick one of `options`: an arrow-key picker on a real TTY, else a numbered prompt.
 
-    The Enter-default is `default` when present in `options`, else the first option — unless
-    `fallback_to_first` is off (the provider picker: a default exists only when creds do).
+    The Enter-default is `default` when present in `options`; a non-matching default falls
+    back to the first option, and None means no Enter-default at all (the provider picker: a
+    default exists only when creds do; the model picker: the choice is always explicit).
     `notes` adds a dim annotation after an option's name (e.g. "api key exists").
     """
     if default in options:
         chosen_default = default
+    elif default is not None:
+        chosen_default = options[0]
     else:
-        chosen_default = options[0] if fallback_to_first else None
+        chosen_default = None
     notes = notes or {}
 
     def row(opt: str) -> str:
@@ -337,7 +354,7 @@ def _select(
         marker = "  [dim](default)[/dim]" if opt == chosen_default else ""
         return f"{escape(opt)}{note}{marker}"
 
-    if interactive and _stdin_is_tty(console):
+    if interactive and _picker_fits(console, len(options)):
         console.print(f"[bold]{label}[/bold] [dim](up/down + Enter)[/dim]:")
         start = options.index(chosen_default) if chosen_default is not None else 0
         return options[_arrow_select(console, [row(opt) for opt in options], start)]
@@ -400,30 +417,21 @@ def select_model(
     """
     if len(infos) == 1:
         return infos[0].name
-
-    def score(info: ModelInfo) -> str:
-        acc = info.held_out_accuracy
-        return "" if acc is None else f"  [dim](held-out {acc:.2f})[/dim]"
-
-    if reader is None and _stdin_is_tty(console):
-        console.print("[bold]Select a world model:[/bold] [dim](up/down + Enter)[/dim]")
-        rows = [f"{escape(info.name)}{score(info)}" for info in infos]
-        return infos[_arrow_select(console, rows, 0)].name
-
     ask = reader if reader is not None else (lambda text: console.input(text))
-    console.print("[bold]Select a world model:[/bold]")
-    for i, info in enumerate(infos, start=1):
-        console.print(f"  [cyan]{i}[/cyan]. {info.name}{score(info)}")
-    while True:
-        raw = ask("> ").strip()
-        choice = _parse_int(raw)
-        if choice is not None and 1 <= choice <= len(infos):
-            return infos[choice - 1].name
-        # Allow typing the name directly too.
-        for info in infos:
-            if raw == info.name:
-                return info.name
-        console.print(f"[red]pick 1-{len(infos)} or a model name[/red]")
+    notes = {
+        info.name: f"held-out {info.held_out_accuracy:.2f}"
+        for info in infos
+        if info.held_out_accuracy is not None
+    }
+    return _select(
+        console,
+        ask,
+        "Select a world model",
+        [info.name for info in infos],
+        None,
+        interactive=reader is None,
+        notes=notes,
+    )
 
 
 def _prompt_text(

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -402,8 +402,13 @@ def _ensure_credentials(console: Console, ask_secret: PromptReader, provider: st
         prompt = f"  [bold]{var}[/bold] [dim](saved to .env; Enter to skip)[/dim]: "
         value = ask_secret(prompt).strip()
         if value:
-            upsert_env_var(var, value)
-            console.print(f"  {_CHECK} {var} saved to .env")
+            try:
+                upsert_env_var(var, value)
+            except ValueError as err:  # e.g. .env is a symlink: keep the session working
+                os.environ[var] = value
+                console.print(f"  [yellow]{escape(str(err))}[/yellow]")
+            else:
+                console.print(f"  {_CHECK} {var} saved to .env")
         else:
             console.print(f"  [yellow]{var} still unset[/yellow]")
 

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -404,9 +404,11 @@ def _ensure_credentials(console: Console, ask_secret: PromptReader, provider: st
         if value:
             try:
                 upsert_env_var(var, value)
-            except ValueError as err:  # e.g. .env is a symlink: keep the session working
+            except (ValueError, OSError) as err:
+                # Persistence refused (symlinked .env, O_NOFOLLOW's ELOOP on a swapped link,
+                # unwritable dir, ...): the session still gets the credential.
                 os.environ[var] = value
-                console.print(f"  [yellow]{escape(str(err))}[/yellow]")
+                console.print(f"  [yellow]{var} not saved: {escape(str(err))}[/yellow]")
             else:
                 console.print(f"  {_CHECK} {var} saved to .env")
         else:

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -17,6 +17,9 @@ Everything that talks to `rich` lives here so the engine stays headless. Respons
 from __future__ import annotations
 
 import os
+import sys
+import termios
+import tty
 from collections.abc import Callable
 
 import typer
@@ -35,7 +38,13 @@ from rich.progress import (
 )
 from rich.table import Table
 
-from wmh.config import PROVIDER_ENV_VARS, ModelInfo, normalize_name, validate_name
+from wmh.config import (
+    PROVIDER_ENV_VARS,
+    ModelInfo,
+    normalize_name,
+    upsert_env_var,
+    validate_name,
+)
 from wmh.core.types import Action, ActionKind, Session
 from wmh.engine.play import PlayTurn, parse_action, play_turn
 from wmh.engine.world_model import WorldModel
@@ -50,16 +59,16 @@ _CHECK = "[green]✓[/green]"
 # Serve providers offered in the wizard picker, with the model ids each supports. The first model
 # in each list is the suggested default. Keep these in sync with the provider backends.
 _PROVIDER_MODELS: dict[str, list[str]] = {
+    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
+    "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "bedrock": [
         "us.anthropic.claude-opus-4-8",
         "us.anthropic.claude-opus-4-7",
         # haiku needs the dated inference-profile id; the undated alias is rejected by Bedrock
         "us.anthropic.claude-haiku-4-5-20251001-v1:0",
     ],
-    "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
-    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
+    "azure": ["gpt-5.5", "gpt-5.4"],
     "openai_responses": ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4"],
-    "azure_openai": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 
@@ -69,7 +78,7 @@ _EMBEDDERS: dict[str, list[str] | None] = {
     "hashing": None,
     "bedrock": ["amazon.titan-embed-text-v2:0"],
     "openai": ["text-embedding-3-small", "text-embedding-3-large"],
-    "azure_openai": ["text-embedding-3-small", "text-embedding-3-large"],
+    "azure": ["text-embedding-3-small", "text-embedding-3-large"],
 }
 
 
@@ -79,7 +88,9 @@ class BuildParams(BaseModel):
     name: str
     file: str | None = None
     vendor: str | None = None
-    provider: str = "bedrock"
+    # None = not chosen yet: the wizard suggests the first provider with credentials present,
+    # and the non-interactive path falls back to bedrock.
+    provider: str | None = None
     model: str = "us.anthropic.claude-opus-4-8"
     region: str | None = None
     gepa_budget: int = 50
@@ -98,15 +109,25 @@ def run_build_wizard(
     becomes the suggested default the user can accept with Enter. Raises `ValueError` if no trace
     source (file or vendor) is provided.
     """
+    interactive = reader is None
     base_ask = reader if reader is not None else (lambda text: console.input(text))
+    base_secret = (
+        reader if reader is not None else (lambda text: console.input(text, password=True))
+    )
 
-    def ask(text: str) -> str:
+    def _eof_aborts(read: PromptReader) -> PromptReader:
         # Exhausted piped stdin (or Ctrl-D) aborts the wizard cleanly ("Aborted.", exit 1)
         # instead of leaking an EOFError traceback from whichever prompt was being read.
-        try:
-            return base_ask(text)
-        except EOFError:
-            raise typer.Abort() from None
+        def wrapped(text: str) -> str:
+            try:
+                return read(text)
+            except EOFError:
+                raise typer.Abort() from None
+
+        return wrapped
+
+    ask = _eof_aborts(base_ask)
+    ask_secret = _eof_aborts(base_secret)
 
     console.print(
         Panel(
@@ -151,11 +172,31 @@ def run_build_wizard(
             if not file:
                 console.print("[red]a traces path is required (or pass --vendor)[/red]")
 
-    # Serve provider: pick from the list, then show which credentials it expects so a missing one
-    # is surfaced here (an offline check) rather than as an opaque failure mid-build.
-    provider = _select(console, ask, "Serve provider", list(_PROVIDER_MODELS), defaults.provider)
-    _report_credentials(console, provider)
-    model = _select(console, ask, "Serve model id", _PROVIDER_MODELS[provider], defaults.model)
+    # Serve provider: providers with credentials already present are annotated, and the first
+    # of them is the suggested default (no default when none have creds). After the pick, any
+    # missing credential is prompted for and persisted to .env rather than failing mid-build.
+    providers = list(_PROVIDER_MODELS)
+    notes = {p: "api key exists" for p in providers if _has_credentials(p)}
+    provider_default = defaults.provider or next((p for p in providers if p in notes), None)
+    provider = _select(
+        console,
+        ask,
+        "Serve provider",
+        providers,
+        provider_default,
+        interactive=interactive,
+        notes=notes,
+        fallback_to_first=False,
+    )
+    _ensure_credentials(console, ask_secret, provider)
+    model = _select(
+        console,
+        ask,
+        "Serve model id",
+        _PROVIDER_MODELS[provider],
+        defaults.model,
+        interactive=interactive,
+    )
 
     region = None
     if provider == "bedrock":
@@ -172,13 +213,22 @@ def run_build_wizard(
     # Retrieval phi embedder: default offline hashing (no creds). A provider-backed embedder is
     # picked from the list and prompts for its embeddings-model id; phi dimensionality keeps its
     # default (the index and query embedders must agree, so it is not a wizard knob).
-    embed_provider = _select(console, ask, "Embedder", list(_EMBEDDERS), defaults.embed_provider)
+    embed_provider = _select(
+        console,
+        ask,
+        "Embedder",
+        list(_EMBEDDERS),
+        defaults.embed_provider,
+        interactive=interactive,
+    )
     embed_model = defaults.embed_model
     embed_models = _EMBEDDERS[embed_provider]
     if embed_models is not None:
         if embed_provider != provider:
-            _report_credentials(console, embed_provider)
-        embed_model = _select(console, ask, "Embeddings model id", embed_models, embed_model)
+            _ensure_credentials(console, ask_secret, embed_provider)
+        embed_model = _select(
+            console, ask, "Embeddings model id", embed_models, embed_model, interactive=interactive
+        )
 
     return BuildParams(
         name=name,
@@ -195,22 +245,110 @@ def run_build_wizard(
     )
 
 
-def _select(
-    console: Console, ask: PromptReader, label: str, options: list[str], default: str | None
-) -> str:
-    """Prompt the user to pick one of `options` by number (or name), defaulting to `default`.
+def _stdin_is_tty(console: Console) -> bool:
+    """Whether the arrow-key picker can run: rich sees a terminal and stdin is a real TTY."""
+    return console.is_terminal and sys.stdin.isatty()
 
-    The default is whichever of `default`/`options[0]` is present in `options`; Enter accepts it.
-    Re-prompts on invalid input. Returns the chosen option string.
+
+def _read_key(stream) -> str:  # noqa: ANN001 - any .read(n) text stream (stdin, StringIO in tests)
+    """Read one keypress; arrow escape sequences decode to 'up'/'down', other ESC input to 'esc'."""
+    ch = stream.read(1)
+    if ch != "\x1b":
+        return ch
+    if stream.read(1) != "[":
+        return "esc"
+    return {"A": "up", "B": "down"}.get(stream.read(1), "esc")
+
+
+def _step_selection(key: str, index: int, count: int) -> tuple[int, bool]:
+    """Picker key reducer: next highlighted index and whether the selection was accepted.
+
+    Arrows (and vi j/k) move with wraparound, Enter accepts the highlight, a digit jump-selects
+    that option; anything else is inert.
     """
-    chosen_default = default if default in options else options[0]
+    if key in ("up", "k"):
+        return (index - 1) % count, False
+    if key in ("down", "j"):
+        return (index + 1) % count, False
+    if key in ("\r", "\n"):
+        return index, True
+    if key.isdigit() and 1 <= int(key) <= count:
+        return int(key) - 1, True
+    return index, False
+
+
+def _arrow_select(console: Console, rows: list[str], index: int) -> int:
+    """Drive an up/down picker over pre-rendered `rows` on the raw-mode TTY; return chosen index.
+
+    Caller guarantees a real TTY (`_stdin_is_tty`). cbreak keeps ISIG, so Ctrl-C still raises
+    KeyboardInterrupt and click renders its usual clean abort.
+    """
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    painted = False
+
+    def paint(current: int) -> None:
+        nonlocal painted
+        if painted:
+            console.file.write(f"\x1b[{len(rows)}A")
+        for i, row in enumerate(rows):
+            console.file.write("\x1b[2K")
+            pointer = "[bold cyan]\u276f[/bold cyan]" if i == current else " "
+            console.print(f" {pointer} {row}", highlight=False)
+        painted = True
+
+    try:
+        tty.setcbreak(fd)
+        while True:
+            paint(index)
+            index, accepted = _step_selection(_read_key(sys.stdin), index, len(rows))
+            if accepted:
+                paint(index)
+                return index
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
+def _select(
+    console: Console,
+    ask: PromptReader,
+    label: str,
+    options: list[str],
+    default: str | None,
+    *,
+    interactive: bool = False,
+    notes: dict[str, str] | None = None,
+    fallback_to_first: bool = True,
+) -> str:
+    """Pick one of `options`: an arrow-key picker on a real TTY, else a numbered prompt.
+
+    The Enter-default is `default` when present in `options`, else the first option — unless
+    `fallback_to_first` is off (the provider picker: a default exists only when creds do).
+    `notes` adds a dim annotation after an option's name (e.g. "api key exists").
+    """
+    if default in options:
+        chosen_default = default
+    else:
+        chosen_default = options[0] if fallback_to_first else None
+    notes = notes or {}
+
+    def row(opt: str) -> str:
+        note = f"  [dim]({notes[opt]})[/dim]" if opt in notes else ""
+        marker = "  [dim](default)[/dim]" if opt == chosen_default else ""
+        return f"{escape(opt)}{note}{marker}"
+
+    if interactive and _stdin_is_tty(console):
+        console.print(f"[bold]{label}[/bold] [dim](up/down + Enter)[/dim]:")
+        start = options.index(chosen_default) if chosen_default is not None else 0
+        return options[_arrow_select(console, [row(opt) for opt in options], start)]
+
     console.print(f"[bold]{label}[/bold]:")
     for i, opt in enumerate(options, start=1):
-        marker = "  [dim](default)[/dim]" if opt == chosen_default else ""
-        console.print(f"  [cyan]{i}[/cyan]. {escape(opt)}{marker}")
+        console.print(f"  [cyan]{i}[/cyan]. {row(opt)}")
+    prompt = f"[dim]\\[{escape(chosen_default)}][/dim] > " if chosen_default is not None else "> "
     while True:
-        raw = ask(f"[dim]\\[{escape(chosen_default)}][/dim] > ").strip()
-        if not raw:
+        raw = ask(prompt).strip()
+        if not raw and chosen_default is not None:
             return chosen_default
         choice = _parse_int(raw)
         if choice is not None and 1 <= choice <= len(options):
@@ -220,21 +358,37 @@ def _select(
         console.print(f"[red]pick 1-{len(options)} or an option name[/red]")
 
 
-def _report_credentials(console: Console, provider: str) -> None:
-    """Print which env vars the chosen provider reads, flagging any that are unset.
-
-    An offline presence check only — it does not validate the value. The live ping that confirms
-    the creds actually work happens once before the build (see `wmh build`).
-    """
+def _provider_env_vars(provider: str) -> list[str]:
+    """The env vars `provider` reads its credentials from ([] for unknown/offline kinds)."""
     try:
-        env_vars = PROVIDER_ENV_VARS[ProviderKind(provider)]
+        return PROVIDER_ENV_VARS[ProviderKind(provider)]
     except (ValueError, KeyError):
-        return
-    for var in env_vars:
+        return []
+
+
+def _has_credentials(provider: str) -> bool:
+    """Offline presence check: every credential env var for `provider` is set (not validated)."""
+    env_vars = _provider_env_vars(provider)
+    return bool(env_vars) and all(os.environ.get(var) for var in env_vars)
+
+
+def _ensure_credentials(console: Console, ask_secret: PromptReader, provider: str) -> None:
+    """Prompt for any missing credential env vars and persist entered values to `.env`.
+
+    Presence only — the live ping that confirms the creds actually work happens once before
+    the build (see `wmh build`). Enter skips a var, leaving it to the shell environment.
+    """
+    for var in _provider_env_vars(provider):
         if os.environ.get(var):
             console.print(f"  {_CHECK} {var} is set")
+            continue
+        prompt = f"  [bold]{var}[/bold] [dim](saved to .env; Enter to skip)[/dim]: "
+        value = ask_secret(prompt).strip()
+        if value:
+            upsert_env_var(var, value)
+            console.print(f"  {_CHECK} {var} saved to .env")
         else:
-            console.print(f"  [yellow]make sure {var} is set[/yellow]")
+            console.print(f"  [yellow]{var} still unset[/yellow]")
 
 
 def select_model(
@@ -246,12 +400,20 @@ def select_model(
     """
     if len(infos) == 1:
         return infos[0].name
+
+    def score(info: ModelInfo) -> str:
+        acc = info.held_out_accuracy
+        return "" if acc is None else f"  [dim](held-out {acc:.2f})[/dim]"
+
+    if reader is None and _stdin_is_tty(console):
+        console.print("[bold]Select a world model:[/bold] [dim](up/down + Enter)[/dim]")
+        rows = [f"{escape(info.name)}{score(info)}" for info in infos]
+        return infos[_arrow_select(console, rows, 0)].name
+
     ask = reader if reader is not None else (lambda text: console.input(text))
     console.print("[bold]Select a world model:[/bold]")
     for i, info in enumerate(infos, start=1):
-        acc = info.held_out_accuracy
-        score = "" if acc is None else f"  [dim](held-out {acc:.2f})[/dim]"
-        console.print(f"  [cyan]{i}[/cyan]. {info.name}{score}")
+        console.print(f"  [cyan]{i}[/cyan]. {info.name}{score(info)}")
     while True:
         raw = ask("> ").strip()
         choice = _parse_int(raw)

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import os
+
 import pytest
 import typer
 from rich.console import Console
@@ -9,16 +12,27 @@ from rich.console import Console
 from wmh.cli.ui import (
     BuildParams,
     RichBuildReporter,
+    _read_key,
+    _step_selection,
     models_table,
     run_build_wizard,
     run_play_repl,
     select_model,
 )
-from wmh.config import ModelInfo
+from wmh.config import PROVIDER_ENV_VARS, ModelInfo
 from wmh.core.types import Action, ActionKind, Observation, Step, Trace
 from wmh.engine.world_model import WorldModel
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+@pytest.fixture(autouse=True)
+def _all_provider_creds(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
+    """Deterministic creds baseline: every provider env var set, so wizard tests never hit the
+    interactive missing-credential prompts unless a test clears vars explicitly."""
+    for env_vars in PROVIDER_ENV_VARS.values():
+        for var in env_vars:
+            monkeypatch.setenv(var, "test-cred")
 
 
 def _scripted_reader(answers: list[str]):  # noqa: ANN202 - returns a PromptReader
@@ -138,6 +152,26 @@ def test_play_repl_exits_cleanly_on_eof() -> None:
 
 
 # --- creation wizard -----------------------------------------------------------------------------
+
+
+def test_read_key_decodes_arrows_and_plain_chars() -> None:
+    assert _read_key(io.StringIO("\x1b[A")) == "up"
+    assert _read_key(io.StringIO("\x1b[B")) == "down"
+    assert _read_key(io.StringIO("\x1b[C")) == "esc"  # unhandled escape sequences are inert
+    assert _read_key(io.StringIO("j")) == "j"
+    assert _read_key(io.StringIO("\r")) == "\r"
+
+
+def test_step_selection_navigates_wraps_and_accepts() -> None:
+    assert _step_selection("down", 0, 3) == (1, False)
+    assert _step_selection("j", 1, 3) == (2, False)
+    assert _step_selection("down", 2, 3) == (0, False)  # wraps
+    assert _step_selection("up", 0, 3) == (2, False)  # wraps backwards
+    assert _step_selection("k", 2, 3) == (1, False)
+    assert _step_selection("\r", 1, 3) == (1, True)  # Enter accepts the highlight
+    assert _step_selection("2", 0, 3) == (1, True)  # digits jump-select
+    assert _step_selection("9", 0, 3) == (0, False)  # out-of-range digit is inert
+    assert _step_selection("x", 1, 3) == (1, False)  # unknown keys are inert
 
 
 def test_build_wizard_collects_all_inputs() -> None:
@@ -266,17 +300,52 @@ def test_build_wizard_reprompts_on_blank_trace_source() -> None:
     assert params.file == "/tmp/t.jsonl"
 
 
-def test_build_wizard_reports_missing_credentials(monkeypatch) -> None:  # noqa: ANN001 - pytest fixture
-    # The wizard flags an unset provider env var (offline presence check) so the user sees it
-    # before the build. With AWS creds cleared, bedrock should warn for each.
+def test_build_wizard_prompts_for_missing_credentials_and_saves(
+    tmp_path,  # noqa: ANN001 - pytest fixture
+    monkeypatch,  # noqa: ANN001 - pytest fixture
+) -> None:
+    # Picking a provider with unset creds prompts for each env var; entered values land in
+    # os.environ AND .env (so the next session has them), Enter skips a var with a warning.
     for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.chdir(tmp_path)
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    reader = _scripted_reader(
+        # name, file, provider, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (skip),
+        # model, region, budget, embedder
+        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "test-key-id", "", "1", "", "8", "1"]
+    )
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    out = console.export_text()
+    assert params.provider == "bedrock"
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "test-key-id"
+    env_file = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "AWS_REGION=us-east-1" in env_file
+    assert "AWS_ACCESS_KEY_ID=test-key-id" in env_file
+    assert "AWS_SECRET_ACCESS_KEY" not in env_file  # skipped with Enter
+    assert "AWS_SECRET_ACCESS_KEY still unset" in out
+
+
+def test_build_wizard_defaults_to_first_provider_with_creds(monkeypatch) -> None:  # noqa: ANN001
+    # No --provider flag: the suggested default is the first provider (in openai, anthropic,
+    # bedrock, azure order) whose creds are present — here anthropic, once openai's key is gone.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     console = Console(force_terminal=False, no_color=True, width=100)
-    with console.capture() as cap:
-        reader = _scripted_reader(["m", "/tmp/t.jsonl", "bedrock", "", "us-east-1", "8", "hashing"])
-        run_build_wizard(console, BuildParams(name="default"), reader=reader)
-    out = cap.get()
-    assert "make sure AWS_ACCESS_KEY_ID is set" in out
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "", "", "", ""])
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.provider == "anthropic"
+    assert params.model == "claude-opus-4-8"  # model default follows the provider
+
+
+def test_build_wizard_annotates_providers_that_have_keys(monkeypatch) -> None:  # noqa: ANN001
+    # Providers whose creds are present are labeled in the picker; cleared ones are not.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "", ""])
+    run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    out = console.export_text()
+    assert "openai  (api key exists)" in out
+    assert "anthropic  (api key exists)" not in out
 
 
 # --- selection picker ----------------------------------------------------------------------------
@@ -323,9 +392,9 @@ def test_select_model_survives_unicode_digit_input() -> None:
 
 def test_build_wizard_reprompts_on_unicode_digit_budget() -> None:
     # Same unicode-digit footgun in the int prompt: must re-ask, not crash. With file provided the
-    # prompts are name/provider/model/region/budget/embedder; blanks accept defaults, '²' is a bad
-    # budget that must be rejected and re-asked.
+    # prompts are name/provider/model/budget/embedder (no region: the creds-default provider is
+    # openai); blanks accept defaults, '²' is a bad budget that must be rejected and re-asked.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["", "", "", "", "²", "7", ""])
+    reader = _scripted_reader(["", "", "", "²", "7", ""])
     params = run_build_wizard(console, BuildParams(name="m", file="/tmp/t.jsonl"), reader=reader)
     assert params.gepa_budget == 7

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import io
+import importlib
 import os
 
 import pytest
@@ -12,7 +12,7 @@ from rich.console import Console
 from wmh.cli.ui import (
     BuildParams,
     RichBuildReporter,
-    _read_key,
+    _decode_key,
     _step_selection,
     models_table,
     run_build_wizard,
@@ -24,6 +24,8 @@ from wmh.core.types import Action, ActionKind, Observation, Step, Trace
 from wmh.engine.world_model import WorldModel
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+ui_module = importlib.import_module("wmh.cli.ui")
 
 
 @pytest.fixture(autouse=True)
@@ -154,12 +156,30 @@ def test_play_repl_exits_cleanly_on_eof() -> None:
 # --- creation wizard -----------------------------------------------------------------------------
 
 
-def test_read_key_decodes_arrows_and_plain_chars() -> None:
-    assert _read_key(io.StringIO("\x1b[A")) == "up"
-    assert _read_key(io.StringIO("\x1b[B")) == "down"
-    assert _read_key(io.StringIO("\x1b[C")) == "esc"  # unhandled escape sequences are inert
-    assert _read_key(io.StringIO("j")) == "j"
-    assert _read_key(io.StringIO("\r")) == "\r"
+def test_decode_key_maps_arrows_and_passes_plain_chars() -> None:
+    assert _decode_key("\x1b[A") == "up"
+    assert _decode_key("\x1bOA") == "up"  # application cursor mode
+    assert _decode_key("\x1b[B") == "down"
+    assert _decode_key("\x1b[1;5A") == "esc"  # modified arrows are inert, not a stray '5'
+    assert _decode_key("\x1b[5~") == "esc"  # PgUp is inert
+    assert _decode_key("\x1b") == "esc"
+    assert _decode_key("j") == "j"
+    assert _decode_key("\r") == "\r"
+
+
+def test_arrow_select_moves_pointer_and_accepts(monkeypatch) -> None:  # noqa: ANN001
+    keys = iter(["\x1b[B", "\x1b[1;5A", "\r"])  # down, inert modified arrow, Enter
+    monkeypatch.setattr(ui_module.click, "getchar", lambda: next(keys))
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    assert ui_module._arrow_select(console, ["a", "b", "c"], 0) == 1
+    assert "\u276f b" in console.export_text()  # pointer painted on the accepted row
+
+
+def test_arrow_select_aborts_on_eof(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(ui_module.click, "getchar", lambda: "")
+    console = Console(force_terminal=False, no_color=True, width=100)
+    with pytest.raises(typer.Abort):  # closed stdin must abort, not busy-loop
+        ui_module._arrow_select(console, ["a", "b"], 0)
 
 
 def test_step_selection_navigates_wraps_and_accepts() -> None:

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -346,6 +346,28 @@ def test_build_wizard_prompts_for_missing_credentials_and_saves(
     assert "AWS_SECRET_ACCESS_KEY still unset" in out
 
 
+def test_build_wizard_keeps_session_creds_when_persistence_fails(
+    monkeypatch,  # noqa: ANN001 - pytest fixture
+) -> None:
+    # A refused .env write (symlink, ELOOP, read-only dir) must not crash the wizard: the
+    # credential still applies to the running session, with a visible warning.
+    for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    def refuse(var: str, value: str) -> None:
+        raise OSError("too many levels of symbolic links")
+
+    monkeypatch.setattr(ui_module, "upsert_env_var", refuse)
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    reader = _scripted_reader(
+        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "key-id", "secret", "1", "", "8", "1"]
+    )
+    params = run_build_wizard(console, BuildParams(name="default"), reader=reader)
+    assert params.provider == "bedrock"
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "key-id"  # session env applied anyway
+    assert "not saved" in console.export_text()
+
+
 def test_build_wizard_defaults_to_first_provider_with_creds(monkeypatch) -> None:  # noqa: ANN001
     # No --provider flag: the suggested default is the first provider (in openai, anthropic,
     # bedrock, azure order) whose creds are present — here anthropic, once openai's key is gone.

--- a/wmh/config/__init__.py
+++ b/wmh/config/__init__.py
@@ -8,6 +8,7 @@ from wmh.config.config import (
     load_config,
     save_config,
 )
+from wmh.config.dotenv import load_env_file, upsert_env_var
 from wmh.config.settings import (
     ProjectSettings,
     TelemetrySettings,
@@ -37,11 +38,13 @@ __all__ = [
     "WorldModelStore",
     "ensure_telemetry_anonymous_id",
     "load_config",
+    "load_env_file",
     "load_settings",
     "normalize_name",
     "save_config",
     "save_settings",
     "set_telemetry_enabled",
     "settings_path",
+    "upsert_env_var",
     "validate_name",
 ]

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -32,7 +32,7 @@ class HarnessConfig(BaseModel):
     providers: list[ProviderConfig] = Field(default_factory=list)
     serve_provider: ProviderKind = ProviderKind.ANTHROPIC  # serves the live world model
     # Which embedder supplies phi for retrieval. Defaults to the offline HashingEmbedder (no creds);
-    # set to a provider-backed kind (bedrock/openai/azure_openai) for semantic phi.
+    # set to a provider-backed kind (bedrock/openai/azure) for semantic phi.
     embed_provider: EmbedderKind = EmbedderKind.HASHING
     embed_dim: int = 512  # phi dimensionality; index + query embedder must agree on this
     top_k: int = 5  # demos retrieved per step (DreamGym k)

--- a/wmh/config/dotenv.py
+++ b/wmh/config/dotenv.py
@@ -33,9 +33,18 @@ def load_env_file(path: str | Path = ENV_FILE) -> None:
 
 
 def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
-    """Set `var` in os.environ and persist it to `path`, replacing any existing line for it."""
-    os.environ[var] = value
+    """Set `var` in os.environ and persist it to `path`, replacing any existing line for it.
+
+    Raises ValueError if `path` is a symlink: a credential rewrite must never truncate or
+    chmod whatever file the link happens to point at.
+    """
     env_path = Path(path)
+    if env_path.is_symlink():
+        raise ValueError(
+            f"refusing to write credentials through the symlink {env_path}; "
+            f"set {var} in the link target or your shell instead"
+        )
+    os.environ[var] = value
     lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
     rendered = f"{var}={value}"
     for i, line in enumerate(lines):
@@ -46,7 +55,9 @@ def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
         lines.append(rendered)
     # Credentials file: owner-only from birth (no umask window) and tightened before the
     # secret is written if the file pre-existed with a looser mode.
-    fd = os.open(env_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    # O_NOFOLLOW backstops the symlink check against a swap between check and open.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(env_path, flags, stat.S_IRUSR | stat.S_IWUSR)
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
         fh.write("\n".join(lines) + "\n")

--- a/wmh/config/dotenv.py
+++ b/wmh/config/dotenv.py
@@ -44,6 +44,9 @@ def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
             break
     else:
         lines.append(rendered)
-    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    # Credentials file: owner-only, whatever the umask or pre-existing mode said.
-    env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    # Credentials file: owner-only from birth (no umask window) and tightened before the
+    # secret is written if the file pre-existed with a looser mode.
+    fd = os.open(env_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        fh.write("\n".join(lines) + "\n")

--- a/wmh/config/dotenv.py
+++ b/wmh/config/dotenv.py
@@ -1,0 +1,42 @@
+"""Minimal `.env` support: loaded on CLI startup, written by the wizard's credential prompts.
+
+No third-party dotenv dependency — the harness only needs KEY=VALUE lines. Values entered in
+the build wizard are persisted here so the next `wmh` invocation has them without re-prompting.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ENV_FILE = ".env"
+
+
+def load_env_file(path: str | Path = ENV_FILE) -> None:
+    """Read KEY=VALUE lines from `path` into os.environ without overriding already-set vars."""
+    env_path = Path(path)
+    if not env_path.exists():
+        return
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key, value = key.strip(), value.strip().strip("'\"")
+        if key and value and key not in os.environ:
+            os.environ[key] = value
+
+
+def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
+    """Set `var` in os.environ and persist it to `path`, replacing any existing line for it."""
+    os.environ[var] = value
+    env_path = Path(path)
+    lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    rendered = f"{var}={value}"
+    for i, line in enumerate(lines):
+        if line.partition("=")[0].strip() == var:
+            lines[i] = rendered
+            break
+    else:
+        lines.append(rendered)
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/wmh/config/dotenv.py
+++ b/wmh/config/dotenv.py
@@ -7,6 +7,7 @@ the build wizard are persisted here so the next `wmh` invocation has them withou
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 
 ENV_FILE = ".env"
@@ -22,7 +23,11 @@ def load_env_file(path: str | Path = ENV_FILE) -> None:
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, _, value = line.partition("=")
-        key, value = key.strip(), value.strip().strip("'\"")
+        key, value = key.strip(), value.strip()
+        # Strip only a MATCHED surrounding quote pair; a secret legitimately ending in a
+        # quote character must survive the round-trip.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            value = value[1:-1]
         if key and value and key not in os.environ:
             os.environ[key] = value
 
@@ -40,3 +45,5 @@ def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
     else:
         lines.append(rendered)
     env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Credentials file: owner-only, whatever the umask or pre-existing mode said.
+    env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)

--- a/wmh/config/dotenv.py
+++ b/wmh/config/dotenv.py
@@ -7,7 +7,7 @@ the build wizard are persisted here so the next `wmh` invocation has them withou
 from __future__ import annotations
 
 import os
-import stat
+import tempfile
 from pathlib import Path
 
 ENV_FILE = ".env"
@@ -35,8 +35,8 @@ def load_env_file(path: str | Path = ENV_FILE) -> None:
 def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
     """Set `var` in os.environ and persist it to `path`, replacing any existing line for it.
 
-    Raises ValueError if `path` is a symlink: a credential rewrite must never truncate or
-    chmod whatever file the link happens to point at.
+    Raises ValueError if `path` is a symlink: a credential rewrite must never end up in
+    whatever file the link happens to point at.
     """
     env_path = Path(path)
     if env_path.is_symlink():
@@ -53,11 +53,15 @@ def upsert_env_var(var: str, value: str, path: str | Path = ENV_FILE) -> None:
             break
     else:
         lines.append(rendered)
-    # Credentials file: owner-only from birth (no umask window) and tightened before the
-    # secret is written if the file pre-existed with a looser mode.
-    # O_NOFOLLOW backstops the symlink check against a swap between check and open.
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(env_path, flags, stat.S_IRUSR | stat.S_IWUSR)
-    with os.fdopen(fd, "w", encoding="utf-8") as fh:
-        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
-        fh.write("\n".join(lines) + "\n")
+    # Write-then-rename: mkstemp creates the temp file 0600 (owner-only, no umask window) and
+    # cannot hit a planted symlink; os.replace swaps the path atomically WITHOUT following a
+    # link that appeared after the check above, so the secret can never land in a linked-to
+    # file. This needs no platform-dependent open flags.
+    fd, tmp_name = tempfile.mkstemp(dir=env_path.parent, prefix=f"{env_path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+        os.replace(tmp_name, env_path)
+    except BaseException:
+        os.unlink(tmp_name)
+        raise

--- a/wmh/config/dotenv_test.py
+++ b/wmh/config/dotenv_test.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 from wmh.config.dotenv import load_env_file, upsert_env_var
 
 
@@ -43,3 +45,16 @@ def test_upsert_env_var_appends_and_replaces(tmp_path, monkeypatch) -> None:  # 
     assert env.stat().st_mode & 0o777 == 0o600  # owner-only, even for a pre-existing file
     monkeypatch.delenv("WMH_TEST_UPSERT")
     monkeypatch.delenv("WMH_TEST_ADDED")
+
+
+def test_upsert_env_var_refuses_symlinked_env(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    target = tmp_path / "victim"
+    target.write_text("do not clobber\n", encoding="utf-8")
+    env = tmp_path / ".env"
+    env.symlink_to(target)
+    monkeypatch.delenv("WMH_TEST_SYMLINK", raising=False)
+
+    with pytest.raises(ValueError, match="symlink"):
+        upsert_env_var("WMH_TEST_SYMLINK", "secret", env)
+    assert target.read_text(encoding="utf-8") == "do not clobber\n"  # untouched
+    assert "WMH_TEST_SYMLINK" not in os.environ  # nothing half-applied

--- a/wmh/config/dotenv_test.py
+++ b/wmh/config/dotenv_test.py
@@ -40,5 +40,6 @@ def test_upsert_env_var_appends_and_replaces(tmp_path, monkeypatch) -> None:  # 
 
     upsert_env_var("WMH_TEST_ADDED", "v", env)
     assert env.read_text(encoding="utf-8").endswith("WMH_TEST_ADDED=v\n")
+    assert env.stat().st_mode & 0o777 == 0o600  # owner-only, even for a pre-existing file
     monkeypatch.delenv("WMH_TEST_UPSERT")
     monkeypatch.delenv("WMH_TEST_ADDED")

--- a/wmh/config/dotenv_test.py
+++ b/wmh/config/dotenv_test.py
@@ -1,0 +1,44 @@
+"""Tests for the minimal .env loader/writer."""
+
+from __future__ import annotations
+
+import os
+
+from wmh.config.dotenv import load_env_file, upsert_env_var
+
+
+def test_load_env_file_sets_only_unset_vars(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    env = tmp_path / ".env"
+    env.write_text(
+        "# comment\nWMH_TEST_NEW=from-file\nWMH_TEST_KEPT='quoted'\nWMH_TEST_SET=ignored\nbroken\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("WMH_TEST_NEW", raising=False)
+    monkeypatch.delenv("WMH_TEST_KEPT", raising=False)
+    monkeypatch.setenv("WMH_TEST_SET", "from-env")
+
+    load_env_file(env)
+    assert os.environ["WMH_TEST_NEW"] == "from-file"
+    assert os.environ["WMH_TEST_KEPT"] == "quoted"  # quotes stripped
+    assert os.environ["WMH_TEST_SET"] == "from-env"  # not overridden
+    monkeypatch.delenv("WMH_TEST_NEW")
+    monkeypatch.delenv("WMH_TEST_KEPT")
+
+
+def test_load_env_file_missing_path_is_a_noop(tmp_path) -> None:  # noqa: ANN001
+    load_env_file(tmp_path / "nope.env")  # must not raise
+
+
+def test_upsert_env_var_appends_and_replaces(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    env = tmp_path / ".env"
+    env.write_text("OTHER=1\nWMH_TEST_UPSERT=old\n", encoding="utf-8")
+    monkeypatch.delenv("WMH_TEST_UPSERT", raising=False)
+
+    upsert_env_var("WMH_TEST_UPSERT", "new", env)
+    assert os.environ["WMH_TEST_UPSERT"] == "new"
+    assert env.read_text(encoding="utf-8") == "OTHER=1\nWMH_TEST_UPSERT=new\n"
+
+    upsert_env_var("WMH_TEST_ADDED", "v", env)
+    assert env.read_text(encoding="utf-8").endswith("WMH_TEST_ADDED=v\n")
+    monkeypatch.delenv("WMH_TEST_UPSERT")
+    monkeypatch.delenv("WMH_TEST_ADDED")

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 class ProviderKind(StrEnum):
     ANTHROPIC = "anthropic"  # Opus 4.8 direct
     BEDROCK = "bedrock"  # Claude 4.8 via AWS
-    AZURE_OPENAI = "azure_openai"  # GPT 5.5 via Azure
+    AZURE_OPENAI = "azure"  # GPT 5.5 via the Azure OpenAI service
     OPENAI = "openai"  # GPT 5.5 direct
     OPENAI_RESPONSES = "openai_responses"  # GPT 5.x direct via the Responses API
 
@@ -27,7 +27,7 @@ class EmbedderKind(StrEnum):
     HASHING = "hashing"  # offline HashingEmbedder (default)
     BEDROCK = "bedrock"  # Titan on AWS Bedrock
     OPENAI = "openai"  # OpenAI embeddings
-    AZURE_OPENAI = "azure_openai"  # Azure OpenAI embedding deployment
+    AZURE_OPENAI = "azure"  # Azure OpenAI embedding deployment
 
     def provider_kind(self) -> ProviderKind:
         """The ProviderKind backing this embedder. Raises for `HASHING` (no provider)."""


### PR DESCRIPTION
Follow-ups from live wizard feedback:

- **Arrow-key selection**: provider/model/embedder selects and the play/demo model picker are real up/down + Enter pickers on a TTY (raw-mode cbreak loop, pure key reducer, wraparound, digit jump-select, vi j/k). Non-TTY/piped/CliRunner falls back to the numbered prompt as before — no test churn.
- **Provider order + creds awareness**: openai → anthropic → bedrock → azure → openai_responses. Providers with keys present show `(api key exists)`; the first of them is the suggested default, and there is no default when none have keys. Picking a provider with missing creds prompts for each env var (hidden input), exports it for the session, and persists it to `.env`; the CLI loads `.env` at startup (new `wmh/config/dotenv.py`, no new dependency).
- **azure_openai → azure**: the ProviderKind/EmbedderKind value and all user-facing strings; env var names (AZURE_OPENAI_*) unchanged.
- **Test hardening**: repo `conftest.py` scrubs `.env`-injected vars and FORCE_COLOR before `wmh.cli.app`'s import-time setup, keeping live-test skips and CliRunner output deterministic on dev machines.

Verified end-to-end through a real PTY (arrows move the pointer, annotations render, missing-key prompt appears and skips cleanly). Full suite green with and without provider keys in the environment.