### PR TITLE
Fix live_session for the provider-agnostic worker API (unbreak main)

### DIFF
--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -10,9 +10,9 @@ output, state changes) that a UI renders live. Everything else is the RunnerLink
 the worker LLM is answered host-side so credentials never reach the runner, and the wire is the
 same length-prefixed / base64-line frame `Channel`.
 
-The engine is transport- and platform-agnostic. It answers `llm_request` frames with an injected
-`worker_fn` (the platform passes a metered, streaming completion; the default calls the same
-`worker_completion` the SSH shim uses), and answers `tool_request` frames with an injected
+The engine is transport- and platform-agnostic. It answers `llm_request` frames host-side via a
+fully-configured `ToolCallingProvider`'s `complete_chat` (Bedrock or Azure — provider-agnostic per
+wmh #142) or an injected `worker_fn` (tests), and answers `tool_request` frames with an injected
 `ToolExecutor` (the platform runs bash/read_file/write_file against the session's E2B sandbox
 filesystem; a CLI would run them against a local directory). Because the host answers every
 `llm_request` and every `tool_request`, it *is* the trusted observer of what the agent did — the
@@ -45,18 +45,13 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
+from llm_waterfall import ChatRequest, ChatResponse
 from pydantic import JsonValue
 
 from wmh.core.types import JsonObject
-from wmh.harness.runner_link import (
-    Channel,
-    TokenUsage,
-    WorkerConfig,
-    WorkerFn,
-    params_schema,
-    worker_completion,
-)
+from wmh.harness.runner_link import Channel, TokenUsage, WorkerFn, params_schema
 from wmh.harness.tools import SUBMIT, ToolSpec
+from wmh.providers.base import ToolCallingProvider
 
 # The action budget a single user turn may spend before the runner is told to stop — the live
 # analogue of `HostEpisode.max_env_actions`, so a champion optimized under that pressure behaves
@@ -151,7 +146,7 @@ class LiveSession:
         files: dict[str, str] | None = None,
         system_prompt: str = "",
         skill_bodies: dict[str, str] | None = None,
-        worker: WorkerConfig | None = None,
+        provider: ToolCallingProvider | None = None,
         worker_fn: WorkerFn | None = None,
         actions_per_turn: int = DEFAULT_ACTIONS_PER_TURN,
         turn_cap: int = DEFAULT_TURN_CAP,
@@ -163,8 +158,16 @@ class LiveSession:
         self._files = dict(files or {})
         self._system_prompt = system_prompt
         self._skill_bodies = dict(skill_bodies or {})
-        cfg = worker or WorkerConfig()
-        self._worker_fn: WorkerFn = worker_fn or (lambda body: worker_completion(body, cfg))
+        # The worker LLM is answered host-side by a fully-configured provider's
+        # `complete_chat` (Bedrock or Azure — provider-agnostic per #142), or an
+        # injected `worker_fn` (tests). Left unset, an `llm_request` is answered
+        # with an error instead of crashing the host.
+        if worker_fn is not None:
+            self._worker_fn: WorkerFn | None = worker_fn
+        elif provider is not None:
+            self._worker_fn = provider.complete_chat
+        else:
+            self._worker_fn = None
         self._actions_per_turn = actions_per_turn
         self._turn_cap = turn_cap
 
@@ -302,11 +305,20 @@ class LiveSession:
     def _answer_llm(self, frame: JsonObject) -> None:
         req_id = frame.get("req_id")
         body = frame.get("openai_body")
+        if self._worker_fn is None:
+            self._emit("error", {"message": "live session has no worker configured"})
+            self._safe_send(
+                {"type": "llm_response", "req_id": req_id, "error": "no worker configured"}
+            )
+            return
         try:
-            completion = self._worker_fn(body if isinstance(body, dict) else {})
+            request = ChatRequest.model_validate(body if isinstance(body, dict) else {})
+            completion = self._worker_fn(request)
             self._meter(completion)
             self._emit_assistant(completion)
-            self._safe_send({"type": "llm_response", "req_id": req_id, "completion": completion})
+            self._safe_send(
+                {"type": "llm_response", "req_id": req_id, "completion": completion.wire_payload()}
+            )
         except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
             self._emit("error", {"message": f"worker LLM error: {exc}"})
             self._safe_send({"type": "llm_response", "req_id": req_id, "error": str(exc)})
@@ -399,21 +411,18 @@ class LiveSession:
             payload["cleared_steers"] = cleared
         self._emit("state", payload)
 
-    def _emit_assistant(self, completion: JsonObject) -> None:
-        choice = _first_choice(completion)
-        message = choice.get("message") if isinstance(choice, dict) else None
-        text = message.get("content") if isinstance(message, dict) else None
+    def _emit_assistant(self, completion: ChatResponse) -> None:
+        if not completion.choices:
+            return
+        text = completion.choices[0].message.content
         if isinstance(text, str) and text.strip():
             self._emit("assistant_message", {"text": text})
 
-    def _meter(self, completion: JsonObject) -> None:
+    def _meter(self, completion: ChatResponse) -> None:
         self.worker_usage.calls += 1
-        reported = completion.get("usage")
-        if isinstance(reported, dict):
-            prompt = reported.get("prompt_tokens")
-            out = reported.get("completion_tokens")
-            self.worker_usage.input_tokens += prompt if isinstance(prompt, int) else 0
-            self.worker_usage.output_tokens += out if isinstance(out, int) else 0
+        reported = completion.token_usage()
+        self.worker_usage.input_tokens += reported.input_tokens
+        self.worker_usage.output_tokens += reported.output_tokens
 
     def _tool_specs(self) -> list[JsonObject]:
         return [
@@ -453,13 +462,6 @@ class LiveSession:
     def _mark_closed(self, status: str) -> None:
         self._closed = True
         self._status = status
-
-
-def _first_choice(completion: JsonObject) -> JsonObject:
-    choices = completion.get("choices")
-    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
-        return cast("JsonObject", choices[0])
-    return {}
 
 
 def _recv_with_timeout(channel: Channel, timeout: float | None) -> JsonObject | None:

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from llm_waterfall import ChatRequest, ChatResponse
+
 from wmh.core.types import JsonObject
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.tools import BASH, READ_SKILL, SUBMIT
@@ -27,7 +29,7 @@ class ScriptedChannel:
 
 def _completion(
     text: str = "", tool_calls: list | None = None, usage: dict | None = None
-) -> JsonObject:
+) -> ChatResponse:
     msg: JsonObject = {"role": "assistant", "content": text}
     if tool_calls is not None:
         msg["tool_calls"] = tool_calls
@@ -35,7 +37,7 @@ def _completion(
     completion: JsonObject = {"choices": [choice]}
     if usage is not None:
         completion["usage"] = usage
-    return completion
+    return ChatResponse.model_validate(completion)
 
 
 def _drain(session: LiveSession) -> None:
@@ -223,8 +225,10 @@ def test_worker_error_is_reported_not_raised() -> None:
         ]
     )
 
-    def boom(body: JsonObject) -> JsonObject:
-        raise RuntimeError("provider down")
+    def boom(request: ChatRequest) -> ChatResponse:
+        _ = request
+        msg = "provider down"
+        raise RuntimeError(msg)
 
     session = LiveSession(
         channel, tools=[], execute_tool=_no_tool, on_event=events.append, worker_fn=boom


### PR DESCRIPTION
## What

wmh `main` is currently broken: `import wmh.harness.live_session` raises `ImportError: cannot import name 'WorkerConfig' from 'wmh.harness.runner_link'`.

#142 (Support Azure models in pi harness runs) replaced runner_link's bespoke `WorkerConfig`/`worker_completion`/`worker_config_for` with the provider-agnostic `ToolCallingProvider.complete_chat(ChatRequest) -> ChatResponse`. #142 branched before #140 (live sessions), so its merge onto main never updated #140's `live_session.py`, which still imports the removed symbols.

## Change

Migrate `LiveSession`'s worker leg to the new API, exactly mirroring `RunnerLink`:
- `LiveSession(provider=ToolCallingProvider)` (or injected `worker_fn`); worker leg = `provider.complete_chat`, so **Bedrock and Azure** agent models both drive it.
- `llm_request` → `ChatRequest.model_validate` → `complete_chat` → `wire_payload()`; meter from `ChatResponse.token_usage()`; assistant text from `choices[0].message.content`. Dropped the OpenAI-dict `_first_choice` helper.
- an unset worker answers `llm_request` with an error rather than crashing the host.

## Validation

- `uv run ruff check .` / `ruff format --check` / `uv run ty check` — clean
- `uv run pytest -q` — 1159 passed, 18 skipped
- `import wmh.harness.live_session` succeeds again

Unblocks platform #282 (live agent sessions), which pins wmh and needs a wmh commit with both live sessions and #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)