### PR TITLE
build reporter: the GEPA bar never pins at 100% while calls keep landing

### DIFF
--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -573,7 +573,11 @@ class RichBuildReporter:
     def rollout(self, done: int, budget: int, score: float | None) -> None:
         label = f"avg fidelity {score:.3f}" if score is not None else "score n/a"
         if self._progress is not None and self._task_id is not None:
-            self._progress.update(self._task_id, completed=min(done, budget), score=label)
+            # The budget is an estimate (GEPA treats max_metric_calls as a soft cap and can
+            # overshoot). Never pin a live run at 100% — rich freezes the elapsed clock once
+            # completed == total, which reads as "stuck". Grow the total instead.
+            total = budget if done < budget else done + 1
+            self._progress.update(self._task_id, completed=done, total=total, score=label)
         elif not self._tty:
             # Non-TTY: emit a sparse heartbeat so long runs still show life without flooding logs.
             if done == 1 or done % 10 == 0 or done >= budget:

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import io
 import os
 
 import pytest
@@ -281,6 +282,24 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     assert params.gepa_budget == 50
     assert params.region == "us-east-1"  # bedrock default suggested + accepted
     assert params.embed_provider == "hashing"  # default embedder, no embed-model prompt
+
+
+def test_build_reporter_bar_never_pins_at_100_while_running() -> None:
+    # The metric-call budget is a soft cap GEPA can overshoot; a live run must never read
+    # completed == total (rich freezes the elapsed clock and the bar looks stuck at 100%).
+    console = Console(force_terminal=True, no_color=True, width=100, file=io.StringIO())
+    reporter = RichBuildReporter(console, "demo")
+    reporter.optimize_start(10)
+    assert reporter._progress is not None
+    task = reporter._progress.tasks[0]
+
+    reporter.rollout(9, 10, 0.5)
+    assert (task.completed, task.total) == (9, 10)
+    reporter.rollout(10, 10, 0.5)  # reaching the estimate: still not "finished"
+    assert task.total is not None and task.completed < task.total
+    reporter.rollout(14, 10, 0.6)  # overshoot: the total grows with reality
+    assert (task.completed, task.total) == (14, 15)
+    reporter.optimize_done(0.6, 1, 14)  # completion is signaled by the done stage, not the bar
 
 
 def test_build_wizard_dashes_spaces_in_name() -> None:


### PR DESCRIPTION
Follow-up to #88. `_metric_call_budget` is an estimate (GEPA treats `max_metric_calls` as a soft cap and finishes in-flight work), and rich freezes a task's elapsed clock once `completed == total` — which is exactly the 'stuck at 100% / 0:02:24 frozen / fidelity still wiggling' symptom. The reporter now keeps `completed < total` for a live run by growing the total to `done + 1` once the estimate is reached; completion is signaled by the `✓ GEPA done` stage, not by the bar filling. Test pins the invariant.