### PR TITLE
build: honest GEPA progress totals + capped selection valset

### DIFF
--- a/wmh/engine/build.py
+++ b/wmh/engine/build.py
@@ -128,11 +128,17 @@ def build(
     # GEPA evolves the env prompt under serving conditions: it retrieves demos the same way the
     # world model will, but from a SEPARATE retriever it re-indexes over train-only (so held-out
     # steps never retrieve themselves). The embedder is stateless, so it's safe to share.
-    report.optimize_start(config.gepa_budget)
-    budget = config.gepa_budget
+    # The progress total is GEPA's REAL translated metric-call budget (reported via on_budget),
+    # not the iteration count — sizing the bar with iterations made it hit 100% while thousands
+    # of valset calls were still running.
+    metric_total = {"calls": config.gepa_budget}
+
+    def _on_budget(total: int) -> None:
+        metric_total["calls"] = total
+        report.optimize_start(total)
 
     def _on_rollout(done: int, score: float | None) -> None:
-        report.rollout(done, budget, score)
+        report.rollout(done, metric_total["calls"], score)
 
     # Optimize against the SAME scorer we evaluate with (RubricJudge), so GEPA hill-climbs the
     # metric we actually report. The coarser LLMJudge here would let GEPA improve a proxy objective
@@ -142,14 +148,40 @@ def build(
         RubricJudge(provider),
         retriever=EmbeddingRetriever(embed),
         on_rollout=_on_rollout,
+        on_budget=_on_budget,
     )
-    result = optimizer.optimize(train, test or train, BASE_ENV_PROMPT, config.gepa_budget)
+    # Every GEPA iteration re-scores the whole valset, so an uncapped held-out split multiplies
+    # wall-clock and spend by its step count for no selection benefit (fidelity saturates fast —
+    # see docs/trace_scaling_law.md). Candidate selection only needs a stable sample; the full
+    # held-out split still backs `wmh eval`.
+    gepa_val = _cap_gepa_valset(test or train)
+    result = optimizer.optimize(train, gepa_val, BASE_ENV_PROMPT, config.gepa_budget)
     report.optimize_done(
         result.metrics.held_out_accuracy, len(result.frontier), result.metrics.rollouts_used
     )
 
     _persist(paths, config, retriever, result)
     return result
+
+
+# Ceiling on GEPA's candidate-selection valset, in steps (~one full-val pass per iteration).
+_GEPA_VAL_STEP_CAP = 64
+
+
+def _cap_gepa_valset(traces: list[Trace], max_steps: int = _GEPA_VAL_STEP_CAP) -> list[Trace]:
+    """A prefix of `traces` totalling at most `max_steps` steps (always at least one trace).
+
+    `split_traces` already shuffles deterministically, so the prefix is an unbiased, stable
+    sample of the held-out split.
+    """
+    capped: list[Trace] = []
+    steps = 0
+    for trace in traces:
+        if capped and steps + len(trace.steps) > max_steps:
+            break
+        capped.append(trace)
+        steps += len(trace.steps)
+    return capped
 
 
 def _persist(

--- a/wmh/engine/build_test.py
+++ b/wmh/engine/build_test.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from wmh.config import ArtifactPaths, HarnessConfig
-from wmh.core.types import Trace
+from wmh.core.types import Action, ActionKind, Observation, Step, Trace
 from wmh.engine.build import build, split_traces, split_traces_3way
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import HashingEmbedder
@@ -84,6 +84,26 @@ def test_split_traces_3way_rejects_degenerate_fractions() -> None:
         split_traces_3way(traces, 0.7, 0.4)  # sums to > 1 -> empty test
     with pytest.raises(ValueError, match="train_frac"):
         split_traces_3way(traces, 0.0, 0.5)
+
+
+def test_cap_gepa_valset_bounds_steps_and_keeps_at_least_one_trace() -> None:
+    from wmh.engine.build import _GEPA_VAL_STEP_CAP, _cap_gepa_valset
+
+    def trace_with_steps(tid: str, n: int) -> Trace:
+        step = Step(
+            action=Action(kind=ActionKind.TOOL_CALL, name="get", arguments={}),
+            observation=Observation(content="ok"),
+        )
+        return Trace(trace_id=tid, steps=[step.model_copy() for _ in range(n)])
+
+    many = [trace_with_steps(f"t{i}", 2) for i in range(200)]  # 400 steps uncapped
+    capped = _cap_gepa_valset(many)
+    assert sum(len(t.steps) for t in capped) <= _GEPA_VAL_STEP_CAP
+    assert capped == many[: len(capped)]  # stable prefix of the (already shuffled) split
+
+    # A single over-cap trace still passes through: never starve GEPA of a valset entirely.
+    huge = trace_with_steps("huge", _GEPA_VAL_STEP_CAP + 10)
+    assert _cap_gepa_valset([huge]) == [huge]
 
 
 def test_build_writes_a_loadable_artifact(tmp_path) -> None:  # noqa: ANN001 - pytest fixture

--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -327,10 +327,15 @@ class GEPAOptimizer:
         retriever: Retriever | None = None,
         on_rollout: RolloutCallback | None = None,
         *,
+        on_budget: Callable[[int], None] | None = None,
         seed: int = 0,
     ) -> None:
         self._provider = provider
         self._judge = judge
+        # `on_budget` receives the REAL translated max_metric_calls right before the run starts —
+        # callers reporting progress must size their bar with it, not with `budget` (iterations),
+        # or the bar finishes while GEPA is still burning valset calls.
+        self._on_budget = on_budget
         # Optional retriever for RAG-aware evaluation. When None, GEPA evaluates zero-shot.
         self._retriever = retriever
         self._on_rollout = on_rollout
@@ -408,6 +413,9 @@ class GEPAOptimizer:
                 valset = hard_val
         adapter = WorldModelGEPAAdapter(self._provider, self._judge, self._on_rollout)
         minibatch = min(3, len(trainset))
+        metric_calls = _metric_call_budget(budget, len(valset), minibatch)
+        if self._on_budget is not None:
+            self._on_budget(metric_calls)
         result = gepa.optimize(
             seed_candidate={ENV_PROMPT_COMPONENT: base_prompt},
             trainset=trainset,
@@ -421,7 +429,7 @@ class GEPAOptimizer:
             # in the library; we enable it so knowledge accumulated on different failure modes
             # composes instead of competing.
             use_merge=True,
-            max_metric_calls=_metric_call_budget(budget, len(valset), minibatch),
+            max_metric_calls=metric_calls,
             reflection_minibatch_size=minibatch,
             display_progress_bar=False,
             raise_on_exception=False,

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -157,6 +157,22 @@ def test_optimize_runs_bounded_loop_and_returns_valid_frontier() -> None:
     assert judge.calls > 0
 
 
+def test_optimize_reports_real_metric_call_budget_via_on_budget() -> None:
+    # Progress bars must be sized by the TRANSLATED metric-call budget, not the iteration count:
+    # sizing by iterations made `wmh build` show 100% while GEPA was still burning valset calls.
+    from wmh.optimize.gepa import _metric_call_budget
+
+    seen: list[int] = []
+    opt = GEPAOptimizer(FakeProvider(), FakeJudge(score=0.5), on_budget=seen.append)
+    budget = 5
+
+    opt.optimize([_trace("tr1"), _trace("tr2")], [_trace("te1")], "BASE", budget)
+
+    # trainset = 2 traces x 2 steps -> minibatch 3; valset = 1 trace x 2 steps.
+    assert seen == [_metric_call_budget(budget, valset_size=2, minibatch=3)]
+    assert seen[0] > budget  # the whole point: the real total exceeds the iteration count
+
+
 def test_optimize_can_retrieve_from_separate_rag_corpus() -> None:
     from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 


### PR DESCRIPTION
Fixes the 'bar at 100% but the build keeps running' report. The bar total was `config.gepa_budget` (iterations), while GEPA really runs `_metric_call_budget()` metric calls — seed valset pass + per-iteration (minibatch + full valset). With 211 held-out traces that's ~11k calls after the bar filled: hours-to-days of silent grinding on gpt-5.5.

- `GEPAOptimizer(on_budget=...)` reports the real translated `max_metric_calls` just before the run; the reporter's bar is sized with it, so 100% now means done and `✓ GEPA done` prints right after.
- The GEPA candidate-selection valset is capped at ~64 steps (stable prefix of the shuffled held-out split). Every iteration re-scores the entire valset, so an uncapped split multiplies wall-clock/spend with no selection benefit (fidelity saturates fast, per docs/trace_scaling_law.md). `wmh eval` still uses the full split.

Tests pin both (on_budget value = translated budget; cap bounds + prefix stability). Full suite green (the 2 live-Bedrock failures are this shell's stale AWS creds, failing identically on main).