### PR TITLE
llm-waterfall: preserve jitter at the backoff cap; fix stale azure comment

### DIFF
--- a/packages/llm-waterfall/llm_waterfall/adapters/__init__.py
+++ b/packages/llm-waterfall/llm_waterfall/adapters/__init__.py
@@ -20,7 +20,7 @@ _ADAPTERS: dict[str, Callable[[Backend], Adapter]] = {
     "bedrock": BedrockAdapter,
     "openai": OpenAIAdapter,
     "anthropic": AnthropicAdapter,
-    "azure_openai": AzureOpenAIAdapter,  # stub: raises NotImplementedError at construction
+    "azure_openai": AzureOpenAIAdapter,  # real; construction validates endpoint/api_version
     "aws_mantle": AwsMantleAdapter,  # stub: raises NotImplementedError at construction
 }
 

--- a/packages/llm-waterfall/llm_waterfall/waterfall.py
+++ b/packages/llm-waterfall/llm_waterfall/waterfall.py
@@ -160,10 +160,14 @@ class Waterfall:
         for round_index in range(1, self._retry.rounds + 1):
             backoff = self._retry.backoff_before_round(round_index)
             if backoff > 0:
-                # Jittered, but never above the configured cap — callers size outer timeouts
-                # from backoff_max_s.
-                jittered = backoff + random.uniform(0, 0.34 * backoff)  # noqa: S311 - jitter
-                _sleep(min(jittered, self._retry.backoff_max_s))
+                # Jittered, and never above the configured cap — callers size outer timeouts
+                # from backoff_max_s. The jitter span is reserved BELOW the cap: capping after
+                # adding jitter would collapse every concurrent caller onto exactly
+                # backoff_max_s once exponential backoff saturates, synchronizing the very
+                # retries jitter exists to spread.
+                span = 0.34 * backoff
+                base = min(backoff, self._retry.backoff_max_s - span)
+                _sleep(base + random.uniform(0, span))  # noqa: S311 - jitter
             capacity_this_round = False
             for backend, adapter in zip(self._backends, self._adapters, strict=True):
                 start = time.monotonic()

--- a/packages/llm-waterfall/llm_waterfall/waterfall_test.py
+++ b/packages/llm-waterfall/llm_waterfall/waterfall_test.py
@@ -263,3 +263,24 @@ def test_verify_ping_budget_fits_reasoning_models() -> None:
     wf = Waterfall([backend], adapter_factory=lambda b: _Recorder(b, []))
     assert wf.verify()[0].ok
     assert captured == [256]
+
+
+def test_jitter_survives_at_the_backoff_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: jitter used to be applied and then re-capped, so once exponential backoff hit
+    # backoff_max_s every concurrent caller slept exactly the cap — synchronized retries defeat
+    # the whole point of jitter. At the cap, sleeps must still spread (within the cap).
+    sleeps: list[float] = []
+    monkeypatch.setattr("llm_waterfall.waterfall._sleep", sleeps.append)
+    draws = iter([0.0, 1.0])  # first capped round draws low jitter, second draws high
+    monkeypatch.setattr(
+        "llm_waterfall.waterfall.random.uniform", lambda a, b: a + (b - a) * next(draws)
+    )
+    wf, _ = _waterfall(
+        {"a": [_Throttle()] * 3},
+        retry=RetryPolicy(rounds=3, backoff_base_s=60.0, backoff_max_s=60.0),  # capped from round 2
+    )
+    with pytest.raises(WaterfallExhausted):
+        wf.complete(system="", messages=MSGS)
+    assert len(sleeps) == 2
+    assert sleeps[0] != sleeps[1], "sleeps at the cap must not be identical"
+    assert all(s <= 60.0 for s in sleeps)


### PR DESCRIPTION
The two Greptile findings from PR #100 that were deferred rather than patched during the byte-identical import:

1. **Jitter was silently stripped at `backoff_max_s`** (`waterfall.py`): backoff was capped, jitter added, then re-capped — so once exponential backoff saturated, every concurrent caller slept exactly `backoff_max_s`, synchronizing the retries jitter exists to spread. The jitter span is now reserved *below* the cap: sleeps spread within `[max − 0.34·backoff, max]` and never exceed the cap. Regression test asserts sleeps at the cap differ across draws.
2. **Stale registry comment**: `azure_openai` is fully implemented (construction validates `endpoint`/`api_version`); only `aws_mantle` is a stub.

Workspace gate green (507 passed; the one intermittent failure is the known AWS-throttling live-test flake, passes on re-run). 124 package tests standalone.