### PR TITLE
skills: ready-for-merge polls reviewers and scopes the test gate

### DIFF
--- a/.claude/skills/ready-for-merge/SKILL.md
+++ b/.claude/skills/ready-for-merge/SKILL.md
@@ -57,29 +57,36 @@ For **every single comment**, without exception:
 The step is done only when zero unresolved review threads remain. Re-check with the GraphQL
 query above; do not assume.
 
-## This process is iterative — wait for reviewers to react
+## This process is iterative — poll for reviewers, don't sleep blind
 
 Every time you push fixes, Cursor and Greptile re-review the PR and humans may leave new
 comments. One pass is never enough. After each push:
 
-1. Sleep 3 minutes to give bot reviewers time to run:
+1. Poll for reviewer reaction instead of sleeping a fixed 3 minutes: check every ~20 seconds
+   for new comments or review threads (same queries as Step 2), and stop polling as soon as a
+   new bot review lands — bots usually post within 60–90 seconds. Cap the wait at 3 minutes;
+   a capped wait with no new activity counts as a quiet window.
    ```bash
-   sleep 180
+   start=$(date +%s); while [ $(( $(date +%s) - start )) -lt 180 ]; do
+     # re-fetch comments/threads; break out early if anything new appeared
+     sleep 20
+   done
    ```
-2. Re-fetch all comments and review threads (same queries as Step 2).
-3. If new unresolved comments appeared, handle them exactly as in Step 2 (fix or reply, then
+2. If new unresolved comments appeared, handle them exactly as in Step 2 (fix or reply, then
    resolve), push, and repeat from 1.
-4. Only exit the loop when a full 3-minute wait produces **zero** new comments and zero
-   unresolved threads.
+3. Only exit the loop when a quiet window produces **zero** new comments and zero unresolved
+   threads.
 
 ## Step 3 — AGENTS.md compliance
 
 Read `AGENTS.md` in full and audit the PR's complete diff (`gh pr diff <number>`) against every
 rule. In particular verify:
 
-- Whole-project gate is clean: `uv run ruff check .`, `uv run ruff format .`, `uv run ty check`,
-  `uv run pytest -q`. If the PR touches `web/`, also run `npm run lint` and `npx tsc --noEmit`
-  from `web/`.
+- Checks are clean, scoped to the diff: `uv run ruff check .` and `uv run ty check` (both fast)
+  always; pytest targeted at the packages the PR touches (`uv run pytest wmh/<pkg>/ -q`) during
+  fix iterations. Run the full `uv run pytest -q` only once, before the final hand-off, and only
+  when the PR touches `wmh/` code at all (docs/skills-only diffs skip it). If the PR touches
+  `web/`, also run `npm run lint` and `npx tsc --noEmit` from `web/`.
 - Module docstrings and Google-style docstrings on significant classes/functions.
 - Tests live inline next to the code (`foo.py` → `foo_test.py`); new behavior has a test or eval
   that would catch its regression.
@@ -101,8 +108,9 @@ Push any fixes made in Steps 1–3, then report a checklist to the user:
 - [ ] `/code-review <level> --fix` completed (state the level chosen and why; N findings, M fixed)
 - [ ] All review comments resolved (list each commenter and how their comments were handled)
 - [ ] AGENTS.md audit clean (note any rules that required fixes)
-- [ ] Full project gate green
-- [ ] Final 3-minute wait after the last push produced zero new comments
+- [ ] Checks green (lint/types always; tests scoped to the diff, one full run before hand-off
+      when the PR touches `wmh/`)
+- [ ] Final polled quiet window after the last push produced zero new comments
 
 If every box is checked, end by telling the user:
 


### PR DESCRIPTION
Two speed fixes for /ready-for-merge, from watching it run:

- **Poll, don't sleep**: after each push it now checks for reviewer reaction every ~20s and exits the window as soon as a new bot review lands (bots usually post in 60–90s), with 3 minutes as the cap — instead of a blind `sleep 180` per round.
- **Scoped checks**: `ruff`/`ty` always; pytest targeted to the touched packages during fix iterations; one full-suite run before the final hand-off, and only when the PR touches `wmh/` code (docs/skills-only diffs skip it).

Skill-text only; merged directly per repo owner instruction.