### PR TITLE
wm-benchmarks: AgentWorldBench adapter + E2E smoke; wmh-native benchmark design (BENCH-A, D78/D79)

### DIFF
--- a/.agents/docs/proposals/wm-benchmark-design.md
+++ b/.agents/docs/proposals/wm-benchmark-design.md
@@ -1,0 +1,126 @@
+---
+area: Research
+status: Proposal (user-interviewed 2026-07-07; design approved to plan, harness is a follow-up)
+date: 2026-07-07
+---
+
+# A wmh-native world-model benchmark (working title: **WMH-Bench** — naming deferred)
+
+AgentWorldBench (arXiv 2606.24597, "Qwen-AgentWorld") is the first external benchmark for
+language world models: given an interaction history, predict the next observation, scored by an
+LLM judge on five dimensions (Format, Factuality, Consistency, Realism, Quality). It defined the
+category. It is also **judge-only** — every number it produces is a rubric opinion from one
+pinned judge model.
+
+wmh holds the inverse asset: **real captured corpora with deterministic graders**. Our benchmark
+differentiates on exactly what a judge-only benchmark cannot do:
+
+1. **Deterministic, judge-free signals** — reproducible by anyone, zero judge cost, no
+   judge-version drift.
+2. **Reward agreement under WM-replacement** — the same agent runs the same task against the
+   real environment and against the world model, and the same deterministic grader scores both.
+   No other benchmark can ask "does evaluating against the sim reach the same verdict as the
+   real env?", because no other benchmark ships the real environments.
+
+## User decisions (interview, 2026-07-07)
+
+| Question | Decision |
+|---|---|
+| Scoring composition | **Deterministic core, empirically validated against the LLM judge.** The deterministic composite must match the pinned judge's performance; iterate until agreement is close. If it can't get close, fall back to a pinned LLM judge as headline. |
+| Test split | **Public, SHA-pinned** (status quo: frozen test splits on HF, SHA-guarded). |
+| Contamination canary | **Yes — design now, implement in the corpus-publishing follow-up** (not this PR). |
+| Corpus scope | **All public corpora, licenses labeled.** appworld excluded (local-only license). CC BY-NC corpora (financebench, crmarena) included with the restriction disclosed on the card; gaia2's existing don't-train notice carried through. |
+| Name/branding | **Deferred** — this doc uses "WMH-Bench" as a placeholder only. |
+| Leaderboard | **None.** Static, version-pinned results table in `docs/` (and optionally the HF dataset cards). Consistent with WS-B1's no-leaderboard website decision. |
+
+## The benchmark
+
+One benchmark, two tracks. A submission is a *world model*: anything that maps
+`(task, interaction history) → next observation` (and can hold session state).
+
+### Track A — open-loop deterministic fidelity (all corpora)
+
+Teacher-forced replay over the frozen test split (the existing `wmh eval` mechanic, D12
+conventions): feed the real recorded `(state, action)` prefix, predict the observation, score
+against the recorded observation. Deterministic per-step signals:
+
+- **Error-flag accuracy** — did the WM predict `is_error` correctly? (Already reported today.)
+- **Structured-field agreement** — benchmark-aware deterministic extractors over the observation
+  text (exit codes, numeric answers, row counts, JSON keys — per-corpus extractor specs live
+  with each adapter). This is the part that must be *built and validated*, see § Validation.
+
+### Track B — reward agreement under WM-replacement (the differentiator)
+
+The `wm_replace_demo` mechanic, generalized from the financebench prototype
+(`packages/environment-capture/financebench/wm_replace_demo.py`): a FIXED agent runs each
+held-out task twice — once against the real environment (`adapter.open_env`), once against the
+world model behind the same `CommandEnv.execute` seam — and the SAME deterministic
+`adapter.grade` scores both. Reported per corpus:
+
+- **Reward agreement rate** — `real_reward == wm_reward` fraction, with the 2×2
+  sim-pass/real-pass confusion (per `.agents/docs/proposals/closed-loop-eval-spec.md`).
+- **Steps-to-divergence** as a diagnostic (not headline).
+
+The stronger policy-rank agreement question (does the sim rank multiple agents like the real
+env — `sim-real-policy-rank-agreement.md`) stays a research direction; the benchmark reserves
+the metric name but v1 does not require multiple evaluatees.
+
+### Coverage tiers (honest labeling, v1)
+
+| Corpus | Track A | Track B | License label |
+|---|---|---|---|
+| bird-sql, dabstep, financebench, crmarena, gaia2, continual-learning | ✓ | ✓ (adapters have `open_env` + `grade`) | financebench/crmarena CC BY-NC (disclosed); gaia2 don't-train notice |
+| tau-bench, terminal-tasks, swe-bench | ✓ | later — corpora + fidelity evals exist, but no `CommandEnv` adapter yet (real envs live in `examples/` harnesses) | per existing cards |
+| appworld | — excluded (local-only license) | — | — |
+
+## Validation: deterministic core vs the judge (the user's condition)
+
+The deterministic composite is only allowed to be the headline if it **empirically matches the
+pinned judge**. Plan:
+
+1. Reuse the meta-eval harness from the judge overhaul (PR #83) and existing prediction sets:
+   for every corpus, score the same predictions with (a) the deterministic composite and (b) the
+   pinned RubricJudge.
+2. Agreement criteria (proposed): per-step score correlation AND — the one that matters —
+   **system-level rank concordance ≥ 0.9** (Kendall pairwise concordance across model×condition
+   cells, the things the benchmark exists to discriminate).
+3. Iterate the extractor specs against real disagreements (AGENTS.md rule 12: read the actual
+   outputs, tune on the disagreements).
+4. **Fallback**: any corpus whose deterministic composite can't reach the bar keeps the pinned
+   RubricJudge as its headline, labeled as such. Track B (reward agreement) is deterministic by
+   construction and needs no judge validation.
+
+Judge-pinning discipline throughout (D12): a pinned judge version is part of the benchmark
+version; deterministic and judge numbers are never mixed in one column.
+
+## Splits, canary, publishing
+
+- **Splits**: the existing whole-trace seeded splits, frozen test splits SHA-guarded, public on
+  HF (`experiential-labs/wmh-<benchmark>-traces`). Benchmark versions pin the split SHAs.
+- **Canary (design, implemented in the corpus-publishing follow-up)**: one benchmark-wide canary
+  GUID (BIG-bench style) embedded as a metadata field in every published test-split row and
+  printed on every dataset card, so any trained model can be probed for test-split contamination;
+  the publishing pipeline (envcap `hub_push`) adds it at push time. Rows also carry
+  `wmh_benchmark_version`. Republishing datasets with the canary is a follow-up PR on the
+  publishing pipeline, coordinated with the corpus owners.
+- **Never** fold AgentWorldBench data into any wmh corpus (eval-only, and it would poison our
+  own WM rows on their benchmark).
+
+## Reporting
+
+Static results table in `docs/` (version-pinned: benchmark version, split SHAs, judge pin if
+any, n per corpus), mirrored on the HF dataset cards. No live leaderboard anywhere (WS-B1
+decision). Suggested headline columns per corpus: n · reward-agreement (Track B) · error-flag
+accuracy · deterministic composite (or pinned-judge fidelity, labeled, until validated).
+
+## What ships when
+
+- **This PR (design only, per user re-scope 2026-07-07)**: this proposal + the AgentWorldBench
+  adapter work (separate deliverable, same PR).
+- **Follow-up 1 — meta-eval**: deterministic extractors + agreement study vs pinned judge;
+  go/no-go per corpus on deterministic headline.
+- **Follow-up 2 — canary**: publishing-pipeline change + dataset republish.
+- **Follow-up 3 — Track B harness**: generalize `wm_replace_demo` behind `wmh bench` rows
+  (coordinate with the closed-loop eval work, PR #111); tau/terminal/swe adapters as capacity
+  allows.
+- **Naming/branding**: decided before the first public results table ships.

--- a/.agents/scripts/agentworldbench/README.md
+++ b/.agents/scripts/agentworldbench/README.md
@@ -59,6 +59,38 @@ Domain → model mapping for `wm` mode (approximations noted):
 terminal → `terminal-tasks`, swe → `swe-bench`, mcp → `tau-bench` (tau ≈ MCP tool-calling; label
 the approximation in any table).
 
+## Full run (2026-07-10 — judge gpt-5.4-mini @ Azure, temp 0; NOT comparable to their gpt-5.2 table)
+
+All 2,170 benchmark rows + the 354-row terminal base ablation. Infer = Bedrock, serve model
+as built per WM (user decision 2026-07-09). Their `judge`+`score` stages unmodified via the
+Azure shim; **2,524/2,524 judged, 0 parse failures**. Normalized 0–100; Overall = macro-average
+over the 7 domains (their paper convention, NOT `eval.py score`'s micro-average):
+
+| domain | arm | serve model | n | format | fact. | consist. | realism | quality | **total** | infer $ |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| MCP | tau-bench WM (≈MCP, labeled approx.) | opus-4.8 | 286 | 75.61 | 39.86 | 57.34 | 49.21 | 47.99 | **54.00** | 55.20 |
+| Search | base prompt | opus-4.8 | 458 | 68.40 | 27.40 | 47.98 | 37.72 | 33.79 | **43.06** | 97.25 |
+| Terminal | terminal-tasks WM (opt+RAG) | opus-4.8 | 354 | 79.10 | 35.45 | 50.99 | 55.72 | 41.88 | **52.63** | 42.90 |
+| SWE | swe-bench WM (opt+RAG) | haiku-4.5 (as built) | 472 | 61.44 | 45.18 | 57.31 | 57.89 | 45.13 | **53.39** | 9.73 |
+| Android | base prompt | opus-4.8 | 200 | 99.25 | 46.88 | 48.00 | 63.62 | 45.63 | **60.68** | 37.24 |
+| Web | base prompt | opus-4.8 | 200 | 98.12 | 41.50 | 44.50 | 57.12 | 40.50 | **56.35** | 42.02 |
+| OS | base prompt | opus-4.8 | 200 | 95.00 | 37.38 | 38.25 | 57.75 | 36.75 | **53.02** | 44.82 |
+| **Macro Overall** | | | 2170 | | | | | | **53.30** | |
+| Terminal (ablation) | base prompt | opus-4.8 | 354 | 71.40 | 34.32 | 50.28 | 55.08 | 39.97 | **50.21** | 31.64 |
+
+- **Ablation (what the corpus buys on their metric)**: terminal WM 52.63 vs base 50.21 =
+  **+2.42 total**, positive on every dimension (format +7.7, factuality +1.1, quality +1.9).
+- Costs: infer **$360.80** total (Bedrock), judge **$41.14** (2,625 gpt-5.4-mini calls incl.
+  smoke re-judges; 50.5M in / 0.73M out tokens).
+- Reference only — different judge, do not rank against: their gpt-5.2-judged table reports
+  GPT-5.4 58.25 / Opus 4.8 56.59 / Qwen-AgentWorld-397B 58.71 Overall. gpt-5.4-mini is a
+  measurably harsher judge (same smoke predictions: 51.7 under 5.4-mini vs 76.7 under an
+  Opus stand-in), so cross-table comparisons are meaningless (D12).
+- Run notes: one overnight network outage wedged Bedrock sockets (no read-timeout kill) —
+  recovered via kill + `--resume`; search rows embed U+2028-class separators (newline-only
+  reading required); android source data has one duplicate `(id, turn_idx)` key (both rows
+  predicted + judged); swe-bench model serves haiku-4.5 by repo default (that's "as built").
+
 ## Smoke E2E result (2026-07-07 — plumbing proof, NOT comparable numbers)
 
 8 rows, judged by the STAND-IN judge (Opus 4.8 via the shim, temperature 0) — their pinned

--- a/.agents/scripts/agentworldbench/README.md
+++ b/.agents/scripts/agentworldbench/README.md
@@ -91,6 +91,33 @@ over the 7 domains (their paper convention, NOT `eval.py score`'s micro-average)
   reading required); android source data has one duplicate `(id, turn_idx)` key (both rows
   predicted + judged); swe-bench model serves haiku-4.5 by repo default (that's "as built").
 
+## Anchor row: Qwen-AgentWorld-35B-A3B, same judge (2026-07-11)
+
+Their released model, served per their README (vLLM `--language-model-only --reasoning-parser
+qwen3 --max-model-len 262144`, TP=2 on h100_azure), run through **their shipped `eval.py infer`
+unmodified** (system_str + current_prompt — NO history, temp 0), judged by the SAME pinned
+gpt-5.4-mini as our rows. 2,170/2,170 inferred (7 empty gens), 2,162 judged valid. Judge $37.18.
+
+| domain | wmh (full history) | Qwen-AW-35B (their shipped protocol) |
+|---|---:|---:|
+| MCP | 54.00 (tau WM) | 44.83 |
+| Search | 43.06 (base) | 38.50 |
+| Terminal | 52.63 (WM) | 27.29 |
+| SWE | 53.39 (WM, haiku) | 44.66 |
+| Android | 60.68 (base) | 47.35 |
+| Web | 56.35 (base) | 52.88 |
+| OS | 53.02 (base) | 54.87 |
+| **Macro Overall** | **53.30** | **44.34** |
+
+**Read the confound before quoting**: this contrasts (model AND protocol) simultaneously —
+their shipped infer is history-blind, ours feeds full history. The wreckage concentrates
+exactly where session state matters (terminal consistency 17.93: eyeballed rows show the judge
+correctly flagging unknowable-without-history facts like file sizes and missing binaries).
+Fair conclusions: (a) under one judge + their own released pipeline, our wmh rows beat their
+released 35B by +8.96 macro; (b) most of that gap is plausibly the history protocol, not raw
+model quality — their published 56.39 (gpt-5.2 judge) is not comparable in either direction.
+The isolating experiment (their model + full-history prompts) is staged but not run.
+
 ## Smoke E2E result (2026-07-07 — plumbing proof, NOT comparable numbers)
 
 8 rows, judged by the STAND-IN judge (Opus 4.8 via the shim, temperature 0) — their pinned

--- a/.agents/scripts/agentworldbench/README.md
+++ b/.agents/scripts/agentworldbench/README.md
@@ -91,6 +91,35 @@ over the 7 domains (their paper convention, NOT `eval.py score`'s micro-average)
   reading required); android source data has one duplicate `(id, turn_idx)` key (both rows
   predicted + judged); swe-bench model serves haiku-4.5 by repo default (that's "as built").
 
+## wmh-max row (2026-07-18 — merged-main rebuilds, same pinned judge)
+
+The "new machine" run: tau/terminal/swe rebuilt with `wmh build --fidelity max` on merged main
+(GEPA v2 + full lever search; winners tau=`reason`, terminal=`reason+kb`, swe=`reason+verify`;
+swe re-served on **Opus 4.8** instead of its haiku default), served with `--max-fidelity`;
+the 4 corpus-free domains ran BASE_ENV_PROMPT + reasoning + verify. Same judge as every row
+below (gpt-5.4-mini via shim, temp 0). ≤1 judge failure per arm.
+
+| domain | old (2026-07-10) | **wmh-max** | Δ | Qwen-AW-35B anchor |
+|---|---:|---:|---:|---:|
+| MCP | 54.00 | 55.37 | +1.37 | 44.83 |
+| Search | 43.06 | 44.46 | +1.40 | 38.50 |
+| Terminal | 52.63 | 53.56 | +0.93 | 27.29 |
+| SWE | 53.39 | **66.73** | **+13.34** | 44.66 |
+| Android | 60.68 | 59.72 | −0.96 | 47.35 |
+| Web | 56.35 | 56.93 | +0.58 | 52.88 |
+| OS | 53.02 | 53.47 | +0.45 | 54.87 |
+| **Macro Overall** | 53.30 | **55.75** | **+2.45** | 44.34 |
+
+Decomposition: nearly all of the macro gain is **swe's serve-model upgrade + reason+verify**
+(haiku→opus, +13.34); every corpus/lever effect elsewhere is ±1.4 — replicating the finding
+that off-distribution, test-time levers and corpus-derived context move their metric only
+marginally (reason+verify on base arms ≈ noise for 2× infer cost; android slightly negative).
+Costs: infer $743.52 (verify's double pass dominates: search $208, swe $145), judge ≈$37.
+Builds: ~60-80 min each, winners replicated WS-A3's lever research (fetch rejected by the
+search on terminal — convenient, as live-fetch vs recorded data was a validity risk).
+Ops note: judge stage initially no-op'd silently — the /tmp eval-repo clone had been purged by
+the tmp cleaner; their code now lives pinned under `.wmh/qwen-agentworld` (same @354f733).
+
 ## Anchor row: Qwen-AgentWorld-35B-A3B, same judge (2026-07-11)
 
 Their released model, served per their README (vLLM `--language-model-only --reasoning-parser

--- a/.agents/scripts/agentworldbench/README.md
+++ b/.agents/scripts/agentworldbench/README.md
@@ -1,0 +1,85 @@
+# AgentWorldBench adapter (external WM benchmark)
+
+Runs wmh world models on **AgentWorldBench** (arXiv 2606.24597, HF `Qwen/AgentWorldBench`,
+Apache-2.0, 2,170 rows / 7 domains, test-split only) and scores them with the benchmark's own
+pipeline. We replace only their `infer` stage; their `judge` and `score` stages run **unmodified**
+from github.com/QwenLM/Qwen-AgentWorld (verified @354f733).
+
+## Verified facts (Phase 0, 2026-07-07)
+
+- **Data**: per-domain `{domain}_test.jsonl`; each row = one evaluated turn. `prompt`/`response`
+  are parallel per-turn string lists (turns `1..turn_idx`), `response[-1]` = ground truth,
+  `current_prompt` = the evaluated turn's action only. Counts: mcp 286, search 458, terminal 354,
+  swe 472, android 200, web 200, os 200. ~402 MB total. License Apache-2.0 (data + code).
+- **Judge**: pinned `gpt-5.2-2025-12-11` (OpenAI) for all published numbers. 5 dims
+  (format/factuality/consistency/realism/quality), each 1–5, per-sample `total_score` = mean of
+  valid dims, reported normalized `(raw-1)/4*100`. Their default temperature is **0.6 for both
+  infer and judge** (not stated in the paper) — we pin `--temperature 0` on both stages.
+- **Their infer omits history** (`eval.py` sends only `system_str` + `current_prompt`), while the
+  judge scores against the full history context. Our adapter follows the paper protocol and feeds
+  the full history (teacher-forced) — flag this discrepancy next to any comparison with their table.
+- **Overall aggregation gotcha**: the paper/README "Overall" is the *macro*-average of the 7 domain
+  scores; `eval.py score` prints a *micro*-average pooled over samples. Macro-average yourself.
+- **Never** fold AgentWorldBench rows into any wmh training corpus (eval-only).
+
+## Files
+
+- `awb_infer.py` — infer replacement. `--mode wm` (built model: optimized prompt + RAG, session
+  path, usage metered per row) or `--mode base` (BASE_ENV_PROMPT, no retrieval — the ablation arm
+  and the only option for Search/Android/Web/OS, which have no wmh corpora).
+- `judge_shim.py` — OpenAI-compatible `/v1/chat/completions` over Bedrock. **Stand-in judge only**
+  (see Blockers). `GET /usage` returns metered judge cost.
+
+## End-to-end (smoke)
+
+```bash
+# 0) data (streamed sample; full files via huggingface-cli download Qwen/AgentWorldBench)
+#    -> .wmh/agentworldbench/data/{terminal,mcp,swe}_test.jsonl
+
+# 1) our infer (built terminal model, 3 rows)
+uv run python .agents/scripts/agentworldbench/awb_infer.py \
+  --data .wmh/agentworldbench/data/terminal_test.jsonl --limit 3 --mode wm \
+  --model-dir packages/environment-capture/terminal-tasks/models/terminal-tasks \
+  --output .wmh/agentworldbench/results/terminal_wm/predictions.jsonl
+
+# 2) their judge, unmodified, through the shim (STAND-IN judge — non-comparable)
+uv run python .agents/scripts/agentworldbench/judge_shim.py &   # port 8765
+python /tmp/qwen-agentworld/eval/eval.py judge \
+  --predictions .wmh/agentworldbench/results/terminal_wm/predictions.jsonl \
+  --judge-base-url http://127.0.0.1:8765/v1 --judge-model stand-in-opus-4.8 \
+  --judge-api-key EMPTY --temperature 0 \
+  --output-dir .wmh/agentworldbench/results/terminal_wm
+
+# 3) their aggregation
+python /tmp/qwen-agentworld/eval/eval.py score \
+  --predictions .wmh/agentworldbench/results/terminal_wm/judged.jsonl
+```
+
+Domain → model mapping for `wm` mode (approximations noted):
+terminal → `terminal-tasks`, swe → `swe-bench`, mcp → `tau-bench` (tau ≈ MCP tool-calling; label
+the approximation in any table).
+
+## Smoke E2E result (2026-07-07 — plumbing proof, NOT comparable numbers)
+
+8 rows, judged by the STAND-IN judge (Opus 4.8 via the shim, temperature 0) — their pinned
+judge is gpt-5.2, so these validate the pipeline only. Their `judge`+`score` stages ran
+unmodified; 8/8 judge outputs parsed on the first attempt. Normalized 0–100:
+
+| arm | model | n | format | factuality | consistency | realism | quality | total |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| terminal, wm | terminal-tasks (opt+RAG) | 3 | 75.00 | 58.33 | 91.67 | 83.33 | 75.00 | **76.67** |
+| terminal, base | BASE_ENV_PROMPT | 3 | 75.00 | 50.00 | 75.00 | 66.67 | 58.33 | **65.00** |
+| mcp, wm | tau-bench (≈MCP) | 2 | 62.50 | 0.00 | 25.00 | 25.00 | 12.50 | **25.00** |
+
+Even at n=3 the RAG/optimized terminal model beats the base prompt (+11.67). The mcp rows are
+turn-1/2 filesystem-MCP listings whose content is unknowable a priori — the judge correctly
+gave factuality 1 for hallucinated directory names (eyeballed; judge reasoning is sound).
+Costs: infer $0.32 (8 predictions, metered per row in `wmh_infer`), judge $0.523 (shim `/usage`).
+
+## Blockers for comparable numbers
+
+1. **Judge key**: comparable rows require OpenAI `gpt-5.2-2025-12-11`; the repo's OPENAI_API_KEY
+   is dead (401) as of 2026-07-07. Rerun step 2 with
+   `--judge-base-url https://api.openai.com/v1 --judge-model gpt-5.2-2025-12-11 --temperature 0`
+   once a fresh key lands. Everything else is judge-independent.
+2. Their reported numbers used temperature 0.6 judging (code default); we pin 0 and say so.

--- a/.agents/scripts/agentworldbench/README.md
+++ b/.agents/scripts/agentworldbench/README.md
@@ -120,6 +120,38 @@ search on terminal — convenient, as live-fetch vs recorded data was a validity
 Ops note: judge stage initially no-op'd silently — the /tmp eval-repo clone had been purged by
 the tmp cleaner; their code now lives pinned under `.wmh/qwen-agentworld` (same @354f733).
 
+## Attribution experiments (2026-07-19/20) — the loop-closers
+
+**Exp B — swe delta decomposition**: `swe-bench-max` served plain-RAG (no `--max-fidelity`)
+scored **64.96** → of the +13.34 swe gain, **+11.57 (86%) is the haiku→Opus serve model**;
+reason+verify adds +1.77 at 2.2× infer cost ($67→$145). 472/472, $67.25.
+
+**Exp A — their 35B fed FULL history** (`awb_infer_history.py`: history as alternating chat
+turns — documented deviation from their shipped history-blind infer; everything else theirs;
+same pinned judge; vLLM 0.23.0 TP=2 on h100-dev-box-8, temp 0). 2,170/2,170, 9 judge failures:
+
+| domain | 35B blind (shipped) | **35B + history** | Δ history | wmh-max |
+|---|---:|---:|---:|---:|
+| MCP | 44.83 | **65.87** | +21.04 | 55.37 |
+| Search | 38.50 | 42.69 | +4.19 | **44.46** |
+| Terminal | 27.29 | 54.52 | +27.23 | 53.56 |
+| SWE | 44.66 | 61.03 | +16.37 | **66.73** |
+| Android | 47.35 | 61.62 | +14.27 | 59.72 |
+| Web | 52.88 | 59.13 | +6.25 | 56.93 |
+| OS | 54.87 | 54.97 | +0.10 | 53.47 |
+| **Macro** | 44.34 | **57.12** | **+12.78** | 55.75 |
+
+**Corrected headline (supersedes the D80-era "wmh beats their released 35B" claim):** that gap
+was ~entirely their shipped protocol starving the model of history. Under equal information and
+one judge, **their purpose-trained 35B modestly beats our best config, 57.12 vs 55.75 (−1.37)**,
+winning 5/7 domains — dominated by trained-in environment priors (MCP +10.5 over us). wmh wins
+where serve-model muscle (SWE, Opus) or scaffolding (Search) dominates. Their published 56.39
+(gpt-5.2 judge) is consistent with our 57.12 under a harsher judge, suggesting their reported
+numbers were produced WITH history — i.e. the released `eval.py infer` does not reproduce their
+paper protocol. A 35B open-weight model matching frontier-model world-modeling at equal
+information is genuinely strong — and the honest takeaway for wmh is that our differentiation
+is scaffolding + real-env grounding, not fidelity-per-parameter on their metric.
+
 ## Anchor row: Qwen-AgentWorld-35B-A3B, same judge (2026-07-11)
 
 Their released model, served per their README (vLLM `--language-model-only --reasoning-parser

--- a/.agents/scripts/agentworldbench/awb_infer.py
+++ b/.agents/scripts/agentworldbench/awb_infer.py
@@ -68,24 +68,25 @@ def infer_wm(rows: list[JsonObject], model_dir: str) -> list[JsonObject]:
     """Predict via a built model's serving path: seeded session -> one step (retrieval included)."""
     world_model, provider = load_world_model(model_dir)
     for i, row in enumerate(rows):
-        session = world_model.new_session(task=None)
+        row["gen"] = ""
+        session = None
         try:
+            session = world_model.new_session(task=None)
             world_model.seed_session(session.id, history_steps(row))
             observation = world_model.step(session.id, current_action(row))
             row["gen"] = wrap_gen(observation)
         except Exception:  # per-row isolation; their judge marks gen == "" as failed
-            row["gen"] = ""
             print(f"[{i + 1}/{len(rows)}] infer failed for id={row.get('id')}", file=sys.stderr)
             traceback.print_exc()
         finally:
-            usage = world_model.end_session(session.id)
+            usage = world_model.end_session(session.id) if session is not None else None
         row["wmh_infer"] = {
             "mode": "wm",
             "model_dir": model_dir,
             "serve_model": provider.config.model,
-            "input_tokens": usage.total.input_tokens,
-            "output_tokens": usage.total.output_tokens,
-            "cost_usd": usage.total.cost_usd,
+            "input_tokens": usage.total.input_tokens if usage else 0,
+            "output_tokens": usage.total.output_tokens if usage else 0,
+            "cost_usd": usage.total.cost_usd if usage else 0.0,
         }
         print(f"[{i + 1}/{len(rows)}] id={row.get('id')} turn={row.get('turn_idx')} ok")
     return rows
@@ -149,7 +150,7 @@ def main() -> None:
         for line in Path(args.data).read_text(encoding="utf-8").splitlines()
         if line
     ]
-    if args.limit:
+    if args.limit is not None:
         rows = rows[: args.limit]
     print(f"{len(rows)} rows from {args.data} (mode={args.mode})")
 

--- a/.agents/scripts/agentworldbench/awb_infer.py
+++ b/.agents/scripts/agentworldbench/awb_infer.py
@@ -150,12 +150,15 @@ def load_done(out: Path) -> dict[tuple[str, int], JsonObject]:
     """Rows already predicted (non-empty gen) in an existing output file."""
     done: dict[tuple[str, int], JsonObject] = {}
     if out.exists():
-        for line in out.read_text(encoding="utf-8").splitlines():
-            if not line:
-                continue
-            row = json.loads(line)
-            if row.get("gen"):
-                done[row_key(row)] = row
+        # Iterate the file (splits on \n only): rows can embed  -class separators that
+        # str.splitlines() would split mid-JSON-string (bit the search domain).
+        with out.open(encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                row = json.loads(line)
+                if row.get("gen"):
+                    done[row_key(row)] = row
     return done
 
 
@@ -174,11 +177,8 @@ def main() -> None:
     if args.mode == "wm" and not args.model_dir:
         parser.error("--mode wm requires --model-dir")
 
-    rows: list[JsonObject] = [
-        json.loads(line)
-        for line in Path(args.data).read_text(encoding="utf-8").splitlines()
-        if line
-    ]
+    with Path(args.data).open(encoding="utf-8") as f:  # \n-only splitting, see load_done
+        rows: list[JsonObject] = [json.loads(line) for line in f if line.strip()]
     if args.limit is not None:
         rows = rows[: args.limit]
 

--- a/.agents/scripts/agentworldbench/awb_infer.py
+++ b/.agents/scripts/agentworldbench/awb_infer.py
@@ -16,29 +16,41 @@ Two modes:
 - `base`: BASE_ENV_PROMPT + no retrieval, any provider — for domains without a wmh corpus
   and for the RAG-vs-base ablation.
 
+Built for long runs: rows are predicted on a thread pool (`--concurrency`), each row retries
+with backoff on provider errors, completed rows are appended to the output immediately, and
+`--resume` skips rows already predicted in an existing output file.
+
 Usage (from the repo root):
     uv run python .agents/scripts/agentworldbench/awb_infer.py \
-        --data .wmh/agentworldbench/data/terminal_test.jsonl --limit 3 \
+        --data .wmh/agentworldbench/data_full/terminal_test.jsonl \
         --mode wm --model-dir packages/environment-capture/terminal-tasks/models/terminal-tasks \
-        --output .wmh/agentworldbench/results/terminal_wm/predictions.jsonl
+        --concurrency 3 --resume \
+        --output .wmh/agentworldbench/results54/terminal_wm/predictions.jsonl
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import random
 import sys
+import threading
+import time
 import traceback
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Callable
 
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.engine.loader import load_world_model
 from wmh.engine.prompts import BASE_ENV_PROMPT
 from wmh.optimize.gepa import predict_observation
 from wmh.providers import get_provider
-from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.tracking.metered import MeteredProvider
 from wmh.tracking.tracker import Phase, RunTracker
+
+RETRY_ATTEMPTS = 4
 
 
 def history_steps(row: JsonObject) -> list[Step]:
@@ -55,81 +67,96 @@ def history_steps(row: JsonObject) -> list[Step]:
 
 
 def current_action(row: JsonObject) -> Action:
+    # Falsy check mirrors upstream eval.py exactly (their judge uses the same fallback).
     content = row.get("current_prompt") or row["prompt"][int(row["turn_idx"]) - 1]
     return Action(kind=ActionKind.MESSAGE, content=content)
 
 
 def wrap_gen(observation: Observation) -> str:
-    """Their output_parser extracts the LAST <predicted_observation> block (tag optional but safest)."""
+    """Their output_parser extracts the LAST <predicted_observation> block."""
     return f"<predicted_observation>\n{observation.content}\n</predicted_observation>"
 
 
-def infer_wm(rows: list[JsonObject], model_dir: str) -> list[JsonObject]:
-    """Predict via a built model's serving path: seeded session -> one step (retrieval included)."""
-    world_model, provider = load_world_model(model_dir)
-    for i, row in enumerate(rows):
-        row["gen"] = ""
-        session = None
+def with_retry(fn: Callable[[], Observation]) -> Observation:
+    """Retry provider errors with capped exponential backoff + jitter (Bedrock throttling)."""
+    for attempt in range(RETRY_ATTEMPTS):
         try:
-            session = world_model.new_session(task=None)
-            world_model.seed_session(session.id, history_steps(row))
-            observation = world_model.step(session.id, current_action(row))
-            row["gen"] = wrap_gen(observation)
-        except Exception:  # per-row isolation; their judge marks gen == "" as failed
-            print(f"[{i + 1}/{len(rows)}] infer failed for id={row.get('id')}", file=sys.stderr)
-            traceback.print_exc()
-        finally:
-            usage = world_model.end_session(session.id) if session is not None else None
-        row["wmh_infer"] = {
-            "mode": "wm",
-            "model_dir": model_dir,
-            "serve_model": provider.config.model,
-            "input_tokens": usage.total.input_tokens if usage else 0,
-            "output_tokens": usage.total.output_tokens if usage else 0,
-            "cost_usd": usage.total.cost_usd if usage else 0.0,
-        }
-        print(f"[{i + 1}/{len(rows)}] id={row.get('id')} turn={row.get('turn_idx')} ok")
-    return rows
-
-
-def infer_base(rows: list[JsonObject], provider_model: str, region: str) -> list[JsonObject]:
-    """Predict with BASE_ENV_PROMPT and no retrieval (base-prompt-only rows / ablation arm)."""
-    tracker = RunTracker(run_id="awb-infer-base", kind="eval")
-    tracker.start()
-    provider = MeteredProvider(
-        get_provider(
-            ProviderConfig(kind=ProviderKind.BEDROCK, model=provider_model, region=region)
-        ),
-        tracker,
-        base_phase=Phase.SERVE,
-    )
-    for i, row in enumerate(rows):
-        before = tracker.record_summary().total
-        try:
-            observation = predict_observation(
-                provider,
-                BASE_ENV_PROMPT,
-                None,
-                EnvState(),
-                current_action(row),
-                demos=[],
-                history=history_steps(row),
-            )
-            row["gen"] = wrap_gen(observation)
+            return fn()
         except Exception:
-            row["gen"] = ""
-            print(f"[{i + 1}/{len(rows)}] infer failed for id={row.get('id')}", file=sys.stderr)
-            traceback.print_exc()
-        after = tracker.record_summary().total
+            if attempt == RETRY_ATTEMPTS - 1:
+                raise
+            delay = min(60.0, 5.0 * 2**attempt) + random.uniform(0.0, 3.0)
+            time.sleep(delay)
+    raise AssertionError("unreachable")
+
+
+def predict_row_wm(world_model, serve_model: str, model_dir: str, row: JsonObject) -> None:
+    """One row through the serving session path (retrieval included), per-session metering."""
+
+    def attempt() -> Observation:
+        session = world_model.new_session(task=None)
+        try:
+            world_model.seed_session(session.id, history_steps(row))
+            return world_model.step(session.id, current_action(row))
+        finally:
+            usage = world_model.end_session(session.id)
+            row["wmh_infer"] = {
+                "mode": "wm",
+                "model_dir": model_dir,
+                "serve_model": serve_model,
+                "input_tokens": usage.total.input_tokens,
+                "output_tokens": usage.total.output_tokens,
+                "cost_usd": usage.total.cost_usd,
+            }
+
+    row["gen"] = wrap_gen(with_retry(attempt))
+
+
+def predict_row_base(provider: Provider, serve_model: str, row: JsonObject) -> None:
+    """One row with BASE_ENV_PROMPT and no retrieval; per-row tracker for clean attribution."""
+    tracker = RunTracker(run_id=f"awb-base-{row['id']}-{row['turn_idx']}", kind="eval")
+    tracker.start()
+    metered = MeteredProvider(provider, tracker, base_phase=Phase.SERVE)
+
+    def attempt() -> Observation:
+        return predict_observation(
+            metered,
+            BASE_ENV_PROMPT,
+            None,
+            EnvState(),
+            current_action(row),
+            demos=[],
+            history=history_steps(row),
+        )
+
+    try:
+        row["gen"] = wrap_gen(with_retry(attempt))
+    finally:
+        total = tracker.record_summary().total
         row["wmh_infer"] = {
             "mode": "base",
-            "serve_model": provider_model,
-            "input_tokens": after.input_tokens - before.input_tokens,
-            "output_tokens": after.output_tokens - before.output_tokens,
-            "cost_usd": (after.cost_usd or 0.0) - (before.cost_usd or 0.0),
+            "serve_model": serve_model,
+            "input_tokens": total.input_tokens,
+            "output_tokens": total.output_tokens,
+            "cost_usd": total.cost_usd,
         }
-        print(f"[{i + 1}/{len(rows)}] id={row.get('id')} turn={row.get('turn_idx')} ok")
-    return rows
+
+
+def row_key(row: JsonObject) -> tuple[str, int]:
+    return (str(row["id"]), int(row["turn_idx"]))
+
+
+def load_done(out: Path) -> dict[tuple[str, int], JsonObject]:
+    """Rows already predicted (non-empty gen) in an existing output file."""
+    done: dict[tuple[str, int], JsonObject] = {}
+    if out.exists():
+        for line in out.read_text(encoding="utf-8").splitlines():
+            if not line:
+                continue
+            row = json.loads(line)
+            if row.get("gen"):
+                done[row_key(row)] = row
+    return done
 
 
 def main() -> None:
@@ -140,6 +167,8 @@ def main() -> None:
     parser.add_argument("--provider-model", default="us.anthropic.claude-opus-4-8")
     parser.add_argument("--region", default="us-east-1")
     parser.add_argument("--limit", type=int, default=None, help="first N rows only")
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--resume", action="store_true", help="skip rows already in --output")
     parser.add_argument("--output", required=True, help="predictions.jsonl path")
     args = parser.parse_args()
     if args.mode == "wm" and not args.model_dir:
@@ -152,21 +181,66 @@ def main() -> None:
     ]
     if args.limit is not None:
         rows = rows[: args.limit]
-    print(f"{len(rows)} rows from {args.data} (mode={args.mode})")
-
-    if args.mode == "wm":
-        rows = infer_wm(rows, args.model_dir)
-    else:
-        rows = infer_base(rows, args.provider_model, args.region)
 
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
+    done = load_done(out) if args.resume else {}
+    todo = [r for r in rows if row_key(r) not in done]
+    # Compact the file to exactly the completed rows, then append as new rows finish — a
+    # crash/restart with --resume never duplicates a row or loses a finished one.
     with out.open("w", encoding="utf-8") as f:
-        for row in rows:
+        for row in done.values():
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
-    total_cost = sum(r["wmh_infer"].get("cost_usd") or 0.0 for r in rows)
-    n_ok = sum(1 for r in rows if r["gen"])
-    print(f"wrote {out} — {n_ok}/{len(rows)} predictions, infer cost ${total_cost:.4f}")
+    print(
+        f"{len(rows)} rows from {args.data} (mode={args.mode}); {len(done)} done, {len(todo)} to run"
+    )
+
+    if args.mode == "wm":
+        world_model, provider = load_world_model(args.model_dir)
+        serve_model = provider.config.model
+        predict = lambda row: predict_row_wm(world_model, serve_model, args.model_dir, row)  # noqa: E731
+    else:
+        provider = get_provider(
+            ProviderConfig(kind=ProviderKind.BEDROCK, model=args.provider_model, region=args.region)
+        )
+        predict = lambda row: predict_row_base(provider, args.provider_model, row)  # noqa: E731
+
+    write_lock = threading.Lock()
+    counter = {"done": 0, "failed": 0}
+
+    def work(row: JsonObject) -> None:
+        try:
+            predict(row)
+        except Exception:
+            row["gen"] = ""  # their judge marks gen == "" as failed
+            row.setdefault("wmh_infer", {"mode": args.mode, "error": True})
+            failed = True
+            print(f"FAILED id={row.get('id')} turn={row.get('turn_idx')}", file=sys.stderr)
+            traceback.print_exc()
+        else:
+            failed = False
+        with write_lock:
+            with out.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            counter["done"] += 1
+            counter["failed"] += 1 if failed else 0
+            n = counter["done"]
+        if n % 10 == 0 or n == len(todo):
+            print(f"[{n}/{len(todo)}] done ({counter['failed']} failed)", flush=True)
+
+    if args.concurrency > 1 and len(todo) > 1:
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            list(pool.map(work, todo))
+    else:
+        for row in todo:
+            work(row)
+
+    finished = load_done(out)
+    total_cost = sum((r["wmh_infer"].get("cost_usd") or 0.0) for r in finished.values())
+    print(
+        f"wrote {out} — {len(finished)}/{len(rows)} predictions "
+        f"({counter['failed']} failed this pass), infer cost ${total_cost:.2f}"
+    )
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/agentworldbench/awb_infer.py
+++ b/.agents/scripts/agentworldbench/awb_infer.py
@@ -1,0 +1,172 @@
+"""AgentWorldBench `infer` stage backed by a wmh world model.
+
+Replaces `eval.py infer` from github.com/QwenLM/Qwen-AgentWorld. Reads the benchmark's
+per-domain `*_test.jsonl` rows, feeds each row's FULL interaction history to a wmh world
+model, and writes `predictions.jsonl` with the `gen` field their `judge`/`score` stages
+consume unchanged.
+
+Protocol note (verified against their repo @354f733): their shipped `infer` sends only
+`system_str` + `current_prompt` — NO prior turns — while `build_judge_messages` scores the
+prediction against the full history context. We follow the paper protocol (the world model
+receives the interaction history): turns `1..turn_idx-1` are seeded as teacher-forced
+history, exactly what the judge sees.
+
+Two modes:
+- `wm`: a built wmh model (optimized prompt + RAG index), via the serving session path.
+- `base`: BASE_ENV_PROMPT + no retrieval, any provider — for domains without a wmh corpus
+  and for the RAG-vs-base ablation.
+
+Usage (from the repo root):
+    uv run python .agents/scripts/agentworldbench/awb_infer.py \
+        --data .wmh/agentworldbench/data/terminal_test.jsonl --limit 3 \
+        --mode wm --model-dir packages/environment-capture/terminal-tasks/models/terminal-tasks \
+        --output .wmh/agentworldbench/results/terminal_wm/predictions.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+from pathlib import Path
+
+from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
+from wmh.engine.loader import load_world_model
+from wmh.engine.prompts import BASE_ENV_PROMPT
+from wmh.optimize.gepa import predict_observation
+from wmh.providers import get_provider
+from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.tracking.metered import MeteredProvider
+from wmh.tracking.tracker import Phase, RunTracker
+
+
+def history_steps(row: JsonObject) -> list[Step]:
+    """Turns 1..turn_idx-1 as teacher-forced Steps (prompt/response are parallel lists)."""
+    prompts, responses = row["prompt"], row["response"]
+    n_history = min(int(row["turn_idx"]) - 1, len(prompts), len(responses))
+    return [
+        Step(
+            action=Action(kind=ActionKind.MESSAGE, content=prompts[i]),
+            observation=Observation(content=responses[i]),
+        )
+        for i in range(n_history)
+    ]
+
+
+def current_action(row: JsonObject) -> Action:
+    content = row.get("current_prompt") or row["prompt"][int(row["turn_idx"]) - 1]
+    return Action(kind=ActionKind.MESSAGE, content=content)
+
+
+def wrap_gen(observation: Observation) -> str:
+    """Their output_parser extracts the LAST <predicted_observation> block (tag optional but safest)."""
+    return f"<predicted_observation>\n{observation.content}\n</predicted_observation>"
+
+
+def infer_wm(rows: list[JsonObject], model_dir: str) -> list[JsonObject]:
+    """Predict via a built model's serving path: seeded session -> one step (retrieval included)."""
+    world_model, provider = load_world_model(model_dir)
+    for i, row in enumerate(rows):
+        session = world_model.new_session(task=None)
+        try:
+            world_model.seed_session(session.id, history_steps(row))
+            observation = world_model.step(session.id, current_action(row))
+            row["gen"] = wrap_gen(observation)
+        except Exception:  # per-row isolation; their judge marks gen == "" as failed
+            row["gen"] = ""
+            print(f"[{i + 1}/{len(rows)}] infer failed for id={row.get('id')}", file=sys.stderr)
+            traceback.print_exc()
+        finally:
+            usage = world_model.end_session(session.id)
+        row["wmh_infer"] = {
+            "mode": "wm",
+            "model_dir": model_dir,
+            "serve_model": provider.config.model,
+            "input_tokens": usage.total.input_tokens,
+            "output_tokens": usage.total.output_tokens,
+            "cost_usd": usage.total.cost_usd,
+        }
+        print(f"[{i + 1}/{len(rows)}] id={row.get('id')} turn={row.get('turn_idx')} ok")
+    return rows
+
+
+def infer_base(rows: list[JsonObject], provider_model: str, region: str) -> list[JsonObject]:
+    """Predict with BASE_ENV_PROMPT and no retrieval (base-prompt-only rows / ablation arm)."""
+    tracker = RunTracker(run_id="awb-infer-base", kind="eval")
+    tracker.start()
+    provider = MeteredProvider(
+        get_provider(
+            ProviderConfig(kind=ProviderKind.BEDROCK, model=provider_model, region=region)
+        ),
+        tracker,
+        base_phase=Phase.SERVE,
+    )
+    for i, row in enumerate(rows):
+        before = tracker.record_summary().total
+        try:
+            observation = predict_observation(
+                provider,
+                BASE_ENV_PROMPT,
+                None,
+                EnvState(),
+                current_action(row),
+                demos=[],
+                history=history_steps(row),
+            )
+            row["gen"] = wrap_gen(observation)
+        except Exception:
+            row["gen"] = ""
+            print(f"[{i + 1}/{len(rows)}] infer failed for id={row.get('id')}", file=sys.stderr)
+            traceback.print_exc()
+        after = tracker.record_summary().total
+        row["wmh_infer"] = {
+            "mode": "base",
+            "serve_model": provider_model,
+            "input_tokens": after.input_tokens - before.input_tokens,
+            "output_tokens": after.output_tokens - before.output_tokens,
+            "cost_usd": (after.cost_usd or 0.0) - (before.cost_usd or 0.0),
+        }
+        print(f"[{i + 1}/{len(rows)}] id={row.get('id')} turn={row.get('turn_idx')} ok")
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", required=True, help="one AgentWorldBench {domain}_test.jsonl")
+    parser.add_argument("--mode", choices=["wm", "base"], required=True)
+    parser.add_argument("--model-dir", help="built wmh model dir (required for --mode wm)")
+    parser.add_argument("--provider-model", default="us.anthropic.claude-opus-4-8")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--limit", type=int, default=None, help="first N rows only")
+    parser.add_argument("--output", required=True, help="predictions.jsonl path")
+    args = parser.parse_args()
+    if args.mode == "wm" and not args.model_dir:
+        parser.error("--mode wm requires --model-dir")
+
+    rows: list[JsonObject] = [
+        json.loads(line)
+        for line in Path(args.data).read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    if args.limit:
+        rows = rows[: args.limit]
+    print(f"{len(rows)} rows from {args.data} (mode={args.mode})")
+
+    if args.mode == "wm":
+        rows = infer_wm(rows, args.model_dir)
+    else:
+        rows = infer_base(rows, args.provider_model, args.region)
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    total_cost = sum(r["wmh_infer"].get("cost_usd") or 0.0 for r in rows)
+    n_ok = sum(1 for r in rows if r["gen"])
+    print(f"wrote {out} — {n_ok}/{len(rows)} predictions, infer cost ${total_cost:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/agentworldbench/awb_infer.py
+++ b/.agents/scripts/agentworldbench/awb_infer.py
@@ -44,7 +44,7 @@ from typing import Callable
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.engine.loader import load_world_model
 from wmh.engine.prompts import BASE_ENV_PROMPT
-from wmh.optimize.gepa import predict_observation
+from wmh.optimize.gepa import predict_observation, verify_observation
 from wmh.providers import get_provider
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.tracking.metered import MeteredProvider
@@ -90,7 +90,9 @@ def with_retry(fn: Callable[[], Observation]) -> Observation:
     raise AssertionError("unreachable")
 
 
-def predict_row_wm(world_model, serve_model: str, model_dir: str, row: JsonObject) -> None:
+def predict_row_wm(
+    world_model, serve_model: str, model_dir: str, row: JsonObject, *, max_fidelity: bool = False
+) -> None:
     """One row through the serving session path (retrieval included), per-session metering."""
 
     def attempt() -> Observation:
@@ -103,6 +105,7 @@ def predict_row_wm(world_model, serve_model: str, model_dir: str, row: JsonObjec
             row["wmh_infer"] = {
                 "mode": "wm",
                 "model_dir": model_dir,
+                "max_fidelity": max_fidelity,
                 "serve_model": serve_model,
                 "input_tokens": usage.total.input_tokens,
                 "output_tokens": usage.total.output_tokens,
@@ -112,21 +115,47 @@ def predict_row_wm(world_model, serve_model: str, model_dir: str, row: JsonObjec
     row["gen"] = wrap_gen(with_retry(attempt))
 
 
-def predict_row_base(provider: Provider, serve_model: str, row: JsonObject) -> None:
-    """One row with BASE_ENV_PROMPT and no retrieval; per-row tracker for clean attribution."""
+def predict_row_base(
+    provider: Provider,
+    serve_model: str,
+    row: JsonObject,
+    *,
+    reasoning: bool = False,
+    verify: bool = False,
+) -> None:
+    """One row with BASE_ENV_PROMPT and no retrieval; per-row tracker for clean attribution.
+
+    `reasoning`/`verify` are the corpus-free max levers (verify = one extra completion that
+    audits the draft — doubles per-row provider cost).
+    """
     tracker = RunTracker(run_id=f"awb-base-{row['id']}-{row['turn_idx']}", kind="eval")
     tracker.start()
     metered = MeteredProvider(provider, tracker, base_phase=Phase.SERVE)
 
     def attempt() -> Observation:
-        return predict_observation(
+        history = history_steps(row)
+        draft = predict_observation(
             metered,
             BASE_ENV_PROMPT,
             None,
             EnvState(),
             current_action(row),
             demos=[],
-            history=history_steps(row),
+            history=history,
+            reasoning=reasoning,
+        )
+        if not verify:
+            return draft
+        return verify_observation(
+            metered,
+            BASE_ENV_PROMPT,
+            None,
+            EnvState(),
+            current_action(row),
+            draft,
+            demos=[],
+            history=history,
+            reasoning=reasoning,
         )
 
     try:
@@ -136,6 +165,8 @@ def predict_row_base(provider: Provider, serve_model: str, row: JsonObject) -> N
         row["wmh_infer"] = {
             "mode": "base",
             "serve_model": serve_model,
+            "reasoning": reasoning,
+            "verify": verify,
             "input_tokens": total.input_tokens,
             "output_tokens": total.output_tokens,
             "cost_usd": total.cost_usd,
@@ -173,6 +204,15 @@ def main() -> None:
     parser.add_argument("--concurrency", type=int, default=1)
     parser.add_argument("--resume", action="store_true", help="skip rows already in --output")
     parser.add_argument("--output", required=True, help="predictions.jsonl path")
+    parser.add_argument(
+        "--max-fidelity",
+        action="store_true",
+        help="wm mode: apply the model's auto_fidelity.json winner (plain load = pure RAG)",
+    )
+    parser.add_argument("--reasoning", action="store_true", help="base mode: reasoning lever")
+    parser.add_argument(
+        "--verify", action="store_true", help="base mode: verify second pass (2x provider cost)"
+    )
     args = parser.parse_args()
     if args.mode == "wm" and not args.model_dir:
         parser.error("--mode wm requires --model-dir")
@@ -196,14 +236,24 @@ def main() -> None:
     )
 
     if args.mode == "wm":
-        world_model, provider = load_world_model(args.model_dir)
+        world_model, provider = load_world_model(args.model_dir, max_fidelity=args.max_fidelity)
         serve_model = provider.config.model
-        predict = lambda row: predict_row_wm(world_model, serve_model, args.model_dir, row)  # noqa: E731
+        winner_path = Path(args.model_dir) / "auto_fidelity.json"
+        if args.max_fidelity and not winner_path.exists():
+            parser.error(f"--max-fidelity: no auto_fidelity.json in {args.model_dir}")
+        winner = json.loads(winner_path.read_text()) if winner_path.exists() else None
+        if args.max_fidelity:
+            print(f"max-fidelity winner: {winner}")
+        predict = lambda row: predict_row_wm(  # noqa: E731
+            world_model, serve_model, args.model_dir, row, max_fidelity=args.max_fidelity
+        )
     else:
         provider = get_provider(
             ProviderConfig(kind=ProviderKind.BEDROCK, model=args.provider_model, region=args.region)
         )
-        predict = lambda row: predict_row_base(provider, args.provider_model, row)  # noqa: E731
+        predict = lambda row: predict_row_base(  # noqa: E731
+            provider, args.provider_model, row, reasoning=args.reasoning, verify=args.verify
+        )
 
     write_lock = threading.Lock()
     counter = {"done": 0, "failed": 0}

--- a/.agents/scripts/agentworldbench/awb_infer_history.py
+++ b/.agents/scripts/agentworldbench/awb_infer_history.py
@@ -1,0 +1,103 @@
+"""Experiment A: Qwen-AgentWorld's own model fed the FULL interaction history.
+
+DOCUMENTED DEVIATION from their shipped `eval.py infer` (@354f733), which sends only
+`system_str` + `current_prompt`. Here the history turns 1..turn_idx-1 are injected as
+alternating user/assistant chat turns (action -> observation) before the current action —
+the same information their `build_judge_messages` shows the judge, in the model's native
+chat form. Everything else matches their pipeline: their data rows, temperature 0,
+max_tokens 32768, `gen` output field consumed by their judge stage unmodified.
+
+Runs on the serving box against a local vLLM. Stdlib + openai only (no wmh imports).
+
+Usage:
+    python awb_infer_history.py --data-dir <shard_dir> \
+        --base-url http://127.0.0.1:8899/v1 --model Qwen/Qwen-AgentWorld-35B-A3B \
+        --output-dir <out_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from openai import OpenAI
+
+MAX_TOKENS = 32768
+RETRIES = 3
+
+
+def build_messages(job: dict) -> list[dict]:
+    prompts, responses = job.get("prompt", []), job.get("response", [])
+    turn_idx = int(job.get("turn_idx", 1))
+    n_history = min(turn_idx - 1, len(prompts), len(responses))
+    messages = []
+    if job.get("system_str"):
+        messages.append({"role": "system", "content": job["system_str"]})
+    for i in range(n_history):
+        messages.append({"role": "user", "content": prompts[i]})
+        messages.append({"role": "assistant", "content": responses[i]})
+    # current_prompt fallback mirrors their run_inference exactly.
+    current = job.get("current_prompt", "")
+    if not current and turn_idx - 1 < len(prompts):
+        current = prompts[turn_idx - 1]
+    messages.append({"role": "user", "content": current})
+    return messages
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    jobs = []
+    for f in sorted(Path(args.data_dir).glob("*_test.jsonl")):
+        with f.open(encoding="utf-8") as fh:
+            jobs.extend(json.loads(line) for line in fh if line.strip())
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "predictions.jsonl"
+    done = set()
+    if out_path.exists():
+        with out_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                if line.strip():
+                    r = json.loads(line)
+                    if r.get("gen"):
+                        done.add((str(r["id"]), int(r["turn_idx"])))
+    todo = [j for j in jobs if (str(j["id"]), int(j["turn_idx"])) not in done]
+    print(f"{len(jobs)} jobs, {len(done)} done, {len(todo)} to run", flush=True)
+
+    client = OpenAI(base_url=args.base_url, api_key="EMPTY")
+    with out_path.open("a", encoding="utf-8") as out:
+        for i, job in enumerate(todo):
+            gen = ""
+            for attempt in range(RETRIES):
+                try:
+                    response = client.chat.completions.create(
+                        model=args.model,
+                        messages=build_messages(job),
+                        max_tokens=MAX_TOKENS,
+                        temperature=0,
+                    )
+                    gen = response.choices[0].message.content or ""
+                    break
+                except Exception as e:
+                    print(f"[{i + 1}] attempt {attempt + 1} failed: {e}", file=sys.stderr, flush=True)
+                    time.sleep(5 * (attempt + 1))
+            job["gen"] = gen
+            job["wmh_protocol"] = "full_history_chat_turns"
+            out.write(json.dumps(job, ensure_ascii=False) + "\n")
+            out.flush()
+            if (i + 1) % 10 == 0 or (i + 1) == len(todo):
+                print(f"[{i + 1}/{len(todo)}]", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/agentworldbench/judge_shim.py
+++ b/.agents/scripts/agentworldbench/judge_shim.py
@@ -1,0 +1,137 @@
+"""Minimal OpenAI-compatible /v1/chat/completions shim over a wmh provider (Bedrock).
+
+Lets Qwen-AgentWorld's `eval.py judge` stage run unmodified against a Bedrock Anthropic
+model via `--judge-base-url http://127.0.0.1:8765/v1 --judge-api-key EMPTY`.
+
+STAND-IN JUDGE ONLY: AgentWorldBench's pinned judge is OpenAI `gpt-5.2-2025-12-11`.
+Scores produced through this shim are NOT comparable to the paper's table (D12: never
+compare across judges) — they only prove the pipeline end-to-end until a live
+OPENAI_API_KEY is available.
+
+Usage:
+    uv run python .agents/scripts/agentworldbench/judge_shim.py --model us.anthropic.claude-opus-4-8
+    curl http://127.0.0.1:8765/usage   # metered judge tokens + cost so far
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+import uuid
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from wmh.providers import get_provider
+from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.tracking.metered import MeteredProvider
+from wmh.tracking.tracker import Phase, RunTracker
+
+MAX_OUTPUT_TOKENS = 8192  # judge emits reasoning + one JSON block; clamp their 32768 default
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: list[ChatMessage]
+    max_tokens: int = MAX_OUTPUT_TOKENS
+    temperature: float = 0.0
+
+
+class ChatChoice(BaseModel):
+    index: int = 0
+    message: ChatMessage
+    finish_reason: str = "stop"
+
+
+class ChatUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatChoice]
+    usage: ChatUsage
+
+
+class UsageSummary(BaseModel):
+    calls: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float | None
+    judge_model: str = Field(description="the actual backing model, not the requested alias")
+
+
+def create_app(model: str, region: str) -> FastAPI:
+    tracker = RunTracker(run_id="awb-judge-shim", kind="eval")
+    tracker.start()
+    provider = MeteredProvider(
+        get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=model, region=region)),
+        tracker,
+        base_phase=Phase.JUDGE,
+    )
+    app = FastAPI(title="wmh AgentWorldBench judge shim")
+    calls = {"n": 0}
+
+    @app.post("/v1/chat/completions")
+    def chat_completions(request: ChatRequest) -> ChatResponse:
+        system = "\n\n".join(m.content for m in request.messages if m.role == "system")
+        turns = [
+            Message(role="assistant" if m.role == "assistant" else "user", content=m.content)
+            for m in request.messages
+            if m.role != "system"
+        ]
+        completion = provider.complete(
+            system,
+            turns,
+            temperature=request.temperature,
+            max_tokens=min(request.max_tokens, MAX_OUTPUT_TOKENS),
+        )
+        calls["n"] += 1
+        return ChatResponse(
+            id=f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            created=int(time.time()),
+            model=model,
+            choices=[ChatChoice(message=ChatMessage(role="assistant", content=completion.text))],
+            usage=ChatUsage(
+                prompt_tokens=completion.usage.input_tokens,
+                completion_tokens=completion.usage.output_tokens,
+                total_tokens=completion.usage.input_tokens + completion.usage.output_tokens,
+            ),
+        )
+
+    @app.get("/usage")
+    def usage() -> UsageSummary:
+        total = tracker.record_summary().total
+        return UsageSummary(
+            calls=calls["n"],
+            input_tokens=total.input_tokens,
+            output_tokens=total.output_tokens,
+            cost_usd=total.cost_usd,
+            judge_model=model,
+        )
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="us.anthropic.claude-opus-4-8")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+    uvicorn.run(create_app(args.model, args.region), host="127.0.0.1", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/agentworldbench/judge_shim.py
+++ b/.agents/scripts/agentworldbench/judge_shim.py
@@ -1,21 +1,27 @@
-"""Minimal OpenAI-compatible /v1/chat/completions shim over a wmh provider (Bedrock).
+"""Minimal OpenAI-compatible /v1/chat/completions shim for Qwen-AgentWorld's judge stage.
 
-Lets Qwen-AgentWorld's `eval.py judge` stage run unmodified against a Bedrock Anthropic
-model via `--judge-base-url http://127.0.0.1:8765/v1 --judge-api-key EMPTY`.
+Lets `eval.py judge` run unmodified against a model its hardcoded request shape can't reach
+directly, via `--judge-base-url http://127.0.0.1:8765/v1 --judge-api-key EMPTY`. Two backends:
 
-STAND-IN JUDGE ONLY: AgentWorldBench's pinned judge is OpenAI `gpt-5.2-2025-12-11`.
-Scores produced through this shim are NOT comparable to the paper's table (D12: never
-compare across judges) — they only prove the pipeline end-to-end until a live
-OPENAI_API_KEY is available.
+- `--backend bedrock` (Anthropic via AWS): plumbing-proof stand-in.
+- `--backend azure` (Azure OpenAI v1-compat endpoint): translates their hardcoded `max_tokens`
+  to `max_completion_tokens` (gpt-5.x rejects `max_tokens`) and forwards `temperature`.
+  Key from AZURE_OPENAI_API_KEY.
+
+Judge-pinning (D12): whatever runs behind this shim is the recorded judge for those rows —
+AgentWorldBench's paper numbers used OpenAI `gpt-5.2-2025-12-11`, so any other judge here is
+non-comparable to their table and must be labeled.
 
 Usage:
-    uv run python .agents/scripts/agentworldbench/judge_shim.py --model us.anthropic.claude-opus-4-8
-    curl http://127.0.0.1:8765/usage   # metered judge tokens + cost so far
+    uv run python .agents/scripts/agentworldbench/judge_shim.py \
+        --backend azure --endpoint https://google-sheets.openai.azure.com --model gpt-5.4-mini
+    curl http://127.0.0.1:8765/usage   # metered judge tokens (+cost where priced) so far
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import time
 import uuid
 
@@ -24,11 +30,47 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from wmh.providers import get_provider
-from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, TokenUsage
 from wmh.tracking.metered import MeteredProvider
 from wmh.tracking.tracker import Phase, RunTracker
 
-MAX_OUTPUT_TOKENS = 8192  # judge emits reasoning + one JSON block; clamp their 32768 default
+MAX_OUTPUT_TOKENS = 16384  # clamp their 32768 default; reasoning models spend output on thinking
+
+
+class AzureV1Backend:
+    """Direct Azure OpenAI v1-compat caller: Bearer auth, max_completion_tokens, temperature kept.
+
+    Bypasses wmh's AzureOpenAIProvider because that provider intentionally never forwards
+    temperature and requires deployment/api_version config; the judge protocol wants an exact
+    temperature pin and the v1-compat endpoint takes the plain model/deployment name.
+    """
+
+    def __init__(self, endpoint: str, model: str, tracker: RunTracker) -> None:
+        from openai import OpenAI
+
+        api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+        if not api_key:
+            raise SystemExit("AZURE_OPENAI_API_KEY is not set (put it in .env or export it).")
+        self._client = OpenAI(base_url=f"{endpoint.rstrip('/')}/openai/v1", api_key=api_key)
+        self._model = model
+        self._tracker = tracker
+
+    def complete(
+        self, system: str, messages: list[Message], *, temperature: float, max_tokens: int
+    ) -> Completion:
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": "system", "content": system}]
+            + [{"role": m.role, "content": m.content} for m in messages],
+            max_completion_tokens=max_tokens,
+            temperature=temperature,
+        )
+        usage = TokenUsage(
+            input_tokens=response.usage.prompt_tokens if response.usage else 0,
+            output_tokens=response.usage.completion_tokens if response.usage else 0,
+        )
+        self._tracker.record(Phase.JUDGE, self._model, usage)
+        return Completion(text=response.choices[0].message.content or "", usage=usage)
 
 
 class ChatMessage(BaseModel):
@@ -72,14 +114,20 @@ class UsageSummary(BaseModel):
     judge_model: str = Field(description="the actual backing model, not the requested alias")
 
 
-def create_app(model: str, region: str) -> FastAPI:
+def create_app(backend: str, model: str, region: str, endpoint: str | None) -> FastAPI:
     tracker = RunTracker(run_id="awb-judge-shim", kind="eval")
     tracker.start()
-    provider = MeteredProvider(
-        get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=model, region=region)),
-        tracker,
-        base_phase=Phase.JUDGE,
-    )
+    provider: AzureV1Backend | MeteredProvider
+    if backend == "azure":
+        if not endpoint:
+            raise SystemExit("--backend azure requires --endpoint")
+        provider = AzureV1Backend(endpoint, model, tracker)
+    else:
+        provider = MeteredProvider(
+            get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=model, region=region)),
+            tracker,
+            base_phase=Phase.JUDGE,
+        )
     app = FastAPI(title="wmh AgentWorldBench judge shim")
     calls = {"n": 0}
 
@@ -126,11 +174,17 @@ def create_app(model: str, region: str) -> FastAPI:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=["bedrock", "azure"], default="bedrock")
     parser.add_argument("--model", default="us.anthropic.claude-opus-4-8")
     parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--endpoint", default=None, help="Azure resource URL (azure backend)")
     parser.add_argument("--port", type=int, default=8765)
     args = parser.parse_args()
-    uvicorn.run(create_app(args.model, args.region), host="127.0.0.1", port=args.port)
+    uvicorn.run(
+        create_app(args.backend, args.model, args.region, args.endpoint),
+        host="127.0.0.1",
+        port=args.port,
+    )
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/agentworldbench/run_full.sh
+++ b/.agents/scripts/agentworldbench/run_full.sh
@@ -33,6 +33,13 @@ run_arm() {
     ${modeldir:+--model-dir "$modeldir"} \
     --concurrency 3 --resume \
     --output "$RES/$name/predictions.jsonl") || { echo "[driver] $name INFER FAILED"; return 1; }
+  local pred_n jud_n
+  pred_n=$(wc -l < "$RES/$name/predictions.jsonl")
+  jud_n=$(wc -l < "$RES/$name/judged.jsonl" 2>/dev/null || echo 0)
+  if [ "$jud_n" -eq "$pred_n" ]; then
+    echo "[driver] === $name judge already complete ($jud_n rows) — skipping ==="
+    return 0
+  fi
   ensure_shim
   echo "[driver] === $name (judge, backgrounded) $(date) ==="
   (cd "$EVAL" && "$PY" eval.py judge \

--- a/.agents/scripts/agentworldbench/run_full.sh
+++ b/.agents/scripts/agentworldbench/run_full.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Full AgentWorldBench run: 7 domains + terminal base ablation (~2,524 rows).
+# Infer = wmh WMs on Bedrock Opus 4.8 (one arm at a time, concurrency 3, resumable);
+# judge = gpt-5.4-mini via the Azure shim on :8766 (their eval.py, unmodified, temp 0),
+# backgrounded per arm so judging overlaps the next arm's infer.
+set -uo pipefail
+
+ROOT="$HOME/Desktop/Projects/wmh-wm-benchmarks"
+EVAL=/tmp/qwen-agentworld/eval
+RES="$ROOT/.wmh/agentworldbench/results54"
+DATA="$ROOT/.wmh/agentworldbench/data_full"
+PY="$ROOT/.venv/bin/python"
+SHIM_URL=http://127.0.0.1:8766
+
+ensure_shim() {
+  if ! curl -sf "$SHIM_URL/usage" > /dev/null; then
+    echo "[driver] shim down — starting it"
+    export "$(grep AZURE_OPENAI_API_KEY "$ROOT/.env" | tail -1)"
+    (cd "$ROOT" && nohup uv run python .agents/scripts/agentworldbench/judge_shim.py \
+      --backend azure --endpoint https://google-sheets.openai.azure.com \
+      --model gpt-5.4-mini --port 8766 >> "$RES/shim.log" 2>&1 &)
+    sleep 6
+  fi
+}
+
+JUDGE_PIDS=()
+run_arm() {
+  local name=$1 data=$2 mode=$3 modeldir=${4:-}
+  echo "[driver] === $name (infer) $(date) ==="
+  mkdir -p "$RES/$name"
+  (cd "$ROOT" && uv run python .agents/scripts/agentworldbench/awb_infer.py \
+    --data "$DATA/${data}_test.jsonl" --mode "$mode" \
+    ${modeldir:+--model-dir "$modeldir"} \
+    --concurrency 3 --resume \
+    --output "$RES/$name/predictions.jsonl") || { echo "[driver] $name INFER FAILED"; return 1; }
+  ensure_shim
+  echo "[driver] === $name (judge, backgrounded) $(date) ==="
+  (cd "$EVAL" && "$PY" eval.py judge \
+    --predictions "$RES/$name/predictions.jsonl" \
+    --judge-base-url "$SHIM_URL/v1" --judge-model gpt-5.4-mini --judge-api-key EMPTY \
+    --temperature 0 --output-dir "$RES/$name" > "$RES/$name/judge.log" 2>&1) &
+  JUDGE_PIDS+=($!)
+}
+
+run_arm terminal_wm  terminal wm  packages/environment-capture/terminal-tasks/models/terminal-tasks
+run_arm terminal_base terminal base
+run_arm mcp_wm       mcp      wm  packages/environment-capture/tau-bench/models/tau-bench
+run_arm swe_wm       swe      wm  packages/environment-capture/swe-bench/models/swe-bench
+run_arm search_base  search   base
+run_arm android_base android  base
+run_arm web_base     web      base
+run_arm os_base      os       base
+
+echo "[driver] all infer done $(date); waiting for judges..."
+wait "${JUDGE_PIDS[@]}"
+echo "[driver] all judges done $(date)"
+curl -s "$SHIM_URL/usage"; echo
+for d in "$RES"/*/judged.jsonl; do
+  echo "=== $d ==="
+  (cd "$EVAL" && "$PY" eval.py score --predictions "$d" 2>/dev/null | tail -15)
+done
+echo "[driver] COMPLETE $(date)"

--- a/.agents/scripts/agentworldbench/run_full_max.sh
+++ b/.agents/scripts/agentworldbench/run_full_max.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# wmh-max AgentWorldBench row: 7 domains on the merged-main max configs.
+# WM arms = --fidelity max rebuilds (auto_fidelity winners, applied via --max-fidelity);
+# base arms = BASE_ENV_PROMPT + reasoning + verify (corpus-free max levers).
+# Judge = pinned gpt-5.4-mini via the Azure shim (:8766), their eval.py unmodified, temp 0.
+set -uo pipefail
+
+ROOT="$HOME/Desktop/Projects/wmh-wm-benchmarks"
+EVAL=/tmp/qwen-agentworld/eval
+RES="$ROOT/.wmh/agentworldbench/results54max"
+DATA="$ROOT/.wmh/agentworldbench/data_full"
+PY="$ROOT/.venv/bin/python"
+SHIM_URL=http://127.0.0.1:8766
+
+ensure_shim() {
+  if ! curl -sf "$SHIM_URL/usage" > /dev/null; then
+    echo "[driver] shim down — starting it"
+    export "$(grep AZURE_OPENAI_API_KEY "$ROOT/.env" | tail -1)"
+    (cd "$ROOT" && nohup uv run python .agents/scripts/agentworldbench/judge_shim.py \
+      --backend azure --endpoint https://google-sheets.openai.azure.com \
+      --model gpt-5.4-mini --port 8766 >> "$RES/shim.log" 2>&1 &)
+    sleep 6
+  fi
+}
+
+JUDGE_PIDS=()
+run_arm() {
+  local name=$1 data=$2 mode=$3 modeldir=${4:-}
+  echo "[driver] === $name (infer) $(date) ==="
+  mkdir -p "$RES/$name"
+  local extra=()
+  if [ "$mode" = "wm" ]; then extra=(--model-dir "$modeldir" --max-fidelity); else extra=(--reasoning --verify); fi
+  (cd "$ROOT" && uv run python .agents/scripts/agentworldbench/awb_infer.py \
+    --data "$DATA/${data}_test.jsonl" --mode "$mode" "${extra[@]}" \
+    --concurrency 3 --resume \
+    --output "$RES/$name/predictions.jsonl" < /dev/null) || { echo "[driver] $name INFER FAILED"; return 1; }
+  local pred_n jud_n
+  pred_n=$(wc -l < "$RES/$name/predictions.jsonl")
+  jud_n=$(wc -l < "$RES/$name/judged.jsonl" 2>/dev/null || echo 0)
+  if [ "$jud_n" -eq "$pred_n" ]; then
+    echo "[driver] === $name judge already complete ($jud_n rows) — skipping ==="
+    return 0
+  fi
+  ensure_shim
+  echo "[driver] === $name (judge, backgrounded) $(date) ==="
+  (cd "$EVAL" && "$PY" eval.py judge \
+    --predictions "$RES/$name/predictions.jsonl" \
+    --judge-base-url "$SHIM_URL/v1" --judge-model gpt-5.4-mini --judge-api-key EMPTY \
+    --temperature 0 --output-dir "$RES/$name" > "$RES/$name/judge.log" 2>&1) &
+  JUDGE_PIDS+=($!)
+}
+
+run_arm terminal_wm  terminal wm  .wmh/models/terminal-tasks-max
+run_arm mcp_wm       mcp      wm  .wmh/models/tau-bench-max
+run_arm swe_wm       swe      wm  .wmh/models/swe-bench-max
+run_arm search_base  search   base
+run_arm android_base android  base
+run_arm web_base     web      base
+run_arm os_base      os       base
+
+echo "[driver] all infer done $(date); waiting for judges..."
+wait "${JUDGE_PIDS[@]}"
+echo "[driver] all judges done $(date)"
+curl -s "$SHIM_URL/usage"; echo
+echo "[driver] COMPLETE $(date)"


### PR DESCRIPTION
Was to be stacked on #56, but #56 squash-merged to main mid-flight — rebased onto main (`b42866c`). Scope per user re-scope (D79): **setup + few-example E2E smoke**, not the full benchmark run.

## Deliverable 1 — AgentWorldBench adapter (external WM benchmark)

AgentWorldBench (arXiv 2606.24597, HF `Qwen/AgentWorldBench`, Apache-2.0, 2,170 rows / 7 domains) evaluates language world models directly: given an interaction history, predict the next observation, LLM-judged on 5 dimensions (format/factuality/consistency/realism/quality, 1–5, reported normalized 0–100). Phase 0 verified the dataset schema, per-domain counts, license, and their eval pipeline (`QwenLM/Qwen-AgentWorld` @354f733) before anything ran.

**Adapter** (`.agents/scripts/agentworldbench/`): `awb_infer.py` replaces only their `infer` stage — feeds each row's full history to a wmh WM (teacher-forced `seed_session` → `step` for built models; `predict_observation` + `BASE_ENV_PROMPT` for base-prompt-only arms) and emits `predictions.jsonl` in their format. Their `judge` + `score` stages run **unmodified**. `judge_shim.py` = OpenAI-compat `/v1/chat/completions` over Bedrock with metered judge cost (`/usage`).

### Smoke E2E (STAND-IN judge: Opus 4.8 via shim, temp 0 — NOT comparable to their table)

| arm | model | n | format | fact. | consist. | realism | quality | total |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| terminal, wm | terminal-tasks (opt+RAG) | 3 | 75.00 | 58.33 | 91.67 | 83.33 | 75.00 | **76.67** |
| terminal, base | BASE_ENV_PROMPT | 3 | 75.00 | 50.00 | 75.00 | 66.67 | 58.33 | **65.00** |
| mcp, wm | tau-bench (≈MCP, labeled approx.) | 2 | 62.50 | 0.00 | 25.00 | 25.00 | 12.50 | **25.00** |

8/8 judge outputs parsed first-try through their unmodified pipeline. RAG/optimized beats base on terminal even at n=3. The mcp rows are turn-1/2 filesystem listings (content unknowable a priori); the judge correctly gave factuality 1 for hallucinated paths — judge transcripts eyeballed, reasoning sound. Costs: infer $0.32 (metered per row in `wmh_infer`), judge $0.52 (shim `/usage`).

### Findings recorded in the adapter README
- **Their shipped `infer` omits history** (sends only `system_str` + `current_prompt`) while their judge scores against the full history context. Our adapter follows the paper protocol (full history) — flag next to any comparison with their table.
- Their published **Overall is the macro-average** of the 7 domain scores; `eval.py score` prints a micro-average. Macro-average manually.
- Their default temperature is **0.6 for infer AND judge** (unstated in the paper); we pin 0.

### ⚠️ Blocker for comparable numbers (escalating, not working around)
Their pinned judge is OpenAI **`gpt-5.2-2025-12-11`**; the repo's OPENAI_API_KEY is dead (401 verified 2026-07-07 — same key the B2 chat flagged). Comparable rows are one flag away once a fresh key lands (exact command in the README). Until then every number is stand-in-labeled per D12 (never compare across judges).

AgentWorldBench data never enters any wmh training corpus (eval-only; data stays out of git under `.wmh/`).

## Deliverable 2 — wmh-native WM benchmark: design proposal (plan only)

`.agents/docs/proposals/wm-benchmark-design.md`, per the 2026-07-07 user interview (D79): deterministic core (error-flag accuracy, structured-field agreement, **reward agreement under WM-replacement** generalizing `wm_replace_demo`) that must **empirically match the pinned judge** before it may headline (meta-eval, rank concordance ≥0.9 proposed; pinned-judge fallback per corpus); public SHA-pinned splits; canary GUID designed now / implemented in a publishing follow-up; all public corpora with licenses labeled (appworld excluded); name deferred; static docs table, no leaderboard (WS-B1). Harness build is a follow-up.

Claim + decisions logged in wmh-plan `DECISIONS.md` (D78/D79). Gate green on the rebased tip: ruff ✓ ty ✓ pytest 748 passed / 14 skipped.