### PR TITLE
demo: stream every step live, show the env prompt, resume after switch

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -23,6 +23,7 @@ import typer
 import uvicorn
 from rich.console import Console
 from rich.markup import escape
+from rich.panel import Panel
 from rich.table import Table
 
 import wmh.providers as providers
@@ -813,7 +814,9 @@ def demo(
     ),
     seed: int = typer.Option(None, help="Seed for the scenario sample (default: random)."),
     show_prompt: bool = typer.Option(
-        False, "--show-prompt", help="Also print the exact env prompt of the first step."
+        True,
+        "--show-prompt/--no-prompt",
+        help="Print the exact env prompt the world model sees for the first step.",
     ),
 ) -> None:
     """Replay a randomly sampled recorded scenario against the world model, open loop."""
@@ -830,25 +833,62 @@ def demo(
         raise typer.BadParameter(f"{traces_file} contains no replayable traces")
     trace = random.Random(seed).choice(candidates)
 
+    total = min(steps, len(trace.steps))
     _console.print(
         f"replaying scenario [bold]{trace.trace_id}[/bold] against [bold]{resolved_name}[/bold] "
-        f"(open loop, {min(steps, len(trace.steps))} of {len(trace.steps)} steps)…"
+        f"(open loop, {total} of {len(trace.steps)} steps)…"
     )
     if trace.steps[0].task:
-        _console.print(f"[dim]task: {escape(trace.steps[0].task[:200])}[/dim]")
+        _console.print(f"[dim]task: {escape(trace.steps[0].task)}[/dim]")
+    if show_prompt:
+        _console.print(
+            Panel(
+                escape(_first_prompt(wm, trace)),
+                title="[dim]env prompt (step 1) — what the world model sees[/dim]",
+                border_style="bright_black",
+            )
+        )
+
+    done: list = []  # DemoStep results stream in as each prediction lands
+
+    def _print_result(i: int, n: int, demo_step) -> None:  # noqa: ANN001 - engine DemoStep
+        done.append(demo_step)
+        action = demo_step.action
+        call = (
+            f"{action.name} {json.dumps(action.arguments)}"
+            if action.name
+            else (action.content or "")[:120]
+        )
+        verdict = (
+            "[green]exact match[/green]" if demo_step.exact_match else "[yellow]differs[/yellow]"
+        )
+        _console.print(f"\n[bold]step {i}/{n}[/bold]  [cyan]{escape(call)}[/cyan]  {verdict}")
+        _console.print(f"  [green]predicted[/green]: {escape(demo_step.predicted.content)}")
+        _console.print(f"  [dim]actual[/dim]:    {escape(demo_step.actual.content)}")
+        note = demo_step.predicted.metadata.get("state_note")
+        if isinstance(note, str) and note.strip():
+            _console.print(f"  [dim]model note: {escape(note.strip())}[/dim]")
+
     while True:
         try:
             busy = "[dim]world model predicting…[/dim]"
             with _console.status(busy, spinner="dots") as status:
                 _NARRATOR.attach(status, busy)
 
-                def _on_step(i: int, total: int) -> None:
-                    text = f"[dim]world model predicting step {i}/{total}…[/dim]"
+                def _on_step(i: int, n: int) -> None:
+                    text = f"[dim]world model predicting step {i}/{n}…[/dim]"
                     _NARRATOR.busy = text
                     status.update(text)
 
                 try:
-                    result = run_demo(wm, trace, max_steps=steps, on_step=_on_step)
+                    run_demo(
+                        wm,
+                        trace,
+                        max_steps=steps,
+                        on_step=_on_step,
+                        on_result=_print_result,
+                        skip=len(done),
+                    )
                 finally:
                     _NARRATOR.detach()
             break
@@ -856,8 +896,9 @@ def demo(
             if not _is_capacity_error(exc) or not _console.is_terminal:
                 raise
             # Retries are exhausted and the backend is still down: offer to re-point the model
-            # at a different provider (same picker as the build wizard) and replay.
-            _console.print(f"\n[red]serve provider is still failing[/red]: {exc}")
+            # at a different provider (same picker as the build wizard) and RESUME from the
+            # failed step — completed steps stay done.
+            _console.print(f"\n[red]serve provider is still failing[/red]: {_short_error(exc)}")
             _console.print("[yellow]pick a different provider to continue the demo[/yellow]")
             provider_name, model_id, region = select_provider_and_model(
                 _console,
@@ -876,26 +917,20 @@ def demo(
                 providers.get_provider(switched), on_retry=_NARRATOR.on_retry, sleep=_NARRATOR.sleep
             )
             wm = WorldModel.load(str(model_dir), provider, telemetry_root=str(model_root))
-            _console.print(f"[dim]replaying with {provider_name} ({model_id})…[/dim]")
-    if show_prompt:
-        _console.print(f"[bold]env prompt (step 1)[/bold]:\n{escape(result.first_env_prompt)}")
-    for i, demo_step in enumerate(result.steps, start=1):
-        action = demo_step.action
-        call = (
-            f"{action.name} {json.dumps(action.arguments)}"
-            if action.name
-            else (action.content or "")[:120]
-        )
-        verdict = (
-            "[green]exact match[/green]" if demo_step.exact_match else "[yellow]differs[/yellow]"
-        )
-        _console.print(f"\n[bold]step {i}[/bold]  [cyan]{escape(call)}[/cyan]  {verdict}")
-        _console.print(f"  [green]predicted[/green]: {escape(demo_step.predicted.content[:300])}")
-        _console.print(f"  [dim]actual[/dim]:    {escape(demo_step.actual.content[:300])}")
-    matches = sum(1 for d in result.steps if d.exact_match)
-    _console.print(
-        f"\n{matches}/{len(result.steps)} exact matches (run `wmh eval` for judged fidelity)"
-    )
+            _console.print(
+                f"[dim]resuming from step {len(done) + 1} with {provider_name} ({model_id})…[/dim]"
+            )
+    matches = sum(1 for d in done if d.exact_match)
+    _console.print(f"\n{matches}/{len(done)} exact matches (run `wmh eval` for judged fidelity)")
+
+
+def _first_prompt(wm: WorldModel, trace) -> str:  # noqa: ANN001 - core Trace
+    """Render the first step's env prompt on a throwaway session (display only)."""
+    probe = wm.new_session(task=trace.steps[0].task)
+    try:
+        return wm.render_step_prompt(probe.id, trace.steps[0].action)
+    finally:
+        wm.end_session(probe.id)
 
 
 @app.command("play")

--- a/wmh/engine/demo.py
+++ b/wmh/engine/demo.py
@@ -42,24 +42,36 @@ def run_demo(
     trace: Trace,
     max_steps: int = 5,
     on_step: Callable[[int, int], None] | None = None,
+    on_result: Callable[[int, int, DemoStep], None] | None = None,
+    skip: int = 0,
 ) -> DemoReplay:
     """Replay up to `max_steps` of `trace` open-loop and collect predicted vs. actual.
 
-    `on_step(i, total)` fires before each prediction so a caller can narrate progress.
+    `on_step(i, total)` fires before each prediction and `on_result(i, total, step)` right
+    after it, so callers can stream the interaction as it happens. `skip` resumes a replay
+    mid-scenario (e.g. after a provider switch): the skipped prefix seeds the session from the
+    recorded trajectory without any predictions, and the returned steps cover only the rest.
     """
     if not trace.steps:
         raise ValueError(f"trace {trace.trace_id!r} has no steps to replay")
     task = trace.steps[0].task
     session = world_model.new_session(task=task)
-    first_env_prompt = world_model.render_step_prompt(session.id, trace.steps[0].action)
-
     replayed = trace.steps[:max_steps]
+    if skip:
+        world_model.seed_session(session.id, replayed[:skip])
+    first_env_prompt = world_model.render_step_prompt(
+        session.id, replayed[min(skip, len(replayed) - 1)].action
+    )
+
     steps: list[DemoStep] = []
-    for i, step in enumerate(replayed, start=1):
+    for i, step in enumerate(replayed[skip:], start=skip + 1):
         if on_step is not None:
             on_step(i, len(replayed))
         predicted = world_model.step_open_loop(session.id, step.action, step.observation)
-        steps.append(DemoStep(action=step.action, predicted=predicted, actual=step.observation))
+        result = DemoStep(action=step.action, predicted=predicted, actual=step.observation)
+        steps.append(result)
+        if on_result is not None:
+            on_result(i, len(replayed), result)
     return DemoReplay(
         trace_id=trace.trace_id, task=task, steps=steps, first_env_prompt=first_env_prompt
     )

--- a/wmh/engine/demo_test.py
+++ b/wmh/engine/demo_test.py
@@ -86,6 +86,33 @@ def test_run_demo_narrates_each_step() -> None:
     assert seen == [(1, 2), (2, 2)]
 
 
+def test_run_demo_streams_results_and_resumes_with_skip() -> None:
+    wm = _world_model(ScriptedProvider())
+    trace = Trace(
+        trace_id="s",
+        steps=[_step("a", "found u1"), _step("b", "RECORDED-2"), _step("c", "RECORDED-3")],
+    )
+    streamed: list[tuple[int, int, str]] = []
+    result = run_demo(
+        wm,
+        trace,
+        max_steps=5,
+        skip=1,
+        on_result=lambda i, n, d: streamed.append((i, n, d.actual.content)),
+    )
+    # skip=1 resumes at step 2: only two predictions, streamed as they landed.
+    assert [(i, n) for i, n, _ in streamed] == [(2, 3), (3, 3)]
+    assert [c for _, _, c in streamed] == ["RECORDED-2", "RECORDED-3"]
+    assert len(result.steps) == 2
+    # The skipped prefix seeded the session, so history covers the WHOLE recorded trajectory.
+    session = next(iter(wm._sessions.values()))
+    assert [s.observation.content for s in session.history] == [
+        "found u1",
+        "RECORDED-2",
+        "RECORDED-3",
+    ]
+
+
 def test_run_demo_caps_steps() -> None:
     wm = _world_model(ScriptedProvider())
     trace = Trace(trace_id="long", steps=[_step(f"t{i}", "x") for i in range(9)])

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -222,6 +222,16 @@ class WorldModel:
         session.history[-1] = session.history[-1].model_copy(update={"observation": actual})
         return prediction
 
+    def seed_session(self, session_id: str, steps: list[Step]) -> None:
+        """Advance a session with already-recorded steps, no prediction (open-loop resume).
+
+        Used when a replay continues on a fresh WorldModel (e.g. after a provider switch):
+        teacher-forced history is the recorded trajectory, so seeding is just advancing.
+        """
+        session = self._sessions[session_id]
+        for step in steps:
+            self._advance(session, step.action, step.observation)
+
     def _advance(self, session: Session, action: Action, observation: Observation) -> None:
         """Append the step, fold its state note into the scratchpad, and enrich the buffer.
 


### PR DESCRIPTION
From live feedback ('it only showed them after instead of streaming them in… including initial prompt… it reran the retry loop twice'):

- **Streaming**: each step prints the moment its prediction lands — action, full (untruncated) predicted vs actual, and the model's `state_note` — with the spinner narrating between steps. `run_demo` grew `on_result`.
- **Initial prompt**: the first step's exact env prompt renders by default in a panel; `--no-prompt` hides it.
- **Resume, not rerun**: after a provider switch the replay continues from the failed step — the completed prefix seeds a fresh session from the recorded trajectory via the new `WorldModel.seed_session` (teacher-forced history is the recorded one, so seeding is exact). This was the 'reran twice' feel; also instrumented the retry path: exactly 4 provider calls (initial + 3 narrated retries) per exhausted cycle.

Verified live against Bedrock: steps stream with full content and notes. Full suite green — 517 passed, 0 failed.