### PR TITLE
The monorepo PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ uv run pytest -q
    reusable harness behavior.
 
 5. **The top level is an allowlist.** Tracked top-level directories are exactly: `wmh/`,
-   `examples/`, `docs/`, `assets/`, `web/`, `.agents/`, `.claude/`, `.github/`. Do not add others
-   (no `benchmarks/`, `scripts/`, `tools/`, `world-models/`, ...). `wmh/repo_layout_test.py`
-   enforces this. What each surface is for:
+   `examples/`, `docs/`, `assets/`, `web/`, `.agents/`, `.claude/`, `.github/`, plus the
+   monorepo package members `llm-waterfall/` and `environment-capture/` (see § Monorepo). Do not
+   add others (no `benchmarks/`, `scripts/`, `tools/`, `world-models/`, ...).
+   `wmh/repo_layout_test.py` enforces this. What each surface is for:
    - `docs/` — **finished products only, kept deliberately small**: `docs/research/`
      (completed research writeups + the one figure each renders) and `docs/reference/` (how-to
      references verified against main). Nothing else: raw result JSONs, vector sources, design
@@ -70,6 +71,9 @@ uv run pytest -q
    - `assets/` — media referenced by README/docs (demo GIFs, logos).
    - `.claude/` — checked-in agent skills (e.g. `/ready-for-merge`); local files
      (`settings.local.json`, locks) stay gitignored.
+   - `llm-waterfall/` — workspace member: stateless LLM failover (own PyPI package).
+   - `environment-capture/` — workspace member (pre-authorized; lands via its own PR):
+     benchmark adapters + real-run trace capture emitting OTel GenAI JSONL (own PyPI package).
 
 6. **Keep dataset-specific logic inside examples.** SWE-bench, tau-bench, terminal-task, and similar
    dataset-specific launch or conversion logic belongs under `examples/<task>/`. A standard example
@@ -135,6 +139,28 @@ uv run pytest -q
     The published figures under `docs/` (e.g. `docs/research/trace_scaling_law.png`) are the visual
     reference. (`.agents/scripts/plot_trace_scaling.py` shows one way to produce them, but
     `.agents/` contents are disposable — the palette above is the contract, not that script.)
+
+## Monorepo
+
+This repo is a **uv workspace** monorepo. The root `pyproject.toml` is the `wmh` flagship
+package (its quickstart is unchanged: clone → `uv sync` → `uv run wmh ...`), and each member is
+a top-level directory with its own `pyproject.toml`, its own version, and its own PyPI release.
+Rules of the road:
+
+- **Membership**: `[tool.uv.workspace].members` in the root pyproject; anything inside the
+  workspace that depends on a member resolves it from source via `[tool.uv.sources]`
+  (`{ workspace = true }`), never from PyPI.
+- **Dependency arrows**: members never import `wmh`, and `wmh` depends on members only through
+  their public, published APIs. Members must be installable and usable standalone.
+- **Gate scoping**: the root gate (`uv run ruff check .`, `uv run ty check`,
+  `uv run pytest -q`) covers the flagship and every Python member (member tests are inline
+  `*_test.py`, discovered via root `testpaths`). A member may carry stricter/looser settings in
+  its own `[tool.ruff]`/`[tool.ty]` tables (ruff resolves the closest config). `web/` keeps its
+  own separate JS gate (rule 5).
+- **Publishing**: each member releases to PyPI independently (`uv build`/`uv publish` from the
+  member dir); version bumps are per-member commits.
+- **One way to do each thing** (rule 13) applies across the workspace: if a capability exists in
+  a member, `wmh` consumes it rather than growing a parallel copy.
 
 ## Docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ uv run pytest -q
 
 5. **The top level is an allowlist.** Tracked top-level directories are exactly: `wmh/`,
    `examples/`, `docs/`, `assets/`, `web/`, `.agents/`, `.claude/`, `.github/`, plus the
-   monorepo package members `llm-waterfall/` and `environment-capture/` (see § Monorepo). Do not
+   monorepo workspace member `llm-waterfall/` and the pre-authorized future member
+   `environment-capture/` (see § Monorepo). Do not
    add others (no `benchmarks/`, `scripts/`, `tools/`, `world-models/`, ...).
    `wmh/repo_layout_test.py` enforces this. What each surface is for:
    - `docs/` — **finished products only, kept deliberately small**: `docs/research/`
@@ -82,7 +83,9 @@ uv run pytest -q
 
 7. **Route reusable workflows through `wmh`.** Avoid parallel top-level scripts for harness actions.
    If a workflow is generally useful outside one example dataset, implement it in `wmh/` and expose
-   it through the CLI.
+   it through the CLI — unless the capability already exists as (or deserves to be) a workspace
+   member, in which case depend on the member instead of growing a copy inside `wmh/`
+   (§ Monorepo, rule 13).
 
 8. **Keep imports explicit and fail-fast.** Put imports at module scope unless moving them is
    required to break a real circular dependency. Do not use lazy imports for optional convenience,
@@ -151,7 +154,10 @@ Rules of the road:
   workspace that depends on a member resolves it from source via `[tool.uv.sources]`
   (`{ workspace = true }`), never from PyPI.
 - **Dependency arrows**: members never import `wmh`, and `wmh` depends on members only through
-  their public, published APIs. Members must be installable and usable standalone.
+  their public, published APIs. Members must be installable and usable standalone. Consuming a
+  member takes BOTH halves: declare it in `[project.dependencies]` (so installs outside the
+  workspace resolve it) AND rely on `[tool.uv.sources]` for in-workspace source resolution —
+  the sources entry alone wires nothing.
 - **Gate scoping**: the root gate (`uv run ruff check .`, `uv run ty check`,
   `uv run pytest -q`) covers the flagship and every Python member (member tests are inline
   `*_test.py`, discovered via root `testpaths`). A member may carry stricter/looser settings in

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ This repository is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/
 `wmh` is the flagship package at the root (the quickstart above), and sibling packages live as
 top-level directories, each installable on its own:
 
-| Package | What it does | Install |
+| Package | What it does | Get it |
 |---|---|---|
-| **wmh** (root) | Agent traces → a faithful world model of your environment | `pip install wmh` *(or the quickstart above)* |
-| [`llm-waterfall/`](./llm-waterfall) | Pool LLM quota across models, providers, and AWS accounts: stateless failover that spills only on capacity errors, returning cost + the full attempt trail | `pip install llm-waterfall` |
+| **wmh** (root) | Agent traces → a faithful world model of your environment | the quickstart above |
+| [`llm-waterfall/`](./llm-waterfall) | Pool LLM quota across models, providers, and AWS accounts: stateless failover that spills only on capacity errors, returning cost + the full attempt trail | `pip install "llm-waterfall @ git+https://github.com/experientiallabs/world-model-harness#subdirectory=llm-waterfall"` *(PyPI release pending)* |
 | `environment-capture/` *(in progress)* | Point it at any agent benchmark: integrate via a small adapter, smoke-test it, capture real-run traces as OTel GenAI JSONL | — |
 
-One clone, one `uv sync`, one gate (`just gate`); each package publishes to PyPI independently.
+One clone, one `uv sync`, one gate (`just gate`); each package is built and released independently.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ One interface, four backends, verified on startup. Credentials are read from the
 | Azure OpenAI | GPT | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` |
 | OpenAI | GPT | `OPENAI_API_KEY` |
 
+## The monorepo
+
+This repository is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/):
+`wmh` is the flagship package at the root (the quickstart above), and sibling packages live as
+top-level directories, each installable on its own:
+
+| Package | What it does | Install |
+|---|---|---|
+| **wmh** (root) | Agent traces → a faithful world model of your environment | `pip install wmh` *(or the quickstart above)* |
+| [`llm-waterfall/`](./llm-waterfall) | Pool LLM quota across models, providers, and AWS accounts: stateless failover that spills only on capacity errors, returning cost + the full attempt trail | `pip install llm-waterfall` |
+| `environment-capture/` *(in progress)* | Point it at any agent benchmark: integrate via a small adapter, smoke-test it, capture real-run traces as OTel GenAI JSONL | — |
+
+One clone, one `uv sync`, one gate (`just gate`); each package publishes to PyPI independently.
+
 ## Development
 
 Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# Task entry points for the monorepo (uv workspace). `just` = list recipes.
+
+default:
+    @just --list
+
+# The whole-repo gate (AGENTS.md rule 1): flagship + every Python member.
+gate:
+    uv run ruff check .
+    uv run ruff format --check .
+    uv run ty check
+    uv run pytest -q
+
+test *ARGS:
+    uv run pytest -q {{ARGS}}
+
+lint:
+    uv run ruff check . && uv run ruff format --check .
+
+# Member-scoped runs from the workspace root, e.g. `just pkg llm-waterfall "pytest -q"`
+pkg member task:
+    uv run --package {{member}} {{task}}
+
+# web/ carries its own JS gate (AGENTS.md rule 5)
+web-gate:
+    cd web && npm run lint && npx tsc --noEmit

--- a/justfile
+++ b/justfile
@@ -20,6 +20,6 @@ lint:
 pkg member task:
     uv run --package {{member}} {{task}}
 
-# web/ carries its own JS gate (AGENTS.md rule 5)
+# web/ carries its own JS gate (AGENTS.md rule 5); no-op until web/ lands
 web-gate:
-    cd web && npm run lint && npx tsc --noEmit
+    @test -d web && (cd web && npm run lint && npx tsc --noEmit) || echo 'web/ not landed yet'

--- a/llm-waterfall/.gitignore
+++ b/llm-waterfall/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+.pytest_cache/
+.ruff_cache/
+uv.lock

--- a/llm-waterfall/AGENTS.md
+++ b/llm-waterfall/AGENTS.md
@@ -1,0 +1,67 @@
+# Agent guide — llm-waterfall
+
+A stateless, provider-agnostic LLM client that sends each call down an ordered waterfall of
+backends, failing over only on capacity errors (throttling / 5xx / timeouts) and propagating real
+client errors immediately. Every call returns which backend served it, token usage, and USD cost.
+
+## Toolchain
+
+Managed with `uv`; lint/format with `ruff`; type-check with `ty`.
+
+```bash
+uv sync --extra dev
+uv run ruff check . && uv run ruff format .
+uv run ty check
+uv run pytest -q
+```
+
+## Python
+
+- Every Python file must have a module docstring.
+- Write Google-style docstrings for all classes and functions with significant logic. Use plain
+  one-line docstrings for simple/self-explanatory classes and functions.
+
+## Rules
+
+1. **Clean tree before every commit.** Run `uv run ruff check .` and `uv run ty check` over the
+   **whole project** and fix **every** error before committing — including errors you don't think
+   you introduced. A commit must never add to or leave behind lint/type errors.
+
+2. **Tests live inline next to the code.** A module `foo.py` is tested by `foo_test.py` in the same
+   directory. There is no top-level `tests/` directory. Pytest is configured
+   (`python_files = ["*_test.py"]`) to discover these. Tests are excluded from the wheel.
+
+3. **Avoid generic types.** Do not use `Any`, bare `dict`/`object`, or untyped `**kwargs` where a
+   concrete type is practical. Prefer explicit pydantic models and fields; for genuinely arbitrary
+   JSON use pydantic's `JsonValue`, not `Any`.
+
+4. **Keep imports explicit and fail-fast.** Imports at module scope, with exactly one exception:
+   provider SDKs (`boto3`, `openai`, `anthropic`) are optional extras and are imported lazily
+   inside each adapter's lock-guarded client constructor so the package imports and constructs with
+   zero SDKs installed. Never catch `ImportError` to fall back to alternate behavior — a missing
+   SDK raises with the extra name to install.
+
+5. **Design every public surface from the perspective of a dev using it.** Write the call site
+   first, then implement. Public surfaces stay small, composable, and explicitly typed. Error
+   messages are part of the interface: a failure a user can hit must say what went wrong *and*
+   what to do about it.
+
+6. **Tests come before functionality.** Write the failing test first, watch it fail, then
+   implement until it passes. Bug fixes are no exception: capture the repro as a test first.
+   Never weaken a test merely to get green.
+
+7. **Verify end-to-end before claiming done.** Unit tests passing is necessary, not sufficient —
+   drive a real chain against a live backend and confirm observed behavior.
+
+8. **Build for now, not for the future.** No speculative generality, no unused hooks, no
+   backwards-compatibility shims pre-1.0. Make breaking changes freely; migrate every caller in
+   the same change; keep exactly one way to do each thing.
+
+9. **The classifier is the product's core contract.** Capacity classification prefers structured
+   error codes; message-substring matching stays conservative (transport phrases only). Never
+   match generic tokens like "429"/"503"/"capacity" against raw messages — a bad request whose
+   message contains them must propagate, not fail over. Every classifier change needs a test.
+
+10. **No global state.** No module-level mutable registries, no env-var reads/writes at call time,
+    no singletons. Configuration flows through constructor arguments; the only mutable state is
+    each adapter's lazily-built SDK client, guarded by a lock.

--- a/llm-waterfall/LICENSE
+++ b/llm-waterfall/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Experiential Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llm-waterfall/README.md
+++ b/llm-waterfall/README.md
@@ -1,0 +1,148 @@
+# llm-waterfall
+
+**Pool every LLM quota you own behind one client.** Rate limits are issued per model, per
+provider, per account — but a workload pinned to one backend can only ever use one of them, and
+stalls the moment it throttles. llm-waterfall chains your backends into a single stateless
+client: each call walks the chain in order, capacity errors (throttling, 5xx, timeouts) spill to
+the next backend, and real errors (bad request, auth, validation) raise immediately. A six-rung
+chain sustains roughly the sum of six rate limits instead of the minimum of one — capacity you
+already pay for, actually reachable.
+
+Every call returns which backend actually served it, token usage, USD cost, and the full attempt
+trail — as a return value, not a log line — so failover never blurs attribution.
+
+```python
+from llm_waterfall import Backend, Waterfall
+
+wf = Waterfall([
+    Backend("bedrock", "us.anthropic.claude-opus-4-6-v1", profile="endflow",   region="us-west-1"),
+    Backend("bedrock", "us.anthropic.claude-sonnet-4-6",  profile="endflow",   region="us-west-1"),
+    Backend("bedrock", "us.anthropic.claude-opus-4-6-v1", profile="stackwise", region="us-west-1"),
+    Backend("bedrock", "us.anthropic.claude-opus-4-7",    profile="stackwise", region="us-west-1"),
+    Backend("bedrock", "us.anthropic.claude-sonnet-4-6",  profile="stackwise", region="us-west-1"),
+    Backend("bedrock", "us.anthropic.claude-opus-4-8",    profile="stackwise", region="us-west-1"),
+])
+
+r = wf.complete(system="You are terse.", messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
+print(r.text, r.model_used, r.provider_used, r.cost_usd, r.usage, r.attempts)
+
+emb = wf.embed(["some text"])  # embeddings waterfall too
+```
+
+Chains can mix providers and credentials freely — the `profile` field maps to a named AWS profile
+(`boto3.Session(profile_name=...)`), so one chain can span multiple AWS accounts.
+
+```python
+wf = Waterfall([
+    Backend("anthropic", "claude-opus-4-8"),
+    Backend("bedrock", "us.anthropic.claude-opus-4-8", region="us-west-2"),
+    Backend("openai", "gpt-5.5"),
+])
+```
+
+## Install
+
+```bash
+pip install "llm-waterfall[bedrock]"           # extras: bedrock, openai, anthropic, azure, all
+pip install "llm-waterfall[all]"
+```
+
+The package imports with zero provider SDKs installed; each adapter imports its SDK on first use
+and raises a clear error naming the extra to install.
+
+## What spills, what doesn't
+
+The classifier is the core contract. It prefers structured error codes over message matching:
+
+| Signal | Examples | Verdict |
+| --- | --- | --- |
+| botocore error code in the capacity set | `ThrottlingException`, `ServiceUnavailableException`, `ModelNotReadyException`, `ModelTimeoutException`, `InternalServerException` | spill |
+| botocore error code **not** in the set | `ValidationException`, `AccessDeniedException` — even if the message contains "timeout" or "429" | raise |
+| OpenAI/Anthropic SDK exception type | `RateLimitError`, `APITimeoutError`, `APIConnectionError`, `InternalServerError`, `OverloadedError` | spill |
+| httpx/httpcore transport failure | `ConnectError`, `ReadError`, `RemoteProtocolError`, `ConnectTimeout`, `PoolTimeout`, ... | spill |
+| HTTP status on an SDK error | 408 / 429 / 500 / 502 / 503 / 504 / 529 | spill |
+| HTTP status on an SDK error | 400 / 401 / 403 / 404 / 422 | raise |
+| Transport-level message (no structure) | "read timeout", "connection reset", "throttl…" | spill |
+| Anything else | bad request, auth, validation | raise |
+
+Generic tokens like `429`, `503`, or `capacity` are **never** matched against raw messages — a bad
+request whose message happens to contain them propagates instead of silently failing over. (That
+was a real bug once.)
+
+## Attribution
+
+`model_used` / `provider_used` / `cost_usd` describe the backend that **actually served** the call,
+not the one you hoped would. `attempts` records the whole path:
+
+```python
+r = wf.complete(system="...", messages=[...])
+for a in r.attempts:
+    print(a.provider, a.model, a.outcome, f"{a.latency_s:.2f}s", a.error_type or "")
+# bedrock us.anthropic.claude-opus-4-6-v1 capacity_error 0.31s ThrottlingException
+# bedrock us.anthropic.claude-sonnet-4-6  ok             8.02s
+```
+
+When every backend is capacity-constrained, `complete()` raises `WaterfallExhausted` carrying the
+full `attempts` list, chained from the last capacity error. `WaterfallExhausted` itself classifies
+as a capacity error, so nested waterfalls and outer retry loops treat it as transient.
+
+## Retries
+
+Default is pure failover: one attempt per backend, no sleeping, restart at the primary next call.
+For long unattended runs where the whole chain may throttle at once, allow bounded wrap-around:
+
+```python
+from llm_waterfall import RetryPolicy
+
+wf = Waterfall(backends, retry=RetryPolicy(rounds=4))  # capped-exponential sleep between rounds
+```
+
+Every adapter disables its SDK's internal retries (`botocore total_max_attempts=1`, `max_retries=0`) so
+the waterfall solely owns retry policy — otherwise one throttled request becomes SDK-retries ×
+chain-length backend calls. Requests are bounded with connect/read timeouts (default 15 s / 600 s —
+generous enough not to cut off a long reasoning generation) so a stalled connection raises and
+fails over instead of hanging forever.
+
+## Cost
+
+A built-in USD-per-Mtok table covers current Claude, GPT-5.x, and embedding models, keyed by
+normalized model id (Bedrock region prefixes and version suffixes are stripped, so
+`us.anthropic.claude-opus-4-8-20260101-v1:0` prices as `claude-opus-4-8`). Unknown models cost
+`0.0`; use `price_for(model)` (returns `None`) to detect unpriced models. Override or extend per
+instance — no global mutation:
+
+```python
+from llm_waterfall import ModelPrice
+
+wf = Waterfall(backends, prices={"my-azure-deployment": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0)})
+```
+
+## Embeddings
+
+`wf.embed(texts)` runs the same waterfall. Each backend embeds with its `embed_model` (or the
+provider default: Titan v2 on Bedrock, `text-embedding-3-small` on OpenAI). Backends with no
+embeddings API (Anthropic) are recorded as `unsupported` in the attempt trail and skipped.
+
+Failover assumes the chain shares **one embedding space** — vectors from different embedding models
+are not comparable, and a chain that mixes them can silently poison a retrieval index. Keep
+`embed_model` consistent across rungs (e.g. the same Titan model behind several AWS profiles).
+
+## Backends
+
+| Provider | Status | Config |
+| --- | --- | --- |
+| `bedrock` | ✅ | `region`, `profile` (named AWS profile), creds via boto3 chain |
+| `openai` | ✅ | `OPENAI_API_KEY`, optional `endpoint` (custom base URL) |
+| `anthropic` | ✅ | `ANTHROPIC_API_KEY` |
+| `azure_openai` | ✅ | `endpoint` + `deployment` + `api_version`, `AZURE_OPENAI_API_KEY` |
+| `aws_mantle` | 🚧 stub (fails at construction) | |
+
+## Design notes
+
+- **Stateless.** A `Waterfall` is immutable after construction; results are returned, never logged
+  to a side channel. No module globals, no env mutation at call time — safe to share one instance
+  across a thread pool.
+- **Client errors never spill.** Failing over on a bad request just masks a real bug behind a
+  different model's answer.
+- **Born from long eval runs** dying at 3am because one endpoint throttled while five perfectly
+  good backends sat idle.

--- a/llm-waterfall/llm_waterfall/__init__.py
+++ b/llm-waterfall/llm_waterfall/__init__.py
@@ -1,0 +1,43 @@
+"""llm-waterfall: stateless LLM failover across an ordered chain of backends.
+
+Capacity errors (throttling, transient 5xx, timeouts) spill to the next backend; real client
+errors raise immediately. Every call returns which backend served it, token usage, USD cost, and
+the full attempt trail.
+"""
+
+from llm_waterfall.classify import is_capacity_error, outcome_for
+from llm_waterfall.pricing import ModelPrice, cost_usd, price_for
+from llm_waterfall.types import (
+    Attempt,
+    Backend,
+    CompletionResult,
+    EmbeddingResult,
+    EmbeddingsUnsupported,
+    Message,
+    RetryPolicy,
+    TokenUsage,
+    VerifyResult,
+    WaterfallExhausted,
+)
+from llm_waterfall.waterfall import Waterfall
+
+__version__ = "0.1.3"
+
+__all__ = [
+    "Attempt",
+    "Backend",
+    "CompletionResult",
+    "EmbeddingResult",
+    "EmbeddingsUnsupported",
+    "Message",
+    "ModelPrice",
+    "RetryPolicy",
+    "TokenUsage",
+    "VerifyResult",
+    "Waterfall",
+    "WaterfallExhausted",
+    "cost_usd",
+    "is_capacity_error",
+    "outcome_for",
+    "price_for",
+]

--- a/llm-waterfall/llm_waterfall/adapters/__init__.py
+++ b/llm-waterfall/llm_waterfall/adapters/__init__.py
@@ -1,0 +1,36 @@
+"""Adapter registry: map a Backend's provider name to its adapter class.
+
+Adapter modules import at module scope (they gate their SDK imports internally, so this package
+imports with zero SDKs installed); only the SDKs themselves are lazy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from llm_waterfall.adapters.anthropic import AnthropicAdapter
+from llm_waterfall.adapters.aws_mantle import AwsMantleAdapter
+from llm_waterfall.adapters.azure_openai import AzureOpenAIAdapter
+from llm_waterfall.adapters.base import Adapter
+from llm_waterfall.adapters.bedrock import BedrockAdapter
+from llm_waterfall.adapters.openai import OpenAIAdapter
+from llm_waterfall.types import PROVIDERS, Backend
+
+_ADAPTERS: dict[str, Callable[[Backend], Adapter]] = {
+    "bedrock": BedrockAdapter,
+    "openai": OpenAIAdapter,
+    "anthropic": AnthropicAdapter,
+    "azure_openai": AzureOpenAIAdapter,  # stub: raises NotImplementedError at construction
+    "aws_mantle": AwsMantleAdapter,  # stub: raises NotImplementedError at construction
+}
+
+
+def build_adapter(backend: Backend) -> Adapter:
+    """Construct the adapter for `backend`. Unimplemented providers fail here, fast."""
+    try:
+        factory = _ADAPTERS[backend.provider]
+    except KeyError:
+        raise ValueError(
+            f"unknown provider {backend.provider!r}; expected one of {', '.join(PROVIDERS)}"
+        ) from None
+    return factory(backend)

--- a/llm-waterfall/llm_waterfall/adapters/anthropic.py
+++ b/llm-waterfall/llm_waterfall/adapters/anthropic.py
@@ -1,0 +1,89 @@
+"""Anthropic direct-API adapter. Reads ANTHROPIC_API_KEY from the environment."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, cast
+
+from llm_waterfall.adapters.base import missing_sdk_error
+from llm_waterfall.types import Backend, EmbeddingsUnsupported, Message, TokenUsage
+
+if TYPE_CHECKING:
+    from anthropic import Anthropic
+    from anthropic.types import MessageParam
+
+
+class AnthropicAdapter:
+    """Claude via the direct Anthropic Messages API."""
+
+    def __init__(self, backend: Backend) -> None:
+        self.backend = backend
+        self._client: Anthropic | None = None
+        self._lock = threading.Lock()
+
+    def _get_client(self) -> Anthropic:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    try:
+                        import httpx
+                        from anthropic import Anthropic
+                    except ModuleNotFoundError as exc:
+                        raise missing_sdk_error("anthropic", "anthropic") from exc
+
+                    # max_retries=0: the waterfall owns retry policy. Granular httpx.Timeout so
+                    # a dead endpoint fails over after connect_timeout_s, not read_timeout_s.
+                    self._client = Anthropic(
+                        max_retries=0,
+                        timeout=httpx.Timeout(
+                            self.backend.read_timeout_s,
+                            connect=self.backend.connect_timeout_s,
+                        ),
+                    )
+        return self._client
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float | None,
+        max_tokens: int,
+    ) -> tuple[str, TokenUsage]:
+        """One Messages API call; system is a top-level arg (Anthropic-native)."""
+        api_messages = [
+            cast("MessageParam", {"role": m.role, "content": m.content}) for m in messages
+        ]
+        client_messages = self._get_client().messages
+        # Claude 4.7+ rejects sampling params; only forward temperature when explicitly set.
+        if temperature is None:
+            response = client_messages.create(
+                model=self.backend.model,
+                system=system,
+                messages=api_messages,
+                max_tokens=max_tokens,
+            )
+        else:
+            response = client_messages.create(
+                model=self.backend.model,
+                system=system,
+                messages=api_messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        text = "".join(block.text for block in response.content if block.type == "text")
+        usage = TokenUsage(
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+        )
+        return text, usage
+
+    def embed_model_id(self) -> str | None:
+        """Anthropic has no embeddings API."""
+        return None
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        raise EmbeddingsUnsupported(
+            "Anthropic has no embeddings API; put a bedrock or openai backend in the chain "
+            "for embeddings (the waterfall skips this backend for embed calls)."
+        )

--- a/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
+++ b/llm-waterfall/llm_waterfall/adapters/anthropic_test.py
@@ -1,0 +1,70 @@
+"""Tests for the Anthropic adapter (SDK stubbed — no network)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from llm_waterfall.adapters.anthropic import AnthropicAdapter
+from llm_waterfall.types import Backend, EmbeddingsUnsupported, Message
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeAnthropic:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.calls: list[dict[str, Any]] = []
+        self.messages = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs: Any) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="claude says hi")],
+            usage=SimpleNamespace(input_tokens=12, output_tokens=6),
+        )
+
+
+@pytest.fixture
+def fake_anthropic(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[_FakeAnthropic]]:
+    clients: list[_FakeAnthropic] = []
+    module = types.ModuleType("anthropic")
+
+    def factory(**kwargs: Any) -> _FakeAnthropic:
+        c = _FakeAnthropic(**kwargs)
+        clients.append(c)
+        return c
+
+    setattr(module, "Anthropic", factory)  # noqa: B010 - fake module attr
+    monkeypatch.setitem(sys.modules, "anthropic", module)
+    yield clients
+
+
+def test_request_shape_and_client_config(fake_anthropic: list[_FakeAnthropic]) -> None:
+    adapter = AnthropicAdapter(Backend("anthropic", "claude-opus-4-8"))
+    text, usage = adapter.complete(
+        "be terse", [Message(role="user", content="hi")], temperature=None, max_tokens=64
+    )
+    (client,) = fake_anthropic
+    assert client.kwargs["max_retries"] == 0
+    # Granular timeout: connect bounded separately so a dead endpoint fails over in ~15s.
+    timeout = client.kwargs["timeout"]
+    assert timeout.connect == 15.0 and timeout.read == 600.0
+    call = client.calls[0]
+    assert call["model"] == "claude-opus-4-8"
+    assert call["system"] == "be terse"  # top-level, not folded into messages
+    assert call["max_tokens"] == 64
+    assert "temperature" not in call
+    assert text == "claude says hi"
+    assert usage.input_tokens == 12 and usage.output_tokens == 6
+
+
+def test_embed_raises_unsupported(fake_anthropic: list[_FakeAnthropic]) -> None:
+    adapter = AnthropicAdapter(Backend("anthropic", "claude-opus-4-8"))
+    with pytest.raises(EmbeddingsUnsupported):
+        adapter.embed(["x"])

--- a/llm-waterfall/llm_waterfall/adapters/aws_mantle.py
+++ b/llm-waterfall/llm_waterfall/adapters/aws_mantle.py
@@ -1,0 +1,44 @@
+"""AWS Mantle adapter — stub that fails at construction.
+
+TODO: implement against the Bedrock Mantle client (`anthropic.AnthropicBedrockMantle` — the
+Messages-API Bedrock endpoint) with `aws_region=backend.region`, credentials via
+`boto3.Session(profile_name=backend.profile)`, `max_retries=0`, and the backend's timeouts.
+Model ids take an `anthropic.` prefix. Classification already covers its error shapes (the
+anthropic SDK exception types + botocore codes).
+
+Failing in `__init__` (not at call time) is deliberate: an unimplemented rung must break
+`Waterfall(...)` construction loudly, never abort a live call mid-chain.
+"""
+
+from __future__ import annotations
+
+from llm_waterfall.types import Backend, Message, TokenUsage
+
+
+class AwsMantleAdapter:
+    """Not implemented yet; constructing one fails fast with the workaround."""
+
+    backend: Backend  # satisfies the Adapter protocol; never assigned (init raises)
+
+    def __init__(self, backend: Backend) -> None:
+        raise NotImplementedError(
+            "the aws_mantle adapter is not implemented yet; use a 'bedrock' backend for AWS "
+            "traffic, or contribute the adapter (see the TODO in "
+            "llm_waterfall/adapters/aws_mantle.py)."
+        )
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float | None,
+        max_tokens: int,
+    ) -> tuple[str, TokenUsage]:
+        raise NotImplementedError  # pragma: no cover - unreachable (init raises)
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        raise NotImplementedError  # pragma: no cover - unreachable (init raises)
+
+    def embed_model_id(self) -> str | None:
+        raise NotImplementedError  # pragma: no cover - unreachable (init raises)

--- a/llm-waterfall/llm_waterfall/adapters/azure_openai.py
+++ b/llm-waterfall/llm_waterfall/adapters/azure_openai.py
@@ -1,0 +1,71 @@
+"""Azure OpenAI adapter: the OpenAI wire mapping behind an AzureOpenAI client.
+
+Requests route by DEPLOYMENT name (`Backend.deployment`, defaulting to `Backend.model`); the key
+is read from AZURE_OPENAI_API_KEY. Construction fails fast when `endpoint`/`api_version` are
+missing — a misconfigured rung must break `Waterfall(...)`, not a live call mid-chain.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from llm_waterfall.adapters.base import missing_sdk_error
+from llm_waterfall.adapters.openai import OpenAIAdapter
+from llm_waterfall.types import Backend, EmbeddingsUnsupported, TokenUsage
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+
+class AzureOpenAIAdapter(OpenAIAdapter):
+    """GPT-5.x Azure deployments; embeddings via an Azure embedding deployment."""
+
+    def __init__(self, backend: Backend) -> None:
+        if not backend.endpoint:
+            raise ValueError(
+                "azure_openai backends need endpoint= (e.g. https://<resource>.openai.azure.com)"
+            )
+        if not backend.api_version:
+            raise ValueError("azure_openai backends need api_version= (e.g. 2024-12-01-preview)")
+        # Validated non-None copies (the dataclass fields stay Optional for other providers).
+        self._azure_endpoint: str = backend.endpoint
+        self._api_version: str = backend.api_version
+        super().__init__(backend)
+
+    def _get_client(self) -> OpenAI:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    try:
+                        import httpx
+                        from openai import AzureOpenAI
+                    except ModuleNotFoundError as exc:
+                        raise missing_sdk_error("openai", "azure") from exc
+
+                    # Same policy as every adapter: the waterfall owns retries; bound connects.
+                    self._client = AzureOpenAI(
+                        azure_endpoint=self._azure_endpoint,
+                        api_version=self._api_version,
+                        max_retries=0,
+                        timeout=httpx.Timeout(
+                            self.backend.read_timeout_s,
+                            connect=self.backend.connect_timeout_s,
+                        ),
+                    )
+        return self._client
+
+    def _request_model(self) -> str:
+        # Azure routes by deployment name, not the base model id.
+        return self.backend.deployment or self.backend.model
+
+    def embed_model_id(self) -> str | None:
+        # Azure embeddings need their own deployment; there is no meaningful default.
+        return self.backend.embed_model
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        if self.backend.embed_model is None:
+            raise EmbeddingsUnsupported(
+                "this azure_openai backend has no embed_model= (an Azure embedding deployment); "
+                "the waterfall skips it for embed calls"
+            )
+        return super().embed(texts)

--- a/llm-waterfall/llm_waterfall/adapters/azure_openai_test.py
+++ b/llm-waterfall/llm_waterfall/adapters/azure_openai_test.py
@@ -1,0 +1,121 @@
+"""Tests for the Azure OpenAI adapter (SDK stubbed — no network)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from llm_waterfall.adapters.azure_openai import AzureOpenAIAdapter
+from llm_waterfall.types import Backend, Message
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeAzureOpenAI:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.chat_calls: list[dict[str, Any]] = []
+        self.embed_calls: list[dict[str, Any]] = []
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._chat_create))
+        self.embeddings = SimpleNamespace(create=self._embed_create)
+
+    def _chat_create(self, **kwargs: Any) -> SimpleNamespace:
+        self.chat_calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="azure says hi"))],
+            usage=SimpleNamespace(prompt_tokens=9, completion_tokens=4),
+        )
+
+    def _embed_create(self, **kwargs: Any) -> SimpleNamespace:
+        self.embed_calls.append(kwargs)
+        return SimpleNamespace(
+            data=[SimpleNamespace(embedding=[0.5])], usage=SimpleNamespace(prompt_tokens=2)
+        )
+
+
+@pytest.fixture
+def fake_azure(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[_FakeAzureOpenAI]]:
+    clients: list[_FakeAzureOpenAI] = []
+    module = types.ModuleType("openai")
+
+    def factory(**kwargs: Any) -> _FakeAzureOpenAI:
+        c = _FakeAzureOpenAI(**kwargs)
+        clients.append(c)
+        return c
+
+    setattr(module, "AzureOpenAI", factory)  # noqa: B010 - fake module attr
+    monkeypatch.setitem(sys.modules, "openai", module)
+    yield clients
+
+
+def _backend() -> Backend:
+    return Backend(
+        "azure_openai",
+        "gpt-5.4",
+        endpoint="https://x.openai.azure.com",
+        deployment="gpt-54-deploy",
+        api_version="2024-12-01-preview",
+    )
+
+
+def test_client_config_and_deployment_as_model(fake_azure: list[_FakeAzureOpenAI]) -> None:
+    adapter = AzureOpenAIAdapter(_backend())
+    text, usage = adapter.complete(
+        "be terse", [Message(role="user", content="hi")], temperature=None, max_tokens=64
+    )
+    (client,) = fake_azure
+    assert client.kwargs["azure_endpoint"] == "https://x.openai.azure.com"
+    assert client.kwargs["api_version"] == "2024-12-01-preview"
+    assert client.kwargs["max_retries"] == 0
+    assert client.kwargs["timeout"].connect == 15.0
+    call = client.chat_calls[0]
+    # Azure routes by DEPLOYMENT name, not the base model id.
+    assert call["model"] == "gpt-54-deploy"
+    assert call["max_completion_tokens"] == 64
+    assert call["messages"][0] == {"role": "system", "content": "be terse"}
+    assert text == "azure says hi"
+    assert usage.input_tokens == 9 and usage.output_tokens == 4
+
+
+def test_deployment_defaults_to_model(fake_azure: list[_FakeAzureOpenAI]) -> None:
+    backend = Backend(
+        "azure_openai", "gpt-5.4", endpoint="https://x.openai.azure.com", api_version="v"
+    )
+    adapter = AzureOpenAIAdapter(backend)
+    adapter.complete("", [Message(role="user", content="x")], temperature=None, max_tokens=8)
+    assert fake_azure[0].chat_calls[0]["model"] == "gpt-5.4"
+
+
+def test_embed_uses_embedding_deployment(fake_azure: list[_FakeAzureOpenAI]) -> None:
+    backend = Backend(
+        "azure_openai",
+        "gpt-5.4",
+        endpoint="https://x.openai.azure.com",
+        api_version="v",
+        embed_model="embed-deploy",
+    )
+    adapter = AzureOpenAIAdapter(backend)
+    vectors, usage = adapter.embed(["a"])
+    assert fake_azure[0].embed_calls[0]["model"] == "embed-deploy"
+    assert adapter.embed_model_id() == "embed-deploy"
+    assert vectors == [[0.5]]
+
+
+def test_construction_requires_endpoint_and_api_version() -> None:
+    with pytest.raises(ValueError, match="endpoint"):
+        AzureOpenAIAdapter(Backend("azure_openai", "gpt-5.4", api_version="v"))
+    with pytest.raises(ValueError, match="api_version"):
+        AzureOpenAIAdapter(Backend("azure_openai", "gpt-5.4", endpoint="https://x"))
+
+
+def test_embed_without_deployment_is_unsupported(fake_azure: list[_FakeAzureOpenAI]) -> None:
+    from llm_waterfall.types import EmbeddingsUnsupported
+
+    adapter = AzureOpenAIAdapter(_backend())
+    with pytest.raises(EmbeddingsUnsupported):
+        adapter.embed(["x"])

--- a/llm-waterfall/llm_waterfall/adapters/base.py
+++ b/llm-waterfall/llm_waterfall/adapters/base.py
@@ -1,0 +1,47 @@
+"""The Adapter protocol every provider backend implements.
+
+An adapter owns exactly one backend's SDK client and wire mapping. It raises its SDK's native
+exceptions — classification (capacity vs client error) happens centrally in
+`llm_waterfall.classify`, and the failover loop in `llm_waterfall.waterfall` owns retry policy.
+Adapters must not retry internally.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from llm_waterfall.types import Backend, Message, TokenUsage
+
+
+def missing_sdk_error(package: str, extra: str) -> ModuleNotFoundError:
+    """A ModuleNotFoundError that tells the user which extra installs the missing SDK."""
+    return ModuleNotFoundError(
+        f"the '{package}' package is required for this backend; "
+        f'install it with: pip install "llm-waterfall[{extra}]"'
+    )
+
+
+@runtime_checkable
+class Adapter(Protocol):
+    """One backend's completion + embedding implementation."""
+
+    backend: Backend
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float | None,
+        max_tokens: int,
+    ) -> tuple[str, TokenUsage]:
+        """Run one completion; return (text, usage). Raises the SDK's native errors."""
+        ...
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        """Embed texts; return (vectors, usage). Raises EmbeddingsUnsupported if N/A."""
+        ...
+
+    def embed_model_id(self) -> str | None:
+        """The model embed() resolves to (None if unsupported) — owns embed attribution."""
+        ...

--- a/llm-waterfall/llm_waterfall/adapters/bedrock.py
+++ b/llm-waterfall/llm_waterfall/adapters/bedrock.py
@@ -1,0 +1,134 @@
+"""AWS Bedrock adapter (Anthropic Messages schema via InvokeModel, Titan embeddings).
+
+Credentials come from the boto3 chain, or a named AWS profile when `Backend.profile` is set —
+`boto3.Session(profile_name=...)` — so one waterfall chain can span multiple AWS accounts.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import TYPE_CHECKING, TypedDict, cast
+
+from llm_waterfall.adapters.base import missing_sdk_error
+from llm_waterfall.types import Backend, Message, TokenUsage
+
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
+# Bedrock speaks the same Anthropic Messages schema as the direct API, pinned by this version tag.
+_ANTHROPIC_BEDROCK_VERSION = "bedrock-2023-05-31"
+
+# Default Titan text-embeddings model (v2 supports `dimensions` 256/512/1024).
+_DEFAULT_EMBED_MODEL = "amazon.titan-embed-text-v2:0"
+
+
+class _ContentBlock(TypedDict):
+    type: str
+    text: str
+
+
+class _Usage(TypedDict):
+    input_tokens: int
+    output_tokens: int
+
+
+class _MessagesResponse(TypedDict):
+    content: list[_ContentBlock]
+    usage: _Usage
+
+
+class _TitanEmbedResponse(TypedDict, total=False):
+    embedding: list[float]
+    inputTextTokenCount: int
+
+
+class BedrockAdapter:
+    """Claude (and Titan embeddings) via the Bedrock Runtime."""
+
+    def __init__(self, backend: Backend) -> None:
+        self.backend = backend
+        self._client: BaseClient | None = None
+        self._lock = threading.Lock()
+
+    def _get_client(self) -> BaseClient:
+        # Lazy + lock-guarded: boto3 is an optional extra, and boto3.Session construction is not
+        # thread-safe (the resulting client is — one Waterfall is shared across thread pools).
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    try:
+                        import boto3
+                        from botocore.config import Config
+                    except ModuleNotFoundError as exc:
+                        raise missing_sdk_error("boto3", "bedrock") from exc
+
+                    # Bound each request so a stalled connection RAISES instead of blocking
+                    # forever — the waterfall can only fail over on a raised error. read_timeout
+                    # is generous because reasoning models can legitimately generate for minutes;
+                    # a mid-generation cutoff wastes the whole call and silently substitutes a
+                    # different model into an eval.
+                    #
+                    # total_max_attempts=1 disables botocore's OWN retries on purpose (it counts
+                    # the initial request; botocore's `max_attempts` counts retries AFTER it, so
+                    # `max_attempts: 1` would still allow one hidden retry). Throttling/5xx/
+                    # timeouts must surface IMMEDIATELY to the waterfall, which owns retry policy
+                    # — SDK retries stack multiplicatively under the failover chain.
+                    config = Config(
+                        connect_timeout=self.backend.connect_timeout_s,
+                        read_timeout=self.backend.read_timeout_s,
+                        retries={"total_max_attempts": 1},
+                    )
+                    session = boto3.Session(
+                        profile_name=self.backend.profile, region_name=self.backend.region
+                    )
+                    self._client = session.client("bedrock-runtime", config=config)
+        return self._client
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float | None,
+        max_tokens: int,
+    ) -> tuple[str, TokenUsage]:
+        """One InvokeModel call with the Anthropic Messages body."""
+        body: dict[str, object] = {
+            "anthropic_version": _ANTHROPIC_BEDROCK_VERSION,
+            "max_tokens": max_tokens,
+            "system": system,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+        }
+        # Claude 4.7+ rejects sampling params; only forward temperature when explicitly set.
+        if temperature is not None:
+            body["temperature"] = temperature
+        raw = self._get_client().invoke_model(modelId=self.backend.model, body=json.dumps(body))
+        data = cast("_MessagesResponse", json.loads(raw["body"].read()))
+        text = "".join(block["text"] for block in data["content"] if block["type"] == "text")
+        usage = TokenUsage(
+            input_tokens=data["usage"]["input_tokens"],
+            output_tokens=data["usage"]["output_tokens"],
+        )
+        return text, usage
+
+    def embed_model_id(self) -> str | None:
+        """The model embed() resolves to — the single source of truth for embed attribution."""
+        return self.backend.embed_model or _DEFAULT_EMBED_MODEL
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        """Embed via Amazon Titan (one InvokeModel per text — Titan has no batch input)."""
+        model = self.backend.embed_model or _DEFAULT_EMBED_MODEL
+        client = self._get_client()
+        vectors: list[list[float]] = []
+        input_tokens = 0
+        for text in texts:
+            body: dict[str, object] = {"inputText": text}
+            if self.backend.embed_dim is not None:
+                body["dimensions"] = self.backend.embed_dim
+                body["normalize"] = True
+            raw = client.invoke_model(modelId=model, body=json.dumps(body))
+            data = cast("_TitanEmbedResponse", json.loads(raw["body"].read()))
+            vectors.append(data["embedding"])
+            input_tokens += data.get("inputTextTokenCount", 0)
+        return vectors, TokenUsage(input_tokens=input_tokens)

--- a/llm-waterfall/llm_waterfall/adapters/bedrock_test.py
+++ b/llm-waterfall/llm_waterfall/adapters/bedrock_test.py
@@ -1,0 +1,140 @@
+"""Tests for the Bedrock adapter (boto3 stubbed — no AWS calls)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+import types
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from llm_waterfall.adapters.bedrock import BedrockAdapter
+from llm_waterfall.types import Backend, Message
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeClient:
+    """Records invoke_model calls and returns canned Anthropic/Titan responses."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def invoke_model(self, *, modelId: str, body: str) -> dict[str, Any]:  # noqa: N803
+        parsed = json.loads(body)
+        self.calls.append({"modelId": modelId, "body": parsed})
+        if "inputText" in parsed:  # Titan embedding request
+            payload = {"embedding": [0.1, 0.2], "inputTextTokenCount": 3}
+        else:
+            payload = {
+                "content": [{"type": "text", "text": "hello"}],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
+        return {"body": io.BytesIO(json.dumps(payload).encode())}
+
+
+class _FakeSession:
+    def __init__(self, **kwargs: str | None) -> None:
+        self.kwargs = kwargs
+        self.client_args: dict[str, Any] = {}
+
+    def client(self, service: str, **kwargs: Any) -> _FakeClient:
+        self.client_args = {"service": service, **kwargs}
+        fake = _FakeClient()
+        self.made_client = fake
+        return fake
+
+
+@pytest.fixture
+def fake_boto3(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[_FakeSession]]:
+    sessions: list[_FakeSession] = []
+    boto3 = types.ModuleType("boto3")
+
+    def session_factory(**kwargs: str | None) -> _FakeSession:
+        s = _FakeSession(**kwargs)
+        sessions.append(s)
+        return s
+
+    setattr(boto3, "Session", session_factory)  # noqa: B010 - fake module attr
+
+    botocore = types.ModuleType("botocore")
+    botocore_config = types.ModuleType("botocore.config")
+
+    class Config:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    setattr(botocore_config, "Config", Config)  # noqa: B010 - fake module attr
+    monkeypatch.setitem(sys.modules, "boto3", boto3)
+    monkeypatch.setitem(sys.modules, "botocore", botocore)
+    monkeypatch.setitem(sys.modules, "botocore.config", botocore_config)
+    yield sessions
+
+
+def test_named_profile_and_region_flow_into_session(fake_boto3: list[_FakeSession]) -> None:
+    backend = Backend(
+        "bedrock", "us.anthropic.claude-opus-4-6-v1", profile="endflow", region="us-west-1"
+    )
+    adapter = BedrockAdapter(backend)
+    adapter.complete("sys", [Message(role="user", content="hi")], temperature=None, max_tokens=64)
+    (session,) = fake_boto3
+    assert session.kwargs == {"profile_name": "endflow", "region_name": "us-west-1"}
+    assert session.client_args["service"] == "bedrock-runtime"
+
+
+def test_sdk_retries_disabled_and_timeouts_bound(fake_boto3: list[_FakeSession]) -> None:
+    adapter = BedrockAdapter(Backend("bedrock", "m", region="us-west-2"))
+    adapter.complete("", [Message(role="user", content="hi")], temperature=None, max_tokens=64)
+    (session,) = fake_boto3
+    config = session.client_args["config"]
+    # total_max_attempts counts the initial request; 1 == zero botocore retries.
+    assert config.kwargs["retries"] == {"total_max_attempts": 1}
+    assert config.kwargs["connect_timeout"] == 15.0
+    assert config.kwargs["read_timeout"] == 600.0
+
+
+def test_request_body_shape(fake_boto3: list[_FakeSession]) -> None:
+    adapter = BedrockAdapter(Backend("bedrock", "model-x"))
+    text, usage = adapter.complete(
+        "be terse", [Message(role="user", content="hi")], temperature=None, max_tokens=99
+    )
+    call = fake_boto3[0].made_client.calls[0]
+    body = call["body"]
+    assert call["modelId"] == "model-x"
+    assert body["system"] == "be terse"
+    assert body["max_tokens"] == 99
+    assert body["messages"] == [{"role": "user", "content": "hi"}]
+    assert "temperature" not in body  # None → not forwarded
+    assert text == "hello"
+    assert usage.input_tokens == 10 and usage.output_tokens == 5
+
+
+def test_titan_embed_loop_and_dimensions(fake_boto3: list[_FakeSession]) -> None:
+    adapter = BedrockAdapter(Backend("bedrock", "m", embed_dim=512))
+    vectors, usage = adapter.embed(["a", "b"])
+    calls = fake_boto3[0].made_client.calls
+    assert len(calls) == 2  # one invoke per text
+    assert calls[0]["modelId"] == "amazon.titan-embed-text-v2:0"
+    assert calls[0]["body"] == {"inputText": "a", "dimensions": 512, "normalize": True}
+    assert vectors == [[0.1, 0.2], [0.1, 0.2]]
+    assert usage.input_tokens == 6
+
+
+def test_client_built_once_under_concurrency(fake_boto3: list[_FakeSession]) -> None:
+    adapter = BedrockAdapter(Backend("bedrock", "m"))
+    barrier = threading.Barrier(8)
+
+    def hit() -> None:
+        barrier.wait()
+        adapter.complete("", [Message(role="user", content="x")], temperature=None, max_tokens=8)
+
+    threads = [threading.Thread(target=hit) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(fake_boto3) == 1  # exactly one Session/client constructed

--- a/llm-waterfall/llm_waterfall/adapters/openai.py
+++ b/llm-waterfall/llm_waterfall/adapters/openai.py
@@ -1,0 +1,118 @@
+"""OpenAI adapter (chat completions + embeddings). Reads OPENAI_API_KEY from the environment."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, cast
+
+from llm_waterfall.adapters.base import missing_sdk_error
+from llm_waterfall.types import Backend, EmbeddingsUnsupported, Message, TokenUsage
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+    from openai.types.chat import ChatCompletionMessageParam
+
+_DEFAULT_EMBED_MODEL = "text-embedding-3-small"
+
+
+class OpenAIAdapter:
+    """GPT-5.x via chat completions; text-embedding-3-* for embeddings."""
+
+    def __init__(self, backend: Backend) -> None:
+        self.backend = backend
+        self._client: OpenAI | None = None
+        self._lock = threading.Lock()
+
+    def _get_client(self) -> OpenAI:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    try:
+                        import httpx
+                        from openai import OpenAI
+                    except ModuleNotFoundError as exc:
+                        raise missing_sdk_error("openai", "openai") from exc
+
+                    # max_retries=0: the waterfall owns retry policy — SDK retries would stack
+                    # multiplicatively under the failover chain. Granular httpx.Timeout so a
+                    # dead endpoint fails over after connect_timeout_s, not read_timeout_s.
+                    self._client = OpenAI(
+                        base_url=self.backend.endpoint,
+                        max_retries=0,
+                        timeout=httpx.Timeout(
+                            self.backend.read_timeout_s,
+                            connect=self.backend.connect_timeout_s,
+                        ),
+                    )
+        return self._client
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float | None,
+        max_tokens: int,
+    ) -> tuple[str, TokenUsage]:
+        """One chat completion.
+
+        `max_completion_tokens` (not the deprecated `max_tokens`) and no default temperature
+        keeps this compatible with GPT-5.x reasoning models, which reject the legacy field and
+        non-default sampling params.
+        """
+        wire: list[dict[str, str]] = []
+        if system:
+            wire.append({"role": "system", "content": system})
+        wire.extend({"role": m.role, "content": m.content} for m in messages)
+        api_messages = cast("list[ChatCompletionMessageParam]", wire)
+        chat = self._get_client().chat.completions
+        model = self._request_model()
+        if temperature is None:
+            response = chat.create(
+                model=model,
+                messages=api_messages,
+                max_completion_tokens=max_tokens,
+            )
+        else:
+            response = chat.create(
+                model=model,
+                messages=api_messages,
+                max_completion_tokens=max_tokens,
+                temperature=temperature,
+            )
+        if not response.choices:
+            # Content filtering (and some error modes) can return zero choices; surface it
+            # clearly rather than letting choices[0] raise a bare IndexError.
+            raise ValueError(f"{model} returned no choices")
+        text = response.choices[0].message.content or ""
+        usage = response.usage
+        token_usage = (
+            TokenUsage(input_tokens=usage.prompt_tokens, output_tokens=usage.completion_tokens)
+            if usage is not None
+            else TokenUsage()
+        )
+        return text, token_usage
+
+    def _request_model(self) -> str:
+        """The id sent as `model` on the wire (Azure overrides this with the deployment)."""
+        return self.backend.model
+
+    def embed_model_id(self) -> str | None:
+        """The model embed() resolves to — the single source of truth for embed attribution."""
+        return self.backend.embed_model or _DEFAULT_EMBED_MODEL
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        """Embed against `embed_model_id()` (OpenAI default: text-embedding-3-small)."""
+        model = self.embed_model_id()
+        if model is None:  # pragma: no cover - only reachable via subclasses
+            raise EmbeddingsUnsupported("no embedding deployment configured for this backend")
+        embeddings = self._get_client().embeddings
+        if self.backend.embed_dim is None:
+            response = embeddings.create(model=model, input=texts)
+        else:
+            response = embeddings.create(
+                model=model, input=texts, dimensions=self.backend.embed_dim
+            )
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", 0) if usage is not None else 0
+        return [item.embedding for item in response.data], TokenUsage(input_tokens=input_tokens)

--- a/llm-waterfall/llm_waterfall/adapters/openai_test.py
+++ b/llm-waterfall/llm_waterfall/adapters/openai_test.py
@@ -1,0 +1,96 @@
+"""Tests for the OpenAI adapter (SDK stubbed — no network)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from llm_waterfall.adapters.openai import OpenAIAdapter
+from llm_waterfall.types import Backend, Message
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.chat_calls: list[dict[str, Any]] = []
+        self.embed_calls: list[dict[str, Any]] = []
+        self.choices: list[Any] = [SimpleNamespace(message=SimpleNamespace(content="hi there"))]
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._chat_create))
+        self.embeddings = SimpleNamespace(create=self._embed_create)
+
+    def _chat_create(self, **kwargs: Any) -> SimpleNamespace:
+        self.chat_calls.append(kwargs)
+        return SimpleNamespace(
+            choices=self.choices,
+            usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3),
+        )
+
+    def _embed_create(self, **kwargs: Any) -> SimpleNamespace:
+        self.embed_calls.append(kwargs)
+        return SimpleNamespace(
+            data=[SimpleNamespace(embedding=[0.5, 0.5])],
+            usage=SimpleNamespace(prompt_tokens=4),
+        )
+
+
+@pytest.fixture
+def fake_openai(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[_FakeOpenAI]]:
+    clients: list[_FakeOpenAI] = []
+    module = types.ModuleType("openai")
+
+    def factory(**kwargs: Any) -> _FakeOpenAI:
+        c = _FakeOpenAI(**kwargs)
+        clients.append(c)
+        return c
+
+    setattr(module, "OpenAI", factory)  # noqa: B010 - fake module attr
+    monkeypatch.setitem(sys.modules, "openai", module)
+    yield clients
+
+
+def test_request_shape_and_client_config(fake_openai: list[_FakeOpenAI]) -> None:
+    adapter = OpenAIAdapter(Backend("openai", "gpt-5.5"))
+    text, usage = adapter.complete(
+        "be terse", [Message(role="user", content="hi")], temperature=None, max_tokens=64
+    )
+    (client,) = fake_openai
+    # SDK-internal retries disabled; requests bounded by the backend's timeouts.
+    assert client.kwargs["max_retries"] == 0
+    # Granular timeout: connect bounded separately so a dead endpoint fails over in ~15s.
+    timeout = client.kwargs["timeout"]
+    assert timeout.connect == 15.0 and timeout.read == 600.0
+    call = client.chat_calls[0]
+    assert call["model"] == "gpt-5.5"
+    assert call["max_completion_tokens"] == 64  # not the deprecated max_tokens
+    assert "temperature" not in call
+    assert call["messages"][0] == {"role": "system", "content": "be terse"}  # folded system
+    assert text == "hi there"
+    assert usage.input_tokens == 7 and usage.output_tokens == 3
+
+
+def test_zero_choices_raises_value_error(fake_openai: list[_FakeOpenAI]) -> None:
+    adapter = OpenAIAdapter(Backend("openai", "gpt-5.5"))
+    fake = adapter  # trigger client creation via one call setup
+    _ = fake
+    # Prime a client whose next response has no choices.
+    adapter.complete("", [Message(role="user", content="x")], temperature=None, max_tokens=8)
+    fake_openai[0].choices = []
+    with pytest.raises(ValueError, match="no choices"):
+        adapter.complete("", [Message(role="user", content="x")], temperature=None, max_tokens=8)
+
+
+def test_embed_default_model_and_dimensions(fake_openai: list[_FakeOpenAI]) -> None:
+    adapter = OpenAIAdapter(Backend("openai", "gpt-5.5", embed_dim=256))
+    vectors, usage = adapter.embed(["a"])
+    call = fake_openai[0].embed_calls[0]
+    assert call["model"] == "text-embedding-3-small"
+    assert call["dimensions"] == 256
+    assert vectors == [[0.5, 0.5]]
+    assert usage.input_tokens == 4

--- a/llm-waterfall/llm_waterfall/classify.py
+++ b/llm-waterfall/llm_waterfall/classify.py
@@ -1,0 +1,132 @@
+"""Capacity-vs-client error classification — the contract that decides failover vs propagate.
+
+Capacity errors (throttling, transient 5xx, model-not-ready, transport timeouts) mean "this backend
+can't serve right now; the next one might" — the waterfall spills. Client errors (bad request,
+auth, validation) mean "this request is wrong" — failing over would just mask a real bug behind a
+different model's answer, so they propagate immediately.
+
+Classification is pure duck-typing with zero SDK imports, so the package works with any subset of
+provider SDKs installed and the logic is testable with fake exceptions. Signals are checked in
+fidelity order: a structured error code always wins over anything derived from the message.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from llm_waterfall.types import WaterfallExhausted
+
+Outcome = Literal["capacity_error", "client_error"]
+
+# Botocore error CODES that mean "this model is capacity-constrained right now" — the reliable
+# signal (from `exc.response["Error"]["Code"]`), preferred over everything else.
+_CAPACITY_ERROR_CODES = frozenset(
+    {
+        "ThrottlingException",
+        "TooManyRequestsException",
+        "ServiceUnavailableException",
+        "ServiceQuotaExceededException",
+        "ModelNotReadyException",
+        "ModelTimeoutException",
+        "InternalServerException",  # transient 5xx, safe to fail over
+    }
+)
+
+# Exception class NAMES from the OpenAI/Anthropic SDKs (and their httpx/httpcore transport) that
+# mean capacity/transport failure. Matched by name + module gate rather than isinstance so the
+# SDKs never need to be importable.
+_SDK_CAPACITY_TYPE_NAMES = frozenset(
+    {
+        "RateLimitError",
+        "APITimeoutError",
+        "APIConnectionError",
+        "InternalServerError",
+        "OverloadedError",  # anthropic 529
+        # httpx/httpcore transient transport failures (no status code on any of them):
+        "ConnectTimeout",
+        "ReadTimeout",
+        "WriteTimeout",
+        "PoolTimeout",
+        "ConnectError",
+        "ReadError",
+        "WriteError",
+        "RemoteProtocolError",  # server disconnected mid-response
+    }
+)
+
+# Top-level modules whose exceptions we trust for name/status-code classification. An exception
+# named `RateLimitError` from arbitrary application code proves nothing.
+_TRUSTED_SDK_MODULES = frozenset({"openai", "anthropic", "httpx", "httpcore"})
+
+# HTTP statuses on a trusted SDK error that mean capacity/transient failure. 529 is Anthropic's
+# "overloaded". Everything else (400/401/403/404/422/...) is a client error.
+_CAPACITY_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504, 529})
+
+# Last-resort substrings for structureless transport errors (e.g. botocore's Read/ConnectTimeout,
+# raw ConnectionError), which carry no code, no trusted type, no status. Kept conservative: only
+# phrases that unambiguously mean capacity/transport failure, NOT generic tokens like "429"/"503"/
+# "capacity" that can appear inside a bad-request message and turn a real error into a silent
+# failover. (That was a real bug once: `ValidationException: request timeout too large`.)
+_TRANSPORT_MARKERS = (
+    "throttl",
+    "read timeout",
+    "connect timeout",
+    "connection reset",
+    "connection aborted",
+    "could not connect to the endpoint",  # botocore EndpointConnectionError (DNS/unreachable)
+    "timed out",
+    "service unavailable",
+    "model not ready",
+)
+
+
+def _from_trusted_sdk(exc: Exception) -> bool:
+    """Whether `exc` was defined by a provider SDK or its HTTP transport."""
+    module = type(exc).__module__ or ""
+    return module.split(".")[0] in _TRUSTED_SDK_MODULES
+
+
+def outcome_for(exc: Exception) -> Outcome:
+    """Classify an exception raised by a backend attempt.
+
+    Checks, in fidelity order:
+      1. Our own `WaterfallExhausted` — a nested chain that exhausted was capacity-constrained
+         by definition (outer waterfalls/retry loops must treat it as transient).
+      2. Structured botocore error code — authoritative; a non-capacity code stops here so a
+         message substring can never overrule it.
+      3. SDK exception type name, gated on the defining module.
+      4. HTTP status, from a `status_code` attribute on the exception or on its `.response`
+         (httpx.HTTPStatusError carries it there), same module gate.
+      5. Conservative transport-phrase substrings for structureless errors.
+    """
+    if isinstance(exc, WaterfallExhausted):
+        return "capacity_error"
+
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error")
+        # Guard the shape: a duck-typed `.response` dict may carry a non-dict "Error" value;
+        # classification must never raise over the original exception.
+        code = error.get("Code") if isinstance(error, dict) else None
+        if code is not None:
+            return "capacity_error" if code in _CAPACITY_ERROR_CODES else "client_error"
+
+    if _from_trusted_sdk(exc):
+        if type(exc).__name__ in _SDK_CAPACITY_TYPE_NAMES:
+            return "capacity_error"
+        status = getattr(exc, "status_code", None)
+        if not isinstance(status, int):
+            # httpx.HTTPStatusError keeps the status on the response object instead.
+            status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return "capacity_error" if status in _CAPACITY_STATUS_CODES else "client_error"
+
+    message = str(exc).lower()
+    if any(marker in message for marker in _TRANSPORT_MARKERS):
+        return "capacity_error"
+    return "client_error"
+
+
+def is_capacity_error(exc: Exception) -> bool:
+    """True when the waterfall should spill to the next backend instead of raising."""
+    return outcome_for(exc) == "capacity_error"

--- a/llm-waterfall/llm_waterfall/classify_test.py
+++ b/llm-waterfall/llm_waterfall/classify_test.py
@@ -1,0 +1,179 @@
+"""Tests for capacity-vs-client error classification (the package's core contract)."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_waterfall.classify import is_capacity_error, outcome_for
+
+
+class _BotocoreShaped(Exception):
+    """Duck-types botocore.exceptions.ClientError: carries `.response["Error"]["Code"]`."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.response = {"Error": {"Code": code, "Message": message}}
+
+
+def _sdk_exception(
+    name: str, module: str, message: str = "", status_code: int | None = None
+) -> Exception:
+    """Build a fake SDK exception with a chosen class name, module, and optional status_code."""
+    attrs: dict[str, int] = {}
+    cls = type(name, (Exception,), attrs)
+    cls.__module__ = module
+    exc = cls(message)
+    if status_code is not None:
+        exc.status_code = status_code
+    return exc
+
+
+# --- Tier 1: botocore structured codes ---
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "ThrottlingException",
+        "TooManyRequestsException",
+        "ServiceUnavailableException",
+        "ServiceQuotaExceededException",
+        "ModelNotReadyException",
+        "ModelTimeoutException",
+        "InternalServerException",
+    ],
+)
+def test_capacity_codes_are_capacity(code: str) -> None:
+    assert is_capacity_error(_BotocoreShaped(code, "boom"))
+
+
+def test_validation_exception_with_timeout_message_is_client_error() -> None:
+    # Regression: a structured non-capacity code must win over message substrings. The prototype
+    # once classified this as capacity because the message contains "timeout".
+    exc = _BotocoreShaped("ValidationException", "request timeout too large for this model")
+    assert not is_capacity_error(exc)
+    assert outcome_for(exc) == "client_error"
+
+
+def test_access_denied_is_client_error() -> None:
+    assert outcome_for(_BotocoreShaped("AccessDeniedException", "not authorized")) == "client_error"
+
+
+# --- Tier 2: SDK exception types, gated on module ---
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "RateLimitError",
+        "APITimeoutError",
+        "APIConnectionError",
+        "InternalServerError",
+        "OverloadedError",
+        "ConnectError",
+        "ReadError",
+        "RemoteProtocolError",
+        "PoolTimeout",
+    ],
+)
+@pytest.mark.parametrize("module", ["openai", "anthropic._exceptions", "httpx", "httpcore"])
+def test_sdk_capacity_types_are_capacity(name: str, module: str) -> None:
+    assert is_capacity_error(_sdk_exception(name, module))
+
+
+def test_sdk_type_name_from_foreign_module_is_client_error() -> None:
+    # Same class name, wrong module: the gate must reject lookalikes from arbitrary code.
+    assert outcome_for(_sdk_exception("RateLimitError", "myapp.errors")) == "client_error"
+
+
+def test_sdk_bad_request_type_is_client_error() -> None:
+    assert outcome_for(_sdk_exception("BadRequestError", "openai")) == "client_error"
+
+
+# --- Tier 3: status codes on SDK errors ---
+
+
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504, 529])
+def test_capacity_status_codes_are_capacity(status: int) -> None:
+    assert is_capacity_error(_sdk_exception("APIStatusError", "anthropic", status_code=status))
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+def test_client_status_codes_are_client_error(status: int) -> None:
+    exc = _sdk_exception("APIStatusError", "openai", status_code=status)
+    assert outcome_for(exc) == "client_error"
+
+
+def test_status_code_from_foreign_module_is_ignored() -> None:
+    # A random exception with a status_code attribute must not be treated as an SDK signal...
+    exc = _sdk_exception("MyError", "myapp", status_code=429)
+    assert outcome_for(exc) == "client_error"
+
+
+# --- Tier 4: conservative transport substrings ---
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Read timeout on endpoint URL",
+        "Connect timeout on endpoint URL",
+        "Connection reset by peer",
+        "Connection aborted.",
+        "request timed out",
+        "throttling: too fast",
+        "Service Unavailable",
+        "model not ready yet",
+        # botocore EndpointConnectionError — found live: an unreachable endpoint must spill.
+        'Could not connect to the endpoint URL: "https://bedrock-runtime.x.amazonaws.com/"',
+    ],
+)
+def test_transport_messages_are_capacity(message: str) -> None:
+    assert is_capacity_error(ConnectionError(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "got 429 in payload",  # never match raw "429"
+        "field must be < 503",  # never match raw "503"
+        "service capacity exceeded",  # never match raw "capacity"
+        "invalid request body",
+    ],
+)
+def test_generic_tokens_never_match(message: str) -> None:
+    assert outcome_for(ValueError(message)) == "client_error"
+
+
+# --- Structural edge cases found in review ---
+
+
+def test_non_dict_error_value_never_crashes_classification() -> None:
+    # Regression: a duck-typed .response with a non-dict "Error" must not raise from classify.
+    class Weird(Exception):
+        def __init__(self) -> None:
+            super().__init__("throttled")
+            self.response = {"Error": "overloaded"}
+
+    assert is_capacity_error(Weird())  # falls through to the "throttl" transport marker
+
+
+def test_status_code_read_from_response_object() -> None:
+    # Regression: httpx.HTTPStatusError carries the status on .response.status_code.
+    class _Resp:
+        status_code = 529
+
+    resp = _Resp()
+    exc = _sdk_exception("HTTPStatusError", "httpx", "Server error '529 ' for url 'https://x'")
+    setattr(exc, "response", resp)  # noqa: B010 - dynamic attr on a synthesized exception
+    assert is_capacity_error(exc)
+    resp.status_code = 404
+    assert outcome_for(exc) == "client_error"
+
+
+def test_waterfall_exhausted_is_capacity() -> None:
+    # Regression: a nested chain's exhaustion is capacity by definition — outer retry loops
+    # and outer waterfalls must treat it as transient, not as a client error.
+    from llm_waterfall.types import WaterfallExhausted
+
+    assert is_capacity_error(WaterfallExhausted("all rungs throttled", []))

--- a/llm-waterfall/llm_waterfall/import_hygiene_test.py
+++ b/llm-waterfall/llm_waterfall/import_hygiene_test.py
@@ -1,0 +1,50 @@
+"""The package must import and construct with zero provider SDKs installed."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+_SDK_ROOTS = ("boto3", "botocore", "openai", "anthropic")
+
+
+def test_import_and_construct_without_sdks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate a bare environment: any SDK import raises, cached modules removed — including
+    # llm_waterfall itself, or an earlier-collected test's import makes this a cache hit that
+    # would mask a top-level SDK import sneaking into the package.
+    for name in list(sys.modules):
+        if name.split(".")[0] in (*_SDK_ROOTS, "llm_waterfall"):
+            monkeypatch.delitem(sys.modules, name)
+    real_import = builtins.__import__
+
+    def blocking_import(
+        name: str,
+        globals: Mapping[str, object] | None = None,  # noqa: A002 - __import__ signature
+        locals: Mapping[str, object] | None = None,  # noqa: A002 - __import__ signature
+        fromlist: Sequence[str] = (),
+        level: int = 0,
+    ) -> types.ModuleType:
+        if name.split(".")[0] in _SDK_ROOTS:
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocking_import)
+
+    from llm_waterfall import Backend, Waterfall
+
+    wf = Waterfall(
+        [
+            Backend("bedrock", "us.anthropic.claude-opus-4-8", profile="p", region="us-west-2"),
+            Backend("openai", "gpt-5.5"),
+            Backend("anthropic", "claude-opus-4-8"),
+        ]
+    )
+    assert len(wf.backends) == 3
+
+    # First actual call must fail with a clear "install the extra" message, not a bare import.
+    with pytest.raises(ModuleNotFoundError, match=r"llm-waterfall\[bedrock\]"):
+        wf.complete(system="", messages=[{"role": "user", "content": "hi"}])

--- a/llm-waterfall/llm_waterfall/pricing.py
+++ b/llm-waterfall/llm_waterfall/pricing.py
@@ -1,0 +1,110 @@
+"""Per-model token pricing → USD cost.
+
+Provider-agnostic: prices are keyed by a normalized model id (routing prefixes like Bedrock's
+`us.anthropic.` are stripped before lookup), so the same Opus 4.8 row covers the direct API and
+Bedrock. Prices are USD per 1M tokens; an unknown model costs 0.0 and `price_for` returns None so
+callers can surface "cost unavailable" rather than silently under-reporting. Per-call overrides are
+passed explicitly — there is no global mutable registry.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from pydantic import BaseModel
+
+from llm_waterfall.types import TokenUsage
+
+# Bedrock appends a snapshot date and/or version to the model id, e.g.
+# `claude-haiku-4-5-20251001-v1:0` or `claude-opus-4-6-v1`. Strip them so the lookup key matches
+# the undated table rows (`claude-haiku-4-5`). Only applied to `claude-*` ids.
+_BEDROCK_SUFFIX = re.compile(r"(-\d{8})?(-v\d+)?(:\d+)?$")
+
+
+class ModelPrice(BaseModel):
+    """USD per 1,000,000 tokens, split by input/output."""
+
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+# Keyed by normalized model id (see `_normalize`). USD per 1M tokens.
+#
+# Completion prices verified 2026-07-01 against the live vendor pricing pages (Claude via
+# platform.claude.com models overview; OpenAI GPT-5.x Standard tier, short context). Embedding
+# prices are long-stable list prices; treat as approximate.
+_PRICES: dict[str, ModelPrice] = {
+    # --- Anthropic / Bedrock (Claude) ---
+    "claude-fable-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
+    "claude-mythos-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
+    "claude-opus-4-8": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-7": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-6": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-1": ModelPrice(input_per_mtok=15.0, output_per_mtok=75.0),
+    "claude-sonnet-5": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
+    "claude-sonnet-4-6": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
+    "claude-haiku-4-5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
+    # --- OpenAI / Azure OpenAI (GPT-5.x; Azure deployments reuse the base model's price) ---
+    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=30.0),
+    "gpt-5.5-pro": ModelPrice(input_per_mtok=30.0, output_per_mtok=180.0),
+    "gpt-5.4": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0),
+    "gpt-5.4-mini": ModelPrice(input_per_mtok=0.75, output_per_mtok=4.5),
+    "gpt-5.4-nano": ModelPrice(input_per_mtok=0.2, output_per_mtok=1.25),
+    # Azure-hosted OSS deployments (qwen3-coder, agentworld, ...) are deliberately absent:
+    # a $0 placeholder row would defeat the price_for()->None "cost unavailable" contract.
+    # Supply their negotiated rates per Waterfall via the `prices` override.
+    # --- Embeddings (output tokens are always 0 for embed calls) ---
+    "text-embedding-3-small": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),
+    "text-embedding-3-large": ModelPrice(input_per_mtok=0.13, output_per_mtok=0.0),
+    "amazon.titan-embed-text-v2:0": ModelPrice(input_per_mtok=0.02, output_per_mtok=0.0),
+}
+
+
+def _normalize(model: str) -> str:
+    """Strip provider/region routing prefixes so one row covers a model across providers.
+
+    Bedrock ids look like `us.anthropic.claude-opus-4-8`; the direct API uses `claude-opus-4-8`.
+    We drop a leading region segment (`us.`/`eu.`/...) and an `anthropic.` vendor segment, but keep
+    `amazon.titan-...` (its `amazon.` is part of the canonical model id, not a routing prefix).
+    """
+    normalized = model.strip()
+    region_prefixes = ("us.", "eu.", "apac.", "us-gov.", "global.", "jp.", "au.", "ca.")
+    for prefix in region_prefixes:
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    if normalized.startswith("anthropic."):
+        normalized = normalized[len("anthropic.") :]
+    if normalized.startswith("claude-"):
+        # Drop a trailing Bedrock snapshot date / version (`-20251001-v1:0`, `-v1`) so dated
+        # inference-profile ids match the undated table rows.
+        normalized = _BEDROCK_SUFFIX.sub("", normalized)
+    return normalized
+
+
+def price_for(model: str, prices: Mapping[str, ModelPrice] | None = None) -> ModelPrice | None:
+    """The price row for `model` (after normalization), or None if unknown.
+
+    `prices` are per-caller overrides consulted before the static table; they are never merged
+    into it, so one Waterfall's overrides can't leak into another's.
+    """
+    key = _normalize(model)
+    if prices is not None:
+        override = prices.get(key) or prices.get(model)
+        if override is not None:
+            return override
+    return _PRICES.get(key)
+
+
+def cost_usd(
+    model: str, usage: TokenUsage, prices: Mapping[str, ModelPrice] | None = None
+) -> float:
+    """USD cost of `usage` on `model`. Unknown models cost 0.0 (`price_for` detects that)."""
+    price = price_for(model, prices)
+    if price is None:
+        return 0.0
+    return (
+        usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+    ) / 1_000_000

--- a/llm-waterfall/llm_waterfall/pricing_test.py
+++ b/llm-waterfall/llm_waterfall/pricing_test.py
@@ -1,0 +1,60 @@
+"""Tests for model-id normalization and USD cost computation."""
+
+from __future__ import annotations
+
+from llm_waterfall.pricing import ModelPrice, cost_usd, price_for
+from llm_waterfall.types import TokenUsage
+
+
+def test_bedrock_id_normalizes_to_table_row() -> None:
+    dated = price_for("us.anthropic.claude-opus-4-8-20260101-v1:0")
+    bare = price_for("claude-opus-4-8")
+    assert dated is not None and dated == bare
+
+
+def test_region_and_vendor_prefixes_stripped() -> None:
+    assert price_for("eu.anthropic.claude-sonnet-4-6") == price_for("claude-sonnet-4-6")
+    assert price_for("anthropic.claude-haiku-4-5") == price_for("claude-haiku-4-5")
+
+
+def test_titan_id_kept_intact() -> None:
+    assert price_for("amazon.titan-embed-text-v2:0") is not None
+
+
+def test_unknown_model_costs_zero_and_prices_none() -> None:
+    assert price_for("mystery-model-9000") is None
+    assert cost_usd("mystery-model-9000", TokenUsage(input_tokens=1000, output_tokens=1000)) == 0.0
+
+
+def test_cost_math() -> None:
+    # Opus 4.8: $5/Mtok in, $25/Mtok out.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=100_000)
+    assert cost_usd("claude-opus-4-8", usage) == 5.0 + 2.5
+
+
+def test_overrides_win_and_do_not_mutate_table() -> None:
+    override = {"claude-opus-4-8": ModelPrice(input_per_mtok=1.0, output_per_mtok=1.0)}
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0)
+    assert cost_usd("claude-opus-4-8", usage, prices=override) == 1.0
+    # The static table is untouched for callers without the override.
+    assert cost_usd("claude-opus-4-8", usage) == 5.0
+
+
+def test_override_adds_unknown_model() -> None:
+    override = {"my-azure-deployment": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0)}
+    usage = TokenUsage(input_tokens=2_000_000, output_tokens=0)
+    assert cost_usd("my-azure-deployment", usage, prices=override) == 5.0
+
+
+def test_global_inference_profile_prefix_stripped() -> None:
+    # Regression: global./jp./au. cross-region profiles must price like their us. siblings.
+    assert price_for("global.anthropic.claude-sonnet-4-6") == price_for("claude-sonnet-4-6")
+    assert price_for("jp.anthropic.claude-haiku-4-5") == price_for("claude-haiku-4-5")
+
+
+def test_no_zero_price_placeholder_rows() -> None:
+    # Regression: a $0 row defeats the price_for()->None "cost unavailable" contract.
+    from llm_waterfall.pricing import _PRICES
+
+    assert price_for("qwen3-coder") is None
+    assert all(p.input_per_mtok > 0 for p in _PRICES.values())

--- a/llm-waterfall/llm_waterfall/types.py
+++ b/llm-waterfall/llm_waterfall/types.py
@@ -1,0 +1,148 @@
+"""Public value types: backends, messages, per-call results, and errors.
+
+`Backend` is a frozen dataclass (positional-friendly, hashable, safely shared across threads);
+results are pydantic models so callers get validation and `.model_dump()` for persistence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+Role = Literal["user", "assistant"]
+
+PROVIDERS = ("openai", "anthropic", "azure_openai", "bedrock", "aws_mantle")
+
+
+class Message(BaseModel):
+    """One chat turn. The system prompt is a separate `complete()` param, not a message."""
+
+    role: Role
+    content: str
+
+
+@dataclass(frozen=True)
+class Backend:
+    """One (provider, model, credentials) rung of the waterfall.
+
+    Credentials come from the environment (API keys) or, for Bedrock, a named AWS profile —
+    `profile` maps to `boto3.Session(profile_name=...)`, so one chain can span multiple accounts.
+    """
+
+    provider: str  # one of PROVIDERS
+    model: str
+    profile: str | None = None  # bedrock: named AWS profile
+    region: str | None = None  # bedrock
+    endpoint: str | None = None  # azure base URL / custom OpenAI base_url
+    deployment: str | None = None  # azure
+    api_version: str | None = None  # azure
+    embed_model: str | None = None  # None → provider default
+    embed_dim: int | None = None
+    connect_timeout_s: float = 15.0
+    # Generous read timeout: reasoning models can legitimately generate for minutes, and a
+    # mid-generation cutoff wastes the whole call — but a stalled connection must still raise
+    # (and thus fail over) instead of hanging forever.
+    read_timeout_s: float = 600.0
+
+    def __post_init__(self) -> None:
+        if self.provider not in PROVIDERS:
+            raise ValueError(
+                f"unknown provider {self.provider!r}; expected one of {', '.join(PROVIDERS)}"
+            )
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """How many times to walk the whole chain before giving up.
+
+    `rounds=1` (default) is pure failover: one attempt per backend, no sleeping. Higher values
+    wrap around — sleep with capped exponential backoff, then restart at the primary — so a long
+    unattended run survives the whole chain throttling at once. The sleep is call-local; the
+    waterfall stays stateless.
+    """
+
+    rounds: int = 1
+    backoff_base_s: float = 15.0
+    backoff_max_s: float = 120.0
+
+    def __post_init__(self) -> None:
+        if self.rounds < 1:
+            raise ValueError("RetryPolicy.rounds must be >= 1")
+
+    def backoff_before_round(self, round_index: int) -> float:
+        """Seconds to sleep before round `round_index` (1-based; round 1 never sleeps)."""
+        if round_index <= 1:
+            return 0.0
+        return min(self.backoff_base_s * 2 ** (round_index - 2), self.backoff_max_s)
+
+
+class TokenUsage(BaseModel):
+    """Raw token counts for one call (pricing converts to USD per 1M tokens)."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+AttemptOutcome = Literal["ok", "capacity_error", "client_error", "unsupported"]
+
+
+class Attempt(BaseModel):
+    """One backend try within a call — the unit of the trace the waterfall returns."""
+
+    provider: str
+    model: str
+    outcome: AttemptOutcome
+    latency_s: float
+    error: str | None = None
+    error_type: str | None = None  # exception class name
+
+
+class CompletionResult(BaseModel):
+    """A completion plus attribution: which backend served it, what it cost, the full path."""
+
+    text: str
+    model_used: str
+    provider_used: str
+    usage: TokenUsage = Field(default_factory=TokenUsage)
+    cost_usd: float = 0.0
+    attempts: list[Attempt] = Field(default_factory=list)
+
+
+class EmbeddingResult(BaseModel):
+    """Embedding vectors plus the same attribution as `CompletionResult`."""
+
+    vectors: list[list[float]]
+    model_used: str
+    provider_used: str
+    usage: TokenUsage = Field(default_factory=TokenUsage)
+    cost_usd: float = 0.0
+    attempts: list[Attempt] = Field(default_factory=list)
+
+
+class VerifyResult(BaseModel):
+    """Outcome of one backend's cheap credential/model ping."""
+
+    ok: bool
+    provider: str
+    model: str
+    detail: str = ""
+
+
+class WaterfallExhausted(RuntimeError):
+    """Every backend in every round was capacity-constrained. Carries the full attempt trail."""
+
+    def __init__(self, message: str, attempts: list[Attempt]) -> None:
+        super().__init__(message)
+        self.attempts = attempts
+
+
+class EmbeddingsUnsupported(NotImplementedError):
+    """Raised by adapters whose provider has no embeddings API; the waterfall skips them."""
+
+
+def normalize_messages(messages: Sequence[Message | Mapping[str, str]]) -> list[Message]:
+    """Coerce caller messages (typed or raw dicts) into the canonical `Message` list."""
+    return [m if isinstance(m, Message) else Message.model_validate(dict(m)) for m in messages]

--- a/llm-waterfall/llm_waterfall/types_test.py
+++ b/llm-waterfall/llm_waterfall/types_test.py
@@ -1,0 +1,45 @@
+"""Tests for public value types."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_waterfall.types import Backend, Message, RetryPolicy, normalize_messages
+
+
+def test_backend_positional_call_site() -> None:
+    b = Backend("bedrock", "us.anthropic.claude-opus-4-6-v1", profile="endflow", region="us-west-1")
+    assert b.provider == "bedrock"
+    assert b.model == "us.anthropic.claude-opus-4-6-v1"
+    assert b.profile == "endflow"
+    assert b.read_timeout_s == 600.0
+
+
+def test_backend_rejects_unknown_provider() -> None:
+    with pytest.raises(ValueError, match="unknown provider"):
+        Backend("gcp", "gemini")
+
+
+def test_backend_is_frozen_and_hashable() -> None:
+    b = Backend("openai", "gpt-5.5")
+    with pytest.raises(AttributeError):
+        b.model = "other"  # ty: ignore[invalid-assignment]
+    assert hash(b) == hash(Backend("openai", "gpt-5.5"))
+
+
+def test_retry_policy_backoff_sequence() -> None:
+    p = RetryPolicy(rounds=5, backoff_base_s=15.0, backoff_max_s=120.0)
+    assert [p.backoff_before_round(n) for n in range(1, 6)] == [0.0, 15.0, 30.0, 60.0, 120.0]
+
+
+def test_retry_policy_rejects_zero_rounds() -> None:
+    with pytest.raises(ValueError, match="rounds"):
+        RetryPolicy(rounds=0)
+
+
+def test_normalize_messages_accepts_dicts_and_typed() -> None:
+    typed = Message(role="user", content="hi")
+    out = normalize_messages([typed, {"role": "assistant", "content": "yo"}])
+    assert all(isinstance(m, Message) for m in out)
+    assert [m.role for m in out] == ["user", "assistant"]
+    assert out[0] is typed

--- a/llm-waterfall/llm_waterfall/waterfall.py
+++ b/llm-waterfall/llm_waterfall/waterfall.py
@@ -1,0 +1,220 @@
+"""The Waterfall: walk an ordered backend chain, spilling only on capacity errors.
+
+Per call: try each backend in order. A capacity error (throttling, transient 5xx, timeout) spills
+to the next backend; a client error (bad request, auth, validation) raises immediately — failing
+over on those would mask a real bug behind a different model's answer. Success returns a result
+attributed to the backend that actually served (model, provider, cost) plus the full attempt
+trail. When every backend in every round is capacity-constrained, `WaterfallExhausted` carries
+that trail.
+
+Stateless by design: a `Waterfall` is immutable after construction, results are return values
+(never side-channel logs), and the only mutable state is each adapter's lazily-built SDK client,
+guarded by a per-adapter lock — one instance is safe to share across a thread pool.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections.abc import Callable, Mapping, Sequence
+from typing import Literal, TypeVar
+
+from llm_waterfall.adapters import build_adapter
+from llm_waterfall.adapters.base import Adapter
+from llm_waterfall.classify import outcome_for
+from llm_waterfall.pricing import ModelPrice, cost_usd
+from llm_waterfall.types import (
+    Attempt,
+    Backend,
+    CompletionResult,
+    EmbeddingResult,
+    EmbeddingsUnsupported,
+    Message,
+    RetryPolicy,
+    TokenUsage,
+    VerifyResult,
+    WaterfallExhausted,
+    normalize_messages,
+)
+
+T = TypeVar("T")
+
+# Module-level indirection so tests can observe/skip real sleeping.
+_sleep = time.sleep
+
+_DEFAULT_RETRY = RetryPolicy()
+
+_PING_MESSAGES = [Message(role="user", content="ping")]
+
+
+class Waterfall:
+    """An immutable, thread-safe failover chain over `Backend`s."""
+
+    def __init__(
+        self,
+        backends: Sequence[Backend],
+        *,
+        retry: RetryPolicy = _DEFAULT_RETRY,
+        prices: Mapping[str, ModelPrice] | None = None,
+        adapter_factory: Callable[[Backend], Adapter] = build_adapter,
+    ) -> None:
+        if not backends:
+            raise ValueError("Waterfall needs at least one backend")
+        self._backends = tuple(backends)
+        self._retry = retry
+        self._prices = dict(prices) if prices else None
+        # Adapters built eagerly (cheap — SDK clients inside are still lazy), so the tuple is
+        # immutable and there is no shared registry to guard at call time.
+        self._adapters = tuple(adapter_factory(b) for b in self._backends)
+
+    @property
+    def backends(self) -> tuple[Backend, ...]:
+        return self._backends
+
+    def complete(
+        self,
+        system: str = "",
+        messages: Sequence[Message | Mapping[str, str]] = (),
+        *,
+        temperature: float | None = None,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        """Run one completion down the chain.
+
+        `temperature=None` means "don't send" — current reasoning models (Claude 4.7+, GPT-5.x)
+        reject non-default sampling params, so omission is the only safe default.
+        """
+        msgs = normalize_messages(messages)
+
+        def attempt(adapter: Adapter) -> tuple[str, TokenUsage]:
+            return adapter.complete(system, msgs, temperature=temperature, max_tokens=max_tokens)
+
+        text, usage, backend, _, attempts = self._run(attempt, embed_call=False)
+        return CompletionResult(
+            text=text,
+            model_used=backend.model,
+            provider_used=backend.provider,
+            usage=usage,
+            cost_usd=cost_usd(backend.model, usage, self._prices),
+            attempts=attempts,
+        )
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingResult:
+        """Embed `texts` down the same chain; backends with no embeddings API are skipped.
+
+        Failover assumes the chain shares ONE embedding space: vectors from different embedding
+        models are not comparable, so a chain mixing embed models can silently poison a retrieval
+        index if rungs alternate mid-corpus. Keep `embed_model` consistent across rungs (e.g. the
+        same Titan model behind several AWS profiles), or embed through a single-backend chain.
+        """
+        text_list = list(texts)
+
+        def attempt(adapter: Adapter) -> tuple[list[list[float]], TokenUsage]:
+            return adapter.embed(text_list)
+
+        vectors, usage, backend, adapter, attempts = self._run(attempt, embed_call=True)
+        # Attribute to the model that actually embedded — the serving adapter is the single
+        # source of truth for how it resolved backend.embed_model.
+        embed_model = adapter.embed_model_id() or backend.model
+        return EmbeddingResult(
+            vectors=vectors,
+            model_used=embed_model,
+            provider_used=backend.provider,
+            usage=usage,
+            cost_usd=cost_usd(embed_model, usage, self._prices),
+            attempts=attempts,
+        )
+
+    def verify(self) -> list[VerifyResult]:
+        """One cheap completion per backend. Reports failures, never raises.
+
+        The ping budget is 256 tokens, not 1: reasoning models (GPT-5.x) spend output tokens on
+        internal reasoning first and return 400 when the cap is hit before any visible text — a
+        1-token ping would mark a perfectly healthy backend as broken.
+        """
+        results: list[VerifyResult] = []
+        for backend, adapter in zip(self._backends, self._adapters, strict=True):
+            try:
+                adapter.complete("", _PING_MESSAGES, temperature=None, max_tokens=256)
+            except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
+                results.append(
+                    VerifyResult(
+                        ok=False, provider=backend.provider, model=backend.model, detail=str(exc)
+                    )
+                )
+            else:
+                results.append(
+                    VerifyResult(ok=True, provider=backend.provider, model=backend.model)
+                )
+        return results
+
+    def _run(
+        self,
+        attempt: Callable[[Adapter], tuple[T, TokenUsage]],
+        *,
+        embed_call: bool,
+    ) -> tuple[T, TokenUsage, Backend, Adapter, list[Attempt]]:
+        """The failover loop shared by complete() and embed(). All state is call-local."""
+        attempts: list[Attempt] = []
+        last_capacity_exc: Exception | None = None
+        for round_index in range(1, self._retry.rounds + 1):
+            backoff = self._retry.backoff_before_round(round_index)
+            if backoff > 0:
+                # Jittered, but never above the configured cap — callers size outer timeouts
+                # from backoff_max_s.
+                jittered = backoff + random.uniform(0, 0.34 * backoff)  # noqa: S311 - jitter
+                _sleep(min(jittered, self._retry.backoff_max_s))
+            capacity_this_round = False
+            for backend, adapter in zip(self._backends, self._adapters, strict=True):
+                start = time.monotonic()
+                try:
+                    payload, usage = attempt(adapter)
+                except EmbeddingsUnsupported as exc:
+                    if not embed_call:
+                        raise
+                    # Not a failure: this backend just has no embeddings API. Recorded and
+                    # skipped without counting toward exhaustion.
+                    attempts.append(self._attempt(backend, "unsupported", start, exc))
+                    continue
+                except Exception as exc:
+                    outcome = outcome_for(exc)
+                    attempts.append(self._attempt(backend, outcome, start, exc))
+                    if outcome == "client_error":
+                        raise  # a real error — never mask it behind a fallback
+                    last_capacity_exc = exc
+                    capacity_this_round = True
+                    continue  # capacity-constrained: spill to the next backend
+                attempts.append(self._attempt(backend, "ok", start, None))
+                return payload, usage, backend, adapter, attempts
+            if not capacity_this_round:
+                # Nothing transient happened this round (every backend was skipped as
+                # unsupported) — further rounds and backoff sleeps can't change the outcome.
+                break
+        if last_capacity_exc is None:
+            # Only reachable for embed() when every backend lacks an embeddings API: a static
+            # configuration error, not a capacity condition — don't dress it up as one.
+            raise EmbeddingsUnsupported(
+                "no backend in this chain supports embeddings; add a bedrock or openai backend "
+                "(anthropic has no embeddings API)."
+            )
+        message = (
+            f"every backend was capacity-constrained after {len(attempts)} attempts "
+            f"across {self._retry.rounds} round(s)"
+        )
+        raise WaterfallExhausted(message, attempts) from last_capacity_exc
+
+    @staticmethod
+    def _attempt(
+        backend: Backend,
+        outcome: Literal["ok", "capacity_error", "client_error", "unsupported"],
+        start: float,
+        exc: Exception | None,
+    ) -> Attempt:
+        return Attempt(
+            provider=backend.provider,
+            model=backend.model,
+            outcome=outcome,
+            latency_s=time.monotonic() - start,
+            error=str(exc) if exc is not None else None,
+            error_type=type(exc).__name__ if exc is not None else None,
+        )

--- a/llm-waterfall/llm_waterfall/waterfall_test.py
+++ b/llm-waterfall/llm_waterfall/waterfall_test.py
@@ -1,0 +1,265 @@
+"""Tests for the Waterfall failover loop (fake adapters — no SDKs, no network)."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from llm_waterfall.pricing import ModelPrice
+from llm_waterfall.types import (
+    Backend,
+    EmbeddingsUnsupported,
+    Message,
+    RetryPolicy,
+    TokenUsage,
+    WaterfallExhausted,
+)
+from llm_waterfall.waterfall import Waterfall
+
+
+class _Throttle(Exception):
+    def __init__(self) -> None:
+        super().__init__("boom")
+        self.response = {"Error": {"Code": "ThrottlingException", "Message": "slow down"}}
+
+
+class _Validation(Exception):
+    def __init__(self) -> None:
+        super().__init__("request timeout too large")
+        self.response = {"Error": {"Code": "ValidationException", "Message": "bad"}}
+
+
+class FakeAdapter:
+    """Scriptable adapter: each call pops the next behavior ('ok' or an exception)."""
+
+    def __init__(self, backend: Backend, script: list[object]) -> None:
+        self.backend = backend
+        self.script = list(script)
+        self.calls = 0
+
+    def _next(self) -> None:
+        self.calls += 1
+        step = self.script.pop(0) if self.script else "ok"
+        if isinstance(step, Exception):
+            raise step
+
+    def complete(
+        self, system: str, messages: list[Message], *, temperature: float | None, max_tokens: int
+    ) -> tuple[str, TokenUsage]:
+        self._next()
+        return f"text-from-{self.backend.model}", TokenUsage(input_tokens=100, output_tokens=10)
+
+    def embed(self, texts: list[str]) -> tuple[list[list[float]], TokenUsage]:
+        self._next()
+        return [[1.0] for _ in texts], TokenUsage(input_tokens=3 * len(texts))
+
+    def embed_model_id(self) -> str | None:
+        return f"embedder-of-{self.backend.model}"
+
+
+def _waterfall(
+    scripts: dict[str, list[object]],
+    *,
+    retry: RetryPolicy | None = None,
+    prices: dict[str, ModelPrice] | None = None,
+) -> tuple[Waterfall, dict[str, FakeAdapter]]:
+    backends = [Backend("bedrock", model) for model in scripts]
+    adapters = {m: FakeAdapter(Backend("bedrock", m), s) for m, s in scripts.items()}
+    wf = Waterfall(
+        backends,
+        retry=retry if retry is not None else RetryPolicy(),
+        prices=prices,
+        adapter_factory=lambda b: adapters[b.model],
+    )
+    return wf, adapters
+
+
+MSGS = [Message(role="user", content="hi")]
+
+
+def test_primary_serves_when_healthy() -> None:
+    wf, adapters = _waterfall({"opus": [], "sonnet": []})
+    r = wf.complete(system="s", messages=MSGS)
+    assert r.text == "text-from-opus"
+    assert r.model_used == "opus" and r.provider_used == "bedrock"
+    assert [a.outcome for a in r.attempts] == ["ok"]
+    assert adapters["sonnet"].calls == 0
+
+
+def test_failover_attributes_cost_to_serving_backend() -> None:
+    # Regression: the prototype attributed cost/model to the PRIMARY even when a fallback served.
+    wf, _ = _waterfall({"claude-opus-4-8": [_Throttle()], "claude-sonnet-4-6": []})
+    r = wf.complete(system="", messages=MSGS)
+    assert r.model_used == "claude-sonnet-4-6"
+    assert [a.outcome for a in r.attempts] == ["capacity_error", "ok"]
+    assert r.attempts[0].error_type == "_Throttle"
+    # 100 in @ $3/M + 10 out @ $15/M — sonnet's rate, not opus's.
+    assert r.cost_usd == pytest.approx((100 * 3.0 + 10 * 15.0) / 1_000_000)
+
+
+def test_client_error_propagates_immediately() -> None:
+    wf, adapters = _waterfall({"opus": [_Validation()], "sonnet": []})
+    with pytest.raises(_Validation):
+        wf.complete(system="", messages=MSGS)
+    assert adapters["sonnet"].calls == 0  # never masked behind a fallback
+
+
+def test_exhaustion_raises_with_full_attempt_trail() -> None:
+    wf, _ = _waterfall({"a": [_Throttle()], "b": [_Throttle()]})
+    with pytest.raises(WaterfallExhausted) as exc_info:
+        wf.complete(system="", messages=MSGS)
+    exc = exc_info.value
+    assert len(exc.attempts) == 2
+    assert all(a.outcome == "capacity_error" for a in exc.attempts)
+    assert isinstance(exc.__cause__, _Throttle)
+
+
+def test_rounds_wrap_around_with_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr("llm_waterfall.waterfall._sleep", sleeps.append)
+    # Both throttle in round 1; primary recovers in round 2.
+    wf, adapters = _waterfall(
+        {"a": [_Throttle()], "b": [_Throttle(), _Throttle()]},
+        retry=RetryPolicy(rounds=3, backoff_base_s=15.0),
+    )
+    r = wf.complete(system="", messages=MSGS)
+    assert r.model_used == "a"
+    assert len(r.attempts) == 3  # a:throttle, b:throttle, a:ok
+    assert len(sleeps) == 1 and 15.0 <= sleeps[0] <= 15.0 * 1.34  # base + jitter
+
+
+def test_exhaustion_after_all_rounds(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr("llm_waterfall.waterfall._sleep", sleeps.append)
+    wf, _ = _waterfall(
+        {"a": [_Throttle()] * 3},
+        retry=RetryPolicy(rounds=3, backoff_base_s=15.0, backoff_max_s=20.0),
+    )
+    with pytest.raises(WaterfallExhausted) as exc_info:
+        wf.complete(system="", messages=MSGS)
+    assert len(exc_info.value.attempts) == 3
+    assert len(sleeps) == 2  # before rounds 2 and 3
+
+
+def test_embed_waterfalls_and_skips_unsupported() -> None:
+    wf, _ = _waterfall(
+        {"anthropic-like": [EmbeddingsUnsupported("no embeddings API")], "titan": []}
+    )
+    r = wf.embed(["x", "y"])
+    assert r.vectors == [[1.0], [1.0]]
+    assert [a.outcome for a in r.attempts] == ["unsupported", "ok"]
+    # Attributed to the embedding model the serving ADAPTER reports, not the chat model id.
+    assert r.model_used == "embedder-of-titan"
+    assert r.provider_used == "bedrock"
+
+
+def test_messages_accept_raw_dicts() -> None:
+    wf, _ = _waterfall({"m": []})
+    r = wf.complete(system="", messages=[{"role": "user", "content": "hi"}])
+    assert r.text == "text-from-m"
+
+
+def test_empty_chain_rejected() -> None:
+    with pytest.raises(ValueError, match="at least one backend"):
+        Waterfall([])
+
+
+def test_price_overrides_apply() -> None:
+    wf, _ = _waterfall(
+        {"custom-deploy": []},
+        prices={"custom-deploy": ModelPrice(input_per_mtok=10.0, output_per_mtok=100.0)},
+    )
+    r = wf.complete(system="", messages=MSGS)
+    assert r.cost_usd == pytest.approx((100 * 10.0 + 10 * 100.0) / 1_000_000)
+
+
+def test_shared_waterfall_is_thread_safe() -> None:
+    wf, adapters = _waterfall({"m": []})
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def hit() -> None:
+        r = wf.complete(system="", messages=MSGS)
+        with lock:
+            results.append(r.text)
+
+    threads = [threading.Thread(target=hit) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(results) == 32
+    assert adapters["m"].calls == 32
+
+
+def test_verify_pings_every_backend_and_never_raises() -> None:
+    wf, _ = _waterfall({"good": [], "bad": [_Validation()]})
+    results = wf.verify()
+    assert [v.ok for v in results] == [True, False]
+    assert "timeout too large" in results[1].detail
+
+
+def test_all_unsupported_embed_raises_embeddings_unsupported_without_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: an embeddings-free chain is a static config error, not a capacity condition —
+    # no misleading WaterfallExhausted, and no pointless backoff rounds.
+    sleeps: list[float] = []
+    monkeypatch.setattr("llm_waterfall.waterfall._sleep", sleeps.append)
+    wf, _ = _waterfall(
+        {"a": [EmbeddingsUnsupported("n/a")], "b": [EmbeddingsUnsupported("n/a")]},
+        retry=RetryPolicy(rounds=3),
+    )
+    with pytest.raises(EmbeddingsUnsupported, match="no backend in this chain"):
+        wf.embed(["x"])
+    assert sleeps == []  # deterministic outcome: no rounds were retried
+
+
+def test_jitter_never_exceeds_backoff_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: jitter was applied after the cap, sleeping up to 1.34x backoff_max_s.
+    sleeps: list[float] = []
+    monkeypatch.setattr("llm_waterfall.waterfall._sleep", sleeps.append)
+    monkeypatch.setattr("llm_waterfall.waterfall.random.uniform", lambda a, b: b)  # worst case
+    wf, _ = _waterfall(
+        {"a": [_Throttle()] * 5},
+        retry=RetryPolicy(rounds=5, backoff_base_s=15.0, backoff_max_s=60.0),
+    )
+    with pytest.raises(WaterfallExhausted):
+        wf.complete(system="", messages=MSGS)
+    assert all(s <= 60.0 for s in sleeps), sleeps
+
+
+def test_stub_backends_fail_at_construction() -> None:
+    # Regression: an unimplemented rung must break Waterfall() construction loudly, never
+    # abort a live call mid-chain (a call-time NotImplementedError reads as a client error).
+    # azure_openai is real but misconfiguration must still fail at construction.
+    with pytest.raises(ValueError, match="endpoint"):
+        Waterfall([Backend("azure_openai", "gpt-5.5", deployment="d")])
+    with pytest.raises(NotImplementedError, match="aws_mantle adapter is not implemented"):
+        Waterfall([Backend("aws_mantle", "anthropic.claude-opus-4-8")])
+
+
+def test_verify_ping_budget_fits_reasoning_models() -> None:
+    # Regression: GPT-5.x spends output tokens on reasoning before any text; a 1-token ping
+    # 400s on a healthy backend. The ping must give visible-output headroom.
+    captured: list[int] = []
+
+    class _Recorder(FakeAdapter):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float | None,
+            max_tokens: int,
+        ) -> tuple[str, TokenUsage]:
+            captured.append(max_tokens)
+            return super().complete(
+                system, messages, temperature=temperature, max_tokens=max_tokens
+            )
+
+    backend = Backend("openai", "gpt-5.5")
+    wf = Waterfall([backend], adapter_factory=lambda b: _Recorder(b, []))
+    assert wf.verify()[0].ok
+    assert captured == [256]

--- a/llm-waterfall/pyproject.toml
+++ b/llm-waterfall/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "llm-waterfall"
+version = "0.1.3"
+description = "Pool LLM quota across models, providers, and AWS accounts: stateless failover that spills only on capacity errors and returns cost plus the full attempt trail."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = ["pydantic>=2.6"]
+keywords = ["llm", "failover", "fallback", "rate-limit", "bedrock", "openai", "anthropic"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Repository = "https://github.com/experientiallabs/world-model-harness/tree/main/llm-waterfall"
+
+[project.optional-dependencies]
+openai = ["openai>=1.40"]
+anthropic = ["anthropic>=0.39"]
+bedrock = ["boto3>=1.34"]
+azure = ["openai>=1.40"]
+all = ["llm-waterfall[openai,anthropic,bedrock,azure]"]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.5",
+    "ty>=0.0.1a1",
+    "llm-waterfall[all]",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["llm_waterfall"]
+exclude = ["**/*_test.py"]
+
+[tool.pytest.ini_options]
+python_files = ["*_test.py"]
+testpaths = ["llm_waterfall"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "ANN", "BLE"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test stubs mimic SDK clients whose kwargs are genuinely arbitrary.
+"**/*_test.py" = ["ANN401"]
+
+[tool.ty.environment]
+python-version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,14 @@ dev = [
     "ruff>=0.5",
     "ty>=0.0.1a1",
     "world-model-harness[otel,viz]",
-    # Workspace members join the dev environment so the root gate covers their tests.
-    # (Runtime dependencies on members are declared per-package when actually used.)
-    "llm-waterfall[all]",
 ]
+
+[dependency-groups]
+# Workspace members join the dev environment (uv syncs the `dev` group by default) so the root
+# gate covers their tests — WITHOUT entering wmh's published metadata: members aren't on PyPI,
+# so a published extra requiring them would make `pip install world-model-harness[dev]`
+# unresolvable outside the workspace.
+dev = ["llm-waterfall[all]"]
 
 [project.scripts]
 wmh = "wmh.cli:main"
@@ -46,6 +50,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["wmh"]
+
+[tool.hatch.build.targets.sdist]
+# The flagship sdist ships the flagship only — not workspace members (independently packaged),
+# not the agents' workspace, not the website.
+include = ["/wmh", "/README.md", "/pyproject.toml", "/conftest.py"]
 
 [tool.uv.workspace]
 # The monorepo (AGENTS.md § Monorepo): root stays the `wmh` flagship package; members are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "ruff>=0.5",
     "ty>=0.0.1a1",
     "world-model-harness[otel,viz]",
+    # Workspace members join the dev environment so the root gate covers their tests.
+    # (Runtime dependencies on members are declared per-package when actually used.)
+    "llm-waterfall[all]",
 ]
 
 [project.scripts]
@@ -44,10 +47,20 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["wmh"]
 
+[tool.uv.workspace]
+# The monorepo (AGENTS.md § Monorepo): root stays the `wmh` flagship package; members are
+# top-level dirs, each independently published to PyPI. `uv sync` resolves the whole workspace.
+members = ["llm-waterfall"]
+
+[tool.uv.sources]
+# Inside the workspace, anything that depends on a member resolves it from source, not PyPI.
+llm-waterfall = { workspace = true }
+
 [tool.pytest.ini_options]
 # Tests live inline next to the modules they cover (foo.py -> foo_test.py).
 python_files = ["*_test.py"]
-testpaths = ["wmh"]
+# One root gate covers the flagship and every Python member (same inline-test convention).
+testpaths = ["wmh", "llm-waterfall"]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -1595,7 +1595,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "llm-waterfall", extra = ["all"] },
     { name = "matplotlib" },
     { name = "opentelemetry-proto" },
     { name = "pytest" },
@@ -1611,6 +1610,11 @@ viz = [
     { name = "seaborn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "llm-waterfall", extra = ["all"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.39" },
@@ -1619,7 +1623,6 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gepa", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "llm-waterfall", extras = ["all"], marker = "extra == 'dev'", editable = "llm-waterfall" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=1.40" },
@@ -1637,3 +1640,6 @@ requires-dist = [
     { name = "world-model-harness", extras = ["otel", "viz"], marker = "extra == 'dev'" },
 ]
 provides-extras = ["otel", "viz", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "llm-waterfall", extras = ["all"], editable = "llm-waterfall" }]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,12 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+members = [
+    "llm-waterfall",
+    "world-model-harness",
+]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -662,6 +668,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
     { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
 ]
+
+[[package]]
+name = "llm-waterfall"
+version = "0.1.3"
+source = { editable = "llm-waterfall" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "anthropic" },
+    { name = "boto3" },
+    { name = "openai" },
+]
+anthropic = [
+    { name = "anthropic" },
+]
+azure = [
+    { name = "openai" },
+]
+bedrock = [
+    { name = "boto3" },
+]
+dev = [
+    { name = "anthropic" },
+    { name = "boto3" },
+    { name = "openai" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+openai = [
+    { name = "openai" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.39" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
+    { name = "llm-waterfall", extras = ["all"], marker = "extra == 'dev'", editable = "llm-waterfall" },
+    { name = "llm-waterfall", extras = ["openai", "anthropic", "bedrock", "azure"], marker = "extra == 'all'", editable = "llm-waterfall" },
+    { name = "openai", marker = "extra == 'azure'", specifier = ">=1.40" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.40" },
+    { name = "pydantic", specifier = ">=2.6" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
+]
+provides-extras = ["openai", "anthropic", "bedrock", "azure", "all", "dev"]
 
 [[package]]
 name = "markdown-it-py"
@@ -1539,6 +1595,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "llm-waterfall", extra = ["all"] },
     { name = "matplotlib" },
     { name = "opentelemetry-proto" },
     { name = "pytest" },
@@ -1562,6 +1619,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gepa", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "llm-waterfall", extras = ["all"], marker = "extra == 'dev'", editable = "llm-waterfall" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "openai", specifier = ">=1.40" },

--- a/wmh/repo_layout_test.py
+++ b/wmh/repo_layout_test.py
@@ -17,7 +17,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # AGENTS.md rule 5: tracked top-level directories must be within this set. The allowlist may
 # exceed the current tree (web/ and .github/ are decided-but-not-yet-landed surfaces): it bounds
 # what MAY exist, it does not require existence.
-ALLOWED_TOP_DIRS = {"wmh", "examples", "docs", "assets", "web", ".agents", ".claude", ".github"}
+ALLOWED_TOP_DIRS = {
+    "wmh",
+    "examples",
+    "docs",
+    "assets",
+    "web",
+    ".agents",
+    ".claude",
+    ".github",
+    # Monorepo workspace members (AGENTS.md § Monorepo):
+    "llm-waterfall",
+    "environment-capture",
+}
 
 
 @functools.lru_cache(maxsize=1)
@@ -98,3 +110,20 @@ def test_no_tracked_file_is_matched_by_ignore_rules() -> None:
         f"tracked files matched by ignore rules: {offenders[:5]}; fix the .gitignore pattern "
         "(add a ! negation or narrow the glob) so tracked artifacts stay re-addable"
     )
+
+
+def test_workspace_members_are_real_packages() -> None:
+    """Every [tool.uv.workspace] member dir that exists must carry its own pyproject.toml."""
+    import tomllib
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        root = tomllib.load(fh)
+    members = root.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+    assert members, "the workspace must declare its members (AGENTS.md § Monorepo)"
+    for member in members:
+        member_dir = REPO_ROOT / member
+        if member_dir.exists():
+            assert (member_dir / "pyproject.toml").is_file(), (
+                f"workspace member {member!r} has no pyproject.toml; every member is an "
+                "independently packaged, publishable unit (AGENTS.md § Monorepo)"
+            )

--- a/wmh/repo_layout_test.py
+++ b/wmh/repo_layout_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -112,18 +113,58 @@ def test_no_tracked_file_is_matched_by_ignore_rules() -> None:
     )
 
 
-def test_workspace_members_are_real_packages() -> None:
-    """Every [tool.uv.workspace] member dir that exists must carry its own pyproject.toml."""
-    import tomllib
-
+def _workspace_member_dirs() -> list[Path]:
+    """Existing member directories from [tool.uv.workspace].members (glob-aware)."""
     with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
         root = tomllib.load(fh)
     members = root.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
     assert members, "the workspace must declare its members (AGENTS.md § Monorepo)"
+    dirs: list[Path] = []
     for member in members:
-        member_dir = REPO_ROOT / member
-        if member_dir.exists():
-            assert (member_dir / "pyproject.toml").is_file(), (
-                f"workspace member {member!r} has no pyproject.toml; every member is an "
-                "independently packaged, publishable unit (AGENTS.md § Monorepo)"
-            )
+        dirs.extend(p for p in REPO_ROOT.glob(member) if p.is_dir())
+    return dirs
+
+
+def test_workspace_members_are_real_packages() -> None:
+    """Every existing [tool.uv.workspace] member dir must carry its own pyproject.toml."""
+    for member_dir in _workspace_member_dirs():
+        assert (member_dir / "pyproject.toml").is_file(), (
+            f"workspace member {member_dir.name!r} has no pyproject.toml; every member is an "
+            "independently packaged, publishable unit (AGENTS.md § Monorepo)"
+        )
+
+
+def test_root_gate_covers_every_python_member() -> None:
+    """AGENTS.md § Monorepo promises one root gate: testpaths must include every member."""
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        root = tomllib.load(fh)
+    testpaths = set(root["tool"]["pytest"]["ini_options"]["testpaths"])
+    missing = [d.name for d in _workspace_member_dirs() if d.name not in testpaths]
+    assert not missing, (
+        f"workspace members {missing} are not in [tool.pytest.ini_options].testpaths; the root "
+        "gate must cover every Python member (AGENTS.md § Monorepo)"
+    )
+
+
+ALLOWED_TOP_FILES = {
+    ".env.example",
+    ".gitignore",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "LICENSE",  # not yet present; allowlisted so adding one never fights the gate
+    "README.md",
+    "conftest.py",
+    "justfile",
+    "pyproject.toml",
+    "uv.lock",
+}
+
+
+def test_top_level_files_are_allowlisted() -> None:
+    """Root files are an allowlist too — no Makefile/tox.ini/setup.cfg sprawl (rule 5)."""
+    tracked_root_files = {p for p in _tracked_files() if "/" not in p}
+    unexpected = tracked_root_files - ALLOWED_TOP_FILES
+    assert not unexpected, (
+        f"top-level files {sorted(unexpected)} are not allowlisted; config belongs in "
+        "pyproject.toml, tasks in the justfile, and everything else under an allowlisted dir"
+    )


### PR DESCRIPTION
## What

world-model-harness becomes a **uv-workspace monorepo, additively** — nothing under `wmh/` moves, the root pyproject stays the `wmh` flagship (quickstart and `pip install wmh` byte-identical, all open PRs unaffected), and packages join as top-level member directories. This is the shape pydantic-ai runs (root-level members, root as flagship) with LangChain-style changed-package CI as the growth path; deliberately **no turborepo** (that's for JS-package monorepos — our members are Python, `web/` is one app with its own gate).

- **Workspace wiring**: `[tool.uv.workspace]` members + `[tool.uv.sources] llm-waterfall = { workspace = true }` — inside the workspace, members resolve from source, never PyPI; one `uv.lock`; root `testpaths` runs member inline tests under the one gate.
- **`llm-waterfall/` joins as the first member** — imported from `experientiallabs/llm-waterfall @ 7235107` (v0.1.3), own pyproject/version/PyPI release, Repository URL repointed here. The source repo should be archived after this merges. PR #51 then consumes the member by declaring `llm-waterfall` in wmh's `[project.dependencies]` — the `[tool.uv.sources]` entry only redirects WHERE that requirement resolves in-workspace; both halves are needed (AGENTS.md § Monorepo).
- **`environment-capture/` pre-authorized** in the rule-5 allowlist so PR #56 lands without a layout conflict; it becomes a packaged member in its own follow-up (transfer prompt ready).
- **AGENTS.md § Monorepo**: membership, dependency arrows (members never import wmh), gate scoping, per-member publishing, rule-13 across the workspace. Rule-5 allowlist updated.
- **Enforcement**: `repo_layout_test` gains the member allowlist + a new test — every declared workspace member must carry its own `pyproject.toml`.
- **DX**: README monorepo table (per-package installs, flagship quickstart untouched at the top); root `justfile` (`gate` / `test` / `lint` / `pkg <member> <task>` / `web-gate`).

## Verification

- Gate: ruff + format + ty clean across the workspace (member's nested ruff config resolves correctly); **498 passed / 6 skipped**.
- End-to-end: `uv run wmh --help` (flagship unchanged) and `uv run --package llm-waterfall python -c "import llm_waterfall"` (member builds + runs standalone from source).
- The two `AWS_REGION`-gated live Bedrock tests currently flake on account throttling (concurrent grid/RL bulk runs) — no provider code is touched here; they pass on retry.

Decisions: D28 (additive-at-root, repo identity kept), D29 (meta-harness-bench import deferred), D30 (uv workspace + path-filter CI, no turbo).

