### PR TITLE
Adopt llm-waterfall classification in research scripts; classify terminal-capture retries

### DIFF
--- a/.agents/scripts/collect_teacher.py
+++ b/.agents/scripts/collect_teacher.py
@@ -30,9 +30,9 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / ".agents" / "scripts"))
 
-from run_scenario_e2e import NOVA_LITE, TRACES, WM_DIR, RetryProvider, bedrock  # noqa: E402
-
 import os  # noqa: E402
+
+from run_scenario_e2e import NOVA_LITE, TRACES, WM_DIR, _retrying, bedrock  # noqa: E402
 
 from wmh.core.parsing import extract_json_object  # noqa: E402
 from wmh.core.types import ActionKind, Trace  # noqa: E402
@@ -103,7 +103,7 @@ FOUNDRY_ENDPOINT = "https://silen-resource.services.ai.azure.com/openai/v1/"
 def foundry(model: str) -> Provider:
     """A model on the user's Azure AI Foundry resource (OpenAI-compatible)."""
     _load_gemini_key()
-    return RetryProvider(
+    return _retrying(
         get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=model, endpoint=FOUNDRY_ENDPOINT))
     )
 
@@ -120,11 +120,11 @@ def opus_judge() -> Provider:
 def openai_direct(model: str) -> Provider:
     """A model on the OpenAI API directly (reads OPENAI_API_KEY)."""
     _load_gemini_key()
-    return RetryProvider(get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=model)))
+    return _retrying(get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=model)))
 
 
 def gemini(model: str) -> Provider:
-    return RetryProvider(
+    return _retrying(
         get_provider(ProviderConfig(kind=ProviderKind.OPENAI, model=model, endpoint=GEMINI_ENDPOINT))
     )
 

--- a/.agents/scripts/run_scenario_e2e.py
+++ b/.agents/scripts/run_scenario_e2e.py
@@ -26,7 +26,7 @@ from wmh.core.types import Trace  # noqa: E402
 from wmh.engine.world_model import WorldModel  # noqa: E402
 from wmh.env.llm_agent import LLMAgent  # noqa: E402
 from wmh.ingest import get_adapter  # noqa: E402
-from wmh.providers import get_provider
+from wmh.providers import get_provider  # noqa: E402
 from wmh.providers.base import (  # noqa: E402
     Message,
     Provider,

--- a/.agents/scripts/run_scenario_e2e.py
+++ b/.agents/scripts/run_scenario_e2e.py
@@ -11,7 +11,6 @@ Usage (from the repo root):
 from __future__ import annotations
 
 import json
-import random
 import sys
 import time
 from collections import defaultdict
@@ -27,8 +26,14 @@ from wmh.core.types import Trace  # noqa: E402
 from wmh.engine.world_model import WorldModel  # noqa: E402
 from wmh.env.llm_agent import LLMAgent  # noqa: E402
 from wmh.ingest import get_adapter  # noqa: E402
-from wmh.providers import get_provider  # noqa: E402
-from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind  # noqa: E402
+from wmh.providers import get_provider
+from wmh.providers.base import (  # noqa: E402
+    Message,
+    Provider,
+    ProviderConfig,
+    ProviderKind,
+)
+from wmh.providers.retry import RetryingProvider  # noqa: E402
 from wmh.research.scenario_fidelity import (  # noqa: E402
     fidelity_report,
     random_subsets,
@@ -60,37 +65,15 @@ TRACES = REPO / "packages" / "environment-capture" / "tau-bench" / "traces.otel.
 WM_DIR = REPO / "packages" / "environment-capture" / "tau-bench" / "models" / "tau-bench"
 
 
-class RetryProvider:
-    """Wraps a provider with retry-on-throttle (botocore retries are disabled by design)."""
-
-    def __init__(self, inner: Provider, attempts: int = 5) -> None:
-        self.config = inner.config
-        self._inner = inner
-        self._attempts = attempts
-
-    def complete(self, system: str, messages: list[Message], **kwargs: object) -> Completion:
-        delay = 2.0
-        for attempt in range(self._attempts):
-            try:
-                return self._inner.complete(system, messages, **kwargs)  # type: ignore[arg-type]
-            except Exception as exc:  # noqa: BLE001
-                name = type(exc).__name__
-                retriable = "Throttl" in str(exc) or "Throttl" in name or "Timeout" in name
-                if not retriable or attempt == self._attempts - 1:
-                    raise
-                time.sleep(delay + random.random())
-                delay = min(delay * 2, 30.0)
-        raise RuntimeError("unreachable")
-
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        return self._inner.embed(texts)
-
-    def verify(self):  # noqa: ANN201
-        return self._inner.verify()
+def _retrying(inner: Provider) -> Provider:
+    """Retry capacity errors with llm-waterfall's classifier (string-matching "Throttl"/"Timeout"
+    against messages — the previous hand-rolled version here — misses httpx transients and
+    misclassifies e.g. ValidationException("timeout too large") as retriable)."""
+    return RetryingProvider(inner, delays=(2.0, 4.0, 8.0, 16.0))
 
 
 def bedrock(model: str, region: str = REGION) -> Provider:
-    return RetryProvider(
+    return _retrying(
         get_provider(ProviderConfig(kind=ProviderKind.BEDROCK, model=model, region=region))
     )
 

--- a/packages/environment-capture/terminal-tasks/capture_terminal.py
+++ b/packages/environment-capture/terminal-tasks/capture_terminal.py
@@ -73,8 +73,28 @@ strings, each a task instruction. No prose."""
 _FENCE_RE = re.compile(r"```(?:bash|sh)?\s*\n(.*?)```", re.DOTALL)
 
 
+# Capacity/transient error codes worth retrying — same set as environment_capture.agent. A bad
+# request or auth error must RAISE immediately: retrying it 6x with backoff only hides the bug.
+_THROTTLE_CODES = {
+    "ThrottlingException",
+    "TooManyRequestsException",
+    "ServiceUnavailableException",
+    "ModelTimeoutException",
+    "InternalServerException",
+}
+
+
+def _retriable(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    code = response.get("Error", {}).get("Code") if isinstance(response, dict) else None
+    if code is not None:
+        return code in _THROTTLE_CODES
+    transient = {"ReadTimeoutError", "ConnectTimeoutError", "EndpointConnectionError"}
+    return type(exc).__name__ in transient
+
+
 def _converse(client: Any, model: str, system: str, messages: list[dict[str, str]], max_tokens: int) -> str:  # noqa: ANN401, E501
-    """One Bedrock converse call -> assistant text (retries on throttling)."""
+    """One Bedrock converse call -> assistant text (retries throttling/transient errors ONLY)."""
     conv = [{"role": m["role"], "content": [{"text": m["content"]}]} for m in messages]
     last_err: Exception | None = None
     for attempt in range(6):
@@ -86,7 +106,9 @@ def _converse(client: Any, model: str, system: str, messages: list[dict[str, str
                 inferenceConfig={"maxTokens": max_tokens},
             )
             return r["output"]["message"]["content"][0]["text"]
-        except Exception as e:  # noqa: BLE001 - retry throttling/transient errors
+        except Exception as e:  # noqa: BLE001 - classified just below
+            if not _retriable(e):
+                raise
             last_err = e
             _sleep(2.0 * (attempt + 1))
     raise RuntimeError(f"converse failed after retries: {last_err}")


### PR DESCRIPTION
Follow-up to #51: swept the monorepo for hand-rolled fallback/retry around LLM calls (two survey agents over wmh/, .agents/, packages/).

**Migrated:**
- `.agents/scripts/run_scenario_e2e.py` + `collect_teacher.py` — the local `RetryProvider` classified capacity errors by substring (`"Throttl" in str(exc)`, `"Timeout" in name`): misses httpx transients, and retries `ValidationException("timeout too large")` — the exact bug class the classifier bans. Now `wmh.providers.retry.RetryingProvider` (llm-waterfall classification).
- `packages/environment-capture/terminal-tasks/capture_terminal.py` — the converse loop retried on bare `Exception` (auth/bad-request errors got 6 backoffs before surfacing). Now classifies via structured botocore codes, matching the package's own `agent.py` pattern. No llm-waterfall dep: capture scripts are stdlib+boto3 by design.

**Surveyed, left alone (with reasons):** `environment_capture/agent.py` + gaia2/appworld agents already classify by structured codes but drive Bedrock *tool-use* converse, which llm-waterfall's adapter doesn't speak yet; tau2 multimodel sharding has no injection seam for a custom client; hub.py retries are plain-HTTP downloads; scenario builder's regeneration retry is a semantic quality gate. `.agents/scripts/eval_with_fallback.py` and the CLI already ride llm-waterfall. The judge-overhaul branch's `serve_tau_eval.py` hand-rolls the cross-geo chain against the deleted `FallbackProvider` — that migration belongs to #83's rebase.

Workspace gate green (936 passed).