### PR TITLE
gepa: stream per-step activity immediately + parallel batch evaluation

### DIFF
--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -19,6 +19,7 @@ against what is actually deployed.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
@@ -36,6 +37,9 @@ from wmh.retrieval.leakfree import DemoRetriever
 
 # The single named component GEPA evolves: the specialized env (system) prompt.
 ENV_PROMPT_COMPONENT = "env_prompt"
+
+# Concurrent rollout+judge calls per GEPA evaluation batch (I/O bound; modest for rate limits).
+_EVAL_CONCURRENCY = 4
 
 # Called once per judged rollout: (rollouts_done, mean_score_so_far). Used to drive build progress.
 RolloutCallback = Callable[[int, float | None], None]
@@ -164,11 +168,14 @@ class WorldModelGEPAAdapter(GEPAAdapter[_EvalStep, _StepTrajectory, Observation]
         capture_traces: bool = False,
     ) -> EvaluationBatch[_StepTrajectory, Observation]:
         prompt = candidate[ENV_PROMPT_COMPONENT]
-        outputs: list[Observation] = []
-        scores: list[float] = []
-        trajectories: list[_StepTrajectory] | None = [] if capture_traces else None
-        last_critique = ""
-        for item in batch:
+        if not batch:
+            return EvaluationBatch(
+                outputs=[], scores=[], trajectories=[] if capture_traces else None
+            )
+        if self._on_activity is not None:
+            self._on_activity(f"evaluating candidate on {len(batch)} steps…")
+
+        def eval_one(item: _EvalStep) -> tuple[Observation, float, str]:
             step = item.step
             try:
                 predicted = predict_observation(
@@ -181,22 +188,37 @@ class WorldModelGEPAAdapter(GEPAAdapter[_EvalStep, _StepTrajectory, Observation]
                     history=item.history,
                 )
                 result = self._judge.score(predicted, step.observation, step)
-                score, critique = result.score, result.critique
+                return predicted, result.score, result.critique
             except Exception as exc:  # noqa: BLE001 - per-example failure must not abort the run
-                predicted = Observation(content="", is_error=True)
-                score, critique = 0.0, f"Rollout failed: {exc}"
-            outputs.append(predicted)
-            scores.append(score)
-            self._note_rollout(score)
-            if trajectories is not None:
-                trajectories.append(
-                    _StepTrajectory(step=step, predicted=predicted, score=score, critique=critique)
-                )
-            last_critique = critique
-        if self._on_activity is not None and scores:
-            avg = sum(scores) / len(scores)
-            note = f" — {last_critique.strip()}" if last_critique and last_critique.strip() else ""
-            self._on_activity(f"judge: avg {avg:.2f} over {len(scores)} steps{note}")
+                return Observation(content="", is_error=True), 0.0, f"Rollout failed: {exc}"
+
+        # Rollout+judge calls are I/O bound; evaluate the batch concurrently (order preserved by
+        # index) and emit callbacks from THIS thread as results land — the live display and the
+        # run tracker see a serial stream.
+        results: list[tuple[Observation, float, str] | None] = [None] * len(batch)
+        with ThreadPoolExecutor(max_workers=min(_EVAL_CONCURRENCY, len(batch))) as pool:
+            futures = {pool.submit(eval_one, item): i for i, item in enumerate(batch)}
+            landed = 0
+            for future in as_completed(futures):
+                index = futures[future]
+                outcome = future.result()
+                results[index] = outcome
+                landed += 1
+                _, score, critique = outcome
+                self._note_rollout(score)
+                if self._on_activity is not None:
+                    note = f" — {critique.strip()[:110]}" if critique.strip() else ""
+                    self._on_activity(f"[{landed}/{len(batch)}] fidelity {score:.2f}{note}")
+
+        outputs = [r[0] for r in results if r is not None]
+        scores = [r[1] for r in results if r is not None]
+        trajectories: list[_StepTrajectory] | None = None
+        if capture_traces:
+            trajectories = [
+                _StepTrajectory(step=item.step, predicted=r[0], score=r[1], critique=r[2])
+                for item, r in zip(batch, results, strict=True)
+                if r is not None
+            ]
         return EvaluationBatch(outputs=outputs, scores=scores, trajectories=trajectories)
 
     def make_reflective_dataset(
@@ -451,6 +473,13 @@ class GEPAOptimizer:
         metric_calls = _metric_call_budget(budget, len(valset), minibatch)
         if self._on_budget is not None:
             self._on_budget(metric_calls)
+        if self._on_activity is not None:
+            # First line lands before any LLM call: the activity window must never sit empty
+            # while the (long) seed valset evaluation runs.
+            self._on_activity(
+                f"scoring the seed prompt on {len(valset)} valset steps "
+                f"({metric_calls} metric calls budgeted)…"
+            )
         result = gepa.optimize(
             seed_candidate={ENV_PROMPT_COMPONENT: base_prompt},
             trainset=trainset,

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -274,15 +274,17 @@ def test_activity_logger_forwards_headlines_and_drops_prompt_bodies() -> None:
     ]
 
 
-def test_adapter_evaluate_emits_judge_summary_via_on_activity() -> None:
+def test_adapter_evaluate_streams_per_step_activity() -> None:
     lines: list[str] = []
     adapter = WorldModelGEPAAdapter(FakeProvider(), FakeJudge(score=0.5), on_activity=lines.append)
     from wmh.retrieval.leakfree import DemoRetriever
 
     steps = _eval_steps([_trace("t1")], DemoRetriever(None, []))
     adapter.evaluate(steps, {ENV_PROMPT_COMPONENT: "BASE"})
-    assert len(lines) == 1
-    assert lines[0].startswith("judge: avg 0.50 over 2 steps")
+    # A batch-start line, then one line per step as each rollout+judge lands.
+    assert lines[0] == "evaluating candidate on 2 steps…"
+    assert len(lines) == 3
+    assert all("fidelity 0.50" in line for line in lines[1:])
 
 
 def test_adapter_evaluate_scores_and_captures_traces() -> None:

--- a/wmh/tracking/tracker.py
+++ b/wmh/tracking/tracker.py
@@ -12,6 +12,7 @@ model's serve `step`.
 
 from __future__ import annotations
 
+import threading
 from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -85,6 +86,7 @@ class RunTracker:
         self._kind = kind
         self._clock = clock or SystemClock()
         self._events: list[UsageEvent] = []
+        self._lock = threading.Lock()
         self._started_at: float | None = None
         self._elapsed: float = 0.0
 
@@ -106,9 +108,13 @@ class RunTracker:
             self.stop()
 
     def record(self, phase: Phase, model: str, usage: TokenUsage) -> UsageEvent:
-        """Record one metered LLM call, pricing it via the model pricing table."""
+        """Record one metered LLM call, pricing it via the model pricing table.
+
+        Thread-safe: GEPA evaluates batches concurrently, so metered calls land in parallel.
+        """
         event = UsageEvent(phase=phase, model=model, usage=usage, cost_usd=cost_usd(model, usage))
-        self._events.append(event)
+        with self._lock:
+            self._events.append(event)
         return event
 
     @property


### PR DESCRIPTION
Smoke test reproduced the report exactly: with a slow provider the activity window had **0 lines at t=5s and t=15s** — the judge summary only fired after a full batch, gepa's narration only after the eval, and the first batch is the (long) seed valset pass.

- A seed line lands **before any LLM call**, then a batch-start line, then one line per step (`[k/N] fidelity 0.62 — critique…`) as each rollout+judge completes. The window is never empty.
- **'Can we make it faster by default?'** — yes: the eval loop was fully serial. Batches now evaluate concurrently (4 workers, I/O bound, order preserved, callbacks from the main thread so the live display and tracker see a serial stream). Same smoke build: **64s → 22s**.
- `RunTracker.record` is now lock-guarded (metered calls land in parallel).

After: window has 8 streaming lines by t=5s. Full suite green (2 known stale-creds live tests).