### PR TITLE
build: separate GEPA judge model with cheap per-provider defaults

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -26,6 +26,7 @@ from wmh.cli.ui import (
     BuildParams,
     RichBuildReporter,
     build_summary_panel,
+    judge_model_default,
     models_table,
     run_build_wizard,
     run_play_repl,
@@ -217,6 +218,9 @@ def build(
         None, "--provider", help="Provider that serves the model (default: bedrock)."
     ),
     model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
+    judge_model: str = typer.Option(
+        None, "--judge-model", help="GEPA judge model id (default: cheap model per provider)."
+    ),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     gepa_budget: int = typer.Option(10, help="GEPA iterations (each ~one capped valset pass)."),
     train_split: float = typer.Option(
@@ -255,6 +259,7 @@ def build(
         region=region,
         gepa_budget=gepa_budget,
         train_split=train_split,
+        judge_model=judge_model,
         embed_provider=embed_provider,
         embed_model=embed_model,
         embed_dim=embed_dim,
@@ -305,6 +310,7 @@ def build(
         embed_dim=params.embed_dim,
         gepa_budget=params.gepa_budget,
         train_split=params.train_split,
+        judge_model=params.judge_model or judge_model_default(params.provider, params.model),
     )
     # Fail fast: ping the serve provider (and the embed path, if provider-backed) before spending
     # any rollouts. A missing SDK or bad creds otherwise surfaces only deep inside GEPA, which
@@ -322,6 +328,12 @@ def build(
         tracker,
         classify=classify_build_call,
     )
+    metered_judge = metered
+    if config.judge_model and config.judge_model != config.serve_provider_config().model:
+        judge_cfg = config.serve_provider_config().model_copy(update={"model": config.judge_model})
+        metered_judge = MeteredProvider(
+            providers.get_provider(judge_cfg), tracker, classify=classify_build_call
+        )
     build_stats = BuildTelemetryStats()
     with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
         result = run_build(
@@ -330,6 +342,7 @@ def build(
             vendor=VendorPull() if params.vendor else None,
             root=model_dir,
             serve_provider=metered,
+            judge_provider=metered_judge,
             embedder=get_embedder(config),
             reporter=TelemetryBuildReporter(reporter, build_stats),
         )

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -359,9 +359,9 @@ def test_build_interactive_wizard_creates_model(
     for var in ("AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
         monkeypatch.setenv(var, "test-cred")  # creds present: no interactive key prompts
     # --interactive forces the wizard even under CliRunner (non-TTY); feed each answer line in
-    # prompt order: name, file, provider (select), model (select), region (bedrock only), budget,
-    # embedder (select). The offline 'hashing' embedder skips the embed-model prompt; phi dim isn't
-    # prompted. Provider/model/embedder are picked by index against their option lists.
+    # prompt order: name, file, provider (select), model (select), region (bedrock only),
+    # judge model (select), budget, embedder (select). The offline 'hashing' embedder skips
+    # the embed-model prompt; phi dim isn't prompted. Provider/model/embedder pick by index.
     answers = "\n".join(
         [
             "wizard-built",
@@ -369,6 +369,7 @@ def test_build_interactive_wizard_creates_model(
             "3",  # provider: bedrock (order: openai, anthropic, bedrock, azure, ...)
             "1",  # model: us.anthropic.claude-opus-4-8
             "us-east-1",
+            "",  # judge model: accept the bedrock default (dated haiku)
             "4",  # gepa budget
             "1",  # embedder: hashing
         ]

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -67,7 +67,7 @@ _ACTIVITY_WINDOW_LINES = 8
 # Serve providers offered in the wizard picker, with the model ids each supports. The first model
 # in each list is the suggested default. Keep these in sync with the provider backends.
 _PROVIDER_MODELS: dict[str, list[str]] = {
-    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4"],
+    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-mini"],
     "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
     "bedrock": [
         "us.anthropic.claude-opus-4-8",
@@ -80,6 +80,20 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "azure": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
+
+# Default GEPA judge model per provider: a cheap, fast model of the same backend. Providers
+# without an entry judge on the serve model itself.
+_JUDGE_MODEL_DEFAULTS: dict[str, str] = {
+    "anthropic": "claude-haiku-4-5",
+    "openai": "gpt-5.4-mini",
+    "bedrock": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+}
+
+
+def judge_model_default(provider: str | None, serve_model: str) -> str:
+    """The GEPA judge model when none was chosen: cheap per-provider, else the serve model."""
+    return _JUDGE_MODEL_DEFAULTS.get(provider or "", serve_model)
+
 
 # Embedders offered in the wizard, with the embeddings-model ids each provider-backed one supports
 # (None = the offline hashing embedder, no model). First entry is the suggested default.
@@ -101,6 +115,8 @@ class BuildParams(BaseModel):
     # and the non-interactive path falls back to bedrock.
     provider: str | None = None
     model: str = "us.anthropic.claude-opus-4-8"
+    # GEPA judge model id; None = pick the cheap per-provider default in the wizard/build.
+    judge_model: str | None = None
     region: str | None = None
     gepa_budget: int = 10
     train_split: float = 0.8
@@ -234,6 +250,34 @@ def run_build_wizard(
         console.print("  [yellow]fix the credentials or pick a different provider/model[/yellow]")
         provider_default = provider
 
+    # GEPA judge model: defaults to a cheap model of the same provider (haiku / gpt-5.4-mini);
+    # picking the serve model itself is always on the list. Same inline verify + retry.
+    judge_default = defaults.judge_model or judge_model_default(provider, model)
+    judge_options = list(dict.fromkeys([judge_default, model, *_PROVIDER_MODELS[provider]]))
+    judge_notes = {model: "same as serve"} if model != judge_default else {}
+    while True:
+        judge_model = _select(
+            console,
+            ask,
+            "GEPA judge model id",
+            judge_options,
+            judge_default,
+            interactive=interactive,
+            notes=judge_notes,
+        )
+        if judge_model == model:
+            break  # the serve model was just verified
+        console.print(f"verifying {provider} (judge)…")
+        ping = check(ProviderConfig(kind=ProviderKind(provider), model=judge_model, region=region))
+        if ping.ok:
+            console.print(f"  {_CHECK} {provider} ({escape(judge_model)}) reachable")
+            break
+        console.print(
+            f"  [red]✗ {provider} ({escape(judge_model)}) failed[/red]: {escape(ping.detail or '')}"
+        )
+        console.print("  [yellow]pick a different judge model[/yellow]")
+        judge_default = judge_model
+
     gepa_budget = _prompt_int(
         console,
         ask,
@@ -296,6 +340,7 @@ def run_build_wizard(
         vendor=vendor,
         provider=provider,
         model=model,
+        judge_model=judge_model,
         region=region,
         gepa_budget=gepa_budget,
         train_split=defaults.train_split,

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -211,6 +211,7 @@ def test_build_wizard_collects_all_inputs() -> None:
             "bedrock",
             "us.anthropic.claude-opus-4-8",
             "us-east-1",
+            "",  # judge model: accept the bedrock default (dated haiku)
             "8",
             "hashing",
         ]
@@ -227,6 +228,7 @@ def test_build_wizard_collects_all_inputs() -> None:
     assert params.file == "/tmp/traces.jsonl"
     assert params.provider == "bedrock"
     assert params.region == "us-east-1"
+    assert params.judge_model == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
     assert params.gepa_budget == 8
     assert params.embed_provider == "hashing"
     assert params.train_split == 0.5
@@ -236,7 +238,7 @@ def test_build_wizard_select_by_number() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # Provider/model/embedder are numbered pickers; choosing by index must work. Pick anthropic (2),
     # its second model, no region prompt (not bedrock), budget 8, hashing embedder (1).
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "2", "2", "8", "1"])
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "2", "2", "", "8", "1"])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -246,6 +248,7 @@ def test_build_wizard_select_by_number() -> None:
     )
     assert params.provider == "anthropic"
     assert params.model == "claude-opus-4-7"  # second anthropic model
+    assert params.judge_model == "claude-haiku-4-5"  # blank accepted the anthropic judge default
     assert params.region is None  # region only prompted for bedrock
     assert params.embed_provider == "hashing"
 
@@ -254,7 +257,7 @@ def test_build_wizard_collects_provider_embedder() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # A provider-backed embedder adds an embeddings-model picker; phi dim keeps its default.
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "openai", "gpt-5.5", "8", "openai", "text-embedding-3-large"]
+        ["m", "/tmp/t.jsonl", "openai", "gpt-5.5", "", "8", "openai", "text-embedding-3-large"]
     )
     params = run_build_wizard(
         console,
@@ -272,7 +275,7 @@ def test_build_wizard_accepts_defaults_with_blank_input() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     # File provided (so that prompt is skipped); press Enter (blank) for every remaining prompt
     # (name/provider/model/region/budget/embedder) to accept the suggested defaults.
-    reader = _scripted_reader(["", "", "", "", "", ""])
+    reader = _scripted_reader(["", "", "", "", "", "", ""])
     defaults = BuildParams(name="seeded", file="/tmp/t.jsonl", provider="bedrock", gepa_budget=50)
     params = run_build_wizard(
         console, defaults, reader=reader, verify=_ok_verify, verify_embed=_ok_verify
@@ -432,7 +435,7 @@ def test_build_wizard_prompts_for_missing_credentials_and_saves(
     reader = _scripted_reader(
         # name, file, provider, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (skip),
         # model, region, budget, embedder
-        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "test-key-id", "", "1", "", "8", "1"]
+        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "test-key-id", "", "1", "", "", "8", "1"]
     )
     params = run_build_wizard(
         console,
@@ -465,7 +468,7 @@ def test_build_wizard_keeps_session_creds_when_persistence_fails(
     monkeypatch.setattr(ui_module, "upsert_env_var", refuse)
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "key-id", "secret", "1", "", "8", "1"]
+        ["m", "/tmp/t.jsonl", "bedrock", "us-east-1", "key-id", "secret", "1", "", "", "8", "1"]
     )
     params = run_build_wizard(
         console,
@@ -490,12 +493,13 @@ def test_build_wizard_verifies_provider_and_retries_on_failure() -> None:
         return VerifyResult(ok=ok, kind=cfg.kind, model=cfg.model, detail="" if ok else "bad key")
 
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "anthropic", "", "", ""])
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "anthropic", "", "", "", ""])
     params = run_build_wizard(
         console, BuildParams(name="default"), reader=reader, verify=flaky, verify_embed=_ok_verify
     )
     assert params.provider == "anthropic"
-    assert calls == ["openai", "anthropic"]
+    # openai fails, anthropic serve verifies, then the judge default (haiku) verifies too.
+    assert calls == ["openai", "anthropic", "anthropic"]
     assert "bad key" in console.export_text()
 
 
@@ -510,7 +514,7 @@ def test_build_wizard_verifies_embedder_with_embed_config() -> None:
 
     console = Console(force_terminal=False, no_color=True, width=100)
     reader = _scripted_reader(
-        ["m", "/tmp/t.jsonl", "openai", "", "", "openai", "text-embedding-3-large"]
+        ["m", "/tmp/t.jsonl", "openai", "", "", "", "openai", "text-embedding-3-large"]
     )
     run_build_wizard(
         console,
@@ -529,7 +533,7 @@ def test_build_wizard_defaults_to_first_provider_with_creds(monkeypatch) -> None
     # bedrock, azure order) whose creds are present — here anthropic, once openai's key is gone.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "", "", "", ""])
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "", "", "", "", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -545,7 +549,7 @@ def test_build_wizard_annotates_providers_that_have_keys(monkeypatch) -> None:  
     # Providers whose creds are present are labeled in the picker; cleared ones are not.
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     console = Console(force_terminal=False, no_color=True, width=100, record=True)
-    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "", ""])
+    reader = _scripted_reader(["m", "/tmp/t.jsonl", "openai", "", "", "", ""])
     run_build_wizard(
         console,
         BuildParams(name="default"),
@@ -606,7 +610,7 @@ def test_build_wizard_reprompts_on_unicode_digit_budget() -> None:
     # prompts are name/provider/model/budget/embedder (no region: the creds-default provider is
     # openai); blanks accept defaults, '²' is a bad budget that must be rejected and re-asked.
     console = Console(force_terminal=False, no_color=True, width=100)
-    reader = _scripted_reader(["", "", "", "²", "7", ""])
+    reader = _scripted_reader(["", "", "", "", "²", "7", ""])
     params = run_build_wizard(
         console,
         BuildParams(name="m", file="/tmp/t.jsonl"),

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -39,6 +39,8 @@ class HarnessConfig(BaseModel):
     # train/held-out ratio for GEPA; a proper fraction so both splits can be non-empty
     train_split: float = Field(default=0.8, gt=0.0, lt=1.0)
     gepa_budget: int = 10  # GEPA iterations; ~valset_cap calls each (see _cap_gepa_valset)
+    # Model id the GEPA judge runs on (same provider kind as serve). None = the serve model.
+    judge_model: str | None = None
     trace_adapter: str = "otel-genai"
 
     def provider_config(self, kind: ProviderKind) -> ProviderConfig:
@@ -77,6 +79,7 @@ class HarnessConfig(BaseModel):
         embed_dim: int,
         gepa_budget: int,
         train_split: float = 0.8,
+        judge_model: str | None = None,
     ) -> HarnessConfig:
         """Assemble a build config from the choices `wmh build` collects.
 
@@ -108,6 +111,7 @@ class HarnessConfig(BaseModel):
             embed_dim=embed_dim,
             gepa_budget=gepa_budget,
             train_split=train_split,
+            judge_model=judge_model,
         )
 
 

--- a/wmh/engine/build.py
+++ b/wmh/engine/build.py
@@ -97,6 +97,7 @@ def build(
     vendor: VendorPull | None = None,
     root: str = ".wmh",
     serve_provider: Provider | None = None,
+    judge_provider: Provider | None = None,
     embedder: Embedder | None = None,
     reporter: BuildReporter | None = None,
 ) -> OptimizeResult:
@@ -118,6 +119,16 @@ def build(
     report.split_done(len(train), len(test))
 
     provider = serve_provider or get_provider(config.serve_provider_config())
+    # The GEPA judge can run on a cheaper model (config.judge_model) of the same provider kind;
+    # with no judge_model it shares the serve provider.
+    if judge_provider is None:
+        serve_cfg = config.serve_provider_config()
+        if config.judge_model and config.judge_model != serve_cfg.model:
+            judge_provider = get_provider(
+                serve_cfg.model_copy(update={"model": config.judge_model})
+            )
+        else:
+            judge_provider = provider
     embed = embedder or HashingEmbedder(dim=config.embed_dim)
 
     # Serving index over the full corpus: at serve time we retrieve from everything we have seen.
@@ -145,7 +156,7 @@ def build(
     # that doesn't move the reported rubric fidelity.
     optimizer = GEPAOptimizer(
         provider,
-        RubricJudge(provider),
+        RubricJudge(judge_provider),
         retriever=EmbeddingRetriever(embed),
         on_rollout=_on_rollout,
         on_budget=_on_budget,


### PR DESCRIPTION
The wizard asked for a serve model but silently ran the GEPA judge on it too — expensive, since the judge fires once per metric call. Now:

- After the serve model verifies, the wizard asks for a **GEPA judge model id**, defaulting to a cheap same-provider model: `claude-haiku-4-5` (anthropic), `gpt-5.4-mini` (openai), `us.anthropic.claude-haiku-4-5-20251001-v1:0` (bedrock); other providers default to the serve model. The serve model is always on the list, annotated `(same as serve)`. The judge pick gets the same inline verify + retry.
- `gpt-5.4-mini` added to the openai serve-model list.
- Plumbing: `HarnessConfig.judge_model`, `wmh build --judge-model` (the flag path defaults to the same cheap mapping), `run_build(judge_provider=...)` so the CLI meters judge calls on the same run tracker.

Driven live: picker renders with default + 'same as serve' note; blank accepts gpt-5.4-mini and its verify pings ok. Full suite green (2 known stale-creds live tests).