### PR TITLE
wmh harness create: delta search over harness-space against the world model

### DIFF
--- a/docs/harness_delta.md
+++ b/docs/harness_delta.md
@@ -1,0 +1,180 @@
+# HarnessDelta: the update-representation interface for `wmh harness`
+
+This is the interface `wmh harness create` mutates through and the archive records: a typed,
+precondition-guarded, gate-audited delta object, replacing "a harness update is a file edit".
+Getting this right matters more than any implementation detail downstream: **the update
+representation IS the search space**, and everything the meta-agent can learn about *how to
+improve harnesses* is bounded by what the update object can express.
+
+Implementation: `wmh/harness/doc.py` (the document), `wmh/harness/delta.py` (the delta),
+`wmh/harness/mutate.py` (the proposer), `wmh/harness/create.py` (clustering, gate, archive).
+
+---
+
+## 1. Why file edits are the wrong interface
+
+A file-edit update — `{motivation, edits: [{path, content}], deletes}` over a harness directory —
+inherits five structural blindnesses from the file/diff abstraction, two of which surfaced as
+review-verified bugs in an earlier draft of this search loop:
+
+| # | Failure mode | Bit us? |
+|---|---|---|
+| 1 | **Untyped target** — an edit changes bytes at a path; it cannot declare "this changes the *tool policy*" vs "the *recovery section of the prompt*". Search cannot reason over change *type*. | — |
+| 2 | **No preconditions** — an edit proposed against one generation silently misapplies to another. Nothing asserts "the thing I edited still looks like what I saw". | — |
+| 3 | **No element identity** — "which skill is this?" was inferred from filename vs frontmatter. | ✅ silent drop/clobber, order-dependent |
+| 4 | **Unknown targets silently vanish** — an edit to a path the format doesn't know about round-trips to nothing. | ✅ a full eval spent on a no-op child with a false motivation |
+| 5 | **Detached rationale** — *why* lives in one motivation string for the whole change, unbound from the field it justifies, so the archive can never answer "which kinds of edits work on which failure classes?" | — |
+
+Patching these piecemeal (path allowlists, filename/frontmatter consistency checks, delete-target
+validation) treats symptoms. The interface below makes each failure mode impossible by
+construction.
+
+One deliberate non-goal: the update *payload* stays a free-form string. Structure lives in the
+envelope — identity, kind, hashes, preconditions, rationale, verdict — not inside the content. A
+whole-component rewrite is easier for a model to produce correctly than a line diff, and richer
+surface kinds can be added later without changing how updates work.
+
+## 2. The interface
+
+### 2.1 `HarnessDoc` — what a harness IS
+
+A harness is a typed document of identity-keyed **surfaces**. Files (`SYSTEM.md`, `config.toml`,
+`skills/*.md`) are a *render target* the store exports for running the harness elsewhere — they
+stop being the interface.
+
+```python
+class SurfaceKind(StrEnum):
+    PROMPT = "prompt"            # a section of the system prompt (joined in id order)
+    SKILL = "skill"              # one skill: frontmatter (name, description) + body
+    TOOL_POLICY = "tool_policy"  # the tool list, one tool name per line
+    PARAM = "param"              # a scalar loop knob, serialized as its string form
+    CODE = "code"                # the agent loop itself: a module defining run(kit)
+
+class Surface(BaseModel):
+    id: str                      # identity key: "prompt:core", "skill:count-words", "param:max-turns"
+    kind: SurfaceKind
+    content: str                 # the payload — deliberately unstructured
+    budget: int | None = None    # size budget (chars), validated at construction, not advisory
+    # content_hash: computed — blake2b(content)
+
+class HarnessDoc(BaseModel):
+    name: str
+    version: int                 # immutable, assigned by the store on save; 0 = unsaved
+    surfaces: list[Surface]      # unique ids; canonical order
+    # doc_hash: computed over sorted (id, content_hash) pairs. "The score of harness X" is
+    # well-defined because X is this hash.
+```
+
+A document validates as a whole at construction — tools resolve, `submit` present, params in
+range, skill frontmatter names match their slugs, budgets respected — so an invalid harness cannot
+exist as a value and nothing downstream re-checks.
+
+The store (`.wmh/harnesses/<name>/`) keeps append-only version directories (`v1/`, `v2/`, …) with
+`doc.json` authoritative plus rendered exports, and movable aliases in `aliases.toml`
+(`champion = 3`). Rollback = re-point. Eval results key to immutable versions (or doc hashes),
+never to "whatever the harness currently is".
+
+### 2.2 `HarnessDelta` — what an update IS
+
+```python
+class FailureSignature(BaseModel):
+    """Machine-clustered trigger: WHY this delta exists, queryably."""
+    mechanism: str               # e.g. the shared unmet assertion, or "none: all tasks pass"
+    task_ids: list[str]          # the cluster of failing tasks exhibiting it
+    unmet_assertions: list[str]  # deduped gold assertions the mechanism explains
+
+class SurfaceOp(BaseModel):
+    op: Literal["add", "replace", "remove"]
+    surface_id: str              # identity, never position or filename
+    kind: SurfaceKind | None     # required on add; must match the existing kind on replace
+    content: str | None          # the FULL new content (component rewrite, not a line diff)
+    budget: int | None           # on replace, None inherits the existing budget
+    rationale: str               # WHY THIS OP — bound to the op, not the delta (fixes blindness #5)
+
+class GateRecord(BaseModel):
+    """Filled at evaluation time; the delta carries its own verdict."""
+    suite_delta: float           # regression suite: child − champion   (tier 1)
+    full_delta: float            # full split: child − best-seen        (tier 2)
+    holdout_delta: float | None  # held-out split: child − champion     (tier 3; None = no holdout)
+    accepted: bool
+    reason: str                  # accept/reject reasoning, incl. the expected-effect audit
+
+class HarnessDelta(BaseModel):
+    delta_id: str                  # content-addressed: blake2b(parent hash + ops)
+    parent_doc_hash: str           # lineage by content, not name
+    trigger: FailureSignature      # built by deterministic clustering, never free-typed
+    preconditions: dict[str, str]  # surface_id -> expected content_hash of the PARENT surface the
+                                   # meta-agent actually read. ANY mismatch rejects the WHOLE delta
+                                   # atomically (fixes blindness #2). Every replace/remove target
+                                   # MUST have one.
+    ops: list[SurfaceOp]           # unknown surface_id on replace/remove = reject (fixes #4)
+    expected_effect: str           # falsifiable prediction: "tasks in the trigger cluster flip"
+    child_doc_hash: str | None     # recorded by application
+    verdict: GateRecord | None     # None until evaluated; the archive stores deltas, not snapshots
+```
+
+### 2.3 Semantics
+
+- **Application is atomic** (`apply_delta`): lineage hash, every precondition, and every op are
+  validated against the parent doc — and the child re-validates as a whole `HarnessDoc` — before a
+  token of eval budget is spent. Path safety, unknown-target rejection, skill-name consistency,
+  and code compilation are impossible-by-construction rather than checked piecemeal.
+- **The strongest lever is code** (`code:runtime`, `wmh/harness/code_runtime.py`): live search
+  campaigns showed correct failure diagnoses that prompt- and skill-level edits could not fix —
+  loop structure, retries, verification passes, context compaction, and token budgets are
+  programs, not wording. The code surface holds a module defining `run(kit)`; the `RuntimeKit` is
+  budgeted (hard caps on LLM calls and env actions), kit-recorded (the judged transcript is
+  written by the kit, so code cannot claim work it did not do), and crash-isolated (an exception
+  fails the episode, not the eval).
+- **Verification is staged by cost**: before a full-split eval, a child is screened on its own
+  trigger cluster — the failing tasks its delta claims to fix. A delta that cannot beat its
+  parent on its own target is rejected (and archived) for a fraction of the price. Every judged
+  delta is fed back to the proposer as history, so the search iterates instead of re-proposing
+  rejected ideas.
+- **Acceptance is the gate, not "applied cleanly"** (`gate_delta`): regression-suite
+  non-regression vs the champion → full-split never-worse-than-best → held-out non-regression vs
+  the champion (when a holdout split is given). Ties pass every tier: with k passes per task the
+  scores are coarse, and "no worse" is the contract. On accept, newly-passing tasks promote into
+  the regression suite, so wins are locked in and later deltas cannot quietly trade them away. The
+  verdict is written onto the delta.
+- **The trigger is machine-made** (`cluster_failures`): failing tasks group by shared unmet gold
+  assertions (connected components; the most common unmet assertion labels the mechanism),
+  deterministically — no LLM, no entropy — so mechanism labels are comparable across deltas and
+  runs. The proposer attacks the largest cluster. An all-pass parent gets an explicit
+  generalization/economization trigger instead of a fabricated failure.
+- **The archive is a lineage of audited deltas** (`DeltaArchive`): a root snapshot plus every
+  proposed delta — accepted, gate-rejected, or invalid-before-eval — with its verdict. Docs are
+  reconstructable by folding accepted deltas from the seed; snapshots are caches, not the record.
+  This makes the meta-question queryable: *"across the archive, which (trigger.mechanism ×
+  op.kind) pairs have positive mean gate deltas?"* — the beginning of the meta-agent learning
+  which kinds of edits work. A pile of file snapshots cannot answer that; this can.
+- **`expected_effect` makes every delta a tested prediction.** At gate time the trigger cluster is
+  re-checked ("trigger cluster: 2/3 tasks now pass") and the result lands in `verdict.reason`.
+  Over time this measures the proposer's *calibration*, not just its win rate.
+
+### 2.4 What the meta-agent emits
+
+The proposal prompt (`MUTATE_SYSTEM`) asks for exactly `{expected_effect, preconditions, ops}` as
+JSON — trigger, lineage, and identity are filled by the caller from ground truth, never trusted
+from the model. The prompt prints every parent surface with its id, kind, and content hash, so
+preconditions are copy-not-guess. An unparseable or shape-invalid reply is a counted skip; a delta
+that fails atomic application is a counted skip that is still archived with its rejection verdict.
+
+## 3. Open questions
+
+1. **Surface granularity of the prompt.** One `prompt:core` surface (whole-component rewrite) vs
+   sectioned surfaces (`prompt:role`, `prompt:verification`, `prompt:recovery`)? Sections give
+   finer credit assignment and smaller merges; they also impose our taxonomy on the meta-agent.
+   Current position: start with `prompt:core` and let the meta-agent *split* a surface via
+   `add` + `replace` — the taxonomy then emerges from search instead of from us.
+2. **Merge.** Identity-keyed surfaces + content lineage make a surface-keyed three-way merge of
+   two accepted lineages nearly free. Deferred to a follow-up.
+3. **Gate resolution.** With k=3 and small suites, per-task deltas are coarse (0, ⅓, ⅔, 1). Ties
+   currently pass as non-regressions; if flappy accepts show up in practice, raise k on gate evals
+   rather than adding thresholds.
+4. **Suite demotion.** Newly-passing tasks promote into the regression suite; nothing ever leaves
+   it. A permanently-flaky task could wedge the gate. Punted until observed.
+5. **Sandboxing the `CODE` surface.** The kit is an interface contract, not a security boundary:
+   searched code runs in-process and is only exercised against the world model during search.
+   Running a searched harness against a real environment is a deployment decision that belongs
+   behind a sandbox.

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -2,22 +2,35 @@
 
 A harness is the scaffold an agent runs with: prompt surfaces, a tool policy, loop parameters, and
 skills, stored as immutable numbered versions with movable aliases (`champion` is what runs by
-default). `init` writes the baseline as v1; `list`/`show` inspect what exists; run one closed-loop
-with `wmh eval closed-loop <tasks> --harness <name>[@ref]`.
+default). `init` writes the baseline as v1; `list`/`show` inspect what exists; `create` searches
+for a better harness by **inverting the world model** — delta variants are scored closed-loop
+against it and gated on non-regression, so the environment model the traces built now steers what
+the agent's scaffold should be. Run one closed-loop with
+`wmh eval closed-loop <tasks> --harness <name>[@ref]`.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import typer
 from rich.console import Console
+from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
-from wmh.config import ARTIFACT_DIR
+from wmh.config import ARTIFACT_DIR, WorldModelStore
+from wmh.config.store import validate_name
+from wmh.engine import load_world_model
+from wmh.engine.world_model import WorldModel
+from wmh.evals.gold import GoldJudge
+from wmh.evals.tasks import TaskSpec, load_tasks
+from wmh.harness.create import create_harness
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.providers.base import Provider
 
 harness_app = typer.Typer(
-    help="Named, versioned agent harnesses (.wmh/harnesses): init, list, show.",
+    help="Named, versioned agent harnesses (.wmh/harnesses): create, init, list, show.",
     no_args_is_help=True,
 )
 _console = Console()
@@ -75,6 +88,135 @@ def show_harness(
             f"hash={surface.content_hash[:12]}{budget})"
         )
         _console.print(surface.content)
+
+
+@harness_app.command("create")
+def create(
+    name: str = typer.Argument(None, help="Name for the created harness."),
+    tasks_file: str = typer.Option(None, "--tasks", help="JSONL task file to optimize against."),
+    holdout_file: str = typer.Option(
+        None,
+        "--holdout",
+        help="Optional JSONL held-out task file: accepted deltas must also be no worse here.",
+    ),
+    model: str = typer.Option(
+        None, "--model", help="World model to search against (default: the only built one)."
+    ),
+    seed: str = typer.Option(
+        None,
+        "--seed",
+        help="Harness to start from, as name[@ref] (default: the built-in baseline).",
+    ),
+    iterations: int = typer.Option(None, min=1, help="Propose-and-gate steps (the search budget)."),
+    k: int = typer.Option(3, min=1, help="Closed-loop passes per task per variant."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+    archive_out: str = typer.Option(
+        None, "--archive", help="Also write the full delta archive JSON here."
+    ),
+    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation prompt."),
+) -> None:
+    """Create a harness by inverting the world model: search harness-space against it.
+
+    An LLM meta-agent proposes typed deltas against the harness document (surface-keyed ops with
+    preconditions), each applied child is scored closed-loop against the world model (k passes per
+    task) and gated on non-regression (regression suite, then full split, then the optional
+    held-out split). The champion is saved as a new immutable version with the `champion` alias.
+    Interactive at a TTY: missing inputs are prompted for.
+    """
+    interactive = _console.is_terminal
+    if name is None:
+        if not interactive:
+            raise typer.BadParameter("provide a harness NAME (or run at a TTY for the wizard)")
+        name = Prompt.ask("Name for the created harness", default="evolved")
+    if tasks_file is None:
+        if not interactive:
+            raise typer.BadParameter("provide --tasks (or run at a TTY for the wizard)")
+        tasks_file = Prompt.ask("Task file (JSONL of task_id/instruction/gold)")
+    if iterations is None:
+        iterations = (
+            IntPrompt.ask("Search iterations (each = 1 delta + 1 gated eval)", default=5)
+            if interactive
+            else 5
+        )
+
+    # Fail on a bad name NOW, not after the search has spent its eval budget on the save.
+    try:
+        validate_name(name)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    tasks = _load_task_file(tasks_file)
+    holdout = _load_task_file(holdout_file) if holdout_file else None
+    store = HarnessStore(root)
+    seed_doc = _resolve_seed(store, seed)
+    world_model, provider, model_name = _load_world_model(model, root)
+
+    rollouts = (iterations + 1) * k * len(tasks)
+    holdout_note = f" (+ up to {(iterations + 1) * k * len(holdout)} held-out)" if holdout else ""
+    _console.print(
+        f"searching from [bold]{seed_doc.name}[/bold] against world model "
+        f"[bold]{model_name}[/bold]: {iterations} iteration(s), k={k}, {len(tasks)} task(s) "
+        f"-> up to ~{rollouts} rollouts{holdout_note} + {iterations} proposal calls"
+    )
+    if interactive and not yes and not Confirm.ask("Proceed?", default=True):
+        raise typer.Exit(0)
+
+    def _progress(iteration: int, variant: str, score: float, accepted: bool) -> None:
+        tag = "seed" if iteration == 0 else f"iter {iteration}"
+        gate = "[green]accepted[/green]" if accepted else "[yellow]rejected[/yellow]"
+        _console.print(f"  [{tag}] {variant}: success_rate={score:.3f} {gate}")
+
+    result = create_harness(
+        name,
+        seed_doc,
+        tasks,
+        world_model,
+        provider,
+        provider,
+        GoldJudge(provider),
+        iterations=iterations,
+        k=k,
+        holdout=holdout,
+        on_progress=_progress,
+    )
+    saved = store.save_version(result.best, alias=CHAMPION_ALIAS)
+    accepted = len(result.archive.accepted())
+    _console.print(
+        f"[green]created[/green] [bold]{name}[/bold] v{saved.version} (champion) "
+        f"success_rate={result.best_score:.3f}: {len(result.archive.deltas)} delta(s) audited, "
+        f"{accepted} accepted, {result.skipped} skipped -> {store.dir_for(name)}"
+    )
+    _console.print(f"  run it: [bold]wmh eval closed-loop {tasks_file} --harness {name}[/bold]")
+    if archive_out:
+        Path(archive_out).write_text(result.archive.model_dump_json(indent=2), encoding="utf-8")
+        _console.print(f"  wrote archive -> {archive_out}")
+
+
+def _load_task_file(path: str) -> list[TaskSpec]:
+    try:
+        return load_tasks(path)
+    except (OSError, ValueError) as exc:
+        raise typer.BadParameter(f"cannot load tasks from {path!r}: {exc}") from exc
+
+
+def _resolve_seed(store: HarnessStore, seed: str | None) -> HarnessDoc:
+    if seed is None:
+        return HarnessDoc.baseline()
+    base, _, ref = seed.partition("@")
+    try:
+        return store.load(base, ref or None)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _load_world_model(name: str | None, root: str) -> tuple[WorldModel, Provider, str]:
+    """Resolve a world model by name (or the sole built one) and load it with its provider."""
+    store = WorldModelStore(root)
+    try:
+        model_dir = store.resolve(name)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    world_model, provider = load_world_model(model_dir)
+    return world_model, provider, model_dir.name
 
 
 @harness_app.command("init")

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -25,7 +25,7 @@ from wmh.engine.world_model import WorldModel
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.environment import AgentEnvironment
-from wmh.harness.runtime import AgentRuntime, RunResult
+from wmh.harness.runtime import AgentRuntime, RunResult, Runtime
 from wmh.providers.base import Provider
 
 DEFAULT_K = 3  # eval-reporting convention: every metric is the mean of k passes, never single-pass
@@ -103,7 +103,7 @@ class ClosedLoopReport(BaseModel):
 def evaluate_with_env(
     tasks: list[TaskSpec],
     make_env: EnvFactory,
-    runtime: AgentRuntime,
+    runtime: Runtime,
     judge: GoldJudge,
     *,
     label: str = "",
@@ -150,7 +150,7 @@ def evaluate_closed_loop(
     *,
     label: str = "world-model",
     k: int = DEFAULT_K,
-    runtime: AgentRuntime | None = None,
+    runtime: Runtime | None = None,
     on_progress: Callable[[str, int, GoldVerdict], None] | None = None,
 ) -> ClosedLoopReport:
     """Score the fixed agent on `tasks` against `world_model` (`wmh eval --mode closed-loop`)."""
@@ -177,7 +177,7 @@ class ClosedLoopEval:
         *,
         label: str = "world-model",
         k: int = DEFAULT_K,
-        runtime: AgentRuntime | None = None,
+        runtime: Runtime | None = None,
         on_progress: Callable[[str, int, GoldVerdict], None] | None = None,
     ) -> None:
         self._tasks = tasks
@@ -202,7 +202,7 @@ class ClosedLoopEval:
         )
 
 
-def _run_once(task: TaskSpec, make_env: EnvFactory, runtime: AgentRuntime) -> RunResult:
+def _run_once(task: TaskSpec, make_env: EnvFactory, runtime: Runtime) -> RunResult:
     """One rollout: a fresh environment per attempt, always closed."""
     env = make_env(task)
     try:

--- a/wmh/harness/__init__.py
+++ b/wmh/harness/__init__.py
@@ -1,25 +1,51 @@
-"""The agent harness: the scaffold a live agent runs with.
+"""The agent harness: the scaffold a live agent runs with, and the machinery to improve it.
 
 A minimal, fixed agent loop (`AgentRuntime`) drives one action at a time against an
 `AgentEnvironment` — an interface, not a backend: closed-loop eval (`wmh.evals.closed_loop`) binds
-it to the world model, and a real execution backend can bind the same loop to reality. `tools`
-defines the small tool registry the loop dispatches.
+it to the world model, and a real execution backend can bind the same loop to reality. What the
+loop runs with is a `HarnessDoc` — a typed document of identity-keyed surfaces (prompt sections,
+tool policy, loop params, skills) stored as immutable versions with movable aliases
+(`wmh.harness.store`) and updated through audited `HarnessDelta`s (`wmh.harness.delta`,
+docs/harness_delta.md) proposed by a meta-agent and gated on non-regression (`wmh.harness.create`,
+the `wmh harness create` search).
 
-The loop is deliberately fixed and small: closed-loop eval tests the *world model*, so the agent
-must be a constant — any divergence is then attributable to the environment alone.
+`create` and `mutate` are imported directly (not re-exported here): they depend on
+`wmh.evals.closed_loop`, which itself binds to this package's runtime — re-exporting them would
+make `import wmh.evals` observe a partially initialized module.
 """
 
+from wmh.harness.delta import (
+    FailureSignature,
+    GateRecord,
+    HarnessDelta,
+    SurfaceOp,
+    apply_delta,
+)
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runtime import AgentRuntime, RunResult, StopReason
+from wmh.harness.skills import Skill, SkillLibrary
+from wmh.harness.store import HarnessStore
 from wmh.harness.tools import TOOL_REGISTRY, ToolCall, parse_tool_call
 
 __all__ = [
     "TOOL_REGISTRY",
     "AgentEnvironment",
     "AgentRuntime",
+    "FailureSignature",
+    "GateRecord",
+    "HarnessDelta",
+    "HarnessDoc",
+    "HarnessStore",
     "RunResult",
+    "Skill",
+    "SkillLibrary",
     "StopReason",
+    "Surface",
+    "SurfaceKind",
+    "SurfaceOp",
     "ToolCall",
+    "apply_delta",
     "is_env_action",
     "parse_tool_call",
 ]

--- a/wmh/harness/code_runtime.py
+++ b/wmh/harness/code_runtime.py
@@ -1,0 +1,288 @@
+"""`CodeRuntime`: the agent loop itself as a searchable harness surface.
+
+Two live search campaigns showed the same wall: the meta-agent diagnoses failure mechanisms
+correctly, but prompt- and skill-level edits cannot express the fixes that actually make a
+harness good — loop structure, retries, context compaction, observation truncation, token
+budgets. Those are *code*. A `code:runtime` surface holds a Python module defining
+`run(kit) -> str`; the search edits that program.
+
+The contract is the `RuntimeKit`, and it carries three guarantees the search relies on:
+
+- **Budgeted.** `kit.complete` and `kit.execute` enforce hard caps on LLM calls and environment
+  actions. A runaway loop raises `BudgetExceeded` instead of wedging an eval; cost is bounded per
+  episode by construction, not by hope.
+- **Kit-recorded.** Every environment action is appended to the transcript by the kit itself, so
+  the judge always scores ground truth: generated code cannot fake, omit, or reorder what it did.
+- **Crash-isolated.** An exception inside `run` fails that episode (scored as a failure with the
+  partial transcript), never the evaluation loop around it.
+
+The kit is an interface contract, not a security boundary: harness code runs in-process and is
+trusted to the same degree as the rest of the search (it is reviewed via the delta archive, and
+only ever exercised against the world model during search). Running searched code against real
+environments is a deployment decision that belongs behind a sandbox.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+from pydantic import BaseModel, Field
+
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
+from wmh.harness.environment import AgentEnvironment, is_env_action
+from wmh.harness.runtime import RunResult, StopReason
+from wmh.harness.skills import SkillLibrary
+from wmh.harness.tools import ToolCall, ToolSpec, parse_tool_call, render_tools
+from wmh.providers.base import Message, Provider
+
+CODE_ENTRYPOINT = "run"
+
+# Defaults sized so a reasonable loop never notices them: the fixed baseline loop uses at most
+# `max_turns` (20) of each.
+DEFAULT_MAX_LLM_CALLS = 40
+DEFAULT_MAX_ENV_ACTIONS = 40
+
+
+class RunBudget(BaseModel):
+    """Hard per-episode caps enforced by the kit."""
+
+    max_llm_calls: int = Field(default=DEFAULT_MAX_LLM_CALLS, ge=1)
+    max_env_actions: int = Field(default=DEFAULT_MAX_ENV_ACTIONS, ge=1)
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised by the kit when harness code exhausts an episode budget."""
+
+
+class RuntimeKit:
+    """Everything harness code may touch, and the recorder of what it actually did."""
+
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        instruction: str,
+        environment: AgentEnvironment,
+        provider: Provider,
+        tools: list[ToolSpec],
+        skills: SkillLibrary,
+        temperature: float,
+        budget: RunBudget,
+        system_prompt: str = "",
+    ) -> None:
+        self.task_id = task_id
+        self.instruction = instruction
+        self.temperature = temperature
+        self.tools = tools
+        # The doc's assembled prompt (prompt surfaces + tools + skills index): prompt surfaces
+        # stay meaningful alongside a code surface, and code may use or ignore this.
+        self.system_prompt = system_prompt
+        self._environment = environment
+        self._provider = provider
+        self._skills = skills
+        self._budget = budget
+        self._llm_calls = 0
+        self._env_actions = 0
+        self.steps: list[Step] = []
+
+    # -- the two budgeted primitives -----------------------------------------------------------
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message] | list[tuple[str, str]],
+        *,
+        temperature: float | None = None,
+        max_tokens: int = 2048,
+    ) -> str:
+        """One LLM call. Accepts `Message`s or plain `(role, content)` tuples."""
+        if self._llm_calls >= self._budget.max_llm_calls:
+            raise BudgetExceeded(f"llm call budget exhausted ({self._budget.max_llm_calls})")
+        self._llm_calls += 1
+        normalized = [_to_message(m) for m in messages]
+        completion = self._provider.complete(
+            system,
+            normalized,
+            temperature=self.temperature if temperature is None else temperature,
+            max_tokens=max_tokens,
+        )
+        return completion.text
+
+    def execute(self, tool: str, arguments: JsonObject) -> Observation:
+        """One environment action, validated against the tool policy and recorded verbatim."""
+        if self._env_actions >= self._budget.max_env_actions:
+            raise BudgetExceeded(f"env action budget exhausted ({self._budget.max_env_actions})")
+        action = Action(kind=ActionKind.TOOL_CALL, name=tool, arguments=arguments)
+        if tool not in {t.name for t in self.tools} or not is_env_action(action):
+            observation = Observation(content=f"tool {tool!r} not available", is_error=True)
+        else:
+            self._env_actions += 1
+            observation = self._environment.execute(action)
+        self.steps.append(
+            Step(
+                action=action,
+                observation=observation,
+                state_before=EnvState(),
+                task=self.instruction,
+            )
+        )
+        return observation
+
+    # -- conveniences (unbudgeted, side-effect free) --------------------------------------------
+
+    def parse_tool_call(self, text: str) -> ToolCall | None:
+        return parse_tool_call(text)
+
+    def tools_text(self) -> str:
+        return render_tools(self.tools)
+
+    def skills_index(self) -> str:
+        return self._skills.render_index()
+
+    def read_skill(self, name: str) -> str | None:
+        skill = self._skills.get(name)
+        return skill.body if skill is not None else None
+
+
+def _to_message(m: Message | tuple[str, str]) -> Message:
+    if isinstance(m, Message):
+        return m
+    role, content = m
+    if role == "user":
+        return Message(role="user", content=content)
+    if role == "assistant":
+        return Message(role="assistant", content=content)
+    raise ValueError(f"message role must be 'user' or 'assistant', got {role!r}")
+
+
+def compile_harness_code(code: str) -> None:
+    """Front-loaded validation: the code must compile and define `run` at module scope.
+
+    Raises `ValueError` so `HarnessDoc` construction rejects an unrunnable harness before any
+    eval budget could be spent on it. Behavioral quality is the gate's job, not this one's.
+    """
+    try:
+        compiled = compile(code, "<code:runtime>", "exec")
+    except SyntaxError as exc:
+        raise ValueError(f"code:runtime does not compile: {exc}") from exc
+    names = set(compiled.co_names)
+    # A module that never binds `run` can't be dispatched. co_names covers references, so also
+    # accept a top-level def by scanning consts for the code object.
+    defines_run = (
+        any(getattr(const, "co_name", None) == CODE_ENTRYPOINT for const in compiled.co_consts)
+        or CODE_ENTRYPOINT in names
+    )
+    if not defines_run:
+        raise ValueError(f"code:runtime must define `{CODE_ENTRYPOINT}(kit)` at module scope")
+
+
+class CodeRuntime:
+    """Drives episodes through a harness-defined `run(kit)` instead of the fixed loop."""
+
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        code: str,
+        tools: list[ToolSpec],
+        temperature: float = 0.7,
+        skills: SkillLibrary | None = None,
+        budget: RunBudget | None = None,
+        system_prompt: str = "",
+    ) -> None:
+        compile_harness_code(code)
+        namespace: dict[str, object] = {"__name__": "wmh_harness_code"}
+        exec(code, namespace)  # noqa: S102 - the code surface IS the artifact under search
+        entry = namespace.get(CODE_ENTRYPOINT)
+        if not callable(entry):
+            raise ValueError(f"code:runtime `{CODE_ENTRYPOINT}` is not callable")
+        self._run = cast("Callable[[RuntimeKit], object]", entry)
+        self._provider = provider
+        self._tools = tools
+        self._temperature = temperature
+        self._skills = skills if skills is not None else SkillLibrary()
+        self._budget = budget if budget is not None else RunBudget()
+        self._system_prompt = system_prompt
+
+    def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+        kit = RuntimeKit(
+            task_id=task_id,
+            instruction=instruction,
+            environment=environment,
+            provider=self._provider,
+            tools=self._tools,
+            skills=self._skills,
+            temperature=self._temperature,
+            budget=self._budget,
+            system_prompt=self._system_prompt,
+        )
+        try:
+            answer = self._run(kit)
+        except BudgetExceeded as exc:
+            return self._result(kit, StopReason.BUDGET, note=str(exc))
+        except Exception as exc:  # noqa: BLE001 - crash-isolation is the contract
+            return self._result(kit, StopReason.ERROR, note=f"{type(exc).__name__}: {exc}")
+        return RunResult(
+            task_id=kit.task_id,
+            steps=kit.steps,
+            stop_reason=StopReason.SUBMITTED,
+            answer=answer if isinstance(answer, str) else "",
+            turns=len(kit.steps),
+        )
+
+    def _result(self, kit: RuntimeKit, stop_reason: StopReason, *, note: str) -> RunResult:
+        # The kit-recorded partial transcript survives, plus one error step so the judge (and the
+        # failure clustering) can see WHY the episode ended.
+        kit.steps.append(
+            Step(
+                action=Action(kind=ActionKind.MESSAGE, content="(harness runtime)"),
+                observation=Observation(content=note, is_error=True),
+                state_before=EnvState(),
+                task=kit.instruction,
+            )
+        )
+        return RunResult(
+            task_id=kit.task_id,
+            steps=kit.steps,
+            stop_reason=stop_reason,
+            answer="",
+            turns=len(kit.steps),
+        )
+
+
+# The reference loop, as the seed content of a `code:runtime` surface: functionally the fixed
+# `AgentRuntime` loop, expressed through the kit so the search can restructure it.
+DEFAULT_RUNTIME_CODE = '''"""Baseline agent loop: one JSON tool call per turn.
+
+Calling `submit` ends the episode."""
+
+
+def run(kit):
+    messages = [("user", "TASK: " + kit.instruction)]
+    nudged = False
+    for _ in range(20):
+        reply = kit.complete(kit.system_prompt, messages).strip()
+        call = kit.parse_tool_call(reply)
+        if call is None:
+            if nudged:
+                return ""
+            nudged = True
+            messages.append(("assistant", reply))
+            messages.append(("user", "[ERROR] reply with EXACTLY one JSON object: "
+                             "{\\"tool\\": \\"<name>\\", \\"arguments\\": {...}}"))
+            continue
+        if call.tool == "submit":
+            answer = call.arguments.get("answer")
+            return answer if isinstance(answer, str) else ""
+        if call.tool == "read_skill":
+            name = call.arguments.get("name")
+            body = kit.read_skill(name if isinstance(name, str) else "")
+            text, is_error = (body, False) if body is not None else ("no such skill", True)
+        else:
+            observation = kit.execute(call.tool, call.arguments)
+            text, is_error = observation.content, observation.is_error
+        messages.append(("assistant", reply))
+        messages.append(("user", ("[ERROR] " if is_error else "[OK] ") + text))
+    return ""
+'''

--- a/wmh/harness/code_runtime_test.py
+++ b/wmh/harness/code_runtime_test.py
@@ -1,0 +1,209 @@
+"""CodeRuntime tests: the kit's budget/recording/crash-isolation guarantees, offline."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.core.types import Action, Observation
+from wmh.harness.code_runtime import (
+    DEFAULT_RUNTIME_CODE,
+    CodeRuntime,
+    RunBudget,
+    compile_harness_code,
+)
+from wmh.harness.doc import CODE_RUNTIME_ID, HarnessDoc, Surface, SurfaceKind, code_baseline
+from wmh.harness.runtime import Runtime, StopReason
+from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+
+
+class ScriptedProvider:
+    """Replays canned completions in order; records calls."""
+
+    def __init__(self, replies: list[str]) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+        self._replies = replies
+        self.calls = 0
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        reply = self._replies[min(self.calls, len(self._replies) - 1)]
+        self.calls += 1
+        return Completion(text=reply)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201 - test fake never calls it
+        raise NotImplementedError
+
+
+class FakeEnv:
+    """Echo environment; records executed actions."""
+
+    def __init__(self) -> None:
+        self.actions: list[Action] = []
+        self.closed = False
+
+    def execute(self, action: Action) -> Observation:
+        self.actions.append(action)
+        return Observation(content=f"ran {action.name}")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _runtime(code: str, replies: list[str] | None = None, **kwargs) -> CodeRuntime:  # noqa: ANN003
+    provider = ScriptedProvider(replies or ['{"tool": "submit", "arguments": {"answer": "ok"}}'])
+    tools = [TOOL_REGISTRY["bash"], SUBMIT]
+    return CodeRuntime(provider, code=code, tools=tools, **kwargs)
+
+
+# -- compile validation -------------------------------------------------------------------------
+
+
+def test_compile_rejects_syntax_errors_and_missing_run() -> None:
+    with pytest.raises(ValueError, match="does not compile"):
+        compile_harness_code("def run(kit:\n")
+    with pytest.raises(ValueError, match="must define"):
+        compile_harness_code("x = 1\n")
+    compile_harness_code(DEFAULT_RUNTIME_CODE)  # the seed passes its own gate
+
+
+def test_run_must_be_callable() -> None:
+    with pytest.raises(ValueError, match="not callable"):
+        _runtime("run = 42\n")
+
+
+# -- the default loop, end to end ---------------------------------------------------------------
+
+
+def test_default_code_runs_the_baseline_loop() -> None:
+    runtime = _runtime(
+        DEFAULT_RUNTIME_CODE,
+        replies=[
+            '{"tool": "bash", "arguments": {"command": "ls"}}',
+            '{"tool": "submit", "arguments": {"answer": "two files"}}',
+        ],
+        system_prompt="You are a capable agent.",
+    )
+    env = FakeEnv()
+    result = runtime.run("t1", "list the files", env)
+    assert result.stop_reason is StopReason.SUBMITTED
+    assert result.answer == "two files"
+    assert [a.name for a in env.actions] == ["bash"]
+    assert len(result.steps) == 1  # the bash step, kit-recorded
+    assert isinstance(runtime, Runtime)
+
+
+# -- kit guarantees -----------------------------------------------------------------------------
+
+
+def test_budget_exhaustion_stops_the_episode() -> None:
+    infinite = 'def run(kit):\n    while True:\n        kit.execute("bash", {"command": "true"})\n'
+    runtime = _runtime(infinite, budget=RunBudget(max_llm_calls=5, max_env_actions=3))
+    result = runtime.run("t1", "loop forever", FakeEnv())
+    assert result.stop_reason is StopReason.BUDGET
+    # 3 recorded env steps + the terminal error step explaining why the episode ended.
+    assert len(result.steps) == 4
+    assert result.steps[-1].observation.is_error
+    assert "budget exhausted" in result.steps[-1].observation.content
+
+
+def test_llm_budget_is_enforced_too() -> None:
+    chatty = 'def run(kit):\n    while True:\n        kit.complete("s", [("user", "hi")])\n'
+    runtime = _runtime(chatty, budget=RunBudget(max_llm_calls=2, max_env_actions=5))
+    result = runtime.run("t1", "chat forever", FakeEnv())
+    assert result.stop_reason is StopReason.BUDGET
+
+
+def test_crash_is_isolated_and_transcript_survives() -> None:
+    crashy = (
+        "def run(kit):\n"
+        '    kit.execute("bash", {"command": "ls"})\n'
+        '    raise RuntimeError("boom")\n'
+    )
+    result = _runtime(crashy).run("t1", "crash", FakeEnv())
+    assert result.stop_reason is StopReason.ERROR
+    assert result.answer == ""
+    assert len(result.steps) == 2  # the real step survives, plus the error note
+    assert "RuntimeError: boom" in result.steps[-1].observation.content
+
+
+def test_transcript_is_kit_recorded_not_code_claimed() -> None:
+    # Code that claims success without acting produces an EMPTY transcript: the judge sees
+    # exactly what the kit recorded, nothing else.
+    liar = 'def run(kit):\n    return "I did everything"\n'
+    result = _runtime(liar).run("t1", "do things", FakeEnv())
+    assert result.stop_reason is StopReason.SUBMITTED
+    assert result.steps == []
+
+
+def test_unavailable_tool_is_an_error_observation_not_an_env_call() -> None:
+    curious = (
+        "def run(kit):\n"
+        '    obs = kit.execute("rm_rf", {})\n'
+        '    return "err" if obs.is_error else "ok"\n'
+    )
+    env = FakeEnv()
+    result = _runtime(curious).run("t1", "poke", env)
+    assert result.answer == "err"
+    assert env.actions == []  # never reached the environment
+    assert result.steps[0].observation.is_error
+
+
+def test_tuple_messages_convert_and_bad_roles_raise() -> None:
+    code = (
+        "def run(kit):\n"
+        '    return kit.complete("s", [("user", "hi"), ("assistant", "yo"), ("user", "go")])\n'
+    )
+    result = _runtime(code, replies=["fine"]).run("t1", "chat", FakeEnv())
+    assert result.answer == "fine"
+    bad = 'def run(kit):\n    return kit.complete("s", [("system", "no")])\n'
+    result = _runtime(bad).run("t1", "chat", FakeEnv())
+    assert result.stop_reason is StopReason.ERROR
+    assert "role" in result.steps[-1].observation.content
+
+
+def test_non_string_return_is_empty_answer() -> None:
+    result = _runtime("def run(kit):\n    return 42\n").run("t1", "x", FakeEnv())
+    assert result.stop_reason is StopReason.SUBMITTED
+    assert result.answer == ""
+
+
+# -- HarnessDoc integration ----------------------------------------------------------------------
+
+
+def test_code_baseline_validates_and_dispatches_code_runtime() -> None:
+    doc = code_baseline("seed")
+    assert doc.surface(CODE_RUNTIME_ID) is not None
+    provider = ScriptedProvider(['{"tool": "submit", "arguments": {"answer": "done"}}'])
+    runtime = doc.runtime(provider)
+    assert isinstance(runtime, CodeRuntime)
+    result = runtime.run("t1", "do it", FakeEnv())
+    assert result.stop_reason is StopReason.SUBMITTED
+    assert result.answer == "done"
+
+
+def test_doc_rejects_bad_code_surface_at_construction() -> None:
+    core = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p")
+    bad = Surface(id=CODE_RUNTIME_ID, kind=SurfaceKind.CODE, content="x = (")
+    with pytest.raises(ValueError, match="does not compile"):
+        HarnessDoc(name="x", surfaces=[core, bad])
+    misnamed = Surface(id="code:other", kind=SurfaceKind.CODE, content="def run(kit):\n    pass\n")
+    with pytest.raises(ValueError, match="singleton"):
+        HarnessDoc(name="x", surfaces=[core, misnamed])
+
+
+def test_doc_without_code_surface_keeps_the_fixed_loop() -> None:
+    from wmh.harness.runtime import AgentRuntime
+
+    doc = HarnessDoc.baseline("plain")
+    provider = ScriptedProvider(['{"tool": "submit", "arguments": {"answer": "ok"}}'])
+    assert isinstance(doc.runtime(provider), AgentRuntime)

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -1,0 +1,506 @@
+"""`wmh harness create`: budgeted search over harness deltas, gated by non-regression.
+
+The loop: select a parent from the accepted pool (stepping-stone weighting — good scores favored,
+already-expanded parents discounted), cluster the parent's failures into mechanisms, ask the
+proposer for one `HarnessDelta` against the largest cluster, apply it atomically, score the child
+closed-loop against the world model, and gate acceptance:
+
+- **Tier 1 — regression suite**: the child's score on the suite (tasks the search has already
+  mastered) must not drop below the champion's. Newly-passing tasks promote into the suite on
+  accept, so wins are locked in and later deltas cannot quietly trade them away.
+- **Tier 2 — full split**: the child's overall success rate must be at least the best seen.
+- **Tier 3 — held-out (optional)**: with a holdout task file, the child must also be no worse than
+  the champion on tasks the proposer never saw evidence from.
+
+Ties pass every tier: with k passes per task, scores are coarse, and "no worse" is the contract.
+Every proposed delta — accepted, rejected, or invalid-before-eval — is recorded in the archive
+with its verdict, so the archive is a queryable lineage of audited updates, not a pile of
+snapshots. Parent SELECTION is deterministic — a blake2b hash of the iteration index replaces RNG
+(per the repo's no-entropy rule) — but the run as a whole is only as reproducible as its
+providers: proposals and rollouts sample real models at temperature.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+
+from pydantic import BaseModel, Field
+
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import DEFAULT_K, ClosedLoopReport, evaluate_closed_loop
+from wmh.evals.gold import GoldJudge
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_delta
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.mutate import propose_delta, render_evidence
+from wmh.providers.base import Provider
+
+# Selection floor: a zero-scoring variant keeps a small chance of being expanded, so early
+# pools with no successes still make progress instead of dividing by zero interest.
+_SELECTION_FLOOR = 0.05
+
+# Non-regression tolerance: fmean over identical verdicts must compare equal, never fail a gate
+# on float noise.
+_TIE_EPS = 1e-9
+
+ALL_PASS_MECHANISM = "none: all tasks pass"
+
+# Reports progress as (iteration, variant name, success_rate, accepted); iteration 0 is the seed.
+CreateProgress = Callable[[int, str, float, bool], None]
+
+
+class PoolEntry(BaseModel):
+    """One accepted variant, as the parent-selection pool sees it."""
+
+    doc_hash: str
+    name: str
+    success_rate: float
+
+
+class DeltaArchive(BaseModel):
+    """The full search record: a root snapshot plus every audited delta, in proposal order.
+
+    Accepted deltas form the lineage (`parent_doc_hash -> delta -> child_doc_hash`); any doc in it
+    is reconstructable by folding them from the seed. Rejected and invalid deltas are kept too —
+    with their verdicts — because "which kinds of edits fail on which failure classes" is as
+    queryable a question as which succeed.
+    """
+
+    seed: HarnessDoc
+    deltas: list[HarnessDelta] = Field(default_factory=list)
+
+    def accepted(self) -> list[HarnessDelta]:
+        return [d for d in self.deltas if d.verdict is not None and d.verdict.accepted]
+
+    def reconstruct(self, doc_hash: str) -> HarnessDoc:
+        """Fold accepted deltas from the seed until `doc_hash` is produced."""
+        docs = {self.seed.doc_hash: self.seed}
+        for delta in self.accepted():
+            parent = docs.get(delta.parent_doc_hash)
+            if parent is not None:
+                child = apply_delta(parent, delta.model_copy(deep=True), parent.name)
+                docs[child.doc_hash] = child
+        if doc_hash not in docs:
+            raise ValueError(f"doc {doc_hash[:12]} is not in this archive's accepted lineage")
+        return docs[doc_hash]
+
+
+class CreateResult(BaseModel):
+    """What a create run produced: the champion, its score, and the full search record."""
+
+    best: HarnessDoc
+    best_score: float
+    archive: DeltaArchive
+    reports: dict[str, ClosedLoopReport] = Field(default_factory=dict)  # by doc_hash
+    holdout_reports: dict[str, ClosedLoopReport] = Field(default_factory=dict)  # by doc_hash
+    suite: list[str] = Field(default_factory=list)  # final regression suite (task ids)
+    skipped: int = 0  # iterations lost to unusable or invalid proposals
+    screened: int = 0  # deltas rejected at the cheap trigger-cluster screen (no full eval spent)
+    confirmations: int = 0  # narrow vetoes retried at higher k (see `narrow_failing_tiers`)
+
+
+def cluster_failures(report: ClosedLoopReport, tasks: list[TaskSpec]) -> list[FailureSignature]:
+    """Group failing tasks into mechanisms, deterministically — no LLM, no entropy.
+
+    Two failing tasks share a mechanism when they share an unmet gold assertion (connected
+    components over the task/assertion graph). The cluster's `mechanism` label is its most common
+    unmet assertion (ties broken lexicographically); clusters are ordered largest-first so the
+    caller's "attack the biggest cluster" policy is a stable choice. A failing task whose verdicts
+    carry no per-assertion detail (an unparseable judge reply) forms its own cluster.
+    """
+    unmet_by_task: dict[str, list[str]] = {}
+    for task in tasks:
+        outcome = report.per_task.get(task.task_id)
+        if outcome is None or outcome.success_rate >= 1.0:
+            continue
+        seen: set[str] = set()
+        unmet: list[str] = []
+        for verdict in outcome.verdicts:
+            for result in verdict.assertions:
+                if not result.passed and result.assertion not in seen:
+                    seen.add(result.assertion)
+                    unmet.append(result.assertion)
+        unmet_by_task[task.task_id] = unmet
+
+    clusters: list[FailureSignature] = []
+    assigned: set[str] = set()
+    for task_id in sorted(unmet_by_task):
+        if task_id in assigned:
+            continue
+        # Flood-fill the component: tasks connected through shared unmet assertions.
+        member_ids = {task_id}
+        assertions = set(unmet_by_task[task_id])
+        grew = True
+        while grew:
+            grew = False
+            for other, other_unmet in unmet_by_task.items():
+                if other in member_ids or not assertions.intersection(other_unmet):
+                    continue
+                member_ids.add(other)
+                assertions.update(other_unmet)
+                grew = True
+        assigned.update(member_ids)
+        counts: dict[str, int] = {}
+        for member in member_ids:
+            for assertion in unmet_by_task[member]:
+                counts[assertion] = counts.get(assertion, 0) + 1
+        # Most common unmet assertion labels the cluster; max() keeps the first (lexicographically
+        # smallest) among ties because the candidates are pre-sorted.
+        mechanism = (
+            max(sorted(counts), key=lambda a: counts[a])
+            if counts
+            else "run failed without per-assertion verdicts"
+        )
+        clusters.append(
+            FailureSignature(
+                mechanism=mechanism,
+                task_ids=sorted(member_ids),
+                unmet_assertions=sorted(assertions),
+            )
+        )
+    clusters.sort(key=lambda c: (-len(c.task_ids), c.mechanism))
+    return clusters
+
+
+def select_parent(
+    entries: list[PoolEntry], children_counts: dict[str, int], seed: int
+) -> PoolEntry:
+    """Pick the next parent by stepping-stone weighting, deterministically.
+
+    Weight = (success_rate + floor) / (1 + children_count): better variants are favored, but each
+    expansion discounts a parent so the search spreads over the pool instead of hill-climbing one
+    lineage. The "random" point is blake2b(seed) mapped to [0, 1) over the cumulative weights —
+    reproducible, no RNG.
+    """
+    if not entries:
+        raise ValueError("cannot select a parent from an empty pool")
+    weights = [
+        (entry.success_rate + _SELECTION_FLOOR) / (1 + children_counts.get(entry.doc_hash, 0))
+        for entry in entries
+    ]
+    point = _fraction(str(seed)) * sum(weights)
+    cumulative = 0.0
+    for entry, weight in zip(entries, weights, strict=True):
+        cumulative += weight
+        if point < cumulative:
+            return entry
+    return entries[-1]  # floating-point edge: the point landed exactly on the total
+
+
+def narrow_failing_tiers(
+    verdict: GateRecord,
+    *,
+    k: int,
+    n_suite: int,
+    n_holdout: int,
+    margin_attempts: int = 2,
+) -> list[str] | None:
+    """Which tiers vetoed this delta narrowly enough to deserve a re-measurement.
+
+    Eligible only when the delta strictly won the full split: the question a confirmation
+    answers is "was this win vetoed by measurement noise?", not "can a loser get lucky?".
+    A tier's veto is narrow when its regression is at most `margin_attempts` single-attempt
+    flips wide (one flip changes a tier mean by 1/(k*n)). Returns the narrowly-failing tier
+    names, or None when the delta is ineligible (no win, a wide veto, or no veto at all).
+    """
+    if verdict.accepted or verdict.full_delta <= _TIE_EPS:
+        return None
+    tiers: list[str] = []
+    if verdict.suite_delta < -_TIE_EPS:
+        if n_suite == 0 or verdict.suite_delta < -(margin_attempts / (k * n_suite)) - _TIE_EPS:
+            return None
+        tiers.append("suite")
+    if verdict.holdout_delta is not None and verdict.holdout_delta < -_TIE_EPS:
+        if (
+            n_holdout == 0
+            or verdict.holdout_delta < -(margin_attempts / (k * n_holdout)) - _TIE_EPS
+        ):
+            return None
+        tiers.append("holdout")
+    return tiers or None
+
+
+def gate_delta(
+    delta: HarnessDelta,
+    *,
+    child: ClosedLoopReport,
+    champion: ClosedLoopReport,
+    best_full: float,
+    suite: list[str],
+    child_holdout: ClosedLoopReport | None = None,
+    champion_holdout: ClosedLoopReport | None = None,
+) -> GateRecord:
+    """Two-tier (plus optional held-out) acceptance; ties pass. Also audits `expected_effect`."""
+    suite_delta = _suite_rate(child, suite) - _suite_rate(champion, suite)
+    full_delta = child.success_rate - best_full
+    holdout_delta = (
+        child_holdout.success_rate - champion_holdout.success_rate
+        if child_holdout is not None and champion_holdout is not None
+        else None
+    )
+    failures: list[str] = []
+    if suite_delta < -_TIE_EPS:
+        failures.append(f"suite regressed by {-suite_delta:.3f}")
+    if full_delta < -_TIE_EPS:
+        failures.append(f"full split {child.success_rate:.3f} below best {best_full:.3f}")
+    if holdout_delta is not None and holdout_delta < -_TIE_EPS:
+        failures.append(f"held-out regressed by {-holdout_delta:.3f}")
+    flipped = sum(
+        1
+        for task_id in delta.trigger.task_ids
+        if (outcome := child.per_task.get(task_id)) is not None and outcome.success_rate >= 1.0
+    )
+    effect = (
+        f"trigger cluster: {flipped}/{len(delta.trigger.task_ids)} tasks now pass"
+        if delta.trigger.task_ids
+        else "no trigger cluster (all-pass parent)"
+    )
+    accepted = not failures
+    reason = ("accepted; " if accepted else "rejected: " + "; ".join(failures) + "; ") + effect
+    return GateRecord(
+        suite_delta=suite_delta,
+        full_delta=full_delta,
+        holdout_delta=holdout_delta,
+        accepted=accepted,
+        reason=reason,
+    )
+
+
+def create_harness(
+    name: str,
+    seed_doc: HarnessDoc,
+    tasks: list[TaskSpec],
+    world_model: WorldModel,
+    agent_provider: Provider,
+    meta_provider: Provider,
+    judge: GoldJudge,
+    *,
+    iterations: int = 5,
+    k: int = DEFAULT_K,
+    holdout: list[TaskSpec] | None = None,
+    confirm_narrow_vetoes: bool = True,
+    on_progress: CreateProgress | None = None,
+) -> CreateResult:
+    """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
+
+    Scores the seed first, then runs `iterations` propose-apply-SCREEN-score-gate steps. An
+    iteration whose proposal is unusable or fails atomic application is skipped (counted in
+    `skipped`; an invalid delta is still archived with its rejection verdict), never fatal.
+
+    Verification is staged by cost: a child is first SCREENED on its own trigger cluster (the
+    2-3 failing tasks its delta claims to fix, k passes) — if the cluster did not improve over
+    the parent, the delta is rejected and archived for a fraction of a full eval's cost, and no
+    `on_progress` event fires. Held-out evals run only for children that pass tiers 1-2, so a
+    bad delta costs at most one full-split eval. Every judged delta (screened, rejected, or
+    accepted) is fed back to the proposer as history, so it iterates instead of re-proposing
+    rejected ideas.
+
+    Symmetrically, a REJECTION can be noise: with k passes over small tiers, one unlucky attempt
+    can veto a genuine win. When `confirm_narrow_vetoes` is set, a delta that strictly won the
+    full split but failed suite/holdout within `narrow_failing_tiers`' margin gets that tier
+    re-measured — child AND champion, at 2k — and the re-measurement decides. The verdict records
+    the retrial either way, so the archive shows which accepts needed confirmation.
+    """
+    docs: dict[str, HarnessDoc] = {seed_doc.doc_hash: seed_doc}
+    reports: dict[str, ClosedLoopReport] = {}
+    holdout_reports: dict[str, ClosedLoopReport] = {}
+    archive = DeltaArchive(seed=seed_doc)
+    children_counts: dict[str, int] = {}
+    skipped = 0
+    screened = 0
+    confirmations = 0
+
+    def _score(
+        doc: HarnessDoc, split: list[TaskSpec], *, k_override: int | None = None
+    ) -> ClosedLoopReport:
+        return evaluate_closed_loop(
+            split,
+            world_model,
+            agent_provider,
+            judge,
+            label=doc.name,
+            k=k if k_override is None else k_override,
+            runtime=doc.runtime(agent_provider),
+        )
+
+    seed_report = _score(seed_doc, tasks)
+    reports[seed_doc.doc_hash] = seed_report
+    if holdout:
+        holdout_reports[seed_doc.doc_hash] = _score(seed_doc, holdout)
+    if on_progress is not None:
+        on_progress(0, seed_doc.name, seed_report.success_rate, True)
+
+    pool = [
+        PoolEntry(
+            doc_hash=seed_doc.doc_hash, name=seed_doc.name, success_rate=seed_report.success_rate
+        )
+    ]
+    champion_hash = seed_doc.doc_hash
+    best_full = seed_report.success_rate
+    # The regression suite: tasks the champion lineage has fully passed. Wins promote in on accept.
+    suite = sorted(
+        task.task_id
+        for task in tasks
+        if seed_report.per_task[task.task_id].success_rate >= 1.0 - _TIE_EPS
+    )
+
+    for i in range(1, iterations + 1):
+        parent_entry = select_parent(pool, children_counts, seed=i)
+        parent = docs[parent_entry.doc_hash]
+        parent_report = reports[parent_entry.doc_hash]
+        # Count the expansion attempt up front so a parent whose proposals keep failing is
+        # progressively discounted instead of re-selected every iteration.
+        children_counts[parent.doc_hash] = children_counts.get(parent.doc_hash, 0) + 1
+
+        clusters = cluster_failures(parent_report, tasks)
+        trigger = clusters[0] if clusters else FailureSignature(mechanism=ALL_PASS_MECHANISM)
+        evidence = render_evidence(trigger, parent_report, tasks)
+        delta = propose_delta(parent, trigger, evidence, meta_provider, history=archive.deltas)
+        if delta is None:
+            skipped += 1
+            continue
+        try:
+            child = apply_delta(parent, delta, f"{name}-g{i}")
+        except ValueError as exc:
+            delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {exc}")
+            archive.deltas.append(delta)
+            skipped += 1
+            continue
+
+        # Cheap screen: before a full-split eval, the delta must improve the very cluster it
+        # was proposed to fix. A delta that cannot beat its parent on its own target is noise.
+        screen_tasks = [t for t in tasks if t.task_id in set(trigger.task_ids)]
+        if screen_tasks:
+            screen_report = _score(child, screen_tasks)
+            parent_mean = _suite_rate(parent_report, sorted(trigger.task_ids))
+            child_mean = _suite_rate(screen_report, sorted(trigger.task_ids))
+            if child_mean <= parent_mean + _TIE_EPS:
+                delta.verdict = GateRecord(
+                    accepted=False,
+                    reason=(
+                        f"screened out: trigger cluster {child_mean:.2f} vs parent "
+                        f"{parent_mean:.2f} over {len(screen_tasks)} task(s), k={k} — "
+                        "the delta did not improve its own target"
+                    ),
+                )
+                archive.deltas.append(delta)
+                screened += 1
+                continue
+
+        child_report = _score(child, tasks)
+        pre_verdict = gate_delta(
+            delta,
+            child=child_report,
+            champion=reports[champion_hash],
+            best_full=best_full,
+            suite=suite,
+        )
+        # The held-out tier is measured for every candidate that could still be accepted —
+        # including candidates whose suite/full veto is narrow enough for a confirmation
+        # re-run. A confirmation may overturn a veto; it must never bypass the held-out tier.
+        could_accept = pre_verdict.accepted or (
+            confirm_narrow_vetoes
+            and narrow_failing_tiers(pre_verdict, k=k, n_suite=len(suite), n_holdout=0) is not None
+        )
+        if holdout and could_accept:
+            child_holdout = _score(child, holdout)
+            holdout_reports[child.doc_hash] = child_holdout
+            if champion_hash not in holdout_reports:
+                holdout_reports[champion_hash] = _score(docs[champion_hash], holdout)
+            verdict = gate_delta(
+                delta,
+                child=child_report,
+                champion=reports[champion_hash],
+                best_full=best_full,
+                suite=suite,
+                child_holdout=child_holdout,
+                champion_holdout=holdout_reports[champion_hash],
+            )
+        else:
+            verdict = pre_verdict
+        tiers = (
+            narrow_failing_tiers(verdict, k=k, n_suite=len(suite), n_holdout=len(holdout or []))
+            if confirm_narrow_vetoes
+            else None
+        )
+        if tiers:
+            confirmations += 1
+            confirmed_ok = True
+            notes: list[str] = []
+            for tier in tiers:
+                tier_tasks = (
+                    [t for t in tasks if t.task_id in set(suite)]
+                    if tier == "suite"
+                    else list(holdout or [])
+                )
+                child_re = _score(child, tier_tasks, k_override=2 * k)
+                champ_re = _score(docs[champion_hash], tier_tasks, k_override=2 * k)
+                re_delta = child_re.success_rate - champ_re.success_rate
+                notes.append(f"{tier} re-measured at k={2 * k}: {re_delta:+.3f}")
+                if re_delta < -_TIE_EPS:
+                    confirmed_ok = False
+            outcome = "veto overturned" if confirmed_ok else "regression confirmed"
+            verdict = GateRecord(
+                suite_delta=verdict.suite_delta,
+                full_delta=verdict.full_delta,
+                holdout_delta=verdict.holdout_delta,
+                accepted=confirmed_ok,
+                reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
+                + verdict.reason,
+            )
+        delta.verdict = verdict
+        archive.deltas.append(delta)
+        docs[child.doc_hash] = child
+        reports[child.doc_hash] = child_report
+        if verdict.accepted:
+            pool.append(
+                PoolEntry(
+                    doc_hash=child.doc_hash,
+                    name=child.name,
+                    success_rate=child_report.success_rate,
+                )
+            )
+            champion_hash = child.doc_hash
+            best_full = max(best_full, child_report.success_rate)
+            promoted = {
+                task_id
+                for task_id, outcome in child_report.per_task.items()
+                if outcome.success_rate >= 1.0 - _TIE_EPS
+            }
+            suite = sorted(set(suite) | promoted)
+        if on_progress is not None:
+            on_progress(i, child.name, child_report.success_rate, verdict.accepted)
+
+    best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
+    return CreateResult(
+        best=best,
+        best_score=reports[champion_hash].success_rate,
+        archive=archive,
+        reports=reports,
+        holdout_reports=holdout_reports,
+        suite=suite,
+        skipped=skipped,
+        screened=screened,
+        confirmations=confirmations,
+    )
+
+
+def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:
+    """Mean per-task success over the regression suite; an empty suite constrains nothing."""
+    if not suite:
+        return 1.0
+    rates = [
+        outcome.success_rate
+        for task_id in suite
+        if (outcome := report.per_task.get(task_id)) is not None
+    ]
+    # Dividing by len(suite), not len(rates): a suite task missing from the report counts as 0
+    # (fail-closed), though suite tasks are always a subset of the scored split in practice.
+    return sum(rates) / len(suite)
+
+
+def _fraction(text: str) -> float:
+    """Stable hash of `text` mapped to [0, 1) — the repo's RNG-free randomness convention."""
+    digest = hashlib.blake2b(text.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") / 2**64

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -1,0 +1,561 @@
+"""End-to-end create-loop tests: one provider plays all four roles, no network, no entropy.
+
+Extends the closed-loop test pattern (`closed_loop_test.RoleProvider`) with a fourth role: the
+meta-agent, keyed on `MUTATE_SYSTEM`'s distinctive phrase. The agent role is the FALLBACK after
+the judge/meta/world-model markers, because a variant's system prompt is exactly what the search
+rewrites — no marker on it is stable across generations. The fake judge echoes the gold assertions
+verbatim from its prompt (the real judge is scored by text-matching those echoes) and passes or
+fails a run based on the submitted answer, so seed and child scores can genuinely differ.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
+from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.create import (
+    CreateResult,
+    PoolEntry,
+    cluster_failures,
+    create_harness,
+    select_parent,
+)
+from wmh.harness.doc import HarnessDoc
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+_CAREFUL_PROMPT = "You are a careful agent. Verify the state of the system before submitting."
+
+
+def _meta_reply(parent: HarnessDoc, new_prompt: str) -> str:
+    """A well-formed delta against `parent`, preconditioned on its actual prompt hash."""
+    core = parent.surface("prompt:core")
+    assert core is not None
+    return json.dumps(
+        {
+            "expected_effect": "the failing tasks flip to pass",
+            "preconditions": {"prompt:core": core.content_hash},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": "prompt:core",
+                    "content": new_prompt,
+                    "rationale": "make the agent verify before submitting",
+                }
+            ],
+        }
+    )
+
+
+class RoleProvider:
+    """Plays agent, world model, gold judge, and meta-agent, keyed off the system prompt."""
+
+    def __init__(
+        self,
+        *,
+        meta_reply: str = "not json at all",
+        judge_fn: Callable[[str], bool] | None = None,
+    ) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+        self._meta_reply = meta_reply
+        self.meta_users: list[str] = []  # every proposer prompt, for history assertions
+        # Default: a run passes iff the agent submitted the verified answer.
+        self._judge_fn = judge_fn if judge_fn is not None else lambda u: "done-verified" in u
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        user = messages[-1].content
+        if "grade whether an agent completed a task" in system:
+            passed = self._judge_fn(user)
+            results = [
+                {"assertion": a, "passed": passed, "why": "x"} for a in _gold_assertions(user)
+            ]
+            return Completion(text=json.dumps({"assertions": results, "passed": passed}))
+        if "meta-agent improving an agent harness" in system:
+            self.meta_users.append(user)
+            return Completion(text=self._meta_reply)
+        if "You ARE the environment" in system:
+            return Completion(text='{"output": "ok", "is_error": false}')
+        # Fallback: the agent role. What it submits depends on the prompt the variant carries.
+        if "careful agent" in system:
+            answer = "done-verified"
+        elif "broken agent" in system:
+            answer = "done-broken"
+        else:
+            answer = "done"
+        return Completion(text=json.dumps({"tool": "submit", "arguments": {"answer": answer}}))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201 - test fake never calls it
+        raise NotImplementedError
+
+
+def _gold_assertions(user: str) -> list[str]:
+    """The gold list the judge prompt carries, echoed back verbatim."""
+    _, _, tail = user.partition("GOLD ASSERTIONS")
+    return [line[2:] for line in tail.splitlines() if line.startswith("- ")]
+
+
+def _wm(provider: RoleProvider) -> WorldModel:
+    return WorldModel(provider, EmbeddingRetriever(HashingEmbedder(dim=16)))
+
+
+def _tasks() -> list[TaskSpec]:
+    return [TaskSpec(task_id="t1", instruction="answer it", gold=["the work was verified"])]
+
+
+def _run(
+    provider: RoleProvider,
+    *,
+    iterations: int = 1,
+    k: int = 3,
+    holdout: list[TaskSpec] | None = None,
+    on_progress: Callable[[int, str, float, bool], None] | None = None,
+) -> CreateResult:
+    return create_harness(
+        "winner",
+        HarnessDoc.baseline("seed"),
+        _tasks(),
+        _wm(provider),
+        provider,
+        provider,
+        GoldJudge(provider),
+        iterations=iterations,
+        k=k,
+        holdout=holdout,
+        on_progress=on_progress,
+    )
+
+
+def test_create_accepts_improving_delta_and_promotes_suite() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    progress: list[tuple[int, str, float, bool]] = []
+    result = _run(provider, on_progress=lambda i, n, r, a: progress.append((i, n, r, a)))
+
+    assert result.skipped == 0
+    assert result.best_score == 1.0
+    assert result.best.name == "winner"
+    assert result.best.system_prompt() == _CAREFUL_PROMPT
+    assert progress == [(0, "seed", 0.0, True), (1, "winner-g1", 1.0, True)]
+
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and delta.verdict.accepted
+    assert delta.verdict.full_delta == 1.0
+    assert delta.verdict.holdout_delta is None
+    assert "1/1 tasks now pass" in delta.verdict.reason
+    # The trigger came from deterministic clustering of the seed's failures.
+    assert delta.trigger.mechanism == "the work was verified"
+    assert delta.trigger.task_ids == ["t1"]
+    # The newly-passing task promoted into the regression suite.
+    assert result.suite == ["t1"]
+    # Reports are keyed by content: seed and child doc hashes, k=3 passes each.
+    assert set(result.reports) == {seed.doc_hash, delta.child_doc_hash}
+    assert all(r.k == 3 for r in result.reports.values())
+
+
+def test_archive_reconstructs_children_by_folding_deltas() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    result = _run(provider)
+    [delta] = result.archive.deltas
+    assert delta.child_doc_hash is not None
+    rebuilt = result.archive.reconstruct(delta.child_doc_hash)
+    assert rebuilt.surfaces == result.best.surfaces
+    with pytest.raises(ValueError, match="not in this archive"):
+        result.archive.reconstruct("0" * 32)
+
+
+def test_create_rejects_regressing_delta_and_keeps_champion() -> None:
+    # The seed already passes; the proposed prompt makes the agent submit a broken answer.
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(
+        meta_reply=_meta_reply(seed, "You are a broken agent."),
+        judge_fn=lambda user: "done-broken" not in user,
+    )
+    result = _run(provider)
+
+    assert result.skipped == 0
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    assert "full split" in delta.verdict.reason
+    assert result.archive.accepted() == []
+    # The champion never moved: the winner is the (renamed) seed at its original score.
+    assert result.best_score == 1.0
+    assert result.best.system_prompt() == seed.system_prompt()
+    assert result.suite == ["t1"]  # and the suite kept the seed's win
+    # An all-pass parent gets the generalization trigger, not a fabricated failure.
+    assert delta.trigger.mechanism == "none: all tasks pass"
+
+
+def test_create_skips_unusable_proposals() -> None:
+    provider = RoleProvider(meta_reply="not json at all")
+    result = _run(provider, iterations=2)
+    assert result.skipped == 2
+    assert result.archive.deltas == []  # nothing to audit: no delta object ever existed
+    assert result.best.name == "winner"  # even a search with no children yields the renamed seed
+
+
+def test_create_audits_invalid_delta_without_spending_eval() -> None:
+    stale = json.dumps(
+        {
+            "expected_effect": "x",
+            "preconditions": {"prompt:core": "0" * 32},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": "prompt:core",
+                    "content": _CAREFUL_PROMPT,
+                    "rationale": "r",
+                }
+            ],
+        }
+    )
+    provider = RoleProvider(meta_reply=stale)
+    result = _run(provider)
+    assert result.skipped == 1
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    assert delta.verdict.reason.startswith("invalid before eval")
+    assert delta.child_doc_hash is None  # it never applied, so it never produced a doc
+    assert len(result.reports) == 1  # only the seed was ever scored
+
+
+def test_holdout_regression_rejects_a_full_split_win() -> None:
+    # The delta fixes the main task but breaks the held-out one: tiers 1-2 pass, tier 3 rejects.
+    seed = HarnessDoc.baseline("seed")
+
+    def judge(user: str) -> bool:
+        if "the holdout task" in user:
+            return "done-verified" not in user  # holdout passes only for the seed's plain answer
+        return "done-verified" in user
+
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT), judge_fn=judge)
+    holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["the base flow works"])]
+    result = _run(provider, holdout=holdout)
+
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    assert delta.verdict.full_delta == 1.0  # it really did win the full split...
+    assert delta.verdict.holdout_delta == -1.0  # ...and really did regress held-out
+    assert "held-out regressed" in delta.verdict.reason
+    assert result.best_score == 0.0  # champion stays the seed
+    assert set(result.holdout_reports) == {seed.doc_hash, delta.child_doc_hash}
+
+
+# -- deterministic failure clustering ---------------------------------------------------------
+
+
+def _failing(task_id: str, unmet: list[str]) -> TaskOutcome:
+    verdict = GoldVerdict(
+        passed=False,
+        fraction=0.0,
+        assertions=[AssertionResult(assertion=a, passed=False, why="w") for a in unmet],
+    )
+    return TaskOutcome(
+        task_id=task_id, success_rate=0.0, mean_fraction=0.0, passes=2, verdicts=[verdict, verdict]
+    )
+
+
+def test_cluster_failures_groups_by_shared_assertions() -> None:
+    report = ClosedLoopReport(
+        per_task={
+            "t1": _failing("t1", ["a", "b"]),
+            "t2": _failing("t2", ["b", "c"]),
+            "t3": _failing("t3", ["z"]),
+            "t4": TaskOutcome(task_id="t4", success_rate=1.0, mean_fraction=1.0, passes=2),
+            "t5": _failing("t5", []),  # unparseable judge: no per-assertion detail
+        }
+    )
+    tasks = [TaskSpec(task_id=t, instruction=t) for t in ("t1", "t2", "t3", "t4", "t5")]
+    clusters = cluster_failures(report, tasks)
+    assert [c.task_ids for c in clusters] == [["t1", "t2"], ["t5"], ["t3"]]
+    # t1+t2 connect through shared assertion "b", which also labels the mechanism.
+    assert clusters[0].mechanism == "b"
+    assert clusters[0].unmet_assertions == ["a", "b", "c"]
+    assert clusters[1].mechanism == "run failed without per-assertion verdicts"
+    assert clusters[2].mechanism == "z"
+
+
+def test_cluster_failures_empty_when_everything_passes() -> None:
+    report = ClosedLoopReport(
+        per_task={"t1": TaskOutcome(task_id="t1", success_rate=1.0, mean_fraction=1.0, passes=3)}
+    )
+    assert cluster_failures(report, [TaskSpec(task_id="t1", instruction="i")]) == []
+
+
+# -- parent selection --------------------------------------------------------------------------
+
+
+def _entry(doc_hash: str, success_rate: float) -> PoolEntry:
+    return PoolEntry(doc_hash=doc_hash, name=doc_hash, success_rate=success_rate)
+
+
+def test_select_parent_is_deterministic_and_discounts_expanded_parents() -> None:
+    entries = [_entry("a", 0.5), _entry("b", 1.0)]
+    assert select_parent(entries, {}, seed=7) == select_parent(entries, {}, seed=7)
+    picks_fresh = [select_parent(entries, {}, seed=s).doc_hash for s in range(50)]
+    picks_worn = [select_parent(entries, {"b": 9}, seed=s).doc_hash for s in range(50)]
+    # Both variants are reachable, and expanding a parent shrinks its share of selections.
+    assert set(picks_fresh) == {"a", "b"}
+    assert picks_worn.count("b") < picks_fresh.count("b")
+
+
+def test_select_parent_rejects_empty_pool() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        select_parent([], {}, seed=1)
+
+
+# -- staged verification: screening + history ---------------------------------------------------
+
+
+def _useless_meta_reply(parent: HarnessDoc) -> str:
+    """A well-formed delta that changes wording but cannot fix the failing task."""
+    return _meta_reply(parent, "You are an agent. Do the task.")
+
+
+def test_screen_rejects_delta_that_does_not_improve_its_trigger() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_useless_meta_reply(seed))
+    progress: list[tuple[int, str, float, bool]] = []
+    result = _run(provider, on_progress=lambda i, n, r, a: progress.append((i, n, r, a)))
+
+    assert result.screened == 1 and result.skipped == 0
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    assert delta.verdict.reason.startswith("screened out")
+    # The cheap screen replaced the full eval: only the seed has a full-split report,
+    # and no child progress event ever fired.
+    assert len(result.reports) == 1
+    assert [e[0] for e in progress] == [0]
+
+
+def test_rejected_history_reaches_the_next_proposal() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_useless_meta_reply(seed))
+    _run(provider, iterations=2)
+    assert len(provider.meta_users) == 2
+    assert "Previous attempts" not in provider.meta_users[0]
+    assert "Previous attempts" in provider.meta_users[1]
+    assert "screened out" in provider.meta_users[1]  # the verdict itself is the lesson
+
+
+# -- code deltas end to end ----------------------------------------------------------------------
+
+
+def _code_meta_reply(parent: HarnessDoc) -> str:
+    from wmh.harness.doc import CODE_RUNTIME_ID
+
+    code_surface = parent.surface(CODE_RUNTIME_ID)
+    assert code_surface is not None
+    new_code = (
+        "def run(kit):\n"
+        '    kit.execute("bash", {"command": "verify the work"})\n'
+        '    return "done-verified"\n'
+    )
+    return json.dumps(
+        {
+            "expected_effect": "the failing task flips to pass",
+            "preconditions": {CODE_RUNTIME_ID: code_surface.content_hash},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": CODE_RUNTIME_ID,
+                    "content": new_code,
+                    "rationale": "verify via the environment before submitting",
+                }
+            ],
+        }
+    )
+
+
+def test_code_delta_passes_screen_and_gate_end_to_end() -> None:
+    from wmh.harness.doc import CODE_RUNTIME_ID, code_baseline
+
+    seed = code_baseline("seed")
+    provider = RoleProvider(meta_reply=_code_meta_reply(seed))
+    result = create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        provider,
+        GoldJudge(provider),
+        iterations=1,
+        k=3,
+    )
+    assert result.screened == 0 and result.skipped == 0
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and delta.verdict.accepted
+    assert [op.surface_id for op in delta.ops] == [CODE_RUNTIME_ID]
+    assert result.best_score == 1.0
+    winner_code = result.best.surface(CODE_RUNTIME_ID)
+    assert winner_code is not None and "done-verified" in winner_code.content
+
+
+def test_broken_code_delta_is_rejected_before_any_eval() -> None:
+    from wmh.harness.doc import CODE_RUNTIME_ID, code_baseline
+
+    seed = code_baseline("seed")
+    code_surface = seed.surface(CODE_RUNTIME_ID)
+    assert code_surface is not None
+    broken = json.dumps(
+        {
+            "expected_effect": "x",
+            "preconditions": {CODE_RUNTIME_ID: code_surface.content_hash},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": CODE_RUNTIME_ID,
+                    "content": "def run(kit:\n",
+                    "rationale": "r",
+                }
+            ],
+        }
+    )
+    provider = RoleProvider(meta_reply=broken)
+    result = create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        provider,
+        GoldJudge(provider),
+        iterations=1,
+        k=2,
+    )
+    assert result.skipped == 1
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and "does not compile" in delta.verdict.reason
+    assert len(result.reports) == 1  # only the seed was ever scored
+
+
+# -- confirmation re-runs -----------------------------------------------------------------------
+
+
+def test_narrow_failing_tiers_eligibility() -> None:
+    from wmh.harness.create import narrow_failing_tiers
+    from wmh.harness.delta import GateRecord
+
+    def record(**kw) -> GateRecord:  # noqa: ANN003
+        return GateRecord(accepted=False, reason="r", **kw)
+
+    # Narrow holdout veto on a full-split win -> retry that tier.
+    narrow = record(full_delta=0.05, holdout_delta=-0.1)
+    assert narrow_failing_tiers(narrow, k=5, n_suite=4, n_holdout=4) == ["holdout"]
+    # A wide veto is a real regression, not noise: ineligible.
+    wide = record(full_delta=0.05, holdout_delta=-1.0)
+    assert narrow_failing_tiers(wide, k=5, n_suite=4, n_holdout=4) is None
+    # No full-split win: nothing to confirm.
+    no_win = record(full_delta=0.0, holdout_delta=-0.1)
+    assert narrow_failing_tiers(no_win, k=5, n_suite=4, n_holdout=4) is None
+    # Both tiers narrowly failing -> both retried.
+    both = record(full_delta=0.05, suite_delta=-0.05, holdout_delta=-0.1)
+    assert narrow_failing_tiers(both, k=5, n_suite=8, n_holdout=4) == ["suite", "holdout"]
+    # Accepted verdicts are never retried.
+    ok = GateRecord(accepted=True, reason="r", full_delta=0.05)
+    assert narrow_failing_tiers(ok, k=5, n_suite=4, n_holdout=4) is None
+
+
+def test_flaky_holdout_veto_is_overturned_by_confirmation() -> None:
+    # The child genuinely fixes the train task; the holdout task fails exactly ONE child
+    # attempt (judge flakiness). The initial k-pass gate vetoes; the 2k re-measurement of
+    # child AND champion overturns it.
+    seed = HarnessDoc.baseline("seed")
+    child_h1_calls = {"n": 0}
+
+    def judge(user: str) -> bool:
+        if "the holdout task" in user:
+            if "done-verified" in user:  # the child's answer style
+                child_h1_calls["n"] += 1
+                return child_h1_calls["n"] != 1  # fail only the first child attempt
+            return True  # the seed always passes holdout
+        return "done-verified" in user  # train task needs the careful child
+
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT), judge_fn=judge)
+    holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["the base flow works"])]
+    result = _run(provider, holdout=holdout, k=5)
+
+    assert result.confirmations == 1
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and delta.verdict.accepted
+    assert "veto overturned" in delta.verdict.reason
+    assert "initially: rejected" in delta.verdict.reason
+    assert result.best_score == 1.0  # the win was kept
+
+
+def test_wide_holdout_regression_skips_confirmation() -> None:
+    # Same setup as the round-2 holdout test: the child ALWAYS fails held-out. -1.0 is far
+    # beyond the narrow margin, so no re-measurement is spent and the plain rejection stands.
+    seed = HarnessDoc.baseline("seed")
+
+    def judge(user: str) -> bool:
+        if "the holdout task" in user:
+            return "done-verified" not in user
+        return "done-verified" in user
+
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT), judge_fn=judge)
+    holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["the base flow works"])]
+    result = _run(provider, holdout=holdout)
+    assert result.confirmations == 0
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    assert "held-out regressed" in delta.verdict.reason
+
+
+def test_confirmed_suite_overturn_still_faces_the_holdout_tier() -> None:
+    # A suite veto narrow enough to overturn must NOT smuggle the child past held-out
+    # verification: here the suite flake clears on re-measurement but the child genuinely
+    # regresses held-out, so the final verdict is a holdout rejection.
+    seed = HarnessDoc.baseline("seed")
+    suite_flake = {"n": 0}
+
+    def judge(user: str) -> bool:
+        if "the holdout task" in user:
+            return "done-verified" not in user  # child ALWAYS fails held-out (wide, real)
+        if "suite task" in user:
+            if "done-verified" in user:
+                suite_flake["n"] += 1
+                return suite_flake["n"] != 1  # one flaky failure for the child
+            return True  # seed masters the suite task
+        return "done-verified" in user  # the trigger task needs the careful child
+
+    tasks = [
+        TaskSpec(task_id="t1", instruction="answer it", gold=["the work was verified"]),
+        TaskSpec(task_id="s1", instruction="the suite task", gold=["steady state holds"]),
+    ]
+    holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["the base flow works"])]
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT), judge_fn=judge)
+    result = create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        provider,
+        GoldJudge(provider),
+        iterations=1,
+        k=5,
+        holdout=holdout,
+    )
+    [delta] = result.archive.deltas
+    assert delta.verdict is not None and not delta.verdict.accepted
+    # The holdout tier was measured (not bypassed) and its regression is the rejection.
+    assert delta.verdict.holdout_delta is not None and delta.verdict.holdout_delta < 0
+    assert result.best_score == pytest.approx(0.5)  # champion stayed the seed

--- a/wmh/harness/delta.py
+++ b/wmh/harness/delta.py
@@ -1,0 +1,185 @@
+"""`HarnessDelta`: the typed update object `wmh harness create` searches through.
+
+The update representation IS the search space: everything the meta-agent can learn about *how to
+improve harnesses* is bounded by what the update object can express. A raw file edit expresses
+almost nothing — no typed target, no assertion about what it believed it was editing, no per-change
+rationale, no verdict. A delta expresses all four:
+
+- **trigger** (`FailureSignature`): the clustered failure mechanism this delta answers to, so the
+  archive can ask "which kinds of edits work on which failure classes?" instead of "what changed?".
+- **preconditions**: `surface_id -> expected content hash` of every surface the proposer read
+  before editing. Application is atomic — ANY mismatch rejects the whole delta before a token of
+  eval budget is spent, so a proposal drafted against one parent can never silently misapply to
+  another.
+- **ops** (`SurfaceOp`): add/replace/remove keyed by surface *identity*, each carrying its own
+  rationale bound to the op it justifies.
+- **verdict** (`GateRecord`): the acceptance decision and the gate deltas that produced it, written
+  back onto the delta. The archive is a lineage of audited deltas, not a pile of snapshots.
+
+`expected_effect` makes every delta a falsifiable prediction: at gate time the trigger cluster is
+re-checked and the outcome lands in `verdict.reason`, measuring the proposer's calibration over
+time, not just its win rate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+
+
+class FailureSignature(BaseModel):
+    """The clustered failure mechanism a delta answers to: WHY it exists, queryably.
+
+    Built deterministically from a closed-loop report (`wmh.harness.create.cluster_failures`),
+    never free-typed by the proposer — so the archive's mechanism labels are comparable across
+    deltas and runs.
+    """
+
+    mechanism: str  # e.g. the shared unmet assertion, or "none: all tasks pass"
+    task_ids: list[str] = Field(default_factory=list)  # the failing tasks exhibiting it
+    unmet_assertions: list[str] = Field(default_factory=list)  # deduped, order-stable
+
+
+class SurfaceOp(BaseModel):
+    """One typed edit to one surface, addressed by identity, justified in place."""
+
+    op: Literal["add", "replace", "remove"]
+    surface_id: str
+    kind: SurfaceKind | None = None  # required on add; on replace must match the existing kind
+    content: str | None = None  # the full new content (component rewrite, never a line diff)
+    budget: int | None = Field(default=None, ge=1)  # replace: None inherits the existing budget
+    rationale: str  # why THIS op, bound to the op — not one motivation string for the whole delta
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> SurfaceOp:
+        if self.op == "add" and self.kind is None:
+            raise ValueError(f"add of {self.surface_id!r} must declare a kind")
+        if self.op in ("add", "replace") and self.content is None:
+            raise ValueError(f"{self.op} of {self.surface_id!r} must carry content")
+        if self.op == "remove" and self.content is not None:
+            raise ValueError(
+                f"remove of {self.surface_id!r} carries content; a remove deletes, it never writes"
+            )
+        if not self.rationale.strip():
+            raise ValueError(f"{self.op} of {self.surface_id!r} has no rationale")
+        return self
+
+
+class GateRecord(BaseModel):
+    """The acceptance verdict, filled at evaluation time and persisted on the delta."""
+
+    suite_delta: float = 0.0  # regression suite: child - champion (tier 1; >= 0 to pass)
+    full_delta: float = 0.0  # full split: child - best seen (tier 2; >= 0 to pass)
+    holdout_delta: float | None = None  # held-out split (tier 3; None when no holdout given)
+    accepted: bool
+    reason: str  # accept/reject reasoning, incl. whether `expected_effect` came true
+
+
+class HarnessDelta(BaseModel):
+    """One proposed update to a `HarnessDoc`, with its audit trail.
+
+    Lineage is by content, not name: `parent_doc_hash` names exactly the document the delta was
+    proposed against, and `child_doc_hash` (recorded on successful application) names exactly what
+    it produced. A doc is reconstructable by folding accepted deltas from any ancestor snapshot.
+    """
+
+    delta_id: str
+    parent_doc_hash: str
+    trigger: FailureSignature
+    # surface_id -> expected content hash of the parent surface the proposer read. Every
+    # replace/remove target MUST appear here; application atomically rejects on any mismatch.
+    preconditions: dict[str, str] = Field(default_factory=dict)
+    ops: list[SurfaceOp] = Field(min_length=1)
+    expected_effect: str  # falsifiable: e.g. "the trigger cluster's tasks flip to pass"
+    child_doc_hash: str | None = None  # set by apply_delta
+    verdict: GateRecord | None = None  # set by the gate; None until evaluated
+
+
+def compute_delta_id(parent_doc_hash: str, ops: list[SurfaceOp]) -> str:
+    """Deterministic delta identity: what it does to what, independent of when it was proposed."""
+    joined = parent_doc_hash + "".join(
+        f"\x00{op.op}\x00{op.surface_id}\x00{op.content or ''}\x00{op.budget or ''}" for op in ops
+    )
+    return hashlib.blake2b(joined.encode("utf-8"), digest_size=16).hexdigest()
+
+
+def apply_delta(parent: HarnessDoc, delta: HarnessDelta, child_name: str) -> HarnessDoc:
+    """Apply `delta` to `parent` atomically; returns the child with `delta.child_doc_hash` set.
+
+    Every check runs before anything is built, and the child itself re-validates as a whole
+    `HarnessDoc` at construction — an invalid delta must fail here, before any eval budget is
+    spent on the variant it would have produced. Raises `ValueError` on any violation.
+    """
+    _check_lineage(parent, delta)
+    _check_preconditions(parent, delta)
+    _check_ops(parent, delta)
+
+    surfaces = {s.id: s for s in parent.surfaces}
+    for op in delta.ops:
+        if op.op == "remove":
+            del surfaces[op.surface_id]
+            continue
+        existing = surfaces.get(op.surface_id)
+        # Narrowing only: SurfaceOp's model validator guarantees add carries a kind and
+        # add/replace carry content, and _check_ops guarantees replace targets exist.
+        kind = op.kind if op.kind is not None else existing.kind if existing else None
+        budget = op.budget if op.budget is not None else existing.budget if existing else None
+        if kind is None or op.content is None:
+            raise ValueError(f"malformed {op.op} of {op.surface_id!r}")
+        surfaces[op.surface_id] = Surface(
+            id=op.surface_id, kind=kind, content=op.content, budget=budget
+        )
+
+    child = HarnessDoc(name=child_name, surfaces=list(surfaces.values()))
+    delta.child_doc_hash = child.doc_hash
+    return child
+
+
+def _check_lineage(parent: HarnessDoc, delta: HarnessDelta) -> None:
+    if delta.parent_doc_hash != parent.doc_hash:
+        raise ValueError(
+            f"delta {delta.delta_id} was proposed against doc {delta.parent_doc_hash[:12]}, "
+            f"not {parent.doc_hash[:12]} ({parent.name} v{parent.version})"
+        )
+
+
+def _check_preconditions(parent: HarnessDoc, delta: HarnessDelta) -> None:
+    for surface_id, expected in delta.preconditions.items():
+        surface = parent.surface(surface_id)
+        if surface is None:
+            raise ValueError(f"precondition on unknown surface {surface_id!r}")
+        if surface.content_hash != expected:
+            raise ValueError(
+                f"precondition mismatch on {surface_id!r}: expected {expected[:12]}, "
+                f"parent has {surface.content_hash[:12]} — the delta was drafted against "
+                "different content"
+            )
+
+
+def _check_ops(parent: HarnessDoc, delta: HarnessDelta) -> None:
+    targets = [op.surface_id for op in delta.ops]
+    duplicates = sorted({t for t in targets if targets.count(t) > 1})
+    if duplicates:
+        raise ValueError(f"multiple ops target the same surface(s): {duplicates}")
+    for op in delta.ops:
+        existing = parent.surface(op.surface_id)
+        if op.op == "add":
+            if existing is not None:
+                raise ValueError(f"add of {op.surface_id!r}: the surface already exists")
+        else:
+            if existing is None:
+                raise ValueError(f"{op.op} of unknown surface {op.surface_id!r}")
+            if op.kind is not None and op.kind is not existing.kind:
+                raise ValueError(
+                    f"{op.op} of {op.surface_id!r} declares kind {op.kind.value!r}; the surface "
+                    f"is {existing.kind.value!r}"
+                )
+            if op.surface_id not in delta.preconditions:
+                raise ValueError(
+                    f"{op.op} of {op.surface_id!r} has no precondition: an update must assert "
+                    "the content hash of every surface it replaces or removes"
+                )

--- a/wmh/harness/delta_test.py
+++ b/wmh/harness/delta_test.py
@@ -1,0 +1,240 @@
+"""Delta tests: op-shape validation and the atomic application guarantees."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.harness.delta import (
+    FailureSignature,
+    HarnessDelta,
+    SurfaceOp,
+    apply_delta,
+    compute_delta_id,
+)
+from wmh.harness.doc import TOOL_POLICY_ID, HarnessDoc, Surface, SurfaceKind
+
+
+def _parent() -> HarnessDoc:
+    doc = HarnessDoc.baseline("parent")
+    skill = Surface(
+        id="skill:old-skill",
+        kind=SurfaceKind.SKILL,
+        content="---\nname: old-skill\ndescription: stale advice\n---\ndo the old thing",
+    )
+    return HarnessDoc(name="parent", surfaces=[*doc.surfaces, skill])
+
+
+def _delta(
+    ops: list[SurfaceOp],
+    *,
+    parent: HarnessDoc,
+    preconditions: dict[str, str] | None = None,
+) -> HarnessDelta:
+    return HarnessDelta(
+        delta_id=compute_delta_id(parent.doc_hash, ops),
+        parent_doc_hash=parent.doc_hash,
+        trigger=FailureSignature(mechanism="m", task_ids=["t1"], unmet_assertions=["a"]),
+        preconditions=preconditions if preconditions is not None else {},
+        ops=ops,
+        expected_effect="t1 flips to pass",
+    )
+
+
+def _replace_prompt(parent: HarnessDoc, content: str) -> HarnessDelta:
+    core = parent.surface("prompt:core")
+    assert core is not None
+    ops = [SurfaceOp(op="replace", surface_id="prompt:core", content=content, rationale="r")]
+    return _delta(ops, parent=parent, preconditions={"prompt:core": core.content_hash})
+
+
+# -- SurfaceOp shape -------------------------------------------------------------------------
+
+
+def test_op_shapes_are_validated_at_construction() -> None:
+    with pytest.raises(ValidationError, match="declare a kind"):
+        SurfaceOp(op="add", surface_id="skill:x", content="c", rationale="r")
+    with pytest.raises(ValidationError, match="must carry content"):
+        SurfaceOp(op="replace", surface_id="prompt:core", rationale="r")
+    with pytest.raises(ValidationError, match="never writes"):
+        SurfaceOp(op="remove", surface_id="skill:x", content="c", rationale="r")
+    with pytest.raises(ValidationError, match="no rationale"):
+        SurfaceOp(op="replace", surface_id="prompt:core", content="c", rationale="  ")
+
+
+def test_delta_requires_at_least_one_op() -> None:
+    parent = _parent()
+    with pytest.raises(ValidationError):
+        _delta([], parent=parent)
+
+
+# -- apply_delta: the atomic gate --------------------------------------------------------------
+
+
+def test_apply_replaces_content_and_records_child_hash() -> None:
+    parent = _parent()
+    delta = _replace_prompt(parent, "You are a careful agent.")
+    child = apply_delta(parent, delta, "child")
+    assert child.name == "child"
+    assert child.system_prompt() == "You are a careful agent."
+    assert delta.child_doc_hash == child.doc_hash
+    assert child.doc_hash != parent.doc_hash
+    # Untouched surfaces carry over identically.
+    assert child.surface(TOOL_POLICY_ID) == parent.surface(TOOL_POLICY_ID)
+
+
+def test_apply_add_and_remove() -> None:
+    parent = _parent()
+    old = parent.surface("skill:old-skill")
+    assert old is not None
+    new_skill = "---\nname: verify-work\ndescription: check results\n---\nRe-run checks."
+    ops = [
+        SurfaceOp(
+            op="add",
+            surface_id="skill:verify-work",
+            kind=SurfaceKind.SKILL,
+            content=new_skill,
+            rationale="r",
+        ),
+        SurfaceOp(op="remove", surface_id="skill:old-skill", rationale="r"),
+    ]
+    delta = _delta(ops, parent=parent, preconditions={"skill:old-skill": old.content_hash})
+    child = apply_delta(parent, delta, "child")
+    assert [s.name for s in child.skills()] == ["verify-work"]
+
+
+def test_apply_rejects_wrong_parent_hash() -> None:
+    parent = _parent()
+    delta = _replace_prompt(parent, "new prompt")
+    other = HarnessDoc.baseline("other")
+    with pytest.raises(ValueError, match="proposed against doc"):
+        apply_delta(other, delta, "child")
+
+
+def test_apply_rejects_precondition_mismatch() -> None:
+    parent = _parent()
+    ops = [SurfaceOp(op="replace", surface_id="prompt:core", content="c", rationale="r")]
+    stale = _delta(ops, parent=parent, preconditions={"prompt:core": "0" * 32})
+    with pytest.raises(ValueError, match="precondition mismatch"):
+        apply_delta(parent, stale, "child")
+    unknown = _delta(
+        [
+            SurfaceOp(
+                op="add", surface_id="skill:s", kind=SurfaceKind.SKILL, content="x", rationale="r"
+            )
+        ],
+        parent=parent,
+        preconditions={"skill:ghost": "0" * 32},
+    )
+    with pytest.raises(ValueError, match="unknown surface"):
+        apply_delta(parent, unknown, "child")
+
+
+def test_replace_and_remove_require_a_precondition() -> None:
+    parent = _parent()
+    naked = _delta(
+        [SurfaceOp(op="replace", surface_id="prompt:core", content="c", rationale="r")],
+        parent=parent,
+    )
+    with pytest.raises(ValueError, match="no precondition"):
+        apply_delta(parent, naked, "child")
+
+
+def test_apply_rejects_unknown_target_and_add_collision() -> None:
+    parent = _parent()
+    ghost = _delta(
+        [SurfaceOp(op="remove", surface_id="skill:ghost", rationale="r")],
+        parent=parent,
+        preconditions={"skill:ghost": "0" * 32},
+    )
+    with pytest.raises(ValueError, match="unknown surface"):
+        apply_delta(parent, ghost, "child")
+    collide = _delta(
+        [
+            SurfaceOp(
+                op="add",
+                surface_id="prompt:core",
+                kind=SurfaceKind.PROMPT,
+                content="c",
+                rationale="r",
+            )
+        ],
+        parent=parent,
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        apply_delta(parent, collide, "child")
+
+
+def test_apply_rejects_kind_mismatch_and_duplicate_targets() -> None:
+    parent = _parent()
+    core = parent.surface("prompt:core")
+    assert core is not None
+    wrong_kind = _delta(
+        [
+            SurfaceOp(
+                op="replace",
+                surface_id="prompt:core",
+                kind=SurfaceKind.SKILL,
+                content="c",
+                rationale="r",
+            )
+        ],
+        parent=parent,
+        preconditions={"prompt:core": core.content_hash},
+    )
+    with pytest.raises(ValueError, match="declares kind"):
+        apply_delta(parent, wrong_kind, "child")
+    doubled = _delta(
+        [
+            SurfaceOp(op="replace", surface_id="prompt:core", content="a", rationale="r"),
+            SurfaceOp(op="replace", surface_id="prompt:core", content="b", rationale="r"),
+        ],
+        parent=parent,
+        preconditions={"prompt:core": core.content_hash},
+    )
+    with pytest.raises(ValueError, match="multiple ops"):
+        apply_delta(parent, doubled, "child")
+
+
+def test_invalid_child_fails_whole_document_validation() -> None:
+    # Dropping `submit` from the tool policy must fail the child's construction gate.
+    parent = _parent()
+    policy = parent.surface(TOOL_POLICY_ID)
+    assert policy is not None
+    delta = _delta(
+        [SurfaceOp(op="replace", surface_id=TOOL_POLICY_ID, content="bash", rationale="r")],
+        parent=parent,
+        preconditions={TOOL_POLICY_ID: policy.content_hash},
+    )
+    with pytest.raises(ValueError, match="submit"):
+        apply_delta(parent, delta, "child")
+
+
+def test_replace_inherits_budget_unless_overridden() -> None:
+    core = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p", budget=100)
+    parent = HarnessDoc(name="parent", surfaces=[core])
+    delta = _delta(
+        [SurfaceOp(op="replace", surface_id="prompt:core", content="q", rationale="r")],
+        parent=parent,
+        preconditions={"prompt:core": core.content_hash},
+    )
+    child = apply_delta(parent, delta, "child")
+    replaced = child.surface("prompt:core")
+    assert replaced is not None and replaced.budget == 100
+    # A budget is enforced through replacement: over-budget content rejects the delta.
+    over = _delta(
+        [SurfaceOp(op="replace", surface_id="prompt:core", content="x" * 101, rationale="r")],
+        parent=parent,
+        preconditions={"prompt:core": core.content_hash},
+    )
+    with pytest.raises(ValueError, match="over its budget"):
+        apply_delta(parent, over, "child")
+
+
+def test_delta_id_is_deterministic_and_content_addressed() -> None:
+    parent = _parent()
+    ops_a = [SurfaceOp(op="replace", surface_id="prompt:core", content="a", rationale="r")]
+    ops_b = [SurfaceOp(op="replace", surface_id="prompt:core", content="b", rationale="r")]
+    assert compute_delta_id(parent.doc_hash, ops_a) == compute_delta_id(parent.doc_hash, ops_a)
+    assert compute_delta_id(parent.doc_hash, ops_a) != compute_delta_id(parent.doc_hash, ops_b)
+    assert compute_delta_id(parent.doc_hash, ops_a) != compute_delta_id("other", ops_a)

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -29,9 +29,14 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from wmh.harness.code_runtime import (
+    DEFAULT_RUNTIME_CODE,
+    CodeRuntime,
+    compile_harness_code,
+)
 from wmh.harness.runtime import DEFAULT_MAX_TURNS, DEFAULT_SYSTEM_PROMPT, AgentRuntime
 from wmh.harness.skills import Skill, SkillLibrary
-from wmh.harness.tools import DEFAULT_TOOLS, resolve_tools
+from wmh.harness.tools import DEFAULT_TOOLS, render_tools, resolve_tools
 from wmh.providers.base import Provider
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -41,6 +46,7 @@ _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 TOOL_POLICY_ID = "tool_policy:main"
 MAX_TURNS_ID = "param:max-turns"
 TEMPERATURE_ID = "param:temperature"
+CODE_RUNTIME_ID = "code:runtime"
 
 DEFAULT_TEMPERATURE = 0.7
 
@@ -50,6 +56,7 @@ class SurfaceKind(StrEnum):
     SKILL = "skill"  # one skill: frontmatter (name, description) + body
     TOOL_POLICY = "tool_policy"  # the tool list, one tool name per line
     PARAM = "param"  # a scalar loop knob, serialized as its string form
+    CODE = "code"  # the agent loop itself: a module defining `run(kit)` (see code_runtime)
 
 
 class Surface(BaseModel):
@@ -117,6 +124,13 @@ class HarnessDoc(BaseModel):
                         f"skill surface {surface.id!r} declares frontmatter name "
                         f"{skill.name!r}; the slug and frontmatter name must match"
                     )
+            elif surface.kind is SurfaceKind.CODE:
+                if surface.id != CODE_RUNTIME_ID:
+                    raise ValueError(
+                        f"code surface must be {CODE_RUNTIME_ID!r} (got {surface.id!r}); "
+                        "the runtime is a singleton"
+                    )
+                compile_harness_code(surface.content)
         return self
 
     # -- surface access ---------------------------------------------------------------------
@@ -180,16 +194,40 @@ class HarnessDoc(BaseModel):
             Skill.from_markdown(s.content) for s in self.surfaces if s.kind is SurfaceKind.SKILL
         ]
 
-    def runtime(self, provider: Provider) -> AgentRuntime:
-        """The configured agent runtime this document describes."""
+    def runtime(self, provider: Provider) -> AgentRuntime | CodeRuntime:
+        """The configured agent runtime this document describes.
+
+        With a `code:runtime` surface the harness's own program drives episodes (budgeted and
+        kit-recorded); otherwise the fixed baseline loop runs. Both expose the same
+        `run(task_id, instruction, environment) -> RunResult` shape closed-loop eval drives.
+        """
+        code = self.surface(CODE_RUNTIME_ID)
+        skills = SkillLibrary(self.skills())
+        if code is not None:
+            return CodeRuntime(
+                provider,
+                code=code.content,
+                tools=resolve_tools(self.tools()),
+                temperature=self.temperature(),
+                skills=skills,
+                system_prompt=self._assembled_prompt(skills),
+            )
         return AgentRuntime(
             provider,
             system_prompt=self.system_prompt(),
             tools=self.tools(),
             max_turns=self.max_turns(),
             temperature=self.temperature(),
-            skills=SkillLibrary(self.skills()),
+            skills=skills,
         )
+
+    def _assembled_prompt(self, skills: SkillLibrary) -> str:
+        """The full system prompt handed to harness code: sections + tools + skills index."""
+        prompt = f"{self.system_prompt()}\n\n## Tools\n{render_tools(resolve_tools(self.tools()))}"
+        index = skills.render_index()
+        if index:
+            prompt += f"\n\n## Your skills (read a body with read_skill)\n{index}"
+        return prompt
 
     @classmethod
     def baseline(cls, name: str = "baseline") -> HarnessDoc:
@@ -209,6 +247,17 @@ class HarnessDoc(BaseModel):
                 ),
             ],
         )
+
+
+def code_baseline(name: str = "baseline") -> HarnessDoc:
+    """The baseline harness with its loop as an editable `code:runtime` surface.
+
+    Behaviorally equivalent to `HarnessDoc.baseline()` — same prompt, tools, and one-call-per-turn
+    loop — but the loop is data, so `wmh harness create` can propose structural changes to it.
+    """
+    base = HarnessDoc.baseline(name)
+    code = Surface(id=CODE_RUNTIME_ID, kind=SurfaceKind.CODE, content=DEFAULT_RUNTIME_CODE)
+    return HarnessDoc(name=name, surfaces=[*base.surfaces, code])
 
 
 def _digest(text: str) -> str:

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -1,0 +1,199 @@
+"""The delta proposer: the meta-agent reads a harness document and emits one `HarnessDelta`.
+
+The proposer is shown the parent's surfaces — each with its id, kind, content hash, and content —
+plus the failure evidence for one clustered mechanism, and replies with the delta's ops,
+preconditions, and expected effect as JSON. The trigger, lineage, and identity fields are filled by
+the caller from ground truth (the cluster and the parent's hashes), never trusted from the model.
+
+Preconditions are copy-not-guess: the prompt prints every surface's current hash, and the proposer
+must echo the hash of each surface it replaces or removes. `apply_delta` then rejects atomically on
+any mismatch, so a proposal is only ever applied to exactly the document it was drafted against.
+
+An unusable reply (no JSON, wrong shape) returns None — the search counts it as a skipped
+iteration; a flaky meta-model costs budget, not the run.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ValidationError
+
+from wmh.core.parsing import extract_json_object
+from wmh.evals.closed_loop import ClosedLoopReport
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.delta import FailureSignature, HarnessDelta, SurfaceOp, compute_delta_id
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
+from wmh.providers.base import Message, Provider
+
+MUTATE_SYSTEM = f"""You are a meta-agent improving an agent harness — a document of named \
+SURFACES that configure an agent. You do NOT solve the agent's tasks yourself. You are shown the \
+harness's current surfaces (each with its id, kind, and content hash) and evidence of ONE failure \
+mechanism its agent exhibits. Propose exactly ONE focused change, grounded in that evidence. Do \
+not shotgun many unrelated changes at once.
+
+Choose the lever that can actually EXPRESS the fix:
+- Structural/behavioral mechanisms (the agent claims without acting, loses context, wastes turns,
+  never verifies, mishandles errors) -> edit `code:runtime`, the agent loop program. This is the
+  strongest lever: loops, verification passes, retries, observation truncation, context
+  compaction, and answer checking are all code.
+- A missing technique on specific tasks -> ADD a `skill:<slug>` teaching it.
+- The agent misusing, missing, or not needing a tool -> edit `tool_policy:main`.
+- Erratic sampling or turn caps -> adjust a `param:*`.
+- Replace a `prompt:*` surface only for wording-level problems; prompt rewrites are the weakest
+  lever and most often regress tasks that currently pass.
+
+The `code:runtime` contract — a Python module defining `run(kit) -> str` (the final answer):
+- `kit.instruction` (the task), `kit.system_prompt` (the assembled prompt), `kit.task_id`.
+- `kit.complete(system, messages, temperature=..., max_tokens=...) -> str` — one LLM call;
+  messages are `("user"|"assistant", content)` tuples. BUDGETED (default 40 calls/episode).
+- `kit.execute(tool, arguments) -> Observation` (`.content`, `.is_error`) — one environment
+  action, validated against the tool policy. BUDGETED (default 40/episode). Every call is
+  recorded to the transcript the judge scores; work not done through `kit.execute` does not
+  exist as far as grading is concerned.
+- `kit.parse_tool_call(text) -> ToolCall | None` (`.tool`, `.arguments`), `kit.tools_text()`,
+  `kit.skills_index()`, `kit.read_skill(name)`.
+- Exceptions and exhausted budgets fail the episode (partial transcript kept). The module must
+  be self-contained (stdlib imports only) and deterministic apart from LLM calls.
+
+Surface kinds:
+- prompt — a section of the agent's system prompt (all prompt surfaces are joined in id order).
+- tool_policy — the tool list, one tool name per line. Valid names: \
+{", ".join(sorted(TOOL_REGISTRY))}. The `{SUBMIT.name}` tool is REQUIRED (without it a run \
+cannot end).
+- param — a scalar loop knob: `param:max-turns` (int >= 1), `param:temperature` (float in [0, 2]).
+- code — the agent loop program, singleton `code:runtime` (contract above). Must compile and
+  define `run`.
+- skill — one reusable technique, shaped as:
+  ---
+  name: <kebab-slug matching the surface id>
+  description: <one-line trigger description>
+  ---
+  <skill body markdown>
+
+Reply with ONLY a JSON object, no prose:
+{{"expected_effect": "<falsifiable prediction: what should change if this works>",
+ "preconditions": {{"<surface_id>": "<that surface's content hash, copied from above>"}},
+ "ops": [{{"op": "add" | "replace" | "remove",
+          "surface_id": "<kind>:<kebab-slug>",
+          "kind": "<required on add>",
+          "content": "<the FULL new content (omit on remove)>",
+          "rationale": "<why this op should help>"}}]}}
+
+Rules:
+- Every surface you replace or remove MUST appear in `preconditions` with its hash copied verbatim.
+- `content` is the complete new surface content, not a diff.
+- An `add` uses a fresh surface id of the right kind (e.g. a new `skill:<slug>` or a new
+  `prompt:<slug>` section)."""
+
+
+class _RawDelta(BaseModel):
+    """What the meta-agent is trusted to provide — everything else is filled from ground truth."""
+
+    expected_effect: str
+    preconditions: dict[str, str] = Field(default_factory=dict)
+    ops: list[SurfaceOp] = Field(min_length=1)
+
+
+def propose_delta(
+    parent: HarnessDoc,
+    trigger: FailureSignature,
+    evidence: str,
+    provider: Provider,
+    *,
+    history: list[HarnessDelta] | None = None,
+) -> HarnessDelta | None:
+    """Ask the meta-agent for one delta against `parent`, or None if the reply is unusable.
+
+    `history` is the run's previously judged deltas (most recent last): their ops and gate
+    verdicts are shown to the proposer so it iterates instead of re-proposing rejected ideas.
+    """
+    user = _build_prompt(parent, trigger, evidence, history or [])
+    completion = provider.complete(
+        MUTATE_SYSTEM,
+        [Message(role="user", content=user)],
+        temperature=0.9,
+        max_tokens=4096,
+    )
+    raw = extract_json_object(completion.text)
+    if raw is None:
+        return None
+    try:
+        proposed = _RawDelta.model_validate_json(raw)
+    except ValidationError:
+        return None
+    return HarnessDelta(
+        delta_id=compute_delta_id(parent.doc_hash, proposed.ops),
+        parent_doc_hash=parent.doc_hash,
+        trigger=trigger,
+        preconditions=proposed.preconditions,
+        ops=proposed.ops,
+        expected_effect=proposed.expected_effect,
+    )
+
+
+def render_evidence(
+    trigger: FailureSignature, report: ClosedLoopReport, tasks: list[TaskSpec]
+) -> str:
+    """Render one failure cluster (instructions + unmet assertions) as reflection fuel.
+
+    A trigger with no failing tasks (the all-pass case) gets an explicit "nothing failed" prompt
+    asking for a generalization/efficiency improvement — not a fake failure section that would
+    send the meta-agent chasing nonexistent problems.
+    """
+    if not trigger.task_ids:
+        return (
+            "The harness passed every task on every pass. There are no failures to fix. "
+            "Propose a change that should GENERALIZE or ECONOMIZE: a tighter, more transferable "
+            "prompt surface; a lower param:max-turns if runs finish early; or a reusable skill "
+            "distilled from what worked."
+        )
+    by_id = {task.task_id: task for task in tasks}
+    sections = [f"Failure mechanism: {trigger.mechanism}"]
+    for task_id in trigger.task_ids:
+        task = by_id.get(task_id)
+        outcome = report.per_task.get(task_id)
+        instruction = task.instruction if task is not None else "(unknown task)"
+        rate = f"{outcome.success_rate:.2f} over {outcome.passes} passes" if outcome else "?"
+        sections.append(f"### Task {task_id} (success_rate={rate})\nInstruction: {instruction}")
+    unmet = "\n".join(f"- {a}" for a in trigger.unmet_assertions)
+    sections.append(f"Unmet assertions across the cluster:\n{unmet or '- (none recorded)'}")
+    return "\n\n".join(sections)
+
+
+def render_history(history: list[HarnessDelta], limit: int = 5) -> str:
+    """The last `limit` judged deltas as lessons: what was tried, and exactly how it fared."""
+    lines: list[str] = []
+    for delta in history[-limit:]:
+        ops = ", ".join(f"{op.op} {op.surface_id}" for op in delta.ops)
+        verdict = delta.verdict.reason if delta.verdict is not None else "(never evaluated)"
+        rationale = delta.ops[0].rationale if delta.ops else ""
+        lines.append(f"- [{ops}] rationale: {rationale[:120]}\n  outcome: {verdict}")
+    return "\n".join(lines)
+
+
+def _build_prompt(
+    parent: HarnessDoc, trigger: FailureSignature, evidence: str, history: list[HarnessDelta]
+) -> str:
+    """The meta-agent's user prompt: every parent surface with its identity, then the evidence."""
+    blocks: list[str] = []
+    for surface in parent.surfaces:
+        budget = f", budget={surface.budget}" if surface.budget is not None else ""
+        blocks.append(
+            f"### {surface.id} (kind={surface.kind.value}, "
+            f"hash={surface.content_hash}{budget})\n```\n{surface.content}\n```"
+        )
+    surfaces_block = "\n\n".join(blocks)
+    history_block = (
+        f"## Previous attempts this run (do NOT repeat failed ideas — iterate or change lever)"
+        f"\n\n{render_history(history)}\n\n"
+        if history
+        else ""
+    )
+    return (
+        f"## Current harness surfaces ({parent.name}, doc_hash={parent.doc_hash})\n\n"
+        f"{surfaces_block}\n\n"
+        f"## Failure evidence\n\n{evidence}\n\n"
+        f"{history_block}"
+        "Propose ONE focused change as the JSON object described in your instructions. "
+        "Remember: copy the hash of every surface you replace or remove into `preconditions`."
+    )

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -1,0 +1,141 @@
+"""Proposer tests: scripted meta-agent replies, prompt contents, and evidence rendering."""
+
+from __future__ import annotations
+
+import json
+
+from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.delta import FailureSignature
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.mutate import propose_delta, render_evidence
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+
+
+class ScriptedProvider:
+    """Returns one canned completion; records every call for assertions."""
+
+    def __init__(self, text: str) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+        self._text = text
+        self.systems: list[str] = []
+        self.users: list[str] = []
+        self.temperatures: list[float] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        self.systems.append(system)
+        self.users.append(messages[-1].content)
+        self.temperatures.append(temperature)
+        return Completion(text=self._text)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201 - test fake never calls it
+        raise NotImplementedError
+
+
+def _trigger() -> FailureSignature:
+    return FailureSignature(
+        mechanism="the file was created",
+        task_ids=["t1"],
+        unmet_assertions=["the file was created"],
+    )
+
+
+def _reply(parent: HarnessDoc) -> str:
+    core = parent.surface("prompt:core")
+    assert core is not None
+    body = {
+        "expected_effect": "t1 flips to pass",
+        "preconditions": {"prompt:core": core.content_hash},
+        "ops": [
+            {
+                "op": "replace",
+                "surface_id": "prompt:core",
+                "content": "You are a careful agent.",
+                "rationale": "verify before submitting",
+            }
+        ],
+    }
+    return f"Here is my change:\n{json.dumps(body)}"
+
+
+def test_propose_delta_parses_scripted_reply_and_fills_ground_truth() -> None:
+    parent = HarnessDoc.baseline("parent")
+    provider = ScriptedProvider(_reply(parent))
+    delta = propose_delta(parent, _trigger(), "the agent never verified its work", provider)
+    assert delta is not None
+    assert delta.parent_doc_hash == parent.doc_hash
+    assert delta.trigger == _trigger()  # from the caller, never trusted from the model
+    assert delta.expected_effect == "t1 flips to pass"
+    assert [op.surface_id for op in delta.ops] == ["prompt:core"]
+    assert delta.verdict is None and delta.child_doc_hash is None
+    assert provider.temperatures == [0.9]
+
+
+def test_prompt_shows_surfaces_with_hashes_and_evidence() -> None:
+    parent = HarnessDoc.baseline("parent")
+    core = parent.surface("prompt:core")
+    assert core is not None
+    provider = ScriptedProvider(_reply(parent))
+    propose_delta(parent, _trigger(), "the agent never verified its work", provider)
+    user = provider.users[0]
+    # Preconditions are copy-not-guess: every surface's id and hash is printed.
+    for surface in parent.surfaces:
+        assert surface.id in user
+        assert surface.content_hash in user
+    assert parent.doc_hash in user
+    assert "the agent never verified its work" in user
+    assert "meta-agent improving an agent harness" in provider.systems[0]
+
+
+def test_propose_delta_returns_none_on_garbage() -> None:
+    parent = HarnessDoc.baseline("parent")
+    trigger = _trigger()
+    assert propose_delta(parent, trigger, "e", ScriptedProvider("no json at all")) is None
+    # JSON that doesn't fit the delta shape is also rejected, not coerced.
+    assert propose_delta(parent, trigger, "e", ScriptedProvider('{"foo": 1}')) is None
+    # A shape-valid delta with a malformed op (add without kind) is rejected at parse time.
+    no_kind = json.dumps(
+        {
+            "expected_effect": "x",
+            "preconditions": {},
+            "ops": [{"op": "add", "surface_id": "skill:s", "content": "c", "rationale": "r"}],
+        }
+    )
+    assert propose_delta(parent, trigger, "e", ScriptedProvider(no_kind)) is None
+
+
+def test_render_evidence_shows_cluster_tasks_and_unmet_assertions() -> None:
+    report = ClosedLoopReport(
+        label="parent",
+        per_task={
+            "t1": TaskOutcome(task_id="t1", success_rate=0.0, mean_fraction=0.0, passes=2),
+            "t2": TaskOutcome(task_id="t2", success_rate=1.0, mean_fraction=1.0, passes=2),
+        },
+    )
+    tasks = [
+        TaskSpec(task_id="t1", instruction="create the file", gold=["the file was created"]),
+        TaskSpec(task_id="t2", instruction="easy one", gold=["done"]),
+    ]
+    evidence = render_evidence(_trigger(), report, tasks)
+    assert "the file was created" in evidence
+    assert "create the file" in evidence
+    assert "0.00 over 2 passes" in evidence
+    assert "easy one" not in evidence  # the passing task is not reflection fuel
+
+
+def test_all_pass_evidence_asks_for_generalization() -> None:
+    trigger = FailureSignature(mechanism="none: all tasks pass")
+    report = ClosedLoopReport(label="x", success_rate=1.0)
+    evidence = render_evidence(trigger, report, [TaskSpec(task_id="t", instruction="do it")])
+    assert "passed every task" in evidence
+    assert "GENERALIZE" in evidence

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -12,6 +12,7 @@ the same types the rest of the harness uses.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
@@ -52,10 +53,23 @@ _NUDGE = (
 )
 
 
+@runtime_checkable
+class Runtime(Protocol):
+    """What closed-loop eval drives: any object that can run one episode against an environment.
+
+    `AgentRuntime` (the fixed loop) and `CodeRuntime` (the harness's own program) both satisfy
+    this; evaluation code depends on the shape, never the implementation.
+    """
+
+    def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult: ...
+
+
 class StopReason(StrEnum):
     SUBMITTED = "submitted"  # the agent called submit
     MAX_TURNS = "max_turns"  # hit the turn cap without submitting
     NO_ACTION = "no_action"  # the agent produced no parseable tool call
+    ERROR = "error"  # harness code raised (CodeRuntime episodes only)
+    BUDGET = "budget"  # harness code exhausted an episode budget (CodeRuntime episodes only)
 
 
 class RunResult(BaseModel):

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -27,6 +27,7 @@ import tomli_w
 
 from wmh.config.store import validate_name
 from wmh.harness.doc import (
+    CODE_RUNTIME_ID,
     MAX_TURNS_ID,
     TEMPERATURE_ID,
     TOOL_POLICY_ID,
@@ -42,6 +43,7 @@ CHAMPION_ALIAS = "champion"
 _DOC_FILE = "doc.json"
 _SYSTEM_FILE = "SYSTEM.md"
 _CONFIG_FILE = "config.toml"
+_RUNTIME_FILE = "runtime.py"
 _SKILLS_DIR = "skills"
 _ALIASES_FILE = "aliases.toml"
 
@@ -168,6 +170,9 @@ def _render(doc: HarnessDoc) -> dict[str, str]:
     }
     for skill in doc.skills():
         files[f"{_SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
+    code = doc.surface(CODE_RUNTIME_ID)
+    if code is not None:
+        files[_RUNTIME_FILE] = code.content
     return files
 
 
@@ -208,6 +213,15 @@ def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
                     id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(config["temperature"])
                 )
             )
+    runtime_path = directory / _RUNTIME_FILE
+    if runtime_path.exists():
+        surfaces.append(
+            Surface(
+                id=CODE_RUNTIME_ID,
+                kind=SurfaceKind.CODE,
+                content=runtime_path.read_text(encoding="utf-8"),
+            )
+        )
     skills_dir = directory / _SKILLS_DIR
     if skills_dir.exists():
         for path in sorted(skills_dir.glob("*.md")):

--- a/wmh/harness/store_test.py
+++ b/wmh/harness/store_test.py
@@ -111,3 +111,18 @@ def test_skill_surfaces_render_and_reload(tmp_path: Path) -> None:
     reloaded = store.load("h")
     assert reloaded == saved
     assert [s.name for s in reloaded.skills()] == ["count-words"]
+
+
+def test_code_surface_round_trips_through_render_and_parse(tmp_path) -> None:  # noqa: ANN001
+    from wmh.harness.doc import CODE_RUNTIME_ID, code_baseline
+
+    store = HarnessStore(tmp_path)
+    saved = store.save_version(code_baseline("coded"))
+    exported = store.dir_for("coded") / f"v{saved.version}" / "runtime.py"
+    assert exported.exists()
+    # Hand-authored dirs (no doc.json) recover the code surface from the rendered file.
+    (store.dir_for("coded") / f"v{saved.version}" / "doc.json").unlink()
+    loaded = store.load("coded")
+    code = loaded.surface(CODE_RUNTIME_ID)
+    assert code is not None
+    assert code.content == exported.read_text(encoding="utf-8")


### PR DESCRIPTION
Stacked on #112. Last of three PRs building the self-improving harness system.

## What

`wmh harness create` searches harness-space by **inverting the world model**: an LLM meta-agent
proposes updates, each applied child is scored closed-loop against the world model (k=3 passes per
task) and gated on non-regression. The champion is saved as a new immutable version behind the
`champion` alias.

The core of this PR is the update representation (`docs/harness_delta.md`): **the update object IS
the search space**, so it is typed, guarded, and audited rather than a file edit:

- `wmh/harness/delta.py` — `HarnessDelta`: a machine-clustered `FailureSignature` trigger;
  `preconditions` (surface_id → expected content hash — ANY mismatch rejects the whole delta
  atomically, before eval spend; every replace/remove target must have one); identity-keyed
  add/replace/remove `SurfaceOp`s, each carrying its own rationale; a falsifiable
  `expected_effect`; and the `GateRecord` verdict written back onto the delta.
- `wmh/harness/mutate.py` — the proposer. The prompt prints every surface with its id/kind/hash so
  preconditions are copy-not-guess; trigger, lineage, and identity are filled from ground truth,
  never trusted from the model. Unusable replies are counted skips.
- `wmh/harness/create.py` — deterministic failure clustering (connected components over shared
  unmet gold assertions; no LLM, no entropy), stepping-stone parent selection over the accepted
  pool, and the **two-tier gate**: regression-suite non-regression vs champion → full-split
  never-worse-than-best → optional held-out non-regression (`--holdout`). Ties pass; newly-passing
  tasks promote into the suite so wins are locked in. The archive keeps every audited delta —
  accepted, gate-rejected, or invalid-before-eval — and docs are reconstructable by folding
  accepted deltas from the seed.
- CLI: `wmh harness create NAME --tasks tasks.jsonl [--holdout h.jsonl] [--seed name@ref]
  [--archive out.json]`, interactive wizard at a TTY, cost preview before spending.

## Why this shape

An earlier file-edit draft hit exactly the failure modes the doc predicts (silent no-op children
costing full evals; filename/frontmatter identity drift). The delta envelope makes those
impossible by construction and makes the archive queryable: which (trigger mechanism × op kind)
pairs actually help — the beginning of the meta-agent learning which kinds of edits work.

## Tests

All offline (one fake provider plays agent/world-model/judge/meta-agent). `delta_test.py` covers
op shapes and every atomic-application rejection; `create_test.py` covers accept/reject/skip/audit
paths, suite promotion, holdout-tier rejection of a full-split win, archive reconstruction, and
deterministic clustering. Full gate green: ruff, ty, pytest (595 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)