### PR TITLE
Harness artifacts: versioned HarnessDoc store under .wmh/harnesses/<name>/

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -36,6 +36,7 @@ from rich.table import Table
 
 import wmh.providers as providers
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
+from wmh.cli.harness_app import harness_app
 from wmh.cli.ui import (
     BuildParams,
     RichBuildReporter,
@@ -120,6 +121,7 @@ app.add_typer(providers_app, name="providers")
 app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")
 app.add_typer(scenarios_app, name="scenarios")
+app.add_typer(harness_app, name="harness")
 _console = Console()
 _CHECK = "[green]✓[/green]"
 
@@ -645,9 +647,14 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     k: int = typer.Option(
         3, min=1, help="Closed-loop passes per task (means reported, never 1-pass)."
     ),
-    max_turns: int = typer.Option(20, min=1, help="Closed-loop agent turn cap per task."),
+    max_turns: int | None = typer.Option(
+        None, min=1, help="Closed-loop agent turn cap (default: 20, or the harness's own)."
+    ),
     threshold: float = typer.Option(
         0.5, help="Agreement pass threshold on a task's k-pass success rate."
+    ),
+    harness: str | None = typer.Option(
+        None, "--harness", help="Stored harness to run for `closed-loop` (default: baseline)."
     ),
 ) -> None:
     """Score reconstruction fidelity, or run named example-local eval suites.
@@ -674,8 +681,14 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
         if len(args) != 1 or args[0] in ("list", "run", "results", "agreement"):
             raise typer.BadParameter("usage: wmh eval <tasks.jsonl> --mode closed-loop")
         run_closed_loop(
-            _console, tasks_file=args[0], name=name, root=root, k=k,
-            max_turns=max_turns, out=out,
+            _console,
+            tasks_file=args[0],
+            name=name,
+            root=root,
+            k=k,
+            max_turns=max_turns,
+            out=out,
+            harness=harness,
         )
         return
     if args and args[0] == "agreement":

--- a/wmh/cli/eval_closed_loop.py
+++ b/wmh/cli/eval_closed_loop.py
@@ -19,7 +19,9 @@ from wmh.evals.agreement import compute_agreement
 from wmh.evals.closed_loop import ClosedLoopEval, ClosedLoopReport
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import load_tasks
-from wmh.harness.runtime import AgentRuntime
+from wmh.harness.doc import MAX_TURNS_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.runtime import DEFAULT_MAX_TURNS, AgentRuntime
+from wmh.harness.store import HarnessStore
 
 
 def run_closed_loop(
@@ -29,10 +31,17 @@ def run_closed_loop(
     name: str | None,
     root: str,
     k: int,
-    max_turns: int,
+    max_turns: int | None,
     out: str | None,
+    harness: str | None = None,
 ) -> None:
-    """Run the fixed agent on each task against the world model; print and optionally save."""
+    """Run an agent harness on each task against the world model; print and optionally save.
+
+    `--harness <name>[@ref]` runs a stored harness version (ref = version or alias; default is
+    the champion alias); without it the built-in baseline loop runs. `max_turns=None` means "the
+    harness's own cap" (or the default for the baseline); an explicit value overrides either —
+    never silently ignored.
+    """
     try:
         tasks = load_tasks(tasks_file)
     except (OSError, ValueError) as exc:  # missing file, malformed JSONL, empty, duplicate ids
@@ -44,23 +53,39 @@ def run_closed_loop(
         raise typer.BadParameter(str(exc)) from exc
     world_model, provider = load_world_model(model_dir)
 
+    loaded_harness = _load_harness(harness, root)
+    agent_label = (
+        f"{loaded_harness.name}-v{loaded_harness.version}"
+        if loaded_harness is not None
+        else "baseline"
+    )
     console.print(
-        f"closed-loop: agent vs world model [bold]{model_dir.name}[/bold] "
-        f"on {len(tasks)} task(s), k={k}…"
+        f"closed-loop: harness [bold]{agent_label}[/bold] vs world model "
+        f"[bold]{model_dir.name}[/bold] on {len(tasks)} task(s), k={k}…"
     )
 
     def _progress(task_id: str, attempt: int, verdict: GoldVerdict) -> None:
         mark = "[green]pass[/green]" if verdict.passed else "[red]fail[/red]"
         console.print(f"  {task_id} #{attempt}: {mark} ({verdict.rationale})")
 
+    if loaded_harness is not None:
+        if max_turns is not None and max_turns != loaded_harness.max_turns():
+            console.print(
+                f"  note: --max-turns {max_turns} overrides the harness's own "
+                f"max_turns={loaded_harness.max_turns()}"
+            )
+            loaded_harness = _with_max_turns(loaded_harness, max_turns)
+        runtime = loaded_harness.runtime(provider)
+    else:
+        runtime = AgentRuntime(provider, max_turns=max_turns or DEFAULT_MAX_TURNS)
     evaluation = ClosedLoopEval(
         tasks,
         world_model,
         provider,
         GoldJudge(provider),
-        label=model_dir.name,
+        label=f"{agent_label}@{model_dir.name}",
         k=k,
-        runtime=AgentRuntime(provider, max_turns=max_turns),
+        runtime=runtime,
         on_progress=_progress,
     )
     report = evaluation.run()
@@ -95,3 +120,20 @@ def _load_report(path: str) -> ClosedLoopReport:
         return ClosedLoopReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         raise typer.BadParameter(f"cannot read closed-loop report {path!r}: {exc}") from exc
+
+
+def _with_max_turns(doc: HarnessDoc, max_turns: int) -> HarnessDoc:
+    """A copy of `doc` with its max-turns surface replaced (re-validated via the constructor)."""
+    surfaces = [s for s in doc.surfaces if s.id != MAX_TURNS_ID]
+    surfaces.append(Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(max_turns)))
+    return HarnessDoc(name=doc.name, version=doc.version, surfaces=surfaces)
+
+
+def _load_harness(name: str | None, root: str) -> HarnessDoc | None:
+    if name is None:
+        return None
+    base, _, ref = name.partition("@")
+    try:
+        return HarnessStore(root).load(base, ref or None)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -1,0 +1,99 @@
+"""`wmh harness` — named, versioned agent harnesses under `.wmh/harnesses/<name>/`.
+
+A harness is the scaffold an agent runs with: prompt surfaces, a tool policy, loop parameters, and
+skills, stored as immutable numbered versions with movable aliases (`champion` is what runs by
+default). `init` writes the baseline as v1; `list`/`show` inspect what exists; run one closed-loop
+with `wmh eval closed-loop <tasks> --harness <name>[@ref]`.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from wmh.config import ARTIFACT_DIR
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+
+harness_app = typer.Typer(
+    help="Named, versioned agent harnesses (.wmh/harnesses): init, list, show.",
+    no_args_is_help=True,
+)
+_console = Console()
+
+
+@harness_app.command("list")
+def list_harnesses(root: str = typer.Option(ARTIFACT_DIR, help="Project dir.")) -> None:
+    """List every harness with its versions and aliases."""
+    store = HarnessStore(root)
+    names = store.list_names()
+    if not names:
+        _console.print(
+            "[yellow]no harnesses yet[/yellow]; `wmh harness init <name>` creates the baseline"
+        )
+        return
+    table = Table(title="Harnesses")
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Versions", justify="right")
+    table.add_column("Aliases")
+    table.add_column("Doc hash (champion)")
+    broken: list[tuple[str, str]] = []
+    for name in names:
+        try:
+            doc = store.load(name)
+            aliases = ", ".join(f"{a}=v{v}" for a, v in sorted(store.aliases(name).items()))
+            table.add_row(
+                name,
+                f"{len(store.versions(name))}",
+                aliases or "—",
+                doc.doc_hash[:12],
+            )
+        except (ValueError, FileNotFoundError) as exc:  # one broken dir must not hide the rest
+            broken.append((name, str(exc)))
+    _console.print(table)
+    for name, reason in broken:
+        _console.print(f"[red]broken[/red] {name}: {reason}")
+
+
+@harness_app.command("show")
+def show_harness(
+    name: str = typer.Argument(..., help="Harness name, optionally name@ref (version or alias)."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+) -> None:
+    """Print one harness version's surfaces."""
+    base, _, ref = name.partition("@")
+    try:
+        doc = HarnessStore(root).load(base, ref or None)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _console.print(f"[bold]{doc.name}[/bold] v{doc.version}  doc_hash={doc.doc_hash[:12]}")
+    for surface in doc.surfaces:
+        budget = f"  budget={surface.budget}" if surface.budget is not None else ""
+        _console.print(
+            f"\n[bold]{surface.id}[/bold]  ({surface.kind.value}, "
+            f"hash={surface.content_hash[:12]}{budget})"
+        )
+        _console.print(surface.content)
+
+
+@harness_app.command("init")
+def init_harness(
+    name: str = typer.Argument("baseline", help="Name for the new harness."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+) -> None:
+    """Write the baseline harness as v1 and point `champion` at it."""
+    store = HarnessStore(root)
+    try:
+        if store.exists(name):
+            raise typer.BadParameter(
+                f"harness {name!r} already exists; new versions are appended by "
+                "`wmh harness create`, and aliases move with `set_alias`"
+            )
+        doc = store.save_version(HarnessDoc.baseline(name), alias=CHAMPION_ALIAS)
+    except ValueError as exc:  # invalid name -> usage error, not a traceback
+        raise typer.BadParameter(str(exc)) from exc
+    _console.print(
+        f"[green]wrote[/green] {name} v{doc.version} (champion) -> {store.dir_for(name)}"
+    )
+    _console.print(f"run it: [bold]wmh eval closed-loop <tasks.jsonl> --harness {name}[/bold]")

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -1,0 +1,215 @@
+"""`HarnessDoc`: a harness as a typed document of identity-keyed surfaces.
+
+A harness is not a directory of files — it is a set of named **surfaces**, each an independently
+addressable unit of behavior: prompt sections, the tool policy, scalar loop parameters, and skills.
+Files (`SYSTEM.md`, `config.toml`, `skills/*.md`) are a *render target* the store exports for
+running the harness elsewhere; the document is the interface everything else programs against.
+
+Why surfaces instead of files:
+- **Identity.** Every surface has a stable id (`prompt:core`, `skill:count-words`). An update names
+  its target; nothing is ever addressed by position or filename, so "which thing changed" is never
+  inferred.
+- **Content addressing.** Each surface has a content hash, and the document has a hash over its
+  surfaces. "The score of harness X" is well-defined because X is a hash; an update can assert
+  exactly what it believes it is editing.
+- **Typed validation.** A document validates as a whole (tools resolve, `submit` present, params in
+  range, budgets respected) the moment it is constructed — an invalid harness cannot exist as a
+  value, so nothing downstream re-checks.
+
+Surface *content* stays a free-form string on purpose: structure lives in the envelope (ids, kinds,
+hashes, budgets), not in the payload, so richer surface kinds can be added without changing how
+updates work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from wmh.harness.runtime import DEFAULT_MAX_TURNS, DEFAULT_SYSTEM_PROMPT, AgentRuntime
+from wmh.harness.skills import Skill, SkillLibrary
+from wmh.harness.tools import DEFAULT_TOOLS, resolve_tools
+from wmh.providers.base import Provider
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Well-known surface ids. Only TOOL_POLICY and the two params are singletons; prompt and skill
+# surfaces may be added freely (an update can split `prompt:core` into finer sections).
+TOOL_POLICY_ID = "tool_policy:main"
+MAX_TURNS_ID = "param:max-turns"
+TEMPERATURE_ID = "param:temperature"
+
+DEFAULT_TEMPERATURE = 0.7
+
+
+class SurfaceKind(StrEnum):
+    PROMPT = "prompt"  # a section of the system prompt (joined in id order)
+    SKILL = "skill"  # one skill: frontmatter (name, description) + body
+    TOOL_POLICY = "tool_policy"  # the tool list, one tool name per line
+    PARAM = "param"  # a scalar loop knob, serialized as its string form
+
+
+class Surface(BaseModel):
+    """One named, independently addressable unit of harness behavior."""
+
+    id: str  # "<kind>:<slug>"
+    kind: SurfaceKind
+    content: str
+    # Optional size budget (characters). Enforced at construction: a surface that exceeds its
+    # budget is invalid, so context cost is a schema property rather than a runtime surprise.
+    budget: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate(self) -> Surface:
+        prefix, sep, slug = self.id.partition(":")
+        if not sep or prefix != self.kind.value or not _SLUG_RE.match(slug):
+            raise ValueError(
+                f"surface id {self.id!r} must be '{self.kind.value}:<kebab-slug>' matching its kind"
+            )
+        if self.budget is not None and len(self.content) > self.budget:
+            raise ValueError(
+                f"surface {self.id!r} content is {len(self.content)} chars, "
+                f"over its budget of {self.budget}"
+            )
+        return self
+
+    @property
+    def slug(self) -> str:
+        return self.id.partition(":")[2]
+
+    @property
+    def content_hash(self) -> str:
+        return _digest(self.content)
+
+
+class HarnessDoc(BaseModel):
+    """A complete, validated harness: the value the runtime runs and updates are applied to."""
+
+    name: str
+    version: int = Field(default=0, ge=0)  # assigned by the store on save; 0 = unsaved
+    surfaces: list[Surface]
+
+    @field_validator("surfaces")
+    @classmethod
+    def _canonical_order(cls, v: list[Surface]) -> list[Surface]:
+        return sorted(v, key=lambda s: s.id)
+
+    @model_validator(mode="after")
+    def _validate_document(self) -> HarnessDoc:
+        ids = [s.id for s in self.surfaces]
+        duplicates = sorted({i for i in ids if ids.count(i) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate surface id(s): {duplicates}")
+        if not any(s.kind is SurfaceKind.PROMPT for s in self.surfaces):
+            raise ValueError("a harness needs at least one prompt surface")
+        # These validations construct the derived values; failures surface here, at the boundary.
+        self.tools()
+        self.max_turns()
+        self.temperature()
+        for surface in self.surfaces:
+            if surface.kind is SurfaceKind.SKILL:
+                skill = Skill.from_markdown(surface.content)
+                if skill.name != surface.slug:
+                    raise ValueError(
+                        f"skill surface {surface.id!r} declares frontmatter name "
+                        f"{skill.name!r}; the slug and frontmatter name must match"
+                    )
+        return self
+
+    # -- surface access ---------------------------------------------------------------------
+
+    def surface(self, surface_id: str) -> Surface | None:
+        for s in self.surfaces:
+            if s.id == surface_id:
+                return s
+        return None
+
+    def surface_hashes(self) -> dict[str, str]:
+        return {s.id: s.content_hash for s in self.surfaces}
+
+    @property
+    def doc_hash(self) -> str:
+        """Content identity of the whole document (order-independent via canonical sort)."""
+        joined = "\n".join(f"{s.id}\x00{s.content_hash}" for s in self.surfaces)
+        return _digest(joined)
+
+    # -- derived, validated views ------------------------------------------------------------
+
+    def system_prompt(self) -> str:
+        """All prompt surfaces joined in id order (a single `prompt:core` is the common case)."""
+        parts = [s.content for s in self.surfaces if s.kind is SurfaceKind.PROMPT]
+        return "\n\n".join(parts)
+
+    def tools(self) -> list[str]:
+        policy = self.surface(TOOL_POLICY_ID)
+        if policy is None:
+            return list(DEFAULT_TOOLS)
+        names = [line.strip() for line in policy.content.splitlines() if line.strip()]
+        resolve_tools(names)  # raises on unknown tools / missing submit
+        return names
+
+    def max_turns(self) -> int:
+        raw = self.surface(MAX_TURNS_ID)
+        if raw is None:
+            return DEFAULT_MAX_TURNS
+        try:
+            value = int(raw.content.strip())
+        except ValueError as exc:
+            raise ValueError(f"{MAX_TURNS_ID} must be an integer, got {raw.content!r}") from exc
+        if value < 1:
+            raise ValueError(f"{MAX_TURNS_ID} must be >= 1, got {value}")
+        return value
+
+    def temperature(self) -> float:
+        raw = self.surface(TEMPERATURE_ID)
+        if raw is None:
+            return DEFAULT_TEMPERATURE
+        try:
+            value = float(raw.content.strip())
+        except ValueError as exc:
+            raise ValueError(f"{TEMPERATURE_ID} must be a float, got {raw.content!r}") from exc
+        if not 0.0 <= value <= 2.0:
+            raise ValueError(f"{TEMPERATURE_ID} must be in [0, 2], got {value}")
+        return value
+
+    def skills(self) -> list[Skill]:
+        return [
+            Skill.from_markdown(s.content) for s in self.surfaces if s.kind is SurfaceKind.SKILL
+        ]
+
+    def runtime(self, provider: Provider) -> AgentRuntime:
+        """The configured agent runtime this document describes."""
+        return AgentRuntime(
+            provider,
+            system_prompt=self.system_prompt(),
+            tools=self.tools(),
+            max_turns=self.max_turns(),
+            temperature=self.temperature(),
+            skills=SkillLibrary(self.skills()),
+        )
+
+    @classmethod
+    def baseline(cls, name: str = "baseline") -> HarnessDoc:
+        """The default harness: one core prompt, the default tools, default loop params."""
+        return cls(
+            name=name,
+            surfaces=[
+                Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content=DEFAULT_SYSTEM_PROMPT),
+                Surface(
+                    id=TOOL_POLICY_ID,
+                    kind=SurfaceKind.TOOL_POLICY,
+                    content="\n".join(DEFAULT_TOOLS),
+                ),
+                Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(DEFAULT_MAX_TURNS)),
+                Surface(
+                    id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(DEFAULT_TEMPERATURE)
+                ),
+            ],
+        )
+
+
+def _digest(text: str) -> str:
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=16).hexdigest()

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -1,0 +1,115 @@
+"""Tests for HarnessDoc: surface validation, hashing, derived views, document invariants."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.harness.doc import (
+    MAX_TURNS_ID,
+    TEMPERATURE_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.skills import Skill
+
+
+def _skill_surface(name: str = "count-words") -> Surface:
+    skill = Skill(name=name, description="count words in a file", body="wc -w <path>")
+    return Surface(id=f"skill:{name}", kind=SurfaceKind.SKILL, content=skill.to_markdown())
+
+
+def test_baseline_is_valid_and_derives_defaults() -> None:
+    doc = HarnessDoc.baseline("base")
+    assert doc.max_turns() == 20
+    assert doc.temperature() == 0.7
+    assert "submit" in doc.tools()
+    assert doc.system_prompt()  # non-empty
+    assert doc.version == 0  # unsaved
+
+
+def test_surface_id_must_match_kind() -> None:
+    with pytest.raises(ValidationError, match="matching its kind"):
+        Surface(id="skill:core", kind=SurfaceKind.PROMPT, content="x")
+    with pytest.raises(ValidationError, match="matching its kind"):
+        Surface(id="no-prefix", kind=SurfaceKind.PROMPT, content="x")
+    with pytest.raises(ValidationError, match="matching its kind"):
+        Surface(id="prompt:Not Kebab", kind=SurfaceKind.PROMPT, content="x")
+
+
+def test_budget_is_enforced_at_construction() -> None:
+    Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="ok", budget=10)
+    with pytest.raises(ValidationError, match="over its budget"):
+        Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="x" * 11, budget=10)
+
+
+def test_doc_hash_is_content_and_order_independent() -> None:
+    a = Surface(id="prompt:a", kind=SurfaceKind.PROMPT, content="A")
+    b = Surface(id="prompt:b", kind=SurfaceKind.PROMPT, content="B")
+    doc1 = HarnessDoc(name="x", surfaces=[a, b])
+    doc2 = HarnessDoc(name="y", version=7, surfaces=[b, a])  # different name/version/order
+    assert doc1.doc_hash == doc2.doc_hash  # identity is the surfaces, nothing else
+    doc3 = HarnessDoc(name="x", surfaces=[a.model_copy(update={"content": "A2"}), b])
+    assert doc3.doc_hash != doc1.doc_hash
+
+
+def test_duplicate_surface_ids_rejected() -> None:
+    a = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="A")
+    with pytest.raises(ValidationError, match="duplicate surface id"):
+        HarnessDoc(name="x", surfaces=[a, a.model_copy(update={"content": "B"})])
+
+
+def test_document_requires_a_prompt_surface() -> None:
+    tools = Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit")
+    with pytest.raises(ValidationError, match="prompt surface"):
+        HarnessDoc(name="x", surfaces=[tools])
+
+
+def test_invalid_derived_values_fail_at_construction() -> None:
+    core = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p")
+    # tool policy without the required submit tool
+    bad_tools = Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash")
+    with pytest.raises(ValidationError, match="submit"):
+        HarnessDoc(name="x", surfaces=[core, bad_tools])
+    bad_turns = Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="zero")
+    with pytest.raises(ValidationError, match="integer"):
+        HarnessDoc(name="x", surfaces=[core, bad_turns])
+    bad_temp = Surface(id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content="9.5")
+    with pytest.raises(ValidationError, match=r"\[0, 2\]"):
+        HarnessDoc(name="x", surfaces=[core, bad_temp])
+
+
+def test_skill_surface_slug_must_match_frontmatter() -> None:
+    core = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p")
+    skill = Skill(name="other-name", description="d", body="b")
+    mismatched = Surface(id="skill:my-skill", kind=SurfaceKind.SKILL, content=skill.to_markdown())
+    with pytest.raises(ValidationError, match="must match"):
+        HarnessDoc(name="x", surfaces=[core, mismatched])
+
+
+def test_prompt_sections_join_in_id_order() -> None:
+    doc = HarnessDoc(
+        name="x",
+        surfaces=[
+            Surface(id="prompt:z-recovery", kind=SurfaceKind.PROMPT, content="RECOVER"),
+            Surface(id="prompt:a-role", kind=SurfaceKind.PROMPT, content="ROLE"),
+        ],
+    )
+    assert doc.system_prompt() == "ROLE\n\nRECOVER"
+
+
+def test_runtime_reflects_document() -> None:
+    doc = HarnessDoc.baseline("base")
+    doc = HarnessDoc(name="base", surfaces=[*doc.surfaces, _skill_surface()])
+    skills = doc.skills()
+    assert [s.name for s in skills] == ["count-words"]
+    assert doc.surface_hashes()["skill:count-words"]
+
+
+def test_json_roundtrip_preserves_identity() -> None:
+    doc = HarnessDoc(name="x", surfaces=[*HarnessDoc.baseline("x").surfaces, _skill_surface()])
+    restored = HarnessDoc.model_validate_json(doc.model_dump_json())
+    assert restored == doc
+    assert restored.doc_hash == doc.doc_hash

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -17,8 +17,10 @@ from pydantic import BaseModel, Field
 
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step
 from wmh.harness.environment import AgentEnvironment, is_env_action
+from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import (
     DEFAULT_TOOLS,
+    READ_SKILL,
     SUBMIT,
     ToolCall,
     parse_tool_call,
@@ -94,12 +96,19 @@ class AgentRuntime:
         tools: list[str] | None = None,
         max_turns: int = DEFAULT_MAX_TURNS,
         temperature: float = 0.7,
+        skills: SkillLibrary | None = None,
     ) -> None:
         if max_turns < 1:
             raise ValueError("max_turns must be >= 1")
         self._provider = provider
         self._system_prompt = system_prompt
-        self._tools = resolve_tools(tools if tools is not None else list(DEFAULT_TOOLS))
+        self._skills = skills if skills is not None else SkillLibrary()
+        tool_names = list(tools) if tools is not None else list(DEFAULT_TOOLS)
+        # A skill-bearing harness needs read_skill for progressive disclosure; add it implicitly so
+        # harness config files don't have to remember the plumbing tool.
+        if len(self._skills) and READ_SKILL.name not in tool_names:
+            tool_names.append(READ_SKILL.name)
+        self._tools = resolve_tools(tool_names)
         self._max_turns = max_turns
         self._temperature = temperature
 
@@ -144,14 +153,26 @@ class AgentRuntime:
     def _dispatch(
         self, call: ToolCall, environment: AgentEnvironment
     ) -> tuple[Action, Observation]:
-        """Route one non-submit call to the environment, rejecting unconfigured tools."""
+        """Route one non-submit call: read_skill handled here, env tools to the environment."""
         action = to_action(call)
-        if call.tool not in {t.name for t in self._tools} or not is_env_action(action):
+        if call.tool not in {t.name for t in self._tools}:
+            return action, Observation(content=f"tool {call.tool!r} not available", is_error=True)
+        if call.tool == READ_SKILL.name:
+            name = _str_arg(call, "name")
+            skill = self._skills.get(name)
+            if skill is None:
+                return action, Observation(content=f"no skill named {name!r}", is_error=True)
+            return action, Observation(content=skill.body)
+        if not is_env_action(action):
             return action, Observation(content=f"tool {call.tool!r} not available", is_error=True)
         return action, environment.execute(action)
 
     def _full_system_prompt(self) -> str:
-        return f"{self._system_prompt}\n\n## Tools\n{render_tools(self._tools)}"
+        prompt = f"{self._system_prompt}\n\n## Tools\n{render_tools(self._tools)}"
+        index = self._skills.render_index()
+        if index:
+            prompt += f"\n\n## Your skills (read a body with read_skill)\n{index}"
+        return prompt
 
     def _result(
         self,

--- a/wmh/harness/runtime_test.py
+++ b/wmh/harness/runtime_test.py
@@ -101,6 +101,34 @@ def test_unavailable_tool_is_an_error_observation_not_a_crash() -> None:
     assert env.actions == []  # and never reached the environment
 
 
+def test_read_skill_returns_body_and_index_is_in_prompt() -> None:
+    from wmh.harness.skills import Skill, SkillLibrary
+
+    provider = ScriptedProvider(
+        [
+            '{"tool": "read_skill", "arguments": {"name": "count-words"}}',
+            '{"tool": "submit", "arguments": {"answer": "ok"}}',
+        ]
+    )
+    library = SkillLibrary(
+        [Skill(name="count-words", description="count words", body="wc -w <path>")]
+    )
+    env = RecordingEnv()
+    result = AgentRuntime(provider, skills=library).run("t", "x", env)
+    # read_skill is handled by the runtime (never reaches the env) and returns the body.
+    assert result.steps[0].observation.content == "wc -w <path>"
+    assert env.actions == []
+    # Unknown skill -> error observation.
+    provider2 = ScriptedProvider(
+        [
+            '{"tool": "read_skill", "arguments": {"name": "ghost"}}',
+            '{"tool": "submit", "arguments": {"answer": "ok"}}',
+        ]
+    )
+    result2 = AgentRuntime(provider2, skills=library).run("t", "x", RecordingEnv())
+    assert result2.steps[0].observation.is_error
+
+
 def test_transcript_shows_actions_and_observations() -> None:
     provider = ScriptedProvider(
         [

--- a/wmh/harness/skills.py
+++ b/wmh/harness/skills.py
@@ -1,0 +1,116 @@
+"""Skills: reusable techniques a harness ships, one `SKILL.md`-style unit each.
+
+A skill is one markdown file with tiny frontmatter (`name`, `description`) and a body. Harnesses
+surface skills by **progressive disclosure**: only the name+description index is preloaded into the
+system prompt (`render_index`); the agent pulls a full body on demand with the `read_skill` tool,
+so always-loaded context stays small while the library grows.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, field_validator
+
+_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+class Skill(BaseModel):
+    """One reusable skill: a name, a one-line trigger description, and a body to reuse.
+
+    Validation lives on the MODEL, not just the markdown parser: skill names become file paths
+    (`skills/<name>.md`), so a programmatically-constructed skill with a hostile name (`../../x`)
+    must be impossible, not merely improbable. The description is coerced to one line (it lives in
+    frontmatter, where a newline silently truncates on round-trip); the body is stripped so
+    round-trips compare equal.
+    """
+
+    name: str
+    description: str
+    body: str
+
+    @field_validator("name")
+    @classmethod
+    def _kebab_name(cls, v: str) -> str:
+        if not _NAME_RE.match(v):
+            raise ValueError(f"skill name {v!r} must be kebab-case ([a-z0-9-])")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def _one_line(cls, v: str) -> str:
+        return " ".join(v.split())
+
+    @field_validator("body")
+    @classmethod
+    def _stripped(cls, v: str) -> str:
+        return v.strip()
+
+    def to_markdown(self) -> str:
+        """Serialize to a SKILL.md-style file (frontmatter + body)."""
+        return f"---\nname: {self.name}\ndescription: {self.description}\n---\n{self.body}"
+
+    @classmethod
+    def from_markdown(cls, text: str) -> Skill:
+        match = _FRONTMATTER_RE.match(text)
+        if match is None:
+            raise ValueError("skill file has no frontmatter")
+        meta = parse_frontmatter(match.group(1))
+        name = meta.get("name", "")
+        if not _NAME_RE.match(name):
+            raise ValueError(f"skill name {name!r} must be kebab-case")
+        return cls(name=name, description=meta.get("description", ""), body=match.group(2))
+
+
+def parse_frontmatter(block: str) -> dict[str, str]:
+    """Parse the tiny `key: value` frontmatter (one field per line)."""
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        key, sep, value = line.partition(":")
+        if sep:
+            out[key.strip()] = value.strip()
+    return out
+
+
+class SkillLibrary:
+    """An in-memory set of skills, loadable from / writable to a `skills/` directory."""
+
+    def __init__(self, skills: list[Skill] | None = None) -> None:
+        self._skills: dict[str, Skill] = {s.name: s for s in (skills or [])}
+
+    @classmethod
+    def from_dir(cls, root: str | Path) -> SkillLibrary:
+        """Load every `*.md` under `root` (a malformed skill file is an error, not skipped —
+        a harness that ships a broken skill should fail loudly at load time, not at rollout)."""
+        library = cls()
+        root = Path(root)
+        if not root.exists():
+            return library
+        for path in sorted(root.glob("*.md")):
+            skill = Skill.from_markdown(path.read_text(encoding="utf-8"))
+            library._skills[skill.name] = skill
+        return library
+
+    def write_dir(self, root: str | Path) -> None:
+        """Write one `<name>.md` per skill under `root` (created if missing)."""
+        root = Path(root)
+        root.mkdir(parents=True, exist_ok=True)
+        for skill in self._skills.values():
+            (root / f"{skill.name}.md").write_text(skill.to_markdown(), encoding="utf-8")
+
+    def __len__(self) -> int:
+        return len(self._skills)
+
+    def names(self) -> list[str]:
+        return sorted(self._skills)
+
+    def get(self, name: str) -> Skill | None:
+        return self._skills.get(name)
+
+    def render_index(self) -> str:
+        """Progressive-disclosure index: name + description only (bodies via read_skill)."""
+        if not self._skills:
+            return ""
+        return "\n".join(f"- {s.name}: {s.description}" for s in self._skills.values())

--- a/wmh/harness/skills_test.py
+++ b/wmh/harness/skills_test.py
@@ -1,0 +1,44 @@
+"""Tests for SKILL.md skills: round-trip, directory IO, progressive-disclosure index."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.skills import Skill, SkillLibrary
+
+
+def test_skill_markdown_roundtrip() -> None:
+    skill = Skill(name="grep-logs", description="find errors in logs", body="grep -i error *.log")
+    assert Skill.from_markdown(skill.to_markdown()) == skill
+
+
+def test_malformed_skill_raises() -> None:
+    with pytest.raises(ValueError, match="frontmatter"):
+        Skill.from_markdown("just a body, no frontmatter")
+    with pytest.raises(ValueError, match="kebab-case"):
+        Skill.from_markdown("---\nname: Not Kebab\ndescription: d\n---\nbody")
+
+
+def test_library_dir_roundtrip(tmp_path: Path) -> None:
+    library = SkillLibrary(
+        [Skill(name="find-big-files", description="locate large files", body="du -ah | sort -h")]
+    )
+    library.write_dir(tmp_path)
+    reloaded = SkillLibrary.from_dir(tmp_path)
+    assert reloaded.names() == ["find-big-files"]
+    got = reloaded.get("find-big-files")
+    assert got is not None and "du -ah" in got.body
+
+
+def test_from_missing_dir_is_empty(tmp_path: Path) -> None:
+    assert len(SkillLibrary.from_dir(tmp_path / "nope")) == 0
+
+
+def test_render_index_is_names_and_descriptions_only() -> None:
+    library = SkillLibrary([Skill(name="a-skill", description="does A", body="secret body A")])
+    index = library.render_index()
+    assert "a-skill: does A" in index
+    assert "secret body A" not in index  # bodies are disclosed only via read_skill
+    assert SkillLibrary().render_index() == ""

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -1,0 +1,220 @@
+"""Harnesses on disk: immutable numbered versions plus movable aliases, per name.
+
+Like world models under `.wmh/models/<name>/`, a harness is a named artifact — but harnesses
+accumulate *versions*, because they are the thing `wmh harness create` iterates on. A version, once
+written, never changes; deployment state lives in movable aliases; and every eval result keys to an
+immutable version rather than to "whatever the harness currently is".
+
+    .wmh/harnesses/<name>/
+      aliases.toml        # [aliases]  champion = 3   (movable pointers; rollback = re-point)
+      v1/
+        doc.json          # the authoritative HarnessDoc serialization
+        SYSTEM.md         # rendered export of the same document, for running the harness
+        config.toml       #   outside wmh — regenerated on every save, never read back
+        skills/<slug>.md  #   when doc.json is present
+      v3/ ...
+
+`doc.json` is authoritative; the rendered files are an export. A directory with rendered files but
+no `doc.json` (a hand-authored harness) still loads: the files parse into a single-prompt document.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+from wmh.config.store import validate_name
+from wmh.harness.doc import (
+    MAX_TURNS_ID,
+    TEMPERATURE_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.skills import Skill
+
+HARNESSES_DIR = "harnesses"
+CHAMPION_ALIAS = "champion"
+
+_DOC_FILE = "doc.json"
+_SYSTEM_FILE = "SYSTEM.md"
+_CONFIG_FILE = "config.toml"
+_SKILLS_DIR = "skills"
+_ALIASES_FILE = "aliases.toml"
+
+
+class HarnessStore:
+    """Named, versioned harnesses under `<root>/harnesses/<name>/`."""
+
+    def __init__(self, root: str | Path = ".wmh") -> None:
+        self.root = Path(root)
+
+    @property
+    def harnesses_dir(self) -> Path:
+        return self.root / HARNESSES_DIR
+
+    def dir_for(self, name: str) -> Path:
+        return self.harnesses_dir / validate_name(name)
+
+    # -- enumeration -------------------------------------------------------------------------
+
+    def list_names(self) -> list[str]:
+        if not self.harnesses_dir.exists():
+            return []
+        return sorted(
+            d.name for d in self.harnesses_dir.iterdir() if d.is_dir() and self.versions(d.name)
+        )
+
+    def versions(self, name: str) -> list[int]:
+        directory = self.dir_for(name)
+        if not directory.exists():
+            return []
+        found: list[int] = []
+        for child in directory.iterdir():
+            if child.is_dir() and child.name.startswith("v") and child.name[1:].isdigit():
+                found.append(int(child.name[1:]))
+        return sorted(found)
+
+    def exists(self, name: str) -> bool:
+        return bool(self.versions(name))
+
+    # -- aliases -----------------------------------------------------------------------------
+
+    def aliases(self, name: str) -> dict[str, int]:
+        path = self.dir_for(name) / _ALIASES_FILE
+        if not path.exists():
+            return {}
+        data = tomllib.loads(path.read_text(encoding="utf-8")).get("aliases", {})
+        return {k: v for k, v in data.items() if isinstance(v, int)}
+
+    def set_alias(self, name: str, alias: str, version: int) -> None:
+        """Point `alias` at `version` (moving it if it exists). Rollback is re-pointing."""
+        if version not in self.versions(name):
+            raise ValueError(f"harness {name!r} has no version v{version}")
+        current = self.aliases(name)
+        current[alias] = version
+        path = self.dir_for(name) / _ALIASES_FILE
+        path.write_text(tomli_w.dumps({"aliases": current}), encoding="utf-8")
+
+    # -- load / save ---------------------------------------------------------------------------
+
+    def resolve_version(self, name: str, ref: str | None = None) -> int:
+        """Resolve a version ref: `None` -> champion alias, else latest; `"vN"`/`"N"`; an alias."""
+        available = self.versions(name)
+        if not available:
+            raise FileNotFoundError(
+                f"no harness named {name!r} under {self.harnesses_dir} "
+                f"(have: {', '.join(self.list_names()) or 'none'})"
+            )
+        aliases = self.aliases(name)
+        if ref is None:
+            return aliases.get(CHAMPION_ALIAS, available[-1])
+        normalized = ref.removeprefix("v")
+        if normalized.isdigit():
+            version = int(normalized)
+            if version not in available:
+                raise ValueError(f"harness {name!r} has no version v{version}")
+            return version
+        if ref in aliases:
+            return aliases[ref]
+        raise ValueError(f"harness {name!r} has no version or alias {ref!r}")
+
+    def load(self, name: str, ref: str | None = None) -> HarnessDoc:
+        version = self.resolve_version(name, ref)
+        directory = self.dir_for(name) / f"v{version}"
+        doc_path = directory / _DOC_FILE
+        if doc_path.exists():
+            doc = HarnessDoc.model_validate_json(doc_path.read_text(encoding="utf-8"))
+        else:
+            doc = _parse_rendered(name, directory)
+        return doc.model_copy(update={"name": name, "version": version})
+
+    def save_version(self, doc: HarnessDoc, *, alias: str | None = None) -> HarnessDoc:
+        """Write `doc` as the next version of its name; optionally point `alias` at it.
+
+        Versions are append-only: this never touches an existing version directory.
+        """
+        validate_name(doc.name)
+        version = (self.versions(doc.name)[-1] + 1) if self.exists(doc.name) else 1
+        stamped = doc.model_copy(update={"version": version})
+        directory = self.dir_for(doc.name) / f"v{version}"
+        directory.mkdir(parents=True, exist_ok=False)  # append-only: collision is a bug
+        (directory / _DOC_FILE).write_text(stamped.model_dump_json(indent=2), encoding="utf-8")
+        for rel_path, content in _render(stamped).items():
+            target = directory / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        if alias is not None:
+            self.set_alias(doc.name, alias, version)
+        return stamped
+
+
+def _render(doc: HarnessDoc) -> dict[str, str]:
+    """Render the document to its file export (relative path -> content)."""
+    files = {
+        _SYSTEM_FILE: doc.system_prompt(),
+        _CONFIG_FILE: tomli_w.dumps(
+            {
+                "harness": {
+                    "tools": doc.tools(),
+                    "max_turns": doc.max_turns(),
+                    "temperature": doc.temperature(),
+                }
+            }
+        ),
+    }
+    for skill in doc.skills():
+        files[f"{_SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
+    return files
+
+
+def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
+    """Parse a rendered/hand-authored directory (no doc.json) into a document.
+
+    The whole `SYSTEM.md` becomes one `prompt:core` surface — section boundaries are not
+    recoverable from a rendered prompt, which is exactly why `doc.json` is the authoritative form.
+    """
+    system_path = directory / _SYSTEM_FILE
+    if not system_path.exists():
+        raise ValueError(f"harness dir {directory} has neither {_DOC_FILE} nor {_SYSTEM_FILE}")
+    surfaces = [
+        Surface(
+            id="prompt:core",
+            kind=SurfaceKind.PROMPT,
+            content=system_path.read_text(encoding="utf-8"),
+        )
+    ]
+    config_path = directory / _CONFIG_FILE
+    if config_path.exists():
+        config = tomllib.loads(config_path.read_text(encoding="utf-8")).get("harness", {})
+        if "tools" in config:
+            surfaces.append(
+                Surface(
+                    id=TOOL_POLICY_ID,
+                    kind=SurfaceKind.TOOL_POLICY,
+                    content="\n".join(str(t) for t in config["tools"]),
+                )
+            )
+        if "max_turns" in config:
+            surfaces.append(
+                Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(config["max_turns"]))
+            )
+        if "temperature" in config:
+            surfaces.append(
+                Surface(
+                    id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(config["temperature"])
+                )
+            )
+    skills_dir = directory / _SKILLS_DIR
+    if skills_dir.exists():
+        for path in sorted(skills_dir.glob("*.md")):
+            skill = Skill.from_markdown(path.read_text(encoding="utf-8"))
+            surfaces.append(
+                Surface(
+                    id=f"skill:{skill.name}", kind=SurfaceKind.SKILL, content=skill.to_markdown()
+                )
+            )
+    return HarnessDoc(name=name, surfaces=surfaces)

--- a/wmh/harness/store_test.py
+++ b/wmh/harness/store_test.py
@@ -1,0 +1,113 @@
+"""Tests for the versioned harness store: append-only versions, aliases, load paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+
+
+def _variant(name: str, prompt: str) -> HarnessDoc:
+    base = HarnessDoc.baseline(name)
+    surfaces = [
+        s.model_copy(update={"content": prompt}) if s.id == "prompt:core" else s
+        for s in base.surfaces
+    ]
+    return HarnessDoc(name=name, surfaces=surfaces)
+
+
+def test_save_assigns_incrementing_versions(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    v1 = store.save_version(HarnessDoc.baseline("h"))
+    v2 = store.save_version(_variant("h", "be careful"))
+    assert (v1.version, v2.version) == (1, 2)
+    assert store.versions("h") == [1, 2]
+    # Load round-trips the exact document, stamped with its version.
+    assert store.load("h", "v1") == v1
+    assert store.load("h", "2") == v2
+
+
+def test_default_load_prefers_champion_alias_else_latest(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    store.save_version(_variant("h", "v2 prompt"))
+    assert store.load("h").version == 2  # no alias yet -> latest
+    store.set_alias("h", CHAMPION_ALIAS, 1)
+    assert store.load("h").version == 1  # champion wins over latest
+    # Rollback/promotion is just re-pointing.
+    store.set_alias("h", CHAMPION_ALIAS, 2)
+    assert store.load("h").version == 2
+
+
+def test_alias_to_missing_version_rejected(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    with pytest.raises(ValueError, match="no version v9"):
+        store.set_alias("h", CHAMPION_ALIAS, 9)
+
+
+def test_unknown_ref_and_missing_harness_are_friendly(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    with pytest.raises(FileNotFoundError, match="no harness named"):
+        store.load("ghost")
+    store.save_version(HarnessDoc.baseline("h"))
+    with pytest.raises(ValueError, match="no version or alias"):
+        store.load("h", "prod")
+
+
+def test_versions_are_append_only(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    # The rendered export exists beside the authoritative doc.json.
+    v1_dir = store.dir_for("h") / "v1"
+    assert (v1_dir / "doc.json").exists()
+    assert (v1_dir / "SYSTEM.md").exists()
+    assert (v1_dir / "config.toml").exists()
+    before = (v1_dir / "doc.json").read_text(encoding="utf-8")
+    store.save_version(_variant("h", "new"))
+    assert (v1_dir / "doc.json").read_text(encoding="utf-8") == before  # v1 untouched
+
+
+def test_hand_authored_dir_without_doc_json_loads(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    directory = store.dir_for("hand") / "v1"
+    directory.mkdir(parents=True)
+    (directory / "SYSTEM.md").write_text("You are careful.", encoding="utf-8")
+    (directory / "config.toml").write_text(
+        '[harness]\ntools = ["bash", "submit"]\nmax_turns = 7\ntemperature = 0.2\n',
+        encoding="utf-8",
+    )
+    doc = store.load("hand")
+    assert doc.system_prompt() == "You are careful."
+    assert doc.tools() == ["bash", "submit"]
+    assert doc.max_turns() == 7
+    assert doc.temperature() == 0.2
+
+
+def test_list_names_only_counts_dirs_with_versions(tmp_path: Path) -> None:
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("real"))
+    (store.harnesses_dir / "empty").mkdir(parents=True)
+    assert store.list_names() == ["real"]
+
+
+def test_skill_surfaces_render_and_reload(tmp_path: Path) -> None:
+    from wmh.harness.skills import Skill
+
+    skill = Skill(name="count-words", description="count words", body="wc -w <p>")
+    doc = HarnessDoc(
+        name="h",
+        surfaces=[
+            *HarnessDoc.baseline("h").surfaces,
+            Surface(id="skill:count-words", kind=SurfaceKind.SKILL, content=skill.to_markdown()),
+        ],
+    )
+    store = HarnessStore(tmp_path)
+    saved = store.save_version(doc)
+    assert (store.dir_for("h") / "v1" / "skills" / "count-words.md").exists()
+    reloaded = store.load("h")
+    assert reloaded == saved
+    assert [s.name for s in reloaded.skills()] == ["count-words"]

--- a/wmh/harness/tools.py
+++ b/wmh/harness/tools.py
@@ -44,9 +44,18 @@ SUBMIT = ToolSpec(
     description="Finish the task and submit your answer/result summary. This ends the run.",
     arguments={"answer": "your final answer or a summary of what you did"},
 )
+READ_SKILL = ToolSpec(
+    name="read_skill",
+    description="Read the full body of a skill from your library (the prompt lists only names).",
+    arguments={"name": "the skill name to read"},
+)
 
-TOOL_REGISTRY: dict[str, ToolSpec] = {t.name: t for t in (BASH, READ_FILE, WRITE_FILE, SUBMIT)}
+TOOL_REGISTRY: dict[str, ToolSpec] = {
+    t.name: t for t in (BASH, READ_FILE, WRITE_FILE, SUBMIT, READ_SKILL)
+}
 
+# `read_skill` is only useful when a harness ships skills, so it is not a default tool; the runtime
+# adds it automatically when constructed with a non-empty skill library.
 DEFAULT_TOOLS = [t.name for t in (BASH, READ_FILE, WRITE_FILE, SUBMIT)]
 
 


### PR DESCRIPTION
Stacked on #111. Second of three PRs building the self-improving harness system.

## What

A harness becomes a **`HarnessDoc`**: a typed document of identity-keyed *surfaces* (prompt
sections, tool policy, loop params, skills), stored as **immutable numbered versions with movable
aliases** — not a directory of files. Files are a render/export target, no longer the interface.

- `wmh/harness/doc.py` — `HarnessDoc`/`Surface`/`SurfaceKind`. Every surface has a stable id
  (`prompt:core`, `skill:count-words`) and a content hash; the doc has a `doc_hash`, so "the score
  of harness X" is well-defined. The document validates as a whole at construction (tools resolve,
  `submit` present, params in range, skill frontmatter matches slug, size budgets enforced) — an
  invalid harness cannot exist as a value.
- `wmh/harness/store.py` — versioned store: append-only `vN/` dirs (`doc.json` authoritative +
  rendered `SYSTEM.md`/`config.toml`/`skills/*.md` export), movable aliases in `aliases.toml`
  (`champion`); rollback = re-point. A hand-authored rendered dir with no `doc.json` still loads.
- CLI: `wmh harness init/list/show` for versioned docs; `wmh eval <tasks> --mode closed-loop --harness name@ref`
  (ref = version or alias).

## Why surfaces instead of files

This is groundwork for #113's `HarnessDelta`: updates name surface ids and assert content hashes,
so "which thing changed" is never inferred from paths, and a stale update can be rejected before
any eval budget is spent. See `docs/harness_delta.md` on #113 for the full design.

## Tests

`doc_test.py` / `store_test.py` cover validation-at-construction, hashing, version append +
aliases, render/parse round-trips. Full gate green: ruff, ty, pytest (595 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
