### PR TITLE
build: stop orphaned activity-window headers; cap GEPA valset at 16

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -9,6 +9,7 @@ models are named (`--name`), stored under `<root>/models/<name>/`, and listed wi
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -901,9 +902,21 @@ if __name__ == "__main__":
     app()
 
 
+def _quiet_http_logs() -> None:
+    """Cap noisy per-request loggers at WARNING.
+
+    The openai SDK (via httpx) logs one INFO line per API call; logging handlers write to the
+    real stderr and bypass the live display's redirection, so during a build each request would
+    scroll the GEPA activity region and litter orphaned frame headers across the terminal.
+    """
+    for name in ("httpx", "httpcore", "openai", "botocore", "urllib3", "anthropic"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
 def main() -> None:
     """CLI entry point: load `.env` from the working directory (so wizard-saved provider keys
     persist across sessions), then dispatch. Kept out of import time so importing the module
     never mutates os.environ."""
     load_env_file()
+    _quiet_http_logs()
     app()

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -631,12 +631,17 @@ class RichBuildReporter:
             # One Live region holding the fixed-height activity window + the bar: GEPA's inner
             # loop (proposals, selections, judge notes) streams inside the window instead of
             # scrolling the terminal. Not transient: the last frame (bar at 100% + final
-            # activity) stays in scrollback above the GEPA-done stage line.
+            # activity) stays in scrollback above the GEPA-done stage line. get_renderable (not
+            # per-event update()) so only the refresh thread repaints, and stray prints are
+            # redirected through the region — anything written straight to the terminal mid-Live
+            # scrolls the region and leaves orphaned frame headers behind.
             self._live = Live(
-                self._render_optimize(),
+                get_renderable=self._render_optimize,
                 console=self._console,
-                refresh_per_second=8,
+                refresh_per_second=4,
                 transient=False,
+                redirect_stdout=True,
+                redirect_stderr=True,
             )
             self._live.start()
 
@@ -658,8 +663,7 @@ class RichBuildReporter:
         if not text:
             return
         if self._live is not None:
-            self._activity.append(text)
-            self._live.update(self._render_optimize())
+            self._activity.append(text)  # the Live's refresh thread picks this up
         # Non-TTY logs keep their sparse heartbeat; streaming every inner-loop line would flood.
 
     def rollout(self, done: int, budget: int, score: float | None) -> None:
@@ -686,7 +690,7 @@ class RichBuildReporter:
                 # final call count on the completion event instead of guessing during the run.
                 self._progress.update(self._task_id, completed=rollouts, total=rollouts)
             if self._live is not None:
-                self._live.update(self._render_optimize())
+                self._live.refresh()  # final frame: bar snapped to 100%
                 self._live.stop()
                 self._live = None
             self._progress = None

--- a/wmh/engine/build.py
+++ b/wmh/engine/build.py
@@ -177,7 +177,8 @@ def build(
 
 
 # Ceiling on GEPA's candidate-selection valset, in steps (~one full-val pass per iteration).
-_GEPA_VAL_STEP_CAP = 64
+# Small on purpose: selection only needs a stable ranking signal, and fidelity saturates fast.
+_GEPA_VAL_STEP_CAP = 16
 
 
 def _cap_gepa_valset(traces: list[Trace], max_steps: int = _GEPA_VAL_STEP_CAP) -> list[Trace]:


### PR DESCRIPTION
The duplicated `GEPA activity` headers reproduced under an emulated terminal (pyte): **the openai SDK logs one `HTTP Request: POST …` INFO line per API call via `httpx` to the real stderr**; every stray line scrolls the Live region and strands its top border — one orphaned header per API call (matches the hundreds seen in a real build).

Fixes, verified by repro matrix (old+noise: **27 orphans** → new+noise: 4 → new+logger-quieting: **1**, the legit final frame):
- `wmh` startup caps per-request loggers (httpx/httpcore/openai/botocore/urllib3/anthropic) at WARNING — their handlers bind stderr before the Live exists, so Live redirection alone can't intercept them
- the Live region paints only from its refresh thread (`get_renderable`, no per-event `update()` churn) and redirects stray stdout/stderr writes through the region
- **valset cap 64 → 16 steps** (per request): budget 10 ≈ 206 metric calls now (was ~646); selection only needs a stable ranking, and fidelity saturates fast

(Scrollback inside the window: skipped as discussed — the fixed window keeps the last 8 events; full narration could be teed to a log file later if wanted.)