### PR TITLE
Run platform agents in E2B with local workspace sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,16 @@ Or over HTTP (same code path), namespaced by model name: `GET /world_models`, th
 
 `wmh run` is the single interactive execution command. After `wmh login`, an opaque platform id
 is resolved automatically: a world-model id opens a hosted model session, while an agent id runs
-that agent's champion pi harness in the platform's E2B sandbox. The CLI snapshots `--dir` (the
-current directory by default), uploads it as the E2B workspace, streams the session, and
-automatically syncs the final regular-file changes back. Concurrent local edits are preserved and
-the full E2B result is saved under `.wmh-conflicts/` for manual recovery. Provider and E2B
-credentials remain platform-side, so no API keys are needed locally.
+that agent's champion pi harness in the platform's E2B sandbox. No local files are uploaded by
+default. Add `-u PATH` (or `--upload-dir PATH`) to upload that directory as the E2B workspace,
+live-sync changes, and automatically sync final regular-file changes back. Concurrent local edits
+are preserved and the full E2B result is saved under `.wmh-conflicts/` for manual recovery.
+Provider and E2B credentials remain platform-side, so no API keys are needed locally.
 
 ```bash
 wmh login
-wmh run <world-model-or-agent-id> --task "inspect this repository"
+wmh run <world-model-or-agent-id>
+wmh run <agent-id> -u . --task "fix the failing tests"
 wmh run --task "fix the failing tests"   # built-in pi harness, also platform-backed when logged in
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,15 @@ print(obs.content)
 
 Or over HTTP (same code path), namespaced by model name: `GET /world_models`, then `POST /world_models/{name}/sessions` and `POST /world_models/{name}/sessions/{id}/step`.
 
-## Run locally after platform login
+## Run after platform login
 
 `wmh run` is the single interactive execution command. After `wmh login`, an opaque platform id
 is resolved automatically: a world-model id opens a hosted model session, while an agent id runs
-that agent's champion pi harness as a local Node.js child process. Agent tools act on `--dir` on
-your machine, but worker completions use platform credentials and organization metering, so no
-provider API keys are needed locally.
+that agent's champion pi harness in the platform's E2B sandbox. The CLI snapshots `--dir` (the
+current directory by default), uploads it as the E2B workspace, streams the session, and
+automatically syncs the final regular-file changes back. Concurrent local edits are preserved and
+the full E2B result is saved under `.wmh-conflicts/` for manual recovery. Provider and E2B
+credentials remain platform-side, so no API keys are needed locally.
 
 ```bash
 wmh login
@@ -80,11 +82,14 @@ non-browser client, pair its browser and backend URLs explicitly:
 wmh login --url https://preview.example --api-url https://preview-api.example
 ```
 
-Local pi execution requires Node.js 22.19 or newer plus npm on `PATH`. WMH installs the pinned pi
-npm dependencies into its user cache on the first run. It does not require E2B. Harness code and
+Workspace transport skips symlinks, VCS internals, virtual environments, dependency trees, and
+common caches. Uploads are capped at 50 MiB compressed and 512 MiB unpacked.
+
+The bare built-in pi path runs locally and requires Node.js 22.19 or newer plus npm on `PATH`. WMH
+installs the pinned pi npm dependencies into its user cache on the first run. Harness code and
 shell commands run with your normal user permissions: file tools are restricted to `--dir`, but
-bash is not OS-sandboxed. The CLI states this boundary before the pi process starts. A logged-out
-bare `wmh run` remains available with local provider environment credentials.
+bash is not OS-sandboxed. The CLI states this boundary before the local pi process starts. A
+logged-out bare `wmh run` remains available with local provider environment credentials.
 
 ## Real agents in E2B sandboxes
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ print(obs.content)
 
 Or over HTTP (same code path), namespaced by model name: `GET /world_models`, then `POST /world_models/{name}/sessions` and `POST /world_models/{name}/sessions/{id}/step`.
 
+## Run locally after platform login
+
+`wmh run` is the single interactive execution command. After `wmh login`, an opaque platform id
+is resolved automatically: a world-model id opens a hosted model session, while an agent id runs
+that agent's champion pi harness as a local Node.js child process. Agent tools act on `--dir` on
+your machine, but worker completions use platform credentials and organization metering, so no
+provider API keys are needed locally.
+
+```bash
+wmh login
+wmh run <world-model-or-agent-id> --task "inspect this repository"
+wmh run --task "fix the failing tests"   # built-in pi harness, also platform-backed when logged in
+```
+
+Local pi execution requires Node.js 22.19 or newer plus npm on `PATH`. WMH installs the pinned pi
+npm dependencies into its user cache on the first run. It does not require E2B. Harness code and
+shell commands run with your normal user permissions: file tools are restricted to `--dir`, but
+bash is not OS-sandboxed. The CLI states this boundary before the pi process starts. A logged-out
+bare `wmh run` remains available with local provider environment credentials.
+
 ## Real agents in E2B sandboxes
 
 Harness evals normally drive a plain in-process agent loop. With `--harness-backend e2b`, a

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ wmh run <world-model-or-agent-id> --task "inspect this repository"
 wmh run --task "fix the failing tests"   # built-in pi harness, also platform-backed when logged in
 ```
 
+For a deployment-protected preview whose public discovery route is not available to a
+non-browser client, pair its browser and backend URLs explicitly:
+
+```bash
+wmh login --url https://preview.example --api-url https://preview-api.example
+```
+
 Local pi execution requires Node.js 22.19 or newer plus npm on `PATH`. WMH installs the pinned pi
 npm dependencies into its user cache on the first run. It does not require E2B. Harness code and
 shell commands run with your normal user permissions: file tools are restricted to `--dir`, but

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -35,7 +35,9 @@ from rich.console import Console
 from rich.panel import Panel
 
 from wmh.cli.workspace_sync import (
+    WorkspaceSnapshot,
     WorkspaceSyncError,
+    apply_workspace_patch,
     snapshot_workspace,
     sync_workspace,
     write_conflict_archive,
@@ -47,6 +49,7 @@ from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import render_tools, resolve_tools
+from wmh.harness.workspace_patch import WorkspacePatchError, build_workspace_patch
 from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmh.platform.credentials import load_credentials
 from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
@@ -67,6 +70,7 @@ _TOOL_OUTPUT_CAP = 16_000
 _BASH_TIMEOUT_S = 300.0
 # Driver housekeeping cadence (event flush).
 _TICK_S = 5.0
+_WORKSPACE_SYNC_TICK_S = 1.0
 # Default local worker when the user pins none.
 _DEFAULT_PROVIDER = "bedrock"
 _DEFAULT_MODEL = "claude-opus-4-8"
@@ -471,9 +475,7 @@ class RemoteAgentCommandReader(threading.Thread):
 
     def _post(self, kind: str, *, text: str | None = None) -> None:
         """Post one command through the authenticated platform client."""
-        self._client.post_agent_session_command(
-            self._agent_id, self._session_id, kind, text=text
-        )
+        self._client.post_agent_session_command(self._agent_id, self._session_id, kind, text=text)
 
 
 class RemoteAgentDriver:
@@ -494,6 +496,7 @@ class RemoteAgentDriver:
         self._jail = jail_root
         self._task = task
         self._interrupts = 0
+        self._live_conflicts: set[str] = set()
 
     def run(self) -> None:
         """Upload, run, stream, download, and conflict-safely sync one E2B session."""
@@ -503,8 +506,8 @@ class RemoteAgentDriver:
             _console.print(
                 f"[dim]uploading {len(initial.files)} files to the platform E2B workspace...[/dim]"
             )
-            session = self._client.create_agent_workspace_session(
-                self._target_id, initial.archive, instruction=self._task
+            session = self._client.create_agent_session(
+                self._target_id, workspace=initial.archive, instruction=self._task
             )
             _console.print(
                 f"[green]E2B session started[/green] for [bold]{self._name}[/bold]. "
@@ -512,12 +515,15 @@ class RemoteAgentDriver:
                 "[bold]:quit[/bold] to end and sync back."
             )
             RemoteAgentCommandReader(self._client, self._target_id, session.id).start()
-            terminal = self._poll(session.id)
+            terminal, synchronized = self._poll(session.id, initial)
             with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
-                final_archive = self._client.download_agent_workspace(
-                    self._target_id, session.id
+                final_archive = self._client.download_agent_workspace(self._target_id, session.id)
+                result = sync_workspace(
+                    self._jail,
+                    synchronized,
+                    final_archive,
+                    protected_paths=frozenset(self._live_conflicts),
                 )
-                result = sync_workspace(self._jail, initial, final_archive)
             if result.conflicts:
                 recovery = write_conflict_archive(self._jail, session.id, final_archive)
                 self._client.acknowledge_agent_workspace(self._target_id, session.id)
@@ -528,22 +534,23 @@ class RemoteAgentDriver:
                 )
                 raise typer.Exit(code=2)
             self._client.acknowledge_agent_workspace(self._target_id, session.id)
-            _console.print(
-                f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
-            )
+            _console.print(f"[green]workspace synced[/green] ({len(result.applied)} changed paths)")
             if terminal.status == "failed":
                 _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
                 raise typer.Exit(code=1)
-        except WorkspaceSyncError as error:
+        except (WorkspacePatchError, WorkspaceSyncError) as error:
             raise typer.BadParameter(str(error)) from error
         except PlatformError as error:
             raise typer.BadParameter(str(error)) from error
         finally:
             self._client.close()
 
-    def _poll(self, session_id: str) -> RemoteAgentSession:
+    def _poll(
+        self, session_id: str, synchronized: WorkspaceSnapshot
+    ) -> tuple[RemoteAgentSession, WorkspaceSnapshot]:
         """Render new transcript events until output export makes the row terminal."""
         cursor = 0
+        last_workspace_push = time.monotonic()
         sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
         while True:
             try:
@@ -551,7 +558,9 @@ class RemoteAgentDriver:
                     self._target_id, session_id, after=cursor
                 )
                 for event in page.events:
-                    if event.kind == "status":
+                    if event.kind == "workspace_patch":
+                        synchronized = self._apply_remote_patch(session_id, event, synchronized)
+                    elif event.kind == "status":
                         detail = event.payload.get("message") or event.payload.get("status")
                         if detail:
                             _console.print(f"[dim]({detail})[/dim]")
@@ -559,7 +568,14 @@ class RemoteAgentDriver:
                         sink(SessionEvent(kind=event.kind, payload=event.payload))
                 cursor = page.last_seq
                 if page.status in {"ended", "failed"}:
-                    return self._client.get_agent_session(self._target_id, session_id)
+                    return (
+                        self._client.get_agent_session(self._target_id, session_id),
+                        synchronized,
+                    )
+                now = time.monotonic()
+                if now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
+                    synchronized = self._push_local_patch(session_id, synchronized)
+                    last_workspace_push = now
                 time.sleep(0.5)
             except KeyboardInterrupt:
                 self._interrupts += 1
@@ -571,6 +587,48 @@ class RemoteAgentDriver:
                 )
                 self._client.post_agent_session_command(self._target_id, session_id, kind)
                 continue
+
+    def _apply_remote_patch(
+        self,
+        session_id: str,
+        event: object,
+        synchronized: WorkspaceSnapshot,
+    ) -> WorkspaceSnapshot:
+        """Download and apply one announced E2B patch, then advance the local base."""
+        payload = getattr(event, "payload", {})
+        revision_value = payload.get("revision") if isinstance(payload, dict) else None
+        if not isinstance(revision_value, int):
+            raise WorkspaceSyncError("workspace patch event has no integer revision")
+        content = self._client.download_agent_workspace_patch(
+            self._target_id, session_id, revision_value
+        )
+        result = apply_workspace_patch(self._jail, content)
+        self._live_conflicts.update(result.conflicts)
+        self._client.acknowledge_agent_workspace_patch(self._target_id, session_id, revision_value)
+        if result.applied:
+            _console.print(f"[dim]workspace updated ({len(result.applied)} changed paths)[/dim]")
+        if result.conflicts:
+            paths = ", ".join(result.conflicts)
+            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
+        return snapshot_workspace(self._jail)
+
+    def _push_local_patch(
+        self, session_id: str, synchronized: WorkspaceSnapshot
+    ) -> WorkspaceSnapshot:
+        """Send local edits made since the last synchronized snapshot."""
+        try:
+            current = snapshot_workspace(self._jail)
+        except WorkspaceSyncError:
+            return synchronized
+        content = build_workspace_patch(synchronized.archive, current.archive)
+        if content is None:
+            return synchronized
+        result = self._client.upload_agent_workspace_patch(self._target_id, session_id, content)
+        self._live_conflicts.update(result.conflicts)
+        if result.conflicts:
+            paths = ", ".join(result.conflicts)
+            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
+        return current
 
 
 class RemoteWorldModelDriver:

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -1,0 +1,569 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""`wmh session start`: run an agent live against the LOCAL working directory.
+
+The agent process (the real vendored pi harness) runs in a cloud E2B sandbox,
+but every tool it calls is answered HERE by the CLI against a jailed local
+directory: read_file / write_file / bash all hit the user's real disk, so the
+agent's view IS the local tree (a bind-mount feel with no file sync). The
+sandbox only hosts the pi runner process.
+
+Three credential modes, chosen automatically (see :func:`register`):
+
+* logged in, default: the worker LLM turn is answered by the platform through a
+  metered proxy (platform keys, billed to the org), and the session is recorded
+  on the platform (create -> append events -> finish) so it shows up in the UI.
+* logged in, ``--local-provider``: the worker runs on the user's own local keys,
+  but the session is still recorded.
+* not logged in (or no agent given): a built-in baseline pi agent runs fully
+  locally on the user's own keys and nothing is recorded.
+
+The agent's bash runs on the user's real machine, so a consent prompt and a hard
+path jail (every read/write resolves under the chosen directory) are mandatory.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated
+
+import typer
+from rich.console import Console
+
+from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.e2b_sandbox import default_sandbox_factory
+from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+from wmh.harness.pi_e2b import start_live_runner
+from wmh.harness.pi_vendor import pi_agent_code_surfaces
+from wmh.harness.skills import SkillLibrary
+from wmh.harness.tools import render_tools, resolve_tools
+from wmh.platform.client import PlatformClient, PlatformError
+from wmh.platform.credentials import load_credentials
+from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
+from wmh.providers.models import resolve_provider_model
+from wmh.providers.registry import get_provider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from llm_waterfall import ChatRequest, ChatResponse
+
+    from wmh.core.types import JsonObject, JsonValue
+    from wmh.harness.e2b_sandbox import SandboxHandle
+
+_console = Console()
+
+# Per-tool-call output cap (head+tail) reported to the transcript.
+_TOOL_OUTPUT_CAP = 16_000
+_BASH_TIMEOUT_S = 300.0
+# How far ahead each keepalive pushes the sandbox timeout while the agent runs.
+_KEEPALIVE_S = 900
+# Short initial ceiling: if the driver dies during boot the sandbox self-expires.
+_STARTUP_TIMEOUT_S = 900
+# Driver housekeeping cadence (event flush + keepalive).
+_TICK_S = 5.0
+# Default local worker when the user pins none.
+_DEFAULT_PROVIDER = "bedrock"
+_DEFAULT_MODEL = "claude-opus-4-8"
+
+
+class _JailEscape(RuntimeError):
+    """A tool path resolved outside the session's working directory."""
+
+
+def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
+    """Cap tool output to the head+tail budget with a truncation marker."""
+    if len(content) <= _TOOL_OUTPUT_CAP:
+        return ToolOutcome(content=content, is_error=is_error)
+    half = _TOOL_OUTPUT_CAP // 2
+    dropped = len(content) - _TOOL_OUTPUT_CAP
+    capped = f"{content[:half]}\n... [{dropped} chars truncated] ...\n{content[-half:]}"
+    return ToolOutcome(content=capped, is_error=is_error, truncated=True)
+
+
+def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str]]:
+    """Derive the LiveSession inputs from a HarnessDoc (mirrors the hosted driver).
+
+    Returns the assembled system prompt (prompt + rendered tools + skills index),
+    the resolved tool specs, the code surfaces as {path: content} (the agent's own
+    code, materialized into the sandbox), and skill bodies answered host-side.
+    """
+    tool_specs = resolve_tools(doc.tools())
+    system = f"{doc.system_prompt()}\n\n## Tools\n{render_tools(tool_specs)}"
+    skills = SkillLibrary(doc.skills())
+    index = skills.render_index()
+    if index:
+        system += f"\n\n## Your skills (read a body with read_skill)\n{index}"
+    files = {surface.path: surface.content for surface in doc.code_files() if surface.path}
+    skill_bodies = {skill.name: skill.body for skill in doc.skills()}
+    return system, tool_specs, files, skill_bodies
+
+
+def _pi_node_baseline() -> HarnessDoc:
+    """A pi-node baseline: the default prompt/tools plus the vendored pi agent code.
+
+    ``HarnessDoc.baseline`` is the in-process loop, which the live E2B runner
+    cannot host (it needs the pi agent's src/agent.ts). This grafts the vendored
+    pi code surfaces on and pins ``param:runtime-kind = pi-node`` so a not-logged-in
+    session has a runnable agent without fetching a champion.
+    """
+    base = HarnessDoc.baseline("local-session")
+    surfaces = [
+        *base.surfaces,
+        *pi_agent_code_surfaces(),
+        Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+    ]
+    return HarnessDoc(name="local-session", surfaces=surfaces)
+
+
+class LocalToolExecutor:
+    """Answer read_file / write_file / bash against a jailed local directory."""
+
+    def __init__(self, jail_root: Path) -> None:
+        """Confine every tool path under ``jail_root`` (its resolved real path)."""
+        self._jail = jail_root.resolve()
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve a tool path under the jail, rejecting any escape."""
+        target = (self._jail / path).resolve()
+        try:
+            target.relative_to(self._jail)
+        except ValueError as error:
+            raise _JailEscape(path) from error
+        return target
+
+    def __call__(
+        self, name: str, args: JsonObject, emit: Callable[[str, str], None]
+    ) -> ToolOutcome:
+        """Execute one tool call locally; a failure is an observation, not a crash."""
+        try:
+            if name == "bash":
+                return self._bash(str(args.get("command", "")), emit)
+            if name == "read_file":
+                target = self._resolve(str(args.get("path", "")))
+                return _capped(target.read_text(encoding="utf-8", errors="replace"))
+            if name == "write_file":
+                path = str(args.get("path", ""))
+                target = self._resolve(path)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(str(args.get("content", "")), encoding="utf-8")
+                return ToolOutcome(content=f"wrote {path}")
+        except _JailEscape as error:
+            return ToolOutcome(
+                content=f"path {error} escapes the session directory", is_error=True
+            )
+        except OSError as error:
+            return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
+        return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+
+    def _bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
+        """Run a fresh ``bash -lc`` in the jail root, streaming output to ``emit``."""
+        try:
+            result = subprocess.run(  # noqa: S603 - the agent's tool is meant to run shell commands
+                ["bash", "-lc", command],  # noqa: S607 - bash on PATH is the documented contract
+                cwd=self._jail,
+                capture_output=True,
+                text=True,
+                timeout=_BASH_TIMEOUT_S,
+                check=False,
+            )
+            stdout, stderr, exit_code = result.stdout, result.stderr, result.returncode
+        except subprocess.TimeoutExpired as error:
+            stdout = _as_text(error.stdout)
+            stderr = _as_text(error.stderr) + f"\n[timed out after {int(_BASH_TIMEOUT_S)}s]"
+            exit_code = 124
+        if stdout:
+            emit("stdout", stdout)
+        if stderr:
+            emit("stderr", stderr)
+        body = stdout + stderr
+        if exit_code != 0:
+            body = f"{body}\n[exit {exit_code}]"
+        return _capped(body, is_error=exit_code != 0)
+
+
+def _as_text(value: object) -> str:
+    """Coerce subprocess stdout/stderr (str | bytes | None) to text."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else ""
+
+
+class SessionRecorder:
+    """Best-effort mirror of the local transcript to the platform (create done already)."""
+
+    def __init__(self, client: PlatformClient, agent_id: str, session_id: str) -> None:
+        """Buffer events for the given already-created platform session."""
+        self._client = client
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._buffer: list[dict[str, JsonValue]] = []
+
+    def record(self, event: SessionEvent) -> None:
+        """Queue one event for the next flush."""
+        self._buffer.append({"kind": event.kind, "payload": event.payload})
+
+    def flush(self) -> None:
+        """Report queued events; drop the batch on a transport error (best-effort)."""
+        if not self._buffer:
+            return
+        batch, self._buffer = self._buffer, []
+        try:
+            self._client.append_local_events(self._agent_id, self._session_id, batch)
+        except PlatformError as error:
+            _console.print(f"[yellow]could not report {len(batch)} events: {error}[/yellow]")
+
+    def finish(self, *, ended_reason: str, sandbox_seconds: int, error: str | None) -> None:
+        """Flush the tail and post the terminal transition."""
+        self.flush()
+        status = "failed" if error is not None else "ended"
+        with contextlib.suppress(PlatformError):
+            self._client.finish_local_session(
+                self._agent_id,
+                self._session_id,
+                status=status,
+                ended_reason=ended_reason,
+                sandbox_seconds=sandbox_seconds,
+                error=error,
+            )
+
+
+class TerminalEventSink:
+    """Render the SessionEvent stream to the terminal and mirror it to a recorder."""
+
+    def __init__(
+        self,
+        *,
+        recorder: SessionRecorder | None,
+        on_running: Callable[[bool], None],
+    ) -> None:
+        """Render to the console; ``on_running`` tracks turn state for keepalive."""
+        self._recorder = recorder
+        self._on_running = on_running
+
+    def __call__(self, event: SessionEvent) -> None:
+        """Render one event and mirror it (never raises: a sink must not stop the loop)."""
+        with contextlib.suppress(Exception):
+            self._render(event)
+        if self._recorder is not None:
+            self._recorder.record(event)
+
+    def _render(self, event: SessionEvent) -> None:
+        payload = event.payload
+        if event.kind == "assistant_message":
+            text = str(payload.get("text", ""))
+            if text:
+                _console.print(f"\n[bold cyan]agent[/bold cyan] {text}")
+        elif event.kind == "tool_call":
+            _console.print(f"[dim]$ {payload.get('name', '')} {payload.get('arguments', '')}[/dim]")
+        elif event.kind == "tool_output":
+            _console.print(str(payload.get("text", "")), end="", markup=False, highlight=False)
+        elif event.kind == "tool_result":
+            if payload.get("is_error"):
+                _console.print(f"[red]{payload.get('content', '')}[/red]")
+        elif event.kind == "submit":
+            _console.print(f"\n[bold green]submitted[/bold green] {payload.get('answer', '')}")
+        elif event.kind == "state":
+            status = str(payload.get("status", ""))
+            self._on_running(status == "running")
+            _console.print(f"[dim]({status})[/dim]")
+        elif event.kind == "error":
+            _console.print(f"[red]error: {payload.get('message', '')}[/red]")
+
+
+class StdinCommandReader(threading.Thread):
+    """Feed typed stdin lines as steer/interrupt/end intents to the session."""
+
+    def __init__(self, session: LiveSession) -> None:
+        """Read stdin on a daemon thread; the session's intents are thread-safe."""
+        super().__init__(daemon=True)
+        self._session = session
+
+    def run(self) -> None:
+        """Map each line to an intent until end-of-input or the session closes."""
+        for raw in sys.stdin:
+            if self._session.closed:
+                return
+            line = raw.strip()
+            if line in {":quit", ":q", ":exit"}:
+                self._session.end()
+                return
+            if line == ":stop":
+                self._session.interrupt()
+            elif line:
+                self._session.send_user_message(line)
+        # EOF (Ctrl-D): end the session gracefully.
+        with contextlib.suppress(Exception):
+            self._session.end()
+
+
+class LocalLiveDriver:
+    """Own one E2B sandbox + LiveSession and drive it against the local directory."""
+
+    def __init__(
+        self,
+        *,
+        jail_root: Path,
+        doc: HarnessDoc,
+        provider: ToolCallingProvider | None,
+        worker_fn: Callable[[ChatRequest], ChatResponse] | None,
+        recorder: SessionRecorder | None,
+        instruction: str | None,
+    ) -> None:
+        """Configure the driver; ``run`` performs boot, loop, and teardown."""
+        self._jail = jail_root
+        self._doc = doc
+        self._provider = provider
+        self._worker_fn = worker_fn
+        self._recorder = recorder
+        self._instruction = instruction
+        self._executor = LocalToolExecutor(jail_root)
+        self._sandbox: SandboxHandle | None = None
+        self._sandbox_started = 0.0
+        self._agent_running = False
+        self._interrupts = 0
+
+    def run(self) -> None:
+        """Boot the sandbox + runner, drive the session, and always tear down."""
+        system, tool_specs, files, skill_bodies = _assemble(self._doc)
+        factory = default_sandbox_factory(
+            timeout=_STARTUP_TIMEOUT_S, metadata={"kind": "wmh-local-session"}
+        )
+        _console.print("[dim]creating sandbox and starting the agent...[/dim]")
+        sandbox = factory()
+        self._sandbox = sandbox
+        self._sandbox_started = time.time()
+        session: LiveSession | None = None
+        reason = "user_ended"
+        error: str | None = None
+        try:
+            channel = start_live_runner(sandbox)
+            session = LiveSession(
+                channel,
+                tools=tool_specs,
+                execute_tool=self._execute,
+                on_event=TerminalEventSink(
+                    recorder=self._recorder, on_running=self._set_running
+                ),
+                files=files,
+                system_prompt=system,
+                skill_bodies=skill_bodies,
+                provider=self._provider,
+                worker_fn=self._worker_fn,
+            )
+            session.start()
+            _console.print(
+                "[green]session ready[/green] - type to steer, [bold]:stop[/bold] to interrupt, "
+                "[bold]:quit[/bold] to end."
+            )
+            if self._instruction:
+                session.send_user_message(self._instruction)
+            StdinCommandReader(session).start()
+            self._loop(session)
+        except Exception as exc:  # noqa: BLE001 - report any driver failure, then tear down
+            error = str(exc)
+            reason = "error"
+            _console.print(f"[red]session failed: {exc}[/red]")
+        finally:
+            self._teardown(session, reason=reason, error=error)
+
+    def _execute(
+        self, name: str, args: JsonObject, emit: Callable[[str, str], None]
+    ) -> ToolOutcome:
+        """Extend the sandbox, then run the tool locally (each tool blocks the pump)."""
+        self._extend_sandbox()
+        return self._executor(name, args, emit)
+
+    def _loop(self, session: LiveSession) -> None:
+        last_tick = 0.0
+        while not session.closed:
+            try:
+                session.pump(timeout=0.5)
+            except KeyboardInterrupt:
+                self._handle_sigint(session)
+            now = time.monotonic()
+            if now - last_tick >= _TICK_S:
+                last_tick = now
+                if self._recorder is not None:
+                    self._recorder.flush()
+                if self._agent_running:
+                    self._extend_sandbox()
+
+    def _handle_sigint(self, session: LiveSession) -> None:
+        """First Ctrl-C interrupts the current turn; a second ends the session."""
+        self._interrupts += 1
+        if self._interrupts == 1:
+            _console.print("\n[yellow]interrupting (press Ctrl-C again to quit)[/yellow]")
+            session.interrupt()
+        else:
+            _console.print("\n[yellow]ending session[/yellow]")
+            session.end()
+
+    def _set_running(self, running: bool) -> None:
+        self._agent_running = running
+
+    def _extend_sandbox(self) -> None:
+        if self._sandbox is not None:
+            with contextlib.suppress(Exception):
+                self._sandbox.set_timeout(_KEEPALIVE_S)
+
+    def _teardown(self, session: LiveSession | None, *, reason: str, error: str | None) -> None:
+        if session is not None and not session.closed:
+            with contextlib.suppress(Exception):
+                session.end()
+        seconds = int(time.time() - self._sandbox_started) if self._sandbox_started else 0
+        if self._recorder is not None:
+            self._recorder.finish(ended_reason=reason, sandbox_seconds=seconds, error=error)
+        if self._sandbox is not None:
+            with contextlib.suppress(Exception):
+                self._sandbox.kill()
+        _console.print(f"[dim]session ended ({reason}), sandbox ran {seconds}s[/dim]")
+
+
+def _local_worker_provider(provider: str | None, model: str | None) -> ToolCallingProvider:
+    """Build a local worker provider from env creds (the --local-provider path)."""
+    try:
+        kind = ProviderKind(provider or _DEFAULT_PROVIDER)
+    except ValueError:
+        kinds = ", ".join(k.value for k in ProviderKind)
+        msg = f"unknown provider {provider!r}; choose one of: {kinds}"
+        raise typer.BadParameter(msg) from None
+    spec = resolve_provider_model(kind, model or _DEFAULT_MODEL)
+    built = get_provider(ProviderConfig(kind=kind, model_type=spec.model_type, model=spec.model_id))
+    if not isinstance(built, ToolCallingProvider):
+        msg = f"provider {kind.value}/{spec.model_id} does not support structured tool calling"
+        raise typer.BadParameter(msg)
+    return built
+
+
+_AGENT_ARG = typer.Argument(
+    help="Platform agent id to run (omit to run the built-in baseline agent locally)."
+)
+_DIR_OPT = typer.Option("--dir", help="Local working directory the agent's tools act on.")
+_LOCAL_PROVIDER_OPT = typer.Option(
+    "--local-provider", help="Answer the worker LLM with your own local keys, not the platform."
+)
+_PROVIDER_OPT = typer.Option(
+    "--provider", help="Local worker provider kind (with --local-provider)."
+)
+_MODEL_OPT = typer.Option("--model", help="Local worker model type (with --local-provider).")
+_INSTRUCTION_OPT = typer.Option("--instruction", help="Opening instruction to send on start.")
+_YES_OPT = typer.Option("--yes", help="Skip the local-execution consent prompt.")
+
+
+def register(app: typer.Typer) -> None:
+    """Register the ``wmh session`` command group on the root app."""
+    session_app = typer.Typer(
+        help="Run an agent live against your local working directory.", no_args_is_help=True
+    )
+
+    @session_app.command("start")
+    def start(  # noqa: PLR0913 - a CLI entrypoint's options are its surface
+        agent: Annotated[str | None, _AGENT_ARG] = None,
+        directory: Annotated[str, _DIR_OPT] = ".",
+        local_provider: Annotated[bool, _LOCAL_PROVIDER_OPT] = False,
+        provider: Annotated[str | None, _PROVIDER_OPT] = None,
+        model: Annotated[str | None, _MODEL_OPT] = None,
+        instruction: Annotated[str | None, _INSTRUCTION_OPT] = None,
+        yes: Annotated[bool, _YES_OPT] = False,
+    ) -> None:
+        """Start an interactive local session (agent in E2B, tools on your disk)."""
+        jail_root = Path(directory).resolve()
+        if not jail_root.is_dir():
+            msg = f"working directory does not exist: {jail_root}"
+            raise typer.BadParameter(msg)
+        _confirm_local_execution(jail_root, agent=agent, yes=yes)
+        driver = _build_driver(
+            agent=agent,
+            jail_root=jail_root,
+            local_provider=local_provider,
+            provider=provider,
+            model=model,
+            instruction=instruction,
+        )
+        driver.run()
+
+    app.add_typer(session_app, name="session")
+
+
+def _confirm_local_execution(jail_root: Path, *, agent: str | None, yes: bool) -> None:
+    """Warn that the agent's bash runs on the real machine; require consent."""
+    target = f"agent {agent}" if agent else "the built-in baseline agent"
+    _console.print(
+        f"[bold yellow]{target} will run shell commands on THIS machine[/bold yellow], "
+        f"confined to:\n  {jail_root}"
+    )
+    if not yes and not typer.confirm("continue?"):
+        raise typer.Exit(code=1)
+
+
+def _build_driver(
+    *,
+    agent: str | None,
+    jail_root: Path,
+    local_provider: bool,
+    provider: str | None,
+    model: str | None,
+    instruction: str | None,
+) -> LocalLiveDriver:
+    """Resolve the credential mode (A/B/C) and assemble the driver."""
+    credentials = load_credentials()
+    logged_in = credentials.is_complete()
+
+    if agent is None:
+        # Built-in baseline, fully local + ephemeral (no recording).
+        if not logged_in:
+            _console.print(
+                "[dim]not logged in: running the built-in baseline agent, no recording[/dim]"
+            )
+        return LocalLiveDriver(
+            jail_root=jail_root,
+            doc=_pi_node_baseline(),
+            provider=_local_worker_provider(provider, model),
+            worker_fn=None,
+            recorder=None,
+            instruction=instruction,
+        )
+
+    if not logged_in:
+        msg = (
+            "run `wmh login` to run a platform agent, or omit the agent id "
+            "to run the built-in baseline agent locally"
+        )
+        raise typer.BadParameter(msg)
+
+    client = PlatformClient(str(credentials.api_url), str(credentials.token))
+    try:
+        champion = client.fetch_champion_harness(agent)
+        doc = HarnessDoc.model_validate(champion.doc)
+        session = client.create_local_session(agent, title=instruction)
+    except PlatformError as error:
+        raise typer.BadParameter(str(error)) from error
+
+    recorder = SessionRecorder(client, agent, session.id)
+    if local_provider:
+        return LocalLiveDriver(
+            jail_root=jail_root,
+            doc=doc,
+            provider=_local_worker_provider(provider, model),
+            worker_fn=None,
+            recorder=recorder,
+            instruction=instruction,
+        )
+
+    def worker_fn(request: ChatRequest) -> ChatResponse:
+        return client.complete_worker(agent, session.id, request)
+
+    return LocalLiveDriver(
+        jail_root=jail_root,
+        doc=doc,
+        provider=None,
+        worker_fn=worker_fn,
+        recorder=recorder,
+        instruction=instruction,
+    )

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -1,25 +1,22 @@
 # Copyright (c) 2026 Experiential Labs. All rights reserved.
 
-"""`wmh session start`: run an agent live against the LOCAL working directory.
+"""Run an agent live against the local working directory.
 
-The agent process (the real vendored pi harness) runs in a cloud E2B sandbox,
-but every tool it calls is answered HERE by the CLI against a jailed local
-directory: read_file / write_file / bash all hit the user's real disk, so the
-agent's view IS the local tree (a bind-mount feel with no file sync). The
-sandbox only hosts the pi runner process.
+The agent process is the real vendored pi harness running as a local Node.js
+child. Every tool it calls is answered by the CLI against a jailed local
+directory: read_file and write_file stay under that directory, while bash
+starts there with the user's normal machine permissions.
 
-Three credential modes, chosen automatically (see :func:`register`):
+The execution mode is chosen automatically (see :func:`register`):
 
-* logged in, default: the worker LLM turn is answered by the platform through a
-  metered proxy (platform keys, billed to the org), and the session is recorded
-  on the platform (create -> append events -> finish) so it shows up in the UI.
-* logged in, ``--local-provider``: the worker runs on the user's own local keys,
-  but the session is still recorded.
-* not logged in (or no agent given): a built-in baseline pi agent runs fully
-  locally on the user's own keys and nothing is recorded.
+* logged in: worker LLM turns use platform credentials and org metering. An
+  agent id also records its transcript; the built-in harness uses an org-level
+  run record.
+* logged out with no target: the built-in baseline pi agent can use the user's
+  local provider credentials.
 
-The agent's bash runs on the user's real machine, so a consent prompt and a hard
-path jail (every read/write resolves under the chosen directory) are mandatory.
+The harness code and bash tool run on the user's real machine, so an explicit
+consent prompt is mandatory. This is local execution, not an OS sandbox.
 """
 
 from __future__ import annotations
@@ -30,15 +27,17 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Protocol
 
 import typer
+from pydantic import ValidationError
 from rich.console import Console
+from rich.panel import Panel
 
+from wmh.engine.play import parse_action
 from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
-from wmh.harness.e2b_sandbox import default_sandbox_factory
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
-from wmh.harness.pi_e2b import start_live_runner
+from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import render_tools, resolve_tools
@@ -54,18 +53,13 @@ if TYPE_CHECKING:
     from llm_waterfall import ChatRequest, ChatResponse
 
     from wmh.core.types import JsonObject, JsonValue
-    from wmh.harness.e2b_sandbox import SandboxHandle
 
 _console = Console()
 
 # Per-tool-call output cap (head+tail) reported to the transcript.
 _TOOL_OUTPUT_CAP = 16_000
 _BASH_TIMEOUT_S = 300.0
-# How far ahead each keepalive pushes the sandbox timeout while the agent runs.
-_KEEPALIVE_S = 900
-# Short initial ceiling: if the driver dies during boot the sandbox self-expires.
-_STARTUP_TIMEOUT_S = 900
-# Driver housekeeping cadence (event flush + keepalive).
+# Driver housekeeping cadence (event flush).
 _TICK_S = 5.0
 # Default local worker when the user pins none.
 _DEFAULT_PROVIDER = "bedrock"
@@ -91,7 +85,7 @@ def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str
 
     Returns the assembled system prompt (prompt + rendered tools + skills index),
     the resolved tool specs, the code surfaces as {path: content} (the agent's own
-    code, materialized into the sandbox), and skill bodies answered host-side.
+    code, materialized into the local runner), and skill bodies answered host-side.
     """
     tool_specs = resolve_tools(doc.tools())
     system = f"{doc.system_prompt()}\n\n## Tools\n{render_tools(tool_specs)}"
@@ -107,7 +101,7 @@ def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str
 def _pi_node_baseline() -> HarnessDoc:
     """A pi-node baseline: the default prompt/tools plus the vendored pi agent code.
 
-    ``HarnessDoc.baseline`` is the in-process loop, which the live E2B runner
+    ``HarnessDoc.baseline`` is the in-process loop, which the live pi runner
     cannot host (it needs the pi agent's src/agent.ts). This grafts the vendored
     pi code surfaces on and pins ``param:runtime-kind = pi-node`` so a not-logged-in
     session has a runnable agent without fetching a champion.
@@ -122,7 +116,7 @@ def _pi_node_baseline() -> HarnessDoc:
 
 
 class LocalToolExecutor:
-    """Answer read_file / write_file / bash against a jailed local directory."""
+    """Jail file tools to one directory and start bash there without OS isolation."""
 
     def __init__(self, jail_root: Path) -> None:
         """Confine every tool path under ``jail_root`` (its resolved real path)."""
@@ -154,9 +148,7 @@ class LocalToolExecutor:
                 target.write_text(str(args.get("content", "")), encoding="utf-8")
                 return ToolOutcome(content=f"wrote {path}")
         except _JailEscape as error:
-            return ToolOutcome(
-                content=f"path {error} escapes the session directory", is_error=True
-            )
+            return ToolOutcome(content=f"path {error} escapes the session directory", is_error=True)
         except OSError as error:
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
         return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
@@ -218,7 +210,7 @@ class SessionRecorder:
         except PlatformError as error:
             _console.print(f"[yellow]could not report {len(batch)} events: {error}[/yellow]")
 
-    def finish(self, *, ended_reason: str, sandbox_seconds: int, error: str | None) -> None:
+    def finish(self, *, ended_reason: str, error: str | None) -> None:
         """Flush the tail and post the terminal transition."""
         self.flush()
         status = "failed" if error is not None else "ended"
@@ -228,9 +220,48 @@ class SessionRecorder:
                 self._session_id,
                 status=status,
                 ended_reason=ended_reason,
-                sandbox_seconds=sandbox_seconds,
                 error=error,
             )
+        self._client.close()
+
+
+class RunRecorder(Protocol):
+    """Recording slice consumed by the local driver and terminal event sink."""
+
+    def record(self, event: SessionEvent) -> None: ...
+
+    def flush(self) -> None: ...
+
+    def finish(self, *, ended_reason: str, error: str | None) -> None: ...
+
+
+class LocalPiRunRecorder:
+    """Finish and close an org-scoped built-in pi run; it has no transcript."""
+
+    def __init__(self, client: PlatformClient, org_id: str, run_id: str) -> None:
+        self._client = client
+        self._org_id = org_id
+        self._run_id = run_id
+
+    def record(self, event: SessionEvent) -> None:
+        """Ignore transcript events; this row exists only for usage accounting."""
+        _ = event
+
+    def flush(self) -> None:
+        """There is no transcript buffer for a built-in run."""
+
+    def finish(self, *, ended_reason: str, error: str | None) -> None:
+        """Report the terminal state and release the HTTP client."""
+        status = "failed" if error is not None else "ended"
+        with contextlib.suppress(PlatformError):
+            self._client.finish_local_pi_run(
+                self._org_id,
+                self._run_id,
+                status=status,
+                ended_reason=ended_reason,
+                error=error,
+            )
+        self._client.close()
 
 
 class TerminalEventSink:
@@ -239,7 +270,7 @@ class TerminalEventSink:
     def __init__(
         self,
         *,
-        recorder: SessionRecorder | None,
+        recorder: RunRecorder | None,
         on_running: Callable[[bool], None],
     ) -> None:
         """Render to the console; ``on_running`` tracks turn state for keepalive."""
@@ -303,7 +334,7 @@ class StdinCommandReader(threading.Thread):
 
 
 class LocalLiveDriver:
-    """Own one E2B sandbox + LiveSession and drive it against the local directory."""
+    """Own one local pi process + LiveSession and drive it against the local directory."""
 
     def __init__(
         self,
@@ -312,7 +343,7 @@ class LocalLiveDriver:
         doc: HarnessDoc,
         provider: ToolCallingProvider | None,
         worker_fn: Callable[[ChatRequest], ChatResponse] | None,
-        recorder: SessionRecorder | None,
+        recorder: RunRecorder | None,
         instruction: str | None,
     ) -> None:
         """Configure the driver; ``run`` performs boot, loop, and teardown."""
@@ -323,32 +354,25 @@ class LocalLiveDriver:
         self._recorder = recorder
         self._instruction = instruction
         self._executor = LocalToolExecutor(jail_root)
-        self._sandbox: SandboxHandle | None = None
-        self._sandbox_started = 0.0
-        self._agent_running = False
+        self._channel: LocalStdioChannel | None = None
         self._interrupts = 0
 
     def run(self) -> None:
-        """Boot the sandbox + runner, drive the session, and always tear down."""
+        """Boot the local runner, drive the session, and always tear down."""
         system, tool_specs, files, skill_bodies = _assemble(self._doc)
-        factory = default_sandbox_factory(
-            timeout=_STARTUP_TIMEOUT_S, metadata={"kind": "wmh-local-session"}
-        )
-        _console.print("[dim]creating sandbox and starting the agent...[/dim]")
-        sandbox = factory()
-        self._sandbox = sandbox
-        self._sandbox_started = time.time()
+        _console.print("[dim]starting the built-in pi harness locally...[/dim]")
         session: LiveSession | None = None
         reason = "user_ended"
         error: str | None = None
         try:
-            channel = start_live_runner(sandbox)
+            channel = start_local_live_runner()
+            self._channel = channel
             session = LiveSession(
                 channel,
                 tools=tool_specs,
                 execute_tool=self._execute,
                 on_event=TerminalEventSink(
-                    recorder=self._recorder, on_running=self._set_running
+                    recorder=self._recorder, on_running=lambda _running: None
                 ),
                 files=files,
                 system_prompt=system,
@@ -375,8 +399,7 @@ class LocalLiveDriver:
     def _execute(
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
     ) -> ToolOutcome:
-        """Extend the sandbox, then run the tool locally (each tool blocks the pump)."""
-        self._extend_sandbox()
+        """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
     def _loop(self, session: LiveSession) -> None:
@@ -391,8 +414,6 @@ class LocalLiveDriver:
                 last_tick = now
                 if self._recorder is not None:
                     self._recorder.flush()
-                if self._agent_running:
-                    self._extend_sandbox()
 
     def _handle_sigint(self, session: LiveSession) -> None:
         """First Ctrl-C interrupts the current turn; a second ends the session."""
@@ -404,29 +425,90 @@ class LocalLiveDriver:
             _console.print("\n[yellow]ending session[/yellow]")
             session.end()
 
-    def _set_running(self, running: bool) -> None:
-        self._agent_running = running
-
-    def _extend_sandbox(self) -> None:
-        if self._sandbox is not None:
-            with contextlib.suppress(Exception):
-                self._sandbox.set_timeout(_KEEPALIVE_S)
-
     def _teardown(self, session: LiveSession | None, *, reason: str, error: str | None) -> None:
         if session is not None and not session.closed:
             with contextlib.suppress(Exception):
                 session.end()
-        seconds = int(time.time() - self._sandbox_started) if self._sandbox_started else 0
         if self._recorder is not None:
-            self._recorder.finish(ended_reason=reason, sandbox_seconds=seconds, error=error)
-        if self._sandbox is not None:
+            self._recorder.finish(ended_reason=reason, error=error)
+        if self._channel is not None:
             with contextlib.suppress(Exception):
-                self._sandbox.kill()
-        _console.print(f"[dim]session ended ({reason}), sandbox ran {seconds}s[/dim]")
+                self._channel.close()
+        _console.print(f"[dim]session ended ({reason})[/dim]")
+
+
+class RemoteWorldModelDriver:
+    """Interactive terminal loop over the platform's world-model session API."""
+
+    def __init__(self, client: PlatformClient, target_id: str, name: str, task: str | None) -> None:
+        """Store the resolved target and opening task."""
+        self._client = client
+        self._target_id = target_id
+        self._name = name
+        self._task = task
+
+    def run(self) -> None:
+        """Create one hosted session and step it until the user exits."""
+        try:
+            session = self._client.create_world_model_session(self._target_id, task=self._task)
+            _console.print(
+                Panel(
+                    'Type an action such as [cyan]search {"q": "SFO"}[/cyan], '
+                    "or a free-text message. Commands: [cyan]:help[/cyan], [cyan]:quit[/cyan].",
+                    title=f"[bold]running world model[/bold] {self._name}",
+                    subtitle=f"task: {self._task}" if self._task else "no task set",
+                    border_style="cyan",
+                )
+            )
+            self._loop(session.id)
+        except PlatformError as error:
+            raise typer.BadParameter(str(error)) from error
+        finally:
+            self._client.close()
+
+    def _loop(self, session_id: str) -> None:
+        """Read actions and render hosted observations."""
+        while True:
+            try:
+                line = _console.input("[bold]agent>[/bold] ").strip()
+            except (EOFError, KeyboardInterrupt):
+                _console.print("\n[dim]bye[/dim]")
+                return
+            if not line:
+                continue
+            if line in {":quit", ":q", ":exit"}:
+                _console.print("[dim]bye[/dim]")
+                return
+            if line in {":help", ":h"}:
+                _console.print(
+                    'Tool call: [cyan]name {"arg": "value"}[/cyan]. '
+                    "Any other text is sent as a message."
+                )
+                continue
+            try:
+                action = parse_action(line)
+            except ValueError as error:
+                _console.print(f"[red]parse error[/red]: {error}")
+                continue
+            try:
+                with _console.status("[dim]world model thinking...[/dim]", spinner="dots"):
+                    observation = self._client.step_world_model_session(session_id, action)
+            except PlatformError as error:
+                _console.print(f"[red]step failed[/red]: {error}")
+                continue
+            style = "red" if observation.is_error else "green"
+            title = "error" if observation.is_error else "observation"
+            _console.print(
+                Panel(
+                    observation.content or "[dim](empty)[/dim]",
+                    title=title,
+                    border_style=style,
+                )
+            )
 
 
 def _local_worker_provider(provider: str | None, model: str | None) -> ToolCallingProvider:
-    """Build a local worker provider from env creds (the --local-provider path)."""
+    """Build the logged-out worker provider from local environment credentials."""
     try:
         kind = ProviderKind(provider or _DEFAULT_PROVIDER)
     except ValueError:
@@ -441,62 +523,54 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
     return built
 
 
-_AGENT_ARG = typer.Argument(
-    help="Platform agent id to run (omit to run the built-in baseline agent locally)."
+_TARGET_ARG = typer.Argument(
+    help="Platform world-model or agent id (omit to run the built-in pi harness locally)."
 )
 _DIR_OPT = typer.Option("--dir", help="Local working directory the agent's tools act on.")
-_LOCAL_PROVIDER_OPT = typer.Option(
-    "--local-provider", help="Answer the worker LLM with your own local keys, not the platform."
-)
 _PROVIDER_OPT = typer.Option(
-    "--provider", help="Local worker provider kind (with --local-provider)."
+    "--provider", help="Worker provider for the built-in local pi harness."
 )
-_MODEL_OPT = typer.Option("--model", help="Local worker model type (with --local-provider).")
-_INSTRUCTION_OPT = typer.Option("--instruction", help="Opening instruction to send on start.")
+_MODEL_OPT = typer.Option("--model", help="Worker model for the built-in local pi harness.")
+_TASK_OPT = typer.Option("--task", "--instruction", help="Opening task for either execution kind.")
 _YES_OPT = typer.Option("--yes", help="Skip the local-execution consent prompt.")
 
 
 def register(app: typer.Typer) -> None:
-    """Register the ``wmh session`` command group on the root app."""
-    session_app = typer.Typer(
-        help="Run an agent live against your local working directory.", no_args_is_help=True
-    )
+    """Register the unified ``wmh run`` command on the root app."""
 
-    @session_app.command("start")
-    def start(  # noqa: PLR0913 - a CLI entrypoint's options are its surface
-        agent: Annotated[str | None, _AGENT_ARG] = None,
+    @app.command("run")
+    def run(
+        target: Annotated[str | None, _TARGET_ARG] = None,
         directory: Annotated[str, _DIR_OPT] = ".",
-        local_provider: Annotated[bool, _LOCAL_PROVIDER_OPT] = False,
         provider: Annotated[str | None, _PROVIDER_OPT] = None,
         model: Annotated[str | None, _MODEL_OPT] = None,
-        instruction: Annotated[str | None, _INSTRUCTION_OPT] = None,
+        task: Annotated[str | None, _TASK_OPT] = None,
         yes: Annotated[bool, _YES_OPT] = False,
     ) -> None:
-        """Start an interactive local session (agent in E2B, tools on your disk)."""
+        """Run a platform world model/agent by id, or the built-in pi harness."""
         jail_root = Path(directory).resolve()
         if not jail_root.is_dir():
             msg = f"working directory does not exist: {jail_root}"
             raise typer.BadParameter(msg)
-        _confirm_local_execution(jail_root, agent=agent, yes=yes)
         driver = _build_driver(
-            agent=agent,
+            target=target,
             jail_root=jail_root,
-            local_provider=local_provider,
             provider=provider,
             model=model,
-            instruction=instruction,
+            task=task,
+            confirm_local=lambda: _confirm_local_execution(jail_root, target=target, yes=yes),
         )
         driver.run()
 
-    app.add_typer(session_app, name="session")
 
-
-def _confirm_local_execution(jail_root: Path, *, agent: str | None, yes: bool) -> None:
-    """Warn that the agent's bash runs on the real machine; require consent."""
-    target = f"agent {agent}" if agent else "the built-in baseline agent"
+def _confirm_local_execution(jail_root: Path, *, target: str | None, yes: bool) -> None:
+    """Warn that harness code and bash run with local user permissions."""
+    label = f"agent {target}" if target else "the built-in pi harness"
     _console.print(
-        f"[bold yellow]{target} will run shell commands on THIS machine[/bold yellow], "
-        f"confined to:\n  {jail_root}"
+        f"[bold yellow]{label}, its harness code, and shell commands run on THIS machine"
+        "[/bold yellow].\n"
+        f"File tools stay under {jail_root}, and bash starts there, but bash is not "
+        "OS-sandboxed and can access anything your user can."
     )
     if not yes and not typer.confirm("continue?"):
         raise typer.Exit(code=1)
@@ -504,60 +578,93 @@ def _confirm_local_execution(jail_root: Path, *, agent: str | None, yes: bool) -
 
 def _build_driver(
     *,
-    agent: str | None,
+    target: str | None,
     jail_root: Path,
-    local_provider: bool,
     provider: str | None,
     model: str | None,
-    instruction: str | None,
-) -> LocalLiveDriver:
-    """Resolve the credential mode (A/B/C) and assemble the driver."""
+    task: str | None,
+    confirm_local: Callable[[], None] | None = None,
+) -> LocalLiveDriver | RemoteWorldModelDriver:
+    """Resolve the target kind once and assemble its execution driver."""
     credentials = load_credentials()
     logged_in = credentials.is_complete()
 
-    if agent is None:
-        # Built-in baseline, fully local + ephemeral (no recording).
-        if not logged_in:
-            _console.print(
-                "[dim]not logged in: running the built-in baseline agent, no recording[/dim]"
-            )
+    if target is None and not logged_in:
+        if confirm_local is not None:
+            confirm_local()
+        _console.print(
+            "[dim]not logged in: running the built-in baseline agent with local credentials[/dim]"
+        )
         return LocalLiveDriver(
             jail_root=jail_root,
             doc=_pi_node_baseline(),
             provider=_local_worker_provider(provider, model),
             worker_fn=None,
             recorder=None,
-            instruction=instruction,
+            instruction=task,
+        )
+
+    if target is None:
+        if provider is not None or model is not None:
+            raise typer.BadParameter(
+                "logged-in runs use platform credentials; omit --provider/--model, "
+                "or run `wmh logout` to use local credentials"
+            )
+        if confirm_local is not None:
+            confirm_local()
+        client = PlatformClient(str(credentials.api_url), str(credentials.token))
+        try:
+            org_id = _default_org(client, credentials.default_org)
+            run = client.create_local_pi_run(org_id)
+        except typer.BadParameter:
+            client.close()
+            raise
+        except PlatformError as error:
+            client.close()
+            raise typer.BadParameter(str(error)) from error
+        recorder = LocalPiRunRecorder(client, org_id, run.id)
+
+        def built_in_worker(request: ChatRequest) -> ChatResponse:
+            return client.complete_local_pi_worker(org_id, run.id, request)
+
+        return LocalLiveDriver(
+            jail_root=jail_root,
+            doc=_pi_node_baseline(),
+            provider=None,
+            worker_fn=built_in_worker,
+            recorder=recorder,
+            instruction=task,
         )
 
     if not logged_in:
-        msg = (
-            "run `wmh login` to run a platform agent, or omit the agent id "
-            "to run the built-in baseline agent locally"
-        )
+        msg = "run `wmh login` to run a platform id, or omit the id to run the built-in pi harness"
         raise typer.BadParameter(msg)
 
+    if provider is not None or model is not None:
+        raise typer.BadParameter(
+            "platform target runs use platform credentials; --provider/--model are not accepted"
+        )
     client = PlatformClient(str(credentials.api_url), str(credentials.token))
     try:
-        champion = client.fetch_champion_harness(agent)
+        resolved = client.resolve_run_target(target)
+        if resolved.kind == "world_model":
+            return RemoteWorldModelDriver(client, resolved.id, resolved.name, task)
+        if confirm_local is not None:
+            try:
+                confirm_local()
+            except BaseException:
+                client.close()
+                raise
+        champion = client.fetch_champion_harness(resolved.id)
         doc = HarnessDoc.model_validate(champion.doc)
-        session = client.create_local_session(agent, title=instruction)
-    except PlatformError as error:
+        session = client.create_local_session(resolved.id, title=task)
+    except (PlatformError, ValidationError) as error:
+        client.close()
         raise typer.BadParameter(str(error)) from error
-
-    recorder = SessionRecorder(client, agent, session.id)
-    if local_provider:
-        return LocalLiveDriver(
-            jail_root=jail_root,
-            doc=doc,
-            provider=_local_worker_provider(provider, model),
-            worker_fn=None,
-            recorder=recorder,
-            instruction=instruction,
-        )
+    recorder = SessionRecorder(client, resolved.id, session.id)
 
     def worker_fn(request: ChatRequest) -> ChatResponse:
-        return client.complete_worker(agent, session.id, request)
+        return client.complete_worker(resolved.id, session.id, request)
 
     return LocalLiveDriver(
         jail_root=jail_root,
@@ -565,5 +672,17 @@ def _build_driver(
         provider=None,
         worker_fn=worker_fn,
         recorder=recorder,
-        instruction=instruction,
+        instruction=task,
+    )
+
+
+def _default_org(client: PlatformClient, configured: str | None) -> str:
+    """Resolve the login's organization, auto-picking only an unambiguous sole org."""
+    if configured is not None:
+        return configured
+    identity = client.whoami()
+    if len(identity.orgs) == 1:
+        return identity.orgs[0].id
+    raise typer.BadParameter(
+        "no default organization selected; run `wmh login` again and choose an organization"
     )

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 
     from llm_waterfall import ChatRequest, ChatResponse
 
-    from wmh.core.types import JsonObject, JsonValue
+    from wmh.core.types import JsonObject
 
 _console = Console()
 
@@ -195,45 +195,6 @@ def _as_text(value: object) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value if isinstance(value, str) else ""
-
-
-class SessionRecorder:
-    """Best-effort mirror of the local transcript to the platform (create done already)."""
-
-    def __init__(self, client: PlatformClient, agent_id: str, session_id: str) -> None:
-        """Buffer events for the given already-created platform session."""
-        self._client = client
-        self._agent_id = agent_id
-        self._session_id = session_id
-        self._buffer: list[dict[str, JsonValue]] = []
-
-    def record(self, event: SessionEvent) -> None:
-        """Queue one event for the next flush."""
-        self._buffer.append({"kind": event.kind, "payload": event.payload})
-
-    def flush(self) -> None:
-        """Report queued events; drop the batch on a transport error (best-effort)."""
-        if not self._buffer:
-            return
-        batch, self._buffer = self._buffer, []
-        try:
-            self._client.append_local_events(self._agent_id, self._session_id, batch)
-        except PlatformError as error:
-            _console.print(f"[yellow]could not report {len(batch)} events: {error}[/yellow]")
-
-    def finish(self, *, ended_reason: str, error: str | None) -> None:
-        """Flush the tail and post the terminal transition."""
-        self.flush()
-        status = "failed" if error is not None else "ended"
-        with contextlib.suppress(PlatformError):
-            self._client.finish_local_session(
-                self._agent_id,
-                self._session_id,
-                status=status,
-                ended_reason=ended_reason,
-                error=error,
-            )
-        self._client.close()
 
 
 class RunRecorder(Protocol):
@@ -590,10 +551,7 @@ class RemoteAgentDriver:
                         synchronized,
                     )
                 now = time.monotonic()
-                if (
-                    synchronized is not None
-                    and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S
-                ):
+                if synchronized is not None and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
                     synchronized = self._push_local_patch(session_id, synchronized)
                     last_workspace_push = now
                 time.sleep(0.5)
@@ -746,9 +704,7 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
 _TARGET_ARG = typer.Argument(
     help="Platform world-model or agent id (omit to run the built-in pi harness locally)."
 )
-_DIR_OPT = typer.Option(
-    "--dir", help="Working directory for the built-in local pi harness."
-)
+_DIR_OPT = typer.Option("--dir", help="Working directory for the built-in local pi harness.")
 _UPLOAD_DIR_OPT = typer.Option(
     "-u", "--upload-dir", help="Directory to upload and live-sync for a hosted agent."
 )

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -597,8 +597,8 @@ class RemoteAgentDriver:
         """Download and apply one announced E2B patch, then advance the local base."""
         payload = getattr(event, "payload", {})
         revision_value = payload.get("revision") if isinstance(payload, dict) else None
-        if not isinstance(revision_value, int):
-            raise WorkspaceSyncError("workspace patch event has no integer revision")
+        if not isinstance(revision_value, str) or not revision_value:
+            raise WorkspaceSyncError("workspace patch event has no revision")
         content = self._client.download_agent_workspace_patch(
             self._target_id, session_id, revision_value
         )

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -286,6 +286,7 @@ class StdinCommandReader(threading.Thread):
         """Read stdin on a daemon thread; the session's intents are thread-safe."""
         super().__init__(daemon=True)
         self._session = session
+        self.eof = threading.Event()
 
     def run(self) -> None:
         """Map each line to an intent until end-of-input or the session closes."""
@@ -300,9 +301,9 @@ class StdinCommandReader(threading.Thread):
                 self._session.interrupt()
             elif line:
                 self._session.send_user_message(line)
-        # EOF (Ctrl-D): end the session gracefully.
-        with contextlib.suppress(Exception):
-            self._session.end()
+        # The driver owns EOF handling. For a one-shot ``--task`` it must wait
+        # until the opening turn returns to idle before ending the session.
+        self.eof.set()
 
 
 class LocalLiveDriver:
@@ -359,14 +360,22 @@ class LocalLiveDriver:
             )
             if self._instruction:
                 session.send_user_message(self._instruction)
-            StdinCommandReader(session).start()
-            self._loop(session)
+            reader = StdinCommandReader(session)
+            reader.start()
+            stdin_eof = getattr(reader, "eof", threading.Event())
+            self._loop(session, stdin_eof)
+            if session.status == "failed":
+                error = "local live session runner failed"
+                reason = "error"
+                _console.print(f"[red]session failed: {error}[/red]")
         except Exception as exc:  # noqa: BLE001 - report any driver failure, then tear down
             error = str(exc)
             reason = "error"
             _console.print(f"[red]session failed: {exc}[/red]")
         finally:
             self._teardown(session, reason=reason, error=error)
+        if error is not None:
+            raise typer.Exit(code=1)
 
     def _execute(
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
@@ -374,13 +383,24 @@ class LocalLiveDriver:
         """Run one tool locally (each tool blocks the session pump)."""
         return self._executor(name, args, emit)
 
-    def _loop(self, session: LiveSession) -> None:
+    def _loop(self, session: LiveSession, stdin_eof: threading.Event) -> None:
+        """Pump until closed, treating closed stdin as one-shot after ``--task``."""
         last_tick = 0.0
+        saw_running = False
+        end_sent = False
         while not session.closed:
             try:
                 session.pump(timeout=0.5)
             except KeyboardInterrupt:
                 self._handle_sigint(session)
+            saw_running = saw_running or session.status == "running"
+            if (
+                stdin_eof.is_set()
+                and not end_sent
+                and (self._instruction is None or (saw_running and session.status == "idle"))
+            ):
+                session.end()
+                end_sent = True
             now = time.monotonic()
             if now - last_tick >= _TICK_S:
                 last_tick = now
@@ -418,6 +438,7 @@ class RemoteAgentCommandReader(threading.Thread):
         self._client = client
         self._agent_id = agent_id
         self._session_id = session_id
+        self.eof = threading.Event()
 
     def run(self) -> None:
         """Map stdin lines to hosted steer, interrupt, and end commands."""
@@ -431,9 +452,10 @@ class RemoteAgentCommandReader(threading.Thread):
                     self._post("interrupt")
                 elif line:
                     self._post("user_message", text=line)
-            self._post("end")
         except (OSError, PlatformError):
-            return
+            pass
+        finally:
+            self.eof.set()
 
     def _post(self, kind: str, *, text: str | None = None) -> None:
         """Post one command through the authenticated platform client."""
@@ -482,9 +504,12 @@ class RemoteAgentDriver:
                 "Type to steer, [bold]:stop[/bold] to interrupt, "
                 f"[bold]:quit[/bold] to {quit_detail}."
             )
-            RemoteAgentCommandReader(self._client, self._target_id, session.id).start()
-            terminal, synchronized = self._poll(session.id, initial)
+            reader = RemoteAgentCommandReader(self._client, self._target_id, session.id)
+            reader.start()
+            stdin_eof = getattr(reader, "eof", threading.Event())
+            terminal, synchronized = self._poll(session.id, initial, stdin_eof)
             jail_root = self._jail
+            workspace_conflicts = False
             if jail_root is not None and synchronized is not None:
                 with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
                     final_archive = self._client.download_agent_workspace(
@@ -497,6 +522,7 @@ class RemoteAgentDriver:
                         protected_paths=frozenset(self._live_conflicts),
                     )
                 if result.conflicts:
+                    workspace_conflicts = True
                     recovery = write_conflict_archive(jail_root, session.id, final_archive)
                     self._client.acknowledge_agent_workspace(self._target_id, session.id)
                     paths = ", ".join(result.conflicts)
@@ -504,14 +530,16 @@ class RemoteAgentDriver:
                         f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
                         f"The full E2B result is saved at [bold]{recovery}[/bold]."
                     )
-                    raise typer.Exit(code=2)
-                self._client.acknowledge_agent_workspace(self._target_id, session.id)
-                _console.print(
-                    f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
-                )
+                else:
+                    self._client.acknowledge_agent_workspace(self._target_id, session.id)
+                    _console.print(
+                        f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
+                    )
             if terminal.status == "failed":
                 _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
                 raise typer.Exit(code=1)
+            if workspace_conflicts:
+                raise typer.Exit(code=2)
         except (WorkspacePatchError, WorkspaceSyncError) as error:
             raise typer.BadParameter(str(error)) from error
         except PlatformError as error:
@@ -520,12 +548,17 @@ class RemoteAgentDriver:
             self._client.close()
 
     def _poll(
-        self, session_id: str, synchronized: WorkspaceSnapshot | None
+        self,
+        session_id: str,
+        synchronized: WorkspaceSnapshot | None,
+        stdin_eof: threading.Event,
     ) -> tuple[RemoteAgentSession, WorkspaceSnapshot | None]:
         """Render new transcript events until output export makes the row terminal."""
         cursor = 0
         last_workspace_push = time.monotonic()
         sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
+        saw_running = False
+        end_sent = False
         while True:
             try:
                 page = self._client.list_agent_session_events(
@@ -544,6 +577,19 @@ class RemoteAgentDriver:
                             _console.print(f"[dim]({detail})[/dim]")
                     else:
                         sink(SessionEvent(kind=event.kind, payload=event.payload))
+                        if event.kind == "state":
+                            state = event.payload.get("status")
+                            saw_running = saw_running or state == "running"
+                            if (
+                                stdin_eof.is_set()
+                                and not end_sent
+                                and saw_running
+                                and state == "idle"
+                            ):
+                                self._client.post_agent_session_command(
+                                    self._target_id, session_id, "end"
+                                )
+                                end_sent = True
                 cursor = page.last_seq
                 if page.status in {"ended", "failed"}:
                     return (
@@ -551,6 +597,9 @@ class RemoteAgentDriver:
                         synchronized,
                     )
                 now = time.monotonic()
+                if stdin_eof.is_set() and self._task is None and not end_sent:
+                    self._client.post_agent_session_command(self._target_id, session_id, "end")
+                    end_sent = True
                 if synchronized is not None and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
                     synchronized = self._push_local_patch(session_id, synchronized)
                     last_workspace_push = now
@@ -612,7 +661,10 @@ class RemoteAgentDriver:
         if result.conflicts:
             paths = ", ".join(result.conflicts)
             _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
-        return current
+        # A conflicted path was rejected by E2B, so ``current`` cannot become
+        # the synchronized base. Keep the prior base and conservatively retry
+        # accepted sibling paths until the conflict is reconciled at teardown.
+        return synchronized if result.conflicts else current
 
 
 class RemoteWorldModelDriver:

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -2,10 +2,11 @@
 
 """Run a platform target or the built-in pi harness from one CLI command.
 
-Agent IDs run the champion pi harness in the platform's E2B sandbox. The CLI
-uploads a bounded snapshot of ``--dir``, streams the hosted transcript, then
-automatically reconciles the final sandbox workspace into that directory.
-Bare runs still launch the built-in vendored pi harness as a local Node child.
+Agent IDs run the champion pi harness in the platform's E2B sandbox. By
+default no local files are sent. ``-u PATH`` opts into uploading a bounded
+snapshot, live-syncing changes, and reconciling the final sandbox workspace
+into that directory. Bare runs still launch the built-in vendored pi harness
+as a local Node child.
 
 The execution mode is chosen automatically (see :func:`register`):
 
@@ -479,17 +480,17 @@ class RemoteAgentCommandReader(threading.Thread):
 
 
 class RemoteAgentDriver:
-    """Stream a hosted E2B agent and reconcile its final workspace locally."""
+    """Stream a hosted E2B agent, optionally syncing one local workspace."""
 
     def __init__(
         self,
         client: PlatformClient,
         target_id: str,
         name: str,
-        jail_root: Path,
+        jail_root: Path | None,
         task: str | None,
     ) -> None:
-        """Store the resolved agent and local workspace transport root."""
+        """Store the resolved agent and optional local workspace transport root."""
         self._client = client
         self._target_id = target_id
         self._name = name
@@ -499,42 +500,54 @@ class RemoteAgentDriver:
         self._live_conflicts: set[str] = set()
 
     def run(self) -> None:
-        """Upload, run, stream, download, and conflict-safely sync one E2B session."""
+        """Run and stream one E2B session, syncing local files only when requested."""
         try:
-            with _console.status("[dim]snapshotting local workspace...[/dim]", spinner="dots"):
-                initial = snapshot_workspace(self._jail)
-            _console.print(
-                f"[dim]uploading {len(initial.files)} files to the platform E2B workspace...[/dim]"
-            )
+            initial: WorkspaceSnapshot | None = None
+            if self._jail is not None:
+                with _console.status("[dim]snapshotting local workspace...[/dim]", spinner="dots"):
+                    initial = snapshot_workspace(self._jail)
+                _console.print(
+                    f"[dim]uploading {len(initial.files)} files to the platform "
+                    "E2B workspace...[/dim]"
+                )
             session = self._client.create_agent_session(
-                self._target_id, workspace=initial.archive, instruction=self._task
+                self._target_id,
+                workspace=initial.archive if initial is not None else None,
+                instruction=self._task,
             )
+            quit_detail = "end and sync back" if initial is not None else "end"
             _console.print(
                 f"[green]E2B session started[/green] for [bold]{self._name}[/bold]. "
                 "Type to steer, [bold]:stop[/bold] to interrupt, "
-                "[bold]:quit[/bold] to end and sync back."
+                f"[bold]:quit[/bold] to {quit_detail}."
             )
             RemoteAgentCommandReader(self._client, self._target_id, session.id).start()
             terminal, synchronized = self._poll(session.id, initial)
-            with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
-                final_archive = self._client.download_agent_workspace(self._target_id, session.id)
-                result = sync_workspace(
-                    self._jail,
-                    synchronized,
-                    final_archive,
-                    protected_paths=frozenset(self._live_conflicts),
-                )
-            if result.conflicts:
-                recovery = write_conflict_archive(self._jail, session.id, final_archive)
+            jail_root = self._jail
+            if jail_root is not None and synchronized is not None:
+                with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
+                    final_archive = self._client.download_agent_workspace(
+                        self._target_id, session.id
+                    )
+                    result = sync_workspace(
+                        jail_root,
+                        synchronized,
+                        final_archive,
+                        protected_paths=frozenset(self._live_conflicts),
+                    )
+                if result.conflicts:
+                    recovery = write_conflict_archive(jail_root, session.id, final_archive)
+                    self._client.acknowledge_agent_workspace(self._target_id, session.id)
+                    paths = ", ".join(result.conflicts)
+                    _console.print(
+                        f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
+                        f"The full E2B result is saved at [bold]{recovery}[/bold]."
+                    )
+                    raise typer.Exit(code=2)
                 self._client.acknowledge_agent_workspace(self._target_id, session.id)
-                paths = ", ".join(result.conflicts)
                 _console.print(
-                    f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
-                    f"The full E2B result is saved at [bold]{recovery}[/bold]."
+                    f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
                 )
-                raise typer.Exit(code=2)
-            self._client.acknowledge_agent_workspace(self._target_id, session.id)
-            _console.print(f"[green]workspace synced[/green] ({len(result.applied)} changed paths)")
             if terminal.status == "failed":
                 _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
                 raise typer.Exit(code=1)
@@ -546,8 +559,8 @@ class RemoteAgentDriver:
             self._client.close()
 
     def _poll(
-        self, session_id: str, synchronized: WorkspaceSnapshot
-    ) -> tuple[RemoteAgentSession, WorkspaceSnapshot]:
+        self, session_id: str, synchronized: WorkspaceSnapshot | None
+    ) -> tuple[RemoteAgentSession, WorkspaceSnapshot | None]:
         """Render new transcript events until output export makes the row terminal."""
         cursor = 0
         last_workspace_push = time.monotonic()
@@ -559,6 +572,10 @@ class RemoteAgentDriver:
                 )
                 for event in page.events:
                     if event.kind == "workspace_patch":
+                        if synchronized is None:
+                            raise WorkspaceSyncError(
+                                "received a workspace patch without --upload-dir"
+                            )
                         synchronized = self._apply_remote_patch(session_id, event, synchronized)
                     elif event.kind == "status":
                         detail = event.payload.get("message") or event.payload.get("status")
@@ -573,7 +590,10 @@ class RemoteAgentDriver:
                         synchronized,
                     )
                 now = time.monotonic()
-                if now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
+                if (
+                    synchronized is not None
+                    and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S
+                ):
                     synchronized = self._push_local_patch(session_id, synchronized)
                     last_workspace_push = now
                 time.sleep(0.5)
@@ -595,6 +615,9 @@ class RemoteAgentDriver:
         synchronized: WorkspaceSnapshot,
     ) -> WorkspaceSnapshot:
         """Download and apply one announced E2B patch, then advance the local base."""
+        jail_root = self._jail
+        if jail_root is None:
+            raise WorkspaceSyncError("workspace sync is not enabled")
         payload = getattr(event, "payload", {})
         revision_value = payload.get("revision") if isinstance(payload, dict) else None
         if not isinstance(revision_value, str) or not revision_value:
@@ -602,7 +625,7 @@ class RemoteAgentDriver:
         content = self._client.download_agent_workspace_patch(
             self._target_id, session_id, revision_value
         )
-        result = apply_workspace_patch(self._jail, content)
+        result = apply_workspace_patch(jail_root, content)
         self._live_conflicts.update(result.conflicts)
         self._client.acknowledge_agent_workspace_patch(self._target_id, session_id, revision_value)
         if result.applied:
@@ -610,14 +633,17 @@ class RemoteAgentDriver:
         if result.conflicts:
             paths = ", ".join(result.conflicts)
             _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
-        return snapshot_workspace(self._jail)
+        return snapshot_workspace(jail_root)
 
     def _push_local_patch(
         self, session_id: str, synchronized: WorkspaceSnapshot
     ) -> WorkspaceSnapshot:
         """Send local edits made since the last synchronized snapshot."""
+        jail_root = self._jail
+        if jail_root is None:
+            return synchronized
         try:
-            current = snapshot_workspace(self._jail)
+            current = snapshot_workspace(jail_root)
         except WorkspaceSyncError:
             return synchronized
         content = build_workspace_patch(synchronized.archive, current.archive)
@@ -721,7 +747,10 @@ _TARGET_ARG = typer.Argument(
     help="Platform world-model or agent id (omit to run the built-in pi harness locally)."
 )
 _DIR_OPT = typer.Option(
-    "--dir", help="Working directory to upload/sync for an agent, or use for a bare local run."
+    "--dir", help="Working directory for the built-in local pi harness."
+)
+_UPLOAD_DIR_OPT = typer.Option(
+    "-u", "--upload-dir", help="Directory to upload and live-sync for a hosted agent."
 )
 _PROVIDER_OPT = typer.Option(
     "--provider", help="Worker provider for the built-in local pi harness."
@@ -737,24 +766,44 @@ def register(app: typer.Typer) -> None:
     @app.command("run")
     def run(
         target: Annotated[str | None, _TARGET_ARG] = None,
-        directory: Annotated[str, _DIR_OPT] = ".",
+        directory: Annotated[str | None, _DIR_OPT] = None,
+        upload_directory: Annotated[str | None, _UPLOAD_DIR_OPT] = None,
         provider: Annotated[str | None, _PROVIDER_OPT] = None,
         model: Annotated[str | None, _MODEL_OPT] = None,
         task: Annotated[str | None, _TASK_OPT] = None,
         yes: Annotated[bool, _YES_OPT] = False,
     ) -> None:
         """Run a platform world model/agent by id, or the built-in pi harness."""
-        jail_root = Path(directory).resolve()
-        if not jail_root.is_dir():
+        if target is None and upload_directory is not None:
+            raise typer.BadParameter("--upload-dir is only supported for platform agent ids")
+        if target is not None and directory is not None:
+            raise typer.BadParameter(
+                "--dir is only supported for a bare `wmh run`; use --upload-dir for an agent"
+            )
+        if target is None:
+            path = directory or "."
+        else:
+            path = upload_directory
+        jail_root = Path(path).resolve() if path is not None else None
+        if jail_root is not None and not jail_root.is_dir():
             msg = f"working directory does not exist: {jail_root}"
             raise typer.BadParameter(msg)
+        confirm_local: Callable[[], None] | None = None
+        if target is None and jail_root is not None:
+            local_root = jail_root
+
+            def confirm_execution() -> None:
+                """Confirm the bare harness's local execution boundary."""
+                _confirm_local_execution(local_root, target=target, yes=yes)
+
+            confirm_local = confirm_execution
         driver = _build_driver(
             target=target,
             jail_root=jail_root,
             provider=provider,
             model=model,
             task=task,
-            confirm_local=lambda: _confirm_local_execution(jail_root, target=target, yes=yes),
+            confirm_local=confirm_local,
         )
         driver.run()
 
@@ -775,7 +824,7 @@ def _confirm_local_execution(jail_root: Path, *, target: str | None, yes: bool) 
 def _build_driver(
     *,
     target: str | None,
-    jail_root: Path,
+    jail_root: Path | None,
     provider: str | None,
     model: str | None,
     task: str | None,
@@ -785,22 +834,24 @@ def _build_driver(
     credentials = load_credentials()
     logged_in = credentials.is_complete()
 
-    if target is None and not logged_in:
-        if confirm_local is not None:
-            confirm_local()
-        _console.print(
-            "[dim]not logged in: running the built-in baseline agent with local credentials[/dim]"
-        )
-        return LocalLiveDriver(
-            jail_root=jail_root,
-            doc=_pi_node_baseline(),
-            provider=_local_worker_provider(provider, model),
-            worker_fn=None,
-            recorder=None,
-            instruction=task,
-        )
-
     if target is None:
+        if jail_root is None:
+            raise typer.BadParameter("a working directory is required for the built-in pi harness")
+        if not logged_in:
+            if confirm_local is not None:
+                confirm_local()
+            _console.print(
+                "[dim]not logged in: running the built-in baseline agent with local "
+                "credentials[/dim]"
+            )
+            return LocalLiveDriver(
+                jail_root=jail_root,
+                doc=_pi_node_baseline(),
+                provider=_local_worker_provider(provider, model),
+                worker_fn=None,
+                recorder=None,
+                instruction=task,
+            )
         if provider is not None or model is not None:
             raise typer.BadParameter(
                 "logged-in runs use platform credentials; omit --provider/--model, "
@@ -844,6 +895,9 @@ def _build_driver(
     try:
         resolved = client.resolve_run_target(target)
         if resolved.kind == "world_model":
+            if jail_root is not None:
+                client.close()
+                raise typer.BadParameter("--upload-dir is only supported for agent ids")
             return RemoteWorldModelDriver(client, resolved.id, resolved.name, task)
         return RemoteAgentDriver(client, resolved.id, resolved.name, jail_root, task)
     except PlatformError as error:

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -1,22 +1,23 @@
 # Copyright (c) 2026 Experiential Labs. All rights reserved.
 
-"""Run an agent live against the local working directory.
+"""Run a platform target or the built-in pi harness from one CLI command.
 
-The agent process is the real vendored pi harness running as a local Node.js
-child. Every tool it calls is answered by the CLI against a jailed local
-directory: read_file and write_file stay under that directory, while bash
-starts there with the user's normal machine permissions.
+Agent IDs run the champion pi harness in the platform's E2B sandbox. The CLI
+uploads a bounded snapshot of ``--dir``, streams the hosted transcript, then
+automatically reconciles the final sandbox workspace into that directory.
+Bare runs still launch the built-in vendored pi harness as a local Node child.
 
 The execution mode is chosen automatically (see :func:`register`):
 
-* logged in: worker LLM turns use platform credentials and org metering. An
-  agent id also records its transcript; the built-in harness uses an org-level
-  run record.
+* logged in + agent id: the platform owns E2B, provider credentials, metering,
+  and the transcript; the CLI owns only workspace transport and terminal I/O.
+* logged in + no id: the built-in harness runs locally with a platform-proxied
+  worker and org-level usage record.
 * logged out with no target: the built-in baseline pi agent can use the user's
   local provider credentials.
 
-The harness code and bash tool run on the user's real machine, so an explicit
-consent prompt is mandatory. This is local execution, not an OS sandbox.
+Only the bare built-in path executes harness code and bash on the user's real
+machine, so that path retains the explicit local-execution consent prompt.
 """
 
 from __future__ import annotations
@@ -30,10 +31,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Protocol
 
 import typer
-from pydantic import ValidationError
 from rich.console import Console
 from rich.panel import Panel
 
+from wmh.cli.workspace_sync import (
+    WorkspaceSyncError,
+    snapshot_workspace,
+    sync_workspace,
+    write_conflict_archive,
+)
 from wmh.engine.play import parse_action
 from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
@@ -41,7 +47,7 @@ from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import render_tools, resolve_tools
-from wmh.platform.client import PlatformClient, PlatformError
+from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmh.platform.credentials import load_credentials
 from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
 from wmh.providers.models import resolve_provider_model
@@ -437,6 +443,136 @@ class LocalLiveDriver:
         _console.print(f"[dim]session ended ({reason})[/dim]")
 
 
+class RemoteAgentCommandReader(threading.Thread):
+    """Forward terminal lines to a platform-owned E2B agent session."""
+
+    def __init__(self, client: PlatformClient, agent_id: str, session_id: str) -> None:
+        """Store the hosted command-channel identity."""
+        super().__init__(daemon=True)
+        self._client = client
+        self._agent_id = agent_id
+        self._session_id = session_id
+
+    def run(self) -> None:
+        """Map stdin lines to hosted steer, interrupt, and end commands."""
+        try:
+            for raw in sys.stdin:
+                line = raw.strip()
+                if line in {":quit", ":q", ":exit"}:
+                    self._post("end")
+                    return
+                if line == ":stop":
+                    self._post("interrupt")
+                elif line:
+                    self._post("user_message", text=line)
+            self._post("end")
+        except (OSError, PlatformError):
+            return
+
+    def _post(self, kind: str, *, text: str | None = None) -> None:
+        """Post one command through the authenticated platform client."""
+        self._client.post_agent_session_command(
+            self._agent_id, self._session_id, kind, text=text
+        )
+
+
+class RemoteAgentDriver:
+    """Stream a hosted E2B agent and reconcile its final workspace locally."""
+
+    def __init__(
+        self,
+        client: PlatformClient,
+        target_id: str,
+        name: str,
+        jail_root: Path,
+        task: str | None,
+    ) -> None:
+        """Store the resolved agent and local workspace transport root."""
+        self._client = client
+        self._target_id = target_id
+        self._name = name
+        self._jail = jail_root
+        self._task = task
+        self._interrupts = 0
+
+    def run(self) -> None:
+        """Upload, run, stream, download, and conflict-safely sync one E2B session."""
+        try:
+            with _console.status("[dim]snapshotting local workspace...[/dim]", spinner="dots"):
+                initial = snapshot_workspace(self._jail)
+            _console.print(
+                f"[dim]uploading {len(initial.files)} files to the platform E2B workspace...[/dim]"
+            )
+            session = self._client.create_agent_workspace_session(
+                self._target_id, initial.archive, instruction=self._task
+            )
+            _console.print(
+                f"[green]E2B session started[/green] for [bold]{self._name}[/bold]. "
+                "Type to steer, [bold]:stop[/bold] to interrupt, "
+                "[bold]:quit[/bold] to end and sync back."
+            )
+            RemoteAgentCommandReader(self._client, self._target_id, session.id).start()
+            terminal = self._poll(session.id)
+            with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
+                final_archive = self._client.download_agent_workspace(
+                    self._target_id, session.id
+                )
+                result = sync_workspace(self._jail, initial, final_archive)
+            if result.conflicts:
+                recovery = write_conflict_archive(self._jail, session.id, final_archive)
+                self._client.acknowledge_agent_workspace(self._target_id, session.id)
+                paths = ", ".join(result.conflicts)
+                _console.print(
+                    f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
+                    f"The full E2B result is saved at [bold]{recovery}[/bold]."
+                )
+                raise typer.Exit(code=2)
+            self._client.acknowledge_agent_workspace(self._target_id, session.id)
+            _console.print(
+                f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
+            )
+            if terminal.status == "failed":
+                _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
+                raise typer.Exit(code=1)
+        except WorkspaceSyncError as error:
+            raise typer.BadParameter(str(error)) from error
+        except PlatformError as error:
+            raise typer.BadParameter(str(error)) from error
+        finally:
+            self._client.close()
+
+    def _poll(self, session_id: str) -> RemoteAgentSession:
+        """Render new transcript events until output export makes the row terminal."""
+        cursor = 0
+        sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
+        while True:
+            try:
+                page = self._client.list_agent_session_events(
+                    self._target_id, session_id, after=cursor
+                )
+                for event in page.events:
+                    if event.kind == "status":
+                        detail = event.payload.get("message") or event.payload.get("status")
+                        if detail:
+                            _console.print(f"[dim]({detail})[/dim]")
+                    else:
+                        sink(SessionEvent(kind=event.kind, payload=event.payload))
+                cursor = page.last_seq
+                if page.status in {"ended", "failed"}:
+                    return self._client.get_agent_session(self._target_id, session_id)
+                time.sleep(0.5)
+            except KeyboardInterrupt:
+                self._interrupts += 1
+                kind = "interrupt" if self._interrupts == 1 else "end"
+                _console.print(
+                    "\n[yellow]interrupting (press Ctrl-C again to end)[/yellow]"
+                    if kind == "interrupt"
+                    else "\n[yellow]ending session[/yellow]"
+                )
+                self._client.post_agent_session_command(self._target_id, session_id, kind)
+                continue
+
+
 class RemoteWorldModelDriver:
     """Interactive terminal loop over the platform's world-model session API."""
 
@@ -526,7 +662,9 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
 _TARGET_ARG = typer.Argument(
     help="Platform world-model or agent id (omit to run the built-in pi harness locally)."
 )
-_DIR_OPT = typer.Option("--dir", help="Local working directory the agent's tools act on.")
+_DIR_OPT = typer.Option(
+    "--dir", help="Working directory to upload/sync for an agent, or use for a bare local run."
+)
 _PROVIDER_OPT = typer.Option(
     "--provider", help="Worker provider for the built-in local pi harness."
 )
@@ -584,7 +722,7 @@ def _build_driver(
     model: str | None,
     task: str | None,
     confirm_local: Callable[[], None] | None = None,
-) -> LocalLiveDriver | RemoteWorldModelDriver:
+) -> LocalLiveDriver | RemoteAgentDriver | RemoteWorldModelDriver:
     """Resolve the target kind once and assemble its execution driver."""
     credentials = load_credentials()
     logged_in = credentials.is_complete()
@@ -649,31 +787,10 @@ def _build_driver(
         resolved = client.resolve_run_target(target)
         if resolved.kind == "world_model":
             return RemoteWorldModelDriver(client, resolved.id, resolved.name, task)
-        if confirm_local is not None:
-            try:
-                confirm_local()
-            except BaseException:
-                client.close()
-                raise
-        champion = client.fetch_champion_harness(resolved.id)
-        doc = HarnessDoc.model_validate(champion.doc)
-        session = client.create_local_session(resolved.id, title=task)
-    except (PlatformError, ValidationError) as error:
+        return RemoteAgentDriver(client, resolved.id, resolved.name, jail_root, task)
+    except PlatformError as error:
         client.close()
         raise typer.BadParameter(str(error)) from error
-    recorder = SessionRecorder(client, resolved.id, session.id)
-
-    def worker_fn(request: ChatRequest) -> ChatResponse:
-        return client.complete_worker(resolved.id, session.id, request)
-
-    return LocalLiveDriver(
-        jail_root=jail_root,
-        doc=doc,
-        provider=None,
-        worker_fn=worker_fn,
-        recorder=recorder,
-        instruction=task,
-    )
 
 
 def _default_org(client: PlatformClient, configured: str | None) -> str:

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -334,6 +334,10 @@ class _FakeLiveSession:
     def closed(self) -> bool:
         return self._closed
 
+    @property
+    def status(self) -> str:
+        return "ended" if self._closed else "idle"
+
     def start(self, hello_timeout: float = 60.0) -> None:
         _ = hello_timeout
 
@@ -415,6 +419,98 @@ def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> N
     assert channel.closed
 
 
+def test_stdin_eof_is_reported_without_aborting_the_opening_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closed stdin is a driver signal, not an immediate local or hosted end command."""
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(""))
+
+    class _Session:
+        closed = False
+        ended = 0
+
+        def end(self) -> None:
+            self.ended += 1
+
+    local_session = _Session()
+    local_reader = mod.StdinCommandReader(cast("mod.LiveSession", local_session))
+    local_reader.run()
+    assert local_reader.eof.is_set()
+    assert local_session.ended == 0
+
+    class _Client:
+        posted: list[str] = []
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            _ = text
+            self.posted.append(kind)
+
+    client = _Client()
+    remote_reader = mod.RemoteAgentCommandReader(
+        cast("mod.PlatformClient", client), "agent-1", "session-1"
+    )
+    remote_reader.run()
+    assert remote_reader.eof.is_set()
+    assert client.posted == []
+
+
+def test_local_driver_returns_nonzero_when_the_runner_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner-side failure cannot look like a successful local CLI run."""
+    channel = _FakeChannel()
+
+    class _FailedSession(_FakeLiveSession):
+        @property
+        def status(self) -> str:
+            return "failed"
+
+        def pump(self, timeout: float = 0.2) -> bool:
+            _ = timeout
+            self._closed = True
+            return False
+
+    monkeypatch.setattr(mod, "start_local_live_runner", lambda: channel)
+    monkeypatch.setattr(mod, "LiveSession", _FailedSession)
+    monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
+
+    with pytest.raises(typer.Exit) as raised:
+        mod.LocalLiveDriver(
+            jail_root=Path.cwd(),
+            doc=mod.HarnessDoc.baseline("t"),
+            provider=_FakeProvider(),
+            worker_fn=None,
+            recorder=None,
+            instruction="do work",
+        ).run()
+
+    assert raised.value.exit_code == 1
+    assert channel.closed
+
+
+def test_conflicted_local_patch_does_not_advance_the_synchronized_base(tmp_path: Path) -> None:
+    """A rejected same-file edit remains outside the platform-accepted snapshot."""
+    path = tmp_path / "answer.txt"
+    path.write_text("before", encoding="utf-8")
+    initial = mod.snapshot_workspace(tmp_path)
+    path.write_text("local", encoding="utf-8")
+
+    class _Client:
+        def upload_agent_workspace_patch(self, *_args: object, **_kwargs: object) -> object:
+            return type("Result", (), {"conflicts": ("answer.txt",)})()
+
+    driver = mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", _Client()), "agent-1", "Agent", tmp_path, "work"
+    )
+
+    synchronized = driver._push_local_patch("session-1", initial)
+
+    assert synchronized is initial
+    assert driver._live_conflicts == {"answer.txt"}
+
+
 def test_remote_agent_driver_syncs_final_e2b_workspace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -479,6 +575,64 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "after"
     assert client.acked == ["session-1"]
     assert client.closed
+
+
+def test_failed_hosted_session_is_not_hidden_by_workspace_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Session failure remains the primary exit even when final sync needs recovery."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    final = mod.snapshot_workspace(tmp_path).archive
+
+    class _HostedClient:
+        def __init__(self) -> None:
+            self.acked = False
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "session-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            return type("Page", (), {"events": [], "last_seq": 0, "status": "failed"})()
+
+        def get_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"status": "failed", "error": "runner crashed"})()
+
+        def download_agent_workspace(self, *_args: object, **_kwargs: object) -> bytes:
+            return final
+
+        def acknowledge_agent_workspace(self, *_args: object, **_kwargs: object) -> None:
+            self.acked = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _NoReader:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    client = _HostedClient()
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
+    monkeypatch.setattr(
+        mod,
+        "sync_workspace",
+        lambda *_args, **_kwargs: type(
+            "Result", (), {"applied": (), "conflicts": ("answer.txt",)}
+        )(),
+    )
+
+    with pytest.raises(typer.Exit) as raised:
+        mod.RemoteAgentDriver(
+            cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, "fix it"
+        ).run()
+
+    assert raised.value.exit_code == 1
+    assert client.acked
+    assert client.closed
+    assert (tmp_path / ".wmh-conflicts" / "session-1.tar.gz").is_file()
 
 
 def test_remote_agent_driver_without_upload_never_reads_local_workspace(

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -494,7 +494,7 @@ def test_remote_agent_driver_applies_live_workspace_patch(
 
     class _HostedClient:
         def __init__(self) -> None:
-            self.patch_acks: list[int] = []
+            self.patch_acks: list[str] = []
             self.closed = False
 
         def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
@@ -504,18 +504,18 @@ def test_remote_agent_driver_applies_live_workspace_patch(
             event = type(
                 "Event",
                 (),
-                {"kind": "workspace_patch", "payload": {"revision": 1}},
+                {"kind": "workspace_patch", "payload": {"revision": "patch-1"}},
             )()
             return type("Page", (), {"events": [event], "last_seq": 1, "status": "ended"})()
 
         def download_agent_workspace_patch(
-            self, _agent_id: str, _session_id: str, revision: int
+            self, _agent_id: str, _session_id: str, revision: str
         ) -> bytes:
-            assert revision == 1
+            assert revision == "patch-1"
             return patch
 
         def acknowledge_agent_workspace_patch(
-            self, _agent_id: str, _session_id: str, revision: int
+            self, _agent_id: str, _session_id: str, revision: str
         ) -> None:
             self.patch_acks.append(revision)
 
@@ -546,5 +546,5 @@ def test_remote_agent_driver_applies_live_workspace_patch(
     ).run()
 
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "during"
-    assert client.patch_acks == [1]
+    assert client.patch_acks == ["patch-1"]
     assert client.closed

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -12,8 +12,10 @@ from typing import TYPE_CHECKING, cast
 import pytest
 import typer
 from llm_waterfall.types import ChatChoice, ChatMessage, ChatRequest, ChatResponse, ChatUsage
+from typer.testing import CliRunner
 
 import wmh.cli.agent_session as mod
+from wmh.cli import app
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.workspace_patch import build_workspace_patch
 from wmh.platform.credentials import PlatformCredentials
@@ -184,8 +186,10 @@ def test_build_driver_not_logged_in_runs_baseline_local(monkeypatch: pytest.Monk
     assert driver._doc.runtime_kind() == "pi-node"
 
 
-def test_build_driver_logged_in_agent_uses_hosted_e2b(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Logged in + agent: execution is platform-owned E2B with local workspace transport."""
+def test_build_driver_logged_in_agent_uses_hosted_e2b_without_local_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Logged in + agent defaults to platform-owned E2B without local files."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
     monkeypatch.setattr(mod, "load_credentials", lambda: creds)
     client = _FakeClient()
@@ -193,15 +197,40 @@ def test_build_driver_logged_in_agent_uses_hosted_e2b(monkeypatch: pytest.Monkey
 
     driver = mod._build_driver(
         target="a1",
-        jail_root=Path.cwd(),
+        jail_root=None,
         provider=None,
         model=None,
         task=None,
     )
     assert isinstance(driver, mod.RemoteAgentDriver)
     assert driver._target_id == "a1"
-    assert driver._jail == Path.cwd()
+    assert driver._jail is None
     assert client.created == []
+
+
+def test_run_upload_dir_is_explicit_opt_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hosted run receives no local path unless -u/--upload-dir is present."""
+    roots: list[Path | None] = []
+
+    class _Driver:
+        def run(self) -> None:
+            pass
+
+    def build_driver(**kwargs: object) -> _Driver:
+        roots.append(cast("Path | None", kwargs["jail_root"]))
+        return _Driver()
+
+    monkeypatch.setattr(mod, "_build_driver", build_driver)
+    runner = CliRunner()
+
+    plain = runner.invoke(app, ["run", "agent-1"])
+    uploaded = runner.invoke(app, ["run", "agent-1", "-u", str(tmp_path)])
+
+    assert plain.exit_code == 0
+    assert uploaded.exit_code == 0
+    assert roots == [None, tmp_path.resolve()]
 
 
 def test_build_driver_logged_in_builtin_pi_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -282,7 +311,7 @@ def test_build_driver_world_model_uses_hosted_session(monkeypatch: pytest.Monkey
 
     driver = mod._build_driver(
         target="wm-1",
-        jail_root=Path.cwd(),
+        jail_root=None,
         provider=None,
         model=None,
         task="help the customer",
@@ -473,6 +502,59 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
 
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "after"
     assert client.acked == ["session-1"]
+    assert client.closed
+
+
+def test_remote_agent_driver_without_upload_never_reads_local_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A default hosted run skips snapshot, upload, patches, and final download."""
+    (tmp_path / "private.txt").write_text("do not upload", encoding="utf-8")
+
+    class _HostedClient:
+        def __init__(self) -> None:
+            self.created_workspaces: list[bytes | None] = []
+            self.closed = False
+
+        def create_agent_session(
+            self,
+            agent_id: str,
+            *,
+            workspace: bytes | None,
+            instruction: str | None = None,
+        ) -> object:
+            assert agent_id == "agent-1"
+            assert instruction == "work remotely"
+            self.created_workspaces.append(workspace)
+            return type("Session", (), {"id": "session-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            return type("Page", (), {"events": [], "last_seq": 0, "status": "ended"})()
+
+        def get_agent_session(self, *_args: object) -> object:
+            return type("Session", (), {"status": "ended", "error": None})()
+
+        def download_agent_workspace(self, *_args: object) -> bytes:
+            pytest.fail("a run without --upload-dir must not download a workspace")
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _NoReader:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    client = _HostedClient()
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
+
+    mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", client), "agent-1", "Agent", None, "work remotely"
+    ).run()
+
+    assert client.created_workspaces == [None]
     assert client.closed
 
 

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -15,6 +15,7 @@ from llm_waterfall.types import ChatChoice, ChatMessage, ChatRequest, ChatRespon
 
 import wmh.cli.agent_session as mod
 from wmh.harness.live_session import SessionEvent
+from wmh.harness.workspace_patch import build_workspace_patch
 from wmh.platform.credentials import PlatformCredentials
 
 if TYPE_CHECKING:
@@ -427,8 +428,8 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
             self.acked: list[str] = []
             self.closed = False
 
-        def create_agent_workspace_session(
-            self, agent_id: str, workspace: bytes, *, instruction: str | None = None
+        def create_agent_session(
+            self, agent_id: str, *, workspace: bytes, instruction: str | None = None
         ) -> object:
             assert agent_id == "agent-1"
             assert workspace
@@ -472,4 +473,78 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
 
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "after"
     assert client.acked == ["session-1"]
+    assert client.closed
+
+
+def test_remote_agent_driver_applies_live_workspace_patch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A workspace_patch event updates the local directory before session end."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    initial = mod.snapshot_workspace(tmp_path)
+    final_buffer = io.BytesIO()
+    with tarfile.open(fileobj=final_buffer, mode="w:gz") as archive:
+        body = b"during"
+        info = tarfile.TarInfo("answer.txt")
+        info.size = len(body)
+        info.mode = 0o644
+        archive.addfile(info, io.BytesIO(body))
+    patch = build_workspace_patch(initial.archive, final_buffer.getvalue())
+    assert patch is not None
+
+    class _HostedClient:
+        def __init__(self) -> None:
+            self.patch_acks: list[int] = []
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "session-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            event = type(
+                "Event",
+                (),
+                {"kind": "workspace_patch", "payload": {"revision": 1}},
+            )()
+            return type("Page", (), {"events": [event], "last_seq": 1, "status": "ended"})()
+
+        def download_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: int
+        ) -> bytes:
+            assert revision == 1
+            return patch
+
+        def acknowledge_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: int
+        ) -> None:
+            self.patch_acks.append(revision)
+
+        def get_agent_session(self, *_args: object) -> object:
+            return type("Session", (), {"status": "ended", "error": None})()
+
+        def download_agent_workspace(self, *_args: object) -> bytes:
+            return final_buffer.getvalue()
+
+        def acknowledge_agent_workspace(self, *_args: object) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _NoReader:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    client = _HostedClient()
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
+
+    mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, None
+    ).run()
+
+    assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "during"
+    assert client.patch_acks == [1]
     assert client.closed

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -98,11 +98,10 @@ class _FakeProvider:
 
 
 class _FakeClient:
-    """Records proxy calls; serves a baseline champion + a created session."""
+    """Records hosted target resolution and built-in Pi proxy calls."""
 
     def __init__(self) -> None:
         self.worker_calls: list[ChatRequest] = []
-        self.created: list[str] = []
         self.target_kind = "agent"
         self.closed = False
         self.local_pi_created: list[str] = []
@@ -114,24 +113,6 @@ class _FakeClient:
             (),
             {"id": target_id, "kind": self.target_kind, "name": "remote-target"},
         )()
-
-    def fetch_champion_harness(self, agent_id: str) -> object:
-        _ = agent_id
-        doc = mod.HarnessDoc.baseline("champ").model_dump(mode="json")
-        return type("Champ", (), {"doc": doc})()
-
-    def create_local_session(self, agent_id: str, *, title: str | None = None) -> object:
-        _ = title
-        self.created.append(agent_id)
-        return type("Sess", (), {"id": "sess-1"})()
-
-    def complete_worker(self, agent_id: str, session_id: str, request: ChatRequest) -> ChatResponse:
-        _ = agent_id, session_id
-        self.worker_calls.append(request)
-        return ChatResponse(
-            choices=[ChatChoice(message=ChatMessage(role="assistant", content="ok"))],
-            usage=ChatUsage(prompt_tokens=1, completion_tokens=1),
-        )
 
     def create_local_pi_run(self, org_id: str) -> object:
         self.local_pi_created.append(org_id)
@@ -205,12 +186,9 @@ def test_build_driver_logged_in_agent_uses_hosted_e2b_without_local_workspace(
     assert isinstance(driver, mod.RemoteAgentDriver)
     assert driver._target_id == "a1"
     assert driver._jail is None
-    assert client.created == []
 
 
-def test_run_upload_dir_is_explicit_opt_in(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_upload_dir_is_explicit_opt_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A hosted run receives no local path unless -u/--upload-dir is present."""
     roots: list[Path | None] = []
 
@@ -274,7 +252,6 @@ def test_platform_target_rejects_local_provider_before_creating_session(
             model=None,
             task=None,
         )
-    assert client.created == []
 
 
 def test_hosted_agent_does_not_prompt_for_local_execution(
@@ -297,7 +274,6 @@ def test_hosted_agent_does_not_prompt_for_local_execution(
     )
     assert isinstance(driver, mod.RemoteAgentDriver)
     assert prompted == []
-    assert client.created == []
     assert not client.closed
 
 

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for `wmh session start`: the jailed local executor, the credential state
+machine (proxy / local-provider / baseline), and the driver's teardown wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import typer
+from llm_waterfall.types import ChatChoice, ChatMessage, ChatRequest, ChatResponse, ChatUsage
+
+import wmh.cli.agent_session as mod
+from wmh.harness.live_session import SessionEvent
+from wmh.platform.credentials import PlatformCredentials
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _noop_emit(_stream: str, _chunk: str) -> None:
+    """A do-nothing output sink for executor calls that ignore streaming."""
+
+
+# -- LocalToolExecutor -----------------------------------------------------------------------------
+
+
+def test_executor_reads_writes_and_jails(tmp_path: Path) -> None:
+    """read/write hit the jail; a traversal or absolute path outside it is a clean error."""
+    executor = mod.LocalToolExecutor(tmp_path)
+    emit = _noop_emit
+
+    wrote = executor("write_file", {"path": "sub/a.txt", "content": "hi"}, emit)
+    assert not wrote.is_error
+    assert (tmp_path / "sub" / "a.txt").read_text(encoding="utf-8") == "hi"
+
+    read = executor("read_file", {"path": "sub/a.txt"}, emit)
+    assert read.content == "hi"
+
+    escaped = executor("read_file", {"path": "../../etc/passwd"}, emit)
+    assert escaped.is_error
+    assert "escapes" in escaped.content
+
+    absolute = executor("write_file", {"path": "/tmp/evil.txt", "content": "x"}, emit)
+    assert absolute.is_error
+
+
+def test_executor_bash_runs_in_jail_and_reports_exit(tmp_path: Path) -> None:
+    """bash runs in the jail root, streams output, and surfaces a non-zero exit."""
+    executor = mod.LocalToolExecutor(tmp_path)
+    chunks: list[tuple[str, str]] = []
+
+    ok = executor("bash", {"command": "pwd && echo hello"}, lambda s, c: chunks.append((s, c)))
+    assert not ok.is_error
+    assert str(tmp_path.resolve()) in ok.content
+    assert "hello" in ok.content
+    assert any(stream == "stdout" for stream, _ in chunks)
+
+    failed = executor("bash", {"command": "exit 3"}, lambda _s, _c: None)
+    assert failed.is_error
+    assert "[exit 3]" in failed.content
+
+
+def test_executor_caps_large_output(tmp_path: Path) -> None:
+    """A read larger than the cap is truncated with a marker."""
+    big = "x" * (mod._TOOL_OUTPUT_CAP + 500)
+    (tmp_path / "big.txt").write_text(big, encoding="utf-8")
+    executor = mod.LocalToolExecutor(tmp_path)
+
+    result = executor("read_file", {"path": "big.txt"}, lambda _s, _c: None)
+    assert result.truncated
+    assert "chars truncated" in result.content
+
+
+def test_unknown_tool_is_an_error(tmp_path: Path) -> None:
+    """An unrecognized tool name is a non-crashing error observation."""
+    result = mod.LocalToolExecutor(tmp_path)("nope", {}, lambda _s, _c: None)
+    assert result.is_error
+    assert "not available" in result.content
+
+
+# -- credential state machine (_build_driver) ------------------------------------------------------
+
+
+class _FakeProvider:
+    """A minimal ToolCallingProvider stand-in."""
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        """Return an empty response (never actually called in these tests)."""
+        _ = request
+        return ChatResponse(choices=[])
+
+
+class _FakeClient:
+    """Records proxy calls; serves a baseline champion + a created session."""
+
+    def __init__(self) -> None:
+        self.worker_calls: list[ChatRequest] = []
+        self.created: list[str] = []
+
+    def fetch_champion_harness(self, agent_id: str) -> object:
+        _ = agent_id
+        doc = mod.HarnessDoc.baseline("champ").model_dump(mode="json")
+        return type("Champ", (), {"doc": doc})()
+
+    def create_local_session(self, agent_id: str, *, title: str | None = None) -> object:
+        _ = title
+        self.created.append(agent_id)
+        return type("Sess", (), {"id": "sess-1"})()
+
+    def complete_worker(
+        self, agent_id: str, session_id: str, request: ChatRequest
+    ) -> ChatResponse:
+        _ = agent_id, session_id
+        self.worker_calls.append(request)
+        return ChatResponse(
+            choices=[ChatChoice(message=ChatMessage(role="assistant", content="ok"))],
+            usage=ChatUsage(prompt_tokens=1, completion_tokens=1),
+        )
+
+
+def _patch_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "get_provider", lambda _config: _FakeProvider())
+
+
+def test_build_driver_not_logged_in_runs_baseline_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No login + no agent: a pi-node baseline runs locally, unrecorded."""
+    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    _patch_local_provider(monkeypatch)
+
+    driver = mod._build_driver(
+        agent=None,
+        jail_root=Path.cwd(),
+        local_provider=False,
+        provider=None,
+        model=None,
+        instruction=None,
+    )
+    assert driver._recorder is None
+    assert driver._worker_fn is None
+    assert isinstance(driver._provider, _FakeProvider)
+    assert driver._doc.runtime_kind() == "pi-node"
+
+
+def test_build_driver_logged_in_default_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logged in + agent: the worker is the platform proxy and the session is recorded."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    driver = mod._build_driver(
+        agent="a1",
+        jail_root=Path.cwd(),
+        local_provider=False,
+        provider=None,
+        model=None,
+        instruction=None,
+    )
+    assert driver._provider is None
+    assert driver._worker_fn is not None
+    assert driver._recorder is not None
+    assert client.created == ["a1"]
+
+    driver._worker_fn(ChatRequest(messages=[ChatMessage(role="user", content="hi")]))
+    assert len(client.worker_calls) == 1
+
+
+def test_build_driver_local_provider_still_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logged in + --local-provider: worker runs locally but the session is still recorded."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: _FakeClient())
+    _patch_local_provider(monkeypatch)
+
+    driver = mod._build_driver(
+        agent="a1",
+        jail_root=Path.cwd(),
+        local_provider=True,
+        provider=None,
+        model=None,
+        instruction=None,
+    )
+    assert isinstance(driver._provider, _FakeProvider)
+    assert driver._worker_fn is None
+    assert driver._recorder is not None
+
+
+def test_build_driver_agent_without_login_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Naming an agent while logged out is a clear parameter error."""
+    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    with pytest.raises(typer.BadParameter):
+        mod._build_driver(
+            agent="a1",
+            jail_root=Path.cwd(),
+            local_provider=False,
+            provider=None,
+            model=None,
+            instruction=None,
+        )
+
+
+# -- driver orchestration --------------------------------------------------------------------------
+
+
+class _FakeSandbox:
+    """Records timeout extensions + kills."""
+
+    def __init__(self) -> None:
+        self.sandbox_id = "sbx-local"
+        self.timeouts: list[int] = []
+        self.kills = 0
+
+    def set_timeout(self, timeout: int) -> None:
+        self.timeouts.append(timeout)
+
+    def kill(self) -> None:
+        self.kills += 1
+
+
+class _FakeLiveSession:
+    """Emits one state event on the first pump, then closes."""
+
+    def __init__(
+        self, _channel: object, *, on_event: Callable[[SessionEvent], None], **_: object
+    ) -> None:
+        self._on_event = on_event
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def start(self, hello_timeout: float = 60.0) -> None:
+        _ = hello_timeout
+
+    def send_user_message(self, text: str) -> str:
+        _ = text
+        return "msg-1"
+
+    def interrupt(self, reason: str = "user_interrupt") -> None:
+        _ = reason
+
+    def end(self) -> None:
+        self._closed = True
+
+    def pump(self, timeout: float = 0.2) -> bool:
+        _ = timeout
+        self._on_event(SessionEvent(kind="state", payload={"status": "idle"}))
+        self._closed = True
+        return False
+
+
+class _FakeReader:
+    """A stdin reader that never touches stdin."""
+
+    def __init__(self, _session: object) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+def _patch_driver_boundaries(monkeypatch: pytest.MonkeyPatch, sandbox: _FakeSandbox) -> None:
+    monkeypatch.setattr(mod, "default_sandbox_factory", lambda **_: lambda: sandbox)
+    monkeypatch.setattr(mod, "start_live_runner", lambda *_a, **_k: object())
+    monkeypatch.setattr(mod, "LiveSession", _FakeLiveSession)
+    monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
+
+
+def test_driver_boots_loops_and_kills_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The driver boots, runs the pump loop to close, and always kills the sandbox."""
+    sandbox = _FakeSandbox()
+    _patch_driver_boundaries(monkeypatch, sandbox)
+
+    mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=mod.HarnessDoc.baseline("t"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=None,
+        instruction=None,
+    ).run()
+
+    assert sandbox.kills == 1
+
+
+def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When recording, the driver posts a terminal finish on teardown."""
+    sandbox = _FakeSandbox()
+    _patch_driver_boundaries(monkeypatch, sandbox)
+    finished: list[str] = []
+
+    class _Recorder:
+        def flush(self) -> None: ...
+        def record(self, event: SessionEvent) -> None:
+            _ = event
+
+        def finish(self, *, ended_reason: str, sandbox_seconds: int, error: str | None) -> None:
+            _ = sandbox_seconds, error
+            finished.append(ended_reason)
+
+    mod.LocalLiveDriver(
+        jail_root=Path.cwd(),
+        doc=mod.HarnessDoc.baseline("t"),
+        provider=_FakeProvider(),
+        worker_fn=None,
+        recorder=cast("mod.SessionRecorder", _Recorder()),
+        instruction=None,
+    ).run()
+
+    assert finished == ["user_ended"]
+    assert sandbox.kills == 1

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import io
+import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -181,8 +183,8 @@ def test_build_driver_not_logged_in_runs_baseline_local(monkeypatch: pytest.Monk
     assert driver._doc.runtime_kind() == "pi-node"
 
 
-def test_build_driver_logged_in_agent_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Logged in + agent: the worker is the platform proxy and the session is recorded."""
+def test_build_driver_logged_in_agent_uses_hosted_e2b(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logged in + agent: execution is platform-owned E2B with local workspace transport."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
     monkeypatch.setattr(mod, "load_credentials", lambda: creds)
     client = _FakeClient()
@@ -195,14 +197,10 @@ def test_build_driver_logged_in_agent_uses_proxy(monkeypatch: pytest.MonkeyPatch
         model=None,
         task=None,
     )
-    assert isinstance(driver, mod.LocalLiveDriver)
-    assert driver._provider is None
-    assert driver._worker_fn is not None
-    assert driver._recorder is not None
-    assert client.created == ["a1"]
-
-    driver._worker_fn(ChatRequest(messages=[ChatMessage(role="user", content="hi")]))
-    assert len(client.worker_calls) == 1
+    assert isinstance(driver, mod.RemoteAgentDriver)
+    assert driver._target_id == "a1"
+    assert driver._jail == Path.cwd()
+    assert client.created == []
 
 
 def test_build_driver_logged_in_builtin_pi_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -249,29 +247,28 @@ def test_platform_target_rejects_local_provider_before_creating_session(
     assert client.created == []
 
 
-def test_declining_local_execution_creates_no_platform_session(
+def test_hosted_agent_does_not_prompt_for_local_execution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Consent happens after kind resolution but before champion or session creation."""
+    """The E2B agent path never presents the bare harness's local-shell warning."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
     monkeypatch.setattr(mod, "load_credentials", lambda: creds)
     client = _FakeClient()
     monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
 
-    def decline() -> None:
-        raise typer.Exit(code=1)
-
-    with pytest.raises(typer.Exit):
-        mod._build_driver(
-            target="a1",
-            jail_root=Path.cwd(),
-            provider=None,
-            model=None,
-            task=None,
-            confirm_local=decline,
-        )
+    prompted: list[bool] = []
+    driver = mod._build_driver(
+        target="a1",
+        jail_root=Path.cwd(),
+        provider=None,
+        model=None,
+        task=None,
+        confirm_local=lambda: prompted.append(True),
+    )
+    assert isinstance(driver, mod.RemoteAgentDriver)
+    assert prompted == []
     assert client.created == []
-    assert client.closed
+    assert not client.closed
 
 
 def test_build_driver_world_model_uses_hosted_session(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -410,3 +407,69 @@ def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert finished == ["user_ended"]
     assert channel.closed
+
+
+def test_remote_agent_driver_syncs_final_e2b_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hosted driver downloads, applies, acknowledges, and closes after terminal state."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    buffer = io.BytesIO()
+    content = b"after"
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo("answer.txt")
+        info.size = len(content)
+        info.mode = 0o644
+        archive.addfile(info, io.BytesIO(content))
+
+    class _HostedClient:
+        def __init__(self) -> None:
+            self.acked: list[str] = []
+            self.closed = False
+
+        def create_agent_workspace_session(
+            self, agent_id: str, workspace: bytes, *, instruction: str | None = None
+        ) -> object:
+            assert agent_id == "agent-1"
+            assert workspace
+            assert instruction == "fix it"
+            return type("Session", (), {"id": "session-1"})()
+
+        def list_agent_session_events(
+            self, agent_id: str, session_id: str, *, after: int
+        ) -> object:
+            _ = agent_id, session_id, after
+            return type("Page", (), {"events": [], "last_seq": 0, "status": "ended"})()
+
+        def get_agent_session(self, agent_id: str, session_id: str) -> object:
+            _ = agent_id, session_id
+            return type("Session", (), {"status": "ended", "error": None})()
+
+        def download_agent_workspace(self, agent_id: str, session_id: str) -> bytes:
+            _ = agent_id, session_id
+            return buffer.getvalue()
+
+        def acknowledge_agent_workspace(self, agent_id: str, session_id: str) -> None:
+            _ = agent_id
+            self.acked.append(session_id)
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _NoReader:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    client = _HostedClient()
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
+
+    mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, "fix it"
+    ).run()
+
+    assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "after"
+    assert client.acked == ["session-1"]
+    assert client.closed

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026 Experiential Labs. All rights reserved.
 
-"""Tests for `wmh session start`: the jailed local executor, the credential state
-machine (proxy / local-provider / baseline), and the driver's teardown wiring."""
+"""Tests for ``wmh run`` target dispatch and local execution boundaries."""
 
 from __future__ import annotations
 
@@ -99,6 +98,17 @@ class _FakeClient:
     def __init__(self) -> None:
         self.worker_calls: list[ChatRequest] = []
         self.created: list[str] = []
+        self.target_kind = "agent"
+        self.closed = False
+        self.local_pi_created: list[str] = []
+        self.local_pi_finished: list[str] = []
+
+    def resolve_run_target(self, target_id: str) -> object:
+        return type(
+            "Target",
+            (),
+            {"id": target_id, "kind": self.target_kind, "name": "remote-target"},
+        )()
 
     def fetch_champion_harness(self, agent_id: str) -> object:
         _ = agent_id
@@ -110,15 +120,42 @@ class _FakeClient:
         self.created.append(agent_id)
         return type("Sess", (), {"id": "sess-1"})()
 
-    def complete_worker(
-        self, agent_id: str, session_id: str, request: ChatRequest
-    ) -> ChatResponse:
+    def complete_worker(self, agent_id: str, session_id: str, request: ChatRequest) -> ChatResponse:
         _ = agent_id, session_id
         self.worker_calls.append(request)
         return ChatResponse(
             choices=[ChatChoice(message=ChatMessage(role="assistant", content="ok"))],
             usage=ChatUsage(prompt_tokens=1, completion_tokens=1),
         )
+
+    def create_local_pi_run(self, org_id: str) -> object:
+        self.local_pi_created.append(org_id)
+        return type("Run", (), {"id": "run-1"})()
+
+    def complete_local_pi_worker(
+        self, org_id: str, run_id: str, request: ChatRequest
+    ) -> ChatResponse:
+        _ = org_id, run_id
+        self.worker_calls.append(request)
+        return ChatResponse(
+            choices=[ChatChoice(message=ChatMessage(role="assistant", content="ok"))],
+            usage=ChatUsage(prompt_tokens=1, completion_tokens=1),
+        )
+
+    def finish_local_pi_run(
+        self,
+        org_id: str,
+        run_id: str,
+        *,
+        status: str,
+        ended_reason: str,
+        error: str | None = None,
+    ) -> None:
+        _ = org_id, status, ended_reason, error
+        self.local_pi_finished.append(run_id)
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _patch_local_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,20 +168,20 @@ def test_build_driver_not_logged_in_runs_baseline_local(monkeypatch: pytest.Monk
     _patch_local_provider(monkeypatch)
 
     driver = mod._build_driver(
-        agent=None,
+        target=None,
         jail_root=Path.cwd(),
-        local_provider=False,
         provider=None,
         model=None,
-        instruction=None,
+        task=None,
     )
+    assert isinstance(driver, mod.LocalLiveDriver)
     assert driver._recorder is None
     assert driver._worker_fn is None
     assert isinstance(driver._provider, _FakeProvider)
     assert driver._doc.runtime_kind() == "pi-node"
 
 
-def test_build_driver_logged_in_default_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_driver_logged_in_agent_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     """Logged in + agent: the worker is the platform proxy and the session is recorded."""
     creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
     monkeypatch.setattr(mod, "load_credentials", lambda: creds)
@@ -152,13 +189,13 @@ def test_build_driver_logged_in_default_uses_proxy(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
-        agent="a1",
+        target="a1",
         jail_root=Path.cwd(),
-        local_provider=False,
         provider=None,
         model=None,
-        instruction=None,
+        task=None,
     )
+    assert isinstance(driver, mod.LocalLiveDriver)
     assert driver._provider is None
     assert driver._worker_fn is not None
     assert driver._recorder is not None
@@ -168,56 +205,117 @@ def test_build_driver_logged_in_default_uses_proxy(monkeypatch: pytest.MonkeyPat
     assert len(client.worker_calls) == 1
 
 
-def test_build_driver_local_provider_still_records(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Logged in + --local-provider: worker runs locally but the session is still recorded."""
-    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+def test_build_driver_logged_in_builtin_pi_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logged-in bare run needs no local provider credentials."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test", default_org="org-1")
     monkeypatch.setattr(mod, "load_credentials", lambda: creds)
-    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: _FakeClient())
-    _patch_local_provider(monkeypatch)
+    client = _FakeClient()
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
 
     driver = mod._build_driver(
-        agent="a1",
+        target=None,
         jail_root=Path.cwd(),
-        local_provider=True,
         provider=None,
         model=None,
-        instruction=None,
+        task=None,
     )
-    assert isinstance(driver._provider, _FakeProvider)
-    assert driver._worker_fn is None
-    assert driver._recorder is not None
+    assert isinstance(driver, mod.LocalLiveDriver)
+    assert driver._provider is None
+    assert driver._worker_fn is not None
+    assert isinstance(driver._recorder, mod.LocalPiRunRecorder)
+    assert client.local_pi_created == ["org-1"]
+
+    driver._worker_fn(ChatRequest(messages=[ChatMessage(role="user", content="hi")]))
+    assert len(client.worker_calls) == 1
 
 
-def test_build_driver_agent_without_login_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Naming an agent while logged out is a clear parameter error."""
+def test_platform_target_rejects_local_provider_before_creating_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider overrides never create an orphan platform run."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    with pytest.raises(typer.BadParameter, match="platform credentials"):
+        mod._build_driver(
+            target="a1",
+            jail_root=Path.cwd(),
+            provider="bedrock",
+            model=None,
+            task=None,
+        )
+    assert client.created == []
+
+
+def test_declining_local_execution_creates_no_platform_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Consent happens after kind resolution but before champion or session creation."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    def decline() -> None:
+        raise typer.Exit(code=1)
+
+    with pytest.raises(typer.Exit):
+        mod._build_driver(
+            target="a1",
+            jail_root=Path.cwd(),
+            provider=None,
+            model=None,
+            task=None,
+            confirm_local=decline,
+        )
+    assert client.created == []
+    assert client.closed
+
+
+def test_build_driver_world_model_uses_hosted_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolved world-model id never boots a local agent process."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    client.target_kind = "world_model"
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    driver = mod._build_driver(
+        target="wm-1",
+        jail_root=Path.cwd(),
+        provider=None,
+        model=None,
+        task="help the customer",
+    )
+    assert isinstance(driver, mod.RemoteWorldModelDriver)
+
+
+def test_build_driver_target_without_login_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Naming any platform target while logged out is a clear parameter error."""
     monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
     with pytest.raises(typer.BadParameter):
         mod._build_driver(
-            agent="a1",
+            target="a1",
             jail_root=Path.cwd(),
-            local_provider=False,
             provider=None,
             model=None,
-            instruction=None,
+            task=None,
         )
 
 
 # -- driver orchestration --------------------------------------------------------------------------
 
 
-class _FakeSandbox:
-    """Records timeout extensions + kills."""
+class _FakeChannel:
+    """Records local runner teardown."""
 
     def __init__(self) -> None:
-        self.sandbox_id = "sbx-local"
-        self.timeouts: list[int] = []
-        self.kills = 0
+        self.closed = False
 
-    def set_timeout(self, timeout: int) -> None:
-        self.timeouts.append(timeout)
-
-    def kill(self) -> None:
-        self.kills += 1
+    def close(self) -> None:
+        self.closed = True
 
 
 class _FakeLiveSession:
@@ -263,17 +361,16 @@ class _FakeReader:
         pass
 
 
-def _patch_driver_boundaries(monkeypatch: pytest.MonkeyPatch, sandbox: _FakeSandbox) -> None:
-    monkeypatch.setattr(mod, "default_sandbox_factory", lambda **_: lambda: sandbox)
-    monkeypatch.setattr(mod, "start_live_runner", lambda *_a, **_k: object())
+def _patch_driver_boundaries(monkeypatch: pytest.MonkeyPatch, channel: _FakeChannel) -> None:
+    monkeypatch.setattr(mod, "start_local_live_runner", lambda: channel)
     monkeypatch.setattr(mod, "LiveSession", _FakeLiveSession)
     monkeypatch.setattr(mod, "StdinCommandReader", _FakeReader)
 
 
-def test_driver_boots_loops_and_kills_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The driver boots, runs the pump loop to close, and always kills the sandbox."""
-    sandbox = _FakeSandbox()
-    _patch_driver_boundaries(monkeypatch, sandbox)
+def test_driver_boots_loops_and_closes_local_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The driver boots, runs the pump loop, and always closes its local process."""
+    channel = _FakeChannel()
+    _patch_driver_boundaries(monkeypatch, channel)
 
     mod.LocalLiveDriver(
         jail_root=Path.cwd(),
@@ -284,13 +381,13 @@ def test_driver_boots_loops_and_kills_sandbox(monkeypatch: pytest.MonkeyPatch) -
         instruction=None,
     ).run()
 
-    assert sandbox.kills == 1
+    assert channel.closed
 
 
 def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> None:
     """When recording, the driver posts a terminal finish on teardown."""
-    sandbox = _FakeSandbox()
-    _patch_driver_boundaries(monkeypatch, sandbox)
+    channel = _FakeChannel()
+    _patch_driver_boundaries(monkeypatch, channel)
     finished: list[str] = []
 
     class _Recorder:
@@ -298,8 +395,8 @@ def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> N
         def record(self, event: SessionEvent) -> None:
             _ = event
 
-        def finish(self, *, ended_reason: str, sandbox_seconds: int, error: str | None) -> None:
-            _ = sandbox_seconds, error
+        def finish(self, *, ended_reason: str, error: str | None) -> None:
+            _ = error
             finished.append(ended_reason)
 
     mod.LocalLiveDriver(
@@ -307,9 +404,9 @@ def test_driver_reports_finish_to_recorder(monkeypatch: pytest.MonkeyPatch) -> N
         doc=mod.HarnessDoc.baseline("t"),
         provider=_FakeProvider(),
         worker_fn=None,
-        recorder=cast("mod.SessionRecorder", _Recorder()),
+        recorder=cast("mod.RunRecorder", _Recorder()),
         instruction=None,
     ).run()
 
     assert finished == ["user_ended"]
-    assert sandbox.kills == 1
+    assert channel.closed

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -36,6 +36,7 @@ from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn
 from rich.table import Table
 
 import wmh.providers as providers
+from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app
 from wmh.cli.platform_cmds import register as register_platform_commands
@@ -127,6 +128,7 @@ app.add_typer(config_app, name="config")
 app.add_typer(scenarios_app, name="scenarios")
 app.add_typer(harness_app, name="harness")
 register_platform_commands(app)
+register_agent_session_commands(app)
 _console = Console()
 _CHECK = "[green]✓[/green]"
 

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -165,7 +165,7 @@ def test_build_survives_card_write_failure(patched_provider, monkeypatch, tmp_pa
 def test_cli_exposes_the_small_command_set() -> None:
     names = {cmd.name for cmd in app.registered_commands}
     core = {"build", "list", "serve", "demo", "eval", "play", "download"}
-    platform = {"login", "logout", "status", "push", "pull"}
+    platform = {"login", "logout", "status", "push", "pull", "run"}
     assert names == core | platform
 
 

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -41,6 +41,10 @@ _CHECK = "[green]✓[/green]"
 _LOGIN_URL = typer.Option(
     "--url", help="Platform URL (defaults to the saved one, then the hosted platform)."
 )
+_LOGIN_API_URL = typer.Option(
+    "--api-url",
+    help="Platform API URL (skips web discovery; useful for protected previews).",
+)
 _LOGIN_TOKEN = typer.Option(
     "--token", help="Paste an existing API key instead of using the browser."
 )
@@ -64,6 +68,7 @@ _ROOT = typer.Option("--root", help="Artifact root directory.")
 
 def login(
     url: Annotated[str | None, _LOGIN_URL] = None,
+    api_url: Annotated[str | None, _LOGIN_API_URL] = None,
     token: Annotated[str | None, _LOGIN_TOKEN] = None,
     no_browser: Annotated[bool, _LOGIN_NO_BROWSER] = False,
 ) -> None:
@@ -71,12 +76,15 @@ def login(
     credentials = load_credentials()
     web_url = (url or credentials.web_url or DEFAULT_WEB_URL).rstrip("/")
 
-    try:
-        api_url = fetch_cli_config(web_url)
-    except PlatformError as error:
-        raise typer.BadParameter(f"{web_url} does not look like a platform: {error}") from error
     if api_url is None:
-        raise typer.BadParameter(f"{web_url} did not advertise a backend URL; is it deployed?")
+        try:
+            api_url = fetch_cli_config(web_url)
+        except PlatformError as error:
+            raise typer.BadParameter(f"{web_url} does not look like a platform: {error}") from error
+        if api_url is None:
+            raise typer.BadParameter(f"{web_url} did not advertise a backend URL; is it deployed?")
+    else:
+        api_url = api_url.rstrip("/")
 
     if token is None:
         token = _browser_login(web_url, open_browser=not no_browser)

--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -127,6 +127,39 @@ def test_login_with_token_drops_stale_default_org(
     assert saved.default_org == "org-1"
 
 
+def test_login_with_explicit_api_url_skips_web_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Protected previews can pair browser auth with their direct backend URL."""
+
+    def unexpected_discovery(_url: str) -> str:
+        pytest.fail("explicit --api-url must skip web discovery")
+
+    monkeypatch.setattr("wmh.cli.platform_cmds.fetch_cli_config", unexpected_discovery)
+    monkeypatch.setattr("wmh.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(
+        app,
+        [
+            "login",
+            "--url",
+            "https://preview.test/",
+            "--api-url",
+            "https://api-preview.test/",
+            "--token",
+            "xpl_new",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    from wmh.platform.credentials import load_credentials
+
+    saved = load_credentials()
+    assert saved.web_url == "https://preview.test"
+    assert saved.api_url == "https://api-preview.test"
+    assert saved.token == "xpl_new"
+
+
 def test_push_requires_login_first(tmp_path: Path) -> None:
     result = runner.invoke(app, ["push", "anything", "--root", str(tmp_path)])
     assert result.exit_code != 0

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Safe local snapshot and three-way sync for hosted E2B agent workspaces."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+MAX_WORKSPACE_ARCHIVE_BYTES = 50 * 1024 * 1024
+MAX_WORKSPACE_UNPACKED_BYTES = 512 * 1024 * 1024
+MAX_WORKSPACE_ENTRIES = 100_000
+
+# Dependency trees, VCS internals, caches, and WMH recovery artifacts are not
+# useful source inputs and can turn a small repository into a multi-GB upload.
+EXCLUDED_DIRECTORY_NAMES = frozenset(
+    {
+        ".cache",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        ".wmh-conflicts",
+        "__pycache__",
+        "node_modules",
+        "venv",
+    }
+)
+
+
+class WorkspaceSyncError(RuntimeError):
+    """A workspace cannot be safely archived or synchronized."""
+
+
+@dataclass(frozen=True)
+class FileState:
+    """Content and executable-mode identity used by the three-way merge."""
+
+    sha256: str
+    mode: int
+
+
+@dataclass(frozen=True)
+class WorkspaceSnapshot:
+    """Initial upload archive plus its regular-file manifest."""
+
+    archive: bytes
+    files: dict[str, FileState]
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Paths applied automatically and paths preserved as local conflicts."""
+
+    applied: tuple[str, ...]
+    conflicts: tuple[str, ...]
+
+
+def snapshot_workspace(root: Path) -> WorkspaceSnapshot:
+    """Archive regular files under ``root`` and capture their initial identities."""
+    resolved = root.resolve()
+    files = _manifest(resolved)
+    try:
+        total = sum(path.stat().st_size for path in _paths_for_manifest(resolved, files))
+    except OSError as error:
+        msg = "workspace changed while it was being inspected; retry the run"
+        raise WorkspaceSyncError(msg) from error
+    if total > MAX_WORKSPACE_UNPACKED_BYTES:
+        msg = f"workspace files exceed {MAX_WORKSPACE_UNPACKED_BYTES} uncompressed bytes"
+        raise WorkspaceSyncError(msg)
+    buffer = io.BytesIO()
+    try:
+        with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+            for relative in sorted(files):
+                source = resolved / relative
+                info = tarfile.TarInfo(relative)
+                file_stat = source.stat()
+                info.size = file_stat.st_size
+                info.mode = stat.S_IMODE(file_stat.st_mode)
+                info.mtime = int(file_stat.st_mtime)
+                with source.open("rb") as handle:
+                    archive.addfile(info, handle)
+    except OSError as error:
+        msg = "workspace changed while it was being archived; retry the run"
+        raise WorkspaceSyncError(msg) from error
+    if _manifest(resolved) != files:
+        msg = "workspace changed while it was being archived; retry the run"
+        raise WorkspaceSyncError(msg)
+    content = buffer.getvalue()
+    if len(content) > MAX_WORKSPACE_ARCHIVE_BYTES:
+        msg = f"workspace archive exceeds {MAX_WORKSPACE_ARCHIVE_BYTES} compressed bytes"
+        raise WorkspaceSyncError(msg)
+    return WorkspaceSnapshot(archive=content, files=files)
+
+
+def sync_workspace(root: Path, initial: WorkspaceSnapshot, final_archive: bytes) -> SyncResult:
+    """Apply remote changes unless the same path changed locally since upload."""
+    resolved = root.resolve()
+    if len(final_archive) > MAX_WORKSPACE_ARCHIVE_BYTES:
+        msg = f"final workspace archive exceeds {MAX_WORKSPACE_ARCHIVE_BYTES} bytes"
+        raise WorkspaceSyncError(msg)
+    with tempfile.TemporaryDirectory(prefix="wmh-workspace-") as staging_name:
+        staging = Path(staging_name)
+        _extract_archive(final_archive, staging)
+        remote = _manifest(staging)
+        current = _manifest(resolved)
+        applied: list[str] = []
+        conflicts: list[str] = []
+        for relative in sorted(set(initial.files) | set(remote)):
+            before = initial.files.get(relative)
+            after = remote.get(relative)
+            if before == after:
+                continue
+            target = resolved / relative
+            now = current.get(relative)
+            if _has_non_file_collision(target, now) or (now != before and now != after):
+                conflicts.append(relative)
+                continue
+            if now == after:
+                continue
+            try:
+                if after is None:
+                    target.unlink(missing_ok=True)
+                    _remove_empty_parents(target.parent, resolved)
+                else:
+                    _atomic_copy(staging / relative, target, root=resolved, mode=after.mode)
+            except OSError:
+                conflicts.append(relative)
+                continue
+            applied.append(relative)
+    return SyncResult(applied=tuple(applied), conflicts=tuple(conflicts))
+
+
+def write_conflict_archive(root: Path, session_id: str, content: bytes) -> Path:
+    """Preserve a downloaded result archive when automatic reconciliation conflicts."""
+    directory = root.resolve() / ".wmh-conflicts"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{session_id}.tar.gz"
+    path.write_bytes(content)
+    return path
+
+
+def _manifest(root: Path) -> dict[str, FileState]:
+    """Hash regular files without following symlinks or entering excluded trees."""
+    manifest: dict[str, FileState] = {}
+    entries = 0
+    for directory, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        base = Path(directory)
+        dirnames[:] = sorted(
+            name
+            for name in dirnames
+            if name not in EXCLUDED_DIRECTORY_NAMES and not (base / name).is_symlink()
+        )
+        for name in sorted(filenames):
+            path = base / name
+            try:
+                file_stat = path.lstat()
+            except OSError as error:
+                raise WorkspaceSyncError(f"could not inspect workspace file: {path}") from error
+            if not stat.S_ISREG(file_stat.st_mode):
+                continue
+            relative = path.relative_to(root).as_posix()
+            manifest[relative] = FileState(
+                sha256=_sha256(path), mode=stat.S_IMODE(file_stat.st_mode)
+            )
+            entries += 1
+            if entries > MAX_WORKSPACE_ENTRIES:
+                msg = f"workspace has more than {MAX_WORKSPACE_ENTRIES} files"
+                raise WorkspaceSyncError(msg)
+    return manifest
+
+
+def _paths_for_manifest(root: Path, manifest: dict[str, FileState]) -> list[Path]:
+    """Resolve manifest paths for aggregate-size accounting."""
+    return [root / relative for relative in manifest]
+
+
+def _sha256(path: Path) -> str:
+    """Hash one regular file without loading it all into memory."""
+    digest = hashlib.sha256(usedforsecurity=False)
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise WorkspaceSyncError(f"could not read workspace file: {path}") from error
+    return digest.hexdigest()
+
+
+def _extract_archive(content: bytes, destination: Path) -> None:
+    """Validate and extract regular files only into an isolated staging directory."""
+    total_size = 0
+    seen: set[str] = set()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            members = archive.getmembers()
+            if len(members) > MAX_WORKSPACE_ENTRIES:
+                msg = f"workspace archive has more than {MAX_WORKSPACE_ENTRIES} entries"
+                raise WorkspaceSyncError(msg)
+            for member in members:
+                relative = _normalized_name(member.name)
+                if relative in seen:
+                    raise WorkspaceSyncError(f"duplicate workspace path: {relative}")
+                seen.add(relative)
+                if not (member.isfile() or member.isdir()):
+                    raise WorkspaceSyncError(
+                        f"workspace entry must be a regular file or directory: {member.name}"
+                    )
+                total_size += member.size
+                if total_size > MAX_WORKSPACE_UNPACKED_BYTES:
+                    msg = f"workspace expands beyond {MAX_WORKSPACE_UNPACKED_BYTES} bytes"
+                    raise WorkspaceSyncError(msg)
+                target = destination if relative == "." else destination / relative
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise WorkspaceSyncError(f"workspace file has no content: {member.name}")
+                with source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                target.chmod(member.mode & 0o777)
+    except WorkspaceSyncError:
+        raise
+    except (tarfile.TarError, OSError, EOFError) as error:
+        msg = "workspace must be a valid gzip tar archive"
+        raise WorkspaceSyncError(msg) from error
+
+
+def _normalized_name(name: str) -> str:
+    """Normalize one tar name and reject absolute or traversing entries."""
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise WorkspaceSyncError(f"unsafe workspace path: {name}")
+    parts = tuple(part for part in path.parts if part not in {"", "."})
+    return PurePosixPath(*parts).as_posix() if parts else "."
+
+
+def _has_non_file_collision(target: Path, state: FileState | None) -> bool:
+    """Return true when a manifest-absent target still exists as a dir/link/special file."""
+    return state is None and (target.exists() or target.is_symlink())
+
+
+def _atomic_copy(source: Path, target: Path, *, root: Path, mode: int) -> None:
+    """Copy through a sibling temporary file after proving the parent stays in ``root``."""
+    relative_parent = target.parent.relative_to(root)
+    current = root
+    for part in relative_parent.parts:
+        current /= part
+        if current.is_symlink():
+            raise OSError(f"workspace path crosses a symlink: {target}")
+        if current.exists() and not current.is_dir():
+            raise OSError(f"workspace parent is not a directory: {current}")
+        current.mkdir(exist_ok=True)
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise OSError(f"workspace target is not a regular file: {target}")
+    temporary = target.parent / f".{target.name}.wmh-{uuid.uuid4().hex}"
+    try:
+        shutil.copyfile(source, temporary)
+        temporary.chmod(mode)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _remove_empty_parents(directory: Path, root: Path) -> None:
+    """Remove newly empty parents after a remote deletion, stopping at the sync root."""
+    current = directory
+    while current != root:
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -15,6 +15,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+from wmh.harness.workspace_patch import PatchFileState, parse_workspace_patch
+
 MAX_WORKSPACE_ARCHIVE_BYTES = 50 * 1024 * 1024
 MAX_WORKSPACE_UNPACKED_BYTES = 512 * 1024 * 1024
 MAX_WORKSPACE_ENTRIES = 100_000
@@ -103,7 +105,13 @@ def snapshot_workspace(root: Path) -> WorkspaceSnapshot:
     return WorkspaceSnapshot(archive=content, files=files)
 
 
-def sync_workspace(root: Path, initial: WorkspaceSnapshot, final_archive: bytes) -> SyncResult:
+def sync_workspace(
+    root: Path,
+    initial: WorkspaceSnapshot,
+    final_archive: bytes,
+    *,
+    protected_paths: frozenset[str] = frozenset(),
+) -> SyncResult:
     """Apply remote changes unless the same path changed locally since upload."""
     resolved = root.resolve()
     if len(final_archive) > MAX_WORKSPACE_ARCHIVE_BYTES:
@@ -123,7 +131,11 @@ def sync_workspace(root: Path, initial: WorkspaceSnapshot, final_archive: bytes)
                 continue
             target = resolved / relative
             now = current.get(relative)
-            if _has_non_file_collision(target, now) or (now != before and now != after):
+            if (
+                relative in protected_paths
+                or _has_non_file_collision(target, now)
+                or (now != before and now != after)
+            ):
                 conflicts.append(relative)
                 continue
             if now == after:
@@ -138,6 +150,36 @@ def sync_workspace(root: Path, initial: WorkspaceSnapshot, final_archive: bytes)
                 conflicts.append(relative)
                 continue
             applied.append(relative)
+    return SyncResult(applied=tuple(applied), conflicts=tuple(conflicts))
+
+
+def apply_workspace_patch(root: Path, content: bytes) -> SyncResult:
+    """Apply an incremental remote patch when each local path still matches its base."""
+    resolved = root.resolve()
+    patch = parse_workspace_patch(content)
+    current = _manifest(resolved)
+    applied: list[str] = []
+    conflicts: list[str] = []
+    for operation in patch.operations:
+        target = resolved / operation.path
+        now = current.get(operation.path)
+        before = _file_state(operation.before)
+        after = _file_state(operation.after)
+        if _has_non_file_collision(target, now) or (now != before and now != after):
+            conflicts.append(operation.path)
+            continue
+        if now == after:
+            continue
+        try:
+            if after is None:
+                target.unlink(missing_ok=True)
+                _remove_empty_parents(target.parent, resolved)
+            else:
+                _atomic_write(patch.files[operation.path], target, root=resolved, mode=after.mode)
+        except OSError:
+            conflicts.append(operation.path)
+            continue
+        applied.append(operation.path)
     return SyncResult(applied=tuple(applied), conflicts=tuple(conflicts))
 
 
@@ -272,6 +314,21 @@ def _atomic_copy(source: Path, target: Path, *, root: Path, mode: int) -> None:
         os.replace(temporary, target)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _atomic_write(content: bytes, target: Path, *, root: Path, mode: int) -> None:
+    """Write patch bytes through the same collision-safe sibling replacement path."""
+    with tempfile.TemporaryDirectory(prefix="wmh-patch-") as staging_name:
+        source = Path(staging_name) / "content"
+        source.write_bytes(content)
+        _atomic_copy(source, target, root=root, mode=mode)
+
+
+def _file_state(state: PatchFileState | None) -> FileState | None:
+    """Translate the shared transport state into the CLI merge state."""
+    if state is None:
+        return None
+    return FileState(sha256=state.sha256, mode=state.mode)
 
 
 def _remove_empty_parents(directory: Path, root: Path) -> None:

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -12,10 +12,12 @@ import pytest
 
 from wmh.cli.workspace_sync import (
     WorkspaceSyncError,
+    apply_workspace_patch,
     snapshot_workspace,
     sync_workspace,
     write_conflict_archive,
 )
+from wmh.harness.workspace_patch import build_workspace_patch
 
 
 def _archive(files: dict[str, tuple[bytes, int]]) -> bytes:
@@ -90,6 +92,54 @@ def test_sync_preserves_concurrent_local_edit_and_applies_other_paths(tmp_path: 
     assert (tmp_path / "other.txt").read_text(encoding="utf-8") == "remote"
     recovery = write_conflict_archive(tmp_path, "session-1", final)
     assert recovery.read_bytes() == final
+
+
+def test_incremental_patch_applies_uncontested_changes(tmp_path: Path) -> None:
+    """A live remote patch lands before the hosted session finishes."""
+    (tmp_path / "changed.txt").write_text("before", encoding="utf-8")
+    (tmp_path / "deleted.txt").write_text("remove", encoding="utf-8")
+    before = snapshot_workspace(tmp_path)
+    after = _archive(
+        {
+            "changed.txt": (b"after", 0o755),
+            "added.txt": (b"new", 0o644),
+        }
+    )
+    patch = build_workspace_patch(before.archive, after)
+    assert patch is not None
+
+    result = apply_workspace_patch(tmp_path, patch)
+
+    assert result.conflicts == ()
+    assert set(result.applied) == {"added.txt", "changed.txt", "deleted.txt"}
+    assert (tmp_path / "changed.txt").read_text(encoding="utf-8") == "after"
+    assert (tmp_path / "changed.txt").stat().st_mode & 0o777 == 0o755
+    assert not (tmp_path / "deleted.txt").exists()
+
+
+def test_incremental_patch_preserves_local_conflict_and_applies_other_path(
+    tmp_path: Path,
+) -> None:
+    """Live sync isolates a same-path conflict instead of stopping the stream."""
+    (tmp_path / "same.txt").write_text("base", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("base", encoding="utf-8")
+    before = snapshot_workspace(tmp_path)
+    after = _archive(
+        {
+            "same.txt": (b"remote", 0o644),
+            "other.txt": (b"remote", 0o644),
+        }
+    )
+    patch = build_workspace_patch(before.archive, after)
+    assert patch is not None
+    (tmp_path / "same.txt").write_text("local", encoding="utf-8")
+
+    result = apply_workspace_patch(tmp_path, patch)
+
+    assert result.conflicts == ("same.txt",)
+    assert result.applied == ("other.txt",)
+    assert (tmp_path / "same.txt").read_text(encoding="utf-8") == "local"
+    assert (tmp_path / "other.txt").read_text(encoding="utf-8") == "remote"
 
 
 def test_sync_rejects_traversal_and_links(tmp_path: Path) -> None:

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for E2B workspace snapshotting and conflict-safe local reconciliation."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from wmh.cli.workspace_sync import (
+    WorkspaceSyncError,
+    snapshot_workspace,
+    sync_workspace,
+    write_conflict_archive,
+)
+
+
+def _archive(files: dict[str, tuple[bytes, int]]) -> bytes:
+    """Build a regular-file-only gzip tar for a simulated final sandbox."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for path, (content, mode) in files.items():
+            info = tarfile.TarInfo(path)
+            info.size = len(content)
+            info.mode = mode
+            archive.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def test_snapshot_skips_links_vcs_and_dependency_trees(tmp_path: Path) -> None:
+    """Only source-like regular files enter the upload archive."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("secret", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("large", encoding="utf-8")
+    (tmp_path / "link").symlink_to(tmp_path / "src" / "app.py")
+
+    snapshot = snapshot_workspace(tmp_path)
+
+    assert set(snapshot.files) == {"src/app.py"}
+    with tarfile.open(fileobj=io.BytesIO(snapshot.archive), mode="r:gz") as archive:
+        assert archive.getnames() == ["src/app.py"]
+
+
+def test_sync_applies_remote_add_modify_delete_and_mode(tmp_path: Path) -> None:
+    """Uncontested remote filesystem changes automatically land in the local directory."""
+    (tmp_path / "changed.txt").write_text("before", encoding="utf-8")
+    (tmp_path / "deleted.txt").write_text("remove", encoding="utf-8")
+    initial = snapshot_workspace(tmp_path)
+    final = _archive(
+        {
+            "changed.txt": (b"after", 0o755),
+            "added.txt": (b"new", 0o644),
+        }
+    )
+
+    result = sync_workspace(tmp_path, initial, final)
+
+    assert result.conflicts == ()
+    assert set(result.applied) == {"added.txt", "changed.txt", "deleted.txt"}
+    assert (tmp_path / "changed.txt").read_text(encoding="utf-8") == "after"
+    assert (tmp_path / "changed.txt").stat().st_mode & 0o777 == 0o755
+    assert (tmp_path / "added.txt").read_text(encoding="utf-8") == "new"
+    assert not (tmp_path / "deleted.txt").exists()
+
+
+def test_sync_preserves_concurrent_local_edit_and_applies_other_paths(tmp_path: Path) -> None:
+    """A local edit wins its path while unrelated remote changes still sync."""
+    (tmp_path / "same.txt").write_text("base", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("base", encoding="utf-8")
+    initial = snapshot_workspace(tmp_path)
+    (tmp_path / "same.txt").write_text("local", encoding="utf-8")
+    final = _archive(
+        {
+            "same.txt": (b"remote", 0o644),
+            "other.txt": (b"remote", 0o644),
+        }
+    )
+
+    result = sync_workspace(tmp_path, initial, final)
+
+    assert result.conflicts == ("same.txt",)
+    assert result.applied == ("other.txt",)
+    assert (tmp_path / "same.txt").read_text(encoding="utf-8") == "local"
+    assert (tmp_path / "other.txt").read_text(encoding="utf-8") == "remote"
+    recovery = write_conflict_archive(tmp_path, "session-1", final)
+    assert recovery.read_bytes() == final
+
+
+def test_sync_rejects_traversal_and_links(tmp_path: Path) -> None:
+    """A malicious sandbox archive cannot escape staging or materialize links locally."""
+    initial = snapshot_workspace(tmp_path)
+    traversal = _archive({"../escape": (b"bad", 0o644)})
+    with pytest.raises(WorkspaceSyncError, match="unsafe"):
+        sync_workspace(tmp_path, initial, traversal)
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo("link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        archive.addfile(info)
+    with pytest.raises(WorkspaceSyncError, match="regular file or directory"):
+        sync_workspace(tmp_path, initial, buffer.getvalue())

--- a/wmh/harness/pi_local.py
+++ b/wmh/harness/pi_local.py
@@ -1,0 +1,255 @@
+"""Run the vendored pi live-session peer as a local Node.js process.
+
+The platform remains the credential boundary: the Node peer receives worker
+completions over the existing stdio frame protocol and never receives provider
+keys. Unlike the E2B backend, this module deliberately runs the harness process
+on the user's machine. The CLI presents an explicit consent prompt before it
+reaches this boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import json
+import os
+import queue
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+from collections import deque
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, TextIO, cast
+
+from wmh.core.types import JsonObject
+from wmh.harness.pi_e2b import HELLO_TIMEOUT_S, PI_NPM_PACKAGES, session_entry_files
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_PI_VERSION = "0.80.3"
+_MIN_NODE = (22, 19, 0)
+_PACKAGE_JSON = '{"name":"wmh-pi-local","private":true,"type":"module"}\n'
+_INSTALL_MARKER = ".wmh-pi-dependencies"
+_STDERR_LINES = 50
+
+
+class _CompletedCommand(Protocol):
+    """The subprocess result slice runtime bootstrap consumes."""
+
+    stdout: str
+
+
+class _TextProcess(Protocol):
+    """The text-mode Popen slice used by the local frame channel."""
+
+    stdin: TextIO | None
+    stdout: TextIO | None
+    stderr: TextIO | None
+
+    def poll(self) -> int | None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
+class _Eof:
+    """Reader-thread sentinel for a closed runner stdout stream."""
+
+
+_EOF = _Eof()
+
+
+def parse_node_version(output: str) -> tuple[int, int, int]:
+    """Parse ``node --version`` output into a semantic-version triple."""
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)\s*", output)
+    if match is None:
+        raise RuntimeError(f"could not parse Node.js version output: {output.strip()!r}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def default_local_pi_runtime_dir() -> Path:
+    """Return the user cache directory for the pinned local pi runtime."""
+    cache = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache / "wmh" / "pi" / _PI_VERSION
+
+
+def ensure_local_pi_runtime(
+    runtime_dir: Path,
+    *,
+    node: str,
+    npm: str,
+    run_command: Callable[..., _CompletedCommand] = subprocess.run,
+) -> Path:
+    """Refresh the live runner and install its pinned npm dependencies once."""
+    version = run_command(
+        [node, "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    parsed = parse_node_version(version)
+    if parsed < _MIN_NODE:
+        required = ".".join(str(part) for part in _MIN_NODE)
+        found = ".".join(str(part) for part in parsed)
+        raise RuntimeError(f"local pi requires Node.js {required} or newer (found {found})")
+
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "package.json").write_text(_PACKAGE_JSON, encoding="utf-8")
+    for name, content in session_entry_files().items():
+        (runtime_dir / name).write_text(content, encoding="utf-8")
+
+    marker = runtime_dir / _INSTALL_MARKER
+    expected = "\n".join(PI_NPM_PACKAGES) + "\n"
+    if marker.is_file() and marker.read_text(encoding="utf-8") == expected:
+        return runtime_dir
+    run_command(
+        [npm, "install", "--no-audit", "--no-fund", "--ignore-scripts", *PI_NPM_PACKAGES],
+        cwd=runtime_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    marker.write_text(expected, encoding="utf-8")
+    return runtime_dir
+
+
+class LocalStdioChannel:
+    """A live-session frame channel over a local Node child process."""
+
+    def __init__(
+        self,
+        process: _TextProcess,
+        *,
+        stderr_lines: int = _STDERR_LINES,
+        cleanup_dir: Path | None = None,
+    ) -> None:
+        """Start bounded stdout/stderr reader threads for ``process``."""
+        if process.stdin is None or process.stdout is None or process.stderr is None:
+            raise RuntimeError("local pi process must expose stdin, stdout, and stderr pipes")
+        self._process = process
+        self._stdin = process.stdin
+        self._stdout = process.stdout
+        self._stderr_stream = process.stderr
+        self._frames: queue.Queue[JsonObject | _Eof] = queue.Queue()
+        self._stderr: deque[str] = deque(maxlen=stderr_lines)
+        self._cleanup_dir = cleanup_dir
+        self._closed = False
+        threading.Thread(target=self._read_stdout, name="pi-local-stdout", daemon=True).start()
+        threading.Thread(target=self._read_stderr, name="pi-local-stderr", daemon=True).start()
+
+    def send(self, frame: JsonObject) -> None:
+        """Write one base64(JSON) frame to the child process."""
+        line = base64.b64encode(json.dumps(frame).encode()).decode() + "\n"
+        self._stdin.write(line)
+        self._stdin.flush()
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        """Return the next decoded frame, optionally bounded by ``timeout``."""
+        try:
+            item = self._frames.get(timeout=timeout)
+        except queue.Empty:
+            message = f"no frame from local pi within {timeout}s{self._stderr_suffix()}"
+            raise TimeoutError(message) from None
+        if isinstance(item, _Eof):
+            self._frames.put(item)
+            if self._closed:
+                return None
+            raise RuntimeError(f"local pi process exited unexpectedly{self._stderr_suffix()}")
+        return item
+
+    def close(self) -> None:
+        """Shut down the child process without leaving a local runner behind."""
+        if self._closed:
+            return
+        self._closed = True
+        with contextlib.suppress(Exception):
+            self.send({"type": "shutdown"})
+        with contextlib.suppress(Exception):
+            self._process.wait(timeout=2)
+        if self._process.poll() is None:
+            with contextlib.suppress(Exception):
+                self._process.terminate()
+            with contextlib.suppress(Exception):
+                self._process.wait(timeout=2)
+        if self._process.poll() is None:
+            with contextlib.suppress(Exception):
+                self._process.kill()
+        if self._cleanup_dir is not None:
+            with contextlib.suppress(OSError):
+                shutil.rmtree(self._cleanup_dir)
+
+    def _read_stdout(self) -> None:
+        try:
+            for raw in self._stdout:
+                text = raw.strip()
+                if not text:
+                    continue
+                try:
+                    frame = json.loads(base64.b64decode(text, validate=True))
+                except ValueError:
+                    self._stderr.append(f"[stdout] {text}")
+                    continue
+                if isinstance(frame, dict):
+                    self._frames.put(cast("JsonObject", frame))
+                else:
+                    self._stderr.append(f"[stdout] {text}")
+        finally:
+            self._frames.put(_EOF)
+
+    def _read_stderr(self) -> None:
+        for raw in self._stderr_stream:
+            text = raw.rstrip()
+            if text:
+                self._stderr.append(text)
+
+    def _stderr_suffix(self) -> str:
+        tail = "\n".join(self._stderr)
+        return f"; recent stderr:\n{tail}" if tail else ""
+
+
+def start_local_live_runner(
+    *,
+    runtime_dir: Path | None = None,
+    hello_timeout: float = HELLO_TIMEOUT_S,
+) -> LocalStdioChannel:
+    """Bootstrap and start the local pi peer, returning a hello-verified channel."""
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    if node is None or npm is None:
+        raise RuntimeError("local pi requires Node.js 22.19+ and npm on PATH")
+    root = ensure_local_pi_runtime(
+        runtime_dir or default_local_pi_runtime_dir(), node=node, npm=npm
+    )
+    # Each process gets a private cwd for materialized champion code. Node still
+    # resolves dependencies from the cached runner's parent directory.
+    process_root = Path(tempfile.mkdtemp(prefix="run-", dir=root))
+    try:
+        process = subprocess.Popen(  # noqa: S603 - fixed executable/args, no shell
+            [node, "--experimental-strip-types", str(root / "runner_live.ts")],
+            cwd=process_root,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+    except BaseException:
+        shutil.rmtree(process_root, ignore_errors=True)
+        raise
+    channel = LocalStdioChannel(cast("_TextProcess", process), cleanup_dir=process_root)
+    try:
+        frame = channel.recv(timeout=hello_timeout)
+        if frame is None or frame.get("type") != "hello":
+            raise RuntimeError("local pi did not send its hello frame")
+    except BaseException:
+        channel.close()
+        raise
+    return channel

--- a/wmh/harness/pi_local_test.py
+++ b/wmh/harness/pi_local_test.py
@@ -1,0 +1,112 @@
+"""Local pi runner tests: runtime bootstrap and stdio frame transport."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import wmh.harness.pi_local as mod
+from wmh.harness.pi_local import (
+    LocalStdioChannel,
+    ensure_local_pi_runtime,
+    parse_node_version,
+)
+
+
+class _FakeResult:
+    """Completed-command slice returned by bootstrap test doubles."""
+
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+def test_parse_node_version_requires_semver_shape() -> None:
+    """Node's normal version output parses; unrelated output fails loudly."""
+    assert parse_node_version("v22.19.0\n") == (22, 19, 0)
+    with pytest.raises(RuntimeError, match="could not parse"):
+        parse_node_version("node unknown")
+
+
+def test_runtime_bootstrap_installs_once(tmp_path: Path) -> None:
+    """The runner refreshes every time while pinned npm dependencies install once."""
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs: object) -> _FakeResult:
+        calls.append(command)
+        if command[-1] == "--version":
+            return _FakeResult("v22.19.0\n")
+        return _FakeResult("")
+
+    runtime = ensure_local_pi_runtime(
+        tmp_path,
+        node="node",
+        npm="npm",
+        run_command=run,
+    )
+    assert runtime == tmp_path
+    assert (tmp_path / "runner_live.ts").is_file()
+    assert (tmp_path / "package.json").is_file()
+    assert any(command[:2] == ["npm", "install"] for command in calls)
+
+    calls.clear()
+    ensure_local_pi_runtime(tmp_path, node="node", npm="npm", run_command=run)
+    assert calls == [["node", "--version"]]
+
+
+def test_runtime_bootstrap_rejects_old_node(tmp_path: Path) -> None:
+    """The local harness fails before npm work when Node cannot strip pi's TypeScript."""
+
+    def run(_command: list[str], **_kwargs: object) -> _FakeResult:
+        return _FakeResult("v20.10.0\n")
+
+    with pytest.raises(RuntimeError, match="Node.js 22.19"):
+        ensure_local_pi_runtime(tmp_path, node="node", npm="npm", run_command=run)
+
+
+class _FakeProcess:
+    """Minimal text-mode Popen stand-in for LocalStdioChannel."""
+
+    def __init__(self, frames: list[dict[str, object]]) -> None:
+        encoded = "".join(
+            base64.b64encode(json.dumps(frame).encode()).decode() + "\n" for frame in frames
+        )
+        self.stdout = io.StringIO(encoded)
+        self.stderr = io.StringIO("")
+        self.stdin = io.StringIO()
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return 0 if self.terminated else None
+
+    def wait(self, timeout: float | None = None) -> int:
+        _ = timeout
+        self.terminated = True
+        return 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.terminated = True
+
+
+def test_local_stdio_channel_round_trips_frames_and_cleans_run_dir(tmp_path: Path) -> None:
+    """The channel transports frames, closes its process, and removes the private cwd."""
+    process = _FakeProcess([{"type": "hello", "mode": "session"}])
+    run_dir = tmp_path / "run-1"
+    run_dir.mkdir()
+    channel = LocalStdioChannel(cast("mod._TextProcess", process), cleanup_dir=run_dir)
+
+    assert channel.recv(timeout=1) == {"type": "hello", "mode": "session"}
+    channel.send({"type": "ping", "nonce": "n1"})
+
+    wire = process.stdin.getvalue().strip()
+    assert json.loads(base64.b64decode(wire)) == {"type": "ping", "nonce": "n1"}
+    channel.close()
+    assert process.terminated
+    assert not run_dir.exists()

--- a/wmh/harness/workspace_patch.py
+++ b/wmh/harness/workspace_patch.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Hash-guarded incremental patch protocol for synchronized workspaces."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+MAX_WORKSPACE_PATCH_BYTES = 50 * 1024 * 1024
+MAX_WORKSPACE_PATCH_UNPACKED_BYTES = 512 * 1024 * 1024
+MAX_WORKSPACE_PATCH_ENTRIES = 100_000
+
+_MANIFEST_PATH = "manifest.json"
+_DATA_PREFIX = "data/"
+_VERSION = 1
+
+
+class WorkspacePatchError(ValueError):
+    """An incremental workspace patch is malformed or unsafe."""
+
+
+@dataclass(frozen=True)
+class PatchFileState:
+    """The content and executable mode expected before or after one operation."""
+
+    sha256: str
+    mode: int
+
+
+@dataclass(frozen=True)
+class WorkspacePatchOperation:
+    """One conditional path transition in an incremental patch."""
+
+    path: str
+    before: PatchFileState | None
+    after: PatchFileState | None
+
+
+@dataclass(frozen=True)
+class WorkspacePatch:
+    """Validated operations and replacement bytes keyed by workspace path."""
+
+    operations: tuple[WorkspacePatchOperation, ...]
+    files: dict[str, bytes]
+
+
+def build_workspace_patch(before_archive: bytes, after_archive: bytes) -> bytes | None:
+    """Build a deterministic patch between two full workspace archives."""
+    before = _read_workspace_archive(before_archive)
+    after = _read_workspace_archive(after_archive)
+    operations: list[WorkspacePatchOperation] = []
+    for path in sorted(set(before) | set(after)):
+        before_state = _state(before.get(path))
+        after_state = _state(after.get(path))
+        if before_state != after_state:
+            operations.append(
+                WorkspacePatchOperation(path=path, before=before_state, after=after_state)
+            )
+    if not operations:
+        return None
+
+    manifest = {
+        "version": _VERSION,
+        "operations": [
+            {
+                "path": operation.path,
+                "before": _state_json(operation.before),
+                "after": _state_json(operation.after),
+            }
+            for operation in operations
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        _add_bytes(archive, _MANIFEST_PATH, manifest_bytes, 0o600)
+        for operation in operations:
+            if operation.after is None:
+                continue
+            body, _mode = after[operation.path]
+            _add_bytes(archive, f"{_DATA_PREFIX}{operation.path}", body, operation.after.mode)
+    content = buffer.getvalue()
+    if len(content) > MAX_WORKSPACE_PATCH_BYTES:
+        raise WorkspacePatchError(f"workspace patch exceeds {MAX_WORKSPACE_PATCH_BYTES} bytes")
+    return content
+
+
+def parse_workspace_patch(content: bytes) -> WorkspacePatch:
+    """Validate and decode one patch without writing any filesystem paths."""
+    if len(content) > MAX_WORKSPACE_PATCH_BYTES:
+        raise WorkspacePatchError(f"workspace patch exceeds {MAX_WORKSPACE_PATCH_BYTES} bytes")
+    members: dict[str, tuple[bytes, int]] = {}
+    total = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            entries = archive.getmembers()
+            if len(entries) > MAX_WORKSPACE_PATCH_ENTRIES + 1:
+                raise WorkspacePatchError("workspace patch has too many entries")
+            for member in entries:
+                name = _normalized_name(member.name)
+                if name in members:
+                    raise WorkspacePatchError(f"duplicate workspace patch path: {name}")
+                if not member.isfile():
+                    raise WorkspacePatchError(
+                        f"workspace patch entry must be a regular file: {member.name}"
+                    )
+                total += member.size
+                if total > MAX_WORKSPACE_PATCH_UNPACKED_BYTES:
+                    raise WorkspacePatchError("workspace patch expands beyond its limit")
+                source = archive.extractfile(member)
+                if source is None:
+                    raise WorkspacePatchError(
+                        f"workspace patch entry has no content: {member.name}"
+                    )
+                members[name] = (source.read(), member.mode & 0o777)
+    except WorkspacePatchError:
+        raise
+    except (tarfile.TarError, OSError, EOFError) as error:
+        raise WorkspacePatchError("workspace patch must be a gzip tar archive") from error
+
+    manifest_entry = members.pop(_MANIFEST_PATH, None)
+    if manifest_entry is None:
+        raise WorkspacePatchError("workspace patch has no manifest")
+    try:
+        raw = json.loads(manifest_entry[0])
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise WorkspacePatchError("workspace patch manifest is not valid JSON") from error
+    if not isinstance(raw, dict) or raw.get("version") != _VERSION:
+        raise WorkspacePatchError("unsupported workspace patch version")
+    raw_operations = raw.get("operations")
+    if not isinstance(raw_operations, list) or not raw_operations:
+        raise WorkspacePatchError("workspace patch has no operations")
+
+    operations: list[WorkspacePatchOperation] = []
+    files: dict[str, bytes] = {}
+    seen: set[str] = set()
+    for raw_operation in raw_operations:
+        operation = _parse_operation(raw_operation)
+        if operation.path in seen:
+            raise WorkspacePatchError(f"duplicate workspace patch operation: {operation.path}")
+        seen.add(operation.path)
+        data_name = f"{_DATA_PREFIX}{operation.path}"
+        entry = members.pop(data_name, None)
+        if operation.after is None:
+            if entry is not None:
+                raise WorkspacePatchError(
+                    f"deleted workspace patch path has replacement data: {operation.path}"
+                )
+        else:
+            if entry is None:
+                raise WorkspacePatchError(
+                    f"workspace patch has no replacement data: {operation.path}"
+                )
+            body, mode = entry
+            if _digest(body) != operation.after.sha256:
+                raise WorkspacePatchError(f"workspace patch digest mismatch: {operation.path}")
+            if mode != operation.after.mode:
+                raise WorkspacePatchError(f"workspace patch mode mismatch: {operation.path}")
+            files[operation.path] = body
+        operations.append(operation)
+    if members:
+        extra = next(iter(sorted(members)))
+        raise WorkspacePatchError(f"unexpected workspace patch entry: {extra}")
+    return WorkspacePatch(operations=tuple(operations), files=files)
+
+
+def _read_workspace_archive(content: bytes) -> dict[str, tuple[bytes, int]]:
+    """Read regular files from a trusted full snapshot used to calculate a patch."""
+    files: dict[str, tuple[bytes, int]] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            entries = archive.getmembers()
+            if len(entries) > MAX_WORKSPACE_PATCH_ENTRIES:
+                raise WorkspacePatchError("workspace archive has too many entries")
+            total = 0
+            for member in entries:
+                name = _normalized_name(member.name)
+                if member.isdir():
+                    continue
+                if not member.isfile():
+                    raise WorkspacePatchError(
+                        f"workspace entry must be a regular file or directory: {member.name}"
+                    )
+                if name in files:
+                    raise WorkspacePatchError(f"duplicate workspace path: {name}")
+                total += member.size
+                if total > MAX_WORKSPACE_PATCH_UNPACKED_BYTES:
+                    raise WorkspacePatchError("workspace archive expands beyond its limit")
+                source = archive.extractfile(member)
+                if source is None:
+                    raise WorkspacePatchError(f"workspace file has no content: {name}")
+                files[name] = (source.read(), member.mode & 0o777)
+    except WorkspacePatchError:
+        raise
+    except (tarfile.TarError, OSError, EOFError) as error:
+        raise WorkspacePatchError("workspace must be a gzip tar archive") from error
+    return files
+
+
+def _parse_operation(value: object) -> WorkspacePatchOperation:
+    if not isinstance(value, dict):
+        raise WorkspacePatchError("workspace patch operation must be an object")
+    path_value = value.get("path")
+    if not isinstance(path_value, str):
+        raise WorkspacePatchError("workspace patch operation has no path")
+    path = _normalized_name(path_value)
+    if path == ".":
+        raise WorkspacePatchError("workspace patch operation cannot target the root")
+    before = _parse_state(value.get("before"))
+    after = _parse_state(value.get("after"))
+    if before == after:
+        raise WorkspacePatchError(f"workspace patch operation does not change: {path}")
+    return WorkspacePatchOperation(path=path, before=before, after=after)
+
+
+def _parse_state(value: object) -> PatchFileState | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise WorkspacePatchError("workspace patch file state must be an object")
+    sha256 = value.get("sha256")
+    mode = value.get("mode")
+    if (
+        not isinstance(sha256, str)
+        or len(sha256) != 64
+        or any(character not in "0123456789abcdef" for character in sha256)
+        or not isinstance(mode, int)
+        or isinstance(mode, bool)
+        or not 0 <= mode <= 0o777
+    ):
+        raise WorkspacePatchError("workspace patch file state is invalid")
+    return PatchFileState(sha256=sha256, mode=mode)
+
+
+def _state(entry: tuple[bytes, int] | None) -> PatchFileState | None:
+    if entry is None:
+        return None
+    body, mode = entry
+    return PatchFileState(sha256=_digest(body), mode=mode)
+
+
+def _state_json(state: PatchFileState | None) -> dict[str, object] | None:
+    if state is None:
+        return None
+    return {"sha256": state.sha256, "mode": state.mode}
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, body: bytes, mode: int) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(body)
+    info.mode = mode
+    info.mtime = 0
+    archive.addfile(info, io.BytesIO(body))
+
+
+def _normalized_name(name: str) -> str:
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise WorkspacePatchError(f"unsafe workspace patch path: {name}")
+    parts = tuple(part for part in path.parts if part not in {"", "."})
+    return PurePosixPath(*parts).as_posix() if parts else "."
+
+
+def _digest(body: bytes) -> str:
+    return hashlib.sha256(body, usedforsecurity=False).hexdigest()

--- a/wmh/harness/workspace_patch_test.py
+++ b/wmh/harness/workspace_patch_test.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for the transport-neutral incremental workspace patch protocol."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from wmh.harness.workspace_patch import (
+    WorkspacePatchError,
+    build_workspace_patch,
+    parse_workspace_patch,
+)
+
+
+def _archive(files: dict[str, tuple[bytes, int]]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for path, (content, mode) in files.items():
+            info = tarfile.TarInfo(path)
+            info.size = len(content)
+            info.mode = mode
+            archive.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def test_patch_round_trip_carries_add_modify_delete_and_mode() -> None:
+    before = _archive(
+        {
+            "changed.txt": (b"before", 0o644),
+            "deleted.txt": (b"remove", 0o644),
+            "mode.txt": (b"same", 0o644),
+        }
+    )
+    after = _archive(
+        {
+            "changed.txt": (b"after", 0o644),
+            "added.txt": (b"new", 0o600),
+            "mode.txt": (b"same", 0o755),
+        }
+    )
+
+    content = build_workspace_patch(before, after)
+
+    assert content is not None
+    patch = parse_workspace_patch(content)
+    assert [operation.path for operation in patch.operations] == [
+        "added.txt",
+        "changed.txt",
+        "deleted.txt",
+        "mode.txt",
+    ]
+    assert patch.files["added.txt"] == b"new"
+    assert patch.files["changed.txt"] == b"after"
+    assert "deleted.txt" not in patch.files
+    assert patch.files["mode.txt"] == b"same"
+    assert patch.operations[-1].after is not None
+    assert patch.operations[-1].after.mode == 0o755
+
+
+def test_patch_builder_returns_none_when_archives_match() -> None:
+    archive = _archive({"same.txt": (b"same", 0o644)})
+
+    assert build_workspace_patch(archive, archive) is None
+
+
+def test_patch_parser_rejects_content_that_does_not_match_manifest() -> None:
+    before = _archive({"changed.txt": (b"before", 0o644)})
+    after = _archive({"changed.txt": (b"after", 0o644)})
+    content = build_workspace_patch(before, after)
+    assert content is not None
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as output:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as source:
+            for member in source.getmembers():
+                body = source.extractfile(member)
+                data = body.read() if body is not None else b""
+                if member.name == "data/changed.txt":
+                    data = b"tampered"
+                    member.size = len(data)
+                output.addfile(member, io.BytesIO(data))
+
+    with pytest.raises(WorkspacePatchError, match="digest"):
+        parse_workspace_patch(buffer.getvalue())

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 from wmh.core.types import Action, JsonValue, Observation
 
 _TIMEOUT_SECONDS = 120.0
+_WORKSPACE_TIMEOUT_SECONDS = 300.0
 
 
 class PlatformError(RuntimeError):
@@ -128,6 +129,44 @@ class RemoteWorldModelSession(BaseModel):
     status: str
 
 
+class RemoteAgentSession(BaseModel):
+    """Hosted E2B agent session state needed by the CLI driver."""
+
+    id: str
+    agent_id: str
+    status: str
+    source: str
+    workspace_sync: bool
+    starting_detail: str | None = None
+    error: str | None = None
+
+
+class RemoteAgentSessionEvent(BaseModel):
+    """One durable event from a hosted agent session transcript."""
+
+    seq: int
+    kind: Literal[
+        "user_message",
+        "assistant_message",
+        "tool_call",
+        "tool_output",
+        "tool_result",
+        "submit",
+        "state",
+        "status",
+        "error",
+    ]
+    payload: dict[str, JsonValue]
+
+
+class RemoteAgentEventPage(BaseModel):
+    """One poll page of hosted transcript events and current session status."""
+
+    events: list[RemoteAgentSessionEvent]
+    last_seq: int
+    status: str
+
+
 class LocalPiRunInfo(BaseModel):
     """An org-scoped platform usage record for the built-in local pi harness."""
 
@@ -228,6 +267,62 @@ class PlatformClient:
         )
         self._raise_for_error(response)
         return Observation.model_validate(response.json()["observation"])
+
+    def create_agent_workspace_session(
+        self, agent_id: str, workspace: bytes, *, instruction: str | None = None
+    ) -> RemoteAgentSession:
+        """Upload a local snapshot and dispatch the agent in platform-owned E2B."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/workspace-sessions",
+            data={"instruction": instruction or ""},
+            files={"workspace": ("workspace.tar.gz", workspace, "application/gzip")},
+            timeout=_WORKSPACE_TIMEOUT_SECONDS,
+        )
+        self._raise_for_error(response)
+        return RemoteAgentSession.model_validate(response.json())
+
+    def get_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+        """Read current hosted agent session state."""
+        response = self._client.get(f"/api/agents/{agent_id}/sessions/{session_id}")
+        self._raise_for_error(response)
+        return RemoteAgentSession.model_validate(response.json())
+
+    def list_agent_session_events(
+        self, agent_id: str, session_id: str, *, after: int
+    ) -> RemoteAgentEventPage:
+        """Poll hosted transcript events after one durable sequence cursor."""
+        response = self._client.get(
+            f"/api/agents/{agent_id}/sessions/{session_id}/events",
+            params={"after": after},
+        )
+        self._raise_for_error(response)
+        return RemoteAgentEventPage.model_validate(response.json())
+
+    def post_agent_session_command(
+        self, agent_id: str, session_id: str, kind: str, *, text: str | None = None
+    ) -> None:
+        """Steer, interrupt, or end one hosted agent session."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/sessions/{session_id}/commands",
+            json={"kind": kind, "text": text},
+        )
+        self._raise_for_error(response)
+
+    def download_agent_workspace(self, agent_id: str, session_id: str) -> bytes:
+        """Download a terminal hosted session's final E2B workspace snapshot."""
+        response = self._client.get(
+            f"/api/agents/{agent_id}/sessions/{session_id}/workspace",
+            timeout=_WORKSPACE_TIMEOUT_SECONDS,
+        )
+        self._raise_for_error(response)
+        return response.content
+
+    def acknowledge_agent_workspace(self, agent_id: str, session_id: str) -> None:
+        """Confirm the final archive is safe locally so platform objects can be removed."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/sessions/{session_id}/workspace/ack"
+        )
+        self._raise_for_error(response)
 
     # -- world models --------------------------------------------------------------------------
 

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -281,20 +281,22 @@ class PlatformClient:
         self,
         agent_id: str,
         *,
-        workspace: bytes,
+        workspace: bytes | None,
         instruction: str | None = None,
     ) -> RemoteAgentSession:
-        """Stage a local snapshot, then create an ordinary hosted agent session."""
-        upload = self._client.post(
-            f"/api/agents/{agent_id}/workspace-uploads",
-            files={"workspace": ("workspace.tar.gz", workspace, "application/gzip")},
-            timeout=_WORKSPACE_TIMEOUT_SECONDS,
-        )
-        self._raise_for_error(upload)
-        upload_id = str(upload.json()["id"])
+        """Create a hosted agent session, optionally staging a local snapshot."""
+        payload: dict[str, JsonValue] = {"instruction": instruction}
+        if workspace is not None:
+            upload = self._client.post(
+                f"/api/agents/{agent_id}/workspace-uploads",
+                files={"workspace": ("workspace.tar.gz", workspace, "application/gzip")},
+                timeout=_WORKSPACE_TIMEOUT_SECONDS,
+            )
+            self._raise_for_error(upload)
+            payload["workspace_upload_id"] = str(upload.json()["id"])
         response = self._client.post(
             f"/api/agents/{agent_id}/sessions",
-            json={"instruction": instruction, "workspace_upload_id": upload_id},
+            json=payload,
         )
         self._raise_for_error(response)
         return RemoteAgentSession.model_validate(response.json())

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -124,7 +124,7 @@ class RemoteAgentSession(BaseModel):
     agent_id: str
     status: str
     workspace_sync: bool
-    launched_from: Literal["web", "cli"]
+    launched_from: str
     starting_detail: str | None = None
     error: str | None = None
 

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -12,12 +12,13 @@ import hashlib
 import json
 from importlib import metadata
 from pathlib import Path
+from typing import Literal
 
 import httpx
 from llm_waterfall import ChatRequest, ChatResponse
 from pydantic import BaseModel
 
-from wmh.core.types import JsonValue
+from wmh.core.types import Action, JsonValue, Observation
 
 _TIMEOUT_SECONDS = 120.0
 
@@ -108,6 +109,35 @@ class LocalSessionInfo(BaseModel):
     title: str | None = None
 
 
+class RunTarget(BaseModel):
+    """A platform id resolved to one executable resource kind."""
+
+    id: str
+    kind: Literal["world_model", "agent"]
+    org_id: str
+    name: str
+    display_name: str | None = None
+    status: str
+
+
+class RemoteWorldModelSession(BaseModel):
+    """The slice of a hosted world-model session needed by ``wmh run``."""
+
+    id: str
+    world_model_id: str
+    status: str
+
+
+class LocalPiRunInfo(BaseModel):
+    """An org-scoped platform usage record for the built-in local pi harness."""
+
+    id: str
+    org_id: str
+    status: str
+    worker_provider: str
+    worker_model: str
+
+
 def fetch_cli_config(web_url: str, *, transport: httpx.BaseTransport | None = None) -> str | None:
     """Ask the web app which backend host the CLI should call.
 
@@ -171,6 +201,33 @@ class PlatformClient:
         response = self._client.get("/api/whoami")
         self._raise_for_error(response)
         return WhoAmI.model_validate(response.json())
+
+    # -- unified runs --------------------------------------------------------------------------
+
+    def resolve_run_target(self, target_id: str) -> RunTarget:
+        """Resolve an opaque platform id without guessing from failed requests."""
+        response = self._client.get(f"/api/run-targets/{target_id}")
+        self._raise_for_error(response)
+        return RunTarget.model_validate(response.json())
+
+    def create_world_model_session(
+        self, world_model_id: str, *, task: str | None = None
+    ) -> RemoteWorldModelSession:
+        """Open a hosted session for a platform world model."""
+        response = self._client.post(
+            f"/api/world-models/{world_model_id}/sessions", json={"task": task}
+        )
+        self._raise_for_error(response)
+        return RemoteWorldModelSession.model_validate(response.json())
+
+    def step_world_model_session(self, session_id: str, action: Action) -> Observation:
+        """Advance a hosted world-model session by one action."""
+        response = self._client.post(
+            f"/api/sessions/{session_id}/step",
+            json={"action": action.model_dump(mode="json")},
+        )
+        self._raise_for_error(response)
+        return Observation.model_validate(response.json()["observation"])
 
     # -- world models --------------------------------------------------------------------------
 
@@ -328,9 +385,7 @@ class PlatformClient:
         seq = response.json().get("last_seq", 0)
         return int(seq) if isinstance(seq, int | float | str) else 0
 
-    def complete_worker(
-        self, agent_id: str, session_id: str, request: ChatRequest
-    ) -> ChatResponse:
+    def complete_worker(self, agent_id: str, session_id: str, request: ChatRequest) -> ChatResponse:
         """Answer one worker turn through the platform proxy (platform keys, org-billed)."""
         response = self._client.post(
             f"/api/agents/{agent_id}/local-sessions/{session_id}/worker-completion",
@@ -346,7 +401,6 @@ class PlatformClient:
         *,
         status: str,
         ended_reason: str,
-        sandbox_seconds: int | None = None,
         error: str | None = None,
     ) -> None:
         """Report the terminal transition of a local session."""
@@ -355,9 +409,43 @@ class PlatformClient:
             json={
                 "status": status,
                 "ended_reason": ended_reason,
-                "sandbox_seconds": sandbox_seconds,
                 "error": error,
             },
+        )
+        self._raise_for_error(response)
+
+    # -- built-in local pi runs ---------------------------------------------------------------
+
+    def create_local_pi_run(self, org_id: str) -> LocalPiRunInfo:
+        """Open a metered platform run for WMH's built-in local pi harness."""
+        response = self._client.post(f"/api/orgs/{org_id}/local-pi-runs")
+        self._raise_for_error(response)
+        return LocalPiRunInfo.model_validate(response.json())
+
+    def complete_local_pi_worker(
+        self, org_id: str, run_id: str, request: ChatRequest
+    ) -> ChatResponse:
+        """Answer one built-in pi worker turn through the platform."""
+        response = self._client.post(
+            f"/api/orgs/{org_id}/local-pi-runs/{run_id}/worker-completion",
+            json=request.model_dump(mode="json", exclude_none=True),
+        )
+        self._raise_for_error(response)
+        return ChatResponse.model_validate(response.json())
+
+    def finish_local_pi_run(
+        self,
+        org_id: str,
+        run_id: str,
+        *,
+        status: str,
+        ended_reason: str,
+        error: str | None = None,
+    ) -> None:
+        """Report the terminal transition of a built-in local pi run."""
+        response = self._client.post(
+            f"/api/orgs/{org_id}/local-pi-runs/{run_id}/finish",
+            json={"status": status, "ended_reason": ended_reason, "error": error},
         )
         self._raise_for_error(response)
 

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -98,18 +98,6 @@ class PushedHarnessVersion(BaseModel):
     created: bool  # False when the push was an idempotent repeat of the tip
 
 
-class LocalSessionInfo(BaseModel):
-    """The platform's record of a CLI-driven local session (a session_view slice)."""
-
-    id: str
-    agent_id: str
-    status: str
-    source: str
-    agent_provider: str
-    agent_model: str
-    title: str | None = None
-
-
 class RunTarget(BaseModel):
     """A platform id resolved to one executable resource kind."""
 
@@ -135,7 +123,6 @@ class RemoteAgentSession(BaseModel):
     id: str
     agent_id: str
     status: str
-    source: str
     workspace_sync: bool
     launched_from: Literal["web", "cli"]
     starting_detail: str | None = None
@@ -501,63 +488,6 @@ class PlatformClient:
         )
         self._raise_for_error(response)
         return PushedHarnessVersion.model_validate(response.json())
-
-    # -- local (CLI-driven) agent sessions -----------------------------------------------------
-
-    def fetch_champion_harness(self, agent_id: str) -> HarnessVersionDoc:
-        """Fetch an agent's champion harness WITH its raw doc (to run locally)."""
-        response = self._client.get(f"/api/agents/{agent_id}/champion")
-        self._raise_for_error(response)
-        return HarnessVersionDoc.model_validate(response.json())
-
-    def create_local_session(self, agent_id: str, *, title: str | None = None) -> LocalSessionInfo:
-        """Open a platform-recorded local session for this agent (no dispatch)."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/local-sessions", json={"title": title}
-        )
-        self._raise_for_error(response)
-        return LocalSessionInfo.model_validate(response.json())
-
-    def append_local_events(
-        self, agent_id: str, session_id: str, events: list[dict[str, JsonValue]]
-    ) -> int:
-        """Report a batch of transcript events; return the session's new last_seq."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/local-sessions/{session_id}/events",
-            json={"events": events},
-        )
-        self._raise_for_error(response)
-        seq = response.json().get("last_seq", 0)
-        return int(seq) if isinstance(seq, int | float | str) else 0
-
-    def complete_worker(self, agent_id: str, session_id: str, request: ChatRequest) -> ChatResponse:
-        """Answer one worker turn through the platform proxy (platform keys, org-billed)."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/local-sessions/{session_id}/worker-completion",
-            json=request.model_dump(mode="json", exclude_none=True),
-        )
-        self._raise_for_error(response)
-        return ChatResponse.model_validate(response.json())
-
-    def finish_local_session(
-        self,
-        agent_id: str,
-        session_id: str,
-        *,
-        status: str,
-        ended_reason: str,
-        error: str | None = None,
-    ) -> None:
-        """Report the terminal transition of a local session."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/local-sessions/{session_id}/finish",
-            json={
-                "status": status,
-                "ended_reason": ended_reason,
-                "error": error,
-            },
-        )
-        self._raise_for_error(response)
 
     # -- built-in local pi runs ---------------------------------------------------------------
 

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -14,6 +14,7 @@ from importlib import metadata
 from pathlib import Path
 
 import httpx
+from llm_waterfall import ChatRequest, ChatResponse
 from pydantic import BaseModel
 
 from wmh.core.types import JsonValue
@@ -93,6 +94,18 @@ class PushedHarnessVersion(BaseModel):
     version: int
     doc_hash: str
     created: bool  # False when the push was an idempotent repeat of the tip
+
+
+class LocalSessionInfo(BaseModel):
+    """The platform's record of a CLI-driven local session (a session_view slice)."""
+
+    id: str
+    agent_id: str
+    status: str
+    source: str
+    agent_provider: str
+    agent_model: str
+    title: str | None = None
 
 
 def fetch_cli_config(web_url: str, *, transport: httpx.BaseTransport | None = None) -> str | None:
@@ -286,6 +299,67 @@ class PlatformClient:
         )
         self._raise_for_error(response)
         return PushedHarnessVersion.model_validate(response.json())
+
+    # -- local (CLI-driven) agent sessions -----------------------------------------------------
+
+    def fetch_champion_harness(self, agent_id: str) -> HarnessVersionDoc:
+        """Fetch an agent's champion harness WITH its raw doc (to run locally)."""
+        response = self._client.get(f"/api/agents/{agent_id}/champion")
+        self._raise_for_error(response)
+        return HarnessVersionDoc.model_validate(response.json())
+
+    def create_local_session(self, agent_id: str, *, title: str | None = None) -> LocalSessionInfo:
+        """Open a platform-recorded local session for this agent (no dispatch)."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/local-sessions", json={"title": title}
+        )
+        self._raise_for_error(response)
+        return LocalSessionInfo.model_validate(response.json())
+
+    def append_local_events(
+        self, agent_id: str, session_id: str, events: list[dict[str, JsonValue]]
+    ) -> int:
+        """Report a batch of transcript events; return the session's new last_seq."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/local-sessions/{session_id}/events",
+            json={"events": events},
+        )
+        self._raise_for_error(response)
+        seq = response.json().get("last_seq", 0)
+        return int(seq) if isinstance(seq, int | float | str) else 0
+
+    def complete_worker(
+        self, agent_id: str, session_id: str, request: ChatRequest
+    ) -> ChatResponse:
+        """Answer one worker turn through the platform proxy (platform keys, org-billed)."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/local-sessions/{session_id}/worker-completion",
+            json=request.model_dump(mode="json", exclude_none=True),
+        )
+        self._raise_for_error(response)
+        return ChatResponse.model_validate(response.json())
+
+    def finish_local_session(
+        self,
+        agent_id: str,
+        session_id: str,
+        *,
+        status: str,
+        ended_reason: str,
+        sandbox_seconds: int | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Report the terminal transition of a local session."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/local-sessions/{session_id}/finish",
+            json={
+                "status": status,
+                "ended_reason": ended_reason,
+                "sandbox_seconds": sandbox_seconds,
+                "error": error,
+            },
+        )
+        self._raise_for_error(response)
 
     # -- internals -----------------------------------------------------------------------------
 

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -339,7 +339,7 @@ class PlatformClient:
         return WorkspacePatchResult.model_validate(response.json())
 
     def download_agent_workspace_patch(
-        self, agent_id: str, session_id: str, revision: int
+        self, agent_id: str, session_id: str, revision: str
     ) -> bytes:
         """Download one remote-to-local live workspace patch."""
         response = self._client.get(
@@ -350,7 +350,7 @@ class PlatformClient:
         return response.content
 
     def acknowledge_agent_workspace_patch(
-        self, agent_id: str, session_id: str, revision: int
+        self, agent_id: str, session_id: str, revision: str
     ) -> None:
         """Remove a remote patch after it is safely reflected or reported locally."""
         response = self._client.post(

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -137,6 +137,7 @@ class RemoteAgentSession(BaseModel):
     status: str
     source: str
     workspace_sync: bool
+    launched_from: Literal["web", "cli"]
     starting_detail: str | None = None
     error: str | None = None
 
@@ -155,6 +156,7 @@ class RemoteAgentSessionEvent(BaseModel):
         "state",
         "status",
         "error",
+        "workspace_patch",
     ]
     payload: dict[str, JsonValue]
 
@@ -165,6 +167,13 @@ class RemoteAgentEventPage(BaseModel):
     events: list[RemoteAgentSessionEvent]
     last_seq: int
     status: str
+
+
+class WorkspacePatchResult(BaseModel):
+    """Paths accepted or rejected while applying a live workspace patch."""
+
+    applied: list[str]
+    conflicts: list[str]
 
 
 class LocalPiRunInfo(BaseModel):
@@ -268,15 +277,24 @@ class PlatformClient:
         self._raise_for_error(response)
         return Observation.model_validate(response.json()["observation"])
 
-    def create_agent_workspace_session(
-        self, agent_id: str, workspace: bytes, *, instruction: str | None = None
+    def create_agent_session(
+        self,
+        agent_id: str,
+        *,
+        workspace: bytes,
+        instruction: str | None = None,
     ) -> RemoteAgentSession:
-        """Upload a local snapshot and dispatch the agent in platform-owned E2B."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/workspace-sessions",
-            data={"instruction": instruction or ""},
+        """Stage a local snapshot, then create an ordinary hosted agent session."""
+        upload = self._client.post(
+            f"/api/agents/{agent_id}/workspace-uploads",
             files={"workspace": ("workspace.tar.gz", workspace, "application/gzip")},
             timeout=_WORKSPACE_TIMEOUT_SECONDS,
+        )
+        self._raise_for_error(upload)
+        upload_id = str(upload.json()["id"])
+        response = self._client.post(
+            f"/api/agents/{agent_id}/sessions",
+            json={"instruction": instruction, "workspace_upload_id": upload_id},
         )
         self._raise_for_error(response)
         return RemoteAgentSession.model_validate(response.json())
@@ -308,6 +326,38 @@ class PlatformClient:
         )
         self._raise_for_error(response)
 
+    def upload_agent_workspace_patch(
+        self, agent_id: str, session_id: str, content: bytes
+    ) -> WorkspacePatchResult:
+        """Apply local changes conditionally to a running hosted workspace."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/sessions/{session_id}/workspace/patches",
+            files={"patch": ("workspace-patch.tar.gz", content, "application/gzip")},
+            timeout=_WORKSPACE_TIMEOUT_SECONDS,
+        )
+        self._raise_for_error(response)
+        return WorkspacePatchResult.model_validate(response.json())
+
+    def download_agent_workspace_patch(
+        self, agent_id: str, session_id: str, revision: int
+    ) -> bytes:
+        """Download one remote-to-local live workspace patch."""
+        response = self._client.get(
+            f"/api/agents/{agent_id}/sessions/{session_id}/workspace/patches/{revision}",
+            timeout=_WORKSPACE_TIMEOUT_SECONDS,
+        )
+        self._raise_for_error(response)
+        return response.content
+
+    def acknowledge_agent_workspace_patch(
+        self, agent_id: str, session_id: str, revision: int
+    ) -> None:
+        """Remove a remote patch after it is safely reflected or reported locally."""
+        response = self._client.post(
+            f"/api/agents/{agent_id}/sessions/{session_id}/workspace/patches/{revision}/ack"
+        )
+        self._raise_for_error(response)
+
     def download_agent_workspace(self, agent_id: str, session_id: str) -> bytes:
         """Download a terminal hosted session's final E2B workspace snapshot."""
         response = self._client.get(
@@ -319,9 +369,7 @@ class PlatformClient:
 
     def acknowledge_agent_workspace(self, agent_id: str, session_id: str) -> None:
         """Confirm the final archive is safe locally so platform objects can be removed."""
-        response = self._client.post(
-            f"/api/agents/{agent_id}/sessions/{session_id}/workspace/ack"
-        )
+        response = self._client.post(f"/api/agents/{agent_id}/sessions/{session_id}/workspace/ack")
         self._raise_for_error(response)
 
     # -- world models --------------------------------------------------------------------------

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -109,6 +109,72 @@ def test_unified_run_target_and_world_model_session_payloads() -> None:
     ]
 
 
+def test_hosted_agent_workspace_session_transport() -> None:
+    """Agent runs upload a snapshot, poll/steer hosted E2B, then download and ack it."""
+    seen: list[str] = []
+    session = {
+        "id": "sess-1",
+        "agent_id": "agent-1",
+        "status": "starting",
+        "source": "hosted",
+        "workspace_sync": True,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        path = request.url.path
+        if path.endswith("/workspace-sessions"):
+            body = request.read()
+            assert b"archive-bytes" in body
+            assert b"fix the tests" in body
+            return httpx.Response(202, json=session)
+        if path.endswith("/events"):
+            assert request.url.params["after"] == "0"
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {"seq": 1, "kind": "assistant_message", "payload": {"text": "done"}}
+                    ],
+                    "last_seq": 1,
+                    "status": "running",
+                },
+            )
+        if path.endswith("/commands"):
+            assert json.loads(request.read()) == {"kind": "user_message", "text": "continue"}
+            return httpx.Response(202, json={"command_id": 1})
+        if path.endswith("/workspace/ack"):
+            return httpx.Response(204)
+        if path.endswith("/workspace"):
+            return httpx.Response(200, content=b"final-archive")
+        return httpx.Response(200, json={**session, "status": "ended"})
+
+    with _client(handler) as client:
+        created = client.create_agent_workspace_session(
+            "agent-1", b"archive-bytes", instruction="fix the tests"
+        )
+        page = client.list_agent_session_events("agent-1", created.id, after=0)
+        client.post_agent_session_command(
+            "agent-1", created.id, "user_message", text="continue"
+        )
+        current = client.get_agent_session("agent-1", created.id)
+        final = client.download_agent_workspace("agent-1", created.id)
+        client.acknowledge_agent_workspace("agent-1", created.id)
+
+    assert created.workspace_sync
+    assert page.events[0].payload["text"] == "done"
+    assert current.status == "ended"
+    assert final == b"final-archive"
+    assert seen == [
+        "POST /api/agents/agent-1/workspace-sessions",
+        "GET /api/agents/agent-1/sessions/sess-1/events",
+        "POST /api/agents/agent-1/sessions/sess-1/commands",
+        "GET /api/agents/agent-1/sessions/sess-1",
+        "GET /api/agents/agent-1/sessions/sess-1/workspace",
+        "POST /api/agents/agent-1/sessions/sess-1/workspace/ack",
+    ]
+
+
 def test_builtin_local_pi_run_payloads() -> None:
     """The built-in harness has an org-scoped, metered platform worker path."""
     seen: list[str] = []

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import httpx
 import pytest
+from llm_waterfall.types import ChatMessage, ChatRequest
 
+from wmh.core.types import Action, ActionKind
 from wmh.platform.client import PlatformClient, PlatformError, fetch_cli_config
 
 API_URL = "https://api.test"
@@ -55,6 +57,106 @@ def test_401_error_suggests_logging_in() -> None:
 
     with _client(handler) as client, pytest.raises(PlatformError, match="wmh login"):
         client.whoami()
+
+
+def test_unified_run_target_and_world_model_session_payloads() -> None:
+    """The run client resolves once, then uses the hosted world-model session API."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/api/run-targets/wm-1":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "wm-1",
+                    "kind": "world_model",
+                    "org_id": "org-1",
+                    "name": "tau",
+                    "status": "ready",
+                },
+            )
+        if request.url.path == "/api/world-models/wm-1/sessions":
+            assert json.loads(request.read()) == {"task": "book a flight"}
+            return httpx.Response(
+                201,
+                json={"id": "sess-1", "world_model_id": "wm-1", "status": "active"},
+            )
+        assert request.url.path == "/api/sessions/sess-1/step"
+        body = json.loads(request.read())
+        assert body["action"] == {
+            "kind": "tool_call",
+            "name": "search",
+            "arguments": {"q": "SFO"},
+            "content": None,
+        }
+        return httpx.Response(200, json={"observation": {"content": "three flights"}})
+
+    with _client(handler) as client:
+        target = client.resolve_run_target("wm-1")
+        session = client.create_world_model_session(target.id, task="book a flight")
+        observation = client.step_world_model_session(
+            session.id,
+            Action(kind=ActionKind.TOOL_CALL, name="search", arguments={"q": "SFO"}),
+        )
+
+    assert target.kind == "world_model"
+    assert observation.content == "three flights"
+    assert seen == [
+        "/api/run-targets/wm-1",
+        "/api/world-models/wm-1/sessions",
+        "/api/sessions/sess-1/step",
+    ]
+
+
+def test_builtin_local_pi_run_payloads() -> None:
+    """The built-in harness has an org-scoped, metered platform worker path."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/api/orgs/org-1/local-pi-runs":
+            return httpx.Response(
+                201,
+                json={
+                    "id": "run-1",
+                    "org_id": "org-1",
+                    "status": "running",
+                    "worker_provider": "bedrock",
+                    "worker_model": "claude-haiku-4-5",
+                },
+            )
+        if request.url.path.endswith("/worker-completion"):
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                },
+            )
+        assert request.url.path.endswith("/finish")
+        assert json.loads(request.read()) == {
+            "status": "ended",
+            "ended_reason": "user_ended",
+            "error": None,
+        }
+        return httpx.Response(202, json={})
+
+    with _client(handler) as client:
+        run = client.create_local_pi_run("org-1")
+        response = client.complete_local_pi_worker(
+            "org-1",
+            run.id,
+            ChatRequest(messages=[ChatMessage(role="user", content="hi")]),
+        )
+        client.finish_local_pi_run("org-1", run.id, status="ended", ended_reason="user_ended")
+
+    assert response.choices[0].message.content == "ok"
+    assert seen == [
+        "/api/orgs/org-1/local-pi-runs",
+        "/api/orgs/org-1/local-pi-runs/run-1/worker-completion",
+        "/api/orgs/org-1/local-pi-runs/run-1/finish",
+    ]
 
 
 def test_push_model_bundle_runs_ticket_put_finalize(tmp_path: Path) -> None:

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -149,9 +149,9 @@ def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -
         if path.endswith("/commands"):
             assert json.loads(request.read()) == {"kind": "user_message", "text": "continue"}
             return httpx.Response(202, json={"command_id": 1})
-        if path.endswith("/workspace/patches/7/ack"):
+        if path.endswith("/workspace/patches/patch-7/ack"):
             return httpx.Response(204)
-        if path.endswith("/workspace/patches/7"):
+        if path.endswith("/workspace/patches/patch-7"):
             return httpx.Response(200, content=b"remote-patch")
         if path.endswith("/workspace/patches"):
             body = request.read()
@@ -171,8 +171,8 @@ def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -
         client.post_agent_session_command("agent-1", created.id, "user_message", text="continue")
         current = client.get_agent_session("agent-1", created.id)
         patch_result = client.upload_agent_workspace_patch("agent-1", created.id, b"local-patch")
-        patch = client.download_agent_workspace_patch("agent-1", created.id, 7)
-        client.acknowledge_agent_workspace_patch("agent-1", created.id, 7)
+        patch = client.download_agent_workspace_patch("agent-1", created.id, "patch-7")
+        client.acknowledge_agent_workspace_patch("agent-1", created.id, "patch-7")
         final = client.download_agent_workspace("agent-1", created.id)
         client.acknowledge_agent_workspace("agent-1", created.id)
 
@@ -189,8 +189,8 @@ def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -
         "POST /api/agents/agent-1/sessions/sess-1/commands",
         "GET /api/agents/agent-1/sessions/sess-1",
         "POST /api/agents/agent-1/sessions/sess-1/workspace/patches",
-        "GET /api/agents/agent-1/sessions/sess-1/workspace/patches/7",
-        "POST /api/agents/agent-1/sessions/sess-1/workspace/patches/7/ack",
+        "GET /api/agents/agent-1/sessions/sess-1/workspace/patches/patch-7",
+        "POST /api/agents/agent-1/sessions/sess-1/workspace/patches/patch-7/ack",
         "GET /api/agents/agent-1/sessions/sess-1/workspace",
         "POST /api/agents/agent-1/sessions/sess-1/workspace/ack",
     ]

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -116,7 +116,6 @@ def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -
         "id": "sess-1",
         "agent_id": "agent-1",
         "status": "starting",
-        "source": "hosted",
         "workspace_sync": True,
         "launched_from": "cli",
     }
@@ -210,16 +209,13 @@ def test_hosted_agent_session_without_workspace_posts_create_directly() -> None:
                 "id": "sess-1",
                 "agent_id": "agent-1",
                 "status": "starting",
-                "source": "hosted",
                 "workspace_sync": False,
-                "launched_from": "web",
+                "launched_from": "cli",
             },
         )
 
     with _client(handler) as client:
-        created = client.create_agent_session(
-            "agent-1", workspace=None, instruction="remote task"
-        )
+        created = client.create_agent_session("agent-1", workspace=None, instruction="remote task")
 
     assert not created.workspace_sync
     assert seen == ["POST /api/agents/agent-1/sessions"]

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -12,7 +12,12 @@ import pytest
 from llm_waterfall.types import ChatMessage, ChatRequest
 
 from wmh.core.types import Action, ActionKind
-from wmh.platform.client import PlatformClient, PlatformError, fetch_cli_config
+from wmh.platform.client import (
+    PlatformClient,
+    PlatformError,
+    RemoteAgentSession,
+    fetch_cli_config,
+)
 
 API_URL = "https://api.test"
 
@@ -219,6 +224,21 @@ def test_hosted_agent_session_without_workspace_posts_create_directly() -> None:
 
     assert not created.workspace_sync
     assert seen == ["POST /api/agents/agent-1/sessions"]
+
+
+def test_hosted_agent_session_accepts_future_launch_origins() -> None:
+    """A compatible platform origin extension does not break session decoding."""
+    session = RemoteAgentSession.model_validate(
+        {
+            "id": "sess-1",
+            "agent_id": "agent-1",
+            "status": "running",
+            "workspace_sync": False,
+            "launched_from": "automation",
+        }
+    )
+
+    assert session.launched_from == "automation"
 
 
 def test_builtin_local_pi_run_payloads() -> None:

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -109,8 +109,8 @@ def test_unified_run_target_and_world_model_session_payloads() -> None:
     ]
 
 
-def test_hosted_agent_workspace_session_transport() -> None:
-    """Agent runs upload a snapshot, poll/steer hosted E2B, then download and ack it."""
+def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -> None:
+    """Agent runs use regular sessions plus the live workspace patch protocol."""
     seen: list[str] = []
     session = {
         "id": "sess-1",
@@ -118,15 +118,21 @@ def test_hosted_agent_workspace_session_transport() -> None:
         "status": "starting",
         "source": "hosted",
         "workspace_sync": True,
+        "launched_from": "cli",
     }
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(f"{request.method} {request.url.path}")
         path = request.url.path
-        if path.endswith("/workspace-sessions"):
+        if path.endswith("/workspace-uploads"):
             body = request.read()
             assert b"archive-bytes" in body
-            assert b"fix the tests" in body
+            return httpx.Response(201, json={"id": "upload-1"})
+        if path.endswith("/sessions") and request.method == "POST":
+            assert json.loads(request.read()) == {
+                "instruction": "fix the tests",
+                "workspace_upload_id": "upload-1",
+            }
             return httpx.Response(202, json=session)
         if path.endswith("/events"):
             assert request.url.params["after"] == "0"
@@ -143,6 +149,14 @@ def test_hosted_agent_workspace_session_transport() -> None:
         if path.endswith("/commands"):
             assert json.loads(request.read()) == {"kind": "user_message", "text": "continue"}
             return httpx.Response(202, json={"command_id": 1})
+        if path.endswith("/workspace/patches/7/ack"):
+            return httpx.Response(204)
+        if path.endswith("/workspace/patches/7"):
+            return httpx.Response(200, content=b"remote-patch")
+        if path.endswith("/workspace/patches"):
+            body = request.read()
+            assert b"local-patch" in body
+            return httpx.Response(200, json={"applied": ["local.txt"], "conflicts": []})
         if path.endswith("/workspace/ack"):
             return httpx.Response(204)
         if path.endswith("/workspace"):
@@ -150,26 +164,33 @@ def test_hosted_agent_workspace_session_transport() -> None:
         return httpx.Response(200, json={**session, "status": "ended"})
 
     with _client(handler) as client:
-        created = client.create_agent_workspace_session(
-            "agent-1", b"archive-bytes", instruction="fix the tests"
+        created = client.create_agent_session(
+            "agent-1", workspace=b"archive-bytes", instruction="fix the tests"
         )
         page = client.list_agent_session_events("agent-1", created.id, after=0)
-        client.post_agent_session_command(
-            "agent-1", created.id, "user_message", text="continue"
-        )
+        client.post_agent_session_command("agent-1", created.id, "user_message", text="continue")
         current = client.get_agent_session("agent-1", created.id)
+        patch_result = client.upload_agent_workspace_patch("agent-1", created.id, b"local-patch")
+        patch = client.download_agent_workspace_patch("agent-1", created.id, 7)
+        client.acknowledge_agent_workspace_patch("agent-1", created.id, 7)
         final = client.download_agent_workspace("agent-1", created.id)
         client.acknowledge_agent_workspace("agent-1", created.id)
 
     assert created.workspace_sync
     assert page.events[0].payload["text"] == "done"
     assert current.status == "ended"
+    assert patch_result.applied == ["local.txt"]
+    assert patch == b"remote-patch"
     assert final == b"final-archive"
     assert seen == [
-        "POST /api/agents/agent-1/workspace-sessions",
+        "POST /api/agents/agent-1/workspace-uploads",
+        "POST /api/agents/agent-1/sessions",
         "GET /api/agents/agent-1/sessions/sess-1/events",
         "POST /api/agents/agent-1/sessions/sess-1/commands",
         "GET /api/agents/agent-1/sessions/sess-1",
+        "POST /api/agents/agent-1/sessions/sess-1/workspace/patches",
+        "GET /api/agents/agent-1/sessions/sess-1/workspace/patches/7",
+        "POST /api/agents/agent-1/sessions/sess-1/workspace/patches/7/ack",
         "GET /api/agents/agent-1/sessions/sess-1/workspace",
         "POST /api/agents/agent-1/sessions/sess-1/workspace/ack",
     ]

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -196,6 +196,35 @@ def test_hosted_agent_session_uses_regular_create_and_workspace_patch_routes() -
     ]
 
 
+def test_hosted_agent_session_without_workspace_posts_create_directly() -> None:
+    """The default agent run does not stage any local workspace upload."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        assert request.url.path == "/api/agents/agent-1/sessions"
+        assert json.loads(request.read()) == {"instruction": "remote task"}
+        return httpx.Response(
+            202,
+            json={
+                "id": "sess-1",
+                "agent_id": "agent-1",
+                "status": "starting",
+                "source": "hosted",
+                "workspace_sync": False,
+                "launched_from": "web",
+            },
+        )
+
+    with _client(handler) as client:
+        created = client.create_agent_session(
+            "agent-1", workspace=None, instruction="remote task"
+        )
+
+    assert not created.workspace_sync
+    assert seen == ["POST /api/agents/agent-1/sessions"]
+
+
 def test_builtin_local_pi_run_payloads() -> None:
     """The built-in harness has an org-scoped, metered platform worker path."""
     seen: list[str] = []


### PR DESCRIPTION
## What changed

- Replace `wmh session start` with one root `wmh run [target]` command.
- Resolve an opaque platform id once: world-model ids open hosted model sessions and agent ids open ordinary hosted sessions in platform-owned E2B.
- Use the saved login for platform execution, provider credentials, metering, transcript polling, steering, and optional workspace transport. Users do not supply provider, E2B, or platform API keys.
- Keep local files private by default. `wmh run <agent-id>` starts with no local workspace upload.
- Add `-u PATH` / `--upload-dir PATH` as the explicit opt-in for uploading and live-syncing a local directory.
- Exchange validated hash-guarded patches in both directions only for opted-in directories. Preserve same-path concurrent edits as conflicts and keep the final E2B archive under `.wmh-conflicts/` when reconciliation needs manual recovery.
- Skip symlinks, VCS internals, dependency trees, virtual environments, caches, and WMH recovery artifacts with explicit archive limits.
- Keep bare `wmh run` as the built-in local pi harness. Logged-in bare runs use a platform-proxied worker; logged-out runs can use local provider credentials.

## Why

After `wmh login`, users can run a platform agent with `uv run wmh run <agent-id>` without sending their current directory. When repository access is wanted, `uv run wmh run <agent-id> -u .` runs in a disposable platform E2B sandbox, mirrors workspace changes live, and keeps the session visible and steerable on the web.

Paired Platform change: https://github.com/experientiallabs/platform/pull/306

## Validation

- `uv run ruff check .`
- `uv run ty check`
- Full suite: `1209 passed`, `18 skipped`
- Focused CLI and platform-client suite: `31 passed`
- `wmh run --help` verified with `-u, --upload-dir`
