### PR TITLE
cli: instant first retry, deduped hiccups, inline countdown + spinner

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -12,6 +12,7 @@ import json
 import logging
 import random
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -837,7 +838,19 @@ def demo(
         _console.print(f"[dim]task: {escape(trace.steps[0].task[:200])}[/dim]")
     while True:
         try:
-            result = run_demo(wm, trace, max_steps=steps)
+            busy = "[dim]world model predicting…[/dim]"
+            with _console.status(busy, spinner="dots") as status:
+                _NARRATOR.attach(status, busy)
+
+                def _on_step(i: int, total: int) -> None:
+                    text = f"[dim]world model predicting step {i}/{total}…[/dim]"
+                    _NARRATOR.busy = text
+                    status.update(text)
+
+                try:
+                    result = run_demo(wm, trace, max_steps=steps, on_step=_on_step)
+                finally:
+                    _NARRATOR.detach()
             break
         except Exception as exc:  # noqa: BLE001 - classified below
             if not _is_capacity_error(exc) or not _console.is_terminal:
@@ -859,7 +872,9 @@ def demo(
             switched = ProviderConfig(
                 kind=ProviderKind(provider_name), model=model_id, region=region
             )
-            provider = RetryingProvider(providers.get_provider(switched), on_retry=_print_retry)
+            provider = RetryingProvider(
+                providers.get_provider(switched), on_retry=_NARRATOR.on_retry, sleep=_NARRATOR.sleep
+            )
             wm = WorldModel.load(str(model_dir), provider, telemetry_root=str(model_root))
             _console.print(f"[dim]replaying with {provider_name} ({model_id})…[/dim]")
     if show_prompt:
@@ -1041,11 +1056,68 @@ def _resolve_example(name: str) -> Path:
     raise typer.BadParameter(f"unknown example {name!r}{hint}")
 
 
-def _print_retry(attempt: int, total: int, delay: float, exc: Exception) -> None:
-    detail = str(exc).splitlines()[0][:120]
-    _console.print(
-        f"  [yellow]provider hiccup ({detail}) — retry {attempt}/{total} in {delay:.0f}s…[/yellow]"
-    )
+def _short_error(exc: Exception) -> str:
+    """The error's code + service message, without transport chatter.
+
+    botocore's text ("... (reached max retries: 1) ...") reads as OUR retry state and confuses
+    the narration; the structured code + message is what the user needs.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error", {})
+        code, message = error.get("Code"), error.get("Message") or ""
+        if code:
+            return f"{code}: {message}".rstrip(": ")[:110]
+    return str(exc).splitlines()[0][:110]
+
+
+class _RetryNarrator:
+    """Console narration for RetryingProvider: hiccup lines + an inline countdown.
+
+    The hiccup line prints only when the failure CHANGES (a stream of identical throttles says
+    it once); while a rich status is attached (demo), the wait counts down in place as
+    "retry k/3 — waiting Ns…" and then hands the spinner back to the busy text.
+    """
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+        self._status = None  # rich Status while a spinner context is active
+        self.busy = ""
+        self._last_error: str | None = None
+        self._attempt = 0
+        self._total = 0
+
+    def attach(self, status, busy: str) -> None:  # noqa: ANN001 - rich Status
+        self._status = status
+        self.busy = busy
+
+    def detach(self) -> None:
+        self._status = None
+        self._last_error = None
+
+    def on_retry(self, attempt: int, total: int, delay: float, exc: Exception) -> None:
+        detail = _short_error(exc)
+        if detail != self._last_error:
+            self._console.print(f"  [yellow]provider hiccup: {escape(detail)}[/yellow]")
+            self._last_error = detail
+        self._attempt, self._total = attempt, total
+        if self._status is None:
+            self._console.print(f"  [yellow]retry {attempt}/{total} in {delay:.0f}s…[/yellow]")
+
+    def sleep(self, delay: float) -> None:
+        remaining = int(delay)
+        while remaining > 0:
+            if self._status is not None:
+                self._status.update(
+                    f"[yellow]retry {self._attempt}/{self._total} — waiting {remaining}s…[/yellow]"
+                )
+            time.sleep(1)
+            remaining -= 1
+        if self._status is not None:
+            self._status.update(self.busy)
+
+
+_NARRATOR = _RetryNarrator(_console)
 
 
 def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, name, Provider)
@@ -1060,7 +1132,9 @@ def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, nam
     model_dir = store.resolve(resolved_name)
     config = load_config(model_dir)
     provider = RetryingProvider(
-        providers.get_provider(config.serve_provider_config()), on_retry=_print_retry
+        providers.get_provider(config.serve_provider_config()),
+        on_retry=_NARRATOR.on_retry,
+        sleep=_NARRATOR.sleep,
     )
     world_model = WorldModel.load(str(model_dir), provider, telemetry_root=store.root)
     return world_model, resolved_name, provider

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -216,6 +216,43 @@ def test_demo_replays_a_sampled_scenario_open_loop(patched_provider, tmp_path) -
     assert "exact matches" in result.output
 
 
+def test_retry_narrator_dedupes_identical_failures_and_counts_down(monkeypatch) -> None:  # noqa: ANN001
+    from rich.console import Console as RichConsole
+
+    _RetryNarrator = cli_app_module._RetryNarrator
+
+    console = RichConsole(force_terminal=False, no_color=True, width=100)
+
+    class Boto(Exception):
+        def __init__(self, code: str) -> None:
+            super().__init__("An error occurred (reached max retries: 1)")
+            self.response = {"Error": {"Code": code, "Message": "Bedrock is unable"}}
+
+    class FakeStatus:
+        def __init__(self) -> None:
+            self.updates: list[str] = []
+
+        def update(self, text: str) -> None:
+            self.updates.append(text)
+
+    monkeypatch.setattr(cli_app_module.time, "sleep", lambda _s: None)
+    narrator = _RetryNarrator(console)
+    status = FakeStatus()
+    narrator.attach(status, "busy")
+    with console.capture() as cap:
+        narrator.on_retry(1, 3, 1.0, Boto("ServiceUnavailableException"))
+        narrator.sleep(1.0)
+        narrator.on_retry(2, 3, 3.0, Boto("ServiceUnavailableException"))  # same failure: silent
+        narrator.sleep(3.0)
+        narrator.on_retry(3, 3, 9.0, Boto("ThrottlingException"))  # different: printed
+    out = cap.get()
+    assert out.count("provider hiccup") == 2  # deduped consecutive identical failures
+    assert "ServiceUnavailableException: Bedrock is unable" in out
+    assert "reached max retries" not in out  # transport chatter stripped
+    assert "retry 2/3 — waiting 3s…" in " ".join(status.updates)  # inline countdown
+    assert status.updates[-1] == "busy"  # spinner text restored after the wait
+
+
 def test_providers_subcommand_is_registered() -> None:
     group_names = {group.name for group in app.registered_groups}
     assert "providers" in group_names

--- a/wmh/engine/demo.py
+++ b/wmh/engine/demo.py
@@ -8,6 +8,8 @@ predicted vs. actual side by side — the harness working end-to-end without nee
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from pydantic import BaseModel
 
 from wmh.core.types import Action, Observation, Trace
@@ -35,16 +37,27 @@ class DemoReplay(BaseModel):
     first_env_prompt: str  # the exact prompt the world model saw for the first step
 
 
-def run_demo(world_model: WorldModel, trace: Trace, max_steps: int = 5) -> DemoReplay:
-    """Replay up to `max_steps` of `trace` open-loop and collect predicted vs. actual."""
+def run_demo(
+    world_model: WorldModel,
+    trace: Trace,
+    max_steps: int = 5,
+    on_step: Callable[[int, int], None] | None = None,
+) -> DemoReplay:
+    """Replay up to `max_steps` of `trace` open-loop and collect predicted vs. actual.
+
+    `on_step(i, total)` fires before each prediction so a caller can narrate progress.
+    """
     if not trace.steps:
         raise ValueError(f"trace {trace.trace_id!r} has no steps to replay")
     task = trace.steps[0].task
     session = world_model.new_session(task=task)
     first_env_prompt = world_model.render_step_prompt(session.id, trace.steps[0].action)
 
+    replayed = trace.steps[:max_steps]
     steps: list[DemoStep] = []
-    for step in trace.steps[:max_steps]:
+    for i, step in enumerate(replayed, start=1):
+        if on_step is not None:
+            on_step(i, len(replayed))
         predicted = world_model.step_open_loop(session.id, step.action, step.observation)
         steps.append(DemoStep(action=step.action, predicted=predicted, actual=step.observation))
     return DemoReplay(

--- a/wmh/engine/demo_test.py
+++ b/wmh/engine/demo_test.py
@@ -78,6 +78,14 @@ def test_run_demo_open_loop_pins_history_to_recorded_observations() -> None:
     assert [s.observation.content for s in session.history] == ["RECORDED-1", "RECORDED-2"]
 
 
+def test_run_demo_narrates_each_step() -> None:
+    wm = _world_model(ScriptedProvider())
+    trace = Trace(trace_id="s", steps=[_step("a", "x"), _step("b", "y")])
+    seen: list[tuple[int, int]] = []
+    run_demo(wm, trace, max_steps=5, on_step=lambda i, n: seen.append((i, n)))
+    assert seen == [(1, 2), (2, 2)]
+
+
 def test_run_demo_caps_steps() -> None:
     wm = _world_model(ScriptedProvider())
     trace = Trace(trace_id="long", steps=[_step(f"t{i}", "x") for i in range(9)])

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -72,10 +72,13 @@ class BedrockProvider:
             # stack 3 internal attempts per model UNDER our 4-model failover — up to 12 backend
             # calls with back-off for one throttled request — turning graceful degradation into a
             # slow crawl.
+            # "standard" mode makes max_attempts mean TOTAL attempts (legacy mode still
+            # sneaks in one internal retry, which showed up as a long silent stall before the
+            # CLI's own narrated backoff could react).
             client_config = Config(
                 connect_timeout=15,
                 read_timeout=600,
-                retries={"max_attempts": 1},
+                retries={"max_attempts": 1, "mode": "standard"},
             )
             self._client = boto3.client(
                 "bedrock-runtime", region_name=self.config.region, config=client_config


### PR DESCRIPTION
Follow-ups on the retry UX report:

- **'Takes forever to retry the first time'**: botocore was doing its own internal retry with backoff UNDER ours (legacy retry mode treats `max_attempts: 1` as one *retry*, and its error text — 'reached max retries: 1' — was leaking into our narration). Bedrock's client now uses `{'max_attempts': 1, 'mode': 'standard'}`: a true single attempt, so the failure reaches the narrated backoff immediately.
- **No repeated hiccup lines**: the narrator prints the failure only when it strictly CHANGES; consecutive identical throttles are silent (the countdown carries the progress). The detail shown is the structured error code + service message, with the misleading botocore retry text stripped.
- **Inline countdown + spinner**: `wmh demo` runs under a status spinner narrating `world model predicting step k/N…`; during a retry wait the same line counts down `retry 2/3 — waiting 3s… 2s… 1s…` and hands back to the busy text. `wmh play` already had its thinking spinner.

Unit-pinned: dedupe, countdown updates, spinner-text restoration, chatter stripping, and the per-step demo callback.