### PR TITLE
wizard: collapsed pickers (2 visible + '… N more') + batched-key handling

### DIFF
--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -99,8 +99,8 @@ def judge_model_default(provider: str | None, serve_model: str) -> str:
 # (None = the offline hashing embedder, no model). First entry is the suggested default.
 _EMBEDDERS: dict[str, list[str] | None] = {
     "hashing": None,
-    "bedrock": ["amazon.titan-embed-text-v2:0"],
     "openai": ["text-embedding-3-small", "text-embedding-3-large"],
+    "bedrock": ["amazon.titan-embed-text-v2:0"],
     "azure": ["text-embedding-3-small", "text-embedding-3-large"],
 }
 
@@ -232,6 +232,7 @@ def run_build_wizard(
             _PROVIDER_MODELS[provider],
             defaults.model,
             interactive=interactive,
+            collapsed=2,
         )
         region = None
         if provider == "bedrock":
@@ -264,6 +265,7 @@ def run_build_wizard(
             judge_default,
             interactive=interactive,
             notes=judge_notes,
+            collapsed=2,
         )
         if judge_model == model:
             break  # the serve model was just verified
@@ -297,6 +299,7 @@ def run_build_wizard(
             list(_EMBEDDERS),
             embed_default,
             interactive=interactive,
+            collapsed=2,
         )
         embed_model = defaults.embed_model
         embed_models = _EMBEDDERS[embed_provider]
@@ -356,6 +359,34 @@ def _picker_fits(console: Console, row_count: int) -> bool:
     return console.is_terminal and sys.stdin.isatty() and row_count + 2 <= console.size.height
 
 
+def _split_keys(raw: str) -> list[str]:
+    """Split one getchar() read into individual key sequences.
+
+    Fast key repeat (holding an arrow) can deliver several escape sequences in a single raw
+    read; treating the batch as one unknown sequence would drop them all as inert.
+    """
+    keys: list[str] = []
+    i = 0
+    while i < len(raw):
+        if raw[i] != "\x1b":
+            keys.append(raw[i])
+            i += 1
+            continue
+        if raw[i : i + 2] == "\x1b[":
+            j = i + 2
+            while j < len(raw) and not ("@" <= raw[j] <= "~"):
+                j += 1
+            keys.append(raw[i : j + 1])
+            i = j + 1
+        elif raw[i : i + 2] == "\x1bO":
+            keys.append(raw[i : i + 3])
+            i += 3
+        else:
+            keys.append("\x1b")
+            i += 1
+    return keys
+
+
 def _decode_key(seq: str) -> str:
     """Map one click.getchar() sequence to a picker key.
 
@@ -390,24 +421,36 @@ def _step_selection(key: str, index: int, count: int) -> tuple[int, bool]:
     return index, False
 
 
-def _arrow_select(console: Console, rows: list[str], index: int) -> int:
+def _arrow_select(
+    console: Console, rows: list[str], index: int, hidden_rows: list[str] | None = None
+) -> int:
     """Drive an up/down picker over pre-rendered `rows`; return the chosen index.
 
     Keys come from click.getchar(): raw mode handled portably (termios on Unix, msvcrt on
     Windows), one whole escape sequence per call, Ctrl-C raised as KeyboardInterrupt for
     click's usual clean abort. EOF (closed stdin) aborts rather than spinning.
+
+    `hidden_rows` collapse behind a dim "… N more" row; navigating (or jump-selecting) onto it
+    reveals the rest in place. The returned index is into rows + hidden_rows.
     """
-    painted = False
+    visible = list(rows)
+    hidden = list(hidden_rows or [])
+    painted_height = 0
+
+    def current_rows() -> list[str]:
+        more = [f"[dim]… {len(hidden)} more[/dim]"] if hidden else []
+        return visible + more
 
     def paint(current: int) -> None:
-        nonlocal painted
-        if painted:
-            console.control(Control.move(y=-len(rows)))
-        for i, row in enumerate(rows):
+        nonlocal painted_height
+        shown = current_rows()
+        if painted_height:
+            console.control(Control.move(y=-painted_height))
+        for i, row in enumerate(shown):
             console.control(Control((ControlType.ERASE_IN_LINE, 2)))
             pointer = "[bold cyan]\u276f[/bold cyan]" if i == current else " "
             console.print(f" {pointer} {row}", highlight=False, no_wrap=True, overflow="ellipsis")
-        painted = True
+        painted_height = len(shown)
 
     while True:
         paint(index)
@@ -417,10 +460,17 @@ def _arrow_select(console: Console, rows: list[str], index: int) -> int:
             raise typer.Abort() from None
         if seq == "":
             raise typer.Abort()
-        index, accepted = _step_selection(_decode_key(seq), index, len(rows))
-        if accepted:
-            paint(index)
-            return index
+        for key in _split_keys(seq):
+            index, accepted = _step_selection(_decode_key(key), index, len(current_rows()))
+            if hidden and index == len(visible):
+                # Landed on the "more" row: reveal the rest in place; the highlight stays
+                # put, now on the first revealed option.
+                visible.extend(hidden)
+                hidden = []
+                accepted = False
+            if accepted:
+                paint(index)
+                return index
 
 
 def _select(
@@ -432,13 +482,16 @@ def _select(
     *,
     interactive: bool = False,
     notes: dict[str, str] | None = None,
+    collapsed: int | None = None,
 ) -> str:
     """Pick one of `options`: an arrow-key picker on a real TTY, else a numbered prompt.
 
     The Enter-default is `default` when present in `options`; a non-matching default falls
     back to the first option, and None means no Enter-default at all (the provider picker: a
     default exists only when creds do; the model picker: the choice is always explicit).
-    `notes` adds a dim annotation after an option's name (e.g. "api key exists").
+    `notes` adds a dim annotation after an option's name (e.g. "api key exists"). `collapsed`
+    shows only the first N options in the arrow picker behind a "… more" row (the numbered
+    fallback always lists everything, so scripted input is unaffected).
     """
     if default in options:
         chosen_default = default
@@ -456,7 +509,10 @@ def _select(
     if interactive and _picker_fits(console, len(options)):
         console.print(f"[bold]{label}[/bold] [dim](up/down + Enter)[/dim]:")
         start = options.index(chosen_default) if chosen_default is not None else 0
-        return options[_arrow_select(console, [row(opt) for opt in options], start)]
+        rows = [row(opt) for opt in options]
+        if collapsed is not None and start < collapsed < len(options):
+            return options[_arrow_select(console, rows[:collapsed], start, rows[collapsed:])]
+        return options[_arrow_select(console, rows, start)]
 
     console.print(f"[bold]{label}[/bold]:")
     for i, opt in enumerate(options, start=1):

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -181,6 +181,43 @@ def test_arrow_select_moves_pointer_and_accepts(monkeypatch) -> None:  # noqa: A
     assert "\u276f b" in console.export_text()  # pointer painted on the accepted row
 
 
+def test_split_keys_separates_batched_sequences() -> None:
+    assert ui_module._split_keys("\x1b[B\x1b[B") == ["\x1b[B", "\x1b[B"]
+    assert ui_module._split_keys("\x1b[1;5A") == ["\x1b[1;5A"]
+    assert ui_module._split_keys("jk\r") == ["j", "k", "\r"]
+    assert ui_module._split_keys("\x1bOA5") == ["\x1bOA", "5"]
+    assert ui_module._split_keys("\x1b") == ["\x1b"]
+
+
+def test_arrow_select_reveals_hidden_rows_on_navigation(monkeypatch) -> None:  # noqa: ANN001
+    # Collapsed picker: two rows + a "… N more" row; arrowing down onto it expands in place
+    # and the highlight lands on the first revealed option.
+    keys = iter(["\x1b[B", "\x1b[B", "\x1b[B", "\r"])  # down to "more", auto-expand, down, Enter
+    monkeypatch.setattr(ui_module.click, "getchar", lambda: next(keys))
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    chosen = ui_module._arrow_select(console, ["a", "b"], 0, ["c", "d"])
+    assert chosen == 3  # a -> b -> (more: expands, highlight on c) -> d -> Enter
+    out = console.export_text()
+    assert "… 2 more" in out  # the collapsed affordance rendered
+    assert "\u276f d" in out  # and the final highlight reached a previously hidden row
+
+
+def test_select_collapsed_keeps_numbered_fallback_complete() -> None:
+    # Non-TTY: collapsed is an arrow-picker affordance only; scripted input sees every option.
+    console = Console(force_terminal=False, no_color=True, width=100, record=True)
+    chosen = ui_module._select(
+        console,
+        _scripted_reader(["4"]),
+        "Pick",
+        ["a", "b", "c", "d"],
+        "a",
+        interactive=False,
+        collapsed=2,
+    )
+    assert chosen == "d"
+    assert "4." in console.export_text()  # all four options listed
+
+
 def test_arrow_select_aborts_on_eof(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(ui_module.click, "getchar", lambda: "")
     console = Console(force_terminal=False, no_color=True, width=100)


### PR DESCRIPTION
Serve model, judge model, and embedder pickers now show just their top two options with a dim `… N more` row; arrowing down onto it expands the full list in place (highlight lands on the first revealed option). The numbered non-TTY fallback still lists everything, so scripted/CI input is unaffected. Embedder order is now hashing, openai, bedrock, azure so the visible pair is hashing + openai.

Bonus robustness fix found by the PTY driver: holding/fast-repeating an arrow key delivers several escape sequences in a single `click.getchar()` read, which previously decoded as one inert unknown sequence (sluggish picker); reads are now split into individual keys.

PTY-verified: 2 rows + '… 2 more' render, no hidden rows leak, arrow-down expands to reveal gpt-5.4/gpt-5.4-mini. Full suite green (2 known stale-creds live tests).