### PR TITLE
Harness ingest: body-map an existing agent repo into a harness

### DIFF
--- a/docs/harness_ingest.md
+++ b/docs/harness_ingest.md
@@ -1,0 +1,52 @@
+# Harness ingest: body mapping an existing agent repo
+
+`wmh harness ingest` turns an agent you already have (a repo of prompts, loop code, tool
+definitions, and configs) into a `HarnessDoc`. We call the repo the agent's **body**, and the
+process **body mapping**: walk the body, include every relevant textual file, and write a
+**harnessdoc** per file describing what it is and how it serves the agent.
+
+```
+wmh harness ingest https://github.com/acme/support-bot --name support-bot
+wmh harness ingest ../my-agent --exclude 'docs/archive/*'
+wmh push support-bot --kind harness
+```
+
+## What the built document contains
+
+| Surface | Content |
+| --- | --- |
+| `prompt:core` | LLM-written overview of the agent + where its body lives |
+| `code:bodymap-md` (`BODYMAP.md`) | The index: every mapped file with its one-line role, plus skips with reasons |
+| `code:<slug>` per file | The file content, its real relative path in `Surface.path`, its harnessdoc in `Surface.doc` |
+| `tool_policy:main`, `param:*` | Explicit defaults so the doc renders and validates like any other |
+
+Directory hierarchy is preserved in `Surface.path`. Paths the safe-path rule cannot represent
+(brackets, spaces, ...) are sanitized segment-wise to `_` and the original path is recorded in the
+harnessdoc. Surface-id slugs are flat kebab; collisions get a short hash suffix.
+
+## Zealous inclusion, explicit exclusion
+
+When in doubt, a file is mapped. The only exclusions, all recorded in `BODYMAP.md`:
+
+- VCS/dependency/cache/build directories (`.git`, `node_modules`, `dist`, ...)
+- lockfiles and OS litter
+- secret-shaped files (`.env*`, `*.pem`, `*.key`, ...) — a harness doc travels; it must never
+  carry credentials
+- binaries (NUL sniff / non-UTF-8), files over the per-file cap, content past the total budget
+- root `.gitignore` patterns (approximate translation) and `--exclude` globs
+
+A file whose mapping reply is unusable still ships with a placeholder harnessdoc and is listed
+under "Unmapped" — one flaky model reply costs one annotation, not the ingest.
+
+## Execution semantics
+
+An ingested harness is a representation and editing substrate: no runtime executes the repo's own
+agent loop. It renders in stores and viewers, seeds `wmh harness create` searches (the meta-agent
+sees pathful code surfaces elided to header + harnessdoc + head, so whole-repo docs do not blow up
+proposal prompts), and is the natural v0 for platform agents connected from GitHub.
+
+## The mapping model
+
+The mapping LLM resolves like other roles: `[models.worker]` from `.wmh/settings.toml`, or
+`--provider`/`--model` explicitly. Calls are metered; the CLI prints tokens and cost at the end.
+Expect one call per file plus one overview call.

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -11,14 +11,18 @@ the agent's scaffold should be. Run one closed-loop with
 
 from __future__ import annotations
 
+import subprocess
+import tempfile
+import uuid
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.progress import Progress
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
-from wmh.config import ARTIFACT_DIR, WorldModelStore
+from wmh.config import ARTIFACT_DIR, WorldModelStore, load_settings
 from wmh.config.store import validate_name
 from wmh.engine import load_world_model
 from wmh.engine.world_model import WorldModel
@@ -26,8 +30,18 @@ from wmh.evals.gold import GoldJudge
 from wmh.evals.tasks import TaskSpec, load_tasks
 from wmh.harness.create import create_harness
 from wmh.harness.doc import HarnessDoc
+from wmh.harness.ingest import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_TOTAL_BYTES,
+    body_map,
+    build_ingest_doc,
+    collect_repo_files,
+)
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
-from wmh.providers.base import Provider
+from wmh.providers import get_provider
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind
+from wmh.providers.retry import RetryingProvider
+from wmh.tracking import MeteredProvider, RunTracker
 
 harness_app = typer.Typer(
     help="Named, versioned agent harnesses (.wmh/harnesses): create, init, list, show.",
@@ -239,3 +253,157 @@ def init_harness(
         f"[green]wrote[/green] {name} v{doc.version} (champion) -> {store.dir_for(name)}"
     )
     _console.print(f"run it: [bold]wmh eval closed-loop <tasks.jsonl> --harness {name}[/bold]")
+
+
+@harness_app.command("ingest")
+def ingest(
+    source: str = typer.Argument(..., help="Local repo directory, or a git URL to clone."),
+    name: str = typer.Option(None, "--name", help="Harness name (default: the repo name)."),
+    ref: str = typer.Option(None, "--ref", help="Branch or tag to clone (URL sources only)."),
+    exclude: list[str] = typer.Option(  # noqa: B008
+        [], "--exclude", help="Extra glob(s) to skip (repeatable)."
+    ),
+    max_file_bytes: int = typer.Option(
+        DEFAULT_MAX_FILE_BYTES, min=1, help="Per-file content cap (bytes)."
+    ),
+    max_total_bytes: int = typer.Option(
+        DEFAULT_MAX_TOTAL_BYTES, min=1, help="Total content cap (bytes)."
+    ),
+    provider_name: str = typer.Option(
+        None, "--provider", help="Mapping LLM provider (default: [models.worker] from settings)."
+    ),
+    model: str = typer.Option(None, "--model", help="Mapping LLM model id."),
+    region: str = typer.Option(None, "--region", help="AWS region (bedrock providers)."),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation prompt."),
+) -> None:
+    """Body-map an existing agent repo into a new harness.
+
+    Every relevant textual file becomes a pathful code surface (directory hierarchy preserved)
+    with an LLM-written harnessdoc; the built document also carries an overview prompt and a
+    BODYMAP.md index. Inclusion is zealous: when in doubt a file is mapped, never dropped
+    silently — skips are listed in BODYMAP.md with reasons. The result is saved as a new harness
+    with the `champion` alias; push it with `wmh push <name> --kind harness`.
+    """
+    store = HarnessStore(root)
+    resolved_name = name or _default_ingest_name(source)
+    try:
+        validate_name(resolved_name)
+    except ValueError as exc:
+        raise typer.BadParameter(f"{exc}; pass --name") from exc
+    if store.exists(resolved_name):
+        raise typer.BadParameter(f"harness {resolved_name!r} already exists; pick another --name")
+    provider = _ingest_provider(provider_name, model, region, root)
+
+    with tempfile.TemporaryDirectory(prefix="wmh-ingest-") as scratch:
+        if _looks_like_git_url(source):
+            checkout = Path(scratch) / "repo"
+            _clone(source, ref, checkout)
+            source_label = source if ref is None else f"{source}@{ref}"
+        else:
+            if ref is not None:
+                raise typer.BadParameter("--ref applies only to git URL sources")
+            checkout = Path(source)
+            source_label = f"local checkout {checkout.resolve().name}"
+        try:
+            collected = collect_repo_files(
+                checkout,
+                max_file_bytes=max_file_bytes,
+                max_total_bytes=max_total_bytes,
+                extra_excludes=tuple(exclude),
+            )
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        if not collected.files:
+            raise typer.BadParameter(f"nothing to ingest under {checkout} (all files excluded?)")
+
+        _console.print(
+            f"body-mapping [bold]{resolved_name}[/bold]: {len(collected.files)} file(s) to map "
+            f"({len(collected.skipped)} skipped) -> ~{len(collected.files) + 1} LLM calls "
+            f"on {provider.config.model}"
+        )
+        if _console.is_terminal and not yes and not Confirm.ask("Proceed?", default=True):
+            raise typer.Exit(0)
+
+        tracker = RunTracker(run_id=uuid.uuid4().hex, kind="ingest")
+        metered = MeteredProvider(RetryingProvider(provider), tracker)
+        with tracker.timed(), Progress(console=_console, transient=True) as progress:
+            task = progress.add_task("mapping", total=len(collected.files))
+
+            def _tick(index: int, total: int, path: str) -> None:
+                progress.update(task, completed=index, description=f"mapping {path}")
+
+            mapping = body_map(collected, metered, name=resolved_name, on_progress=_tick)
+        doc = build_ingest_doc(resolved_name, collected, mapping, source=source_label)
+
+    saved = store.save_version(doc, alias=CHAMPION_ALIAS)
+    totals = tracker.totals()
+    unmapped = f", {len(mapping.unmapped)} unmapped" if mapping.unmapped else ""
+    _console.print(
+        f"[green]ingested[/green] [bold]{resolved_name}[/bold] v{saved.version} (champion): "
+        f"{len(collected.files)} file(s) mapped{unmapped}, {len(collected.skipped)} skipped "
+        f"-> {store.dir_for(resolved_name)}"
+    )
+    _console.print(
+        f"  mapping cost: {totals.total_tokens} tokens, ${totals.cost_usd:.4f} "
+        f"({totals.calls} calls, {tracker.duration_seconds():.0f}s)"
+    )
+    _console.print(
+        f"  inspect: [bold]wmh harness show {resolved_name}[/bold]   "
+        f"push: [bold]wmh push {resolved_name} --kind harness[/bold]"
+    )
+
+
+def _default_ingest_name(source: str) -> str:
+    tail = source.rstrip("/").rpartition("/")[2]
+    return tail.removesuffix(".git") or "ingested"
+
+
+def _looks_like_git_url(source: str) -> bool:
+    return source.startswith(("http://", "https://", "git@", "ssh://")) or source.endswith(".git")
+
+
+def _clone(url: str, ref: str | None, target: Path) -> None:
+    """Shallow-clone `url` (optionally a branch/tag) for a one-shot read; fail as a usage error."""
+    command = ["git", "clone", "--depth", "1", "--quiet"]
+    if ref is not None:
+        command += ["--branch", ref]
+    command += [url, str(target)]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        raise typer.BadParameter(
+            f"git clone failed for {url!r}: {detail[-1] if detail else 'unknown error'}"
+        )
+
+
+def _ingest_provider(
+    provider_name: str | None, model: str | None, region: str | None, root: str
+) -> Provider:
+    """The mapping LLM: explicit --provider/--model, else the settings worker role."""
+    if provider_name is not None or model is not None:
+        if provider_name is None or model is None:
+            raise typer.BadParameter("--provider and --model must be given together")
+        try:
+            kind = ProviderKind(provider_name)
+        except ValueError:
+            kinds = ", ".join(k.value for k in ProviderKind)
+            raise typer.BadParameter(
+                f"unknown provider {provider_name!r}; choose one of: {kinds}"
+            ) from None
+        return get_provider(ProviderConfig(kind=kind, model=model, region=region))
+    configured = load_settings(root).models.resolve("worker")
+    if configured is None:
+        raise typer.BadParameter(
+            "no mapping model configured: set [models.worker] in .wmh/settings.toml "
+            "(wmh config models) or pass --provider/--model"
+        )
+    return get_provider(
+        ProviderConfig(
+            kind=ProviderKind(configured.provider),
+            model=configured.model,
+            region=configured.region or region,
+            endpoint=configured.endpoint,
+            deployment=configured.deployment,
+        )
+    )

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -1,0 +1,103 @@
+"""Tests for the `wmh harness` CLI: the ingest command wiring (fake provider, local repo)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from wmh.cli import app
+from wmh.harness.store import HarnessStore
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, VerifyResult
+
+harness_app_module = importlib.import_module("wmh.cli.harness_app")
+
+runner = CliRunner()
+
+
+class FakeProvider:
+    """Canned harnessdoc/overview JSON for every mapping call."""
+
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.OPENAI, model="fake")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        if "## File tree" in messages[0].content:
+            return Completion(text=json.dumps({"overview": "A tiny agent."}))
+        return Completion(text=json.dumps({"role": "a file", "doc": "Maps a thing."}))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:  # pragma: no cover - protocol filler
+        raise NotImplementedError
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "my-agent"
+    (root / "src").mkdir(parents=True)
+    (root / "README.md").write_text("# my agent", encoding="utf-8")
+    (root / "src" / "loop.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    return root
+
+
+def _fake_provider_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        harness_app_module, "_ingest_provider", lambda *args, **kwargs: FakeProvider()
+    )
+
+
+def test_ingest_local_repo_saves_champion(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_provider_factory(monkeypatch)
+    root = tmp_path / "proj"
+    result = runner.invoke(app, ["harness", "ingest", str(repo), "--root", str(root), "--yes"])
+    assert result.exit_code == 0, result.output
+    assert "ingested" in result.output and "my-agent" in result.output
+    doc = HarnessStore(str(root)).load("my-agent")
+    assert {s.path for s in doc.code_files()} == {"BODYMAP.md", "README.md", "src/loop.py"}
+    loop = next(s for s in doc.code_files() if s.path == "src/loop.py")
+    assert loop.doc == "Maps a thing."
+
+
+def test_ingest_rejects_existing_name(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_provider_factory(monkeypatch)
+    root = tmp_path / "proj"
+    first = runner.invoke(app, ["harness", "ingest", str(repo), "--root", str(root), "--yes"])
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(app, ["harness", "ingest", str(repo), "--root", str(root), "--yes"])
+    assert second.exit_code == 2
+    assert "already exists" in second.output
+
+
+def test_ingest_ref_requires_url_source(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fake_provider_factory(monkeypatch)
+    result = runner.invoke(
+        app,
+        ["harness", "ingest", str(repo), "--ref", "main", "--root", str(tmp_path / "p"), "--yes"],
+    )
+    assert result.exit_code == 2
+    assert "git URL sources" in result.output
+
+
+def test_ingest_default_name_from_url() -> None:
+    assert harness_app_module._default_ingest_name("https://github.com/acme/demo.git") == "demo"
+    assert harness_app_module._default_ingest_name("git@github.com:acme/demo.git") == "demo"
+    assert harness_app_module._looks_like_git_url("https://github.com/acme/demo")
+    assert not harness_app_module._looks_like_git_url("/tmp/somewhere")

--- a/wmh/harness/__init__.py
+++ b/wmh/harness/__init__.py
@@ -23,6 +23,16 @@ from wmh.harness.delta import (
 )
 from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 from wmh.harness.environment import AgentEnvironment, is_env_action
+from wmh.harness.ingest import (
+    BodyMap,
+    CollectedRepo,
+    FileDoc,
+    RepoFile,
+    SkippedFile,
+    body_map,
+    build_ingest_doc,
+    collect_repo_files,
+)
 from wmh.harness.runtime import AgentRuntime, RunResult, StopReason
 from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.store import HarnessStore
@@ -32,20 +42,28 @@ __all__ = [
     "TOOL_REGISTRY",
     "AgentEnvironment",
     "AgentRuntime",
+    "BodyMap",
+    "CollectedRepo",
     "FailureSignature",
+    "FileDoc",
     "GateRecord",
     "HarnessDelta",
     "HarnessDoc",
     "HarnessStore",
+    "RepoFile",
     "RunResult",
     "Skill",
     "SkillLibrary",
+    "SkippedFile",
     "StopReason",
     "Surface",
     "SurfaceKind",
     "SurfaceOp",
     "ToolCall",
     "apply_delta",
+    "body_map",
+    "build_ingest_doc",
+    "collect_repo_files",
     "is_env_action",
     "parse_tool_call",
 ]

--- a/wmh/harness/delta.py
+++ b/wmh/harness/delta.py
@@ -137,10 +137,13 @@ def apply_delta(parent: HarnessDoc, delta: HarnessDelta, child_name: str) -> Har
         # Carry the file path: a replace inherits the existing surface's path unless overridden,
         # so mutating a vendored pi `code:src-...` surface stays a valid pathful CODE surface.
         path = op.path if op.path is not None else existing.path if existing else None
+        # The harnessdoc annotation always survives a replace: it describes the surface's role,
+        # which an in-place content edit does not change.
+        doc = existing.doc if existing else None
         if kind is None or op.content is None:
             raise ValueError(f"malformed {op.op} of {op.surface_id!r}")
         surfaces[op.surface_id] = Surface(
-            id=op.surface_id, kind=kind, content=op.content, budget=budget, path=path
+            id=op.surface_id, kind=kind, content=op.content, budget=budget, path=path, doc=doc
         )
 
     child = HarnessDoc(name=child_name, surfaces=list(surfaces.values()))

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -28,7 +28,7 @@ import os
 import re
 from enum import StrEnum
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from wmh.harness.code_runtime import (
     DEFAULT_RUNTIME_CODE,
@@ -66,6 +66,11 @@ class SurfaceKind(StrEnum):
 class Surface(BaseModel):
     """One named, independently addressable unit of harness behavior."""
 
+    # Unknown fields are rejected, not ignored: a consumer pinned to an older schema must fail
+    # loudly on a newer document instead of silently dropping fields it does not know (which
+    # would corrupt the doc on the next round-trip).
+    model_config = ConfigDict(extra="forbid")
+
     id: str  # "<kind>:<slug>"
     kind: SurfaceKind
     content: str
@@ -76,6 +81,10 @@ class Surface(BaseModel):
     # Optional size budget (characters). Enforced at construction: a surface that exceeds its
     # budget is invalid, so context cost is a schema property rather than a runtime surprise.
     budget: int | None = Field(default=None, ge=1)
+    # Optional harnessdoc: a short annotation describing what this surface is and how it serves
+    # the agent (ingest writes one per mapped repo file). Like `path` and `budget` it is envelope
+    # metadata, not content: it does not participate in hashing.
+    doc: str | None = None
 
     @model_validator(mode="after")
     def _validate(self) -> Surface:
@@ -107,6 +116,8 @@ class Surface(BaseModel):
 
 class HarnessDoc(BaseModel):
     """A complete, validated harness: the value the runtime runs and updates are applied to."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     version: int = Field(default=0, ge=0)  # assigned by the store on save; 0 = unsaved

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -149,3 +149,42 @@ def test_runtime_backend_selector() -> None:
     # Unknown backends are rejected.
     with pytest.raises(ValueError, match="unknown backend"):
         coded.runtime(provider, backend="bogus")
+
+
+def test_surface_doc_annotation_roundtrips_and_is_not_hashed() -> None:
+    plain = Surface(id="code:x-py", kind=SurfaceKind.CODE, content="X = 1\n", path="x.py")
+    annotated = plain.model_copy(update={"doc": "Defines X."})
+    doc_a = HarnessDoc(
+        name="a",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            plain,
+        ],
+    )
+    doc_b = HarnessDoc(
+        name="a",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            annotated,
+        ],
+    )
+    # The annotation is envelope metadata: identical content -> identical identity.
+    assert doc_a.doc_hash == doc_b.doc_hash
+    reloaded = HarnessDoc.model_validate_json(doc_b.model_dump_json())
+    surface = reloaded.surface("code:x-py")
+    assert surface is not None and surface.doc == "Defines X."
+
+
+def test_unknown_fields_are_rejected_not_dropped() -> None:
+    with pytest.raises(ValueError, match="future_field"):
+        Surface.model_validate(
+            {"id": "prompt:core", "kind": "prompt", "content": "p", "future_field": 1}
+        )
+    with pytest.raises(ValueError, match="future_field"):
+        HarnessDoc.model_validate(
+            {
+                "name": "a",
+                "surfaces": [{"id": "prompt:core", "kind": "prompt", "content": "p"}],
+                "future_field": 1,
+            }
+        )

--- a/wmh/harness/ingest.py
+++ b/wmh/harness/ingest.py
@@ -1,0 +1,511 @@
+"""Ingest: build a harness from an existing agent repo by **body mapping**.
+
+An agent you already have — a repo of prompts, loop code, tool definitions, and configs — is the
+agent's *body*. Body mapping walks that body and turns it into a `HarnessDoc`: every relevant
+textual file becomes a pathful CODE surface (directory hierarchy preserved in `Surface.path`), and
+an LLM writes a **harnessdoc** per file (`Surface.doc`) describing what the file is and how it
+serves the agent. Inclusion is deliberately zealous: anything textual that survives the exclusion
+rules is mapped — when in doubt, a file goes in with a harnessdoc rather than being dropped.
+
+The built document also carries:
+- `prompt:core` — an LLM-written overview of the agent (what it is, how its body is organized),
+- `BODYMAP.md` (a pathful CODE surface) — the index: one line per mapped file, plus what was
+  skipped and why,
+- the default tool policy and loop params, so the doc validates and renders like any other.
+
+An ingested harness is a *representation and editing substrate*: it does not execute the repo's
+own agent loop (no runtime knows how to run an arbitrary repo). It is the v0 a platform agent is
+born with, the thing the harness editor edits, and the context `wmh harness create` mutates.
+
+Callers own provider metering (wrap with `MeteredProvider`) and checkout acquisition: the CLI
+clones or walks a directory; the platform fetches a tarball. Everything here is pure library code.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel, Field
+
+from wmh.core.parsing import extract_json_object
+from wmh.harness.doc import (
+    DEFAULT_TEMPERATURE,
+    MAX_TURNS_ID,
+    TEMPERATURE_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.runtime import DEFAULT_MAX_TURNS
+from wmh.harness.tools import DEFAULT_TOOLS
+from wmh.providers.base import Message, Provider
+
+DEFAULT_MAX_FILE_BYTES = 65_536
+DEFAULT_MAX_TOTAL_BYTES = 2_500_000
+
+BODYMAP_PATH = "BODYMAP.md"
+_BODYMAP_SLUG = "bodymap-md"
+
+# Directories that never contain agent body: VCS internals, dependency trees, caches, build
+# output. Pruned by basename at any depth.
+EXCLUDED_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        ".tox",
+        ".idea",
+        ".vscode",
+        "dist",
+        "build",
+        ".next",
+        ".turbo",
+        "target",
+        ".cache",
+        ".terraform",
+        ".wmh",  # a repo that used wmh locally carries artifacts, not body
+    }
+)
+
+# Generated files with no mapping value (lockfiles, OS litter).
+EXCLUDED_FILES = frozenset(
+    {
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "bun.lockb",
+        "uv.lock",
+        "poetry.lock",
+        "Pipfile.lock",
+        "Cargo.lock",
+        "composer.lock",
+        "Gemfile.lock",
+        "go.sum",
+        ".DS_Store",
+    }
+)
+
+# Files that plausibly hold credentials are never ingested, zealousness notwithstanding: a
+# harness doc travels (registry push, platform rows, editor payloads) and must not carry secrets.
+SECRET_FILE_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "id_rsa*",
+    "id_ed25519*",
+    "*.keystore",
+)
+
+_OVERVIEW_CLIP_CHARS = 6_000
+_FILE_PROMPT_CLIP_CHARS = 12_000
+_TREE_CLIP_LINES = 400
+
+INGEST_SYSTEM = """You are mapping the body of an existing software agent: its repo of prompts, \
+loop code, tool definitions, and configuration. For the ONE file you are shown, write its \
+harnessdoc. Reply with ONLY a JSON object, no prose:
+{"role": "<one line: what this file is, <= 100 chars>",
+ "doc": "<2-5 sentences: what the file contains, the key symbols/sections, and how it serves \
+the agent>"}
+Ground everything in the file content shown; never invent symbols or behavior."""
+
+OVERVIEW_SYSTEM = """You are mapping the body of an existing software agent: its repo of \
+prompts, loop code, tool definitions, and configuration. From the file tree and excerpts shown, \
+write a compact overview of this agent for someone about to work on it. Reply with ONLY a JSON \
+object, no prose:
+{"overview": "<1-3 paragraphs: what the agent is and does, how the repo is organized, where the \
+prompts / loop / tools live>"}
+Ground everything in what is shown; never invent files or behavior."""
+
+
+class RepoFile(BaseModel):
+    """One textual file of the agent's body, ready to map."""
+
+    path: str  # relative posix path inside the repo
+    content: str
+
+
+class SkippedFile(BaseModel):
+    """One file body mapping left out, and exactly why (skips are reported, never silent)."""
+
+    path: str
+    reason: str
+
+
+class CollectedRepo(BaseModel):
+    """The walk result: what will be mapped and what was skipped."""
+
+    files: list[RepoFile]
+    skipped: list[SkippedFile]
+
+
+class FileDoc(BaseModel):
+    """The harnessdoc body mapping wrote for one file."""
+
+    path: str
+    role: str  # one line
+    doc: str  # 2-5 sentences
+
+
+class BodyMap(BaseModel):
+    """The body-mapping output: the agent overview plus one harnessdoc per mapped file."""
+
+    overview: str
+    file_docs: list[FileDoc]
+    unmapped: list[str] = Field(default_factory=list)  # files whose model reply was unusable
+
+    def doc_for(self, path: str) -> FileDoc | None:
+        for file_doc in self.file_docs:
+            if file_doc.path == path:
+                return file_doc
+        return None
+
+
+def collect_repo_files(
+    root: Path,
+    *,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    extra_excludes: tuple[str, ...] = (),
+) -> CollectedRepo:
+    """Walk a checkout and collect every textual file worth mapping, in deterministic path order.
+
+    Exclusions: the fixed dir/file lists, secret-shaped files, extra caller globs, patterns from
+    the repo's root `.gitignore` (approximate fnmatch translation; negations ignored), binaries
+    (NUL sniff or undecodable UTF-8), files over `max_file_bytes`, and everything past
+    `max_total_bytes` cumulative content (paths sort first, so the cut is deterministic). Every
+    exclusion is recorded with its reason.
+    """
+    if not root.is_dir():
+        raise ValueError(f"not a directory: {root}")
+    ignore_patterns = _gitignore_patterns(root)
+    files: list[RepoFile] = []
+    skipped: list[SkippedFile] = []
+    total = 0
+    for path in _walk_sorted(root):
+        rel = path.relative_to(root).as_posix()
+        reason = _exclusion_reason(rel, path.name, ignore_patterns, extra_excludes)
+        if reason is not None:
+            skipped.append(SkippedFile(path=rel, reason=reason))
+            continue
+        size = path.stat().st_size
+        if size > max_file_bytes:
+            skipped.append(
+                SkippedFile(path=rel, reason=f"over per-file cap ({size} > {max_file_bytes} bytes)")
+            )
+            continue
+        raw = path.read_bytes()
+        if b"\x00" in raw[:8192]:
+            skipped.append(SkippedFile(path=rel, reason="binary (NUL bytes)"))
+            continue
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            skipped.append(SkippedFile(path=rel, reason="binary (not UTF-8)"))
+            continue
+        if total + len(raw) > max_total_bytes:
+            skipped.append(
+                SkippedFile(path=rel, reason=f"over total budget ({max_total_bytes} bytes)")
+            )
+            continue
+        total += len(raw)
+        files.append(RepoFile(path=rel, content=content))
+    return CollectedRepo(files=files, skipped=skipped)
+
+
+def body_map(
+    collected: CollectedRepo,
+    provider: Provider,
+    *,
+    name: str,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> BodyMap:
+    """Write the harnessdocs: one LLM call per file plus one overview call.
+
+    A file whose reply is unusable (no JSON, wrong shape) still ships — with a placeholder
+    harnessdoc and its path recorded in `unmapped` — so one flaky reply costs one annotation,
+    not the ingest. Deterministic prompts; sampling is the only nondeterminism.
+    """
+    file_docs: list[FileDoc] = []
+    unmapped: list[str] = []
+    total = len(collected.files)
+    for index, repo_file in enumerate(collected.files, start=1):
+        if on_progress is not None:
+            on_progress(index, total, repo_file.path)
+        parsed = _complete_json(provider, INGEST_SYSTEM, _file_prompt(repo_file), _RawFileDoc)
+        if parsed is None:
+            unmapped.append(repo_file.path)
+            file_docs.append(
+                FileDoc(
+                    path=repo_file.path,
+                    role="(unmapped: unusable model reply)",
+                    doc="(no harnessdoc: the mapping model returned an unusable reply)",
+                )
+            )
+            continue
+        file_docs.append(FileDoc(path=repo_file.path, role=parsed.role, doc=parsed.doc))
+    overview = _complete_json(
+        provider, OVERVIEW_SYSTEM, _overview_prompt(name, collected, file_docs), _RawOverview
+    )
+    overview_text = (
+        overview.overview
+        if overview is not None
+        else f"{name}: an agent ingested from an existing repo ({total} files mapped)."
+    )
+    return BodyMap(overview=overview_text, file_docs=file_docs, unmapped=unmapped)
+
+
+def build_ingest_doc(
+    name: str, collected: CollectedRepo, mapping: BodyMap, *, source: str
+) -> HarnessDoc:
+    """Assemble the validated `HarnessDoc`: prompt:core, BODYMAP.md, and one CODE surface per file.
+
+    Each file keeps its directory hierarchy in `Surface.path` (sanitized where the safe-path rule
+    requires, with the original path noted in the harnessdoc) and carries its harnessdoc in
+    `Surface.doc`. Defaults (tool policy, loop params) are explicit so the rendered `config.toml`
+    shows them.
+    """
+    taken_slugs = {_BODYMAP_SLUG}
+    taken_paths = {BODYMAP_PATH}
+    surfaces = [
+        Surface(
+            id="prompt:core",
+            kind=SurfaceKind.PROMPT,
+            content=(
+                f"{mapping.overview.strip()}\n\n"
+                f"This agent was ingested from {source}. Its body (the repo's files) is carried "
+                f"as code surfaces with their original paths; the body map index in "
+                f"{BODYMAP_PATH} lists every file with its role."
+            ),
+        ),
+        Surface(
+            id=f"code:{_BODYMAP_SLUG}",
+            kind=SurfaceKind.CODE,
+            path=BODYMAP_PATH,
+            content=_render_bodymap(name, collected, mapping, source=source),
+            doc="The body map index: every mapped file with its one-line role, plus skips.",
+        ),
+        Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="\n".join(DEFAULT_TOOLS)),
+        Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(DEFAULT_MAX_TURNS)),
+        Surface(id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(DEFAULT_TEMPERATURE)),
+    ]
+    for repo_file in collected.files:
+        slug = slug_for_path(repo_file.path, taken_slugs)
+        taken_slugs.add(slug)
+        safe_path, changed = sanitize_path(repo_file.path)
+        safe_path = _disambiguate_path(safe_path, repo_file.path, taken_paths)
+        taken_paths.add(safe_path)
+        file_doc = mapping.doc_for(repo_file.path)
+        doc_text = file_doc.doc if file_doc is not None else "(no harnessdoc)"
+        if changed or safe_path != repo_file.path:
+            doc_text = f"Original path: {repo_file.path}. {doc_text}"
+        surfaces.append(
+            Surface(
+                id=f"code:{slug}",
+                kind=SurfaceKind.CODE,
+                path=safe_path,
+                content=repo_file.content,
+                doc=doc_text,
+            )
+        )
+    return HarnessDoc(name=name, surfaces=surfaces)
+
+
+def slug_for_path(path: str, taken: set[str]) -> str:
+    """A valid surface-id slug for a repo path; collisions get a short content-free hash suffix.
+
+    The mapping is lossy by design (ids are flat kebab); `Surface.path` keeps the real location.
+    """
+    slug = _kebab(path)
+    if slug not in taken:
+        return slug
+    return f"{slug}-{_path_digest(path)}"
+
+
+def sanitize_path(path: str) -> tuple[str, bool]:
+    """Rewrite a repo path so it satisfies the surface safe-path rule; report whether it changed.
+
+    Characters outside `[A-Za-z0-9._-]` become `_` per segment (e.g. `app/[id]/page.tsx` ->
+    `app/_id_/page.tsx`); `.` and `..` segments become `_`. The original path is preserved in the
+    harnessdoc by the caller.
+    """
+    segments = []
+    changed = False
+    for segment in path.split("/"):
+        clean = "".join(
+            c if (c.isascii() and (c.isalnum() or c in "._-")) else "_" for c in segment
+        )
+        if not clean or clean in {".", ".."}:
+            clean = "_"
+        changed = changed or clean != segment
+        segments.append(clean)
+    return "/".join(segments), changed
+
+
+def _disambiguate_path(safe_path: str, original: str, taken: set[str]) -> str:
+    if safe_path not in taken:
+        return safe_path
+    head, dot, ext = safe_path.rpartition(".")
+    digest = _path_digest(original)
+    if dot:
+        return f"{head}-{digest}.{ext}"
+    return f"{safe_path}-{digest}"
+
+
+def _kebab(text: str) -> str:
+    out: list[str] = []
+    for c in text.lower():
+        if c.isascii() and c.isalnum():
+            out.append(c)
+        elif not out or out[-1] != "-":
+            out.append("-")
+    slug = "".join(out).strip("-")
+    return slug or "file"
+
+
+def _path_digest(path: str) -> str:
+    return hashlib.blake2b(path.encode("utf-8"), digest_size=3).hexdigest()
+
+
+def _walk_sorted(root: Path) -> list[Path]:
+    """Every regular file under `root`, sorted by relative posix path; excluded dirs pruned."""
+    results: list[Path] = []
+
+    def _walk(directory: Path) -> None:
+        for entry in sorted(directory.iterdir(), key=lambda p: p.name):
+            if entry.is_symlink():
+                continue  # a symlink can escape the checkout; the body is what is physically here
+            if entry.is_dir():
+                if entry.name not in EXCLUDED_DIRS:
+                    _walk(entry)
+            elif entry.is_file():
+                results.append(entry)
+
+    _walk(root)
+    return sorted(results, key=lambda p: p.relative_to(root).as_posix())
+
+
+def _exclusion_reason(
+    rel: str, basename: str, ignore_patterns: list[str], extra_excludes: tuple[str, ...]
+) -> str | None:
+    if basename in EXCLUDED_FILES:
+        return "generated file (lockfile or OS litter)"
+    for pattern in SECRET_FILE_PATTERNS:
+        if fnmatch.fnmatch(basename, pattern):
+            return "may contain secrets"
+    for pattern in extra_excludes:
+        if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(basename, pattern):
+            return f"excluded by --exclude {pattern!r}"
+    for pattern in ignore_patterns:
+        if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(basename, pattern):
+            return "matched .gitignore"
+    return None
+
+
+def _gitignore_patterns(root: Path) -> list[str]:
+    """Root `.gitignore` lines as fnmatch patterns (approximate: no negations, no anchoring)."""
+    gitignore = root / ".gitignore"
+    if not gitignore.is_file():
+        return []
+    patterns: list[str] = []
+    for line in gitignore.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("!"):
+            continue
+        stripped = stripped.lstrip("/")
+        if stripped.endswith("/"):
+            base = stripped.rstrip("/")
+            patterns += [f"{base}/*", f"*/{base}/*"]
+        else:
+            patterns += [stripped, f"*/{stripped}"]
+    return patterns
+
+
+class _RawFileDoc(BaseModel):
+    role: str
+    doc: str
+
+
+class _RawOverview(BaseModel):
+    overview: str
+
+
+_ReplyT = TypeVar("_ReplyT", bound=BaseModel)
+
+
+def _complete_json(
+    provider: Provider, system: str, user: str, model: type[_ReplyT]
+) -> _ReplyT | None:
+    completion = provider.complete(
+        system, [Message(role="user", content=user)], temperature=0.2, max_tokens=1024
+    )
+    raw = extract_json_object(completion.text)
+    if raw is None:
+        return None
+    try:
+        return model.model_validate_json(raw)
+    except ValueError:
+        return None
+
+
+def _file_prompt(repo_file: RepoFile) -> str:
+    content = repo_file.content
+    clipped = ""
+    if len(content) > _FILE_PROMPT_CLIP_CHARS:
+        content = content[:_FILE_PROMPT_CLIP_CHARS]
+        clipped = f"\n... [clipped at {_FILE_PROMPT_CLIP_CHARS} chars]"
+    return f"## File: {repo_file.path}\n\n```\n{content}{clipped}\n```"
+
+
+def _overview_prompt(name: str, collected: CollectedRepo, file_docs: list[FileDoc]) -> str:
+    tree_lines = [f.path for f in collected.files][:_TREE_CLIP_LINES]
+    readme = next(
+        (f for f in collected.files if f.path.lower() in {"readme.md", "readme.rst", "readme"}),
+        None,
+    )
+    readme_block = (
+        f"\n\n## README excerpt\n\n{readme.content[:_OVERVIEW_CLIP_CHARS]}" if readme else ""
+    )
+    roles = "\n".join(f"- {d.path}: {d.role}" for d in file_docs[:_TREE_CLIP_LINES])
+    return (
+        f"## Agent: {name}\n\n## File tree ({len(collected.files)} files)\n\n"
+        + "\n".join(tree_lines)
+        + readme_block
+        + f"\n\n## Per-file roles\n\n{roles}"
+    )
+
+
+def _render_bodymap(name: str, collected: CollectedRepo, mapping: BodyMap, *, source: str) -> str:
+    lines = [
+        f"# Body map: {name}",
+        "",
+        f"Source: {source}. {len(collected.files)} files mapped, {len(collected.skipped)} skipped.",
+        "",
+        "## Files",
+        "",
+    ]
+    for file_doc in mapping.file_docs:
+        lines.append(f"- `{file_doc.path}` - {file_doc.role}")
+    if collected.skipped:
+        lines += ["", "## Skipped", ""]
+        for skip in collected.skipped:
+            lines.append(f"- `{skip.path}` - {skip.reason}")
+    if mapping.unmapped:
+        lines += ["", "## Unmapped (kept, but the mapping reply was unusable)", ""]
+        for path in mapping.unmapped:
+            lines.append(f"- `{path}`")
+    return "\n".join(lines) + "\n"

--- a/wmh/harness/ingest.py
+++ b/wmh/harness/ingest.py
@@ -51,6 +51,11 @@ DEFAULT_MAX_TOTAL_BYTES = 2_500_000
 BODYMAP_PATH = "BODYMAP.md"
 _BODYMAP_SLUG = "bodymap-md"
 
+# Paths the harness store's render owns (SYSTEM.md, config.toml, ...): a repo
+# file at one of these paths keeps its content but moves aside (hash suffix),
+# so the rendered bundle never carries two files with one path.
+RESERVED_RENDER_PATHS = frozenset({"SYSTEM.md", "config.toml", "runtime.py", "doc.json"})
+
 # Directories that never contain agent body: VCS internals, dependency trees, caches, build
 # output. Pruned by basename at any depth.
 EXCLUDED_DIRS = frozenset(
@@ -280,7 +285,7 @@ def build_ingest_doc(
     shows them.
     """
     taken_slugs = {_BODYMAP_SLUG}
-    taken_paths = {BODYMAP_PATH}
+    taken_paths = {BODYMAP_PATH, *RESERVED_RENDER_PATHS}
     surfaces = [
         Surface(
             id="prompt:core",

--- a/wmh/harness/ingest.py
+++ b/wmh/harness/ingest.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import fnmatch
 import hashlib
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar
@@ -137,6 +138,24 @@ prompts / loop / tools live>"}
 Ground everything in what is shown; never invent files or behavior."""
 
 
+class _GitignoreMatcher(BaseModel):
+    """One compiled .gitignore rule: a regex over the relative posix path, plus its kind.
+
+    We deliberately implement only the conservative subset git uses that cannot silently drop
+    body files: no negations (a whitelist .gitignore disables gitignore handling entirely, see
+    `_gitignore_patterns`), no per-parent-directory .gitignore files, no character classes. A
+    root-anchored pattern (one containing a non-trailing '/') matches the full relative path; a
+    bare pattern matches any path segment at any depth; a trailing '/' marks a directory prefix.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    regex: re.Pattern[str]
+
+    def matches(self, rel: str) -> bool:
+        return self.regex.match(rel) is not None
+
+
 class RepoFile(BaseModel):
     """One textual file of the agent's body, ready to map."""
 
@@ -190,20 +209,20 @@ def collect_repo_files(
     """Walk a checkout and collect every textual file worth mapping, in deterministic path order.
 
     Exclusions: the fixed dir/file lists, secret-shaped files, extra caller globs, patterns from
-    the repo's root `.gitignore` (approximate fnmatch translation; negations ignored), binaries
-    (NUL sniff or undecodable UTF-8), files over `max_file_bytes`, and everything past
+    the repo's root `.gitignore` (conservative gitignore subset, negations disable it entirely),
+    binaries (NUL sniff or undecodable UTF-8), files over `max_file_bytes`, and everything past
     `max_total_bytes` cumulative content (paths sort first, so the cut is deterministic). Every
-    exclusion is recorded with its reason.
+    exclusion is recorded with its reason, including symlinks and pruned directories from the walk.
     """
     if not root.is_dir():
         raise ValueError(f"not a directory: {root}")
-    ignore_patterns = _gitignore_patterns(root)
+    ignore_matchers = _gitignore_patterns(root)
     files: list[RepoFile] = []
-    skipped: list[SkippedFile] = []
+    walked, skipped = _walk_sorted(root)
     total = 0
-    for path in _walk_sorted(root):
+    for path in walked:
         rel = path.relative_to(root).as_posix()
-        reason = _exclusion_reason(rel, path.name, ignore_patterns, extra_excludes)
+        reason = _exclusion_reason(rel, path.name, ignore_matchers, extra_excludes)
         if reason is not None:
             skipped.append(SkippedFile(path=rel, reason=reason))
             continue
@@ -229,6 +248,7 @@ def collect_repo_files(
             continue
         total += len(raw)
         files.append(RepoFile(path=rel, content=content))
+    skipped.sort(key=lambda s: s.path)
     return CollectedRepo(files=files, skipped=skipped)
 
 
@@ -262,12 +282,21 @@ def body_map(
                 )
             )
             continue
-        file_docs.append(FileDoc(path=repo_file.path, role=parsed.role, doc=parsed.doc))
+        # The mapping model's output travels into prompt:core, BODYMAP.md, and (transitively) the
+        # mutate proposal prompt, so a hostile repo could poison those with fence injection or
+        # unbounded length. Sanitize at this boundary before the text is ever embedded.
+        file_docs.append(
+            FileDoc(
+                path=repo_file.path,
+                role=_clean_role(parsed.role),
+                doc=_clean_doc(parsed.doc),
+            )
+        )
     overview = _complete_json(
         provider, OVERVIEW_SYSTEM, _overview_prompt(name, collected, file_docs), _RawOverview
     )
     overview_text = (
-        overview.overview
+        _clean_overview(overview.overview)
         if overview is not None
         else f"{name}: an agent ingested from an existing repo ({total} files mapped)."
     )
@@ -364,11 +393,16 @@ def sanitize_path(path: str) -> tuple[str, bool]:
 def _disambiguate_path(safe_path: str, original: str, taken: set[str]) -> str:
     if safe_path not in taken:
         return safe_path
-    head, dot, ext = safe_path.rpartition(".")
+    directory, sep, basename = safe_path.rpartition("/")
+    stem, dot, ext = basename.rpartition(".")
     digest = _path_digest(original)
-    if dot:
-        return f"{head}-{digest}.{ext}"
-    return f"{safe_path}-{digest}"
+    # `stem` guards dotfiles: '.gitignore'.rpartition('.') == ('', '.', 'gitignore'), so an empty
+    # stem means there is no real extension to preserve and we suffix the whole basename instead.
+    if dot and stem:
+        moved = f"{stem}-{digest}.{ext}"
+    else:
+        moved = f"{basename}-{digest}"
+    return f"{directory}{sep}{moved}"
 
 
 def _kebab(text: str) -> str:
@@ -386,26 +420,65 @@ def _path_digest(path: str) -> str:
     return hashlib.blake2b(path.encode("utf-8"), digest_size=3).hexdigest()
 
 
-def _walk_sorted(root: Path) -> list[Path]:
-    """Every regular file under `root`, sorted by relative posix path; excluded dirs pruned."""
+_ROLE_MAX_CHARS = 120
+_DOC_MAX_CHARS = 600
+_OVERVIEW_MAX_CHARS = 4_000
+
+
+def _clean_role(text: str) -> str:
+    """One-line role: drop backticks, collapse all whitespace, cap at `_ROLE_MAX_CHARS`."""
+    collapsed = " ".join(text.replace("`", "").split())
+    return collapsed[:_ROLE_MAX_CHARS]
+
+
+def _clean_doc(text: str) -> str:
+    """Harnessdoc body: strip backticks (defence against fence injection), strip, cap length."""
+    return text.replace("`", "").strip()[:_DOC_MAX_CHARS]
+
+
+def _clean_overview(text: str) -> str:
+    """Agent overview: strip backticks, cap length; newlines are kept (paragraph structure)."""
+    return text.replace("`", "").strip()[:_OVERVIEW_MAX_CHARS]
+
+
+def _walk_sorted(root: Path) -> tuple[list[Path], list[SkippedFile]]:
+    """Every regular file under `root`, sorted by relative posix path, plus the walk's own skips.
+
+    Symlinks are not followed (they can escape the checkout) and pruned excluded dirs are not
+    descended, but neither is silently dropped: each symlink and each pruned dir gets a
+    `SkippedFile` so the reported skips match the 'skips are reported, never silent' contract. A
+    pruned directory yields exactly one skip for the dir, not one per file it would have contained.
+    """
     results: list[Path] = []
+    skips: list[SkippedFile] = []
 
     def _walk(directory: Path) -> None:
         for entry in sorted(directory.iterdir(), key=lambda p: p.name):
+            rel = entry.relative_to(root).as_posix()
             if entry.is_symlink():
-                continue  # a symlink can escape the checkout; the body is what is physically here
+                skips.append(SkippedFile(path=rel, reason="symlink (not followed)"))
+                continue
             if entry.is_dir():
-                if entry.name not in EXCLUDED_DIRS:
+                if entry.name in EXCLUDED_DIRS:
+                    skips.append(
+                        SkippedFile(
+                            path=f"{rel}/", reason="excluded directory (contents not walked)"
+                        )
+                    )
+                else:
                     _walk(entry)
             elif entry.is_file():
                 results.append(entry)
 
     _walk(root)
-    return sorted(results, key=lambda p: p.relative_to(root).as_posix())
+    return sorted(results, key=lambda p: p.relative_to(root).as_posix()), skips
 
 
 def _exclusion_reason(
-    rel: str, basename: str, ignore_patterns: list[str], extra_excludes: tuple[str, ...]
+    rel: str,
+    basename: str,
+    ignore_matchers: list[_GitignoreMatcher],
+    extra_excludes: tuple[str, ...],
 ) -> str | None:
     if basename in EXCLUDED_FILES:
         return "generated file (lockfile or OS litter)"
@@ -415,29 +488,65 @@ def _exclusion_reason(
     for pattern in extra_excludes:
         if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(basename, pattern):
             return f"excluded by --exclude {pattern!r}"
-    for pattern in ignore_patterns:
-        if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(basename, pattern):
+    for matcher in ignore_matchers:
+        if matcher.matches(rel):
             return "matched .gitignore"
     return None
 
 
-def _gitignore_patterns(root: Path) -> list[str]:
-    """Root `.gitignore` lines as fnmatch patterns (approximate: no negations, no anchoring)."""
+def _gitignore_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile one conservative gitignore pattern into an anchored full-relative-path regex.
+
+    A pattern with a non-trailing '/' is root-anchored: it matches the whole relative path from the
+    repo root. A bare pattern (no '/') matches that segment as a basename at any depth. A trailing
+    '/' marks a directory: it and everything under it match. '**' becomes '.*', a single '*'
+    becomes '[^/]*' (no directory crossing), and all other characters are escaped literally.
+    """
+    is_dir = pattern.endswith("/")
+    body = pattern.rstrip("/")
+    anchored = "/" in body
+    # Translate glob tokens to regex on the literal-escaped text so '.' and friends stay literal.
+    escaped = re.escape(body).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+    if anchored:
+        prefix = ""
+        core = escaped
+    else:
+        # Match the pattern as a full path segment at any depth: at the start or after a '/'.
+        prefix = r"(?:.*/)?"
+        core = escaped
+    if is_dir:
+        # A directory pattern matches the directory itself and everything beneath it.
+        suffix = r"/.*"
+    else:
+        # A file/either pattern matches the path itself or, if it names a dir, its contents.
+        suffix = r"(?:/.*)?"
+    return re.compile(f"^{prefix}{core}{suffix}$")
+
+
+def _gitignore_patterns(root: Path) -> list[_GitignoreMatcher]:
+    """Root `.gitignore` as conservative compiled matchers, or [] if it uses negation/whitelist.
+
+    Whitelist-style .gitignore files (any '!' line, e.g. '*' then '!src/') re-include paths a
+    plain pattern list would exclude; approximating them by dropping the '!' lines would collapse
+    ingest to zero. Since body files must never be silently dropped, the presence of ANY negation
+    disables gitignore handling entirely rather than over-excluding.
+    """
     gitignore = root / ".gitignore"
     if not gitignore.is_file():
         return []
-    patterns: list[str] = []
-    for line in gitignore.read_text(encoding="utf-8", errors="replace").splitlines():
+    lines = gitignore.read_text(encoding="utf-8", errors="replace").splitlines()
+    matchers: list[_GitignoreMatcher] = []
+    for line in lines:
         stripped = line.strip()
-        if not stripped or stripped.startswith("#") or stripped.startswith("!"):
+        if not stripped or stripped.startswith("#"):
             continue
+        if stripped.startswith("!"):
+            return []  # negation/whitelist: do not apply gitignore at all
         stripped = stripped.lstrip("/")
-        if stripped.endswith("/"):
-            base = stripped.rstrip("/")
-            patterns += [f"{base}/*", f"*/{base}/*"]
-        else:
-            patterns += [stripped, f"*/{stripped}"]
-    return patterns
+        if not stripped:
+            continue
+        matchers.append(_GitignoreMatcher(regex=_gitignore_to_regex(stripped)))
+    return matchers
 
 
 class _RawFileDoc(BaseModel):

--- a/wmh/harness/ingest_test.py
+++ b/wmh/harness/ingest_test.py
@@ -201,3 +201,17 @@ def test_build_ingest_doc_disambiguates_sanitized_collisions() -> None:
     assert len(set(code_paths)) == 2  # both kept, paths disambiguated
     original_notes = [s.doc for s in doc.code_files() if s.path != BODYMAP_PATH]
     assert any(note is not None and "Original path: a/[x].ts" in note for note in original_notes)
+
+
+def test_build_ingest_doc_moves_reserved_render_paths_aside() -> None:
+    collected = CollectedRepo(
+        files=[RepoFile(path="SYSTEM.md", content="the repo's own system doc")],
+        skipped=[],
+    )
+    mapping = BodyMap(overview="o", file_docs=[FileDoc(path="SYSTEM.md", role="r", doc="d")])
+    doc = build_ingest_doc("demo", collected, mapping, source="local")
+    paths = [s.path for s in doc.code_files()]
+    assert "SYSTEM.md" not in paths  # the store's rendered SYSTEM.md owns that path
+    moved = next(s for s in doc.code_files() if s.path not in {BODYMAP_PATH})
+    assert moved.path.startswith("SYSTEM-") and moved.content == "the repo's own system doc"
+    assert moved.doc is not None and "Original path: SYSTEM.md" in moved.doc

--- a/wmh/harness/ingest_test.py
+++ b/wmh/harness/ingest_test.py
@@ -213,5 +213,154 @@ def test_build_ingest_doc_moves_reserved_render_paths_aside() -> None:
     paths = [s.path for s in doc.code_files()]
     assert "SYSTEM.md" not in paths  # the store's rendered SYSTEM.md owns that path
     moved = next(s for s in doc.code_files() if s.path not in {BODYMAP_PATH})
+    assert moved.path is not None
     assert moved.path.startswith("SYSTEM-") and moved.content == "the repo's own system doc"
     assert moved.doc is not None and "Original path: SYSTEM.md" in moved.doc
+
+
+# ---- FINDING 4: gitignore is conservative and correct ---------------------------------------
+
+
+def test_gitignore_whitelist_disables_gitignore_entirely(tmp_path: Path) -> None:
+    # A negation (whitelist-style) .gitignore must NOT collapse ingest: body files stay in.
+    root = tmp_path / "repo"
+    _write(root, ".gitignore", "*\n!src/\n")
+    _write(root, "src/agent.py", "print(1)\n")
+    _write(root, "README.md", "# hi\n")
+    collected = collect_repo_files(root)
+    included = {f.path for f in collected.files}
+    assert "src/agent.py" in included
+    assert "README.md" in included  # not dropped despite the leading '*'
+    assert not any(s.reason == "matched .gitignore" for s in collected.skipped)
+
+
+def test_gitignore_dir_pattern_excludes_contents_but_not_similarly_named_file(
+    tmp_path: Path,
+) -> None:
+    # 'coverage/' is not in EXCLUDED_DIRS, so the walk descends it and gitignore does the excluding.
+    root = tmp_path / "repo"
+    _write(root, ".gitignore", "coverage/\n")
+    _write(root, "coverage/out.js", "x\n")
+    _write(root, "recoverage.py", "y\n")  # 'coverage/' must NOT catch this substring match
+    collected = collect_repo_files(root)
+    included = {f.path for f in collected.files}
+    reasons = {s.path: s.reason for s in collected.skipped}
+    assert "recoverage.py" in included
+    assert reasons.get("coverage/out.js") == "matched .gitignore"
+
+
+def test_gitignore_anchored_pattern_does_not_match_deeper_path(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write(root, ".gitignore", "src/generated.py\n")
+    _write(root, "src/generated.py", "a\n")
+    _write(root, "lib/src/generated.py", "b\n")  # anchored: NOT excluded
+    collected = collect_repo_files(root)
+    included = {f.path for f in collected.files}
+    reasons = {s.path: s.reason for s in collected.skipped}
+    assert "lib/src/generated.py" in included
+    assert reasons.get("src/generated.py") == "matched .gitignore"
+
+
+def test_gitignore_bare_pattern_excludes_at_any_depth(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write(root, ".gitignore", "*.log\n")
+    _write(root, "app.log", "a\n")
+    _write(root, "deep/nested/trace.log", "b\n")
+    _write(root, "keep.txt", "c\n")
+    collected = collect_repo_files(root)
+    included = {f.path for f in collected.files}
+    reasons = {s.path: s.reason for s in collected.skipped}
+    assert "keep.txt" in included
+    assert reasons.get("app.log") == "matched .gitignore"
+    assert reasons.get("deep/nested/trace.log") == "matched .gitignore"
+
+
+# ---- FINDING 5: mapping-LLM output is sanitized at the boundary -------------------------------
+
+
+class _PoisonProvider:
+    """Replies with fence-laden, oversized role/doc/overview to test boundary sanitization."""
+
+    def __init__(self) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.OPENAI, model="fake")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        user = messages[0].content
+        if "## File tree" in user:
+            payload = {"overview": "```injected fence``` " + ("o" * 5000)}
+        else:
+            payload = {
+                "role": "```role fence``` " + ("r" * 500),
+                "doc": "```doc fence``` " + ("d" * 5000),
+            }
+        return Completion(text=json.dumps(payload), usage=TokenUsage(), model="fake")
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:  # pragma: no cover - protocol filler
+        raise NotImplementedError
+
+
+def test_body_map_defences_fence_injection_and_length(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write(root, "README.md", "# tree seed\n")
+    _write(root, "src/agent.py", "print(1)\n")
+    collected = collect_repo_files(root)
+    mapping = body_map(collected, _PoisonProvider(), name="demo")
+    doc = mapping.doc_for("src/agent.py")
+    assert doc is not None
+    assert "`" not in doc.role and "`" not in doc.doc  # fences stripped
+    assert len(doc.role) <= 120
+    assert len(doc.doc) <= 600
+    assert "`" not in mapping.overview  # overview fences stripped
+    assert len(mapping.overview) <= 4000  # overview clamped
+
+
+# ---- FINDING 7: disambiguation operates on the final path segment only ------------------------
+
+
+def test_disambiguate_preserves_dotted_directory_on_collision() -> None:
+    # 'a.b/c' collides: the digest must land on the basename, never mangle the 'a.b' directory.
+    collected = CollectedRepo(
+        files=[
+            RepoFile(path="a.b/c", content="one"),
+            RepoFile(path="a.b/c", content="two"),  # forces a path collision after sanitize
+        ],
+        skipped=[],
+    )
+    mapping = BodyMap(
+        overview="o",
+        file_docs=[FileDoc(path="a.b/c", role="r", doc="d")],
+    )
+    doc = build_ingest_doc("demo", collected, mapping, source="local")
+    code_paths = [s.path for s in doc.code_files() if s.path not in {BODYMAP_PATH}]
+    assert len(set(code_paths)) == 2
+    for path in code_paths:
+        assert path is not None and path.startswith("a.b/")  # dotted directory kept intact
+
+
+# ---- FINDING 8: symlinks and pruned dirs are reported as skips --------------------------------
+
+
+def test_symlink_and_pruned_dir_are_reported_skips(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write(root, "real.txt", "content\n")
+    _write(root, "node_modules/a/index.js", "1\n")
+    _write(root, "node_modules/b/index.js", "2\n")
+    (root / "link.txt").symlink_to(root / "real.txt")
+    collected = collect_repo_files(root)
+    reasons = {s.path: s.reason for s in collected.skipped}
+    assert reasons.get("link.txt") == "symlink (not followed)"
+    assert reasons.get("node_modules/") == "excluded directory (contents not walked)"
+    # Exactly one skip entry for the pruned dir, not one per contained file.
+    node_skips = [s for s in collected.skipped if s.path.startswith("node_modules")]
+    assert len(node_skips) == 1
+    assert "real.txt" in {f.path for f in collected.files}

--- a/wmh/harness/ingest_test.py
+++ b/wmh/harness/ingest_test.py
@@ -1,0 +1,203 @@
+"""Tests for body-mapping ingest: collection rules, slug/path mapping, doc assembly."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.doc import SurfaceKind
+from wmh.harness.ingest import (
+    BODYMAP_PATH,
+    BodyMap,
+    CollectedRepo,
+    FileDoc,
+    RepoFile,
+    body_map,
+    build_ingest_doc,
+    collect_repo_files,
+    sanitize_path,
+    slug_for_path,
+)
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+    VerifyResult,
+)
+
+
+class FakeProvider:
+    """Replies with a canned harnessdoc JSON (or garbage when `garbage_for` matches)."""
+
+    def __init__(self, garbage_for: set[str] | None = None) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.OPENAI, model="fake")
+        self.calls: list[str] = []
+        self._garbage_for = garbage_for or set()
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        user = messages[0].content
+        self.calls.append(user)
+        if "## File tree" in user:  # the overview call (checked first: it embeds every path)
+            if "## File tree" in self._garbage_for:
+                return Completion(text="not json at all", usage=TokenUsage(), model="fake")
+            payload = {"overview": "A demo agent. Prompts in prompts/, loop in src/."}
+        elif any(marker in user for marker in self._garbage_for):
+            return Completion(text="not json at all", usage=TokenUsage(), model="fake")
+        else:
+            payload = {"role": "a mapped file", "doc": "Does a thing. Serves the agent."}
+        return Completion(text=json.dumps(payload), usage=TokenUsage(), model="fake")
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:  # pragma: no cover - protocol filler
+        raise NotImplementedError
+
+
+def _write(root: Path, rel: str, content: str | bytes) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        target.write_bytes(content)
+    else:
+        target.write_text(content, encoding="utf-8")
+
+
+def _demo_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    _write(root, "README.md", "# Demo agent\nDoes demo things.")
+    _write(root, "src/agent.py", "def run():\n    return 'hi'\n")
+    _write(root, "src/tools/search.py", "QUERY = 'x'\n")
+    _write(root, "prompts/system.txt", "You are a demo agent.")
+    _write(root, ".github/workflows/ci.yml", "on: push\n")
+    _write(root, "node_modules/dep/index.js", "module.exports = 1")
+    _write(root, "package-lock.json", "{}")
+    _write(root, ".env", "SECRET=1")
+    _write(root, "logo.png", b"\x89PNG\x00\x00binary")
+    _write(root, "big.txt", "x" * 200_000)
+    _write(root, ".gitignore", "ignored_dir/\n*.tmp\n")
+    _write(root, "ignored_dir/inner.txt", "nope")
+    _write(root, "scratch.tmp", "nope")
+    return root
+
+
+def test_collect_includes_zealously_and_skips_with_reasons(tmp_path: Path) -> None:
+    collected = collect_repo_files(_demo_repo(tmp_path))
+    included = [f.path for f in collected.files]
+    assert included == sorted(included)  # deterministic order
+    assert ".github/workflows/ci.yml" in included
+    assert "README.md" in included
+    assert "src/tools/search.py" in included
+    assert ".gitignore" in included  # zealous: meta files are body too
+    reasons = {s.path: s.reason for s in collected.skipped}
+    assert "package-lock.json" in reasons
+    assert reasons[".env"] == "may contain secrets"
+    assert "binary" in reasons["logo.png"]
+    assert "per-file cap" in reasons["big.txt"]
+    assert "matched .gitignore" in reasons["ignored_dir/inner.txt"]
+    assert "matched .gitignore" in reasons["scratch.tmp"]
+    assert not any("node_modules" in p for p in included)
+
+
+def test_collect_total_budget_is_deterministic(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write(root, "a.txt", "x" * 60)
+    _write(root, "b.txt", "y" * 60)
+    collected = collect_repo_files(root, max_total_bytes=100)
+    assert [f.path for f in collected.files] == ["a.txt"]
+    assert collected.skipped[0].path == "b.txt"
+    assert "total budget" in collected.skipped[0].reason
+
+
+def test_collect_rejects_non_directory(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not a directory"):
+        collect_repo_files(tmp_path / "missing")
+
+
+def test_slug_for_path_normalizes_and_disambiguates() -> None:
+    taken: set[str] = set()
+    assert slug_for_path("README.md", taken) == "readme-md"
+    assert slug_for_path("src/__init__.py", taken) == "src-init-py"
+    first = slug_for_path("a/b.ts", taken)
+    taken.add(first)
+    second = slug_for_path("a/b_ts", taken)  # same kebab, different path
+    assert first == "a-b-ts" and second.startswith("a-b-ts-") and second != first
+
+
+def test_sanitize_path_handles_unrepresentable_segments() -> None:
+    assert sanitize_path("app/[id]/page.tsx") == ("app/_id_/page.tsx", True)
+    assert sanitize_path("src/agent.py") == ("src/agent.py", False)
+    assert sanitize_path("weird/../escape.txt") == ("weird/_/escape.txt", True)
+
+
+def test_body_map_survives_unusable_replies(tmp_path: Path) -> None:
+    collected = collect_repo_files(_demo_repo(tmp_path))
+    provider = FakeProvider(garbage_for={"prompts/system.txt"})
+    mapping = body_map(collected, provider, name="demo")
+    assert mapping.unmapped == ["prompts/system.txt"]
+    kept = mapping.doc_for("prompts/system.txt")
+    assert kept is not None and "unusable" in kept.doc
+    mapped = mapping.doc_for("src/agent.py")
+    assert mapped is not None and mapped.role == "a mapped file"
+    assert "demo agent" in mapping.overview.lower()
+
+
+def test_body_map_overview_fallback_on_unusable_reply(tmp_path: Path) -> None:
+    collected = collect_repo_files(_demo_repo(tmp_path))
+    mapping = body_map(collected, FakeProvider(garbage_for={"## File tree"}), name="demo")
+    assert "ingested from an existing repo" in mapping.overview  # deterministic fallback
+
+
+def test_build_ingest_doc_preserves_hierarchy_and_docs(tmp_path: Path) -> None:
+    collected = collect_repo_files(_demo_repo(tmp_path))
+    mapping = body_map(collected, FakeProvider(), name="demo")
+    doc = build_ingest_doc("demo", collected, mapping, source="github.com/acme/demo")
+    paths = {s.path for s in doc.code_files()}
+    assert "src/tools/search.py" in paths  # hierarchy preserved
+    assert BODYMAP_PATH in paths
+    agent_surface = next(s for s in doc.code_files() if s.path == "src/agent.py")
+    assert agent_surface.doc == "Does a thing. Serves the agent."
+    assert agent_surface.kind is SurfaceKind.CODE
+    assert "BODYMAP.md" in doc.system_prompt()
+    bodymap = next(s for s in doc.code_files() if s.path == BODYMAP_PATH)
+    assert "`src/agent.py` - a mapped file" in bodymap.content
+    assert "## Skipped" in bodymap.content
+    # The doc validates as a whole and round-trips through JSON with annotations intact.
+    reloaded = type(doc).model_validate_json(doc.model_dump_json())
+    assert reloaded.doc_hash == doc.doc_hash
+    assert (
+        next(s for s in reloaded.code_files() if s.path == "src/agent.py").doc == agent_surface.doc
+    )
+
+
+def test_build_ingest_doc_disambiguates_sanitized_collisions() -> None:
+    collected = CollectedRepo(
+        files=[
+            RepoFile(path="a/[x].ts", content="one"),
+            RepoFile(path="a/_x_.ts", content="two"),
+        ],
+        skipped=[],
+    )
+    mapping = BodyMap(
+        overview="o",
+        file_docs=[
+            FileDoc(path="a/[x].ts", role="r", doc="d"),
+            FileDoc(path="a/_x_.ts", role="r", doc="d"),
+        ],
+    )
+    doc = build_ingest_doc("demo", collected, mapping, source="local")
+    code_paths = [s.path for s in doc.code_files() if s.path != BODYMAP_PATH]
+    assert len(set(code_paths)) == 2  # both kept, paths disambiguated
+    original_notes = [s.doc for s in doc.code_files() if s.path != BODYMAP_PATH]
+    assert any(note is not None and "Original path: a/[x].ts" in note for note in original_notes)

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -62,7 +62,9 @@ Surface kinds:
 cannot end).
 - param — a scalar loop knob: `param:max-turns` (int >= 1), `param:temperature` (float in [0, 2]).
 - code — the agent loop program, singleton `code:runtime` (contract above). Must compile and
-  define `run`.
+  define `run`. Code surfaces carrying a `path` are vendored/ingested repo files; they are shown
+  ELIDED (header, harnessdoc, and first lines only) and are inert to the running loop — prefer
+  other levers unless the evidence names one specifically.
 - skill — one reusable technique, shaped as:
   ---
   name: <kebab-slug matching the surface id>
@@ -171,6 +173,12 @@ def render_history(history: list[HarnessDelta], limit: int = 5) -> str:
     return "\n".join(lines)
 
 
+# Pathful CODE surfaces (vendored or ingested repo files) are shown elided: a whole-repo harness
+# would otherwise put megabytes into every proposal prompt. The header keeps id/hash/path (enough
+# to target an op), the harnessdoc says what the file is for, and the head keeps orientation.
+_CODE_FILE_PREVIEW_LINES = 20
+
+
 def _build_prompt(
     parent: HarnessDoc, trigger: FailureSignature, evidence: str, history: list[HarnessDelta]
 ) -> str:
@@ -178,6 +186,15 @@ def _build_prompt(
     blocks: list[str] = []
     for surface in parent.surfaces:
         budget = f", budget={surface.budget}" if surface.budget is not None else ""
+        if surface.path is not None:
+            head = "\n".join(surface.content.splitlines()[:_CODE_FILE_PREVIEW_LINES])
+            note = f"\ndoc: {surface.doc}" if surface.doc else ""
+            blocks.append(
+                f"### {surface.id} (kind={surface.kind.value}, hash={surface.content_hash}"
+                f"{budget}, path={surface.path}, {len(surface.content)} chars, content elided)"
+                f"{note}\n```\n{head}\n... [elided]\n```"
+            )
+            continue
         blocks.append(
             f"### {surface.id} (kind={surface.kind.value}, "
             f"hash={surface.content_hash}{budget})\n```\n{surface.content}\n```"

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -189,8 +189,14 @@ def _build_prompt(
         if surface.path is not None:
             head = "\n".join(surface.content.splitlines()[:_CODE_FILE_PREVIEW_LINES])
             note = f"\ndoc: {surface.doc}" if surface.doc else ""
+            # The real content_hash is WITHHELD for elided surfaces: the proposer never saw the
+            # full content, so it must not be able to copy a hash into preconditions and replace or
+            # remove the surface (a truncating replace of an inert body file could otherwise pass
+            # `delta.py` preconditions and become champion). Without the hash, replace/remove is
+            # impossible; `add` still works with a fresh id.
             blocks.append(
-                f"### {surface.id} (kind={surface.kind.value}, hash={surface.content_hash}"
+                f"### {surface.id} (kind={surface.kind.value}, "
+                f"hash=(withheld: content elided; replace/remove not available from this view)"
                 f"{budget}, path={surface.path}, {len(surface.content)} chars, content elided)"
                 f"{note}\n```\n{head}\n... [elided]\n```"
             )

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -7,7 +7,7 @@ import json
 from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature
-from wmh.harness.doc import HarnessDoc
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 from wmh.harness.mutate import propose_delta, render_evidence
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
@@ -139,3 +139,32 @@ def test_all_pass_evidence_asks_for_generalization() -> None:
     evidence = render_evidence(trigger, report, [TaskSpec(task_id="t", instruction="do it")])
     assert "passed every task" in evidence
     assert "GENERALIZE" in evidence
+
+
+def test_prompt_elides_pathful_code_surfaces() -> None:
+    body = "\n".join(f"line {i}" for i in range(200))
+    parent = HarnessDoc(
+        name="parent",
+        surfaces=[
+            *HarnessDoc.baseline("parent").surfaces,
+            Surface(
+                id="code:src-agent-ts",
+                kind=SurfaceKind.CODE,
+                content=body,
+                path="src/agent.ts",
+                doc="The agent loop entry.",
+            ),
+        ],
+    )
+    provider = ScriptedProvider(_reply(parent))
+    propose_delta(parent, _trigger(), "evidence", provider)
+    user = provider.users[0]
+    # Header keeps identity + path + harnessdoc; the tail of the content never ships.
+    assert "path=src/agent.ts" in user
+    assert "content elided" in user
+    assert "The agent loop entry." in user
+    assert "line 5" in user  # head preview
+    assert "line 199" not in user
+    # Non-pathful surfaces (the baseline prompt) still ship in full.
+    core = parent.surface("prompt:core")
+    assert core is not None and core.content in user

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -165,6 +165,13 @@ def test_prompt_elides_pathful_code_surfaces() -> None:
     assert "The agent loop entry." in user
     assert "line 5" in user  # head preview
     assert "line 199" not in user
-    # Non-pathful surfaces (the baseline prompt) still ship in full.
+    # The real content hash is WITHHELD for the elided (pathful) surface: the proposer never saw
+    # its content, so it must not be able to copy a hash and replace/remove it. Sentinel says so.
+    elided = parent.surface("code:src-agent-ts")
+    assert elided is not None and elided.content_hash not in user
+    assert "hash=(withheld: content elided; replace/remove not available from this view)" in user
+    # Non-pathful surfaces (the baseline prompt) still ship in full, with their real hash intact
+    # so the precondition (copy-not-guess) path stays usable for them.
     core = parent.surface("prompt:core")
     assert core is not None and core.content in user
+    assert core.content_hash in user


### PR DESCRIPTION
## What

Adds `wmh harness ingest`: turn an existing agent repo (its "body") into a `HarnessDoc` by **body mapping**. Walk the repo, include every relevant textual file as a pathful CODE surface (directory hierarchy preserved), and have an LLM write a **harnessdoc** per file describing what it is and how it serves the agent. The built document also carries an LLM overview (`prompt:core`), a `BODYMAP.md` index, and the default tool policy / loop params so it validates and renders like any other harness.

This is the wmh half of the platform "connect a GitHub repo as an agent" feature (platform PR: `feat/github-connect-agents`); the platform ingest worker calls this library in-process.

## Highlights

- **`wmh/harness/ingest.py`** (new) — `collect_repo_files` (zealous inclusion; explicit, reported skips for secrets/binaries/lockfiles/gitignored/oversized files), `body_map` (one metered LLM call per file + one overview call; a flaky reply costs one annotation, not the ingest), `build_ingest_doc` (paths sanitized to the surface safe-path rule with the original recorded in the harnessdoc, collisions disambiguated, the store's rendered paths reserved).
- **`wmh harness ingest <dir|git-url>`** — thin CLI over the library; local checkout or shallow clone; worker-role provider, metered, prints cost.
- **`Surface.doc`** — a new optional, unhashed annotation field (the per-file harnessdoc). `extra="forbid"` on `Surface`/`HarnessDoc` so a consumer pinned to an older schema fails loudly instead of silently dropping fields on round-trip.
- **Proposal-prompt elision** — `mutate.py` renders pathful code surfaces as header + harnessdoc + head only (and withholds their content hash), so a whole-repo doc does not blow up `wmh harness create` proposal prompts, and an inert body file cannot be truncate-replaced into the champion.
- Execution semantics: an ingested harness is a representation/editing substrate — no runtime runs the repo's own loop. Documented in `docs/harness_ingest.md`.

## Review

Built and then adversarially reviewed (5 lenses × verify); confirmed findings fixed in the second commit: correct gitignore semantics (whitelist files no longer collapse ingest to zero), de-fenced + length-clamped mapping output (hostile-repo hardening), final-segment path disambiguation, and reported symlink/pruned-dir skips.

## Tests / gate

`just gate` green: ruff check + ruff format --check + ty check + `pytest -q` (1083 passed, 18 skipped). New inline tests in `ingest_test.py`, `mutate_test.py`, `harness_app_test.py`; `doc_test.py` covers the annotation round-trip and `extra=forbid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
