### PR TITLE
environment-capture: PyPI-ready packaging + pure-package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This repository is a [uv workspace](https://docs.astral.sh/uv/concepts/projects/
 |---|---|---|
 | **wmh** (root) | Agent traces → a faithful world model of your environment | the quickstart above |
 | [`packages/llm-waterfall/`](./packages/llm-waterfall) | Pool LLM quota across models, providers, and AWS accounts: stateless failover that spills only on capacity errors, returning cost + the full attempt trail | `pip install "llm-waterfall @ git+https://github.com/experientiallabs/world-model-harness#subdirectory=packages/llm-waterfall"` *(PyPI release pending)* |
-| `packages/environment-capture/` *(in progress)* | Point it at any agent benchmark: integrate via a small adapter, smoke-test it, capture real-run traces as OTel GenAI JSONL | — |
+| [`packages/environment-capture/`](./packages/environment-capture) | Point it at any agent benchmark: integrate via a small adapter, capture every real agent-environment transition as OTel GenAI JSONL; 27k+ transitions already published on the [Hub](https://huggingface.co/experiential-labs) | `pip install environment-capture` |
 
 One clone, one `uv sync`, one gate (`just gate`); each package is built and released independently.
 

--- a/packages/environment-capture/LICENSE
+++ b/packages/environment-capture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Experiential Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/environment-capture/README.md
+++ b/packages/environment-capture/README.md
@@ -8,14 +8,15 @@ JSONL. Ten benchmarks are integrated behind one small contract, with **5,900+ re
 
 ## Why
 
-- **Capture real traces.** Every agent-environment transition — each `(action → observation)`
-  pair, exactly as the environment returned it — recorded as standard OTel GenAI JSONL while
-  your agent runs. Nothing synthesized, ever.
-- **One standard interface.** `tasks / open_env / grade` covers ten wildly different benchmarks
-  (SQL, terminal, SWE, finance docs, CRM, multi-app worlds, ...). A new benchmark is one
-  adapter — hand your coding agent [INTEGRATION.md](INTEGRATION.md) and it has the full playbook.
-- **Deterministic, LLM-free grading.** Rewards are fixed functions: reproducible, free,
-  comparable across runs. No judge drift, no judge bill.
+Because it's annoying to:
+
+- **set up benchmarks and run models against them** — ten real benchmarks, one three-method
+  interface, any agent or provider
+- **capture traces in a standardized format** — every `(action → observation)` transition as
+  OTel GenAI JSONL, agnostic to benchmark and provider
+
+Adding a benchmark? Point your coding agent at [INTEGRATION.md](INTEGRATION.md) — it's the
+complete, self-contained playbook for integrating one.
 
 ## The benchmarks
 

--- a/packages/environment-capture/README.md
+++ b/packages/environment-capture/README.md
@@ -6,36 +6,16 @@ JSONL. Ten benchmarks are integrated behind one small contract, with **5,900+ re
 / 27,000+ real transitions** already captured and published as license-tagged datasets on the
 [Hugging Face Hub](https://huggingface.co/experiential-labs).
 
-## Why this over the alternatives
+## Why
 
-- **Real transitions, never synthesized.** Every observation in a corpus came from a live
-  benchmark environment (a real SQLite query, a real container shell, a real simulated-world
-  API) — not from a model imagining what an environment might say. If you are training or
-  evaluating environment/world models, imitation policies, or reward models, synthetic
-  observations teach the model your generator's quirks; these teach it the environment.
-- **One contract across wildly different benchmarks.** `tasks(split) / open_env(task) /
-  grade(task, submission)` plus a single env seam (`execute(command) -> output, returncode`)
-  covers text-to-SQL, document QA, pandas data analysis, CRM analytics, stateful multi-app
-  worlds, customer-service tool agents, terminal computer-use, and software engineering. A new
-  benchmark is one adapter, not a new harness.
-- **Deterministic, LLM-free grading.** Every `grade` is a fixed function — rewards are
-  reproducible, free, and comparable across runs. No judge drift, no judge bill.
-- **A standard wire format, not a proprietary one.** Corpora are OTel GenAI semantic-convention
-  spans, one JSON object per line — readable by any OTel-aware tooling and trivially parseable
-  without this package installed.
-- **Privacy hygiene is built in, because it bit us.** Agents that can't find their data wander
-  the host; a built-in scanner (`scan_spans_jsonl`) detects host-escape content (home paths,
-  credentials, machine identity) at capture time and in committed corpora, and flagged
-  trajectories are dropped whole, never redacted.
-- **Capture runs survive the real world.** Per-task fault isolation with retries: one throttled
-  provider call, grader edge case, or backend crash records a failure and moves on — a
-  multi-hour capture never loses its completed trajectories.
-- **License discipline end to end.** Each corpus ships with provenance and the upstream's
-  license tag on its dataset card; benchmarks whose terms forbid plain-text redistribution
-  (AppWorld) are refused by the publisher and stay local-only.
-- **Agent-first integration.** [INTEGRATION.md](INTEGRATION.md) is a complete, self-contained
-  playbook: hand it to a coding agent and it has everything needed to integrate a new benchmark
-  — contract, step order, non-negotiables, and the acceptance checklist.
+- **Capture real traces.** Every agent-environment transition — each `(action → observation)`
+  pair, exactly as the environment returned it — recorded as standard OTel GenAI JSONL while
+  your agent runs. Nothing synthesized, ever.
+- **One standard interface.** `tasks / open_env / grade` covers ten wildly different benchmarks
+  (SQL, terminal, SWE, finance docs, CRM, multi-app worlds, ...). A new benchmark is one
+  adapter — hand your coding agent [INTEGRATION.md](INTEGRATION.md) and it has the full playbook.
+- **Deterministic, LLM-free grading.** Rewards are fixed functions: reproducible, free,
+  comparable across runs. No judge drift, no judge bill.
 
 ## The benchmarks
 
@@ -54,6 +34,34 @@ JSONL. Ten benchmarks are integrated behind one small contract, with **5,900+ re
 
 All published bundles include the trace corpus plus the task data needed to run the benchmark
 (task index, gold sidecars, evidence/context files).
+
+## Install
+
+```bash
+pip install environment-capture            # the library: contract, capture driver, hygiene, hub fetch
+pip install 'environment-capture[fetch]'   # + huggingface_hub, for publishing bundles
+```
+
+Pure-package usage — capture YOUR benchmark and pull OUR data, no repo checkout needed:
+
+```python
+from pathlib import Path
+from environment_capture import run_capture, trajectory_to_spans, write_spans_jsonl
+from environment_capture.hub import fetch_corpus
+
+# 1) pull a published bundle (lands in ./environment-capture-data/, or $ENVCAP_DATA_ROOT)
+corpus = fetch_corpus("bird-sql")
+
+# 2) capture your own benchmark: implement the 3-method adapter + an agent, then
+result = run_capture(my_adapter, my_agent, split="train")
+spans = [s for t in result.trajectories for s in trajectory_to_spans(t, benchmark="my-bench")]
+write_spans_jsonl(spans, Path("traces.otel.jsonl"))
+```
+
+The wheel ships the library and every benchmark adapter; benchmark *data* always comes from the
+Hub (or your own capture runs). Note: `hub` publishing is currently pinned to the
+`experiential-labs` org manifest — pushing your own benchmark's bundle means adding a
+`CorpusSpec` (see INTEGRATION.md).
 
 ## The contract
 

--- a/packages/environment-capture/README.md
+++ b/packages/environment-capture/README.md
@@ -2,16 +2,16 @@
 
 Run agent benchmarks **for real** and record every agent-environment transition — each
 `(action → observation)` pair, exactly as the environment returned it — as OpenTelemetry GenAI
-JSONL. Ten benchmarks are integrated behind one small contract, with **5,900+ real trajectories
-/ 27,000+ real transitions** already captured and published as license-tagged datasets on the
-[Hugging Face Hub](https://huggingface.co/experiential-labs).
+JSONL. Integrating a benchmark is one small adapter; ten are already in (**5,900+ real
+trajectories / 27,000+ real transitions** captured and published as license-tagged datasets on
+the [Hugging Face Hub](https://huggingface.co/experiential-labs)).
 
 ## Why
 
 Because it's annoying to:
 
-- **set up benchmarks and run models against them** — ten real benchmarks, one three-method
-  interface, any agent or provider
+- **set up benchmarks and run models against them** — one three-method interface for any
+  benchmark, any agent, any provider
 - **capture traces in a standardized format** — every `(action → observation)` transition as
   OTel GenAI JSONL, agnostic to benchmark and provider
 

--- a/packages/environment-capture/environment_capture/hub.py
+++ b/packages/environment-capture/environment_capture/hub.py
@@ -305,8 +305,20 @@ def fetch_corpus(
 
 
 def _data_root() -> Path:
-    """The sibling benchmark data dirs (packages/environment-capture/<benchmark>/)."""
-    return Path(__file__).resolve().parents[1]
+    """Where benchmark data dirs live (``<root>/<benchmark>/traces.otel.jsonl``).
+
+    Resolution order: the ``ENVCAP_DATA_ROOT`` env var; a repo checkout (the dir holding
+    this package — its sibling benchmark dirs); else, for an installed wheel,
+    ``environment-capture-data/`` under the current directory — a pip user's bundles land in
+    their project, never inside site-packages.
+    """
+    override = os.environ.get("ENVCAP_DATA_ROOT")
+    if override:
+        return Path(override)
+    sibling = Path(__file__).resolve().parents[1]
+    if (sibling / "pyproject.toml").exists():  # repo checkout: the member dir itself
+        return sibling
+    return Path.cwd() / "environment-capture-data"
 
 
 def _default_token() -> str | None:

--- a/packages/environment-capture/environment_capture/hub_test.py
+++ b/packages/environment-capture/environment_capture/hub_test.py
@@ -244,3 +244,19 @@ def test_published_corpora_follows_pagination(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(hub, "_http_json_page", page)
     assert [c.benchmark for c in published_corpora()] == ["gaia2", "bird-sql"]
+
+
+def test_data_root_resolution(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Env override wins; a repo checkout uses the package's sibling dirs; an installed wheel
+    (no sibling pyproject) lands bundles under the CWD, never inside site-packages."""
+    monkeypatch.setenv("ENVCAP_DATA_ROOT", str(tmp_path / "override"))
+    assert hub._data_root() == tmp_path / "override"
+
+    monkeypatch.delenv("ENVCAP_DATA_ROOT")
+    assert (hub._data_root() / "pyproject.toml").exists()  # repo checkout: the member dir
+
+    site = tmp_path / "venv" / "site-packages" / "environment_capture"
+    site.mkdir(parents=True)
+    monkeypatch.setattr(hub, "__file__", str(site / "hub.py"))
+    monkeypatch.chdir(tmp_path)
+    assert hub._data_root() == tmp_path / "environment-capture-data"

--- a/packages/environment-capture/pyproject.toml
+++ b/packages/environment-capture/pyproject.toml
@@ -3,6 +3,7 @@ name = "environment-capture"
 version = "0.1.0"
 description = "Run benchmarks for real and record agent-environment transitions as OTel GenAI JSONL."
 readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = []
 
@@ -19,3 +20,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["environment_capture"]
+
+[tool.hatch.build.targets.sdist]
+# Ship ONLY the library: the sibling benchmark dirs are repo working data (capture scripts,
+# prebuilt example models, fetched bundles) and would bloat the sdist by tens of MB.
+include = ["/environment_capture", "/README.md", "/LICENSE", "/INTEGRATION.md"]


### PR DESCRIPTION
Follow-up to #56, prompted by "can we upload to PyPI?":

- **LICENSE** (MIT, matching llm-waterfall) + `license` field in the member pyproject
- **sdist scoped to the library** — anchored includes; sibling benchmark dirs (scripts, prebuilt models, READMEs) no longer leak into the tarball (43 files, verified)
- **installed-wheel data root**: `ENVCAP_DATA_ROOT` env var → repo checkout sibling dirs → `./environment-capture-data/` under the cwd; a pip user's fetched bundles never land inside site-packages (tested)
- **README**: "Why" trimmed to three bullets; new Install section documenting the pure-package flow
- **verified end-to-end**: built wheel+sdist, installed into a bare venv, ran the advertised flow (list 9 published datasets, fetch two bundles, capture a custom benchmark with a 3-method adapter, emit OTel JSONL, module CLI)

Publishing itself needs a PyPI token (`uv publish` from `packages/environment-capture/`) — the artifacts in `dist/` are ready.

