### PR TITLE
cli: demo replays sampled scenarios open-loop; play suggests real actions

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import random
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -20,6 +21,7 @@ from uuid import uuid4
 import typer
 import uvicorn
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 import wmh.providers as providers
@@ -49,6 +51,7 @@ from wmh.config import (
     validate_name,
 )
 from wmh.engine.build import build as run_build
+from wmh.engine.build import ingest
 from wmh.engine.demo import run_demo
 from wmh.engine.eval import EvalReport, evaluate_files
 from wmh.engine.eval_suites import (
@@ -59,6 +62,7 @@ from wmh.engine.eval_suites import (
 )
 from wmh.engine.loader import load_world_model
 from wmh.engine.prompts import BASE_ENV_PROMPT
+from wmh.engine.world_model import WorldModel
 from wmh.ingest import VendorPull
 from wmh.optimize.judge import LLMJudge, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
@@ -798,28 +802,153 @@ def _eval_report_payload(report: EvalReport) -> dict[str, object]:
 
 @app.command("demo")
 def demo(
-    name: str = typer.Option(None, "--name", help="World model to demo (default: the only one)."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+    name: str = typer.Option(None, "--name", help="World model to demo (default: pick one)."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (example models are found too)."),
+    steps: int = typer.Option(5, help="Max scenario steps to replay."),
+    traces: str = typer.Option(
+        None, "--traces", help="Trace file to sample the scenario from (default: the model's)."
+    ),
+    seed: int = typer.Option(None, help="Seed for the scenario sample (default: random)."),
+    show_prompt: bool = typer.Option(
+        False, "--show-prompt", help="Also print the exact env prompt of the first step."
+    ),
 ) -> None:
-    """Demo the harness: an LLM agent makes a tool call vs the world model; show prompt+output."""
-    wm, _resolved_name, provider = _load_model(name, root)
-    # Seed the demo agent from whatever steps the index holds.
-    examples = wm.sample_steps(3)
-    result = run_demo(wm, provider, examples)
-    _console.print(f"[bold]agent action[/bold]: {result.agent_action.model_dump()}")
-    _console.print(f"[bold]env prompt[/bold]:\n{result.env_prompt}")
-    _console.print(f"[bold]observation[/bold]: {result.observation.model_dump()}")
+    """Replay a randomly sampled recorded scenario against the world model, open loop."""
+    wm, resolved_name, _provider, model_root = _load_model_any(name, root)
+    traces_file = Path(traces) if traces else _traces_for_root(model_root)
+    if traces_file is None or not traces_file.exists():
+        raise typer.BadParameter(
+            f"no trace file found for {resolved_name!r} under {model_root}; pass --traces"
+        )
+    model_dir = WorldModelStore(str(model_root)).resolve(resolved_name)
+    config = load_config(model_dir)  # the model dir holds its own HarnessConfig
+    candidates = [t for t in ingest(config, file=str(traces_file)) if t.steps]
+    if not candidates:
+        raise typer.BadParameter(f"{traces_file} contains no replayable traces")
+    trace = random.Random(seed).choice(candidates)
+
+    _console.print(
+        f"replaying scenario [bold]{trace.trace_id}[/bold] against [bold]{resolved_name}[/bold] "
+        f"(open loop, {min(steps, len(trace.steps))} of {len(trace.steps)} steps)…"
+    )
+    if trace.steps[0].task:
+        _console.print(f"[dim]task: {escape(trace.steps[0].task[:200])}[/dim]")
+    result = run_demo(wm, trace, max_steps=steps)
+    if show_prompt:
+        _console.print(f"[bold]env prompt (step 1)[/bold]:\n{escape(result.first_env_prompt)}")
+    for i, demo_step in enumerate(result.steps, start=1):
+        action = demo_step.action
+        call = (
+            f"{action.name} {json.dumps(action.arguments)}"
+            if action.name
+            else (action.content or "")[:120]
+        )
+        verdict = (
+            "[green]exact match[/green]" if demo_step.exact_match else "[yellow]differs[/yellow]"
+        )
+        _console.print(f"\n[bold]step {i}[/bold]  [cyan]{escape(call)}[/cyan]  {verdict}")
+        _console.print(f"  [green]predicted[/green]: {escape(demo_step.predicted.content[:300])}")
+        _console.print(f"  [dim]actual[/dim]:    {escape(demo_step.actual.content[:300])}")
+    matches = sum(1 for d in result.steps if d.exact_match)
+    _console.print(
+        f"\n{matches}/{len(result.steps)} exact matches (run `wmh eval` for judged fidelity)"
+    )
 
 
 @app.command("play")
 def play(
-    name: str = typer.Option(None, "--name", help="World model to play (default: the only one)."),
+    name: str = typer.Option(None, "--name", help="World model to play (default: pick one)."),
     task: str = typer.Option(None, "--task", help="Task to seed the session with."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (example models are found too)."),
 ) -> None:
     """Step into the environment yourself: type actions, the world model returns observations."""
-    wm, resolved_name, _provider = _load_model(name, root)
-    run_play_repl(_console, wm, resolved_name, task)
+    wm, resolved_name, _provider, _model_root = _load_model_any(name, root)
+    suggestions = _action_suggestions(wm)
+    run_play_repl(_console, wm, resolved_name, task, suggestions=suggestions)
+
+
+def _traces_for_root(model_root: Path) -> Path | None:
+    """The trace corpus that built the models under `model_root`, when it ships alongside."""
+    candidate = model_root / "traces.otel.jsonl"
+    return candidate if candidate.exists() else None
+
+
+def _action_suggestions(wm: WorldModel, n: int = 3) -> list[str]:
+    """Real action lines sampled from the model's corpus, to seed the play prompt."""
+    suggestions: list[str] = []
+    for step in wm.sample_steps(8):
+        action = step.action
+        if action.name:
+            args = json.dumps(action.arguments) if action.arguments else ""
+            line = f"{action.name} {args}".strip()
+        elif action.content:
+            line = f"say {action.content[:60]}"
+        else:
+            continue
+        if line not in suggestions:
+            suggestions.append(line)
+        if len(suggestions) >= n:
+            break
+    return suggestions
+
+
+def _load_model_any(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, name, Provider, Path)
+    """Resolve a model across the project dir AND shipped examples, then load it.
+
+    An explicit non-default `--root` keeps the old single-root behavior. Otherwise the picker
+    spans `<root>/models/*` plus `examples/*/models/*`, labeling each with its source.
+    """
+    if root != ARTIFACT_DIR:
+        wm, resolved, provider = _load_model(name, root)
+        return wm, resolved, provider, Path(root)
+
+    candidates: list[tuple[str, Path, str]] = []  # (label, store_root, name)
+    local = WorldModelStore(root)
+    candidates.extend((f"{n}  [dim](local)[/dim]", Path(root), n) for n in local.list_names())
+    for example_dir in _discover_examples():
+        example_store = WorldModelStore(example_dir)
+        candidates.extend(
+            (f"{n}  [dim]({example_dir.name} example)[/dim]", example_dir, n)
+            for n in example_store.list_names()
+        )
+
+    if name is not None:
+        matched = [c for c in candidates if c[2] == name]
+        if not matched:
+            have = ", ".join(c[2] for c in candidates) or "none built"
+            raise typer.BadParameter(f"no world model named {name!r} (have: {have})")
+        # Prefer the local build over a same-named example artifact.
+        label, store_root, resolved = matched[0]
+    elif not candidates:
+        raise typer.BadParameter(
+            "no world models found; run `wmh build` or try an example (examples/tau-bench)"
+        )
+    elif len(candidates) == 1:
+        label, store_root, resolved = candidates[0]
+    elif _console.is_terminal:
+        labels = [c[0] for c in candidates]
+        chosen = _select_from(labels)
+        label, store_root, resolved = candidates[labels.index(chosen)]
+    else:
+        have = ", ".join(c[2] for c in candidates)
+        raise typer.BadParameter(f"multiple world models ({have}); pass --name")
+
+    wm, resolved, provider = _load_model(resolved, str(store_root))
+    return wm, resolved, provider, store_root
+
+
+def _select_from(labels: list[str]) -> str:
+    """Interactive picker over pre-rendered labels (arrow keys on a TTY)."""
+    from wmh.cli import ui as _ui  # package-internal: reuse the wizard's picker machinery
+
+    return _ui._select(
+        _console,
+        lambda text: _console.input(text),
+        "Select a world model",
+        labels,
+        None,
+        interactive=True,
+    )
 
 
 def _resolve_name(store: WorldModelStore, name: str | None) -> str:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -190,6 +190,32 @@ def test_main_entry_loads_dotenv_before_dispatch(tmp_path, monkeypatch) -> None:
     assert os.environ["WMH_TEST_MAIN_VAR"] == "loaded"
 
 
+def test_demo_replays_a_sampled_scenario_open_loop(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    root = tmp_path / ".wmh"
+    _build(root, "demo-model", tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--seed",
+            "0",
+            "--steps",
+            "3",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "replaying scenario" in result.output
+    assert "predicted" in result.output
+    assert "actual" in result.output
+    assert "exact matches" in result.output
+
+
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -846,6 +846,7 @@ def run_play_repl(
     model_name: str,
     task: str | None,
     reader: PromptReader | None = None,
+    suggestions: list[str] | None = None,
 ) -> None:
     """Run the human-in-the-loop demo against `world_model`.
 
@@ -854,9 +855,18 @@ def run_play_repl(
     """
     ask = reader if reader is not None else console.input
     session = world_model.new_session(task=task)
+    body = _PLAY_HELP
+    if suggestions:
+        sampled = "\n".join(f"  [cyan]{escape(line)}[/cyan]" for line in suggestions)
+        body = (
+            "You are the agent. Type an action and the world model answers.\n"
+            "Real actions from this model's traces to try:\n"
+            f"{sampled}\n"
+            "Commands: :state show session state  \u00b7  :help  \u00b7  :quit (or Ctrl-D) to exit"
+        )
     console.print(
         Panel(
-            _PLAY_HELP,
+            body,
             title=f"[bold]playing[/bold] {model_name}",
             subtitle=f"task: {task}" if task else "no task set",
             border_style="cyan",

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -633,6 +633,22 @@ def test_select_model_picks_by_number() -> None:
     assert select_model(console, infos, reader=_scripted_reader(["2"])) == "retail"
 
 
+def test_play_repl_shows_sampled_action_suggestions() -> None:
+    console = Console(force_terminal=False, no_color=True, width=100)
+    with console.capture() as cap:
+        run_play_repl(
+            console,
+            _world_model(),
+            "airline",
+            task=None,
+            reader=_scripted_reader([":quit"]),
+            suggestions=['get_user {"id": "u1"}', "list_flights"],
+        )
+    out = cap.get()
+    assert "Real actions from this model's traces" in out
+    assert 'get_user {"id": "u1"}' in out
+
+
 def test_select_model_reprompts_then_accepts_name() -> None:
     console = Console(force_terminal=False, no_color=True, width=100)
     infos = [

--- a/wmh/engine/__init__.py
+++ b/wmh/engine/__init__.py
@@ -1,7 +1,7 @@
 """The world-model engine: prompt assembly, the WorldModel, the build pipeline, eval, demo, play."""
 
 from wmh.engine.build import build, ingest, split_traces, split_traces_3way
-from wmh.engine.demo import DemoResult, run_demo
+from wmh.engine.demo import DemoReplay, DemoStep, run_demo
 from wmh.engine.eval import EvalReport, evaluate_files
 from wmh.engine.loader import load_world_model
 from wmh.engine.play import PlayTurn, parse_action, play_turn
@@ -13,7 +13,8 @@ __all__ = [
     "ingest",
     "split_traces",
     "split_traces_3way",
-    "DemoResult",
+    "DemoReplay",
+    "DemoStep",
     "run_demo",
     "EvalReport",
     "evaluate_files",

--- a/wmh/engine/demo.py
+++ b/wmh/engine/demo.py
@@ -1,61 +1,52 @@
-"""`wmh demo`: show the harness working end-to-end.
+"""`wmh demo`: replay a real recorded scenario against the world model, open loop.
 
-A throwaway LLM-as-agent (base prompt + a few sampled trace examples, NO GEPA) is asked to emit one
-tool call. We feed that to the WorldModel and print (1) the exact env prompt sent and (2) the
-predicted observation — demonstrating the loop without needing the user's real agent.
+A randomly sampled trace supplies the task and the agent's recorded actions; the world model
+predicts each observation while the session is teacher-forced with the recorded one
+(`step_open_loop`), so every prediction is conditioned on the real trajectory. The result shows
+predicted vs. actual side by side — the harness working end-to-end without needing a live agent.
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
-from wmh.core.parsing import extract_json_object
-from wmh.core.types import Action, ActionKind, JsonObject, Observation, Step
-from wmh.engine.prompts import build_demo_agent_prompt
+from wmh.core.types import Action, Observation, Trace
 from wmh.engine.world_model import WorldModel
-from wmh.providers.base import Message, Provider
 
 
-class DemoResult(BaseModel):
-    agent_action: Action  # what the demo agent chose to do
-    env_prompt: str  # the exact prompt the world model received
-    observation: Observation  # what the environment returned
+class DemoStep(BaseModel):
+    """One replayed step: the recorded action with the predicted and recorded observations."""
+
+    action: Action
+    predicted: Observation
+    actual: Observation
+
+    @property
+    def exact_match(self) -> bool:
+        return self.predicted.content.strip() == self.actual.content.strip()
 
 
-class _AgentToolCall(BaseModel):
-    name: str
-    arguments: JsonObject = {}
+class DemoReplay(BaseModel):
+    """The rendered scenario replay for `wmh demo`."""
+
+    trace_id: str
+    task: str | None
+    steps: list[DemoStep]
+    first_env_prompt: str  # the exact prompt the world model saw for the first step
 
 
-def run_demo(world_model: WorldModel, agent_provider: Provider, examples: list[Step]) -> DemoResult:
-    """Drive one agent->env round-trip for demonstration.
-
-    A throwaway agent (base prompt + sampled examples, no GEPA) proposes one tool call; the world
-    model predicts the environment's response. We capture the exact env prompt for display.
-    """
-    task = examples[0].task if examples and examples[0].task else "complete the task"
-    action = _propose_action(agent_provider, task, examples)
-
+def run_demo(world_model: WorldModel, trace: Trace, max_steps: int = 5) -> DemoReplay:
+    """Replay up to `max_steps` of `trace` open-loop and collect predicted vs. actual."""
+    if not trace.steps:
+        raise ValueError(f"trace {trace.trace_id!r} has no steps to replay")
+    task = trace.steps[0].task
     session = world_model.new_session(task=task)
-    # Capture the exact prompt the world model will send (same retrieval + assembly as step()).
-    env_prompt = world_model.render_step_prompt(session.id, action)
-    observation = world_model.step(session.id, action)
-    return DemoResult(agent_action=action, env_prompt=env_prompt, observation=observation)
+    first_env_prompt = world_model.render_step_prompt(session.id, trace.steps[0].action)
 
-
-def _propose_action(agent_provider: Provider, task: str, examples: list[Step]) -> Action:
-    """Ask the demo agent for one tool call; fall back to a message action if it's free-form."""
-    prompt = build_demo_agent_prompt(task, examples)
-    completion = agent_provider.complete(
-        "You role-play an agent. Reply with one tool call as JSON only.",
-        [Message(role="user", content=prompt)],
-        temperature=0.0,
+    steps: list[DemoStep] = []
+    for step in trace.steps[:max_steps]:
+        predicted = world_model.step_open_loop(session.id, step.action, step.observation)
+        steps.append(DemoStep(action=step.action, predicted=predicted, actual=step.observation))
+    return DemoReplay(
+        trace_id=trace.trace_id, task=task, steps=steps, first_env_prompt=first_env_prompt
     )
-    raw = extract_json_object(completion.text)
-    if raw is not None:
-        try:
-            call = _AgentToolCall.model_validate_json(raw)
-            return Action(kind=ActionKind.TOOL_CALL, name=call.name, arguments=call.arguments)
-        except ValidationError:
-            pass
-    return Action(kind=ActionKind.MESSAGE, content=completion.text.strip())

--- a/wmh/engine/demo_test.py
+++ b/wmh/engine/demo_test.py
@@ -1,4 +1,4 @@
-"""Tests for the demo round-trip, with a fake agent + world-model provider (no network)."""
+"""Tests for the demo scenario replay, with a fake world-model provider (no network)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
 
 class ScriptedProvider:
-    """Returns an agent tool-call JSON first, then world-model JSON for the env step."""
+    """World-model provider that always predicts the same observation."""
 
     def __init__(self) -> None:
         self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
@@ -23,8 +23,6 @@ class ScriptedProvider:
         temperature: float = 0.7,
         max_tokens: int = 8192,
     ) -> Completion:
-        if "role-play an agent" in system:
-            return Completion(text='{"name": "get_user", "arguments": {"id": "u1"}}')
         return Completion(text='{"output": "found u1", "is_error": false}')
 
     def embed(self, texts: list[str]) -> list[list[float]]:
@@ -34,21 +32,54 @@ class ScriptedProvider:
         raise NotImplementedError
 
 
-def test_run_demo_produces_action_prompt_and_observation() -> None:
-    provider = ScriptedProvider()
-    retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
-    examples = [
-        Step(
-            action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u0"}),
-            observation=Observation(content="found u0"),
-            task="look up users",
-        )
-    ]
-    retriever.index([Trace(trace_id="t", steps=examples)])
-    wm = WorldModel(provider, retriever, top_k=3)
+def _step(name: str, observed: str) -> Step:
+    return Step(
+        action=Action(kind=ActionKind.TOOL_CALL, name=name, arguments={"id": "u1"}),
+        observation=Observation(content=observed),
+        task="look up users",
+    )
 
-    result = run_demo(wm, provider, examples)
-    assert result.agent_action.kind == ActionKind.TOOL_CALL
-    assert result.agent_action.name == "get_user"
-    assert "get_user" in result.env_prompt  # the retrieved demo shows up in the prompt
-    assert result.observation.content == "found u1"
+
+def _world_model(provider: ScriptedProvider) -> WorldModel:
+    retriever = EmbeddingRetriever(HashingEmbedder(dim=32))
+    retriever.index([Trace(trace_id="corpus", steps=[_step("get_user", "found u0")])])
+    return WorldModel(provider, retriever, top_k=3)
+
+
+def test_run_demo_replays_open_loop_with_predicted_vs_actual() -> None:
+    wm = _world_model(ScriptedProvider())
+    trace = Trace(
+        trace_id="scenario",
+        steps=[_step("get_user", "found u1"), _step("list_users", "u1, u2")],
+    )
+
+    result = run_demo(wm, trace, max_steps=5)
+
+    assert result.trace_id == "scenario"
+    assert result.task == "look up users"
+    assert len(result.steps) == 2
+    assert "get_user" in result.first_env_prompt  # retrieved demo appears in the first prompt
+    # Prediction always "found u1": exact match on step 1, differs on step 2.
+    assert result.steps[0].exact_match is True
+    assert result.steps[1].exact_match is False
+    assert result.steps[1].actual.content == "u1, u2"
+
+
+def test_run_demo_open_loop_pins_history_to_recorded_observations() -> None:
+    wm = _world_model(ScriptedProvider())
+    trace = Trace(
+        trace_id="scenario",
+        steps=[_step("get_user", "RECORDED-1"), _step("list_users", "RECORDED-2")],
+    )
+    run_demo(wm, trace, max_steps=5)
+    # Open loop: after replay, the session history holds the RECORDED observations, not the
+    # model's predictions — later steps were conditioned on ground truth.
+    session = next(iter(wm._sessions.values()))
+    assert [s.observation.content for s in session.history] == ["RECORDED-1", "RECORDED-2"]
+
+
+def test_run_demo_caps_steps() -> None:
+    wm = _world_model(ScriptedProvider())
+    trace = Trace(trace_id="long", steps=[_step(f"t{i}", "x") for i in range(9)])
+    result = run_demo(wm, trace, max_steps=3)
+    assert len(result.steps) == 3

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -193,19 +193,7 @@ class WorldModel:
             usage_event = tracker.record(Phase.SERVE, self._provider.config.model, completion.usage)
             usage_cost_usd = usage_event.cost_usd
 
-        # (4) advance session: append step, update structured state + scratchpad, enrich buffer.
-        # state_before is a deep copy: _update_state mutates session.state in place, and an aliased
-        # reference would rewrite every recorded step (and the text the retriever embeds in add())
-        # to the post-mutation state.
-        step = Step(
-            action=action,
-            observation=observation,
-            state_before=session.state.model_copy(deep=True),
-            task=session.task,
-        )
-        session.history.append(step)
-        self._update_state(session, step)
-        self._retriever.add(step)
+        self._advance(session, action, observation)
         capture(
             "wmh generated step completed",
             {
@@ -220,6 +208,36 @@ class WorldModel:
             root=self._telemetry_root,
         )
         return observation
+
+    def step_open_loop(self, session_id: str, action: Action, actual: Observation) -> Observation:
+        """Predict like `step`, but advance the session with the RECORDED observation.
+
+        Teacher-forced replay: the prediction is returned for display/scoring while the session
+        continues from ground truth, so later predictions are conditioned on the real trajectory
+        (the open-loop protocol used by `wmh demo` and the replay eval).
+        """
+        prediction = self.step(session_id, action)
+        session = self._sessions[session_id]
+        # Re-pin the just-appended step to the actual observation (history + scratchpad note).
+        session.history[-1] = session.history[-1].model_copy(update={"observation": actual})
+        return prediction
+
+    def _advance(self, session: Session, action: Action, observation: Observation) -> None:
+        """Append the step, fold its state note into the scratchpad, and enrich the buffer.
+
+        `state_before` is a deep copy: `_update_state` mutates `session.state` in place, and an
+        aliased reference would rewrite every recorded step (and the text the retriever embeds)
+        to the post-mutation state.
+        """
+        step = Step(
+            action=action,
+            observation=observation,
+            state_before=session.state.model_copy(deep=True),
+            task=session.task,
+        )
+        session.history.append(step)
+        self._update_state(session, step)
+        self._retriever.add(step)
 
     def _update_state(self, session: Session, step: Step) -> None:
         """Fold the step's effect into session.state (the env's free-text scratchpad "database").


### PR DESCRIPTION
From live feedback that `wmh demo` was one hardcoded round-trip dumping a wall of prompt, and `wmh play` greeted with generic placeholder actions:

- **`wmh demo`** now samples a random recorded scenario (the model's shipped `traces.otel.jsonl`, or `--traces`) and replays it **open loop** via the new `WorldModel.step_open_loop` — predictions are displayed while the session is teacher-forced with recorded observations, so each step is conditioned on the real trajectory. Output: per-step action, predicted vs actual, exact-match verdicts, and a tally; `--show-prompt` optionally prints the first step's env prompt. `--steps/--seed` control length and sampling.
- **`wmh play`** suggests real tool calls sampled from the model's corpus (e.g. `get_reservation_details {\reservation_id\: \MZDDS4\}`) so you know the action vocabulary immediately.
- **Model discovery spans examples**: both commands find `examples/*/models/*` alongside `.wmh`, with a labeled picker on a TTY — no more `--root` gymnastics.

Verified live: `wmh play --name tau-bench` renders corpus-sampled suggestions; `wmh demo --name tau-bench --steps 1` replayed a sampled tau scenario against real Bedrock with predicted-vs-actual output. Full suite green (511).