### PR TITLE
cli: provider SDKs install with plain uv sync; wizard drops openai_responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,22 +16,22 @@ dependencies = [
     "gepa>=0.1.1",
     "tomli-w>=1.0",  # writing .wmh/config.toml (stdlib tomllib reads); every `wmh build` needs it
     "posthog>=7.0",
+    # Provider SDKs ship with the core install: a fresh `uv sync` must serve every provider the
+    # wizard offers without a "No module named ..." follow-up step.
+    "anthropic>=0.39",
+    "openai>=1.40",
+    "boto3>=1.34",
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.39"]
-openai = ["openai>=1.40"]
-bedrock = ["boto3>=1.34"]
 otel = ["opentelemetry-proto>=1.24"]
 # Plotting/figures for research runs; kept out of the core install.
 viz = ["seaborn>=0.13", "matplotlib>=3.8"]
-# dev pulls in every backend SDK so `ty check` and the full test suite resolve over the whole
-# project (the providers import anthropic/openai/boto3 lazily, but type-checking needs them present).
 dev = [
     "pytest>=8.0",
     "ruff>=0.5",
     "ty>=0.0.1a1",
-    "world-model-harness[anthropic,openai,bedrock,otel,viz]",
+    "world-model-harness[otel,viz]",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1520,12 +1520,15 @@ name = "world-model-harness"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
+    { name = "boto3" },
     { name = "click" },
     { name = "fastapi" },
     { name = "gepa" },
     { name = "httpx" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "openai" },
     { name = "posthog" },
     { name = "pydantic" },
     { name = "rich" },
@@ -1535,25 +1538,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-anthropic = [
-    { name = "anthropic" },
-]
-bedrock = [
-    { name = "boto3" },
-]
 dev = [
-    { name = "anthropic" },
-    { name = "boto3" },
     { name = "matplotlib" },
-    { name = "openai" },
     { name = "opentelemetry-proto" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "seaborn" },
     { name = "ty" },
-]
-openai = [
-    { name = "openai" },
 ]
 otel = [
     { name = "opentelemetry-proto" },
@@ -1565,15 +1556,15 @@ viz = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.39" },
-    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
+    { name = "anthropic", specifier = ">=0.39" },
+    { name = "boto3", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.2" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gepa", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.40" },
+    { name = "openai", specifier = ">=1.40" },
     { name = "opentelemetry-proto", marker = "extra == 'otel'", specifier = ">=1.24" },
     { name = "posthog", specifier = ">=7.0" },
     { name = "pydantic", specifier = ">=2.6" },
@@ -1585,6 +1576,6 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.29" },
-    { name = "world-model-harness", extras = ["anthropic", "openai", "bedrock", "otel", "viz"], marker = "extra == 'dev'" },
+    { name = "world-model-harness", extras = ["otel", "viz"], marker = "extra == 'dev'" },
 ]
-provides-extras = ["anthropic", "openai", "bedrock", "otel", "viz", "dev"]
+provides-extras = ["otel", "viz", "dev"]

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -357,9 +357,6 @@ def build(
             )
 
 
-# The `uv sync` extra that installs each provider's SDK, surfaced when a verify ping fails with a
-# missing module so the fix is one copy-paste away.
-
 
 def _verify_or_abort(config: HarnessConfig) -> None:
     """Ping the serve provider (and any provider-backed embedder) and abort on failure.

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -357,7 +357,6 @@ def build(
             )
 
 
-
 def _verify_or_abort(config: HarnessConfig) -> None:
     """Ping the serve provider (and any provider-backed embedder) and abort on failure.
 

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -359,12 +359,6 @@ def build(
 
 # The `uv sync` extra that installs each provider's SDK, surfaced when a verify ping fails with a
 # missing module so the fix is one copy-paste away.
-_PROVIDER_EXTRA: dict[ProviderKind, str] = {
-    ProviderKind.ANTHROPIC: "anthropic",
-    ProviderKind.BEDROCK: "bedrock",
-    ProviderKind.OPENAI: "openai",
-    ProviderKind.AZURE_OPENAI: "openai",
-}
 
 
 def _verify_or_abort(config: HarnessConfig) -> None:
@@ -372,7 +366,7 @@ def _verify_or_abort(config: HarnessConfig) -> None:
 
     Runs before any rollouts so a missing SDK or bad creds fails loudly and immediately, instead of
     being swallowed inside GEPA and yielding a useless model. Raises `typer.Exit(1)` with an
-    actionable hint (the `uv sync` extra for a missing SDK; "check creds / model id" otherwise).
+    actionable hint (`uv sync` for a missing SDK; "check creds / model id" otherwise).
     """
     checks = [(config.serve_provider_config(), False)]
     if config.embed_provider is not EmbedderKind.HASHING:
@@ -389,8 +383,8 @@ def _verify_or_abort(config: HarnessConfig) -> None:
         failed = True
         _console.print(f"  [red]✗ {label} ({result.model}) failed[/red]: {result.detail}")
         if "No module named" in result.detail:
-            extra = _PROVIDER_EXTRA.get(cfg.kind, cfg.kind.value)
-            _console.print(f"    [yellow]run `uv sync --extra {extra}` to install the SDK[/yellow]")
+            # SDKs are core deps; a missing module means the env is stale or hand-rolled.
+            _console.print("    [yellow]run `uv sync` to install the provider SDKs[/yellow]")
         else:
             envs = ", ".join(PROVIDER_ENV_VARS.get(cfg.kind, []))
             hint = f" ({envs})" if envs else ""

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -414,7 +414,7 @@ def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None: 
         app, ["build", "--name", "x", "--file", _traces_file(tmp_path), "--root", str(root)]
     )
     assert result.exit_code == 1
-    assert "uv sync --extra bedrock" in result.output
+    assert "run `uv sync` to install the provider SDKs" in result.output
     # Aborted before building: no artifact written.
     assert not (root / "models" / "x" / "config.toml").exists()
 

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -68,8 +68,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # haiku needs the dated inference-profile id; the undated alias is rejected by Bedrock
         "us.anthropic.claude-haiku-4-5-20251001-v1:0",
     ],
+    # openai_responses (the Responses API) stays flag-only (`wmh build --provider
+    # openai_responses`); the wizard list keeps to the four everyday backends.
     "azure": ["gpt-5.5", "gpt-5.4"],
-    "openai_responses": ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 


### PR DESCRIPTION
Two UX fixes from live wizard feedback:

- **SDKs are core deps**: `anthropic`/`openai`/`boto3` move out of optional extras, so a fresh `uv sync` can serve every provider the wizard offers — no more `No module named 'openai'` → `uv sync --extra openai` dead end. The missing-SDK hint (still useful for stale/hand-rolled envs) now just says `uv sync`. The `dev` extra no longer needs to re-pull provider extras.
- **Wizard picker trimmed**: `openai_responses` is out of the serve-provider list (it's the niche Responses-API path); still fully available via `wmh build --provider openai_responses`.

Verified live: openai without a key now fails at credential verify (not module import); the picker shows openai/anthropic/bedrock/azure only. Full suite green.