### PR TITLE
feat: seed demo sessions from trace state_before

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -67,7 +67,7 @@ from wmh.config import (
 )
 from wmh.engine.build import build as run_build
 from wmh.engine.build import ingest
-from wmh.engine.demo import run_demo
+from wmh.engine.demo import run_demo, seed_state_for
 from wmh.engine.eval_suites import (
     discover_eval_suites,
     list_eval_results,
@@ -1383,8 +1383,12 @@ def demo(
 
 
 def _first_prompt(wm: WorldModel, trace) -> str:  # noqa: ANN001 - core Trace
-    """Render the first step's env prompt on a throwaway session (display only)."""
-    probe = wm.new_session(task=trace.steps[0].task)
+    """Render the first step's env prompt on a throwaway session (display only).
+
+    Seeds the probe session with the trace's initial `state_before` the same way `run_demo` does,
+    so the previewed step-1 prompt matches the state the actual replay session runs against.
+    """
+    probe = wm.new_session(task=trace.steps[0].task, seed_state=seed_state_for(trace))
     try:
         return wm.render_step_prompt(probe.id, trace.steps[0].action)
     finally:

--- a/wmh/engine/demo.py
+++ b/wmh/engine/demo.py
@@ -12,8 +12,23 @@ from collections.abc import Callable
 
 from pydantic import BaseModel
 
-from wmh.core.types import Action, Observation, Trace
+from wmh.core.types import Action, EnvState, Observation, Trace
 from wmh.engine.world_model import WorldModel
+
+
+def seed_state_for(trace: Trace) -> EnvState | None:
+    """The first step's recorded env state, when it carries something worth seeding.
+
+    Returns `None` for an empty snapshot (no structured config and no scratchpad) so the session
+    falls back to `new_session`'s default `EnvState()` rather than being handed a pointless empty
+    seed. Most provider traces leave `state_before` empty; benchmarks that capture a compact env
+    state (e.g. bird-sql) populate it, and seeding it lets the replay start from the real initial
+    state instead of the world model hallucinating it.
+    """
+    if not trace.steps:
+        return None
+    state = trace.steps[0].state_before
+    return state if (state.structured or state.scratchpad) else None
 
 
 class DemoStep(BaseModel):
@@ -55,7 +70,7 @@ def run_demo(
     if not trace.steps:
         raise ValueError(f"trace {trace.trace_id!r} has no steps to replay")
     task = trace.steps[0].task
-    session = world_model.new_session(task=task)
+    session = world_model.new_session(task=task, seed_state=seed_state_for(trace))
     replayed = trace.steps[:max_steps]
     if skip:
         world_model.seed_session(session.id, replayed[:skip])

--- a/wmh/engine/demo_test.py
+++ b/wmh/engine/demo_test.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from wmh.core.types import Action, ActionKind, Observation, Step, Trace
+from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
 from wmh.engine.demo import run_demo
 from wmh.engine.world_model import WorldModel
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
@@ -118,3 +118,40 @@ def test_run_demo_caps_steps() -> None:
     trace = Trace(trace_id="long", steps=[_step(f"t{i}", "x") for i in range(9)])
     result = run_demo(wm, trace, max_steps=3)
     assert len(result.steps) == 3
+
+
+def test_run_demo_seeds_session_from_first_step_state_before() -> None:
+    wm = _world_model(ScriptedProvider())
+    seeded = EnvState(structured={"cart": ["A1"]}, scratchpad="logged in as u1")
+    trace = Trace(
+        trace_id="scenario",
+        steps=[
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u1"}),
+                observation=Observation(content="found u1"),
+                state_before=seeded,
+                task="look up users",
+            )
+        ],
+    )
+
+    result = run_demo(wm, trace, max_steps=5)
+
+    session = next(iter(wm._sessions.values()))
+    assert session.state.structured == {"cart": ["A1"]}
+    # The seeded state renders into the step-1 prompt the world model actually saw.
+    assert '"cart":["A1"]' in result.first_env_prompt
+    assert "logged in as u1" in result.first_env_prompt
+
+
+def test_run_demo_empty_state_before_starts_with_default_state() -> None:
+    wm = _world_model(ScriptedProvider())
+    # _step leaves state_before at its default (empty structured + scratchpad).
+    trace = Trace(trace_id="scenario", steps=[_step("get_user", "found u1")])
+
+    run_demo(wm, trace, max_steps=5)
+
+    session = next(iter(wm._sessions.values()))
+    assert session.state == EnvState()
+    assert session.state.structured == {}
+    assert session.state.scratchpad == ""


### PR DESCRIPTION
Seeds the demo replay session from the trace's initial `state_before` instead of always starting empty. `run_demo` (and the `_first_prompt` preview, which must mirror it) now pass `trace.steps[0].state_before` into `new_session(seed_state=...)` when it carries structured config or a scratchpad - closing the gap noted in `world_model._update_state`'s docstring ("structured state is left to explicit seeding/tooling").

Two tests added in `demo_test.py`: a populated seed lands in `session.state` and shows up in the step-1 prompt, and an empty `state_before` still starts from a default `EnvState()` with no behavior change.

`play` is intentionally left out of this PR -- it doesn't load a trace today, so seeding it needs a separate design decision.

Checks: `uv run ty check` clean. `uv run pytest wmh/ -q` - 640 passed, 9 skipped, with 3 pre-existing Windows failures tracked separately in #124 (unrelated to this change).