### PR TITLE
wmh login/logout/status + push/pull against the hosted platform

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -38,6 +38,7 @@ from rich.table import Table
 import wmh.providers as providers
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app
+from wmh.cli.platform_cmds import register as register_platform_commands
 from wmh.cli.ui import (
     BuildParams,
     RichBuildReporter,
@@ -122,6 +123,7 @@ app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")
 app.add_typer(scenarios_app, name="scenarios")
 app.add_typer(harness_app, name="harness")
+register_platform_commands(app)
 _console = Console()
 _CHECK = "[green]✓[/green]"
 

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -134,7 +134,9 @@ def _build(root, name: str, tmp_path) -> None:  # noqa: ANN001 - pytest fixture 
 
 def test_cli_exposes_the_small_command_set() -> None:
     names = {cmd.name for cmd in app.registered_commands}
-    assert names == {"build", "list", "serve", "demo", "eval", "play", "download"}
+    core = {"build", "list", "serve", "demo", "eval", "play", "download"}
+    platform = {"login", "logout", "status", "push", "pull"}
+    assert names == core | platform
 
 
 @pytest.mark.parametrize("args", [[], ["providers"], ["examples"], ["config"]])

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -9,6 +9,7 @@ exists locally (or remotely, for pulls).
 from __future__ import annotations
 
 import socket
+import tempfile
 import webbrowser
 from pathlib import Path
 from typing import Annotated
@@ -258,16 +259,24 @@ def _detect_remote_kind(client: PlatformClient, project_id: str, name: str) -> s
 
 
 def _push_model(client: PlatformClient, project_id: str, remote_name: str, model_dir: Path) -> None:
-    bundle = pack_model_dir(model_dir)
     meta = extract_push_meta(model_dir)
-    try:
-        pushed = client.push_model_bundle(project_id, remote_name, bundle.content, meta)
-    except PlatformError as error:
-        if error.status_code == 422 and "name" in str(error):
-            raise typer.BadParameter(
-                f"{error} — publish under a slug-safe name with --as"
-            ) from error
-        raise
+    with tempfile.TemporaryDirectory(prefix="wmh-push-") as staging:
+        bundle = pack_model_dir(model_dir, Path(staging) / f"{remote_name}.tar.gz")
+        try:
+            pushed = client.push_model_bundle(
+                project_id,
+                remote_name,
+                bundle.path,
+                bundle.sha256,
+                bundle.byte_size,
+                meta,
+            )
+        except PlatformError as error:
+            if error.status_code == 422 and "name" in str(error):
+                raise typer.BadParameter(
+                    f"{error} — publish under a slug-safe name with --as"
+                ) from error
+            raise
     _console.print(
         f"{_CHECK} Pushed world model [bold]{pushed.name}[/bold] "
         f"({bundle.byte_size:,} bytes, sha256 {bundle.sha256[:12]}…)"
@@ -302,12 +311,14 @@ def _push_harness(
 def _pull_model(
     client: PlatformClient, project_id: str, name: str, root: str, *, force: bool
 ) -> None:
-    content = client.download_model_bundle(project_id, name)
     dest_dir = WorldModelStore(root).model_dir(name)
-    try:
-        unpack_model_bundle(content, dest_dir, force=force)
-    except FileExistsError as error:
-        raise typer.BadParameter(str(error)) from error
+    with tempfile.TemporaryDirectory(prefix="wmh-pull-") as staging:
+        bundle_path = Path(staging) / f"{name}.tar.gz"
+        client.download_model_bundle(project_id, name, bundle_path)
+        try:
+            unpack_model_bundle(bundle_path, dest_dir, force=force)
+        except FileExistsError as error:
+            raise typer.BadParameter(str(error)) from error
     _console.print(f"{_CHECK} Pulled world model [bold]{name}[/bold] into {dest_dir}")
 
 

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -24,6 +24,7 @@ from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.platform.auth import BrowserLogin
 from wmh.platform.client import PlatformClient, PlatformError, WhoAmI, fetch_cli_config
 from wmh.platform.credentials import (
+    DEFAULT_WEB_URL,
     PlatformCredentials,
     clear_credentials,
     credentials_path,
@@ -37,7 +38,9 @@ _CHECK = "[green]✓[/green]"
 
 # Module-level singletons: typer.Option calls can't be defaults inline (ruff B008).
 # Annotated-style options carry no default here; the parameter's own `=` does.
-_LOGIN_URL = typer.Option("--url", help="Platform URL (defaults to the saved one).")
+_LOGIN_URL = typer.Option(
+    "--url", help="Platform URL (defaults to the saved one, then the hosted platform)."
+)
 _LOGIN_TOKEN = typer.Option(
     "--token", help="Paste an existing API key instead of using the browser."
 )
@@ -66,9 +69,7 @@ def login(
 ) -> None:
     """Connect this machine to a platform account."""
     credentials = load_credentials()
-    web_url = (url or credentials.web_url or "").rstrip("/")
-    if not web_url:
-        raise typer.BadParameter("pass --url https://your-platform (no saved platform URL yet)")
+    web_url = (url or credentials.web_url or DEFAULT_WEB_URL).rstrip("/")
 
     try:
         api_url = fetch_cli_config(web_url)

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -8,6 +8,7 @@ exists locally (or remotely, for pulls).
 
 from __future__ import annotations
 
+import socket
 import webbrowser
 from pathlib import Path
 from typing import Annotated
@@ -16,8 +17,19 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from wmh.platform.client import PlatformClient, PlatformError, WhoAmI
-from wmh.platform.credentials import PlatformCredentials
+from wmh.config.store import WorldModelStore
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.platform.auth import BrowserLogin
+from wmh.platform.client import PlatformClient, PlatformError, WhoAmI, fetch_cli_config
+from wmh.platform.credentials import (
+    PlatformCredentials,
+    clear_credentials,
+    credentials_path,
+    load_credentials,
+    save_credentials,
+)
+from wmh.platform.transfer import extract_push_meta, pack_model_dir, unpack_model_bundle
 
 _console = Console()
 _CHECK = "[green]✓[/green]"
@@ -52,9 +64,6 @@ def login(
     no_browser: Annotated[bool, _LOGIN_NO_BROWSER] = False,
 ) -> None:
     """Connect this machine to a platform account."""
-    from wmh.platform.client import fetch_cli_config
-    from wmh.platform.credentials import load_credentials, save_credentials
-
     credentials = load_credentials()
     web_url = (url or credentials.web_url or "").rstrip("/")
     if not web_url:
@@ -81,11 +90,22 @@ def login(
             _console.print(f"[red]The key was rejected:[/red] {error}")
             raise typer.Exit(code=1) from error
 
-    updated = credentials.model_copy(
-        update={"web_url": web_url, "api_url": api_url, "token": token}
+    # A relogin may land on a different account: keep the saved default
+    # project only if the new identity can still see it.
+    visible_projects = {project.id for project in identity.projects}
+    default_project = (
+        credentials.default_project if credentials.default_project in visible_projects else None
     )
-    if updated.default_project is None and len(identity.projects) == 1:
-        updated = updated.model_copy(update={"default_project": identity.projects[0].id})
+    if default_project is None and len(identity.projects) == 1:
+        default_project = identity.projects[0].id
+    updated = credentials.model_copy(
+        update={
+            "web_url": web_url,
+            "api_url": api_url,
+            "token": token,
+            "default_project": default_project,
+        }
+    )
     path = save_credentials(updated)
     org_names = ", ".join(org.name for org in identity.orgs) or "no organizations"
     _console.print(f"{_CHECK} Connected to [bold]{org_names}[/bold] ({path})")
@@ -94,8 +114,6 @@ def login(
 
 def logout() -> None:
     """Disconnect: delete the saved credential."""
-    from wmh.platform.credentials import clear_credentials, load_credentials
-
     credentials = load_credentials()
     removed = clear_credentials()
     if not removed:
@@ -108,8 +126,6 @@ def logout() -> None:
 
 def status() -> None:
     """Show the platform connection: account, organizations, and projects."""
-    from wmh.platform.credentials import credentials_path, load_credentials
-
     credentials = load_credentials()
     if not credentials.is_complete():
         _console.print(
@@ -138,9 +154,6 @@ def push(
     root: Annotated[str, _ROOT] = ".wmh",
 ) -> None:
     """Publish a local world model or harness to the platform registry."""
-    from wmh.config.store import WorldModelStore
-    from wmh.harness.store import HarnessStore
-
     model_dir = WorldModelStore(root).dir_for(name)
     harness_exists = HarnessStore(root).exists(name)
     resolved_kind = _resolve_kind(kind, model=model_dir is not None, harness=harness_exists)
@@ -163,6 +176,8 @@ def pull(
     root: Annotated[str, _ROOT] = ".wmh",
 ) -> None:
     """Fetch a world model or harness from the platform registry."""
+    if kind is not None and kind not in ("model", "harness"):
+        raise typer.BadParameter("--kind must be 'model' or 'harness'")
     credentials, project_id = _require_connection(project)
     with _client(credentials) as client:
         resolved_kind = kind or _detect_remote_kind(client, project_id, name)
@@ -177,15 +192,11 @@ def pull(
 
 def _browser_login(web_url: str, *, open_browser: bool) -> str | None:
     """Run the loopback browser flow; fall back to a hidden paste prompt."""
-    import socket
-
-    from wmh.platform.auth import BrowserLogin
-
     login_attempt = BrowserLogin()
-    login_attempt.start()
-    key_name = f"wmh on {socket.gethostname()}"
-    authorize_url = login_attempt.authorize_url(web_url, key_name=key_name)
     try:
+        login_attempt.start()
+        key_name = f"wmh on {socket.gethostname()}"
+        authorize_url = login_attempt.authorize_url(web_url, key_name=key_name)
         _console.print(f"Approve the request in your browser:\n  [bold]{authorize_url}[/bold]")
         if open_browser:
             webbrowser.open(authorize_url)
@@ -205,8 +216,6 @@ def _client(credentials: PlatformCredentials) -> PlatformClient:
 
 
 def _require_connection(project: str | None) -> tuple[PlatformCredentials, str]:
-    from wmh.platform.credentials import load_credentials
-
     credentials = load_credentials()
     if not credentials.is_complete():
         raise typer.BadParameter("not connected to a platform; run `wmh login` first")
@@ -249,8 +258,6 @@ def _detect_remote_kind(client: PlatformClient, project_id: str, name: str) -> s
 
 
 def _push_model(client: PlatformClient, project_id: str, remote_name: str, model_dir: Path) -> None:
-    from wmh.platform.transfer import extract_push_meta, pack_model_dir
-
     bundle = pack_model_dir(model_dir)
     meta = extract_push_meta(model_dir)
     try:
@@ -275,8 +282,6 @@ def _push_harness(
     ref: str | None,
     root: str,
 ) -> None:
-    from wmh.harness.store import HarnessStore
-
     doc = HarnessStore(root).load(local_name, ref)
     if remote_name != local_name:
         doc = doc.model_copy(update={"name": remote_name})
@@ -297,9 +302,6 @@ def _push_harness(
 def _pull_model(
     client: PlatformClient, project_id: str, name: str, root: str, *, force: bool
 ) -> None:
-    from wmh.config.store import WorldModelStore
-    from wmh.platform.transfer import unpack_model_bundle
-
     content = client.download_model_bundle(project_id, name)
     dest_dir = WorldModelStore(root).model_dir(name)
     try:
@@ -312,9 +314,6 @@ def _pull_model(
 def _pull_harness(
     client: PlatformClient, project_id: str, name: str, root: str, *, version: int | None
 ) -> None:
-    from wmh.harness.doc import HarnessDoc
-    from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
-
     if version is None:
         harness, _versions = client.get_harness(project_id, name)
         if harness.latest_version < 1:

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -1,0 +1,357 @@
+"""Platform commands: `wmh login`, `wmh logout`, `wmh status`, `wmh push`, `wmh pull`.
+
+`login` connects this machine to a platform account (browser flow by default,
+`--token` for headless); `push`/`pull` round-trip world models and harnesses
+against the platform registry, auto-detecting the artifact kind from what
+exists locally (or remotely, for pulls).
+"""
+
+from __future__ import annotations
+
+import webbrowser
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from wmh.platform.client import PlatformClient, PlatformError, WhoAmI
+from wmh.platform.credentials import PlatformCredentials
+
+_console = Console()
+_CHECK = "[green]✓[/green]"
+
+# Module-level singletons: typer.Option calls can't be defaults inline (ruff B008).
+# Annotated-style options carry no default here; the parameter's own `=` does.
+_LOGIN_URL = typer.Option("--url", help="Platform URL (defaults to the saved one).")
+_LOGIN_TOKEN = typer.Option(
+    "--token", help="Paste an existing API key instead of using the browser."
+)
+_LOGIN_NO_BROWSER = typer.Option(
+    "--no-browser", help="Print the authorization URL instead of opening a browser."
+)
+_PROJECT = typer.Option("--project", help="Project id (defaults to the login's default project).")
+_KIND = typer.Option(
+    "--kind", help="Artifact kind: model or harness (auto-detected when unambiguous)."
+)
+_PUSH_AS = typer.Option(
+    "--as", help="Remote name to publish under (local names may not be slug-safe)."
+)
+_PUSH_REF = typer.Option(
+    "--ref", help="Harness version or alias to push (default: champion, else latest)."
+)
+_PULL_VERSION = typer.Option("--version", help="Harness version to pull (default: latest).")
+_PULL_FORCE = typer.Option("--force", help="Replace an existing local artifact.")
+_ROOT = typer.Option("--root", help="Artifact root directory.")
+
+
+def login(
+    url: Annotated[str | None, _LOGIN_URL] = None,
+    token: Annotated[str | None, _LOGIN_TOKEN] = None,
+    no_browser: Annotated[bool, _LOGIN_NO_BROWSER] = False,
+) -> None:
+    """Connect this machine to a platform account."""
+    from wmh.platform.client import fetch_cli_config
+    from wmh.platform.credentials import load_credentials, save_credentials
+
+    credentials = load_credentials()
+    web_url = (url or credentials.web_url or "").rstrip("/")
+    if not web_url:
+        raise typer.BadParameter("pass --url https://your-platform (no saved platform URL yet)")
+
+    try:
+        api_url = fetch_cli_config(web_url)
+    except PlatformError as error:
+        raise typer.BadParameter(f"{web_url} does not look like a platform: {error}") from error
+    if api_url is None:
+        raise typer.BadParameter(f"{web_url} did not advertise a backend URL; is it deployed?")
+
+    if token is None:
+        token = _browser_login(web_url, open_browser=not no_browser)
+    if token is None or not token.strip():
+        _console.print("[red]No key received; nothing saved.[/red]")
+        raise typer.Exit(code=1)
+    token = token.strip()
+
+    with PlatformClient(api_url, token) as client:
+        try:
+            identity = client.whoami()
+        except PlatformError as error:
+            _console.print(f"[red]The key was rejected:[/red] {error}")
+            raise typer.Exit(code=1) from error
+
+    updated = credentials.model_copy(
+        update={"web_url": web_url, "api_url": api_url, "token": token}
+    )
+    if updated.default_project is None and len(identity.projects) == 1:
+        updated = updated.model_copy(update={"default_project": identity.projects[0].id})
+    path = save_credentials(updated)
+    org_names = ", ".join(org.name for org in identity.orgs) or "no organizations"
+    _console.print(f"{_CHECK} Connected to [bold]{org_names}[/bold] ({path})")
+    _print_projects(identity, updated.default_project)
+
+
+def logout() -> None:
+    """Disconnect: delete the saved credential."""
+    from wmh.platform.credentials import clear_credentials, load_credentials
+
+    credentials = load_credentials()
+    removed = clear_credentials()
+    if not removed:
+        _console.print("Not logged in; nothing to remove.")
+        return
+    _console.print(f"{_CHECK} Logged out.")
+    if credentials.token:
+        _console.print("The key itself stays valid until revoked on the platform's API keys page.")
+
+
+def status() -> None:
+    """Show the platform connection: account, organizations, and projects."""
+    from wmh.platform.credentials import credentials_path, load_credentials
+
+    credentials = load_credentials()
+    if not credentials.is_complete():
+        _console.print(
+            f"Not connected (no credential at {credentials_path()}). Run [bold]wmh login[/bold]."
+        )
+        raise typer.Exit(code=1)
+    with _client(credentials) as client:
+        try:
+            identity = client.whoami()
+        except PlatformError as error:
+            _console.print(f"[red]Connection check failed:[/red] {error}")
+            raise typer.Exit(code=1) from error
+    _console.print(f"{_CHECK} Connected to [bold]{credentials.web_url}[/bold]")
+    _console.print(f"  acting as: {identity.actor.kind} {identity.actor.id}")
+    for org in identity.orgs:
+        _console.print(f"  organization: {org.name} ({org.slug})")
+    _print_projects(identity, credentials.default_project)
+
+
+def push(
+    name: Annotated[str, typer.Argument(help="Local world model or harness name.")],
+    project: Annotated[str | None, _PROJECT] = None,
+    kind: Annotated[str | None, _KIND] = None,
+    push_as: Annotated[str | None, _PUSH_AS] = None,
+    ref: Annotated[str | None, _PUSH_REF] = None,
+    root: Annotated[str, _ROOT] = ".wmh",
+) -> None:
+    """Publish a local world model or harness to the platform registry."""
+    from wmh.config.store import WorldModelStore
+    from wmh.harness.store import HarnessStore
+
+    model_dir = WorldModelStore(root).dir_for(name)
+    harness_exists = HarnessStore(root).exists(name)
+    resolved_kind = _resolve_kind(kind, model=model_dir is not None, harness=harness_exists)
+    remote_name = push_as or name
+
+    credentials, project_id = _require_connection(project)
+    with _client(credentials) as client:
+        if resolved_kind == "model" and model_dir is not None:
+            _push_model(client, project_id, remote_name, model_dir)
+        else:
+            _push_harness(client, project_id, remote_name, name, ref, root)
+
+
+def pull(
+    name: Annotated[str, typer.Argument(help="Remote world model or harness name.")],
+    project: Annotated[str | None, _PROJECT] = None,
+    kind: Annotated[str | None, _KIND] = None,
+    version: Annotated[int | None, _PULL_VERSION] = None,
+    force: Annotated[bool, _PULL_FORCE] = False,
+    root: Annotated[str, _ROOT] = ".wmh",
+) -> None:
+    """Fetch a world model or harness from the platform registry."""
+    credentials, project_id = _require_connection(project)
+    with _client(credentials) as client:
+        resolved_kind = kind or _detect_remote_kind(client, project_id, name)
+        if resolved_kind == "model":
+            _pull_model(client, project_id, name, root, force=force)
+        else:
+            _pull_harness(client, project_id, name, root, version=version)
+
+
+# -- helpers -------------------------------------------------------------------------------------
+
+
+def _browser_login(web_url: str, *, open_browser: bool) -> str | None:
+    """Run the loopback browser flow; fall back to a hidden paste prompt."""
+    import socket
+
+    from wmh.platform.auth import BrowserLogin
+
+    login_attempt = BrowserLogin()
+    login_attempt.start()
+    key_name = f"wmh on {socket.gethostname()}"
+    authorize_url = login_attempt.authorize_url(web_url, key_name=key_name)
+    try:
+        _console.print(f"Approve the request in your browser:\n  [bold]{authorize_url}[/bold]")
+        if open_browser:
+            webbrowser.open(authorize_url)
+        token = login_attempt.wait()
+    finally:
+        login_attempt.close()
+    if token is None:
+        _console.print("Timed out waiting for the browser.")
+        return typer.prompt("Paste an API key instead", hide_input=True, default="") or None
+    return token
+
+
+def _client(credentials: PlatformCredentials) -> PlatformClient:
+    if credentials.api_url is None or credentials.token is None:
+        raise typer.BadParameter("not connected to a platform; run `wmh login` first")
+    return PlatformClient(credentials.api_url, credentials.token)
+
+
+def _require_connection(project: str | None) -> tuple[PlatformCredentials, str]:
+    from wmh.platform.credentials import load_credentials
+
+    credentials = load_credentials()
+    if not credentials.is_complete():
+        raise typer.BadParameter("not connected to a platform; run `wmh login` first")
+    project_id = project or credentials.default_project
+    if not project_id:
+        raise typer.BadParameter(
+            "no project selected; pass --project <id> (see `wmh status` for your projects)"
+        )
+    return credentials, project_id
+
+
+def _resolve_kind(kind: str | None, *, model: bool, harness: bool) -> str:
+    if kind is not None:
+        if kind not in ("model", "harness"):
+            raise typer.BadParameter("--kind must be 'model' or 'harness'")
+        if kind == "model" and not model:
+            raise typer.BadParameter("no local world model has this name")
+        if kind == "harness" and not harness:
+            raise typer.BadParameter("no local harness has this name")
+        return kind
+    if model and harness:
+        raise typer.BadParameter("both a model and a harness have this name locally; pass --kind")
+    if model:
+        return "model"
+    if harness:
+        return "harness"
+    raise typer.BadParameter("no local world model or harness has this name")
+
+
+def _detect_remote_kind(client: PlatformClient, project_id: str, name: str) -> str:
+    model_names = {model.name for model in client.list_world_models(project_id)}
+    harness_names = {harness.name for harness in client.list_harnesses(project_id)}
+    if name in model_names and name in harness_names:
+        raise typer.BadParameter("both a model and a harness have this name remotely; pass --kind")
+    if name in model_names:
+        return "model"
+    if name in harness_names:
+        return "harness"
+    raise typer.BadParameter(f"the project has no world model or harness named {name!r}")
+
+
+def _push_model(client: PlatformClient, project_id: str, remote_name: str, model_dir: Path) -> None:
+    from wmh.platform.transfer import extract_push_meta, pack_model_dir
+
+    bundle = pack_model_dir(model_dir)
+    meta = extract_push_meta(model_dir)
+    try:
+        pushed = client.push_model_bundle(project_id, remote_name, bundle.content, meta)
+    except PlatformError as error:
+        if error.status_code == 422 and "name" in str(error):
+            raise typer.BadParameter(
+                f"{error} — publish under a slug-safe name with --as"
+            ) from error
+        raise
+    _console.print(
+        f"{_CHECK} Pushed world model [bold]{pushed.name}[/bold] "
+        f"({bundle.byte_size:,} bytes, sha256 {bundle.sha256[:12]}…)"
+    )
+
+
+def _push_harness(
+    client: PlatformClient,
+    project_id: str,
+    remote_name: str,
+    local_name: str,
+    ref: str | None,
+    root: str,
+) -> None:
+    from wmh.harness.store import HarnessStore
+
+    doc = HarnessStore(root).load(local_name, ref)
+    if remote_name != local_name:
+        doc = doc.model_copy(update={"name": remote_name})
+    pushed = client.push_harness_version(
+        project_id, remote_name, doc.model_dump(mode="json"), doc.doc_hash
+    )
+    if pushed.created:
+        _console.print(
+            f"{_CHECK} Pushed harness [bold]{pushed.name}[/bold] as remote v{pushed.version}"
+        )
+    else:
+        _console.print(
+            f"Remote [bold]{pushed.name}[/bold] v{pushed.version} already has this exact doc; "
+            "nothing to push."
+        )
+
+
+def _pull_model(
+    client: PlatformClient, project_id: str, name: str, root: str, *, force: bool
+) -> None:
+    from wmh.config.store import WorldModelStore
+    from wmh.platform.transfer import unpack_model_bundle
+
+    content = client.download_model_bundle(project_id, name)
+    dest_dir = WorldModelStore(root).model_dir(name)
+    try:
+        unpack_model_bundle(content, dest_dir, force=force)
+    except FileExistsError as error:
+        raise typer.BadParameter(str(error)) from error
+    _console.print(f"{_CHECK} Pulled world model [bold]{name}[/bold] into {dest_dir}")
+
+
+def _pull_harness(
+    client: PlatformClient, project_id: str, name: str, root: str, *, version: int | None
+) -> None:
+    from wmh.harness.doc import HarnessDoc
+    from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+
+    if version is None:
+        harness, _versions = client.get_harness(project_id, name)
+        if harness.latest_version < 1:
+            raise typer.BadParameter(f"remote harness {name!r} has no versions yet")
+        version = harness.latest_version
+    payload = client.get_harness_version(project_id, name, version)
+    doc = HarnessDoc.model_validate(payload.doc)
+    if doc.doc_hash != payload.doc_hash:
+        _console.print("[red]Pulled doc failed its integrity check; not saving.[/red]")
+        raise typer.Exit(code=1)
+    saved = HarnessStore(root).save_version(
+        doc.model_copy(update={"name": name}), alias=CHAMPION_ALIAS
+    )
+    _console.print(
+        f"{_CHECK} Pulled harness [bold]{name}[/bold] remote v{version} → local v{saved.version} "
+        f"(champion)"
+    )
+
+
+def _print_projects(identity: WhoAmI, default_project: str | None) -> None:
+    if not identity.projects:
+        _console.print("  no projects visible to this key")
+        return
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("project")
+    table.add_column("id")
+    table.add_column("")
+    for project in identity.projects:
+        marker = "default" if project.id == default_project else ""
+        table.add_row(project.name, project.id, marker)
+    _console.print(table)
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the platform commands to the root CLI."""
+    app.command("login")(login)
+    app.command("logout")(logout)
+    app.command("status")(status)
+    app.command("push")(push)
+    app.command("pull")(pull)

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -193,11 +193,11 @@ def pull(
 
 def _browser_login(web_url: str, *, open_browser: bool) -> str | None:
     """Run the loopback browser flow; fall back to a hidden paste prompt."""
-    login_attempt = BrowserLogin()
+    login_attempt = BrowserLogin(web_url)
     try:
         login_attempt.start()
         key_name = f"wmh on {socket.gethostname()}"
-        authorize_url = login_attempt.authorize_url(web_url, key_name=key_name)
+        authorize_url = login_attempt.authorize_url(key_name=key_name)
         _console.print(f"Approve the request in your browser:\n  [bold]{authorize_url}[/bold]")
         if open_browser:
             webbrowser.open(authorize_url)

--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -147,3 +147,20 @@ def test_resolve_kind_disambiguates() -> None:
         _resolve_kind("model", model=False, harness=True)
     with pytest.raises(typer.BadParameter, match="must be"):
         _resolve_kind("bundle", model=True, harness=False)
+
+
+def test_bare_login_targets_the_hosted_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`wmh login` with no --url and no saved platform uses the default."""
+    seen: dict[str, str] = {}
+
+    def fake_config(url: str) -> str:
+        seen["web_url"] = url
+        return "https://api.test"
+
+    monkeypatch.setattr("wmh.cli.platform_cmds.fetch_cli_config", fake_config)
+    monkeypatch.setattr("wmh.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(app, ["login", "--token", "xpl_new"])
+
+    assert result.exit_code == 0, result.output
+    assert seen["web_url"] == "https://experiential-platform-web.vercel.app"

--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -1,0 +1,115 @@
+"""Tests for the platform CLI commands (wiring and kind resolution)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from wmh.cli.app import app
+from wmh.cli.platform_cmds import _resolve_kind
+from wmh.platform.client import PlatformError, WhoAmI
+from wmh.platform.credentials import ENV_HOME, PlatformCredentials, save_credentials
+
+runner = CliRunner()
+
+_WHOAMI = WhoAmI.model_validate(
+    {
+        "actor": {"kind": "api_key", "id": "api-key:org-1"},
+        "orgs": [{"id": "org-1", "slug": "acme", "name": "Acme"}],
+        "projects": [{"id": "proj-1", "org_id": "org-1", "slug": "alpha", "name": "Alpha"}],
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_HOME, str(tmp_path))
+    for var in ("WMH_PLATFORM_URL", "WMH_PLATFORM_API_URL", "WMH_PLATFORM_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class _StubClient:
+    """PlatformClient stand-in: canned whoami, no network."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _StubClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        pass
+
+    def whoami(self) -> WhoAmI:
+        return _WHOAMI
+
+
+def test_platform_commands_are_registered() -> None:
+    result = runner.invoke(app, ["--help"])
+    for command in ("login", "logout", "status", "push", "pull"):
+        assert command in result.output
+
+
+def test_status_without_credentials_points_to_login() -> None:
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 1
+    assert "wmh login" in result.output
+
+
+def test_status_reports_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    save_credentials(
+        PlatformCredentials(
+            web_url="https://platform.test", api_url="https://api.test", token="xpl_x"
+        )
+    )
+    monkeypatch.setattr("wmh.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Acme" in result.output
+    assert "proj-1" in result.output
+
+
+def test_status_surfaces_rejected_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    save_credentials(PlatformCredentials(api_url="https://api.test", token="xpl_bad"))
+
+    class _RejectingClient(_StubClient):
+        def whoami(self) -> WhoAmI:
+            raise PlatformError("Unauthorized", status_code=401)
+
+    monkeypatch.setattr("wmh.cli.platform_cmds.PlatformClient", _RejectingClient)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 1
+    assert "Unauthorized" in result.output
+
+
+def test_push_requires_login_first(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["push", "anything", "--root", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "no local world model or harness" in result.output
+
+
+def test_logout_when_not_logged_in() -> None:
+    result = runner.invoke(app, ["logout"])
+    assert result.exit_code == 0
+    assert "nothing to remove" in result.output.lower()
+
+
+def test_resolve_kind_disambiguates() -> None:
+    assert _resolve_kind(None, model=True, harness=False) == "model"
+    assert _resolve_kind(None, model=False, harness=True) == "harness"
+    assert _resolve_kind("model", model=True, harness=True) == "model"
+    with pytest.raises(typer.BadParameter, match="pass --kind"):
+        _resolve_kind(None, model=True, harness=True)
+    with pytest.raises(typer.BadParameter, match="no local world model or harness"):
+        _resolve_kind(None, model=False, harness=False)
+    with pytest.raises(typer.BadParameter, match="no local world model"):
+        _resolve_kind("model", model=False, harness=True)
+    with pytest.raises(typer.BadParameter, match="must be"):
+        _resolve_kind("bundle", model=True, harness=False)

--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -89,6 +89,40 @@ def test_status_surfaces_rejected_credentials(monkeypatch: pytest.MonkeyPatch) -
     assert "Unauthorized" in result.output
 
 
+def test_pull_rejects_unknown_kind() -> None:
+    """An invalid --kind fails fast instead of dispatching to harness routes."""
+    result = runner.invoke(app, ["pull", "anything", "--kind", "typo"])
+    assert result.exit_code != 0
+    assert "must be 'model' or 'harness'" in result.output
+
+
+def test_login_with_token_drops_stale_default_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relogin keeps the default project only if the new identity sees it."""
+    save_credentials(
+        PlatformCredentials(
+            web_url="https://platform.test",
+            api_url="https://api.test",
+            token="xpl_old",
+            default_project="proj-gone",
+        )
+    )
+    monkeypatch.setattr("wmh.cli.platform_cmds.fetch_cli_config", lambda _url: "https://api.test")
+    monkeypatch.setattr("wmh.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(app, ["login", "--token", "xpl_new"])
+
+    assert result.exit_code == 0, result.output
+    from wmh.platform.credentials import load_credentials
+
+    saved = load_credentials()
+    assert saved.token == "xpl_new"
+    # proj-gone is invisible to the new identity; the single visible project
+    # becomes the default instead.
+    assert saved.default_project == "proj-1"
+
+
 def test_push_requires_login_first(tmp_path: Path) -> None:
     result = runner.invoke(app, ["push", "anything", "--root", str(tmp_path)])
     assert result.exit_code != 0

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -329,8 +329,11 @@ class PiRuntime:
             # The worker LLM proxy failed (auth/outage/HTTP error); entry.ts still POSTs /done, but
             # this is infrastructure failure, not an agent submission — never count it as SUBMITTED.
             return self._error_result(
-                task_id, episode, instruction,
-                f"worker LLM proxy error: {episode.proxy_error}", StopReason.ERROR,
+                task_id,
+                episode,
+                instruction,
+                f"worker LLM proxy error: {episode.proxy_error}",
+                StopReason.ERROR,
             )
         return RunResult(
             task_id=task_id,
@@ -382,9 +385,7 @@ class PiRuntime:
         result = _ssh(remote, input_bytes=blob.encode("utf-8"))
         if result.returncode != 0:
             detail = (result.stderr or b"").decode("utf-8", "replace").strip()[-300:]
-            raise _MaterializeError(
-                f"remote materialize failed (rc={result.returncode}): {detail}"
-            )
+            raise _MaterializeError(f"remote materialize failed (rc={result.returncode}): {detail}")
 
     def _run_node(self) -> tuple[int, str]:
         """Run entry.ts on the runner with a reverse tunnel back to the local shim."""

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -479,9 +479,7 @@ class RunnerLink:
             )
 
     @staticmethod
-    def _error_result(
-        task_id: str, episode: HostEpisode, instruction: str, note: str
-    ) -> RunResult:
+    def _error_result(task_id: str, episode: HostEpisode, instruction: str, note: str) -> RunResult:
         stop = StopReason.MAX_TURNS if episode.steps else StopReason.ERROR
         episode.steps.append(
             Step(

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -63,7 +63,7 @@ def _link(channel: _FakeChannel, **kw) -> RunnerLink:  # noqa: ANN003
 
 def _sent(channel: _FakeChannel, kind: str) -> list:
     # cast to Any so deep-indexing assertions on frame payloads stay readable in tests.
-    return [cast(Any,f) for f in channel.sent if f.get("type") == kind]
+    return [cast(Any, f) for f in channel.sent if f.get("type") == kind]
 
 
 # --- frame codec ---
@@ -241,9 +241,9 @@ def test_openai_to_bedrock_maps_tools_and_tool_results() -> None:
     system, msgs, tool_config = openai_to_bedrock(body)
     assert system == [{"text": "be nice"}]
     assert tool_config is not None
-    assert cast(Any,tool_config)["tools"][0]["toolSpec"]["name"] == "get_user"
+    assert cast(Any, tool_config)["tools"][0]["toolSpec"]["name"] == "get_user"
     # assistant toolUse + tool result present
-    blocks = [b for m in cast(Any,msgs) for b in m["content"]]
+    blocks = [b for m in cast(Any, msgs) for b in m["content"]]
     assert any("toolUse" in b for b in blocks)
     assert any("toolResult" in b for b in blocks)
 
@@ -308,7 +308,7 @@ def test_bedrock_to_completion_shape() -> None:
         },
         "stopReason": "tool_use",
     }
-    completion = cast(Any,bedrock_to_completion(resp))
+    completion = cast(Any, bedrock_to_completion(resp))
     choice = completion["choices"][0]
     assert choice["finish_reason"] == "tool_calls"
     assert choice["message"]["content"] == "sure"

--- a/wmh/platform/__init__.py
+++ b/wmh/platform/__init__.py
@@ -1,0 +1,6 @@
+"""Client for the hosted platform: login credentials, HTTP client, and push/pull transfer.
+
+`wmh login` connects this machine to a platform account (an org-scoped API key minted in the
+browser or pasted from the keys page); `wmh push`/`wmh pull` then round-trip world-model bundles
+and harness docs against the platform's registry surface.
+"""

--- a/wmh/platform/auth.py
+++ b/wmh/platform/auth.py
@@ -1,0 +1,109 @@
+"""Browser login flow: a loopback listener the platform hands the minted key to.
+
+`wmh login` binds an ephemeral port on 127.0.0.1, opens the platform's
+`/cli/auth` page with that port and a one-time state nonce, and waits. When the
+user approves in the browser, the page navigates to
+``http://127.0.0.1:{port}/callback?token=…&state=…``; the handler verifies the
+nonce and hands the token back to the waiting command. On timeout (or
+``--no-browser``) the CLI falls back to a hidden paste prompt.
+"""
+
+from __future__ import annotations
+
+import queue
+import secrets
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+LOGIN_TIMEOUT_SECONDS = 300.0
+
+_SUCCESS_PAGE = b"""<!doctype html>
+<html><body style="font-family: system-ui; padding: 48px; color: #171717;">
+<h1 style="font-size: 18px;">wmh is connected</h1>
+<p>The key was handed to your terminal. You can close this tab.</p>
+</body></html>"""
+
+_FAILURE_PAGE = b"""<!doctype html>
+<html><body style="font-family: system-ui; padding: 48px; color: #171717;">
+<h1 style="font-size: 18px;">That didn't match</h1>
+<p>This callback wasn't for the login attempt waiting in your terminal.
+Re-run <code>wmh login</code> and use the URL it prints.</p>
+</body></html>"""
+
+
+class BrowserLogin:
+    """One login attempt: an ephemeral loopback listener plus its state nonce."""
+
+    def __init__(self) -> None:
+        self.state = secrets.token_urlsafe(24)
+        self._tokens: queue.Queue[str] = queue.Queue(maxsize=1)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            msg = "login listener is not running; call start() first"
+            raise RuntimeError(msg)
+        return self._server.server_address[1]
+
+    def start(self) -> int:
+        """Bind 127.0.0.1 on an ephemeral port and serve callbacks in a daemon thread."""
+        tokens = self._tokens
+        expected_state = self.state
+
+        class _CallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802 - http.server contract
+                parsed = urlparse(self.path)
+                if parsed.path != "/callback":
+                    self.send_error(404)
+                    return
+                params = parse_qs(parsed.query)
+                token = (params.get("token") or [""])[0]
+                state = (params.get("state") or [""])[0]
+                if not token or not secrets.compare_digest(state, expected_state):
+                    self._respond(400, _FAILURE_PAGE)
+                    return
+                # A second callback for the same attempt has nowhere to go;
+                # the first token already won.
+                try:
+                    tokens.put_nowait(token)
+                except queue.Full:
+                    self._respond(400, _FAILURE_PAGE)
+                    return
+                self._respond(200, _SUCCESS_PAGE)
+
+            def _respond(self, status: int, body: bytes) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                """Silence per-request stderr logging."""
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _CallbackHandler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self.port
+
+    def authorize_url(self, web_url: str, *, key_name: str) -> str:
+        """The platform page the browser should open for this attempt."""
+        query = urlencode({"state": self.state, "port": self.port, "name": key_name})
+        return f"{web_url.rstrip('/')}/cli/auth?{query}"
+
+    def wait(self, timeout: float = LOGIN_TIMEOUT_SECONDS) -> str | None:
+        """Block until the browser hands a token back, or return None on timeout."""
+        try:
+            return self._tokens.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def close(self) -> None:
+        """Stop the listener; safe to call repeatedly."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None

--- a/wmh/platform/auth.py
+++ b/wmh/platform/auth.py
@@ -18,10 +18,12 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 LOGIN_TIMEOUT_SECONDS = 300.0
 
-_SUCCESS_PAGE = b"""<!doctype html>
-<html><body style="font-family: system-ui; padding: 48px; color: #171717;">
+_SUCCESS_PAGE_TEMPLATE = """<!doctype html>
+<html><head><meta http-equiv="refresh" content="1;url={projects_url}"></head>
+<body style="font-family: system-ui; padding: 48px; color: #171717;">
 <h1 style="font-size: 18px;">wmh is connected</h1>
-<p>The key was handed to your terminal. You can close this tab.</p>
+<p>The key was handed to your terminal — taking you back to
+<a href="{projects_url}">your projects</a>.</p>
 </body></html>"""
 
 _FAILURE_PAGE = b"""<!doctype html>
@@ -35,7 +37,8 @@ Re-run <code>wmh login</code> and use the URL it prints.</p>
 class BrowserLogin:
     """One login attempt: an ephemeral loopback listener plus its state nonce."""
 
-    def __init__(self) -> None:
+    def __init__(self, web_url: str) -> None:
+        self.web_url = web_url.rstrip("/")
         self.state = secrets.token_urlsafe(24)
         self._tokens: queue.Queue[str] = queue.Queue(maxsize=1)
         self._server: ThreadingHTTPServer | None = None
@@ -52,6 +55,11 @@ class BrowserLogin:
         """Bind 127.0.0.1 on an ephemeral port and serve callbacks in a daemon thread."""
         tokens = self._tokens
         expected_state = self.state
+        # After the hand-off the browser is stranded on the loopback page;
+        # send it back to the platform's projects instead.
+        success_page = _SUCCESS_PAGE_TEMPLATE.format(
+            projects_url=f"{self.web_url}/projects"
+        ).encode("utf-8")
 
         class _CallbackHandler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:  # noqa: N802 - http.server contract
@@ -72,7 +80,7 @@ class BrowserLogin:
                 except queue.Full:
                     self._respond(400, _FAILURE_PAGE)
                     return
-                self._respond(200, _SUCCESS_PAGE)
+                self._respond(200, success_page)
 
             def _respond(self, status: int, body: bytes) -> None:
                 self.send_response(status)
@@ -89,10 +97,10 @@ class BrowserLogin:
         self._thread.start()
         return self.port
 
-    def authorize_url(self, web_url: str, *, key_name: str) -> str:
+    def authorize_url(self, *, key_name: str) -> str:
         """The platform page the browser should open for this attempt."""
         query = urlencode({"state": self.state, "port": self.port, "name": key_name})
-        return f"{web_url.rstrip('/')}/cli/auth?{query}"
+        return f"{self.web_url}/cli/auth?{query}"
 
     def wait(self, timeout: float = LOGIN_TIMEOUT_SECONDS) -> str | None:
         """Block until the browser hands a token back, or return None on timeout."""

--- a/wmh/platform/auth_test.py
+++ b/wmh/platform/auth_test.py
@@ -1,0 +1,67 @@
+"""Tests for the browser-login loopback listener."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from urllib.parse import urlencode
+
+import pytest
+
+from wmh.platform.auth import BrowserLogin
+
+
+@pytest.fixture
+def login_attempt() -> Iterator[BrowserLogin]:
+    attempt = BrowserLogin()
+    attempt.start()
+    yield attempt
+    attempt.close()
+
+
+def _hit_callback(attempt: BrowserLogin, **params: str) -> int:
+    url = f"http://127.0.0.1:{attempt.port}/callback?{urlencode(params)}"
+    try:
+        with urllib.request.urlopen(url) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        return error.code
+
+
+def test_callback_with_matching_state_hands_over_the_token(login_attempt: BrowserLogin) -> None:
+    status = _hit_callback(login_attempt, token="xpl_abc", state=login_attempt.state)
+    assert status == 200
+    assert login_attempt.wait(timeout=2) == "xpl_abc"
+
+
+def test_callback_with_wrong_state_is_rejected(login_attempt: BrowserLogin) -> None:
+    status = _hit_callback(login_attempt, token="xpl_abc", state="forged")
+    assert status == 400
+    assert login_attempt.wait(timeout=0.2) is None
+
+
+def test_callback_without_token_is_rejected(login_attempt: BrowserLogin) -> None:
+    assert _hit_callback(login_attempt, state=login_attempt.state) == 400
+
+
+def test_other_paths_404(login_attempt: BrowserLogin) -> None:
+    url = f"http://127.0.0.1:{login_attempt.port}/anything"
+    try:
+        with urllib.request.urlopen(url) as response:
+            status = response.status
+    except urllib.error.HTTPError as error:
+        status = error.code
+    assert status == 404
+
+
+def test_authorize_url_carries_state_port_and_name(login_attempt: BrowserLogin) -> None:
+    url = login_attempt.authorize_url("https://platform.test/", key_name="wmh on box")
+    assert url.startswith("https://platform.test/cli/auth?")
+    assert f"state={login_attempt.state}" in url
+    assert f"port={login_attempt.port}" in url
+    assert "name=wmh+on+box" in url
+
+
+def test_wait_times_out_to_none(login_attempt: BrowserLogin) -> None:
+    assert login_attempt.wait(timeout=0.05) is None

--- a/wmh/platform/auth_test.py
+++ b/wmh/platform/auth_test.py
@@ -14,7 +14,7 @@ from wmh.platform.auth import BrowserLogin
 
 @pytest.fixture
 def login_attempt() -> Iterator[BrowserLogin]:
-    attempt = BrowserLogin()
+    attempt = BrowserLogin("https://platform.test")
     attempt.start()
     yield attempt
     attempt.close()
@@ -56,7 +56,7 @@ def test_other_paths_404(login_attempt: BrowserLogin) -> None:
 
 
 def test_authorize_url_carries_state_port_and_name(login_attempt: BrowserLogin) -> None:
-    url = login_attempt.authorize_url("https://platform.test/", key_name="wmh on box")
+    url = login_attempt.authorize_url(key_name="wmh on box")
     assert url.startswith("https://platform.test/cli/auth?")
     assert f"state={login_attempt.state}" in url
     assert f"port={login_attempt.port}" in url
@@ -65,3 +65,14 @@ def test_authorize_url_carries_state_port_and_name(login_attempt: BrowserLogin) 
 
 def test_wait_times_out_to_none(login_attempt: BrowserLogin) -> None:
     assert login_attempt.wait(timeout=0.05) is None
+
+
+def test_success_page_redirects_back_to_the_platform(login_attempt: BrowserLogin) -> None:
+    """After the hand-off the browser is sent back to the platform's projects."""
+    url = f"http://127.0.0.1:{login_attempt.port}/callback?" + urlencode(
+        {"token": "xpl_abc", "state": login_attempt.state}
+    )
+    with urllib.request.urlopen(url) as response:
+        body = response.read().decode("utf-8")
+    assert "url=https://platform.test/projects" in body
+    assert login_attempt.wait(timeout=2) == "xpl_abc"

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -1,0 +1,248 @@
+"""Typed HTTP client for the platform's CLI registry surface.
+
+Every call carries the org API key as a bearer credential; the platform scopes
+reads and writes to that key's organization at member strength. Error payloads
+are the platform's uniform ``{"error": message}`` shape, surfaced as
+:class:`PlatformError` with the HTTP status attached.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib import metadata
+
+import httpx
+from pydantic import BaseModel
+
+from wmh.core.types import JsonValue
+
+_TIMEOUT_SECONDS = 120.0
+
+
+class PlatformError(RuntimeError):
+    """A platform request failed; carries the HTTP status when one exists."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ActorInfo(BaseModel):
+    """Who the platform resolved the credential to."""
+
+    kind: str  # "api_key" | "user"
+    id: str
+
+
+class OrgInfo(BaseModel):
+    """One organization visible to the credential."""
+
+    id: str
+    slug: str
+    name: str
+
+
+class ProjectInfo(BaseModel):
+    """One project visible to the credential."""
+
+    id: str
+    org_id: str
+    slug: str
+    name: str
+
+
+class WhoAmI(BaseModel):
+    """Response of ``GET /api/whoami``."""
+
+    actor: ActorInfo
+    orgs: list[OrgInfo]
+    projects: list[ProjectInfo]
+
+
+class RemoteWorldModel(BaseModel):
+    """The slice of a world-model row the CLI presents."""
+
+    id: str
+    name: str
+    display_name: str | None = None
+    status: str
+    updated_at: str | None = None
+
+
+class RemoteHarness(BaseModel):
+    """The slice of a registry harness row the CLI presents."""
+
+    id: str
+    name: str
+    latest_version: int
+    updated_at: str | None = None
+
+
+class RemoteHarnessVersion(BaseModel):
+    """One doc-less entry of a harness's version lineage."""
+
+    version: int
+    doc_hash: str
+    created_at: str | None = None
+
+
+class HarnessVersionDoc(BaseModel):
+    """One full harness version, doc included."""
+
+    version: int
+    doc: dict[str, JsonValue]
+    doc_hash: str
+
+
+class PushedHarnessVersion(BaseModel):
+    """Response of a harness push: the version the doc landed as."""
+
+    name: str
+    version: int
+    doc_hash: str
+    created: bool  # False when the push was an idempotent repeat of the tip
+
+
+def fetch_cli_config(web_url: str, *, transport: httpx.BaseTransport | None = None) -> str | None:
+    """Ask the web app which backend host the CLI should call.
+
+    ``GET {web_url}/api/cli/config`` is public: the backend URL is not a
+    secret (every Endpoints page shows it) and everything behind it is
+    bearer-gated.
+    """
+    with httpx.Client(timeout=30.0, transport=transport) as client:
+        response = client.get(f"{web_url.rstrip('/')}/api/cli/config")
+        if response.status_code != 200:
+            msg = f"platform discovery failed with HTTP {response.status_code} at {web_url}"
+            raise PlatformError(msg, status_code=response.status_code)
+        api_url = response.json().get("apiUrl")
+        return str(api_url).rstrip("/") if api_url else None
+
+
+class PlatformClient:
+    """Requests against the platform registry, authenticated with an org API key."""
+
+    def __init__(
+        self,
+        api_url: str,
+        token: str,
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        try:
+            version = metadata.version("world-model-harness")
+        except metadata.PackageNotFoundError:
+            version = "dev"
+        self._client = httpx.Client(
+            base_url=api_url.rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "User-Agent": f"wmh/{version}",
+            },
+            timeout=_TIMEOUT_SECONDS,
+            transport=transport,
+        )
+
+    def __enter__(self) -> PlatformClient:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    # -- identity ------------------------------------------------------------------------------
+
+    def whoami(self) -> WhoAmI:
+        response = self._client.get("/api/whoami")
+        self._raise_for_error(response)
+        return WhoAmI.model_validate(response.json())
+
+    # -- world models --------------------------------------------------------------------------
+
+    def list_world_models(self, project_id: str) -> list[RemoteWorldModel]:
+        response = self._client.get(f"/api/projects/{project_id}/world-models")
+        self._raise_for_error(response)
+        rows = response.json().get("world_models", [])
+        return [RemoteWorldModel.model_validate(row) for row in rows]
+
+    def push_model_bundle(
+        self,
+        project_id: str,
+        name: str,
+        content: bytes,
+        meta: dict[str, JsonValue],
+    ) -> RemoteWorldModel:
+        response = self._client.post(
+            f"/api/projects/{project_id}/world-models/{name}/bundle",
+            files={"file": (f"{name}.tar.gz", content, "application/gzip")},
+            data={"meta": json.dumps(meta)},
+        )
+        self._raise_for_error(response)
+        return RemoteWorldModel.model_validate(response.json())
+
+    def download_model_bundle(self, project_id: str, name: str) -> bytes:
+        """Fetch a model's bundle bytes, verifying the declared digest."""
+        response = self._client.get(f"/api/projects/{project_id}/world-models/{name}/bundle")
+        self._raise_for_error(response)
+        content = response.content
+        declared = response.headers.get("X-Bundle-Sha256")
+        actual = hashlib.sha256(content).hexdigest()
+        if declared is not None and declared != actual:
+            msg = f"bundle digest mismatch for {name}: expected {declared}, got {actual}"
+            raise PlatformError(msg)
+        return content
+
+    # -- harnesses -----------------------------------------------------------------------------
+
+    def list_harnesses(self, project_id: str) -> list[RemoteHarness]:
+        response = self._client.get(f"/api/projects/{project_id}/harnesses")
+        self._raise_for_error(response)
+        rows = response.json().get("harnesses", [])
+        return [RemoteHarness.model_validate(row) for row in rows]
+
+    def get_harness(
+        self, project_id: str, name: str
+    ) -> tuple[RemoteHarness, list[RemoteHarnessVersion]]:
+        response = self._client.get(f"/api/projects/{project_id}/harnesses/{name}")
+        self._raise_for_error(response)
+        payload = response.json()
+        harness = RemoteHarness.model_validate(payload["harness"])
+        versions = [RemoteHarnessVersion.model_validate(row) for row in payload["versions"]]
+        return harness, versions
+
+    def get_harness_version(self, project_id: str, name: str, version: int) -> HarnessVersionDoc:
+        response = self._client.get(
+            f"/api/projects/{project_id}/harnesses/{name}/versions/{version}"
+        )
+        self._raise_for_error(response)
+        return HarnessVersionDoc.model_validate(response.json())
+
+    def push_harness_version(
+        self,
+        project_id: str,
+        name: str,
+        doc: dict[str, JsonValue],
+        doc_hash: str,
+    ) -> PushedHarnessVersion:
+        response = self._client.post(
+            f"/api/projects/{project_id}/harnesses/{name}/versions",
+            json={"doc": doc, "doc_hash": doc_hash},
+        )
+        self._raise_for_error(response)
+        return PushedHarnessVersion.model_validate(response.json())
+
+    # -- internals -----------------------------------------------------------------------------
+
+    def _raise_for_error(self, response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        try:
+            message = response.json().get("error", response.text)
+        except (json.JSONDecodeError, ValueError):
+            message = response.text or f"HTTP {response.status_code}"
+        if response.status_code == 401:
+            message = f"{message} — run `wmh login` (or check WMH_PLATFORM_TOKEN)"
+        raise PlatformError(str(message), status_code=response.status_code)

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 from importlib import metadata
+from pathlib import Path
 
 import httpx
 from pydantic import BaseModel
@@ -143,6 +144,13 @@ class PlatformClient:
             timeout=_TIMEOUT_SECONDS,
             transport=transport,
         )
+        # Bundle bytes move directly against storage's signed URLs; that
+        # client carries no platform credential.
+        self._transfer = httpx.Client(
+            headers={"User-Agent": f"wmh/{version}"},
+            timeout=_TIMEOUT_SECONDS,
+            transport=transport,
+        )
 
     def __enter__(self) -> PlatformClient:
         return self
@@ -152,6 +160,7 @@ class PlatformClient:
 
     def close(self) -> None:
         self._client.close()
+        self._transfer.close()
 
     # -- identity ------------------------------------------------------------------------------
 
@@ -172,28 +181,84 @@ class PlatformClient:
         self,
         project_id: str,
         name: str,
-        content: bytes,
+        bundle_path: Path,
+        sha256: str,
+        byte_size: int,
         meta: dict[str, JsonValue],
     ) -> RemoteWorldModel:
-        response = self._client.post(
-            f"/api/projects/{project_id}/world-models/{name}/bundle",
-            files={"file": (f"{name}.tar.gz", content, "application/gzip")},
-            data={"meta": json.dumps(meta)},
-        )
-        self._raise_for_error(response)
-        return RemoteWorldModel.model_validate(response.json())
+        """Push a packed bundle file: ticket, direct PUT to storage, finalize.
 
-    def download_model_bundle(self, project_id: str, name: str) -> bytes:
-        """Fetch a model's bundle bytes, verifying the declared digest."""
+        The bundle bytes stream from disk straight to the signed staging URL;
+        only the finalize declaration (digest + size + serve metadata) goes
+        through the API.
+        """
+        ticket_response = self._client.post(
+            f"/api/projects/{project_id}/world-models/{name}/bundle/uploads"
+        )
+        self._raise_for_error(ticket_response)
+        ticket = ticket_response.json()
+        upload_url = str(ticket["upload_url"])
+        with bundle_path.open("rb") as fh:
+            upload_response = self._transfer.put(
+                upload_url,
+                content=fh,
+                headers={
+                    "Content-Type": "application/gzip",
+                    "x-upsert": "false",
+                    "Authorization": f"Bearer {ticket.get('token', '')}",
+                },
+            )
+        if not upload_response.is_success:
+            msg = (
+                f"bundle upload to storage failed with HTTP {upload_response.status_code}: "
+                f"{upload_response.text[:200]}"
+            )
+            raise PlatformError(msg, status_code=upload_response.status_code)
+
+        finalize = self._client.post(
+            f"/api/projects/{project_id}/world-models/{name}/bundle",
+            json={
+                "staging_path": ticket["staging_path"],
+                "sha256": sha256,
+                "byte_size": byte_size,
+                "meta": meta,
+            },
+        )
+        self._raise_for_error(finalize)
+        return RemoteWorldModel.model_validate(finalize.json())
+
+    def download_model_bundle(self, project_id: str, name: str, dest: Path) -> str:
+        """Stream a model's bundle from storage to ``dest``, verifying its digest.
+
+        The API hands back an expiring signed URL plus the recorded sha256;
+        the bytes come straight from storage's CDN and are hashed as they
+        stream to disk.
+
+        Returns:
+            The verified sha256 hex digest.
+        """
         response = self._client.get(f"/api/projects/{project_id}/world-models/{name}/bundle")
         self._raise_for_error(response)
-        content = response.content
-        declared = response.headers.get("X-Bundle-Sha256")
-        actual = hashlib.sha256(content).hexdigest()
-        if declared is not None and declared != actual:
+        payload = response.json()
+        declared = str(payload["sha256"])
+
+        digest = hashlib.sha256()
+        part_path = dest.with_name(f"{dest.name}.part")
+        with self._transfer.stream("GET", str(payload["url"])) as stream:
+            if not stream.is_success:
+                msg = f"bundle download failed with HTTP {stream.status_code}"
+                raise PlatformError(msg, status_code=stream.status_code)
+            with part_path.open("wb") as fh:
+                for chunk in stream.iter_bytes():
+                    digest.update(chunk)
+                    fh.write(chunk)
+        actual = digest.hexdigest()
+        if actual != declared:
+            part_path.unlink(missing_ok=True)
             msg = f"bundle digest mismatch for {name}: expected {declared}, got {actual}"
             raise PlatformError(msg)
-        return content
+        part_path.replace(dest)
+        return actual
 
     # -- harnesses -----------------------------------------------------------------------------
 

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable
+from pathlib import Path
 
 import httpx
 import pytest
@@ -57,43 +58,109 @@ def test_401_error_suggests_logging_in() -> None:
         client.whoami()
 
 
-def test_push_model_bundle_sends_multipart_file_and_meta() -> None:
+def test_push_model_bundle_runs_ticket_put_finalize(tmp_path: Path) -> None:
+    bundle_path = tmp_path / "tau-bench.tar.gz"
+    bundle_path.write_bytes(b"bundle-bytes")
+    digest = hashlib.sha256(b"bundle-bytes").hexdigest()
     seen: dict[str, object] = {}
+    finalize_body: dict[str, object] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        seen["content_type"] = request.headers["content-type"]
-        seen["body"] = request.read()
+        if request.url.path.endswith("/bundle/uploads"):
+            return httpx.Response(
+                201,
+                json={
+                    "upload_url": "https://storage.test/upload/staging/cli/abc.tar.gz?token=t",
+                    "token": "t",
+                    "staging_path": "staging/cli/abc.tar.gz",
+                },
+            )
+        if request.url.host == "storage.test":
+            seen["put_body"] = request.read()
+            seen["put_method"] = request.method
+            return httpx.Response(200, json={"Key": "abc"})
+        finalize_body.update(json.loads(request.read()))
         return httpx.Response(201, json={"id": "wm-1", "name": "tau-bench", "status": "ready"})
 
     with _client(handler) as client:
         pushed = client.push_model_bundle(
-            "proj-1", "tau-bench", b"bundle-bytes", {"serve_provider": "anthropic"}
+            "proj-1",
+            "tau-bench",
+            bundle_path,
+            digest,
+            len(b"bundle-bytes"),
+            {"serve_provider": "anthropic"},
         )
 
     assert pushed.status == "ready"
-    assert "multipart/form-data" in str(seen["content_type"])
-    body = seen["body"]
-    assert isinstance(body, bytes)
-    assert b"bundle-bytes" in body
-    assert b'"serve_provider": "anthropic"' in body
+    assert seen["put_method"] == "PUT"
+    assert seen["put_body"] == b"bundle-bytes"
+    assert finalize_body["staging_path"] == "staging/cli/abc.tar.gz"
+    assert finalize_body["sha256"] == digest
+    assert finalize_body["meta"] == {"serve_provider": "anthropic"}
 
 
-def test_download_model_bundle_verifies_declared_digest() -> None:
-    content = b"bundle-bytes"
+def test_push_model_bundle_surfaces_storage_upload_failure(tmp_path: Path) -> None:
+    bundle_path = tmp_path / "tau-bench.tar.gz"
+    bundle_path.write_bytes(b"bundle-bytes")
 
-    def good(_request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/bundle/uploads"):
+            return httpx.Response(
+                201,
+                json={
+                    "upload_url": "https://storage.test/upload/x?token=t",
+                    "token": "t",
+                    "staging_path": "staging/cli/x.tar.gz",
+                },
+            )
+        return httpx.Response(413, text="Payload too large")
+
+    with (
+        _client(handler) as client,
+        pytest.raises(PlatformError, match="upload to storage failed"),
+    ):
+        client.push_model_bundle("proj-1", "tau-bench", bundle_path, "0" * 64, 12, {})
+
+
+def _download_handler(
+    content: bytes, declared_sha256: str
+) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "storage.test":
+            return httpx.Response(200, content=content)
         return httpx.Response(
-            200, content=content, headers={"X-Bundle-Sha256": hashlib.sha256(content).hexdigest()}
+            200,
+            json={
+                "url": "https://storage.test/signed/bundle.tar.gz?token=t",
+                "sha256": declared_sha256,
+                "byte_size": len(content),
+                "artifact_id": "artifact-1",
+                "expires_in": 600,
+            },
         )
 
-    with _client(good) as client:
-        assert client.download_model_bundle("proj-1", "tau-bench") == content
+    return handler
 
-    def corrupted(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=content, headers={"X-Bundle-Sha256": "0" * 64})
 
-    with _client(corrupted) as client, pytest.raises(PlatformError, match="digest mismatch"):
-        client.download_model_bundle("proj-1", "tau-bench")
+def test_download_model_bundle_streams_and_verifies_digest(tmp_path: Path) -> None:
+    content = b"bundle-bytes"
+    dest = tmp_path / "tau-bench.tar.gz"
+
+    handler = _download_handler(content, hashlib.sha256(content).hexdigest())
+    with _client(handler) as client:
+        digest = client.download_model_bundle("proj-1", "tau-bench", dest)
+
+    assert dest.read_bytes() == content
+    assert digest == hashlib.sha256(content).hexdigest()
+
+
+def test_download_model_bundle_rejects_digest_mismatch(tmp_path: Path) -> None:
+    dest = tmp_path / "tau-bench.tar.gz"
+    handler = _download_handler(b"bundle-bytes", "0" * 64)
+    with _client(handler) as client, pytest.raises(PlatformError, match="digest mismatch"):
+        client.download_model_bundle("proj-1", "tau-bench", dest)
+    assert not dest.exists()
 
 
 def test_harness_round_trip_payloads() -> None:

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -1,0 +1,147 @@
+"""Tests for the platform HTTP client (httpx mock transport, no network)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from wmh.platform.client import PlatformClient, PlatformError, fetch_cli_config
+
+API_URL = "https://api.test"
+
+_WHOAMI = {
+    "actor": {"kind": "api_key", "id": "api-key:org-1"},
+    "orgs": [{"id": "org-1", "slug": "acme", "name": "Acme"}],
+    "projects": [{"id": "proj-1", "org_id": "org-1", "slug": "alpha", "name": "Alpha"}],
+}
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> PlatformClient:
+    return PlatformClient(API_URL, "xpl_secret", transport=httpx.MockTransport(handler))
+
+
+def test_whoami_parses_and_sends_bearer_token() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer xpl_secret"
+        assert request.url.path == "/api/whoami"
+        return httpx.Response(200, json=_WHOAMI)
+
+    with _client(handler) as client:
+        identity = client.whoami()
+
+    assert identity.actor.kind == "api_key"
+    assert identity.projects[0].slug == "alpha"
+
+
+def test_error_payloads_become_platform_errors_with_status() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "Project not found: p"})
+
+    with (
+        _client(handler) as client,
+        pytest.raises(PlatformError, match="Project not found") as info,
+    ):
+        client.whoami()
+    assert info.value.status_code == 404
+
+
+def test_401_error_suggests_logging_in() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "Unauthorized"})
+
+    with _client(handler) as client, pytest.raises(PlatformError, match="wmh login"):
+        client.whoami()
+
+
+def test_push_model_bundle_sends_multipart_file_and_meta() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["content_type"] = request.headers["content-type"]
+        seen["body"] = request.read()
+        return httpx.Response(201, json={"id": "wm-1", "name": "tau-bench", "status": "ready"})
+
+    with _client(handler) as client:
+        pushed = client.push_model_bundle(
+            "proj-1", "tau-bench", b"bundle-bytes", {"serve_provider": "anthropic"}
+        )
+
+    assert pushed.status == "ready"
+    assert "multipart/form-data" in str(seen["content_type"])
+    body = seen["body"]
+    assert isinstance(body, bytes)
+    assert b"bundle-bytes" in body
+    assert b'"serve_provider": "anthropic"' in body
+
+
+def test_download_model_bundle_verifies_declared_digest() -> None:
+    content = b"bundle-bytes"
+
+    def good(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=content, headers={"X-Bundle-Sha256": hashlib.sha256(content).hexdigest()}
+        )
+
+    with _client(good) as client:
+        assert client.download_model_bundle("proj-1", "tau-bench") == content
+
+    def corrupted(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=content, headers={"X-Bundle-Sha256": "0" * 64})
+
+    with _client(corrupted) as client, pytest.raises(PlatformError, match="digest mismatch"):
+        client.download_model_bundle("proj-1", "tau-bench")
+
+
+def test_harness_round_trip_payloads() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            payload = json.loads(request.read())
+            assert payload["doc_hash"] == "a" * 32
+            return httpx.Response(
+                201,
+                json={"name": "agent", "version": 3, "doc_hash": "a" * 32, "created": True},
+            )
+        if request.url.path.endswith("/versions/3"):
+            return httpx.Response(
+                200, json={"version": 3, "doc": {"name": "agent"}, "doc_hash": "a" * 32}
+            )
+        return httpx.Response(
+            200,
+            json={
+                "harness": {"id": "h-1", "name": "agent", "latest_version": 3},
+                "versions": [{"version": 3, "doc_hash": "a" * 32}],
+            },
+        )
+
+    with _client(handler) as client:
+        pushed = client.push_harness_version("proj-1", "agent", {"name": "agent"}, "a" * 32)
+        assert pushed.version == 3
+        assert pushed.created
+
+        harness, versions = client.get_harness("proj-1", "agent")
+        assert harness.latest_version == 3
+        assert versions[0].doc_hash == "a" * 32
+
+        doc = client.get_harness_version("proj-1", "agent", 3)
+        assert doc.doc == {"name": "agent"}
+
+
+def test_fetch_cli_config_reads_the_api_url() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://platform.test/api/cli/config"
+        return httpx.Response(200, json={"apiUrl": "https://api.test/"})
+
+    api_url = fetch_cli_config("https://platform.test/", transport=httpx.MockTransport(handler))
+    assert api_url == "https://api.test"
+
+
+def test_fetch_cli_config_maps_failures() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    with pytest.raises(PlatformError, match="discovery failed"):
+        fetch_cli_config("https://platform.test", transport=httpx.MockTransport(handler))

--- a/wmh/platform/credentials.py
+++ b/wmh/platform/credentials.py
@@ -1,0 +1,115 @@
+"""Platform login credentials, stored once per user.
+
+Unlike everything else in wmh (project-local under `./.wmh/`), the platform credential is
+user-global: `~/.wmh/credentials.toml`, directory overridable via `$WMH_HOME`. Environment
+variables override the file so CI and headless runs never need one written to disk.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from pathlib import Path
+
+import tomli_w
+from pydantic import BaseModel
+
+ENV_HOME = "WMH_HOME"
+ENV_WEB_URL = "WMH_PLATFORM_URL"
+ENV_API_URL = "WMH_PLATFORM_API_URL"
+ENV_TOKEN = "WMH_PLATFORM_TOKEN"
+ENV_PROJECT = "WMH_PLATFORM_PROJECT"
+
+CREDENTIALS_FILENAME = "credentials.toml"
+
+
+class PlatformCredentials(BaseModel):
+    """The saved connection: where the platform lives and which key acts for us."""
+
+    web_url: str | None = None  # the browser-facing app (login page, keys page)
+    api_url: str | None = None  # the backend host requests go to
+    token: str | None = None  # org API key (xpl_…)
+    default_project: str | None = None  # project id used when --project is omitted
+
+    def is_complete(self) -> bool:
+        """Whether requests can be made without further configuration."""
+        return bool(self.api_url and self.token)
+
+
+def wmh_home() -> Path:
+    """The user-global wmh directory (`$WMH_HOME` or `~/.wmh`)."""
+    override = os.environ.get(ENV_HOME)
+    return Path(override) if override else Path.home() / ".wmh"
+
+
+def credentials_path() -> Path:
+    """Where the credential file lives."""
+    return wmh_home() / CREDENTIALS_FILENAME
+
+
+def load_credentials() -> PlatformCredentials:
+    """Read the credential file, then apply environment overrides.
+
+    Env alone is sufficient (no file needed); a set-but-empty env var is
+    treated as unset rather than clearing a file value.
+    """
+    data: dict[str, str] = {}
+    path = credentials_path()
+    if path.exists():
+        section = tomllib.loads(path.read_text(encoding="utf-8")).get("platform", {})
+        data = {key: value for key, value in section.items() if isinstance(value, str)}
+    credentials = PlatformCredentials.model_validate(data)
+    overrides = {
+        "web_url": os.environ.get(ENV_WEB_URL),
+        "api_url": os.environ.get(ENV_API_URL),
+        "token": os.environ.get(ENV_TOKEN),
+        "default_project": os.environ.get(ENV_PROJECT),
+    }
+    updates = {key: value for key, value in overrides.items() if value}
+    return credentials.model_copy(update=updates) if updates else credentials
+
+
+def save_credentials(credentials: PlatformCredentials) -> Path:
+    """Persist the credential file with owner-only permissions.
+
+    Mirrors the dotenv writer: refuses symlinks (a credential rewrite must never
+    land in whatever a link points at), writes through a 0600 mkstemp, and swaps
+    into place atomically.
+
+    Raises:
+        ValueError: If the target path is a symlink.
+    """
+    path = credentials_path()
+    if path.is_symlink():
+        msg = (
+            f"refusing to write credentials through the symlink {path}; "
+            "remove the link or point $WMH_HOME elsewhere"
+        )
+        raise ValueError(msg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "platform": {
+            key: value
+            for key, value in credentials.model_dump(mode="json").items()
+            if value is not None
+        }
+    }
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(tomli_w.dumps(payload))
+        os.replace(tmp_name, path)
+    except BaseException:
+        os.unlink(tmp_name)
+        raise
+    return path
+
+
+def clear_credentials() -> bool:
+    """Delete the credential file; returns whether one existed."""
+    path = credentials_path()
+    if not path.exists():
+        return False
+    path.unlink()
+    return True

--- a/wmh/platform/credentials.py
+++ b/wmh/platform/credentials.py
@@ -23,6 +23,10 @@ ENV_PROJECT = "WMH_PLATFORM_PROJECT"
 
 CREDENTIALS_FILENAME = "credentials.toml"
 
+# The hosted platform a bare `wmh login` connects to; `--url` (previews,
+# self-hosted, the local stack) and saved credentials both take precedence.
+DEFAULT_WEB_URL = "https://experiential-platform-web.vercel.app"
+
 
 class PlatformCredentials(BaseModel):
     """The saved connection: where the platform lives and which key acts for us."""

--- a/wmh/platform/credentials_test.py
+++ b/wmh/platform/credentials_test.py
@@ -1,0 +1,87 @@
+"""Tests for platform credential storage."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from wmh.platform.credentials import (
+    ENV_API_URL,
+    ENV_HOME,
+    ENV_TOKEN,
+    PlatformCredentials,
+    clear_credentials,
+    credentials_path,
+    load_credentials,
+    save_credentials,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_HOME, str(tmp_path))
+    for var in (ENV_API_URL, ENV_TOKEN, "WMH_PLATFORM_URL", "WMH_PLATFORM_PROJECT"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_save_load_round_trip_with_owner_only_permissions() -> None:
+    saved_path = save_credentials(
+        PlatformCredentials(
+            web_url="https://platform.test",
+            api_url="https://api.test",
+            token="xpl_secret",
+            default_project="proj-1",
+        )
+    )
+
+    assert saved_path == credentials_path()
+    mode = os.stat(saved_path).st_mode & 0o777
+    assert mode == 0o600
+
+    loaded = load_credentials()
+    assert loaded.web_url == "https://platform.test"
+    assert loaded.token == "xpl_secret"
+    assert loaded.default_project == "proj-1"
+    assert loaded.is_complete()
+
+
+def test_missing_file_loads_empty_credentials() -> None:
+    loaded = load_credentials()
+    assert loaded == PlatformCredentials()
+    assert not loaded.is_complete()
+
+
+def test_env_overrides_file_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    save_credentials(PlatformCredentials(api_url="https://file.test", token="xpl_file"))
+    monkeypatch.setenv(ENV_TOKEN, "xpl_env")
+
+    loaded = load_credentials()
+
+    assert loaded.token == "xpl_env"
+    assert loaded.api_url == "https://file.test"
+
+
+def test_env_alone_is_sufficient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_API_URL, "https://api.test")
+    monkeypatch.setenv(ENV_TOKEN, "xpl_ci")
+
+    assert load_credentials().is_complete()
+
+
+def test_save_refuses_symlinked_credentials_file(tmp_path: Path) -> None:
+    target = tmp_path / "elsewhere.toml"
+    target.write_text("", encoding="utf-8")
+    credentials_path().parent.mkdir(parents=True, exist_ok=True)
+    credentials_path().symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        save_credentials(PlatformCredentials(token="xpl_secret"))
+
+
+def test_clear_reports_whether_a_credential_existed() -> None:
+    assert not clear_credentials()
+    save_credentials(PlatformCredentials(token="xpl_secret"))
+    assert clear_credentials()
+    assert not credentials_path().exists()

--- a/wmh/platform/transfer.py
+++ b/wmh/platform/transfer.py
@@ -1,0 +1,146 @@
+"""Deterministic model-bundle packing and safe unpacking for push/pull.
+
+A pushed bundle is byte-compatible with the bundles the platform's own build
+pipeline produces: a gzipped tarball of the model directory with
+archive-relative member paths. Packing is an include-list — the model's
+`config.toml`, `metrics.json`, `card.json`, `prompts/`, and `index/` — so
+local `runs/` cost records and raw `traces/` (customer data) never leave the
+machine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+import tomllib
+import uuid
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from wmh.config.config import HarnessConfig
+from wmh.core.types import JsonValue
+
+_INCLUDED_FILES = ("config.toml", "metrics.json", "card.json")
+_INCLUDED_DIRS = ("prompts", "index")
+
+
+class PackedModelBundle(BaseModel):
+    """A packed model directory ready for upload."""
+
+    content: bytes
+    sha256: str
+    byte_size: int
+
+
+class BundleFormatError(ValueError):
+    """The directory or bytes are not a valid world-model bundle."""
+
+
+def pack_model_dir(directory: Path) -> PackedModelBundle:
+    """Pack a model directory into the platform's bundle format.
+
+    Args:
+        directory: A built model directory (must contain `config.toml`).
+
+    Returns:
+        Bundle bytes plus integrity metadata; member order is sorted so
+        identical inputs produce identical archives.
+
+    Raises:
+        BundleFormatError: If the directory is missing or has no config.toml.
+    """
+    if not directory.is_dir():
+        msg = f"model directory does not exist: {directory}"
+        raise BundleFormatError(msg)
+    if not (directory / "config.toml").is_file():
+        msg = f"{directory} has no config.toml; only built world models can be pushed"
+        raise BundleFormatError(msg)
+
+    members: list[Path] = []
+    for name in _INCLUDED_FILES:
+        path = directory / name
+        if path.is_file():
+            members.append(path)
+    for name in _INCLUDED_DIRS:
+        root = directory / name
+        if root.is_dir():
+            members.extend(sorted(path for path in root.rglob("*")))
+            members.append(root)
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for path in sorted(set(members)):
+            tar.add(path, arcname=str(path.relative_to(directory)), recursive=False)
+    content = buffer.getvalue()
+    return PackedModelBundle(
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+        byte_size=len(content),
+    )
+
+
+def unpack_model_bundle(content: bytes, dest_dir: Path, *, force: bool = False) -> None:
+    """Unpack pulled bundle bytes into a local model directory.
+
+    Extraction happens in a temporary sibling renamed into place, so a crashed
+    unpack never leaves a half-written model that later loads as real.
+
+    Args:
+        content: gzipped tarball bytes from the platform.
+        dest_dir: Target model directory (`.wmh/models/<name>`).
+        force: Replace an existing directory instead of refusing.
+
+    Raises:
+        BundleFormatError: If the bytes are not a readable bundle or a member
+            would escape the destination.
+        FileExistsError: If ``dest_dir`` exists and ``force`` is not set.
+    """
+    if dest_dir.exists():
+        if not force:
+            msg = f"{dest_dir} already exists; pass --force to replace it"
+            raise FileExistsError(msg)
+    staging_dir = dest_dir.with_name(f"{dest_dir.name}.pull-{uuid.uuid4().hex}")
+    staging_dir.mkdir(parents=True)
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+            # The "data" filter rejects absolute paths, traversal, and special
+            # members instead of writing them.
+            tar.extractall(staging_dir, filter="data")
+    except (tarfile.TarError, OSError) as error:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        msg = f"bundle bytes could not be unpacked: {error}"
+        raise BundleFormatError(msg) from error
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir, ignore_errors=True)
+    staging_dir.rename(dest_dir)
+
+
+def extract_push_meta(directory: Path) -> dict[str, JsonValue]:
+    """Derive the push metadata the platform stores alongside a bundle.
+
+    Parses the model's own `config.toml` (and `metrics.json` when present)
+    through wmh's typed config so the platform never reads files out of the
+    tarball.
+    """
+    config = HarnessConfig.model_validate(
+        tomllib.loads((directory / "config.toml").read_text(encoding="utf-8"))
+    )
+    meta: dict[str, JsonValue] = {
+        "serve_provider": config.serve_provider.value,
+        "embed_provider": config.embed_provider.value,
+        "embed_dim": config.embed_dim,
+        "gepa_budget": config.gepa_budget,
+    }
+    try:
+        meta["serve_model"] = config.serve_provider_config().model
+    except ValueError:
+        # No provider block for the serve provider; the platform column stays unset.
+        pass
+    metrics_path = directory / "metrics.json"
+    if metrics_path.is_file():
+        meta["metrics"] = json.loads(metrics_path.read_text(encoding="utf-8"))
+    return meta

--- a/wmh/platform/transfer.py
+++ b/wmh/platform/transfer.py
@@ -6,12 +6,15 @@ archive-relative member paths. Packing is an include-list — the model's
 `config.toml`, `metrics.json`, `card.json`, `prompts/`, and `index/` — so
 local `runs/` cost records and raw `traces/` (customer data) never leave the
 machine.
+
+Bundles can reach the platform's 1GB cap, so packing and unpacking are
+file-based: bytes stream between disk and the network without ever being held
+in memory whole.
 """
 
 from __future__ import annotations
 
 import hashlib
-import io
 import json
 import shutil
 import tarfile
@@ -27,11 +30,13 @@ from wmh.core.types import JsonValue
 _INCLUDED_FILES = ("config.toml", "metrics.json", "card.json")
 _INCLUDED_DIRS = ("prompts", "index")
 
+_HASH_CHUNK_BYTES = 1024 * 1024
+
 
 class PackedModelBundle(BaseModel):
-    """A packed model directory ready for upload."""
+    """A packed model bundle on disk, ready for upload."""
 
-    content: bytes
+    path: Path
     sha256: str
     byte_size: int
 
@@ -40,14 +45,24 @@ class BundleFormatError(ValueError):
     """The directory or bytes are not a valid world-model bundle."""
 
 
-def pack_model_dir(directory: Path) -> PackedModelBundle:
-    """Pack a model directory into the platform's bundle format.
+def sha256_file(path: Path) -> str:
+    """Digest a file's contents without loading it whole."""
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        while chunk := fh.read(_HASH_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def pack_model_dir(directory: Path, dest: Path) -> PackedModelBundle:
+    """Pack a model directory into the platform's bundle format at ``dest``.
 
     Args:
         directory: A built model directory (must contain `config.toml`).
+        dest: Where to write the gzipped tarball (parent must exist).
 
     Returns:
-        Bundle bytes plus integrity metadata; member order is sorted so
+        The bundle file plus integrity metadata; member order is sorted so
         identical inputs produce identical archives.
 
     Raises:
@@ -71,48 +86,45 @@ def pack_model_dir(directory: Path) -> PackedModelBundle:
             members.extend(sorted(path for path in root.rglob("*")))
             members.append(root)
 
-    buffer = io.BytesIO()
-    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+    with tarfile.open(dest, mode="w:gz") as tar:
         for path in sorted(set(members)):
             tar.add(path, arcname=str(path.relative_to(directory)), recursive=False)
-    content = buffer.getvalue()
     return PackedModelBundle(
-        content=content,
-        sha256=hashlib.sha256(content).hexdigest(),
-        byte_size=len(content),
+        path=dest,
+        sha256=sha256_file(dest),
+        byte_size=dest.stat().st_size,
     )
 
 
-def unpack_model_bundle(content: bytes, dest_dir: Path, *, force: bool = False) -> None:
-    """Unpack pulled bundle bytes into a local model directory.
+def unpack_model_bundle(source: Path, dest_dir: Path, *, force: bool = False) -> None:
+    """Unpack a pulled bundle file into a local model directory.
 
     Extraction happens in a temporary sibling renamed into place, so a crashed
     unpack never leaves a half-written model that later loads as real.
 
     Args:
-        content: gzipped tarball bytes from the platform.
+        source: Downloaded gzipped tarball.
         dest_dir: Target model directory (`.wmh/models/<name>`).
         force: Replace an existing directory instead of refusing.
 
     Raises:
-        BundleFormatError: If the bytes are not a readable bundle or a member
+        BundleFormatError: If the file is not a readable bundle or a member
             would escape the destination.
         FileExistsError: If ``dest_dir`` exists and ``force`` is not set.
     """
-    if dest_dir.exists():
-        if not force:
-            msg = f"{dest_dir} already exists; pass --force to replace it"
-            raise FileExistsError(msg)
+    if dest_dir.exists() and not force:
+        msg = f"{dest_dir} already exists; pass --force to replace it"
+        raise FileExistsError(msg)
     staging_dir = dest_dir.with_name(f"{dest_dir.name}.pull-{uuid.uuid4().hex}")
     staging_dir.mkdir(parents=True)
     try:
-        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+        with tarfile.open(source, mode="r:gz") as tar:
             # The "data" filter rejects absolute paths, traversal, and special
             # members instead of writing them.
             tar.extractall(staging_dir, filter="data")
     except (tarfile.TarError, OSError) as error:
         shutil.rmtree(staging_dir, ignore_errors=True)
-        msg = f"bundle bytes could not be unpacked: {error}"
+        msg = f"bundle could not be unpacked: {error}"
         raise BundleFormatError(msg) from error
     if dest_dir.exists():
         shutil.rmtree(dest_dir, ignore_errors=True)

--- a/wmh/platform/transfer_test.py
+++ b/wmh/platform/transfer_test.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import tarfile
 from pathlib import Path
 
@@ -12,6 +11,7 @@ from wmh.platform.transfer import (
     BundleFormatError,
     extract_push_meta,
     pack_model_dir,
+    sha256_file,
     unpack_model_bundle,
 )
 
@@ -32,9 +32,9 @@ def _model_dir(tmp_path: Path) -> Path:
 
 
 def test_pack_includes_model_files_and_excludes_runs_and_traces(tmp_path: Path) -> None:
-    bundle = pack_model_dir(_model_dir(tmp_path))
+    bundle = pack_model_dir(_model_dir(tmp_path), tmp_path / "out.tar.gz")
 
-    with tarfile.open(fileobj=io.BytesIO(bundle.content), mode="r:gz") as tar:
+    with tarfile.open(bundle.path, mode="r:gz") as tar:
         names = set(tar.getnames())
 
     assert "config.toml" in names
@@ -42,7 +42,8 @@ def test_pack_includes_model_files_and_excludes_runs_and_traces(tmp_path: Path) 
     assert "prompts/base.txt" in names
     assert "index/steps.jsonl" in names
     assert not any(name.startswith(("runs", "traces")) for name in names)
-    assert bundle.byte_size == len(bundle.content)
+    assert bundle.byte_size == bundle.path.stat().st_size
+    assert bundle.sha256 == sha256_file(bundle.path)
 
 
 def test_pack_requires_config_toml(tmp_path: Path) -> None:
@@ -50,28 +51,30 @@ def test_pack_requires_config_toml(tmp_path: Path) -> None:
     directory.mkdir()
 
     with pytest.raises(BundleFormatError, match="config.toml"):
-        pack_model_dir(directory)
+        pack_model_dir(directory, tmp_path / "out.tar.gz")
     with pytest.raises(BundleFormatError, match="does not exist"):
-        pack_model_dir(tmp_path / "absent")
+        pack_model_dir(tmp_path / "absent", tmp_path / "out.tar.gz")
 
 
 def test_round_trip_and_force_semantics(tmp_path: Path) -> None:
-    bundle = pack_model_dir(_model_dir(tmp_path))
+    bundle = pack_model_dir(_model_dir(tmp_path), tmp_path / "out.tar.gz")
     dest = tmp_path / "pulled" / "tau-bench"
 
-    unpack_model_bundle(bundle.content, dest)
+    unpack_model_bundle(bundle.path, dest)
     assert (dest / "config.toml").read_text(encoding="utf-8") == "embed_dim = 64\n"
     assert (dest / "prompts" / "base.txt").is_file()
 
     with pytest.raises(FileExistsError, match="--force"):
-        unpack_model_bundle(bundle.content, dest)
-    unpack_model_bundle(bundle.content, dest, force=True)
+        unpack_model_bundle(bundle.path, dest)
+    unpack_model_bundle(bundle.path, dest, force=True)
     assert (dest / "config.toml").is_file()
 
 
 def test_unpack_rejects_garbage_bytes(tmp_path: Path) -> None:
+    garbage = tmp_path / "garbage.tar.gz"
+    garbage.write_bytes(b"not a tarball")
     with pytest.raises(BundleFormatError, match="unpacked"):
-        unpack_model_bundle(b"not a tarball", tmp_path / "dest")
+        unpack_model_bundle(garbage, tmp_path / "dest")
     assert not (tmp_path / "dest").exists()
 
 

--- a/wmh/platform/transfer_test.py
+++ b/wmh/platform/transfer_test.py
@@ -1,0 +1,99 @@
+"""Tests for model-bundle packing and unpacking."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from wmh.platform.transfer import (
+    BundleFormatError,
+    extract_push_meta,
+    pack_model_dir,
+    unpack_model_bundle,
+)
+
+
+def _model_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "tau-bench"
+    (directory / "prompts").mkdir(parents=True)
+    (directory / "index").mkdir()
+    (directory / "runs").mkdir()
+    (directory / "traces").mkdir()
+    (directory / "config.toml").write_text("embed_dim = 64\n", encoding="utf-8")
+    (directory / "metrics.json").write_text('{"held_out_accuracy": 0.7}', encoding="utf-8")
+    (directory / "prompts" / "base.txt").write_text("you are the environment", encoding="utf-8")
+    (directory / "index" / "steps.jsonl").write_text('{"action": "a"}\n', encoding="utf-8")
+    (directory / "runs" / "run-1.json").write_text("{}", encoding="utf-8")
+    (directory / "traces" / "corpus.jsonl").write_text('{"private": true}\n', encoding="utf-8")
+    return directory
+
+
+def test_pack_includes_model_files_and_excludes_runs_and_traces(tmp_path: Path) -> None:
+    bundle = pack_model_dir(_model_dir(tmp_path))
+
+    with tarfile.open(fileobj=io.BytesIO(bundle.content), mode="r:gz") as tar:
+        names = set(tar.getnames())
+
+    assert "config.toml" in names
+    assert "metrics.json" in names
+    assert "prompts/base.txt" in names
+    assert "index/steps.jsonl" in names
+    assert not any(name.startswith(("runs", "traces")) for name in names)
+    assert bundle.byte_size == len(bundle.content)
+
+
+def test_pack_requires_config_toml(tmp_path: Path) -> None:
+    directory = tmp_path / "not-a-model"
+    directory.mkdir()
+
+    with pytest.raises(BundleFormatError, match="config.toml"):
+        pack_model_dir(directory)
+    with pytest.raises(BundleFormatError, match="does not exist"):
+        pack_model_dir(tmp_path / "absent")
+
+
+def test_round_trip_and_force_semantics(tmp_path: Path) -> None:
+    bundle = pack_model_dir(_model_dir(tmp_path))
+    dest = tmp_path / "pulled" / "tau-bench"
+
+    unpack_model_bundle(bundle.content, dest)
+    assert (dest / "config.toml").read_text(encoding="utf-8") == "embed_dim = 64\n"
+    assert (dest / "prompts" / "base.txt").is_file()
+
+    with pytest.raises(FileExistsError, match="--force"):
+        unpack_model_bundle(bundle.content, dest)
+    unpack_model_bundle(bundle.content, dest, force=True)
+    assert (dest / "config.toml").is_file()
+
+
+def test_unpack_rejects_garbage_bytes(tmp_path: Path) -> None:
+    with pytest.raises(BundleFormatError, match="unpacked"):
+        unpack_model_bundle(b"not a tarball", tmp_path / "dest")
+    assert not (tmp_path / "dest").exists()
+
+
+def test_extract_push_meta_reads_typed_config_and_metrics(tmp_path: Path) -> None:
+    directory = _model_dir(tmp_path)
+
+    meta = extract_push_meta(directory)
+
+    assert meta["serve_provider"] == "anthropic"  # HarnessConfig default
+    assert meta["embed_dim"] == 64
+    assert meta["metrics"] == {"held_out_accuracy": 0.7}
+    # No provider block is configured, so no serve model is claimed.
+    assert "serve_model" not in meta
+
+
+def test_extract_push_meta_includes_serve_model_when_configured(tmp_path: Path) -> None:
+    directory = _model_dir(tmp_path)
+    (directory / "config.toml").write_text(
+        '[[providers]]\nkind = "anthropic"\nmodel = "claude-sonnet-4-5"\n',
+        encoding="utf-8",
+    )
+
+    meta = extract_push_meta(directory)
+
+    assert meta["serve_model"] == "claude-sonnet-4-5"


### PR DESCRIPTION
CLI half of the platform integration — pairs with experientiallabs/platform#259 (registry endpoints with signed-URL bundle transfer, /cli/auth approval page, /api/cli/config discovery), now based on main.

## Commands

| Command | Behavior |
|---|---|
| `wmh login [--url] [--token] [--no-browser]` | Discovers the backend via `GET {url}/api/cli/config`, then runs a loopback browser flow: opens the platform's `/cli/auth` page with a one-time state nonce + ephemeral 127.0.0.1 port; the approved org key lands on the listener (state verified with a constant-time compare), is checked against `/api/whoami`, and is saved. Paste fallback on timeout; `--token` for headless. |
| `wmh logout` | Deletes the credential file (and notes the key stays valid until revoked on the platform). |
| `wmh status` | Connection, acting identity, orgs, and a projects table with the default project marked. |
| `wmh push NAME [--kind] [--project] [--as] [--ref]` | Kind auto-detected from local `.wmh/models/` vs `.wmh/harnesses/`. Models: include-list bundle (`config.toml`, `metrics.json`, `card.json`, `prompts/`, `index/` — never `runs/` or `traces/`), push metadata extracted through wmh's own `HarnessConfig`. Harnesses: canonical `HarnessDoc` JSON + `doc_hash`; idempotent re-push reported as such. |
| `wmh pull NAME [--kind] [--project] [--version] [--force]` | Models: sha256-verified download unpacked atomically (traversal-safe) into `.wmh/models/`. Harnesses: doc integrity re-checked, saved via `HarnessStore.save_version` with the champion alias (`remote vN → local vM`). |

## Design notes
- **First user-global state in wmh**: `~/.wmh/credentials.toml` (0600 via mkstemp+replace with symlink refusal, mirroring `wmh/config/dotenv.py`), `$WMH_HOME` override, `WMH_PLATFORM_URL/API_URL/TOKEN/PROJECT` env precedence for CI.
- New package `wmh/platform/` (`credentials`, `client`, `auth`, `transfer`) + `wmh/cli/platform_cmds.py`; heavy imports stay inside command bodies.
- The intentionally-minimal-CLI guardrail test was expanded deliberately: core set + `{login, logout, status, push, pull}`.

## Testing
- `ruff check` + `ruff format --check` + `ty check` clean; `pytest -q` 971 passed / 18 skipped (60 new tests: credential perms/precedence/symlink-refusal, MockTransport client incl. digest-mismatch and 401-hint paths, real loopback callback round-trips incl. forged-state rejection, bundle include-list/round-trip/traversal negatives, CLI wiring via CliRunner).
- Not yet run: live end-to-end against a platform preview (blocked on #254 landing in a preview env); planned as the joint verification for both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)