### PR TITLE
Retry E2B transport timeouts safely

### DIFF
--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -388,7 +388,9 @@ class E2BPiRuntime:
     def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
         try:
             return self._run_episode(task_id, instruction, environment)
-        except (RuntimeError, TimeoutError):
+        except Exception as exc:
+            if not _is_retryable_transport_error(exc):
+                raise
             # Transport death (stream drop, sandbox lifetime, dead runner) — the failed
             # attempt's sandbox was already discarded on release. Retry ONCE on a fresh
             # sandbox: the environment session may replay the dead attempt's opening steps,
@@ -427,6 +429,16 @@ class E2BPiRuntime:
 
     def __exit__(self, *exc_info: object) -> None:
         self.close()
+
+
+def _is_retryable_transport_error(exc: Exception) -> bool:
+    """Whether an episode exception means its E2B transport is no longer trustworthy."""
+    if isinstance(exc, (RuntimeError, TimeoutError)):
+        return True
+    # Keep the E2B SDK optional at import time. Its TimeoutException is not a built-in
+    # TimeoutError, but any instance means the sandbox/channel state is uncertain.
+    exc_type = type(exc)
+    return exc_type.__module__ == "e2b.exceptions" and exc_type.__name__ == "TimeoutException"
 
 
 def session_entry_files() -> dict[str, str]:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -93,6 +93,10 @@ class _Eof:
 _EOF = _Eof()
 
 
+class _E2BChannelSendError(RuntimeError):
+    """A raw socket failure while sending a frame to the E2B runner."""
+
+
 class E2BStdioChannel:
     """A `runner_link.Channel` over an E2B background command's stdin/stdout.
 
@@ -119,7 +123,10 @@ class E2BStdioChannel:
 
     def send(self, frame: JsonObject) -> None:
         line = base64.b64encode(json.dumps(frame).encode("utf-8")).decode("ascii") + "\n"
-        self._sandbox.commands.send_stdin(self._handle.pid, line)
+        try:
+            self._sandbox.commands.send_stdin(self._handle.pid, line)
+        except OSError as exc:
+            raise _E2BChannelSendError("failed to send a frame to the E2B runner") from exc
 
     def recv(self, timeout: float | None = None) -> JsonObject | None:
         """The next frame from the runner; blocks (up to `timeout` seconds when given).
@@ -433,7 +440,7 @@ class E2BPiRuntime:
 
 def _is_retryable_transport_error(exc: Exception) -> bool:
     """Whether an episode exception means its E2B transport is no longer trustworthy."""
-    if isinstance(exc, (RuntimeError, TimeoutError, OSError)):
+    if isinstance(exc, (RuntimeError, TimeoutError)):
         return True
     # Keep the E2B SDK optional at import time. Its TimeoutException is not a built-in
     # TimeoutError, but any instance means the sandbox/channel state is uncertain.

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -433,7 +433,7 @@ class E2BPiRuntime:
 
 def _is_retryable_transport_error(exc: Exception) -> bool:
     """Whether an episode exception means its E2B transport is no longer trustworthy."""
-    if isinstance(exc, (RuntimeError, TimeoutError)):
+    if isinstance(exc, (RuntimeError, TimeoutError, OSError)):
         return True
     # Keep the E2B SDK optional at import time. Its TimeoutException is not a built-in
     # TimeoutError, but any instance means the sandbox/channel state is uncertain.

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -674,6 +674,33 @@ def test_run_retries_broken_pipe_once_on_a_fresh_sandbox(
     pool.close()
 
 
+def test_environment_os_error_propagates_without_episode_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool-side OS failure is not mistaken for an E2B transport failure."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}},
+    ]
+    factory, made = _factory_for([script, script])
+
+    class FailingEnv(_RecordingEnv):
+        def execute(self, action: Action) -> Observation:
+            self.actions.append(action)
+            raise OSError("tool filesystem failed")
+
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    env = FailingEnv()
+    with pytest.raises(OSError, match="tool filesystem failed"):
+        _runtime(pool=pool).run("t1", "do it", env)
+
+    assert len(env.actions) == 1
+    assert len(made) == 1
+    assert made[0].kills == 1
+    pool.close()
+
+
 def test_run_propagates_a_second_e2b_send_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -22,6 +22,7 @@ from collections.abc import Callable, Iterator
 from typing import cast
 
 import pytest
+from e2b.exceptions import TimeoutException
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
@@ -91,6 +92,7 @@ class _FakeCommands:
         self.calls: list[str] = []  # foreground commands, in order (installs, ...)
         self.background_cmds: list[str] = []
         self.stdin: list[tuple[int, str]] = []
+        self.fail_sends_from: int | None = None
 
     def run(
         self,
@@ -109,6 +111,8 @@ class _FakeCommands:
 
     def send_stdin(self, pid: int, data: str) -> None:
         self.stdin.append((pid, data))
+        if self.fail_sends_from is not None and len(self.stdin) >= self.fail_sends_from:
+            raise TimeoutException("request timed out")
 
 
 class _FakeFiles:
@@ -481,6 +485,31 @@ def test_two_runtimes_sharing_a_pool_reuse_warm_sandboxes(
         assert (starts[0]["instruction"], starts[1]["instruction"]) == ("first", "second")
 
 
+def test_pi_episode_error_is_not_retried_and_keeps_the_sandbox_reusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner-reported episode failure stays a result, not a transport retry."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "episode_error", "note": "pi failed"},
+        {"type": "done", "answer": "next episode"},
+    ]
+    factory, made = _factory_for([script])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    runtime = _runtime(pool=pool)
+
+    failed = runtime.run("t1", "first", _RecordingEnv())
+    recovered = runtime.run("t2", "second", _RecordingEnv())
+
+    assert failed.stop_reason is StopReason.ERROR
+    assert "pi failed" in failed.steps[-1].observation.content
+    assert recovered.answer == "next episode"
+    assert len(made) == 1
+    assert made[0].kills == 0
+    pool.close()
+
+
 def test_close_kills_a_private_pool_but_never_a_shared_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -577,6 +606,62 @@ def test_run_retries_once_on_a_fresh_sandbox_after_transport_death(
     assert result.answer == "recovered"
     assert len(made) == 2
     assert made[0].kills == 1  # the dead attempt's sandbox was discarded, not reused
+    pool.close()
+
+
+def test_run_retries_e2b_send_timeout_once_on_a_fresh_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An uncertain send retires its sandbox and replays the episode on a fresh one."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        {"type": "done", "answer": "recovered"},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def timeout_first_factory() -> FakeSandbox:
+        fake = factory()
+        if len(made) == 1:
+            # episode_start is send 1; fail the response send and every attempted resend.
+            fake.commands.fail_sends_from = 2
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=timeout_first_factory)
+    result = _runtime(pool=pool).run("t1", "do it", _RecordingEnv())
+
+    assert result.stop_reason is StopReason.SUBMITTED
+    assert result.answer == "recovered"
+    assert len(made) == 2
+    assert len(_of_kind(made[0], "llm_response")) == 1
+    assert made[0].kills == 1
+    pool.close()
+
+
+def test_run_propagates_a_second_e2b_send_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fresh-sandbox recovery is attempted once, then the transport failure escapes."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def timeout_factory() -> FakeSandbox:
+        fake = factory()
+        fake.commands.fail_sends_from = 2
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=timeout_factory)
+    with pytest.raises(TimeoutException, match="request timed out"):
+        _runtime(pool=pool).run("t1", "do it", _RecordingEnv())
+
+    assert len(made) == 2
+    assert [len(_of_kind(fake, "llm_response")) for fake in made] == [1, 1]
+    assert [fake.kills for fake in made] == [1, 1]
     pool.close()
 
 

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -22,7 +22,6 @@ from collections.abc import Callable, Iterator
 from typing import cast
 
 import pytest
-from e2b.exceptions import TimeoutException
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
@@ -45,6 +44,13 @@ from wmh.harness.tools import SUBMIT, TOOL_REGISTRY, ToolSpec
 
 _Event = tuple[str | None, str | None, str | None]
 _PID = 4242
+
+
+class TimeoutException(Exception):
+    """SDK-shaped timeout exception without importing the optional E2B package."""
+
+
+TimeoutException.__module__ = "e2b.exceptions"
 
 
 def _line(frame: JsonObject) -> str:
@@ -93,6 +99,7 @@ class _FakeCommands:
         self.background_cmds: list[str] = []
         self.stdin: list[tuple[int, str]] = []
         self.fail_sends_from: int | None = None
+        self.send_error: Exception = TimeoutException("request timed out")
 
     def run(
         self,
@@ -112,7 +119,7 @@ class _FakeCommands:
     def send_stdin(self, pid: int, data: str) -> None:
         self.stdin.append((pid, data))
         if self.fail_sends_from is not None and len(self.stdin) >= self.fail_sends_from:
-            raise TimeoutException("request timed out")
+            raise self.send_error
 
 
 class _FakeFiles:
@@ -635,6 +642,34 @@ def test_run_retries_e2b_send_timeout_once_on_a_fresh_sandbox(
     assert result.answer == "recovered"
     assert len(made) == 2
     assert len(_of_kind(made[0], "llm_response")) == 1
+    assert made[0].kills == 1
+    pool.close()
+
+
+def test_run_retries_broken_pipe_once_on_a_fresh_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raw socket-style send failure also retires the uncertain sandbox."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        {"type": "done", "answer": "recovered"},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def broken_first_factory() -> FakeSandbox:
+        fake = factory()
+        if len(made) == 1:
+            fake.commands.fail_sends_from = 2
+            fake.commands.send_error = BrokenPipeError("broken pipe")
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=broken_first_factory)
+    result = _runtime(pool=pool).run("t1", "do it", _RecordingEnv())
+
+    assert result.answer == "recovered"
+    assert len(made) == 2
     assert made[0].kills == 1
     pool.close()
 

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -282,23 +282,22 @@ class RunnerLink:
             reported = completion.token_usage()
             usage.input_tokens += reported.input_tokens
             usage.output_tokens += reported.output_tokens
-            self._channel.send(
-                {
-                    "type": "llm_response",
-                    "episode_id": episode_id,
-                    "req_id": req_id,
-                    "completion": completion.wire_payload(),
-                }
-            )
+            response: JsonObject = {
+                "type": "llm_response",
+                "episode_id": episode_id,
+                "req_id": req_id,
+                "completion": completion.wire_payload(),
+            }
         except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
-            self._channel.send(
-                {
-                    "type": "llm_response",
-                    "episode_id": episode_id,
-                    "req_id": req_id,
-                    "error": str(exc),
-                }
-            )
+            response = {
+                "type": "llm_response",
+                "episode_id": episode_id,
+                "req_id": req_id,
+                "error": str(exc),
+            }
+        # A send timeout is transport failure with an uncertain delivery state. Let it propagate
+        # so the owning runtime retires the channel instead of sending a second response frame.
+        self._channel.send(response)
 
     @staticmethod
     def _error_result(

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
@@ -41,6 +42,15 @@ class _FakeChannel:
 
     def recv(self) -> JsonObject | None:
         return self._script.pop(0) if self._script else None
+
+
+class _ResponseSendTimeoutChannel(_FakeChannel):
+    """Records the attempted response, then fails every response transport send."""
+
+    def send(self, frame: JsonObject) -> None:
+        self.sent.append(frame)
+        if frame.get("type") == "llm_response":
+            raise TimeoutError("transport send timed out")
 
 
 def _tools() -> list:
@@ -178,9 +188,25 @@ def test_worker_fn_error_is_reported_not_crashed() -> None:
     ]
     ch = _FakeChannel(script)
     result = RunnerLink(ch, worker_fn=boom).run("t1", "x", _Env(), tools=_tools())
-    resp = _sent(ch, "llm_response")[0]
+    responses = _sent(ch, "llm_response")
+    assert len(responses) == 1
+    resp = responses[0]
     assert "provider down" in resp["error"]  # surfaced to the runner, host survives
     assert result.stop_reason is StopReason.SUBMITTED
+
+
+def test_llm_response_send_timeout_propagates_without_error_response_retry() -> None:
+    """A transport send failure is not mislabeled as a provider failure or sent twice."""
+    script = [{"type": "llm_request", "req_id": 1, "openai_body": {}}]
+    ch = _ResponseSendTimeoutChannel(script)
+
+    with pytest.raises(TimeoutError, match="transport send timed out"):
+        _link(ch).run("t1", "x", _Env(), tools=_tools())
+
+    responses = _sent(ch, "llm_response")
+    assert len(responses) == 1
+    assert "completion" in responses[0]
+    assert "error" not in responses[0]
 
 
 def test_channel_close_without_done_reports_error() -> None:


### PR DESCRIPTION
## Summary

- Build the provider result or error response before touching the channel, then send exactly one response frame.
- Propagate channel send failures as transport failures instead of relabeling them as provider errors.
- Treat the E2B SDK's `TimeoutException` as an existing one-time episode retry signal.
- Retire the uncertain sandbox before replaying the episode on a fresh sandbox.
- Cover provider errors, pi episode errors, healthy reuse, first-timeout recovery, and second-timeout propagation with credential-free tests.

## Root cause

`RunnerLink._answer_llm` included `channel.send` inside its provider error handler. An E2B acknowledgement timeout was caught as if the provider had failed, and the handler attempted a second non-idempotent response send. The SDK exception is not a built-in `TimeoutError`, so `E2BPiRuntime` also skipped its existing fresh-sandbox retry.

## Production traceback status

I attempted to inspect the affected Modal application before implementing the fix. The local Modal CLI has no configured token, so the production traceback was not accessible from this environment. This PR therefore does not attribute the timeout to Sonnet or any other model.

## E2B request timeout decision

E2B Python SDK 2.31.0 already applies a finite 60 second request timeout. This change keeps that finite default and does not use `request_timeout=0`. A stdin response frame should not need a longer acknowledgement window, and once the finite timeout expires delivery is uncertain. Retiring the sandbox and replaying at the episode boundary is safer than extending or disabling the acknowledgement deadline. No additional timeout setting is introduced without evidence for a different bound and an outer cancellation path.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q wmh/harness/runner_link_test.py wmh/harness/pi_e2b_test.py` (40 passed)
- `uv run pytest -q` (1,178 passed, 18 skipped)
