### PR TITLE
providers: reasoning-safe verify ping budget

### DIFF
--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -123,16 +123,22 @@ class Provider(Protocol):
 # One read-only instance reused across every verify() ping (complete() never mutates messages).
 _PING_MESSAGES: list[Message] = [Message(role="user", content="ping")]
 
+# Ping output budget. Reasoning models (GPT-5.x) spend output tokens on reasoning before any
+# visible text, and OpenAI 400s ("max_tokens or model output limit was reached") when the budget
+# can't cover it — which reads like bad credentials. Non-reasoning models stop after a token or
+# two regardless, so the headroom costs nothing there.
+PING_MAX_TOKENS = 2048
+
 
 def verify_via_ping(provider: Provider) -> VerifyResult:
-    """Shared `verify()`: one cheap 1-token completion, reporting failure as ok=False.
+    """Shared `verify()`: one cheap short completion, reporting failure as ok=False.
 
     Every backend's verify() is identical apart from its kind/model (both on the config), so they
     all delegate here. Never raises — `verify_all` relies on that to not crash startup.
     """
     cfg = provider.config
     try:
-        provider.complete("", _PING_MESSAGES, max_tokens=1)
+        provider.complete("", _PING_MESSAGES, max_tokens=PING_MAX_TOKENS)
     except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
         return VerifyResult(ok=False, kind=cfg.kind, model=cfg.model, detail=str(exc))
     return VerifyResult(ok=True, kind=cfg.kind, model=cfg.model)

--- a/wmh/providers/base_test.py
+++ b/wmh/providers/base_test.py
@@ -1,0 +1,48 @@
+"""Tests for the shared provider verify ping."""
+
+from __future__ import annotations
+
+from wmh.providers.base import (
+    PING_MAX_TOKENS,
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    verify_via_ping,
+)
+
+
+class RecordingProvider:
+    """Captures the ping's max_tokens so the budget is pinned by a test."""
+
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5")
+        self.seen_max_tokens: int | None = None
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.seen_max_tokens = max_tokens
+        return Completion(text="pong")
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        return verify_via_ping(self)
+
+
+def test_ping_budget_covers_reasoning_models() -> None:
+    # Reasoning models (GPT-5.x) burn output budget on reasoning before any visible token, so a
+    # tiny ping budget makes OpenAI 400 with "max_tokens or model output limit was reached" even
+    # though the credentials are fine. The ping must send a budget with headroom for that.
+    provider = RecordingProvider()
+    result = verify_via_ping(provider)
+    assert result.ok is True
+    assert provider.seen_max_tokens == PING_MAX_TOKENS
+    assert PING_MAX_TOKENS >= 1024


### PR DESCRIPTION
The shared verify ping sent `max_tokens=1`, which GPT-5.x rejects with a 400 ('max_tokens or model output limit was reached') because reasoning consumes the output budget before any visible token — surfacing as a credentials-looking failure in the build wizard. The ping now sends `PING_MAX_TOKENS = 2048`; non-reasoning models stop after a couple of tokens regardless, so the ping stays cheap. Test pins the budget; verified live against gpt-5.5 (400 before, ok after).