### PR TITLE
build reporter: bar snaps to 100% on the completion event, stays visible

### DIFF
--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -563,7 +563,9 @@ class RichBuildReporter:
                 TextColumn("{task.fields[score]}"),
                 TimeElapsedColumn(),
                 console=self._console,
-                transient=True,
+                # Not transient: the finished bar stays in scrollback, snapped to 100% with the
+                # true final call count and elapsed time (see optimize_done).
+                transient=False,
             )
             self._progress.start()
             self._task_id = self._progress.add_task(
@@ -588,6 +590,11 @@ class RichBuildReporter:
 
     def optimize_done(self, held_out_accuracy: float, frontier_size: int, rollouts: int) -> None:
         if self._progress is not None:
+            if self._task_id is not None and rollouts > 0:
+                # 100% exactly when GEPA is actually done: the endpoint can't be predicted (soft
+                # cap + per-iteration costs decided at runtime), so the bar snaps to the ACTUAL
+                # final call count on the completion event instead of guessing during the run.
+                self._progress.update(self._task_id, completed=rollouts, total=rollouts)
             self._progress.stop()
             self._progress = None
             self._task_id = None

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -299,7 +299,9 @@ def test_build_reporter_bar_never_pins_at_100_while_running() -> None:
     assert task.total is not None and task.completed < task.total
     reporter.rollout(14, 10, 0.6)  # overshoot: the total grows with reality
     assert (task.completed, task.total) == (14, 15)
-    reporter.optimize_done(0.6, 1, 14)  # completion is signaled by the done stage, not the bar
+    reporter.optimize_done(0.6, 1, 14)
+    # 100% happens exactly at completion: the bar snaps to the actual final call count.
+    assert (task.completed, task.total) == (14, 14)
 
 
 def test_build_wizard_dashes_spaces_in_name() -> None:


### PR DESCRIPTION
Answer to 'why can't it hit 100% at the correct time': the endpoint genuinely can't be predicted up front (GEPA's cap is soft and each iteration costs minibatch-only or minibatch+valset depending on runtime accept/reject), so the bar now derives its 100% moment from the completion event itself — `optimize_done` snaps `completed=total=rollouts` (the actual final count) and the bar is non-transient, so the finished 100% line with true count and elapsed persists above `✓ GEPA done`. During the run the estimate-based percent approaches honestly (never pinning, per #89).