### PR TITLE
Standardize provider-independent model types

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -1012,12 +1012,7 @@ def _run_eval_files(
     for path in files:
         if not path.exists():
             raise typer.BadParameter(f"trace file not found: {path}")
-    try:
-        serve_provider = ProviderKind(provider)
-    except ValueError:
-        kinds = ", ".join(k.value for k in ProviderKind)
-        raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
-    provider_config = ProviderConfig(kind=serve_provider, model=model, region=region)
+    provider_config = _provider_config(provider, model, region)
     llm = providers.provider_or_chain(provider_config, chain=chain)
     if isinstance(llm, providers.WaterfallProvider):
         _console.print("failover chain active (.wmh/fallback.toml) — world-model calls only")
@@ -1402,7 +1397,7 @@ def demo(
             # failed step — completed steps stay done.
             _console.print(f"\n[red]serve provider is still failing[/red]: {_short_error(exc)}")
             _console.print("[yellow]pick a different provider to continue the demo[/yellow]")
-            provider_name, model_id, region = select_provider_and_model(
+            provider_name, model_type, region = select_provider_and_model(
                 _console,
                 lambda text: _console.input(text),
                 lambda text: _console.input(text, password=True),
@@ -1412,15 +1407,14 @@ def demo(
                 interactive=True,
                 check=lambda cfg: verify_all([cfg])[0],
             )
-            switched = ProviderConfig(
-                kind=ProviderKind(provider_name), model=model_id, region=region
-            )
+            switched = _provider_config(provider_name, model_type, region)
             provider = RetryingProvider(
                 providers.get_provider(switched), on_retry=_NARRATOR.on_retry, sleep=_NARRATOR.sleep
             )
             wm = WorldModel.load(str(model_dir), provider, telemetry_root=str(model_root))
             _console.print(
-                f"[dim]resuming from step {len(done) + 1} with {provider_name} ({model_id})…[/dim]"
+                f"[dim]resuming from step {len(done) + 1} with "
+                f"{provider_name} ({model_type})…[/dim]"
             )
     matches = sum(1 for d in done if d.exact_match)
     _console.print(f"\n{matches}/{len(done)} exact matches (run `wmh eval` for judged fidelity)")

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -85,6 +85,7 @@ from wmh.ingest import VendorPull, get_adapter, list_adapters
 from wmh.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import Embedder, EmbedderKind, Provider
+from wmh.providers.models import resolve_provider_model
 from wmh.providers.retry import RetryingProvider
 from wmh.retrieval import HashingEmbedder, get_embedder
 from wmh.scenarios import (
@@ -273,9 +274,9 @@ def build(
     provider: str = typer.Option(
         None, "--provider", help="Provider that serves the model (default: bedrock)."
     ),
-    model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Serve provider model id."),
+    model: str = typer.Option("claude-opus-4-8", help="Canonical serve model type."),
     judge_model: str = typer.Option(
-        None, "--judge-model", help="GEPA judge model id (default: cheap model per provider)."
+        None, "--judge-model", help="Canonical GEPA judge model type (default: cheap per provider)."
     ),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     chain: str = typer.Option(
@@ -650,7 +651,7 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
         None, "--prompt", help="Prompt file; default=BASE_ENV_PROMPT."
     ),
     provider: str = typer.Option("bedrock", "--provider", help="Provider running the model."),
-    model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Model id."),
+    model: str = typer.Option("claude-opus-4-8", help="Canonical model type."),
     region: str | None = typer.Option(None, help="AWS region (Bedrock)."),
     chain: str | None = typer.Option(
         None, "--chain", help="Named failover chain from .wmh/fallback.toml (default: its default)."
@@ -1145,7 +1146,7 @@ def scenarios_verify(
     name: str = typer.Option(None, "--name", help="World model to roll against."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding world models."),
     provider: str = typer.Option(None, "--provider", help="Override serve provider kind."),
-    model: str = typer.Option(None, help="Override serve model id (e.g. a small/cheap model)."),
+    model: str = typer.Option(None, help="Override canonical serve model type."),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     max_steps: int = typer.Option(12, help="Rollout step budget per scenario."),
     drop: bool = typer.Option(False, "--drop", help="Write back only verified scenarios."),
@@ -1161,9 +1162,7 @@ def scenarios_verify(
     if provider is not None or model is not None:
         store = WorldModelStore(root)
         model_dir = store.resolve(_resolve_name(store, name))
-        override = _provider_config(
-            provider or "bedrock", model or "us.anthropic.claude-opus-4-8", region
-        )
+        override = _provider_config(provider or "bedrock", model or "claude-opus-4-8", region)
         llm = RetryingProvider(providers.get_provider(override))
         world_model = WorldModel.load(str(model_dir), llm)
     else:
@@ -1221,11 +1220,17 @@ def _provider_config(provider: str, model: str, region: str | None) -> ProviderC
     except ValueError:
         kinds = ", ".join(k.value for k in ProviderKind)
         raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
-    return ProviderConfig(kind=kind, model=model, region=region)
+    spec = resolve_provider_model(kind, model)
+    return ProviderConfig(
+        kind=kind,
+        model_type=spec.model_type,
+        model=spec.model_id,
+        region=region,
+    )
 
 
 _SCENARIO_DEFAULT_PROVIDER = "bedrock"
-_SCENARIO_DEFAULT_MODEL = "us.anthropic.claude-opus-4-8"
+_SCENARIO_DEFAULT_MODEL = "claude-opus-4-8"
 
 
 def _role_provider_config(role: str, region: str | None) -> ProviderConfig | None:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -366,8 +366,18 @@ def test_eval_pins_the_judge_off_the_failover_chain(monkeypatch, tmp_path) -> No
 
     chain = FakeProvider()
     pinned = FakeProvider()
-    monkeypatch.setattr(providers_pkg, "provider_or_chain", lambda config, **kw: chain)
-    monkeypatch.setattr(providers_pkg, "get_provider", lambda config: pinned)
+    configs: list[ProviderConfig] = []
+
+    def provider_or_chain(config: ProviderConfig, **kw) -> FakeProvider:  # noqa: ANN003
+        configs.append(config)
+        return chain
+
+    def get_provider(config: ProviderConfig) -> FakeProvider:
+        configs.append(config)
+        return pinned
+
+    monkeypatch.setattr(providers_pkg, "provider_or_chain", provider_or_chain)
+    monkeypatch.setattr(providers_pkg, "get_provider", get_provider)
 
     result = runner.invoke(app, ["eval", _traces_file(tmp_path), "--no-rag"])
 
@@ -378,6 +388,11 @@ def test_eval_pins_the_judge_off_the_failover_chain(monkeypatch, tmp_path) -> No
     assert judge_systems_pinned  # every judge call went to the pinned backend
     prediction_systems = [s for s in chain.systems if "grade a world model" not in s]
     assert prediction_systems  # predictions went through the chain
+    assert [config.model for config in configs] == [
+        "us.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4-8",
+    ]
+    assert all(config.model_type == "claude-opus-4-8" for config in configs)
 
 
 def test_eval_suite_list_run_and_results(patched_provider, tmp_path) -> None:  # noqa: ANN001

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -54,6 +54,7 @@ from wmh.engine.play import PlayTurn, parse_action, play_turn
 from wmh.engine.world_model import WorldModel
 from wmh.providers import verify_all, verify_embedder
 from wmh.providers.base import ProviderConfig, ProviderKind, VerifyResult
+from wmh.providers.models import model_types_for_provider, resolve_provider_model
 
 # A reader takes a fully-rendered prompt string and returns the user's typed line.
 PromptReader = Callable[[str], str]
@@ -67,17 +68,12 @@ _ACTIVITY_WINDOW_LINES = 8
 # Serve providers offered in the wizard picker, with the model ids each supports. The first model
 # in each list is the suggested default. Keep these in sync with the provider backends.
 _PROVIDER_MODELS: dict[str, list[str]] = {
-    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-mini"],
-    "anthropic": ["claude-opus-4-8", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
-    "bedrock": [
-        "us.anthropic.claude-opus-4-8",
-        "us.anthropic.claude-opus-4-7",
-        # haiku needs the dated inference-profile id; the undated alias is rejected by Bedrock
-        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    ],
+    "openai": list(model_types_for_provider(ProviderKind.OPENAI)),
+    "anthropic": list(model_types_for_provider(ProviderKind.ANTHROPIC)),
+    "bedrock": list(model_types_for_provider(ProviderKind.BEDROCK)),
     # openai_responses (the Responses API) stays flag-only (`wmh build --provider
     # openai_responses`); the wizard list keeps to the four everyday backends.
-    "azure": ["gpt-5.5", "gpt-5.4"],
+    "azure": list(model_types_for_provider(ProviderKind.AZURE_OPENAI)),
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 
@@ -86,7 +82,7 @@ _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 _JUDGE_MODEL_DEFAULTS: dict[str, str] = {
     "anthropic": "claude-haiku-4-5",
     "openai": "gpt-5.4-mini",
-    "bedrock": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "bedrock": "claude-haiku-4-5",
 }
 
 
@@ -125,8 +121,8 @@ class BuildParams(BaseModel):
     # None = not chosen yet: the wizard suggests the first provider with credentials present,
     # and the non-interactive path falls back to bedrock.
     provider: str | None = None
-    model: str = "us.anthropic.claude-opus-4-8"
-    # GEPA judge model id; None = pick the cheap per-provider default in the wizard/build.
+    model: str = "claude-opus-4-8"
+    # Canonical GEPA judge model type; None = pick the cheap per-provider default.
     judge_model: str | None = None
     region: str | None = None
     gepa_budget: int = 10
@@ -253,7 +249,7 @@ def select_provider_and_model(
         model = _select(
             console,
             ask,
-            "Serve model id",
+            "Serve model type",
             _PROVIDER_MODELS[provider],
             default_model,
             interactive=interactive,
@@ -266,7 +262,15 @@ def select_provider_and_model(
         # Live ping now, not at the end: a bad key or model id loops straight back to the
         # picker (the failed pick becomes the suggested retry default).
         console.print(f"verifying {provider}…")
-        ping = check(ProviderConfig(kind=ProviderKind(provider), model=model, region=region))
+        model_spec = resolve_provider_model(ProviderKind(provider), model)
+        ping = check(
+            ProviderConfig(
+                kind=ProviderKind(provider),
+                model_type=model_spec.model_type,
+                model=model_spec.model_id,
+                region=region,
+            )
+        )
         if ping.ok:
             console.print(f"  {_CHECK} {provider} ({escape(model)}) reachable")
             return provider, model, region
@@ -369,7 +373,7 @@ def run_build_wizard(
         judge_model = _select(
             console,
             ask,
-            "GEPA judge model id",
+            "GEPA judge model type",
             judge_options,
             judge_default,
             interactive=interactive,
@@ -379,7 +383,15 @@ def run_build_wizard(
         if judge_model == model:
             break  # the serve model was just verified
         console.print(f"verifying {provider} (judge)…")
-        ping = check(ProviderConfig(kind=ProviderKind(provider), model=judge_model, region=region))
+        judge_spec = resolve_provider_model(ProviderKind(provider), judge_model)
+        ping = check(
+            ProviderConfig(
+                kind=ProviderKind(provider),
+                model_type=judge_spec.model_type,
+                model=judge_spec.model_id,
+                region=region,
+            )
+        )
         if ping.ok:
             console.print(f"  {_CHECK} {provider} ({escape(judge_model)}) reachable")
             break

--- a/wmh/cli/ui.py
+++ b/wmh/cli/ui.py
@@ -54,7 +54,7 @@ from wmh.engine.play import PlayTurn, parse_action, play_turn
 from wmh.engine.world_model import WorldModel
 from wmh.providers import verify_all, verify_embedder
 from wmh.providers.base import ProviderConfig, ProviderKind, VerifyResult
-from wmh.providers.models import model_types_for_provider, resolve_provider_model
+from wmh.providers.models import resolve_provider_model
 
 # A reader takes a fully-rendered prompt string and returns the user's typed line.
 PromptReader = Callable[[str], str]
@@ -68,12 +68,19 @@ _ACTIVITY_WINDOW_LINES = 8
 # Serve providers offered in the wizard picker, with the model ids each supports. The first model
 # in each list is the suggested default. Keep these in sync with the provider backends.
 _PROVIDER_MODELS: dict[str, list[str]] = {
-    "openai": list(model_types_for_provider(ProviderKind.OPENAI)),
-    "anthropic": list(model_types_for_provider(ProviderKind.ANTHROPIC)),
-    "bedrock": list(model_types_for_provider(ProviderKind.BEDROCK)),
+    "openai": ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-mini"],
+    "anthropic": [
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+    ],
+    # Keep this picker curated to inference profiles verified by the normal interactive flow.
+    # The full canonical registry remains available to flags and programmatic callers.
+    "bedrock": ["claude-opus-4-8", "claude-opus-4-7", "claude-haiku-4-5"],
     # openai_responses (the Responses API) stays flag-only (`wmh build --provider
     # openai_responses`); the wizard list keeps to the four everyday backends.
-    "azure": list(model_types_for_provider(ProviderKind.AZURE_OPENAI)),
+    "azure": ["gpt-5.5", "gpt-5.4"],
 }
 _DEFAULT_REGIONS: dict[str, str] = {"bedrock": "us-east-1"}
 

--- a/wmh/cli/ui_test.py
+++ b/wmh/cli/ui_test.py
@@ -247,7 +247,7 @@ def test_build_wizard_collects_all_inputs() -> None:
             "",  # trace source: accept the default (otel-genai)
             "/tmp/traces.jsonl",
             "bedrock",
-            "us.anthropic.claude-opus-4-8",
+            "claude-opus-4-8",
             "us-east-1",
             "",  # judge model: accept the bedrock default (dated haiku)
             "8",
@@ -266,7 +266,7 @@ def test_build_wizard_collects_all_inputs() -> None:
     assert params.file == "/tmp/traces.jsonl"
     assert params.provider == "bedrock"
     assert params.region == "us-east-1"
-    assert params.judge_model == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    assert params.judge_model == "claude-haiku-4-5"
     assert params.gepa_budget == 8
     assert params.embed_provider == "hashing"
     assert params.train_split == 0.5

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, JsonValue, ValidationError
 
 from wmh.core.types import JsonObject
 from wmh.providers.base import EmbedderKind, ProviderConfig, ProviderKind
+from wmh.providers.models import resolve_provider_model
 
 ARTIFACT_DIR = ".wmh"
 
@@ -90,7 +91,13 @@ class HarnessConfig(BaseModel):
         entry point one place to construct a build config. Callers must already have validated that
         a non-hashing embedder has an `embed_model`.
         """
-        serve = ProviderConfig(kind=serve_provider, model=serve_model, region=region)
+        serve_spec = resolve_provider_model(serve_provider, serve_model)
+        serve = ProviderConfig(
+            kind=serve_provider,
+            model_type=serve_spec.model_type,
+            model=serve_spec.model_id,
+            region=region,
+        )
         providers = [serve]
         if embed_provider is not EmbedderKind.HASHING:
             embed_kind = embed_provider.provider_kind()
@@ -112,7 +119,11 @@ class HarnessConfig(BaseModel):
             embed_dim=embed_dim,
             gepa_budget=gepa_budget,
             train_split=train_split,
-            judge_model=judge_model,
+            judge_model=(
+                resolve_provider_model(serve_provider, judge_model).model_id
+                if judge_model is not None
+                else None
+            ),
             trace_adapter=trace_adapter,
         )
 

--- a/wmh/config/store.py
+++ b/wmh/config/store.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, JsonValue
 
 from wmh.config.card import ModelCard, load_card
 from wmh.config.config import ARTIFACT_DIR, ArtifactPaths, HarnessConfig
+from wmh.providers.models import resolve_provider_model
 
 # The implicit model name used when the user does not pass `--name`.
 DEFAULT_MODEL_NAME = "default"
@@ -153,10 +154,11 @@ class WorldModelStore:
             if isinstance(frontier, list):
                 frontier_size = len(frontier)
         serve = config.serve_provider_config()
+        model_type = serve.model_type or resolve_provider_model(serve.kind, serve.model).model_type
         return ModelInfo(
             name=name,
             serve_provider=serve.kind.value,
-            serve_model=serve.model,
+            serve_model=model_type,
             held_out_accuracy=accuracy,
             rollouts_used=rollouts,
             frontier_size=frontier_size,

--- a/wmh/providers/__init__.py
+++ b/wmh/providers/__init__.py
@@ -16,6 +16,7 @@ from wmh.providers.base import (
     ProviderKind,
     VerifyResult,
 )
+from wmh.providers.models import ProviderModel, model_types_for_provider, resolve_provider_model
 from wmh.providers.registry import get_provider, verify_all, verify_embedder
 from wmh.providers.waterfall import WaterfallProvider, provider_or_chain
 
@@ -23,6 +24,7 @@ __all__ = [
     "Provider",
     "ProviderConfig",
     "ProviderKind",
+    "ProviderModel",
     "EmbedderKind",
     "DEFAULT_MAX_TOKENS",
     "Completion",
@@ -33,4 +35,6 @@ __all__ = [
     "WaterfallProvider",
     "verify_all",
     "verify_embedder",
+    "model_types_for_provider",
+    "resolve_provider_model",
 ]

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -76,6 +76,9 @@ class ProviderConfig(BaseModel):
     """
 
     kind: ProviderKind
+    # Canonical, provider-independent identity. ``model`` remains the exact
+    # provider runtime id for SDK calls and old persisted configs.
+    model_type: str | None = None
     model: str
     embed_model: str | None = None  # embeddings model id / Azure embedding deployment
     embed_dim: int | None = None  # requested embedding dimension (Titan v2, text-embedding-3-*)

--- a/wmh/providers/models.py
+++ b/wmh/providers/models.py
@@ -1,0 +1,128 @@
+"""Canonical model types and provider-specific runtime identifiers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from wmh.providers.base import ProviderKind
+
+
+class ProviderModel(BaseModel):
+    """One canonical model type as exposed by a concrete provider.
+
+    ``model_type`` is the provider-independent identity used in product and
+    configuration surfaces. ``model_id`` is the provider-specific value sent
+    over the wire. Keeping both prevents Bedrock inference-profile ids and
+    Azure deployment names from leaking into model identity.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: ProviderKind
+    model_type: str
+    model_id: str
+
+
+_MODELS: tuple[ProviderModel, ...] = (
+    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.5", model_id="gpt-5.5"),
+    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.5-pro", model_id="gpt-5.5-pro"),
+    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.4", model_id="gpt-5.4"),
+    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.4-mini", model_id="gpt-5.4-mini"),
+    ProviderModel(provider=ProviderKind.OPENAI_RESPONSES, model_type="gpt-5.5", model_id="gpt-5.5"),
+    ProviderModel(
+        provider=ProviderKind.OPENAI_RESPONSES,
+        model_type="gpt-5.5-pro",
+        model_id="gpt-5.5-pro",
+    ),
+    ProviderModel(provider=ProviderKind.OPENAI_RESPONSES, model_type="gpt-5.4", model_id="gpt-5.4"),
+    ProviderModel(
+        provider=ProviderKind.OPENAI_RESPONSES,
+        model_type="gpt-5.4-mini",
+        model_id="gpt-5.4-mini",
+    ),
+    ProviderModel(
+        provider=ProviderKind.ANTHROPIC,
+        model_type="claude-opus-4-8",
+        model_id="claude-opus-4-8",
+    ),
+    ProviderModel(
+        provider=ProviderKind.ANTHROPIC,
+        model_type="claude-opus-4-7",
+        model_id="claude-opus-4-7",
+    ),
+    ProviderModel(
+        provider=ProviderKind.ANTHROPIC,
+        model_type="claude-sonnet-4-6",
+        model_id="claude-sonnet-4-6",
+    ),
+    ProviderModel(
+        provider=ProviderKind.ANTHROPIC,
+        model_type="claude-haiku-4-5",
+        model_id="claude-haiku-4-5",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="claude-opus-4-8",
+        model_id="us.anthropic.claude-opus-4-8",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="claude-opus-4-7",
+        model_id="us.anthropic.claude-opus-4-7",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="claude-sonnet-4-6",
+        model_id="us.anthropic.claude-sonnet-4-6",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="claude-haiku-4-5",
+        model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    ),
+    ProviderModel(provider=ProviderKind.BEDROCK, model_type="glm-5", model_id="zai.glm-5"),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="qwen3-vl-235b-a22b",
+        model_id="qwen.qwen3-vl-235b-a22b",
+    ),
+    ProviderModel(
+        provider=ProviderKind.BEDROCK,
+        model_type="gpt-oss-120b",
+        model_id="openai.gpt-oss-120b-1:0",
+    ),
+    # Azure uses deployment names at runtime. These defaults deliberately
+    # match the canonical type; callers with custom deployment names override
+    # ProviderConfig.deployment without changing model identity.
+    ProviderModel(provider=ProviderKind.AZURE_OPENAI, model_type="gpt-5.5", model_id="gpt-5.5"),
+    ProviderModel(provider=ProviderKind.AZURE_OPENAI, model_type="gpt-5.4", model_id="gpt-5.4"),
+    ProviderModel(
+        provider=ProviderKind.AZURE_OPENAI,
+        model_type="gpt-5.4-mini",
+        model_id="gpt-5.4-mini",
+    ),
+    ProviderModel(
+        provider=ProviderKind.AZURE_OPENAI,
+        model_type="deepseek-v4-pro",
+        model_id="deepseek-v4-pro",
+    ),
+    ProviderModel(provider=ProviderKind.AZURE_OPENAI, model_type="kimi-k2.6", model_id="kimi-k2.6"),
+)
+
+
+def model_types_for_provider(provider: ProviderKind) -> tuple[str, ...]:
+    """Return canonical model types offered by ``provider`` in catalog order."""
+    return tuple(spec.model_type for spec in _MODELS if spec.provider is provider)
+
+
+def resolve_provider_model(provider: ProviderKind, model: str) -> ProviderModel:
+    """Resolve a canonical model type or known runtime id for ``provider``.
+
+    Unknown values remain valid as custom/self-hosted model types whose wire id
+    is identical. This preserves WMH's open-ended provider contract while
+    canonicalizing every model in the built-in catalog.
+    """
+    for spec in _MODELS:
+        if spec.provider is provider and model in (spec.model_type, spec.model_id):
+            return spec
+    return ProviderModel(provider=provider, model_type=model, model_id=model)

--- a/wmh/providers/models_test.py
+++ b/wmh/providers/models_test.py
@@ -1,0 +1,39 @@
+"""Tests for canonical model types and provider runtime ids."""
+
+from wmh.providers.base import ProviderKind
+from wmh.providers.models import model_types_for_provider, resolve_provider_model
+
+
+def test_same_model_type_resolves_to_provider_specific_ids() -> None:
+    """Claude keeps one identity while direct and Bedrock wire ids differ."""
+    direct = resolve_provider_model(ProviderKind.ANTHROPIC, "claude-opus-4-8")
+    bedrock = resolve_provider_model(ProviderKind.BEDROCK, "claude-opus-4-8")
+
+    assert direct.model_type == bedrock.model_type == "claude-opus-4-8"
+    assert direct.model_id == "claude-opus-4-8"
+    assert bedrock.model_id == "us.anthropic.claude-opus-4-8"
+
+
+def test_runtime_id_resolves_back_to_canonical_model_type() -> None:
+    """Known provider ids never become a second public model identity."""
+    resolved = resolve_provider_model(
+        ProviderKind.BEDROCK, "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    )
+
+    assert resolved.model_type == "claude-haiku-4-5"
+    assert resolved.model_id == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+def test_provider_catalog_exposes_only_canonical_model_types() -> None:
+    assert model_types_for_provider(ProviderKind.BEDROCK)[:4] == (
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+    )
+
+
+def test_unknown_custom_model_round_trips() -> None:
+    resolved = resolve_provider_model(ProviderKind.OPENAI, "my-fine-tune")
+    assert resolved.model_type == "my-fine-tune"
+    assert resolved.model_id == "my-fine-tune"

--- a/wmh/serving/builds.py
+++ b/wmh/serving/builds.py
@@ -55,7 +55,7 @@ class BuildRouteRequest(BaseModel):
     description: str = ""
     tags: list[str] = Field(default_factory=list)
     provider: str = "bedrock"
-    model: str = "us.anthropic.claude-opus-4-8"
+    model: str = "claude-opus-4-8"
     region: str | None = None
     gepa_budget: int = 50
     train_split: float = 0.8


### PR DESCRIPTION
## What changed

- add a canonical model-type registry shared across providers
- keep provider-specific runtime IDs separate from public model identity
- make the CLI and build API accept canonical model types while resolving Bedrock inference-profile IDs internally
- persist `model_type` alongside the runtime `model` in provider config and surface canonical names in model listings

## Why

The same underlying model should keep one stable name regardless of whether it runs through Anthropic, Bedrock, OpenAI, or Azure. Provider routing and deployment identifiers are transport details, not model identity.

## Validation

- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff format .`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ruff check .`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run ty check`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest -q` (1122 passed, 18 skipped)