### PR TITLE
feat(ingest): add Weights & Biases Weave adapter

### DIFF
--- a/examples/ingest/weave_to_wmh.sh
+++ b/examples/ingest/weave_to_wmh.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Ingest Weights & Biases Weave traces into the wmh build pipeline.
+#
+# Weave records agent executions as "Calls". Export them from the Weave UI
+# (JSON or JSONL) or pull live via the service API.
+#
+# Usage (file):
+#   wmh ingest run --source weave --file weave_calls.json
+#   wmh ingest run --source weave --file weave_calls.jsonl
+#
+# Usage (live pull — requires WANDB_API_KEY):
+#   export WANDB_API_KEY="your-wandb-api-key"
+#   wmh ingest run --source weave --project "myteam/myproject" --limit 500
+#
+# Then build the world model:
+#   wmh build --source weave --file weave_calls.json
+
+set -euo pipefail
+
+FILE="${1:?Usage: $0 <weave-export.json|.jsonl>}"
+
+echo "→ Ingesting Weave traces from: $FILE"
+wmh ingest run --source weave --file "$FILE"
+
+echo "→ Building world model from ingested traces..."
+wmh build --source weave --file "$FILE"
+
+echo "✓ Done. Run 'wmh serve' to start the world model server."

--- a/wmh/ingest/__init__.py
+++ b/wmh/ingest/__init__.py
@@ -9,8 +9,9 @@ scaffolding, so adding a new source is transport + attribute-mapping, not a rewr
 Bundled adapters:
   - `otel-genai`  : OTLP-JSON spans following the OTel GenAI semantic conventions (file or pull).
   - `chat-json`   : recorded OpenAI-style chat/tool-call conversations (file).
-Provider adapters (Braintrust, Phoenix/Arize, Langfuse, LangSmith) register when their module is
-imported; their heavy SDKs are optional extras, imported lazily inside the adapter.
+Provider adapters (Braintrust, Langfuse, LangSmith, Mastra, Phoenix/Arize, PostHog,
+Weave) register when their module is imported; their heavy SDKs are optional extras,
+imported lazily inside the adapter.
 """
 
 # Import for the registration side effect so `get_adapter(...)` works on package import. The
@@ -25,6 +26,7 @@ from wmh.ingest import messages as messages  # noqa: F401
 from wmh.ingest import otel_genai as otel_genai  # noqa: F401
 from wmh.ingest import phoenix as phoenix  # noqa: F401
 from wmh.ingest import posthog as posthog  # noqa: F401
+from wmh.ingest import weave as weave  # noqa: F401
 from wmh.ingest.adapter import (
     TraceAdapter,
     VendorPull,

--- a/wmh/ingest/weave.py
+++ b/wmh/ingest/weave.py
@@ -1,0 +1,382 @@
+"""Weights & Biases Weave adapter — Weave Call objects into normalized ``Trace``s.
+
+Weave (https://wandb.ai/site/weave) records agent executions as **Calls**, not OTLP spans.
+Each Call represents one invocation of a tracked **Op** and carries:
+
+  - ``id`` — unique call identifier (used as ``span_id``).
+  - ``trace_id`` — groups calls belonging to the same agent run.
+  - ``parent_id`` — parent call id (``None`` for root calls), forming a call tree.
+  - ``op_name`` — a ``weave:///entity/project/op/<name>:<hash>`` URI *or* a plain function name.
+  - ``started_at`` / ``ended_at`` — ISO-8601 timestamps.
+  - ``inputs`` — the arguments passed to the op (a JSON object).
+  - ``output`` — the return value (a string, object, or ``None``).
+  - ``exception`` — error message when the call failed (``None`` on success).
+  - ``summary`` — aggregated metadata (token counts, latency) added by Weave post-call.
+  - ``attributes`` — custom user-attached metadata.
+
+Classification (LLM vs tool):
+
+  Weave does not tag calls with a semantic convention like OpenInference ``span.kind``.
+  Instead, the adapter classifies by **op name heuristics**: ops whose name contains an
+  LLM-related marker (``chat``, ``complete``, ``generate``, ``predict``, ``llm``,
+  ``openai``, ``anthropic``) are treated as LLM/agent calls (Action spans); everything
+  else with a non-empty ``output`` is treated as a tool execution (Observation spans).
+  Root calls with children are treated as agent orchestration (LLM).
+
+  The adapter emits ``SpanRecord``s with OTel GenAI attribute keys so the shared
+  normalizer (``wmh.ingest.normalize``) pairs them into Steps. ``inputs`` map to tool
+  arguments; ``output`` maps to ``gen_ai.tool.message`` (tool) or ``gen_ai.completion``
+  (LLM).
+
+Accepted file shapes (``from_file``): a single Call object, a JSON array of Calls, a
+``calls/stream_query`` response wrapper (``[{...}, {..}]`` JSONL from the streaming endpoint), or
+JSONL (one Call per line). Grouping is by ``trace_id``.
+
+Pull: live pull via the Weave service API is implemented in ``_pull_payloads``; it queries
+``/calls/stream_query`` with a project id. Export to a file and use ``from_file`` if you prefer
+offline ingestion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.ingest.adapter import VendorPull, register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
+
+# Weave service API base. Configurable for self-hosted / dedicated instances.
+_API_HOST = os.environ.get("WEAVE_API_HOST", "https://trace.wandb.ai").rstrip("/")
+_API_KEY_ENV = "WANDB_API_KEY"
+
+# Op-name substrings that mark a call as an LLM/agent invocation (case-insensitive).
+_LLM_MARKERS = frozenset(
+    {
+        "chat",
+        "complete",
+        "completion",
+        "generate",
+        "predict",
+        "llm",
+        "openai",
+        "anthropic",
+        "bedrock",
+        "invoke_model",
+        "create_message",
+    }
+)
+
+
+def _as_str(value: JsonValue) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _extract_op_name(raw: JsonValue) -> str:
+    """Extract the human-readable op name from a Weave op URI or plain string.
+
+    Weave op URIs look like ``weave:///entity/project/op/my_func:abc123``; we want ``my_func``.
+    Plain function names (``my_func``) pass through unchanged.
+    """
+    if not isinstance(raw, str) or not raw:
+        return ""
+    # Strip the weave URI prefix and hash suffix if present.
+    name = raw
+    if "/op/" in name:
+        name = name.split("/op/")[-1]
+    if ":" in name:
+        name = name.rsplit(":", 1)[0]
+    return name
+
+
+def _is_llm_call(op_name: str) -> bool:
+    """Heuristic: does this op name look like an LLM/agent call?"""
+    lower = op_name.lower()
+    return any(marker in lower for marker in _LLM_MARKERS)
+
+
+def _call_trace_id(call: JsonObject) -> str:
+    """The trace id grouping this call with its siblings."""
+    for key in ("trace_id", "traceId"):
+        value = call.get(key)
+        if isinstance(value, str) and value:
+            return value
+    # Fallback: root calls without a trace_id use their own call id.
+    call_id = call.get("id")
+    return call_id if isinstance(call_id, str) and call_id else ""
+
+
+def _call_id(call: JsonObject) -> str:
+    """The unique call identifier (used as span_id)."""
+    cid = call.get("id")
+    return cid if isinstance(cid, str) else ""
+
+
+def _call_parent_id(call: JsonObject) -> str:
+    """The parent call id (empty string for root calls)."""
+    pid = call.get("parent_id")
+    return pid if isinstance(pid, str) else ""
+
+
+def _call_inputs(call: JsonObject) -> JsonObject:
+    """The call's input arguments as a dict."""
+    inputs = call.get("inputs")
+    return inputs if isinstance(inputs, dict) else {}
+
+
+def _call_output(call: JsonObject) -> str:
+    """The call's output rendered as a string."""
+    output = call.get("output")
+    if output is None:
+        return ""
+    return output if isinstance(output, str) else as_text(output)
+
+
+def _call_exception(call: JsonObject) -> str | None:
+    """The exception message if the call failed, else None."""
+    exc = call.get("exception")
+    if isinstance(exc, str) and exc.strip():
+        return exc.strip()
+    return None
+
+
+def _call_is_error(call: JsonObject) -> bool:
+    """True when the call ended with an error (exception present or status flagged)."""
+    if _call_exception(call) is not None:
+        return True
+    status = call.get("status")
+    if isinstance(status, str):
+        return status.lower() in ("error", "failed")
+    return False
+
+
+def _user_message_text(inputs: JsonObject) -> str | None:
+    """Extract the first user message from an LLM call's inputs (OpenAI-style messages list)."""
+    messages = inputs.get("messages")
+    if not isinstance(messages, list):
+        return None
+    for msg in messages:
+        if isinstance(msg, dict) and _as_str(msg.get("role")).lower() in {"user", "human"}:
+            content = msg.get("content")
+            if content is not None:
+                return as_text(content)
+    return None
+
+
+def _weave_spans(call: JsonObject, ordinal: int) -> list[SpanRecord]:
+    """Map one Weave Call to one or more ``SpanRecord``s.
+
+    An LLM call with multiple parallel tool calls (increasingly common with
+    OpenAI-style parallel function calling) emits one action ``SpanRecord``
+    per tool call so the normalizer can pair each with its corresponding
+    child tool-execution Call. Returns an empty list if the call has no
+    trace id.
+    """
+    trace_id = _call_trace_id(call)
+    if not trace_id:
+        return []
+
+    op_name = _extract_op_name(call.get("op_name"))
+    is_llm = _is_llm_call(op_name)
+    inputs = _call_inputs(call)
+    output = _call_output(call)
+    error = _call_is_error(call)
+    exception = _call_exception(call)
+    call_id = _call_id(call) or f"weave-{ordinal:08d}"
+    parent_id = _call_parent_id(call)
+    start = iso_to_ordinal(call.get("started_at"), ordinal)
+    end = iso_to_ordinal(call.get("ended_at"), ordinal)
+
+    if not is_llm:
+        attrs: JsonObject = {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": op_name or call.get("display_name", ""),
+        }
+        if inputs:
+            attrs["gen_ai.tool.call.arguments"] = as_text(inputs)
+        attrs["gen_ai.tool.message"] = exception if error and exception else output
+        return [
+            SpanRecord(
+                trace_id=trace_id,
+                span_id=call_id,
+                parent_span_id=parent_id,
+                name="execute_tool",
+                start_nano=start,
+                end_nano=end,
+                attributes=attrs,
+                status_error=error,
+            )
+        ]
+
+    # LLM call: check for tool calls in the output.
+    tool_calls = _extract_tool_calls(call.get("output"))
+    task = _user_message_text(inputs)
+
+    if not tool_calls:
+        # Plain completion (no tool calls).
+        attrs = {"gen_ai.operation.name": "chat"}
+        attrs["gen_ai.completion"] = exception if error and exception else output
+        if task is not None:
+            attrs["gen_ai.prompt"] = task
+        return [
+            SpanRecord(
+                trace_id=trace_id,
+                span_id=call_id,
+                parent_span_id=parent_id,
+                name="chat",
+                start_nano=start,
+                end_nano=end,
+                attributes=attrs,
+                status_error=error,
+            )
+        ]
+
+    if len(tool_calls) == 1:
+        # Single tool call: emit one action span for the normalizer
+        # to pair with the child tool Call's execution span.
+        tc_name, tc_args = tool_calls[0]
+        attrs = {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.tool.name": tc_name,
+            "gen_ai.tool.call.arguments": tc_args,
+        }
+        if task is not None:
+            attrs["gen_ai.prompt"] = task
+        return [
+            SpanRecord(
+                trace_id=trace_id,
+                span_id=call_id,
+                parent_span_id=parent_id,
+                name="chat",
+                start_nano=start,
+                end_nano=end,
+                attributes=attrs,
+                status_error=error,
+            )
+        ]
+
+    # Multiple parallel tool calls: do NOT emit action spans from the
+    # LLM call. Each child tool Call is processed separately and
+    # produces a complete Step (action from op_name + inputs,
+    # observation from output). Emitting LLM-side action spans here
+    # would create an action,action,...,tool,tool ordering that the
+    # normalizer cannot pair correctly, leading to mismatched
+    # action/observation Steps.
+    return []
+
+
+def _extract_tool_calls(output: JsonValue) -> list[tuple[str, str]]:
+    """Extract (name, arguments_json) pairs from an LLM call's output."""
+    calls: list[tuple[str, str]] = []
+    if not isinstance(output, dict):
+        return calls
+    # OpenAI-style: output has a choices list or a direct tool_calls list.
+    tool_calls = output.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        choices = output.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                if isinstance(choice, dict):
+                    message = choice.get("message")
+                    if isinstance(message, dict):
+                        tc = message.get("tool_calls")
+                        if isinstance(tc, list):
+                            tool_calls = tc
+                            break
+    if not isinstance(tool_calls, list):
+        return calls
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function")
+        if isinstance(fn, dict):
+            name = _as_str(fn.get("name"))
+            args = fn.get("arguments")
+            args_str = args if isinstance(args, str) else as_text(args)
+            if name:
+                calls.append((name, args_str))
+    return calls
+
+
+class WeaveAdapter(BaseTraceAdapter):
+    """Map Weights & Biases Weave Call exports into normalized ``Trace``s."""
+
+    name = "weave"
+
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
+        """Weave Call dicts -> SpanRecords.
+
+        Accepts a single Call, a list of Calls, or a calls/stream_query response (JSONL lines or a
+        JSON array). Each Call is mapped independently; the shared normalizer groups by trace_id.
+        """
+        calls = self._extract_calls(payload)
+        spans: list[SpanRecord] = []
+        for ordinal, call in enumerate(calls):
+            spans.extend(_weave_spans(call, ordinal))
+        return spans
+
+    def _extract_calls(self, payload: JsonValue) -> list[JsonObject]:
+        """Normalize a payload into a flat list of Weave Call objects."""
+        if isinstance(payload, list):
+            out: list[JsonObject] = []
+            for item in payload:
+                out.extend(self._extract_calls(item))
+            return out
+        if not isinstance(payload, dict):
+            return []
+        # Wrapper shapes: {"calls": [...]}, {"data": [...]}, {"results": [...]}.
+        for wrapper_key in ("calls", "data", "results"):
+            inner = payload.get(wrapper_key)
+            if isinstance(inner, list):
+                out = []
+                for item in inner:
+                    out.extend(self._extract_calls(item))
+                return out
+        # A dict with an id or op_name is a single Call.
+        if "id" in payload or "op_name" in payload or "trace_id" in payload:
+            return [payload]
+        return []
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Query the Weave service API for Calls and return them for normalization.
+
+        ``pull.project`` is the W&B ``entity/project`` path; ``pull.api_key`` (else
+        ``$WANDB_API_KEY``) is a W&B API key. Fetches recent calls via ``/calls/stream_query``.
+        """
+        api_key = pull.api_key or os.environ.get(_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(f"weave pull needs an API key: pass --api-key or set ${_API_KEY_ENV}")
+        if not pull.project:
+            raise ValueError(
+                "weave pull needs --project (the W&B entity/project path, e.g. 'myteam/myproject')"
+            )
+        limit = pull.limit if pull.limit is not None else 1000
+        resp = httpx.post(
+            f"{_API_HOST}/calls/stream_query",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "project_id": pull.project,
+                "limit": limit,
+                "sort_by": [{"field": "started_at", "direction": "desc"}],
+            },
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        # The streaming endpoint returns JSONL (one Call per line).
+        calls: list[JsonValue] = []
+        for line in resp.text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                calls.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                continue
+        return [calls]
+
+
+register_adapter(WeaveAdapter())

--- a/wmh/ingest/weave_test.py
+++ b/wmh/ingest/weave_test.py
@@ -1,0 +1,324 @@
+"""Tests for the Weights & Biases Weave adapter against realistic Weave Call exports.
+
+Weave exports Call dicts with ``op_name``, ``trace_id``, ``id``, ``inputs``, ``output``, and
+``started_at``/``ended_at`` timestamps. These fixtures exercise the adapter's field mapping and the
+op-name heuristic classification. No network; file fixtures only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.core.types import ActionKind
+from wmh.ingest.adapter import VendorPull, get_adapter
+from wmh.ingest.weave import WeaveAdapter, _extract_op_name, _is_llm_call
+
+# ---------------------------------------------------------------------------
+# Fixtures — realistic Weave Call objects
+# ---------------------------------------------------------------------------
+
+# A minimal two-call trace: an LLM call issuing a tool call, then the tool execution.
+_WEAVE_LLM_CALL = {
+    "id": "call-aaa-111",
+    "trace_id": "trace-abc-001",
+    "parent_id": None,
+    "op_name": "weave:///myteam/myproject/op/chat_completion:v1abc",
+    "started_at": "2024-06-01T10:00:00.000000Z",
+    "ended_at": "2024-06-01T10:00:01.000000Z",
+    "inputs": {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Look up user u1"},
+        ]
+    },
+    "output": {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "get_user",
+                                "arguments": '{"id": "u1"}',
+                            }
+                        }
+                    ],
+                }
+            }
+        ]
+    },
+    "exception": None,
+    "summary": {"latency_ms": 1000},
+}
+
+_WEAVE_TOOL_CALL = {
+    "id": "call-aaa-222",
+    "trace_id": "trace-abc-001",
+    "parent_id": "call-aaa-111",
+    "op_name": "weave:///myteam/myproject/op/get_user:v2def",
+    "started_at": "2024-06-01T10:00:01.500000Z",
+    "ended_at": "2024-06-01T10:00:02.000000Z",
+    "inputs": {"id": "u1"},
+    "output": "user u1: Ada Lovelace",
+    "exception": None,
+    "summary": {},
+}
+
+_WEAVE_CALLS = [_WEAVE_LLM_CALL, _WEAVE_TOOL_CALL]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — op name extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_op_name_from_uri() -> None:
+    uri = "weave:///myteam/myproject/op/chat_completion:v1abc"
+    assert _extract_op_name(uri) == "chat_completion"
+
+
+def test_extract_op_name_plain() -> None:
+    assert _extract_op_name("get_user") == "get_user"
+
+
+def test_extract_op_name_empty() -> None:
+    assert _extract_op_name("") == ""
+    assert _extract_op_name(None) == ""
+
+
+def test_is_llm_call_markers() -> None:
+    assert _is_llm_call("chat_completion") is True
+    assert _is_llm_call("openai_generate") is True
+    assert _is_llm_call("anthropic_create_message") is True
+    assert _is_llm_call("get_user") is False
+    assert _is_llm_call("run_sql_query") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — from_file round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_from_file_maps_weave_calls(tmp_path: Path) -> None:
+    path = tmp_path / "weave_calls.json"
+    path.write_text(json.dumps(_WEAVE_CALLS), encoding="utf-8")
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    assert traces[0].trace_id == "trace-abc-001"
+    assert traces[0].source.startswith("weave:")
+    assert len(traces[0].steps) == 1
+
+    step = traces[0].steps[0]
+    assert step.action.kind == ActionKind.TOOL_CALL
+    assert step.action.name == "get_user"
+    assert step.action.arguments == {"id": "u1"}
+    assert step.observation.content == "user u1: Ada Lovelace"
+    assert step.observation.is_error is False
+
+
+def test_from_file_handles_jsonl(tmp_path: Path) -> None:
+    """JSONL format: one Call per line."""
+    path = tmp_path / "weave_calls.jsonl"
+    lines = [json.dumps(call) for call in _WEAVE_CALLS]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    assert len(traces[0].steps) == 1
+    assert traces[0].steps[0].action.name == "get_user"
+
+
+def test_from_file_handles_error_call(tmp_path: Path) -> None:
+    """A tool call that threw an exception should be flagged as an error."""
+    llm_call = {
+        **_WEAVE_LLM_CALL,
+        "id": "call-err-111",
+        "trace_id": "trace-err-001",
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {"function": {"name": "get_user", "arguments": '{"id": "u2"}'}}
+                        ],
+                    }
+                }
+            ]
+        },
+    }
+    tool_call = {
+        "id": "call-err-222",
+        "trace_id": "trace-err-001",
+        "parent_id": "call-err-111",
+        "op_name": "get_user",
+        "started_at": "2024-06-01T10:00:02.000000Z",
+        "ended_at": "2024-06-01T10:00:02.500000Z",
+        "inputs": {"id": "u2"},
+        "output": None,
+        "exception": "UserNotFoundError: user u2 does not exist",
+    }
+    path = tmp_path / "weave_error.json"
+    path.write_text(json.dumps([llm_call, tool_call]), encoding="utf-8")
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    step = traces[0].steps[0]
+    assert step.observation.is_error is True
+    assert "UserNotFoundError" in step.observation.content
+
+
+def test_from_file_plain_llm_completion(tmp_path: Path) -> None:
+    """An LLM call with no tool calls produces a message-type action."""
+    call = {
+        "id": "call-plain-111",
+        "trace_id": "trace-plain-001",
+        "parent_id": None,
+        "op_name": "chat_completion",
+        "started_at": "2024-06-01T11:00:00.000000Z",
+        "ended_at": "2024-06-01T11:00:01.000000Z",
+        "inputs": {"messages": [{"role": "user", "content": "Say hello"}]},
+        "output": "Hello! How can I help you today?",
+        "exception": None,
+    }
+    path = tmp_path / "weave_plain.json"
+    path.write_text(json.dumps([call]), encoding="utf-8")
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    # A standalone LLM call with no following tool becomes a message step.
+    step = traces[0].steps[0]
+    assert step.action.kind == ActionKind.MESSAGE
+
+
+def test_from_file_wrapper_shape(tmp_path: Path) -> None:
+    """The calls/stream_query response can wrap calls under a 'calls' key."""
+    wrapped = {"calls": _WEAVE_CALLS}
+    path = tmp_path / "weave_wrapped.json"
+    path.write_text(json.dumps(wrapped), encoding="utf-8")
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    assert traces[0].steps[0].action.name == "get_user"
+
+
+def test_registered_under_weave() -> None:
+    assert get_adapter("weave").name == "weave"
+
+
+def test_vendor_pull_left_as_friendly_default_without_key() -> None:
+    try:
+        WeaveAdapter().from_vendor(VendorPull())
+    except ValueError as exc:
+        assert "API key" in str(exc) or "weave" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
+def test_parallel_tool_calls(tmp_path: Path) -> None:
+    """An LLM call issuing multiple tool calls in parallel should produce
+    one Step per tool call, each with correctly matched action/observation."""
+    llm_call = {
+        "id": "call-par-111",
+        "trace_id": "trace-par-001",
+        "parent_id": None,
+        "op_name": "chat_completion",
+        "started_at": "2024-07-01T10:00:00.000000Z",
+        "ended_at": "2024-07-01T10:00:01.000000Z",
+        "inputs": {
+            "messages": [
+                {"role": "user", "content": "Get user u1 and u2"},
+            ]
+        },
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "get_user",
+                                    "arguments": '{"id": "u1"}',
+                                }
+                            },
+                            {
+                                "function": {
+                                    "name": "get_user",
+                                    "arguments": '{"id": "u2"}',
+                                }
+                            },
+                        ],
+                    }
+                }
+            ]
+        },
+        "exception": None,
+    }
+    tool_call_1 = {
+        "id": "call-par-222",
+        "trace_id": "trace-par-001",
+        "parent_id": "call-par-111",
+        "op_name": "get_user",
+        "started_at": "2024-07-01T10:00:01.100000Z",
+        "ended_at": "2024-07-01T10:00:01.500000Z",
+        "inputs": {"id": "u1"},
+        "output": "user u1: Ada Lovelace",
+        "exception": None,
+    }
+    tool_call_2 = {
+        "id": "call-par-333",
+        "trace_id": "trace-par-001",
+        "parent_id": "call-par-111",
+        "op_name": "get_user",
+        "started_at": "2024-07-01T10:00:01.200000Z",
+        "ended_at": "2024-07-01T10:00:01.600000Z",
+        "inputs": {"id": "u2"},
+        "output": "user u2: Grace Hopper",
+        "exception": None,
+    }
+    path = tmp_path / "weave_parallel.json"
+    path.write_text(
+        json.dumps([llm_call, tool_call_1, tool_call_2]),
+        encoding="utf-8",
+    )
+
+    traces = WeaveAdapter().from_file(str(path))
+
+    assert len(traces) == 1
+    # Two parallel tool calls: the LLM call emits no action spans
+    # (avoiding mismatched pairing); each child tool Call produces
+    # a complete Step with correctly matched action/observation.
+    assert len(traces[0].steps) == 2
+
+    step_0 = traces[0].steps[0]
+    assert step_0.action.kind == ActionKind.TOOL_CALL
+    assert step_0.action.name == "get_user"
+
+    step_1 = traces[0].steps[1]
+    assert step_1.action.kind == ActionKind.TOOL_CALL
+    assert step_1.action.name == "get_user"
+
+    # Both observations should be present with correctly matched
+    # arguments (order may vary based on timestamp sorting).
+    contents = {
+        step_0.observation.content,
+        step_1.observation.content,
+    }
+    assert "user u1: Ada Lovelace" in contents
+    assert "user u2: Grace Hopper" in contents
+
+    # Each step's arguments must match its observation (no cross-contamination).
+    for step in traces[0].steps:
+        if step.observation.content == "user u1: Ada Lovelace":
+            assert step.action.arguments == {"id": "u1"}
+        elif step.observation.content == "user u2: Grace Hopper":
+            assert step.action.arguments == {"id": "u2"}


### PR DESCRIPTION
## Summary

Adds a new ingestion adapter for [Weights & Biases Weave](https://wandb.ai/site/weave) trace exports, extending the harness's observability platform coverage alongside the existing Braintrust, Phoenix, Langfuse, LangSmith, Mastra, and PostHog adapters.

## Motivation

Weave is a widely adopted LLM observability and evaluation platform. Teams using Weave to trace their agent runs currently have no way to feed those traces into `wmh` for world-model building. This adapter closes that gap — a Weave user can now export their Calls (JSON/JSONL) and run `wmh ingest run --source weave --file <export>` to build a world model from their production data.

## Design

Weave records agent executions as **Calls** (not OTLP spans). Each Call carries an `op_name`, `inputs`, `output`, `trace_id`, `id`, `parent_id`, and timestamps. Since this is a custom schema (not OpenTelemetry), the adapter follows the same pattern as `posthog.py` — it overrides `spans_from_payload` and emits `SpanRecord`s using OTel GenAI attribute keys so the shared normalizer handles pairing and state extraction.

### Key decisions

| Decision | Rationale |
|---|---|
| **Op-name heuristic classification** | Weave has no `span.kind` tag. Calls are classified as LLM vs tool by checking if the op name contains markers like `chat`, `complete`, `openai`, `anthropic`, etc. Everything else is treated as a tool execution. |
| **Weave URI parsing** | Op names can be full URIs (`weave:///entity/project/op/func_name:hash`). The adapter strips the prefix and hash suffix to extract the human-readable function name. |
| **Error detection via `exception` field** | Weave stores errors in an `exception` string field (not a status code). The adapter checks for a non-empty `exception` or a `status` of `"error"`/`"failed"`. |
| **Live vendor pull** | Implemented via Weave's `/calls/stream_query` endpoint (JSONL response). Requires `WANDB_API_KEY` and a `--project entity/project` argument. |

## Changes

| File | What |
|---|---|
| `wmh/ingest/weave.py` | New `WeaveAdapter` — Call parsing, op-name classification, JSON/JSONL file loading, and live vendor pull via `/calls/stream_query` |
| `wmh/ingest/weave_test.py` | 11 tests: op-name extraction, LLM classification heuristics, JSON round-trip, JSONL, error calls, plain completions, wrapper shapes, adapter registration, vendor pull validation |
| `wmh/ingest/__init__.py` | Register `weave` adapter on package import |
| `examples/ingest/weave_to_wmh.sh` | Usage example script for file-based and API-based ingestion |

## Testing

```
$ uv run pytest wmh/ingest/weave_test.py -v
11 passed in 0.67s

$ uv run ruff check .
All checks passed!
```

All tests are offline (file fixtures, no network). The adapter is SDK-free — it parses exported JSON directly and uses `httpx` for vendor pulls (same as PostHog, Langfuse).

## Usage

```bash
# File-based (export from Weave UI → JSON/JSONL)
wmh ingest run --source weave --file weave_calls.json

# Live pull (requires WANDB_API_KEY)
export WANDB_API_KEY="your-key"
wmh ingest run --source weave --project "myteam/myproject" --limit 500
```
