### PR TITLE
test: fix wmh test portability on Windows

### DIFF
--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -302,7 +302,7 @@ def test_examples_run_invokes_task_launcher(monkeypatch) -> None:  # noqa: ANN00
     command = cast(list[str], seen["command"])
     assert Path(command[0]).as_posix().endswith("environment-capture/tau-bench/run.sh")
     assert command[1:] == ["--trace", "0"]
-    assert Path(seen["cwd"]).as_posix().endswith("environment-capture/tau-bench")
+    assert Path(cast(str, seen["cwd"])).as_posix().endswith("environment-capture/tau-bench")
     assert seen["check"] is False
 
 

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -300,9 +300,9 @@ def test_examples_run_invokes_task_launcher(monkeypatch) -> None:  # noqa: ANN00
 
     assert result.exit_code == 0, result.output
     command = cast(list[str], seen["command"])
-    assert command[0].endswith("environment-capture/tau-bench/run.sh")
+    assert Path(command[0]).as_posix().endswith("environment-capture/tau-bench/run.sh")
     assert command[1:] == ["--trace", "0"]
-    assert str(seen["cwd"]).endswith("environment-capture/tau-bench")
+    assert Path(seen["cwd"]).as_posix().endswith("environment-capture/tau-bench")
     assert seen["check"] is False
 
 

--- a/wmh/config/dotenv_test.py
+++ b/wmh/config/dotenv_test.py
@@ -42,11 +42,16 @@ def test_upsert_env_var_appends_and_replaces(tmp_path, monkeypatch) -> None:  # 
 
     upsert_env_var("WMH_TEST_ADDED", "v", env)
     assert env.read_text(encoding="utf-8").endswith("WMH_TEST_ADDED=v\n")
-    assert env.stat().st_mode & 0o777 == 0o600  # owner-only, even for a pre-existing file
+    if os.name != "nt":
+        assert env.stat().st_mode & 0o777 == 0o600  # owner-only, even for a pre-existing file
     monkeypatch.delenv("WMH_TEST_UPSERT")
     monkeypatch.delenv("WMH_TEST_ADDED")
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows symlink creation requires elevated privileges (Developer Mode or admin)",
+)
 def test_upsert_env_var_refuses_symlinked_env(tmp_path, monkeypatch) -> None:  # noqa: ANN001
     target = tmp_path / "victim"
     target.write_text("do not clobber\n", encoding="utf-8")


### PR DESCRIPTION
Ran `uv run pytest wmh/ -q` locally on Windows and hit 3 failures, none related to actual logic:

- `app_test.py::test_examples_run_invokes_task_launcher` - assertion compared a hardcoded forward-slash path, fails on Windows
- `dotenv_test.py::test_upsert_env_var_appends_and_replaces` - asserts chmod 0600, which Windows doesn't support
- `dotenv_test.py::test_upsert_env_var_refuses_symlinked_env` - needs symlink creation, which requires elevated privileges on Windows

Fixed the path comparison with `Path.as_posix()`, gated the chmod check to skip on Windows, and skipped the symlink test on Windows with a reason.

Test-only change, nothing in production code touched.

`uv run pytest wmh/ -q` → 454 passed, 10 skipped, 0 failed.