### PR TITLE
cli: narrated provider retries + switch-provider flow in demo

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -34,6 +34,7 @@ from wmh.cli.ui import (
     run_build_wizard,
     run_play_repl,
     select_model,
+    select_provider_and_model,
 )
 from wmh.config import (
     ARTIFACT_DIR,
@@ -60,13 +61,14 @@ from wmh.engine.eval_suites import (
     resolve_eval_suite,
     result_path,
 )
-from wmh.engine.loader import load_world_model
 from wmh.engine.prompts import BASE_ENV_PROMPT
 from wmh.engine.world_model import WorldModel
 from wmh.ingest import VendorPull
 from wmh.optimize.judge import LLMJudge, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import EmbedderKind
+from wmh.providers.fallback import _is_capacity_error
+from wmh.providers.retry import RetryingProvider
 from wmh.retrieval import HashingEmbedder, get_embedder
 from wmh.serving.server import create_app
 from wmh.telemetry import (
@@ -833,7 +835,33 @@ def demo(
     )
     if trace.steps[0].task:
         _console.print(f"[dim]task: {escape(trace.steps[0].task[:200])}[/dim]")
-    result = run_demo(wm, trace, max_steps=steps)
+    while True:
+        try:
+            result = run_demo(wm, trace, max_steps=steps)
+            break
+        except Exception as exc:  # noqa: BLE001 - classified below
+            if not _is_capacity_error(exc) or not _console.is_terminal:
+                raise
+            # Retries are exhausted and the backend is still down: offer to re-point the model
+            # at a different provider (same picker as the build wizard) and replay.
+            _console.print(f"\n[red]serve provider is still failing[/red]: {exc}")
+            _console.print("[yellow]pick a different provider to continue the demo[/yellow]")
+            provider_name, model_id, region = select_provider_and_model(
+                _console,
+                lambda text: _console.input(text),
+                lambda text: _console.input(text, password=True),
+                default_provider=None,
+                default_model=None,
+                default_region=None,
+                interactive=True,
+                check=lambda cfg: verify_all([cfg])[0],
+            )
+            switched = ProviderConfig(
+                kind=ProviderKind(provider_name), model=model_id, region=region
+            )
+            provider = RetryingProvider(providers.get_provider(switched), on_retry=_print_retry)
+            wm = WorldModel.load(str(model_dir), provider, telemetry_root=str(model_root))
+            _console.print(f"[dim]replaying with {provider_name} ({model_id})…[/dim]")
     if show_prompt:
         _console.print(f"[bold]env prompt (step 1)[/bold]:\n{escape(result.first_env_prompt)}")
     for i, demo_step in enumerate(result.steps, start=1):
@@ -904,11 +932,11 @@ def _load_model_any(name: str | None, root: str):  # noqa: ANN202 - (WorldModel,
 
     candidates: list[tuple[str, Path, str]] = []  # (label, store_root, name)
     local = WorldModelStore(root)
-    candidates.extend((f"{n}  [dim](local)[/dim]", Path(root), n) for n in local.list_names())
+    candidates.extend((f"{n} (local)", Path(root), n) for n in local.list_names())
     for example_dir in _discover_examples():
         example_store = WorldModelStore(example_dir)
         candidates.extend(
-            (f"{n}  [dim]({example_dir.name} example)[/dim]", example_dir, n)
+            (f"{n} ({example_dir.name} example)", example_dir, n)
             for n in example_store.list_names()
         )
 
@@ -1013,17 +1041,28 @@ def _resolve_example(name: str) -> Path:
     raise typer.BadParameter(f"unknown example {name!r}{hint}")
 
 
+def _print_retry(attempt: int, total: int, delay: float, exc: Exception) -> None:
+    detail = str(exc).splitlines()[0][:120]
+    _console.print(
+        f"  [yellow]provider hiccup ({detail}) — retry {attempt}/{total} in {delay:.0f}s…[/yellow]"
+    )
+
+
 def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, name, Provider)
     """Resolve + load a named world model (or the single built one) with its serve provider.
 
-    Returns `(world_model, resolved_name, provider)` so callers can reuse the provider without
-    re-reading config / reconstructing it.
+    The serve provider comes from the MODEL'S OWN config (the one it was built to serve on),
+    wrapped so transient capacity errors retry with narrated exponential backoff instead of
+    dying. Returns `(world_model, resolved_name, provider)`.
     """
     store = WorldModelStore(root)
     resolved_name = _resolve_name(store, name)
-    world_model, provider = load_world_model(
-        store.resolve(resolved_name), telemetry_root=store.root
+    model_dir = store.resolve(resolved_name)
+    config = load_config(model_dir)
+    provider = RetryingProvider(
+        providers.get_provider(config.serve_provider_config()), on_retry=_print_retry
     )
+    world_model = WorldModel.load(str(model_dir), provider, telemetry_root=store.root)
     return world_model, resolved_name, provider
 
 

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -125,6 +125,68 @@ class BuildParams(BaseModel):
     embed_dim: int = 512
 
 
+def select_provider_and_model(
+    console: Console,
+    ask: PromptReader,
+    ask_secret: PromptReader,
+    *,
+    default_provider: str | None,
+    default_model: str | None,
+    default_region: str | None,
+    interactive: bool,
+    check: Callable[[ProviderConfig], VerifyResult],
+) -> tuple[str, str, str | None]:
+    """The wizard's serve-provider block: pick provider + model (+ region), creds, live verify.
+
+    Providers with credentials present are annotated and the first becomes the suggested default
+    (none otherwise); a failed live ping loops back to the picker with the failed pick as the
+    retry default. Also reused by `wmh demo`'s switch-provider flow. Returns
+    (provider, model, region).
+    """
+    providers = list(_PROVIDER_MODELS)
+    with_creds = [p for p in providers if _has_credentials(p)]
+    # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
+    # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
+    notes = {p: _creds_note(p) for p in with_creds}
+    provider_default = default_provider or (with_creds[0] if with_creds else None)
+    while True:
+        provider = _select(
+            console,
+            ask,
+            "Serve provider",
+            providers,
+            provider_default,
+            interactive=interactive,
+            notes=notes,
+        )
+        _ensure_credentials(console, ask_secret, provider)
+        model = _select(
+            console,
+            ask,
+            "Serve model id",
+            _PROVIDER_MODELS[provider],
+            default_model,
+            interactive=interactive,
+            collapsed=2,
+        )
+        region = None
+        if provider == "bedrock":
+            region_default = default_region or _DEFAULT_REGIONS.get(provider)
+            region = _prompt_text(console, ask, "AWS region", region_default) or None
+        # Live ping now, not at the end: a bad key or model id loops straight back to the
+        # picker (the failed pick becomes the suggested retry default).
+        console.print(f"verifying {provider}…")
+        ping = check(ProviderConfig(kind=ProviderKind(provider), model=model, region=region))
+        if ping.ok:
+            console.print(f"  {_CHECK} {provider} ({escape(model)}) reachable")
+            return provider, model, region
+        console.print(
+            f"  [red]✗ {provider} ({escape(model)}) failed[/red]: {escape(ping.detail or '')}"
+        )
+        console.print("  [yellow]fix the credentials or pick a different provider/model[/yellow]")
+        provider_default = provider
+
+
 def run_build_wizard(
     console: Console,
     defaults: BuildParams,
@@ -205,51 +267,16 @@ def run_build_wizard(
             if not file:
                 console.print("[red]a traces path is required (or pass --vendor)[/red]")
 
-    # Serve provider: providers with credentials already present are annotated, and the first
-    # of them is the suggested default (no default when none have creds). After the pick, any
-    # missing credential is prompted for and persisted to .env rather than failing mid-build.
-    providers = list(_PROVIDER_MODELS)
-    with_creds = [p for p in providers if _has_credentials(p)]
-    # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
-    # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
-    notes = {p: _creds_note(p) for p in with_creds}
-    provider_default = defaults.provider or (with_creds[0] if with_creds else None)
-    while True:
-        provider = _select(
-            console,
-            ask,
-            "Serve provider",
-            providers,
-            provider_default,
-            interactive=interactive,
-            notes=notes,
-        )
-        _ensure_credentials(console, ask_secret, provider)
-        model = _select(
-            console,
-            ask,
-            "Serve model id",
-            _PROVIDER_MODELS[provider],
-            defaults.model,
-            interactive=interactive,
-            collapsed=2,
-        )
-        region = None
-        if provider == "bedrock":
-            region_default = defaults.region or _DEFAULT_REGIONS.get(provider)
-            region = _prompt_text(console, ask, "AWS region", region_default) or None
-        # Live ping now, not after the whole wizard: a bad key or model id loops straight
-        # back to the picker (the failed pick becomes the suggested retry default).
-        console.print(f"verifying {provider}…")
-        ping = check(ProviderConfig(kind=ProviderKind(provider), model=model, region=region))
-        if ping.ok:
-            console.print(f"  {_CHECK} {provider} ({escape(model)}) reachable")
-            break
-        console.print(
-            f"  [red]✗ {provider} ({escape(model)}) failed[/red]: {escape(ping.detail or '')}"
-        )
-        console.print("  [yellow]fix the credentials or pick a different provider/model[/yellow]")
-        provider_default = provider
+    provider, model, region = select_provider_and_model(
+        console,
+        ask,
+        ask_secret,
+        default_provider=defaults.provider,
+        default_model=defaults.model,
+        default_region=defaults.region,
+        interactive=interactive,
+        check=check,
+    )
 
     # GEPA judge model: defaults to a cheap model of the same provider (haiku / gpt-5.4-mini);
     # picking the serve model itself is always on the list. Same inline verify + retry.

--- a/wmh/providers/retry.py
+++ b/wmh/providers/retry.py
@@ -1,0 +1,82 @@
+"""A Provider wrapper that retries capacity errors with narrated exponential backoff.
+
+Interactive commands (`wmh demo` / `wmh play`) wrap the serve provider in this so a transient
+throttle or 5xx becomes "retry 1/3 in 1s..." instead of a traceback. Non-capacity errors (bad
+request, auth) propagate immediately — retrying those only hides real bugs.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    Completion,
+    Message,
+    Provider,
+    ProviderConfig,
+    VerifyResult,
+)
+from wmh.providers.fallback import _is_capacity_error
+
+# attempt -> sleep before the next try
+_DELAYS = (1.0, 3.0, 9.0)
+
+# on_retry(attempt_number, total_attempts, delay_seconds, error)
+RetryCallback = Callable[[int, int, float, Exception], None]
+
+
+class RetryingProvider:
+    """Retries `complete`/`embed` on capacity errors with exponential backoff (1s, 3s, 9s)."""
+
+    def __init__(
+        self,
+        provider: Provider,
+        on_retry: RetryCallback | None = None,
+        *,
+        delays: tuple[float, ...] = _DELAYS,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._provider = provider
+        self._on_retry = on_retry
+        self._delays = delays
+        self._sleep = sleep
+
+    @property
+    def config(self) -> ProviderConfig:
+        return self._provider.config
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        def call() -> Completion:
+            return self._provider.complete(
+                system, messages, temperature=temperature, max_tokens=max_tokens
+            )
+
+        return self._retry(call)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._retry(lambda: self._provider.embed(texts))
+
+    def verify(self) -> VerifyResult:
+        return self._provider.verify()
+
+    def _retry(self, call):  # noqa: ANN001, ANN202 - generic over the wrapped call's return
+        total = len(self._delays)
+        for attempt, delay in enumerate(self._delays, start=1):
+            try:
+                return call()
+            except Exception as exc:  # noqa: BLE001 - classified below; non-capacity re-raises
+                if not _is_capacity_error(exc):
+                    raise
+                if self._on_retry is not None:
+                    self._on_retry(attempt, total, delay, exc)
+                self._sleep(delay)
+        return call()  # final attempt: let any error propagate

--- a/wmh/providers/retry_test.py
+++ b/wmh/providers/retry_test.py
@@ -1,0 +1,81 @@
+"""Tests for the narrated retry wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.providers.retry import RetryingProvider
+
+
+class _Throttle(Exception):
+    def __init__(self) -> None:
+        super().__init__("Bedrock is unable to process your request")
+        self.response = {"Error": {"Code": "ServiceUnavailableException"}}
+
+
+class FlakyProvider:
+    """Raises `failures` capacity errors, then succeeds."""
+
+    def __init__(self, failures: int) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+        self._failures = failures
+        self.calls = 0
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.calls += 1
+        if self.calls <= self._failures:
+            raise _Throttle()
+        return Completion(text="ok")
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def test_retries_capacity_errors_with_backoff_and_narration() -> None:
+    events: list[tuple[int, int, float]] = []
+    slept: list[float] = []
+    provider = FlakyProvider(failures=2)
+    retrying = RetryingProvider(
+        provider,
+        on_retry=lambda a, t, d, e: events.append((a, t, d)),
+        sleep=slept.append,
+    )
+    result = retrying.complete("s", [Message(role="user", content="hi")])
+    assert result.text == "ok"
+    assert events == [(1, 3, 1.0), (2, 3, 3.0)]  # narrated attempt k/total with the delay
+    assert slept == [1.0, 3.0]
+
+
+def test_exhausted_retries_reraise_the_capacity_error() -> None:
+    provider = FlakyProvider(failures=10)
+    retrying = RetryingProvider(provider, sleep=lambda _s: None)
+    with pytest.raises(_Throttle):
+        retrying.complete("s", [Message(role="user", content="hi")])
+    assert provider.calls == 4  # 3 backoff attempts + the final propagate attempt
+
+
+def test_non_capacity_errors_propagate_immediately() -> None:
+    class Auth(Exception):
+        pass
+
+    class BadProvider(FlakyProvider):
+        def complete(self, system, messages, *, temperature=0.7, max_tokens=8192):  # noqa: ANN001, ANN202
+            self.calls += 1
+            raise Auth("invalid api key")
+
+    provider = BadProvider(failures=0)
+    retrying = RetryingProvider(provider, sleep=lambda _s: None)
+    with pytest.raises(Auth):
+        retrying.complete("s", [Message(role="user", content="hi")])
+    assert provider.calls == 1


### PR DESCRIPTION
From the ServiceUnavailableException traceback report:

- **Config check**: `wmh demo`/`play` were already serving on the model's own persisted config (the tau-bench example pins Bedrock) — that behavior is kept and now documented in `_load_model`.
- **Narrated retries**: the CLI wraps the serve provider in `RetryingProvider` — capacity errors (throttling, 5xx, timeouts; same classification as the fallback chain) back off 1s → 3s → 9s printing `provider hiccup (…) — retry 1/3 in 1s…`; auth/bad-request errors still fail fast.
- **Switch provider mid-demo**: if the backend is still down after retries, the demo (on a TTY) offers the exact build-wizard provider/model/region picker — extracted as `ui.select_provider_and_model` and reused by both — re-points the world model, and replays the scenario.
- Model-picker labels no longer leak raw `[dim]` markup.

Unit tests: backoff cadence + narration callback, exhausted-retry propagation, fail-fast on non-capacity errors; wizard tests all green through the extraction. Full suite green (the 2 live-Bedrock tests fail on this shell's flaky Bedrock — the very condition this PR narrates).