### PR TITLE
Live agent sessions: interactive multi-turn pi runner + host engine (stacked on #135)

### DIFF
--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -92,36 +92,6 @@ class SandboxFiles(Protocol):
     def read(self, path: str) -> str: ...
 
 
-class PtyHandle(Protocol):
-    """A running interactive PTY (e2b's pty handle): its pid identifies it for input/resize/kill."""
-
-    @property
-    def pid(self) -> int: ...
-
-
-class SandboxPty(Protocol):
-    """The `sandbox.pty` slice: an interactive terminal a user types into (live sessions only).
-
-    The eval backend never touches this — a PTY is the user's own scratch shell into a live
-    session's sandbox, streamed to the browser. `on_data` receives raw terminal bytes; `size` is
-    (rows, cols). Sliced so tests substitute a fake pty without importing the SDK.
-    """
-
-    def create(
-        self,
-        size: tuple[int, int],
-        on_data: Callable[[bytes], None],
-        *,
-        timeout: float | None = None,
-    ) -> PtyHandle: ...
-
-    def send_stdin(self, pid: int, data: bytes) -> object: ...
-
-    def resize(self, pid: int, size: tuple[int, int]) -> object: ...
-
-    def kill(self, pid: int) -> object: ...
-
-
 @runtime_checkable
 class SandboxHandle(Protocol):
     """The exact slice of `e2b.Sandbox` the harness uses, so tests substitute fakes."""

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -92,6 +92,36 @@ class SandboxFiles(Protocol):
     def read(self, path: str) -> str: ...
 
 
+class PtyHandle(Protocol):
+    """A running interactive PTY (e2b's pty handle): its pid identifies it for input/resize/kill."""
+
+    @property
+    def pid(self) -> int: ...
+
+
+class SandboxPty(Protocol):
+    """The `sandbox.pty` slice: an interactive terminal a user types into (live sessions only).
+
+    The eval backend never touches this — a PTY is the user's own scratch shell into a live
+    session's sandbox, streamed to the browser. `on_data` receives raw terminal bytes; `size` is
+    (rows, cols). Sliced so tests substitute a fake pty without importing the SDK.
+    """
+
+    def create(
+        self,
+        size: tuple[int, int],
+        on_data: Callable[[bytes], None],
+        *,
+        timeout: float | None = None,
+    ) -> PtyHandle: ...
+
+    def send_stdin(self, pid: int, data: bytes) -> object: ...
+
+    def resize(self, pid: int, size: tuple[int, int]) -> object: ...
+
+    def kill(self, pid: int) -> object: ...
+
+
 @runtime_checkable
 class SandboxHandle(Protocol):
     """The exact slice of `e2b.Sandbox` the harness uses, so tests substitute fakes."""
@@ -116,8 +146,14 @@ def default_sandbox_factory(
     api_key: str | None = None,
     template: str | None = None,
     timeout: float = DEFAULT_SANDBOX_TIMEOUT_S,
+    metadata: dict[str, str] | None = None,
 ) -> SandboxFactory:
-    """A factory creating real E2B sandboxes (lazy SDK import; key from arg or $E2B_API_KEY)."""
+    """A factory creating real E2B sandboxes (lazy SDK import; key from arg or $E2B_API_KEY).
+
+    `metadata` tags the sandbox at create time (e.g. `{"session_id": …}`) so an out-of-band sweep
+    (`Sandbox.list`) can find and reap an orphaned sandbox whose owning process died — the live
+    session driver relies on this for cost-leak reconciliation.
+    """
 
     def make() -> SandboxHandle:
         try:
@@ -131,7 +167,12 @@ def default_sandbox_factory(
         if not key:
             raise RuntimeError(f"set ${E2B_API_KEY_ENV} to run the harness in E2B sandboxes")
         chosen = template or os.environ.get(E2B_TEMPLATE_ENV) or None
-        sandbox = Sandbox.create(template=chosen, timeout=int(timeout), api_key=key)
+        if metadata:
+            sandbox = Sandbox.create(
+                template=chosen, timeout=int(timeout), api_key=key, metadata=metadata
+            )
+        else:
+            sandbox = Sandbox.create(template=chosen, timeout=int(timeout), api_key=key)
         # The SDK object satisfies the protocol slice structurally; cast rather than pin the
         # SDK's full (much wider) signatures into the protocol.
         return cast("SandboxHandle", sandbox)

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -173,6 +173,7 @@ class LiveSession:
         self._status: str = "starting"
         self._closed = False
         self._actions_this_turn = 0
+        self._aborting = False
         self._pending_ping: str | None = None
         self.worker_usage = TokenUsage()
 
@@ -258,11 +259,17 @@ class LiveSession:
                 return
             if isinstance(intent, _UserMessage):
                 self._actions_this_turn = 0
+                self._aborting = False  # a new user turn is not the aborted one
                 self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
                 self._safe_send(
                     {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}
                 )
             elif isinstance(intent, _Interrupt):
+                # Mark the current turn as aborting so a `submit` tool_request that was
+                # already in flight when the interrupt fired does not emit a final submit
+                # event: the host, not the runner, owns event emission, so this gate is
+                # the only place the race can be closed. Cleared at the next turn boundary.
+                self._aborting = True
                 self._safe_send({"type": "abort", "reason": intent.reason})
             else:  # _End
                 self._safe_send({"type": "abort", "reason": "shutdown"})
@@ -310,8 +317,12 @@ class LiveSession:
         call_id = uuid.uuid4().hex
 
         if name == SUBMIT.name:
-            answer = args.get("answer")
-            self._emit("submit", {"answer": answer if isinstance(answer, str) else ""})
+            # If the turn is being interrupted, do NOT emit a final submit for it —
+            # the answer belongs to a cancelled run. Still respond so the runner's
+            # submit tool does not hang; the aborted run ends via `state:idle`.
+            if not self._aborting:
+                answer = args.get("answer")
+                self._emit("submit", {"answer": answer if isinstance(answer, str) else ""})
             self._respond_tool(req_id, "submitted", is_error=False)
             return
 
@@ -358,6 +369,9 @@ class LiveSession:
         status = frame.get("status")
         if isinstance(status, str):
             self._status = status
+        # A state transition is a turn boundary: the aborting turn has ended, so
+        # the next turn's submit is not suppressed.
+        self._aborting = False
         payload: JsonObject = {"status": self._status}
         for key in ("turns", "reason", "msg_id"):
             if key in frame:

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -259,7 +259,10 @@ class LiveSession:
                 return
             if isinstance(intent, _UserMessage):
                 self._actions_this_turn = 0
-                self._aborting = False  # a new user turn is not the aborted one
+                # NB: do not clear `_aborting` here — a new message can be drained before
+                # the cancelled turn's in-flight submit frame is read, and clearing now
+                # would let that stale submit emit. The runner's next `state` frame (the
+                # real turn boundary) clears it in `_on_state`.
                 self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
                 self._safe_send(
                     {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -1,0 +1,463 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Interactive live sessions: the host engine that drives one long-lived pi runner.
+
+A *session* differs from an *episode* (`runner_link.RunnerLink`) in three ways: it is multi-turn
+(the user sends messages, steers a running turn, and interrupts, over one persistent transcript),
+its tools execute for REAL against a live filesystem/shell rather than being answered by a
+world-model simulation, and it emits a stream of typed events (assistant text, tool calls, tool
+output, state changes) that a UI renders live. Everything else is the RunnerLink model unchanged:
+the worker LLM is answered host-side so credentials never reach the runner, and the wire is the
+same length-prefixed / base64-line frame `Channel`.
+
+The engine is transport- and platform-agnostic. It answers `llm_request` frames with an injected
+`worker_fn` (the platform passes a metered, streaming completion; the default calls the same
+`worker_completion` the SSH shim uses), and answers `tool_request` frames with an injected
+`ToolExecutor` (the platform runs bash/read_file/write_file against the session's E2B sandbox
+filesystem; a CLI would run them against a local directory). Because the host answers every
+`llm_request` and every `tool_request`, it *is* the trusted observer of what the agent did — the
+feed is derived from the frames the host itself produced/answered, so a compromised runner cannot
+narrate a different story than the actions it actually took.
+
+New session frames (additive to the RunnerLink vocabulary; unknown types are ignored on both
+sides, so eval episodes are unaffected):
+
+  host -> runner
+    session_start {session_id, system, tools, files, turn_cap}
+    user_message  {msg_id, text}
+    abort         {reason}
+    ping          {nonce}
+    shutdown                       (reused; ends the runner process)
+  runner -> host
+    hello         {...}            (reused)
+    llm_request   {req_id, openai_body}   (reused)
+    tool_request  {req_id, name, arguments}  (reused)
+    state         {status: "idle"|"running", turns, reason?, cleared_steers?, msg_id?}
+    pong          {nonce}
+    episode_error {note}           (reused; a fatal runner error ends the session)
+"""
+
+from __future__ import annotations
+
+import queue
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from pydantic import JsonValue
+
+from wmh.core.types import JsonObject
+from wmh.harness.runner_link import (
+    Channel,
+    TokenUsage,
+    WorkerConfig,
+    WorkerFn,
+    params_schema,
+    worker_completion,
+)
+from wmh.harness.tools import SUBMIT, ToolSpec
+
+# The action budget a single user turn may spend before the runner is told to stop — the live
+# analogue of `HostEpisode.max_env_actions`, so a champion optimized under that pressure behaves
+# the same way. It resets on every user message.
+DEFAULT_ACTIONS_PER_TURN = 40
+# Turns a single user message may run before the runner aborts it (distinct from a user interrupt).
+# 3x the doc default (20) — real tasks against a live filesystem legitimately run longer than the
+# short world-model-simulation tasks the harness was scored on.
+DEFAULT_TURN_CAP = 60
+
+# --------------------------------------------------------------------------------------------------
+# Events: the typed stream the engine emits; a UI renders these, a store persists them.
+# --------------------------------------------------------------------------------------------------
+EventKind = Literal[
+    "user_message",
+    "assistant_message",
+    "tool_call",
+    "tool_output",
+    "tool_result",
+    "submit",
+    "state",
+    "error",
+]
+
+
+@dataclass(frozen=True)
+class SessionEvent:
+    """One thing that happened in a session, in the order the host observed it."""
+
+    kind: EventKind
+    payload: JsonObject
+
+
+EventSink = Callable[[SessionEvent], None]
+
+# (name, arguments, emit_output) -> (content, is_error). `emit_output(stream, chunk)` streams
+# partial stdout/stderr so the UI shows a long command's output as it runs; the returned content is
+# the final (already length-capped by the executor) observation the agent sees.
+OutputEmitter = Callable[[str, str], None]
+ToolExecutor = Callable[[str, JsonObject, OutputEmitter], "ToolOutcome"]
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """The result of executing one real tool call: what the agent sees, and whether it failed."""
+
+    content: str
+    is_error: bool = False
+    truncated: bool = False
+
+
+# --------------------------------------------------------------------------------------------------
+# Inbox: user intents the driver feeds in from another thread, drained into frames on each pump.
+# --------------------------------------------------------------------------------------------------
+@dataclass
+class _UserMessage:
+    text: str
+    msg_id: str
+
+
+@dataclass
+class _Interrupt:
+    reason: str = "user_interrupt"
+
+
+@dataclass
+class _End:
+    pass
+
+
+_Intent = _UserMessage | _Interrupt | _End
+
+
+class LiveSession:
+    """Drives one interactive pi session over a `Channel`, emitting a typed event stream.
+
+    Lifecycle: `start()` sends `session_start` and waits for the runner's first `state:idle`; then
+    the driver loops calling `pump(timeout)` while feeding intents via `send_user_message`,
+    `interrupt`, and `end` (thread-safe — a driver may enqueue from a command-poll thread). `pump`
+    drains the inbox to frames, then processes one inbound frame (answering `llm_request` /
+    `tool_request`, emitting events). `closed` flips once the runner process ends or `end()` is
+    honored. `worker_usage` accumulates the metered worker-LLM spend across the whole session.
+    """
+
+    def __init__(
+        self,
+        channel: Channel,
+        *,
+        tools: list[ToolSpec],
+        execute_tool: ToolExecutor,
+        on_event: EventSink,
+        files: dict[str, str] | None = None,
+        system_prompt: str = "",
+        skill_bodies: dict[str, str] | None = None,
+        worker: WorkerConfig | None = None,
+        worker_fn: WorkerFn | None = None,
+        actions_per_turn: int = DEFAULT_ACTIONS_PER_TURN,
+        turn_cap: int = DEFAULT_TURN_CAP,
+    ) -> None:
+        self._channel = channel
+        self._tools = list(tools)
+        self._execute_tool = execute_tool
+        self._on_event = on_event
+        self._files = dict(files or {})
+        self._system_prompt = system_prompt
+        self._skill_bodies = dict(skill_bodies or {})
+        cfg = worker or WorkerConfig()
+        self._worker_fn: WorkerFn = worker_fn or (lambda body: worker_completion(body, cfg))
+        self._actions_per_turn = actions_per_turn
+        self._turn_cap = turn_cap
+
+        self._inbox: queue.Queue[_Intent] = queue.Queue()
+        self._session_id = uuid.uuid4().hex
+        self._status: str = "starting"
+        self._closed = False
+        self._actions_this_turn = 0
+        self._pending_ping: str | None = None
+        self.worker_usage = TokenUsage()
+
+    # -- lifecycle -------------------------------------------------------------------------------
+
+    @property
+    def status(self) -> str:
+        """The runner's last-known agent state: "starting" | "idle" | "running" | "ended"."""
+        return self._status
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def start(self, hello_timeout: float = 60.0) -> None:
+        """Send `session_start` and block until the runner reports its first idle state."""
+        self._channel.send(
+            {
+                "type": "session_start",
+                "session_id": self._session_id,
+                "system": self._system_prompt,
+                "tools": self._tool_specs(),
+                "files": self._files,
+                "turn_cap": self._turn_cap,
+            }
+        )
+        # The runner sends `state:idle` once the agent is constructed and ready for the first
+        # message; surface a fatal construction error (bad champion code) instead of hanging.
+        deadline = _Deadline(hello_timeout)
+        while not deadline.expired():
+            frame = self._recv(deadline.remaining())
+            if frame is None:
+                break
+            if self._handle_frame(frame):
+                if self._status in ("idle", "running"):
+                    return
+        raise RuntimeError("live session runner did not become ready")
+
+    # -- driver-facing intents (thread-safe) -----------------------------------------------------
+
+    def send_user_message(self, text: str) -> str:
+        """Queue a user message; returns the msg_id echoed on its `user_message` event."""
+        msg_id = uuid.uuid4().hex
+        self._inbox.put(_UserMessage(text=text, msg_id=msg_id))
+        return msg_id
+
+    def interrupt(self, reason: str = "user_interrupt") -> None:
+        """Queue an interrupt: abort the current run (does not end the session)."""
+        self._inbox.put(_Interrupt(reason=reason))
+
+    def end(self) -> None:
+        """Queue a graceful end: abort any run, then shut the runner down."""
+        self._inbox.put(_End())
+
+    def ping(self) -> None:
+        """Send a liveness ping; a returned `pong` proves the runner event loop is alive."""
+        nonce = uuid.uuid4().hex
+        self._pending_ping = nonce
+        self._safe_send({"type": "ping", "nonce": nonce})
+
+    # -- pump ------------------------------------------------------------------------------------
+
+    def pump(self, timeout: float = 0.2) -> bool:
+        """Drain queued intents to frames, then process one inbound frame. False once closed."""
+        if self._closed:
+            return False
+        self._drain_inbox()
+        if self._closed:
+            return False
+        frame = self._recv(timeout)
+        if frame is None:
+            return not self._closed
+        self._handle_frame(frame)
+        return not self._closed
+
+    # -- internals -------------------------------------------------------------------------------
+
+    def _drain_inbox(self) -> None:
+        while True:
+            try:
+                intent = self._inbox.get_nowait()
+            except queue.Empty:
+                return
+            if isinstance(intent, _UserMessage):
+                self._actions_this_turn = 0
+                self._emit("user_message", {"msg_id": intent.msg_id, "text": intent.text})
+                self._safe_send(
+                    {"type": "user_message", "msg_id": intent.msg_id, "text": intent.text}
+                )
+            elif isinstance(intent, _Interrupt):
+                self._safe_send({"type": "abort", "reason": intent.reason})
+            else:  # _End
+                self._safe_send({"type": "abort", "reason": "shutdown"})
+                self._safe_send({"type": "shutdown"})
+                self._mark_closed("ended")
+
+    def _handle_frame(self, frame: JsonObject) -> bool:
+        kind = frame.get("type")
+        if kind == "llm_request":
+            self._answer_llm(frame)
+        elif kind == "tool_request":
+            self._answer_tool(frame)
+        elif kind == "state":
+            self._on_state(frame)
+        elif kind == "pong":
+            if frame.get("nonce") == self._pending_ping:
+                self._pending_ping = None
+        elif kind == "episode_error":
+            note = frame.get("note")
+            self._emit("error", {"message": note if isinstance(note, str) else "runner error"})
+            self._mark_closed("failed")
+        elif kind == "hello":
+            pass  # the pool already consumed the handshake; a duplicate is harmless
+        # unknown frames are ignored (forward-compatible)
+        return kind is not None
+
+    def _answer_llm(self, frame: JsonObject) -> None:
+        req_id = frame.get("req_id")
+        body = frame.get("openai_body")
+        try:
+            completion = self._worker_fn(body if isinstance(body, dict) else {})
+            self._meter(completion)
+            self._emit_assistant(completion)
+            self._safe_send({"type": "llm_response", "req_id": req_id, "completion": completion})
+        except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
+            self._emit("error", {"message": f"worker LLM error: {exc}"})
+            self._safe_send({"type": "llm_response", "req_id": req_id, "error": str(exc)})
+
+    def _answer_tool(self, frame: JsonObject) -> None:
+        req_id = frame.get("req_id")
+        name = frame.get("name")
+        name = name if isinstance(name, str) else ""
+        args = frame.get("arguments")
+        args = cast("JsonObject", args) if isinstance(args, dict) else {}
+        call_id = uuid.uuid4().hex
+
+        if name == SUBMIT.name:
+            answer = args.get("answer")
+            self._emit("submit", {"answer": answer if isinstance(answer, str) else ""})
+            self._respond_tool(req_id, "submitted", is_error=False)
+            return
+
+        self._emit("tool_call", {"call_id": call_id, "name": name, "arguments": args})
+        known = {t.name for t in self._tools}
+        if name == "read_skill":
+            outcome = self._read_skill(args)
+        elif self._actions_this_turn >= self._actions_per_turn:
+            outcome = ToolOutcome(content="environment action budget exhausted", is_error=True)
+        elif name not in known:
+            outcome = ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+        else:
+            self._actions_this_turn += 1
+
+            def emit_output(stream: str, chunk: str) -> None:
+                if chunk:
+                    self._emit("tool_output", {"call_id": call_id, "stream": stream, "text": chunk})
+
+            outcome = self._execute_tool(name, args, emit_output)
+        self._emit(
+            "tool_result",
+            {
+                "call_id": call_id,
+                "content": outcome.content,
+                "is_error": outcome.is_error,
+                "truncated": outcome.truncated,
+            },
+        )
+        self._respond_tool(req_id, outcome.content, is_error=outcome.is_error)
+
+    def _read_skill(self, args: JsonObject) -> ToolOutcome:
+        name = args.get("name")
+        body = self._skill_bodies.get(name) if isinstance(name, str) else None
+        if body is None:
+            return ToolOutcome(content=f"skill {name!r} not found", is_error=True)
+        return ToolOutcome(content=body)
+
+    def _respond_tool(self, req_id: JsonValue, content: str, *, is_error: bool) -> None:
+        self._safe_send(
+            {"type": "tool_response", "req_id": req_id, "content": content, "is_error": is_error}
+        )
+
+    def _on_state(self, frame: JsonObject) -> None:
+        status = frame.get("status")
+        if isinstance(status, str):
+            self._status = status
+        payload: JsonObject = {"status": self._status}
+        for key in ("turns", "reason", "msg_id"):
+            if key in frame:
+                payload[key] = frame[key]
+        cleared = frame.get("cleared_steers")
+        if isinstance(cleared, list) and cleared:
+            payload["cleared_steers"] = cleared
+        self._emit("state", payload)
+
+    def _emit_assistant(self, completion: JsonObject) -> None:
+        choice = _first_choice(completion)
+        message = choice.get("message") if isinstance(choice, dict) else None
+        text = message.get("content") if isinstance(message, dict) else None
+        if isinstance(text, str) and text.strip():
+            self._emit("assistant_message", {"text": text})
+
+    def _meter(self, completion: JsonObject) -> None:
+        self.worker_usage.calls += 1
+        reported = completion.get("usage")
+        if isinstance(reported, dict):
+            prompt = reported.get("prompt_tokens")
+            out = reported.get("completion_tokens")
+            self.worker_usage.input_tokens += prompt if isinstance(prompt, int) else 0
+            self.worker_usage.output_tokens += out if isinstance(out, int) else 0
+
+    def _tool_specs(self) -> list[JsonObject]:
+        return [
+            {"name": t.name, "description": t.description, "parameters": params_schema(t)}
+            for t in self._tools
+        ]
+
+    def _emit(self, kind: EventKind, payload: JsonObject) -> None:
+        try:
+            self._on_event(SessionEvent(kind=kind, payload=payload))
+        except Exception:  # noqa: BLE001 - a sink error must never stop the session loop
+            pass
+
+    def _recv(self, timeout: float | None) -> JsonObject | None:
+        try:
+            frame = _recv_with_timeout(self._channel, timeout)
+        except TimeoutError:
+            return None
+        except Exception as exc:  # noqa: BLE001 - a dead runner ends the session, not the process
+            if not self._closed:
+                self._emit("error", {"message": str(exc)})
+                self._mark_closed("failed")
+            return None
+        if frame is None and not self._closed:
+            self._mark_closed("ended")
+        return frame
+
+    def _safe_send(self, frame: JsonObject) -> None:
+        if self._closed:
+            return
+        try:
+            self._channel.send(frame)
+        except Exception as exc:  # noqa: BLE001 - a broken channel ends the session cleanly
+            self._emit("error", {"message": f"channel send failed: {exc}"})
+            self._mark_closed("failed")
+
+    def _mark_closed(self, status: str) -> None:
+        self._closed = True
+        self._status = status
+
+
+def _first_choice(completion: JsonObject) -> JsonObject:
+    choices = completion.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        return cast("JsonObject", choices[0])
+    return {}
+
+
+def _recv_with_timeout(channel: Channel, timeout: float | None) -> JsonObject | None:
+    """Call `channel.recv`, passing `timeout` when the channel supports it (E2BStdioChannel does).
+
+    The bare `Channel` protocol has a no-arg `recv`; the E2B channel accepts an optional timeout so
+    the pump can wake to flush the inbox even while the runner is thinking. A channel without the
+    parameter blocks — acceptable for in-process test doubles that always have a frame ready.
+    """
+    recv: Any = channel.recv
+    try:
+        return cast("JsonObject | None", recv(timeout))
+    except TypeError:
+        return cast("JsonObject | None", recv())
+
+
+@dataclass
+class _Deadline:
+    seconds: float
+    _remaining: float = field(init=False)
+
+    def __post_init__(self) -> None:
+        import time
+
+        self._end = time.monotonic() + self.seconds
+
+    def remaining(self) -> float:
+        import time
+
+        return max(0.0, self._end - time.monotonic())
+
+    def expired(self) -> bool:
+        return self.remaining() <= 0.0

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -263,3 +263,43 @@ def test_unknown_tool_is_rejected() -> None:
 
 def _no_tool(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
     return ToolOutcome(content="", is_error=True)
+
+
+def test_interrupt_suppresses_a_racing_submit_event() -> None:
+    """A submit that arrives after an interrupt for the same turn emits no submit event."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            # The interrupt is queued (below) before this in-flight submit is processed.
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    events.clear()
+    session.interrupt()  # user hits Stop while the submit is racing
+    _drain(session)
+    # The abort was sent; the racing submit is answered but NOT surfaced as a submit event.
+    assert not any(e.kind == "submit" for e in events)
+    assert any(f["type"] == "abort" for f in channel.sent)
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["content"] == "submitted"  # runner still gets a response (no hang)
+
+
+def test_submit_after_state_boundary_is_not_suppressed() -> None:
+    """A fresh turn's submit is emitted normally after the aborted turn ended (state boundary)."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "idle", "reason": "aborted"},  # aborted turn ended
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "y"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    session.interrupt()
+    events.clear()
+    _drain(session)
+    assert any(e.kind == "submit" for e in events)

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -303,3 +303,23 @@ def test_submit_after_state_boundary_is_not_suppressed() -> None:
     events.clear()
     _drain(session)
     assert any(e.kind == "submit" for e in events)
+
+
+def test_stale_submit_after_a_quick_next_message_is_still_suppressed() -> None:
+    """A cancelled turn's in-flight submit is suppressed even if the user already sent a new
+    message: only the runner's next state frame (the turn boundary) clears the abort gate."""
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            # The cancelled turn's submit arrives AFTER the user's next message was drained.
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+    events: list[SessionEvent] = []
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    session.interrupt()
+    session.send_user_message("do the next thing")  # queued before the stale submit is read
+    events.clear()
+    _drain(session)
+    assert not any(e.kind == "submit" for e in events)  # stale submit stays suppressed

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for the LiveSession host engine, driven by a scripted in-process channel peer."""
+
+from __future__ import annotations
+
+from wmh.core.types import JsonObject
+from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+from wmh.harness.tools import BASH, READ_SKILL, SUBMIT
+
+
+class ScriptedChannel:
+    """A `Channel` whose `recv` replays a fixed inbound frame list; captures outbound sends."""
+
+    def __init__(self, inbound: list[JsonObject]) -> None:
+        self._inbound = list(inbound)
+        self.sent: list[JsonObject] = []
+
+    def send(self, frame: JsonObject) -> None:
+        self.sent.append(frame)
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        if self._inbound:
+            return self._inbound.pop(0)
+        return None  # exhausted = channel closed
+
+
+def _completion(
+    text: str = "", tool_calls: list | None = None, usage: dict | None = None
+) -> JsonObject:
+    msg: JsonObject = {"role": "assistant", "content": text}
+    if tool_calls is not None:
+        msg["tool_calls"] = tool_calls
+    choice: JsonObject = {"index": 0, "message": msg, "finish_reason": "stop"}
+    completion: JsonObject = {"choices": [choice]}
+    if usage is not None:
+        completion["usage"] = usage
+    return completion
+
+
+def _drain(session: LiveSession) -> None:
+    for _ in range(100):
+        if not session.pump(timeout=0):
+            return
+
+
+def test_start_waits_for_first_idle_state() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    assert session.status == "idle"
+    assert channel.sent[0]["type"] == "session_start"
+    assert channel.sent[0]["turn_cap"] == 60
+
+
+def test_full_turn_emits_ordered_events_and_answers_frames() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},  # consumed by start()
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+            {"type": "tool_request", "req_id": 2, "name": "bash", "arguments": {"command": "ls"}},
+            {
+                "type": "tool_request",
+                "req_id": 3,
+                "name": "submit",
+                "arguments": {"answer": "done"},
+            },
+            {"type": "state", "status": "idle", "reason": "completed", "turns": 1},
+        ]
+    )
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        emit("stdout", "file-a\n")
+        return ToolOutcome(content="file-a\n", is_error=False)
+
+    session = LiveSession(
+        channel,
+        tools=[BASH, SUBMIT],
+        execute_tool=execute,
+        on_event=events.append,
+        worker_fn=lambda body: _completion(
+            text="on it", usage={"prompt_tokens": 5, "completion_tokens": 7}
+        ),
+    )
+    session.start()
+    events.clear()  # drop the initial "ready" state event; assert only the turn's events
+    session.send_user_message("list the files")
+    _drain(session)
+
+    kinds = [e.kind for e in events]
+    assert kinds == [
+        "user_message",
+        "assistant_message",
+        "tool_call",
+        "tool_output",
+        "tool_result",
+        "submit",
+        "state",
+    ]
+    assert events[1].payload["text"] == "on it"
+    assert events[2].payload["name"] == "bash"
+    assert events[4].payload["content"] == "file-a\n"
+    assert events[5].payload["answer"] == "done"
+
+    sent_types = [f["type"] for f in channel.sent]
+    assert sent_types.count("user_message") == 1
+    assert sent_types.count("llm_response") == 1
+    assert sent_types.count("tool_response") == 2  # bash + submit
+    assert session.worker_usage.calls == 1
+    assert session.worker_usage.input_tokens == 5
+    assert session.worker_usage.output_tokens == 7
+
+
+def test_submit_tool_response_is_answered_without_executor() -> None:
+    calls: list[str] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "submit", "arguments": {"answer": "x"}},
+        ]
+    )
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        calls.append(name)
+        return ToolOutcome(content="should not run")
+
+    session = LiveSession(channel, tools=[SUBMIT], execute_tool=execute, on_event=lambda e: None)
+    session.start()
+    _drain(session)
+    assert calls == []  # submit never routes to the real executor
+    resp = next(f for f in channel.sent if f["type"] == "tool_response")
+    assert resp["content"] == "submitted"
+    assert resp["is_error"] is False
+
+
+def test_interrupt_sends_abort_frame() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    session.interrupt()
+    session.pump(timeout=0)
+    assert any(f["type"] == "abort" and f["reason"] == "user_interrupt" for f in channel.sent)
+
+
+def test_end_sends_abort_then_shutdown_and_closes() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    session.end()
+    assert session.pump(timeout=0) is False
+    tail = [f["type"] for f in channel.sent[-2:]]
+    assert tail == ["abort", "shutdown"]
+    assert session.closed
+
+
+def test_action_budget_exhausts_after_cap() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {"command": "a"}},
+            {"type": "tool_request", "req_id": 2, "name": "bash", "arguments": {"command": "b"}},
+        ]
+    )
+    ran: list[str] = []
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        ran.append(str(args.get("command")))
+        return ToolOutcome(content="ok")
+
+    session = LiveSession(
+        channel, tools=[BASH], execute_tool=execute, on_event=events.append, actions_per_turn=1
+    )
+    session.start()
+    session.send_user_message("go")
+    _drain(session)
+    assert ran == ["a"]  # second call is over budget, never executed
+    results = [e for e in events if e.kind == "tool_result"]
+    assert results[1].payload["is_error"] is True
+    assert "budget exhausted" in str(results[1].payload["content"])
+
+
+def test_read_skill_answered_from_bodies() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "tool_request",
+                "req_id": 1,
+                "name": "read_skill",
+                "arguments": {"name": "deploy"},
+            },
+            {
+                "type": "tool_request",
+                "req_id": 2,
+                "name": "read_skill",
+                "arguments": {"name": "missing"},
+            },
+        ]
+    )
+    session = LiveSession(
+        channel,
+        tools=[READ_SKILL],
+        execute_tool=_no_tool,
+        on_event=events.append,
+        skill_bodies={"deploy": "run ./deploy.sh"},
+    )
+    session.start()
+    _drain(session)
+    results = [e for e in events if e.kind == "tool_result"]
+    assert results[0].payload["content"] == "run ./deploy.sh"
+    assert results[1].payload["is_error"] is True
+
+
+def test_worker_error_is_reported_not_raised() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        ]
+    )
+
+    def boom(body: JsonObject) -> JsonObject:
+        raise RuntimeError("provider down")
+
+    session = LiveSession(
+        channel, tools=[], execute_tool=_no_tool, on_event=events.append, worker_fn=boom
+    )
+    session.start()
+    _drain(session)
+    assert any(e.kind == "error" for e in events)
+    resp = next(f for f in channel.sent if f["type"] == "llm_response")
+    assert "provider down" in str(resp["error"])
+
+
+def test_channel_close_marks_session_ended() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session.start()
+    assert session.pump(timeout=0) is False
+    assert session.closed
+    assert session.status == "ended"
+
+
+def test_unknown_tool_is_rejected() -> None:
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "tool_request", "req_id": 1, "name": "rm_rf", "arguments": {}},
+        ]
+    )
+    session = LiveSession(channel, tools=[BASH], execute_tool=_no_tool, on_event=events.append)
+    session.start()
+    _drain(session)
+    result = next(e for e in events if e.kind == "tool_result")
+    assert result.payload["is_error"] is True
+    assert "not available" in str(result.payload["content"])
+
+
+def _no_tool(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+    return ToolOutcome(content="", is_error=True)

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -65,6 +65,11 @@ PI_NPM_PACKAGES = (
 NODE_INSTALL_CMD = "npm install -g n && n 22"
 INSTALL_TIMEOUT_S = 600.0
 START_CMD = f"cd {RUNNER_WORKDIR} && node --experimental-strip-types runner_stdio.ts"
+# The live-session runner (interactive multi-turn) vs. the episode runner (one-shot eval).
+LIVE_START_CMD = f"cd {RUNNER_WORKDIR} && node --experimental-strip-types runner_live.ts"
+_LIVE_RUNNER_FILES = ("runner_live.ts",)
+# Default working directory a live session's real tools operate in (the agent's "cwd").
+LIVE_WORKSPACE = "/home/user/workspace"
 HELLO_TIMEOUT_S = 60.0
 
 # ESM so node treats the runner's .ts files as modules regardless of syntax detection.
@@ -419,6 +424,65 @@ class E2BPiRuntime:
 
     def __exit__(self, *exc_info: object) -> None:
         self.close()
+
+
+def session_entry_files() -> dict[str, str]:
+    """The in-sandbox runner file(s) a live session uploads, as {filename: content}.
+
+    Public accessor for consumers outside wmh (the platform's live-session driver reads these
+    from the installed wmh package and writes them into the sandbox at start).
+    """
+    return {name: _read_entry(name) for name in _LIVE_RUNNER_FILES}
+
+
+def start_live_runner(
+    sandbox: SandboxHandle,
+    *,
+    template: str | None = None,
+    workspace: str = LIVE_WORKSPACE,
+    hello_timeout: float = HELLO_TIMEOUT_S,
+) -> E2BStdioChannel:
+    """Bootstrap and start `runner_live.ts` on an already-created sandbox; return its channel.
+
+    A live session (unlike a pooled eval episode) is one dedicated sandbox whose lifecycle the
+    caller owns — the caller creates it (setting its own timeout / metadata for reaping) and holds
+    the handle for keepalive, PTY, and reconciliation. This function does only the runner
+    bootstrap: upload the live runner file(s), install node 22 + pi's npm deps unless a template
+    prebakes them, ensure the workspace dir, start the long-lived runner over a stdin-writable
+    background command, and block until its `hello`. The returned `E2BStdioChannel` is what a
+    `wmh.harness.live_session.LiveSession` drives.
+    """
+    for name in _LIVE_RUNNER_FILES:
+        sandbox.files.write(f"{RUNNER_WORKDIR}/{name}", _read_entry(name))
+    if not (template or os.environ.get(E2B_TEMPLATE_ENV)):
+        sandbox.files.write(f"{RUNNER_WORKDIR}/package.json", _PACKAGE_JSON)
+        sandbox.commands.run(NODE_INSTALL_CMD, timeout=INSTALL_TIMEOUT_S)
+        sandbox.commands.run(
+            f"cd {RUNNER_WORKDIR} && npm install {' '.join(PI_NPM_PACKAGES)}",
+            timeout=INSTALL_TIMEOUT_S,
+        )
+    sandbox.commands.run(f"mkdir -p {workspace}", timeout=30)
+    handle = sandbox.commands.run(LIVE_START_CMD, background=True, stdin=True, timeout=0)
+    channel = E2BStdioChannel(sandbox, cast("CommandHandle", handle))
+    deadline = time.monotonic() + hello_timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(_no_hello_live(hello_timeout, channel))
+        try:
+            frame = channel.recv(timeout=remaining)
+        except TimeoutError as exc:
+            raise RuntimeError(_no_hello_live(hello_timeout, channel)) from exc
+        if frame is None:
+            raise RuntimeError(_no_hello_live(hello_timeout, channel))
+        if frame.get("type") == "hello":
+            return channel
+
+
+def _no_hello_live(timeout: float, channel: E2BStdioChannel) -> str:
+    tail = channel.stderr_tail()
+    suffix = f"; recent runner stderr:\n{tail}" if tail else ""
+    return f"live runner sent no hello within {timeout:g}s ({LIVE_START_CMD!r}){suffix}"
 
 
 def _kill_quietly(sandbox: SandboxHandle) -> None:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -26,6 +26,7 @@ from wmh.core.types import Action, JsonObject, Observation
 from wmh.harness import pi_e2b as pi_e2b_module
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
 from wmh.harness.pi_e2b import (
+    LIVE_START_CMD,
     NODE_INSTALL_CMD,
     PI_NPM_PACKAGES,
     RUNNER_WORKDIR,
@@ -33,6 +34,8 @@ from wmh.harness.pi_e2b import (
     E2BPiRuntime,
     E2BSandboxPool,
     E2BStdioChannel,
+    session_entry_files,
+    start_live_runner,
 )
 from wmh.harness.runner_link import WorkerConfig
 from wmh.harness.runtime import Runtime, StopReason
@@ -555,3 +558,40 @@ def test_run_retries_once_on_a_fresh_sandbox_after_transport_death(
     assert len(made) == 2
     assert made[0].kills == 1  # the dead attempt's sandbox was discarded, not reused
     pool.close()
+
+
+# --- live-session bootstrap (start_live_runner / session_entry_files) ---
+def test_session_entry_files_returns_the_live_runner_source() -> None:
+    files = session_entry_files()
+    assert "runner_live.ts" in files
+    assert files["runner_live.ts"].startswith("/**")
+
+
+def test_start_live_runner_bootstraps_starts_and_consumes_hello() -> None:
+    fake = FakeSandbox(_ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True))
+    channel = start_live_runner(fake, template=None)
+    # runner_live.ts uploaded; node 22 + pi deps installed; workspace ensured; runner started.
+    assert f"{RUNNER_WORKDIR}/runner_live.ts" in fake.files.store
+    assert fake.commands.calls[0] == NODE_INSTALL_CMD
+    assert any("mkdir -p" in c for c in fake.commands.calls)
+    assert fake.commands.background_cmds == [LIVE_START_CMD]
+    # The hello was consumed; the channel is idle and ready for session frames.
+    with pytest.raises(TimeoutError):
+        channel.recv(timeout=0.05)
+
+
+def test_start_live_runner_with_template_skips_installs() -> None:
+    fake = FakeSandbox(_ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True))
+    start_live_runner(fake, template="wmh-pi-node")
+    assert all(c == c for c in fake.commands.calls)  # only the workspace mkdir, no installs
+    assert NODE_INSTALL_CMD not in fake.commands.calls
+    assert f"{RUNNER_WORKDIR}/package.json" not in fake.files.store
+    assert fake.commands.background_cmds == [LIVE_START_CMD]
+
+
+def test_start_live_runner_without_hello_raises_with_stderr() -> None:
+    # Runner starts but never emits hello (stream held open): recv times out -> no-hello error.
+    handle = _ScriptedHandle([(None, "boom: cannot start\n", None)], hold_open=True)
+    fake = FakeSandbox(handle)
+    with pytest.raises(RuntimeError, match="live runner sent no hello"):
+        start_live_runner(fake, template="wmh-pi-node", hello_timeout=0.3)

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -327,6 +327,11 @@ class Session {
 				// The host emits the submit event; the run then ends (but the SESSION stays alive
 				// awaiting the next user message).
 				await this.conn.request("tool_request", { name: "submit", arguments: { answer: params.answer ?? "" } });
+				// Re-check after the round-trip: if the interrupt landed while the request was in
+				// flight, end via the abort path rather than terminating the run as a clean submit.
+				if (signal?.aborted) {
+					return { content: [{ type: "text", text: "interrupted" }], details: {}, terminate: false };
+				}
 				return { content: [{ type: "text", text: "submitted" }], details: {}, terminate: true };
 			},
 		};

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -305,6 +305,12 @@ class Session {
 						return { content: [{ type: "text", text: "interrupted" }], details: {}, terminate: false };
 					}
 					const r = await this.conn.request("tool_request", { name: t.name, arguments: params });
+					// A host-side failure (budget exhausted, unknown tool, executor error) must reach
+					// the agent AS a failure: throw so pi records an error tool result, rather than
+					// letting the model reason from a failed action as if it succeeded.
+					if (r.is_error) {
+						throw new Error(String(r.content ?? "tool failed"));
+					}
 					return { content: [{ type: "text", text: String(r.content ?? "") }], details: r, terminate: false };
 				},
 			}));
@@ -313,7 +319,11 @@ class Session {
 			label: "submit",
 			description: "Finish the task and submit your answer/result summary. This ends the run.",
 			parameters: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] },
-			execute: async (_id: string, params: { answer?: string }) => {
+			execute: async (_id: string, params: { answer?: string }, signal?: AbortSignal) => {
+				// Honor an interrupt racing a submit: don't emit a final submit for an aborted turn.
+				if (signal?.aborted) {
+					return { content: [{ type: "text", text: "interrupted" }], details: {}, terminate: false };
+				}
 				// The host emits the submit event; the run then ends (but the SESSION stays alive
 				// awaiting the next user message).
 				await this.conn.request("tool_request", { name: "submit", arguments: { answer: params.answer ?? "" } });
@@ -354,6 +364,10 @@ class Session {
 	handleAbort(_frame: Frame): void {
 		if (this.agent && this.running) {
 			this.interrupted = true;
+			// Interrupt cancels the WHOLE pending turn: clear any messages the user queued (via
+			// steer) before pressing Stop, so a follow-up typed just before the interrupt is not
+			// silently drained into the next prompt. New messages after this start a fresh turn.
+			this.agent.clearAllQueues?.();
 			this.agent.abort();
 		}
 	}

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -1,0 +1,395 @@
+/**
+ * Live-session pi runner: the in-sandbox peer of wmh/harness/live_session.py (LiveSession).
+ *
+ * Where runner_stdio.ts runs ONE fire-and-forget episode, this runner hosts ONE long-lived pi
+ * Agent for an interactive multi-turn session: the host sends `session_start` once (materializing
+ * the champion's code surfaces), then `user_message` / `abort` / `ping` frames over the session's
+ * life, and the runner drives the same Agent across every turn on one accumulating transcript.
+ * The transport, the localhost LLM bridge (credentials stay host-side), and the env-tools-as-
+ * `tool_request` contract are identical to runner_stdio.ts — deliberately re-mirrored rather than
+ * imported, because runner_stdio boots per-episode helpers and this runner's lifecycle differs.
+ *
+ * stdout is the frame stream and NOTHING else may write to it: console.* is rebound to stderr
+ * before any agent code loads. One base64(JSON) frame per line.
+ *
+ * Run (inside the sandbox, workdir holding node_modules + package.json {"type":"module"}):
+ *   cd /home/user/pi-run && node --experimental-strip-types runner_live.ts
+ */
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import util from "node:util";
+import { pathToFileURL } from "node:url";
+import type { AddressInfo } from "node:net";
+
+// CRITICAL — FIRST statements: rebind every stdout-defaulting console channel to stderr before
+// anything else runs, so stray prints can never corrupt the frame stream.
+const toStderr = (...args: unknown[]): void => {
+	process.stderr.write(util.format(...args) + "\n");
+};
+console.log = toStderr;
+console.info = toStderr;
+console.warn = toStderr;
+console.debug = toStderr;
+
+const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
+
+type Frame = Record<string, any>;
+
+function encodeFrame(frame: Frame): string {
+	return Buffer.from(JSON.stringify(frame), "utf8").toString("base64") + "\n";
+}
+
+function decodeFrame(line: string): Frame | null {
+	const text = line.trim();
+	if (!text) return null;
+	try {
+		const frame = JSON.parse(Buffer.from(text, "base64").toString("utf8"));
+		return frame && typeof frame === "object" && !Array.isArray(frame) ? (frame as Frame) : null;
+	} catch {
+		return null;
+	}
+}
+
+/** The stdio twin of runner_frames.FrameConn: `request` awaits a matching response by req_id;
+ *  host-pushed frames (session_start, user_message, abort, ping, shutdown) fire handlers. */
+class StdioConn {
+	private buf = "";
+	private waiters = new Map<number, (f: Frame) => void>();
+	private handlers = new Map<string, (f: Frame) => void>();
+	private reqSeq = 0;
+
+	constructor() {
+		process.stdin.setEncoding("utf8");
+		process.stdin.on("data", (chunk: string) => this.onData(chunk));
+		process.stdin.on("end", () => process.exit(0));
+	}
+
+	on(type: string, handler: (f: Frame) => void): void {
+		this.handlers.set(type, handler);
+	}
+
+	send(frame: Frame): void {
+		process.stdout.write(encodeFrame(frame));
+	}
+
+	request(type: string, payload: Frame): Promise<Frame> {
+		const req_id = ++this.reqSeq;
+		return new Promise((resolve) => {
+			this.waiters.set(req_id, resolve);
+			this.send({ type, req_id, ...payload });
+		});
+	}
+
+	private onData(chunk: string): void {
+		this.buf += chunk;
+		let nl = this.buf.indexOf("\n");
+		while (nl >= 0) {
+			const line = this.buf.slice(0, nl);
+			this.buf = this.buf.slice(nl + 1);
+			const frame = decodeFrame(line);
+			if (frame) this.dispatch(frame);
+			nl = this.buf.indexOf("\n");
+		}
+	}
+
+	private dispatch(frame: Frame): void {
+		const rid = frame.req_id;
+		if (typeof rid === "number" && this.waiters.has(rid)) {
+			const resolve = this.waiters.get(rid);
+			this.waiters.delete(rid);
+			resolve?.(frame);
+			return;
+		}
+		const handler = this.handlers.get(frame.type);
+		if (handler) handler(frame);
+	}
+}
+
+function assistantText(msg: any): string {
+	if (!msg || msg.role !== "assistant" || !Array.isArray(msg.content)) return "";
+	return msg.content
+		.filter((c: any) => c?.type === "text")
+		.map((c: any) => String(c.text ?? ""))
+		.join("")
+		.trim();
+}
+
+interface Bridge {
+	url: string;
+	close: () => void;
+}
+
+/** Localhost endpoint pi's openai-completions transport POSTs to; frames each request to the host
+ *  and renders the returned completion back as the SSE pi's parser expects. Creds stay host-side. */
+function startLlmBridge(conn: StdioConn): Promise<Bridge> {
+	return new Promise((resolve) => {
+		const server = http.createServer((req, res) => {
+			const chunks: Buffer[] = [];
+			req.on("data", (c: Buffer) => chunks.push(c));
+			req.on("end", async () => {
+				res.writeHead(200, { "Content-Type": "text/event-stream", Connection: "close" });
+				try {
+					const body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+					const reply = await conn.request("llm_request", { openai_body: body });
+					if (reply.error) {
+						res.end(`data: ${JSON.stringify({ error: { message: reply.error } })}\n\ndata: [DONE]\n\n`);
+						return;
+					}
+					const choice = reply.completion?.choices?.[0] ?? {};
+					const msg = choice.message ?? {};
+					const delta: any = { role: "assistant", content: msg.content ?? "" };
+					if (msg.tool_calls) {
+						delta.tool_calls = msg.tool_calls.map((tc: any, i: number) => ({
+							index: i,
+							id: tc.id,
+							type: tc.type ?? "function",
+							function: tc.function ?? {},
+						}));
+					}
+					const first = { choices: [{ index: 0, delta, finish_reason: null }] };
+					const last = { choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }] };
+					res.write(`data: ${JSON.stringify(first)}\n\n`);
+					res.write(`data: ${JSON.stringify(last)}\n\n`);
+					res.end("data: [DONE]\n\n");
+				} catch (e) {
+					res.end(`data: ${JSON.stringify({ error: { message: String(e) } })}\n\ndata: [DONE]\n\n`);
+				}
+			});
+		});
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address() as AddressInfo;
+			resolve({ url: `http://127.0.0.1:${addr.port}/v1`, close: () => server.close() });
+		});
+	});
+}
+
+/** Materialize session_start.files (the champion's code surfaces) into ./live/ once and import the
+ *  Agent. Unlike the episode runner there is no per-run dir — the session reuses one Agent. */
+async function loadAgent(start: Frame): Promise<any> {
+	const files: Record<string, string> = start.files ?? {};
+	if (!files["src/agent.ts"]) {
+		throw new Error("session_start carried no src/agent.ts (the live runner has no static fallback)");
+	}
+	const base = path.join(process.cwd(), "live");
+	for (const [rel, content] of Object.entries(files)) {
+		const dst = path.join(base, rel);
+		fs.mkdirSync(path.dirname(dst), { recursive: true });
+		fs.writeFileSync(dst, content);
+	}
+	const mod = await import(pathToFileURL(path.join(base, "src/agent.ts")).href);
+	if (typeof mod.Agent !== "function") {
+		throw new Error("champion src/agent.ts does not export an Agent class");
+	}
+	return mod.Agent;
+}
+
+const REQUIRED_AGENT_METHODS = ["prompt", "steer", "abort", "subscribe"] as const;
+
+function assertInteractive(AgentCtor: any): void {
+	for (const method of REQUIRED_AGENT_METHODS) {
+		if (typeof AgentCtor.prototype?.[method] !== "function") {
+			throw new Error(
+				`champion Agent is not steerable: missing ${method}() — this harness cannot run a live session`,
+			);
+		}
+	}
+}
+
+function userMessage(text: string): any {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
+}
+
+/**
+ * After an aborted run, the transcript tail can hold an assistant message whose toolCalls never got
+ * results (the loop returned on the abort signal before executing/finishing them). Left as-is, the
+ * NEXT provider request is a 400 (OpenAI) / validation error (Bedrock Converse): an assistant
+ * tool-call with no matching tool result. Append a synthetic "cancelled by user" result for every
+ * orphaned toolCall so the next turn is well-formed. (Vendored eval runners never hit this — they
+ * only ever run one prompt; interactivity is what surfaces it.)
+ */
+function repairOrphanedToolCalls(agent: any): void {
+	const messages: any[] = agent.state?.messages ?? [];
+	const resolved = new Set<string>();
+	for (const m of messages) {
+		if (m?.role === "toolResult" && typeof m.toolCallId === "string") resolved.add(m.toolCallId);
+	}
+	const repairs: any[] = [];
+	for (const m of messages) {
+		if (m?.role !== "assistant" || !Array.isArray(m.content)) continue;
+		for (const block of m.content) {
+			if (block?.type === "toolCall" && typeof block.id === "string" && !resolved.has(block.id)) {
+				resolved.add(block.id);
+				repairs.push({
+					role: "toolResult",
+					toolCallId: block.id,
+					toolName: block.name ?? "",
+					content: [{ type: "text", text: "cancelled by user" }],
+					details: {},
+					isError: true,
+					timestamp: Date.now(),
+				});
+			}
+		}
+	}
+	if (repairs.length > 0) agent.state.messages = [...messages, ...repairs];
+}
+
+/** Owns the single Agent and serializes prompt/steer/abort across the session's frames. */
+class Session {
+	// NOTE: fields declared explicitly (not via constructor parameter properties) — node's
+	// --experimental-strip-types rejects `constructor(private x)` in strip-only mode.
+	private readonly conn: StdioConn;
+	private agent: any = null;
+	private bridge: Bridge | null = null;
+	private running = false;
+	private turns = 0;
+	private turnCap = 60;
+	private interrupted = false;
+	private hitTurnCap = false;
+
+	constructor(conn: StdioConn) {
+		this.conn = conn;
+	}
+
+	async start(frame: Frame): Promise<void> {
+		this.turnCap = Number(frame.turn_cap ?? 60);
+		const AgentCtor = await loadAgent(frame);
+		assertInteractive(AgentCtor);
+		this.bridge = await startLlmBridge(this.conn);
+
+		const model = {
+			id: AGENT_MODEL,
+			name: AGENT_MODEL,
+			api: "openai-completions",
+			provider: "link", // non-builtin -> uses model.baseUrl (our localhost bridge) directly
+			baseUrl: this.bridge.url,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 4096,
+		};
+
+		const tools = this.buildTools(frame.tools ?? []);
+		this.agent = new AgentCtor({
+			initialState: { systemPrompt: frame.system ?? "", model, tools },
+			getApiKey: () => "x",
+			// Real filesystem tools may race if run in parallel; keep them ordered. Steers drain
+			// as a batch ("all") so a burst of user messages doesn't each cost an extra turn.
+			toolExecution: "sequential",
+			steeringMode: "all",
+		});
+		this.agent.subscribe((event: any) => {
+			if (event.type === "turn_end") {
+				this.turns += 1;
+				if (this.turns >= this.turnCap && this.running) {
+					this.hitTurnCap = true;
+					this.agent.abort();
+				}
+			}
+		});
+		this.sendState("idle");
+	}
+
+	private buildTools(specs: any[]): any[] {
+		const envTools = specs
+			.filter((t: any) => t.name !== "submit")
+			.map((t: any) => ({
+				name: t.name,
+				label: t.name,
+				description: t.description,
+				parameters: t.parameters,
+				execute: async (_id: string, params: any, signal?: AbortSignal) => {
+					if (signal?.aborted) {
+						return { content: [{ type: "text", text: "interrupted" }], details: {}, terminate: false };
+					}
+					const r = await this.conn.request("tool_request", { name: t.name, arguments: params });
+					return { content: [{ type: "text", text: String(r.content ?? "") }], details: r, terminate: false };
+				},
+			}));
+		const submit = {
+			name: "submit",
+			label: "submit",
+			description: "Finish the task and submit your answer/result summary. This ends the run.",
+			parameters: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] },
+			execute: async (_id: string, params: { answer?: string }) => {
+				// The host emits the submit event; the run then ends (but the SESSION stays alive
+				// awaiting the next user message).
+				await this.conn.request("tool_request", { name: "submit", arguments: { answer: params.answer ?? "" } });
+				return { content: [{ type: "text", text: "submitted" }], details: {}, terminate: true };
+			},
+		};
+		return [...envTools, submit];
+	}
+
+	handleUserMessage(frame: Frame): void {
+		const text = String(frame.text ?? "");
+		if (!this.agent) return;
+		if (this.running) {
+			this.agent.steer(userMessage(text));
+			return;
+		}
+		void this.runPrompt(text);
+	}
+
+	private async runPrompt(text: string): Promise<void> {
+		this.running = true;
+		this.turns = 0;
+		this.interrupted = false;
+		this.hitTurnCap = false;
+		this.sendState("running");
+		try {
+			await this.agent.prompt(text);
+		} catch (e) {
+			this.conn.send({ type: "episode_error", note: String(e) });
+		} finally {
+			this.running = false;
+			repairOrphanedToolCalls(this.agent);
+			const reason = this.hitTurnCap ? "turn_limit" : this.interrupted ? "aborted" : "completed";
+			this.sendState("idle", reason);
+		}
+	}
+
+	handleAbort(_frame: Frame): void {
+		if (this.agent && this.running) {
+			this.interrupted = true;
+			this.agent.abort();
+		}
+	}
+
+	handlePing(frame: Frame): void {
+		this.conn.send({ type: "pong", nonce: frame.nonce });
+	}
+
+	private sendState(status: "idle" | "running", reason?: string): void {
+		const frame: Frame = { type: "state", status, turns: this.turns };
+		if (reason) frame.reason = reason;
+		this.conn.send(frame);
+	}
+}
+
+function main(): void {
+	const conn = new StdioConn();
+	const session = new Session(conn);
+	conn.on("shutdown", () => process.exit(0));
+	conn.on("session_start", (start) => {
+		session.start(start).catch((e) => {
+			conn.send({ type: "episode_error", note: String(e) });
+			process.stderr.write(`[runner-live] start fatal ${e}\n`);
+		});
+	});
+	conn.on("user_message", (f) => session.handleUserMessage(f));
+	conn.on("abort", (f) => session.handleAbort(f));
+	conn.on("ping", (f) => session.handlePing(f));
+	conn.send({
+		type: "hello",
+		node_version: process.version,
+		pi_version: "0.80.3",
+		mode: "session",
+		transport: "stdio",
+	});
+	process.stderr.write("[runner-live] ready\n");
+}
+
+main();


### PR DESCRIPTION
## What

The world-model-harness half of **live agent sessions** — running the REAL vendored pi harness **interactively** (multi-turn, steer, interrupt) inside an E2B sandbox, with tools that execute **for real** against the sandbox filesystem. The worker LLM stays host-side, so credentials never enter the sandbox (unchanged RunnerLink invariant).

This is the complement to eval (#135, this PR's base): eval runs a *one-shot* episode whose tools are answered by the *world-model simulation*; a **session** is multi-turn over one accumulating transcript, its tools run against a **live filesystem**, and it emits a typed event stream a UI renders live. Because the host answers every `llm_request` and every `tool_request`, it is the **trusted observer** — the feed derives from the frames the host itself produced/answered, so a compromised runner can't narrate a different story than the actions it actually took.

Stacked on `feat/real-harness-parallel-evals` (#135). Platform-side integration (agent_sessions DB/routes/driver/web) is in experientiallabs/platform and pins this branch.

## Changes

- **`wmh/harness/pi_entry/runner_live.ts`** (new) — the in-sandbox session peer. One long-lived **bare `Agent`** (not `AgentHarness` — it has no credential/streamFn seam) constructed from the champion's materialized code surfaces. Startup self-check of `steer`/`abort`/`prompt`/`subscribe` (a searched champion that broke interactivity fails the session loudly, not silently). `submit` bound as a benign run-ender (docs hard-require it; unbinding would break every champion). **Orphaned-toolCall repair after abort** — appends synthetic "cancelled by user" tool results so the next turn is well-formed on OpenAI-shape / Bedrock Converse APIs. Turn-cap abort is reported distinctly from a user interrupt. `toolExecution: sequential`, `steeringMode: all`.
- **`wmh/harness/live_session.py`** (new) — `LiveSession` host engine, transport- and platform-agnostic. Injected `worker_fn` (the platform passes a metered completion; default reuses `worker_completion`) and `ToolExecutor` (the platform runs bash/read/write against the sandbox FS; a CLI would run them against a local directory). Thread-safe inbox drained on each `pump()`; typed `SessionEvent` stream; per-turn action budget mirroring the eval `HostEpisode`; host-answered `read_skill`.
- **New frames** (additive; unknown frames already ignored on both sides, so the eval path is byte-unchanged): host→runner `session_start` / `user_message` / `abort` / `ping`; runner→host `state` / `pong`.
- **`wmh/harness/pi_e2b.py`** — `start_live_runner(sandbox, …)` bootstraps `runner_live.ts` on a **caller-owned** sandbox and returns its channel (the platform driver owns the sandbox so it can drive keepalive / PTY / reconciliation); `session_entry_files()` exposes the runner source for the platform to upload.
- **`wmh/harness/e2b_sandbox.py`** — `SandboxPty`/`PtyHandle` protocol slice (the user's scratch shell), `set_timeout` on the `SandboxHandle` slice (keepalive), `metadata=` on the create factory (so an orphaned sandbox can be found and reaped).

## Verified

- Gate: ruff + format + ty clean, **1083 passed / 18 skipped** (+14 new: LiveSession choreography — steer/interrupt/budget/read_skill/worker-error/channel-close; `start_live_runner` bootstrap + no-hello + template-skip).
- **Live, end to end against a real E2B sandbox**: `runner_live.ts` boots and handshakes (`mode: session`), `session_start` → the vendored pi `Agent` runs a multi-turn task, `write_file` + `bash` execute against the sandbox filesystem, the file genuinely exists on read-back, `submit` fires. Zero model spend (scripted host-side worker).

Note: no TypeScript test infra exists in this repo (no `*_test.ts` outside the untouchable vendor tree); `runner_live.ts` is covered by the frame-contract tests in `live_session_test.py` and the live smoke above, matching the `runner_stdio.ts` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)