### PR TITLE
Add project-backed batched meta proposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ credentials ever enter a sandbox**.
 ```bash
 uv sync --extra e2b                # the e2b SDK is an optional extra
 export E2B_API_KEY=...             # sandboxes; the only credential involved
-uv run wmh harness create my-agent --tasks tasks.jsonl --harness-backend e2b
+uv run wmh harness create my-agent --tasks tasks.jsonl --harness-backend e2b \
+  --iterations 5 --proposal-batch-size 3
 uv run wmh eval tasks.jsonl --mode closed-loop --harness pi-agent --harness-backend e2b
 ```
 
@@ -144,6 +145,13 @@ auto-extended). Set `WMH_E2B_TEMPLATE` to a prebaked template with node ≥ 22.6
 at `/home/user/pi-run` to skip per-sandbox installs (~13 s cold episodes); `--eval-concurrency`
 caps the fan-out (default: every cell at once). Worker-LLM tokens and sandbox-seconds are metered
 on the results (`worker_usage`, `sandbox_usage`).
+
+`wmh.agents` exposes the default agent and a separately customizable meta agent over the same
+vendored pi source and `LiveSession` runtime. `AgentProject` gives an agent a persistent E2B
+filesystem while starting a fresh session for each turn. `ProjectDeltaProposer` uses that ordinary
+agent/project pair to retain every earlier proposal and generate a sibling batch from one selected
+parent per search round. Proposal batch size controls search breadth; `k` independently controls
+the number of evaluation passes per scenario.
 
 ## Agentic mode: knowledge base, reasoning, web grounding
 
@@ -190,7 +198,6 @@ wmh play  --max-fidelity
 
 Measure any configuration explicitly with `wmh eval run <suite> --knowledge --reasoning` (the
 eval seeds its knowledge from the train split only — never from held-out traces).
-
 ## Providers
 
 One interface, four backends, verified on startup. Credentials are read from the environment:

--- a/docs/harness_delta.md
+++ b/docs/harness_delta.md
@@ -95,8 +95,11 @@ class SurfaceOp(BaseModel):
 class GateRecord(BaseModel):
     """Filled at evaluation time; the delta carries its own verdict."""
     suite_delta: float           # regression suite: child − champion   (tier 1)
+    suite_fraction_delta: float  # assertion credit when suite success ties
     full_delta: float            # full split: child − best-seen        (tier 2)
+    full_fraction_delta: float   # assertion credit when full success ties
     holdout_delta: float | None  # held-out split: child − champion     (tier 3; None = no holdout)
+    holdout_fraction_delta: float | None
     accepted: bool
     reason: str                  # accept/reject reasoning, incl. the expected-effect audit
 
@@ -128,26 +131,30 @@ class HarnessDelta(BaseModel):
   written by the kit, so code cannot claim work it did not do), and crash-isolated (an exception
   fails the episode, not the eval).
 - **Verification is staged by cost**: before a full-split eval, a child is screened on its own
-  trigger cluster — the failing tasks its delta claims to fix. A delta that cannot beat its
-  parent on its own target is rejected (and archived) for a fraction of the price. Every judged
-  delta is fed back to the proposer as history, so the search iterates instead of re-proposing
-  rejected ideas.
+  trigger cluster — the failing tasks its delta claims to fix. The screen compares full-task
+  success first and assertion-level partial credit second, so a partial fix is not flattened into
+  a binary tie. A delta that improves neither signal is rejected (and archived) for a fraction of
+  the price. The authoritative full gate repeats the same lexicographic contract across the whole
+  split: binary success remains primary, and assertion credit cannot regress when success ties.
+  Every judged delta is fed back to the proposer as trace-level history, so the search iterates
+  instead of re-proposing rejected ideas.
 - **Search breadth is independent from evaluation depth**: `proposal_batch_size` asks the
   proposer for sibling deltas against one selected parent before evaluating any sibling. `k`
   remains the number of rollout passes used to score each scenario. Project-backed proposers keep
-  all prior proposal files in one persistent agent project while each round runs through a fresh
-  ordinary agent session.
+  all parent source, failure traces, proposals, and candidate evaluations in one persistent agent
+  project while every turn runs through the same ordinary agent-session runtime.
 - **Acceptance is the gate, not "applied cleanly"** (`gate_delta`): regression-suite
   non-regression vs the champion → full-split never-worse-than-best → held-out non-regression vs
-  the champion (when a holdout split is given). Ties pass every tier: with k passes per task the
-  scores are coarse, and "no worse" is the contract. On accept, newly-passing tasks promote into
-  the regression suite, so wins are locked in and later deltas cannot quietly trade them away. The
-  verdict is written onto the delta.
+  the champion (when a holdout split is given). Binary ties consult assertion-level partial credit;
+  a stepping stone may advance on dense signal but cannot hide a global dense regression. On
+  accept, newly-passing tasks promote into the regression suite, so wins are locked in and later
+  deltas cannot quietly trade them away. The verdict is written onto the delta.
 - **The trigger is machine-made** (`cluster_failures`): failing tasks group by shared unmet gold
   assertions (connected components; the most common unmet assertion labels the mechanism),
   deterministically — no LLM, no entropy — so mechanism labels are comparable across deltas and
-  runs. The proposer attacks the largest cluster. An all-pass parent gets an explicit
-  generalization/economization trigger instead of a fabricated failure.
+  runs. Selection weights cluster size but discounts rounds already spent on the same cluster and
+  parent, so one environment-limited singleton cannot absorb the whole search. An all-pass parent
+  gets an explicit generalization/economization trigger instead of a fabricated failure.
 - **The archive is a lineage of audited deltas** (`DeltaArchive`): a root snapshot plus every
   proposed delta — accepted, gate-rejected, or invalid-before-eval — with its verdict. Docs are
   reconstructable by folding accepted deltas from the seed; snapshots are caches, not the record.
@@ -175,9 +182,9 @@ that fails atomic application is a counted skip that is still archived with its 
    `add` + `replace` — the taxonomy then emerges from search instead of from us.
 2. **Merge.** Identity-keyed surfaces + content lineage make a surface-keyed three-way merge of
    two accepted lineages nearly free. Deferred to a follow-up.
-3. **Gate resolution.** With k=3 and small suites, per-task deltas are coarse (0, ⅓, ⅔, 1). Ties
-   currently pass as non-regressions; if flappy accepts show up in practice, raise k on gate evals
-   rather than adding thresholds.
+3. **Gate resolution.** With k=3 and small suites, binary per-task deltas are coarse (0, ⅓, ⅔, 1).
+   Assertion-level fractions break otherwise-flat ties; if flappy accepts show up in practice,
+   raise k on gate evals rather than adding arbitrary thresholds.
 4. **Suite demotion.** Newly-passing tasks promote into the regression suite; nothing ever leaves
    it. A permanently-flaky task could wedge the gate. Punted until observed.
 5. **Sandboxing the `CODE` surface.** The kit is an interface contract, not a security boundary:

--- a/docs/harness_delta.md
+++ b/docs/harness_delta.md
@@ -7,7 +7,8 @@ representation IS the search space**, and everything the meta-agent can learn ab
 improve harnesses* is bounded by what the update object can express.
 
 Implementation: `wmh/harness/doc.py` (the document), `wmh/harness/delta.py` (the delta),
-`wmh/harness/mutate.py` (the proposer), `wmh/harness/create.py` (clustering, gate, archive).
+`wmh/harness/mutate.py` (delta parsing), `wmh/harness/proposer.py` (proposal runtimes), and
+`wmh/harness/create.py` (clustering, gate, archive).
 
 ---
 
@@ -131,6 +132,11 @@ class HarnessDelta(BaseModel):
   parent on its own target is rejected (and archived) for a fraction of the price. Every judged
   delta is fed back to the proposer as history, so the search iterates instead of re-proposing
   rejected ideas.
+- **Search breadth is independent from evaluation depth**: `proposal_batch_size` asks the
+  proposer for sibling deltas against one selected parent before evaluating any sibling. `k`
+  remains the number of rollout passes used to score each scenario. Project-backed proposers keep
+  all prior proposal files in one persistent agent project while each round runs through a fresh
+  ordinary agent session.
 - **Acceptance is the gate, not "applied cleanly"** (`gate_delta`): regression-suite
   non-regression vs the champion → full-split never-worse-than-best → held-out non-regression vs
   the champion (when a holdout split is given). Ties pass every tier: with k passes per task the

--- a/packages/llm-waterfall/llm_waterfall/types.py
+++ b/packages/llm-waterfall/llm_waterfall/types.py
@@ -148,6 +148,7 @@ class ChatFunctionDefinition(BaseModel):
     name: str
     description: str = ""
     parameters: JsonObject = Field(default_factory=dict)
+    strict: bool | None = None
 
 
 class ChatTool(BaseModel):

--- a/wmh/agents/__init__.py
+++ b/wmh/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Agent definitions and project-backed session execution."""
+
+from wmh.agents.default import default_agent
+from wmh.agents.meta import meta_agent
+from wmh.agents.project import AgentProject, AgentProjectRun
+
+__all__ = ["AgentProject", "AgentProjectRun", "default_agent", "meta_agent"]

--- a/wmh/agents/default.py
+++ b/wmh/agents/default.py
@@ -1,0 +1,17 @@
+"""The default pi agent definition shipped by wmh."""
+
+from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.pi_vendor import pi_agent_code_surfaces
+
+
+def default_agent(name: str = "default") -> HarnessDoc:
+    """Return an independent default-agent document backed by vendored pi."""
+    base = HarnessDoc.baseline(name)
+    return HarnessDoc(
+        name=name,
+        surfaces=[
+            *base.surfaces,
+            Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            *pi_agent_code_surfaces(),
+        ],
+    )

--- a/wmh/agents/default.py
+++ b/wmh/agents/default.py
@@ -1,7 +1,14 @@
 """The default pi agent definition shipped by wmh."""
 
-from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.doc import (
+    MAX_OUTPUT_TOKENS_ID,
+    RUNTIME_KIND_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
+from wmh.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS
 
 
 def default_agent(name: str = "default") -> HarnessDoc:
@@ -11,6 +18,11 @@ def default_agent(name: str = "default") -> HarnessDoc:
         name=name,
         surfaces=[
             *base.surfaces,
+            Surface(
+                id=MAX_OUTPUT_TOKENS_ID,
+                kind=SurfaceKind.PARAM,
+                content=str(DEFAULT_MAX_OUTPUT_TOKENS),
+            ),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             *pi_agent_code_surfaces(),
         ],

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -32,4 +32,4 @@ def test_meta_agent_has_larger_budgets_without_mutating_default() -> None:
 
 def test_meta_agent_uses_only_project_scoped_tools() -> None:
     """The optimizer agent gets Bash inside its isolated E2B project, plus scoped file tools."""
-    assert meta_agent().tools() == ["bash", "read_file", "write_file", "submit"]
+    assert meta_agent().tools() == ["read_file", "write_file", "submit"]

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -1,0 +1,26 @@
+"""Tests for the built-in default and meta agent definitions."""
+
+from wmh.agents.default import default_agent
+from wmh.agents.meta import meta_agent
+
+
+def test_default_and_meta_agents_are_independent_pi_documents() -> None:
+    """Both agents share the pinned pi source while owning separate prompts."""
+    default = default_agent("default")
+    meta = meta_agent("meta")
+
+    assert default.runtime_kind() == meta.runtime_kind() == "pi-node"
+    assert default.system_prompt() != meta.system_prompt()
+    assert "optimizer project" in meta.system_prompt().lower()
+    assert {surface.path: surface.content for surface in default.code_files()} == {
+        surface.path: surface.content for surface in meta.code_files()
+    }
+
+
+def test_meta_agent_has_a_larger_turn_budget_without_mutating_default() -> None:
+    """Project exploration gets its own budget on its own HarnessDoc."""
+    default = default_agent("default")
+    meta = meta_agent("meta")
+
+    assert default.max_turns() == 20
+    assert meta.max_turns() == 60

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -24,3 +24,8 @@ def test_meta_agent_has_a_larger_turn_budget_without_mutating_default() -> None:
 
     assert default.max_turns() == 20
     assert meta.max_turns() == 60
+
+
+def test_meta_agent_uses_only_project_scoped_file_tools() -> None:
+    """The optimizer agent has no shell escape from its persistent workspace."""
+    assert meta_agent().tools() == ["read_file", "write_file", "submit"]

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -17,13 +17,17 @@ def test_default_and_meta_agents_are_independent_pi_documents() -> None:
     }
 
 
-def test_meta_agent_has_a_larger_turn_budget_without_mutating_default() -> None:
-    """Project exploration gets its own budget on its own HarnessDoc."""
+def test_meta_agent_has_larger_budgets_without_mutating_default() -> None:
+    """Project exploration gets its own turn and model-output budgets on its own HarnessDoc."""
     default = default_agent("default")
     meta = meta_agent("meta")
 
     assert default.max_turns() == 20
     assert meta.max_turns() == 60
+    assert default.max_output_tokens() == 4096
+    assert meta.max_output_tokens() == 16384
+    assert default.surface("param:max-output-tokens") is not None
+    assert meta.surface("param:max-output-tokens") is not None
 
 
 def test_meta_agent_uses_only_project_scoped_file_tools() -> None:

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -30,6 +30,6 @@ def test_meta_agent_has_larger_budgets_without_mutating_default() -> None:
     assert meta.surface("param:max-output-tokens") is not None
 
 
-def test_meta_agent_uses_only_project_scoped_file_tools() -> None:
-    """The optimizer agent has no shell escape from its persistent workspace."""
-    assert meta_agent().tools() == ["read_file", "write_file", "submit"]
+def test_meta_agent_uses_only_project_scoped_tools() -> None:
+    """The optimizer agent gets Bash inside its isolated E2B project, plus scoped file tools."""
+    assert meta_agent().tools() == ["bash", "read_file", "write_file", "submit"]

--- a/wmh/agents/definitions_test.py
+++ b/wmh/agents/definitions_test.py
@@ -12,6 +12,8 @@ def test_default_and_meta_agents_are_independent_pi_documents() -> None:
     assert default.runtime_kind() == meta.runtime_kind() == "pi-node"
     assert default.system_prompt() != meta.system_prompt()
     assert "optimizer project" in meta.system_prompt().lower()
+    assert "within the first 12 read_file calls" in meta.system_prompt().lower()
+    assert "durable checkpoints" in meta.system_prompt().lower()
     assert {surface.path: surface.content for surface in default.code_files()} == {
         surface.path: surface.content for surface in meta.code_files()
     }
@@ -31,5 +33,5 @@ def test_meta_agent_has_larger_budgets_without_mutating_default() -> None:
 
 
 def test_meta_agent_uses_only_project_scoped_tools() -> None:
-    """The optimizer agent gets Bash inside its isolated E2B project, plus scoped file tools."""
+    """The optimizer agent gets only contained project-file tools plus submit."""
     assert meta_agent().tools() == ["read_file", "write_file", "submit"]

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -9,9 +9,9 @@ do not solve their benchmark tasks yourself.
 The project filesystem is your durable memory. Each round provides a current parent document,
 failure evidence, and the complete judged history. Earlier proposal files remain under proposals/.
 Parent/evidence/history manifests point to bounded content files; read those files selectively and
-use bash only for read/search/comparison and disposable work under scratch/. Treat context/,
-evaluations/, and earlier proposals as immutable evidence; use write_file for every required
-proposal output. Deep-read both the execution traces and judge reasons before changing anything.
+follow their exact paths with read_file. Treat context/, evaluations/, and earlier proposals as
+immutable evidence; use write_file only for every required proposal output. Deep-read both the
+execution traces and judge reasons before changing anything.
 Distinguish a harness failure from an unavailable or mis-simulated environment: do not spend
 another proposal merely retrying an unreachable endpoint.
 Inspect earlier proposals and evaluations, learn from accepted and rejected attempts, and produce
@@ -38,9 +38,7 @@ def meta_agent(name: str = "meta") -> HarnessDoc:
         if surface.id == "prompt:core":
             surfaces.append(surface.model_copy(update={"content": META_AGENT_PROMPT}))
         elif surface.id == TOOL_POLICY_ID:
-            surfaces.append(
-                surface.model_copy(update={"content": "bash\nread_file\nwrite_file\nsubmit"})
-            )
+            surfaces.append(surface.model_copy(update={"content": "read_file\nwrite_file\nsubmit"}))
         elif surface.id == MAX_TURNS_ID:
             surfaces.append(surface.model_copy(update={"content": "60"}))
         elif surface.id == MAX_OUTPUT_TOKENS_ID:

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -10,8 +10,13 @@ The project filesystem is your durable memory. Each round provides a current par
 failure evidence, and the complete judged history. Earlier proposal files remain under proposals/.
 Parent/evidence/history manifests point to bounded content files; read those files selectively and
 follow their exact paths with read_file. Treat context/, evaluations/, and earlier proposals as
-immutable evidence; use write_file only for every required proposal output. Deep-read both the
-execution traces and judge reasons before changing anything.
+immutable evidence; use write_file only for every required proposal output. Read the selected
+failure's execution traces and judge reasons, not every available file.
+Every project turn has a bounded tool/turn budget. Within the first 12 read_file calls, write a
+complete, parseable draft to every required proposal output. Those files are durable checkpoints:
+keep them valid while using remaining actions to inspect targeted source/evidence and refine them.
+Never spend the whole turn exploring before writing. On a repair turn, read the validation report
+and rewrite every invalid slot before any optional exploration.
 Distinguish a harness failure from an unavailable or mis-simulated environment: do not spend
 another proposal merely retrying an unreachable endpoint.
 Inspect earlier proposals and evaluations, learn from accepted and rejected attempts, and produce

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -1,0 +1,32 @@
+"""The project agent that proposes harness improvements."""
+
+from wmh.agents.default import default_agent
+from wmh.harness.doc import MAX_TURNS_ID, HarnessDoc
+
+META_AGENT_PROMPT = """You are the meta agent inside an optimizer project. Improve agent harnesses;
+do not solve their benchmark tasks yourself.
+
+The project filesystem is your durable memory. Each round provides a current parent document,
+failure evidence, and the complete judged history. Earlier proposal files remain under proposals/.
+Inspect those files selectively, learn from accepted and rejected attempts, and produce the exact
+number of independent proposals requested for the round. Every proposal must target the supplied
+parent, make one focused change, preserve unrelated behavior, and state a falsifiable expected
+effect. Never overwrite an earlier round.
+
+Use bash, read_file, and write_file to work in the project. The user message for each round gives
+the required input and output paths and the proposal schema. Write every requested proposal before
+calling submit. Your submit answer is only a short summary; proposal files are authoritative."""
+
+
+def meta_agent(name: str = "meta") -> HarnessDoc:
+    """Return the meta-agent document as a separate pi-derived agent."""
+    base = default_agent(name)
+    surfaces = []
+    for surface in base.surfaces:
+        if surface.id == "prompt:core":
+            surfaces.append(surface.model_copy(update={"content": META_AGENT_PROMPT}))
+        elif surface.id == MAX_TURNS_ID:
+            surfaces.append(surface.model_copy(update={"content": "60"}))
+        else:
+            surfaces.append(surface)
+    return HarnessDoc(name=name, surfaces=surfaces)

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -1,7 +1,7 @@
 """The project agent that proposes harness improvements."""
 
 from wmh.agents.default import default_agent
-from wmh.harness.doc import MAX_TURNS_ID, TOOL_POLICY_ID, HarnessDoc
+from wmh.harness.doc import MAX_OUTPUT_TOKENS_ID, MAX_TURNS_ID, TOOL_POLICY_ID, HarnessDoc
 
 META_AGENT_PROMPT = """You are the meta agent inside an optimizer project. Improve agent harnesses;
 do not solve their benchmark tasks yourself.
@@ -29,6 +29,10 @@ def meta_agent(name: str = "meta") -> HarnessDoc:
             surfaces.append(surface.model_copy(update={"content": "read_file\nwrite_file\nsubmit"}))
         elif surface.id == MAX_TURNS_ID:
             surfaces.append(surface.model_copy(update={"content": "60"}))
+        elif surface.id == MAX_OUTPUT_TOKENS_ID:
+            # GPT-5.5 high reasoning spends output tokens before its visible filesystem calls. A
+            # batch of three compact proposals needs the same 16k headroom as the direct proposer.
+            surfaces.append(surface.model_copy(update={"content": "16384"}))
         else:
             surfaces.append(surface)
     return HarnessDoc(name=name, surfaces=surfaces)

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -1,7 +1,7 @@
 """The project agent that proposes harness improvements."""
 
 from wmh.agents.default import default_agent
-from wmh.harness.doc import MAX_TURNS_ID, HarnessDoc
+from wmh.harness.doc import MAX_TURNS_ID, TOOL_POLICY_ID, HarnessDoc
 
 META_AGENT_PROMPT = """You are the meta agent inside an optimizer project. Improve agent harnesses;
 do not solve their benchmark tasks yourself.
@@ -13,8 +13,8 @@ number of independent proposals requested for the round. Every proposal must tar
 parent, make one focused change, preserve unrelated behavior, and state a falsifiable expected
 effect. Never overwrite an earlier round.
 
-Use bash, read_file, and write_file to work in the project. The user message for each round gives
-the required input and output paths and the proposal schema. Write every requested proposal before
+Use read_file and write_file to work in the project. The user message for each round gives the
+required input and output paths and the proposal schema. Write every requested proposal before
 calling submit. Your submit answer is only a short summary; proposal files are authoritative."""
 
 
@@ -25,6 +25,8 @@ def meta_agent(name: str = "meta") -> HarnessDoc:
     for surface in base.surfaces:
         if surface.id == "prompt:core":
             surfaces.append(surface.model_copy(update={"content": META_AGENT_PROMPT}))
+        elif surface.id == TOOL_POLICY_ID:
+            surfaces.append(surface.model_copy(update={"content": "read_file\nwrite_file\nsubmit"}))
         elif surface.id == MAX_TURNS_ID:
             surfaces.append(surface.model_copy(update={"content": "60"}))
         else:

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -8,10 +8,22 @@ do not solve their benchmark tasks yourself.
 
 The project filesystem is your durable memory. Each round provides a current parent document,
 failure evidence, and the complete judged history. Earlier proposal files remain under proposals/.
-Inspect those files selectively, learn from accepted and rejected attempts, and produce the exact
-number of independent proposals requested for the round. Every proposal must target the supplied
-parent, make one focused change, preserve unrelated behavior, and state a falsifiable expected
-effect. Never overwrite an earlier round.
+Parent/evidence/history manifests point to bounded content files; read those files selectively and
+use bash only for read/search/comparison and disposable work under scratch/. Treat context/,
+evaluations/, and earlier proposals as immutable evidence; use write_file for every required
+proposal output. Deep-read both the execution traces and judge reasons before changing anything.
+Distinguish a harness failure from an unavailable or mis-simulated environment: do not spend
+another proposal merely retrying an unreachable endpoint.
+Inspect earlier proposals and evaluations, learn from accepted and rejected attempts, and produce
+the exact number of independent proposals requested for the round.
+
+The harness's real source-code surfaces are the primary search space. Prefer a focused structural
+code change when the failure is in control flow, context handling, tool dispatch, verification,
+recovery, or output parsing. Use a skill for a reusable technique, tool policy for capability,
+and params for genuine sampling/budget issues. Prompt wording is the weakest lever. Every proposal
+must target the supplied parent, change one mechanism, preserve unrelated behavior, and state a
+falsifiable expected effect. Compact exact edits are preferred for large source files. Never
+overwrite an earlier round.
 
 Use read_file and write_file to work in the project. The user message for each round gives the
 required input and output paths and the proposal schema. Write every requested proposal before
@@ -26,7 +38,9 @@ def meta_agent(name: str = "meta") -> HarnessDoc:
         if surface.id == "prompt:core":
             surfaces.append(surface.model_copy(update={"content": META_AGENT_PROMPT}))
         elif surface.id == TOOL_POLICY_ID:
-            surfaces.append(surface.model_copy(update={"content": "read_file\nwrite_file\nsubmit"}))
+            surfaces.append(
+                surface.model_copy(update={"content": "bash\nread_file\nwrite_file\nsubmit"})
+            )
         elif surface.id == MAX_TURNS_ID:
             surfaces.append(surface.model_copy(update={"content": "60"}))
         elif surface.id == MAX_OUTPUT_TOKENS_ID:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -203,9 +203,10 @@ class AgentProject:
                 command = str(arguments.get("command", ""))
                 return self._run_bash(command, emit)
             if name == "read_file":
-                return _capped(self._sandbox.files.read(str(arguments.get("path", ""))))
+                path = self._tool_path(str(arguments.get("path", "")))
+                return _capped(self._sandbox.files.read(path))
             if name == "write_file":
-                path = str(arguments.get("path", ""))
+                path = self._tool_path(str(arguments.get("path", "")))
                 self._sandbox.files.write(path, str(arguments.get("content", "")))
                 return ToolOutcome(content=f"wrote {path}")
         except Exception as error:  # noqa: BLE001 - tool errors are agent observations
@@ -232,6 +233,19 @@ class AgentProject:
         if exit_code:
             content = f"{content}\n[exit {exit_code}]"
         return _capped(content, is_error=exit_code != 0)
+
+    def _tool_path(self, path: str) -> str:
+        """Resolve an agent-supplied path while containing it to the project."""
+        candidate = PurePosixPath(path)
+        workspace = PurePosixPath(self.workspace)
+        if candidate.is_absolute():
+            try:
+                candidate = candidate.relative_to(workspace)
+            except ValueError as error:
+                raise ValueError(f"path escapes project workspace: {path!r}") from error
+        if not candidate.parts or ".." in candidate.parts:
+            raise ValueError(f"path escapes project workspace: {path!r}")
+        return str(workspace / candidate)
 
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -30,8 +30,11 @@ from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
+_BASH_TIMEOUT_S = 60.0
+_BASH_PROCESS_TIMEOUT_S = 50
+_BASH_STREAM_CAP = 7_000
 _OUTPUT_CAP = 16_000
-_PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
+_PROJECT_TOOLS = frozenset({"bash", "read_file", "write_file", "submit"})
 _RECOVERABLE_SESSION_MARKERS = (
     "server disconnected",
     "connection reset",
@@ -48,6 +51,40 @@ _RECOVERABLE_SESSION_MARKERS = (
     "live session runner did not become ready",
     "channel send failed",
 )
+
+_BASH_FILTER_SCRIPT = f"""\
+const cap = {_BASH_STREAM_CAP};
+const half = Math.floor(cap / 2);
+let small = Buffer.alloc(0);
+let head = Buffer.alloc(0);
+let tail = Buffer.alloc(0);
+let total = 0;
+let truncated = false;
+process.stdin.on("data", (chunk) => {{
+  total += chunk.length;
+  if (!truncated) {{
+    small = Buffer.concat([small, chunk]);
+    if (small.length > cap) {{
+      truncated = true;
+      head = small.subarray(0, half);
+      tail = small.subarray(small.length - half);
+      small = Buffer.alloc(0);
+    }}
+  }} else {{
+    tail = Buffer.concat([tail, chunk]);
+    if (tail.length > half) tail = tail.subarray(tail.length - half);
+  }}
+}});
+process.stdin.on("end", () => {{
+  if (truncated) {{
+    process.stdout.write(head);
+    process.stdout.write(`\\n... ${{total - cap}} bytes truncated in sandbox ...\\n`);
+    process.stdout.write(tail);
+  }} else {{
+    process.stdout.write(small);
+  }}
+}});
+"""
 
 
 class ChannelFactory(Protocol):
@@ -104,14 +141,14 @@ class AgentProject:
         }
         self._closing = False
         self._finished_at: float | None = None
-        # Every supported project mutation is mediated by write_text or the contained write_file
-        # tool. Keep an in-process mirror so a dead E2B transport can be replaced without
-        # discarding the prior proposals that make this a persistent meta-agent project.
+        # Keep an in-process mirror of mediated writes so a dead E2B transport can be replaced
+        # without discarding the prior proposals that make this a persistent meta-agent project.
         self._file_contents: dict[str, str] = {}
         self._channel: Channel | None = None
         self._session: LiveSession | None = None
         self._session_agent_hash: str | None = None
         self._session_provider: ToolCallingProvider | None = None
+        self._network_locked_sandbox_id: int | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
         self._retired_worker_usage = TokenUsage()
         try:
@@ -339,20 +376,26 @@ class AgentProject:
             return self._session
         self._close_agent_session()
         channel = self._channel_factory(self._sandbox, self.workspace)
-        skills = agent.skills()
-        session = LiveSession(
-            channel,
-            tools=resolve_tools(agent.tools()),
-            execute_tool=self._execute_tool,
-            on_event=self._emit_session_event,
-            files={surface.path: surface.content for surface in agent.code_files() if surface.path},
-            system_prompt=agent.assembled_prompt(),
-            skill_bodies={skill.name: skill.body for skill in skills},
-            provider=provider,
-            turn_cap=agent.max_turns(),
-            max_output_tokens=agent.max_output_tokens(),
-        )
         try:
+            # Runner bootstrap has completed in channel_factory, but no agent-controlled source
+            # has been imported yet. Remove egress before session_start materializes that code.
+            self._lock_project_network()
+            skills = agent.skills()
+            session = LiveSession(
+                channel,
+                tools=resolve_tools(agent.tools()),
+                execute_tool=self._execute_tool,
+                on_event=self._emit_session_event,
+                files={
+                    surface.path: surface.content for surface in agent.code_files() if surface.path
+                },
+                system_prompt=agent.assembled_prompt(),
+                skill_bodies={skill.name: skill.body for skill in skills},
+                provider=provider,
+                turn_cap=agent.max_turns(),
+                max_output_tokens=agent.max_output_tokens(),
+                temperature=agent.temperature(),
+            )
             session.start()
         except Exception:
             close = getattr(channel, "close", None)
@@ -365,6 +408,16 @@ class AgentProject:
         self._session_agent_hash = agent.doc_hash
         self._session_provider = provider
         return session
+
+    def _lock_project_network(self) -> None:
+        """Remove internet egress before untrusted project evidence can drive tools."""
+        if not self._owns_sandbox or self._network_locked_sandbox_id == id(self._sandbox):
+            return
+        update_network = getattr(self._sandbox, "update_network", None)
+        if not callable(update_network):
+            raise RuntimeError("owned project sandbox cannot disable internet access")
+        update_network({"allow_internet_access": False})
+        self._network_locked_sandbox_id = id(self._sandbox)
 
     def _emit_session_event(self, event: SessionEvent) -> None:
         """Route session events to the currently active project turn."""
@@ -489,11 +542,9 @@ class AgentProject:
         factory = self._sandbox_factory
         if factory is None:
             raise RuntimeError("project sandbox replacement is unavailable")
-        # Normal project writes are mirrored synchronously. This best-effort refresh also captures
-        # files produced directly by future custom harness code before replacing a still-readable
-        # sandbox; a poisoned command API simply falls back to the mediated-write mirror.
-        with contextlib.suppress(Exception):
-            self._refresh_file_mirror()
+        # Required durable files are synchronously mirrored by write_text/write_file. Bash is
+        # explicitly scratch-only, so recovery never scans or replays an unbounded agent-created
+        # tree before honoring cancellation or replacing a poisoned transport.
         replacement = create_sandbox(factory)
         replacement_started_at = time.monotonic()
         self._sandbox_count += 1
@@ -511,6 +562,7 @@ class AgentProject:
         self._close_agent_session()
         self._active_sandbox_started_at = replacement_started_at
         self._sandbox = replacement
+        self._network_locked_sandbox_id = None
         if self._owns_sandbox:
             self._retire_sandbox(previous)
 
@@ -524,19 +576,49 @@ class AgentProject:
         _handle, started_at = self._live_sandboxes.pop(id(sandbox))
         self._retired_sandbox_seconds += max(0.0, retired_at - started_at)
 
-    def _refresh_file_mirror(self) -> None:
-        """Snapshot all text files currently visible in the project workspace."""
-        result = self._sandbox.commands.run(
-            f"find {shlex.quote(self.workspace)} -type f -print0", timeout=30
+    def _run_bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
+        """Run one bounded command in the networkless E2B project.
+
+        Durable outputs use ``write_file`` and are mirrored synchronously. Bash is for search and
+        disposable prototypes; scanning and re-reading the entire growing project after every
+        grep would turn one agent turn into hundreds of E2B control-plane requests. The rare
+        sandbox replacement replays only this bounded authoritative mirror.
+        """
+        # Bound the streams *inside* the sandbox before the E2B SDK buffers them. Keeping a
+        # second host-side bound below protects the event channel if an older template lacks the
+        # wrapper contract or an SDK exception carries its own streams.
+        # Node is guaranteed by the pi project template; do not assume Python exists there.
+        filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
+        script = (
+            "set -o pipefail\n"
+            f"timeout --kill-after=3s {_BASH_PROCESS_TIMEOUT_S}s "
+            f"bash -lc {shlex.quote(command)} "
+            f"2> >({filter_command} >&2) | {filter_command}\n"
+            "status=${PIPESTATUS[0]}\n"
+            'exit "$status"'
         )
-        stdout = getattr(result, "stdout", "")
-        snapshot: dict[str, str] = {}
-        for absolute in str(stdout).split("\0"):
-            if not absolute:
-                continue
-            relative = self._relative_path(absolute)
-            snapshot[relative] = self._sandbox.files.read(absolute)
-        self._file_contents.update(snapshot)
+        wrapped = f"cd {shlex.quote(self.workspace)} && bash -lc {shlex.quote(script)}"
+        try:
+            result = self._sandbox.commands.run(
+                wrapped,
+                timeout=_BASH_TIMEOUT_S,
+            )
+            stdout = _bounded_bash_stream(str(getattr(result, "stdout", "") or ""))
+            stderr = _bounded_bash_stream(str(getattr(result, "stderr", "") or ""))
+            exit_code = int(getattr(result, "exit_code", 0) or 0)
+        except Exception as error:  # noqa: BLE001 - E2B reports non-zero exits as exceptions
+            stdout = _bounded_bash_stream(str(getattr(error, "stdout", "") or ""))
+            stderr = _bounded_bash_stream(str(getattr(error, "stderr", "") or str(error)))
+            exit_code = int(getattr(error, "exit_code", 1) or 1)
+
+        if stdout:
+            emit("stdout", stdout)
+        if stderr:
+            emit("stderr", stderr)
+        body = stdout + stderr
+        if exit_code != 0:
+            body = f"{body}\n[exit {exit_code}]"
+        return _capped(body, is_error=exit_code != 0)
 
     def _execute_tool(
         self,
@@ -544,8 +626,9 @@ class AgentProject:
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
-        del emit
         try:
+            if name == "bash":
+                return self._run_bash(str(arguments.get("command", "")), emit)
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
                 relative = self._relative_path(path)
@@ -625,6 +708,22 @@ def _usage_delta(after: TokenUsage, before: TokenUsage) -> TokenUsage:
         input_tokens=after.input_tokens - before.input_tokens,
         output_tokens=after.output_tokens - before.output_tokens,
         calls=after.calls - before.calls,
+    )
+
+
+def _bounded_bash_stream(content: str) -> str:
+    """Keep both ends of one Bash stream within the live-session event budget."""
+    # The in-sandbox filter adds a small truthful omission marker outside its payload budget.
+    # Preserve that marker; the guard below is for unwrapped/SDK exception streams.
+    if len(content) <= _BASH_STREAM_CAP or (
+        len(content) <= _BASH_STREAM_CAP + 512 and "bytes truncated in sandbox" in content
+    ):
+        return content
+    half = _BASH_STREAM_CAP // 2
+    omitted = len(content) - _BASH_STREAM_CAP
+    return (
+        f"{content[:half]}\n... {omitted} characters truncated by Bash boundary ...\n"
+        f"{content[-half:]}"
     )
 
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -13,6 +13,7 @@ from typing import Protocol
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import (
+    SandboxFactory,
     SandboxHandle,
     SandboxUsage,
     create_sandbox,
@@ -35,6 +36,10 @@ _RECOVERABLE_SESSION_MARKERS = (
     "broken pipe",
     "remoteprotocolerror",
     "readerror",
+    "pi runner process exited",
+    "session ended before completing its turn",
+    "live session runner did not become ready",
+    "channel send failed",
 )
 
 
@@ -68,20 +73,31 @@ class AgentProject:
         *,
         workspace: str = PROJECT_WORKSPACE,
         channel_factory: ChannelFactory | None = None,
+        sandbox_factory: SandboxFactory | None = None,
         owns_sandbox: bool = True,
     ) -> None:
         self._sandbox = sandbox
         self.workspace = workspace.rstrip("/")
         self._channel_factory = channel_factory or _start_channel
+        # Replacing a caller-owned sandbox would exceed this object's authority. Injected test or
+        # application sandboxes still get the bounded fresh-session retry in the same filesystem.
+        self._sandbox_factory = sandbox_factory if owns_sandbox else None
         self._owns_sandbox = owns_sandbox
-        self._started_at = time.monotonic()
+        self._active_sandbox_started_at = time.monotonic()
+        self._retired_sandbox_seconds = 0.0
+        self._sandbox_count = 1
         self._finished_at: float | None = None
+        # Every supported project mutation is mediated by write_text or the contained write_file
+        # tool. Keep an in-process mirror so a dead E2B transport can be replaced without
+        # discarding the prior proposals that make this a persistent meta-agent project.
+        self._file_contents: dict[str, str] = {}
         self._channel: Channel | None = None
         self._session: LiveSession | None = None
         self._session_agent_hash: str | None = None
         self._session_provider: ToolCallingProvider | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
-        self._sandbox.commands.run(f"mkdir -p {shlex.quote(self.workspace)}", timeout=30)
+        self._retired_worker_usage = TokenUsage()
+        self._initialize_sandbox(self._sandbox)
 
     @classmethod
     def create(
@@ -93,26 +109,33 @@ class AgentProject:
         metadata: dict[str, str] | None = None,
     ) -> AgentProject:
         """Create one owned E2B project sandbox."""
-        sandbox = create_sandbox(
-            default_sandbox_factory(
-                timeout=timeout,
-                template=template,
-                api_key=api_key,
-                metadata=metadata,
-            )
+        factory = default_sandbox_factory(
+            timeout=timeout,
+            template=template,
+            api_key=api_key,
+            metadata=metadata,
         )
-        return cls(sandbox)
+        sandbox = create_sandbox(factory)
+        return cls(sandbox, sandbox_factory=factory)
 
     def write_text(self, path: str, content: str) -> None:
         """Write one project-relative file without allowing path traversal."""
         absolute = self._absolute_path(path)
-        directory = str(PurePosixPath(absolute).parent)
-        self._sandbox.commands.run(f"mkdir -p {shlex.quote(directory)}", timeout=30)
-        self._sandbox.files.write(absolute, content)
+        self._write_sandbox_file(self._sandbox, absolute, content)
+        self._file_contents[self._relative_path(absolute)] = content
 
     def read_text(self, path: str) -> str:
         """Read one project-relative file."""
-        return self._sandbox.files.read(self._absolute_path(path))
+        absolute = self._absolute_path(path)
+        relative = self._relative_path(absolute)
+        try:
+            content = self._sandbox.files.read(absolute)
+        except Exception:
+            if relative in self._file_contents:
+                return self._file_contents[relative]
+            raise
+        self._file_contents[relative] = content
+        return content
 
     def run(
         self,
@@ -125,10 +148,10 @@ class AgentProject:
     ) -> AgentProjectRun:
         """Run one turn of an ordinary agent against this persistent project.
 
-        A transient runner-channel disconnect retires only the ordinary live
-        session and retries the turn once on a fresh channel. The E2B project
-        sandbox and its filesystem stay intact, so a recovered agent can still
-        inspect every earlier proposal and the current round context.
+        A transient runner-channel disconnect retries the turn once. Owned E2B
+        projects replace a transport-poisoned sandbox and replay their mirrored
+        filesystem first; injected test projects keep the sandbox and replace
+        only the ordinary live session.
         """
         if self._finished_at is not None:
             raise RuntimeError("cannot run an agent in a closed project")
@@ -138,15 +161,30 @@ class AgentProject:
         if unsupported:
             names = ", ".join(sorted(unsupported))
             raise ValueError(f"project agents cannot use uncontained tools: {names}")
+        usage_before = self._total_worker_usage()
         for attempt in range(2):
             try:
-                return self._run_turn(
+                result = self._run_turn(
                     agent, provider, instruction, timeout=timeout, on_event=on_event
+                )
+                usage_after = self._total_worker_usage()
+                return AgentProjectRun(
+                    answer=result.answer,
+                    events=result.events,
+                    worker_usage=_usage_delta(usage_after, usage_before),
                 )
             except Exception as error:
                 if attempt > 0 or not _is_recoverable_session_error(error):
                     raise
-                self._close_agent_session()
+                if self._sandbox_factory is None:
+                    self._close_agent_session()
+                    continue
+                try:
+                    self._replace_sandbox()
+                except Exception as recovery_error:
+                    raise RuntimeError(
+                        f"{error}; fresh project sandbox recovery failed: {recovery_error}"
+                    ) from recovery_error
         raise AssertionError("unreachable")
 
     def _run_turn(
@@ -176,11 +214,6 @@ class AgentProject:
             if on_event is not None:
                 on_event(event)
 
-        usage_before = TokenUsage(
-            input_tokens=session.worker_usage.input_tokens,
-            output_tokens=session.worker_usage.output_tokens,
-            calls=session.worker_usage.calls,
-        )
         self._active_event_sink = sink
         try:
             session.send_user_message(instruction)
@@ -198,14 +231,9 @@ class AgentProject:
                             f"project agent session failed: {session.failure_message}"
                         )
                     raise RuntimeError("project agent session ended before completing its turn")
-            usage = TokenUsage(
-                input_tokens=session.worker_usage.input_tokens - usage_before.input_tokens,
-                output_tokens=session.worker_usage.output_tokens - usage_before.output_tokens,
-                calls=session.worker_usage.calls - usage_before.calls,
-            )
         finally:
             self._active_event_sink = None
-        return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=usage)
+        return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=TokenUsage())
 
     def _ensure_session(self, agent: HarnessDoc, provider: ToolCallingProvider) -> LiveSession:
         """Return the compatible live session, starting one when the harness changed."""
@@ -257,6 +285,10 @@ class AgentProject:
         self._channel = None
         self._session_agent_hash = None
         self._session_provider = None
+        if session is not None:
+            self._retired_worker_usage.input_tokens += session.worker_usage.input_tokens
+            self._retired_worker_usage.output_tokens += session.worker_usage.output_tokens
+            self._retired_worker_usage.calls += session.worker_usage.calls
         if session is not None and not session.closed:
             with contextlib.suppress(Exception):
                 session.end()
@@ -269,7 +301,20 @@ class AgentProject:
     def usage(self) -> SandboxUsage:
         """Return this project's sandbox lifetime meter."""
         ended = self._finished_at if self._finished_at is not None else time.monotonic()
-        return SandboxUsage(count=1, seconds=max(0.0, ended - self._started_at))
+        active_seconds = max(0.0, ended - self._active_sandbox_started_at)
+        return SandboxUsage(
+            count=self._sandbox_count,
+            seconds=self._retired_sandbox_seconds + active_seconds,
+        )
+
+    def _total_worker_usage(self) -> TokenUsage:
+        """Return worker usage across retired and currently attached live sessions."""
+        current = self._session.worker_usage if self._session is not None else TokenUsage()
+        return TokenUsage(
+            input_tokens=self._retired_worker_usage.input_tokens + current.input_tokens,
+            output_tokens=self._retired_worker_usage.output_tokens + current.output_tokens,
+            calls=self._retired_worker_usage.calls + current.calls,
+        )
 
     def close(self) -> None:
         """Kill an owned sandbox and finalize its usage meter."""
@@ -293,6 +338,68 @@ class AgentProject:
             raise ValueError(f"expected a relative project path, got {path!r}")
         return f"{self.workspace}/{candidate.as_posix()}"
 
+    def _relative_path(self, absolute: str) -> str:
+        """Return one already-contained absolute path relative to the project root."""
+        return PurePosixPath(absolute).relative_to(PurePosixPath(self.workspace)).as_posix()
+
+    def _initialize_sandbox(self, sandbox: SandboxHandle) -> None:
+        """Create the workspace and replay the authoritative project-file mirror."""
+        sandbox.commands.run(f"mkdir -p {shlex.quote(self.workspace)}", timeout=30)
+        for relative, content in self._file_contents.items():
+            absolute = f"{self.workspace}/{relative}"
+            self._write_sandbox_file(sandbox, absolute, content)
+
+    @staticmethod
+    def _write_sandbox_file(sandbox: SandboxHandle, absolute: str, content: str) -> None:
+        directory = str(PurePosixPath(absolute).parent)
+        sandbox.commands.run(f"mkdir -p {shlex.quote(directory)}", timeout=30)
+        sandbox.files.write(absolute, content)
+
+    def _replace_sandbox(self) -> None:
+        """Replace a transport-poisoned sandbox while retaining every project file."""
+        factory = self._sandbox_factory
+        if factory is None:
+            raise RuntimeError("project sandbox replacement is unavailable")
+        # Normal project writes are mirrored synchronously. This best-effort refresh also captures
+        # files produced directly by future custom harness code before replacing a still-readable
+        # sandbox; a poisoned command API simply falls back to the mediated-write mirror.
+        with contextlib.suppress(Exception):
+            self._refresh_file_mirror()
+        replacement = create_sandbox(factory)
+        replacement_started_at = time.monotonic()
+        self._sandbox_count += 1
+        try:
+            self._initialize_sandbox(replacement)
+        except Exception:
+            with contextlib.suppress(Exception):
+                replacement.kill()
+            self._retired_sandbox_seconds += max(0.0, time.monotonic() - replacement_started_at)
+            raise
+
+        previous = self._sandbox
+        self._close_agent_session()
+        now = time.monotonic()
+        self._retired_sandbox_seconds += max(0.0, now - self._active_sandbox_started_at)
+        self._active_sandbox_started_at = replacement_started_at
+        self._sandbox = replacement
+        if self._owns_sandbox:
+            with contextlib.suppress(Exception):
+                previous.kill()
+
+    def _refresh_file_mirror(self) -> None:
+        """Snapshot all text files currently visible in the project workspace."""
+        result = self._sandbox.commands.run(
+            f"find {shlex.quote(self.workspace)} -type f -print0", timeout=30
+        )
+        stdout = getattr(result, "stdout", "")
+        snapshot: dict[str, str] = {}
+        for absolute in str(stdout).split("\0"):
+            if not absolute:
+                continue
+            relative = self._relative_path(absolute)
+            snapshot[relative] = self._sandbox.files.read(absolute)
+        self._file_contents.update(snapshot)
+
     def _execute_tool(
         self,
         name: str,
@@ -303,10 +410,21 @@ class AgentProject:
         try:
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
-                return _capped(self._sandbox.files.read(path))
+                relative = self._relative_path(path)
+                try:
+                    content = self._sandbox.files.read(path)
+                except Exception:
+                    if relative not in self._file_contents:
+                        raise
+                    content = self._file_contents[relative]
+                else:
+                    self._file_contents[relative] = content
+                return _capped(content)
             if name == "write_file":
                 path = self._tool_path(str(arguments.get("path", "")))
-                self._sandbox.files.write(path, str(arguments.get("content", "")))
+                content = str(arguments.get("content", ""))
+                self._write_sandbox_file(self._sandbox, path, content)
+                self._file_contents[self._relative_path(path)] = content
                 return ToolOutcome(content=f"wrote {path}")
         except Exception as error:  # noqa: BLE001 - tool errors are agent observations
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
@@ -327,7 +445,10 @@ class AgentProject:
 
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:
-    return start_live_runner(sandbox, workspace=workspace)
+    # Project turns can be separated by long evaluation waves. Reattach only across the runner's
+    # proven-idle state so its transcript survives an E2B stream reset without risking missed
+    # semantic frames mid-turn.
+    return start_live_runner(sandbox, workspace=workspace, reconnect_while_idle=True)
 
 
 def _is_recoverable_session_error(error: Exception) -> bool:
@@ -337,6 +458,15 @@ def _is_recoverable_session_error(error: Exception) -> bool:
         return True
     text = str(error).lower()
     return any(marker in text for marker in _RECOVERABLE_SESSION_MARKERS)
+
+
+def _usage_delta(after: TokenUsage, before: TokenUsage) -> TokenUsage:
+    """Subtract cumulative usage snapshots for one logical project run."""
+    return TokenUsage(
+        input_tokens=after.input_tokens - before.input_tokens,
+        output_tokens=after.output_tokens - before.output_tokens,
+        calls=after.calls - before.calls,
+    )
 
 
 def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -22,6 +22,7 @@ from wmh.harness.e2b_sandbox import (
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_e2b import start_live_runner
 from wmh.harness.runner_link import Channel, TokenUsage
+from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.harness.tools import resolve_tools
 from wmh.providers.base import ToolCallingProvider
 
@@ -153,6 +154,7 @@ class AgentProject:
         *,
         timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
         on_event: Callable[[SessionEvent], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> AgentProjectRun:
         """Run one turn of an ordinary agent against this persistent project.
 
@@ -163,6 +165,7 @@ class AgentProject:
         """
         if self._finished_at is not None:
             raise RuntimeError("cannot run an agent in a closed project")
+        _check_cancelled(should_cancel)
         if self._active_event_sink is not None:
             raise RuntimeError("a project agent turn is already running")
         unsupported = set(agent.tools()) - _PROJECT_TOOLS
@@ -173,7 +176,12 @@ class AgentProject:
         for attempt in range(2):
             try:
                 result = self._run_turn(
-                    agent, provider, instruction, timeout=timeout, on_event=on_event
+                    agent,
+                    provider,
+                    instruction,
+                    timeout=timeout,
+                    on_event=on_event,
+                    should_cancel=should_cancel,
                 )
                 usage_after = self._total_worker_usage()
                 return AgentProjectRun(
@@ -181,6 +189,8 @@ class AgentProject:
                     events=result.events,
                     worker_usage=_usage_delta(usage_after, usage_before),
                 )
+            except HarnessSearchCancelled:
+                raise
             except Exception as error:
                 if attempt > 0 or not _is_recoverable_session_error(error):
                     raise
@@ -203,6 +213,7 @@ class AgentProject:
         *,
         timeout: float,
         on_event: Callable[[SessionEvent], None] | None,
+        should_cancel: Callable[[], bool] | None,
     ) -> AgentProjectRun:
         """Execute one attempt using the compatible ordinary live session."""
         session = self._ensure_session(agent, provider)
@@ -240,15 +251,20 @@ class AgentProject:
             turn_started = True
             deadline = time.monotonic() + timeout
             while not turn_finished:
+                self._cancel_turn_if_requested(session, should_cancel)
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     session.interrupt("project_run_timeout")
-                    session.pump(timeout=0)
+                    session.flush_pending_intents()
                     # An abort acknowledgement can arrive after this deadline. Retiring the
                     # session prevents that stale idle boundary from completing the next turn.
                     self._close_agent_session()
                     raise TimeoutError(f"project agent did not finish within {timeout:g}s")
-                if not session.pump(timeout=min(0.5, remaining)) and not turn_finished:
+                running = session.pump(timeout=min(0.5, remaining))
+                # A pump can synchronously run one provider completion. Observe cancellation as
+                # soon as it returns, before consuming a second model or tool request.
+                self._cancel_turn_if_requested(session, should_cancel)
+                if not running and not turn_finished:
                     if session.failure_message is not None:
                         raise RuntimeError(
                             f"project agent session failed: {session.failure_message}"
@@ -263,6 +279,20 @@ class AgentProject:
         finally:
             self._active_event_sink = None
         return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=TokenUsage())
+
+    def _cancel_turn_if_requested(
+        self,
+        session: LiveSession,
+        should_cancel: Callable[[], bool] | None,
+    ) -> None:
+        """Abort and retire the active session at one cooperative cancellation boundary."""
+        if should_cancel is None or not should_cancel():
+            return
+        session.interrupt("harness_search_cancelled")
+        with contextlib.suppress(Exception):
+            session.flush_pending_intents()
+        self._close_agent_session()
+        raise HarnessSearchCancelled("harness search cancelled")
 
     def _ensure_session(self, agent: HarnessDoc, provider: ToolCallingProvider) -> LiveSession:
         """Return the compatible live session, starting one when the harness changed."""
@@ -493,6 +523,12 @@ def _is_recoverable_session_error(error: Exception) -> bool:
         return True
     text = str(error).lower()
     return any(marker in text for marker in _RECOVERABLE_SESSION_MARKERS)
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    """Fail before creating or retrying a project turn when search cancellation is already set."""
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness search cancelled")
 
 
 def _usage_delta(after: TokenUsage, before: TokenUsage) -> TokenUsage:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -73,8 +73,9 @@ class AgentProject:
     """A persistent filesystem that can run project-scoped pi agents.
 
     The project owns environment state, while :class:`LiveSession` owns ordinary agent execution.
-    Repeated ``run`` calls for the same agent and provider reuse one live session and its
-    transcript.
+    Repeated ``run`` calls for the same agent and provider reuse one live session and runner, while
+    each outer project task gets a fresh model transcript. The project filesystem is the durable
+    memory shared across those tasks.
     Changing the agent harness or provider starts a new session against the same filesystem.
     """
 
@@ -372,6 +373,10 @@ class AgentProject:
                 turn_cap=agent.max_turns(),
                 max_output_tokens=agent.max_output_tokens(),
                 temperature=agent.temperature(),
+                # Project files are durable memory. Replaying every prior project task in the
+                # model transcript only duplicates that state and eventually collapses pi's
+                # available output budget as context fills.
+                conversation_scope="turn",
             )
             session.start()
         except Exception:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -26,8 +26,8 @@ from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
-_COMMAND_TIMEOUT_S = 900.0
 _OUTPUT_CAP = 16_000
+_PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
 
 
 class ChannelFactory(Protocol):
@@ -46,7 +46,7 @@ class AgentProjectRun:
 
 
 class AgentProject:
-    """A persistent filesystem that can run any pi-backed ``HarnessDoc`` agent.
+    """A persistent filesystem that can run project-scoped pi agents.
 
     The project owns environment state, while :class:`LiveSession` owns agent execution. A new
     session is created for each ``run`` call, but every session sees the same sandbox filesystem.
@@ -108,7 +108,11 @@ class AgentProject:
         timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
         on_event: Callable[[SessionEvent], None] | None = None,
     ) -> AgentProjectRun:
-        """Run one ordinary agent session against this project's filesystem."""
+        """Run one project-contained agent session against the persistent filesystem."""
+        unsupported = set(agent.tools()) - _PROJECT_TOOLS
+        if unsupported:
+            names = ", ".join(sorted(unsupported))
+            raise ValueError(f"project agents cannot use uncontained tools: {names}")
         channel = self._channel_factory(self._sandbox, self.workspace)
         events: list[SessionEvent] = []
         answer = ""
@@ -198,10 +202,8 @@ class AgentProject:
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
+        del emit
         try:
-            if name == "bash":
-                command = str(arguments.get("command", ""))
-                return self._run_bash(command, emit)
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
                 return _capped(self._sandbox.files.read(path))
@@ -212,27 +214,6 @@ class AgentProject:
         except Exception as error:  # noqa: BLE001 - tool errors are agent observations
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
         return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
-
-    def _run_bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
-        try:
-            result = self._sandbox.commands.run(
-                f"cd {shlex.quote(self.workspace)} && {command}", timeout=_COMMAND_TIMEOUT_S
-            )
-            stdout = str(getattr(result, "stdout", "") or "")
-            stderr = str(getattr(result, "stderr", "") or "")
-            exit_code = int(getattr(result, "exit_code", 0) or 0)
-        except Exception as error:  # noqa: BLE001 - E2B raises command results on nonzero exit
-            stdout = str(getattr(error, "stdout", "") or "")
-            stderr = str(getattr(error, "stderr", "") or str(error))
-            exit_code = int(getattr(error, "exit_code", 1) or 1)
-        if stdout:
-            emit("stdout", stdout)
-        if stderr:
-            emit("stderr", stderr)
-        content = stdout + stderr
-        if exit_code:
-            content = f"{content}\n[exit {exit_code}]"
-        return _capped(content, is_error=exit_code != 0)
 
     def _tool_path(self, path: str) -> str:
         """Resolve an agent-supplied path while containing it to the project."""

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -130,7 +130,21 @@ class AgentProject:
     def write_text(self, path: str, content: str) -> None:
         """Write one project-relative file without allowing path traversal."""
         absolute = self._absolute_path(path)
-        self._write_sandbox_file(self._sandbox, absolute, content)
+        try:
+            self._write_sandbox_file(self._sandbox, absolute, content)
+        except Exception as error:
+            # Proposer context is written before ``run()``, so its recovery loop cannot own an
+            # exhausted control-plane retry. Replace an owned, transport-poisoned sandbox once,
+            # replay the established mirror, and then apply this idempotent overwrite there.
+            if self._sandbox_factory is None or not _is_recoverable_transport_error(error):
+                raise
+            try:
+                self._replace_sandbox()
+                self._write_sandbox_file(self._sandbox, absolute, content)
+            except Exception as recovery_error:
+                raise RuntimeError(
+                    f"{error}; fresh project sandbox recovery failed: {recovery_error}"
+                ) from recovery_error
         self._file_contents[self._relative_path(absolute)] = content
 
     def read_text(self, path: str) -> str:
@@ -537,6 +551,13 @@ def _is_recoverable_transport_error(error: Exception) -> bool:
     if error_type.__module__ == "e2b.exceptions" and error_type.__name__ == "TimeoutException":
         return True
     text = str(error).lower()
+    # httpcore can race an E2B HTTP/2 GOAWAY with request body delivery. h2 then surfaces a raw
+    # ProtocolError instead of httpx's usual transport wrapper. The pool will not reassign that
+    # unavailable closed connection, so the next idempotent control-plane request opens a fresh
+    # one. Match the state-machine shape rather than every h2 ProtocolError: malformed responses
+    # remain fatal.
+    if "invalid input connectioninputs." in text and "connectionstate.closed" in text:
+        return True
     return any(marker in text for marker in _RECOVERABLE_SESSION_MARKERS)
 
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -62,6 +62,10 @@ class AgentProjectRun:
     worker_usage: TokenUsage
 
 
+class _ProjectAgentTurnError(RuntimeError):
+    """A worker/provider error reported by a live agent turn, not its transport."""
+
+
 class AgentProject:
     """A persistent filesystem that can run project-scoped pi agents.
 
@@ -205,16 +209,28 @@ class AgentProject:
         events: list[SessionEvent] = []
         answer = ""
         turn_started = False
+        turn_running = False
         turn_finished = False
+        turn_terminal_reason: str | None = None
+        turn_error: str | None = None
 
         def sink(event: SessionEvent) -> None:
-            nonlocal answer, turn_finished
+            nonlocal answer, turn_error, turn_finished, turn_running, turn_terminal_reason
             events.append(event)
             if event.kind == "submit":
                 submitted = event.payload.get("answer")
                 answer = submitted if isinstance(submitted, str) else ""
-            elif turn_started and event.kind == "state" and event.payload.get("status") == "idle":
-                turn_finished = True
+            elif event.kind == "error" and turn_error is None:
+                message = event.payload.get("message")
+                turn_error = message if isinstance(message, str) else "project agent session error"
+            elif turn_started and event.kind == "state":
+                status = event.payload.get("status")
+                if status == "running":
+                    turn_running = True
+                elif status == "idle" and turn_running:
+                    turn_finished = True
+                    reason = event.payload.get("reason")
+                    turn_terminal_reason = reason if isinstance(reason, str) else None
             if on_event is not None:
                 on_event(event)
 
@@ -228,6 +244,9 @@ class AgentProject:
                 if remaining <= 0:
                     session.interrupt("project_run_timeout")
                     session.pump(timeout=0)
+                    # An abort acknowledgement can arrive after this deadline. Retiring the
+                    # session prevents that stale idle boundary from completing the next turn.
+                    self._close_agent_session()
                     raise TimeoutError(f"project agent did not finish within {timeout:g}s")
                 if not session.pump(timeout=min(0.5, remaining)) and not turn_finished:
                     if session.failure_message is not None:
@@ -235,6 +254,12 @@ class AgentProject:
                             f"project agent session failed: {session.failure_message}"
                         )
                     raise RuntimeError("project agent session ended before completing its turn")
+            if turn_error is not None:
+                raise _ProjectAgentTurnError(f"project agent session failed: {turn_error}")
+            if turn_terminal_reason in {"aborted", "turn_limit"}:
+                raise _ProjectAgentTurnError(
+                    f"project agent turn ended with reason: {turn_terminal_reason}"
+                )
         finally:
             self._active_event_sink = None
         return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=TokenUsage())
@@ -461,6 +486,8 @@ def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:
 
 def _is_recoverable_session_error(error: Exception) -> bool:
     """Return whether one fresh live session may recover this transport failure."""
+    if isinstance(error, _ProjectAgentTurnError):
+        return False
     error_type = type(error)
     if error_type.__module__ == "e2b.exceptions" and error_type.__name__ == "TimeoutException":
         return True

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -13,11 +13,13 @@ from typing import Protocol
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import (
+    SandboxCleanupError,
     SandboxFactory,
     SandboxHandle,
     SandboxUsage,
     create_sandbox,
     default_sandbox_factory,
+    kill_sandbox,
 )
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_e2b import start_live_runner
@@ -95,6 +97,12 @@ class AgentProject:
         self._active_sandbox_started_at = time.monotonic()
         self._retired_sandbox_seconds = 0.0
         self._sandbox_count = 1
+        # A lease remains live until E2B confirms its kill. Replacement failures retain both
+        # handles here so usage keeps accruing and close() can retry every unproven teardown.
+        self._live_sandboxes: dict[int, tuple[SandboxHandle, float]] = {
+            id(sandbox): (sandbox, self._active_sandbox_started_at)
+        }
+        self._closing = False
         self._finished_at: float | None = None
         # Every supported project mutation is mediated by write_text or the contained write_file
         # tool. Keep an in-process mirror so a dead E2B transport can be replaced without
@@ -106,7 +114,15 @@ class AgentProject:
         self._session_provider: ToolCallingProvider | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
         self._retired_worker_usage = TokenUsage()
-        self._initialize_sandbox(self._sandbox)
+        try:
+            self._initialize_sandbox(self._sandbox)
+        except Exception as error:
+            if self._owns_sandbox:
+                try:
+                    self._retire_sandbox(self._sandbox)
+                except SandboxCleanupError as cleanup_error:
+                    raise cleanup_error from error
+            raise
 
     @classmethod
     def create(
@@ -129,6 +145,8 @@ class AgentProject:
 
     def write_text(self, path: str, content: str) -> None:
         """Write one project-relative file without allowing path traversal."""
+        if self._closing:
+            raise RuntimeError("cannot write to a closed project")
         absolute = self._absolute_path(path)
         try:
             self._write_sandbox_file(self._sandbox, absolute, content)
@@ -149,6 +167,8 @@ class AgentProject:
 
     def read_text(self, path: str) -> str:
         """Read one project-relative file."""
+        if self._closing:
+            raise RuntimeError("cannot read from a closed project")
         absolute = self._absolute_path(path)
         relative = self._relative_path(absolute)
         try:
@@ -177,7 +197,7 @@ class AgentProject:
         filesystem first; injected test projects keep the sandbox and replace
         only the ordinary live session.
         """
-        if self._finished_at is not None:
+        if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
         _check_cancelled(should_cancel)
         if self._active_event_sink is not None:
@@ -377,8 +397,10 @@ class AgentProject:
 
     def usage(self) -> SandboxUsage:
         """Return this project's sandbox lifetime meter."""
-        ended = self._finished_at if self._finished_at is not None else time.monotonic()
-        active_seconds = max(0.0, ended - self._active_sandbox_started_at)
+        now = time.monotonic()
+        active_seconds = sum(
+            max(0.0, now - started_at) for _sandbox, started_at in self._live_sandboxes.values()
+        )
         return SandboxUsage(
             count=self._sandbox_count,
             seconds=self._retired_sandbox_seconds + active_seconds,
@@ -394,14 +416,35 @@ class AgentProject:
         )
 
     def close(self) -> None:
-        """Kill an owned sandbox and finalize its usage meter."""
+        """Release every owned lease, retaining unproven kills for a later retry."""
         if self._finished_at is not None:
             return
+        self._closing = True
         self._close_agent_session()
+        if not self._owns_sandbox:
+            finished_at = time.monotonic()
+            for _sandbox, started_at in self._live_sandboxes.values():
+                self._retired_sandbox_seconds += max(0.0, finished_at - started_at)
+            self._live_sandboxes.clear()
+            self._finished_at = finished_at
+            return
+
+        leases = list(self._live_sandboxes.values())
+        failures: list[SandboxCleanupError] = []
+        for sandbox, _started_at in leases:
+            try:
+                self._retire_sandbox(sandbox)
+            except SandboxCleanupError as error:
+                failures.append(error)
+        if failures:
+            raise SandboxCleanupError(
+                "failed to prove cleanup for "
+                f"{len(failures)} of {len(leases)} "
+                "meta-project E2B sandboxes",
+                resource="meta_project_sandbox",
+                sandbox_usage=self.usage(),
+            ) from failures[0]
         self._finished_at = time.monotonic()
-        if self._owns_sandbox:
-            with contextlib.suppress(Exception):
-                self._sandbox.kill()
 
     def __enter__(self) -> AgentProject:
         return self
@@ -454,23 +497,32 @@ class AgentProject:
         replacement = create_sandbox(factory)
         replacement_started_at = time.monotonic()
         self._sandbox_count += 1
+        self._live_sandboxes[id(replacement)] = (replacement, replacement_started_at)
         try:
             self._initialize_sandbox(replacement)
-        except Exception:
-            with contextlib.suppress(Exception):
-                replacement.kill()
-            self._retired_sandbox_seconds += max(0.0, time.monotonic() - replacement_started_at)
+        except Exception as error:
+            try:
+                self._retire_sandbox(replacement)
+            except SandboxCleanupError as cleanup_error:
+                raise cleanup_error from error
             raise
 
         previous = self._sandbox
         self._close_agent_session()
-        now = time.monotonic()
-        self._retired_sandbox_seconds += max(0.0, now - self._active_sandbox_started_at)
         self._active_sandbox_started_at = replacement_started_at
         self._sandbox = replacement
         if self._owns_sandbox:
-            with contextlib.suppress(Exception):
-                previous.kill()
+            self._retire_sandbox(previous)
+
+    def _retire_sandbox(self, sandbox: SandboxHandle) -> None:
+        """Finalize one lease only after E2B confirms that it is gone."""
+        lease = self._live_sandboxes.get(id(sandbox))
+        if lease is None:
+            return
+        kill_sandbox(sandbox)
+        retired_at = time.monotonic()
+        _handle, started_at = self._live_sandboxes.pop(id(sandbox))
+        self._retired_sandbox_seconds += max(0.0, retired_at - started_at)
 
     def _refresh_file_mirror(self) -> None:
         """Snapshot all text files currently visible in the project workspace."""

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -28,6 +28,14 @@ PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
 _OUTPUT_CAP = 16_000
 _PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
+_RECOVERABLE_SESSION_MARKERS = (
+    "server disconnected",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "remoteprotocolerror",
+    "readerror",
+)
 
 
 class ChannelFactory(Protocol):
@@ -115,7 +123,13 @@ class AgentProject:
         timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
         on_event: Callable[[SessionEvent], None] | None = None,
     ) -> AgentProjectRun:
-        """Run one turn of an ordinary agent against this persistent project."""
+        """Run one turn of an ordinary agent against this persistent project.
+
+        A transient runner-channel disconnect retires only the ordinary live
+        session and retries the turn once on a fresh channel. The E2B project
+        sandbox and its filesystem stay intact, so a recovered agent can still
+        inspect every earlier proposal and the current round context.
+        """
         if self._finished_at is not None:
             raise RuntimeError("cannot run an agent in a closed project")
         if self._active_event_sink is not None:
@@ -124,6 +138,27 @@ class AgentProject:
         if unsupported:
             names = ", ".join(sorted(unsupported))
             raise ValueError(f"project agents cannot use uncontained tools: {names}")
+        for attempt in range(2):
+            try:
+                return self._run_turn(
+                    agent, provider, instruction, timeout=timeout, on_event=on_event
+                )
+            except Exception as error:
+                if attempt > 0 or not _is_recoverable_session_error(error):
+                    raise
+                self._close_agent_session()
+        raise AssertionError("unreachable")
+
+    def _run_turn(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        timeout: float,
+        on_event: Callable[[SessionEvent], None] | None,
+    ) -> AgentProjectRun:
+        """Execute one attempt using the compatible ordinary live session."""
         session = self._ensure_session(agent, provider)
         events: list[SessionEvent] = []
         answer = ""
@@ -223,8 +258,9 @@ class AgentProject:
         self._session_agent_hash = None
         self._session_provider = None
         if session is not None and not session.closed:
-            session.end()
-            session.pump(timeout=0)
+            with contextlib.suppress(Exception):
+                session.end()
+                session.pump(timeout=0)
         close = getattr(channel, "close", None)
         if callable(close):
             with contextlib.suppress(Exception):
@@ -292,6 +328,15 @@ class AgentProject:
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:
     return start_live_runner(sandbox, workspace=workspace)
+
+
+def _is_recoverable_session_error(error: Exception) -> bool:
+    """Return whether one fresh live session may recover this transport failure."""
+    error_type = type(error)
+    if error_type.__module__ == "e2b.exceptions" and error_type.__name__ == "TimeoutException":
+        return True
+    text = str(error).lower()
+    return any(marker in text for marker in _RECOVERABLE_SESSION_MARKERS)
 
 
 def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -37,6 +37,10 @@ _RECOVERABLE_SESSION_MARKERS = (
     "remoteprotocolerror",
     "readerror",
     "pi runner process exited",
+    "pi live runner process exited",
+    "durable outbox",
+    "durable runner",
+    "failed to send a frame to the e2b runner",
     "session ended before completing its turn",
     "live session runner did not become ready",
     "channel send failed",
@@ -289,14 +293,17 @@ class AgentProject:
             self._retired_worker_usage.input_tokens += session.worker_usage.input_tokens
             self._retired_worker_usage.output_tokens += session.worker_usage.output_tokens
             self._retired_worker_usage.calls += session.worker_usage.calls
-        if session is not None and not session.closed:
-            with contextlib.suppress(Exception):
-                session.end()
-                session.pump(timeout=0)
         close = getattr(channel, "close", None)
         if callable(close):
             with contextlib.suppress(Exception):
                 close()
+        elif session is not None and not session.closed:
+            # Test/local channels without an owned close hook still get the protocol-level end.
+            # Real project channels close the runner directly above so cancellation never waits
+            # for two durable abort/shutdown acknowledgements from an unreachable process.
+            with contextlib.suppress(Exception):
+                session.end()
+                session.pump(timeout=0)
 
     def usage(self) -> SandboxUsage:
         """Return this project's sandbox lifetime meter."""
@@ -445,10 +452,11 @@ class AgentProject:
 
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:
-    # Project turns can be separated by long evaluation waves. Reattach only across the runner's
-    # proven-idle state so its transcript survives an E2B stream reset without risking missed
-    # semantic frames mid-turn.
-    return start_live_runner(sandbox, workspace=workspace, reconnect_while_idle=True)
+    # Project turns can be separated by long evaluation waves. Their ordinary live runner writes
+    # every semantic output frame to a sequenced E2B outbox before stdout, so the shared
+    # LiveSession can replay a dropped command stream without replacing the agent, transcript, or
+    # project sandbox. Platform live sessions keep start_live_runner's established stdio default.
+    return start_live_runner(sandbox, workspace=workspace, durable_outbox=True)
 
 
 def _is_recoverable_session_error(error: Exception) -> bool:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -48,8 +48,10 @@ class AgentProjectRun:
 class AgentProject:
     """A persistent filesystem that can run project-scoped pi agents.
 
-    The project owns environment state, while :class:`LiveSession` owns agent execution. A new
-    session is created for each ``run`` call, but every session sees the same sandbox filesystem.
+    The project owns environment state, while :class:`LiveSession` owns ordinary agent execution.
+    Repeated ``run`` calls for the same agent and provider reuse one live session and its
+    transcript.
+    Changing the agent harness or provider starts a new session against the same filesystem.
     """
 
     def __init__(
@@ -66,6 +68,11 @@ class AgentProject:
         self._owns_sandbox = owns_sandbox
         self._started_at = time.monotonic()
         self._finished_at: float | None = None
+        self._channel: Channel | None = None
+        self._session: LiveSession | None = None
+        self._session_agent_hash: str | None = None
+        self._session_provider: ToolCallingProvider | None = None
+        self._active_event_sink: Callable[[SessionEvent], None] | None = None
         self._sandbox.commands.run(f"mkdir -p {shlex.quote(self.workspace)}", timeout=30)
 
     @classmethod
@@ -108,12 +115,16 @@ class AgentProject:
         timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
         on_event: Callable[[SessionEvent], None] | None = None,
     ) -> AgentProjectRun:
-        """Run one project-contained agent session against the persistent filesystem."""
+        """Run one turn of an ordinary agent against this persistent project."""
+        if self._finished_at is not None:
+            raise RuntimeError("cannot run an agent in a closed project")
+        if self._active_event_sink is not None:
+            raise RuntimeError("a project agent turn is already running")
         unsupported = set(agent.tools()) - _PROJECT_TOOLS
         if unsupported:
             names = ", ".join(sorted(unsupported))
             raise ValueError(f"project agents cannot use uncontained tools: {names}")
-        channel = self._channel_factory(self._sandbox, self.workspace)
+        session = self._ensure_session(agent, provider)
         events: list[SessionEvent] = []
         answer = ""
         turn_started = False
@@ -130,20 +141,13 @@ class AgentProject:
             if on_event is not None:
                 on_event(event)
 
-        skills = agent.skills()
-        session = LiveSession(
-            channel,
-            tools=resolve_tools(agent.tools()),
-            execute_tool=self._execute_tool,
-            on_event=sink,
-            files={surface.path: surface.content for surface in agent.code_files() if surface.path},
-            system_prompt=agent.assembled_prompt(),
-            skill_bodies={skill.name: skill.body for skill in skills},
-            provider=provider,
-            turn_cap=agent.max_turns(),
+        usage_before = TokenUsage(
+            input_tokens=session.worker_usage.input_tokens,
+            output_tokens=session.worker_usage.output_tokens,
+            calls=session.worker_usage.calls,
         )
+        self._active_event_sink = sink
         try:
-            session.start()
             session.send_user_message(instruction)
             turn_started = True
             deadline = time.monotonic() + timeout
@@ -154,21 +158,77 @@ class AgentProject:
                     session.pump(timeout=0)
                     raise TimeoutError(f"project agent did not finish within {timeout:g}s")
                 if not session.pump(timeout=min(0.5, remaining)) and not turn_finished:
+                    if session.failure_message is not None:
+                        raise RuntimeError(
+                            f"project agent session failed: {session.failure_message}"
+                        )
                     raise RuntimeError("project agent session ended before completing its turn")
             usage = TokenUsage(
-                input_tokens=session.worker_usage.input_tokens,
-                output_tokens=session.worker_usage.output_tokens,
-                calls=session.worker_usage.calls,
+                input_tokens=session.worker_usage.input_tokens - usage_before.input_tokens,
+                output_tokens=session.worker_usage.output_tokens - usage_before.output_tokens,
+                calls=session.worker_usage.calls - usage_before.calls,
             )
         finally:
-            if not session.closed:
-                session.end()
-                session.pump(timeout=0)
+            self._active_event_sink = None
+        return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=usage)
+
+    def _ensure_session(self, agent: HarnessDoc, provider: ToolCallingProvider) -> LiveSession:
+        """Return the compatible live session, starting one when the harness changed."""
+        if (
+            self._session is not None
+            and not self._session.closed
+            and self._session_agent_hash == agent.doc_hash
+            and self._session_provider is provider
+        ):
+            return self._session
+        self._close_agent_session()
+        channel = self._channel_factory(self._sandbox, self.workspace)
+        skills = agent.skills()
+        session = LiveSession(
+            channel,
+            tools=resolve_tools(agent.tools()),
+            execute_tool=self._execute_tool,
+            on_event=self._emit_session_event,
+            files={surface.path: surface.content for surface in agent.code_files() if surface.path},
+            system_prompt=agent.assembled_prompt(),
+            skill_bodies={skill.name: skill.body for skill in skills},
+            provider=provider,
+            turn_cap=agent.max_turns(),
+        )
+        try:
+            session.start()
+        except Exception:
             close = getattr(channel, "close", None)
             if callable(close):
                 with contextlib.suppress(Exception):
                     close()
-        return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=usage)
+            raise
+        self._channel = channel
+        self._session = session
+        self._session_agent_hash = agent.doc_hash
+        self._session_provider = provider
+        return session
+
+    def _emit_session_event(self, event: SessionEvent) -> None:
+        """Route session events to the currently active project turn."""
+        if self._active_event_sink is not None:
+            self._active_event_sink(event)
+
+    def _close_agent_session(self) -> None:
+        """Close the current agent session without touching the project filesystem."""
+        session = self._session
+        channel = self._channel
+        self._session = None
+        self._channel = None
+        self._session_agent_hash = None
+        self._session_provider = None
+        if session is not None and not session.closed:
+            session.end()
+            session.pump(timeout=0)
+        close = getattr(channel, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
 
     def usage(self) -> SandboxUsage:
         """Return this project's sandbox lifetime meter."""
@@ -179,6 +239,7 @@ class AgentProject:
         """Kill an owned sandbox and finalize its usage meter."""
         if self._finished_at is not None:
             return
+        self._close_agent_session()
         self._finished_at = time.monotonic()
         if self._owns_sandbox:
             with contextlib.suppress(Exception):

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import shlex
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Protocol
@@ -113,6 +113,10 @@ class AgentProject:
         self._session_provider: ToolCallingProvider | None = None
         self._network_locked_sandbox_id: int | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
+        # ``None`` preserves the historical unrestricted project-tool behavior. A concrete set is
+        # one logical run's exact, project-relative write grant; it is cleared even when the turn
+        # fails so a reused live session cannot inherit the preceding turn's authority.
+        self._active_writable_files: frozenset[str] | None = None
         self._retired_worker_usage = TokenUsage()
         try:
             self._initialize_sandbox(self._sandbox)
@@ -189,13 +193,18 @@ class AgentProject:
         timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
         on_event: Callable[[SessionEvent], None] | None = None,
         should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
     ) -> AgentProjectRun:
         """Run one turn of an ordinary agent against this persistent project.
 
         A transient runner-channel disconnect retries the turn once. Owned E2B
         projects replace a transport-poisoned sandbox and replay their mirrored
         filesystem first; injected test projects keep the sandbox and replace
-        only the ordinary live session.
+        only the ordinary live session. ``writable_files`` optionally grants the
+        agent's ``write_file`` tool access to exact project-relative files for
+        this logical run. Omitting it preserves unrestricted project writes;
+        an empty collection denies every agent write. Host ``write_text`` calls
+        are not constrained by an agent turn's grant.
         """
         if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
@@ -206,38 +215,43 @@ class AgentProject:
         if unsupported:
             names = ", ".join(sorted(unsupported))
             raise ValueError(f"project agents cannot use uncontained tools: {names}")
+        write_grant = self._normalize_writable_files(writable_files)
         usage_before = self._total_worker_usage()
-        for attempt in range(2):
-            try:
-                result = self._run_turn(
-                    agent,
-                    provider,
-                    instruction,
-                    timeout=timeout,
-                    on_event=on_event,
-                    should_cancel=should_cancel,
-                )
-                usage_after = self._total_worker_usage()
-                return AgentProjectRun(
-                    answer=result.answer,
-                    events=result.events,
-                    worker_usage=_usage_delta(usage_after, usage_before),
-                )
-            except HarnessSearchCancelled:
-                raise
-            except Exception as error:
-                if attempt > 0 or not _is_recoverable_session_error(error):
-                    raise
-                if self._sandbox_factory is None:
-                    self._close_agent_session()
-                    continue
+        self._active_writable_files = write_grant
+        try:
+            for attempt in range(2):
                 try:
-                    self._replace_sandbox()
-                except Exception as recovery_error:
-                    raise RuntimeError(
-                        f"{error}; fresh project sandbox recovery failed: {recovery_error}"
-                    ) from recovery_error
-        raise AssertionError("unreachable")
+                    result = self._run_turn(
+                        agent,
+                        provider,
+                        instruction,
+                        timeout=timeout,
+                        on_event=on_event,
+                        should_cancel=should_cancel,
+                    )
+                    usage_after = self._total_worker_usage()
+                    return AgentProjectRun(
+                        answer=result.answer,
+                        events=result.events,
+                        worker_usage=_usage_delta(usage_after, usage_before),
+                    )
+                except HarnessSearchCancelled:
+                    raise
+                except Exception as error:
+                    if attempt > 0 or not _is_recoverable_session_error(error):
+                        raise
+                    if self._sandbox_factory is None:
+                        self._close_agent_session()
+                        continue
+                    try:
+                        self._replace_sandbox()
+                    except Exception as recovery_error:
+                        raise RuntimeError(
+                            f"{error}; fresh project sandbox recovery failed: {recovery_error}"
+                        ) from recovery_error
+            raise AssertionError("unreachable")
+        finally:
+            self._active_writable_files = None
 
     def _run_turn(
         self,
@@ -561,9 +575,17 @@ class AgentProject:
                 return _capped(content)
             if name == "write_file":
                 path = self._tool_path(str(arguments.get("path", "")))
+                relative = self._relative_path(path)
+                if (
+                    self._active_writable_files is not None
+                    and relative not in self._active_writable_files
+                ):
+                    raise PermissionError(
+                        f"path is not writable in this project turn: {relative!r}"
+                    )
                 content = str(arguments.get("content", ""))
                 self._write_sandbox_file(self._sandbox, path, content)
-                self._file_contents[self._relative_path(path)] = content
+                self._file_contents[relative] = content
                 return ToolOutcome(content=f"wrote {path}")
         except Exception as error:  # noqa: BLE001 - tool errors are agent observations
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
@@ -581,6 +603,14 @@ class AgentProject:
         if not candidate.parts or ".." in candidate.parts:
             raise ValueError(f"path escapes project workspace: {path!r}")
         return str(workspace / candidate)
+
+    def _normalize_writable_files(
+        self, writable_files: Collection[str] | None
+    ) -> frozenset[str] | None:
+        """Normalize one optional exact-file grant to project-relative paths."""
+        if writable_files is None:
+            return None
+        return frozenset(self._relative_path(self._absolute_path(path)) for path in writable_files)
 
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -414,8 +414,17 @@ class AgentProject:
     @staticmethod
     def _write_sandbox_file(sandbox: SandboxHandle, absolute: str, content: str) -> None:
         directory = str(PurePosixPath(absolute).parent)
-        sandbox.commands.run(f"mkdir -p {shlex.quote(directory)}", timeout=30)
-        sandbox.files.write(absolute, content)
+        for attempt in range(2):
+            try:
+                sandbox.commands.run(f"mkdir -p {shlex.quote(directory)}", timeout=30)
+                sandbox.files.write(absolute, content)
+                return
+            except Exception as error:  # noqa: BLE001 - classify the E2B transport boundary
+                # Both operations are idempotent: replaying ``mkdir -p`` and the same overwrite is
+                # safe even when the first request reached E2B but its response was disconnected.
+                # Keep the live project sandbox/session intact for a one-off control-plane drop.
+                if attempt > 0 or not _is_recoverable_transport_error(error):
+                    raise
 
     def _replace_sandbox(self) -> None:
         """Replace a transport-poisoned sandbox while retaining every project file."""
@@ -518,6 +527,11 @@ def _is_recoverable_session_error(error: Exception) -> bool:
     """Return whether one fresh live session may recover this transport failure."""
     if isinstance(error, _ProjectAgentTurnError):
         return False
+    return _is_recoverable_transport_error(error)
+
+
+def _is_recoverable_transport_error(error: Exception) -> bool:
+    """Return whether one idempotent E2B transport operation may be retried once."""
     error_type = type(error)
     if error_type.__module__ == "e2b.exceptions" and error_type.__name__ == "TimeoutException":
         return True

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -30,11 +30,8 @@ from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
-_BASH_TIMEOUT_S = 60.0
-_BASH_PROCESS_TIMEOUT_S = 50
-_BASH_STREAM_CAP = 7_000
 _OUTPUT_CAP = 16_000
-_PROJECT_TOOLS = frozenset({"bash", "read_file", "write_file", "submit"})
+_PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
 _RECOVERABLE_SESSION_MARKERS = (
     "server disconnected",
     "connection reset",
@@ -51,40 +48,6 @@ _RECOVERABLE_SESSION_MARKERS = (
     "live session runner did not become ready",
     "channel send failed",
 )
-
-_BASH_FILTER_SCRIPT = f"""\
-const cap = {_BASH_STREAM_CAP};
-const half = Math.floor(cap / 2);
-let small = Buffer.alloc(0);
-let head = Buffer.alloc(0);
-let tail = Buffer.alloc(0);
-let total = 0;
-let truncated = false;
-process.stdin.on("data", (chunk) => {{
-  total += chunk.length;
-  if (!truncated) {{
-    small = Buffer.concat([small, chunk]);
-    if (small.length > cap) {{
-      truncated = true;
-      head = small.subarray(0, half);
-      tail = small.subarray(small.length - half);
-      small = Buffer.alloc(0);
-    }}
-  }} else {{
-    tail = Buffer.concat([tail, chunk]);
-    if (tail.length > half) tail = tail.subarray(tail.length - half);
-  }}
-}});
-process.stdin.on("end", () => {{
-  if (truncated) {{
-    process.stdout.write(head);
-    process.stdout.write(`\\n... ${{total - cap}} bytes truncated in sandbox ...\\n`);
-    process.stdout.write(tail);
-  }} else {{
-    process.stdout.write(small);
-  }}
-}});
-"""
 
 
 class ChannelFactory(Protocol):
@@ -576,59 +539,14 @@ class AgentProject:
         _handle, started_at = self._live_sandboxes.pop(id(sandbox))
         self._retired_sandbox_seconds += max(0.0, retired_at - started_at)
 
-    def _run_bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
-        """Run one bounded command in the networkless E2B project.
-
-        Durable outputs use ``write_file`` and are mirrored synchronously. Bash is for search and
-        disposable prototypes; scanning and re-reading the entire growing project after every
-        grep would turn one agent turn into hundreds of E2B control-plane requests. The rare
-        sandbox replacement replays only this bounded authoritative mirror.
-        """
-        # Bound the streams *inside* the sandbox before the E2B SDK buffers them. Keeping a
-        # second host-side bound below protects the event channel if an older template lacks the
-        # wrapper contract or an SDK exception carries its own streams.
-        # Node is guaranteed by the pi project template; do not assume Python exists there.
-        filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
-        script = (
-            "set -o pipefail\n"
-            f"timeout --kill-after=3s {_BASH_PROCESS_TIMEOUT_S}s "
-            f"bash -lc {shlex.quote(command)} "
-            f"2> >({filter_command} >&2) | {filter_command}\n"
-            "status=${PIPESTATUS[0]}\n"
-            'exit "$status"'
-        )
-        wrapped = f"cd {shlex.quote(self.workspace)} && bash -lc {shlex.quote(script)}"
-        try:
-            result = self._sandbox.commands.run(
-                wrapped,
-                timeout=_BASH_TIMEOUT_S,
-            )
-            stdout = _bounded_bash_stream(str(getattr(result, "stdout", "") or ""))
-            stderr = _bounded_bash_stream(str(getattr(result, "stderr", "") or ""))
-            exit_code = int(getattr(result, "exit_code", 0) or 0)
-        except Exception as error:  # noqa: BLE001 - E2B reports non-zero exits as exceptions
-            stdout = _bounded_bash_stream(str(getattr(error, "stdout", "") or ""))
-            stderr = _bounded_bash_stream(str(getattr(error, "stderr", "") or str(error)))
-            exit_code = int(getattr(error, "exit_code", 1) or 1)
-
-        if stdout:
-            emit("stdout", stdout)
-        if stderr:
-            emit("stderr", stderr)
-        body = stdout + stderr
-        if exit_code != 0:
-            body = f"{body}\n[exit {exit_code}]"
-        return _capped(body, is_error=exit_code != 0)
-
     def _execute_tool(
         self,
         name: str,
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
+        del emit  # Project file tools return one bounded observation; they do not stream output.
         try:
-            if name == "bash":
-                return self._run_bash(str(arguments.get("command", "")), emit)
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
                 relative = self._relative_path(path)
@@ -708,22 +626,6 @@ def _usage_delta(after: TokenUsage, before: TokenUsage) -> TokenUsage:
         input_tokens=after.input_tokens - before.input_tokens,
         output_tokens=after.output_tokens - before.output_tokens,
         calls=after.calls - before.calls,
-    )
-
-
-def _bounded_bash_stream(content: str) -> str:
-    """Keep both ends of one Bash stream within the live-session event budget."""
-    # The in-sandbox filter adds a small truthful omission marker outside its payload budget.
-    # Preserve that marker; the guard below is for unwrapped/SDK exception streams.
-    if len(content) <= _BASH_STREAM_CAP or (
-        len(content) <= _BASH_STREAM_CAP + 512 and "bytes truncated in sandbox" in content
-    ):
-        return content
-    half = _BASH_STREAM_CAP // 2
-    omitted = len(content) - _BASH_STREAM_CAP
-    return (
-        f"{content[:half]}\n... {omitted} characters truncated by Bash boundary ...\n"
-        f"{content[-half:]}"
     )
 
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -316,6 +316,7 @@ class AgentProject:
             skill_bodies={skill.name: skill.body for skill in skills},
             provider=provider,
             turn_cap=agent.max_turns(),
+            max_output_tokens=agent.max_output_tokens(),
         )
         try:
             session.start()

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -1,0 +1,250 @@
+"""Persistent E2B filesystem projects driven by the shared pi session runtime."""
+
+from __future__ import annotations
+
+import contextlib
+import shlex
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Protocol
+
+from wmh.core.types import JsonObject
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.e2b_sandbox import (
+    SandboxHandle,
+    SandboxUsage,
+    create_sandbox,
+    default_sandbox_factory,
+)
+from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+from wmh.harness.pi_e2b import start_live_runner
+from wmh.harness.runner_link import Channel, TokenUsage
+from wmh.harness.tools import resolve_tools
+from wmh.providers.base import ToolCallingProvider
+
+PROJECT_WORKSPACE = "/home/user/project"
+DEFAULT_PROJECT_TIMEOUT_S = 21_600
+_COMMAND_TIMEOUT_S = 900.0
+_OUTPUT_CAP = 16_000
+
+
+class ChannelFactory(Protocol):
+    """Start one fresh runner channel in a project's sandbox."""
+
+    def __call__(self, sandbox: SandboxHandle, workspace: str) -> Channel: ...
+
+
+@dataclass(frozen=True)
+class AgentProjectRun:
+    """Result of one agent turn inside a project."""
+
+    answer: str
+    events: tuple[SessionEvent, ...]
+    worker_usage: TokenUsage
+
+
+class AgentProject:
+    """A persistent filesystem that can run any pi-backed ``HarnessDoc`` agent.
+
+    The project owns environment state, while :class:`LiveSession` owns agent execution. A new
+    session is created for each ``run`` call, but every session sees the same sandbox filesystem.
+    """
+
+    def __init__(
+        self,
+        sandbox: SandboxHandle,
+        *,
+        workspace: str = PROJECT_WORKSPACE,
+        channel_factory: ChannelFactory | None = None,
+        owns_sandbox: bool = True,
+    ) -> None:
+        self._sandbox = sandbox
+        self.workspace = workspace.rstrip("/")
+        self._channel_factory = channel_factory or _start_channel
+        self._owns_sandbox = owns_sandbox
+        self._started_at = time.monotonic()
+        self._finished_at: float | None = None
+        self._sandbox.commands.run(f"mkdir -p {shlex.quote(self.workspace)}", timeout=30)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
+        template: str | None = None,
+        api_key: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> AgentProject:
+        """Create one owned E2B project sandbox."""
+        sandbox = create_sandbox(
+            default_sandbox_factory(
+                timeout=timeout,
+                template=template,
+                api_key=api_key,
+                metadata=metadata,
+            )
+        )
+        return cls(sandbox)
+
+    def write_text(self, path: str, content: str) -> None:
+        """Write one project-relative file without allowing path traversal."""
+        absolute = self._absolute_path(path)
+        directory = str(PurePosixPath(absolute).parent)
+        self._sandbox.commands.run(f"mkdir -p {shlex.quote(directory)}", timeout=30)
+        self._sandbox.files.write(absolute, content)
+
+    def read_text(self, path: str) -> str:
+        """Read one project-relative file."""
+        return self._sandbox.files.read(self._absolute_path(path))
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        timeout: float = DEFAULT_PROJECT_TIMEOUT_S,
+        on_event: Callable[[SessionEvent], None] | None = None,
+    ) -> AgentProjectRun:
+        """Run one ordinary agent session against this project's filesystem."""
+        channel = self._channel_factory(self._sandbox, self.workspace)
+        events: list[SessionEvent] = []
+        answer = ""
+        turn_started = False
+        turn_finished = False
+
+        def sink(event: SessionEvent) -> None:
+            nonlocal answer, turn_finished
+            events.append(event)
+            if event.kind == "submit":
+                submitted = event.payload.get("answer")
+                answer = submitted if isinstance(submitted, str) else ""
+            elif turn_started and event.kind == "state" and event.payload.get("status") == "idle":
+                turn_finished = True
+            if on_event is not None:
+                on_event(event)
+
+        skills = agent.skills()
+        session = LiveSession(
+            channel,
+            tools=resolve_tools(agent.tools()),
+            execute_tool=self._execute_tool,
+            on_event=sink,
+            files={surface.path: surface.content for surface in agent.code_files() if surface.path},
+            system_prompt=agent.assembled_prompt(),
+            skill_bodies={skill.name: skill.body for skill in skills},
+            provider=provider,
+            turn_cap=agent.max_turns(),
+        )
+        try:
+            session.start()
+            session.send_user_message(instruction)
+            turn_started = True
+            deadline = time.monotonic() + timeout
+            while not turn_finished:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    session.interrupt("project_run_timeout")
+                    session.pump(timeout=0)
+                    raise TimeoutError(f"project agent did not finish within {timeout:g}s")
+                if not session.pump(timeout=min(0.5, remaining)) and not turn_finished:
+                    raise RuntimeError("project agent session ended before completing its turn")
+            usage = TokenUsage(
+                input_tokens=session.worker_usage.input_tokens,
+                output_tokens=session.worker_usage.output_tokens,
+                calls=session.worker_usage.calls,
+            )
+        finally:
+            if not session.closed:
+                session.end()
+                session.pump(timeout=0)
+            close = getattr(channel, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+        return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=usage)
+
+    def usage(self) -> SandboxUsage:
+        """Return this project's sandbox lifetime meter."""
+        ended = self._finished_at if self._finished_at is not None else time.monotonic()
+        return SandboxUsage(count=1, seconds=max(0.0, ended - self._started_at))
+
+    def close(self) -> None:
+        """Kill an owned sandbox and finalize its usage meter."""
+        if self._finished_at is not None:
+            return
+        self._finished_at = time.monotonic()
+        if self._owns_sandbox:
+            with contextlib.suppress(Exception):
+                self._sandbox.kill()
+
+    def __enter__(self) -> AgentProject:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def _absolute_path(self, path: str) -> str:
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+            raise ValueError(f"expected a relative project path, got {path!r}")
+        return f"{self.workspace}/{candidate.as_posix()}"
+
+    def _execute_tool(
+        self,
+        name: str,
+        arguments: JsonObject,
+        emit: Callable[[str, str], None],
+    ) -> ToolOutcome:
+        try:
+            if name == "bash":
+                command = str(arguments.get("command", ""))
+                return self._run_bash(command, emit)
+            if name == "read_file":
+                return _capped(self._sandbox.files.read(str(arguments.get("path", ""))))
+            if name == "write_file":
+                path = str(arguments.get("path", ""))
+                self._sandbox.files.write(path, str(arguments.get("content", "")))
+                return ToolOutcome(content=f"wrote {path}")
+        except Exception as error:  # noqa: BLE001 - tool errors are agent observations
+            return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
+        return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+
+    def _run_bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
+        try:
+            result = self._sandbox.commands.run(
+                f"cd {shlex.quote(self.workspace)} && {command}", timeout=_COMMAND_TIMEOUT_S
+            )
+            stdout = str(getattr(result, "stdout", "") or "")
+            stderr = str(getattr(result, "stderr", "") or "")
+            exit_code = int(getattr(result, "exit_code", 0) or 0)
+        except Exception as error:  # noqa: BLE001 - E2B raises command results on nonzero exit
+            stdout = str(getattr(error, "stdout", "") or "")
+            stderr = str(getattr(error, "stderr", "") or str(error))
+            exit_code = int(getattr(error, "exit_code", 1) or 1)
+        if stdout:
+            emit("stdout", stdout)
+        if stderr:
+            emit("stderr", stderr)
+        content = stdout + stderr
+        if exit_code:
+            content = f"{content}\n[exit {exit_code}]"
+        return _capped(content, is_error=exit_code != 0)
+
+
+def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:
+    return start_live_runner(sandbox, workspace=workspace)
+
+
+def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
+    if len(content) <= _OUTPUT_CAP:
+        return ToolOutcome(content=content, is_error=is_error)
+    half = _OUTPUT_CAP // 2
+    marker = f"\n... {len(content) - _OUTPUT_CAP} characters truncated ...\n"
+    return ToolOutcome(
+        content=f"{content[:half]}{marker}{content[-half:]}",
+        is_error=is_error,
+        truncated=True,
+    )

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -21,7 +21,12 @@ from wmh.harness.e2b_sandbox import (
     default_sandbox_factory,
     kill_sandbox,
 )
-from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
+from wmh.harness.live_session import (
+    DEFAULT_ACTIONS_PER_TURN,
+    LiveSession,
+    SessionEvent,
+    ToolOutcome,
+)
 from wmh.harness.pi_e2b import start_live_runner
 from wmh.harness.runner_link import Channel, TokenUsage
 from wmh.harness.runtime import HarnessSearchCancelled
@@ -370,6 +375,10 @@ class AgentProject:
                 system_prompt=agent.assembled_prompt(),
                 skill_bodies={skill.name: skill.body for skill in skills},
                 provider=provider,
+                # Project agents explore a durable filesystem and can legitimately need one
+                # project action per model turn. Never let LiveSession's generic 40-action default
+                # silently undercut a harness that explicitly raises its turn budget.
+                actions_per_turn=max(DEFAULT_ACTIONS_PER_TURN, agent.max_turns()),
                 turn_cap=agent.max_turns(),
                 max_output_tokens=agent.max_output_tokens(),
                 temperature=agent.temperature(),

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
 from llm_waterfall import ChatResponse
 
 from wmh.agents.default import default_agent
+from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
 from wmh.providers.base import ProviderConfig, ProviderKind
@@ -107,7 +109,7 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     )
 
     project.write_text("history/round-1.json", "{}")
-    result = project.run(default_agent(), _Provider(), "produce a result", timeout=1)
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
 
     assert project.read_text("history/round-1.json") == "{}"
     assert project.read_text("result.txt") == "done"
@@ -140,3 +142,19 @@ def test_agent_file_tools_reject_paths_outside_the_project() -> None:
         outcome = project._execute_tool("read_file", {"path": path}, lambda stream, data: None)
         assert outcome.is_error is True
         assert "escapes project workspace" in outcome.content
+
+
+def test_project_rejects_agents_with_uncontained_tools() -> None:
+    """Tool policy is enforced before a shell-enabled project session can start."""
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    with pytest.raises(ValueError, match="uncontained tools: bash"):
+        project.run(default_agent(), _Provider(), "escape", timeout=1)
+
+    outcome = project._execute_tool(
+        "bash",
+        {"command": "cat /home/user/runner.js"},
+        lambda stream, data: None,
+    )
+    assert outcome.is_error is True
+    assert outcome.content == "tool 'bash' not available"

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -10,6 +10,8 @@ from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
+from wmh.harness import e2b_sandbox as e2b_sandbox_module
+from wmh.harness.e2b_sandbox import SandboxCleanupError, SandboxUsage
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.providers.base import ProviderConfig, ProviderKind
@@ -63,7 +65,23 @@ class _Sandbox:
     def set_timeout(self, timeout: int) -> None:
         del timeout
 
-    def kill(self) -> object:
+    def kill(self, request_timeout: float | None = None) -> object:
+        del request_timeout
+        self.killed = True
+        return None
+
+
+class _FlakyKillSandbox(_Sandbox):
+    def __init__(self, *, failures: int) -> None:
+        super().__init__()
+        self.failures = failures
+        self.kill_attempts = 0
+
+    def kill(self, request_timeout: float | None = None) -> object:
+        del request_timeout
+        self.kill_attempts += 1
+        if self.kill_attempts <= self.failures:
+            raise RuntimeError("control plane unavailable")
         self.killed = True
         return None
 
@@ -878,6 +896,81 @@ def test_project_meters_a_replacement_that_fails_during_restore(
     assert replacement.killed is True
     assert usage.count == 2
     assert usage.seconds == 40.0  # original: 0..30 plus failed replacement: 10..20
+
+
+def test_project_initialization_failure_releases_only_an_owned_sandbox() -> None:
+    """Constructor setup cannot orphan an owned project or kill a caller-owned lease."""
+
+    class _BrokenCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del cmd, background, kwargs
+            raise RuntimeError("workspace setup failed")
+
+    owned = _Sandbox()
+    owned.commands = _BrokenCommands()
+    with pytest.raises(RuntimeError, match="workspace setup failed"):
+        AgentProject(owned)
+    assert owned.killed is True
+
+    caller_owned = _Sandbox()
+    caller_owned.commands = _BrokenCommands()
+    with pytest.raises(RuntimeError, match="workspace setup failed"):
+        AgentProject(caller_owned, owns_sandbox=False)
+    assert caller_owned.killed is False
+
+
+def test_project_failed_close_keeps_usage_live_and_retries_every_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed meta-project kill remains billable and retryable instead of looking final."""
+    now = [0.0]
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(e2b_sandbox_module.time, "sleep", lambda delay: None)
+    sandbox = _FlakyKillSandbox(failures=3)
+    project = AgentProject(sandbox)
+
+    now[0] = 5.0
+    with pytest.raises(SandboxCleanupError, match="1 of 1") as raised:
+        project.close()
+    assert sandbox.kill_attempts == 3
+    assert raised.value.resource == "meta_project_sandbox"
+    assert raised.value.sandbox_usage == SandboxUsage(count=1, seconds=5.0)
+    assert project.usage().seconds == 5.0
+
+    now[0] = 8.0
+    assert project.usage().seconds == 8.0
+    project.close()
+    assert sandbox.kill_attempts == 4
+    assert sandbox.killed is True
+    assert project.usage().seconds == 8.0
+    project.close()
+
+
+def test_project_retains_old_and_replacement_leases_after_failed_retirement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery cannot drop the old sandbox handle when its kill is unproven."""
+    now = [0.0]
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(e2b_sandbox_module.time, "sleep", lambda delay: None)
+    original = _FlakyKillSandbox(failures=3)
+    replacement = _Sandbox()
+    project = AgentProject(original, sandbox_factory=lambda: replacement)
+
+    now[0] = 10.0
+    with pytest.raises(SandboxCleanupError, match="cleanup failed"):
+        project._replace_sandbox()  # noqa: SLF001
+
+    now[0] = 20.0
+    usage = project.usage()
+    assert usage.count == 2
+    assert usage.seconds == 30.0  # old: 0..20 plus replacement: 10..20
+
+    project.close()
+    assert original.kill_attempts == 4
+    assert original.killed is True
+    assert replacement.killed is True
+    assert project.usage().seconds == 30.0
 
 
 def test_project_retries_a_clean_premature_session_end() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from llm_waterfall import ChatResponse
 
+from wmh.agents import project as project_module
 from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
@@ -97,6 +98,44 @@ class _Provider:
     def complete_chat(self, request: object) -> ChatResponse:
         del request
         raise AssertionError("scripted channel never requests the worker")
+
+
+class _MeteredProvider(_Provider):
+    def complete_chat(self, request: object) -> ChatResponse:
+        del request
+        return ChatResponse.model_validate(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "working"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 7},
+            }
+        )
+
+
+def test_default_project_channel_enables_safe_idle_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = _Sandbox()
+    channel = _Channel()
+    captured: dict[str, object] = {}
+
+    def start(sandbox_arg: object, **kwargs: object) -> _Channel:
+        captured["sandbox"] = sandbox_arg
+        captured.update(kwargs)
+        return channel
+
+    monkeypatch.setattr(project_module, "start_live_runner", start)
+
+    assert project_module._start_channel(sandbox, "/project") is channel  # noqa: SLF001
+    assert captured == {
+        "sandbox": sandbox,
+        "workspace": "/project",
+        "reconnect_while_idle": True,
+    }
 
 
 def test_project_preserves_files_and_runs_through_live_session() -> None:
@@ -215,6 +254,183 @@ def test_project_restarts_one_live_session_after_transport_disconnect() -> None:
     assert project.read_text("history/round-1.json") == '{"kept": true}'
     assert [frame["type"] for frame in disconnected.sent].count("user_message") == 1
     assert [frame["type"] for frame in recovered.sent].count("user_message") == 1
+
+
+def test_project_retries_a_transient_channel_send_failure() -> None:
+    """E2B stdin timeouts are transport failures even after LiveSession stringifies them."""
+
+    class _SendFailureChannel(_Channel):
+        def send(self, frame: JsonObject) -> None:
+            if frame.get("type") == "user_message":
+                raise RuntimeError("request timed out")
+            super().send(frame)
+
+    failed = _SendFailureChannel()
+    failed.inbound = [{"type": "state", "status": "idle"}]
+    recovered = _Channel()
+    channels = iter([failed, recovered])
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: next(channels),
+        owns_sandbox=False,
+    )
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert failed.closed is True
+    assert recovered.closed is False
+
+
+def test_project_counts_worker_usage_from_failed_and_recovered_attempts() -> None:
+    """A logical run reports tokens spent before and after its bounded recovery."""
+
+    class _DisconnectedAfterLlmChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+                {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("Server disconnected")
+
+    failed = _DisconnectedAfterLlmChannel()
+    recovered = _Channel()
+    recovered.inbound.insert(
+        2, {"type": "llm_request", "req_id": 3, "openai_body": {"messages": []}}
+    )
+    channels = iter([failed, recovered])
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: next(channels),
+        owns_sandbox=False,
+    )
+
+    result = project.run(meta_agent(), _MeteredProvider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert result.worker_usage.calls == 2
+    assert result.worker_usage.input_tokens == 10
+    assert result.worker_usage.output_tokens == 14
+
+
+def test_project_replaces_owned_sandbox_and_restores_files_after_disconnect() -> None:
+    """A poisoned E2B transport is replaced without losing the project archive."""
+
+    class _DisconnectedChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("Server disconnected")
+
+    original = _Sandbox()
+    replacement = _Sandbox()
+    disconnected = _DisconnectedChannel()
+    recovered = _Channel()
+    replacement_calls = 0
+
+    def sandbox_factory() -> _Sandbox:
+        nonlocal replacement_calls
+        replacement_calls += 1
+        return replacement
+
+    project = AgentProject(
+        original,
+        channel_factory=lambda sandbox, workspace: (
+            recovered if sandbox is replacement else disconnected
+        ),
+        sandbox_factory=sandbox_factory,
+    )
+    project.write_text("history/round-1.json", '{"kept": true}')
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    archived = "/home/user/project/history/round-1.json"
+    assert result.answer == "finished"
+    assert replacement_calls == 1
+    assert original.killed is True
+    assert replacement.killed is False
+    assert replacement.files.values[archived] == '{"kept": true}'
+    assert project.read_text("history/round-1.json") == '{"kept": true}'
+    assert project.usage().count == 2
+
+
+def test_project_meters_overlapping_replacement_sandbox_lifetimes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replacement bootstrap time bills both the old and new live sandboxes."""
+    ticks = iter([0.0, 10.0, 15.0, 30.0])
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: next(ticks))
+    original = _Sandbox()
+    replacement = _Sandbox()
+    project = AgentProject(original, sandbox_factory=lambda: replacement)
+
+    project._replace_sandbox()  # noqa: SLF001
+    usage = project.usage()
+
+    assert usage.count == 2
+    assert usage.seconds == 35.0  # old: 0..15 plus replacement: 10..30
+
+
+def test_project_meters_a_replacement_that_fails_during_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A created sandbox is billable even if replay fails before it becomes active."""
+
+    class _BrokenCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del cmd, background, kwargs
+            raise RuntimeError("restore failed")
+
+    ticks = iter([0.0, 10.0, 20.0, 30.0])
+    monkeypatch.setattr(project_module.time, "monotonic", lambda: next(ticks))
+    original = _Sandbox()
+    replacement = _Sandbox()
+    replacement.commands = _BrokenCommands()
+    project = AgentProject(original, sandbox_factory=lambda: replacement)
+
+    with pytest.raises(RuntimeError, match="restore failed"):
+        project._replace_sandbox()  # noqa: SLF001
+    usage = project.usage()
+
+    assert replacement.killed is True
+    assert usage.count == 2
+    assert usage.seconds == 40.0  # original: 0..30 plus failed replacement: 10..20
+
+
+def test_project_retries_a_clean_premature_session_end() -> None:
+    """A clean EOF before the turn boundary is a recoverable runner lifecycle loss."""
+
+    ended = _Channel()
+    ended.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+    ]
+    recovered = _Channel()
+    channels = iter([ended, recovered])
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: next(channels),
+        owns_sandbox=False,
+    )
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert ended.closed is True
+    assert recovered.closed is False
 
 
 def test_project_rejects_paths_that_escape_its_workspace() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -215,6 +215,124 @@ def test_project_retries_one_context_write_after_e2b_disconnect() -> None:
     assert sandbox.killed is False
 
 
+def test_project_retries_one_context_write_after_closed_http2_connection() -> None:
+    """A stale E2B HTTP/2 connection cannot invalidate an entire proposal batch."""
+
+    class _ClosedHttp2OnceCommands(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_next = False
+            self.attempts = 0
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            self.attempts += 1
+            if self.close_next:
+                self.close_next = False
+                raise RuntimeError(
+                    "Invalid input ConnectionInputs.SEND_DATA in state ConnectionState.CLOSED"
+                )
+            return super().run(cmd, background=background, **kwargs)
+
+    sandbox = _Sandbox()
+    commands = _ClosedHttp2OnceCommands()
+    sandbox.commands = commands
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: _Channel(),
+        sandbox_factory=lambda: pytest.fail("a fresh HTTP/2 request must reuse the project"),
+    )
+    attempts_before = commands.attempts
+    commands.close_next = True
+
+    project.write_text("context/round-0007/parent.json", '{"round": 7}')
+
+    assert commands.attempts - attempts_before == 2
+    assert project.read_text("context/round-0007/parent.json") == '{"round": 7}'
+    assert project.usage().count == 1
+    assert sandbox.killed is False
+
+
+def test_project_replaces_owned_sandbox_after_repeated_closed_http2_writes() -> None:
+    """An exhausted context-write retry reaches the project's bounded sandbox fallback."""
+
+    class _ClosedHttp2Commands(_Commands):
+        closed = False
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            if self.closed:
+                raise RuntimeError(
+                    "Invalid input ConnectionInputs.SEND_DATA in state ConnectionState.CLOSED"
+                )
+            return super().run(cmd, background=background, **kwargs)
+
+    original = _Sandbox()
+    original_commands = _ClosedHttp2Commands()
+    original.commands = original_commands
+    replacement = _Sandbox()
+    project = AgentProject(original, sandbox_factory=lambda: replacement)
+    project.write_text("history/round-0006.json", '{"kept": true}')
+    original_commands.closed = True
+
+    project.write_text("context/round-0007/parent.json", '{"round": 7}')
+
+    assert original.killed is True
+    assert replacement.killed is False
+    assert project.usage().count == 2
+    assert replacement.files.values["/home/user/project/history/round-0006.json"] == (
+        '{"kept": true}'
+    )
+    assert replacement.files.values["/home/user/project/context/round-0007/parent.json"] == (
+        '{"round": 7}'
+    )
+
+
+def test_context_write_recovery_restarts_an_idle_project_session() -> None:
+    """A poisoned next-round write preserves the archive and resumes on a fresh live session."""
+
+    class _ClosedHttp2Commands(_Commands):
+        closed = False
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            if self.closed:
+                raise RuntimeError(
+                    "Invalid input ConnectionInputs.SEND_DATA in state ConnectionState.CLOSED"
+                )
+            return super().run(cmd, background=background, **kwargs)
+
+    original = _Sandbox()
+    original_commands = _ClosedHttp2Commands()
+    original.commands = original_commands
+    replacement = _Sandbox()
+    original_channel = _Channel()
+    replacement_channel = _Channel()
+    project = AgentProject(
+        original,
+        channel_factory=lambda sandbox, workspace: (
+            replacement_channel if sandbox is replacement else original_channel
+        ),
+        sandbox_factory=lambda: replacement,
+    )
+    agent = meta_agent()
+    provider = _Provider()
+    project.write_text("history/round-0006.json", '{"kept": true}')
+    first = project.run(agent, provider, "round 6", timeout=1)
+    original_commands.closed = True
+
+    project.write_text("context/round-0007/parent.json", '{"round": 7}')
+    second = project.run(agent, provider, "round 7", timeout=1)
+
+    assert first.answer == second.answer == "finished"
+    assert original_channel.closed is True
+    assert replacement_channel.closed is False
+    assert original.killed is True
+    assert replacement.killed is False
+    assert project.usage().count == 2
+    assert project.read_text("history/round-0006.json") == '{"kept": true}'
+    assert project.read_text("context/round-0007/parent.json") == '{"round": 7}'
+    assert [frame["type"] for frame in original_channel.sent].count("user_message") == 1
+    assert [frame["type"] for frame in replacement_channel.sent].count("user_message") == 1
+
+
 def test_project_does_not_retry_non_transport_context_write_failure() -> None:
     """A real filesystem failure still propagates after exactly one attempt."""
 

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -207,6 +207,126 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     assert channel.closed is True
 
 
+def test_project_grants_agent_writes_to_exact_files_only() -> None:
+    """A turn grant contains agent writes without constraining trusted host writes."""
+    sandbox = _Sandbox()
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "write_file",
+            "arguments": {
+                "path": "/home/user/project/context/round-1/parent.json",
+                "content": "poisoned",
+            },
+        },
+        {
+            "type": "tool_request",
+            "req_id": 2,
+            "name": "write_file",
+            "arguments": {
+                "path": "/home/user/project/proposals/round-1/proposal-01.json",
+                "content": "candidate",
+            },
+        },
+        {
+            "type": "tool_request",
+            "req_id": 3,
+            "name": "submit",
+            "arguments": {"answer": "done"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+    project.write_text("context/round-1/parent.json", "trusted")
+    host_write_pending = [True]
+
+    def on_event(event: SessionEvent) -> None:
+        if event.kind != "tool_call" or not host_write_pending:
+            return
+        host_write_pending.clear()
+        project.write_text("context/round-1/host-note.txt", "host-authored")
+
+    result = project.run(
+        meta_agent(),
+        _Provider(),
+        "produce one proposal",
+        timeout=1,
+        on_event=on_event,
+        writable_files=["proposals/round-1/proposal-01.json"],
+    )
+
+    assert result.answer == "done"
+    assert project.read_text("context/round-1/parent.json") == "trusted"
+    assert project.read_text("context/round-1/host-note.txt") == "host-authored"
+    assert project.read_text("proposals/round-1/proposal-01.json") == "candidate"
+    tool_results = [event for event in result.events if event.kind == "tool_result"]
+    assert [event.payload["is_error"] for event in tool_results] == [True, False]
+    assert "not writable in this project turn" in str(tool_results[0].payload["content"])
+
+
+def test_project_write_grant_resets_between_turns_on_one_session() -> None:
+    """A restricted turn cannot narrow a later backward-compatible unrestricted turn."""
+    sandbox = _Sandbox()
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "write_file",
+            "arguments": {"path": "memory.txt", "content": "blocked"},
+        },
+        {
+            "type": "tool_request",
+            "req_id": 2,
+            "name": "submit",
+            "arguments": {"answer": "restricted"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 3,
+            "name": "write_file",
+            "arguments": {"path": "memory.txt", "content": "unrestricted"},
+        },
+        {
+            "type": "tool_request",
+            "req_id": 4,
+            "name": "submit",
+            "arguments": {"answer": "second"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+    project.write_text("memory.txt", "original")
+    agent = meta_agent()
+    provider = _Provider()
+
+    first = project.run(agent, provider, "restricted", timeout=1, writable_files=[])
+    assert first.answer == "restricted"
+    assert project.read_text("memory.txt") == "original"
+
+    second = project.run(agent, provider, "unrestricted", timeout=1)
+
+    assert second.answer == "second"
+    assert project.read_text("memory.txt") == "unrestricted"
+    assert [frame["type"] for frame in channel.sent].count("session_start") == 1
+
+
 def test_owned_project_disables_internet_before_the_agent_turn() -> None:
     order: list[str] = []
 
@@ -805,6 +925,58 @@ def test_project_replaces_owned_sandbox_after_durable_outbox_failure() -> None:
     assert original.killed is True
     assert replacement.killed is False
     assert project.usage().count == 2
+
+
+def test_denied_agent_write_never_enters_the_replayed_project_mirror() -> None:
+    """A sandbox replacement replays trusted bytes, not a rejected agent overwrite."""
+
+    class _DisconnectedAfterDeniedWrite(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+                {
+                    "type": "tool_request",
+                    "req_id": 1,
+                    "name": "write_file",
+                    "arguments": {
+                        "path": "context/round-1/parent.json",
+                        "content": "poisoned",
+                    },
+                },
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("Server disconnected")
+
+    original = _Sandbox()
+    replacement = _Sandbox()
+    failed = _DisconnectedAfterDeniedWrite()
+    recovered = _Channel()
+    project = AgentProject(
+        original,
+        channel_factory=lambda sandbox, workspace: recovered if sandbox is replacement else failed,
+        sandbox_factory=lambda: replacement,
+    )
+    parent_path = "context/round-1/parent.json"
+    project.write_text(parent_path, "trusted")
+
+    result = project.run(
+        meta_agent(),
+        _Provider(),
+        "produce a result",
+        timeout=1,
+        writable_files=["result.txt"],
+    )
+
+    assert result.answer == "finished"
+    assert original.killed is True
+    assert replacement.files.values[f"/home/user/project/{parent_path}"] == "trusted"
+    assert project.read_text(parent_path) == "trusted"
+    assert project.read_text("result.txt") == "done"
 
 
 def test_project_counts_worker_usage_from_failed_and_recovered_attempts() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1,0 +1,132 @@
+"""Tests for running ordinary agents inside a persistent filesystem project."""
+
+from __future__ import annotations
+
+from llm_waterfall import ChatResponse
+
+from wmh.agents.default import default_agent
+from wmh.agents.project import AgentProject
+from wmh.core.types import JsonObject
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+
+class _Files:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def write(self, path: str, data: str) -> object:
+        self.values[path] = data
+        return None
+
+    def read(self, path: str) -> str:
+        return self.values[path]
+
+
+class _Output:
+    stdout = ""
+    stderr = ""
+    exit_code = 0
+
+
+class _Commands:
+    def __init__(self) -> None:
+        self.runs: list[str] = []
+
+    def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+        del background, kwargs
+        self.runs.append(cmd)
+        return _Output()
+
+    def send_stdin(self, pid: int, data: str) -> object:
+        del pid, data
+        return None
+
+
+class _Sandbox:
+    def __init__(self) -> None:
+        self.files = _Files()
+        self.commands = _Commands()
+        self.killed = False
+
+    def set_timeout(self, timeout: int) -> None:
+        del timeout
+
+    def kill(self) -> object:
+        self.killed = True
+        return None
+
+
+class _Channel:
+    def __init__(self) -> None:
+        self.inbound: list[JsonObject] = [
+            {"type": "state", "status": "idle"},
+            {"type": "state", "status": "running"},
+            {
+                "type": "tool_request",
+                "req_id": 1,
+                "name": "write_file",
+                "arguments": {"path": "/home/user/project/result.txt", "content": "done"},
+            },
+            {
+                "type": "tool_request",
+                "req_id": 2,
+                "name": "submit",
+                "arguments": {"answer": "finished"},
+            },
+            {"type": "state", "status": "idle", "reason": "completed"},
+        ]
+        self.sent: list[JsonObject] = []
+        self.closed = False
+
+    def send(self, frame: JsonObject) -> None:
+        self.sent.append(frame)
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        del timeout
+        return self.inbound.pop(0) if self.inbound else None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _Provider:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="worker")
+
+    def complete_chat(self, request: object) -> ChatResponse:
+        del request
+        raise AssertionError("scripted channel never requests the worker")
+
+
+def test_project_preserves_files_and_runs_through_live_session() -> None:
+    sandbox = _Sandbox()
+    channel = _Channel()
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    project.write_text("history/round-1.json", "{}")
+    result = project.run(default_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert project.read_text("history/round-1.json") == "{}"
+    assert project.read_text("result.txt") == "done"
+    assert result.answer == "finished"
+    assert any(frame["type"] == "session_start" for frame in channel.sent)
+    assert any(frame["type"] == "user_message" for frame in channel.sent)
+    assert channel.closed is True
+    assert sandbox.commands.runs[:2] == [
+        "mkdir -p /home/user/project",
+        "mkdir -p /home/user/project/history",
+    ]
+
+
+def test_project_rejects_paths_that_escape_its_workspace() -> None:
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    try:
+        project.write_text("../escape", "no")
+    except ValueError as error:
+        assert "relative project path" in str(error)
+    else:
+        raise AssertionError("path traversal should fail")

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -21,7 +21,14 @@ class _Files:
         self.values[path] = data
         return None
 
-    def read(self, path: str) -> str:
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        del request_timeout, gzip
         return self.values[path]
 
 
@@ -40,8 +47,8 @@ class _Commands:
         self.runs.append(cmd)
         return _Output()
 
-    def send_stdin(self, pid: int, data: str) -> object:
-        del pid, data
+    def send_stdin(self, pid: int, data: str, request_timeout: float | None = None) -> object:
+        del pid, data, request_timeout
         return None
 
 
@@ -116,7 +123,7 @@ class _MeteredProvider(_Provider):
         )
 
 
-def test_default_project_channel_enables_safe_idle_reconnect(
+def test_default_project_channel_enables_durable_outbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sandbox = _Sandbox()
@@ -134,7 +141,7 @@ def test_default_project_channel_enables_safe_idle_reconnect(
     assert captured == {
         "sandbox": sandbox,
         "workspace": "/project",
-        "reconnect_while_idle": True,
+        "durable_outbox": True,
     }
 
 
@@ -280,6 +287,65 @@ def test_project_retries_a_transient_channel_send_failure() -> None:
     assert result.answer == "finished"
     assert failed.closed is True
     assert recovered.closed is False
+
+
+def test_project_retries_an_initial_session_start_socket_failure() -> None:
+    """The direct LiveSession.start send reaches the same bounded recovery path."""
+
+    class _StartFailureChannel(_Channel):
+        def send(self, frame: JsonObject) -> None:
+            if frame.get("type") == "session_start":
+                raise RuntimeError("failed to send a frame to the E2B runner")
+            super().send(frame)
+
+    failed = _StartFailureChannel()
+    recovered = _Channel()
+    channels = iter([failed, recovered])
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: next(channels),
+        owns_sandbox=False,
+    )
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert failed.closed is True
+    assert recovered.closed is False
+
+
+def test_project_replaces_owned_sandbox_after_durable_outbox_failure() -> None:
+    """A corrupt durable transport still reaches the bounded fresh-sandbox fallback."""
+
+    class _CorruptOutboxChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("durable outbox frame 4 unavailable after 5s")
+
+    original = _Sandbox()
+    replacement = _Sandbox()
+    failed = _CorruptOutboxChannel()
+    recovered = _Channel()
+    project = AgentProject(
+        original,
+        channel_factory=lambda sandbox, workspace: recovered if sandbox is replacement else failed,
+        sandbox_factory=lambda: replacement,
+    )
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert original.killed is True
+    assert replacement.killed is False
+    assert project.usage().count == 2
 
 
 def test_project_counts_worker_usage_from_failed_and_recovered_attempts() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -130,3 +130,13 @@ def test_project_rejects_paths_that_escape_its_workspace() -> None:
         assert "relative project path" in str(error)
     else:
         raise AssertionError("path traversal should fail")
+
+
+def test_agent_file_tools_reject_paths_outside_the_project() -> None:
+    """Absolute and traversing agent paths cannot reach runner or sibling files."""
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    for path in ("/home/user/runner.js", "../runner.js"):
+        outcome = project._execute_tool("read_file", {"path": path}, lambda stream, data: None)
+        assert outcome.is_error is True
+        assert "escapes project workspace" in outcome.content

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -197,6 +197,7 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     assert result.answer == "finished"
     [session_start] = [frame for frame in channel.sent if frame["type"] == "session_start"]
     assert session_start["max_output_tokens"] == meta_agent().max_output_tokens() == 16384
+    assert session_start["conversation_scope"] == "turn"
     assert any(frame["type"] == "user_message" for frame in channel.sent)
     assert channel.closed is False
     assert sandbox.commands.runs[:2] == [
@@ -537,7 +538,7 @@ def test_project_does_not_retry_non_transport_context_write_failure() -> None:
     assert commands.attempts - attempts_before == 1
 
 
-def test_project_reuses_one_agent_session_across_turns() -> None:
+def test_project_reuses_one_agent_runner_across_fresh_project_turns() -> None:
     sandbox = _Sandbox()
     channel = _Channel()
     channel.inbound.extend(
@@ -572,6 +573,12 @@ def test_project_reuses_one_agent_session_across_turns() -> None:
     assert starts == 1
     assert [frame["type"] for frame in channel.sent].count("session_start") == 1
     assert [frame["type"] for frame in channel.sent].count("user_message") == 2
+    assert (
+        next(frame for frame in channel.sent if frame["type"] == "session_start")[
+            "conversation_scope"
+        ]
+        == "turn"
+    )
 
 
 def test_project_surfaces_a_mid_turn_runner_error() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -116,11 +116,68 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     assert result.answer == "finished"
     assert any(frame["type"] == "session_start" for frame in channel.sent)
     assert any(frame["type"] == "user_message" for frame in channel.sent)
-    assert channel.closed is True
+    assert channel.closed is False
     assert sandbox.commands.runs[:2] == [
         "mkdir -p /home/user/project",
         "mkdir -p /home/user/project/history",
     ]
+    project.close()
+    assert channel.closed is True
+
+
+def test_project_reuses_one_agent_session_across_turns() -> None:
+    sandbox = _Sandbox()
+    channel = _Channel()
+    channel.inbound.extend(
+        [
+            {"type": "state", "status": "running"},
+            {
+                "type": "tool_request",
+                "req_id": 3,
+                "name": "submit",
+                "arguments": {"answer": "second"},
+            },
+            {"type": "state", "status": "idle", "reason": "completed"},
+        ]
+    )
+    starts = 0
+
+    def channel_factory(sandbox: object, workspace: str) -> _Channel:
+        nonlocal starts
+        del sandbox, workspace
+        starts += 1
+        return channel
+
+    project = AgentProject(sandbox, channel_factory=channel_factory, owns_sandbox=False)
+    agent = meta_agent()
+    provider = _Provider()
+
+    first = project.run(agent, provider, "first turn", timeout=1)
+    second = project.run(agent, provider, "second turn", timeout=1)
+
+    assert first.answer == "finished"
+    assert second.answer == "second"
+    assert starts == 1
+    assert [frame["type"] for frame in channel.sent].count("session_start") == 1
+    assert [frame["type"] for frame in channel.sent].count("user_message") == 2
+
+
+def test_project_surfaces_a_mid_turn_runner_error() -> None:
+    sandbox = _Sandbox()
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {"type": "episode_error", "note": "worker bridge disconnected"},
+    ]
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(RuntimeError, match="worker bridge disconnected"):
+        project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
 
 
 def test_project_rejects_paths_that_escape_its_workspace() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1054,99 +1054,14 @@ def test_agent_file_tools_reject_paths_outside_the_project() -> None:
         assert "escapes project workspace" in outcome.content
 
 
-def test_project_bash_is_bounded_without_rescanning_the_whole_project() -> None:
-    """Bash stays in E2B and does not add one file-read RPC per growing context artifact."""
-    sandbox = _Sandbox()
-    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
-    project.write_text("old.txt", "remove me")
-
-    class _BashCommands(_Commands):
-        def __init__(self) -> None:
-            super().__init__()
-            self.timeouts: list[object] = []
-
-        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
-            del background
-            self.runs.append(cmd)
-            self.timeouts.append(kwargs.get("timeout"))
-            assert cmd.startswith("cd /home/user/project && bash -lc ")
-            assert "generate-output" in cmd
-            assert "timeout --kill-after=3s 50s" in cmd
-            assert "node -e" in cmd
-            sandbox.files.values.pop("/home/user/project/old.txt")
-            sandbox.files.values["/home/user/project/generated.txt"] = "generated"
-            return _Output(stdout="x" * 20_000, stderr="warning")
-
-    commands = _BashCommands()
-    sandbox.commands = commands
-    emitted: list[tuple[str, str]] = []
-
-    outcome = project._execute_tool(
-        "bash",
-        {"command": "generate-output"},
-        lambda stream, data: emitted.append((stream, data)),
-    )
-
-    assert len(commands.runs) == 1
-    assert commands.timeouts == [60.0]
-    assert outcome.is_error is False
-    assert outcome.truncated is False
-    assert "13000 characters truncated by Bash boundary" in outcome.content
-    assert emitted[0][0] == "stdout"
-    assert len(emitted[0][1]) < 7_100
-    assert emitted[1] == ("stderr", "warning")
-    # Host-mediated files remain the recovery authority. A Bash-created scratch file is readable
-    # in the live sandbox and becomes mirrored only if the agent explicitly reads it.
-    assert project._file_contents == {"old.txt": "remove me"}  # noqa: SLF001
-    assert project.read_text("generated.txt") == "generated"
-
-
-def test_project_bash_surfaces_nonzero_exit_without_a_project_rescan() -> None:
-    """E2B command exceptions retain streams and status without O(project files) reads."""
-
-    class _CommandError(RuntimeError):
-        stdout = "partial output"
-        stderr = "command failed"
-        exit_code = 7
-
-    sandbox = _Sandbox()
-    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
-
-    class _FailingCommands(_Commands):
-        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
-            del background, kwargs
-            self.runs.append(cmd)
-            sandbox.files.values["/home/user/project/partial.txt"] = "kept"
-            raise _CommandError("non-zero")
-
-    commands = _FailingCommands()
-    sandbox.commands = commands
-    emitted: list[tuple[str, str]] = []
-
-    outcome = project._execute_tool(
-        "bash", {"command": "fail"}, lambda stream, data: emitted.append((stream, data))
-    )
-
-    assert outcome.is_error is True
-    assert outcome.content == "partial outputcommand failed\n[exit 7]"
-    assert emitted == [("stdout", "partial output"), ("stderr", "command failed")]
-    assert all(not cmd.startswith("find ") for cmd in commands.runs)
-    assert project.read_text("partial.txt") == "kept"
-
-
-def test_host_guard_preserves_the_sandbox_stream_omission_count() -> None:
-    content = "a" * 3_500 + "\n... 13000 bytes truncated in sandbox ...\n" + "z" * 3_500
-
-    assert project_module._bounded_bash_stream(content) == content  # noqa: SLF001
-
-
-def test_project_rejects_agents_with_uncontained_tools() -> None:
+@pytest.mark.parametrize("tool", ["bash", "read_skill"])
+def test_project_rejects_agents_with_uncontained_tools(tool: str) -> None:
     """The project still rejects capabilities outside its isolated tool allowlist."""
     base = meta_agent()
     uncontained = HarnessDoc(
         name="uncontained",
         surfaces=[
-            surface.model_copy(update={"content": "read_skill\nsubmit"})
+            surface.model_copy(update={"content": f"{tool}\nsubmit"})
             if surface.id == TOOL_POLICY_ID
             else surface
             for surface in base.surfaces
@@ -1154,5 +1069,5 @@ def test_project_rejects_agents_with_uncontained_tools() -> None:
     )
     project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
 
-    with pytest.raises(ValueError, match="uncontained tools: read_skill"):
+    with pytest.raises(ValueError, match=f"uncontained tools: {tool}"):
         project.run(uncontained, _Provider(), "escape", timeout=1)

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -180,6 +180,43 @@ def test_project_surfaces_a_mid_turn_runner_error() -> None:
         project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
 
 
+def test_project_restarts_one_live_session_after_transport_disconnect() -> None:
+    """A dropped runner stream retries once without replacing project storage."""
+
+    class _DisconnectedChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("Server disconnected")
+
+    sandbox = _Sandbox()
+    disconnected = _DisconnectedChannel()
+    recovered = _Channel()
+    channels = iter([disconnected, recovered])
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: next(channels),
+        owns_sandbox=False,
+    )
+    project.write_text("history/round-1.json", '{"kept": true}')
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "finished"
+    assert disconnected.closed is True
+    assert recovered.closed is False
+    assert project.read_text("history/round-1.json") == '{"kept": true}'
+    assert [frame["type"] for frame in disconnected.sent].count("user_message") == 1
+    assert [frame["type"] for frame in recovered.sent].count("user_message") == 1
+
+
 def test_project_rejects_paths_that_escape_its_workspace() -> None:
     project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
 

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -168,7 +168,8 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     assert project.read_text("history/round-1.json") == "{}"
     assert project.read_text("result.txt") == "done"
     assert result.answer == "finished"
-    assert any(frame["type"] == "session_start" for frame in channel.sent)
+    [session_start] = [frame for frame in channel.sent if frame["type"] == "session_start"]
+    assert session_start["max_output_tokens"] == meta_agent().max_output_tokens() == 16384
     assert any(frame["type"] == "user_message" for frame in channel.sent)
     assert channel.closed is False
     assert sandbox.commands.runs[:2] == [

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -10,6 +10,7 @@ from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
+from wmh.harness.live_session import SessionEvent
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 
@@ -123,6 +124,12 @@ class _MeteredProvider(_Provider):
         )
 
 
+class _FailingProvider(_Provider):
+    def complete_chat(self, request: object) -> ChatResponse:
+        del request
+        raise RuntimeError("provider down")
+
+
 def test_default_project_channel_enables_durable_outbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -223,6 +230,177 @@ def test_project_surfaces_a_mid_turn_runner_error() -> None:
     )
 
     with pytest.raises(RuntimeError, match="worker bridge disconnected"):
+        project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+
+def test_project_promotes_a_worker_error_after_the_runner_returns_idle() -> None:
+    """A provider failure cannot look like a normally completed project turn."""
+    sandbox = _Sandbox()
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    events: list[SessionEvent] = []
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="project agent session failed: worker LLM error: provider down",
+    ):
+        project.run(
+            meta_agent(),
+            _FailingProvider(),
+            "produce a result",
+            timeout=1,
+            on_event=events.append,
+        )
+
+    error = next(event for event in events if event.kind == "error")
+    assert error.payload == {"message": "worker LLM error: provider down"}
+    response = next(frame for frame in channel.sent if frame["type"] == "llm_response")
+    assert response["error"] == "provider down"
+
+
+def test_project_does_not_retry_a_provider_error_that_looks_like_transport() -> None:
+    """Provider text cannot borrow the project transport's retry ownership."""
+
+    class _TransportLookingProvider(_Provider):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete_chat(self, request: object) -> ChatResponse:
+            del request
+            self.calls += 1
+            raise RuntimeError("Server disconnected without sending a response")
+
+    failed = _Channel()
+    failed.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    recovered = _Channel()
+    channels = iter([failed, recovered])
+    starts = 0
+
+    def channel_factory(sandbox: object, workspace: str) -> _Channel:
+        nonlocal starts
+        del sandbox, workspace
+        starts += 1
+        return next(channels)
+
+    provider = _TransportLookingProvider()
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=channel_factory,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="worker LLM error: Server disconnected without sending a response",
+    ):
+        project.run(meta_agent(), provider, "produce a result", timeout=1)
+
+    assert provider.calls == 1
+    assert starts == 1
+    assert failed.closed is False
+
+
+def test_project_ignores_idle_until_the_new_turn_reports_running() -> None:
+    """A stale idle frame cannot complete a newly queued project turn."""
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "idle", "reason": "stale_abort"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "submit",
+            "arguments": {"answer": "fresh"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    result = project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert result.answer == "fresh"
+
+
+def test_project_timeout_retires_the_session_before_the_next_turn() -> None:
+    """A late abort boundary cannot leak from a timed-out turn into its successor."""
+
+    class _HangingChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise TimeoutError
+
+    hanging = _HangingChannel()
+    recovered = _Channel()
+    channels = iter([hanging, recovered])
+    starts = 0
+
+    def channel_factory(sandbox: object, workspace: str) -> _Channel:
+        nonlocal starts
+        del sandbox, workspace
+        starts += 1
+        return next(channels)
+
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=channel_factory,
+        owns_sandbox=False,
+    )
+    agent = meta_agent()
+    provider = _Provider()
+
+    with pytest.raises(TimeoutError, match="project agent did not finish"):
+        project.run(agent, provider, "timed-out turn", timeout=0.001)
+    result = project.run(agent, provider, "next turn", timeout=1)
+
+    assert hanging.closed is True
+    assert result.answer == "finished"
+    assert starts == 2
+
+
+@pytest.mark.parametrize("reason", ["aborted", "turn_limit"])
+def test_project_promotes_unsuccessful_terminal_turn_reasons(reason: str) -> None:
+    """A bounded/aborted agent turn cannot masquerade as a completed proposal turn."""
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {"type": "state", "status": "idle", "reason": reason},
+    ]
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(RuntimeError, match=f"turn ended with reason: {reason}"):
         project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
 
 

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -179,6 +179,70 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     assert channel.closed is True
 
 
+def test_project_retries_one_context_write_after_e2b_disconnect() -> None:
+    """A transient context-file transport drop cannot fan out into a failed proposal batch."""
+
+    class _DisconnectOnceCommands(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.disconnect_next = False
+            self.attempts = 0
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            self.attempts += 1
+            if self.disconnect_next:
+                self.disconnect_next = False
+                raise RuntimeError("Server disconnected")
+            return super().run(cmd, background=background, **kwargs)
+
+    sandbox = _Sandbox()
+    commands = _DisconnectOnceCommands()
+    sandbox.commands = commands
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: _Channel(),
+        sandbox_factory=lambda: pytest.fail("an idempotent write must not replace the sandbox"),
+    )
+    attempts_before = commands.attempts
+    commands.disconnect_next = True
+
+    project.write_text("context/round-0003/parent.json", '{"round": 3}')
+
+    assert commands.attempts - attempts_before == 2
+    assert project.read_text("context/round-0003/parent.json") == '{"round": 3}'
+    assert project.usage().count == 1
+    assert sandbox.killed is False
+
+
+def test_project_does_not_retry_non_transport_context_write_failure() -> None:
+    """A real filesystem failure still propagates after exactly one attempt."""
+
+    class _FailOnceCommands(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_next = False
+            self.attempts = 0
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            self.attempts += 1
+            if self.fail_next:
+                self.fail_next = False
+                raise RuntimeError("permission denied")
+            return super().run(cmd, background=background, **kwargs)
+
+    sandbox = _Sandbox()
+    commands = _FailOnceCommands()
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    attempts_before = commands.attempts
+    commands.fail_next = True
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        project.write_text("context/round-0003/parent.json", '{"round": 3}')
+
+    assert commands.attempts - attempts_before == 1
+
+
 def test_project_reuses_one_agent_session_across_turns() -> None:
     sandbox = _Sandbox()
     channel = _Channel()

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -11,6 +11,7 @@ from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
 from wmh.harness.live_session import SessionEvent
+from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 
@@ -383,6 +384,48 @@ def test_project_timeout_retires_the_session_before_the_next_turn() -> None:
     assert hanging.closed is True
     assert result.answer == "finished"
     assert starts == 2
+
+
+def test_project_cancellation_interrupts_and_retires_the_active_session() -> None:
+    """Cancellation after one blocking provider pump cannot start a second model call."""
+
+    class _CountingProvider(_MeteredProvider):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete_chat(self, request: object) -> ChatResponse:
+            self.calls += 1
+            return super().complete_chat(request)
+
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        {"type": "llm_request", "req_id": 2, "openai_body": {"messages": []}},
+    ]
+    provider = _CountingProvider()
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        project.run(
+            meta_agent(),
+            provider,
+            "produce a result",
+            timeout=1,
+            should_cancel=lambda: provider.calls >= 1,
+        )
+
+    assert provider.calls == 1
+    assert channel.closed is True
+    assert any(
+        frame.get("type") == "abort" and frame.get("reason") == "harness_search_cancelled"
+        for frame in channel.sent
+    )
 
 
 @pytest.mark.parametrize("reason", ["aborted", "turn_limit"])

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -6,11 +6,11 @@ import pytest
 from llm_waterfall import ChatResponse
 
 from wmh.agents import project as project_module
-from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
 from wmh.harness import e2b_sandbox as e2b_sandbox_module
+from wmh.harness.doc import TOOL_POLICY_ID, HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxCleanupError, SandboxUsage
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.runtime import HarnessSearchCancelled
@@ -37,18 +37,23 @@ class _Files:
 
 
 class _Output:
-    stdout = ""
-    stderr = ""
-    exit_code = 0
+    def __init__(self, *, stdout: str = "", stderr: str = "", exit_code: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
 
 
 class _Commands:
-    def __init__(self) -> None:
+    def __init__(self, files: _Files | None = None) -> None:
         self.runs: list[str] = []
+        self.files = files
 
     def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
         del background, kwargs
         self.runs.append(cmd)
+        if cmd.startswith("find ") and self.files is not None:
+            paths = sorted(self.files.values)
+            return _Output(stdout="\0".join(paths) + ("\0" if paths else ""))
         return _Output()
 
     def send_stdin(self, pid: int, data: str, request_timeout: float | None = None) -> object:
@@ -59,11 +64,15 @@ class _Commands:
 class _Sandbox:
     def __init__(self) -> None:
         self.files = _Files()
-        self.commands = _Commands()
+        self.commands = _Commands(self.files)
         self.killed = False
+        self.network_updates: list[dict[str, object]] = []
 
     def set_timeout(self, timeout: int) -> None:
         del timeout
+
+    def update_network(self, network: dict[str, object]) -> None:
+        self.network_updates.append(network)
 
     def kill(self, request_timeout: float | None = None) -> object:
         del request_timeout
@@ -196,6 +205,34 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     ]
     project.close()
     assert channel.closed is True
+
+
+def test_owned_project_disables_internet_before_the_agent_turn() -> None:
+    order: list[str] = []
+
+    class _OrderedSandbox(_Sandbox):
+        def update_network(self, network: dict[str, object]) -> None:
+            super().update_network(network)
+            order.append("network-locked")
+
+    class _OrderedChannel(_Channel):
+        def send(self, frame: JsonObject) -> None:
+            if frame["type"] == "session_start":
+                order.append("session-start")
+            super().send(frame)
+
+    sandbox = _OrderedSandbox()
+    channel = _OrderedChannel()
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+    )
+
+    project.run(meta_agent(), _Provider(), "produce a result", timeout=1)
+
+    assert sandbox.network_updates == [{"allow_internet_access": False}]
+    assert order[:2] == ["network-locked", "session-start"]
+    project.close()
 
 
 def test_project_retries_one_context_write_after_e2b_disconnect() -> None:
@@ -1017,17 +1054,105 @@ def test_agent_file_tools_reject_paths_outside_the_project() -> None:
         assert "escapes project workspace" in outcome.content
 
 
-def test_project_rejects_agents_with_uncontained_tools() -> None:
-    """Tool policy is enforced before a shell-enabled project session can start."""
-    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+def test_project_bash_is_bounded_without_rescanning_the_whole_project() -> None:
+    """Bash stays in E2B and does not add one file-read RPC per growing context artifact."""
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    project.write_text("old.txt", "remove me")
 
-    with pytest.raises(ValueError, match="uncontained tools: bash"):
-        project.run(default_agent(), _Provider(), "escape", timeout=1)
+    class _BashCommands(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.timeouts: list[object] = []
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background
+            self.runs.append(cmd)
+            self.timeouts.append(kwargs.get("timeout"))
+            assert cmd.startswith("cd /home/user/project && bash -lc ")
+            assert "generate-output" in cmd
+            assert "timeout --kill-after=3s 50s" in cmd
+            assert "node -e" in cmd
+            sandbox.files.values.pop("/home/user/project/old.txt")
+            sandbox.files.values["/home/user/project/generated.txt"] = "generated"
+            return _Output(stdout="x" * 20_000, stderr="warning")
+
+    commands = _BashCommands()
+    sandbox.commands = commands
+    emitted: list[tuple[str, str]] = []
 
     outcome = project._execute_tool(
         "bash",
-        {"command": "cat /home/user/runner.js"},
-        lambda stream, data: None,
+        {"command": "generate-output"},
+        lambda stream, data: emitted.append((stream, data)),
     )
+
+    assert len(commands.runs) == 1
+    assert commands.timeouts == [60.0]
+    assert outcome.is_error is False
+    assert outcome.truncated is False
+    assert "13000 characters truncated by Bash boundary" in outcome.content
+    assert emitted[0][0] == "stdout"
+    assert len(emitted[0][1]) < 7_100
+    assert emitted[1] == ("stderr", "warning")
+    # Host-mediated files remain the recovery authority. A Bash-created scratch file is readable
+    # in the live sandbox and becomes mirrored only if the agent explicitly reads it.
+    assert project._file_contents == {"old.txt": "remove me"}  # noqa: SLF001
+    assert project.read_text("generated.txt") == "generated"
+
+
+def test_project_bash_surfaces_nonzero_exit_without_a_project_rescan() -> None:
+    """E2B command exceptions retain streams and status without O(project files) reads."""
+
+    class _CommandError(RuntimeError):
+        stdout = "partial output"
+        stderr = "command failed"
+        exit_code = 7
+
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    class _FailingCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background, kwargs
+            self.runs.append(cmd)
+            sandbox.files.values["/home/user/project/partial.txt"] = "kept"
+            raise _CommandError("non-zero")
+
+    commands = _FailingCommands()
+    sandbox.commands = commands
+    emitted: list[tuple[str, str]] = []
+
+    outcome = project._execute_tool(
+        "bash", {"command": "fail"}, lambda stream, data: emitted.append((stream, data))
+    )
+
     assert outcome.is_error is True
-    assert outcome.content == "tool 'bash' not available"
+    assert outcome.content == "partial outputcommand failed\n[exit 7]"
+    assert emitted == [("stdout", "partial output"), ("stderr", "command failed")]
+    assert all(not cmd.startswith("find ") for cmd in commands.runs)
+    assert project.read_text("partial.txt") == "kept"
+
+
+def test_host_guard_preserves_the_sandbox_stream_omission_count() -> None:
+    content = "a" * 3_500 + "\n... 13000 bytes truncated in sandbox ...\n" + "z" * 3_500
+
+    assert project_module._bounded_bash_stream(content) == content  # noqa: SLF001
+
+
+def test_project_rejects_agents_with_uncontained_tools() -> None:
+    """The project still rejects capabilities outside its isolated tool allowlist."""
+    base = meta_agent()
+    uncontained = HarnessDoc(
+        name="uncontained",
+        surfaces=[
+            surface.model_copy(update={"content": "read_skill\nsubmit"})
+            if surface.id == TOOL_POLICY_ID
+            else surface
+            for surface in base.surfaces
+        ],
+    )
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    with pytest.raises(ValueError, match="uncontained tools: read_skill"):
+        project.run(uncontained, _Provider(), "escape", timeout=1)

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -198,6 +198,8 @@ def test_project_preserves_files_and_runs_through_live_session() -> None:
     [session_start] = [frame for frame in channel.sent if frame["type"] == "session_start"]
     assert session_start["max_output_tokens"] == meta_agent().max_output_tokens() == 16384
     assert session_start["conversation_scope"] == "turn"
+    assert project._session is not None  # noqa: SLF001 - runtime wiring contract
+    assert project._session._actions_per_turn == meta_agent().max_turns() == 60  # noqa: SLF001
     assert any(frame["type"] == "user_message" for frame in channel.sent)
     assert channel.closed is False
     assert sandbox.commands.runs[:2] == [

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -59,8 +59,7 @@ from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
-from wmh.harness.skills import SkillLibrary
-from wmh.harness.tools import render_tools, resolve_tools
+from wmh.harness.tools import READ_SKILL, resolve_tools
 from wmh.harness.workspace_patch import WorkspacePatchError
 from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmh.platform.credentials import PlatformCredentials, load_credentials
@@ -109,12 +108,11 @@ def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str
     the resolved tool specs, the code surfaces as {path: content} (the agent's own
     code, materialized into the local runner), and skill bodies answered host-side.
     """
-    tool_specs = resolve_tools(doc.tools())
-    system = f"{doc.system_prompt()}\n\n## Tools\n{render_tools(tool_specs)}"
-    skills = SkillLibrary(doc.skills())
-    index = skills.render_index()
-    if index:
-        system += f"\n\n## Your skills (read a body with read_skill)\n{index}"
+    tool_names = doc.tools()
+    if doc.skills() and READ_SKILL.name not in tool_names:
+        tool_names.append(READ_SKILL.name)
+    tool_specs = resolve_tools(tool_names)
+    system = doc.assembled_prompt()
     files = {surface.path: surface.content for surface in doc.code_files() if surface.path}
     skill_bodies = {skill.name: skill.body for skill in doc.skills()}
     return system, tool_specs, files, skill_bodies
@@ -364,6 +362,7 @@ class LocalLiveDriver:
                 provider=self._provider,
                 worker_fn=self._worker_fn,
                 max_output_tokens=self._doc.max_output_tokens(),
+                temperature=self._doc.temperature(),
             )
             session.start()
             _console.print(

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -363,6 +363,7 @@ class LocalLiveDriver:
                 skill_bodies=skill_bodies,
                 provider=self._provider,
                 worker_fn=self._worker_fn,
+                max_output_tokens=self._doc.max_output_tokens(),
             )
             session.start()
             _console.print(

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -28,6 +28,7 @@ from wmh.evals.tasks import TaskSpec, load_tasks
 from wmh.harness.create import create_harness
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
+from wmh.harness.proposer import ProviderDeltaProposer
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.providers.registry import get_provider
@@ -133,6 +134,12 @@ def create(
         help="Harness to start from, as name[@ref] (default: the built-in baseline).",
     ),
     iterations: int = typer.Option(None, min=1, help="Propose-and-gate steps (the search budget)."),
+    proposal_batch_size: int = typer.Option(
+        1,
+        "--proposal-batch-size",
+        min=1,
+        help="Sibling proposals generated against each selected parent.",
+    ),
     k: int = typer.Option(3, min=1, help="Closed-loop passes per task per variant."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
     archive_out: str = typer.Option(
@@ -189,8 +196,11 @@ def create(
     world_model, provider, model_name = _load_world_model(model, root)
     meta_provider, meta_model = _meta_provider_from_settings(root, provider)
 
-    rollouts = (iterations + 1) * k * len(tasks)
-    holdout_note = f" (+ up to {(iterations + 1) * k * len(holdout)} held-out)" if holdout else ""
+    candidate_count = iterations * proposal_batch_size
+    rollouts = (candidate_count + 1) * k * len(tasks)
+    holdout_note = (
+        f" (+ up to {(candidate_count + 1) * k * len(holdout)} held-out)" if holdout else ""
+    )
     backend_note = (
         " (pi harness in pooled E2B sandboxes; env stays the world model)"
         if harness_backend == "e2b"
@@ -201,8 +211,9 @@ def create(
     )
     _console.print(
         f"searching from [bold]{seed_doc.name}[/bold] against world model "
-        f"[bold]{model_name}[/bold]: {iterations} iteration(s), k={k}, {len(tasks)} task(s) "
-        f"-> up to ~{rollouts} rollouts{holdout_note} + {iterations} proposal calls"
+        f"[bold]{model_name}[/bold]: {iterations} round(s), "
+        f"{proposal_batch_size} proposal(s)/round, k={k}, {len(tasks)} task(s) "
+        f"-> up to ~{rollouts} rollouts{holdout_note} + {candidate_count} proposals"
         f"{meta_note}{backend_note}"
     )
     if interactive and not yes and not Confirm.ask("Proceed?", default=True):
@@ -225,9 +236,10 @@ def create(
         tasks,
         world_model,
         provider,
-        meta_provider,
+        ProviderDeltaProposer(meta_provider),
         GoldJudge(provider),
         iterations=iterations,
+        proposal_batch_size=proposal_batch_size,
         k=k,
         holdout=holdout,
         harness_backend="e2b" if harness_backend == "e2b" else "local",

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -19,6 +19,7 @@ from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.create import CreateResult, DeltaArchive
 from wmh.harness.doc import HarnessDoc
+from wmh.harness.proposer import ProviderDeltaProposer
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 # The Typer object `harness_app` shadows the submodule name on plain attribute access; go
@@ -56,7 +57,7 @@ class _CreateRecorder:
         tasks: list[TaskSpec],
         world_model: object,
         agent_provider: object,
-        meta_provider: object,
+        proposer: object,
         judge: object,
         **kwargs: object,
     ) -> CreateResult:
@@ -65,7 +66,7 @@ class _CreateRecorder:
                 "name": name,
                 "world_model": world_model,
                 "provider": agent_provider,
-                "meta_provider": meta_provider,
+                "proposer": proposer,
                 **kwargs,
             }
         )
@@ -208,7 +209,8 @@ def test_create_meta_role_from_settings_drives_the_proposer(
     assert result.exit_code == 0, result.output
     [call] = recorder.calls
     assert call["provider"] is anchored  # agent + judge stay on the world model's provider
-    assert call["meta_provider"] is meta_sentinel
+    assert isinstance(call["proposer"], ProviderDeltaProposer)
+    assert call["proposer"].provider is meta_sentinel
     [config] = configs
     assert config.kind is ProviderKind.AZURE_OPENAI
     assert config.model == "gpt-5.5"
@@ -266,7 +268,8 @@ def test_create_meta_defaults_to_the_world_model_provider(
 
     assert result.exit_code == 0, result.output
     [call] = recorder.calls
-    assert call["meta_provider"] is anchored
+    assert isinstance(call["proposer"], ProviderDeltaProposer)
+    assert call["proposer"].provider is anchored
     assert "models.meta" not in result.output
 
 

--- a/wmh/core/text.py
+++ b/wmh/core/text.py
@@ -1,0 +1,40 @@
+"""Text canonicalization for UTF-8 files, transports, and durable JSON stores."""
+
+from __future__ import annotations
+
+_REPLACEMENT_CHARACTER = "\N{REPLACEMENT CHARACTER}"
+
+
+def normalize_durable_text(value: str) -> str:
+    """Replace code points that cannot safely cross every WMH persistence boundary.
+
+    PostgreSQL JSONB rejects embedded NULs and lone UTF-16 surrogates; UTF-8 filesystem and HTTP
+    clients reject surrogates as well. A valid surrogate pair is folded into its Unicode scalar.
+    """
+    normalized: list[str] = []
+    index = 0
+    while index < len(value):
+        code_point = ord(value[index])
+        if code_point == 0:
+            normalized.append(_REPLACEMENT_CHARACTER)
+        elif 0xD800 <= code_point <= 0xDBFF:
+            if index + 1 < len(value) and 0xDC00 <= (low := ord(value[index + 1])) <= 0xDFFF:
+                scalar = 0x10000 + ((code_point - 0xD800) << 10) + (low - 0xDC00)
+                normalized.append(chr(scalar))
+                index += 1
+            else:
+                normalized.append(_REPLACEMENT_CHARACTER)
+        elif 0xDC00 <= code_point <= 0xDFFF:
+            normalized.append(_REPLACEMENT_CHARACTER)
+        else:
+            normalized.append(value[index])
+        index += 1
+    return "".join(normalized)
+
+
+def validate_durable_text(value: str, *, field: str) -> None:
+    """Reject content-addressed text that canonicalization would change."""
+    if "\x00" in value:
+        raise ValueError(f"{field} contains an embedded NUL character")
+    if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+        raise ValueError(f"{field} contains an unpaired UTF-16 surrogate")

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -26,7 +26,14 @@ from wmh.engine.world_model import WorldModel
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.environment import AgentEnvironment
-from wmh.harness.runtime import AgentRuntime, RunResult, Runtime, TokenUsage, combine_usage
+from wmh.harness.runtime import (
+    AgentRuntime,
+    RunResult,
+    Runtime,
+    RuntimeCancelled,
+    TokenUsage,
+    combine_usage,
+)
 from wmh.providers.base import Provider
 
 DEFAULT_K = 3  # eval-reporting convention: every metric is the mean of k passes, never single-pass
@@ -114,6 +121,7 @@ def evaluate_with_env(
     k: int = DEFAULT_K,
     concurrency: int = 1,
     on_progress: Callable[[str, int, GoldVerdict], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> ClosedLoopReport:
     """Score the agent on `tasks` against whatever env `make_env` opens, k passes per task.
 
@@ -131,11 +139,14 @@ def evaluate_with_env(
         for task in tasks:
             verdicts: list[GoldVerdict] = []
             for attempt in range(k):
+                _check_cancelled(should_cancel)
                 result = _run_once(task, make_env, runtime)
                 usages.append(result.worker_usage)
+                _check_cancelled(should_cancel)
                 verdict = judge.score(
                     task.instruction, result.answer, result.transcript(), task.gold
                 )
+                _check_cancelled(should_cancel)
                 verdicts.append(verdict)
                 if on_progress is not None:
                     on_progress(task.task_id, attempt + 1, verdict)
@@ -156,6 +167,7 @@ def evaluate_with_env(
             k=k,
             concurrency=concurrency,
             on_progress=on_progress,
+            should_cancel=should_cancel,
         )
         for index, task in enumerate(tasks):
             verdicts = by_cell[index * k : (index + 1) * k]  # cells are task-major, attempt-minor
@@ -191,6 +203,7 @@ def evaluate_closed_loop(
     concurrency: int = 1,
     runtime: Runtime | None = None,
     on_progress: Callable[[str, int, GoldVerdict], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> ClosedLoopReport:
     """Score the fixed agent on `tasks` against `world_model` (`wmh eval --mode closed-loop`).
 
@@ -210,6 +223,7 @@ def evaluate_closed_loop(
             k=k,
             concurrency=concurrency,
             on_progress=on_progress,
+            should_cancel=should_cancel,
         )
 
     if concurrency == 1:
@@ -276,6 +290,7 @@ def _run_cells_concurrently(
     k: int,
     concurrency: int,
     on_progress: Callable[[str, int, GoldVerdict], None] | None,
+    should_cancel: Callable[[], bool] | None,
 ) -> tuple[list[GoldVerdict], list[TokenUsage | None]]:
     """Run every (task, attempt) cell on a thread pool; verdicts return in cell order.
 
@@ -296,8 +311,11 @@ def _run_cells_concurrently(
     usage_slots: list[TokenUsage | None] = [None] * len(cells)
 
     def run_cell(task: TaskSpec) -> tuple[GoldVerdict, TokenUsage | None]:
+        _check_cancelled(should_cancel)
         result = _run_once(task, make_env, runtime)
+        _check_cancelled(should_cancel)
         verdict = judge.score(task.instruction, result.answer, result.transcript(), task.gold)
+        _check_cancelled(should_cancel)
         return verdict, result.worker_usage
 
     pool = ThreadPoolExecutor(max_workers=max_workers)
@@ -322,3 +340,8 @@ def _run_cells_concurrently(
             raise RuntimeError("a cell completed without producing a verdict")
         verdicts.append(slot)
     return verdicts, usage_slots
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise RuntimeCancelled("runtime evaluation cancelled")

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -156,31 +156,38 @@ def evaluate_with_env(
     per_task: dict[str, TaskOutcome] = {}
     usages: list[TokenUsage | None] = []
     if concurrency != 0 and concurrency <= 1:
-        for task in tasks:
-            verdicts: list[GoldVerdict] = []
-            attempts: list[RolloutEvidence] = []
-            for attempt in range(k):
-                _check_cancelled(should_cancel)
-                result = _run_once(task, make_env, runtime)
-                usages.append(result.worker_usage)
-                attempts.append(_rollout_evidence(result))
-                _check_cancelled(should_cancel)
-                verdict = judge.score(
-                    task.instruction, result.answer, result.transcript(), task.gold
+        try:
+            for task in tasks:
+                verdicts: list[GoldVerdict] = []
+                attempts: list[RolloutEvidence] = []
+                for attempt in range(k):
+                    _check_cancelled(should_cancel)
+                    result = _run_once(task, make_env, runtime)
+                    # Record the episode before the next cancellation boundary. If
+                    # cancellation landed during the bounded worker call, RunnerLink
+                    # raises with that episode's partial usage instead.
+                    usages.append(result.worker_usage)
+                    attempts.append(_rollout_evidence(result))
+                    _check_cancelled(should_cancel)
+                    verdict = judge.score(
+                        task.instruction, result.answer, result.transcript(), task.gold
+                    )
+                    _check_cancelled(should_cancel)
+                    verdicts.append(verdict)
+                    if on_progress is not None:
+                        on_progress(task.task_id, attempt + 1, verdict)
+                successes = [1.0 if v.passed else 0.0 for v in verdicts]
+                per_task[task.task_id] = TaskOutcome(
+                    task_id=task.task_id,
+                    success_rate=fmean(successes),
+                    mean_fraction=fmean(v.fraction for v in verdicts),
+                    passes=k,
+                    verdicts=verdicts,
+                    attempts=attempts,
                 )
-                _check_cancelled(should_cancel)
-                verdicts.append(verdict)
-                if on_progress is not None:
-                    on_progress(task.task_id, attempt + 1, verdict)
-            successes = [1.0 if v.passed else 0.0 for v in verdicts]
-            per_task[task.task_id] = TaskOutcome(
-                task_id=task.task_id,
-                success_rate=fmean(successes),
-                mean_fraction=fmean(v.fraction for v in verdicts),
-                passes=k,
-                verdicts=verdicts,
-                attempts=attempts,
-            )
+        except RuntimeCancelled as error:
+            error.worker_usage = combine_usage([*usages, error.worker_usage])
+            raise
     else:
         by_cell, usages, evidence_by_cell = _run_cells_concurrently(
             tasks,
@@ -370,9 +377,15 @@ def _run_cells_concurrently(
     ) -> tuple[GoldVerdict, TokenUsage | None, RolloutEvidence]:
         _check_cancelled(should_cancel)
         result = _run_once(task, make_env, runtime)
-        _check_cancelled(should_cancel)
-        verdict = judge.score(task.instruction, result.answer, result.transcript(), task.gold)
-        _check_cancelled(should_cancel)
+        try:
+            _check_cancelled(should_cancel)
+            verdict = judge.score(task.instruction, result.answer, result.transcript(), task.gold)
+            _check_cancelled(should_cancel)
+        except RuntimeCancelled as error:
+            # The rollout finished before cancellation, even though its verdict
+            # did not. Preserve that worker spend for the coordinator's drain.
+            error.worker_usage = combine_usage([result.worker_usage, error.worker_usage])
+            raise
         return verdict, result.worker_usage, _rollout_evidence(result)
 
     pool = ThreadPoolExecutor(max_workers=max_workers)
@@ -420,10 +433,33 @@ def _run_cells_concurrently(
                 abort_error = candidate
             else:
                 abort_error = None
+        cancelled_error: RuntimeCancelled | None = None
+        if cancelled:
+            # Every started future is done after shutdown(wait=True). Collect
+            # successful episode usage and partial usage carried by cancelled
+            # episodes exactly once, including futures the coordinator had not
+            # observed before the cancellation boundary.
+            partial_usages: list[TokenUsage | None] = []
+            for future in futures:
+                if future.cancelled():
+                    continue
+                try:
+                    _verdict, usage, _evidence = future.result()
+                except RuntimeCancelled as candidate:
+                    partial_usages.append(candidate.worker_usage)
+                except BaseException:  # noqa: BLE001 - original error remains authoritative
+                    continue
+                else:
+                    partial_usages.append(usage)
+            if isinstance(error, RuntimeCancelled):
+                cancelled_error = error
+            else:
+                cancelled_error = RuntimeCancelled("runtime evaluation cancelled")
+            cancelled_error.worker_usage = combine_usage(partial_usages)
         if abort_error is not None:
-            raise abort_error from error
-        if cancelled and not isinstance(error, RuntimeCancelled):
-            raise RuntimeCancelled("runtime evaluation cancelled") from error
+            raise abort_error from (cancelled_error or error)
+        if cancelled_error is not None and cancelled_error is not error:
+            raise cancelled_error from error
         raise
     else:
         pool.shutdown(wait=True)

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -16,7 +16,7 @@ The environment is a factory parameter: `evaluate_closed_loop` binds it to the w
 from __future__ import annotations
 
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from statistics import fmean, pstdev
 
 from pydantic import BaseModel, Field
@@ -298,10 +298,11 @@ def _run_cells_concurrently(
     caller can slice per task and aggregate deterministically. `on_progress` fires from THIS
     thread as futures land (gepa.py precedent: UI callbacks must be a serial stream). A rollout or
     judge call that raises is a real failure: pending cells are cancelled and the exception
-    propagates IMMEDIATELY (fail-fast, scenario_fidelity precedent) — never swallowed into a
-    verdict, and never held back while in-flight cells (minutes-long sandbox rollouts) drain:
-    the pool is shut down with wait=False, so still-running cells finish on their own threads
-    and release their environments through `_run_once`'s finally.
+    propagates after owned work drains — never swallowed into a verdict. Any failure drains
+    already-started cells before returning while cancelling cells
+    that have not started: those threads can still own billable provider calls, rollout
+    persistence, and sandbox leases, so the caller must not terminalize the enclosing run while
+    they remain active. Every cell releases its environment through ``_run_once``'s ``finally``.
     """
     cells = [(task, attempt) for task in tasks for attempt in range(k)]
     if not cells:
@@ -321,16 +322,49 @@ def _run_cells_concurrently(
     pool = ThreadPoolExecutor(max_workers=max_workers)
     try:
         futures = {pool.submit(run_cell, task): i for i, (task, _attempt) in enumerate(cells)}
-        for future in as_completed(futures):
-            index = futures[future]
-            verdict, usage = future.result()  # a raised rollout/judge exception propagates here
-            slots[index] = verdict
-            usage_slots[index] = usage
-            if on_progress is not None:
-                task, attempt = cells[index]
-                on_progress(task.task_id, attempt + 1, verdict)
-    except BaseException:
-        pool.shutdown(wait=False, cancel_futures=True)
+        pending = set(futures)
+        while pending:
+            done, pending = wait(pending, timeout=0.25, return_when=FIRST_COMPLETED)
+            # Do not rely on a cell reaching RunnerLink before noticing API cancellation: all
+            # cells may still be inside cold E2B startup. This caller-side poll aborts the shared
+            # runtime below, which closes registered sandboxes before the ownership drain.
+            _check_cancelled(should_cancel)
+            for future in sorted(done, key=futures.__getitem__):
+                index = futures[future]
+                verdict, usage = future.result()  # a rollout/judge exception propagates here
+                slots[index] = verdict
+                usage_slots[index] = usage
+                if on_progress is not None:
+                    task, attempt = cells[index]
+                    on_progress(task.task_id, attempt + 1, verdict)
+    except BaseException as error:
+        cancelled = isinstance(error, RuntimeCancelled)
+        if not cancelled and isinstance(error, Exception) and should_cancel is not None:
+            try:
+                cancelled = should_cancel()
+            except Exception:  # noqa: BLE001 - preserve the cell's original failure
+                pass
+        abort_error: BaseException | None = None
+        abort = getattr(runtime, "abort", None)
+        if callable(abort):
+            try:
+                abort()
+            except BaseException as candidate:  # noqa: BLE001 - cleanup must survive the drain
+                abort_error = candidate
+        pool.shutdown(wait=True, cancel_futures=True)
+        if abort_error is not None and callable(abort):
+            # A worker's release() during the drain may have retried and proved the exact lease
+            # whose first abort failed. Re-run the idempotent close before declaring a leak.
+            try:
+                abort()
+            except BaseException as candidate:  # noqa: BLE001 - this is the final cleanup proof
+                abort_error = candidate
+            else:
+                abort_error = None
+        if abort_error is not None:
+            raise abort_error from error
+        if cancelled and not isinstance(error, RuntimeCancelled):
+            raise RuntimeCancelled("runtime evaluation cancelled") from error
         raise
     else:
         pool.shutdown(wait=True)

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -21,6 +21,7 @@ from statistics import fmean, pstdev
 
 from pydantic import BaseModel, Field
 
+from wmh.core.text import normalize_durable_text
 from wmh.core.types import Action, Observation
 from wmh.engine.world_model import WorldModel
 from wmh.evals.gold import GoldJudge, GoldVerdict
@@ -31,12 +32,15 @@ from wmh.harness.runtime import (
     RunResult,
     Runtime,
     RuntimeCancelled,
+    StopReason,
     TokenUsage,
     combine_usage,
 )
 from wmh.providers.base import Provider
 
 DEFAULT_K = 3  # eval-reporting convention: every metric is the mean of k passes, never single-pass
+_ROLLOUT_EVIDENCE_CHARS = 12_000
+_ROLLOUT_ANSWER_CHARS = 4_000
 
 # Opens a fresh environment for one task. The world-model backend and any real backend both fit
 # this shape, which is what lets the SAME scoring core measure simulation and reality.
@@ -71,6 +75,21 @@ class WorldModelEnvironment:
             self._closed = True
 
 
+class RolloutEvidence(BaseModel):
+    """The execution evidence behind one judged pass.
+
+    Aggregate scores are sufficient for ranking, but not for improving a harness: the proposer
+    needs to see what the agent actually tried, what the environment returned, and why the run
+    stopped. Keeping this alongside each verdict lets every optimizer backend expose the same
+    trace-level feedback without reaching into a platform-specific rollout store.
+    """
+
+    answer: str = ""
+    transcript: str = ""
+    stop_reason: StopReason
+    turns: int = 0
+
+
 class TaskOutcome(BaseModel):
     """One task's closed-loop result across k passes."""
 
@@ -79,6 +98,7 @@ class TaskOutcome(BaseModel):
     mean_fraction: float = 0.0  # mean fraction-of-assertions across passes (partial credit)
     passes: int = 0
     verdicts: list[GoldVerdict] = Field(default_factory=list)
+    attempts: list[RolloutEvidence] = Field(default_factory=list)
 
 
 class ClosedLoopReport(BaseModel):
@@ -138,10 +158,12 @@ def evaluate_with_env(
     if concurrency != 0 and concurrency <= 1:
         for task in tasks:
             verdicts: list[GoldVerdict] = []
+            attempts: list[RolloutEvidence] = []
             for attempt in range(k):
                 _check_cancelled(should_cancel)
                 result = _run_once(task, make_env, runtime)
                 usages.append(result.worker_usage)
+                attempts.append(_rollout_evidence(result))
                 _check_cancelled(should_cancel)
                 verdict = judge.score(
                     task.instruction, result.answer, result.transcript(), task.gold
@@ -157,9 +179,10 @@ def evaluate_with_env(
                 mean_fraction=fmean(v.fraction for v in verdicts),
                 passes=k,
                 verdicts=verdicts,
+                attempts=attempts,
             )
     else:
-        by_cell, usages = _run_cells_concurrently(
+        by_cell, usages, evidence_by_cell = _run_cells_concurrently(
             tasks,
             make_env,
             runtime,
@@ -171,6 +194,7 @@ def evaluate_with_env(
         )
         for index, task in enumerate(tasks):
             verdicts = by_cell[index * k : (index + 1) * k]  # cells are task-major, attempt-minor
+            attempts = evidence_by_cell[index * k : (index + 1) * k]
             successes = [1.0 if v.passed else 0.0 for v in verdicts]
             per_task[task.task_id] = TaskOutcome(
                 task_id=task.task_id,
@@ -178,6 +202,7 @@ def evaluate_with_env(
                 mean_fraction=fmean(v.fraction for v in verdicts),
                 passes=k,
                 verdicts=verdicts,
+                attempts=attempts,
             )
 
     task_rates = [o.success_rate for o in per_task.values()]
@@ -281,6 +306,34 @@ def _run_once(task: TaskSpec, make_env: EnvFactory, runtime: Runtime) -> RunResu
         env.close()
 
 
+def _rollout_evidence(result: RunResult) -> RolloutEvidence:
+    """Freeze the proposer-facing parts of a run before its environment is gone."""
+    return RolloutEvidence(
+        answer=_bounded_evidence_text(
+            normalize_durable_text(result.answer),
+            _ROLLOUT_ANSWER_CHARS,
+            label="answer",
+        ),
+        transcript=_bounded_evidence_text(
+            normalize_durable_text(result.transcript()),
+            _ROLLOUT_EVIDENCE_CHARS,
+            label="trace",
+        ),
+        stop_reason=result.stop_reason,
+        turns=result.turns,
+    )
+
+
+def _bounded_evidence_text(content: str, limit: int, *, label: str) -> str:
+    """Retain the beginning and terminal behavior without unbounded report memory."""
+    if len(content) <= limit:
+        return content
+    head = limit // 2
+    tail = limit - head
+    omitted = len(content) - limit
+    return f"{content[:head]}\n... ({omitted} {label} characters omitted) ...\n{content[-tail:]}"
+
+
 def _run_cells_concurrently(
     tasks: list[TaskSpec],
     make_env: EnvFactory,
@@ -291,7 +344,7 @@ def _run_cells_concurrently(
     concurrency: int,
     on_progress: Callable[[str, int, GoldVerdict], None] | None,
     should_cancel: Callable[[], bool] | None,
-) -> tuple[list[GoldVerdict], list[TokenUsage | None]]:
+) -> tuple[list[GoldVerdict], list[TokenUsage | None], list[RolloutEvidence]]:
     """Run every (task, attempt) cell on a thread pool; verdicts return in cell order.
 
     Cell order is task-major, attempt-minor — the exact order the sequential loop visits — so the
@@ -306,18 +359,21 @@ def _run_cells_concurrently(
     """
     cells = [(task, attempt) for task in tasks for attempt in range(k)]
     if not cells:
-        return [], []
+        return [], [], []
     max_workers = len(cells) if concurrency == 0 else min(concurrency, len(cells))
     slots: list[GoldVerdict | None] = [None] * len(cells)
     usage_slots: list[TokenUsage | None] = [None] * len(cells)
+    evidence_slots: list[RolloutEvidence | None] = [None] * len(cells)
 
-    def run_cell(task: TaskSpec) -> tuple[GoldVerdict, TokenUsage | None]:
+    def run_cell(
+        task: TaskSpec,
+    ) -> tuple[GoldVerdict, TokenUsage | None, RolloutEvidence]:
         _check_cancelled(should_cancel)
         result = _run_once(task, make_env, runtime)
         _check_cancelled(should_cancel)
         verdict = judge.score(task.instruction, result.answer, result.transcript(), task.gold)
         _check_cancelled(should_cancel)
-        return verdict, result.worker_usage
+        return verdict, result.worker_usage, _rollout_evidence(result)
 
     pool = ThreadPoolExecutor(max_workers=max_workers)
     try:
@@ -331,9 +387,12 @@ def _run_cells_concurrently(
             _check_cancelled(should_cancel)
             for future in sorted(done, key=futures.__getitem__):
                 index = futures[future]
-                verdict, usage = future.result()  # a rollout/judge exception propagates here
+                verdict, usage, evidence = (
+                    future.result()
+                )  # a rollout/judge exception propagates here
                 slots[index] = verdict
                 usage_slots[index] = usage
+                evidence_slots[index] = evidence
                 if on_progress is not None:
                     task, attempt = cells[index]
                     on_progress(task.task_id, attempt + 1, verdict)
@@ -369,11 +428,15 @@ def _run_cells_concurrently(
     else:
         pool.shutdown(wait=True)
     verdicts: list[GoldVerdict] = []
-    for slot in slots:
+    attempts: list[RolloutEvidence] = []
+    for slot, evidence in zip(slots, evidence_slots, strict=True):
         if slot is None:  # pragma: no cover - every future completed, or we raised above
             raise RuntimeError("a cell completed without producing a verdict")
+        if evidence is None:  # pragma: no cover - same future produced both values atomically
+            raise RuntimeError("a cell completed without preserving rollout evidence")
         verdicts.append(slot)
-    return verdicts, usage_slots
+        attempts.append(evidence)
+    return verdicts, usage_slots, attempts
 
 
 def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:

--- a/wmh/evals/closed_loop_test.py
+++ b/wmh/evals/closed_loop_test.py
@@ -22,7 +22,7 @@ from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.e2b_sandbox import SandboxCleanupError
 from wmh.harness.environment import AgentEnvironment, is_env_action
-from wmh.harness.runtime import RunResult, RuntimeCancelled, StopReason
+from wmh.harness.runtime import RunResult, RuntimeCancelled, StopReason, TokenUsage
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
@@ -609,10 +609,14 @@ def test_rollout_cancellation_drains_already_started_cells() -> None:
                     task_id=task_id,
                     stop_reason=StopReason.SUBMITTED,
                     answer="pass",
+                    worker_usage=TokenUsage(input_tokens=11, output_tokens=3, calls=1),
                 )
             blocker_started.wait(timeout=30)
             cancellation_raised.set()
-            raise RuntimeCancelled("cancelled")
+            raise RuntimeCancelled(
+                "cancelled",
+                worker_usage=TokenUsage(input_tokens=7, output_tokens=2, calls=1),
+            )
 
     def evaluate() -> None:
         try:
@@ -643,6 +647,11 @@ def test_rollout_cancellation_drains_already_started_cells() -> None:
         assert late_finished.is_set()
         assert len(errors) == 1
         assert isinstance(errors[0], RuntimeCancelled)
+        usage = errors[0].worker_usage
+        assert usage is not None
+        assert usage.input_tokens == 18
+        assert usage.output_tokens == 5
+        assert usage.calls == 2
     finally:
         release.set()
         worker.join(timeout=5)

--- a/wmh/evals/closed_loop_test.py
+++ b/wmh/evals/closed_loop_test.py
@@ -18,7 +18,7 @@ from wmh.evals.closed_loop import (
     evaluate_closed_loop,
     evaluate_with_env,
 )
-from wmh.evals.gold import GoldJudge, GoldVerdict
+from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.e2b_sandbox import SandboxCleanupError
 from wmh.harness.environment import AgentEnvironment, is_env_action
@@ -80,7 +80,12 @@ def test_closed_loop_scores_success_over_k_passes() -> None:
     report = evaluate_closed_loop(tasks, _wm(provider), provider, GoldJudge(provider), k=3)
     assert report.k == 3
     assert report.success_rate == 1.0
-    assert report.per_task["q1"].passes == 3
+    outcome = report.per_task["q1"]
+    assert outcome.passes == 3
+    assert len(outcome.attempts) == 3
+    assert all(attempt.answer == "the answer is 42" for attempt in outcome.attempts)
+    assert all(attempt.stop_reason == StopReason.SUBMITTED for attempt in outcome.attempts)
+    assert all("submit" in attempt.transcript for attempt in outcome.attempts)
 
 
 def test_closed_loop_reports_failure_when_judge_rejects() -> None:
@@ -203,6 +208,87 @@ def test_concurrent_report_matches_sequential() -> None:
     assert sequential.per_task["b-fail"].success_rate == 0.0
     for concurrency in (0, 2):
         assert run(concurrency).model_dump() == sequential.model_dump()
+
+
+def test_rollout_evidence_is_bounded_without_losing_trace_tail() -> None:
+    class LongTraceRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            del environment
+            steps = [
+                Step(
+                    action=Action(
+                        kind=ActionKind.TOOL_CALL,
+                        name="bash",
+                        arguments={"command": f"step-{index}"},
+                    ),
+                    observation=Observation(content=f"obs-{index}-" + ("x" * 2_000)),
+                    state_before=EnvState(),
+                    task=instruction,
+                )
+                for index in range(30)
+            ]
+            return RunResult(
+                task_id=task_id,
+                steps=steps,
+                stop_reason=StopReason.SUBMITTED,
+                answer="pass",
+                turns=len(steps),
+            )
+
+    report = evaluate_with_env(
+        [TaskSpec(task_id="a-pass", instruction="long", gold=["g"])],
+        lambda _task: _StaticEnv(),
+        LongTraceRuntime(),
+        _AnswerJudge(),
+        k=1,
+    )
+
+    trace = report.per_task["a-pass"].attempts[0].transcript
+    assert len(trace) < 13_000
+    assert "trace characters omitted" in trace
+    assert "step-0" in trace
+    assert "step-29" in trace
+
+
+def test_rollout_and_judge_evidence_is_safe_for_utf8_project_files() -> None:
+    class InvalidTextRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            del instruction, environment
+            return RunResult(
+                task_id=task_id,
+                stop_reason=StopReason.SUBMITTED,
+                answer="before\x00after",
+                steps=[
+                    Step(
+                        action=Action(kind=ActionKind.MESSAGE, content="before\ud800after"),
+                        observation=Observation(content="before\udcffafter"),
+                    )
+                ],
+            )
+
+    report = evaluate_with_env(
+        [TaskSpec(task_id="t", instruction="i", gold=["g"])],
+        lambda _task: _StaticEnv(),
+        InvalidTextRuntime(),
+        _AnswerJudge(),
+        k=1,
+    )
+
+    replacement = "\N{REPLACEMENT CHARACTER}"
+    attempt = report.per_task["t"].attempts[0]
+    assert attempt.answer == f"before{replacement}after"
+    assert "\x00" not in attempt.transcript
+    assert not any(0xD800 <= ord(char) <= 0xDFFF for char in attempt.transcript)
+
+    assertion = AssertionResult(
+        assertion="before\x00after",
+        passed=False,
+        why="before\ud800after",
+    )
+    verdict = GoldVerdict(rationale="before\udcffafter", assertions=[assertion])
+    assert verdict.assertions[0].assertion == f"before{replacement}after"
+    assert verdict.assertions[0].why == f"before{replacement}after"
+    assert verdict.rationale == f"before{replacement}after"
 
 
 def test_concurrency_zero_overlaps_all_cells() -> None:

--- a/wmh/evals/closed_loop_test.py
+++ b/wmh/evals/closed_loop_test.py
@@ -20,6 +20,7 @@ from wmh.evals.closed_loop import (
 )
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
+from wmh.harness.e2b_sandbox import SandboxCleanupError
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runtime import RunResult, RuntimeCancelled, StopReason
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
@@ -348,31 +349,37 @@ def test_budget_result_with_partial_transcript_is_still_judged(concurrency: int)
     assert "partial work" in judge.transcripts[0]
 
 
-def test_rollout_exception_surfaces_while_other_cells_are_still_in_flight() -> None:
-    """Fail-fast must not drain in-flight cells: with sandbox rollouts those run for minutes.
-
-    One cell blocks on an event; another raises immediately. The exception must reach the
-    caller while the blocker is STILL blocked (shutdown(wait=False)) — then the blocker is
-    released so its thread exits cleanly.
-    """
+def test_rollout_exception_drains_other_started_cells_before_returning() -> None:
+    """A failed wave cannot terminalize while another cell still owns billable work."""
     release = threading.Event()
     blocker_started = threading.Event()
+    failure_raised = threading.Event()
+    blocker_finished = threading.Event()
+    abort_called = threading.Event()
+    done = threading.Event()
+    errors: list[BaseException] = []
 
     class HalfStuckRuntime:
         def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
             if task_id == "stuck":
                 blocker_started.set()
                 release.wait(timeout=30)
+                blocker_finished.set()
                 return RunResult(task_id=task_id, stop_reason=StopReason.SUBMITTED, answer="pass")
             blocker_started.wait(timeout=30)  # raise only once the slow cell is truly in flight
+            failure_raised.set()
             raise RuntimeError("sandbox died")
+
+        def abort(self) -> None:
+            abort_called.set()
 
     tasks = [
         TaskSpec(task_id="stuck", instruction="x", gold=["g"]),
         TaskSpec(task_id="boom", instruction="y", gold=["g"]),
     ]
-    try:
-        with pytest.raises(RuntimeError, match="sandbox died"):
+
+    def evaluate() -> None:
+        try:
             evaluate_with_env(
                 tasks,
                 lambda task: _StaticEnv(),
@@ -381,9 +388,178 @@ def test_rollout_exception_surfaces_while_other_cells_are_still_in_flight() -> N
                 k=1,
                 concurrency=0,
             )
-        assert not release.is_set()  # the raise did not wait for the stuck cell to drain
+        except BaseException as error:  # noqa: BLE001 - assert exact failure below
+            errors.append(error)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=evaluate)
+    worker.start()
+    try:
+        assert failure_raised.wait(timeout=5)
+        assert abort_called.wait(timeout=5)
+        assert not done.wait(timeout=0.1)
+        assert not blocker_finished.is_set()
+        release.set()
+        assert done.wait(timeout=5)
+        assert blocker_finished.is_set()
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeError)
+        assert str(errors[0]) == "sandbox died"
     finally:
-        release.set()  # let the worker thread exit
+        release.set()
+        worker.join(timeout=5)
+
+
+def test_external_cancellation_aborts_blocked_cells_before_joining() -> None:
+    """Caller polling can stop cells that have not reached runtime cancellation checks."""
+    started = threading.Event()
+    released = threading.Event()
+    abort_called = threading.Event()
+    cancelled = threading.Event()
+    done = threading.Event()
+    errors: list[BaseException] = []
+
+    class BlockedRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            del instruction, environment
+            started.set()
+            released.wait(timeout=30)
+            return RunResult(task_id=task_id, stop_reason=StopReason.SUBMITTED, answer="pass")
+
+        def abort(self) -> None:
+            abort_called.set()
+            released.set()
+
+    def evaluate() -> None:
+        try:
+            evaluate_with_env(
+                [TaskSpec(task_id="blocked", instruction="x", gold=["g"])],
+                lambda task: _StaticEnv(),
+                BlockedRuntime(),
+                _AnswerJudge(),
+                k=1,
+                concurrency=0,
+                should_cancel=cancelled.is_set,
+            )
+        except BaseException as error:  # noqa: BLE001 - assert exact type below
+            errors.append(error)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=evaluate)
+    worker.start()
+    try:
+        assert started.wait(timeout=5)
+        cancelled.set()
+        assert abort_called.wait(timeout=5)
+        assert done.wait(timeout=5)
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeCancelled)
+    finally:
+        released.set()
+        worker.join(timeout=5)
+
+
+def test_abort_cleanup_is_rechecked_after_worker_release_drain() -> None:
+    """A transient abort failure does not survive a clean post-drain retry."""
+    blocker_started = threading.Event()
+    first_abort = threading.Event()
+    abort_calls = 0
+
+    class RetryCleanRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            del instruction, environment
+            if task_id == "blocked":
+                blocker_started.set()
+                first_abort.wait(timeout=30)
+                return RunResult(
+                    task_id=task_id,
+                    stop_reason=StopReason.SUBMITTED,
+                    answer="pass",
+                )
+            blocker_started.wait(timeout=30)
+            raise RuntimeError("cell failed")
+
+        def abort(self) -> None:
+            nonlocal abort_calls
+            abort_calls += 1
+            first_abort.set()
+            if abort_calls == 1:
+                raise SandboxCleanupError("first cleanup attempt failed")
+
+    with pytest.raises(RuntimeError, match="cell failed"):
+        evaluate_with_env(
+            [
+                TaskSpec(task_id="blocked", instruction="x", gold=["g"]),
+                TaskSpec(task_id="failed", instruction="y", gold=["g"]),
+            ],
+            lambda task: _StaticEnv(),
+            RetryCleanRuntime(),
+            _AnswerJudge(),
+            k=1,
+            concurrency=0,
+        )
+    assert abort_calls == 2
+
+
+def test_rollout_cancellation_drains_already_started_cells() -> None:
+    """Cancellation waits for bounded in-flight work so its usage can finalize."""
+    blocker_started = threading.Event()
+    cancellation_raised = threading.Event()
+    release = threading.Event()
+    late_finished = threading.Event()
+    done = threading.Event()
+    errors: list[BaseException] = []
+
+    class CancellingRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            del instruction, environment
+            if task_id == "stuck":
+                blocker_started.set()
+                release.wait(timeout=30)
+                late_finished.set()
+                return RunResult(
+                    task_id=task_id,
+                    stop_reason=StopReason.SUBMITTED,
+                    answer="pass",
+                )
+            blocker_started.wait(timeout=30)
+            cancellation_raised.set()
+            raise RuntimeCancelled("cancelled")
+
+    def evaluate() -> None:
+        try:
+            evaluate_with_env(
+                [
+                    TaskSpec(task_id="stuck", instruction="x", gold=["g"]),
+                    TaskSpec(task_id="cancel", instruction="y", gold=["g"]),
+                ],
+                lambda task: _StaticEnv(),
+                CancellingRuntime(),
+                _AnswerJudge(),
+                k=1,
+                concurrency=0,
+            )
+        except BaseException as error:  # noqa: BLE001 - assert exact type below
+            errors.append(error)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=evaluate)
+    worker.start()
+    try:
+        assert cancellation_raised.wait(timeout=5)
+        assert not done.wait(timeout=0.1)
+        assert not late_finished.is_set()
+        release.set()
+        assert done.wait(timeout=5)
+        assert late_finished.is_set()
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeCancelled)
+    finally:
+        release.set()
+        worker.join(timeout=5)
 
 
 def test_evaluate_closed_loop_passes_concurrency_through() -> None:

--- a/wmh/evals/closed_loop_test.py
+++ b/wmh/evals/closed_loop_test.py
@@ -10,7 +10,7 @@ import threading
 
 import pytest
 
-from wmh.core.types import Action, ActionKind, Observation
+from wmh.core.types import Action, ActionKind, EnvState, Observation, Step
 from wmh.engine.world_model import WorldModel
 from wmh.evals.closed_loop import (
     ClosedLoopReport,
@@ -21,7 +21,7 @@ from wmh.evals.closed_loop import (
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.environment import AgentEnvironment, is_env_action
-from wmh.harness.runtime import RunResult, StopReason
+from wmh.harness.runtime import RunResult, RuntimeCancelled, StopReason
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
@@ -269,6 +269,83 @@ def test_rollout_exception_propagates_and_does_not_hang() -> None:
         evaluate_with_env(
             tasks, lambda task: _StaticEnv(), ExplodingRuntime(), _AnswerJudge(), k=2, concurrency=0
         )
+
+
+@pytest.mark.parametrize("concurrency", [1, 0])
+def test_cancellation_after_rollout_skips_the_judge(concurrency: int) -> None:
+    cancelled = threading.Event()
+
+    class CancellingRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            cancelled.set()
+            return RunResult(task_id=task_id, stop_reason=StopReason.SUBMITTED, answer="pass")
+
+    class CountingJudge(_AnswerJudge):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def score(
+            self, instruction: str, answer: str, transcript: str, gold: list[str]
+        ) -> GoldVerdict:
+            self.calls += 1
+            return super().score(instruction, answer, transcript, gold)
+
+    judge = CountingJudge()
+    with pytest.raises(RuntimeCancelled, match="cancelled"):
+        evaluate_with_env(
+            [TaskSpec(task_id="cancel", instruction="x", gold=["g"])],
+            lambda task: _StaticEnv(),
+            CancellingRuntime(),
+            judge,
+            k=1,
+            concurrency=concurrency,
+            should_cancel=cancelled.is_set,
+        )
+
+    assert judge.calls == 0
+
+
+@pytest.mark.parametrize("concurrency", [1, 0])
+def test_budget_result_with_partial_transcript_is_still_judged(concurrency: int) -> None:
+    class BudgetRuntime:
+        def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+            return RunResult(
+                task_id=task_id,
+                stop_reason=StopReason.BUDGET,
+                steps=[
+                    Step(
+                        action=Action(kind=ActionKind.TOOL_CALL, name="bash", arguments={}),
+                        observation=Observation(content="partial work"),
+                        state_before=EnvState(),
+                        task=instruction,
+                    )
+                ],
+            )
+
+    class CapturingJudge(_AnswerJudge):
+        def __init__(self) -> None:
+            super().__init__()
+            self.transcripts: list[str] = []
+
+        def score(
+            self, instruction: str, answer: str, transcript: str, gold: list[str]
+        ) -> GoldVerdict:
+            self.transcripts.append(transcript)
+            return super().score(instruction, answer, transcript, gold)
+
+    judge = CapturingJudge()
+    evaluate_with_env(
+        [TaskSpec(task_id="budget", instruction="x", gold=["g"])],
+        lambda task: _StaticEnv(),
+        BudgetRuntime(),
+        judge,
+        k=1,
+        concurrency=concurrency,
+    )
+
+    assert len(judge.transcripts) == 1
+    assert "partial work" in judge.transcripts[0]
 
 
 def test_rollout_exception_surfaces_while_other_cells_are_still_in_flight() -> None:

--- a/wmh/evals/gold.py
+++ b/wmh/evals/gold.py
@@ -9,9 +9,10 @@ gold list: a truncated judge reply that omits assertions cannot report success.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from wmh.core.parsing import extract_json_object
+from wmh.core.text import normalize_durable_text
 from wmh.providers.base import Message, Provider
 
 GOLD_JUDGE_MARKER = "grade whether an agent completed a task"
@@ -33,6 +34,11 @@ class AssertionResult(BaseModel):
     passed: bool
     why: str = ""
 
+    @field_validator("assertion", "why")
+    @classmethod
+    def _normalize_text(cls, value: str) -> str:
+        return normalize_durable_text(value)
+
 
 class GoldVerdict(BaseModel):
     """The judge's verdict on one run against its gold assertions."""
@@ -41,6 +47,11 @@ class GoldVerdict(BaseModel):
     fraction: float = 0.0  # fraction of assertions satisfied (partial-credit signal)
     assertions: list[AssertionResult] = Field(default_factory=list)
     rationale: str = ""
+
+    @field_validator("rationale")
+    @classmethod
+    def _normalize_rationale(cls, value: str) -> str:
+        return normalize_durable_text(value)
 
     @classmethod
     def trivially_passed(cls) -> GoldVerdict:

--- a/wmh/evals/tasks.py
+++ b/wmh/evals/tasks.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from wmh.core.text import normalize_durable_text
 
 
 class TaskSpec(BaseModel):
@@ -19,6 +21,16 @@ class TaskSpec(BaseModel):
     task_id: str
     instruction: str
     gold: list[str] = Field(default_factory=list)  # assertions that define success
+
+    @field_validator("task_id", "instruction")
+    @classmethod
+    def _normalize_scalar_text(cls, value: str) -> str:
+        return normalize_durable_text(value)
+
+    @field_validator("gold")
+    @classmethod
+    def _normalize_gold(cls, value: list[str]) -> list[str]:
+        return [normalize_durable_text(assertion) for assertion in value]
 
 
 def load_tasks(path: str | Path) -> list[TaskSpec]:

--- a/wmh/evals/tasks_test.py
+++ b/wmh/evals/tasks_test.py
@@ -38,3 +38,16 @@ def test_load_tasks_duplicate_ids_raise(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="duplicate task_id"):
         load_tasks(path)
+
+
+def test_task_text_is_canonicalized_before_evaluation_and_persistence() -> None:
+    task = TaskSpec(
+        task_id="before\x00after",
+        instruction="before\ud800after",
+        gold=["before\udcffafter", "emoji \ud83d\ude00"],
+    )
+
+    replacement = "\N{REPLACEMENT CHARACTER}"
+    assert task.task_id == f"before{replacement}after"
+    assert task.instruction == f"before{replacement}after"
+    assert task.gold == [f"before{replacement}after", "emoji 😀"]

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -334,6 +334,7 @@ def create_harness(
     harness_backend: Literal["local", "e2b"] = "local",
     eval_concurrency: int | None = None,
     e2b_template: str | None = None,
+    e2b_metadata: dict[str, str] | None = None,
     on_progress: CreateProgress | None = None,
     on_note: Callable[[str], None] | None = None,
     on_iteration: Callable[[IterationRecord], None] | None = None,
@@ -369,7 +370,8 @@ def create_harness(
     is how many (task, attempt) cells run at once; `None` means the backend default — 1
     (sequential) for local, 0 (every cell at once, one pooled sandbox each) for e2b.
     `e2b_template` names a prebaked sandbox template (node 22 + the pi runner deps) so e2b
-    rollouts skip bootstrap installs.
+    rollouts skip bootstrap installs. `e2b_metadata` tags every sandbox created by the shared
+    evaluation pool, including fresh replacements for retired runners.
 
     Verification is staged by cost: a child is first SCREENED on its own trigger cluster (the
     2-3 failing tasks its delta claims to fix, k passes) — if the cluster did not improve over
@@ -400,7 +402,7 @@ def create_harness(
         # Lazy: the e2b backend is an optional extra; local searches must import none of it.
         from wmh.harness.pi_e2b import E2BSandboxPool as _Pool
 
-        sandbox_pool = _Pool(template=e2b_template)
+        sandbox_pool = _Pool(template=e2b_template, metadata=e2b_metadata)
 
     try:
 

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -37,7 +37,12 @@ from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.mutate import render_evidence
 from wmh.harness.proposer import DeltaProposer, ProposalFailure
-from wmh.harness.runtime import RuntimeCancelled, TokenUsage, combine_usage
+from wmh.harness.runtime import (
+    HarnessSearchCancelled,
+    RuntimeCancelled,
+    TokenUsage,
+    combine_usage,
+)
 from wmh.providers.base import Provider
 
 if TYPE_CHECKING:
@@ -57,10 +62,6 @@ ALL_PASS_MECHANISM = "none: all tasks pass"
 
 # Reports progress as (iteration, variant name, success_rate, accepted); iteration 0 is the seed.
 CreateProgress = Callable[[int, str, float, bool], None]
-
-
-class HarnessSearchCancelled(RuntimeError):
-    """The caller requested that a harness search stop before its next costly phase."""
 
 
 class PoolEntry(BaseModel):
@@ -543,12 +544,15 @@ def create_harness(
                         evidence,
                         history=archive.deltas,
                         count=proposal_batch_size,
+                        should_cancel=should_cancel,
                     )
                     if len(batch) != proposal_batch_size:
                         raise ValueError(
                             f"proposer returned {len(batch)} proposals; "
                             f"expected {proposal_batch_size}"
                         )
+                except HarnessSearchCancelled:
+                    raise
                 except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
                     batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
                 _check_cancelled()
@@ -767,6 +771,11 @@ def create_harness(
                     reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
                     + verdict.reason,
                 )
+            if verdict.accepted:
+                # Scoring checks cancellation on return, but gating and confirmation bookkeeping
+                # happen afterward. Check again at the acceptance commit boundary so a cancelled
+                # child never enters lineage or reaches the persistence callback.
+                _check_cancelled()
             delta.verdict = verdict
             archive.deltas.append(delta)
             docs[child.doc_hash] = child
@@ -808,6 +817,7 @@ def create_harness(
             if on_progress is not None:
                 on_progress(i, child.name, child_report.success_rate, verdict.accepted)
 
+        _check_cancelled()
         best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
         sandbox_usage = None
         if sandbox_pool is not None:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -558,12 +558,16 @@ def create_harness(
                 # Cancelled cells are not scoreable outcomes: do not judge them. Converting at the
                 # search boundary preserves the public cancellation contract while the surrounding
                 # finally closes the shared pool and retires every active evaluator sandbox.
-                raise HarnessSearchCancelled("harness search cancelled") from exc
-            _check_cancelled()
+                raise HarnessSearchCancelled(
+                    "harness search cancelled", worker_usage=exc.worker_usage
+                ) from exc
             # Tally the pi worker's self-metered tokens across every score wave (seed, screens,
             # full splits, holdout, confirmations): its LLM calls bypass the Provider, so this is
             # the only record. None on backends whose runtimes don't self-meter (local).
             worker_usages.append(report.worker_usage)
+            # Append first so a cancellation that lands after evaluation but before
+            # the report is consumed still carries the completed wave's spend.
+            _check_cancelled()
             return report
 
         seed_report = _score(seed_doc, tasks)
@@ -1024,6 +1028,11 @@ def create_harness(
         )
         return result
     except HarnessSearchCancelled as error:
+        # A cancellation inside evaluation carries that wave's completed and
+        # partial cells. Waves that returned normally were appended above. The
+        # search exception is the authoritative aggregate for callers because
+        # cancellation intentionally has no partial CreateResult.
+        error.worker_usage = combine_usage([*worker_usages, error.worker_usage])
         cancelled = error
         raise
     finally:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -360,7 +360,9 @@ def create_harness(
     in/from this process exactly as before; `e2b` runs the real pi agent inside E2B sandboxes
     (pi-node seeds only — that harness's context management is the thing under search), with its
     tool calls still answered by the world model host-side. One `E2BSandboxPool` is shared across
-    every `_score` wave so sandbox bootstraps amortize over the whole search. `eval_concurrency`
+    score waves within a proposal batch, then its idle runners are retired before the next batch's
+    proposer call. This amortizes bootstrap work across sibling proposals without carrying E2B
+    command streams through the potentially long proposal gap between rounds. `eval_concurrency`
     is how many (task, attempt) cells run at once; `None` means the backend default — 1
     (sequential) for local, 0 (every cell at once, one pooled sandbox each) for e2b.
     `e2b_template` names a prebaked sandbox template (node 22 + the pi runner deps) so e2b
@@ -507,6 +509,11 @@ def create_harness(
             proposal_index = ((i - 1) % proposal_batch_size) + 1
             champion_score = reports[champion_hash].success_rate
             if proposal_index == 1:
+                # The previous round's eval runners would otherwise sit idle through this
+                # potentially long proposer call. Retire only idle runners now; subsequent score
+                # waves for this batch still share the newly warmed pool.
+                if sandbox_pool is not None:
+                    sandbox_pool.retire_idle()
                 parent_entry = select_parent(pool, children_counts, seed=round_index)
                 parent = docs[parent_entry.doc_hash]
                 parent_report = reports[parent_entry.doc_hash]

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -59,6 +59,10 @@ ALL_PASS_MECHANISM = "none: all tasks pass"
 CreateProgress = Callable[[int, str, float, bool], None]
 
 
+class HarnessSearchCancelled(RuntimeError):
+    """The caller requested that a harness search stop before its next costly phase."""
+
+
 class PoolEntry(BaseModel):
     """One accepted variant, as the parent-selection pool sees it."""
 
@@ -333,6 +337,7 @@ def create_harness(
     on_note: Callable[[str], None] | None = None,
     on_iteration: Callable[[IterationRecord], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
     """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
 
@@ -345,6 +350,10 @@ def create_harness(
     moment a delta is accepted, with the new champion doc, its delta (verdict attached),
     and its full-suite score, so callers can persist champions in real time instead of
     waiting for the search to finish.
+
+    ``should_cancel`` is checked before and after every score wave, before each proposal slot,
+    and after each batched proposer call. Returning true raises :class:`HarnessSearchCancelled`
+    before the next costly phase while the normal ``finally`` path retires sandbox resources.
 
     Every rollout scores against the world-model simulation — the environment is always sim.
     `harness_backend` picks where the harness PROCESS executes: `local` (the default) runs it
@@ -390,6 +399,10 @@ def create_harness(
 
     try:
 
+        def _check_cancelled() -> None:
+            if should_cancel is not None and should_cancel():
+                raise HarnessSearchCancelled("harness search cancelled")
+
         def _note(message: str) -> None:
             # Narration for iterations that produce NO on_progress event (unusable/invalid/screened
             # proposals): without it a run whose proposals all fail looks like it never iterated.
@@ -409,6 +422,7 @@ def create_harness(
         def _score(
             doc: HarnessDoc, split: list[TaskSpec], *, k_override: int | None = None
         ) -> ClosedLoopReport:
+            _check_cancelled()
             k_eff = k if k_override is None else k_override
             if harness_backend == "local":
                 concurrency = eval_concurrency if eval_concurrency is not None else 1
@@ -437,6 +451,7 @@ def create_harness(
                 concurrency=concurrency,
                 runtime=runtime,
             )
+            _check_cancelled()
             # Tally the pi worker's self-metered tokens across every score wave (seed, screens,
             # full splits, holdout, confirmations): its LLM calls bypass the Provider, so this is
             # the only record. None on backends whose runtimes don't self-meter (local).
@@ -487,6 +502,7 @@ def create_harness(
         ] = []
         total_attempts = iterations * proposal_batch_size
         for i in range(1, total_attempts + 1):
+            _check_cancelled()
             round_index = ((i - 1) // proposal_batch_size) + 1
             proposal_index = ((i - 1) % proposal_batch_size) + 1
             champion_score = reports[champion_hash].success_rate
@@ -514,6 +530,7 @@ def create_harness(
                         )
                 except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
                     batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
+                _check_cancelled()
                 proposal_queue.extend((parent, parent_report, trigger, delta) for delta in batch)
 
             parent, parent_report, trigger, delta = proposal_queue.pop(0)

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -612,6 +612,8 @@ def create_harness(
                 HarnessDelta | ProposalFailure | None,
             ]
         ] = []
+        batch_cluster_key: FailureClusterKey | None = None
+        batch_cluster_expansion_recorded = False
         total_attempts = iterations * proposal_batch_size
         for i in range(1, total_attempts + 1):
             _check_cancelled()
@@ -628,14 +630,15 @@ def create_harness(
                 parent = docs[parent_entry.doc_hash]
                 parent_report = reports[parent_entry.doc_hash]
                 clusters = cluster_failures(parent_report, tasks)
-                key: FailureClusterKey | None = None
+                batch_cluster_key = None
+                batch_cluster_expansion_recorded = False
                 if clusters:
                     trigger = select_failure_cluster(
                         clusters,
                         failure_cluster_expansions,
                         parent_doc_hash=parent.doc_hash,
                     )
-                    key = _failure_cluster_key(parent.doc_hash, trigger)
+                    batch_cluster_key = _failure_cluster_key(parent.doc_hash, trigger)
                 else:
                     trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
                 evidence = render_evidence(trigger, parent_report, tasks)
@@ -658,13 +661,6 @@ def create_harness(
                 except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
                     batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
                 _check_cancelled()
-                # Discount a cluster only after the proposer produced at least one candidate that
-                # can enter validation. A transient project/provider failure learned nothing about
-                # the mechanism and must not consume that cluster's search allocation.
-                if key is not None and any(
-                    isinstance(candidate, HarnessDelta) for candidate in batch
-                ):
-                    failure_cluster_expansions[key] = failure_cluster_expansions.get(key, 0) + 1
                 proposal_queue.extend((parent, parent_report, trigger, delta) for delta in batch)
 
             parent, parent_report, trigger, delta = proposal_queue.pop(0)
@@ -790,6 +786,16 @@ def create_harness(
                     "(e2b runs pi-node only); skipped",
                 )
                 continue
+
+            # Discount the selected cluster only when this batch produces its first child that can
+            # actually enter evaluation. Parsed-but-duplicate, inapplicable, or backend-invalid
+            # deltas teach the search nothing about that failure mechanism. Sibling proposals share
+            # one batch expansion, so later evaluable children must not discount it again.
+            if batch_cluster_key is not None and not batch_cluster_expansion_recorded:
+                failure_cluster_expansions[batch_cluster_key] = (
+                    failure_cluster_expansions.get(batch_cluster_key, 0) + 1
+                )
+                batch_cluster_expansion_recorded = True
 
             # Only an evaluable child counts as a real expansion. Provider faults,
             # unusable replies, duplicates, and invalid deltas leave the parent fresh.

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -339,6 +339,7 @@ def create_harness(
     on_note: Callable[[str], None] | None = None,
     on_iteration: Callable[[IterationRecord], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
+    on_sandbox_usage: Callable[[SandboxUsage], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
     """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
@@ -353,6 +354,10 @@ def create_harness(
     and its full-suite score, so callers can persist champions in real time instead of
     waiting for the search to finish.
 
+    ``on_sandbox_usage`` fires after the shared E2B pool is successfully closed on every exit
+    path, including failures and cancellation, so callers can persist already-incurred evaluator
+    spend without requiring a partial result. An unproven close raises instead of publishing a
+    falsely final meter.
     ``should_cancel`` is checked before and after every score wave, before each proposal slot,
     and after each batched proposer call. E2B runtimes also poll it while waiting for runner
     frames, so cancellation aborts the active wave without judging partial cells. A provider/tool
@@ -405,6 +410,7 @@ def create_harness(
         sandbox_pool = _Pool(template=e2b_template, metadata=e2b_metadata)
 
     cancelled: HarnessSearchCancelled | None = None
+    result: CreateResult | None = None
     try:
 
         def _check_cancelled() -> None:
@@ -822,11 +828,7 @@ def create_harness(
 
         _check_cancelled()
         best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
-        sandbox_usage = None
-        if sandbox_pool is not None:
-            sandbox_pool.close()  # idempotent; finalize lifetimes so the meter is complete
-            sandbox_usage = sandbox_pool.usage()
-        return CreateResult(
+        result = CreateResult(
             best=best,
             best_score=reports[champion_hash].success_rate,
             archive=archive,
@@ -840,16 +842,21 @@ def create_harness(
             rounds=iterations,
             proposal_batch_size=proposal_batch_size,
             worker_usage=combine_usage(worker_usages),
-            sandbox_usage=sandbox_usage,
         )
+        return result
     except HarnessSearchCancelled as error:
         cancelled = error
         raise
     finally:
         if sandbox_pool is not None:
             sandbox_pool.close()
+            usage = sandbox_pool.usage()
+            if result is not None:
+                result.sandbox_usage = usage
             if cancelled is not None:
-                cancelled.sandbox_usage = sandbox_pool.usage()
+                cancelled.sandbox_usage = usage
+            if on_sandbox_usage is not None:
+                on_sandbox_usage(usage)
 
 
 def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -36,7 +36,7 @@ from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.mutate import render_evidence
-from wmh.harness.proposer import DeltaProposer
+from wmh.harness.proposer import DeltaProposer, ProposalFailure
 from wmh.harness.runtime import TokenUsage, combine_usage
 from wmh.providers.base import Provider
 
@@ -482,8 +482,7 @@ def create_harness(
                 HarnessDoc,
                 ClosedLoopReport,
                 FailureSignature,
-                HarnessDelta | None,
-                str | None,
+                HarnessDelta | ProposalFailure | None,
             ]
         ] = []
         total_attempts = iterations * proposal_batch_size
@@ -495,10 +494,6 @@ def create_harness(
                 parent_entry = select_parent(pool, children_counts, seed=round_index)
                 parent = docs[parent_entry.doc_hash]
                 parent_report = reports[parent_entry.doc_hash]
-                # Every sibling is an expansion of the selected parent, including dead proposals.
-                children_counts[parent.doc_hash] = (
-                    children_counts.get(parent.doc_hash, 0) + proposal_batch_size
-                )
                 clusters = cluster_failures(parent_report, tasks)
                 trigger = (
                     clusters[0] if clusters else FailureSignature(mechanism=ALL_PASS_MECHANISM)
@@ -517,23 +512,18 @@ def create_harness(
                             f"proposer returned {len(batch)} proposals; "
                             f"expected {proposal_batch_size}"
                         )
-                    errors: list[str | None] = [None] * proposal_batch_size
                 except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
-                    batch = [None] * proposal_batch_size
-                    errors = [str(exc)] * proposal_batch_size
-                proposal_queue.extend(
-                    (parent, parent_report, trigger, delta, error)
-                    for delta, error in zip(batch, errors, strict=True)
-                )
+                    batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
+                proposal_queue.extend((parent, parent_report, trigger, delta) for delta in batch)
 
-            parent, parent_report, trigger, delta, proposer_error = proposal_queue.pop(0)
+            parent, parent_report, trigger, delta = proposal_queue.pop(0)
             label = _proposal_label(
                 round_index,
                 proposal_index,
                 rounds=iterations,
                 batch_size=proposal_batch_size,
             )
-            if proposer_error is not None:
+            if isinstance(delta, ProposalFailure):
                 skipped += 1
                 _dead(
                     IterationRecord(
@@ -541,10 +531,10 @@ def create_harness(
                         round=round_index,
                         proposal_index=proposal_index,
                         outcome="proposer_error",
-                        reason=proposer_error,
+                        reason=delta.reason,
                         champion_score=champion_score,
                     ),
-                    f"{label}: proposer call failed ({proposer_error}); skipped",
+                    f"{label}: proposer call failed ({delta.reason}); skipped",
                 )
                 continue
             if delta is None:
@@ -635,6 +625,10 @@ def create_harness(
                     "(e2b runs pi-node only); skipped",
                 )
                 continue
+
+            # Only an evaluable child counts as a real expansion. Provider faults,
+            # unusable replies, duplicates, and invalid deltas leave the parent fresh.
+            children_counts[parent.doc_hash] = children_counts.get(parent.doc_hash, 0) + 1
 
             # Cheap screen: before a full-split eval, the delta must improve the very cluster it
             # was proposed to fix. A delta that cannot beat its parent on its own target is noise.

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -2,8 +2,8 @@
 
 The loop: select a parent from the accepted pool (stepping-stone weighting — good scores favored,
 already-expanded parents discounted), cluster the parent's failures into mechanisms, ask the
-proposer for one `HarnessDelta` against the largest cluster, apply it atomically, score the child
-closed-loop against the world model, and gate acceptance:
+proposer for a sibling batch of `HarnessDelta` objects against the largest cluster, apply each
+atomically, score each child closed-loop against the world model, and gate acceptance:
 
 - **Tier 1 — regression suite**: the child's score on the suite (tasks the search has already
   mastered) must not drop below the champion's. Newly-passing tasks promote into the suite on
@@ -35,7 +35,8 @@ from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_delta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
-from wmh.harness.mutate import propose_delta, render_evidence
+from wmh.harness.mutate import render_evidence
+from wmh.harness.proposer import DeltaProposer
 from wmh.harness.runtime import TokenUsage, combine_usage
 from wmh.providers.base import Provider
 
@@ -95,18 +96,20 @@ class DeltaArchive(BaseModel):
 
 
 class IterationRecord(BaseModel):
-    """One search iteration, scored or dead, in order: the complete search history.
+    """One proposal attempt, scored or dead, in order: the complete search history.
 
-    Every iteration proposes exactly one delta. A dead iteration (every outcome but
-    "scored") ends early: the proposal died before a full-split eval, the search moves
-    straight to the next iteration, and the record here is what remains of it. Callers
-    render these as records and plot points, so a run full of dead proposals shows its
+    Every search round proposes a sibling batch from one selected parent. A dead attempt
+    (every outcome but "scored") ends early: the proposal died before a full-split eval,
+    the search moves straight to the next sibling, and the record here is what remains of it.
+    Callers render these as records and plot points, so a run full of dead proposals shows its
     work instead of looking like it never iterated. `champion_score` is the champion's
     full-suite rate when the iteration resolved: the honest y-level for plotting a dead
     iteration (the line it failed to move).
     """
 
     iteration: int
+    round: int
+    proposal_index: int
     outcome: Literal["scored", "screened", "invalid", "unusable", "proposer_error"]
     candidate: str | None = None
     delta_id: str | None = None
@@ -132,6 +135,8 @@ class CreateResult(BaseModel):
     iteration_records: list[IterationRecord] = Field(default_factory=list)  # every iteration
     screened: int = 0  # deltas rejected at the cheap trigger-cluster screen (no full eval spent)
     confirmations: int = 0  # narrow vetoes retried at higher k (see `narrow_failing_tiers`)
+    rounds: int = 0
+    proposal_batch_size: int = 1
     # Spend meters over the WHOLE search (seed, screens, full splits, holdout, confirmations).
     # worker_usage: worker-LLM tokens from self-metering runtimes (the pi worker path; None on
     # provider-wrapped runtimes, which are metered upstream). sandbox_usage: E2B sandbox count +
@@ -313,10 +318,11 @@ def create_harness(
     tasks: list[TaskSpec],
     world_model: WorldModel,
     agent_provider: Provider,
-    meta_provider: Provider,
+    proposer: DeltaProposer,
     judge: GoldJudge,
     *,
     iterations: int = 5,
+    proposal_batch_size: int = 1,
     k: int = DEFAULT_K,
     holdout: list[TaskSpec] | None = None,
     confirm_narrow_vetoes: bool = True,
@@ -330,8 +336,9 @@ def create_harness(
 ) -> CreateResult:
     """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
 
-    Scores the seed first, then runs `iterations` propose-apply-SCREEN-score-gate
-    iterations, one proposal each. A dead iteration (unusable/invalid proposal, or one
+    Scores the seed first, then runs `iterations` proposal rounds. Each round asks the proposer
+    for `proposal_batch_size` sibling deltas against one selected parent before any sibling is
+    evaluated. A dead proposal (unusable/invalid proposal, or one
     screened out on its own trigger cluster) ends early and cheaply: it is counted
     (`skipped`/`screened`), recorded in `iteration_records`, narrated via `on_note`, and
     the search moves straight to the next iteration. Never fatal. `on_accept` fires the
@@ -366,6 +373,8 @@ def create_harness(
     """
     if harness_backend not in ("local", "e2b"):
         raise ValueError(f"unknown harness_backend {harness_backend!r}; choose local or e2b")
+    if proposal_batch_size < 1:
+        raise ValueError(f"proposal_batch_size must be positive, got {proposal_batch_size}")
     if harness_backend == "e2b" and seed_doc.runtime_kind() != "pi-node":
         raise ValueError(
             "harness_backend='e2b' runs the pi-node harness process in sandboxes; seed "
@@ -468,36 +477,74 @@ def create_harness(
                 on_iteration(record)
             _note(note)
 
-        for i in range(1, iterations + 1):
+        proposal_queue: list[
+            tuple[
+                HarnessDoc,
+                ClosedLoopReport,
+                FailureSignature,
+                HarnessDelta | None,
+                str | None,
+            ]
+        ] = []
+        total_attempts = iterations * proposal_batch_size
+        for i in range(1, total_attempts + 1):
+            round_index = ((i - 1) // proposal_batch_size) + 1
+            proposal_index = ((i - 1) % proposal_batch_size) + 1
             champion_score = reports[champion_hash].success_rate
-            parent_entry = select_parent(pool, children_counts, seed=i)
-            parent = docs[parent_entry.doc_hash]
-            parent_report = reports[parent_entry.doc_hash]
-            # Count the expansion attempt up front so a parent whose proposals keep failing is
-            # progressively discounted instead of re-selected every iteration.
-            children_counts[parent.doc_hash] = children_counts.get(parent.doc_hash, 0) + 1
-
-            clusters = cluster_failures(parent_report, tasks)
-            trigger = clusters[0] if clusters else FailureSignature(mechanism=ALL_PASS_MECHANISM)
-            evidence = render_evidence(trigger, parent_report, tasks)
-            # A meta-provider failure (an API rejecting the 16k reply budget, a rate limit, a
-            # network fault) costs this iteration, not the run: same contract as an unusable
-            # reply, but narrated with the error so a systematically failing provider is
-            # visible on every iteration instead of aborting the search on the first one.
-            try:
-                delta = propose_delta(
-                    parent, trigger, evidence, meta_provider, history=archive.deltas
+            if proposal_index == 1:
+                parent_entry = select_parent(pool, children_counts, seed=round_index)
+                parent = docs[parent_entry.doc_hash]
+                parent_report = reports[parent_entry.doc_hash]
+                # Every sibling is an expansion of the selected parent, including dead proposals.
+                children_counts[parent.doc_hash] = (
+                    children_counts.get(parent.doc_hash, 0) + proposal_batch_size
                 )
-            except Exception as exc:  # noqa: BLE001 - any provider/transport error, by design
+                clusters = cluster_failures(parent_report, tasks)
+                trigger = (
+                    clusters[0] if clusters else FailureSignature(mechanism=ALL_PASS_MECHANISM)
+                )
+                evidence = render_evidence(trigger, parent_report, tasks)
+                try:
+                    batch = proposer.propose_batch(
+                        parent,
+                        trigger,
+                        evidence,
+                        history=archive.deltas,
+                        count=proposal_batch_size,
+                    )
+                    if len(batch) != proposal_batch_size:
+                        raise ValueError(
+                            f"proposer returned {len(batch)} proposals; "
+                            f"expected {proposal_batch_size}"
+                        )
+                    errors: list[str | None] = [None] * proposal_batch_size
+                except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
+                    batch = [None] * proposal_batch_size
+                    errors = [str(exc)] * proposal_batch_size
+                proposal_queue.extend(
+                    (parent, parent_report, trigger, delta, error)
+                    for delta, error in zip(batch, errors, strict=True)
+                )
+
+            parent, parent_report, trigger, delta, proposer_error = proposal_queue.pop(0)
+            label = _proposal_label(
+                round_index,
+                proposal_index,
+                rounds=iterations,
+                batch_size=proposal_batch_size,
+            )
+            if proposer_error is not None:
                 skipped += 1
                 _dead(
                     IterationRecord(
                         iteration=i,
+                        round=round_index,
+                        proposal_index=proposal_index,
                         outcome="proposer_error",
-                        reason=str(exc),
+                        reason=proposer_error,
                         champion_score=champion_score,
                     ),
-                    f"iteration {i}/{iterations}: proposer call failed ({exc}); skipped",
+                    f"{label}: proposer call failed ({proposer_error}); skipped",
                 )
                 continue
             if delta is None:
@@ -505,12 +552,13 @@ def create_harness(
                 _dead(
                     IterationRecord(
                         iteration=i,
+                        round=round_index,
+                        proposal_index=proposal_index,
                         outcome="unusable",
                         reason="unparseable or truncated meta reply",
                         champion_score=champion_score,
                     ),
-                    f"iteration {i}/{iterations}: proposal unusable (unparseable or truncated "
-                    "meta reply); skipped",
+                    f"{label}: proposal unusable (unparseable or truncated meta reply); skipped",
                 )
                 continue
             ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
@@ -522,18 +570,24 @@ def create_harness(
                 _dead(
                     IterationRecord(
                         iteration=i,
+                        round=round_index,
+                        proposal_index=proposal_index,
                         outcome="invalid",
                         delta_id=delta.delta_id,
                         ops=ops_summary,
                         reason="duplicate of an already-judged delta",
                         champion_score=champion_score,
                     ),
-                    f"iteration {i}/{iterations}: proposal duplicates an already-judged delta; "
-                    "skipped",
+                    f"{label}: proposal duplicates an already-judged delta; skipped",
                 )
                 continue
             try:
-                child = apply_delta(parent, delta, f"{name}-g{i}")
+                child_name = (
+                    f"{name}-g{round_index}"
+                    if proposal_batch_size == 1
+                    else f"{name}-g{round_index}-p{proposal_index}"
+                )
+                child = apply_delta(parent, delta, child_name)
             except ValueError as exc:
                 delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {exc}")
                 archive.deltas.append(delta)
@@ -541,13 +595,15 @@ def create_harness(
                 _dead(
                     IterationRecord(
                         iteration=i,
+                        round=round_index,
+                        proposal_index=proposal_index,
                         outcome="invalid",
                         delta_id=delta.delta_id,
                         ops=ops_summary,
                         reason=f"invalid before eval: {exc}",
                         champion_score=champion_score,
                     ),
-                    f"iteration {i}/{iterations}: delta invalid before eval ({exc}); skipped",
+                    f"{label}: delta invalid before eval ({exc}); skipped",
                 )
                 continue
             if harness_backend == "e2b" and child.runtime_kind() != "pi-node":
@@ -566,6 +622,8 @@ def create_harness(
                 _dead(
                     IterationRecord(
                         iteration=i,
+                        round=round_index,
+                        proposal_index=proposal_index,
                         outcome="invalid",
                         candidate=child.name,
                         delta_id=delta.delta_id,
@@ -573,7 +631,7 @@ def create_harness(
                         reason=str(delta.verdict.reason),
                         champion_score=champion_score,
                     ),
-                    f"iteration {i}/{iterations}: delta abandoned the pi-node runtime "
+                    f"{label}: delta abandoned the pi-node runtime "
                     "(e2b runs pi-node only); skipped",
                 )
                 continue
@@ -599,6 +657,8 @@ def create_harness(
                     _dead(
                         IterationRecord(
                             iteration=i,
+                            round=round_index,
+                            proposal_index=proposal_index,
                             outcome="screened",
                             candidate=child.name,
                             delta_id=delta.delta_id,
@@ -608,7 +668,7 @@ def create_harness(
                             screen_parent=parent_mean,
                             champion_score=champion_score,
                         ),
-                        f"iteration {i}/{iterations}: screened out: trigger cluster "
+                        f"{label}: screened out: trigger cluster "
                         f"{child_mean:.2f} vs parent {parent_mean:.2f}",
                     )
                     continue
@@ -699,6 +759,8 @@ def create_harness(
                     on_accept(child, delta, child_report.success_rate)
             record = IterationRecord(
                 iteration=i,
+                round=round_index,
+                proposal_index=proposal_index,
                 outcome="scored",
                 candidate=child.name,
                 delta_id=delta.delta_id,
@@ -730,6 +792,8 @@ def create_harness(
             iteration_records=iteration_records,
             screened=screened,
             confirmations=confirmations,
+            rounds=iterations,
+            proposal_batch_size=proposal_batch_size,
             worker_usage=combine_usage(worker_usages),
             sandbox_usage=sandbox_usage,
         )
@@ -750,6 +814,13 @@ def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:
     # Dividing by len(suite), not len(rates): a suite task missing from the report counts as 0
     # (fail-closed), though suite tasks are always a subset of the scored split in practice.
     return sum(rates) / len(suite)
+
+
+def _proposal_label(round_index: int, proposal_index: int, *, rounds: int, batch_size: int) -> str:
+    """Human-readable attempt identity that stays concise for singleton batches."""
+    if batch_size == 1:
+        return f"iteration {round_index}/{rounds}"
+    return f"round {round_index}/{rounds} proposal {proposal_index}/{batch_size}"
 
 
 def _fraction(text: str) -> float:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -404,6 +404,7 @@ def create_harness(
 
         sandbox_pool = _Pool(template=e2b_template, metadata=e2b_metadata)
 
+    cancelled: HarnessSearchCancelled | None = None
     try:
 
         def _check_cancelled() -> None:
@@ -841,9 +842,14 @@ def create_harness(
             worker_usage=combine_usage(worker_usages),
             sandbox_usage=sandbox_usage,
         )
+    except HarnessSearchCancelled as error:
+        cancelled = error
+        raise
     finally:
         if sandbox_pool is not None:
             sandbox_pool.close()
+            if cancelled is not None:
+                cancelled.sandbox_usage = sandbox_pool.usage()
 
 
 def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -2,8 +2,9 @@
 
 The loop: select a parent from the accepted pool (stepping-stone weighting — good scores favored,
 already-expanded parents discounted), cluster the parent's failures into mechanisms, ask the
-proposer for a sibling batch of `HarnessDelta` objects against the largest cluster, apply each
-atomically, score each child closed-loop against the world model, and gate acceptance:
+proposer for a sibling batch of `HarnessDelta` objects against a size-weighted, expansion-
+discounted cluster, apply each atomically, score each child closed-loop against the world model,
+and gate acceptance:
 
 - **Tier 1 — regression suite**: the child's score on the suite (tasks the search has already
   mastered) must not drop below the champion's. Newly-passing tasks promote into the suite on
@@ -59,6 +60,8 @@ _SELECTION_FLOOR = 0.05
 _TIE_EPS = 1e-9
 
 ALL_PASS_MECHANISM = "none: all tasks pass"
+
+FailureClusterKey = tuple[str, str, tuple[str, ...]]
 
 # Reports progress as (iteration, variant name, success_rate, accepted); iteration 0 is the seed.
 CreateProgress = Callable[[int, str, float, bool], None]
@@ -117,13 +120,19 @@ class IterationRecord(BaseModel):
     proposal_index: int
     outcome: Literal["scored", "screened", "invalid", "unusable", "proposer_error"]
     candidate: str | None = None
+    candidate_doc_hash: str | None = None
     delta_id: str | None = None
+    trigger: FailureSignature | None = None
+    expected_effect: str | None = None
     ops: list[str] = Field(default_factory=list)  # "replace prompt:main" style summaries
+    rationales: list[str] = Field(default_factory=list)
     reason: str | None = None
     score: float | None = None  # full-suite success rate; scored attempts only
     accepted: bool | None = None  # gate verdict; scored attempts only
     screen_child: float | None = None  # trigger-cluster means; screened attempts only
     screen_parent: float | None = None
+    screen_child_fraction: float | None = None  # denser assertion-level screen signal
+    screen_parent_fraction: float | None = None
     champion_score: float | None = None
 
 
@@ -156,8 +165,8 @@ def cluster_failures(report: ClosedLoopReport, tasks: list[TaskSpec]) -> list[Fa
     Two failing tasks share a mechanism when they share an unmet gold assertion (connected
     components over the task/assertion graph). The cluster's `mechanism` label is its most common
     unmet assertion (ties broken lexicographically); clusters are ordered largest-first so the
-    caller's "attack the biggest cluster" policy is a stable choice. A failing task whose verdicts
-    carry no per-assertion detail (an unparseable judge reply) forms its own cluster.
+    size-weighted, expansion-discounted selector has a stable base order. A failing task whose
+    verdicts carry no per-assertion detail (an unparseable judge reply) forms its own cluster.
     """
     unmet_by_task: dict[str, list[str]] = {}
     for task in tasks:
@@ -213,6 +222,38 @@ def cluster_failures(report: ClosedLoopReport, tasks: list[TaskSpec]) -> list[Fa
     return clusters
 
 
+def select_failure_cluster(
+    clusters: list[FailureSignature],
+    expansion_counts: dict[FailureClusterKey, int],
+    *,
+    parent_doc_hash: str,
+) -> FailureSignature:
+    """Choose a high-impact cluster without getting trapped on one exhausted failure.
+
+    A cluster's priority is ``task_count / (1 + prior_rounds_on_this_parent)``. Large mechanisms
+    still receive proportionally more search budget, but equally sized singleton failures rotate
+    after one batch instead of a deterministic ``clusters[0]`` absorbing the entire run. The
+    stable mechanism/task ordering resolves exact ties without entropy.
+    """
+    if not clusters:
+        raise ValueError("cannot select from an empty failure-cluster list")
+
+    def _priority(cluster: FailureSignature) -> tuple[float, str, tuple[str, ...]]:
+        key = _failure_cluster_key(parent_doc_hash, cluster)
+        rounds = expansion_counts.get(key, 0)
+        return (
+            -(len(cluster.task_ids) / (1 + rounds)),
+            cluster.mechanism,
+            tuple(cluster.task_ids),
+        )
+
+    return min(clusters, key=_priority)
+
+
+def _failure_cluster_key(parent_doc_hash: str, cluster: FailureSignature) -> FailureClusterKey:
+    return parent_doc_hash, cluster.mechanism, tuple(cluster.task_ids)
+
+
 def select_parent(
     entries: list[PoolEntry], children_counts: dict[str, int], seed: int
 ) -> PoolEntry:
@@ -256,6 +297,17 @@ def narrow_failing_tiers(
     """
     if verdict.accepted or verdict.full_delta <= _TIE_EPS:
         return None
+    # A confirmation may only revisit the explicitly returned binary vetoes. Do not let it erase
+    # a separate tied-success dense veto on another tier.
+    if abs(verdict.suite_delta) <= _TIE_EPS and verdict.suite_fraction_delta < -_TIE_EPS:
+        return None
+    if (
+        verdict.holdout_delta is not None
+        and abs(verdict.holdout_delta) <= _TIE_EPS
+        and verdict.holdout_fraction_delta is not None
+        and verdict.holdout_fraction_delta < -_TIE_EPS
+    ):
+        return None
     tiers: list[str] = []
     if verdict.suite_delta < -_TIE_EPS:
         if n_suite == 0 or verdict.suite_delta < -(margin_attempts / (k * n_suite)) - _TIE_EPS:
@@ -281,21 +333,45 @@ def gate_delta(
     child_holdout: ClosedLoopReport | None = None,
     champion_holdout: ClosedLoopReport | None = None,
 ) -> GateRecord:
-    """Two-tier (plus optional held-out) acceptance; ties pass. Also audits `expected_effect`."""
+    """Lexicographic success/partial-credit gate plus optional held-out acceptance.
+
+    End-to-end task success remains the primary objective. When a tier's binary score ties, its
+    assertion-level fraction must not regress. This admits useful partial-progress stepping
+    stones without promoting a target-local improvement that silently damages more work across
+    the full split.
+    """
     suite_delta = _suite_rate(child, suite) - _suite_rate(champion, suite)
+    suite_fraction_delta = _suite_fraction(child, suite) - _suite_fraction(champion, suite)
     full_delta = child.success_rate - best_full
+    full_fraction_delta = child.mean_fraction - champion.mean_fraction
     holdout_delta = (
         child_holdout.success_rate - champion_holdout.success_rate
+        if child_holdout is not None and champion_holdout is not None
+        else None
+    )
+    holdout_fraction_delta = (
+        child_holdout.mean_fraction - champion_holdout.mean_fraction
         if child_holdout is not None and champion_holdout is not None
         else None
     )
     failures: list[str] = []
     if suite_delta < -_TIE_EPS:
         failures.append(f"suite regressed by {-suite_delta:.3f}")
+    elif abs(suite_delta) <= _TIE_EPS and suite_fraction_delta < -_TIE_EPS:
+        failures.append(f"suite assertion fraction regressed by {-suite_fraction_delta:.3f}")
     if full_delta < -_TIE_EPS:
         failures.append(f"full split {child.success_rate:.3f} below best {best_full:.3f}")
+    elif abs(full_delta) <= _TIE_EPS and full_fraction_delta < -_TIE_EPS:
+        failures.append(f"full-split assertion fraction regressed by {-full_fraction_delta:.3f}")
     if holdout_delta is not None and holdout_delta < -_TIE_EPS:
         failures.append(f"held-out regressed by {-holdout_delta:.3f}")
+    elif (
+        holdout_delta is not None
+        and abs(holdout_delta) <= _TIE_EPS
+        and holdout_fraction_delta is not None
+        and holdout_fraction_delta < -_TIE_EPS
+    ):
+        failures.append(f"held-out assertion fraction regressed by {-holdout_fraction_delta:.3f}")
     flipped = sum(
         1
         for task_id in delta.trigger.task_ids
@@ -310,8 +386,11 @@ def gate_delta(
     reason = ("accepted; " if accepted else "rejected: " + "; ".join(failures) + "; ") + effect
     return GateRecord(
         suite_delta=suite_delta,
+        suite_fraction_delta=suite_fraction_delta,
         full_delta=full_delta,
+        full_fraction_delta=full_fraction_delta,
         holdout_delta=holdout_delta,
+        holdout_fraction_delta=holdout_fraction_delta,
         accepted=accepted,
         reason=reason,
     )
@@ -379,12 +458,14 @@ def create_harness(
     evaluation pool, including fresh replacements for retired runners.
 
     Verification is staged by cost: a child is first SCREENED on its own trigger cluster (the
-    2-3 failing tasks its delta claims to fix, k passes) — if the cluster did not improve over
-    the parent, the delta is rejected and archived for a fraction of a full eval's cost, and no
-    `on_progress` event fires. Held-out evals run only for children that pass tiers 1-2, so a
-    bad delta costs at most one full-split eval. Every judged delta (screened, rejected, or
-    accepted) is fed back to the proposer as history, so it iterates instead of re-proposing
-    rejected ideas.
+    2-3 failing tasks its delta claims to fix, k passes). The screen is lexicographic: full-task
+    success first, then assertion-level partial credit, so a real partial fix is not flattened
+    into a binary tie. If neither signal improves, the delta is rejected and archived for a
+    fraction of a full eval's cost, and no `on_progress` event fires. Repeated batches discount
+    their cluster on that parent, preventing one environment-limited singleton from absorbing the
+    whole run. Held-out evals run only for children that pass tiers 1-2, so a bad delta costs at
+    most one full-split eval. Every judged delta (screened, rejected, or accepted) is fed back to
+    the proposer as history, so it iterates instead of re-proposing rejected ideas.
 
     Symmetrically, a REJECTION can be noise: with k passes over small tiers, one unlucky attempt
     can veto a genuine win. When `confirm_narrow_vetoes` is set, a delta that strictly won the
@@ -429,6 +510,7 @@ def create_harness(
         holdout_reports: dict[str, ClosedLoopReport] = {}
         archive = DeltaArchive(seed=seed_doc)
         children_counts: dict[str, int] = {}
+        failure_cluster_expansions: dict[FailureClusterKey, int] = {}
         skipped = 0
         screened = 0
         confirmations = 0
@@ -542,9 +624,16 @@ def create_harness(
                 parent = docs[parent_entry.doc_hash]
                 parent_report = reports[parent_entry.doc_hash]
                 clusters = cluster_failures(parent_report, tasks)
-                trigger = (
-                    clusters[0] if clusters else FailureSignature(mechanism=ALL_PASS_MECHANISM)
-                )
+                key: FailureClusterKey | None = None
+                if clusters:
+                    trigger = select_failure_cluster(
+                        clusters,
+                        failure_cluster_expansions,
+                        parent_doc_hash=parent.doc_hash,
+                    )
+                    key = _failure_cluster_key(parent.doc_hash, trigger)
+                else:
+                    trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
                 evidence = render_evidence(trigger, parent_report, tasks)
                 try:
                     batch = proposer.propose_batch(
@@ -565,6 +654,13 @@ def create_harness(
                 except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
                     batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
                 _check_cancelled()
+                # Discount a cluster only after the proposer produced at least one candidate that
+                # can enter validation. A transient project/provider failure learned nothing about
+                # the mechanism and must not consume that cluster's search allocation.
+                if key is not None and any(
+                    isinstance(candidate, HarnessDelta) for candidate in batch
+                ):
+                    failure_cluster_expansions[key] = failure_cluster_expansions.get(key, 0) + 1
                 proposal_queue.extend((parent, parent_report, trigger, delta) for delta in batch)
 
             parent, parent_report, trigger, delta = proposal_queue.pop(0)
@@ -582,6 +678,7 @@ def create_harness(
                         round=round_index,
                         proposal_index=proposal_index,
                         outcome="proposer_error",
+                        trigger=trigger,
                         reason=delta.reason,
                         champion_score=champion_score,
                     ),
@@ -596,6 +693,7 @@ def create_harness(
                         round=round_index,
                         proposal_index=proposal_index,
                         outcome="unusable",
+                        trigger=trigger,
                         reason="unparseable or truncated meta reply",
                         champion_score=champion_score,
                     ),
@@ -603,6 +701,8 @@ def create_harness(
                 )
                 continue
             ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
+            rationales = [op.rationale[:1_000] for op in delta.ops]
+            expected_effect = delta.expected_effect[:1_000]
             if any(d.delta_id == delta.delta_id for d in archive.deltas):
                 # The proposer re-proposed a delta this run already judged. Re-evaluating it
                 # would spend a screen (or worse) to learn a known verdict; skip without spend.
@@ -615,7 +715,10 @@ def create_harness(
                         proposal_index=proposal_index,
                         outcome="invalid",
                         delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
                         ops=ops_summary,
+                        rationales=rationales,
                         reason="duplicate of an already-judged delta",
                         champion_score=champion_score,
                     ),
@@ -640,7 +743,10 @@ def create_harness(
                         proposal_index=proposal_index,
                         outcome="invalid",
                         delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
                         ops=ops_summary,
+                        rationales=rationales,
                         reason=f"invalid before eval: {exc}",
                         champion_score=champion_score,
                     ),
@@ -667,8 +773,12 @@ def create_harness(
                         proposal_index=proposal_index,
                         outcome="invalid",
                         candidate=child.name,
+                        candidate_doc_hash=child.doc_hash,
                         delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
                         ops=ops_summary,
+                        rationales=rationales,
                         reason=str(delta.verdict.reason),
                         champion_score=champion_score,
                     ),
@@ -682,18 +792,51 @@ def create_harness(
             children_counts[parent.doc_hash] = children_counts.get(parent.doc_hash, 0) + 1
 
             # Cheap screen: before a full-split eval, the delta must improve the very cluster it
-            # was proposed to fix. A delta that cannot beat its parent on its own target is noise.
+            # was proposed to fix. Compare task success first, then assertion-level partial credit:
+            # a 0%-to-75% assertion lift must not be flattened into the same "0 vs 0" as no effect.
+            screen_child_value: float | None = None
+            screen_parent_value: float | None = None
+            screen_child_fraction_value: float | None = None
+            screen_parent_fraction_value: float | None = None
             screen_tasks = [t for t in tasks if t.task_id in set(trigger.task_ids)]
             if screen_tasks:
                 screen_report = _score(child, screen_tasks)
                 parent_mean = _suite_rate(parent_report, sorted(trigger.task_ids))
                 child_mean = _suite_rate(screen_report, sorted(trigger.task_ids))
-                if child_mean <= parent_mean + _TIE_EPS:
+                parent_fraction = _suite_fraction(parent_report, sorted(trigger.task_ids))
+                child_fraction = _suite_fraction(screen_report, sorted(trigger.task_ids))
+                screen_child_value = child_mean
+                screen_parent_value = parent_mean
+                screen_child_fraction_value = child_fraction
+                screen_parent_fraction_value = parent_fraction
+                success_regressed = child_mean < parent_mean - _TIE_EPS
+                success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
+                fraction_did_not_improve = child_fraction <= parent_fraction + _TIE_EPS
+                feedback_error = _record_proposer_evaluation(
+                    proposer,
+                    delta,
+                    stage="screen",
+                    report=screen_report,
+                    tasks=screen_tasks,
+                    summary=(
+                        f"trigger success {child_mean:.3f} vs parent {parent_mean:.3f}; "
+                        f"assertion fraction {child_fraction:.3f} vs parent "
+                        f"{parent_fraction:.3f}"
+                    ),
+                )
+                if feedback_error is not None:
+                    _note(
+                        f"{label}: screen feedback could not be persisted "
+                        f"({feedback_error}); continuing"
+                    )
+                if success_regressed or (success_tied and fraction_did_not_improve):
                     delta.verdict = GateRecord(
                         accepted=False,
                         reason=(
-                            f"screened out: trigger cluster {child_mean:.2f} vs parent "
-                            f"{parent_mean:.2f} over {len(screen_tasks)} task(s), k={k}; "
+                            f"screened out: trigger success {child_mean:.2f} vs parent "
+                            f"{parent_mean:.2f}; assertion fraction {child_fraction:.2f} vs "
+                            f"parent {parent_fraction:.2f} over {len(screen_tasks)} task(s), "
+                            f"k={k}; "
                             "the delta did not improve its own target"
                         ),
                     )
@@ -706,15 +849,22 @@ def create_harness(
                             proposal_index=proposal_index,
                             outcome="screened",
                             candidate=child.name,
+                            candidate_doc_hash=child.doc_hash,
                             delta_id=delta.delta_id,
+                            trigger=delta.trigger,
+                            expected_effect=expected_effect,
                             ops=ops_summary,
+                            rationales=rationales,
                             reason=str(delta.verdict.reason),
                             screen_child=child_mean,
                             screen_parent=parent_mean,
+                            screen_child_fraction=child_fraction,
+                            screen_parent_fraction=parent_fraction,
                             champion_score=champion_score,
                         ),
-                        f"{label}: screened out: trigger cluster "
-                        f"{child_mean:.2f} vs parent {parent_mean:.2f}",
+                        f"{label}: screened out: trigger success "
+                        f"{child_mean:.2f} vs parent {parent_mean:.2f}; assertion fraction "
+                        f"{child_fraction:.2f} vs parent {parent_fraction:.2f}",
                     )
                     continue
 
@@ -768,14 +918,23 @@ def create_harness(
                     child_re = _score(child, tier_tasks, k_override=2 * k)
                     champ_re = _score(docs[champion_hash], tier_tasks, k_override=2 * k)
                     re_delta = child_re.success_rate - champ_re.success_rate
-                    notes.append(f"{tier} re-measured at k={2 * k}: {re_delta:+.3f}")
-                    if re_delta < -_TIE_EPS:
+                    re_fraction_delta = child_re.mean_fraction - champ_re.mean_fraction
+                    notes.append(
+                        f"{tier} re-measured at k={2 * k}: success {re_delta:+.3f}, "
+                        f"assertion fraction {re_fraction_delta:+.3f}"
+                    )
+                    if re_delta < -_TIE_EPS or (
+                        abs(re_delta) <= _TIE_EPS and re_fraction_delta < -_TIE_EPS
+                    ):
                         confirmed_ok = False
                 outcome = "veto overturned" if confirmed_ok else "regression confirmed"
                 verdict = GateRecord(
                     suite_delta=verdict.suite_delta,
+                    suite_fraction_delta=verdict.suite_fraction_delta,
                     full_delta=verdict.full_delta,
+                    full_fraction_delta=verdict.full_fraction_delta,
                     holdout_delta=verdict.holdout_delta,
+                    holdout_fraction_delta=verdict.holdout_fraction_delta,
                     accepted=confirmed_ok,
                     reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
                     + verdict.reason,
@@ -785,6 +944,18 @@ def create_harness(
                 # happen afterward. Check again at the acceptance commit boundary so a cancelled
                 # child never enters lineage or reaches the persistence callback.
                 _check_cancelled()
+            feedback_error = _record_proposer_evaluation(
+                proposer,
+                delta,
+                stage="full",
+                report=child_report,
+                tasks=tasks,
+                summary=verdict.reason,
+            )
+            if feedback_error is not None:
+                _note(
+                    f"{label}: full feedback could not be persisted ({feedback_error}); continuing"
+                )
             delta.verdict = verdict
             archive.deltas.append(delta)
             docs[child.doc_hash] = child
@@ -813,11 +984,19 @@ def create_harness(
                 proposal_index=proposal_index,
                 outcome="scored",
                 candidate=child.name,
+                candidate_doc_hash=child.doc_hash,
                 delta_id=delta.delta_id,
+                trigger=delta.trigger,
+                expected_effect=expected_effect,
                 ops=ops_summary,
+                rationales=rationales,
                 reason=str(verdict.reason),
                 score=child_report.success_rate,
                 accepted=verdict.accepted,
+                screen_child=screen_child_value,
+                screen_parent=screen_parent_value,
+                screen_child_fraction=screen_child_fraction_value,
+                screen_parent_fraction=screen_parent_fraction_value,
                 champion_score=reports[champion_hash].success_rate,
             )
             iteration_records.append(record)
@@ -871,6 +1050,47 @@ def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:
     # Dividing by len(suite), not len(rates): a suite task missing from the report counts as 0
     # (fail-closed), though suite tasks are always a subset of the scored split in practice.
     return sum(rates) / len(suite)
+
+
+def _suite_fraction(report: ClosedLoopReport, suite: list[str]) -> float:
+    """Mean assertion completion over a task subset; missing tasks fail closed."""
+    if not suite:
+        return 1.0
+    fractions = [
+        outcome.mean_fraction
+        for task_id in suite
+        if (outcome := report.per_task.get(task_id)) is not None
+    ]
+    return sum(fractions) / len(suite)
+
+
+def _record_proposer_evaluation(
+    proposer: DeltaProposer,
+    delta: HarnessDelta,
+    *,
+    stage: str,
+    report: ClosedLoopReport,
+    tasks: list[TaskSpec],
+    summary: str,
+) -> str | None:
+    """Best-effort durable trace feedback; evaluation correctness never depends on telemetry."""
+    recorder = getattr(proposer, "record_evaluation", None)
+    if not callable(recorder):
+        return None
+    content = (
+        f"# Candidate evaluation: {stage}\n\n"
+        f"Delta: {delta.delta_id}\n\n"
+        f"Expected effect: {delta.expected_effect}\n\n"
+        f"Outcome: {summary}\n\n"
+        f"{render_evidence(delta.trigger, report, tasks)}"
+    )
+    try:
+        recorder(delta, stage=stage, content=content)
+    except HarnessSearchCancelled:
+        raise
+    except Exception as error:  # noqa: BLE001 - optional E2B feedback must not abort scored work
+        return str(error)
+    return None
 
 
 def _proposal_label(round_index: int, proposal_index: int, *, rounds: int, batch_size: int) -> str:

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -37,7 +37,7 @@ from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.mutate import render_evidence
 from wmh.harness.proposer import DeltaProposer, ProposalFailure
-from wmh.harness.runtime import TokenUsage, combine_usage
+from wmh.harness.runtime import RuntimeCancelled, TokenUsage, combine_usage
 from wmh.providers.base import Provider
 
 if TYPE_CHECKING:
@@ -352,8 +352,10 @@ def create_harness(
     waiting for the search to finish.
 
     ``should_cancel`` is checked before and after every score wave, before each proposal slot,
-    and after each batched proposer call. Returning true raises :class:`HarnessSearchCancelled`
-    before the next costly phase while the normal ``finally`` path retires sandbox resources.
+    and after each batched proposer call. E2B runtimes also poll it while waiting for runner
+    frames, so cancellation aborts the active wave without judging partial cells. A provider/tool
+    call already in progress remains bounded by that call's own timeout. Cancellation raises
+    :class:`HarnessSearchCancelled` while the normal ``finally`` path retires sandbox resources.
 
     Every rollout scores against the world-model simulation — the environment is always sim.
     `harness_backend` picks where the harness PROCESS executes: `local` (the default) runs it
@@ -442,17 +444,29 @@ def create_harness(
                 # The pi process runs in pooled sandboxes; every cell at once by default. Tool calls
                 # still route to the world model — the environment is sim regardless of backend.
                 concurrency = eval_concurrency if eval_concurrency is not None else 0
-                runtime = doc.runtime(agent_provider, backend="e2b", e2b_pool=sandbox_pool)
-            report = evaluate_closed_loop(
-                split,
-                world_model,
-                agent_provider,
-                judge,
-                label=doc.name,
-                k=k_eff,
-                concurrency=concurrency,
-                runtime=runtime,
-            )
+                runtime = doc.runtime(
+                    agent_provider,
+                    backend="e2b",
+                    e2b_pool=sandbox_pool,
+                    should_cancel=should_cancel,
+                )
+            try:
+                report = evaluate_closed_loop(
+                    split,
+                    world_model,
+                    agent_provider,
+                    judge,
+                    label=doc.name,
+                    k=k_eff,
+                    concurrency=concurrency,
+                    runtime=runtime,
+                    should_cancel=should_cancel,
+                )
+            except RuntimeCancelled as exc:
+                # Cancelled cells are not scoreable outcomes: do not judge them. Converting at the
+                # search boundary preserves the public cancellation contract while the surrounding
+                # finally closes the shared pool and retires every active evaluator sandbox.
+                raise HarnessSearchCancelled("harness search cancelled") from exc
             _check_cancelled()
             # Tally the pi worker's self-metered tokens across every score wave (seed, screens,
             # full splits, holdout, confirmations): its LLM calls bypass the Provider, so this is

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -1148,6 +1148,26 @@ def test_dead_iteration_ends_early_and_the_search_moves_on() -> None:
     assert scored.candidate == "winner-g2"
 
 
+def test_dead_proposals_do_not_discount_the_selected_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selection freshness changes only after a valid child is constructed."""
+    observed_counts: list[dict[str, int]] = []
+
+    def capture_selection(
+        entries: list[PoolEntry], children_counts: dict[str, int], seed: int
+    ) -> PoolEntry:
+        del seed
+        observed_counts.append(dict(children_counts))
+        return entries[0]
+
+    monkeypatch.setattr(create_module, "select_parent", capture_selection)
+    result = _run(RoleProvider(meta_reply="not json"), iterations=2)
+
+    assert result.skipped == 2
+    assert observed_counts == [{}, {}]
+
+
 def test_skipped_iterations_narrate_through_on_note() -> None:
     """Every iteration whose proposal dies before scoring reports itself.
 

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -31,7 +31,7 @@ from wmh.harness.create import (
     create_harness,
     select_parent,
 )
-from wmh.harness.delta import HarnessDelta
+from wmh.harness.delta import GateRecord, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.proposer import ProviderDeltaProposer
@@ -258,6 +258,88 @@ def test_create_stops_before_the_next_expensive_phase_when_cancelled() -> None:
         _run(provider, should_cancel=should_cancel)
 
     assert provider.meta_users == []
+
+
+def test_create_passes_cancellation_into_a_batched_provider_proposer() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        _run(
+            provider,
+            proposal_batch_size=3,
+            should_cancel=lambda: len(provider.meta_users) >= 1,
+        )
+
+    assert len(provider.meta_users) == 1
+
+
+def test_create_never_converts_explicit_proposer_cancellation_to_failures() -> None:
+    class _CancellingMetaProvider(RoleProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 2048,
+        ) -> Completion:
+            if "meta-agent improving an agent harness" in system:
+                raise HarnessSearchCancelled("harness search cancelled")
+            return super().complete(
+                system,
+                messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        _run(_CancellingMetaProvider())
+
+
+def test_cancellation_wins_before_accepted_lineage_and_callback_mutate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    cancelled = False
+    crowned: list[str] = []
+    gate_delta = create_module.gate_delta
+
+    def cancelling_gate(
+        delta: HarnessDelta,
+        *,
+        child: ClosedLoopReport,
+        champion: ClosedLoopReport,
+        best_full: float,
+        suite: list[str],
+        child_holdout: ClosedLoopReport | None = None,
+        champion_holdout: ClosedLoopReport | None = None,
+    ) -> GateRecord:
+        nonlocal cancelled
+        verdict = gate_delta(
+            delta,
+            child=child,
+            champion=champion,
+            best_full=best_full,
+            suite=suite,
+            child_holdout=child_holdout,
+            champion_holdout=champion_holdout,
+        )
+        if verdict.accepted:
+            cancelled = True
+        return verdict
+
+    monkeypatch.setattr(create_module, "gate_delta", cancelling_gate)
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        _run(
+            provider,
+            should_cancel=lambda: cancelled,
+            on_accept=lambda doc, delta, score: crowned.append(doc.doc_hash),
+        )
+
+    assert crowned == []
 
 
 def test_create_audits_invalid_delta_without_spending_eval() -> None:

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -769,6 +769,7 @@ class _FakePool:
         self.releases: list[bool] = []
         self.retire_idle_calls = 0
         self.closes = 0
+        self.close_failures = 0
         _FakePool.instances.append(self)
 
     def usage(self) -> SandboxUsage:
@@ -788,6 +789,10 @@ class _FakePool:
 
     def close(self) -> None:
         self.closes += 1
+        if self.closes <= self.close_failures:
+            from wmh.harness.e2b_sandbox import SandboxCleanupError
+
+            raise SandboxCleanupError("evaluator cleanup unproven")
 
 
 @pytest.fixture
@@ -916,9 +921,8 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
     [pool] = fake_pool_cls.instances  # ONE shared pool for the whole search
     assert pool.template == "tmpl-1"
     assert pool.metadata == {"optimizer_run_id": "run-1", "purpose": "evaluation"}
-    # Closed on return (finalizing the usage meter) and again by the finally — the real pool's
-    # close is idempotent, so "at least once, before usage capture" is the contract.
-    assert pool.closes >= 1
+    # One finally owns teardown and mutates the returned model with the finalized meter.
+    assert pool.closes == 1
     assert result.sandbox_usage is not None
     assert result.sandbox_usage.count == len(pool.channels)  # the fake meters per acquire
     assert len(pool.channels) == 3  # one pooled runner episode per (task, attempt) cell
@@ -935,6 +939,7 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
     monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
 ) -> None:
     provider = RoleProvider()
+    observed_usage: list[SandboxUsage] = []
 
     def exploding_evaluate(*args: object, **kwargs: object) -> ClosedLoopReport:
         raise RuntimeError("boom mid-eval")
@@ -950,9 +955,46 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
             ProviderDeltaProposer(provider),
             GoldJudge(provider),
             harness_backend="e2b",
+            on_sandbox_usage=observed_usage.append,
         )
     [pool] = fake_pool_cls.instances
     assert pool.closes == 1  # the try/finally tears the pool down even on failure
+    assert observed_usage == [SandboxUsage(count=0, seconds=0.0)]
+
+
+def test_e2b_cleanup_failure_replaces_cancellation_and_withholds_final_usage(
+    monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
+) -> None:
+    """Cancellation cannot look clean when evaluator release remains unproven."""
+    from wmh.harness.e2b_sandbox import SandboxCleanupError
+    from wmh.harness.runtime import RuntimeCancelled
+
+    provider = RoleProvider()
+    observed_usage: list[SandboxUsage] = []
+
+    def cancelled_evaluate(*args: object, **kwargs: object) -> ClosedLoopReport:
+        del args, kwargs
+        [pool] = fake_pool_cls.instances
+        pool.close_failures = 1
+        raise RuntimeCancelled("runtime episode cancelled")
+
+    monkeypatch.setattr(create_module, "evaluate_closed_loop", cancelled_evaluate)
+
+    with pytest.raises(SandboxCleanupError, match="cleanup unproven") as raised:
+        create_harness(
+            "winner",
+            _pi_seed(),
+            _tasks(),
+            _wm(provider),
+            provider,
+            ProviderDeltaProposer(provider),
+            GoldJudge(provider),
+            harness_backend="e2b",
+            on_sandbox_usage=observed_usage.append,
+        )
+
+    assert isinstance(raised.value.__context__, HarnessSearchCancelled)
+    assert observed_usage == []
 
 
 def test_runtime_cancellation_aborts_the_wave_without_judging_and_closes_pool(

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -25,6 +25,7 @@ from wmh.evals.tasks import TaskSpec
 from wmh.harness import create as create_module
 from wmh.harness.create import (
     CreateResult,
+    HarnessSearchCancelled,
     PoolEntry,
     cluster_failures,
     create_harness,
@@ -149,6 +150,7 @@ def _run(
     on_progress: Callable[[int, str, float, bool], None] | None = None,
     on_note: Callable[[str], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
     return create_harness(
         "winner",
@@ -165,6 +167,7 @@ def _run(
         on_progress=on_progress,
         on_note=on_note,
         on_accept=on_accept,
+        should_cancel=should_cancel,
     )
 
 
@@ -240,6 +243,21 @@ def test_create_skips_unusable_proposals() -> None:
         (1, "unusable"),
         (2, "unusable"),
     ]
+
+
+def test_create_stops_before_the_next_expensive_phase_when_cancelled() -> None:
+    provider = RoleProvider(meta_reply="not json at all")
+    checks = 0
+
+    def should_cancel() -> bool:
+        nonlocal checks
+        checks += 1
+        return checks >= 2
+
+    with pytest.raises(HarnessSearchCancelled):
+        _run(provider, should_cancel=should_cancel)
+
+    assert provider.meta_users == []
 
 
 def test_create_audits_invalid_delta_without_spending_eval() -> None:

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -33,6 +33,7 @@ from wmh.harness.create import (
 from wmh.harness.delta import HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.proposer import ProviderDeltaProposer
 from wmh.harness.runtime import Runtime
 from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
@@ -143,6 +144,7 @@ def _run(
     *,
     iterations: int = 1,
     k: int = 3,
+    proposal_batch_size: int = 1,
     holdout: list[TaskSpec] | None = None,
     on_progress: Callable[[int, str, float, bool], None] | None = None,
     on_note: Callable[[str], None] | None = None,
@@ -154,9 +156,10 @@ def _run(
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=iterations,
+        proposal_batch_size=proposal_batch_size,
         k=k,
         holdout=holdout,
         on_progress=on_progress,
@@ -427,7 +430,7 @@ def test_code_delta_passes_screen_and_gate_end_to_end() -> None:
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
         k=3,
@@ -468,7 +471,7 @@ def test_broken_code_delta_is_rejected_before_any_eval() -> None:
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
         k=2,
@@ -581,7 +584,7 @@ def test_confirmed_suite_overturn_still_faces_the_holdout_tier() -> None:
         tasks,
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
         k=5,
@@ -701,7 +704,7 @@ def test_unknown_harness_backend_is_rejected() -> None:
             _tasks(),
             _wm(provider),
             provider,
-            provider,
+            ProviderDeltaProposer(provider),
             GoldJudge(provider),
             harness_backend=bogus,
         )
@@ -717,7 +720,7 @@ def test_e2b_backend_rejects_non_pi_node_seeds() -> None:
             _tasks(),
             _wm(provider),
             provider,
-            provider,
+            ProviderDeltaProposer(provider),
             GoldJudge(provider),
             harness_backend="e2b",
         )
@@ -737,7 +740,7 @@ def test_local_backend_rejects_parallel_pi_node_scoring() -> None:
             _tasks(),
             _wm(provider),
             provider,
-            provider,
+            ProviderDeltaProposer(provider),
             GoldJudge(provider),
             eval_concurrency=2,
         )
@@ -788,7 +791,7 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=0,  # the seed eval alone exercises the whole scoring path
         k=3,
@@ -832,7 +835,7 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
             _tasks(),
             _wm(provider),
             provider,
-            provider,
+            ProviderDeltaProposer(provider),
             GoldJudge(provider),
             harness_backend="e2b",
         )
@@ -870,7 +873,7 @@ def test_eval_concurrency_overrides_both_backend_defaults(
             _tasks(),
             _wm(provider),
             provider,
-            provider,
+            ProviderDeltaProposer(provider),
             GoldJudge(provider),
             iterations=0,  # score the seed only: one eval call per run
             harness_backend="local" if harness_backend == "local" else "e2b",
@@ -921,7 +924,7 @@ def test_create_sums_worker_usage_across_score_waves(
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
         harness_backend="e2b",
@@ -955,7 +958,7 @@ def test_create_worker_usage_is_none_when_no_wave_reports_it(
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=0,
         harness_backend="local",
@@ -1003,7 +1006,7 @@ def test_e2b_rejects_a_delta_that_abandons_the_pi_runtime(
         _tasks(),
         _wm(provider),
         provider,
-        provider,
+        ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
         harness_backend="e2b",
@@ -1074,6 +1077,30 @@ class _SequencedMetaProvider(RoleProvider):
             reply = self._replies[min(len(self.meta_users) - 1, len(self._replies) - 1)]
             return Completion(text=reply)
         return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
+
+
+def test_proposal_batch_is_generated_before_siblings_are_evaluated() -> None:
+    """One round expands one parent into independently tracked sibling candidates."""
+    seed = HarnessDoc.baseline("seed")
+    provider = _SequencedMetaProvider(
+        [
+            _meta_reply(seed, _CAREFUL_PROMPT),
+            _meta_reply(seed, f"{_CAREFUL_PROMPT} Double-check the result."),
+        ]
+    )
+
+    result = _run(provider, iterations=1, proposal_batch_size=2)
+
+    assert len(provider.meta_users) == 2
+    assert [(record.round, record.proposal_index) for record in result.iteration_records] == [
+        (1, 1),
+        (1, 2),
+    ]
+    assert [record.candidate for record in result.iteration_records] == [
+        "winner-g1-p1",
+        "winner-g1-p2",
+    ]
+    assert len(result.archive.deltas) == 2
 
 
 def test_on_accept_delivers_the_new_champion_the_moment_it_is_crowned() -> None:

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -662,7 +662,8 @@ class _ScriptedPoolChannel:
     def send(self, frame: JsonObject) -> None:
         self.sent.append(frame)
 
-    def recv(self) -> JsonObject | None:
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        del timeout
         return self._script.pop(0) if self._script else None
 
 
@@ -793,6 +794,7 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
         k: int,
         concurrency: int,
         runtime: Runtime | None = None,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> ClosedLoopReport:
         concurrencies.append(concurrency)
         return real_evaluate(
@@ -804,6 +806,7 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
             k=k,
             concurrency=concurrency,
             runtime=runtime,
+            should_cancel=should_cancel,
         )
 
     monkeypatch.setattr(create_module, "evaluate_closed_loop", spying_evaluate)
@@ -866,6 +869,45 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
     assert pool.closes == 1  # the try/finally tears the pool down even on failure
 
 
+def test_runtime_cancellation_aborts_the_wave_without_judging_and_closes_pool(
+    monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
+) -> None:
+    from wmh.harness.pi_e2b import E2BPiRuntime
+    from wmh.harness.runtime import RuntimeCancelled
+
+    provider = RoleProvider()
+    callback_seen = False
+
+    def should_cancel() -> bool:
+        return False
+
+    def cancelled_evaluate(*args: object, **kwargs: object) -> ClosedLoopReport:
+        nonlocal callback_seen
+        runtime = kwargs.get("runtime")
+        assert isinstance(runtime, E2BPiRuntime)
+        callback_seen = runtime._should_cancel is should_cancel  # noqa: SLF001
+        raise RuntimeCancelled("runtime episode cancelled")
+
+    monkeypatch.setattr(create_module, "evaluate_closed_loop", cancelled_evaluate)
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        create_harness(
+            "winner",
+            _pi_seed(),
+            _tasks(),
+            _wm(provider),
+            provider,
+            ProviderDeltaProposer(provider),
+            GoldJudge(provider),
+            harness_backend="e2b",
+            should_cancel=should_cancel,
+        )
+
+    assert callback_seen
+    [pool] = fake_pool_cls.instances
+    assert pool.closes == 1
+
+
 def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(
     monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
 ) -> None:
@@ -912,7 +954,9 @@ def test_eval_concurrency_overrides_both_backend_defaults(
         k: int,
         concurrency: int,
         runtime: Runtime | None = None,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> ClosedLoopReport:
+        del should_cancel
         concurrencies.append(concurrency)
         return _canned_report(1.0, k=k)
 
@@ -962,7 +1006,9 @@ def test_create_sums_worker_usage_across_score_waves(
         k: int,
         concurrency: int,
         runtime: Runtime | None = None,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> ClosedLoopReport:
+        del should_cancel
         report = _canned_report(0.5, k=k)
         return report.model_copy(
             update={"worker_usage": TokenUsage(input_tokens=100, output_tokens=10, calls=2)}

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -515,6 +515,48 @@ def test_create_does_not_discount_a_cluster_when_the_proposer_failed() -> None:
     assert [trigger.task_ids for trigger in proposer.triggers] == [["t1"], ["t1"]]
 
 
+def test_create_does_not_discount_a_cluster_when_every_delta_is_invalid() -> None:
+    """Parsed deltas spend no cluster allocation until one can enter evaluation."""
+    seed = HarnessDoc.baseline("seed")
+    stale = json.dumps(
+        {
+            "expected_effect": "fix the selected failure",
+            "preconditions": {"prompt:core": "0" * 32},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": "prompt:core",
+                    "content": _CAREFUL_PROMPT,
+                    "rationale": "exercise the invalid-before-eval path",
+                }
+            ],
+        }
+    )
+    provider = RoleProvider(meta_reply=stale, judge_fn=lambda _user: False)
+    tasks = [
+        TaskSpec(task_id="t1", instruction="first failure", gold=["alpha assertion"]),
+        TaskSpec(task_id="t2", instruction="second failure", gold=["beta assertion"]),
+    ]
+
+    result = create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=2,
+        k=1,
+    )
+
+    assert result.skipped == 2
+    assert "[TARGET] t1" in provider.meta_users[0]
+    assert "[TARGET] t1" in provider.meta_users[1]
+    assert "[other] t2" in provider.meta_users[0]
+    assert "[other] t2" in provider.meta_users[1]
+
+
 # -- parent selection --------------------------------------------------------------------------
 
 

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -682,6 +682,7 @@ class _FakePool:
         self.template = template
         self.channels: list[_ScriptedPoolChannel] = []
         self.releases: list[bool] = []
+        self.retire_idle_calls = 0
         self.closes = 0
         _FakePool.instances.append(self)
 
@@ -695,6 +696,10 @@ class _FakePool:
 
     def release(self, sandbox: object, channel: object, *, healthy: bool) -> None:
         self.releases.append(healthy)
+
+    def retire_idle(self) -> int:
+        self.retire_idle_calls += 1
+        return 0
 
     def close(self) -> None:
         self.closes += 1
@@ -859,6 +864,35 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
         )
     [pool] = fake_pool_cls.instances
     assert pool.closes == 1  # the try/finally tears the pool down even on failure
+
+
+def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(
+    monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
+) -> None:
+    """Round boundaries rotate eval streams without rotating between sibling proposals."""
+    provider = RoleProvider()
+    monkeypatch.setattr(
+        create_module,
+        "evaluate_closed_loop",
+        lambda *a, **k: _canned_report(0.5, k=k.get("k", 3)),
+    )
+
+    result = create_harness(
+        "winner",
+        _pi_seed(),
+        _tasks(),
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=2,
+        proposal_batch_size=3,
+        harness_backend="e2b",
+    )
+
+    assert result.rounds == 2 and len(result.iteration_records) == 6
+    [pool] = fake_pool_cls.instances
+    assert pool.retire_idle_calls == 2  # once per batch, never between its three siblings
 
 
 def test_eval_concurrency_overrides_both_backend_defaults(

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -759,10 +759,12 @@ class _FakePool:
         *,
         template: str | None = None,
         api_key: str | None = None,
+        metadata: dict[str, str] | None = None,
         sandbox_factory: object = None,
         hello_timeout: float = 0.0,
     ) -> None:
         self.template = template
+        self.metadata = metadata
         self.channels: list[_ScriptedPoolChannel] = []
         self.releases: list[bool] = []
         self.retire_idle_calls = 0
@@ -905,6 +907,7 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
         k=3,
         harness_backend="e2b",
         e2b_template="tmpl-1",
+        e2b_metadata={"optimizer_run_id": "run-1", "purpose": "evaluation"},
     )
 
     # The judge passed the runner's submitted answer: the eval genuinely ran end to end.
@@ -912,6 +915,7 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
     assert concurrencies == [0]  # e2b default: every (task, attempt) cell at once
     [pool] = fake_pool_cls.instances  # ONE shared pool for the whole search
     assert pool.template == "tmpl-1"
+    assert pool.metadata == {"optimizer_run_id": "run-1", "purpose": "evaluation"}
     # Closed on return (finalizing the usage meter) and again by the finally — the real pool's
     # close is idempotent, so "at least once, before usage capture" is the contract.
     assert pool.closes >= 1

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -976,7 +976,7 @@ def test_runtime_cancellation_aborts_the_wave_without_judging_and_closes_pool(
 
     monkeypatch.setattr(create_module, "evaluate_closed_loop", cancelled_evaluate)
 
-    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+    with pytest.raises(HarnessSearchCancelled, match="cancelled") as raised:
         create_harness(
             "winner",
             _pi_seed(),
@@ -992,6 +992,7 @@ def test_runtime_cancellation_aborts_the_wave_without_judging_and_closes_pool(
     assert callback_seen
     [pool] = fake_pool_cls.instances
     assert pool.closes == 1
+    assert raised.value.sandbox_usage == SandboxUsage(count=0, seconds=0.0)
 
 
 def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -1343,6 +1343,53 @@ def test_runtime_cancellation_aborts_the_wave_without_judging_and_closes_pool(
     assert raised.value.sandbox_usage == SandboxUsage(count=0, seconds=0.0)
 
 
+def test_cancellation_carries_completed_and_partial_wave_worker_usage(
+    monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
+) -> None:
+    """The public cancellation result owns all worker spend without a partial CreateResult."""
+    from wmh.harness.runtime import RuntimeCancelled, TokenUsage
+
+    seed = _pi_seed()
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    evaluate_calls = 0
+
+    def cancel_second_wave(*args: object, **kwargs: object) -> ClosedLoopReport:
+        nonlocal evaluate_calls
+        del args
+        evaluate_calls += 1
+        if evaluate_calls == 1:
+            k = kwargs.get("k", 3)
+            assert isinstance(k, int)
+            return _canned_report(0.5, k=k).model_copy(
+                update={"worker_usage": TokenUsage(input_tokens=100, output_tokens=10, calls=2)}
+            )
+        raise RuntimeCancelled(
+            "runtime episode cancelled",
+            worker_usage=TokenUsage(input_tokens=7, output_tokens=2, calls=1),
+        )
+
+    monkeypatch.setattr(create_module, "evaluate_closed_loop", cancel_second_wave)
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled") as raised:
+        create_harness(
+            "winner",
+            seed,
+            _tasks(),
+            _wm(provider),
+            provider,
+            ProviderDeltaProposer(provider),
+            GoldJudge(provider),
+            iterations=1,
+            harness_backend="e2b",
+        )
+
+    assert evaluate_calls == 2
+    assert raised.value.worker_usage == TokenUsage(input_tokens=107, output_tokens=12, calls=3)
+    assert raised.value.sandbox_usage == SandboxUsage(count=0, seconds=0.0)
+    [pool] = fake_pool_cls.instances
+    assert pool.closes == 1
+
+
 def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(
     monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
 ) -> None:

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -29,12 +29,13 @@ from wmh.harness.create import (
     PoolEntry,
     cluster_failures,
     create_harness,
+    select_failure_cluster,
     select_parent,
 )
-from wmh.harness.delta import GateRecord, HarnessDelta
+from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
-from wmh.harness.proposer import ProviderDeltaProposer
+from wmh.harness.proposer import ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runtime import Runtime
 from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
@@ -430,6 +431,90 @@ def test_cluster_failures_empty_when_everything_passes() -> None:
     assert cluster_failures(report, [TaskSpec(task_id="t1", instruction="i")]) == []
 
 
+def test_select_failure_cluster_rotates_equally_sized_failures() -> None:
+    clusters = [
+        FailureSignature(mechanism=mechanism, task_ids=[f"t-{mechanism}"])
+        for mechanism in ("a", "b", "c")
+    ]
+    counts: dict[tuple[str, str, tuple[str, ...]], int] = {}
+    selected: list[str] = []
+    for _ in range(4):
+        cluster = select_failure_cluster(clusters, counts, parent_doc_hash="parent")
+        selected.append(cluster.mechanism)
+        key = ("parent", cluster.mechanism, tuple(cluster.task_ids))
+        counts[key] = counts.get(key, 0) + 1
+
+    assert selected == ["a", "b", "c", "a"]
+
+
+def test_create_rotates_failure_evidence_after_a_screened_batch() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_useless_meta_reply(seed), judge_fn=lambda _user: False)
+    tasks = [
+        TaskSpec(task_id="t1", instruction="first failure", gold=["alpha assertion"]),
+        TaskSpec(task_id="t2", instruction="second failure", gold=["beta assertion"]),
+    ]
+
+    create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=2,
+        k=1,
+    )
+
+    assert "[TARGET] t1" in provider.meta_users[0]
+    assert "[other] t2" in provider.meta_users[0]
+    assert "[TARGET] t2" in provider.meta_users[1]
+    assert "[other] t1" in provider.meta_users[1]
+
+
+def test_create_does_not_discount_a_cluster_when_the_proposer_failed() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(judge_fn=lambda _user: False)
+    tasks = [
+        TaskSpec(task_id="t1", instruction="first failure", gold=["alpha assertion"]),
+        TaskSpec(task_id="t2", instruction="second failure", gold=["beta assertion"]),
+    ]
+
+    class FailingProposer:
+        def __init__(self) -> None:
+            self.triggers: list[FailureSignature] = []
+
+        def propose_batch(  # noqa: PLR0913 - mirrors the proposer protocol
+            self,
+            parent: HarnessDoc,
+            trigger: FailureSignature,
+            evidence: str,
+            *,
+            history: list[HarnessDelta],
+            count: int,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> list[HarnessDelta | ProposalFailure | None]:
+            del parent, evidence, history, should_cancel
+            self.triggers.append(trigger)
+            return [ProposalFailure(reason="temporary transport failure")] * count
+
+    proposer = FailingProposer()
+    create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        proposer,
+        GoldJudge(provider),
+        iterations=2,
+        k=1,
+    )
+
+    assert [trigger.task_ids for trigger in proposer.triggers] == [["t1"], ["t1"]]
+
+
 # -- parent selection --------------------------------------------------------------------------
 
 
@@ -478,6 +563,219 @@ def test_screen_rejects_delta_that_does_not_improve_its_trigger() -> None:
     # and no child progress event ever fired.
     assert len(result.reports) == 1
     assert [e[0] for e in progress] == [0]
+
+
+def test_screen_uses_assertion_fraction_to_admit_partial_improvement() -> None:
+    seed = HarnessDoc.baseline("seed")
+
+    class PartialJudgeProvider(RoleProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 2048,
+        ) -> Completion:
+            if "grade whether an agent completed a task" not in system:
+                return super().complete(
+                    system,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            user = messages[-1].content
+            improved = "done-verified" in user
+            assertions = _gold_assertions(user)
+            results = [
+                {
+                    "assertion": assertion,
+                    "passed": improved and index == 0,
+                    "why": "one subgoal improved" if improved and index == 0 else "still missing",
+                }
+                for index, assertion in enumerate(assertions)
+            ]
+            return Completion(text=json.dumps({"assertions": results, "passed": False}))
+
+    provider = PartialJudgeProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    tasks = [
+        TaskSpec(
+            task_id="t1",
+            instruction="complete both parts",
+            gold=["part one complete", "part two complete"],
+        )
+    ]
+
+    result = create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=1,
+        k=1,
+    )
+
+    assert result.screened == 0
+    [record] = result.iteration_records
+    assert record.outcome == "scored"
+    assert record.screen_child == record.screen_parent == 0.0
+    assert record.screen_parent_fraction == 0.0
+    assert record.screen_child_fraction == 0.5
+
+
+def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regresses() -> None:
+    """Dense screening is a prefilter; the authoritative full gate protects other tasks."""
+    delta = HarnessDelta.model_construct(
+        trigger=FailureSignature(mechanism="target", task_ids=["target"])
+    )
+    champion = ClosedLoopReport(
+        success_rate=0.0,
+        mean_fraction=0.45,
+        per_task={
+            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.0),
+            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.9),
+        },
+    )
+    child = ClosedLoopReport(
+        success_rate=0.0,
+        mean_fraction=0.25,
+        per_task={
+            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.5),
+            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.0),
+        },
+    )
+
+    verdict = create_module.gate_delta(
+        delta,
+        child=child,
+        champion=champion,
+        best_full=0.0,
+        suite=[],
+    )
+
+    assert verdict.accepted is False
+    assert verdict.full_delta == 0.0
+    assert verdict.full_fraction_delta == pytest.approx(-0.2)
+    assert "full-split assertion fraction regressed" in verdict.reason
+
+
+def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() -> None:
+    delta = HarnessDelta.model_construct(
+        trigger=FailureSignature(mechanism="target", task_ids=["target"])
+    )
+    champion = ClosedLoopReport(
+        success_rate=0.0,
+        mean_fraction=0.1,
+        per_task={
+            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.0),
+            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.2),
+        },
+    )
+    child = ClosedLoopReport(
+        success_rate=0.0,
+        mean_fraction=0.35,
+        per_task={
+            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.5),
+            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.2),
+        },
+    )
+
+    verdict = create_module.gate_delta(
+        delta,
+        child=child,
+        champion=champion,
+        best_full=0.0,
+        suite=[],
+    )
+
+    assert verdict.accepted is True
+    assert verdict.full_fraction_delta == pytest.approx(0.25)
+
+
+def test_search_records_screen_and_full_trace_feedback_for_project_proposers() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+
+    class RecordingProposer(ProviderDeltaProposer):
+        def __init__(self, wrapped: Provider) -> None:
+            super().__init__(wrapped)
+            self.evaluations: list[tuple[str, str]] = []
+
+        def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
+            del delta
+            self.evaluations.append((stage, content))
+
+    proposer = RecordingProposer(provider)
+    create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        proposer,
+        GoldJudge(provider),
+        iterations=1,
+        k=1,
+    )
+
+    assert [stage for stage, _content in proposer.evaluations] == ["screen", "full"]
+    assert all("Execution transcript" in content for _stage, content in proposer.evaluations)
+    assert all("Judge feedback" in content for _stage, content in proposer.evaluations)
+
+
+def test_feedback_persistence_failure_does_not_abort_scored_search() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+    notes: list[str] = []
+
+    class BrokenFeedbackProposer(ProviderDeltaProposer):
+        def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
+            del delta, stage, content
+            raise RuntimeError("project filesystem disconnected")
+
+    result = create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        BrokenFeedbackProposer(provider),
+        GoldJudge(provider),
+        iterations=1,
+        k=1,
+        on_note=notes.append,
+    )
+
+    assert result.best_score == 1.0
+    assert len(result.iteration_records) == 1
+    assert any("screen feedback could not be persisted" in note for note in notes)
+    assert any("full feedback could not be persisted" in note for note in notes)
+
+
+def test_feedback_persistence_preserves_explicit_cancellation() -> None:
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+
+    class CancellingFeedbackProposer(ProviderDeltaProposer):
+        def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
+            del delta, stage, content
+            raise HarnessSearchCancelled("harness search cancelled")
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        create_harness(
+            "winner",
+            seed,
+            _tasks(),
+            _wm(provider),
+            provider,
+            CancellingFeedbackProposer(provider),
+            GoldJudge(provider),
+            iterations=1,
+            k=1,
+        )
 
 
 def test_rejected_history_reaches_the_next_proposal() -> None:
@@ -604,6 +902,14 @@ def test_narrow_failing_tiers_eligibility() -> None:
     # Both tiers narrowly failing -> both retried.
     both = record(full_delta=0.05, suite_delta=-0.05, holdout_delta=-0.1)
     assert narrow_failing_tiers(both, k=5, n_suite=8, n_holdout=4) == ["suite", "holdout"]
+    # Confirmation of one binary veto cannot erase a separate dense-signal veto.
+    dense_veto = record(
+        full_delta=0.05,
+        suite_delta=-0.05,
+        holdout_delta=0.0,
+        holdout_fraction_delta=-0.2,
+    )
+    assert narrow_failing_tiers(dense_veto, k=5, n_suite=8, n_holdout=4) is None
     # Accepted verdicts are never retried.
     ok = GateRecord(accepted=True, reason="r", full_delta=0.05)
     assert narrow_failing_tiers(ok, k=5, n_suite=4, n_holdout=4) is None

--- a/wmh/harness/delta.py
+++ b/wmh/harness/delta.py
@@ -28,6 +28,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from wmh.core.text import validate_durable_text
 from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 
 
@@ -42,6 +43,15 @@ class FailureSignature(BaseModel):
     mechanism: str  # e.g. the shared unmet assertion, or "none: all tasks pass"
     task_ids: list[str] = Field(default_factory=list)  # the failing tasks exhibiting it
     unmet_assertions: list[str] = Field(default_factory=list)  # deduped, order-stable
+
+    @model_validator(mode="after")
+    def _validate_text(self) -> FailureSignature:
+        validate_durable_text(self.mechanism, field="failure mechanism")
+        for task_id in self.task_ids:
+            validate_durable_text(task_id, field="failure task id")
+        for assertion in self.unmet_assertions:
+            validate_durable_text(assertion, field="failure assertion")
+        return self
 
 
 class SurfaceOp(BaseModel):
@@ -60,6 +70,9 @@ class SurfaceOp(BaseModel):
 
     @model_validator(mode="after")
     def _validate_shape(self) -> SurfaceOp:
+        if self.content is not None:
+            validate_durable_text(self.content, field=f"{self.surface_id!r} operation content")
+        validate_durable_text(self.rationale, field=f"{self.surface_id!r} operation rationale")
         if self.op == "add" and self.kind is None:
             raise ValueError(f"add of {self.surface_id!r} must declare a kind")
         if self.op in ("add", "replace") and self.content is None:
@@ -77,10 +90,18 @@ class GateRecord(BaseModel):
     """The acceptance verdict, filled at evaluation time and persisted on the delta."""
 
     suite_delta: float = 0.0  # regression suite: child - champion (tier 1; >= 0 to pass)
+    suite_fraction_delta: float = 0.0  # assertion credit; vetoes only when suite success ties
     full_delta: float = 0.0  # full split: child - best seen (tier 2; >= 0 to pass)
+    full_fraction_delta: float = 0.0  # assertion credit; vetoes only when full success ties
     holdout_delta: float | None = None  # held-out split (tier 3; None when no holdout given)
+    holdout_fraction_delta: float | None = None  # dense held-out signal when success ties
     accepted: bool
     reason: str  # accept/reject reasoning, incl. whether `expected_effect` came true
+
+    @model_validator(mode="after")
+    def _validate_text(self) -> GateRecord:
+        validate_durable_text(self.reason, field="gate reason")
+        return self
 
 
 class HarnessDelta(BaseModel):
@@ -101,6 +122,11 @@ class HarnessDelta(BaseModel):
     expected_effect: str  # falsifiable: e.g. "the trigger cluster's tasks flip to pass"
     child_doc_hash: str | None = None  # set by apply_delta
     verdict: GateRecord | None = None  # set by the gate; None until evaluated
+
+    @model_validator(mode="after")
+    def _validate_text(self) -> HarnessDelta:
+        validate_durable_text(self.expected_effect, field="delta expected effect")
+        return self
 
 
 def compute_delta_id(parent_doc_hash: str, ops: list[SurfaceOp]) -> str:

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -234,6 +235,7 @@ class HarnessDoc(BaseModel):
         backend: str = "local",
         e2b_template: str | None = None,
         e2b_pool: E2BSandboxPool | None = None,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> Runtime:
         """The configured agent runtime this document describes.
 
@@ -275,6 +277,8 @@ class HarnessDoc(BaseModel):
                     system_prompt=self.assembled_prompt(skills),
                     template=e2b_template,
                     pool=e2b_pool,
+                    max_turns=self.max_turns(),
+                    should_cancel=should_cancel,
                 )
             # PI_TRANSPORT=link routes pi to the RunnerLink frame transport (a persistent runner the
             # host set via runner_link.set_active_channel) instead of the per-episode SSH shim; the
@@ -298,6 +302,8 @@ class HarnessDoc(BaseModel):
                     provider=structured_provider,
                     system_prompt=self.assembled_prompt(skills),
                     files=code_files,
+                    max_turns=self.max_turns(),
+                    should_cancel=should_cancel,
                 )
             from wmh.harness.pi_runtime import PiRuntime  # circular: pi_runtime imports doc
 
@@ -308,6 +314,7 @@ class HarnessDoc(BaseModel):
                 temperature=self.temperature(),
                 skills=skills,
                 system_prompt=self.assembled_prompt(skills),
+                max_turns=self.max_turns(),
             )
         if backend == "e2b":
             raise ValueError(

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -272,7 +272,7 @@ class HarnessDoc(BaseModel):
                     provider=structured_provider,
                     files=code_files,
                     tools=resolve_tools(self.tools()),
-                    system_prompt=self._assembled_prompt(skills),
+                    system_prompt=self.assembled_prompt(skills),
                     template=e2b_template,
                     pool=e2b_pool,
                 )
@@ -296,7 +296,7 @@ class HarnessDoc(BaseModel):
                     channel,
                     tools=resolve_tools(self.tools()),
                     provider=structured_provider,
-                    system_prompt=self._assembled_prompt(skills),
+                    system_prompt=self.assembled_prompt(skills),
                     files=code_files,
                 )
             from wmh.harness.pi_runtime import PiRuntime  # circular: pi_runtime imports doc
@@ -307,7 +307,7 @@ class HarnessDoc(BaseModel):
                 tools=resolve_tools(self.tools()),
                 temperature=self.temperature(),
                 skills=skills,
-                system_prompt=self._assembled_prompt(skills),
+                system_prompt=self.assembled_prompt(skills),
             )
         if backend == "e2b":
             raise ValueError(
@@ -324,7 +324,7 @@ class HarnessDoc(BaseModel):
                 tools=resolve_tools(self.tools()),
                 temperature=self.temperature(),
                 skills=skills,
-                system_prompt=self._assembled_prompt(skills),
+                system_prompt=self.assembled_prompt(skills),
             )
         return AgentRuntime(
             provider,
@@ -335,10 +335,11 @@ class HarnessDoc(BaseModel):
             skills=skills,
         )
 
-    def _assembled_prompt(self, skills: SkillLibrary) -> str:
-        """The full system prompt handed to harness code: sections + tools + skills index."""
+    def assembled_prompt(self, skills: SkillLibrary | None = None) -> str:
+        """Return the system prompt shared by episode and project session runtimes."""
+        resolved_skills = skills if skills is not None else SkillLibrary(self.skills())
         prompt = f"{self.system_prompt()}\n\n## Tools\n{render_tools(resolve_tools(self.tools()))}"
-        index = skills.render_index()
+        index = resolved_skills.render_index()
         if index:
             prompt += f"\n\n## Your skills (read a body with read_skill)\n{index}"
         return prompt

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -37,7 +37,13 @@ from wmh.harness.code_runtime import (
     CodeRuntime,
     compile_harness_code,
 )
-from wmh.harness.runtime import DEFAULT_MAX_TURNS, DEFAULT_SYSTEM_PROMPT, AgentRuntime, Runtime
+from wmh.harness.runtime import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_MAX_TURNS,
+    DEFAULT_SYSTEM_PROMPT,
+    AgentRuntime,
+    Runtime,
+)
 from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import DEFAULT_TOOLS, render_tools, resolve_tools
 from wmh.providers.base import Provider, ToolCallingProvider
@@ -49,10 +55,11 @@ if TYPE_CHECKING:
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
-# Well-known surface ids. Only TOOL_POLICY and the two params are singletons; prompt and skill
+# Well-known surface ids. The tool policy and scalar parameters are singletons; prompt and skill
 # surfaces may be added freely (an update can split `prompt:core` into finer sections).
 TOOL_POLICY_ID = "tool_policy:main"
 MAX_TURNS_ID = "param:max-turns"
+MAX_OUTPUT_TOKENS_ID = "param:max-output-tokens"
 TEMPERATURE_ID = "param:temperature"
 RUNTIME_KIND_ID = "param:runtime-kind"  # absent/"kit-python" -> in-process; "pi-node" -> PiRuntime
 CODE_RUNTIME_ID = "code:runtime"
@@ -135,6 +142,7 @@ class HarnessDoc(BaseModel):
         # These validations construct the derived values; failures surface here, at the boundary.
         self.tools()
         self.max_turns()
+        self.max_output_tokens()
         self.temperature()
         for surface in self.surfaces:
             if surface.kind is SurfaceKind.SKILL:
@@ -201,6 +209,21 @@ class HarnessDoc(BaseModel):
             raise ValueError(f"{MAX_TURNS_ID} must be an integer, got {raw.content!r}") from exc
         if value < 1:
             raise ValueError(f"{MAX_TURNS_ID} must be >= 1, got {value}")
+        return value
+
+    def max_output_tokens(self) -> int:
+        """Return the per-model-call output cap carried by every pi execution mode."""
+        raw = self.surface(MAX_OUTPUT_TOKENS_ID)
+        if raw is None:
+            return DEFAULT_MAX_OUTPUT_TOKENS
+        try:
+            value = int(raw.content.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"{MAX_OUTPUT_TOKENS_ID} must be an integer, got {raw.content!r}"
+            ) from exc
+        if value < 1:
+            raise ValueError(f"{MAX_OUTPUT_TOKENS_ID} must be >= 1, got {value}")
         return value
 
     def temperature(self) -> float:
@@ -278,6 +301,7 @@ class HarnessDoc(BaseModel):
                     template=e2b_template,
                     pool=e2b_pool,
                     max_turns=self.max_turns(),
+                    max_output_tokens=self.max_output_tokens(),
                     should_cancel=should_cancel,
                 )
             # PI_TRANSPORT=link routes pi to the RunnerLink frame transport (a persistent runner the
@@ -303,6 +327,7 @@ class HarnessDoc(BaseModel):
                     system_prompt=self.assembled_prompt(skills),
                     files=code_files,
                     max_turns=self.max_turns(),
+                    max_output_tokens=self.max_output_tokens(),
                     should_cancel=should_cancel,
                 )
             from wmh.harness.pi_runtime import PiRuntime  # circular: pi_runtime imports doc
@@ -315,6 +340,7 @@ class HarnessDoc(BaseModel):
                 skills=skills,
                 system_prompt=self.assembled_prompt(skills),
                 max_turns=self.max_turns(),
+                max_output_tokens=self.max_output_tokens(),
             )
         if backend == "e2b":
             raise ValueError(

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from wmh.core.text import validate_durable_text
 from wmh.harness.code_runtime import (
     DEFAULT_RUNTIME_CODE,
     CodeRuntime,
@@ -45,7 +46,7 @@ from wmh.harness.runtime import (
     Runtime,
 )
 from wmh.harness.skills import Skill, SkillLibrary
-from wmh.harness.tools import DEFAULT_TOOLS, render_tools, resolve_tools
+from wmh.harness.tools import DEFAULT_TOOLS, READ_SKILL, render_tools, resolve_tools
 from wmh.providers.base import Provider, ToolCallingProvider
 
 if TYPE_CHECKING:
@@ -93,6 +94,7 @@ class Surface(BaseModel):
 
     @model_validator(mode="after")
     def _validate(self) -> Surface:
+        validate_durable_text(self.content, field=f"surface {self.id!r} content")
         prefix, sep, slug = self.id.partition(":")
         if not sep or prefix != self.kind.value or not _SLUG_RE.match(slug):
             raise ValueError(
@@ -280,6 +282,13 @@ class HarnessDoc(BaseModel):
         if self.runtime_kind() == "pi-node":
             skills = SkillLibrary(self.skills())
             code_files = {s.path: s.content for s in self.code_files() if s.path is not None}
+            tool_names = self.tools()
+            # Progressive disclosure is runtime plumbing, not a burden on every persisted tool
+            # policy. Keep pi-node behavior aligned with AgentRuntime: a skill-bearing document
+            # always exposes read_skill, even when the authored policy lists only env tools.
+            if len(skills) and READ_SKILL.name not in tool_names:
+                tool_names.append(READ_SKILL.name)
+            tools = resolve_tools(tool_names)
             structured_provider = provider if isinstance(provider, ToolCallingProvider) else None
             if (
                 backend == "e2b" or os.environ.get("PI_TRANSPORT") == "link"
@@ -296,8 +305,10 @@ class HarnessDoc(BaseModel):
                 return E2BPiRuntime(
                     provider=structured_provider,
                     files=code_files,
-                    tools=resolve_tools(self.tools()),
+                    tools=tools,
                     system_prompt=self.assembled_prompt(skills),
+                    temperature=self.temperature(),
+                    skills=skills,
                     template=e2b_template,
                     pool=e2b_pool,
                     max_turns=self.max_turns(),
@@ -322,10 +333,12 @@ class HarnessDoc(BaseModel):
                 assert structured_provider is not None
                 return RunnerLink(
                     channel,
-                    tools=resolve_tools(self.tools()),
+                    tools=tools,
                     provider=structured_provider,
                     system_prompt=self.assembled_prompt(skills),
                     files=code_files,
+                    temperature=self.temperature(),
+                    skills=skills,
                     max_turns=self.max_turns(),
                     max_output_tokens=self.max_output_tokens(),
                     should_cancel=should_cancel,
@@ -335,7 +348,7 @@ class HarnessDoc(BaseModel):
             return PiRuntime(
                 provider,
                 files=code_files,
-                tools=resolve_tools(self.tools()),
+                tools=tools,
                 temperature=self.temperature(),
                 skills=skills,
                 system_prompt=self.assembled_prompt(skills),
@@ -371,7 +384,10 @@ class HarnessDoc(BaseModel):
     def assembled_prompt(self, skills: SkillLibrary | None = None) -> str:
         """Return the system prompt shared by episode and project session runtimes."""
         resolved_skills = skills if skills is not None else SkillLibrary(self.skills())
-        prompt = f"{self.system_prompt()}\n\n## Tools\n{render_tools(resolve_tools(self.tools()))}"
+        tool_names = self.tools()
+        if len(resolved_skills) and READ_SKILL.name not in tool_names:
+            tool_names.append(READ_SKILL.name)
+        prompt = f"{self.system_prompt()}\n\n## Tools\n{render_tools(resolve_tools(tool_names))}"
         index = resolved_skills.render_index()
         if index:
             prompt += f"\n\n## Your skills (read a body with read_skill)\n{index}"

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -160,6 +160,7 @@ def _pi_doc() -> HarnessDoc:
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
         ],
     )
@@ -216,6 +217,7 @@ def test_runtime_e2b_backend_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     shared = _pi_doc().runtime(provider, backend="e2b", e2b_pool=shared_pool)
     assert isinstance(shared, E2BPiRuntime)
     assert shared._pool is shared_pool  # noqa: SLF001 - pins the pool passthrough
+    assert shared._max_turns == 7  # noqa: SLF001 - document parameter reaches the runner
 
 
 def test_runtime_e2b_backend_rejects_in_process_runtime_kinds() -> None:

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from wmh.harness.doc import (
+    MAX_OUTPUT_TOKENS_ID,
     MAX_TURNS_ID,
     TEMPERATURE_ID,
     TOOL_POLICY_ID,
@@ -24,6 +25,7 @@ def _skill_surface(name: str = "count-words") -> Surface:
 def test_baseline_is_valid_and_derives_defaults() -> None:
     doc = HarnessDoc.baseline("base")
     assert doc.max_turns() == 20
+    assert doc.max_output_tokens() == 4096
     assert doc.temperature() == 0.7
     assert "submit" in doc.tools()
     assert doc.system_prompt()  # non-empty
@@ -76,6 +78,12 @@ def test_invalid_derived_values_fail_at_construction() -> None:
     bad_turns = Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="zero")
     with pytest.raises(ValidationError, match="integer"):
         HarnessDoc(name="x", surfaces=[core, bad_turns])
+    bad_output = Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="many")
+    with pytest.raises(ValidationError, match="integer"):
+        HarnessDoc(name="x", surfaces=[core, bad_output])
+    zero_output = Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="0")
+    with pytest.raises(ValidationError, match=">= 1"):
+        HarnessDoc(name="x", surfaces=[core, zero_output])
     bad_temp = Surface(id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content="9.5")
     with pytest.raises(ValidationError, match=r"\[0, 2\]"):
         HarnessDoc(name="x", surfaces=[core, bad_temp])
@@ -161,6 +169,7 @@ def _pi_doc() -> HarnessDoc:
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
             Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
         ],
     )
@@ -218,6 +227,7 @@ def test_runtime_e2b_backend_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(shared, E2BPiRuntime)
     assert shared._pool is shared_pool  # noqa: SLF001 - pins the pool passthrough
     assert shared._max_turns == 7  # noqa: SLF001 - document parameter reaches the runner
+    assert shared._max_output_tokens == 16384  # noqa: SLF001 - same agent model contract
 
 
 def test_runtime_e2b_backend_rejects_in_process_runtime_kinds() -> None:

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -47,6 +47,14 @@ def test_budget_is_enforced_at_construction() -> None:
         Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="x" * 11, budget=10)
 
 
+@pytest.mark.parametrize("content", ["before\x00after", "before\ud800after"])
+def test_surface_rejects_text_that_cannot_roundtrip_through_durable_storage(
+    content: str,
+) -> None:
+    with pytest.raises(ValidationError, match="NUL|surrogate"):
+        Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content=content)
+
+
 def test_doc_hash_is_content_and_order_independent() -> None:
     a = Surface(id="prompt:a", kind=SurfaceKind.PROMPT, content="A")
     b = Surface(id="prompt:b", kind=SurfaceKind.PROMPT, content="B")
@@ -114,6 +122,9 @@ def test_runtime_reflects_document() -> None:
     skills = doc.skills()
     assert [s.name for s in skills] == ["count-words"]
     assert doc.surface_hashes()["skill:count-words"]
+    assembled = doc.assembled_prompt()
+    assert "read_skill:" in assembled
+    assert "wc -w <path>" not in assembled  # bodies remain progressive-disclosure only
 
 
 def test_json_roundtrip_preserves_identity() -> None:
@@ -228,6 +239,36 @@ def test_runtime_e2b_backend_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     assert shared._pool is shared_pool  # noqa: SLF001 - pins the pool passthrough
     assert shared._max_turns == 7  # noqa: SLF001 - document parameter reaches the runner
     assert shared._max_output_tokens == 16384  # noqa: SLF001 - same agent model contract
+
+
+def test_pi_e2b_runtime_inherits_temperature_and_skill_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from wmh.harness.pi_e2b import E2BPiRuntime, E2BSandboxPool
+
+    base = _pi_doc()
+    doc = HarnessDoc(
+        name="pi-with-skill",
+        surfaces=[
+            *base.surfaces,
+            Surface(id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content="0.35"),
+            _skill_surface(),
+        ],
+    )
+    monkeypatch.delenv("WMH_E2B_TEMPLATE", raising=False)
+    pool = E2BSandboxPool()
+    runtime = doc.runtime(_stub_provider(), backend="e2b", e2b_pool=pool)
+
+    assert isinstance(runtime, E2BPiRuntime)
+    assert runtime._temperature == 0.35  # noqa: SLF001 - doc parameter reaches worker boundary
+    assert runtime._skills.get("count-words") is not None  # noqa: SLF001 - body stays available
+    assert {tool.name for tool in runtime._tools} >= {  # noqa: SLF001 - implicit runtime tool
+        "bash",
+        "submit",
+        "read_skill",
+    }
+    assert "read_skill:" in runtime._system_prompt  # noqa: SLF001 - visible in pi's prompt
+    pool.close()
 
 
 def test_runtime_e2b_backend_rejects_in_process_runtime_kinds() -> None:

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -70,7 +70,7 @@ class CommandHandle(Protocol):
 
 
 class SandboxCommands(Protocol):
-    """The `sandbox.commands` slice: run (foreground or background) and stdin injection."""
+    """The `sandbox.commands` slice: run/connect commands and inject stdin."""
 
     def run(
         self,
@@ -80,6 +80,13 @@ class SandboxCommands(Protocol):
         stdin: bool | None = None,
         timeout: float | None = None,
     ) -> CommandOutput | CommandHandle: ...
+
+    def connect(
+        self,
+        pid: int,
+        *,
+        timeout: float | None = None,
+    ) -> CommandHandle: ...
 
     def send_stdin(self, pid: int, data: str) -> object: ...
 

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -40,6 +40,26 @@ DEFAULT_SANDBOX_TIMEOUT_S = 900.0
 
 # Fixed delays before each retry of sandbox creation (RetryingProvider precedent: 1s, 3s, 9s).
 _CREATE_DELAYS = (1.0, 3.0, 9.0)
+# Teardown is normally one cheap request. Two short deterministic retries cover a stale HTTP/2
+# connection without adding latency to the success path or hiding a sandbox whose release cannot
+# be proved.
+_KILL_DELAYS = (0.1, 0.5)
+_KILL_REQUEST_TIMEOUT_S = 5.0
+
+
+class SandboxCleanupError(RuntimeError):
+    """An E2B sandbox may still be live after bounded teardown retries."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        resource: str = "e2b_sandbox",
+        sandbox_usage: SandboxUsage | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.resource = resource
+        self.sandbox_usage = sandbox_usage
 
 
 @runtime_checkable
@@ -134,7 +154,7 @@ class SandboxHandle(Protocol):
 
     def set_timeout(self, timeout: int) -> None: ...
 
-    def kill(self) -> object: ...
+    def kill(self, request_timeout: float | None = None) -> object: ...
 
 
 # Opens one sandbox. The default factory calls the real SDK; tests inject fakes.
@@ -192,6 +212,34 @@ def create_sandbox(factory: SandboxFactory) -> SandboxHandle:
     return factory()  # final attempt: let any error propagate
 
 
+def kill_sandbox(sandbox: SandboxHandle) -> None:
+    """Kill one sandbox with bounded retries, failing closed when release is unproven.
+
+    A successful call, a falsey SDK result, or an explicit already-gone response all mean there
+    is no live resource left to meter. Other exceptions are retried twice; exhausting that bound
+    raises :class:`SandboxCleanupError` so callers cannot report clean cancellation while the
+    sandbox may still be billable.
+    """
+    for delay in _KILL_DELAYS:
+        try:
+            sandbox.kill(request_timeout=_KILL_REQUEST_TIMEOUT_S)
+            return
+        except Exception as error:  # noqa: BLE001 - E2B SDK errors are optional/import-free here
+            if _is_already_gone_error(error):
+                return
+            time.sleep(delay)
+    try:
+        sandbox.kill(request_timeout=_KILL_REQUEST_TIMEOUT_S)
+    except Exception as error:  # noqa: BLE001 - promote the bounded cleanup failure uniformly
+        if _is_already_gone_error(error):
+            return
+        sandbox_id = getattr(sandbox, "sandbox_id", None) or getattr(sandbox, "id", None)
+        identity = f" {sandbox_id!r}" if sandbox_id is not None else ""
+        raise SandboxCleanupError(
+            f"E2B sandbox{identity} cleanup failed after {len(_KILL_DELAYS) + 1} attempts: {error}"
+        ) from error
+
+
 def _is_retryable_create_error(exc: Exception) -> bool:
     """True for capacity-shaped creation failures (rate limit / no capacity / 5xx).
 
@@ -204,3 +252,19 @@ def _is_retryable_create_error(exc: Exception) -> bool:
     if "rate limit" in text or "capacity" in text or "too many requests" in text:
         return True
     return any(code in text for code in ("429", "500", "502", "503", "504"))
+
+
+def _is_already_gone_error(exc: Exception) -> bool:
+    """Whether a failed kill explicitly proves the sandbox no longer exists."""
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "sandbox not found",
+            "sandbox is not found",
+            "sandbox already killed",
+            "sandbox has been killed",
+            "sandbox already closed",
+            "sandbox has expired",
+        )
+    )

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from typing import Protocol, cast, runtime_checkable
 
 from pydantic import BaseModel
@@ -77,6 +77,7 @@ class SandboxCommands(Protocol):
         cmd: str,
         background: bool | None = None,
         *,
+        envs: dict[str, str] | None = None,
         stdin: bool | None = None,
         timeout: float | None = None,
     ) -> CommandOutput | CommandHandle: ...
@@ -88,7 +89,23 @@ class SandboxCommands(Protocol):
         timeout: float | None = None,
     ) -> CommandHandle: ...
 
-    def send_stdin(self, pid: int, data: str) -> object: ...
+    def send_stdin(
+        self,
+        pid: int,
+        data: str,
+        request_timeout: float | None = None,
+    ) -> object: ...
+
+    def list(self, request_timeout: float | None = None) -> Sequence[SandboxProcess]: ...
+
+    def kill(self, pid: int, request_timeout: float | None = None) -> object: ...
+
+
+class SandboxProcess(Protocol):
+    """The running-process field used to classify a durable runner stream EOF."""
+
+    @property
+    def pid(self) -> int: ...
 
 
 class SandboxFiles(Protocol):
@@ -96,7 +113,13 @@ class SandboxFiles(Protocol):
 
     def write(self, path: str, data: str) -> object: ...
 
-    def read(self, path: str) -> str: ...
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str: ...
 
 
 @runtime_checkable

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -189,7 +189,7 @@ def test_default_factory_passes_metadata_to_the_lazy_e2b_sdk(
             return fake
 
     e2b = ModuleType("e2b")
-    e2b.Sandbox = _SandboxSdk  # type: ignore[attr-defined]
+    e2b.__dict__["Sandbox"] = _SandboxSdk
     monkeypatch.setitem(sys.modules, "e2b", e2b)
     metadata = {"kind": "optimizer-evaluator", "run_id": "run-1"}
 

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -7,11 +7,17 @@ locally-defined `RateLimitException` stands in for e2b's, and a plain fake satis
 
 from __future__ import annotations
 
+import sys
 import time
+from types import ModuleType
 
 import pytest
 
-from wmh.harness.e2b_sandbox import SandboxHandle, create_sandbox
+from wmh.harness.e2b_sandbox import (
+    SandboxHandle,
+    create_sandbox,
+    default_sandbox_factory,
+)
 
 
 class RateLimitException(Exception):
@@ -168,6 +174,41 @@ def test_create_sandbox_does_not_retry_non_capacity_errors(
         create_sandbox(factory)
     assert len(attempts) == 1  # auth/template/config errors fail immediately
     assert sleeps == []
+
+
+def test_default_factory_passes_metadata_to_the_lazy_e2b_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeSandbox()
+    calls: list[dict[str, object]] = []
+
+    class _SandboxSdk:
+        @staticmethod
+        def create(**kwargs: object) -> FakeSandbox:
+            calls.append(kwargs)
+            return fake
+
+    e2b = ModuleType("e2b")
+    e2b.Sandbox = _SandboxSdk  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "e2b", e2b)
+    metadata = {"kind": "optimizer-evaluator", "run_id": "run-1"}
+
+    factory = default_sandbox_factory(
+        api_key="key",
+        template="tmpl",
+        timeout=61.9,
+        metadata=metadata,
+    )
+
+    assert factory() is fake
+    assert calls == [
+        {
+            "template": "tmpl",
+            "timeout": 61,
+            "api_key": "key",
+            "metadata": metadata,
+        }
+    ]
 
 
 def test_fake_sandbox_satisfies_the_sandbox_handle_protocol() -> None:

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -38,7 +38,8 @@ class _FakeCommands:
     ) -> _Result:
         return _Result()
 
-    def send_stdin(self, pid: int, data: str) -> None:
+    def send_stdin(self, pid: int, data: str, request_timeout: float | None = None) -> None:
+        del pid, data, request_timeout
         return None
 
 
@@ -49,7 +50,14 @@ class _FakeFiles:
     def write(self, path: str, data: str) -> None:
         self.store[path] = data
 
-    def read(self, path: str) -> str:
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        del request_timeout, gzip
         return self.store[path]
 
 

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -14,9 +14,11 @@ from types import ModuleType
 import pytest
 
 from wmh.harness.e2b_sandbox import (
+    SandboxCleanupError,
     SandboxHandle,
     create_sandbox,
     default_sandbox_factory,
+    kill_sandbox,
 )
 
 
@@ -82,7 +84,8 @@ class FakeSandbox:
             raise RuntimeError("sandbox not found")
         self.timeouts.append(timeout)
 
-    def kill(self) -> bool:
+    def kill(self, request_timeout: float | None = None) -> bool:
+        del request_timeout
         self.kills += 1
         return True
 
@@ -173,6 +176,74 @@ def test_create_sandbox_does_not_retry_non_capacity_errors(
     with pytest.raises(ValueError, match="template does not exist"):
         create_sandbox(factory)
     assert len(attempts) == 1  # auth/template/config errors fail immediately
+    assert sleeps == []
+
+
+def test_kill_sandbox_retries_transient_errors_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    fake = FakeSandbox()
+    attempts = 0
+
+    request_timeouts: list[float | None] = []
+
+    def flaky_kill(request_timeout: float | None = None) -> bool:
+        nonlocal attempts
+        attempts += 1
+        request_timeouts.append(request_timeout)
+        if attempts < 3:
+            raise RuntimeError("connection closed")
+        return True
+
+    monkeypatch.setattr(fake, "kill", flaky_kill)
+
+    kill_sandbox(fake)
+
+    assert attempts == 3
+    assert sleeps == [0.1, 0.5]
+    assert request_timeouts == [5.0, 5.0, 5.0]
+
+
+def test_kill_sandbox_fails_closed_after_bounded_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    fake = FakeSandbox()
+    attempts = 0
+
+    def broken_kill(request_timeout: float | None = None) -> bool:
+        nonlocal attempts
+        del request_timeout
+        attempts += 1
+        raise RuntimeError("control plane unavailable")
+
+    monkeypatch.setattr(fake, "kill", broken_kill)
+
+    with pytest.raises(SandboxCleanupError, match="cleanup failed after 3 attempts"):
+        kill_sandbox(fake)
+
+    assert attempts == 3
+    assert sleeps == [0.1, 0.5]
+
+
+def test_kill_sandbox_accepts_explicit_already_gone_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    fake = FakeSandbox()
+
+    def gone(request_timeout: float | None = None) -> bool:
+        del request_timeout
+        raise RuntimeError("sandbox not found")
+
+    monkeypatch.setattr(fake, "kill", gone)
+
+    kill_sandbox(fake)
+
     assert sleeps == []
 
 

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -237,6 +237,16 @@ class LiveSession:
         """Queue an interrupt: abort the current run (does not end the session)."""
         self._inbox.put(_Interrupt(reason=reason))
 
+    def flush_pending_intents(self) -> None:
+        """Send queued controls without consuming another runner frame.
+
+        The driver uses this when it must abort and retire a session immediately. Calling
+        :meth:`pump` would also read one inbound frame, which could start another synchronous
+        provider or tool operation after cancellation was already observed.
+        """
+        if not self._closed:
+            self._drain_inbox()
+
     def end(self) -> None:
         """Queue a graceful end: abort any run, then shut the runner down."""
         self._inbox.put(_End())

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -23,7 +23,7 @@ New session frames (additive to the RunnerLink vocabulary; unknown types are ign
 sides, so eval episodes are unaffected):
 
   host -> runner
-    session_start {session_id, system, tools, files, turn_cap, max_output_tokens}
+    session_start {session_id, system, tools, files, turn_cap, max_output_tokens, temperature}
     user_message  {msg_id, text}
     abort         {reason}
     ping          {nonce}
@@ -51,7 +51,7 @@ from pydantic import JsonValue
 from wmh.core.types import JsonObject
 from wmh.harness.runner_link import Channel, TokenUsage, WorkerFn, params_schema
 from wmh.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS
-from wmh.harness.tools import SUBMIT, ToolSpec
+from wmh.harness.tools import READ_SKILL, SUBMIT, ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
 # The action budget a single user turn may spend before the runner is told to stop — the live
@@ -152,6 +152,7 @@ class LiveSession:
         actions_per_turn: int = DEFAULT_ACTIONS_PER_TURN,
         turn_cap: int = DEFAULT_TURN_CAP,
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
+        temperature: float = 0.7,
     ) -> None:
         self._channel = channel
         self._tools = list(tools)
@@ -160,6 +161,8 @@ class LiveSession:
         self._files = dict(files or {})
         self._system_prompt = system_prompt
         self._skill_bodies = dict(skill_bodies or {})
+        if self._skill_bodies and READ_SKILL.name not in {tool.name for tool in self._tools}:
+            self._tools.append(READ_SKILL)
         # The worker LLM is answered host-side by a fully-configured provider's
         # `complete_chat` (Bedrock or Azure — provider-agnostic per #142), or an
         # injected `worker_fn` (tests). Left unset, an `llm_request` is answered
@@ -174,7 +177,10 @@ class LiveSession:
         self._turn_cap = turn_cap
         if max_output_tokens < 1:
             raise ValueError("max_output_tokens must be >= 1")
+        if not 0.0 <= temperature <= 2.0:
+            raise ValueError("temperature must be in [0, 2]")
         self._max_output_tokens = max_output_tokens
+        self._temperature = temperature
 
         self._inbox: queue.Queue[_Intent] = queue.Queue()
         self._session_id = uuid.uuid4().hex
@@ -213,6 +219,7 @@ class LiveSession:
                 "files": self._files,
                 "turn_cap": self._turn_cap,
                 "max_output_tokens": self._max_output_tokens,
+                "temperature": self._temperature,
             }
         )
         # The runner sends `state:idle` once the agent is constructed and ready for the first
@@ -339,7 +346,9 @@ class LiveSession:
             )
             return
         try:
-            request = ChatRequest.model_validate(body if isinstance(body, dict) else {})
+            request_body = dict(body) if isinstance(body, dict) else {}
+            request_body["temperature"] = self._temperature
+            request = ChatRequest.model_validate(request_body)
             completion = self._worker_fn(request)
             self._meter(completion)
             self._emit_assistant(completion)
@@ -377,12 +386,12 @@ class LiveSession:
 
         self._emit("tool_call", {"call_id": call_id, "name": name, "arguments": args})
         known = {t.name for t in self._tools}
-        if name == "read_skill":
+        if name not in known:
+            outcome = ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+        elif name == READ_SKILL.name:
             outcome = self._read_skill(args)
         elif self._actions_this_turn >= self._actions_per_turn:
             outcome = ToolOutcome(content="environment action budget exhausted", is_error=True)
-        elif name not in known:
-            outcome = ToolOutcome(content=f"tool {name!r} not available", is_error=True)
         else:
             self._actions_this_turn += 1
 
@@ -408,10 +417,11 @@ class LiveSession:
         self._respond_tool(req_id, outcome.content, is_error=outcome.is_error)
 
     def _read_skill(self, args: JsonObject) -> ToolOutcome:
-        name = args.get("name")
-        body = self._skill_bodies.get(name) if isinstance(name, str) else None
+        raw_name = args.get("name")
+        name = raw_name if isinstance(raw_name, str) else ""
+        body = self._skill_bodies.get(name)
         if body is None:
-            return ToolOutcome(content=f"skill {name!r} not found", is_error=True)
+            return ToolOutcome(content=f"no skill named {name!r}", is_error=True)
         return ToolOutcome(content=body)
 
     def _respond_tool(self, req_id: JsonValue, content: str, *, is_error: bool) -> None:

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -175,6 +175,7 @@ class LiveSession:
         self._session_id = uuid.uuid4().hex
         self._status: str = "starting"
         self._closed = False
+        self._failure_message: str | None = None
         self._actions_this_turn = 0
         self._aborting = False
         self._pending_ping: str | None = None
@@ -190,6 +191,11 @@ class LiveSession:
     @property
     def closed(self) -> bool:
         return self._closed
+
+    @property
+    def failure_message(self) -> str | None:
+        """Return the runner or channel error that closed this session, when one exists."""
+        return self._failure_message
 
     def start(self, hello_timeout: float = 60.0) -> None:
         """Send `session_start` and block until the runner reports its first idle state."""
@@ -213,6 +219,10 @@ class LiveSession:
             if self._handle_frame(frame):
                 if self._status in ("idle", "running"):
                     return
+                if self._closed:
+                    break
+        if self._failure_message is not None:
+            raise RuntimeError(f"live session runner did not become ready: {self._failure_message}")
         raise RuntimeError("live session runner did not become ready")
 
     # -- driver-facing intents (thread-safe) -----------------------------------------------------
@@ -295,7 +305,8 @@ class LiveSession:
                 self._pending_ping = None
         elif kind == "episode_error":
             note = frame.get("note")
-            self._emit("error", {"message": note if isinstance(note, str) else "runner error"})
+            self._failure_message = note if isinstance(note, str) else "runner error"
+            self._emit("error", {"message": self._failure_message})
             self._mark_closed("failed")
         elif kind == "hello":
             pass  # the pool already consumed the handshake; a duplicate is harmless
@@ -443,7 +454,8 @@ class LiveSession:
             return None
         except Exception as exc:  # noqa: BLE001 - a dead runner ends the session, not the process
             if not self._closed:
-                self._emit("error", {"message": str(exc)})
+                self._failure_message = str(exc)
+                self._emit("error", {"message": self._failure_message})
                 self._mark_closed("failed")
             return None
         if frame is None and not self._closed:
@@ -456,7 +468,8 @@ class LiveSession:
         try:
             self._channel.send(frame)
         except Exception as exc:  # noqa: BLE001 - a broken channel ends the session cleanly
-            self._emit("error", {"message": f"channel send failed: {exc}"})
+            self._failure_message = f"channel send failed: {exc}"
+            self._emit("error", {"message": self._failure_message})
             self._mark_closed("failed")
 
     def _mark_closed(self, status: str) -> None:

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -23,7 +23,7 @@ New session frames (additive to the RunnerLink vocabulary; unknown types are ign
 sides, so eval episodes are unaffected):
 
   host -> runner
-    session_start {session_id, system, tools, files, turn_cap}
+    session_start {session_id, system, tools, files, turn_cap, max_output_tokens}
     user_message  {msg_id, text}
     abort         {reason}
     ping          {nonce}
@@ -50,6 +50,7 @@ from pydantic import JsonValue
 
 from wmh.core.types import JsonObject
 from wmh.harness.runner_link import Channel, TokenUsage, WorkerFn, params_schema
+from wmh.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS
 from wmh.harness.tools import SUBMIT, ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
@@ -150,6 +151,7 @@ class LiveSession:
         worker_fn: WorkerFn | None = None,
         actions_per_turn: int = DEFAULT_ACTIONS_PER_TURN,
         turn_cap: int = DEFAULT_TURN_CAP,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
     ) -> None:
         self._channel = channel
         self._tools = list(tools)
@@ -170,6 +172,9 @@ class LiveSession:
             self._worker_fn = None
         self._actions_per_turn = actions_per_turn
         self._turn_cap = turn_cap
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
+        self._max_output_tokens = max_output_tokens
 
         self._inbox: queue.Queue[_Intent] = queue.Queue()
         self._session_id = uuid.uuid4().hex
@@ -207,6 +212,7 @@ class LiveSession:
                 "tools": self._tool_specs(),
                 "files": self._files,
                 "turn_cap": self._turn_cap,
+                "max_output_tokens": self._max_output_tokens,
             }
         )
         # The runner sends `state:idle` once the agent is constructed and ready for the first

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -23,7 +23,8 @@ New session frames (additive to the RunnerLink vocabulary; unknown types are ign
 sides, so eval episodes are unaffected):
 
   host -> runner
-    session_start {session_id, system, tools, files, turn_cap, max_output_tokens, temperature}
+    session_start {session_id, system, tools, files, turn_cap, max_output_tokens, temperature,
+                   conversation_scope}
     user_message  {msg_id, text}
     abort         {reason}
     ping          {nonce}
@@ -76,6 +77,7 @@ EventKind = Literal[
     "state",
     "error",
 ]
+ConversationScope = Literal["session", "turn"]
 
 
 @dataclass(frozen=True)
@@ -153,6 +155,7 @@ class LiveSession:
         turn_cap: int = DEFAULT_TURN_CAP,
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         temperature: float = 0.7,
+        conversation_scope: ConversationScope = "session",
     ) -> None:
         self._channel = channel
         self._tools = list(tools)
@@ -179,8 +182,11 @@ class LiveSession:
             raise ValueError("max_output_tokens must be >= 1")
         if not 0.0 <= temperature <= 2.0:
             raise ValueError("temperature must be in [0, 2]")
+        if conversation_scope not in ("session", "turn"):
+            raise ValueError("conversation_scope must be 'session' or 'turn'")
         self._max_output_tokens = max_output_tokens
         self._temperature = temperature
+        self._conversation_scope = conversation_scope
 
         self._inbox: queue.Queue[_Intent] = queue.Queue()
         self._session_id = uuid.uuid4().hex
@@ -220,6 +226,7 @@ class LiveSession:
                 "turn_cap": self._turn_cap,
                 "max_output_tokens": self._max_output_tokens,
                 "temperature": self._temperature,
+                "conversation_scope": self._conversation_scope,
             }
         )
         # The runner sends `state:idle` once the agent is constructed and ready for the first

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -49,11 +49,18 @@ def _drain(session: LiveSession) -> None:
 
 def test_start_waits_for_first_idle_state() -> None:
     channel = ScriptedChannel([{"type": "state", "status": "idle"}])
-    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda e: None,
+        max_output_tokens=16384,
+    )
     session.start()
     assert session.status == "idle"
     assert channel.sent[0]["type"] == "session_start"
     assert channel.sent[0]["turn_cap"] == 60
+    assert channel.sent[0]["max_output_tokens"] == 16384
 
 
 def test_start_surfaces_the_runner_construction_error() -> None:

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import pytest
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import JsonObject
@@ -53,6 +54,16 @@ def test_start_waits_for_first_idle_state() -> None:
     assert session.status == "idle"
     assert channel.sent[0]["type"] == "session_start"
     assert channel.sent[0]["turn_cap"] == 60
+
+
+def test_start_surfaces_the_runner_construction_error() -> None:
+    channel = ScriptedChannel(
+        [{"type": "episode_error", "note": "could not import the agent harness"}]
+    )
+    session = LiveSession(channel, tools=[], execute_tool=_no_tool, on_event=lambda e: None)
+
+    with pytest.raises(RuntimeError, match="could not import the agent harness"):
+        session.start()
 
 
 def test_full_turn_emits_ordered_events_and_answers_frames() -> None:

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -55,12 +55,14 @@ def test_start_waits_for_first_idle_state() -> None:
         execute_tool=_no_tool,
         on_event=lambda e: None,
         max_output_tokens=16384,
+        temperature=0.35,
     )
     session.start()
     assert session.status == "idle"
     assert channel.sent[0]["type"] == "session_start"
     assert channel.sent[0]["turn_cap"] == 60
     assert channel.sent[0]["max_output_tokens"] == 16384
+    assert channel.sent[0]["temperature"] == 0.35
 
 
 def test_start_surfaces_the_runner_construction_error() -> None:
@@ -222,16 +224,52 @@ def test_read_skill_answered_from_bodies() -> None:
     )
     session = LiveSession(
         channel,
-        tools=[READ_SKILL],
+        tools=[],
         execute_tool=_no_tool,
         on_event=events.append,
         skill_bodies={"deploy": "run ./deploy.sh"},
     )
     session.start()
+    raw_tools = channel.sent[0]["tools"]
+    assert isinstance(raw_tools, list)
+    advertised = {tool["name"] for tool in raw_tools if isinstance(tool, dict) and "name" in tool}
+    assert READ_SKILL.name in advertised
     _drain(session)
     results = [e for e in events if e.kind == "tool_result"]
     assert results[0].payload["content"] == "run ./deploy.sh"
+    assert results[1].payload["content"] == "no skill named 'missing'"
     assert results[1].payload["is_error"] is True
+
+
+def test_harness_temperature_overrides_live_runner_request() -> None:
+    requests: list[ChatRequest] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "llm_request",
+                "req_id": 1,
+                "openai_body": {"messages": [], "temperature": 1.75},
+            },
+        ]
+    )
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        requests.append(request)
+        return _completion()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=worker,
+        temperature=0.35,
+    )
+    session.start()
+    _drain(session)
+
+    assert [request.temperature for request in requests] == [0.35]
 
 
 def test_worker_error_is_reported_not_raised() -> None:

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -63,6 +63,35 @@ def test_start_waits_for_first_idle_state() -> None:
     assert channel.sent[0]["turn_cap"] == 60
     assert channel.sent[0]["max_output_tokens"] == 16384
     assert channel.sent[0]["temperature"] == 0.35
+    assert channel.sent[0]["conversation_scope"] == "session"
+
+
+def test_start_can_scope_conversation_to_each_outer_turn() -> None:
+    channel = ScriptedChannel([{"type": "state", "status": "idle"}])
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda e: None,
+        conversation_scope="turn",
+    )
+
+    session.start()
+
+    assert channel.sent[0]["conversation_scope"] == "turn"
+
+
+def test_rejects_unknown_conversation_scope() -> None:
+    channel = ScriptedChannel([])
+
+    with pytest.raises(ValueError, match="conversation_scope"):
+        LiveSession(
+            channel,
+            tools=[],
+            execute_tool=_no_tool,
+            on_event=lambda e: None,
+            conversation_scope="message",  # ty: ignore[invalid-argument-type]
+        )
 
 
 def test_start_surfaces_the_runner_construction_error() -> None:

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -15,6 +15,8 @@ iteration; a flaky meta-model costs budget, not the run.
 
 from __future__ import annotations
 
+import json
+
 from pydantic import BaseModel, Field, ValidationError
 
 from wmh.core.parsing import extract_json_object
@@ -125,12 +127,25 @@ def propose_delta(
         temperature=0.9,
         max_tokens=16384,
     )
-    raw = extract_json_object(completion.text)
+    return parse_delta(parent, trigger, completion.text)
+
+
+def parse_delta(
+    parent: HarnessDoc,
+    trigger: FailureSignature,
+    text: str,
+) -> HarnessDelta | None:
+    """Parse one full-content or compact-edit proposal against ``parent``."""
+    raw = extract_json_object(text)
     if raw is None:
         return None
     try:
-        proposed = _RawDelta.model_validate_json(raw)
-    except ValidationError:
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            return None
+        value["ops"] = _expand_compact_ops(parent, value.get("ops"))
+        proposed = _RawDelta.model_validate(value)
+    except (TypeError, ValueError, ValidationError):
         return None
     return HarnessDelta(
         delta_id=compute_delta_id(parent.doc_hash, proposed.ops),
@@ -140,6 +155,44 @@ def propose_delta(
         ops=proposed.ops,
         expected_effect=proposed.expected_effect,
     )
+
+
+def _expand_compact_ops(parent: HarnessDoc, value: object) -> list[dict[str, object]]:
+    """Expand exact replacement hunks into ordinary full-content surface ops."""
+    if not isinstance(value, list):
+        raise ValueError("ops must be an array")
+    expanded: list[dict[str, object]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("each op must be an object")
+        op = dict(item)
+        edits = op.pop("edits", None)
+        if op.get("op") == "replace" and "content" not in op and edits is not None:
+            surface_id = op.get("surface_id")
+            if not isinstance(surface_id, str) or (surface := parent.surface(surface_id)) is None:
+                raise ValueError("compact replace targets an unknown surface")
+            op["content"] = _apply_edits(surface.content, edits)
+        elif edits is not None:
+            raise ValueError("edits are only valid on content-less replace ops")
+        expanded.append(op)
+    return expanded
+
+
+def _apply_edits(content: str, value: object) -> str:
+    """Apply ordered exact edits, rejecting missing or ambiguous anchors."""
+    if not isinstance(value, list) or not value:
+        raise ValueError("edits must be a non-empty array")
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("each edit must be an object")
+        old = item.get("old")
+        new = item.get("new")
+        if not isinstance(old, str) or not old or not isinstance(new, str):
+            raise ValueError("edits need non-empty old and string new values")
+        if content.count(old) != 1:
+            raise ValueError("edit old text must occur exactly once")
+        content = content.replace(old, new, 1)
+    return content
 
 
 def render_evidence(

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -20,12 +20,16 @@ import json
 from pydantic import BaseModel, Field, ValidationError
 
 from wmh.core.parsing import extract_json_object
-from wmh.evals.closed_loop import ClosedLoopReport
+from wmh.core.text import normalize_durable_text
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence
+from wmh.evals.gold import GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature, HarnessDelta, SurfaceOp, compute_delta_id
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 from wmh.providers.base import Message, Provider
+
+_TRACE_CHARS_PER_ATTEMPT = 12_000
 
 MUTATE_SYSTEM = f"""You are a meta-agent improving an agent harness — a document of named \
 SURFACES that configure an agent. You do NOT solve the agent's tasks yourself. You are shown the \
@@ -146,16 +150,16 @@ def parse_delta(
             return None
         value["ops"] = _expand_compact_ops(parent, value.get("ops"))
         proposed = _RawDelta.model_validate(value)
+        return HarnessDelta(
+            delta_id=compute_delta_id(parent.doc_hash, proposed.ops),
+            parent_doc_hash=parent.doc_hash,
+            trigger=trigger,
+            preconditions=proposed.preconditions,
+            ops=proposed.ops,
+            expected_effect=proposed.expected_effect,
+        )
     except (TypeError, ValueError, ValidationError):
         return None
-    return HarnessDelta(
-        delta_id=compute_delta_id(parent.doc_hash, proposed.ops),
-        parent_doc_hash=parent.doc_hash,
-        trigger=trigger,
-        preconditions=proposed.preconditions,
-        ops=proposed.ops,
-        expected_effect=proposed.expected_effect,
-    )
 
 
 def _expand_compact_ops(parent: HarnessDoc, value: object) -> list[dict[str, object]]:
@@ -213,16 +217,91 @@ def render_evidence(
             "distilled from what worked."
         )
     by_id = {task.task_id: task for task in tasks}
-    sections = [f"Failure mechanism: {trigger.mechanism}"]
+    selected = set(trigger.task_ids)
+    scorecard = [
+        "## Evaluation scorecard",
+        "The selected failure is marked TARGET; preserve behavior on the other tasks.",
+    ]
+    for task in tasks:
+        outcome = report.per_task.get(task.task_id)
+        success = outcome.success_rate if outcome is not None else 0.0
+        fraction = outcome.mean_fraction if outcome is not None else 0.0
+        instruction = " ".join(normalize_durable_text(task.instruction).split())
+        if len(instruction) > 240:
+            instruction = f"{instruction[:237]}..."
+        marker = "TARGET" if task.task_id in selected else "other"
+        scorecard.append(
+            f"- [{marker}] {task.task_id}: success={success:.2f}, "
+            f"assertion_fraction={fraction:.2f} — {instruction}"
+        )
+    sections = [
+        "\n".join(scorecard),
+        f"## Selected failure\n\nFailure mechanism: {trigger.mechanism}",
+    ]
     for task_id in trigger.task_ids:
         task = by_id.get(task_id)
         outcome = report.per_task.get(task_id)
-        instruction = task.instruction if task is not None else "(unknown task)"
+        instruction = (
+            normalize_durable_text(task.instruction) if task is not None else "(unknown task)"
+        )
         rate = f"{outcome.success_rate:.2f} over {outcome.passes} passes" if outcome else "?"
-        sections.append(f"### Task {task_id} (success_rate={rate})\nInstruction: {instruction}")
+        fraction = f", assertion_fraction={outcome.mean_fraction:.2f}" if outcome else ""
+        task_section = [
+            f"### Task {task_id} (success_rate={rate}{fraction})",
+            f"Instruction: {instruction}",
+        ]
+        if outcome is not None:
+            for index, verdict in enumerate(outcome.verdicts, 1):
+                attempt = outcome.attempts[index - 1] if index <= len(outcome.attempts) else None
+                task_section.append(_render_attempt(index=index, attempt=attempt, verdict=verdict))
+        sections.append("\n\n".join(task_section))
     unmet = "\n".join(f"- {a}" for a in trigger.unmet_assertions)
-    sections.append(f"Unmet assertions across the cluster:\n{unmet or '- (none recorded)'}")
+    sections.append(
+        "Original trigger assertions from the parent (current attempt verdicts above are "
+        f"authoritative):\n{unmet or '- (none recorded)'}"
+    )
     return "\n\n".join(sections)
+
+
+def _render_attempt(*, index: int, attempt: RolloutEvidence | None, verdict: GoldVerdict) -> str:
+    """Render one rollout plus its judge feedback without unbounded prompt growth."""
+    # Keep this helper tolerant of old/deserialized reports that predate RolloutEvidence. The
+    # verdict fields remain useful even when no trace was retained.
+    lines = [
+        f"#### Attempt {index} (passed={str(verdict.passed).lower()}, "
+        f"assertion_fraction={verdict.fraction:.2f})"
+    ]
+    if attempt is not None:
+        lines.append(
+            f"Stop: {attempt.stop_reason.value}; turns={attempt.turns}\n"
+            f"Final answer:\n{normalize_durable_text(attempt.answer) or '(none)'}\n\n"
+            f"Execution transcript:\n"
+            f"{_bounded_trace(normalize_durable_text(attempt.transcript))}"
+        )
+    if verdict.assertions:
+        judged = "\n".join(
+            f"- {'PASS' if assertion.passed else 'FAIL'}: "
+            f"{normalize_durable_text(assertion.assertion)}"
+            f" — {normalize_durable_text(assertion.why) if assertion.why else '(no judge reason)'}"
+            for assertion in verdict.assertions
+        )
+        lines.append(f"Judge feedback:\n{judged}")
+    else:
+        rationale = normalize_durable_text(verdict.rationale) if verdict.rationale else ""
+        lines.append(f"Judge feedback: {rationale or '(no per-assertion feedback)'}")
+    return "\n\n".join(lines)
+
+
+def _bounded_trace(trace: str, limit: int = _TRACE_CHARS_PER_ATTEMPT) -> str:
+    """Keep both the setup and terminal behavior when a long run exceeds the evidence budget."""
+    if not trace:
+        return "(empty)"
+    if len(trace) <= limit:
+        return trace
+    head = limit // 2
+    tail = limit - head
+    omitted = len(trace) - limit
+    return f"{trace[:head]}\n... ({omitted} trace characters omitted) ...\n{trace[-tail:]}"
 
 
 def render_history(history: list[HarnessDelta], limit: int = 5) -> str:

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -65,7 +65,8 @@ Surface kinds:
 - tool_policy — the tool list, one tool name per line. Valid names: \
 {", ".join(sorted(TOOL_REGISTRY))}. The `{SUBMIT.name}` tool is REQUIRED (without it a run \
 cannot end).
-- param — a scalar loop knob: `param:max-turns` (int >= 1), `param:temperature` (float in [0, 2]).
+- param — a scalar loop knob: `param:max-turns` (int >= 1), `param:max-output-tokens` for a
+  `pi-node` harness (int >= 1), or `param:temperature` (float in [0, 2]).
 - code — the agent's source. Either the singleton in-process `code:runtime` (contract above; must
   compile and define `run`), OR the pathful `code:<...>` files of a real multi-file harness (the
   vendored pi agent's own source). Editing a pathful `code:` surface REPLACES that file's whole

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import json
 
-from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
+import pytest
+
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, TaskOutcome
+from wmh.evals.gold import AssertionResult, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.mutate import parse_delta, propose_delta, render_evidence
+from wmh.harness.runtime import StopReason
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 
@@ -116,6 +120,38 @@ def test_propose_delta_returns_none_on_garbage() -> None:
     assert propose_delta(parent, trigger, "e", ScriptedProvider(no_kind)) is None
 
 
+@pytest.mark.parametrize(
+    ("field", "invalid_text"),
+    [
+        ("content", "before\x00after"),
+        ("rationale", "before\ud800after"),
+        ("expected_effect", "before\udcffafter"),
+    ],
+)
+def test_parse_delta_rejects_nonpersistent_model_text(field: str, invalid_text: str) -> None:
+    parent = HarnessDoc.baseline("parent")
+    core = parent.surface("prompt:core")
+    assert core is not None
+    payload = {
+        "expected_effect": "t1 passes",
+        "preconditions": {"prompt:core": core.content_hash},
+        "ops": [
+            {
+                "op": "replace",
+                "surface_id": "prompt:core",
+                "content": "safe content",
+                "rationale": "safe rationale",
+            }
+        ],
+    }
+    if field == "expected_effect":
+        payload[field] = invalid_text
+    else:
+        payload["ops"][0][field] = invalid_text
+
+    assert parse_delta(parent, _trigger(), json.dumps(payload)) is None
+
+
 def test_parse_delta_expands_compact_exact_replacement_edits() -> None:
     parent = HarnessDoc.baseline("parent")
     core = parent.surface("prompt:core")
@@ -159,7 +195,61 @@ def test_render_evidence_shows_cluster_tasks_and_unmet_assertions() -> None:
     assert "the file was created" in evidence
     assert "create the file" in evidence
     assert "0.00 over 2 passes" in evidence
-    assert "easy one" not in evidence  # the passing task is not reflection fuel
+    assert "[TARGET] t1" in evidence
+    assert "[other] t2" in evidence
+    assert "easy one" in evidence  # passing behavior remains visible in the compact scorecard
+
+
+def test_render_evidence_includes_execution_trace_answer_and_judge_reason() -> None:
+    report = ClosedLoopReport(
+        label="parent",
+        per_task={
+            "t1": TaskOutcome(
+                task_id="t1",
+                success_rate=0.0,
+                mean_fraction=0.5,
+                passes=1,
+                attempts=[
+                    RolloutEvidence(
+                        answer="I could not verify it",
+                        transcript="[1] tool_call: curl endpoint\n    -> connection reset",
+                        stop_reason=StopReason.SUBMITTED,
+                        turns=2,
+                    )
+                ],
+                verdicts=[
+                    GoldVerdict(
+                        passed=False,
+                        fraction=0.5,
+                        assertions=[
+                            AssertionResult(
+                                assertion="the value was printed",
+                                passed=False,
+                                why="the final answer contained no value",
+                            )
+                        ],
+                    )
+                ],
+            )
+        },
+    )
+    trigger = FailureSignature(
+        mechanism="the value was printed",
+        task_ids=["t1"],
+        unmet_assertions=["the value was printed"],
+    )
+
+    evidence = render_evidence(
+        trigger,
+        report,
+        [TaskSpec(task_id="t1", instruction="fetch the value", gold=["the value was printed"])],
+    )
+
+    assert "assertion_fraction=0.50" in evidence
+    assert "Stop: submitted; turns=2" in evidence
+    assert "I could not verify it" in evidence
+    assert "connection reset" in evidence
+    assert "the final answer contained no value" in evidence
 
 
 def test_all_pass_evidence_asks_for_generalization() -> None:

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -8,7 +8,7 @@ from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.mutate import propose_delta, render_evidence
+from wmh.harness.mutate import parse_delta, propose_delta, render_evidence
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 
@@ -114,6 +114,33 @@ def test_propose_delta_returns_none_on_garbage() -> None:
         }
     )
     assert propose_delta(parent, trigger, "e", ScriptedProvider(no_kind)) is None
+
+
+def test_parse_delta_expands_compact_exact_replacement_edits() -> None:
+    parent = HarnessDoc.baseline("parent")
+    core = parent.surface("prompt:core")
+    assert core is not None
+    old = "You are a capable command-line agent"
+    assert core.content.count(old) == 1
+    raw = json.dumps(
+        {
+            "expected_effect": "verification improves",
+            "preconditions": {"prompt:core": core.content_hash},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": "prompt:core",
+                    "edits": [{"old": old, "new": "You are a careful agent"}],
+                    "rationale": "add care",
+                }
+            ],
+        }
+    )
+
+    delta = parse_delta(parent, _trigger(), raw)
+
+    assert delta is not None
+    assert delta.ops[0].content == core.content.replace(old, "You are a careful agent")
 
 
 def test_render_evidence_shows_cluster_tasks_and_unmet_assertions() -> None:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -60,6 +60,7 @@ from wmh.harness.runtime import (
     RuntimeCancelled,
     StopReason,
 )
+from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
@@ -1220,6 +1221,8 @@ class E2BPiRuntime:
         hello_timeout: float = HELLO_TIMEOUT_S,
         max_turns: int = DEFAULT_MAX_TURNS,
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
+        temperature: float = 0.7,
+        skills: SkillLibrary | None = None,
         episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         should_cancel: Callable[[], bool] | None = None,
     ) -> None:
@@ -1227,6 +1230,8 @@ class E2BPiRuntime:
             raise ValueError("max_turns must be >= 1")
         if max_output_tokens < 1:
             raise ValueError("max_output_tokens must be >= 1")
+        if not 0.0 <= temperature <= 2.0:
+            raise ValueError("temperature must be in [0, 2]")
         if episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive")
         self._provider = provider
@@ -1236,6 +1241,8 @@ class E2BPiRuntime:
         self._worker_fn = worker_fn  # test seam, exactly like RunnerLink's
         self._max_turns = max_turns
         self._max_output_tokens = max_output_tokens
+        self._temperature = temperature
+        self._skills = skills if skills is not None else SkillLibrary()
         self._episode_timeout_s = episode_timeout_s
         self._should_cancel = should_cancel
         self._aborted = threading.Event()
@@ -1277,6 +1284,8 @@ class E2BPiRuntime:
                 system_prompt=self._system_prompt,
                 max_turns=self._max_turns,
                 max_output_tokens=self._max_output_tokens,
+                temperature=self._temperature,
+                skills=self._skills,
                 episode_timeout_s=self._episode_timeout_s,
                 should_cancel=self._cancel_requested,
             )

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -34,6 +34,7 @@ import threading
 import time
 import uuid
 from collections import deque
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Literal, cast, overload
 
@@ -50,7 +51,12 @@ from wmh.harness.e2b_sandbox import (
 )
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.runner_link import RunnerLink, WorkerFn
-from wmh.harness.runtime import RunResult
+from wmh.harness.runtime import (
+    DEFAULT_MAX_TURNS,
+    RunResult,
+    RuntimeCancelled,
+    StopReason,
+)
 from wmh.harness.tools import ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
@@ -114,6 +120,9 @@ _SANDBOX_TIMEOUT_REFRESH_S = 300.0
 # Renewal must not turn mutated agent code into an unbounded cost leak. A legitimate slow episode
 # may cross the base 15-minute lease, but one cell still gets a hard one-hour sandbox lifetime.
 MAX_EVAL_EPISODE_LIFETIME_S = 3_600.0
+# A score cell must finish much sooner than the E2B lease-renewal safety cap. This wall budget is
+# host-enforced by RunnerLink and may be exceeded only by one already-running provider/tool call.
+DEFAULT_EVAL_EPISODE_TIMEOUT_S = 300.0
 _MAX_RETIRE_WORKERS = 16
 
 
@@ -192,9 +201,9 @@ class E2BStdioChannel:
     def recv(self, timeout: float | None = None) -> JsonObject | None:
         """The next frame from the runner; blocks (up to `timeout` seconds when given).
 
-        The optional `timeout` is beyond the `Channel` protocol (which always blocks) — it exists
-        for the hello handshake. Timing out raises `TimeoutError`; a dead runner process raises
-        `RuntimeError`; both messages include the recent stderr.
+        Timing out raises `TimeoutError`; a dead runner process raises `RuntimeError`; both
+        messages include the recent stderr. RunnerLink uses bounded receives for evaluation wall
+        budgets and cooperative cancellation; the hello handshake uses the same contract.
         """
         try:
             item = self._frames.get(timeout=timeout)
@@ -1002,6 +1011,16 @@ class E2BSandboxPool:
         with self._lock:
             self._created += 1
             self._started[id(sandbox)] = time.monotonic()
+            if not self._closed:
+                # Register before bootstrap so cancellation can kill cold-start sandboxes that
+                # are still installing dependencies or waiting for the runner hello.
+                self._all.append(sandbox)
+                registered = True
+            else:
+                registered = False
+        if not registered:
+            self._retire(sandbox)
+            raise RuntimeError("E2BSandboxPool is closed")
         try:
             self._bootstrap(sandbox)
             channel = self._start_runner(sandbox)
@@ -1010,7 +1029,6 @@ class E2BSandboxPool:
             raise
         with self._lock:
             if not self._closed:
-                self._all.append(sandbox)
                 return sandbox, channel
         self._retire(sandbox)  # closed while we were bootstrapping: don't leak the sandbox
         raise RuntimeError("E2BSandboxPool is closed")
@@ -1056,8 +1074,13 @@ class E2BSandboxPool:
             self._closed = True
             sandboxes, self._all = self._all, []
             self._idle = []
-        for sandbox in sandboxes:
-            self._retire(sandbox)
+        if len(sandboxes) == 1:
+            self._retire(sandboxes[0])
+        elif sandboxes:
+            # Cancellation commonly lands during a full-concurrency eval wave. Retiring every
+            # active lease in parallel keeps teardown latency bounded by one E2B kill request.
+            with ThreadPoolExecutor(max_workers=min(_MAX_RETIRE_WORKERS, len(sandboxes))) as pool:
+                list(pool.map(self._retire, sandboxes))
 
     def usage(self) -> SandboxUsage:
         """The pool's spend meter so far: sandbox count and total lifetime seconds."""
@@ -1070,8 +1093,11 @@ class E2BSandboxPool:
         """Finalize the sandbox's lifetime on the meter, then kill it (best-effort)."""
         with self._lock:
             started = self._started.pop(id(sandbox), None)
-            if started is not None:
-                self._retired_seconds += time.monotonic() - started
+            if started is None:
+                return  # another close/release path already retired this exact lease
+            self._all = [item for item in self._all if item is not sandbox]
+            self._idle = [item for item in self._idle if item[0] is not sandbox]
+            self._retired_seconds += time.monotonic() - started
         _kill_quietly(sandbox)
 
     def __enter__(self) -> E2BSandboxPool:
@@ -1152,21 +1178,35 @@ class E2BPiRuntime:
         pool: E2BSandboxPool | None = None,
         worker_fn: WorkerFn | None = None,
         hello_timeout: float = HELLO_TIMEOUT_S,
+        max_turns: int = DEFAULT_MAX_TURNS,
+        episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> None:
+        if max_turns < 1:
+            raise ValueError("max_turns must be >= 1")
+        if episode_timeout_s <= 0:
+            raise ValueError("episode_timeout_s must be positive")
         self._provider = provider
         self._files = dict(files)
         self._tools = list(tools)
         self._system_prompt = system_prompt
         self._worker_fn = worker_fn  # test seam, exactly like RunnerLink's
+        self._max_turns = max_turns
+        self._episode_timeout_s = episode_timeout_s
+        self._should_cancel = should_cancel
         self._owns_pool = pool is None
         self._pool = pool or E2BSandboxPool(
             template=template, api_key=api_key, hello_timeout=hello_timeout
         )
 
     def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
+        if self._should_cancel is not None and self._should_cancel():
+            raise RuntimeCancelled("runtime episode cancelled")
         try:
             return self._run_episode(task_id, instruction, environment)
         except Exception as exc:
+            if self._should_cancel is not None and self._should_cancel():
+                raise RuntimeCancelled("runtime episode cancelled") from exc
             if not _is_retryable_transport_error(exc):
                 raise
             # Transport death (stream drop, sandbox lifetime, dead runner) — the failed
@@ -1190,9 +1230,14 @@ class E2BPiRuntime:
                 worker_fn=self._worker_fn,
                 files=self._files,
                 system_prompt=self._system_prompt,
+                max_turns=self._max_turns,
+                episode_timeout_s=self._episode_timeout_s,
+                should_cancel=self._should_cancel,
             )
             result = link.run(task_id, instruction, environment)
-            healthy = True
+            # A wall-budget stop may leave the runner mid-turn. Never reuse or retry it: the
+            # partial result is scoreable, but the sandbox's protocol state is not trustworthy.
+            healthy = result.stop_reason is not StopReason.BUDGET
             return result
         finally:
             self._pool.release(sandbox, channel, healthy=healthy)
@@ -1211,6 +1256,8 @@ class E2BPiRuntime:
 
 def _is_retryable_transport_error(exc: Exception) -> bool:
     """Whether an episode exception means its E2B transport is no longer trustworthy."""
+    if isinstance(exc, RuntimeCancelled):
+        return False
     if isinstance(exc, (RuntimeError, TimeoutError)):
         return True
     # Keep the E2B SDK optional at import time. Its TimeoutException is not a built-in

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -966,12 +966,15 @@ class E2BSandboxPool:
         *,
         template: str | None = None,
         api_key: str | None = None,
+        metadata: dict[str, str] | None = None,
         sandbox_factory: SandboxFactory | None = None,
         hello_timeout: float = HELLO_TIMEOUT_S,
     ) -> None:
         self._template = template
         self._factory = sandbox_factory or default_sandbox_factory(
-            api_key=api_key, template=template
+            api_key=api_key,
+            template=template,
+            metadata=metadata,
         )
         self._hello_timeout = hello_timeout
         self._lock = threading.Lock()

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -43,11 +43,13 @@ from wmh.harness.e2b_sandbox import (
     DEFAULT_SANDBOX_TIMEOUT_S,
     E2B_TEMPLATE_ENV,
     CommandHandle,
+    SandboxCleanupError,
     SandboxFactory,
     SandboxHandle,
     SandboxUsage,
     create_sandbox,
     default_sandbox_factory,
+    kill_sandbox,
 )
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.runner_link import RunnerLink, WorkerFn
@@ -986,6 +988,10 @@ class E2BSandboxPool:
         # live sandboxes are counted from their _started stamp. Keyed by id() — SandboxHandle is
         # a protocol, not hashable-by-contract.
         self._started: dict[int, float] = {}
+        # An exact lease can be reached concurrently by pool.close() and an in-flight episode's
+        # release(). The event makes one caller own each kill attempt while every other caller
+        # waits for its proof before deciding whether a retry is still needed.
+        self._retiring: dict[int, threading.Event] = {}
         self._created = 0
         self._retired_seconds = 0.0
 
@@ -1044,9 +1050,6 @@ class E2BSandboxPool:
                 if not self._closed:
                     self._idle.append((sandbox, channel))
                     return
-        with self._lock:
-            if sandbox in self._all:
-                self._all.remove(sandbox)
         self._retire(sandbox)
 
     def retire_idle(self) -> int:
@@ -1062,29 +1065,17 @@ class E2BSandboxPool:
         """
         with self._lock:
             idle, self._idle = self._idle, []
-            idle_ids = {id(sandbox) for sandbox, _channel in idle}
-            self._all = [sandbox for sandbox in self._all if id(sandbox) not in idle_ids]
         sandboxes = [sandbox for sandbox, _channel in idle]
-        if len(sandboxes) == 1:
-            self._retire(sandboxes[0])
-        elif sandboxes:
-            with ThreadPoolExecutor(max_workers=min(_MAX_RETIRE_WORKERS, len(sandboxes))) as pool:
-                list(pool.map(self._retire, sandboxes))
+        self._retire_many(sandboxes)
         return len(sandboxes)
 
     def close(self) -> None:
         """Kill every pooled sandbox; safe to call more than once."""
         with self._lock:
             self._closed = True
-            sandboxes, self._all = self._all, []
+            sandboxes = list(self._all)
             self._idle = []
-        if len(sandboxes) == 1:
-            self._retire(sandboxes[0])
-        elif sandboxes:
-            # Cancellation commonly lands during a full-concurrency eval wave. Retiring every
-            # active lease in parallel keeps teardown latency bounded by one E2B kill request.
-            with ThreadPoolExecutor(max_workers=min(_MAX_RETIRE_WORKERS, len(sandboxes))) as pool:
-                list(pool.map(self._retire, sandboxes))
+        self._retire_many(sandboxes)
 
     def usage(self) -> SandboxUsage:
         """The pool's spend meter so far: sandbox count and total lifetime seconds."""
@@ -1094,15 +1085,60 @@ class E2BSandboxPool:
             return SandboxUsage(count=self._created, seconds=self._retired_seconds + live)
 
     def _retire(self, sandbox: SandboxHandle) -> None:
-        """Finalize the sandbox's lifetime on the meter, then kill it (best-effort)."""
-        with self._lock:
-            started = self._started.pop(id(sandbox), None)
-            if started is None:
-                return  # another close/release path already retired this exact lease
-            self._all = [item for item in self._all if item is not sandbox]
-            self._idle = [item for item in self._idle if item[0] is not sandbox]
-            self._retired_seconds += time.monotonic() - started
-        _kill_quietly(sandbox)
+        """Kill one lease, finalizing its meter only after teardown is proved."""
+        sandbox_id = id(sandbox)
+        while True:
+            with self._lock:
+                if sandbox_id not in self._started:
+                    return  # another close/release path proved this exact lease gone
+                owner_done = self._retiring.get(sandbox_id)
+                if owner_done is None:
+                    owner_done = threading.Event()
+                    self._retiring[sandbox_id] = owner_done
+                    # Never make a lease available again once retirement begins. Keep it in
+                    # _all until kill succeeds so a later close() can retry a failed cleanup.
+                    self._idle = [item for item in self._idle if item[0] is not sandbox]
+                    break
+            owner_done.wait()
+
+        try:
+            kill_sandbox(sandbox)
+            retired_at = time.monotonic()
+            with self._lock:
+                started = self._started.pop(sandbox_id)
+                self._all = [item for item in self._all if item is not sandbox]
+                self._retired_seconds += retired_at - started
+        finally:
+            with self._lock:
+                self._retiring.pop(sandbox_id, None)
+                owner_done.set()
+
+    def _retire_many(self, sandboxes: list[SandboxHandle]) -> None:
+        """Retire every requested lease and report all unproven cleanup as one failure."""
+        if not sandboxes:
+            return
+
+        def retire(sandbox: SandboxHandle) -> SandboxCleanupError | None:
+            try:
+                self._retire(sandbox)
+            except SandboxCleanupError as error:
+                return error
+            return None
+
+        if len(sandboxes) == 1:
+            failures = [retire(sandboxes[0])]
+        else:
+            # Cancellation commonly lands during a full-concurrency eval wave. Retiring every
+            # active lease in parallel keeps teardown latency bounded by one E2B retry sequence.
+            with ThreadPoolExecutor(max_workers=min(_MAX_RETIRE_WORKERS, len(sandboxes))) as pool:
+                failures = list(pool.map(retire, sandboxes))
+        errors = [error for error in failures if error is not None]
+        if errors:
+            raise SandboxCleanupError(
+                f"failed to prove cleanup for {len(errors)} of {len(sandboxes)} E2B sandboxes",
+                resource="evaluator_sandbox_pool",
+                sandbox_usage=self.usage(),
+            ) from errors[0]
 
     def __enter__(self) -> E2BSandboxPool:
         return self
@@ -1202,18 +1238,19 @@ class E2BPiRuntime:
         self._max_output_tokens = max_output_tokens
         self._episode_timeout_s = episode_timeout_s
         self._should_cancel = should_cancel
+        self._aborted = threading.Event()
         self._owns_pool = pool is None
         self._pool = pool or E2BSandboxPool(
             template=template, api_key=api_key, hello_timeout=hello_timeout
         )
 
     def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
-        if self._should_cancel is not None and self._should_cancel():
+        if self._cancel_requested():
             raise RuntimeCancelled("runtime episode cancelled")
         try:
             return self._run_episode(task_id, instruction, environment)
         except Exception as exc:
-            if self._should_cancel is not None and self._should_cancel():
+            if self._cancel_requested():
                 raise RuntimeCancelled("runtime episode cancelled") from exc
             if not _is_retryable_transport_error(exc):
                 raise
@@ -1241,7 +1278,7 @@ class E2BPiRuntime:
                 max_turns=self._max_turns,
                 max_output_tokens=self._max_output_tokens,
                 episode_timeout_s=self._episode_timeout_s,
-                should_cancel=self._should_cancel,
+                should_cancel=self._cancel_requested,
             )
             result = link.run(task_id, instruction, environment)
             # A wall-budget stop may leave the runner mid-turn. Never reuse or retry it: the
@@ -1250,6 +1287,14 @@ class E2BPiRuntime:
             return result
         finally:
             self._pool.release(sandbox, channel, healthy=healthy)
+
+    def abort(self) -> None:
+        """Stop every sibling episode and close the shared pool before its caller joins them."""
+        self._aborted.set()
+        self._pool.close()
+
+    def _cancel_requested(self) -> bool:
+        return self._aborted.is_set() or (self._should_cancel is not None and self._should_cancel())
 
     def close(self) -> None:
         """Close the private pool; a no-op when the pool is shared (its owner closes it)."""
@@ -1405,14 +1450,6 @@ def _no_hello_live(
     tail = channel.stderr_tail()
     suffix = f"; recent runner stderr:\n{tail}" if tail else ""
     return f"live runner sent no hello within {timeout:g}s ({start_cmd!r}){suffix}"
-
-
-def _kill_quietly(sandbox: SandboxHandle) -> None:
-    """Best-effort sandbox teardown; a dead sandbox is already gone."""
-    try:
-        sandbox.kill()
-    except Exception:  # noqa: BLE001 - teardown must never mask the original error
-        pass
 
 
 def _no_hello(timeout: float, channel: E2BStdioChannel) -> str:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -33,6 +33,7 @@ import shlex
 import threading
 import time
 from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
 from wmh.core.types import JsonObject
@@ -96,6 +97,7 @@ _SANDBOX_TIMEOUT_REFRESH_S = 300.0
 # Renewal must not turn mutated agent code into an unbounded cost leak. A legitimate slow episode
 # may cross the base 15-minute lease, but one cell still gets a hard one-hour sandbox lifetime.
 MAX_EVAL_EPISODE_LIFETIME_S = 3_600.0
+_MAX_RETIRE_WORKERS = 16
 
 
 class _Eof:
@@ -325,16 +327,18 @@ class E2BStdioChannel:
 
 
 class E2BSandboxPool:
-    """Bootstrapped sandboxes with a running pi runner, reused across episodes and docs.
+    """Bootstrapped sandboxes with a running pi runner, reused within a proposal batch.
 
     The bootstrap (runner files + node 22 + pi's npm deps unless a template prebakes them) is
     doc-independent — a mutated harness's code surfaces travel per-episode in
-    `episode_start.files` — so one pool serves a whole search: `create_harness` opens it once and
-    every `_score` wave reuses warm sandboxes instead of re-paying installs. Concurrent episodes
-    acquire distinct sandboxes; a sandbox whose episode raised is discarded (the runner process
-    is in an unknown state — reuse could cross frames between episodes). `close()` kills
-    everything; the pool lock guards only the free lists, so parallel bootstraps never serialize
-    behind one sandbox's multi-minute npm install.
+    `episode_start.files` — so one pool serves a whole search. `create_harness` retires the idle
+    pool at each round boundary before the proposer runs, preventing long proposer/evaluation gaps
+    from leaving stale E2B command streams alive; score waves for sibling proposals in that round
+    still reuse warm sandboxes instead of re-paying installs. Concurrent episodes acquire distinct
+    sandboxes; a sandbox whose episode raised is discarded (the runner process is in an unknown
+    state — reuse could cross frames between episodes). `close()` kills everything; the pool lock
+    guards only the free lists, so parallel bootstraps never serialize behind one sandbox's
+    multi-minute npm install.
     """
 
     def __init__(
@@ -411,6 +415,29 @@ class E2BSandboxPool:
             if sandbox in self._all:
                 self._all.remove(sandbox)
         self._retire(sandbox)
+
+    def retire_idle(self) -> int:
+        """Retire every sandbox currently idle, preserving any episode still in flight.
+
+        The idle set is detached atomically so a concurrent acquire cannot reclaim a stream that
+        this call is about to kill. Teardown happens outside the pool lock and in a bounded worker
+        set: a normal E2B evaluation wave can leave dozens of idle sandboxes, and serial network
+        teardown would otherwise add material latency before every proposer call. Usage remains
+        cumulative because each sandbox still passes through ``_retire`` exactly once.
+
+        Returns the number retired, primarily for diagnostics and tests.
+        """
+        with self._lock:
+            idle, self._idle = self._idle, []
+            idle_ids = {id(sandbox) for sandbox, _channel in idle}
+            self._all = [sandbox for sandbox in self._all if id(sandbox) not in idle_ids]
+        sandboxes = [sandbox for sandbox, _channel in idle]
+        if len(sandboxes) == 1:
+            self._retire(sandboxes[0])
+        elif sandboxes:
+            with ThreadPoolExecutor(max_workers=min(_MAX_RETIRE_WORKERS, len(sandboxes))) as pool:
+                list(pool.map(self._retire, sandboxes))
+        return len(sandboxes)
 
     def close(self) -> None:
         """Kill every pooled sandbox; safe to call more than once."""

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import json
+import math
 import os
 import queue
 import shlex
@@ -85,6 +86,16 @@ _RUNNER_FILES = ("runner_stdio.ts", "runner_frames.ts")
 
 _STDERR_LINES = 50  # bounded diagnostics buffer: enough for a stack trace, never unbounded
 
+# A runner-originated heartbeat keeps the background command stream active while the host is
+# synchronously waiting on a slow provider call. Pooled evaluation channels also use the same
+# heartbeat to renew the sandbox lease; live-session callers own their own idle/suspend lifecycle
+# and therefore leave renewal disabled.
+TRANSPORT_KEEPALIVE_TYPE = "transport_keepalive"
+_SANDBOX_TIMEOUT_REFRESH_S = 300.0
+# Renewal must not turn mutated agent code into an unbounded cost leak. A legitimate slow episode
+# may cross the base 15-minute lease, but one cell still gets a hard one-hour sandbox lifetime.
+MAX_EVAL_EPISODE_LIFETIME_S = 3_600.0
+
 
 class _Eof:
     """Reader-thread sentinel: the runner process's output stream ended."""
@@ -109,12 +120,24 @@ class E2BStdioChannel:
     """
 
     def __init__(
-        self, sandbox: SandboxHandle, handle: CommandHandle, *, stderr_lines: int = _STDERR_LINES
+        self,
+        sandbox: SandboxHandle,
+        handle: CommandHandle,
+        *,
+        stderr_lines: int = _STDERR_LINES,
+        sandbox_timeout_s: int | None = None,
+        timeout_refresh_interval_s: float = _SANDBOX_TIMEOUT_REFRESH_S,
+        max_episode_lifetime_s: float = MAX_EVAL_EPISODE_LIFETIME_S,
     ) -> None:
         self._sandbox = sandbox
         self._handle = handle
         self._frames: queue.Queue[JsonObject | _Eof] = queue.Queue()
         self._stderr: deque[str] = deque(maxlen=stderr_lines)
+        self._sandbox_timeout_s = sandbox_timeout_s
+        self._timeout_refresh_interval_s = timeout_refresh_interval_s
+        self._max_episode_lifetime_s = max_episode_lifetime_s
+        self._next_timeout_refresh_at = 0.0
+        self._episode_renewal_deadline_at: float | None = None
         self._closed = False
         self._reader = threading.Thread(
             target=self._read_events, name="e2b-stdio-reader", daemon=True
@@ -122,6 +145,12 @@ class E2BStdioChannel:
         self._reader.start()
 
     def send(self, frame: JsonObject) -> None:
+        if frame.get("type") == "episode_start" and self._sandbox_timeout_s is not None:
+            now = time.monotonic()
+            self._episode_renewal_deadline_at = now + self._max_episode_lifetime_s
+            # The pool reset the lease immediately before this episode. Wait until the normal
+            # refresh cadence instead of bursting one set_timeout call per sandbox at 30 seconds.
+            self._next_timeout_refresh_at = now + self._timeout_refresh_interval_s
         line = base64.b64encode(json.dumps(frame).encode("utf-8")).decode("ascii") + "\n"
         try:
             self._sandbox.commands.send_stdin(self._handle.pid, line)
@@ -153,6 +182,7 @@ class E2BStdioChannel:
         if self._closed:
             return
         self._closed = True
+        self._episode_renewal_deadline_at = None
         try:
             self.send({"type": "shutdown"})
         except Exception:  # noqa: BLE001 - the process/sandbox may already be gone; close is best-effort
@@ -195,9 +225,38 @@ class E2BStdioChannel:
             self._stderr.append(f"[stdout] {text}")  # not a frame; keep it as a diagnostic
             return
         if isinstance(frame, dict):
+            if frame.get("type") == TRANSPORT_KEEPALIVE_TYPE:
+                self._refresh_sandbox_timeout()
+                return
+            if frame.get("type") in {"done", "episode_error"}:
+                self._episode_renewal_deadline_at = None
             self._frames.put(cast("JsonObject", frame))
         else:
             self._stderr.append(f"[stdout] {text}")
+
+    def _refresh_sandbox_timeout(self) -> None:
+        """Renew a pooled eval sandbox lease without surfacing the heartbeat as a protocol frame.
+
+        A provider call can keep one episode active longer than E2B's 900-second sandbox timeout.
+        The runner remains responsive during that host-side wait and emits transport heartbeats;
+        refreshing here prevents E2B from killing an otherwise healthy in-flight episode. A
+        transient refresh failure stays diagnostic-only and the next heartbeat retries it.
+        """
+        timeout = self._sandbox_timeout_s
+        deadline = self._episode_renewal_deadline_at
+        if timeout is None or deadline is None:
+            return
+        now = time.monotonic()
+        if now < self._next_timeout_refresh_at or now >= deadline:
+            return
+        # Shorten the final lease so the sandbox still dies at the absolute episode deadline.
+        refreshed_timeout = min(timeout, max(1, math.ceil(deadline - now)))
+        try:
+            self._sandbox.set_timeout(refreshed_timeout)
+        except Exception as exc:  # noqa: BLE001 - retry on the next heartbeat; I/O remains authoritative
+            self._stderr.append(f"[channel] sandbox timeout refresh failed: {exc}")
+            return
+        self._next_timeout_refresh_at = now + self._timeout_refresh_interval_s
 
 
 class E2BSandboxPool:
@@ -332,11 +391,20 @@ class E2BSandboxPool:
         )
 
     def _start_runner(self, sandbox: SandboxHandle) -> E2BStdioChannel:
+        # Bootstrap can consume much of the creation-time lease on a template-less sandbox. Reset
+        # it immediately before the long-lived runner starts; subsequent in-flight heartbeats keep
+        # extending it while an episode is active.
+        timeout = int(DEFAULT_SANDBOX_TIMEOUT_S)
+        sandbox.set_timeout(timeout)
         # timeout=0 = no command-connection limit (SDK-documented): the runner must outlive every
         # episode on this sandbox; the sandbox's own lifetime is the real bound.
         handle = sandbox.commands.run(START_CMD, background=True, stdin=True, timeout=0)
         # background=True always yields a handle; the union return type is the protocol's.
-        channel = E2BStdioChannel(sandbox, cast("CommandHandle", handle))
+        channel = E2BStdioChannel(
+            sandbox,
+            cast("CommandHandle", handle),
+            sandbox_timeout_s=timeout,
+        )
         self._await_hello(channel)
         return channel
 

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -1256,6 +1256,10 @@ class E2BPiRuntime:
             raise RuntimeCancelled("runtime episode cancelled")
         try:
             return self._run_episode(task_id, instruction, environment)
+        except RuntimeCancelled:
+            # RunnerLink owns the episode's authoritative partial worker meter.
+            # Preserve it instead of replacing the cancellation at this wrapper.
+            raise
         except Exception as exc:
             if self._cancel_requested():
                 raise RuntimeCancelled("runtime episode cancelled") from exc

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -32,6 +32,7 @@ import queue
 import shlex
 import threading
 import time
+import uuid
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import cast
@@ -88,6 +89,22 @@ _RUNNER_FILES = ("runner_stdio.ts", "runner_frames.ts")
 _STDERR_LINES = 50  # bounded diagnostics buffer: enough for a stack trace, never unbounded
 _IDLE_RECONNECT_DELAYS_S = (0.0, 0.25, 1.0)
 
+# Durable live sessions mirror every runner -> host semantic frame into a sequenced filesystem
+# outbox. Stdout remains the low-latency path; these deliberately short unary RPC bounds keep a
+# 500ms LiveSession pump (and cancellation) from inheriting the E2B SDK's much longer default
+# request timeout when it polls the outbox.
+_DURABLE_FILE_REQUEST_TIMEOUT_S = 0.25
+_DURABLE_FRAME_REQUEST_TIMEOUT_S = 5.0
+_DURABLE_POLL_INTERVAL_S = 0.25
+_DURABLE_STDOUT_FAST_WAIT_S = 0.025
+_DURABLE_STREAM_DEATH_GRACE_S = 0.5
+_DURABLE_FRAME_READ_GRACE_S = 5.0
+_DURABLE_PID_PROBE_INTERVAL_S = 5.0
+_DURABLE_SEND_REQUEST_TIMEOUT_S = 2.0
+_DURABLE_SEND_ACK_TIMEOUT_S = 5.0
+_DURABLE_CLOSE_REQUEST_TIMEOUT_S = 0.25
+_DURABLE_STDOUT_SILENCE_GRACE_S = 45.0
+
 # A runner-originated heartbeat keeps the background command stream active while the host is
 # synchronously waiting on a slow provider call. Pooled evaluation channels also use the same
 # heartbeat to renew the sandbox lease; live-session callers own their own idle/suspend lifecycle
@@ -108,7 +125,7 @@ _EOF = _Eof()
 
 
 class _E2BChannelSendError(RuntimeError):
-    """A raw socket failure while sending a frame to the E2B runner."""
+    """A durable host frame could not be acknowledged by the E2B runner."""
 
 
 class E2BStdioChannel:
@@ -324,6 +341,600 @@ class E2BStdioChannel:
             self._stderr.append(f"[channel] sandbox timeout refresh failed: {exc}")
             return
         self._next_timeout_refresh_at = now + self._timeout_refresh_interval_s
+
+
+class E2BDurableChannel:
+    """A lossless live-runner channel backed by a sequenced E2B filesystem outbox.
+
+    Host -> runner traffic uses the same unary ``commands.send_stdin`` operation as
+    :class:`E2BStdioChannel`, wrapped in a monotonically sequenced envelope. The runner dispatches
+    each inbound sequence once and emits a durable acknowledgement, so an RPC that delivers bytes
+    and then times out can safely reuse the same sequence instead of replaying the whole agent
+    turn. In the other direction, the durable runner publishes each semantic frame as
+    ``{transport_seq, frame}`` to an exact per-sequence file, advances ``head``, and only then
+    writes the same envelope to stdout. The stdout stream is therefore a fast notification path,
+    not the source of truth: one expected-sequence cursor deduplicates both sources, fills gaps
+    from exact files, and keeps polling ``head`` even when stdout is merely silent.
+
+    A command-stream EOF or HTTP failure is not a runner failure. The channel continues over unary
+    filesystem reads and only classifies process death after a grace period and an explicit
+    ``commands.list`` result that omits the runner PID. This is what lets an ordinary
+    ``LiveSession`` survive a dropped E2B output stream without changing its frame protocol.
+    """
+
+    def __init__(
+        self,
+        sandbox: SandboxHandle,
+        handle: CommandHandle,
+        *,
+        outbox_root: str,
+        stderr_path: str,
+        stderr_lines: int = _STDERR_LINES,
+        file_request_timeout_s: float = _DURABLE_FILE_REQUEST_TIMEOUT_S,
+        frame_request_timeout_s: float = _DURABLE_FRAME_REQUEST_TIMEOUT_S,
+        poll_interval_s: float = _DURABLE_POLL_INTERVAL_S,
+        stdout_fast_wait_s: float = _DURABLE_STDOUT_FAST_WAIT_S,
+        stream_death_grace_s: float = _DURABLE_STREAM_DEATH_GRACE_S,
+        frame_read_grace_s: float = _DURABLE_FRAME_READ_GRACE_S,
+        pid_probe_interval_s: float = _DURABLE_PID_PROBE_INTERVAL_S,
+        send_request_timeout_s: float = _DURABLE_SEND_REQUEST_TIMEOUT_S,
+        send_ack_timeout_s: float = _DURABLE_SEND_ACK_TIMEOUT_S,
+        close_request_timeout_s: float = _DURABLE_CLOSE_REQUEST_TIMEOUT_S,
+        stdout_silence_grace_s: float = _DURABLE_STDOUT_SILENCE_GRACE_S,
+    ) -> None:
+        self._sandbox = sandbox
+        self._handle = handle
+        self._pid = handle.pid
+        self._outbox_root = outbox_root.rstrip("/")
+        self._stderr_path = stderr_path
+        self._stderr_lines = stderr_lines
+        self._stderr: deque[str] = deque(maxlen=stderr_lines)
+        self._durable_stderr = ""
+        self._frames: queue.Queue[JsonObject | _Eof] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._send_lock = threading.Lock()
+        self._close_lock = threading.Lock()
+        self._ack_condition = threading.Condition()
+        self._closed = threading.Event()
+        self._cleanup_done = threading.Event()
+        self._next_inbound_seq = 0
+        self._acked_inbound_seq = 0
+        self._last_seq = 0
+        self._known_head = 0
+        self._pending: dict[int, JsonObject] = {}
+        self._missing_since: dict[int, float] = {}
+        self._fatal_error: str | None = None
+        self._eof_queued = False
+        self._stream_dead_at: float | None = None
+        self._stream_death_probe_done = False
+        self._stream_error: str | None = None
+        self._last_stdout_at = time.monotonic()
+        self._head_failure_since: float | None = None
+        self._last_head_failure_at: float | None = None
+        self._next_pid_check_at = time.monotonic() + pid_probe_interval_s
+        self._pid_dead_at: float | None = None
+        self._last_outbox_error: str | None = None
+        self._file_request_timeout_s = file_request_timeout_s
+        self._frame_request_timeout_s = frame_request_timeout_s
+        self._poll_interval_s = poll_interval_s
+        self._stdout_fast_wait_s = stdout_fast_wait_s
+        self._stream_death_grace_s = stream_death_grace_s
+        self._frame_read_grace_s = frame_read_grace_s
+        self._pid_probe_interval_s = pid_probe_interval_s
+        self._send_request_timeout_s = send_request_timeout_s
+        self._send_ack_timeout_s = send_ack_timeout_s
+        self._close_request_timeout_s = close_request_timeout_s
+        self._stdout_silence_grace_s = stdout_silence_grace_s
+        self._reader = threading.Thread(
+            target=self._read_events, name="e2b-durable-reader", daemon=True
+        )
+        self._reader.start()
+
+    def send(self, frame: JsonObject) -> None:
+        """Deliver one host frame once, retrying the same sequence until its durable ack."""
+        with self._send_lock:
+            if self._closed.is_set():
+                raise _E2BChannelSendError("durable runner channel is closed")
+            self._next_inbound_seq += 1
+            inbound_seq = self._next_inbound_seq
+            line = self._encode_inbound(inbound_seq, frame)
+            deadline = time.monotonic() + self._send_ack_timeout_s
+            last_error: Exception | None = None
+            attempts = 0
+
+            while True:
+                if self._inbound_acknowledged(inbound_seq):
+                    return
+                if self._closed.is_set():
+                    raise _E2BChannelSendError(
+                        f"durable runner closed before acknowledging inbound frame {inbound_seq}"
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error = _E2BChannelSendError(
+                        "durable runner did not acknowledge inbound frame "
+                        f"{inbound_seq} within {self._send_ack_timeout_s:g}s"
+                    )
+                    if last_error is not None:
+                        raise error from last_error
+                    raise error
+
+                # At most two physical writes, always with the exact same sequence. If the first
+                # write was accepted but its HTTP response or ack notification was lost, the
+                # runner deduplicates the second and republishes the ack without dispatching.
+                if attempts < 2:
+                    attempts += 1
+                    try:
+                        self._sandbox.commands.send_stdin(
+                            self._pid,
+                            line,
+                            request_timeout=min(self._send_request_timeout_s, remaining),
+                        )
+                    except Exception as exc:  # noqa: BLE001 - delivery may still have succeeded
+                        last_error = exc
+
+                remaining = deadline - time.monotonic()
+                if self._wait_for_inbound_ack(
+                    inbound_seq,
+                    timeout=min(self._stdout_fast_wait_s, max(0.0, remaining)),
+                ):
+                    return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    continue
+                self._poll_outbox(
+                    request_timeout=min(self._file_request_timeout_s, remaining),
+                    frame_request_timeout=min(self._frame_request_timeout_s, remaining),
+                )
+                if self._inbound_acknowledged(inbound_seq):
+                    return
+                if self._fatal_error is not None:
+                    raise _E2BChannelSendError(self._fatal_error)
+                remaining = deadline - time.monotonic()
+                self._wait_for_inbound_ack(
+                    inbound_seq,
+                    timeout=min(self._poll_interval_s, max(0.0, remaining)),
+                )
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        """Return the next semantic frame in transport-sequence order.
+
+        Queue waits are capped by the outbox poll cadence, including during the hello handshake.
+        This covers a silently hung stdout iterator as well as an explicit stream error. Every E2B
+        head/liveness read gets a request timeout no larger than the caller's remaining deadline;
+        exact committed frame reads get their own bounded budget because they can contain a full
+        model context and are gzip-compressed by the E2B transport.
+        """
+        if self._closed.is_set():
+            return None
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            item = self._get_queued_nowait()
+            if item is not None:
+                return self._unwrap_item(item)
+
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise TimeoutError(
+                    f"no frame from the pi runner within {timeout}s"
+                    f"{self._stderr_suffix(include_durable=False)}"
+                )
+
+            # Stdout is the common, low-latency path. Give its reader one short scheduling window
+            # before issuing an E2B filesystem RPC; after an explicit stream failure, skip the
+            # window and fall through to the durable source immediately.
+            if self._stream_dead_at is None:
+                fast_wait = self._stdout_fast_wait_s
+                if remaining is not None:
+                    fast_wait = min(fast_wait, remaining)
+                if fast_wait > 0:
+                    try:
+                        item = self._frames.get(timeout=fast_wait)
+                    except queue.Empty:
+                        pass
+                    else:
+                        return self._unwrap_item(item)
+
+            request_timeout = self._file_request_timeout_s
+            if remaining is not None:
+                request_timeout = min(request_timeout, max(0.001, remaining))
+            self._poll_outbox(request_timeout=request_timeout)
+
+            item = self._get_queued_nowait()
+            if item is not None:
+                return self._unwrap_item(item)
+
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is None or remaining > 0:
+                liveness_timeout = self._file_request_timeout_s
+                if remaining is not None:
+                    liveness_timeout = min(liveness_timeout, max(0.001, remaining))
+                self._classify_runner_liveness(request_timeout=liveness_timeout)
+
+            item = self._get_queued_nowait()
+            if item is not None:
+                return self._unwrap_item(item)
+
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                raise TimeoutError(
+                    f"no frame from the pi runner within {timeout}s"
+                    f"{self._stderr_suffix(include_durable=False)}"
+                )
+            wait = (
+                self._poll_interval_s
+                if remaining is None
+                else min(self._poll_interval_s, remaining)
+            )
+            try:
+                item = self._frames.get(timeout=max(0.001, wait))
+            except queue.Empty:
+                continue
+            return self._unwrap_item(item)
+
+    def close(self) -> None:
+        """Logically close immediately and retire the runner in bounded background cleanup."""
+        with self._close_lock:
+            if self._closed.is_set():
+                return
+            # Never wait for a filesystem replay that currently owns `_state_lock`: cancellation
+            # must be able to retire the process even if a large exact-frame read is in flight.
+            self._closed.set()
+            if not self._eof_queued:
+                self._eof_queued = True
+                self._frames.put(_EOF)
+            threading.Thread(
+                target=self._cleanup_runner,
+                name="e2b-durable-cleanup",
+                daemon=True,
+            ).start()
+
+    def _cleanup_runner(self) -> None:
+        """Best-effort remote teardown; isolated because the SDK may add a 5s health probe."""
+        # Preserve a graceful shutdown when no logical send is in flight, but never wait behind
+        # one: PID termination below is the authoritative bounded cleanup path.
+        try:
+            if self._send_lock.acquire(blocking=False):
+                try:
+                    self._next_inbound_seq += 1
+                    line = self._encode_inbound(
+                        self._next_inbound_seq,
+                        {"type": "shutdown"},
+                    )
+                    try:
+                        self._sandbox.commands.send_stdin(
+                            self._pid,
+                            line,
+                            request_timeout=self._close_request_timeout_s,
+                        )
+                    except Exception:  # noqa: BLE001 - transport may already be dead
+                        pass
+                finally:
+                    self._send_lock.release()
+            try:
+                self._sandbox.commands.kill(
+                    self._pid,
+                    request_timeout=self._close_request_timeout_s,
+                )
+            except Exception:  # noqa: BLE001 - the process may already have exited
+                pass
+            disconnect = getattr(self._handle, "disconnect", None)
+            if callable(disconnect):
+                with contextlib.suppress(Exception):
+                    disconnect()
+            if threading.current_thread() is not self._reader:
+                self._reader.join(timeout=self._close_request_timeout_s)
+        finally:
+            self._cleanup_done.set()
+
+    def stderr_tail(self) -> str:
+        """Recent stream diagnostics plus the runner's durable stderr file."""
+        self._refresh_durable_stderr(self._file_request_timeout_s)
+        lines = [*self._stderr, *self._durable_stderr.splitlines()]
+        return "\n".join(lines[-self._stderr_lines :])
+
+    def _stderr_suffix(self, *, include_durable: bool = True) -> str:
+        if include_durable:
+            tail = self.stderr_tail()
+        else:
+            tail = "\n".join(self._stderr)
+        return f"; recent runner stderr:\n{tail}" if tail else ""
+
+    def _get_queued_nowait(self) -> JsonObject | _Eof | None:
+        try:
+            return self._frames.get_nowait()
+        except queue.Empty:
+            return None
+
+    def _unwrap_item(self, item: JsonObject | _Eof) -> JsonObject | None:
+        if self._closed.is_set():
+            return None  # cancellation discards every semantic frame queued before teardown
+        if not isinstance(item, _Eof):
+            return item
+        self._frames.put(item)  # sticky for every later recv
+        if self._closed.is_set():
+            return None
+        message = self._fatal_error or "pi live runner process exited"
+        raise RuntimeError(f"{message}{self._stderr_suffix()}")
+
+    def _read_events(self) -> None:
+        pending = ""
+        try:
+            for stdout, stderr, _pty in self._handle:
+                if self._closed.is_set():
+                    return
+                if stderr:
+                    for line in stderr.splitlines():
+                        if line.strip():
+                            self._stderr.append(line)
+                if not stdout:
+                    continue
+                self._last_stdout_at = time.monotonic()
+                pending += stdout
+                while "\n" in pending:
+                    line, pending = pending.split("\n", 1)
+                    self._decode_stdout_line(line)
+        except Exception as exc:  # noqa: BLE001 - stdout is only a fallible notification path
+            self._stream_error = f"[channel] output stream failed: {exc}"
+            self._stderr.append(self._stream_error)
+        else:
+            self._stream_error = "[channel] output stream ended"
+        finally:
+            if not self._closed.is_set():
+                self._stream_dead_at = time.monotonic()
+
+    def _decode_stdout_line(self, line: str) -> None:
+        text = line.strip()
+        if not text:
+            return
+        try:
+            value = json.loads(base64.b64decode(text, validate=True))
+        except ValueError:
+            self._stderr.append(f"[stdout] {text}")
+            return
+        if isinstance(value, dict) and value.get("type") == TRANSPORT_KEEPALIVE_TYPE:
+            return  # deliberately unsequenced and never persisted by the durable runner
+        envelope = self._parse_envelope(value)
+        if envelope is None:
+            if isinstance(value, dict):
+                with self._state_lock:
+                    self._mark_fatal_locked(
+                        "durable runner emitted an unsequenced or malformed semantic frame"
+                    )
+                return
+            self._stderr.append(f"[stdout] invalid durable envelope: {text}")
+            return
+        seq, frame = envelope
+        with self._state_lock:
+            if seq <= self._last_seq:
+                return
+            self._pending.setdefault(seq, frame)
+            # The runner publishes the exact frame + head before stdout, so the notification is
+            # proof that disk has committed through this sequence even if `head` is briefly stale.
+            self._known_head = max(self._known_head, seq)
+            # Never make the notification thread replay an unbounded disk gap while holding the
+            # ordering lock. ``recv`` continues one exact file per bounded poll.
+            self._drain_committed_locked(
+                request_timeout=self._frame_request_timeout_s,
+                max_file_reads=1,
+            )
+
+    def _poll_outbox(
+        self,
+        *,
+        request_timeout: float,
+        frame_request_timeout: float | None = None,
+    ) -> None:
+        if self._closed.is_set():
+            return
+        # Head is tiny and latency-sensitive. Exact frames use a separate, gzip-enabled budget:
+        # an LLM request can carry the agent's entire context and must not be misclassified as
+        # unavailable merely because it cannot fit inside this short polling interval.
+        unary_timeout = max(0.001, request_timeout)
+        try:
+            raw_head = self._sandbox.files.read(
+                f"{self._outbox_root}/head", request_timeout=unary_timeout
+            )
+            head = int(raw_head.strip())
+            if head < 0:
+                raise ValueError("negative sequence")
+        except Exception as exc:  # noqa: BLE001 - startup/momentary unary read misses are normal
+            self._last_outbox_error = f"head read failed: {exc}"
+            now = time.monotonic()
+            # Treat only uninterrupted failures as one outage. AgentProject does not pump this
+            # channel while it is idle between proposal rounds, so a long idle gap must not make
+            # the next isolated read failure look ancient.
+            if self._last_head_failure_at is None or now - self._last_head_failure_at > max(
+                1.0, self._poll_interval_s * 4
+            ):
+                self._head_failure_since = now
+            self._last_head_failure_at = now
+            head_failure_since = self._head_failure_since or now
+            output_unavailable = self._stream_dead_at is not None or (
+                now - self._last_stdout_at >= self._stdout_silence_grace_s
+            )
+            if output_unavailable and now - head_failure_since >= self._frame_read_grace_s:
+                with self._state_lock:
+                    self._mark_fatal_locked(
+                        "durable outbox head unavailable after "
+                        f"{self._frame_read_grace_s:g}s: {self._last_outbox_error}"
+                    )
+            return
+        self._head_failure_since = None
+        self._last_head_failure_at = None
+        with self._state_lock:
+            self._known_head = max(self._known_head, head)
+            self._drain_committed_locked(
+                request_timeout=(
+                    self._frame_request_timeout_s
+                    if frame_request_timeout is None
+                    else frame_request_timeout
+                ),
+                max_file_reads=1,
+            )
+
+    def _drain_committed_locked(
+        self, *, request_timeout: float, max_file_reads: int | None = None
+    ) -> None:
+        """Advance the one delivery cursor; caller holds ``_state_lock``."""
+        file_reads = 0
+        while not self._closed.is_set() and self._fatal_error is None:
+            expected = self._last_seq + 1
+            frame = self._pending.pop(expected, None)
+            if frame is None:
+                if expected > self._known_head:
+                    return
+                if max_file_reads is not None and file_reads >= max_file_reads:
+                    return
+                file_reads += 1
+                envelope = self._read_frame_file(expected, request_timeout=request_timeout)
+                if self._closed.is_set():
+                    return
+                if envelope is None:
+                    started = self._missing_since.setdefault(expected, time.monotonic())
+                    if time.monotonic() - started >= self._frame_read_grace_s:
+                        detail = f": {self._last_outbox_error}" if self._last_outbox_error else ""
+                        self._mark_fatal_locked(
+                            f"durable outbox frame {expected} unavailable after "
+                            f"{self._frame_read_grace_s:g}s{detail}"
+                        )
+                    return
+                _seq, frame = envelope
+            self._missing_since.pop(expected, None)
+            self._last_seq = expected
+            if frame.get("type") != TRANSPORT_KEEPALIVE_TYPE:
+                self._deliver_frame_locked(frame)
+
+    def _deliver_frame_locked(self, frame: JsonObject) -> None:
+        """Filter transport control frames; caller holds the outbound ordering lock."""
+        kind = frame.get("type")
+        if kind == "transport_ack":
+            inbound_seq = frame.get("transport_in_seq")
+            if (
+                isinstance(inbound_seq, bool)
+                or not isinstance(inbound_seq, int)
+                or inbound_seq <= 0
+                or inbound_seq > self._next_inbound_seq
+            ):
+                self._mark_fatal_locked("durable runner emitted an invalid inbound acknowledgement")
+                return
+            with self._ack_condition:
+                self._acked_inbound_seq = max(self._acked_inbound_seq, inbound_seq)
+                self._ack_condition.notify_all()
+            return
+        if kind == "transport_nack":
+            expected = frame.get("expected_transport_in_seq")
+            received = frame.get("transport_in_seq")
+            self._mark_fatal_locked(
+                f"durable runner rejected inbound sequence {received!r}; expected {expected!r}"
+            )
+            return
+        self._frames.put(frame)
+
+    @staticmethod
+    def _encode_inbound(inbound_seq: int, frame: JsonObject) -> str:
+        envelope: JsonObject = {
+            "transport_in_seq": inbound_seq,
+            "frame": frame,
+        }
+        return base64.b64encode(json.dumps(envelope).encode("utf-8")).decode("ascii") + "\n"
+
+    def _inbound_acknowledged(self, inbound_seq: int) -> bool:
+        with self._ack_condition:
+            return self._acked_inbound_seq >= inbound_seq
+
+    def _wait_for_inbound_ack(self, inbound_seq: int, *, timeout: float) -> bool:
+        with self._ack_condition:
+            if self._acked_inbound_seq >= inbound_seq:
+                return True
+            if timeout > 0:
+                self._ack_condition.wait(timeout=timeout)
+            return self._acked_inbound_seq >= inbound_seq
+
+    def _read_frame_file(
+        self, seq: int, *, request_timeout: float
+    ) -> tuple[int, JsonObject] | None:
+        path = f"{self._outbox_root}/frames/{seq:020d}.json"
+        try:
+            raw = self._sandbox.files.read(
+                path,
+                request_timeout=request_timeout,
+                gzip=True,
+            )
+            value = json.loads(raw)
+            envelope = self._parse_envelope(value)
+            if envelope is None or envelope[0] != seq:
+                raise ValueError(f"expected transport_seq {seq}")
+            return envelope
+        except Exception as exc:  # noqa: BLE001 - retried by subsequent bounded recv polls
+            self._last_outbox_error = f"{path} read failed: {exc}"
+            return None
+
+    def _classify_runner_liveness(self, *, request_timeout: float) -> None:
+        dead_at = self._stream_dead_at
+        if self._closed.is_set():
+            return
+        now = time.monotonic()
+        stream_failure_is_due = (
+            dead_at is not None
+            and not self._stream_death_probe_done
+            and now - dead_at >= self._stream_death_grace_s
+        )
+        if not stream_failure_is_due and now < self._next_pid_check_at:
+            return
+        if stream_failure_is_due:
+            self._stream_death_probe_done = True
+        self._next_pid_check_at = now + self._pid_probe_interval_s
+        try:
+            processes = self._sandbox.commands.list(request_timeout=request_timeout)
+        except Exception as exc:  # noqa: BLE001 - a failed probe is not proof of process death
+            message = f"[channel] runner liveness probe failed: {exc}"
+            if not self._stderr or self._stderr[-1] != message:
+                self._stderr.append(message)
+            return
+        if any(process.pid == self._pid for process in processes):
+            self._pid_dead_at = None
+            return
+        # `recv` polls disk before every liveness probe. Keep doing so for a bounded grace after the
+        # PID disappears, allowing a final frame and head update to become visible before EOF.
+        if self._pid_dead_at is None:
+            self._pid_dead_at = now
+            return
+        if now - self._pid_dead_at < self._frame_read_grace_s:
+            return
+        self._refresh_durable_stderr(request_timeout)
+        with self._state_lock:
+            detail = f" after {self._stream_error}" if self._stream_error else ""
+            self._mark_fatal_locked(f"pi live runner process exited{detail}")
+
+    def _refresh_durable_stderr(self, request_timeout: float) -> None:
+        try:
+            stderr = self._sandbox.files.read(self._stderr_path, request_timeout=request_timeout)
+            self._durable_stderr = "\n".join(stderr.splitlines()[-self._stderr_lines :])
+        except Exception:  # noqa: BLE001 - diagnostics must never mask the transport error
+            pass
+
+    @staticmethod
+    def _parse_envelope(value: object) -> tuple[int, JsonObject] | None:
+        if not isinstance(value, dict):
+            return None
+        seq = value.get("transport_seq")
+        frame = value.get("frame")
+        if isinstance(seq, bool) or not isinstance(seq, int) or seq <= 0:
+            return None
+        if not isinstance(frame, dict):
+            return None
+        return seq, cast("JsonObject", frame)
+
+    def _mark_fatal_locked(self, message: str) -> None:
+        if self._fatal_error is None:
+            self._fatal_error = message
+        self._queue_eof_locked()
+
+    def _queue_eof_locked(self) -> None:
+        if not self._eof_queued:
+            self._eof_queued = True
+            self._frames.put(_EOF)
 
 
 class E2BSandboxPool:
@@ -624,7 +1235,8 @@ def start_live_runner(
     workspace: str = LIVE_WORKSPACE,
     hello_timeout: float = HELLO_TIMEOUT_S,
     reconnect_while_idle: bool = False,
-) -> E2BStdioChannel:
+    durable_outbox: bool = False,
+) -> E2BStdioChannel | E2BDurableChannel:
     """Bootstrap and start `runner_live.ts` on an already-created sandbox; return its channel.
 
     A live session (unlike a pooled eval episode) is one dedicated sandbox whose lifecycle the
@@ -632,8 +1244,10 @@ def start_live_runner(
     the handle for keepalive, PTY, and reconciliation. This function does only the runner
     bootstrap: upload the live runner file(s), install node 22 + pi's npm deps unless a template
     prebakes them, ensure the workspace dir, start the long-lived runner over a stdin-writable
-    background command, and block until its `hello`. The returned `E2BStdioChannel` is what a
-    `wmh.harness.live_session.LiveSession` drives.
+    background command, and block until its `hello`. By default this returns the established
+    ``E2BStdioChannel`` unchanged. ``durable_outbox=True`` instead gives the same ordinary runner a
+    unique sequenced outbox below ``RUNNER_WORKDIR`` and returns an ``E2BDurableChannel``; project
+    files and the agent-facing workspace remain separate from transport state.
     """
     for name in _LIVE_RUNNER_FILES:
         sandbox.files.write(f"{RUNNER_WORKDIR}/{name}", _read_entry(name))
@@ -646,25 +1260,52 @@ def start_live_runner(
         )
     # `workspace` is a public parameter; quote it so a caller-supplied path can't
     # inject extra shell commands into the live sandbox.
-    sandbox.commands.run(f"mkdir -p {shlex.quote(workspace)}", timeout=30)
-    handle = sandbox.commands.run(LIVE_START_CMD, background=True, stdin=True, timeout=0)
-    channel = E2BStdioChannel(
-        sandbox,
-        cast("CommandHandle", handle),
-        reconnect_while_idle=reconnect_while_idle,
-    )
+    outbox_root: str | None = None
+    stderr_path: str | None = None
+    start_cmd = LIVE_START_CMD
+    if durable_outbox:
+        outbox_root = f"{RUNNER_WORKDIR}/live-outbox-{uuid.uuid4().hex}"
+        stderr_path = f"{outbox_root}/stderr.log"
+        sandbox.commands.run(
+            f"mkdir -p {shlex.quote(workspace)} {shlex.quote(outbox_root + '/frames')}",
+            timeout=30,
+        )
+        start_cmd = f"{LIVE_START_CMD} 2>> {shlex.quote(stderr_path)}"
+        handle = sandbox.commands.run(
+            start_cmd,
+            background=True,
+            envs={"WMH_LIVE_OUTBOX": outbox_root},
+            stdin=True,
+            timeout=0,
+        )
+        channel: E2BStdioChannel | E2BDurableChannel = E2BDurableChannel(
+            sandbox,
+            cast("CommandHandle", handle),
+            outbox_root=outbox_root,
+            stderr_path=stderr_path,
+        )
+    else:
+        sandbox.commands.run(f"mkdir -p {shlex.quote(workspace)}", timeout=30)
+        handle = sandbox.commands.run(LIVE_START_CMD, background=True, stdin=True, timeout=0)
+        channel = E2BStdioChannel(
+            sandbox,
+            cast("CommandHandle", handle),
+            reconnect_while_idle=reconnect_while_idle,
+        )
     try:
         deadline = time.monotonic() + hello_timeout
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise RuntimeError(_no_hello_live(hello_timeout, channel))
+                raise RuntimeError(_no_hello_live(hello_timeout, channel, start_cmd=start_cmd))
             try:
                 frame = channel.recv(timeout=remaining)
             except TimeoutError as exc:
-                raise RuntimeError(_no_hello_live(hello_timeout, channel)) from exc
+                raise RuntimeError(
+                    _no_hello_live(hello_timeout, channel, start_cmd=start_cmd)
+                ) from exc
             if frame is None:
-                raise RuntimeError(_no_hello_live(hello_timeout, channel))
+                raise RuntimeError(_no_hello_live(hello_timeout, channel, start_cmd=start_cmd))
             if frame.get("type") == "hello":
                 return channel
     except Exception:
@@ -675,10 +1316,15 @@ def start_live_runner(
         raise
 
 
-def _no_hello_live(timeout: float, channel: E2BStdioChannel) -> str:
+def _no_hello_live(
+    timeout: float,
+    channel: E2BStdioChannel | E2BDurableChannel,
+    *,
+    start_cmd: str = LIVE_START_CMD,
+) -> str:
     tail = channel.stderr_tail()
     suffix = f"; recent runner stderr:\n{tail}" if tail else ""
-    return f"live runner sent no hello within {timeout:g}s ({LIVE_START_CMD!r}){suffix}"
+    return f"live runner sent no hello within {timeout:g}s ({start_cmd!r}){suffix}"
 
 
 def _kill_quietly(sandbox: SandboxHandle) -> None:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -35,7 +35,7 @@ import time
 import uuid
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from typing import cast
+from typing import Literal, cast, overload
 
 from wmh.core.types import JsonObject
 from wmh.harness.e2b_sandbox import (
@@ -1226,6 +1226,30 @@ def session_entry_files() -> dict[str, str]:
     from the installed wmh package and writes them into the sandbox at start).
     """
     return {name: _read_entry(name) for name in _LIVE_RUNNER_FILES}
+
+
+@overload
+def start_live_runner(
+    sandbox: SandboxHandle,
+    *,
+    template: str | None = None,
+    workspace: str = LIVE_WORKSPACE,
+    hello_timeout: float = HELLO_TIMEOUT_S,
+    reconnect_while_idle: bool = False,
+    durable_outbox: Literal[False] = False,
+) -> E2BStdioChannel: ...
+
+
+@overload
+def start_live_runner(
+    sandbox: SandboxHandle,
+    *,
+    template: str | None = None,
+    workspace: str = LIVE_WORKSPACE,
+    hello_timeout: float = HELLO_TIMEOUT_S,
+    reconnect_while_idle: bool = False,
+    durable_outbox: Literal[True],
+) -> E2BDurableChannel: ...
 
 
 def start_live_runner(

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -29,6 +29,7 @@ import json
 import math
 import os
 import queue
+import re
 import shlex
 import threading
 import time
@@ -129,6 +130,10 @@ MAX_EVAL_EPISODE_LIFETIME_S = 3_600.0
 DEFAULT_EVAL_EPISODE_TIMEOUT_S = 300.0
 _MAX_RETIRE_WORKERS = 16
 
+_HTTPCORE_REMOTE_STREAM_RESET = re.compile(
+    r"<StreamReset stream_id:\d+, error_code:\d+, remote_reset:True>"
+)
+
 
 class _Eof:
     """Reader-thread sentinel: the runner process's output stream ended."""
@@ -201,6 +206,12 @@ class E2BStdioChannel:
                 self._sandbox.commands.send_stdin(self._pid, line)
             except OSError as exc:
                 raise _E2BChannelSendError("failed to send a frame to the E2B runner") from exc
+            except Exception as exc:  # noqa: BLE001 - classify one optional-SDK transport shape
+                if _is_httpcore_remote_stream_reset(exc):
+                    raise _E2BChannelSendError(
+                        "failed to send a frame to the E2B runner after an HTTP/2 stream reset"
+                    ) from exc
+                raise
 
     def recv(self, timeout: float | None = None) -> JsonObject | None:
         """The next frame from the runner; blocks (up to `timeout` seconds when given).
@@ -1331,6 +1342,16 @@ def _is_retryable_transport_error(exc: Exception) -> bool:
     # TimeoutError, but any instance means the sandbox/channel state is uncertain.
     exc_type = type(exc)
     return exc_type.__module__ == "e2b.exceptions" and exc_type.__name__ == "TimeoutException"
+
+
+def _is_httpcore_remote_stream_reset(exc: Exception) -> bool:
+    """Recognize the exact HTTP/2 reset emitted by E2B's httpcore control-plane call."""
+    exc_type = type(exc)
+    return (
+        exc_type.__module__ == "httpcore"
+        and exc_type.__name__ == "RemoteProtocolError"
+        and _HTTPCORE_REMOTE_STREAM_RESET.fullmatch(str(exc)) is not None
+    )
 
 
 def session_entry_files() -> dict[str, str]:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -85,6 +85,7 @@ _PI_ENTRY_DIR = os.path.join(os.path.dirname(__file__), "pi_entry")
 _RUNNER_FILES = ("runner_stdio.ts", "runner_frames.ts")
 
 _STDERR_LINES = 50  # bounded diagnostics buffer: enough for a stack trace, never unbounded
+_IDLE_RECONNECT_DELAYS_S = (0.0, 0.25, 1.0)
 
 # A runner-originated heartbeat keeps the background command stream active while the host is
 # synchronously waiting on a slow provider call. Pooled evaluation channels also use the same
@@ -128,9 +129,11 @@ class E2BStdioChannel:
         sandbox_timeout_s: int | None = None,
         timeout_refresh_interval_s: float = _SANDBOX_TIMEOUT_REFRESH_S,
         max_episode_lifetime_s: float = MAX_EVAL_EPISODE_LIFETIME_S,
+        reconnect_while_idle: bool = False,
     ) -> None:
         self._sandbox = sandbox
         self._handle = handle
+        self._pid = handle.pid
         self._frames: queue.Queue[JsonObject | _Eof] = queue.Queue()
         self._stderr: deque[str] = deque(maxlen=stderr_lines)
         self._sandbox_timeout_s = sandbox_timeout_s
@@ -138,6 +141,12 @@ class E2BStdioChannel:
         self._max_episode_lifetime_s = max_episode_lifetime_s
         self._next_timeout_refresh_at = 0.0
         self._episode_renewal_deadline_at: float | None = None
+        self._reconnect_while_idle = reconnect_while_idle
+        # Guards the definitely-idle proof and the same-PID reconnect. A user message clears the
+        # proof while holding this lock *before* stdin delivery, so the reader cannot reconnect
+        # across a turn-start race where a semantic runner frame might be lost.
+        self._transport_lock = threading.Lock()
+        self._session_idle = False
         self._closed = False
         self._reader = threading.Thread(
             target=self._read_events, name="e2b-stdio-reader", daemon=True
@@ -145,17 +154,21 @@ class E2BStdioChannel:
         self._reader.start()
 
     def send(self, frame: JsonObject) -> None:
-        if frame.get("type") == "episode_start" and self._sandbox_timeout_s is not None:
+        kind = frame.get("type")
+        if kind == "episode_start" and self._sandbox_timeout_s is not None:
             now = time.monotonic()
             self._episode_renewal_deadline_at = now + self._max_episode_lifetime_s
             # The pool reset the lease immediately before this episode. Wait until the normal
             # refresh cadence instead of bursting one set_timeout call per sandbox at 30 seconds.
             self._next_timeout_refresh_at = now + self._timeout_refresh_interval_s
         line = base64.b64encode(json.dumps(frame).encode("utf-8")).decode("ascii") + "\n"
-        try:
-            self._sandbox.commands.send_stdin(self._handle.pid, line)
-        except OSError as exc:
-            raise _E2BChannelSendError("failed to send a frame to the E2B runner") from exc
+        with self._transport_lock:
+            if kind in {"session_start", "user_message"}:
+                self._session_idle = False
+            try:
+                self._sandbox.commands.send_stdin(self._pid, line)
+            except OSError as exc:
+                raise _E2BChannelSendError("failed to send a frame to the E2B runner") from exc
 
     def recv(self, timeout: float | None = None) -> JsonObject | None:
         """The next frame from the runner; blocks (up to `timeout` seconds when given).
@@ -179,10 +192,12 @@ class E2BStdioChannel:
 
     def close(self) -> None:
         """Ask the runner to exit (best-effort); marks the stream end as clean for recv."""
-        if self._closed:
-            return
-        self._closed = True
-        self._episode_renewal_deadline_at = None
+        with self._transport_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._session_idle = False
+            self._episode_renewal_deadline_at = None
         try:
             self.send({"type": "shutdown"})
         except Exception:  # noqa: BLE001 - the process/sandbox may already be gone; close is best-effort
@@ -198,22 +213,66 @@ class E2BStdioChannel:
 
     def _read_events(self) -> None:
         pending = ""
-        try:
-            for stdout, stderr, _pty in self._handle:
-                if stderr:
-                    for line in stderr.splitlines():
-                        if line.strip():
-                            self._stderr.append(line)
-                if not stdout:
+        handle = self._handle
+        while True:
+            try:
+                for stdout, stderr, _pty in handle:
+                    if stderr:
+                        for line in stderr.splitlines():
+                            if line.strip():
+                                self._stderr.append(line)
+                    if not stdout:
+                        continue
+                    pending += stdout
+                    while "\n" in pending:
+                        line, pending = pending.split("\n", 1)
+                        self._decode_line(line)
+            except Exception as exc:  # noqa: BLE001 - classified by definitely-idle reconnect
+                reconnected = self._reconnect_idle_stream()
+                if reconnected is not None:
+                    # A partially delivered line is not replay-safe. The runner writes one frame
+                    # per line; dropping the fragment lets the next complete frame resynchronize.
+                    pending = ""
+                    handle = reconnected
                     continue
-                pending += stdout
-                while "\n" in pending:
-                    line, pending = pending.split("\n", 1)
-                    self._decode_line(line)
-        except Exception as exc:  # noqa: BLE001 - a broken stream becomes EOF + a diagnostic, not a dead thread
-            self._stderr.append(f"[channel] output stream failed: {exc}")
-        finally:
+                self._stderr.append(f"[channel] output stream failed: {exc}")
+            else:
+                # E2B's stream generator may also end without an exception when the HTTP stream
+                # disappears before a process-end event. Same-PID reconnect remains safe only at
+                # the exact idle boundary; a real process exit simply makes connect fail.
+                reconnected = self._reconnect_idle_stream()
+                if reconnected is not None:
+                    pending = ""
+                    handle = reconnected
+                    continue
             self._frames.put(_EOF)
+            return
+
+    def _reconnect_idle_stream(self) -> CommandHandle | None:
+        """Reattach to the same live runner only while it is provably between turns.
+
+        E2B command streams can suffer a transient HTTP/2 disconnect while their process and
+        sandbox remain healthy. Reconnecting mid-turn is not safe because an LLM/tool/state frame
+        may have been lost. Once ``state:idle`` was decoded, however, the runner emits only filtered
+        transport heartbeats until the next host ``user_message``; same-PID reconnect is lossless.
+        """
+        if not self._reconnect_while_idle:
+            return None
+        for delay in _IDLE_RECONNECT_DELAYS_S:
+            if delay:
+                time.sleep(delay)
+            # Hold the proof across connect. `send(user_message)` takes this same lock and clears
+            # idle before stdin delivery, so it either happens entirely before or after reattach.
+            with self._transport_lock:
+                if self._closed or not self._session_idle:
+                    return None
+                try:
+                    handle = self._sandbox.commands.connect(self._pid, timeout=0)
+                except Exception:  # noqa: BLE001 - the next bounded attempt uses a fresh stream
+                    continue
+                self._handle = handle
+                return handle
+        return None
 
     def _decode_line(self, line: str) -> None:
         text = line.strip()
@@ -228,6 +287,12 @@ class E2BStdioChannel:
             if frame.get("type") == TRANSPORT_KEEPALIVE_TYPE:
                 self._refresh_sandbox_timeout()
                 return
+            if frame.get("type") == "state":
+                status = frame.get("status")
+                with self._transport_lock:
+                    # Only an exact idle acknowledgement is a replay-safety proof. Any new or
+                    # malformed state value conservatively disables transparent reconnect.
+                    self._session_idle = status == "idle"
             if frame.get("type") in {"done", "episode_error"}:
                 self._episode_renewal_deadline_at = None
             self._frames.put(cast("JsonObject", frame))
@@ -531,6 +596,7 @@ def start_live_runner(
     template: str | None = None,
     workspace: str = LIVE_WORKSPACE,
     hello_timeout: float = HELLO_TIMEOUT_S,
+    reconnect_while_idle: bool = False,
 ) -> E2BStdioChannel:
     """Bootstrap and start `runner_live.ts` on an already-created sandbox; return its channel.
 
@@ -555,7 +621,11 @@ def start_live_runner(
     # inject extra shell commands into the live sandbox.
     sandbox.commands.run(f"mkdir -p {shlex.quote(workspace)}", timeout=30)
     handle = sandbox.commands.run(LIVE_START_CMD, background=True, stdin=True, timeout=0)
-    channel = E2BStdioChannel(sandbox, cast("CommandHandle", handle))
+    channel = E2BStdioChannel(
+        sandbox,
+        cast("CommandHandle", handle),
+        reconnect_while_idle=reconnect_while_idle,
+    )
     try:
         deadline = time.monotonic() + hello_timeout
         while True:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -52,6 +52,7 @@ from wmh.harness.e2b_sandbox import (
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.runner_link import RunnerLink, WorkerFn
 from wmh.harness.runtime import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_MAX_TURNS,
     RunResult,
     RuntimeCancelled,
@@ -1182,11 +1183,14 @@ class E2BPiRuntime:
         worker_fn: WorkerFn | None = None,
         hello_timeout: float = HELLO_TIMEOUT_S,
         max_turns: int = DEFAULT_MAX_TURNS,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         should_cancel: Callable[[], bool] | None = None,
     ) -> None:
         if max_turns < 1:
             raise ValueError("max_turns must be >= 1")
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
         if episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive")
         self._provider = provider
@@ -1195,6 +1199,7 @@ class E2BPiRuntime:
         self._system_prompt = system_prompt
         self._worker_fn = worker_fn  # test seam, exactly like RunnerLink's
         self._max_turns = max_turns
+        self._max_output_tokens = max_output_tokens
         self._episode_timeout_s = episode_timeout_s
         self._should_cancel = should_cancel
         self._owns_pool = pool is None
@@ -1234,6 +1239,7 @@ class E2BPiRuntime:
                 files=self._files,
                 system_prompt=self._system_prompt,
                 max_turns=self._max_turns,
+                max_output_tokens=self._max_output_tokens,
                 episode_timeout_s=self._episode_timeout_s,
                 should_cancel=self._should_cancel,
             )

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -8,8 +8,8 @@ lifecycle, and `E2BPiRuntime.run` end-to-end — the runner script speaks the sa
 environment answering tool calls is a plain host-side `AgentEnvironment` fake: the sandbox is only
 where the harness process lives, never where tool calls land.
 
-No TS-side test: the repo has no TypeScript test precedent (no *_test.ts outside the untouchable
-vendor tree, no root package.json), so runner_stdio.ts is covered by the frame-contract tests here.
+The TypeScript runners have no package-level test harness here, so source-contract checks below
+pin the host-provided model budget in addition to the Python frame-contract tests.
 """
 
 from __future__ import annotations
@@ -65,6 +65,16 @@ def test_all_pi_llm_bridges_forward_opaque_reasoning_details() -> None:
     for filename in ("runner_stdio.ts", "runner_live.ts", "runner_service.ts"):
         source = (entry / filename).read_text(encoding="utf-8")
         assert "delta.reasoning_details = msg.reasoning_details" in source
+
+
+def test_all_pi_entrypoints_use_the_host_output_budget() -> None:
+    """No execution mode may silently fall back to the old hard-coded 4k model ceiling."""
+    entry = Path(pi_e2b_module.__file__).with_name("pi_entry")
+    for filename in ("entry.ts", "runner_stdio.ts", "runner_live.ts", "runner_service.ts"):
+        source = (entry / filename).read_text(encoding="utf-8")
+        assert "max_output_tokens" in source
+        assert "maxTokens: maxOutputTokens" in source
+        assert "maxTokens: 4096" not in source
 
 
 def _line(frame: JsonObject) -> str:
@@ -465,6 +475,7 @@ def _runtime(
     template: str | None = None,
     worker_fn: Callable[[ChatRequest], ChatResponse] | None = None,
     max_turns: int = 20,
+    max_output_tokens: int = 4096,
     episode_timeout_s: float = 300.0,
     should_cancel: Callable[[], bool] | None = None,
 ) -> E2BPiRuntime:
@@ -477,6 +488,7 @@ def _runtime(
         pool=pool,
         worker_fn=worker_fn,
         max_turns=max_turns,
+        max_output_tokens=max_output_tokens,
         episode_timeout_s=episode_timeout_s,
         should_cancel=should_cancel,
     )
@@ -942,7 +954,12 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
         return completion
 
     with E2BSandboxPool(sandbox_factory=factory) as pool:
-        result = _runtime(pool=pool, worker_fn=worker, max_turns=7).run("t1", "do it", env)
+        result = _runtime(
+            pool=pool,
+            worker_fn=worker,
+            max_turns=7,
+            max_output_tokens=16384,
+        ).run("t1", "do it", env)
 
     assert result.stop_reason is StopReason.SUBMITTED
     assert result.answer == "finished"
@@ -963,6 +980,7 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
     assert start["instruction"] == "do it" and start["system"] == "sys"
     assert start["files"] == {"src/agent.ts": "// a"}
     assert start["max_turns"] == 7
+    assert start["max_output_tokens"] == 16384
     assert start["episode_timeout_s"] == 300.0
     tool_names = {t["name"] for t in cast("list[JsonObject]", start["tools"])}
     assert tool_names >= {"bash", "submit"}

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -66,6 +66,13 @@ class TimeoutException(Exception):
 TimeoutException.__module__ = "e2b.exceptions"
 
 
+class RemoteProtocolError(Exception):
+    """httpcore-shaped protocol exception without depending on its implementation."""
+
+
+RemoteProtocolError.__module__ = "httpcore"
+
+
 def test_all_pi_llm_bridges_forward_opaque_reasoning_details() -> None:
     """Every runner preserves stateless Responses reasoning through Pi's SSE parser."""
     entry = Path(pi_e2b_module.__file__).with_name("pi_entry")
@@ -1374,6 +1381,92 @@ def test_run_retries_broken_pipe_once_on_a_fresh_sandbox(
     assert result.answer == "recovered"
     assert len(made) == 2
     assert made[0].kills == 1
+    pool.close()
+
+
+def test_run_retries_http2_remote_stream_reset_once_on_a_fresh_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """E2B's exact HTTP/2 send reset retires the uncertain sandbox and replays once."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        {"type": "done", "answer": "recovered"},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def reset_first_factory() -> FakeSandbox:
+        fake = factory()
+        if len(made) == 1:
+            fake.commands.fail_sends_from = 2
+            fake.commands.send_error = RemoteProtocolError(
+                "<StreamReset stream_id:13, error_code:1, remote_reset:True>"
+            )
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=reset_first_factory)
+    result = _runtime(pool=pool).run("t1", "do it", _RecordingEnv())
+
+    assert result.answer == "recovered"
+    assert len(made) == 2
+    assert [len(_of_kind(fake, "llm_response")) for fake in made] == [1, 1]
+    assert made[0].kills == 1
+    pool.close()
+
+
+def test_arbitrary_httpcore_protocol_error_propagates_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A protocol error without the proven remote-reset shape remains ambiguous."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def protocol_error_factory() -> FakeSandbox:
+        fake = factory()
+        fake.commands.fail_sends_from = 2
+        fake.commands.send_error = RemoteProtocolError("Server disconnected")
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=protocol_error_factory)
+    with pytest.raises(RemoteProtocolError, match="Server disconnected"):
+        _runtime(pool=pool).run("t1", "do it", _RecordingEnv())
+
+    assert len(made) == 1
+    assert len(_of_kind(made[0], "llm_response")) == 1
+    assert made[0].kills == 1
+    pool.close()
+
+
+def test_provider_http2_remote_stream_reset_is_not_a_transport_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same exception from the worker provider is reported to pi, not replayed."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        {"type": "done", "answer": "provider error handled"},
+    ]
+    factory, made = _factory_for([script, script])
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        del request
+        raise RemoteProtocolError("<StreamReset stream_id:13, error_code:1, remote_reset:True>")
+
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    result = _runtime(pool=pool, worker_fn=worker).run("t1", "do it", _RecordingEnv())
+
+    assert result.answer == "provider error handled"
+    assert len(made) == 1
+    responses = _of_kind(made[0], "llm_response")
+    assert len(responses) == 1
+    assert "StreamReset" in cast("str", responses[0]["error"])
+    assert made[0].kills == 0
     pool.close()
 
 

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -18,7 +18,9 @@ import base64
 import json
 import shlex
 import threading
-from collections.abc import Callable, Iterator
+import time
+from collections.abc import Callable, Iterator, Sequence
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -27,6 +29,7 @@ from llm_waterfall import ChatRequest, ChatResponse
 from wmh.core.types import Action, JsonObject, Observation
 from wmh.harness import pi_e2b as pi_e2b_module
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage
+from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_e2b import (
     LIVE_START_CMD,
     NODE_INSTALL_CMD,
@@ -34,6 +37,7 @@ from wmh.harness.pi_e2b import (
     RUNNER_WORKDIR,
     START_CMD,
     TRANSPORT_KEEPALIVE_TYPE,
+    E2BDurableChannel,
     E2BPiRuntime,
     E2BSandboxPool,
     E2BStdioChannel,
@@ -63,6 +67,10 @@ def _stdout_events(frames: list[JsonObject]) -> list[_Event]:
     return [(_line(f), None, None) for f in frames]
 
 
+def _envelope(seq: int, frame: JsonObject) -> JsonObject:
+    return {"transport_seq": seq, "frame": frame}
+
+
 class _ScriptedHandle:
     """A fake background command handle: yields scripted (stdout, stderr, pty) events.
 
@@ -75,11 +83,16 @@ class _ScriptedHandle:
         self._events = list(events)
         self._hold_open = hold_open
         self._release = threading.Event()
+        self.disconnects = 0
 
     def __iter__(self) -> Iterator[_Event]:
         yield from self._events
         if self._hold_open:
             self._release.wait(2.0)  # self-releasing so the daemon reader never lingers
+
+    def disconnect(self) -> None:
+        self.disconnects += 1
+        self._release.set()
 
 
 class _DisconnectingHandle(_ScriptedHandle):
@@ -96,6 +109,18 @@ class _DisconnectingHandle(_ScriptedHandle):
         raise RuntimeError("Server disconnected")
 
 
+class _GatedHandle(_ScriptedHandle):
+    """Keep stdout silent until a test has consumed the same frame from disk."""
+
+    def __init__(self, events: list[_Event], gate: threading.Event) -> None:
+        super().__init__(events, hold_open=True)
+        self._gate = gate
+
+    def __iter__(self) -> Iterator[_Event]:
+        self._gate.wait(2.0)
+        yield from super().__iter__()
+
+
 class _Result:
     """A minimal CommandOutput for foreground runs."""
 
@@ -105,6 +130,11 @@ class _Result:
         self.exit_code = exit_code
 
 
+class _Process:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
 class _FakeCommands:
     """Foreground runs are recorded and echoed; background=True returns the scripted handle."""
 
@@ -112,28 +142,38 @@ class _FakeCommands:
         self,
         handle: _ScriptedHandle,
         *,
-        reconnect_handles: list[_ScriptedHandle] | None = None,
+        reconnect_handles: Sequence[_ScriptedHandle] | None = None,
+        on_stdin: Callable[[str], None] | None = None,
     ) -> None:
         self._handle = handle
         self._reconnect_handles = list(reconnect_handles or [])
         self.calls: list[str] = []  # foreground commands, in order (installs, ...)
         self.background_cmds: list[str] = []
+        self.background_envs: list[dict[str, str] | None] = []
         self.connects: list[tuple[int, float | None]] = []
         self.stdin: list[tuple[int, str]] = []
+        self.stdin_request_timeouts: list[float | None] = []
+        self.running_pids = {_PID}
+        self.killed: list[int] = []
+        self.kill_request_timeouts: list[float | None] = []
         self.fail_sends_from: int | None = None
+        self.fail_before_delivery: set[int] = set()
         self.send_error: Exception = TimeoutException("request timed out")
+        self._on_stdin = on_stdin
 
     def run(
         self,
         cmd: str,
         background: bool | None = None,
         *,
+        envs: dict[str, str] | None = None,
         stdin: bool | None = None,
         timeout: float | None = None,
     ) -> object:
         if background:
             assert stdin is True  # the runner is useless without a writable stdin
             self.background_cmds.append(cmd)
+            self.background_envs.append(envs)
             return self._handle
         self.calls.append(cmd)
         return _Result(stdout=f"ran: {cmd}")
@@ -144,10 +184,24 @@ class _FakeCommands:
             raise RuntimeError("process connection unavailable")
         return self._reconnect_handles.pop(0)
 
-    def send_stdin(self, pid: int, data: str) -> None:
+    def send_stdin(self, pid: int, data: str, request_timeout: float | None = None) -> None:
         self.stdin.append((pid, data))
+        self.stdin_request_timeouts.append(request_timeout)
+        if len(self.stdin) in self.fail_before_delivery:
+            raise self.send_error
+        if self._on_stdin is not None:
+            self._on_stdin(data)
         if self.fail_sends_from is not None and len(self.stdin) >= self.fail_sends_from:
             raise self.send_error
+
+    def list(self, request_timeout: float | None = None) -> Sequence[_Process]:
+        del request_timeout
+        return [_Process(pid) for pid in self.running_pids]
+
+    def kill(self, pid: int, request_timeout: float | None = None) -> None:
+        self.killed.append(pid)
+        self.kill_request_timeouts.append(request_timeout)
+        self.running_pids.discard(pid)
 
 
 class _FakeFiles:
@@ -161,8 +215,78 @@ class _FakeFiles:
         self.writes.append(path)
         self.store[path] = data
 
-    def read(self, path: str) -> str:
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        del request_timeout, gzip
         return self.store[path]
+
+
+class _TransientFiles(_FakeFiles):
+    """Fail selected reads a bounded number of times to model E2B visibility/RPC races."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failures: dict[str, int] = {}
+        self.request_timeouts: list[float | None] = []
+        self.gzip_values: list[bool] = []
+        self.read_calls: list[tuple[str, float | None, bool]] = []
+
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        self.request_timeouts.append(request_timeout)
+        self.gzip_values.append(gzip)
+        self.read_calls.append((path, request_timeout, gzip))
+        remaining = self.failures.get(path, 0)
+        if remaining:
+            self.failures[path] = remaining - 1
+            raise FileNotFoundError(path)
+        return super().read(path, request_timeout=request_timeout, gzip=gzip)
+
+
+class _LargeFrameFiles(_TransientFiles):
+    """Require the durable frame path's long, gzip-enabled read contract."""
+
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        if "/frames/" in path and ((request_timeout or 0) < 1.0 or not gzip):
+            raise TimeoutError("large replay frame needs a compressed multi-second read")
+        return super().read(path, request_timeout=request_timeout, gzip=gzip)
+
+
+class _BlockingFrameFiles(_FakeFiles):
+    """Hold one exact frame read until a cancellation test releases it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.frame_read_started = threading.Event()
+        self.release_frame_read = threading.Event()
+
+    def read(
+        self,
+        path: str,
+        *,
+        request_timeout: float | None = None,
+        gzip: bool = False,
+    ) -> str:
+        if "/frames/" in path:
+            self.frame_read_started.set()
+            self.release_frame_read.wait(2.0)
+        return super().read(path, request_timeout=request_timeout, gzip=gzip)
 
 
 class FakeSandbox:
@@ -174,8 +298,15 @@ class FakeSandbox:
         *,
         reconnect_handles: list[_ScriptedHandle] | None = None,
     ) -> None:
-        self.commands = _FakeCommands(handle, reconnect_handles=reconnect_handles)
         self.files = _FakeFiles()
+        self.durable_dispatches: list[JsonObject] = []
+        self._last_durable_inbound_seq = 0
+        self.drop_durable_acks = 0
+        self.commands = _FakeCommands(
+            handle,
+            reconnect_handles=reconnect_handles,
+            on_stdin=self._accept_durable_inbound,
+        )
         self.kills = 0
         self.timeouts: list[int] = []
         self.dead = False
@@ -188,6 +319,49 @@ class FakeSandbox:
     def kill(self) -> bool:
         self.kills += 1
         return True
+
+    def _accept_durable_inbound(self, data: str) -> None:
+        """Model runner-side inbound dedupe and append its ack to the durable fake outbox."""
+        try:
+            value = json.loads(base64.b64decode(data.strip()))
+        except (ValueError, TypeError):
+            return
+        if not isinstance(value, dict):
+            return
+        inbound_seq = value.get("transport_in_seq")
+        frame = value.get("frame")
+        if (
+            isinstance(inbound_seq, bool)
+            or not isinstance(inbound_seq, int)
+            or inbound_seq <= 0
+            or not isinstance(frame, dict)
+        ):
+            return
+        head_paths = [path for path in self.files.store if path.endswith("/head")]
+        if not head_paths:
+            return  # legacy stdio runner: raw frames have no transport envelope anyway
+        root = head_paths[-1].removesuffix("/head")
+        output_seq = int(self.files.store[head_paths[-1]].strip()) + 1
+        ack: JsonObject
+        if inbound_seq == self._last_durable_inbound_seq + 1:
+            self._last_durable_inbound_seq = inbound_seq
+            self.durable_dispatches.append(cast("JsonObject", frame))
+            ack = {"type": "transport_ack", "transport_in_seq": inbound_seq}
+        elif inbound_seq <= self._last_durable_inbound_seq:
+            ack = {"type": "transport_ack", "transport_in_seq": inbound_seq}
+        else:
+            ack = {
+                "type": "transport_nack",
+                "transport_in_seq": inbound_seq,
+                "expected_transport_in_seq": self._last_durable_inbound_seq + 1,
+            }
+        if self.drop_durable_acks > 0:
+            self.drop_durable_acks -= 1
+            return
+        self.files.store[f"{root}/frames/{output_seq:020d}.json"] = json.dumps(
+            _envelope(output_seq, ack)
+        )
+        self.files.store[head_paths[-1]] = str(output_seq)
 
 
 class _RecordingEnv:
@@ -280,9 +454,15 @@ def _runtime(
 
 
 def _sent_frames(fake: FakeSandbox) -> list[JsonObject]:
-    """Decode every frame the host pushed into the runner's stdin."""
+    """Decode every logical frame the host pushed, unwrapping durable inbound envelopes."""
     lines = [data for _pid, data in fake.commands.stdin]
-    return [cast("JsonObject", json.loads(base64.b64decode(data.strip()))) for data in lines]
+    decoded = [cast("JsonObject", json.loads(base64.b64decode(data.strip()))) for data in lines]
+    return [
+        cast("JsonObject", value["frame"])
+        if isinstance(value.get("transport_in_seq"), int) and isinstance(value.get("frame"), dict)
+        else value
+        for value in decoded
+    ]
 
 
 def _of_kind(fake: FakeSandbox, kind: str) -> list[JsonObject]:
@@ -951,6 +1131,416 @@ def test_run_propagates_a_second_e2b_send_timeout(
     assert [len(_of_kind(fake, "llm_response")) for fake in made] == [1, 1]
     assert [fake.kills for fake in made] == [1, 1]
     pool.close()
+
+
+# --- durable live-session transport ---
+_OUTBOX = f"{RUNNER_WORKDIR}/test-outbox"
+_OUTBOX_STDERR = f"{_OUTBOX}/stderr.log"
+
+
+def _frame_path(seq: int) -> str:
+    return f"{_OUTBOX}/frames/{seq:020d}.json"
+
+
+def _store_outbox(fake: FakeSandbox, frames: list[JsonObject]) -> None:
+    for seq, frame in enumerate(frames, start=1):
+        fake.files.store[_frame_path(seq)] = json.dumps(_envelope(seq, frame))
+    fake.files.store[f"{_OUTBOX}/head"] = str(len(frames))
+
+
+def _durable_channel(
+    fake: FakeSandbox,
+    handle: _ScriptedHandle,
+    *,
+    frame_read_grace_s: float = 0.1,
+    stdout_silence_grace_s: float = 45.0,
+) -> E2BDurableChannel:
+    return E2BDurableChannel(
+        fake,
+        handle,
+        outbox_root=_OUTBOX,
+        stderr_path=_OUTBOX_STDERR,
+        poll_interval_s=0.005,
+        stream_death_grace_s=0.005,
+        frame_read_grace_s=frame_read_grace_s,
+        pid_probe_interval_s=0.005,
+        stdout_silence_grace_s=stdout_silence_grace_s,
+    )
+
+
+def test_durable_channel_backfills_a_stdout_gap_before_delivering_the_newer_frame() -> None:
+    one: JsonObject = {"type": "hello"}
+    two: JsonObject = {"type": "state", "status": "ready"}
+    three: JsonObject = {"type": "state", "status": "idle"}
+    handle = _ScriptedHandle(
+        _stdout_events([_envelope(1, one), _envelope(3, three)]), hold_open=True
+    )
+    fake = FakeSandbox(handle)
+    _store_outbox(fake, [one, two, three])
+    channel = _durable_channel(fake, handle)
+
+    assert [channel.recv(timeout=0.5) for _ in range(3)] == [one, two, three]
+
+
+def test_durable_channel_dedupes_the_same_sequence_from_disk_and_stdout() -> None:
+    hello: JsonObject = {"type": "hello"}
+    gate = threading.Event()
+    handle = _GatedHandle(_stdout_events([_envelope(1, hello), _envelope(1, hello)]), gate)
+    fake = FakeSandbox(handle)
+    _store_outbox(fake, [hello])
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == hello  # unary outbox wins the race
+    gate.set()  # both duplicate stdout notifications arrive afterward
+    with pytest.raises(TimeoutError):
+        channel.recv(timeout=0.05)
+
+
+def test_durable_channel_recovers_after_stdout_drops() -> None:
+    hello: JsonObject = {"type": "hello"}
+    idle: JsonObject = {"type": "state", "status": "idle"}
+    handle = _DisconnectingHandle(_stdout_events([_envelope(1, hello)]))
+    fake = FakeSandbox(handle)
+    _store_outbox(fake, [hello, idle])
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == hello
+    assert channel.recv(timeout=0.5) == idle
+    assert "Server disconnected" in channel.stderr_tail()
+
+
+def test_durable_channel_retries_a_transiently_missing_committed_frame() -> None:
+    hello: JsonObject = {"type": "hello"}
+    ready: JsonObject = {"type": "state", "status": "ready"}
+    handle = _ScriptedHandle(_stdout_events([_envelope(2, ready)]), hold_open=True)
+    fake = FakeSandbox(handle)
+    transient = _TransientFiles()
+    fake.files = transient
+    _store_outbox(fake, [hello, ready])
+    transient.failures[_frame_path(1)] = 2
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == hello
+    assert channel.recv(timeout=0.5) == ready
+    assert transient.failures[_frame_path(1)] == 0
+    assert transient.request_timeouts
+    head_calls = [call for call in transient.read_calls if call[0].endswith("/head")]
+    frame_calls = [call for call in transient.read_calls if "/frames/" in call[0]]
+    assert head_calls
+    assert all(timeout is not None and timeout <= 0.25 for _, timeout, _ in head_calls)
+    assert frame_calls
+    assert all(timeout == 5.0 and gzip for _, timeout, gzip in frame_calls)
+
+
+def test_durable_channel_replays_a_large_context_with_a_compressed_frame_budget() -> None:
+    frame: JsonObject = {
+        "type": "llm_request",
+        "req_id": 1,
+        "openai_body": {"messages": [{"role": "user", "content": "x" * 1_000_000}]},
+    }
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    files = _LargeFrameFiles()
+    fake.files = files
+    _store_outbox(fake, [frame])
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == frame
+    frame_calls = [call for call in files.read_calls if "/frames/" in call[0]]
+    assert frame_calls == [(_frame_path(1), 5.0, True)]
+
+
+def test_live_session_completes_exactly_once_across_a_durable_stdout_drop() -> None:
+    """A dropped notification stream cannot duplicate model/tool work during one real turn."""
+    frames: list[JsonObject] = [
+        {"type": "hello"},
+        {"type": "state", "status": "idle"},
+        {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        {
+            "type": "tool_request",
+            "req_id": 2,
+            "name": "bash",
+            "arguments": {"command": "pwd"},
+        },
+        {
+            "type": "tool_request",
+            "req_id": 3,
+            "name": "submit",
+            "arguments": {"answer": "done"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed", "turns": 1},
+    ]
+    # stdout carries the opening frames, repeats the LLM request, then disconnects. The tool,
+    # submit, and final state must continue from the exact filesystem frames.
+    handle = _DisconnectingHandle(
+        _stdout_events(
+            [
+                _envelope(1, frames[0]),
+                _envelope(2, frames[1]),
+                _envelope(3, frames[2]),
+                _envelope(3, frames[2]),
+            ]
+        )
+    )
+    fake = FakeSandbox(handle)
+    _store_outbox(fake, frames)
+    channel = _durable_channel(fake, handle)
+    assert channel.recv(timeout=0.5) == {"type": "hello"}
+
+    worker_calls: list[ChatRequest] = []
+    tool_calls: list[str] = []
+    events: list[SessionEvent] = []
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        worker_calls.append(request)
+        return _completion("on it")
+
+    def execute(name: str, arguments: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        del arguments, emit
+        tool_calls.append(name)
+        return ToolOutcome(content="/home/user/project\n")
+
+    session = LiveSession(
+        channel,
+        tools=[TOOL_REGISTRY["bash"], SUBMIT],
+        execute_tool=execute,
+        on_event=events.append,
+        worker_fn=worker,
+    )
+    session.start()
+    events.clear()
+    session.send_user_message("finish once")
+    for _ in range(20):
+        session.pump(timeout=0.05)
+        if any(
+            event.kind == "state" and event.payload.get("reason") == "completed" for event in events
+        ):
+            break
+
+    assert session.status == "idle"
+    assert len(worker_calls) == 1
+    assert tool_calls == ["bash"]
+    dispatched_types = [frame["type"] for frame in fake.durable_dispatches]
+    assert dispatched_types.count("llm_response") == 1
+    assert dispatched_types.count("tool_response") == 2
+    assert [event.kind for event in events].count("assistant_message") == 1
+    assert [event.kind for event in events].count("tool_call") == 1
+    assert [event.kind for event in events].count("submit") == 1
+
+
+def test_durable_channel_fails_after_a_committed_frame_stays_corrupt() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "1"
+    fake.files.store[_frame_path(1)] = "{not-json"
+    channel = _durable_channel(fake, handle, frame_read_grace_s=0.01)
+
+    with pytest.raises(RuntimeError, match="durable outbox frame 1 unavailable"):
+        channel.recv(timeout=0.5)
+
+
+def test_durable_channel_fails_when_stream_and_head_reads_stay_unavailable() -> None:
+    """A live PID cannot turn a combined output/filesystem outage into a six-hour spin."""
+    handle = _DisconnectingHandle([])
+    fake = FakeSandbox(handle)
+    channel = _durable_channel(fake, handle, frame_read_grace_s=0.01)
+
+    with pytest.raises(RuntimeError, match="durable outbox head unavailable"):
+        channel.recv(timeout=0.5)
+
+
+def test_durable_channel_rejects_an_unsequenced_semantic_stdout_frame() -> None:
+    handle = _ScriptedHandle(_stdout_events([{"type": "llm_request", "req_id": 1}]))
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    channel = _durable_channel(fake, handle)
+
+    with pytest.raises(RuntimeError, match="unsequenced or malformed semantic frame"):
+        channel.recv(timeout=0.5)
+
+
+def test_durable_channel_fails_when_silent_stream_and_head_reads_stay_unavailable() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    channel = _durable_channel(
+        fake,
+        handle,
+        frame_read_grace_s=0.01,
+        stdout_silence_grace_s=0.01,
+    )
+
+    with pytest.raises(RuntimeError, match="durable outbox head unavailable"):
+        channel.recv(timeout=0.5)
+
+
+def test_durable_channel_pid_exit_includes_the_durable_stderr_tail() -> None:
+    handle = _DisconnectingHandle([])
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    fake.files.store[_OUTBOX_STDERR] = "runner booted\nfatal durable detail\n"
+    fake.commands.running_pids.clear()
+    channel = _durable_channel(fake, handle, frame_read_grace_s=0.01)
+
+    with pytest.raises(RuntimeError, match="fatal durable detail"):
+        channel.recv(timeout=0.5)
+
+
+def test_durable_channel_polls_disk_while_stdout_is_silently_open() -> None:
+    hello: JsonObject = {"type": "hello"}
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    _store_outbox(fake, [hello])
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == hello
+
+
+def test_start_live_runner_durable_handshake_survives_immediate_stdout_drop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pi_e2b_module.uuid, "uuid4", lambda: SimpleNamespace(hex="fixed-outbox-id"))
+    root = f"{RUNNER_WORKDIR}/live-outbox-fixed-outbox-id"
+    handle = _DisconnectingHandle([])
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{root}/head"] = "1"
+    fake.files.store[f"{root}/frames/{1:020d}.json"] = json.dumps(_envelope(1, {"type": "hello"}))
+
+    channel = start_live_runner(
+        fake, template="wmh-pi-node", durable_outbox=True, hello_timeout=0.5
+    )
+
+    assert isinstance(channel, E2BDurableChannel)
+    assert fake.commands.background_envs == [{"WMH_LIVE_OUTBOX": root}]
+    assert fake.commands.background_cmds == [f"{LIVE_START_CMD} 2>> {root}/stderr.log"]
+
+
+def test_durable_channel_close_sends_shutdown_and_kills_the_runner_once() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    channel = _durable_channel(fake, handle)
+
+    channel.close()
+    channel.close()
+
+    assert channel._cleanup_done.wait(1.0)
+    assert [f.get("type") for f in _sent_frames(fake)] == ["shutdown"]
+    assert fake.commands.stdin_request_timeouts == [0.25]
+    assert fake.commands.killed == [_PID]
+    assert fake.commands.kill_request_timeouts == [0.25]
+    assert handle.disconnects == 1
+    assert channel.recv(timeout=0.01) is None
+
+
+def test_durable_channel_close_does_not_wait_for_an_inflight_frame_read() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    files = _BlockingFrameFiles()
+    fake.files = files
+    _store_outbox(fake, [{"type": "state", "status": "idle"}])
+    channel = _durable_channel(fake, handle)
+    received: list[JsonObject | None] = []
+
+    receiver = threading.Thread(target=lambda: received.append(channel.recv(timeout=1.0)))
+    receiver.start()
+    assert files.frame_read_started.wait(0.5)
+
+    started = time.monotonic()
+    channel.close()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert channel._cleanup_done.wait(1.0)
+    assert fake.commands.killed == [_PID]
+    files.release_frame_read.set()
+    receiver.join(timeout=1.0)
+    assert not receiver.is_alive()
+    assert received == [None]
+
+
+def test_durable_channel_close_discards_a_prequeued_tool_request() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    channel = _durable_channel(fake, handle)
+    channel._frames.put(
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "bash",
+            "arguments": {"command": "touch should-not-run"},
+        }
+    )
+
+    channel.close()
+
+    assert channel.recv(timeout=0.01) is None
+    assert channel.recv(timeout=0.01) is None
+    assert channel.recv(timeout=0.01) is None
+    assert channel._cleanup_done.wait(1.0)
+
+
+def test_durable_channel_bounds_normal_stdin_delivery() -> None:
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    channel = _durable_channel(fake, handle)
+
+    channel.send({"type": "ping", "nonce": "n"})
+
+    assert fake.commands.stdin_request_timeouts == [2.0]
+    assert fake.durable_dispatches == [{"type": "ping", "nonce": "n"}]
+
+
+def test_durable_channel_recovers_when_an_accepted_stdin_write_times_out() -> None:
+    """A delivered-then-timeout RPC resolves through its durable ack without replaying."""
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    fake.commands.fail_sends_from = 1
+    channel = _durable_channel(fake, handle)
+    frame: JsonObject = {"type": "user_message", "msg_id": "m1", "text": "improve"}
+
+    channel.send(frame)
+
+    assert len(fake.commands.stdin) == 1
+    assert fake.durable_dispatches == [frame]
+    with pytest.raises(TimeoutError):
+        channel.recv(timeout=0.02)  # the transport ack never leaks into LiveSession
+
+
+def test_durable_channel_retries_the_same_sequence_after_a_lost_ack() -> None:
+    """A duplicate physical write repairs ack loss without duplicate logical dispatch."""
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    fake.drop_durable_acks = 1
+    channel = _durable_channel(fake, handle)
+    frame: JsonObject = {"type": "tool_response", "req_id": 7, "content": "once"}
+
+    channel.send(frame)
+
+    assert len(fake.commands.stdin) == 2
+    wires = [json.loads(base64.b64decode(data.strip())) for _pid, data in fake.commands.stdin]
+    assert wires[0] == wires[1] == {"transport_in_seq": 1, "frame": frame}
+    assert fake.durable_dispatches == [frame]
+
+
+def test_durable_channel_retries_the_same_sequence_after_a_pre_delivery_timeout() -> None:
+    """A failed physical write retries once without advancing the logical sequence."""
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    fake.files.store[f"{_OUTBOX}/head"] = "0"
+    fake.commands.fail_before_delivery.add(1)
+    channel = _durable_channel(fake, handle)
+    frame: JsonObject = {"type": "session_start", "session_id": "s1"}
+
+    channel.send(frame)
+
+    assert len(fake.commands.stdin) == 2
+    wires = [json.loads(base64.b64decode(data.strip())) for _pid, data in fake.commands.stdin]
+    assert wires[0] == wires[1] == {"transport_in_seq": 1, "frame": frame}
+    assert fake.durable_dispatches == [frame]
 
 
 # --- live-session bootstrap (start_live_runner / session_entry_files) ---

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -20,6 +20,7 @@ import shlex
 import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
@@ -56,6 +57,14 @@ class TimeoutException(Exception):
 
 
 TimeoutException.__module__ = "e2b.exceptions"
+
+
+def test_all_pi_llm_bridges_forward_opaque_reasoning_details() -> None:
+    """Every runner preserves stateless Responses reasoning through Pi's SSE parser."""
+    entry = Path(pi_e2b_module.__file__).with_name("pi_entry")
+    for filename in ("runner_stdio.ts", "runner_live.ts", "runner_service.ts"):
+        source = (entry / filename).read_text(encoding="utf-8")
+        assert "delta.reasoning_details = msg.reasoning_details" in source
 
 
 def _line(frame: JsonObject) -> str:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -74,6 +74,14 @@ def test_all_pi_llm_bridges_forward_opaque_reasoning_details() -> None:
         assert "delta.reasoning_details = msg.reasoning_details" in source
 
 
+def test_all_pi_llm_bridges_forward_usage_for_context_accounting() -> None:
+    """Pi must see real usage instead of estimating an ever-growing transcript by characters."""
+    entry = Path(pi_e2b_module.__file__).with_name("pi_entry")
+    for filename in ("runner_stdio.ts", "runner_live.ts", "runner_service.ts"):
+        source = (entry / filename).read_text(encoding="utf-8")
+        assert "usage: reply.completion?.usage" in source
+
+
 def test_all_pi_entrypoints_use_the_host_output_budget() -> None:
     """No execution mode may silently fall back to the old hard-coded 4k model ceiling."""
     entry = Path(pi_e2b_module.__file__).with_name("pi_entry")
@@ -1840,6 +1848,8 @@ def test_session_entry_files_returns_the_live_runner_source() -> None:
     assert TRANSPORT_KEEPALIVE_TYPE in files["runner_live.ts"]
     assert ".unref()" in files["runner_live.ts"]
     assert "conn.startTransportKeepalive();" in files["runner_live.ts"]
+    assert 'frame.conversation_scope === "turn"' in files["runner_live.ts"]
+    assert "this.agent.state.messages = [];" in files["runner_live.ts"]
 
 
 def test_start_live_runner_bootstraps_starts_and_consumes_hello() -> None:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -82,6 +82,20 @@ class _ScriptedHandle:
             self._release.wait(2.0)  # self-releasing so the daemon reader never lingers
 
 
+class _DisconnectingHandle(_ScriptedHandle):
+    """Yield a prefix, optionally wait for a race gate, then drop the output stream."""
+
+    def __init__(self, events: list[_Event], *, gate: threading.Event | None = None) -> None:
+        super().__init__(events)
+        self._gate = gate
+
+    def __iter__(self) -> Iterator[_Event]:
+        yield from self._events
+        if self._gate is not None:
+            self._gate.wait(2.0)
+        raise RuntimeError("Server disconnected")
+
+
 class _Result:
     """A minimal CommandOutput for foreground runs."""
 
@@ -94,10 +108,17 @@ class _Result:
 class _FakeCommands:
     """Foreground runs are recorded and echoed; background=True returns the scripted handle."""
 
-    def __init__(self, handle: _ScriptedHandle) -> None:
+    def __init__(
+        self,
+        handle: _ScriptedHandle,
+        *,
+        reconnect_handles: list[_ScriptedHandle] | None = None,
+    ) -> None:
         self._handle = handle
+        self._reconnect_handles = list(reconnect_handles or [])
         self.calls: list[str] = []  # foreground commands, in order (installs, ...)
         self.background_cmds: list[str] = []
+        self.connects: list[tuple[int, float | None]] = []
         self.stdin: list[tuple[int, str]] = []
         self.fail_sends_from: int | None = None
         self.send_error: Exception = TimeoutException("request timed out")
@@ -116,6 +137,12 @@ class _FakeCommands:
             return self._handle
         self.calls.append(cmd)
         return _Result(stdout=f"ran: {cmd}")
+
+    def connect(self, pid: int, *, timeout: float | None = None) -> object:
+        self.connects.append((pid, timeout))
+        if not self._reconnect_handles:
+            raise RuntimeError("process connection unavailable")
+        return self._reconnect_handles.pop(0)
 
     def send_stdin(self, pid: int, data: str) -> None:
         self.stdin.append((pid, data))
@@ -141,8 +168,13 @@ class _FakeFiles:
 class FakeSandbox:
     """The `SandboxHandle` slice over a scripted runner process."""
 
-    def __init__(self, handle: _ScriptedHandle) -> None:
-        self.commands = _FakeCommands(handle)
+    def __init__(
+        self,
+        handle: _ScriptedHandle,
+        *,
+        reconnect_handles: list[_ScriptedHandle] | None = None,
+    ) -> None:
+        self.commands = _FakeCommands(handle, reconnect_handles=reconnect_handles)
         self.files = _FakeFiles()
         self.kills = 0
         self.timeouts: list[int] = []
@@ -179,6 +211,7 @@ def _channel(
     sandbox_timeout_s: int | None = None,
     timeout_refresh_interval_s: float = 300.0,
     max_episode_lifetime_s: float = 3_600.0,
+    reconnect_while_idle: bool = False,
 ) -> E2BStdioChannel:
     return E2BStdioChannel(
         fake,
@@ -186,6 +219,7 @@ def _channel(
         sandbox_timeout_s=sandbox_timeout_s,
         timeout_refresh_interval_s=timeout_refresh_interval_s,
         max_episode_lifetime_s=max_episode_lifetime_s,
+        reconnect_while_idle=reconnect_while_idle,
     )
 
 
@@ -410,6 +444,70 @@ def test_close_sends_shutdown_and_makes_the_stream_end_clean() -> None:
     assert channel.recv() is None  # host-initiated shutdown reads as a clean channel close
     shutdowns = [f for f in _sent_frames(fake) if f["type"] == "shutdown"]
     assert len(shutdowns) == 1
+
+
+def test_live_channel_reconnects_same_pid_after_an_idle_stream_drop() -> None:
+    """An idle reconnect preserves the runner transcript without surfacing a false process exit."""
+    idle: JsonObject = {"type": "state", "status": "idle"}
+    after_reconnect: JsonObject = {"type": "pong", "nonce": "still-here"}
+    dropped = _DisconnectingHandle(_stdout_events([idle]))
+    resumed = _ScriptedHandle(_stdout_events([after_reconnect]), hold_open=True)
+    fake = FakeSandbox(dropped, reconnect_handles=[resumed])
+    channel = _channel(fake, dropped, reconnect_while_idle=True)
+
+    assert channel.recv(timeout=2.0) == idle
+    assert channel.recv(timeout=2.0) == after_reconnect
+    assert fake.commands.connects == [(_PID, 0)]
+    assert "output stream failed" not in channel.stderr_tail()
+
+
+def test_live_channel_reconnects_when_an_idle_stream_ends_without_an_exception() -> None:
+    """The SDK can report a dropped HTTP stream as normal iterator exhaustion."""
+    idle: JsonObject = {"type": "state", "status": "idle"}
+    after_reconnect: JsonObject = {"type": "pong", "nonce": "still-here"}
+    ended = _ScriptedHandle(_stdout_events([idle]))
+    resumed = _ScriptedHandle(_stdout_events([after_reconnect]), hold_open=True)
+    fake = FakeSandbox(ended, reconnect_handles=[resumed])
+    channel = _channel(fake, ended, reconnect_while_idle=True)
+
+    assert channel.recv(timeout=2.0) == idle
+    assert channel.recv(timeout=2.0) == after_reconnect
+    assert fake.commands.connects == [(_PID, 0)]
+
+
+def test_live_channel_does_not_reconnect_a_busy_stream() -> None:
+    """Mid-turn reconnect cannot prove whether a semantic frame was lost, so it fails closed."""
+    running: JsonObject = {"type": "state", "status": "running"}
+    dropped = _DisconnectingHandle(_stdout_events([running]))
+    fake = FakeSandbox(
+        dropped,
+        reconnect_handles=[_ScriptedHandle([], hold_open=True)],
+    )
+    channel = _channel(fake, dropped, reconnect_while_idle=True)
+
+    assert channel.recv(timeout=2.0) == running
+    with pytest.raises(RuntimeError, match="Server disconnected"):
+        channel.recv(timeout=2.0)
+    assert fake.commands.connects == []
+
+
+def test_user_message_wins_the_race_with_idle_reconnect() -> None:
+    """Turn delivery clears the idle proof before stdin, so a concurrent drop is not resumed."""
+    gate = threading.Event()
+    idle: JsonObject = {"type": "state", "status": "idle"}
+    dropped = _DisconnectingHandle(_stdout_events([idle]), gate=gate)
+    fake = FakeSandbox(
+        dropped,
+        reconnect_handles=[_ScriptedHandle([], hold_open=True)],
+    )
+    channel = _channel(fake, dropped, reconnect_while_idle=True)
+
+    assert channel.recv(timeout=2.0) == idle
+    channel.send({"type": "user_message", "msg_id": "next", "text": "go"})
+    gate.set()
+    with pytest.raises(RuntimeError, match="Server disconnected"):
+        channel.recv(timeout=2.0)
+    assert fake.commands.connects == []
 
 
 # --- E2BSandboxPool ---

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -26,7 +26,7 @@ from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
 from wmh.harness import pi_e2b as pi_e2b_module
-from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage
 from wmh.harness.pi_e2b import (
     LIVE_START_CMD,
     NODE_INSTALL_CMD,
@@ -548,6 +548,34 @@ def test_pool_reuses_a_healthy_sandbox_without_rebootstrap(
     assert made[0].commands.calls.count(NODE_INSTALL_CMD) == 1  # bootstrap paid once
     assert made[0].commands.background_cmds == [START_CMD]  # one runner process
     pool.close()
+
+
+def test_pool_retire_idle_rotates_only_free_sandboxes_and_preserves_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A round boundary kills idle streams, leaves in-flight work, and meters both lifetimes."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    now = [10.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    factory, made = _factory_for([[{"type": "hello"}], [{"type": "hello"}]])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    idle, idle_channel = pool.acquire()
+    in_flight, in_flight_channel = pool.acquire()
+    pool.release(idle, idle_channel, healthy=True)
+
+    now[0] = 14.0
+    assert pool.retire_idle() == 1
+    assert made[0].kills == 1
+    assert made[1].kills == 0  # an active episode is outside the idle rotation boundary
+    assert pool.usage() == SandboxUsage(count=2, seconds=8.0)
+
+    pool.release(in_flight, in_flight_channel, healthy=True)
+    reused, _ = pool.acquire()
+    assert reused is in_flight  # work that was active at the boundary remains safely reusable
+    assert len(made) == 2
+    now[0] = 16.0
+    pool.close()
+    assert pool.usage() == SandboxUsage(count=2, seconds=10.0)
 
 
 def test_pool_discards_an_unhealthy_sandbox_and_creates_a_fresh_one(

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -52,6 +52,7 @@ from wmh.harness.pi_e2b import (
     start_live_runner,
 )
 from wmh.harness.runtime import Runtime, RuntimeCancelled, StopReason
+from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY, ToolSpec
 
 _Event = tuple[str | None, str | None, str | None]
@@ -483,6 +484,8 @@ def _runtime(
     worker_fn: Callable[[ChatRequest], ChatResponse] | None = None,
     max_turns: int = 20,
     max_output_tokens: int = 4096,
+    temperature: float = 0.7,
+    skills: SkillLibrary | None = None,
     episode_timeout_s: float = 300.0,
     should_cancel: Callable[[], bool] | None = None,
 ) -> E2BPiRuntime:
@@ -496,6 +499,8 @@ def _runtime(
         worker_fn=worker_fn,
         max_turns=max_turns,
         max_output_tokens=max_output_tokens,
+        temperature=temperature,
+        skills=skills,
         episode_timeout_s=episode_timeout_s,
         should_cancel=should_cancel,
     )
@@ -1035,6 +1040,7 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
             worker_fn=worker,
             max_turns=7,
             max_output_tokens=16384,
+            temperature=0.35,
         ).run("t1", "do it", env)
 
     assert result.stop_reason is StopReason.SUBMITTED
@@ -1057,14 +1063,55 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
     assert start["files"] == {"src/agent.ts": "// a"}
     assert start["max_turns"] == 7
     assert start["max_output_tokens"] == 16384
+    assert start["temperature"] == 0.35
     assert start["episode_timeout_s"] == 300.0
     tool_names = {t["name"] for t in cast("list[JsonObject]", start["tools"])}
     assert tool_names >= {"bash", "submit"}
     llm = _of_kind(fake, "llm_response")[0]
     assert llm["req_id"] == 1 and llm["completion"] == completion.wire_payload()
     assert [request.messages[0].content for request in worker_calls] == ["hi"]
+    assert [request.temperature for request in worker_calls] == [0.35]
     tool = _of_kind(fake, "tool_response")[0]
     assert tool["req_id"] == 2 and tool["content"] == "wm says ok" and tool["is_error"] is False
+
+
+def test_skill_bodies_are_advertised_and_served_host_side_in_e2b(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    script: list[JsonObject] = [
+        {"type": "hello"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "read_skill",
+            "arguments": {"name": "count-words"},
+        },
+        {
+            "type": "tool_request",
+            "req_id": 2,
+            "name": "read_skill",
+            "arguments": {"name": "missing"},
+        },
+        {"type": "done", "answer": "finished"},
+    ]
+    factory, made = _factory_for([script])
+    env = _RecordingEnv()
+    skills = SkillLibrary(
+        [Skill(name="count-words", description="count words", body="wc -w <path>")]
+    )
+
+    with E2BSandboxPool(sandbox_factory=factory) as pool:
+        result = _runtime(pool=pool, skills=skills).run("t1", "do it", env)
+
+    start = _of_kind(made[0], "episode_start")[0]
+    assert "read_skill" in {tool["name"] for tool in cast("list[JsonObject]", start["tools"])}
+    responses = _of_kind(made[0], "tool_response")
+    assert responses[0]["content"] == "wc -w <path>" and responses[0]["is_error"] is False
+    assert responses[1]["content"] == "no skill named 'missing'"
+    assert responses[1]["is_error"] is True
+    assert [step.action.name for step in result.steps] == ["read_skill", "read_skill"]
+    assert env.actions == []
 
 
 def test_two_runtimes_sharing_a_pool_reuse_warm_sandboxes(

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -29,7 +29,7 @@ from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
 from wmh.harness import pi_e2b as pi_e2b_module
-from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxFactory, SandboxUsage
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_e2b import (
     LIVE_START_CMD,
@@ -799,6 +799,31 @@ def test_pool_discards_an_unhealthy_sandbox_and_creates_a_fresh_one(
     fresh, _fresh_channel = pool.acquire()
     assert fresh is made[1] and fresh is not sandbox
     assert made[1].commands.calls.count(NODE_INSTALL_CMD) == 1  # the fresh one bootstrapped
+    pool.close()
+
+
+def test_pool_default_factory_tags_initial_and_replacement_sandboxes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for([[{"type": "hello"}], [{"type": "hello"}]])
+    factory_calls: list[dict[str, object]] = []
+
+    def recording_default_factory(**kwargs: object) -> SandboxFactory:
+        factory_calls.append(kwargs)
+        return factory
+
+    monkeypatch.setattr(pi_e2b_module, "default_sandbox_factory", recording_default_factory)
+    metadata = {"optimizer_run_id": "run-1", "purpose": "evaluation"}
+    pool = E2BSandboxPool(template="tmpl", api_key="key", metadata=metadata)
+
+    sandbox, channel = pool.acquire()
+    pool.release(sandbox, channel, healthy=False)
+    replacement, _ = pool.acquire()
+
+    assert replacement is made[1]
+    assert len(made) == 2
+    assert factory_calls == [{"api_key": "key", "template": "tmpl", "metadata": metadata}]
     pool.close()
 
 

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -44,7 +44,7 @@ from wmh.harness.pi_e2b import (
     session_entry_files,
     start_live_runner,
 )
-from wmh.harness.runtime import Runtime, StopReason
+from wmh.harness.runtime import Runtime, RuntimeCancelled, StopReason
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY, ToolSpec
 
 _Event = tuple[str | None, str | None, str | None]
@@ -289,6 +289,20 @@ class _BlockingFrameFiles(_FakeFiles):
         return super().read(path, request_timeout=request_timeout, gzip=gzip)
 
 
+class _BlockingBootstrapFiles(_FakeFiles):
+    """Hold the first bootstrap write so pool cancellation can race cold start."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def write(self, path: str, data: str) -> None:
+        self.started.set()
+        self.release.wait(2.0)
+        super().write(path, data)
+
+
 class FakeSandbox:
     """The `SandboxHandle` slice over a scripted runner process."""
 
@@ -441,6 +455,9 @@ def _runtime(
     pool: E2BSandboxPool | None = None,
     template: str | None = None,
     worker_fn: Callable[[ChatRequest], ChatResponse] | None = None,
+    max_turns: int = 20,
+    episode_timeout_s: float = 300.0,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> E2BPiRuntime:
     return E2BPiRuntime(
         provider=_Provider(),
@@ -450,6 +467,9 @@ def _runtime(
         template=template,
         pool=pool,
         worker_fn=worker_fn,
+        max_turns=max_turns,
+        episode_timeout_s=episode_timeout_s,
+        should_cancel=should_cancel,
     )
 
 
@@ -789,6 +809,53 @@ def test_pool_close_kills_everything_and_acquire_after_close_raises(
     pool.close()  # idempotent
 
 
+def test_inflight_release_after_pool_close_does_not_kill_the_lease_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for([[{"type": "hello"}]])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    sandbox, channel = pool.acquire()
+
+    pool.close()
+    pool.release(sandbox, channel, healthy=False)  # in-flight episode unwinds after cancellation
+
+    assert made[0].kills == 1
+
+
+def test_pool_close_kills_a_sandbox_while_its_bootstrap_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation retires cold-start leases without waiting for their bootstrap RPC."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    handle = _ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True)
+    fake = FakeSandbox(handle)
+    files = _BlockingBootstrapFiles()
+    fake.files = files
+    pool = E2BSandboxPool(sandbox_factory=lambda: fake)
+    errors: list[BaseException] = []
+
+    def acquire() -> None:
+        try:
+            pool.acquire()
+        except BaseException as exc:  # noqa: BLE001 - the worker hands its failure to the test
+            errors.append(exc)
+
+    worker = threading.Thread(target=acquire)
+    worker.start()
+    assert files.started.wait(1.0)
+
+    pool.close()
+    assert fake.kills == 1  # killed before the blocked bootstrap call is released
+
+    files.release.set()
+    worker.join(timeout=2.0)
+    assert not worker.is_alive()
+    assert len(errors) == 1
+    assert "closed" in str(errors[0])
+    assert fake.kills == 1  # bootstrap cleanup is idempotent after close already retired it
+
+
 def test_pool_acquire_without_hello_raises_with_stderr_and_kills_the_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -841,7 +908,7 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
         return completion
 
     with E2BSandboxPool(sandbox_factory=factory) as pool:
-        result = _runtime(pool=pool, worker_fn=worker).run("t1", "do it", env)
+        result = _runtime(pool=pool, worker_fn=worker, max_turns=7).run("t1", "do it", env)
 
     assert result.stop_reason is StopReason.SUBMITTED
     assert result.answer == "finished"
@@ -861,6 +928,8 @@ def test_end_to_end_fake_episode_answers_tools_via_the_host_side_environment(
     start = _of_kind(fake, "episode_start")[0]
     assert start["instruction"] == "do it" and start["system"] == "sys"
     assert start["files"] == {"src/agent.ts": "// a"}
+    assert start["max_turns"] == 7
+    assert start["episode_timeout_s"] == 300.0
     tool_names = {t["name"] for t in cast("list[JsonObject]", start["tools"])}
     assert tool_names >= {"bash", "submit"}
     llm = _of_kind(fake, "llm_response")[0]
@@ -920,6 +989,51 @@ def test_pi_episode_error_is_not_retried_and_keeps_the_sandbox_reusable(
     assert recovered.answer == "next episode"
     assert len(made) == 1
     assert made[0].kills == 0
+    pool.close()
+
+
+def test_episode_wall_budget_retires_without_retry_or_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for(
+        [
+            [{"type": "hello"}],
+            [{"type": "hello"}, {"type": "done", "answer": "fresh"}],
+        ]
+    )
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    runtime = _runtime(pool=pool, episode_timeout_s=0.01)
+
+    expired = runtime.run("t1", "first", _RecordingEnv())
+    recovered = runtime.run("t2", "second", _RecordingEnv())
+
+    assert expired.stop_reason is StopReason.BUDGET
+    assert "wall budget" in expired.transcript()
+    assert recovered.answer == "fresh"
+    assert len(made) == 2  # no retry for the expired episode; the next episode gets a fresh lease
+    assert made[0].kills == 1
+    pool.close()
+
+
+def test_runtime_cancellation_retires_the_active_sandbox_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for([[{"type": "hello"}]])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    checks = 0
+
+    def should_cancel() -> bool:
+        nonlocal checks
+        checks += 1
+        return checks >= 3
+
+    with pytest.raises(RuntimeCancelled, match="cancelled"):
+        _runtime(pool=pool, should_cancel=should_cancel).run("t1", "first", _RecordingEnv())
+
+    assert len(made) == 1
+    assert made[0].kills == 1
     pool.close()
 
 

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -33,6 +33,7 @@ from wmh.harness.pi_e2b import (
     PI_NPM_PACKAGES,
     RUNNER_WORKDIR,
     START_CMD,
+    TRANSPORT_KEEPALIVE_TYPE,
     E2BPiRuntime,
     E2BSandboxPool,
     E2BStdioChannel,
@@ -171,8 +172,21 @@ class _RecordingEnv:
         pass
 
 
-def _channel(fake: FakeSandbox, handle: _ScriptedHandle) -> E2BStdioChannel:
-    return E2BStdioChannel(fake, handle)
+def _channel(
+    fake: FakeSandbox,
+    handle: _ScriptedHandle,
+    *,
+    sandbox_timeout_s: int | None = None,
+    timeout_refresh_interval_s: float = 300.0,
+    max_episode_lifetime_s: float = 3_600.0,
+) -> E2BStdioChannel:
+    return E2BStdioChannel(
+        fake,
+        handle,
+        sandbox_timeout_s=sandbox_timeout_s,
+        timeout_refresh_interval_s=timeout_refresh_interval_s,
+        max_episode_lifetime_s=max_episode_lifetime_s,
+    )
 
 
 def _tools() -> list[ToolSpec]:
@@ -289,6 +303,90 @@ def test_non_frame_stdout_noise_becomes_a_diagnostic_not_a_frame() -> None:
     assert "stray print!!" in channel.stderr_tail()
 
 
+def test_transport_keepalive_renews_a_pooled_lease_without_becoming_a_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Active runner heartbeats keep E2B alive but stay below RunnerLink's protocol."""
+    now = [100.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    keepalive: JsonObject = {"type": TRANSPORT_KEEPALIVE_TYPE}
+    hello: JsonObject = {"type": "hello"}
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    channel = _channel(fake, handle, sandbox_timeout_s=900)
+
+    channel.send({"type": "episode_start"})
+    channel._decode_line(_line(keepalive))  # noqa: SLF001 - exercise the reader's exact decoder
+    assert fake.timeouts == []  # the pool's initial reset covers the first refresh window
+    now[0] += 300
+    channel._decode_line(_line(keepalive))  # noqa: SLF001
+    channel._decode_line(_line(keepalive))  # noqa: SLF001 - throttled at the same timestamp
+    channel._decode_line(_line(hello))  # noqa: SLF001
+    assert channel.recv(timeout=2.0) == hello
+    assert fake.timeouts == [900]
+
+
+def test_transport_keepalive_stops_renewing_at_the_episode_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A yielding bad candidate cannot turn lease renewal into an unbounded sandbox leak."""
+    now = [100.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    keepalive: JsonObject = {"type": TRANSPORT_KEEPALIVE_TYPE}
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    channel = _channel(
+        fake,
+        handle,
+        sandbox_timeout_s=900,
+        timeout_refresh_interval_s=300,
+        max_episode_lifetime_s=600,
+    )
+
+    channel.send({"type": "episode_start"})
+    now[0] += 300
+    channel._decode_line(_line(keepalive))  # noqa: SLF001
+    now[0] += 300
+    channel._decode_line(_line(keepalive))  # noqa: SLF001
+
+    assert fake.timeouts == [300]  # the final refresh expires exactly at the hard deadline
+
+
+def test_transport_keepalive_refresh_failure_is_nonfatal_and_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A control-plane blip cannot poison the frame stream; the next heartbeat retries."""
+
+    class FlakyTimeoutSandbox(FakeSandbox):
+        def __init__(self, handle: _ScriptedHandle) -> None:
+            super().__init__(handle)
+            self.refresh_attempts = 0
+
+        def set_timeout(self, timeout: int) -> None:
+            self.refresh_attempts += 1
+            if self.refresh_attempts == 1:
+                raise RuntimeError("temporary control-plane failure")
+            super().set_timeout(timeout)
+
+    now = [100.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    keepalive: JsonObject = {"type": TRANSPORT_KEEPALIVE_TYPE}
+    hello: JsonObject = {"type": "hello"}
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FlakyTimeoutSandbox(handle)
+    channel = _channel(fake, handle, sandbox_timeout_s=900)
+
+    channel.send({"type": "episode_start"})
+    now[0] += 300
+    channel._decode_line(_line(keepalive))  # noqa: SLF001
+    channel._decode_line(_line(keepalive))  # noqa: SLF001
+    channel._decode_line(_line(hello))  # noqa: SLF001
+    assert channel.recv(timeout=2.0) == hello
+    assert fake.refresh_attempts == 2
+    assert fake.timeouts == [900]
+    assert "sandbox timeout refresh failed" in channel.stderr_tail()
+
+
 def test_recv_after_process_exit_raises_with_recent_stderr() -> None:
     events: list[_Event] = [
         (_line({"type": "hello"}), None, None),
@@ -326,6 +424,8 @@ def test_pool_acquire_creates_bootstraps_starts_runner_and_awaits_hello(
     fake = made[0]
     # Bootstrap: runner files up, node 22 + pinned pi deps installed, the runner started.
     assert fake.files.store[f"{RUNNER_WORKDIR}/runner_stdio.ts"].startswith("/**")
+    assert TRANSPORT_KEEPALIVE_TYPE in fake.files.store[f"{RUNNER_WORKDIR}/runner_stdio.ts"]
+    assert ".unref()" in fake.files.store[f"{RUNNER_WORKDIR}/runner_stdio.ts"]
     assert f"{RUNNER_WORKDIR}/runner_frames.ts" in fake.files.store
     assert fake.commands.calls[0] == NODE_INSTALL_CMD
     assert all(pkg in fake.commands.calls[1] for pkg in PI_NPM_PACKAGES)
@@ -549,11 +649,11 @@ def test_acquire_extends_the_lifetime_of_a_reused_sandbox(
     pool = E2BSandboxPool(sandbox_factory=factory)
     sandbox, channel = pool.acquire()
     [fake] = made
-    assert fake.timeouts == []  # fresh sandboxes carry their creation-time lifetime
+    assert fake.timeouts == [900]  # reset after bootstrap, immediately before the runner starts
     pool.release(sandbox, channel, healthy=True)
     again, _ = pool.acquire()
     assert again is sandbox
-    assert fake.timeouts == [900]  # the reuse extended the countdown
+    assert fake.timeouts == [900, 900]  # the reuse extended the countdown again
     pool.close()
 
 
@@ -732,16 +832,30 @@ def test_session_entry_files_returns_the_live_runner_source() -> None:
     files = session_entry_files()
     assert "runner_live.ts" in files
     assert files["runner_live.ts"].startswith("/**")
+    assert TRANSPORT_KEEPALIVE_TYPE in files["runner_live.ts"]
+    assert ".unref()" in files["runner_live.ts"]
+    assert "conn.startTransportKeepalive();" in files["runner_live.ts"]
 
 
 def test_start_live_runner_bootstraps_starts_and_consumes_hello() -> None:
-    fake = FakeSandbox(_ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True))
+    fake = FakeSandbox(
+        _ScriptedHandle(
+            _stdout_events(
+                [
+                    {"type": TRANSPORT_KEEPALIVE_TYPE},
+                    {"type": "hello"},
+                ]
+            ),
+            hold_open=True,
+        )
+    )
     channel = start_live_runner(fake, template=None)
     # runner_live.ts uploaded; node 22 + pi deps installed; workspace ensured; runner started.
     assert f"{RUNNER_WORKDIR}/runner_live.ts" in fake.files.store
     assert fake.commands.calls[0] == NODE_INSTALL_CMD
     assert any("mkdir -p" in c for c in fake.commands.calls)
     assert fake.commands.background_cmds == [LIVE_START_CMD]
+    assert fake.timeouts == []  # Platform owns live-session timeout and idle/suspend behavior
     # The hello was consumed; the channel is idle and ready for session frames.
     with pytest.raises(TimeoutError):
         channel.recv(timeout=0.05)

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -28,8 +28,14 @@ import pytest
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
+from wmh.harness import e2b_sandbox as e2b_sandbox_module
 from wmh.harness import pi_e2b as pi_e2b_module
-from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxFactory, SandboxUsage
+from wmh.harness.e2b_sandbox import (
+    E2B_TEMPLATE_ENV,
+    SandboxCleanupError,
+    SandboxFactory,
+    SandboxUsage,
+)
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_e2b import (
     LIVE_START_CMD,
@@ -349,7 +355,8 @@ class FakeSandbox:
             raise RuntimeError("sandbox not found")
         self.timeouts.append(timeout)
 
-    def kill(self) -> bool:
+    def kill(self, request_timeout: float | None = None) -> bool:
+        del request_timeout
         self.kills += 1
         return True
 
@@ -853,6 +860,75 @@ def test_pool_close_kills_everything_and_acquire_after_close_raises(
     with pytest.raises(RuntimeError, match="closed"):
         pool.acquire()
     pool.close()  # idempotent
+
+
+def test_pool_failed_kill_stays_live_in_usage_and_a_later_close_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unproven kill remains owned and billable until a retry succeeds."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    monkeypatch.setattr(e2b_sandbox_module.time, "sleep", lambda delay: None)
+    now = [10.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    factory, made = _factory_for([[{"type": "hello"}]])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    pool.acquire()
+    fake = made[0]
+    attempts = 0
+
+    def broken_kill(request_timeout: float | None = None) -> bool:
+        nonlocal attempts
+        del request_timeout
+        attempts += 1
+        raise RuntimeError("control plane unavailable")
+
+    monkeypatch.setattr(fake, "kill", broken_kill)
+    now[0] = 14.0
+    with pytest.raises(SandboxCleanupError, match="failed to prove cleanup") as raised:
+        pool.close()
+    assert attempts == 3
+    assert raised.value.resource == "evaluator_sandbox_pool"
+    assert raised.value.sandbox_usage == SandboxUsage(count=1, seconds=4.0)
+    assert pool.usage() == SandboxUsage(count=1, seconds=4.0)
+
+    now[0] = 16.0
+    assert pool.usage() == SandboxUsage(count=1, seconds=6.0)
+
+    def successful_kill(request_timeout: float | None = None) -> bool:
+        nonlocal attempts
+        del request_timeout
+        attempts += 1
+        return True
+
+    monkeypatch.setattr(fake, "kill", successful_kill)
+    pool.close()
+    assert attempts == 4
+    assert pool.usage() == SandboxUsage(count=1, seconds=6.0)
+    pool.close()  # proved cleanup remains idempotent
+
+
+def test_pool_close_attempts_every_sandbox_when_one_kill_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One failed teardown cannot prevent sibling leases from being released."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    monkeypatch.setattr(e2b_sandbox_module.time, "sleep", lambda delay: None)
+    factory, made = _factory_for([[{"type": "hello"}], [{"type": "hello"}]])
+    pool = E2BSandboxPool(sandbox_factory=factory)
+    pool.acquire()
+    pool.acquire()
+
+    def broken_kill(request_timeout: float | None = None) -> bool:
+        del request_timeout
+        made[0].kills += 1
+        raise RuntimeError("control plane unavailable")
+
+    monkeypatch.setattr(made[0], "kill", broken_kill)
+    with pytest.raises(SandboxCleanupError, match="1 of 2"):
+        pool.close()
+
+    assert made[0].kills == 3
+    assert made[1].kills == 1
 
 
 def test_inflight_release_after_pool_close_does_not_kill_the_lease_twice(

--- a/wmh/harness/pi_entry/entry.ts
+++ b/wmh/harness/pi_entry/entry.ts
@@ -24,7 +24,7 @@ if (!SHIM) {
 	process.exit(2);
 }
 const BASE = SHIM.replace(/\/$/, "");
-const MAX_TURNS = 20;
+const DEFAULT_MAX_TURNS = 20;
 
 interface TaskTool {
 	name: string;
@@ -35,6 +35,7 @@ interface Task {
 	instruction: string;
 	system?: string;
 	tools: TaskTool[];
+	max_turns?: number;
 }
 
 async function getJson<T>(path: string): Promise<T> {
@@ -116,6 +117,13 @@ function makeSubmitTool(): AgentTool<any> {
 
 async function main(): Promise<void> {
 	const task = await getJson<Task>("/task");
+	const configuredMaxTurns = task.max_turns;
+	const maxTurns =
+		configuredMaxTurns !== undefined &&
+		Number.isInteger(configuredMaxTurns) &&
+		configuredMaxTurns >= 1
+			? configuredMaxTurns
+			: DEFAULT_MAX_TURNS;
 
 	const model: Model<"openai-completions"> = {
 		id: "stub-model",
@@ -145,7 +153,7 @@ async function main(): Promise<void> {
 		getApiKey: () => "x",
 	});
 
-	// Hard turn cap: abort after MAX_TURNS assistant turns to avoid runaway loops.
+	// Hard turn cap: use the harness document's per-episode value.
 	let turnCount = 0;
 	agent.subscribe((event) => {
 		if (event.type === "turn_end" || event.type === "message_end") {
@@ -154,7 +162,7 @@ async function main(): Promise<void> {
 		}
 		if (event.type === "turn_end") {
 			turnCount += 1;
-			if (turnCount >= MAX_TURNS) agent.abort();
+			if (turnCount >= maxTurns) agent.abort();
 		}
 	});
 

--- a/wmh/harness/pi_entry/entry.ts
+++ b/wmh/harness/pi_entry/entry.ts
@@ -36,6 +36,7 @@ interface Task {
 	system?: string;
 	tools: TaskTool[];
 	max_turns?: number;
+	max_output_tokens?: number;
 }
 
 async function getJson<T>(path: string): Promise<T> {
@@ -124,6 +125,13 @@ async function main(): Promise<void> {
 		configuredMaxTurns >= 1
 			? configuredMaxTurns
 			: DEFAULT_MAX_TURNS;
+	const configuredMaxOutputTokens = task.max_output_tokens;
+	const maxOutputTokens =
+		configuredMaxOutputTokens !== undefined &&
+		Number.isInteger(configuredMaxOutputTokens) &&
+		configuredMaxOutputTokens >= 1
+			? configuredMaxOutputTokens
+			: 4096;
 
 	const model: Model<"openai-completions"> = {
 		id: "stub-model",
@@ -135,7 +143,7 @@ async function main(): Promise<void> {
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128000,
-		maxTokens: 4096,
+		maxTokens: maxOutputTokens,
 	};
 
 	// `submit` is provided by entry.ts (it drives /done + loop termination); drop any

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -275,6 +275,7 @@ function startLlmBridge(conn: StdioConn): Promise<Bridge> {
 					const choice = reply.completion?.choices?.[0] ?? {};
 					const msg = choice.message ?? {};
 					const delta: any = { role: "assistant", content: msg.content ?? "" };
+					if (msg.reasoning_details) delta.reasoning_details = msg.reasoning_details;
 					if (msg.tool_calls) {
 						delta.tool_calls = msg.tool_calls.map((tc: any, i: number) => ({
 							index: i,

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -398,6 +398,10 @@ class Session {
 
 	async start(frame: Frame): Promise<void> {
 		this.turnCap = Number(frame.turn_cap ?? 60);
+		const maxOutputTokens =
+			Number.isInteger(frame.max_output_tokens) && frame.max_output_tokens >= 1
+				? frame.max_output_tokens
+				: 4096;
 		const AgentCtor = await loadAgent(frame);
 		assertInteractive(AgentCtor);
 		this.bridge = await startLlmBridge(this.conn);
@@ -412,7 +416,7 @@ class Session {
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 128000,
-			maxTokens: 4096,
+			maxTokens: maxOutputTokens,
 		};
 
 		const tools = this.buildTools(frame.tools ?? []);

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -33,6 +33,7 @@ console.warn = toStderr;
 console.debug = toStderr;
 
 const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
+const TRANSPORT_KEEPALIVE_MS = 30_000;
 
 type Frame = Record<string, any>;
 
@@ -79,6 +80,16 @@ class StdioConn {
 			this.waiters.set(req_id, resolve);
 			this.send({ type, req_id, ...payload });
 		});
+	}
+
+	/** Keep the command stream active across the persistent session; timeout remains host-owned. */
+	startTransportKeepalive(): () => void {
+		const timer = setInterval(
+			() => this.send({ type: "transport_keepalive" }),
+			TRANSPORT_KEEPALIVE_MS,
+		);
+		timer.unref();
+		return () => clearInterval(timer);
 	}
 
 	private onData(chunk: string): void {
@@ -397,6 +408,9 @@ class Session {
 
 function main(): void {
 	const conn = new StdioConn();
+	// AgentProject deliberately keeps this ordinary live session between proposal turns. Keep the
+	// output stream attached while idle too; host-side E2B timeout/idle-suspend policy is separate.
+	conn.startTransportKeepalive();
 	const session = new Session(conn);
 	conn.on("shutdown", () => process.exit(0));
 	conn.on("session_start", (start) => {

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -34,8 +34,10 @@ console.debug = toStderr;
 
 const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
 const TRANSPORT_KEEPALIVE_MS = 30_000;
+const LIVE_OUTBOX = process.env.WMH_LIVE_OUTBOX?.trim() || null;
 
 type Frame = Record<string, any>;
+type TransportEnvelope = { transport_seq: number; frame: Frame };
 
 function encodeFrame(frame: Frame): string {
 	return Buffer.from(JSON.stringify(frame), "utf8").toString("base64") + "\n";
@@ -52,6 +54,68 @@ function decodeFrame(line: string): Frame | null {
 	}
 }
 
+/**
+ * Durable, replayable copy of the semantic output stream.
+ *
+ * A frame file is published before the head watermark advances, and both writes use a temporary
+ * sibling plus rename. Readers may therefore trust every sequence through `head` without ever
+ * observing partial JSON. The decimal watermark also lets a replacement runner continue a
+ * pre-existing outbox without reusing committed sequence numbers.
+ */
+class DurableOutbox {
+	private readonly framesDir: string;
+	private readonly headPath: string;
+	private readonly tmpNamespace = `${process.pid}-${Date.now().toString(36)}-${process.hrtime.bigint().toString(36)}`;
+	private transportSeq = 0;
+	private tmpSeq = 0;
+
+	constructor(root: string) {
+		const resolvedRoot = path.resolve(root);
+		this.framesDir = path.join(resolvedRoot, "frames");
+		this.headPath = path.join(resolvedRoot, "head");
+		fs.mkdirSync(this.framesDir, { recursive: true });
+
+		if (fs.existsSync(this.headPath)) {
+			const current = fs.readFileSync(this.headPath, "utf8").trim();
+			const parsed = Number(current);
+			if (!Number.isSafeInteger(parsed) || parsed < 0) {
+				throw new Error(`invalid live outbox head at ${this.headPath}: ${JSON.stringify(current)}`);
+			}
+			this.transportSeq = parsed;
+		} else {
+			this.atomicWrite(this.headPath, "0\n");
+		}
+	}
+
+	publish(frame: Frame): TransportEnvelope {
+		const transport_seq = this.transportSeq + 1;
+		const envelope: TransportEnvelope = { transport_seq, frame };
+		const filename = `${String(transport_seq).padStart(20, "0")}.json`;
+		this.atomicWrite(path.join(this.framesDir, filename), JSON.stringify(envelope) + "\n");
+		this.atomicWrite(this.headPath, `${transport_seq}\n`);
+		this.transportSeq = transport_seq;
+		return envelope;
+	}
+
+	private atomicWrite(target: string, content: string): void {
+		const tmp = path.join(
+			path.dirname(target),
+			`.${path.basename(target)}.tmp-${this.tmpNamespace}-${++this.tmpSeq}`,
+		);
+		try {
+			fs.writeFileSync(tmp, content, { encoding: "utf8", flag: "wx" });
+			fs.renameSync(tmp, target);
+		} catch (error) {
+			try {
+				fs.unlinkSync(tmp);
+			} catch {
+				// The temp file may not have been created, or rename may already have consumed it.
+			}
+			throw error;
+		}
+	}
+}
+
 /** The stdio twin of runner_frames.FrameConn: `request` awaits a matching response by req_id;
  *  host-pushed frames (session_start, user_message, abort, ping, shutdown) fire handlers. */
 class StdioConn {
@@ -59,8 +123,12 @@ class StdioConn {
 	private waiters = new Map<number, (f: Frame) => void>();
 	private handlers = new Map<string, (f: Frame) => void>();
 	private reqSeq = 0;
+	private readonly outbox: DurableOutbox | null;
+	private lastInboundSeq = 0;
 
 	constructor() {
+		// Initialize the complete durable layout before `main` can emit its ready/hello frame.
+		this.outbox = LIVE_OUTBOX ? new DurableOutbox(LIVE_OUTBOX) : null;
 		process.stdin.setEncoding("utf8");
 		process.stdin.on("data", (chunk: string) => this.onData(chunk));
 		process.stdin.on("end", () => process.exit(0));
@@ -71,7 +139,13 @@ class StdioConn {
 	}
 
 	send(frame: Frame): void {
-		process.stdout.write(encodeFrame(frame));
+		if (!this.outbox) {
+			// Keep the original wire format byte-for-byte when durable transport is not requested.
+			process.stdout.write(encodeFrame(frame));
+			return;
+		}
+		const envelope = this.outbox.publish(frame);
+		process.stdout.write(encodeFrame(envelope));
 	}
 
 	request(type: string, payload: Frame): Promise<Frame> {
@@ -85,7 +159,9 @@ class StdioConn {
 	/** Keep the command stream active across the persistent session; timeout remains host-owned. */
 	startTransportKeepalive(): () => void {
 		const timer = setInterval(
-			() => this.send({ type: "transport_keepalive" }),
+			// Liveness ticks carry no semantic state: leave them on the legacy wire and out of the
+			// replay log so they neither advance the sequence nor create unbounded tiny files.
+			() => process.stdout.write(encodeFrame({ type: "transport_keepalive" })),
 			TRANSPORT_KEEPALIVE_MS,
 		);
 		timer.unref();
@@ -99,9 +175,58 @@ class StdioConn {
 			const line = this.buf.slice(0, nl);
 			this.buf = this.buf.slice(nl + 1);
 			const frame = decodeFrame(line);
-			if (frame) this.dispatch(frame);
+			if (frame) this.dispatchInbound(frame);
 			nl = this.buf.indexOf("\n");
 		}
+	}
+
+	private dispatchInbound(value: Frame): void {
+		if (!this.outbox) {
+			this.dispatch(value);
+			return;
+		}
+
+		const inboundSeq = value.transport_in_seq;
+		const frame = value.frame;
+		if (
+			typeof inboundSeq !== "number" ||
+			!Number.isSafeInteger(inboundSeq) ||
+			inboundSeq <= 0 ||
+			!frame ||
+			typeof frame !== "object" ||
+			Array.isArray(frame)
+		) {
+			this.send({
+				type: "transport_nack",
+				transport_in_seq: inboundSeq,
+				expected_transport_in_seq: this.lastInboundSeq + 1,
+			});
+			return;
+		}
+		if (inboundSeq <= this.lastInboundSeq) {
+			// The original dispatch succeeded but its ack notification was lost. Re-publish only
+			// the acknowledgement: repeating a response, prompt, or tool result is unsafe.
+			this.send({ type: "transport_ack", transport_in_seq: inboundSeq });
+			return;
+		}
+		if (inboundSeq !== this.lastInboundSeq + 1) {
+			this.send({
+				type: "transport_nack",
+				transport_in_seq: inboundSeq,
+				expected_transport_in_seq: this.lastInboundSeq + 1,
+			});
+			return;
+		}
+
+		this.lastInboundSeq = inboundSeq;
+		if (frame.type === "shutdown") {
+			// shutdown exits synchronously, so persist acceptance before dispatching it.
+			this.send({ type: "transport_ack", transport_in_seq: inboundSeq });
+			this.dispatch(frame);
+			return;
+		}
+		this.dispatch(frame);
+		this.send({ type: "transport_ack", transport_in_seq: inboundSeq });
 	}
 
 	private dispatch(frame: Frame): void {

--- a/wmh/harness/pi_entry/runner_live.ts
+++ b/wmh/harness/pi_entry/runner_live.ts
@@ -4,7 +4,8 @@
  * Where runner_stdio.ts runs ONE fire-and-forget episode, this runner hosts ONE long-lived pi
  * Agent for an interactive multi-turn session: the host sends `session_start` once (materializing
  * the champion's code surfaces), then `user_message` / `abort` / `ping` frames over the session's
- * life, and the runner drives the same Agent across every turn on one accumulating transcript.
+ * life. Interactive sessions retain one transcript; filesystem-backed projects can instead scope
+ * conversation to each outer turn while reusing the same Agent, runner, and project filesystem.
  * The transport, the localhost LLM bridge (credentials stay host-side), and the env-tools-as-
  * `tool_request` contract are identical to runner_stdio.ts — deliberately re-mirrored rather than
  * imported, because runner_stdio boots per-episode helpers and this runner's lifecycle differs.
@@ -285,7 +286,12 @@ function startLlmBridge(conn: StdioConn): Promise<Bridge> {
 						}));
 					}
 					const first = { choices: [{ index: 0, delta, finish_reason: null }] };
-					const last = { choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }] };
+					const last = {
+						choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }],
+						// Pi uses the latest assistant usage to estimate occupied context. Without this,
+						// it falls back to chars/4 and can prematurely clamp the next output budget.
+						usage: reply.completion?.usage,
+					};
 					res.write(`data: ${JSON.stringify(first)}\n\n`);
 					res.write(`data: ${JSON.stringify(last)}\n\n`);
 					res.end("data: [DONE]\n\n");
@@ -389,6 +395,7 @@ class Session {
 	private running = false;
 	private turns = 0;
 	private turnCap = 60;
+	private conversationScope: "session" | "turn" = "session";
 	private interrupted = false;
 	private hitTurnCap = false;
 
@@ -398,6 +405,7 @@ class Session {
 
 	async start(frame: Frame): Promise<void> {
 		this.turnCap = Number(frame.turn_cap ?? 60);
+		this.conversationScope = frame.conversation_scope === "turn" ? "turn" : "session";
 		const maxOutputTokens =
 			Number.isInteger(frame.max_output_tokens) && frame.max_output_tokens >= 1
 				? frame.max_output_tokens
@@ -501,6 +509,13 @@ class Session {
 		this.turns = 0;
 		this.interrupted = false;
 		this.hitTurnCap = false;
+		if (this.conversationScope === "turn") {
+			// AgentProject stores durable memory in its filesystem and gives every outer task a
+			// self-contained request. Retaining all prior task transcripts duplicates that state,
+			// grows input cost without bound, and makes pi clamp maxTokens to 1 near its context cap.
+			// Reset only here, while idle: tool calls within this logical turn still share context.
+			this.agent.state.messages = [];
+		}
 		this.sendState("running");
 		try {
 			await this.agent.prompt(text);

--- a/wmh/harness/pi_entry/runner_service.ts
+++ b/wmh/harness/pi_entry/runner_service.ts
@@ -78,7 +78,12 @@ function startLlmBridge(conn: FrameConn): Promise<Bridge> {
 						}));
 					}
 					const first = { choices: [{ index: 0, delta, finish_reason: null }] };
-					const last = { choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }] };
+					const last = {
+						choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }],
+						// Pi uses the latest assistant usage to estimate occupied context. Without this,
+						// it falls back to chars/4 and can prematurely clamp the next output budget.
+						usage: reply.completion?.usage,
+					};
 					res.write(`data: ${JSON.stringify(first)}\n\n`);
 					res.write(`data: ${JSON.stringify(last)}\n\n`);
 					res.end("data: [DONE]\n\n");

--- a/wmh/harness/pi_entry/runner_service.ts
+++ b/wmh/harness/pi_entry/runner_service.ts
@@ -29,7 +29,9 @@ import { FrameConn, type Frame } from "./runner_frames.ts";
 
 const [HOST, PORT] = (process.env.PI_LINK_ADDR ?? "127.0.0.1:8900").split(":");
 const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
-const MAX_TURNS = Number(process.env.PI_MAX_TURNS ?? "20");
+const configuredMaxTurns = Number(process.env.PI_MAX_TURNS ?? "20");
+const DEFAULT_MAX_TURNS =
+	Number.isInteger(configuredMaxTurns) && configuredMaxTurns >= 1 ? configuredMaxTurns : 20;
 
 function assistantText(msg: any): string {
 	if (!msg || msg.role !== "assistant" || !Array.isArray(msg.content)) return "";
@@ -115,6 +117,10 @@ async function runEpisode(conn: FrameConn, start: Frame): Promise<void> {
 	const bridge = await startLlmBridge(conn);
 	const [AgentCtor, cleanupSrc] = await loadAgent(start);
 	const episodeId = start.episode_id;
+	const maxTurns =
+		Number.isInteger(start.max_turns) && start.max_turns >= 1
+			? start.max_turns
+			: DEFAULT_MAX_TURNS;
 	let doneSent = false;
 	let lastAssistantText = "";
 
@@ -173,7 +179,7 @@ async function runEpisode(conn: FrameConn, start: Frame): Promise<void> {
 		}
 		if (event.type === "turn_end") {
 			turns += 1;
-			if (turns >= MAX_TURNS) agent.abort();
+			if (turns >= maxTurns) agent.abort();
 		}
 	});
 

--- a/wmh/harness/pi_entry/runner_service.ts
+++ b/wmh/harness/pi_entry/runner_service.ts
@@ -122,6 +122,10 @@ async function runEpisode(conn: FrameConn, start: Frame): Promise<void> {
 		Number.isInteger(start.max_turns) && start.max_turns >= 1
 			? start.max_turns
 			: DEFAULT_MAX_TURNS;
+	const maxOutputTokens =
+		Number.isInteger(start.max_output_tokens) && start.max_output_tokens >= 1
+			? start.max_output_tokens
+			: 4096;
 	let doneSent = false;
 	let lastAssistantText = "";
 
@@ -135,7 +139,7 @@ async function runEpisode(conn: FrameConn, start: Frame): Promise<void> {
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128000,
-		maxTokens: 4096,
+		maxTokens: maxOutputTokens,
 	};
 
 	const envTools: AgentTool<any>[] = (start.tools ?? [])

--- a/wmh/harness/pi_entry/runner_service.ts
+++ b/wmh/harness/pi_entry/runner_service.ts
@@ -66,6 +66,7 @@ function startLlmBridge(conn: FrameConn): Promise<Bridge> {
 					const choice = reply.completion?.choices?.[0] ?? {};
 					const msg = choice.message ?? {};
 					const delta: any = { role: "assistant", content: msg.content ?? "" };
+					if (msg.reasoning_details) delta.reasoning_details = msg.reasoning_details;
 					if (msg.tool_calls) {
 						// Keep `function` explicitly nested (the streaming OpenAI shape the pi parser
 						// expects); index each call.

--- a/wmh/harness/pi_entry/runner_stdio.ts
+++ b/wmh/harness/pi_entry/runner_stdio.ts
@@ -178,7 +178,12 @@ function startLlmBridge(conn: StdioConn): Promise<Bridge> {
 						}));
 					}
 					const first = { choices: [{ index: 0, delta, finish_reason: null }] };
-					const last = { choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }] };
+					const last = {
+						choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason ?? "stop" }],
+						// Pi uses the latest assistant usage to estimate occupied context. Without this,
+						// it falls back to chars/4 and can prematurely clamp the next output budget.
+						usage: reply.completion?.usage,
+					};
 					res.write(`data: ${JSON.stringify(first)}\n\n`);
 					res.write(`data: ${JSON.stringify(last)}\n\n`);
 					res.end("data: [DONE]\n\n");

--- a/wmh/harness/pi_entry/runner_stdio.ts
+++ b/wmh/harness/pi_entry/runner_stdio.ts
@@ -166,6 +166,7 @@ function startLlmBridge(conn: StdioConn): Promise<Bridge> {
 					const choice = reply.completion?.choices?.[0] ?? {};
 					const msg = choice.message ?? {};
 					const delta: any = { role: "assistant", content: msg.content ?? "" };
+					if (msg.reasoning_details) delta.reasoning_details = msg.reasoning_details;
 					if (msg.tool_calls) {
 						// Keep `function` explicitly nested (the streaming OpenAI shape the pi parser
 						// expects); index each call.

--- a/wmh/harness/pi_entry/runner_stdio.ts
+++ b/wmh/harness/pi_entry/runner_stdio.ts
@@ -221,6 +221,10 @@ async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 		Number.isInteger(start.max_turns) && start.max_turns >= 1
 			? start.max_turns
 			: DEFAULT_MAX_TURNS;
+	const maxOutputTokens =
+		Number.isInteger(start.max_output_tokens) && start.max_output_tokens >= 1
+			? start.max_output_tokens
+			: 4096;
 	let doneSent = false;
 	let lastAssistantText = "";
 	let bridge: Bridge | null = null;
@@ -242,7 +246,7 @@ async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: 128000,
-			maxTokens: 4096,
+			maxTokens: maxOutputTokens,
 		};
 
 		const envTools: any[] = (start.tools ?? [])

--- a/wmh/harness/pi_entry/runner_stdio.ts
+++ b/wmh/harness/pi_entry/runner_stdio.ts
@@ -39,7 +39,9 @@ console.warn = toStderr;
 console.debug = toStderr;
 
 const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
-const MAX_TURNS = Number(process.env.PI_MAX_TURNS ?? "20");
+const configuredMaxTurns = Number(process.env.PI_MAX_TURNS ?? "20");
+const DEFAULT_MAX_TURNS =
+	Number.isInteger(configuredMaxTurns) && configuredMaxTurns >= 1 ? configuredMaxTurns : 20;
 const TRANSPORT_KEEPALIVE_MS = 30_000;
 
 type Frame = Record<string, any>;
@@ -214,6 +216,10 @@ async function loadAgent(start: Frame): Promise<[any, () => void]> {
 
 async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 	const episodeId = start.episode_id;
+	const maxTurns =
+		Number.isInteger(start.max_turns) && start.max_turns >= 1
+			? start.max_turns
+			: DEFAULT_MAX_TURNS;
 	let doneSent = false;
 	let lastAssistantText = "";
 	let bridge: Bridge | null = null;
@@ -278,7 +284,7 @@ async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 			}
 			if (event.type === "turn_end") {
 				turns += 1;
-				if (turns >= MAX_TURNS) agent.abort();
+				if (turns >= maxTurns) agent.abort();
 			}
 		});
 

--- a/wmh/harness/pi_entry/runner_stdio.ts
+++ b/wmh/harness/pi_entry/runner_stdio.ts
@@ -40,6 +40,7 @@ console.debug = toStderr;
 
 const AGENT_MODEL = process.env.PI_AGENT_MODEL ?? "worker";
 const MAX_TURNS = Number(process.env.PI_MAX_TURNS ?? "20");
+const TRANSPORT_KEEPALIVE_MS = 30_000;
 
 type Frame = Record<string, any>;
 
@@ -92,6 +93,16 @@ class StdioConn {
 			this.waiters.set(req_id, resolve);
 			this.send({ type, req_id, ...payload });
 		});
+	}
+
+	/** Keep the E2B command stream and its pooled sandbox lease alive during one active episode. */
+	startTransportKeepalive(): () => void {
+		const timer = setInterval(
+			() => this.send({ type: "transport_keepalive" }),
+			TRANSPORT_KEEPALIVE_MS,
+		);
+		timer.unref();
+		return () => clearInterval(timer);
 	}
 
 	private onData(chunk: string): void {
@@ -207,6 +218,7 @@ async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 	let lastAssistantText = "";
 	let bridge: Bridge | null = null;
 	let cleanupSrc: () => void = () => {};
+	const stopTransportKeepalive = conn.startTransportKeepalive();
 
 	try {
 		const [AgentCtor, cleanup] = await loadAgent(start);
@@ -275,6 +287,7 @@ async function runEpisode(conn: StdioConn, start: Frame): Promise<void> {
 	} catch (e) {
 		if (!doneSent) conn.send({ type: "episode_error", episode_id: episodeId, note: String(e) });
 	} finally {
+		stopTransportKeepalive();
 		bridge?.close();
 		cleanupSrc();
 	}

--- a/wmh/harness/pi_local.py
+++ b/wmh/harness/pi_local.py
@@ -24,7 +24,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TextIO, cast
 
 from wmh.core.types import JsonObject
-from wmh.harness.pi_e2b import HELLO_TIMEOUT_S, PI_NPM_PACKAGES, session_entry_files
+from wmh.harness.pi_e2b import (
+    HELLO_TIMEOUT_S,
+    PI_NPM_PACKAGES,
+    TRANSPORT_KEEPALIVE_TYPE,
+    session_entry_files,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -198,6 +203,8 @@ class LocalStdioChannel:
                     self._stderr.append(f"[stdout] {text}")
                     continue
                 if isinstance(frame, dict):
+                    if frame.get("type") == TRANSPORT_KEEPALIVE_TYPE:
+                        continue
                     self._frames.put(cast("JsonObject", frame))
                 else:
                     self._stderr.append(f"[stdout] {text}")

--- a/wmh/harness/pi_local_test.py
+++ b/wmh/harness/pi_local_test.py
@@ -45,7 +45,9 @@ def _node_22() -> str:
     return node
 
 
-def _start_live_runner(node: str, env: dict[str, str]) -> subprocess.Popen[str]:
+def _start_live_runner(
+    node: str, env: dict[str, str], *, cwd: Path | None = None
+) -> subprocess.Popen[str]:
     runner = Path(mod.__file__).with_name("pi_entry") / "runner_live.ts"
     return subprocess.Popen(  # noqa: S603 - resolved local Node executable, no shell
         [node, "--experimental-strip-types", str(runner)],
@@ -54,6 +56,7 @@ def _start_live_runner(node: str, env: dict[str, str]) -> subprocess.Popen[str]:
         stderr=subprocess.PIPE,
         text=True,
         env=env,
+        cwd=cwd,
     )
 
 
@@ -62,6 +65,9 @@ def _read_live_frame(process: subprocess.Popen[str]) -> dict[str, object]:
     ready, _, _ = select.select([process.stdout], [], [], 5)
     assert ready, "live runner did not emit a frame within five seconds"
     wire = process.stdout.readline().strip()
+    if not wire:
+        stderr = process.stderr.read() if process.stderr is not None else ""
+        raise AssertionError(f"live runner exited before its next frame: {stderr}")
     return cast("dict[str, object]", json.loads(base64.b64decode(wire)))
 
 
@@ -200,6 +206,53 @@ def test_live_runner_durable_outbox_precedes_sequenced_stdout(tmp_path: Path) ->
         assert list(outbox.rglob(".*.tmp-*")) == []
     finally:
         _stop_live_runner(process, durable_inbound_seq=2)
+
+
+def test_live_runner_turn_scope_clears_only_the_prior_outer_turn(tmp_path: Path) -> None:
+    """Project turns reuse one runner but never accumulate an unbounded chat transcript."""
+    node = _node_22()
+    env = os.environ.copy()
+    env.pop("WMH_LIVE_OUTBOX", None)
+    env["NODE_NO_WARNINGS"] = "1"
+    process = _start_live_runner(node, env, cwd=tmp_path)
+    agent_source = """export class Agent {
+  state = { messages: [] };
+  listeners = [];
+  constructor(_options) {}
+  subscribe(listener) { this.listeners.push(listener); return () => {}; }
+  steer(_message) {}
+  abort() {}
+  async prompt(text) {
+    if (this.state.messages.length !== 0) throw new Error("prior outer turn was retained");
+    this.state.messages = [{ role: "user", text }];
+    for (const listener of this.listeners) await listener({ type: "turn_end" });
+  }
+}
+"""
+    try:
+        assert _read_live_frame(process)["type"] == "hello"
+        _send_live_frame(
+            process,
+            {
+                "type": "session_start",
+                "files": {"src/agent.ts": agent_source},
+                "tools": [],
+                "conversation_scope": "turn",
+            },
+        )
+        assert _read_live_frame(process) == {"type": "state", "status": "idle", "turns": 0}
+
+        for index in range(2):
+            _send_live_frame(
+                process,
+                {"type": "user_message", "msg_id": f"m{index}", "text": f"round {index}"},
+            )
+            assert _read_live_frame(process)["status"] == "running"
+            terminal = _read_live_frame(process)
+            assert terminal["status"] == "idle"
+            assert terminal["reason"] == "completed"
+    finally:
+        _stop_live_runner(process)
 
 
 class _FakeProcess:

--- a/wmh/harness/pi_local_test.py
+++ b/wmh/harness/pi_local_test.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
+import select
+import shutil
+import subprocess
 from pathlib import Path
 from typing import cast
 
@@ -24,6 +28,66 @@ class _FakeResult:
 
     def __init__(self, stdout: str) -> None:
         self.stdout = stdout
+
+
+def _node_22() -> str:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is not installed")
+    result = subprocess.run(  # noqa: S603 - resolved local Node executable, no shell
+        [node, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if parse_node_version(result.stdout) < (22, 19, 0):
+        pytest.skip("runner_live.ts requires Node.js 22.19+")
+    return node
+
+
+def _start_live_runner(node: str, env: dict[str, str]) -> subprocess.Popen[str]:
+    runner = Path(mod.__file__).with_name("pi_entry") / "runner_live.ts"
+    return subprocess.Popen(  # noqa: S603 - resolved local Node executable, no shell
+        [node, "--experimental-strip-types", str(runner)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def _read_live_frame(process: subprocess.Popen[str]) -> dict[str, object]:
+    assert process.stdout is not None
+    ready, _, _ = select.select([process.stdout], [], [], 5)
+    assert ready, "live runner did not emit a frame within five seconds"
+    wire = process.stdout.readline().strip()
+    return cast("dict[str, object]", json.loads(base64.b64decode(wire)))
+
+
+def _send_live_frame(process: subprocess.Popen[str], frame: dict[str, object]) -> None:
+    assert process.stdin is not None
+    wire = base64.b64encode(json.dumps(frame).encode()).decode() + "\n"
+    process.stdin.write(wire)
+    process.stdin.flush()
+
+
+def _stop_live_runner(
+    process: subprocess.Popen[str], *, durable_inbound_seq: int | None = None
+) -> None:
+    if process.poll() is None:
+        try:
+            frame: dict[str, object] = {"type": "shutdown"}
+            if durable_inbound_seq is not None:
+                frame = {"transport_in_seq": durable_inbound_seq, "frame": frame}
+            _send_live_frame(process, frame)
+            process.wait(timeout=5)
+        except (BrokenPipeError, subprocess.TimeoutExpired):
+            process.kill()
+            process.wait(timeout=5)
+    for stream in (process.stdin, process.stdout, process.stderr):
+        if stream is not None:
+            stream.close()
 
 
 def test_parse_node_version_requires_semver_shape() -> None:
@@ -67,6 +131,75 @@ def test_runtime_bootstrap_rejects_old_node(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="Node.js 22.19"):
         ensure_local_pi_runtime(tmp_path, node="node", npm="npm", run_command=run)
+
+
+def test_live_runner_default_output_keeps_the_legacy_frame_shape() -> None:
+    """Without an outbox opt-in, stdout remains the original unwrapped frame stream."""
+    node = _node_22()
+    env = os.environ.copy()
+    env.pop("WMH_LIVE_OUTBOX", None)
+    env["NODE_NO_WARNINGS"] = "1"
+    process = _start_live_runner(node, env)
+    try:
+        hello = _read_live_frame(process)
+        assert hello["type"] == "hello"
+        assert "transport_seq" not in hello
+        assert "frame" not in hello
+    finally:
+        _stop_live_runner(process)
+
+
+def test_live_runner_durable_outbox_precedes_sequenced_stdout(tmp_path: Path) -> None:
+    """Semantic frames are committed in sequence before their matching envelopes reach stdout."""
+    node = _node_22()
+    outbox = tmp_path / "live-outbox"
+    env = os.environ.copy()
+    env["NODE_NO_WARNINGS"] = "1"
+    env["WMH_LIVE_OUTBOX"] = str(outbox)
+    process = _start_live_runner(node, env)
+    try:
+        hello = _read_live_frame(process)
+        assert hello["transport_seq"] == 1
+        assert cast("dict[str, object]", hello["frame"])["type"] == "hello"
+        # Seeing stdout is sufficient proof that both atomic outbox writes have completed: publish
+        # is synchronous and send writes stdout only after publishing the frame and head.
+        assert (outbox / "head").read_text() == "1\n"
+        assert json.loads((outbox / "frames" / "00000000000000000001.json").read_text()) == hello
+
+        inbound: dict[str, object] = {
+            "transport_in_seq": 1,
+            "frame": {"type": "ping", "nonce": "n1"},
+        }
+        _send_live_frame(process, inbound)
+        pong = _read_live_frame(process)
+        assert pong == {
+            "transport_seq": 2,
+            "frame": {"type": "pong", "nonce": "n1"},
+        }
+        ack = _read_live_frame(process)
+        assert ack == {
+            "transport_seq": 3,
+            "frame": {"type": "transport_ack", "transport_in_seq": 1},
+        }
+
+        # A physical resend after an ambiguous HTTP timeout repairs the lost ack but must not
+        # dispatch the logical ping twice.
+        _send_live_frame(process, inbound)
+        duplicate_ack = _read_live_frame(process)
+        assert duplicate_ack == {
+            "transport_seq": 4,
+            "frame": {"type": "transport_ack", "transport_in_seq": 1},
+        }
+        assert (outbox / "head").read_text() == "4\n"
+        assert json.loads((outbox / "frames" / "00000000000000000002.json").read_text()) == pong
+        assert json.loads((outbox / "frames" / "00000000000000000003.json").read_text()) == ack
+        assert (
+            json.loads((outbox / "frames" / "00000000000000000004.json").read_text())
+            == duplicate_ack
+        )
+        assert list(outbox.rglob(".*.tmp-*")) == []
+    finally:
+        _stop_live_runner(process, durable_inbound_seq=2)
 
 
 class _FakeProcess:

--- a/wmh/harness/pi_local_test.py
+++ b/wmh/harness/pi_local_test.py
@@ -11,6 +11,7 @@ from typing import cast
 import pytest
 
 import wmh.harness.pi_local as mod
+from wmh.harness.pi_e2b import TRANSPORT_KEEPALIVE_TYPE
 from wmh.harness.pi_local import (
     LocalStdioChannel,
     ensure_local_pi_runtime,
@@ -110,3 +111,17 @@ def test_local_stdio_channel_round_trips_frames_and_cleans_run_dir(tmp_path: Pat
     channel.close()
     assert process.terminated
     assert not run_dir.exists()
+
+
+def test_local_stdio_channel_filters_transport_keepalives() -> None:
+    """Runner liveness is transport-only and never leaks into an interactive session."""
+    process = _FakeProcess(
+        [
+            {"type": TRANSPORT_KEEPALIVE_TYPE},
+            {"type": "hello", "mode": "session"},
+        ]
+    )
+    channel = LocalStdioChannel(cast("mod._TextProcess", process))
+
+    assert channel.recv(timeout=1) == {"type": "hello", "mode": "session"}
+    channel.close()

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -38,7 +38,7 @@ from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runner_link import params_schema
 from wmh.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_MAX_TURNS, RunResult, StopReason
 from wmh.harness.skills import SkillLibrary
-from wmh.harness.tools import ToolSpec
+from wmh.harness.tools import READ_SKILL, ToolSpec
 from wmh.providers.base import Provider, ToolCallingProvider
 
 # The runner: node runs here, reached over SSH. The checkout keeps pi's node_modules; per-episode
@@ -67,6 +67,8 @@ class _Episode:
         tools: list[ToolSpec],
         provider: ToolCallingProvider,
         environment: AgentEnvironment,
+        temperature: float,
+        skills: SkillLibrary,
         max_env_actions: int,
         max_turns: int,
         max_output_tokens: int,
@@ -76,6 +78,8 @@ class _Episode:
         self.tools = tools
         self.provider = provider
         self.environment = environment
+        self.temperature = temperature
+        self.skills = skills
         self.max_env_actions = max_env_actions
         self.max_turns = max_turns
         self.max_output_tokens = max_output_tokens
@@ -99,9 +103,19 @@ class _Episode:
 
     def run_tool(self, name: str, arguments: JsonObject) -> JsonObject:
         action = Action(kind=ActionKind.TOOL_CALL, name=name, arguments=arguments)
-        if self._env_calls >= self.max_env_actions:
+        if name not in {t.name for t in self.tools}:
+            obs = Observation(content=f"tool {name!r} not available", is_error=True)
+        elif name == READ_SKILL.name:
+            raw_name = arguments.get("name")
+            skill_name = raw_name if isinstance(raw_name, str) else ""
+            skill = self.skills.get(skill_name)
+            if skill is None:
+                obs = Observation(content=f"no skill named {skill_name!r}", is_error=True)
+            else:
+                obs = Observation(content=skill.body)
+        elif self._env_calls >= self.max_env_actions:
             obs = Observation(content="environment action budget exhausted", is_error=True)
-        elif name not in {t.name for t in self.tools} or not is_env_action(action):
+        elif not is_env_action(action):
             obs = Observation(content=f"tool {name!r} not available", is_error=True)
         else:
             self._env_calls += 1
@@ -110,6 +124,12 @@ class _Episode:
             Step(action=action, observation=obs, state_before=EnvState(), task=self.instruction)
         )
         return {"content": obs.content, "is_error": obs.is_error}
+
+    def worker_request(self, body: JsonObject) -> ChatRequest:
+        """Apply the document sampling policy to one runner-authored structured request."""
+        request_body = dict(body)
+        request_body["temperature"] = self.temperature
+        return ChatRequest.model_validate(request_body)
 
 
 # The tool `parameters` schema builder lives in runner_link (shared with the frame transport);
@@ -185,7 +205,7 @@ class _ShimHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.close_connection = True
         try:
-            completion = self._ep.provider.complete_chat(ChatRequest.model_validate(body))
+            completion = self._ep.provider.complete_chat(self._ep.worker_request(body))
             choice = completion.choices[0]
             message = choice.message
             content = message.content if isinstance(message.content, str) else ""
@@ -235,7 +255,13 @@ class PiRuntime:
             raise TypeError("PiRuntime needs a ToolCallingProvider")
         self._provider = provider
         self._files = files
-        self._tools = tools
+        self._skills = skills if skills is not None else SkillLibrary()
+        self._tools = list(tools)
+        if len(self._skills) and READ_SKILL.name not in {tool.name for tool in self._tools}:
+            self._tools.append(READ_SKILL)
+        if not 0.0 <= temperature <= 2.0:
+            raise ValueError("temperature must be in [0, 2]")
+        self._temperature = temperature
         self._system_prompt = system_prompt
         self._port = port
         self._workdir = workdir or f"{PI_RUNNER_DIR}/ep-{port}"
@@ -260,6 +286,8 @@ class PiRuntime:
             tools=self._tools,
             provider=self._provider,
             environment=environment,
+            temperature=self._temperature,
+            skills=self._skills,
             max_env_actions=self._max_env_actions,
             max_turns=self._max_turns,
             max_output_tokens=self._max_output_tokens,

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -36,7 +36,7 @@ from pydantic import JsonValue
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runner_link import params_schema
-from wmh.harness.runtime import DEFAULT_MAX_TURNS, RunResult, StopReason
+from wmh.harness.runtime import DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_MAX_TURNS, RunResult, StopReason
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import ToolSpec
 from wmh.providers.base import Provider, ToolCallingProvider
@@ -69,6 +69,7 @@ class _Episode:
         environment: AgentEnvironment,
         max_env_actions: int,
         max_turns: int,
+        max_output_tokens: int,
     ) -> None:
         self.instruction = instruction
         self.system_prompt = system_prompt
@@ -77,6 +78,7 @@ class _Episode:
         self.environment = environment
         self.max_env_actions = max_env_actions
         self.max_turns = max_turns
+        self.max_output_tokens = max_output_tokens
         self.steps: list[Step] = []
         self.answer: str = ""
         self.proxy_error: str = ""
@@ -88,6 +90,7 @@ class _Episode:
             "instruction": self.instruction,
             "system": self.system_prompt,
             "max_turns": self.max_turns,
+            "max_output_tokens": self.max_output_tokens,
             "tools": [
                 {"name": t.name, "description": t.description, "parameters": _params_schema(t)}
                 for t in self.tools
@@ -226,6 +229,7 @@ class PiRuntime:
         workdir: str | None = None,
         max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS,
         max_turns: int = DEFAULT_MAX_TURNS,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
     ) -> None:
         if not isinstance(provider, ToolCallingProvider):
             raise TypeError("PiRuntime needs a ToolCallingProvider")
@@ -238,7 +242,10 @@ class PiRuntime:
         self._max_env_actions = max_env_actions
         if max_turns < 1:
             raise ValueError("max_turns must be >= 1")
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
         self._max_turns = max_turns
+        self._max_output_tokens = max_output_tokens
         for label, path in (("PI_RUNNER_DIR", PI_RUNNER_DIR), ("workdir", self._workdir)):
             if not _SAFE_REMOTE_PATH.match(path):
                 raise ValueError(
@@ -255,6 +262,7 @@ class PiRuntime:
             environment=environment,
             max_env_actions=self._max_env_actions,
             max_turns=self._max_turns,
+            max_output_tokens=self._max_output_tokens,
         )
         server = _ShimServer(("127.0.0.1", self._port), _ShimHandler)
         server.episode = episode

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -36,7 +36,7 @@ from pydantic import JsonValue
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runner_link import params_schema
-from wmh.harness.runtime import RunResult, StopReason
+from wmh.harness.runtime import DEFAULT_MAX_TURNS, RunResult, StopReason
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import ToolSpec
 from wmh.providers.base import Provider, ToolCallingProvider
@@ -68,6 +68,7 @@ class _Episode:
         provider: ToolCallingProvider,
         environment: AgentEnvironment,
         max_env_actions: int,
+        max_turns: int,
     ) -> None:
         self.instruction = instruction
         self.system_prompt = system_prompt
@@ -75,6 +76,7 @@ class _Episode:
         self.provider = provider
         self.environment = environment
         self.max_env_actions = max_env_actions
+        self.max_turns = max_turns
         self.steps: list[Step] = []
         self.answer: str = ""
         self.proxy_error: str = ""
@@ -85,6 +87,7 @@ class _Episode:
         return {
             "instruction": self.instruction,
             "system": self.system_prompt,
+            "max_turns": self.max_turns,
             "tools": [
                 {"name": t.name, "description": t.description, "parameters": _params_schema(t)}
                 for t in self.tools
@@ -222,6 +225,7 @@ class PiRuntime:
         port: int = 8891,
         workdir: str | None = None,
         max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS,
+        max_turns: int = DEFAULT_MAX_TURNS,
     ) -> None:
         if not isinstance(provider, ToolCallingProvider):
             raise TypeError("PiRuntime needs a ToolCallingProvider")
@@ -232,6 +236,9 @@ class PiRuntime:
         self._port = port
         self._workdir = workdir or f"{PI_RUNNER_DIR}/ep-{port}"
         self._max_env_actions = max_env_actions
+        if max_turns < 1:
+            raise ValueError("max_turns must be >= 1")
+        self._max_turns = max_turns
         for label, path in (("PI_RUNNER_DIR", PI_RUNNER_DIR), ("workdir", self._workdir)):
             if not _SAFE_REMOTE_PATH.match(path):
                 raise ValueError(
@@ -247,6 +254,7 @@ class PiRuntime:
             provider=self._provider,
             environment=environment,
             max_env_actions=self._max_env_actions,
+            max_turns=self._max_turns,
         )
         server = _ShimServer(("127.0.0.1", self._port), _ShimHandler)
         server.episode = episode

--- a/wmh/harness/pi_runtime_test.py
+++ b/wmh/harness/pi_runtime_test.py
@@ -6,6 +6,7 @@ from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, Observation
 from wmh.harness.doc import (
+    MAX_OUTPUT_TOKENS_ID,
     MAX_TURNS_ID,
     RUNTIME_KIND_ID,
     TOOL_POLICY_ID,
@@ -53,6 +54,7 @@ def _episode(env: _Env, *, budget: int = 40) -> _Episode:
         environment=env,
         max_env_actions=budget,
         max_turns=7,
+        max_output_tokens=16384,
     )
 
 
@@ -63,6 +65,7 @@ def test_task_json_shape() -> None:
     tj = json.loads(json.dumps(ep.task_json()))
     assert tj["instruction"] == "do it" and tj["system"] == "sys"
     assert tj["max_turns"] == 7
+    assert tj["max_output_tokens"] == 16384
     names = {t["name"] for t in tj["tools"]}
     assert "bash" in names and "submit" in names
     schema = json.loads(json.dumps(_params_schema(TOOL_REGISTRY["bash"])))
@@ -113,6 +116,7 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
             Surface(
                 id="code:src-agent-ts",
                 kind=SurfaceKind.CODE,
@@ -130,3 +134,4 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
     runtime = doc.runtime(cast("Provider", _P()))
     assert isinstance(runtime, PiRuntime)
     assert runtime._max_turns == 7  # noqa: SLF001 - document parameter reaches entry.ts
+    assert runtime._max_output_tokens == 16384  # noqa: SLF001 - same agent model contract

--- a/wmh/harness/pi_runtime_test.py
+++ b/wmh/harness/pi_runtime_test.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, Observation
-from wmh.harness.doc import RUNTIME_KIND_ID, TOOL_POLICY_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.doc import (
+    MAX_TURNS_ID,
+    RUNTIME_KIND_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
 from wmh.harness.pi_runtime import PiRuntime, _Episode, _params_schema
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 
@@ -45,6 +52,7 @@ def _episode(env: _Env, *, budget: int = 40) -> _Episode:
         provider=_Provider(),
         environment=env,
         max_env_actions=budget,
+        max_turns=7,
     )
 
 
@@ -54,6 +62,7 @@ def test_task_json_shape() -> None:
 
     tj = json.loads(json.dumps(ep.task_json()))
     assert tj["instruction"] == "do it" and tj["system"] == "sys"
+    assert tj["max_turns"] == 7
     names = {t["name"] for t in tj["tools"]}
     assert "bash" in names and "submit" in names
     schema = json.loads(json.dumps(_params_schema(TOOL_REGISTRY["bash"])))
@@ -103,6 +112,7 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(
                 id="code:src-agent-ts",
                 kind=SurfaceKind.CODE,
@@ -117,4 +127,6 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
 
     from wmh.providers.base import Provider
 
-    assert isinstance(doc.runtime(cast("Provider", _P())), PiRuntime)
+    runtime = doc.runtime(cast("Provider", _P()))
+    assert isinstance(runtime, PiRuntime)
+    assert runtime._max_turns == 7  # noqa: SLF001 - document parameter reaches entry.ts

--- a/wmh/harness/pi_runtime_test.py
+++ b/wmh/harness/pi_runtime_test.py
@@ -9,12 +9,14 @@ from wmh.harness.doc import (
     MAX_OUTPUT_TOKENS_ID,
     MAX_TURNS_ID,
     RUNTIME_KIND_ID,
+    TEMPERATURE_ID,
     TOOL_POLICY_ID,
     HarnessDoc,
     Surface,
     SurfaceKind,
 )
 from wmh.harness.pi_runtime import PiRuntime, _Episode, _params_schema
+from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 
 
@@ -45,13 +47,17 @@ class _Provider:
         )
 
 
-def _episode(env: _Env, *, budget: int = 40) -> _Episode:
+def _episode(
+    env: _Env, *, budget: int = 40, skills: SkillLibrary | None = None, temperature: float = 0.7
+) -> _Episode:
     return _Episode(
         instruction="do it",
         system_prompt="sys",
         tools=[TOOL_REGISTRY["bash"], SUBMIT],
         provider=_Provider(),
         environment=env,
+        temperature=temperature,
+        skills=skills if skills is not None else SkillLibrary(),
         max_env_actions=budget,
         max_turns=7,
         max_output_tokens=16384,
@@ -91,6 +97,29 @@ def test_env_action_budget_is_enforced() -> None:
     assert "budget exhausted" in ep.steps[-1].observation.content
 
 
+def test_worker_request_uses_document_temperature() -> None:
+    request = _episode(_Env(), temperature=0.35).worker_request(
+        {"messages": [], "temperature": 1.75}
+    )
+    assert request.temperature == 0.35
+
+
+def test_read_skill_is_runtime_local_and_does_not_consume_environment_budget() -> None:
+    env = _Env()
+    skills = SkillLibrary(
+        [Skill(name="count-words", description="count words", body="wc -w <path>")]
+    )
+    ep = _episode(env, budget=0, skills=skills)
+    ep.tools.append(TOOL_REGISTRY["read_skill"])
+
+    found = ep.run_tool("read_skill", {"name": "count-words"})
+    missing = ep.run_tool("read_skill", {"name": "ghost"})
+
+    assert found == {"content": "wc -w <path>", "is_error": False}
+    assert missing == {"content": "no skill named 'ghost'", "is_error": True}
+    assert env.actions == []
+
+
 def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
     from wmh.providers.base import ProviderConfig, ProviderKind
 
@@ -117,6 +146,14 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
+            Surface(id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content="0.35"),
+            Surface(
+                id="skill:count-words",
+                kind=SurfaceKind.SKILL,
+                content=Skill(
+                    name="count-words", description="count words", body="wc -w <path>"
+                ).to_markdown(),
+            ),
             Surface(
                 id="code:src-agent-ts",
                 kind=SurfaceKind.CODE,
@@ -135,3 +172,9 @@ def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:
     assert isinstance(runtime, PiRuntime)
     assert runtime._max_turns == 7  # noqa: SLF001 - document parameter reaches entry.ts
     assert runtime._max_output_tokens == 16384  # noqa: SLF001 - same agent model contract
+    assert runtime._temperature == 0.35  # noqa: SLF001 - same worker sampling contract
+    assert {tool.name for tool in runtime._tools} >= {  # noqa: SLF001 - runtime plumbing
+        "bash",
+        "submit",
+        "read_skill",
+    }

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -11,6 +12,7 @@ from wmh.core.types import JsonObject
 from wmh.harness.delta import FailureSignature, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.mutate import parse_delta, propose_delta
+from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.providers.base import Provider, ToolCallingProvider
 
 
@@ -28,6 +30,8 @@ class AgentProject(Protocol):
         agent: HarnessDoc,
         provider: ToolCallingProvider,
         instruction: str,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> AgentProjectRun: ...
 
 
@@ -42,6 +46,7 @@ class DeltaProposer(Protocol):
         *,
         history: list[HarnessDelta],
         count: int,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> list[HarnessDelta | ProposalFailure | None]: ...
 
 
@@ -71,12 +76,14 @@ class ProviderDeltaProposer:
         *,
         history: list[HarnessDelta],
         count: int,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> list[HarnessDelta | ProposalFailure | None]:
         """Make ``count`` independent proposal calls against the same parent."""
         if count < 1:
             raise ValueError(f"proposal count must be positive, got {count}")
         proposals: list[HarnessDelta | ProposalFailure | None] = []
         for _ in range(count):
+            _check_cancelled(should_cancel)
             try:
                 proposal = propose_delta(
                     parent,
@@ -85,6 +92,8 @@ class ProviderDeltaProposer:
                     self._provider,
                     history=history,
                 )
+            except HarnessSearchCancelled:
+                raise
             except Exception as error:  # noqa: BLE001 - isolate one flaky sibling call
                 proposal = ProposalFailure(reason=str(error))
             proposals.append(proposal)
@@ -113,10 +122,12 @@ class ProjectDeltaProposer:
         *,
         history: list[HarnessDelta],
         count: int,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> list[HarnessDelta | ProposalFailure | None]:
         """Run one meta-agent turn that writes ``count`` proposal files."""
         if count < 1:
             raise ValueError(f"proposal count must be positive, got {count}")
+        _check_cancelled(should_cancel)
         self._round += 1
         round_dir = f"round-{self._round:04d}"
         context_dir = f"context/{round_dir}"
@@ -138,9 +149,17 @@ class ProjectDeltaProposer:
         self._project.write_text(f"{context_dir}/REQUEST.md", request)
         run_error: Exception | None = None
         try:
-            self._project.run(self._agent, self._provider, request)
+            self._project.run(
+                self._agent,
+                self._provider,
+                request,
+                should_cancel=should_cancel,
+            )
+        except HarnessSearchCancelled:
+            raise
         except Exception as error:  # noqa: BLE001 - durable project files may still be complete
             run_error = error
+        _check_cancelled(should_cancel)
 
         proposals: list[HarnessDelta | ProposalFailure | None] = []
         for index in range(1, count + 1):
@@ -170,6 +189,12 @@ class ProjectDeltaProposer:
                 else:
                     proposals.append(_stamp_project_preconditions(parent, proposal))
         return proposals
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    """Raise the shared search signal without converting it into a failed proposal slot."""
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness search cancelled")
 
 
 def _parent_context(parent: HarnessDoc) -> JsonObject:

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -558,7 +558,7 @@ Read:
 - parent manifest: {absolute_context}/parent.json
   - follow surface_index_manifest to find every independently readable surface manifest
   - each surface manifest lists ordered content_files; concatenate them to inspect exact content
-  - pathful code is also mirrored under source_root with exact source_file paths for shell search
+  - pathful code is also mirrored under source_root with exact source_file paths for direct reads
 - failure evidence manifest: {absolute_context}/evidence.json
   - read its content_files in listed order and concatenate them exactly
 - judged history manifest: {absolute_context}/history.json

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -155,9 +155,20 @@ class ProjectDeltaProposer:
             try:
                 proposal = parse_delta(parent, trigger, raw)
             except Exception as error:  # noqa: BLE001 - isolate one malformed sibling output
-                proposals.append(ProposalFailure(reason=f"invalid proposal output: {error}"))
+                proposals.append(
+                    ProposalFailure(
+                        reason=(
+                            str(run_error)
+                            if run_error is not None
+                            else f"invalid proposal output: {error}"
+                        )
+                    )
+                )
             else:
-                proposals.append(_stamp_project_preconditions(parent, proposal))
+                if proposal is None and run_error is not None:
+                    proposals.append(ProposalFailure(reason=str(run_error)))
+                else:
+                    proposals.append(_stamp_project_preconditions(parent, proposal))
         return proposals
 
 

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Protocol
 
 from wmh.agents.project import AgentProjectRun
@@ -40,7 +41,14 @@ class DeltaProposer(Protocol):
         *,
         history: list[HarnessDelta],
         count: int,
-    ) -> list[HarnessDelta | None]: ...
+    ) -> list[HarnessDelta | ProposalFailure | None]: ...
+
+
+@dataclass(frozen=True)
+class ProposalFailure:
+    """One proposal slot whose provider or agent call failed."""
+
+    reason: str
 
 
 class ProviderDeltaProposer:
@@ -62,14 +70,24 @@ class ProviderDeltaProposer:
         *,
         history: list[HarnessDelta],
         count: int,
-    ) -> list[HarnessDelta | None]:
+    ) -> list[HarnessDelta | ProposalFailure | None]:
         """Make ``count`` independent proposal calls against the same parent."""
         if count < 1:
             raise ValueError(f"proposal count must be positive, got {count}")
-        return [
-            propose_delta(parent, trigger, evidence, self._provider, history=history)
-            for _ in range(count)
-        ]
+        proposals: list[HarnessDelta | ProposalFailure | None] = []
+        for _ in range(count):
+            try:
+                proposal = propose_delta(
+                    parent,
+                    trigger,
+                    evidence,
+                    self._provider,
+                    history=history,
+                )
+            except Exception as error:  # noqa: BLE001 - isolate one flaky sibling call
+                proposal = ProposalFailure(reason=str(error))
+            proposals.append(proposal)
+        return proposals
 
 
 class ProjectDeltaProposer:
@@ -94,7 +112,7 @@ class ProjectDeltaProposer:
         *,
         history: list[HarnessDelta],
         count: int,
-    ) -> list[HarnessDelta | None]:
+    ) -> list[HarnessDelta | ProposalFailure | None]:
         """Run one meta-agent turn that writes ``count`` proposal files."""
         if count < 1:
             raise ValueError(f"proposal count must be positive, got {count}")
@@ -117,7 +135,7 @@ class ProjectDeltaProposer:
         self._project.write_text(f"{context_dir}/REQUEST.md", request)
         self._project.run(self._agent, self._provider, request)
 
-        proposals: list[HarnessDelta | None] = []
+        proposals: list[HarnessDelta | ProposalFailure | None] = []
         for index in range(1, count + 1):
             try:
                 raw = self._project.read_text(f"{proposal_dir}/proposal-{index:02d}.json")

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -4,19 +4,31 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from typing import Protocol
 
 from wmh.agents.project import AgentProjectRun
 from wmh.core.types import JsonObject
-from wmh.harness.delta import FailureSignature, HarnessDelta
+from wmh.harness.delta import FailureSignature, HarnessDelta, apply_delta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.mutate import parse_delta, propose_delta
 from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.providers.base import Provider, ToolCallingProvider
 
 _CONTEXT_CONTENT_CHUNK_CHARS = 12_000
+_MAX_PROJECT_REPAIR_TURNS = 2
+_SUPPORTED_RUNTIME_KINDS = frozenset({"kit-python", "pi-node"})
+
+
+@dataclass(frozen=True)
+class _ProposalValidation:
+    """Host-validated proposal slots plus the raw files needed to protect valid siblings."""
+
+    proposals: dict[int, HarnessDelta]
+    raw_files: dict[int, str]
+    child_hashes: dict[int, str]
+    errors: dict[int, str]
 
 
 class AgentProject(Protocol):
@@ -35,6 +47,7 @@ class AgentProject(Protocol):
         instruction: str,
         *,
         should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
     ) -> AgentProjectRun: ...
 
 
@@ -111,6 +124,8 @@ class ProjectDeltaProposer:
         project: AgentProject,
         agent: HarnessDoc,
         provider: ToolCallingProvider,
+        *,
+        preserve_runtime_kind: bool = False,
     ) -> None:
         self._project = project
         self._agent = agent
@@ -120,6 +135,7 @@ class ProjectDeltaProposer:
         self._proposal_files: dict[str, str] = {}
         self._parent_manifests: dict[str, JsonObject] = {}
         self._should_cancel: Callable[[], bool] | None = None
+        self._preserve_runtime_kind = preserve_runtime_kind
 
     def propose_batch(
         self,
@@ -213,6 +229,8 @@ class ProjectDeltaProposer:
             context_dir=context_dir,
             proposal_dir=proposal_dir,
             count=count,
+            runtime_kind=parent.runtime_kind(),
+            preserve_runtime_kind=self._preserve_runtime_kind,
         )
         _write_project_text(
             self._project,
@@ -227,6 +245,9 @@ class ProjectDeltaProposer:
                 self._provider,
                 request,
                 should_cancel=should_cancel,
+                writable_files=[
+                    f"{proposal_dir}/proposal-{index:02d}.json" for index in range(1, count + 1)
+                ],
             )
         except HarnessSearchCancelled:
             raise
@@ -234,47 +255,172 @@ class ProjectDeltaProposer:
             run_error = error
         _check_cancelled(should_cancel)
 
-        proposals: list[HarnessDelta | ProposalFailure | None] = []
-        for index in range(1, count + 1):
+        slots = list(range(1, count + 1))
+        validation = _validate_project_proposals(
+            self._project,
+            parent,
+            trigger,
+            proposal_dir=proposal_dir,
+            slots=slots,
+            history=history,
+            preserve_runtime_kind=self._preserve_runtime_kind,
+            should_cancel=should_cancel,
+        )
+        # A lost terminal frame does not invalidate durable files. Host-preflight whatever was
+        # written, then repair only the bad/missing slots in an ordinary follow-up project turn.
+        # The last project-channel error matters only while a slot remains unresolved.
+        terminal_error = run_error
+        if validation.errors:
+            validation_report_ready = True
             try:
-                raw = _read_project_text(
+                _write_project_text(
                     self._project,
-                    f"{proposal_dir}/proposal-{index:02d}.json",
+                    f"{context_dir}/proposal-validation-attempt-01.json",
+                    _proposal_validation_report(
+                        parent=parent,
+                        proposal_dir=proposal_dir,
+                        attempt=1,
+                        valid_slots=validation.proposals,
+                        errors=validation.errors,
+                    ),
                     should_cancel=should_cancel,
                 )
-            except Exception:  # noqa: BLE001 - a missing output is one unusable proposal
-                if run_error is None:
-                    proposals.append(None)
-                else:
-                    proposals.append(ProposalFailure(reason=str(run_error)))
-                continue
-            try:
-                proposal = parse_delta(parent, trigger, raw)
-            except Exception as error:  # noqa: BLE001 - isolate one malformed sibling output
-                proposals.append(
-                    ProposalFailure(
-                        reason=(
-                            str(run_error)
-                            if run_error is not None
-                            else f"invalid proposal output: {error}"
-                        )
-                    )
+            except HarnessSearchCancelled:
+                raise
+            except Exception as error:  # noqa: BLE001 - no report means no safe repair prompt
+                terminal_error = error
+                validation_report_ready = False
+
+            for repair_turn in range(1, _MAX_PROJECT_REPAIR_TURNS + 1):
+                if not validation.errors or not validation_report_ready:
+                    break
+                validation_report_ready = False
+                validation_path = (
+                    f"{context_dir}/proposal-validation-attempt-{repair_turn:02d}.json"
                 )
+                repair_request = _project_repair_request(
+                    workspace=self._project.workspace,
+                    validation_path=validation_path,
+                    request_path=f"{context_dir}/REQUEST.md",
+                    proposal_dir=proposal_dir,
+                    errors=validation.errors,
+                    valid_slots=validation.proposals,
+                    runtime_kind=parent.runtime_kind(),
+                    preserve_runtime_kind=self._preserve_runtime_kind,
+                    repair_turn=repair_turn,
+                )
+                invalid_slots = sorted(validation.errors)
+                protected_restore_error: Exception | None = None
+                turn_error: Exception | None = None
+                try:
+                    _write_project_text(
+                        self._project,
+                        f"{context_dir}/REPAIR-{repair_turn:02d}.md",
+                        repair_request,
+                        should_cancel=should_cancel,
+                    )
+                    try:
+                        self._project.run(
+                            self._agent,
+                            self._provider,
+                            repair_request,
+                            should_cancel=should_cancel,
+                            writable_files=[
+                                f"{proposal_dir}/proposal-{index:02d}.json"
+                                for index in invalid_slots
+                            ],
+                        )
+                    except HarnessSearchCancelled:
+                        raise
+                    except Exception as error:  # noqa: BLE001 - salvage durable repaired files
+                        turn_error = error
+                    finally:
+                        # The agent is asked to rewrite only invalid slots. Restore every
+                        # byte-exact valid sibling after each turn as an enforcement boundary.
+                        for index in sorted(validation.proposals):
+                            try:
+                                _write_project_text(
+                                    self._project,
+                                    f"{proposal_dir}/proposal-{index:02d}.json",
+                                    validation.raw_files[index],
+                                    should_cancel=should_cancel,
+                                )
+                            except HarnessSearchCancelled:
+                                raise
+                            except Exception as error:  # noqa: BLE001 - attempt every restore
+                                if protected_restore_error is None:
+                                    protected_restore_error = error
+                except HarnessSearchCancelled:
+                    raise
+                except Exception as error:  # noqa: BLE001 - preserve good siblings, fail bad ones
+                    turn_error = error
+                if protected_restore_error is not None:
+                    # The in-memory delta and its durable proposal_file must always name the
+                    # same bytes. If protection cannot be proven, abort this batch instead of
+                    # returning a valid object whose persistent provenance may have been changed.
+                    raise protected_restore_error
+                terminal_error = turn_error
+
+                repaired = _validate_project_proposals(
+                    self._project,
+                    parent,
+                    trigger,
+                    proposal_dir=proposal_dir,
+                    slots=invalid_slots,
+                    history=history,
+                    valid_proposals=validation.proposals,
+                    preserve_runtime_kind=self._preserve_runtime_kind,
+                    should_cancel=should_cancel,
+                )
+                validation = _ProposalValidation(
+                    proposals=repaired.proposals,
+                    raw_files={**validation.raw_files, **repaired.raw_files},
+                    child_hashes={**validation.child_hashes, **repaired.child_hashes},
+                    errors=repaired.errors,
+                )
+                # Each host result becomes the next turn's nested input and the durable final
+                # audit. These turns happen wholly inside proposal generation, before search.
+                try:
+                    _write_project_text(
+                        self._project,
+                        f"{context_dir}/proposal-validation-attempt-{repair_turn + 1:02d}.json",
+                        _proposal_validation_report(
+                            parent=parent,
+                            proposal_dir=proposal_dir,
+                            attempt=repair_turn + 1,
+                            valid_slots=validation.proposals,
+                            errors=validation.errors,
+                        ),
+                        should_cancel=should_cancel,
+                    )
+                    validation_report_ready = True
+                except HarnessSearchCancelled:
+                    raise
+                except Exception as error:  # noqa: BLE001 - preserve validated in-memory output
+                    if terminal_error is None:
+                        terminal_error = error
+                if not validation.errors:
+                    # A prior turn can lose its terminal control frame after durable repaired
+                    # files were written. Successful preflight is authoritative salvage.
+                    terminal_error = None
+
+        proposals: list[HarnessDelta | ProposalFailure | None] = []
+        for index in slots:
+            stamped = validation.proposals.get(index)
+            if stamped is not None:
+                proposals.append(stamped)
+                self._proposal_files.setdefault(
+                    stamped.delta_id,
+                    f"{self._project.workspace}/{proposal_dir}/proposal-{index:02d}.json",
+                )
+                self._evaluation_dirs.setdefault(
+                    stamped.delta_id,
+                    f"evaluations/{round_dir}/proposal-{index:02d}",
+                )
+            elif terminal_error is not None:
+                proposals.append(ProposalFailure(reason=str(terminal_error)))
             else:
-                if proposal is None and run_error is not None:
-                    proposals.append(ProposalFailure(reason=str(run_error)))
-                else:
-                    stamped = _stamp_project_preconditions(parent, proposal)
-                    proposals.append(stamped)
-                    if stamped is not None:
-                        self._proposal_files.setdefault(
-                            stamped.delta_id,
-                            f"{self._project.workspace}/{proposal_dir}/proposal-{index:02d}.json",
-                        )
-                        self._evaluation_dirs.setdefault(
-                            stamped.delta_id,
-                            f"evaluations/{round_dir}/proposal-{index:02d}",
-                        )
+                proposals.append(None)
         return proposals
 
     def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
@@ -545,12 +691,219 @@ def _stamp_project_preconditions(
     return proposal
 
 
-def _project_request(*, workspace: str, context_dir: str, proposal_dir: str, count: int) -> str:
+def _validate_project_proposals(
+    project: AgentProject,
+    parent: HarnessDoc,
+    trigger: FailureSignature,
+    *,
+    proposal_dir: str,
+    slots: list[int],
+    history: list[HarnessDelta],
+    valid_proposals: dict[int, HarnessDelta] | None = None,
+    preserve_runtime_kind: bool,
+    should_cancel: Callable[[], bool] | None,
+) -> _ProposalValidation:
+    """Parse, stamp, apply, and de-duplicate selected project proposal slots.
+
+    Applying a deep copy exercises the complete typed ``HarnessDoc`` boundary without stamping
+    ``child_doc_hash`` onto the delta the search will later apply and archive. Previously the
+    project proposer returned syntactically parsed deltas and left this check to the search loop,
+    where a missing skill frontmatter block consumed an iteration as ``invalid before eval``.
+    """
+    accepted = dict(valid_proposals or {})
+    raw_files: dict[int, str] = {}
+    child_hashes: dict[int, str] = {}
+    errors: dict[int, str] = {}
+    history_ids = {delta.delta_id for delta in history}
+    history_child_hashes = {
+        delta.child_doc_hash for delta in history if delta.child_doc_hash is not None
+    }
+    sibling_ids = {delta.delta_id: index for index, delta in accepted.items()}
+    for accepted_index, accepted_delta in accepted.items():
+        accepted_child = apply_delta(
+            parent,
+            accepted_delta.model_copy(deep=True),
+            f"{parent.name}-accepted-preflight-{accepted_index:02d}",
+        )
+        child_hashes[accepted_index] = accepted_child.doc_hash
+    sibling_child_hashes = {child_hash: index for index, child_hash in child_hashes.items()}
+    parent_runtime_kind = parent.runtime_kind()
+    for index in slots:
+        _check_cancelled(should_cancel)
+        relative = f"{proposal_dir}/proposal-{index:02d}.json"
+        try:
+            raw = _read_project_text(project, relative, should_cancel=should_cancel)
+        except HarnessSearchCancelled:
+            raise
+        except Exception as error:  # noqa: BLE001 - one missing file is one repairable slot
+            errors[index] = f"proposal file is missing or unreadable: {error}"
+            continue
+        raw_files[index] = raw
+        proposal = parse_delta(parent, trigger, raw)
+        if proposal is None:
+            errors[index] = "proposal is not a parseable typed delta JSON object"
+            continue
+        stamped = _stamp_project_preconditions(parent, proposal)
+        assert stamped is not None
+        try:
+            child = apply_delta(
+                parent,
+                stamped.model_copy(deep=True),
+                f"{parent.name}-proposal-preflight-{index:02d}",
+            )
+            child_runtime_kind = child.runtime_kind()
+            if child_runtime_kind not in _SUPPORTED_RUNTIME_KINDS:
+                supported = ", ".join(sorted(_SUPPORTED_RUNTIME_KINDS))
+                raise ValueError(
+                    f"project proposal resolves to unsupported runtime kind "
+                    f"{child_runtime_kind!r}; choose one of: {supported}"
+                )
+            if preserve_runtime_kind and child_runtime_kind != parent_runtime_kind:
+                raise ValueError(
+                    "project proposals must preserve the parent's runtime kind "
+                    f"{parent_runtime_kind!r}; this proposal resolves to {child_runtime_kind!r}"
+                )
+        except ValueError as error:
+            errors[index] = f"delta does not apply to the supplied parent: {error}"
+            continue
+        child_hash = child.doc_hash
+        if child_hash == parent.doc_hash:
+            errors[index] = "delta is a semantic no-op: its child document equals the parent"
+            continue
+        if stamped.delta_id in history_ids:
+            errors[index] = (
+                f"delta {stamped.delta_id} duplicates a proposal already present in judged history"
+            )
+            continue
+        if child_hash in history_child_hashes:
+            errors[index] = (
+                f"child document {child_hash} duplicates a proposal already present in "
+                "judged history"
+            )
+            continue
+        duplicate_slot = sibling_ids.get(stamped.delta_id)
+        if duplicate_slot is not None:
+            errors[index] = (
+                f"delta {stamped.delta_id} duplicates valid sibling proposal-{duplicate_slot:02d}"
+            )
+            continue
+        duplicate_child_slot = sibling_child_hashes.get(child_hash)
+        if duplicate_child_slot is not None:
+            errors[index] = (
+                f"child document {child_hash} duplicates valid sibling "
+                f"proposal-{duplicate_child_slot:02d}"
+            )
+            continue
+        accepted[index] = stamped
+        sibling_ids[stamped.delta_id] = index
+        child_hashes[index] = child_hash
+        sibling_child_hashes[child_hash] = index
+    _check_cancelled(should_cancel)
+    return _ProposalValidation(
+        proposals=accepted,
+        raw_files=raw_files,
+        child_hashes=child_hashes,
+        errors=errors,
+    )
+
+
+def _proposal_validation_report(
+    *,
+    parent: HarnessDoc,
+    proposal_dir: str,
+    attempt: int,
+    valid_slots: dict[int, HarnessDelta],
+    errors: dict[int, str],
+) -> str:
+    """Serialize actionable per-slot host validation for the project and run audit."""
+    return json.dumps(
+        {
+            "kind": "proposal-validation",
+            "attempt": attempt,
+            "parent_doc_hash": parent.doc_hash,
+            "parent_runtime_kind": parent.runtime_kind(),
+            "valid_slots": sorted(valid_slots),
+            "errors": [
+                {
+                    "slot": index,
+                    "proposal_file": f"{proposal_dir}/proposal-{index:02d}.json",
+                    "reason": errors[index],
+                }
+                for index in sorted(errors)
+            ],
+        },
+        indent=2,
+    )
+
+
+def _project_repair_request(
+    *,
+    workspace: str,
+    validation_path: str,
+    request_path: str,
+    proposal_dir: str,
+    errors: dict[int, str],
+    valid_slots: dict[int, HarnessDelta],
+    runtime_kind: str,
+    preserve_runtime_kind: bool,
+    repair_turn: int,
+) -> str:
+    """Render one of the bounded repair turns for only invalid batch slots."""
+    invalid_outputs = "\n".join(
+        f"- {workspace}/{proposal_dir}/proposal-{index:02d}.json" for index in sorted(errors)
+    )
+    protected_outputs = "\n".join(
+        f"- {workspace}/{proposal_dir}/proposal-{index:02d}.json" for index in sorted(valid_slots)
+    )
+    if not protected_outputs:
+        protected_outputs = "- (none)"
+    runtime_constraint = (
+        f"preserve its resolved runtime kind {runtime_kind!r}"
+        if preserve_runtime_kind
+        else "produce a valid resolved runtime kind"
+    )
+    return f"""Repair exactly {len(errors)} invalid proposal slot(s) from this round.
+This is repair turn {repair_turn} of {_MAX_PROJECT_REPAIR_TURNS}.
+
+Read the host validation report: {workspace}/{validation_path}
+It contains the exact error for each invalid slot. Re-read the original round request at
+{workspace}/{request_path} and its supplied parent manifests as needed, then rewrite ONLY these
+invalid files:
+{invalid_outputs}
+
+These siblings already passed host preflight. Do not rewrite them:
+{protected_outputs}
+
+Every repaired file must follow the original typed delta JSON schema, apply cleanly to that same
+parent, {runtime_constraint}, produce a child document different from the parent, differ from
+judged history, and differ from every sibling. A skill's content must include the complete
+four-line frontmatter shown in the original request. Validate every rewritten file before calling
+submit with a short summary."""
+
+
+def _project_request(
+    *,
+    workspace: str,
+    context_dir: str,
+    proposal_dir: str,
+    count: int,
+    runtime_kind: str,
+    preserve_runtime_kind: bool,
+) -> str:
     """Render one filesystem-first proposal task for the ordinary meta agent."""
     absolute_context = f"{workspace}/{context_dir}"
     absolute_proposals = f"{workspace}/{proposal_dir}"
     outputs = "\n".join(
         f"- {absolute_proposals}/proposal-{index:02d}.json" for index in range(1, count + 1)
+    )
+    runtime_constraint = (
+        f"This project must preserve the parent's resolved runtime kind {runtime_kind!r}; do not "
+        "add, replace, or remove runtime-kind in a way that changes it."
+        if preserve_runtime_kind
+        else (
+            "A runtime-kind edit is allowed only when the resulting child remains a valid harness; "
+            "the search backend makes the final executability decision."
+        )
     )
     return f"""Produce exactly {count} independent harness proposals for this optimization round.
 
@@ -578,6 +931,34 @@ Each file must be one JSON object:
 
 For a replacement, you may omit content and use compact exact edits instead:
 "edits":[{{"old":"<nonempty text occurring exactly once>","new":"<replacement>"}}].
-The optimizer expands those edits against the parent before validation. Every proposal must be
-focused, valid against the same supplied parent, and meaningfully different from its siblings.
+The optimizer expands those edits against the parent before validation.
+
+Typed surface constraints (host preflight enforces all of these before evaluation):
+- Every surface id is `<kind>:<kebab-slug>` and its prefix must exactly match `kind`.
+- `add` needs a fresh id, `kind`, full `content`, and a nonempty `rationale`. `replace` needs an
+  existing id, full `content` or exact `edits`, and a nonempty `rationale`; if it declares `kind`,
+  that kind must match the parent. `remove` needs an existing id and rationale and must omit
+  content. Every replace/remove target must have its exact parent hash in `preconditions`.
+- A `skill:<slug>` add/replace has kind `skill`; its content is the complete markdown below,
+  beginning at the first character, with kebab-case `name` exactly equal to `<slug>`:
+  ---
+  name: <slug>
+  description: <one-line description of when the agent should use this skill>
+  ---
+  <nonempty reusable technique body>
+- Prompt content is plain text, and the child must retain at least one prompt surface.
+- `tool_policy:main` is one registered tool name per line and must retain `submit`.
+- Supported scalar params are `param:max-turns` and `param:max-output-tokens` (integers >= 1),
+  `param:temperature` (number in [0, 2]), and `param:runtime-kind` (`kit-python` or `pi-node`).
+  {runtime_constraint}
+- A path-less code surface can only be `code:runtime` and must remain valid Python defining
+  `run(kit)`. Pathful code surfaces use safe relative paths without `..`; replacements inherit the
+  parent's path unless explicitly supplied, and paths must stay unique.
+- Respect each surface's character budget. Do not remove required singleton surfaces or create
+  duplicate ids/paths. Do not emit a semantic no-op or repeat any child document from judged
+  history or another sibling, even through differently ordered operations.
+
+Every proposal must be focused, valid against the same supplied parent, and meaningfully different
+from its siblings. The host will parse, stamp mechanical missing preconditions, deep-copy apply,
+and de-duplicate every file. Invalid slots receive at most two repair turns and are never evaluated.
 After all files exist, call submit with a short summary."""

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
@@ -14,6 +15,8 @@ from wmh.harness.doc import HarnessDoc
 from wmh.harness.mutate import parse_delta, propose_delta
 from wmh.harness.runtime import HarnessSearchCancelled
 from wmh.providers.base import Provider, ToolCallingProvider
+
+_CONTEXT_CONTENT_CHUNK_CHARS = 12_000
 
 
 class AgentProject(Protocol):
@@ -113,6 +116,10 @@ class ProjectDeltaProposer:
         self._agent = agent
         self._provider = provider
         self._round = 0
+        self._evaluation_dirs: dict[str, str] = {}
+        self._proposal_files: dict[str, str] = {}
+        self._parent_manifests: dict[str, JsonObject] = {}
+        self._should_cancel: Callable[[], bool] | None = None
 
     def propose_batch(
         self,
@@ -127,18 +134,79 @@ class ProjectDeltaProposer:
         """Run one meta-agent turn that writes ``count`` proposal files."""
         if count < 1:
             raise ValueError(f"proposal count must be positive, got {count}")
+        self._should_cancel = should_cancel
         _check_cancelled(should_cancel)
         self._round += 1
         round_dir = f"round-{self._round:04d}"
         context_dir = f"context/{round_dir}"
         proposal_dir = f"proposals/{round_dir}"
-        self._project.write_text(
-            f"{context_dir}/parent.json", json.dumps(_parent_context(parent), indent=2)
+        parent_context = self._parent_manifests.get(parent.doc_hash)
+        if parent_context is None:
+            parent_context = _materialize_parent(
+                self._project,
+                parent,
+                context_dir=f"parents/{parent.doc_hash}",
+                should_cancel=should_cancel,
+            )
+            self._parent_manifests[parent.doc_hash] = parent_context
+        _write_project_text(
+            self._project,
+            f"{context_dir}/parent.json",
+            json.dumps(parent_context, indent=2),
+            should_cancel=should_cancel,
         )
-        self._project.write_text(f"{context_dir}/evidence.md", evidence)
-        self._project.write_text(
+        evidence_context = _materialize_context_content(
+            self._project,
+            evidence,
+            directory=f"{context_dir}/evidence",
+            extension=".md",
+            should_cancel=should_cancel,
+        )
+        _write_project_text(
+            self._project,
+            f"{context_dir}/evidence.json",
+            json.dumps(
+                {
+                    "kind": "failure-evidence",
+                    "format": "markdown",
+                    **evidence_context,
+                },
+                indent=2,
+            ),
+            should_cancel=should_cancel,
+        )
+        history_content = json.dumps(
+            [
+                _project_history_entry(
+                    delta,
+                    proposal_file=self._proposal_files.get(delta.delta_id),
+                    evaluation_dir=self._evaluation_dirs.get(delta.delta_id),
+                    workspace=self._project.workspace,
+                )
+                for delta in history
+            ],
+            indent=2,
+        )
+        history_context = _materialize_context_content(
+            self._project,
+            history_content,
+            directory=f"{context_dir}/history",
+            extension=".json.part",
+            should_cancel=should_cancel,
+        )
+        _write_project_text(
+            self._project,
             f"{context_dir}/history.json",
-            json.dumps([delta.model_dump(mode="json") for delta in history], indent=2),
+            json.dumps(
+                {
+                    "kind": "judged-history",
+                    "format": "json-array",
+                    "entry_count": len(history),
+                    **history_context,
+                },
+                indent=2,
+            ),
+            should_cancel=should_cancel,
         )
         request = _project_request(
             workspace=self._project.workspace,
@@ -146,7 +214,12 @@ class ProjectDeltaProposer:
             proposal_dir=proposal_dir,
             count=count,
         )
-        self._project.write_text(f"{context_dir}/REQUEST.md", request)
+        _write_project_text(
+            self._project,
+            f"{context_dir}/REQUEST.md",
+            request,
+            should_cancel=should_cancel,
+        )
         run_error: Exception | None = None
         try:
             self._project.run(
@@ -164,7 +237,11 @@ class ProjectDeltaProposer:
         proposals: list[HarnessDelta | ProposalFailure | None] = []
         for index in range(1, count + 1):
             try:
-                raw = self._project.read_text(f"{proposal_dir}/proposal-{index:02d}.json")
+                raw = _read_project_text(
+                    self._project,
+                    f"{proposal_dir}/proposal-{index:02d}.json",
+                    should_cancel=should_cancel,
+                )
             except Exception:  # noqa: BLE001 - a missing output is one unusable proposal
                 if run_error is None:
                     proposals.append(None)
@@ -187,8 +264,49 @@ class ProjectDeltaProposer:
                 if proposal is None and run_error is not None:
                     proposals.append(ProposalFailure(reason=str(run_error)))
                 else:
-                    proposals.append(_stamp_project_preconditions(parent, proposal))
+                    stamped = _stamp_project_preconditions(parent, proposal)
+                    proposals.append(stamped)
+                    if stamped is not None:
+                        self._proposal_files.setdefault(
+                            stamped.delta_id,
+                            f"{self._project.workspace}/{proposal_dir}/proposal-{index:02d}.json",
+                        )
+                        self._evaluation_dirs.setdefault(
+                            stamped.delta_id,
+                            f"evaluations/{round_dir}/proposal-{index:02d}",
+                        )
         return proposals
+
+    def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
+        """Persist one candidate's judged evidence for later project-agent rounds."""
+        should_cancel = self._should_cancel
+        _check_cancelled(should_cancel)
+        root = self._evaluation_dirs.get(
+            delta.delta_id,
+            f"evaluations/by-delta/{delta.delta_id}",
+        )
+        context = _materialize_context_content(
+            self._project,
+            content,
+            directory=f"{root}/{stage}",
+            extension=".md",
+            should_cancel=should_cancel,
+        )
+        _write_project_text(
+            self._project,
+            f"{root}/{stage}.json",
+            json.dumps(
+                {
+                    "kind": "candidate-evaluation",
+                    "stage": stage,
+                    "delta_id": delta.delta_id,
+                    "format": "markdown",
+                    **context,
+                },
+                indent=2,
+            ),
+            should_cancel=should_cancel,
+        )
 
 
 def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
@@ -197,23 +315,213 @@ def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
         raise HarnessSearchCancelled("harness search cancelled")
 
 
-def _parent_context(parent: HarnessDoc) -> JsonObject:
-    """Serialize a parent with the computed identities a project agent must copy."""
+def _write_project_text(
+    project: AgentProject,
+    path: str,
+    content: str,
+    *,
+    should_cancel: Callable[[], bool] | None,
+) -> None:
+    """Make each E2B filesystem RPC a cancellation boundary."""
+    _check_cancelled(should_cancel)
+    project.write_text(path, content)
+    _check_cancelled(should_cancel)
+
+
+def _read_project_text(
+    project: AgentProject,
+    path: str,
+    *,
+    should_cancel: Callable[[], bool] | None,
+) -> str:
+    """Read one project output without hiding cancellation behind the next round."""
+    _check_cancelled(should_cancel)
+    content = project.read_text(path)
+    _check_cancelled(should_cancel)
+    return content
+
+
+def _materialize_parent(
+    project: AgentProject,
+    parent: HarnessDoc,
+    *,
+    context_dir: str,
+    should_cancel: Callable[[], bool] | None = None,
+) -> JsonObject:
+    """Write a bounded manifest plus individually readable parent-surface chunks.
+
+    A real pi document is hundreds of kilobytes, while one project ``read_file`` observation is
+    intentionally capped. Putting every surface inline in one parent.json therefore hid most of
+    the harness from the proposer. The manifest remains small and points to ordered chunks below
+    the read cap; concatenating a surface's chunks reconstructs its exact content.
+    """
+    surface_index: list[JsonObject] = []
+    for index, surface in enumerate(parent.surfaces, 1):
+        surface_dir = f"{context_dir}/parent-surfaces/surface-{index:03d}"
+        content_context = _materialize_context_content(
+            project,
+            surface.content,
+            directory=surface_dir,
+            extension=".txt",
+            include_contract=False,
+            should_cancel=should_cancel,
+        )
+        source_file: str | None = None
+        if surface.path is not None:
+            source_relative = f"{context_dir}/parent-source/{surface.path}"
+            _write_project_text(
+                project,
+                source_relative,
+                surface.content,
+                should_cancel=should_cancel,
+            )
+            source_file = f"{project.workspace}/{source_relative}"
+        entry: JsonObject = {
+            "id": surface.id,
+            "kind": surface.kind.value,
+            "content_hash": surface.content_hash,
+            **content_context,
+        }
+        if surface.budget is not None:
+            entry["budget"] = surface.budget
+        if surface.path is not None:
+            entry["path"] = surface.path
+            entry["source_file"] = source_file
+        surface_manifest_relative = f"{surface_dir}/manifest.json"
+        _write_project_text(
+            project,
+            surface_manifest_relative,
+            json.dumps(entry, indent=2),
+            should_cancel=should_cancel,
+        )
+        surface_index.append(
+            {
+                "id": surface.id,
+                "kind": surface.kind.value,
+                "content_hash": surface.content_hash,
+                "manifest_file": f"{project.workspace}/{surface_manifest_relative}",
+            }
+        )
+    index_content = json.dumps(surface_index, indent=2)
+    index_context = _materialize_context_content(
+        project,
+        index_content,
+        directory=f"{context_dir}/parent-surface-index",
+        extension=".json.part",
+        should_cancel=should_cancel,
+    )
+    index_manifest_relative = f"{context_dir}/parent-surfaces.json"
+    _write_project_text(
+        project,
+        index_manifest_relative,
+        json.dumps(
+            {
+                "kind": "parent-surface-index",
+                "format": "json-array",
+                "entry_count": len(surface_index),
+                **index_context,
+            },
+            indent=2,
+        ),
+        should_cancel=should_cancel,
+    )
     return {
         "name": parent.name,
         "version": parent.version,
         "doc_hash": parent.doc_hash,
-        "surfaces": [
-            {
-                "id": surface.id,
-                "kind": surface.kind.value,
-                "content": surface.content,
-                "content_hash": surface.content_hash,
-                "budget": surface.budget,
-                "path": surface.path,
-            }
-            for surface in parent.surfaces
-        ],
+        "source_root": f"{project.workspace}/{context_dir}/parent-source",
+        "surface_count": len(surface_index),
+        "surface_index_manifest": f"{project.workspace}/{index_manifest_relative}",
+        "content_contract": (
+            "Read surface_index_manifest, then concatenate its content_files and parse that JSON "
+            "array. Each index entry points to one independently readable surface manifest. "
+            "Within a surface manifest, concatenate content_files exactly to reconstruct the "
+            "surface. Pathful code is also mirrored beneath source_root at its exact path."
+        ),
+    }
+
+
+def _materialize_context_content(
+    project: AgentProject,
+    content: str,
+    *,
+    directory: str,
+    extension: str,
+    include_contract: bool = True,
+    should_cancel: Callable[[], bool] | None = None,
+) -> JsonObject:
+    """Write exact ordered chunks that each fit in one project ``read_file`` result."""
+    chunk_count = max(1, math.ceil(len(content) / _CONTEXT_CONTENT_CHUNK_CHARS))
+    width = max(3, len(str(chunk_count)))
+    content_files: list[str] = []
+    for chunk_index in range(chunk_count):
+        start = chunk_index * _CONTEXT_CONTENT_CHUNK_CHARS
+        chunk = content[start : start + _CONTEXT_CONTENT_CHUNK_CHARS]
+        relative = (
+            f"{directory}/part-{chunk_index + 1:0{width}d}-of-{chunk_count:0{width}d}{extension}"
+        )
+        _write_project_text(
+            project,
+            relative,
+            chunk,
+            should_cancel=should_cancel,
+        )
+        content_files.append(f"{project.workspace}/{relative}")
+    result: JsonObject = {
+        "content_length": len(content),
+        "content_files": content_files,
+    }
+    if include_contract:
+        result["content_contract"] = (
+            "Read content_files in listed order and concatenate them exactly. Each file is "
+            "independently readable without truncation."
+        )
+    return result
+
+
+def _project_history_entry(
+    delta: HarnessDelta,
+    *,
+    proposal_file: str | None,
+    evaluation_dir: str | None,
+    workspace: str,
+) -> JsonObject:
+    """Compact judged metadata while raw proposals retain exact replacement payloads.
+
+    Re-serializing every prior full code surface into every later round makes persistent history
+    quadratic in run length. The project already owns each raw proposal file, so history carries
+    queryable identities, rationales, sizes, and verdicts plus a direct pointer to the exact bytes.
+    """
+    ops: list[JsonObject] = []
+    for op in delta.ops:
+        item: JsonObject = {
+            "op": op.op,
+            "surface_id": op.surface_id,
+            "rationale": op.rationale[:2_000],
+            "content_length": len(op.content) if op.content is not None else 0,
+        }
+        if op.kind is not None:
+            item["kind"] = op.kind.value
+        if op.path is not None:
+            item["path"] = op.path
+        if op.budget is not None:
+            item["budget"] = op.budget
+        ops.append(item)
+    return {
+        "delta_id": delta.delta_id,
+        "parent_doc_hash": delta.parent_doc_hash,
+        "child_doc_hash": delta.child_doc_hash,
+        "trigger": delta.trigger.model_dump(mode="json"),
+        "preconditions": dict(delta.preconditions),
+        "expected_effect": delta.expected_effect[:2_000],
+        "ops": ops,
+        "verdict": delta.verdict.model_dump(mode="json") if delta.verdict is not None else None,
+        "proposal_file": proposal_file,
+        "evaluation_dir": (f"{workspace}/{evaluation_dir}" if evaluation_dir is not None else None),
+        "content_contract": (
+            "Exact op content remains in proposal_file; this entry intentionally omits it to "
+            "keep cumulative judged history linear and fast."
+        ),
     }
 
 
@@ -247,10 +555,16 @@ def _project_request(*, workspace: str, context_dir: str, proposal_dir: str, cou
     return f"""Produce exactly {count} independent harness proposals for this optimization round.
 
 Read:
-- parent document: {absolute_context}/parent.json
-- failure evidence: {absolute_context}/evidence.md
-- judged history: {absolute_context}/history.json
+- parent manifest: {absolute_context}/parent.json
+  - follow surface_index_manifest to find every independently readable surface manifest
+  - each surface manifest lists ordered content_files; concatenate them to inspect exact content
+  - pathful code is also mirrored under source_root with exact source_file paths for shell search
+- failure evidence manifest: {absolute_context}/evidence.json
+  - read its content_files in listed order and concatenate them exactly
+- judged history manifest: {absolute_context}/history.json
+  - read its content_files in listed order, concatenate them exactly, then parse the JSON array
 - earlier raw proposals, when useful: {workspace}/proposals/
+- earlier candidate evaluation manifests and traces: {workspace}/evaluations/
 
 Write exactly these files, without changing earlier rounds:
 {outputs}

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -1,0 +1,160 @@
+"""Typed delta proposers for direct providers and project-backed meta agents."""
+
+from __future__ import annotations
+
+import json
+from typing import Protocol
+
+from wmh.agents.project import AgentProjectRun
+from wmh.harness.delta import FailureSignature, HarnessDelta
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.mutate import parse_delta, propose_delta
+from wmh.providers.base import Provider, ToolCallingProvider
+
+
+class AgentProject(Protocol):
+    """Project operations required by the optimizer wiring."""
+
+    workspace: str
+
+    def write_text(self, path: str, content: str) -> None: ...
+
+    def read_text(self, path: str) -> str: ...
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+    ) -> AgentProjectRun: ...
+
+
+class DeltaProposer(Protocol):
+    """Produce sibling deltas against one selected parent."""
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+    ) -> list[HarnessDelta | None]: ...
+
+
+class ProviderDeltaProposer:
+    """Adapt the original single-completion proposer to the batched search contract."""
+
+    def __init__(self, provider: Provider) -> None:
+        self._provider = provider
+
+    @property
+    def provider(self) -> Provider:
+        """Return the provider used for direct proposal calls."""
+        return self._provider
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+    ) -> list[HarnessDelta | None]:
+        """Make ``count`` independent proposal calls against the same parent."""
+        if count < 1:
+            raise ValueError(f"proposal count must be positive, got {count}")
+        return [
+            propose_delta(parent, trigger, evidence, self._provider, history=history)
+            for _ in range(count)
+        ]
+
+
+class ProjectDeltaProposer:
+    """Wire a normal agent in a persistent project into harness search."""
+
+    def __init__(
+        self,
+        project: AgentProject,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+    ) -> None:
+        self._project = project
+        self._agent = agent
+        self._provider = provider
+        self._round = 0
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+    ) -> list[HarnessDelta | None]:
+        """Run one meta-agent turn that writes ``count`` proposal files."""
+        if count < 1:
+            raise ValueError(f"proposal count must be positive, got {count}")
+        self._round += 1
+        round_dir = f"round-{self._round:04d}"
+        context_dir = f"context/{round_dir}"
+        proposal_dir = f"proposals/{round_dir}"
+        self._project.write_text(f"{context_dir}/parent.json", parent.model_dump_json(indent=2))
+        self._project.write_text(f"{context_dir}/evidence.md", evidence)
+        self._project.write_text(
+            f"{context_dir}/history.json",
+            json.dumps([delta.model_dump(mode="json") for delta in history], indent=2),
+        )
+        request = _project_request(
+            workspace=self._project.workspace,
+            context_dir=context_dir,
+            proposal_dir=proposal_dir,
+            count=count,
+        )
+        self._project.write_text(f"{context_dir}/REQUEST.md", request)
+        self._project.run(self._agent, self._provider, request)
+
+        proposals: list[HarnessDelta | None] = []
+        for index in range(1, count + 1):
+            try:
+                raw = self._project.read_text(f"{proposal_dir}/proposal-{index:02d}.json")
+            except Exception:  # noqa: BLE001 - a missing output is one unusable proposal
+                proposals.append(None)
+                continue
+            proposals.append(parse_delta(parent, trigger, raw))
+        return proposals
+
+
+def _project_request(*, workspace: str, context_dir: str, proposal_dir: str, count: int) -> str:
+    """Render one filesystem-first proposal task for the ordinary meta agent."""
+    absolute_context = f"{workspace}/{context_dir}"
+    absolute_proposals = f"{workspace}/{proposal_dir}"
+    outputs = "\n".join(
+        f"- {absolute_proposals}/proposal-{index:02d}.json" for index in range(1, count + 1)
+    )
+    return f"""Produce exactly {count} independent harness proposals for this optimization round.
+
+Read:
+- parent document: {absolute_context}/parent.json
+- failure evidence: {absolute_context}/evidence.md
+- judged history: {absolute_context}/history.json
+- earlier raw proposals, when useful: {workspace}/proposals/
+
+Write exactly these files, without changing earlier rounds:
+{outputs}
+
+Each file must be one JSON object:
+{{"expected_effect":"<falsifiable prediction>",
+ "preconditions":{{"<surface id>":"<hash copied from parent>"}},
+ "ops":[{{"op":"add|replace|remove","surface_id":"<kind:slug>",
+           "kind":"<required for add>","content":"<full content>",
+           "rationale":"<why this helps>"}}]}}
+
+For a replacement, you may omit content and use compact exact edits instead:
+"edits":[{{"old":"<nonempty text occurring exactly once>","new":"<replacement>"}}].
+The optimizer expands those edits against the parent before validation. Every proposal must be
+focused, valid against the same supplied parent, and meaningfully different from its siblings.
+After all files exist, call submit with a short summary."""

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -136,17 +136,28 @@ class ProjectDeltaProposer:
             count=count,
         )
         self._project.write_text(f"{context_dir}/REQUEST.md", request)
-        self._project.run(self._agent, self._provider, request)
+        run_error: Exception | None = None
+        try:
+            self._project.run(self._agent, self._provider, request)
+        except Exception as error:  # noqa: BLE001 - durable project files may still be complete
+            run_error = error
 
         proposals: list[HarnessDelta | ProposalFailure | None] = []
         for index in range(1, count + 1):
             try:
                 raw = self._project.read_text(f"{proposal_dir}/proposal-{index:02d}.json")
             except Exception:  # noqa: BLE001 - a missing output is one unusable proposal
-                proposals.append(None)
+                if run_error is None:
+                    proposals.append(None)
+                else:
+                    proposals.append(ProposalFailure(reason=str(run_error)))
                 continue
-            proposal = parse_delta(parent, trigger, raw)
-            proposals.append(_stamp_project_preconditions(parent, proposal))
+            try:
+                proposal = parse_delta(parent, trigger, raw)
+            except Exception as error:  # noqa: BLE001 - isolate one malformed sibling output
+                proposals.append(ProposalFailure(reason=f"invalid proposal output: {error}"))
+            else:
+                proposals.append(_stamp_project_preconditions(parent, proposal))
         return proposals
 
 

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from wmh.agents.project import AgentProjectRun
+from wmh.core.types import JsonObject
 from wmh.harness.delta import FailureSignature, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.mutate import parse_delta, propose_delta
@@ -120,7 +121,9 @@ class ProjectDeltaProposer:
         round_dir = f"round-{self._round:04d}"
         context_dir = f"context/{round_dir}"
         proposal_dir = f"proposals/{round_dir}"
-        self._project.write_text(f"{context_dir}/parent.json", parent.model_dump_json(indent=2))
+        self._project.write_text(
+            f"{context_dir}/parent.json", json.dumps(_parent_context(parent), indent=2)
+        )
         self._project.write_text(f"{context_dir}/evidence.md", evidence)
         self._project.write_text(
             f"{context_dir}/history.json",
@@ -142,8 +145,49 @@ class ProjectDeltaProposer:
             except Exception:  # noqa: BLE001 - a missing output is one unusable proposal
                 proposals.append(None)
                 continue
-            proposals.append(parse_delta(parent, trigger, raw))
+            proposal = parse_delta(parent, trigger, raw)
+            proposals.append(_stamp_project_preconditions(parent, proposal))
         return proposals
+
+
+def _parent_context(parent: HarnessDoc) -> JsonObject:
+    """Serialize a parent with the computed identities a project agent must copy."""
+    return {
+        "name": parent.name,
+        "version": parent.version,
+        "doc_hash": parent.doc_hash,
+        "surfaces": [
+            {
+                "id": surface.id,
+                "kind": surface.kind.value,
+                "content": surface.content,
+                "content_hash": surface.content_hash,
+                "budget": surface.budget,
+                "path": surface.path,
+            }
+            for surface in parent.surfaces
+        ],
+    }
+
+
+def _stamp_project_preconditions(
+    parent: HarnessDoc, proposal: HarnessDelta | None
+) -> HarnessDelta | None:
+    """Stamp missing concurrency metadata from the exact project-round parent.
+
+    The ordinary agent still chooses every semantic operation. The host owns this mechanical
+    identity field because it wrote the immutable parent snapshot for the same synchronous round.
+    An explicitly supplied but incorrect hash is preserved so normal validation rejects it.
+    """
+    if proposal is None:
+        return None
+    for op in proposal.ops:
+        if op.op not in ("replace", "remove") or op.surface_id in proposal.preconditions:
+            continue
+        surface = parent.surface(op.surface_id)
+        if surface is not None:
+            proposal.preconditions[op.surface_id] = surface.content_hash
+    return proposal
 
 
 def _project_request(*, workspace: str, context_dir: str, proposal_dir: str, count: int) -> str:

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -420,7 +420,14 @@ class ProjectDeltaProposer:
             elif terminal_error is not None:
                 proposals.append(ProposalFailure(reason=str(terminal_error)))
             else:
-                proposals.append(None)
+                proposals.append(
+                    ProposalFailure(
+                        reason=validation.errors.get(
+                            index,
+                            "proposal slot remained invalid after bounded repair turns",
+                        )
+                    )
+                )
         return proposals
 
     def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
@@ -877,8 +884,9 @@ These siblings already passed host preflight. Do not rewrite them:
 Every repaired file must follow the original typed delta JSON schema, apply cleanly to that same
 parent, {runtime_constraint}, produce a child document different from the parent, differ from
 judged history, and differ from every sibling. A skill's content must include the complete
-four-line frontmatter shown in the original request. Validate every rewritten file before calling
-submit with a short summary."""
+four-line frontmatter shown in the original request. Rewrite every invalid file immediately after
+reading the validation report; only then spend remaining actions on optional evidence. Validate
+every rewritten file before calling submit with a short summary."""
 
 
 def _project_request(
@@ -959,6 +967,8 @@ Typed surface constraints (host preflight enforces all of these before evaluatio
   history or another sibling, even through differently ordered operations.
 
 Every proposal must be focused, valid against the same supplied parent, and meaningfully different
-from its siblings. The host will parse, stamp mechanical missing preconditions, deep-copy apply,
-and de-duplicate every file. Invalid slots receive at most two repair turns and are never evaluated.
-After all files exist, call submit with a short summary."""
+from its siblings. Your project tool budget is bounded: after reading the three root manifests,
+write a complete, parseable draft to every output before doing deeper optional exploration. Keep
+those files valid as you refine them. The host will parse, stamp mechanical missing preconditions,
+deep-copy apply, and de-duplicate every file. Invalid slots receive at most two repair turns and
+are never evaluated. After all files exist, call submit with a short summary."""

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -1,0 +1,137 @@
+"""Tests for provider and persistent-project delta proposers."""
+
+from __future__ import annotations
+
+import json
+
+from llm_waterfall import ChatResponse
+
+from wmh.agents.meta import meta_agent
+from wmh.agents.project import AgentProjectRun
+from wmh.harness.delta import FailureSignature
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.proposer import ProjectDeltaProposer, ProviderDeltaProposer
+from wmh.harness.runner_link import TokenUsage
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    ToolCallingProvider,
+    VerifyResult,
+)
+
+
+def _trigger() -> FailureSignature:
+    return FailureSignature(mechanism="verification", task_ids=["t1"])
+
+
+def _payload(parent: HarnessDoc, content: str) -> str:
+    core = parent.surface("prompt:core")
+    assert core is not None
+    return json.dumps(
+        {
+            "expected_effect": "t1 passes",
+            "preconditions": {"prompt:core": core.content_hash},
+            "ops": [
+                {
+                    "op": "replace",
+                    "surface_id": "prompt:core",
+                    "content": content,
+                    "rationale": "verify before submit",
+                }
+            ],
+        }
+    )
+
+
+class _Provider:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+
+    def __init__(self, reply: str) -> None:
+        self.reply = reply
+        self.calls = 0
+
+    def complete(self, system: str, messages: list[Message], **kwargs: object) -> Completion:
+        del system, messages, kwargs
+        self.calls += 1
+        return Completion(text=self.reply)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self) -> VerifyResult:
+        return VerifyResult(ok=True, kind=ProviderKind.BEDROCK, model="m")
+
+    def complete_chat(self, request: object) -> ChatResponse:
+        del request
+        raise AssertionError("fake project never calls the provider")
+
+
+class _Project:
+    workspace = "/home/user/project"
+
+    def __init__(self, outputs: list[str]) -> None:
+        self.files: dict[str, str] = {}
+        self.outputs = outputs
+        self.runs = 0
+
+    def write_text(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    def read_text(self, path: str) -> str:
+        return self.files[path]
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+    ) -> AgentProjectRun:
+        del agent, provider
+        self.runs += 1
+        assert "exactly 2" in instruction
+        round_dir = f"round-{self.runs:04d}"
+        for index, output in enumerate(self.outputs, start=1):
+            self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
+        return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
+
+
+def test_provider_proposer_produces_requested_sibling_count() -> None:
+    parent = HarnessDoc.baseline("parent")
+    provider = _Provider(_payload(parent, "careful"))
+
+    proposals = ProviderDeltaProposer(provider).propose_batch(
+        parent, _trigger(), "evidence", history=[], count=3
+    )
+
+    assert provider.calls == 3
+    assert len(proposals) == 3
+    assert all(proposal is not None for proposal in proposals)
+
+
+def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _Project([_payload(parent, "careful"), _payload(parent, "verify")])
+    provider = _Provider("unused")
+
+    proposer = ProjectDeltaProposer(project, meta_agent(), provider)
+    proposals = proposer.propose_batch(parent, _trigger(), "inspect failures", history=[], count=2)
+    first_files = dict(project.files)
+    second = proposer.propose_batch(
+        parent,
+        _trigger(),
+        "inspect the next failures",
+        history=[proposal for proposal in proposals if proposal is not None],
+        count=2,
+    )
+
+    assert project.runs == 2
+    assert len(proposals) == 2
+    assert len(second) == 2
+    assert all(proposal is not None for proposal in proposals)
+    assert "context/round-0001/parent.json" in project.files
+    assert "context/round-0001/history.json" in project.files
+    assert "context/round-0002/history.json" in project.files
+    assert "proposal-01.json" in project.files["context/round-0002/REQUEST.md"]
+    assert all(project.files[path] == content for path, content in first_files.items())

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from typing import cast
 
 import pytest
 from llm_waterfall import ChatResponse
 
+from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProjectRun
-from wmh.harness.delta import FailureSignature, HarnessDelta
-from wmh.harness.doc import HarnessDoc
+from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 from wmh.harness.proposer import ProjectDeltaProposer, ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
 from wmh.providers.base import (
@@ -113,6 +115,26 @@ class _Project:
         for index, output in enumerate(self.outputs, start=1):
             self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
         return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
+
+
+def _manifest_content(project: _Project, path: str) -> tuple[dict[str, object], list[str]]:
+    manifest = json.loads(project.files[path])
+    chunks = [
+        project.files[str(absolute).removeprefix(f"{project.workspace}/")]
+        for absolute in manifest["content_files"]
+    ]
+    return manifest, chunks
+
+
+def _parent_surface_manifests(project: _Project, root_path: str) -> list[dict[str, object]]:
+    root = json.loads(project.files[root_path])
+    index_path = str(root["surface_index_manifest"]).removeprefix(f"{project.workspace}/")
+    _index_manifest, index_chunks = _manifest_content(project, index_path)
+    index = json.loads("".join(index_chunks))
+    return [
+        json.loads(project.files[str(item["manifest_file"]).removeprefix(f"{project.workspace}/")])
+        for item in index
+    ]
 
 
 class _InterruptedProject(_Project):
@@ -226,6 +248,35 @@ def test_project_proposer_propagates_project_cancellation() -> None:
         )
 
 
+def test_project_proposer_checks_cancellation_between_context_writes() -> None:
+    parent = HarnessDoc.baseline("parent")
+
+    class _CountingProject(_Project):
+        def __init__(self) -> None:
+            super().__init__([_payload(parent, "careful")])
+            self.writes = 0
+
+        def write_text(self, path: str, content: str) -> None:
+            self.writes += 1
+            super().write_text(path, content)
+
+    project = _CountingProject()
+    proposer = ProjectDeltaProposer(project, meta_agent(), _Provider("unused"))
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        proposer.propose_batch(
+            parent,
+            _trigger(),
+            "inspect failures",
+            history=[],
+            count=1,
+            should_cancel=lambda: project.writes >= 2,
+        )
+
+    assert project.writes == 2
+    assert project.runs == 0
+
+
 def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     parent = HarnessDoc.baseline("parent")
     project = _Project([_payload(parent, "careful"), _payload(parent, "verify")])
@@ -247,15 +298,180 @@ def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     assert len(second) == 2
     assert all(proposal is not None for proposal in proposals)
     assert "context/round-0001/parent.json" in project.files
+    assert "context/round-0001/evidence.json" in project.files
     assert "context/round-0001/history.json" in project.files
     assert "context/round-0002/history.json" in project.files
     assert "proposal-01.json" in project.files["context/round-0002/REQUEST.md"]
+    assert "failure evidence manifest" in project.files["context/round-0002/REQUEST.md"]
+    assert "content_files in listed order" in project.files["context/round-0002/REQUEST.md"]
     assert all(project.files[path] == content for path, content in first_files.items())
+    assert {path for path in project.files if path.startswith("parents/")} == {
+        path for path in first_files if path.startswith("parents/")
+    }
     parent_context = json.loads(project.files["context/round-0001/parent.json"])
+    surface_manifests = _parent_surface_manifests(project, "context/round-0001/parent.json")
     assert parent_context["doc_hash"] == parent.doc_hash
     assert {
-        surface["id"]: surface["content_hash"] for surface in parent_context["surfaces"]
+        surface["id"]: surface["content_hash"] for surface in surface_manifests
     } == parent.surface_hashes()
+    assert all("content" not in surface for surface in surface_manifests)
+    for surface, manifest_surface in zip(parent.surfaces, surface_manifests, strict=True):
+        files = [
+            path.removeprefix(f"{project.workspace}/")
+            for path in cast("list[str]", manifest_surface["content_files"])
+        ]
+        assert "".join(project.files[path] for path in files) == surface.content
+        assert "source_file" not in manifest_surface
+
+
+def test_project_parent_manifest_splits_large_surfaces_below_read_cap() -> None:
+    content = "0123456789" * 4_001
+    parent = HarnessDoc(
+        name="large",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            Surface(
+                id="tool_policy:main",
+                kind=SurfaceKind.TOOL_POLICY,
+                content="submit",
+            ),
+            Surface(
+                id="code:large",
+                kind=SurfaceKind.CODE,
+                content=content,
+                path="src/large.ts",
+            ),
+        ],
+    )
+    project = _Project([_payload(parent, "careful")])
+
+    ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    manifest_text = project.files["context/round-0001/parent.json"]
+    surfaces = _parent_surface_manifests(project, "context/round-0001/parent.json")
+    code_surface = next(surface for surface in surfaces if surface["id"] == "code:large")
+    relative_files = [
+        path.removeprefix(f"{project.workspace}/")
+        for path in cast("list[str]", code_surface["content_files"])
+    ]
+    chunks = [project.files[path] for path in relative_files]
+    source_file = cast("str", code_surface["source_file"]).removeprefix(f"{project.workspace}/")
+    assert len(manifest_text) < 16_000
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 12_000 for chunk in chunks)
+    assert "".join(chunks) == content
+    assert source_file == f"parents/{parent.doc_hash}/parent-source/src/large.ts"
+    assert project.files[source_file] == content
+
+
+def test_real_pi_parent_manifest_itself_fits_one_project_read() -> None:
+    parent = default_agent("parent")
+    project = _Project([_payload(parent, "careful")])
+
+    ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    manifest_text = project.files["context/round-0001/parent.json"]
+    manifest = json.loads(manifest_text)
+    surfaces = _parent_surface_manifests(project, "context/round-0001/parent.json")
+    assert len(manifest_text) < 16_000
+    assert manifest["surface_count"] == len(parent.surfaces)
+    assert len(surfaces) == len(parent.surfaces)
+    for surface in surfaces:
+        chunks = [
+            project.files[path.removeprefix(f"{project.workspace}/")]
+            for path in cast("list[str]", surface["content_files"])
+        ]
+        assert all(len(chunk) <= 12_000 for chunk in chunks)
+    assert all(surface.get("source_file") for surface in surfaces if surface["kind"] == "code")
+
+
+def test_project_context_preserves_evidence_and_compacts_judged_history() -> None:
+    parent = HarnessDoc.baseline("parent")
+    large_change = "changed source\n" * 2_001
+    project = _Project([_payload(parent, large_change)])
+    proposer = ProjectDeltaProposer(project, meta_agent(), _Provider("unused"))
+
+    first = proposer.propose_batch(parent, _trigger(), "first evidence", history=[], count=1)[0]
+    assert isinstance(first, HarnessDelta)
+    first.verdict = GateRecord(accepted=False, reason="screened out after exact trace review")
+    second = first.model_copy(
+        deep=True,
+        update={"delta_id": "second-history-entry", "expected_effect": "different prediction"},
+    )
+    evidence = "failure trace line\n" * 1_501
+    history = [second, first]
+
+    proposer.propose_batch(parent, _trigger(), evidence, history=history, count=1)
+
+    evidence_manifest, evidence_chunks = _manifest_content(
+        project, "context/round-0002/evidence.json"
+    )
+    history_manifest, history_chunks = _manifest_content(project, "context/round-0002/history.json")
+    reconstructed_history = "".join(history_chunks)
+    judged_history = json.loads(reconstructed_history)
+
+    assert evidence_manifest["format"] == "markdown"
+    assert evidence_manifest["content_length"] == len(evidence)
+    assert len(evidence_chunks) > 1
+    assert all(len(chunk) <= 12_000 for chunk in evidence_chunks)
+    assert "".join(evidence_chunks) == evidence
+    assert history_manifest["format"] == "json-array"
+    assert history_manifest["entry_count"] == 2
+    assert history_manifest["content_length"] == len(reconstructed_history)
+    assert all(len(chunk) <= 12_000 for chunk in history_chunks)
+    assert len(reconstructed_history) < len(large_change)
+    assert [entry["delta_id"] for entry in judged_history] == [second.delta_id, first.delta_id]
+    assert all("content" not in entry["ops"][0] for entry in judged_history)
+    assert all(entry["ops"][0]["content_length"] == len(large_change) for entry in judged_history)
+    assert judged_history[0]["proposal_file"] is None
+    assert judged_history[1]["proposal_file"].endswith("/proposals/round-0001/proposal-01.json")
+
+
+def test_project_proposer_persists_candidate_evaluation_beside_its_proposal() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _Project([_payload(parent, "careful")])
+    proposer = ProjectDeltaProposer(project, meta_agent(), _Provider("unused"))
+    proposal = proposer.propose_batch(parent, _trigger(), "inspect failures", history=[], count=1)[
+        0
+    ]
+    assert isinstance(proposal, HarnessDelta)
+    evidence = "candidate trace\n" * 2_001
+
+    proposer.record_evaluation(proposal, stage="screen", content=evidence)
+
+    manifest_path = "evaluations/round-0001/proposal-01/screen.json"
+    manifest, chunks = _manifest_content(project, manifest_path)
+    assert manifest["delta_id"] == proposal.delta_id
+    assert manifest["stage"] == "screen"
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 12_000 for chunk in chunks)
+    assert "".join(chunks) == evidence
+
+
+def test_project_proposer_checks_cancellation_before_evaluation_writes() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _Project([_payload(parent, "careful")])
+    cancelled = False
+    proposer = ProjectDeltaProposer(project, meta_agent(), _Provider("unused"))
+    proposal = proposer.propose_batch(
+        parent,
+        _trigger(),
+        "inspect failures",
+        history=[],
+        count=1,
+        should_cancel=lambda: cancelled,
+    )[0]
+    assert isinstance(proposal, HarnessDelta)
+    cancelled = True
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        proposer.record_evaluation(proposal, stage="screen", content="candidate trace")
+
+    assert not any(path.startswith("evaluations/") for path in project.files)
 
 
 def test_project_proposer_stamps_missing_parent_preconditions() -> None:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -128,6 +128,20 @@ class _InterruptedProject(_Project):
         raise RuntimeError("Server disconnected after durable writes")
 
 
+class _FailedProject(_Project):
+    """Fail the project turn before any proposal output reaches durable storage."""
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+    ) -> AgentProjectRun:
+        del agent, provider, instruction
+        self.runs += 1
+        raise RuntimeError("provider down")
+
+
 def test_provider_proposer_produces_requested_sibling_count() -> None:
     parent = HarnessDoc.baseline("parent")
     provider = _Provider(_payload(parent, "careful"))
@@ -214,3 +228,40 @@ def test_project_proposer_salvages_outputs_written_before_runner_disconnect() ->
 
     assert isinstance(proposals[0], HarnessDelta)
     assert proposals[1] == ProposalFailure(reason="Server disconnected after durable writes")
+
+
+def test_project_proposer_only_salvages_fully_parsed_outputs_after_failure() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _InterruptedProject([_payload(parent, "careful"), "{"])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=3
+    )
+
+    assert isinstance(proposals[0], HarnessDelta)
+    assert proposals[1:] == [
+        ProposalFailure(reason="Server disconnected after durable writes"),
+        ProposalFailure(reason="Server disconnected after durable writes"),
+    ]
+
+
+def test_project_proposer_keeps_a_clean_malformed_output_unusable() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _Project(["{"])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    assert proposals == [None]
+
+
+def test_project_proposer_marks_every_missing_output_as_a_proposal_failure() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _FailedProject([])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=3
+    )
+
+    assert proposals == [ProposalFailure(reason="provider down")] * 3

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import cast
 
 import pytest
@@ -12,8 +12,9 @@ from llm_waterfall import ChatResponse
 from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProjectRun
-from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta
+from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_delta
 from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.mutate import parse_delta
 from wmh.harness.proposer import ProjectDeltaProposer, ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
 from wmh.providers.base import (
@@ -43,6 +44,24 @@ def _payload(parent: HarnessDoc, content: str) -> str:
                     "surface_id": "prompt:core",
                     "content": content,
                     "rationale": "verify before submit",
+                }
+            ],
+        }
+    )
+
+
+def _skill_payload(content: str, *, slug: str = "parse-json") -> str:
+    return json.dumps(
+        {
+            "expected_effect": "the agent parses JSON responses reliably",
+            "preconditions": {},
+            "ops": [
+                {
+                    "op": "add",
+                    "surface_id": f"skill:{slug}",
+                    "kind": "skill",
+                    "content": content,
+                    "rationale": "teach response parsing without changing unrelated behavior",
                 }
             ],
         }
@@ -107,8 +126,9 @@ class _Project:
         instruction: str,
         *,
         should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider, should_cancel
+        del agent, provider, should_cancel, writable_files
         self.runs += 1
         assert f"exactly {len(self.outputs)}" in instruction
         round_dir = f"round-{self.runs:04d}"
@@ -147,8 +167,9 @@ class _InterruptedProject(_Project):
         instruction: str,
         *,
         should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider, instruction, should_cancel
+        del agent, provider, instruction, should_cancel, writable_files
         self.runs += 1
         round_dir = f"round-{self.runs:04d}"
         for index, output in enumerate(self.outputs, start=1):
@@ -166,10 +187,64 @@ class _FailedProject(_Project):
         instruction: str,
         *,
         should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider, instruction, should_cancel
+        del agent, provider, instruction, should_cancel, writable_files
         self.runs += 1
         raise RuntimeError("provider down")
+
+
+class _RepairingProject(_Project):
+    """Drive one proposal round with explicit per-turn rewrites of the same slot files."""
+
+    def __init__(
+        self,
+        outputs: list[str],
+        repairs: list[dict[int, str]],
+        *,
+        extra_rewrites: dict[int, str] | None = None,
+        initial_error: str | None = None,
+    ) -> None:
+        super().__init__(outputs)
+        self.repairs = repairs
+        self.extra_rewrites = extra_rewrites or {}
+        self.initial_error = initial_error
+        self.instructions: list[str] = []
+        self.write_grants: list[tuple[str, ...] | None] = []
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
+    ) -> AgentProjectRun:
+        del agent, provider, should_cancel
+        self.runs += 1
+        self.instructions.append(instruction)
+        self.write_grants.append(None if writable_files is None else tuple(sorted(writable_files)))
+        if self.runs == 1:
+            writes = {index: output for index, output in enumerate(self.outputs, start=1)}
+        else:
+            repair_index = self.runs - 2
+            writes = self.repairs[repair_index] if repair_index < len(self.repairs) else {}
+            writes = {**self.extra_rewrites, **writes}
+        for index, output in writes.items():
+            self.files[f"proposals/round-0001/proposal-{index:02d}.json"] = output
+        if self.runs == 1 and self.initial_error is not None:
+            raise RuntimeError(self.initial_error)
+        return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
+
+
+class _RestoreFailingProject(_RepairingProject):
+    """Lose the durable-write channel while the host restores a valid sibling."""
+
+    def write_text(self, path: str, content: str) -> None:
+        if self.runs >= 2 and path == "proposals/round-0001/proposal-01.json":
+            raise RuntimeError("valid sibling restoration failed")
+        super().write_text(path, content)
 
 
 def test_provider_proposer_produces_requested_sibling_count() -> None:
@@ -230,8 +305,9 @@ def test_project_proposer_propagates_project_cancellation() -> None:
             instruction: str,
             *,
             should_cancel: Callable[[], bool] | None = None,
+            writable_files: Collection[str] | None = None,
         ) -> AgentProjectRun:
-            del agent, provider, instruction
+            del agent, provider, instruction, writable_files
             assert should_cancel is callback
             raise HarnessSearchCancelled("harness search cancelled")
 
@@ -285,6 +361,7 @@ def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     proposer = ProjectDeltaProposer(project, meta_agent(), provider)
     proposals = proposer.propose_batch(parent, _trigger(), "inspect failures", history=[], count=2)
     first_files = dict(project.files)
+    project.outputs = [_payload(parent, "careful next"), _payload(parent, "verify next")]
     second = proposer.propose_batch(
         parent,
         _trigger(),
@@ -487,6 +564,297 @@ def test_project_proposer_stamps_missing_parent_preconditions() -> None:
     proposal = proposals[0]
     assert isinstance(proposal, HarnessDelta)
     assert proposal.preconditions == {"prompt:core": parent.surface_hashes()["prompt:core"]}
+
+
+def test_project_proposer_repairs_skill_frontmatter_and_protects_valid_sibling() -> None:
+    parent = HarnessDoc.baseline("parent")
+    valid_raw = _payload(parent, "careful")
+    invalid_skill = _skill_payload("Parse the JSON response before formatting the answer.")
+    repaired_skill = _skill_payload(
+        "---\n"
+        "name: parse-json\n"
+        "description: Parse a JSON API response before formatting the requested fields\n"
+        "---\n"
+        "Parse the JSON response, select the requested fields, and format only after parsing."
+    )
+    # The fake repair agent also tries to overwrite slot 1. The host must restore that valid file
+    # byte-for-byte and re-read only slot 2.
+    project = _RepairingProject(
+        [valid_raw, invalid_skill],
+        [{2: repaired_skill}],
+        extra_rewrites={1: "{"},
+    )
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=2
+    )
+
+    assert project.runs == 2
+    assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
+    assert project.write_grants == [
+        (
+            "proposals/round-0001/proposal-01.json",
+            "proposals/round-0001/proposal-02.json",
+        ),
+        ("proposals/round-0001/proposal-02.json",),
+    ]
+    assert project.files["proposals/round-0001/proposal-01.json"] == valid_raw
+    assert "name: <slug>" in project.instructions[0]
+    assert "rewrite ONLY these" in project.instructions[1]
+    assert "invalid files:" in project.instructions[1]
+    assert "proposals/round-0001/proposal-02.json" in project.instructions[1]
+    assert "Do not rewrite them" in project.instructions[1]
+    first_report = json.loads(
+        project.files["context/round-0001/proposal-validation-attempt-01.json"]
+    )
+    final_report = json.loads(
+        project.files["context/round-0001/proposal-validation-attempt-02.json"]
+    )
+    assert first_report["valid_slots"] == [1]
+    assert "skill file has no frontmatter" in first_report["errors"][0]["reason"]
+    assert final_report["valid_slots"] == [1, 2]
+    assert final_report["errors"] == []
+    for proposal in proposals:
+        assert isinstance(proposal, HarnessDelta)
+        assert proposal.child_doc_hash is None
+        apply_delta(parent, proposal.model_copy(deep=True), "preflight-proven")
+
+
+def test_project_proposer_fails_if_valid_sibling_provenance_cannot_be_restored() -> None:
+    """Never return an in-memory delta whose durable proposal file may have changed."""
+    parent = HarnessDoc.baseline("parent")
+    project = _RestoreFailingProject(
+        [_payload(parent, "careful"), _skill_payload("missing frontmatter")],
+        [
+            {
+                2: _skill_payload(
+                    "---\nname: parse-json\ndescription: Parse JSON responses\n---\nParse first."
+                )
+            }
+        ],
+        extra_rewrites={1: "{"},
+    )
+
+    with pytest.raises(RuntimeError, match="valid sibling restoration failed"):
+        ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+            parent, _trigger(), "inspect failures", history=[], count=2
+        )
+
+
+def test_project_proposer_repairs_history_and_sibling_duplicates() -> None:
+    parent = HarnessDoc.baseline("parent")
+    sibling = _payload(parent, "sibling")
+    historic_raw = _payload(parent, "historic")
+    historic = parse_delta(parent, _trigger(), historic_raw)
+    assert isinstance(historic, HarnessDelta)
+    project = _RepairingProject(
+        [sibling, sibling, historic_raw],
+        [{2: _payload(parent, "repaired sibling"), 3: _payload(parent, "repaired history")}],
+    )
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[historic], count=3
+    )
+
+    assert project.runs == 2
+    assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
+    delta_ids = [proposal.delta_id for proposal in proposals if isinstance(proposal, HarnessDelta)]
+    assert len(delta_ids) == len(set(delta_ids)) == 3
+    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-01.json"])
+    reasons = [error["reason"] for error in report["errors"]]
+    assert any("duplicates valid sibling proposal-01" in reason for reason in reasons)
+    assert any("already present in judged history" in reason for reason in reasons)
+
+
+def test_project_proposer_repairs_semantically_identical_children_and_no_ops() -> None:
+    base = HarnessDoc.baseline("parent")
+    parent = HarnessDoc(
+        name="parent",
+        surfaces=[
+            *base.surfaces,
+            Surface(id="prompt:extra", kind=SurfaceKind.PROMPT, content="extra"),
+        ],
+    )
+
+    def payload(*, reverse: bool, core: str = "core changed", extra: str = "extra changed") -> str:
+        ops = [
+            {
+                "op": "replace",
+                "surface_id": "prompt:core",
+                "content": core,
+                "rationale": "change the main instruction",
+            },
+            {
+                "op": "replace",
+                "surface_id": "prompt:extra",
+                "content": extra,
+                "rationale": "change the supporting instruction",
+            },
+        ]
+        if reverse:
+            ops.reverse()
+        return json.dumps(
+            {
+                "expected_effect": "the two prompt sections work together",
+                "preconditions": {},
+                "ops": ops,
+            }
+        )
+
+    core_surface = parent.surface("prompt:core")
+    assert core_surface is not None
+    no_op = _payload(parent, core_surface.content)
+    project = _RepairingProject(
+        [payload(reverse=False), payload(reverse=True), no_op],
+        [
+            {
+                2: payload(reverse=True, extra="independent extra"),
+                3: _payload(parent, "nonempty semantic change"),
+            }
+        ],
+    )
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=3
+    )
+
+    assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
+    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-01.json"])
+    reasons = [error["reason"] for error in report["errors"]]
+    assert any("duplicates valid sibling proposal-01" in reason for reason in reasons)
+    assert any("semantic no-op" in reason for reason in reasons)
+
+
+def test_project_proposer_never_returns_a_delta_that_remains_invalid_after_two_repairs() -> None:
+    parent = HarnessDoc.baseline("parent")
+    invalid = _skill_payload("Still missing required frontmatter.")
+    project = _RepairingProject([invalid], [{1: invalid}, {1: invalid}])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    assert project.runs == 3
+    assert proposals == [None]
+    final_report = json.loads(
+        project.files["context/round-0001/proposal-validation-attempt-03.json"]
+    )
+    assert final_report["valid_slots"] == []
+    assert "skill file has no frontmatter" in final_report["errors"][0]["reason"]
+
+
+def test_project_proposer_repairs_partial_durable_outputs_after_runner_disconnect() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _RepairingProject(
+        [_payload(parent, "careful"), _skill_payload("missing frontmatter")],
+        [
+            {
+                2: _skill_payload(
+                    "---\nname: parse-json\ndescription: Parse JSON responses\n---\nParse first."
+                )
+            }
+        ],
+        initial_error="Server disconnected after durable writes",
+    )
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=2
+    )
+
+    assert project.runs == 2
+    assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
+    final_report = json.loads(
+        project.files["context/round-0001/proposal-validation-attempt-02.json"]
+    )
+    assert final_report["valid_slots"] == [1, 2]
+    assert final_report["errors"] == []
+
+
+def test_project_proposer_rejects_a_runtime_kind_switch_when_fixed_before_search() -> None:
+    parent = HarnessDoc.baseline("parent")
+    switch = json.dumps(
+        {
+            "expected_effect": "run the vendored node harness",
+            "preconditions": {},
+            "ops": [
+                {
+                    "op": "add",
+                    "surface_id": "param:runtime-kind",
+                    "kind": "param",
+                    "content": "pi-node",
+                    "rationale": "switch execution engines",
+                }
+            ],
+        }
+    )
+    project = _RepairingProject([switch], [{1: switch}, {1: switch}])
+
+    proposals = ProjectDeltaProposer(
+        project,
+        meta_agent(),
+        _Provider("unused"),
+        preserve_runtime_kind=True,
+    ).propose_batch(parent, _trigger(), "inspect failures", history=[], count=1)
+
+    assert proposals == [None]
+    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
+    assert "must preserve the parent's runtime kind 'kit-python'" in report["errors"][0]["reason"]
+
+
+def test_project_proposer_allows_runtime_kind_switch_for_generic_local_search() -> None:
+    parent = HarnessDoc.baseline("parent")
+    switch = json.dumps(
+        {
+            "expected_effect": "run the vendored node harness",
+            "preconditions": {},
+            "ops": [
+                {
+                    "op": "add",
+                    "surface_id": "param:runtime-kind",
+                    "kind": "param",
+                    "content": "pi-node",
+                    "rationale": "switch execution engines",
+                }
+            ],
+        }
+    )
+    project = _Project([switch])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    proposal = proposals[0]
+    assert isinstance(proposal, HarnessDelta)
+    assert apply_delta(parent, proposal, "child").runtime_kind() == "pi-node"
+
+
+def test_project_proposer_repairs_an_unknown_runtime_kind_before_search() -> None:
+    parent = HarnessDoc.baseline("parent")
+    invalid = json.dumps(
+        {
+            "expected_effect": "run a misspelled execution engine",
+            "preconditions": {},
+            "ops": [
+                {
+                    "op": "add",
+                    "surface_id": "param:runtime-kind",
+                    "kind": "param",
+                    "content": "pi-nod",
+                    "rationale": "switch execution engines",
+                }
+            ],
+        }
+    )
+    project = _RepairingProject([invalid], [{1: invalid}, {1: invalid}])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    assert proposals == [None]
+    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
+    assert "unsupported runtime kind 'pi-nod'" in report["errors"][0]["reason"]
 
 
 def test_project_proposer_salvages_outputs_written_before_runner_disconnect() -> None:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -104,7 +104,7 @@ class _Project:
     ) -> AgentProjectRun:
         del agent, provider
         self.runs += 1
-        assert "exactly 2" in instruction
+        assert f"exactly {len(self.outputs)}" in instruction
         round_dir = f"round-{self.runs:04d}"
         for index, output in enumerate(self.outputs, start=1):
             self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
@@ -165,3 +165,23 @@ def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     assert "context/round-0002/history.json" in project.files
     assert "proposal-01.json" in project.files["context/round-0002/REQUEST.md"]
     assert all(project.files[path] == content for path, content in first_files.items())
+    parent_context = json.loads(project.files["context/round-0001/parent.json"])
+    assert parent_context["doc_hash"] == parent.doc_hash
+    assert {
+        surface["id"]: surface["content_hash"] for surface in parent_context["surfaces"]
+    } == parent.surface_hashes()
+
+
+def test_project_proposer_stamps_missing_parent_preconditions() -> None:
+    parent = HarnessDoc.baseline("parent")
+    raw = json.loads(_payload(parent, "careful"))
+    raw["preconditions"] = {}
+    project = _Project([json.dumps(raw)])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=1
+    )
+
+    proposal = proposals[0]
+    assert isinstance(proposal, HarnessDelta)
+    assert proposal.preconditions == {"prompt:core": parent.surface_hashes()["prompt:core"]}

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -68,6 +68,11 @@ def _skill_payload(content: str, *, slug: str = "parse-json") -> str:
     )
 
 
+def _proposal_failure_reason(proposal: object) -> str:
+    assert isinstance(proposal, ProposalFailure)
+    return proposal.reason
+
+
 class _Provider:
     config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
 
@@ -735,7 +740,7 @@ def test_project_proposer_never_returns_a_delta_that_remains_invalid_after_two_r
     )
 
     assert project.runs == 3
-    assert proposals == [None]
+    assert "skill file has no frontmatter" in _proposal_failure_reason(proposals[0])
     final_report = json.loads(
         project.files["context/round-0001/proposal-validation-attempt-03.json"]
     )
@@ -796,7 +801,9 @@ def test_project_proposer_rejects_a_runtime_kind_switch_when_fixed_before_search
         preserve_runtime_kind=True,
     ).propose_batch(parent, _trigger(), "inspect failures", history=[], count=1)
 
-    assert proposals == [None]
+    assert "must preserve the parent's runtime kind 'kit-python'" in _proposal_failure_reason(
+        proposals[0]
+    )
     report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
     assert "must preserve the parent's runtime kind 'kit-python'" in report["errors"][0]["reason"]
 
@@ -852,7 +859,7 @@ def test_project_proposer_repairs_an_unknown_runtime_kind_before_search() -> Non
         parent, _trigger(), "inspect failures", history=[], count=1
     )
 
-    assert proposals == [None]
+    assert "unsupported runtime kind 'pi-nod'" in _proposal_failure_reason(proposals[0])
     report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
     assert "unsupported runtime kind 'pi-nod'" in report["errors"][0]["reason"]
 
@@ -884,7 +891,7 @@ def test_project_proposer_only_salvages_fully_parsed_outputs_after_failure() -> 
     ]
 
 
-def test_project_proposer_keeps_a_clean_malformed_output_unusable() -> None:
+def test_project_proposer_reports_the_exact_clean_malformed_output_failure() -> None:
     parent = HarnessDoc.baseline("parent")
     project = _Project(["{"])
 
@@ -892,7 +899,9 @@ def test_project_proposer_keeps_a_clean_malformed_output_unusable() -> None:
         parent, _trigger(), "inspect failures", history=[], count=1
     )
 
-    assert proposals == [None]
+    assert _proposal_failure_reason(proposals[0]) == (
+        "proposal is not a parseable typed delta JSON object"
+    )
 
 
 def test_project_proposer_marks_every_missing_output_as_a_proposal_failure() -> None:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -111,6 +111,23 @@ class _Project:
         return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
 
 
+class _InterruptedProject(_Project):
+    """Write a prefix of the batch, then lose the runner's terminal control frame."""
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+    ) -> AgentProjectRun:
+        del agent, provider, instruction
+        self.runs += 1
+        round_dir = f"round-{self.runs:04d}"
+        for index, output in enumerate(self.outputs, start=1):
+            self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
+        raise RuntimeError("Server disconnected after durable writes")
+
+
 def test_provider_proposer_produces_requested_sibling_count() -> None:
     parent = HarnessDoc.baseline("parent")
     provider = _Provider(_payload(parent, "careful"))
@@ -185,3 +202,15 @@ def test_project_proposer_stamps_missing_parent_preconditions() -> None:
     proposal = proposals[0]
     assert isinstance(proposal, HarnessDelta)
     assert proposal.preconditions == {"prompt:core": parent.surface_hashes()["prompt:core"]}
+
+
+def test_project_proposer_salvages_outputs_written_before_runner_disconnect() -> None:
+    parent = HarnessDoc.baseline("parent")
+    project = _InterruptedProject([_payload(parent, "careful")])
+
+    proposals = ProjectDeltaProposer(project, meta_agent(), _Provider("unused")).propose_batch(
+        parent, _trigger(), "inspect failures", history=[], count=2
+    )
+
+    assert isinstance(proposals[0], HarnessDelta)
+    assert proposals[1] == ProposalFailure(reason="Server disconnected after durable writes")

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 
+import pytest
 from llm_waterfall import ChatResponse
 
 from wmh.agents.meta import meta_agent
@@ -11,7 +13,7 @@ from wmh.agents.project import AgentProjectRun
 from wmh.harness.delta import FailureSignature, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.proposer import ProjectDeltaProposer, ProposalFailure, ProviderDeltaProposer
-from wmh.harness.runner_link import TokenUsage
+from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
 from wmh.providers.base import (
     Completion,
     Message,
@@ -101,8 +103,10 @@ class _Project:
         agent: HarnessDoc,
         provider: ToolCallingProvider,
         instruction: str,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider
+        del agent, provider, should_cancel
         self.runs += 1
         assert f"exactly {len(self.outputs)}" in instruction
         round_dir = f"round-{self.runs:04d}"
@@ -119,8 +123,10 @@ class _InterruptedProject(_Project):
         agent: HarnessDoc,
         provider: ToolCallingProvider,
         instruction: str,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider, instruction
+        del agent, provider, instruction, should_cancel
         self.runs += 1
         round_dir = f"round-{self.runs:04d}"
         for index, output in enumerate(self.outputs, start=1):
@@ -136,8 +142,10 @@ class _FailedProject(_Project):
         agent: HarnessDoc,
         provider: ToolCallingProvider,
         instruction: str,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
     ) -> AgentProjectRun:
-        del agent, provider, instruction
+        del agent, provider, instruction, should_cancel
         self.runs += 1
         raise RuntimeError("provider down")
 
@@ -169,6 +177,53 @@ def test_provider_proposer_isolates_one_failed_sibling_call() -> None:
     assert proposals[0] is not None and not isinstance(proposals[0], ProposalFailure)
     assert proposals[1] == ProposalFailure(reason="rate limited")
     assert proposals[2] is not None and not isinstance(proposals[2], ProposalFailure)
+
+
+def test_provider_proposer_checks_cancellation_between_sibling_calls() -> None:
+    parent = HarnessDoc.baseline("parent")
+    provider = _Provider(_payload(parent, "careful"))
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        ProviderDeltaProposer(provider).propose_batch(
+            parent,
+            _trigger(),
+            "evidence",
+            history=[],
+            count=3,
+            should_cancel=lambda: provider.calls >= 1,
+        )
+
+    assert provider.calls == 1
+
+
+def test_project_proposer_propagates_project_cancellation() -> None:
+    parent = HarnessDoc.baseline("parent")
+    callback = lambda: False  # noqa: E731 - identity is the behavior under test
+
+    class _CancellingProject(_Project):
+        def run(
+            self,
+            agent: HarnessDoc,
+            provider: ToolCallingProvider,
+            instruction: str,
+            *,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> AgentProjectRun:
+            del agent, provider, instruction
+            assert should_cancel is callback
+            raise HarnessSearchCancelled("harness search cancelled")
+
+    proposer = ProjectDeltaProposer(_CancellingProject([]), meta_agent(), _Provider("unused"))
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        proposer.propose_batch(
+            parent,
+            _trigger(),
+            "inspect failures",
+            history=[],
+            count=2,
+            should_cancel=callback,
+        )
 
 
 def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -8,9 +8,9 @@ from llm_waterfall import ChatResponse
 
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProjectRun
-from wmh.harness.delta import FailureSignature
+from wmh.harness.delta import FailureSignature, HarnessDelta
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.proposer import ProjectDeltaProposer, ProviderDeltaProposer
+from wmh.harness.proposer import ProjectDeltaProposer, ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runner_link import TokenUsage
 from wmh.providers.base import (
     Completion,
@@ -68,6 +68,20 @@ class _Provider:
         raise AssertionError("fake project never calls the provider")
 
 
+class _FlakyProvider(_Provider):
+    def __init__(self, replies: list[str | Exception]) -> None:
+        super().__init__("")
+        self.replies = replies
+
+    def complete(self, system: str, messages: list[Message], **kwargs: object) -> Completion:
+        del system, messages, kwargs
+        reply = self.replies[self.calls]
+        self.calls += 1
+        if isinstance(reply, Exception):
+            raise reply
+        return Completion(text=reply)
+
+
 class _Project:
     workspace = "/home/user/project"
 
@@ -110,6 +124,22 @@ def test_provider_proposer_produces_requested_sibling_count() -> None:
     assert all(proposal is not None for proposal in proposals)
 
 
+def test_provider_proposer_isolates_one_failed_sibling_call() -> None:
+    parent = HarnessDoc.baseline("parent")
+    provider = _FlakyProvider(
+        [_payload(parent, "first"), RuntimeError("rate limited"), _payload(parent, "third")]
+    )
+
+    proposals = ProviderDeltaProposer(provider).propose_batch(
+        parent, _trigger(), "evidence", history=[], count=3
+    )
+
+    assert provider.calls == 3
+    assert proposals[0] is not None and not isinstance(proposals[0], ProposalFailure)
+    assert proposals[1] == ProposalFailure(reason="rate limited")
+    assert proposals[2] is not None and not isinstance(proposals[2], ProposalFailure)
+
+
 def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     parent = HarnessDoc.baseline("parent")
     project = _Project([_payload(parent, "careful"), _payload(parent, "verify")])
@@ -122,7 +152,7 @@ def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
         parent,
         _trigger(),
         "inspect the next failures",
-        history=[proposal for proposal in proposals if proposal is not None],
+        history=[proposal for proposal in proposals if isinstance(proposal, HarnessDelta)],
         count=2,
     )
 

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -39,7 +39,8 @@ from wmh.harness.runtime import (
     StopReason,
     TokenUsage,
 )
-from wmh.harness.tools import ToolSpec
+from wmh.harness.skills import SkillLibrary
+from wmh.harness.tools import READ_SKILL, ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
 DEFAULT_MAX_ENV_ACTIONS = 40
@@ -164,6 +165,7 @@ class HostEpisode:
     instruction: str
     tools: list[ToolSpec]
     environment: AgentEnvironment
+    skills: SkillLibrary = field(default_factory=SkillLibrary)
     max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS
     steps: list[Step] = field(default_factory=list)
     answer: str = ""
@@ -176,11 +178,21 @@ class HostEpisode:
         ]
 
     def run_tool(self, name: str, arguments: JsonObject) -> JsonObject:
-        """Answer one environment tool call: enforce the budget, record the Step."""
+        """Answer one runtime/environment tool call under AgentRuntime-compatible semantics."""
         action = Action(kind=ActionKind.TOOL_CALL, name=name, arguments=arguments)
-        if self._env_calls >= self.max_env_actions:
+        if name not in {t.name for t in self.tools}:
+            obs = Observation(content=f"tool {name!r} not available", is_error=True)
+        elif name == READ_SKILL.name:
+            raw_name = arguments.get("name")
+            skill_name = raw_name if isinstance(raw_name, str) else ""
+            skill = self.skills.get(skill_name)
+            if skill is None:
+                obs = Observation(content=f"no skill named {skill_name!r}", is_error=True)
+            else:
+                obs = Observation(content=skill.body)
+        elif self._env_calls >= self.max_env_actions:
             obs = Observation(content="environment action budget exhausted", is_error=True)
-        elif name not in {t.name for t in self.tools} or not is_env_action(action):
+        elif not is_env_action(action):
             obs = Observation(content=f"tool {name!r} not available", is_error=True)
         else:
             self._env_calls += 1
@@ -216,6 +228,8 @@ class RunnerLink:
         max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS,
         max_turns: int = DEFAULT_MAX_TURNS,
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
+        temperature: float = 0.7,
+        skills: SkillLibrary | None = None,
         episode_timeout_s: float | None = None,
         should_cancel: Callable[[], bool] | None = None,
         cancel_poll_interval_s: float = DEFAULT_CANCEL_POLL_INTERVAL_S,
@@ -224,7 +238,10 @@ class RunnerLink:
         # Tools bound at construction make RunnerLink satisfy the runtime contract closed-loop eval
         # drives — `run(task_id, instruction, environment)` — while `run(..., tools=...)` still lets
         # a caller (or the conformance tests) override per episode.
-        self._tools = tools or []
+        self._tools = list(tools or [])
+        self._skills = skills if skills is not None else SkillLibrary()
+        if len(self._skills) and READ_SKILL.name not in {tool.name for tool in self._tools}:
+            self._tools.append(READ_SKILL)
         if worker_fn is None and provider is None:
             raise ValueError("RunnerLink needs a ToolCallingProvider or worker_fn")
         # worker_fn lets tests answer llm_request without a real provider.
@@ -240,12 +257,15 @@ class RunnerLink:
             raise ValueError("max_turns must be >= 1")
         if max_output_tokens < 1:
             raise ValueError("max_output_tokens must be >= 1")
+        if not 0.0 <= temperature <= 2.0:
+            raise ValueError("temperature must be in [0, 2]")
         if episode_timeout_s is not None and episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive when set")
         if cancel_poll_interval_s <= 0:
             raise ValueError("cancel_poll_interval_s must be positive")
         self._max_turns = max_turns
         self._max_output_tokens = max_output_tokens
+        self._temperature = temperature
         self._episode_timeout_s = episode_timeout_s
         self._should_cancel = should_cancel
         self._cancel_poll_interval_s = cancel_poll_interval_s
@@ -258,10 +278,14 @@ class RunnerLink:
         *,
         tools: list[ToolSpec] | None = None,
     ) -> RunResult:
+        episode_tools = list(tools) if tools is not None else list(self._tools)
+        if len(self._skills) and READ_SKILL.name not in {tool.name for tool in episode_tools}:
+            episode_tools.append(READ_SKILL)
         episode = HostEpisode(
             instruction=instruction,
-            tools=tools if tools is not None else self._tools,
+            tools=episode_tools,
             environment=environment,
+            skills=self._skills,
             max_env_actions=self._max_env_actions,
         )
         episode_id = uuid.uuid4().hex
@@ -298,6 +322,7 @@ class RunnerLink:
                 "max_env_actions": self._max_env_actions,
                 "max_turns": self._max_turns,
                 "max_output_tokens": self._max_output_tokens,
+                "temperature": self._temperature,
                 "episode_timeout_s": self._episode_timeout_s,
             }
         )
@@ -414,7 +439,11 @@ class RunnerLink:
         req_id = frame.get("req_id")
         body = frame.get("openai_body")
         try:
-            request = ChatRequest.model_validate(body if isinstance(body, dict) else {})
+            # The runner owns message/tool serialization, while HarnessDoc owns sampling policy.
+            # Override any runner default at the final host boundary before the real model call.
+            request_body = dict(body) if isinstance(body, dict) else {}
+            request_body["temperature"] = self._temperature
+            request = ChatRequest.model_validate(request_body)
             completion = self._worker_fn(request)
             # Meter the worker leg from the provider's structured response.
             usage.calls += 1

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -32,6 +32,7 @@ from llm_waterfall import ChatRequest, ChatResponse
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.runtime import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_MAX_TURNS,
     RunResult,
     RuntimeCancelled,
@@ -214,6 +215,7 @@ class RunnerLink:
         system_prompt: str = "",
         max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS,
         max_turns: int = DEFAULT_MAX_TURNS,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         episode_timeout_s: float | None = None,
         should_cancel: Callable[[], bool] | None = None,
         cancel_poll_interval_s: float = DEFAULT_CANCEL_POLL_INTERVAL_S,
@@ -236,11 +238,14 @@ class RunnerLink:
         self._max_env_actions = max_env_actions
         if max_turns < 1:
             raise ValueError("max_turns must be >= 1")
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
         if episode_timeout_s is not None and episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive when set")
         if cancel_poll_interval_s <= 0:
             raise ValueError("cancel_poll_interval_s must be positive")
         self._max_turns = max_turns
+        self._max_output_tokens = max_output_tokens
         self._episode_timeout_s = episode_timeout_s
         self._should_cancel = should_cancel
         self._cancel_poll_interval_s = cancel_poll_interval_s
@@ -292,6 +297,7 @@ class RunnerLink:
                 "files": self._files,
                 "max_env_actions": self._max_env_actions,
                 "max_turns": self._max_turns,
+                "max_output_tokens": self._max_output_tokens,
                 "episode_timeout_s": self._episode_timeout_s,
             }
         )

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import struct
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -30,11 +31,18 @@ from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step
 from wmh.harness.environment import AgentEnvironment, is_env_action
-from wmh.harness.runtime import RunResult, StopReason, TokenUsage
+from wmh.harness.runtime import (
+    DEFAULT_MAX_TURNS,
+    RunResult,
+    RuntimeCancelled,
+    StopReason,
+    TokenUsage,
+)
 from wmh.harness.tools import ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
 DEFAULT_MAX_ENV_ACTIONS = 40
+DEFAULT_CANCEL_POLL_INTERVAL_S = 0.5
 
 
 # --------------------------------------------------------------------------------------------------
@@ -77,7 +85,7 @@ class Channel(Protocol):
     """A bidirectional frame channel to the runner peer (a socket, or a test double)."""
 
     def send(self, frame: JsonObject) -> None: ...
-    def recv(self) -> JsonObject | None: ...
+    def recv(self, timeout: float | None = None) -> JsonObject | None: ...
 
 
 class SocketChannel:
@@ -85,12 +93,38 @@ class SocketChannel:
 
     def __init__(self, sock: _SupportsSocket) -> None:
         self._sock = sock
+        self._recv_buffer = bytearray()
 
     def send(self, frame: JsonObject) -> None:
         write_frame(self._sock, frame)
 
-    def recv(self) -> JsonObject | None:
-        return read_frame(self._sock)
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        settimeout = getattr(self._sock, "settimeout", None)
+        gettimeout = getattr(self._sock, "gettimeout", None)
+        previous = gettimeout() if timeout is not None and callable(gettimeout) else None
+        if timeout is not None and callable(settimeout):
+            settimeout(timeout)
+        try:
+            if not self._fill_recv_buffer(4):
+                return None
+            (length,) = struct.unpack(">I", self._recv_buffer[:4])
+            if not self._fill_recv_buffer(4 + length):
+                return None
+            body = bytes(self._recv_buffer[4 : 4 + length])
+            del self._recv_buffer[: 4 + length]
+            return cast("JsonObject", json.loads(body))
+        finally:
+            if timeout is not None and callable(settimeout):
+                settimeout(previous)
+
+    def _fill_recv_buffer(self, size: int) -> bool:
+        """Read through ``size`` bytes while preserving partial frames across timed polls."""
+        while len(self._recv_buffer) < size:
+            chunk = self._sock.recv(size - len(self._recv_buffer))
+            if not chunk:
+                return False
+            self._recv_buffer += chunk
+        return True
 
 
 # The process-wide runner channel doc.runtime(PI_TRANSPORT=link) drives. A search/eval sets it once
@@ -179,6 +213,10 @@ class RunnerLink:
         files: dict[str, str] | None = None,
         system_prompt: str = "",
         max_env_actions: int = DEFAULT_MAX_ENV_ACTIONS,
+        max_turns: int = DEFAULT_MAX_TURNS,
+        episode_timeout_s: float | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        cancel_poll_interval_s: float = DEFAULT_CANCEL_POLL_INTERVAL_S,
     ) -> None:
         self._channel = channel
         # Tools bound at construction make RunnerLink satisfy the runtime contract closed-loop eval
@@ -196,6 +234,16 @@ class RunnerLink:
         self._files = files or {}
         self._system_prompt = system_prompt
         self._max_env_actions = max_env_actions
+        if max_turns < 1:
+            raise ValueError("max_turns must be >= 1")
+        if episode_timeout_s is not None and episode_timeout_s <= 0:
+            raise ValueError("episode_timeout_s must be positive when set")
+        if cancel_poll_interval_s <= 0:
+            raise ValueError("cancel_poll_interval_s must be positive")
+        self._max_turns = max_turns
+        self._episode_timeout_s = episode_timeout_s
+        self._should_cancel = should_cancel
+        self._cancel_poll_interval_s = cancel_poll_interval_s
 
     def run(
         self,
@@ -212,7 +260,28 @@ class RunnerLink:
             max_env_actions=self._max_env_actions,
         )
         episode_id = uuid.uuid4().hex
-        self._channel.send(
+        self._check_cancelled()
+        deadline = (
+            time.monotonic() + self._episode_timeout_s
+            if self._episode_timeout_s is not None
+            else None
+        )
+        usage = TokenUsage()
+
+        def send_frame(frame: JsonObject) -> RunResult | None:
+            try:
+                self._channel.send(frame)
+            except Exception:
+                self._check_cancelled()
+                if deadline is not None and time.monotonic() >= deadline:
+                    return self._budget_result(task_id, episode, instruction, usage)
+                raise
+            self._check_cancelled()
+            if deadline is not None and time.monotonic() >= deadline:
+                return self._budget_result(task_id, episode, instruction, usage)
+            return None
+
+        stopped = send_frame(
             {
                 "type": "episode_start",
                 "episode_id": episode_id,
@@ -222,18 +291,56 @@ class RunnerLink:
                 "tools": episode.tool_specs(),
                 "files": self._files,
                 "max_env_actions": self._max_env_actions,
+                "max_turns": self._max_turns,
+                "episode_timeout_s": self._episode_timeout_s,
             }
         )
-        usage = TokenUsage()
+        if stopped is not None:
+            return stopped
         while True:
-            frame = self._channel.recv()
+            self._check_cancelled()
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                return self._budget_result(task_id, episode, instruction, usage)
+            recv_timeout = remaining
+            if self._should_cancel is not None:
+                recv_timeout = (
+                    self._cancel_poll_interval_s
+                    if recv_timeout is None
+                    else min(recv_timeout, self._cancel_poll_interval_s)
+                )
+            try:
+                frame = self._channel.recv(timeout=recv_timeout)
+            except TimeoutError:
+                self._check_cancelled()
+                if deadline is not None and time.monotonic() >= deadline:
+                    return self._budget_result(task_id, episode, instruction, usage)
+                if self._should_cancel is not None:
+                    continue
+                raise
+            except Exception:
+                self._check_cancelled()
+                if deadline is not None and time.monotonic() >= deadline:
+                    return self._budget_result(task_id, episode, instruction, usage)
+                raise
+            self._check_cancelled()
+            if deadline is not None and time.monotonic() >= deadline:
+                return self._budget_result(task_id, episode, instruction, usage)
             if frame is None:  # channel closed before the episode finished
                 return self._error_result(
                     task_id, episode, instruction, "runner channel closed", usage=usage
                 )
             kind = frame.get("type")
             if kind == "llm_request":
-                self._answer_llm(episode_id, frame, usage)
+                response = self._llm_response(episode_id, frame, usage)
+                self._check_cancelled()
+                if deadline is not None and time.monotonic() >= deadline:
+                    return self._budget_result(task_id, episode, instruction, usage)
+                # A send timeout is transport failure with an uncertain delivery state. Let it
+                # propagate so the owning runtime retires rather than sending a second response.
+                stopped = send_frame(response)
+                if stopped is not None:
+                    return stopped
             elif kind == "tool_request":
                 name = frame.get("name")
                 args = frame.get("arguments")
@@ -241,7 +348,10 @@ class RunnerLink:
                     name if isinstance(name, str) else "",
                     args if isinstance(args, dict) else {},
                 )
-                self._channel.send(
+                self._check_cancelled()
+                if deadline is not None and time.monotonic() >= deadline:
+                    return self._budget_result(task_id, episode, instruction, usage)
+                stopped = send_frame(
                     {
                         "type": "tool_response",
                         "episode_id": episode_id,
@@ -249,6 +359,8 @@ class RunnerLink:
                         **obs,
                     }
                 )
+                if stopped is not None:
+                    return stopped
             elif kind == "done":
                 answer = frame.get("answer")
                 episode.answer = answer if isinstance(answer, str) else ""
@@ -271,7 +383,28 @@ class RunnerLink:
                 )
             # unknown frame types are ignored (forward-compatible)
 
-    def _answer_llm(self, episode_id: str, frame: JsonObject, usage: TokenUsage) -> None:
+    def _check_cancelled(self) -> None:
+        if self._should_cancel is not None and self._should_cancel():
+            raise RuntimeCancelled("runtime episode cancelled")
+
+    def _budget_result(
+        self,
+        task_id: str,
+        episode: HostEpisode,
+        instruction: str,
+        usage: TokenUsage,
+    ) -> RunResult:
+        assert self._episode_timeout_s is not None
+        return self._error_result(
+            task_id,
+            episode,
+            instruction,
+            f"evaluation episode exceeded {self._episode_timeout_s:g}s wall budget",
+            stop=StopReason.BUDGET,
+            usage=usage,
+        )
+
+    def _llm_response(self, episode_id: str, frame: JsonObject, usage: TokenUsage) -> JsonObject:
         req_id = frame.get("req_id")
         body = frame.get("openai_body")
         try:
@@ -295,9 +428,7 @@ class RunnerLink:
                 "req_id": req_id,
                 "error": str(exc),
             }
-        # A send timeout is transport failure with an uncertain delivery state. Let it propagate
-        # so the owning runtime retires the channel instead of sending a second response frame.
-        self._channel.send(response)
+        return response
 
     @staticmethod
     def _error_result(
@@ -306,9 +437,10 @@ class RunnerLink:
         instruction: str,
         note: str,
         *,
+        stop: StopReason | None = None,
         usage: TokenUsage | None = None,
     ) -> RunResult:
-        stop = StopReason.MAX_TURNS if episode.steps else StopReason.ERROR
+        resolved_stop = stop or (StopReason.MAX_TURNS if episode.steps else StopReason.ERROR)
         episode.steps.append(
             Step(
                 action=Action(kind=ActionKind.MESSAGE, content="(runner link)"),
@@ -320,7 +452,7 @@ class RunnerLink:
         return RunResult(
             task_id=task_id,
             steps=episode.steps,
-            stop_reason=stop,
+            stop_reason=resolved_stop,
             answer="",
             turns=len(episode.steps),
             worker_usage=usage if usage is not None and usage.calls else None,

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -289,23 +289,23 @@ class RunnerLink:
             max_env_actions=self._max_env_actions,
         )
         episode_id = uuid.uuid4().hex
-        self._check_cancelled()
+        usage = TokenUsage()
+        self._check_cancelled(usage)
         deadline = (
             time.monotonic() + self._episode_timeout_s
             if self._episode_timeout_s is not None
             else None
         )
-        usage = TokenUsage()
 
         def send_frame(frame: JsonObject) -> RunResult | None:
             try:
                 self._channel.send(frame)
             except Exception:
-                self._check_cancelled()
+                self._check_cancelled(usage)
                 if deadline is not None and time.monotonic() >= deadline:
                     return self._budget_result(task_id, episode, instruction, usage)
                 raise
-            self._check_cancelled()
+            self._check_cancelled(usage)
             if deadline is not None and time.monotonic() >= deadline:
                 return self._budget_result(task_id, episode, instruction, usage)
             return None
@@ -329,7 +329,7 @@ class RunnerLink:
         if stopped is not None:
             return stopped
         while True:
-            self._check_cancelled()
+            self._check_cancelled(usage)
             remaining = None if deadline is None else deadline - time.monotonic()
             if remaining is not None and remaining <= 0:
                 return self._budget_result(task_id, episode, instruction, usage)
@@ -343,18 +343,18 @@ class RunnerLink:
             try:
                 frame = self._channel.recv(timeout=recv_timeout)
             except TimeoutError:
-                self._check_cancelled()
+                self._check_cancelled(usage)
                 if deadline is not None and time.monotonic() >= deadline:
                     return self._budget_result(task_id, episode, instruction, usage)
                 if self._should_cancel is not None:
                     continue
                 raise
             except Exception:
-                self._check_cancelled()
+                self._check_cancelled(usage)
                 if deadline is not None and time.monotonic() >= deadline:
                     return self._budget_result(task_id, episode, instruction, usage)
                 raise
-            self._check_cancelled()
+            self._check_cancelled(usage)
             if deadline is not None and time.monotonic() >= deadline:
                 return self._budget_result(task_id, episode, instruction, usage)
             if frame is None:  # channel closed before the episode finished
@@ -364,7 +364,7 @@ class RunnerLink:
             kind = frame.get("type")
             if kind == "llm_request":
                 response = self._llm_response(episode_id, frame, usage)
-                self._check_cancelled()
+                self._check_cancelled(usage)
                 if deadline is not None and time.monotonic() >= deadline:
                     return self._budget_result(task_id, episode, instruction, usage)
                 # A send timeout is transport failure with an uncertain delivery state. Let it
@@ -379,7 +379,7 @@ class RunnerLink:
                     name if isinstance(name, str) else "",
                     args if isinstance(args, dict) else {},
                 )
-                self._check_cancelled()
+                self._check_cancelled(usage)
                 if deadline is not None and time.monotonic() >= deadline:
                     return self._budget_result(task_id, episode, instruction, usage)
                 stopped = send_frame(
@@ -414,9 +414,12 @@ class RunnerLink:
                 )
             # unknown frame types are ignored (forward-compatible)
 
-    def _check_cancelled(self) -> None:
+    def _check_cancelled(self, usage: TokenUsage) -> None:
         if self._should_cancel is not None and self._should_cancel():
-            raise RuntimeCancelled("runtime episode cancelled")
+            raise RuntimeCancelled(
+                "runtime episode cancelled",
+                worker_usage=(usage.model_copy() if usage.calls else None),
+            )
 
     def _budget_result(
         self,

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -17,6 +17,7 @@ from wmh.core.types import Action, JsonObject, Observation
 from wmh.harness import runner_link as runner_link_module
 from wmh.harness.runner_link import RunnerLink, SocketChannel, read_frame, write_frame
 from wmh.harness.runtime import RuntimeCancelled, StopReason
+from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 
 
@@ -184,6 +185,7 @@ def test_episode_start_carries_task_tools_and_limits() -> None:
         files={"src/agent.ts": "// a"},
         max_turns=7,
         max_output_tokens=16384,
+        temperature=0.25,
         episode_timeout_s=12.5,
     ).run("t1", "do it", _Env(), tools=_tools())
     start = _sent(ch, "episode_start")
@@ -193,6 +195,7 @@ def test_episode_start_carries_task_tools_and_limits() -> None:
     assert s["files"] == {"src/agent.ts": "// a"}
     assert s["max_turns"] == 7
     assert s["max_output_tokens"] == 16384
+    assert s["temperature"] == 0.25
     assert s["episode_timeout_s"] == 12.5
     assert {t["name"] for t in s["tools"]} >= {"bash", "submit"}
 
@@ -245,6 +248,65 @@ def test_llm_request_answered_via_worker_fn() -> None:
     resp = _sent(ch, "llm_response")[0]
     assert resp["req_id"] == 7
     assert resp["completion"]["choices"][0]["message"]["content"] == "hi"
+
+
+def test_harness_temperature_overrides_the_runner_request_before_the_worker_call() -> None:
+    calls: list[ChatRequest] = []
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        calls.append(request)
+        return _completion()
+
+    ch = _FakeChannel(
+        [
+            {
+                "type": "llm_request",
+                "req_id": 1,
+                "openai_body": {"messages": [], "temperature": 1.75},
+            },
+            {"type": "done", "answer": "ok"},
+        ]
+    )
+    RunnerLink(ch, worker_fn=worker, temperature=0.35).run("t1", "x", _Env(), tools=_tools())
+
+    assert [request.temperature for request in calls] == [0.35]
+
+
+def test_skill_library_implicitly_adds_and_serves_read_skill_without_env_budget() -> None:
+    skill = Skill(name="count-words", description="count words", body="wc -w <path>")
+    script = [
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "read_skill",
+            "arguments": {"name": "count-words"},
+        },
+        {
+            "type": "tool_request",
+            "req_id": 2,
+            "name": "read_skill",
+            "arguments": {"name": "ghost"},
+        },
+        {"type": "done", "answer": "ok"},
+    ]
+    channel = _FakeChannel(script)
+    env = _Env()
+    result = RunnerLink(
+        channel,
+        tools=_tools(),
+        worker_fn=lambda request: _completion(),
+        skills=SkillLibrary([skill]),
+        max_env_actions=0,
+    ).run("t1", "x", env)
+
+    advertised = {tool["name"] for tool in _sent(channel, "episode_start")[0]["tools"]}
+    assert "read_skill" in advertised
+    responses = _sent(channel, "tool_response")
+    assert responses[0]["content"] == "wc -w <path>" and responses[0]["is_error"] is False
+    assert responses[1]["content"] == "no skill named 'ghost'"
+    assert responses[1]["is_error"] is True
+    assert [step.action.name for step in result.steps] == ["read_skill", "read_skill"]
+    assert env.actions == []
 
 
 def test_worker_fn_error_is_reported_not_crashed() -> None:

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -183,6 +183,7 @@ def test_episode_start_carries_task_tools_and_limits() -> None:
         system_prompt="sys",
         files={"src/agent.ts": "// a"},
         max_turns=7,
+        max_output_tokens=16384,
         episode_timeout_s=12.5,
     ).run("t1", "do it", _Env(), tools=_tools())
     start = _sent(ch, "episode_start")
@@ -191,6 +192,7 @@ def test_episode_start_carries_task_tools_and_limits() -> None:
     assert s["instruction"] == "do it" and s["system"] == "sys"
     assert s["files"] == {"src/agent.ts": "// a"}
     assert s["max_turns"] == 7
+    assert s["max_output_tokens"] == 16384
     assert s["episode_timeout_s"] == 12.5
     assert {t["name"] for t in s["tools"]} >= {"bash", "submit"}
 
@@ -455,6 +457,7 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
     import os as _os
 
     from wmh.harness.doc import (
+        MAX_OUTPUT_TOKENS_ID,
         MAX_TURNS_ID,
         RUNTIME_KIND_ID,
         TOOL_POLICY_ID,
@@ -487,6 +490,7 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
             Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
         ],
     )
@@ -504,6 +508,7 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
         runtime = doc.runtime(provider)
         assert isinstance(runtime, RunnerLink)
         assert runtime._max_turns == 7  # noqa: SLF001 - document parameter reaches the link frame
+        assert runtime._max_output_tokens == 16384  # noqa: SLF001 - same agent model contract
     finally:
         set_active_channel(None)
         if prev is None:

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -7,14 +7,16 @@ for the world model; `worker_fn` is injected so the worker-LLM callback needs no
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 
 import pytest
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, JsonObject, Observation
-from wmh.harness.runner_link import RunnerLink, read_frame, write_frame
-from wmh.harness.runtime import StopReason
+from wmh.harness import runner_link as runner_link_module
+from wmh.harness.runner_link import RunnerLink, SocketChannel, read_frame, write_frame
+from wmh.harness.runtime import RuntimeCancelled, StopReason
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 
 
@@ -40,7 +42,8 @@ class _FakeChannel:
     def send(self, frame: JsonObject) -> None:
         self.sent.append(frame)
 
-    def recv(self) -> JsonObject | None:
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        del timeout
         return self._script.pop(0) if self._script else None
 
 
@@ -51,6 +54,29 @@ class _ResponseSendTimeoutChannel(_FakeChannel):
         self.sent.append(frame)
         if frame.get("type") == "llm_response":
             raise TimeoutError("transport send timed out")
+
+
+class _EpisodeStartTimeoutChannel(_FakeChannel):
+    def send(self, frame: JsonObject) -> None:
+        self.sent.append(frame)
+        raise TimeoutError("episode start send timed out")
+
+
+class _TimedWaitChannel(_FakeChannel):
+    """Play a prefix, then model a timed wait with no runner frame."""
+
+    def __init__(self, script: list) -> None:
+        super().__init__(script)
+        self.recv_timeouts: list[float | None] = []
+
+    def recv(self, timeout: float | None = None) -> JsonObject | None:
+        self.recv_timeouts.append(timeout)
+        if self._script:
+            return self._script.pop(0)
+        if timeout is not None:
+            time.sleep(timeout)
+            raise TimeoutError("no frame before poll deadline")
+        return None
 
 
 def _tools() -> list:
@@ -102,6 +128,29 @@ class _PipeSock:
         return chunk
 
 
+class _TimedPipeSock(_PipeSock):
+    """Timeout after a partial frame, then resume from the remaining bytes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._recv_calls = 0
+        self._timeout: float | None = None
+
+    def gettimeout(self) -> float | None:
+        return self._timeout
+
+    def settimeout(self, timeout: float | None) -> None:
+        self._timeout = timeout
+
+    def recv(self, n: int) -> bytes:
+        self._recv_calls += 1
+        if self._recv_calls == 1:
+            return super().recv(min(2, n))  # half the length header
+        if self._recv_calls == 2:
+            raise TimeoutError("fragment stalled")
+        return super().recv(n)
+
+
 def test_frame_codec_roundtrip_and_eof() -> None:
     sock = _PipeSock()
     hello: JsonObject = {"type": "hello", "n": 1, "s": "x" * 5000}
@@ -113,17 +162,36 @@ def test_frame_codec_roundtrip_and_eof() -> None:
     assert read_frame(sock) is None  # clean EOF
 
 
+def test_socket_channel_preserves_a_partial_frame_across_timed_polls() -> None:
+    sock = _TimedPipeSock()
+    frame: JsonObject = {"type": "done", "answer": "fragmented"}
+    write_frame(sock, frame)
+    channel = SocketChannel(sock)
+
+    with pytest.raises(TimeoutError, match="fragment stalled"):
+        channel.recv(timeout=0.01)
+
+    assert channel.recv(timeout=0.01) == frame
+    assert sock.gettimeout() is None  # each bounded poll restores the caller's socket setting
+
+
 # --- episode broker ---
-def test_episode_start_carries_task_and_tools() -> None:
+def test_episode_start_carries_task_tools_and_limits() -> None:
     ch = _FakeChannel([{"type": "done", "answer": "x"}])
-    _link(ch, system_prompt="sys", files={"src/agent.ts": "// a"}).run(
-        "t1", "do it", _Env(), tools=_tools()
-    )
+    _link(
+        ch,
+        system_prompt="sys",
+        files={"src/agent.ts": "// a"},
+        max_turns=7,
+        episode_timeout_s=12.5,
+    ).run("t1", "do it", _Env(), tools=_tools())
     start = _sent(ch, "episode_start")
     assert len(start) == 1
     s = start[0]
     assert s["instruction"] == "do it" and s["system"] == "sys"
     assert s["files"] == {"src/agent.ts": "// a"}
+    assert s["max_turns"] == 7
+    assert s["episode_timeout_s"] == 12.5
     assert {t["name"] for t in s["tools"]} >= {"bash", "submit"}
 
 
@@ -209,6 +277,87 @@ def test_llm_response_send_timeout_propagates_without_error_response_retry() -> 
     assert "error" not in responses[0]
 
 
+def test_send_failure_after_wall_deadline_returns_budget_instead_of_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter([0.0, 2.0])  # deadline starts at 1; the failed start send returns after it
+    monkeypatch.setattr(runner_link_module.time, "monotonic", lambda: next(ticks))
+    ch = _EpisodeStartTimeoutChannel([])
+
+    result = _link(ch, episode_timeout_s=1.0).run("t1", "x", _Env(), tools=_tools())
+
+    assert result.stop_reason is StopReason.BUDGET
+    assert "wall budget" in result.transcript()
+    assert len(_sent(ch, "episode_start")) == 1
+
+
+def test_cancellation_during_worker_call_suppresses_the_llm_response() -> None:
+    cancelled = False
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        nonlocal cancelled
+        del request
+        cancelled = True
+        return _completion()
+
+    ch = _FakeChannel([{"type": "llm_request", "req_id": 1, "openai_body": {}}])
+    with pytest.raises(RuntimeCancelled, match="cancelled"):
+        RunnerLink(ch, worker_fn=worker, should_cancel=lambda: cancelled).run(
+            "t1", "x", _Env(), tools=_tools()
+        )
+
+    assert _sent(ch, "llm_response") == []
+
+
+def test_wall_deadline_during_worker_call_suppresses_the_llm_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter([0.0, 0.0, 0.0, 0.0, 2.0])
+    monkeypatch.setattr(runner_link_module.time, "monotonic", lambda: next(ticks))
+    ch = _FakeChannel([{"type": "llm_request", "req_id": 1, "openai_body": {}}])
+
+    result = RunnerLink(
+        ch,
+        worker_fn=lambda request: _completion(input_tokens=5),
+        episode_timeout_s=1.0,
+    ).run("t1", "x", _Env(), tools=_tools())
+
+    assert result.stop_reason is StopReason.BUDGET
+    assert result.worker_usage is not None and result.worker_usage.calls == 1
+    assert _sent(ch, "llm_response") == []
+
+
+def test_cancellation_during_environment_call_suppresses_the_tool_response() -> None:
+    cancelled = False
+
+    class CancellingEnv(_Env):
+        def execute(self, action: Action) -> Observation:
+            nonlocal cancelled
+            observation = super().execute(action)
+            cancelled = True
+            return observation
+
+    ch = _FakeChannel([{"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}}])
+    with pytest.raises(RuntimeCancelled, match="cancelled"):
+        _link(ch, should_cancel=lambda: cancelled).run("t1", "x", CancellingEnv(), tools=_tools())
+
+    assert _sent(ch, "tool_response") == []
+
+
+def test_wall_deadline_during_environment_call_suppresses_the_tool_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter([0.0, 0.0, 0.0, 0.0, 2.0])
+    monkeypatch.setattr(runner_link_module.time, "monotonic", lambda: next(ticks))
+    ch = _FakeChannel([{"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}}])
+
+    result = _link(ch, episode_timeout_s=1.0).run("t1", "x", _Env(), tools=_tools())
+
+    assert result.stop_reason is StopReason.BUDGET
+    assert "ran bash" in result.transcript()
+    assert _sent(ch, "tool_response") == []
+
+
 def test_channel_close_without_done_reports_error() -> None:
     ch = _FakeChannel(
         [{"type": "tool_request", "req_id": 1, "name": "bash", "arguments": {}}]  # then EOF
@@ -216,6 +365,51 @@ def test_channel_close_without_done_reports_error() -> None:
     result = _link(ch).run("t1", "x", _Env(), tools=_tools())
     assert result.stop_reason is StopReason.MAX_TURNS  # a step ran, so not a bare ERROR
     assert result.steps[-1].observation.is_error
+
+
+def test_episode_wall_budget_returns_partial_usage_and_budget_stop() -> None:
+    ch = _TimedWaitChannel(
+        [
+            {"type": "llm_request", "req_id": 1, "openai_body": {}},
+            {"type": "tool_request", "req_id": 2, "name": "bash", "arguments": {}},
+        ]
+    )
+    env = _Env()
+    result = RunnerLink(
+        ch,
+        worker_fn=lambda request: _completion("working", input_tokens=11, output_tokens=3),
+        episode_timeout_s=0.01,
+    ).run("t1", "x", env, tools=_tools())
+
+    assert result.stop_reason is StopReason.BUDGET
+    assert result.worker_usage is not None
+    assert result.worker_usage.calls == 1
+    assert result.worker_usage.input_tokens == 11
+    assert [action.name for action in env.actions] == ["bash"]
+    assert "ran bash" in result.transcript()
+    assert "wall budget" in result.transcript()
+    assert ch.recv_timeouts[-1] is not None
+
+
+def test_cooperative_cancellation_interrupts_a_timed_runner_wait() -> None:
+    checks = 0
+
+    def should_cancel() -> bool:
+        nonlocal checks
+        checks += 1
+        return checks >= 4
+
+    ch = _TimedWaitChannel([])
+    with pytest.raises(RuntimeCancelled, match="cancelled"):
+        RunnerLink(
+            ch,
+            worker_fn=lambda request: _completion(),
+            episode_timeout_s=60,
+            should_cancel=should_cancel,
+            cancel_poll_interval_s=0.01,
+        ).run("t1", "x", _Env(), tools=_tools())
+
+    assert ch.recv_timeouts == [0.01]
 
 
 def test_episode_error_frame_reports_error() -> None:
@@ -260,7 +454,14 @@ def test_multiple_episodes_over_one_channel() -> None:
 def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
     import os as _os
 
-    from wmh.harness.doc import RUNTIME_KIND_ID, TOOL_POLICY_ID, HarnessDoc, Surface, SurfaceKind
+    from wmh.harness.doc import (
+        MAX_TURNS_ID,
+        RUNTIME_KIND_ID,
+        TOOL_POLICY_ID,
+        HarnessDoc,
+        Surface,
+        SurfaceKind,
+    )
     from wmh.harness.runner_link import RunnerLink, set_active_channel
     from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 
@@ -285,6 +486,7 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
         ],
     )
@@ -299,7 +501,9 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
         except RuntimeError as exc:
             assert "no active runner channel" in str(exc)
         set_active_channel(_FakeChannel([]))
-        assert isinstance(doc.runtime(provider), RunnerLink)
+        runtime = doc.runtime(provider)
+        assert isinstance(runtime, RunnerLink)
+        assert runtime._max_turns == 7  # noqa: SLF001 - document parameter reaches the link frame
     finally:
         set_active_channel(None)
         if prev is None:

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -362,15 +362,19 @@ def test_cancellation_during_worker_call_suppresses_the_llm_response() -> None:
         nonlocal cancelled
         del request
         cancelled = True
-        return _completion()
+        return _completion(input_tokens=17, output_tokens=5)
 
     ch = _FakeChannel([{"type": "llm_request", "req_id": 1, "openai_body": {}}])
-    with pytest.raises(RuntimeCancelled, match="cancelled"):
+    with pytest.raises(RuntimeCancelled, match="cancelled") as raised:
         RunnerLink(ch, worker_fn=worker, should_cancel=lambda: cancelled).run(
             "t1", "x", _Env(), tools=_tools()
         )
 
     assert _sent(ch, "llm_response") == []
+    assert raised.value.worker_usage is not None
+    assert raised.value.worker_usage.input_tokens == 17
+    assert raised.value.worker_usage.output_tokens == 5
+    assert raised.value.worker_usage.calls == 1
 
 
 def test_wall_deadline_during_worker_call_suppresses_the_llm_response(

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -54,6 +54,16 @@ _NUDGE = (
 )
 
 
+class RuntimeCancelled(RuntimeError):
+    """The caller cancelled an in-flight runtime episode.
+
+    This is deliberately distinct from a normal ``RunResult`` stop reason: evaluation must not
+    send cancelled cells to a judge, and transport owners must not retry them as infrastructure
+    failures. Runtimes that cannot interrupt an active provider call raise this immediately after
+    that bounded call returns.
+    """
+
+
 @runtime_checkable
 class Runtime(Protocol):
     """What closed-loop eval drives: any object that can run one episode against an environment.

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -61,18 +61,22 @@ _NUDGE = (
 class HarnessSearchCancelled(RuntimeError):
     """The caller requested that an optimizer search stop before its next costly phase.
 
-    ``sandbox_usage`` is populated by ``create_harness`` after its evaluator
-    pool has been closed, so a caller can persist already-incurred E2B spend
-    even though cancellation intentionally produces no partial search result.
+    ``worker_usage`` aggregates every completed score wave plus the partial
+    wave interrupted by cancellation. ``sandbox_usage`` is populated by
+    ``create_harness`` after its evaluator pool has been closed. Together they
+    let a caller persist already-incurred runtime spend even though
+    cancellation intentionally produces no partial search result.
     """
 
     def __init__(
         self,
         message: str = "harness search cancelled",
         *,
+        worker_usage: TokenUsage | None = None,
         sandbox_usage: SandboxUsage | None = None,
     ) -> None:
         super().__init__(message)
+        self.worker_usage = worker_usage
         self.sandbox_usage = sandbox_usage
 
 
@@ -82,8 +86,19 @@ class RuntimeCancelled(RuntimeError):
     This is deliberately distinct from a normal ``RunResult`` stop reason: evaluation must not
     send cancelled cells to a judge, and transport owners must not retry them as infrastructure
     failures. Runtimes that cannot interrupt an active provider call raise this immediately after
-    that bounded call returns.
+    that bounded call returns. Self-metering runtimes attach the worker tokens
+    incurred before that boundary so an owning evaluator can aggregate them
+    while it drains sibling episodes.
     """
+
+    def __init__(
+        self,
+        message: str = "runtime episode cancelled",
+        *,
+        worker_usage: TokenUsage | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.worker_usage = worker_usage
 
 
 @runtime_checkable

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -54,6 +54,10 @@ _NUDGE = (
 )
 
 
+class HarnessSearchCancelled(RuntimeError):
+    """The caller requested that an optimizer search stop before its next costly phase."""
+
+
 class RuntimeCancelled(RuntimeError):
     """The caller cancelled an in-flight runtime episode.
 

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -42,6 +42,9 @@ Work in small, verifiable steps: inspect state, act, check the result, then cont
 task is done, call `submit` with your answer. Prefer composing small bash commands over guessing."""
 
 DEFAULT_MAX_TURNS = 20  # small shell tasks converge well before this; raise for longer horizons
+# Per-call output budget used by the pi runtimes. This remains separate from the turn cap: a
+# reasoning model can exhaust one response before it emits a tool call even when many turns remain.
+DEFAULT_MAX_OUTPUT_TOKENS = 4096
 
 # Per-observation cap in the judge-facing transcript. Generous rather than tight: gold evidence
 # routinely lives deep in long outputs (`cat` of a produced file, `ls -R`), and truncating it away

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -18,6 +18,7 @@ from typing import Protocol, runtime_checkable
 from pydantic import BaseModel, Field
 
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step
+from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.environment import AgentEnvironment, is_env_action
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import (
@@ -58,7 +59,21 @@ _NUDGE = (
 
 
 class HarnessSearchCancelled(RuntimeError):
-    """The caller requested that an optimizer search stop before its next costly phase."""
+    """The caller requested that an optimizer search stop before its next costly phase.
+
+    ``sandbox_usage`` is populated by ``create_harness`` after its evaluator
+    pool has been closed, so a caller can persist already-incurred E2B spend
+    even though cancellation intentionally produces no partial search result.
+    """
+
+    def __init__(
+        self,
+        message: str = "harness search cancelled",
+        *,
+        sandbox_usage: SandboxUsage | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.sandbox_usage = sandbox_usage
 
 
 class RuntimeCancelled(RuntimeError):

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -28,6 +28,7 @@ import tomli_w
 from wmh.config.store import validate_name
 from wmh.harness.doc import (
     CODE_RUNTIME_ID,
+    MAX_OUTPUT_TOKENS_ID,
     MAX_TURNS_ID,
     RUNTIME_KIND_ID,
     TEMPERATURE_ID,
@@ -168,6 +169,7 @@ def _render(doc: HarnessDoc) -> dict[str, str]:
                 "harness": {
                     "tools": doc.tools(),
                     "max_turns": doc.max_turns(),
+                    "max_output_tokens": doc.max_output_tokens(),
                     "temperature": doc.temperature(),
                     "runtime_kind": doc.runtime_kind(),
                 }
@@ -220,6 +222,14 @@ def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
         if "max_turns" in config:
             surfaces.append(
                 Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(config["max_turns"]))
+            )
+        if "max_output_tokens" in config:
+            surfaces.append(
+                Surface(
+                    id=MAX_OUTPUT_TOKENS_ID,
+                    kind=SurfaceKind.PARAM,
+                    content=str(config["max_output_tokens"]),
+                )
             )
         if "temperature" in config:
             surfaces.append(

--- a/wmh/harness/store_test.py
+++ b/wmh/harness/store_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.doc import MAX_OUTPUT_TOKENS_ID, HarnessDoc, Surface, SurfaceKind
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 
 
@@ -84,7 +84,27 @@ def test_hand_authored_dir_without_doc_json_loads(tmp_path: Path) -> None:
     assert doc.system_prompt() == "You are careful."
     assert doc.tools() == ["bash", "submit"]
     assert doc.max_turns() == 7
+    assert doc.max_output_tokens() == 4096  # old exports keep the runtime default
     assert doc.temperature() == 0.2
+
+
+def test_model_output_budget_renders_and_reparses_without_doc_json(tmp_path: Path) -> None:
+    """The editable Pi model budget survives the portable config.toml representation."""
+    base = HarnessDoc.baseline("budgeted")
+    doc = HarnessDoc(
+        name="budgeted",
+        surfaces=[
+            *base.surfaces,
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
+        ],
+    )
+    store = HarnessStore(tmp_path)
+    saved = store.save_version(doc)
+    version_dir = store.dir_for(doc.name) / f"v{saved.version}"
+    assert "max_output_tokens = 16384" in (version_dir / "config.toml").read_text()
+
+    (version_dir / "doc.json").unlink()
+    assert store.load(doc.name).max_output_tokens() == 16384
 
 
 def test_list_names_only_counts_dirs_with_versions(tmp_path: Path) -> None:
@@ -164,7 +184,7 @@ def test_pi_node_source_tree_renders_and_round_trips(tmp_path: Path) -> None:
     assert store.load("pi").doc_hash == doc.doc_hash
     # Without it, the rendered tree still reconstructs a pi-node harness with the identical code
     # files (id + path + content). The full doc hash need not match — config.toml materializes the
-    # effective max-turns/temperature the sparse doc omitted — but the source tree is preserved.
+    # effective scalar defaults the sparse doc omitted — but the source tree is preserved.
     (version_dir / "doc.json").unlink()
     reloaded = store.load("pi")
     assert reloaded.runtime_kind() == "pi-node"

--- a/wmh/providers/_responses_common.py
+++ b/wmh/providers/_responses_common.py
@@ -1,0 +1,472 @@
+"""Shared structured request and response translation for OpenAI's Responses API.
+
+The agent runtime speaks the OpenAI-compatible Chat Completions shape because that is pi's
+transport contract. Responses is a different wire protocol: assistant tool calls and tool
+results are top-level input items, tool definitions are flat, and output tokens use a different
+field name. This module is the single stateless bridge between those contracts.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from llm_waterfall import ChatRequest, ChatResponse
+from pydantic import JsonValue
+
+
+def responses_request(
+    request: ChatRequest,
+    model: str,
+    *,
+    reasoning_effort: str | None = None,
+    service_tier: str | None = None,
+    allow_sampling: bool = True,
+) -> dict[str, object]:
+    """Translate one structured chat request into a native Responses API payload.
+
+    Args:
+        request: Validated OpenAI-compatible request emitted by the agent runtime.
+        model: Provider-controlled model or deployment name.
+        reasoning_effort: Provider-controlled reasoning effort. Caller request extras cannot
+            override this value.
+        service_tier: Provider-controlled service tier. Caller request extras cannot override
+            this value.
+        allow_sampling: Whether compatible non-reasoning models may receive ``temperature`` and
+            ``top_p`` from the agent request.
+
+    Returns:
+        Keyword arguments suitable for ``client.responses.create``.
+
+    Raises:
+        ValueError: If the request contains a non-text message or malformed structured option.
+    """
+    payload: dict[str, object] = {
+        "model": model,
+        "input": _responses_input(request),
+        # pi asks its OpenAI-compatible endpoint for a stream. The Python runtime needs one
+        # complete Response object, so the provider boundary deliberately terminates streaming.
+        "stream": False,
+        # Stateless replay is the harness contract and avoids accumulating provider-side state.
+        "store": _boolean_extra(request, "store", default=False),
+        # The adapter reconstructs every turn from chat history instead of using a prior response
+        # id. Request the opaque reasoning payload even when the caller leaves effort at the model
+        # default, since reasoning models still need that item replayed before their tool calls.
+        "include": ["reasoning.encrypted_content"],
+    }
+
+    max_output_tokens = (
+        request.max_completion_tokens
+        if request.max_completion_tokens is not None
+        else request.max_tokens
+    )
+    if max_output_tokens is not None:
+        payload["max_output_tokens"] = max_output_tokens
+
+    parallel_tool_calls = _optional_boolean_extra(request, "parallel_tool_calls")
+    if parallel_tool_calls is not None:
+        payload["parallel_tool_calls"] = parallel_tool_calls
+
+    if request.tool_choice is not None:
+        payload["tool_choice"] = _responses_tool_choice(request.tool_choice)
+
+    if request.tools:
+        payload["tools"] = [
+            {
+                "type": "function",
+                "name": tool.function.name,
+                "description": tool.function.description,
+                "parameters": tool.function.parameters,
+                **({"strict": tool.function.strict} if tool.function.strict is not None else {}),
+            }
+            for tool in request.tools
+        ]
+
+    if reasoning_effort is not None:
+        payload["reasoning"] = {"effort": reasoning_effort}
+    elif allow_sampling:
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        top_p = _optional_number_extra(request, "top_p")
+        if top_p is not None:
+            payload["top_p"] = top_p
+
+    if service_tier is not None:
+        payload["service_tier"] = service_tier
+    return payload
+
+
+def responses_response(raw: dict[str, object]) -> ChatResponse:
+    """Translate one native Responses object into the structured chat response contract.
+
+    Args:
+        raw: JSON-mode dump of an OpenAI SDK ``Response``.
+
+    Returns:
+        A single-choice response consumable by the pi OpenAI-compatible bridge.
+
+    Raises:
+        ValueError: If a failed response or malformed function call cannot be represented safely.
+    """
+    _require_completed_response(raw)
+
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, object]] = []
+    reasoning_details: list[dict[str, str]] = []
+    pending_reasoning: list[dict[str, object]] = []
+    recognized_output = False
+    output = raw.get("output")
+    if not isinstance(output, list):
+        raise ValueError("Responses API completed without an output array")
+    for item_value in output:
+        item = _object_dict(item_value)
+        if item is None:
+            raise ValueError("Responses API output item must be an object")
+        _require_completed_output_item(item)
+        item_type = item.get("type")
+        if item_type == "reasoning":
+            pending_reasoning.append(item)
+        elif item_type == "message":
+            recognized_output = True
+            _append_message_text(item, text_parts)
+        elif item_type == "function_call":
+            recognized_output = True
+            tool_call = _chat_tool_call(item)
+            call_id = cast("str", tool_call["id"])
+            if pending_reasoning:
+                reasoning_details.append(_encrypted_reasoning_detail(pending_reasoning, call_id))
+            pending_reasoning.clear()
+            tool_calls.append(tool_call)
+        else:
+            raise ValueError(f"unsupported Responses output item type {item_type!r}")
+    if not recognized_output:
+        raise ValueError("Responses API completed without a message or function call")
+
+    message: dict[str, object] = {
+        "role": "assistant",
+        "content": "".join(text_parts),
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning_details:
+        # Pi's OpenAI-completions parser stores each opaque detail on the matching tool call's
+        # thoughtSignature and re-emits it in the next request's assistant message.
+        message["reasoning_details"] = reasoning_details
+
+    response: dict[str, object] = {
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": _finish_reason(raw, has_tool_calls=bool(tool_calls)),
+            }
+        ]
+    }
+    model = raw.get("model")
+    if isinstance(model, str):
+        response["model"] = model
+
+    usage = _object_dict(raw.get("usage"))
+    if usage is not None:
+        response["usage"] = {
+            "prompt_tokens": _usage_count(usage.get("input_tokens")),
+            "completion_tokens": _usage_count(usage.get("output_tokens")),
+        }
+
+    service_tier = raw.get("service_tier")
+    if isinstance(service_tier, str):
+        response["service_tier"] = service_tier
+    return ChatResponse.model_validate(response)
+
+
+def complete_chat(
+    responses: object,
+    model: str,
+    request: ChatRequest,
+    *,
+    reasoning_effort: str | None = None,
+    service_tier: str | None = None,
+    allow_sampling: bool = True,
+) -> ChatResponse:
+    """Run a structured chat turn against an OpenAI SDK Responses resource.
+
+    Args:
+        responses: ``client.responses`` from either OpenAI or an OpenAI-compatible client.
+        model: Provider-controlled model or deployment name.
+        request: Validated structured request from the agent runtime.
+        reasoning_effort: Provider-controlled reasoning effort.
+        service_tier: Provider-controlled service tier.
+        allow_sampling: Whether compatible non-reasoning models may receive sampling fields.
+
+    Returns:
+        Provider-neutral structured chat response.
+    """
+    # OpenAI models create() as a broad TypedDict union whose exact surface changes between SDK
+    # releases. The payload is validated by the narrow translation above, so keep that churn at
+    # this one SDK boundary instead of leaking Any through the runtime contract.
+    resource = cast("Any", responses)
+    sdk_response = resource.create(
+        **responses_request(
+            request,
+            model,
+            reasoning_effort=reasoning_effort,
+            service_tier=service_tier,
+            allow_sampling=allow_sampling,
+        )
+    )
+    raw = cast("dict[str, object]", sdk_response.model_dump(mode="json"))
+    return responses_response(raw)
+
+
+def _responses_input(request: ChatRequest) -> list[dict[str, object]]:
+    """Translate ordered chat history into stateless Responses input items."""
+    items: list[dict[str, object]] = []
+    for message in request.messages:
+        if message.role == "tool":
+            if message.tool_call_id is None:
+                raise ValueError("Responses tool result requires tool_call_id")
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message.tool_call_id,
+                    "output": _chat_text(message.content) or "",
+                }
+            )
+            continue
+
+        text = _chat_text(message.content)
+        if text is not None:
+            items.append({"role": message.role, "content": text})
+
+        if message.role != "assistant" and message.tool_calls:
+            raise ValueError("Responses function calls must belong to an assistant message")
+        reasoning_by_call = _reasoning_items_by_call(message)
+        replayed_reasoning_ids: set[str] = set()
+        for tool_call in message.tool_calls or []:
+            for reasoning in reasoning_by_call.get(tool_call.id, []):
+                reasoning_id = cast("str", reasoning["id"])
+                if reasoning_id not in replayed_reasoning_ids:
+                    items.append(reasoning)
+                    replayed_reasoning_ids.add(reasoning_id)
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": tool_call.id,
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                }
+            )
+    return items
+
+
+def _reasoning_items_by_call(message: object) -> dict[str, list[dict[str, object]]]:
+    """Decode Pi's opaque thought signatures into validated Responses reasoning items."""
+    extras = getattr(message, "model_extra", None)
+    if not isinstance(extras, dict) or extras.get("reasoning_details") is None:
+        return {}
+    details = extras["reasoning_details"]
+    if not isinstance(details, list):
+        raise ValueError("Responses reasoning_details must be an array")
+    calls = getattr(message, "tool_calls", None) or []
+    call_ids = {call.id for call in calls}
+    by_call: dict[str, list[dict[str, object]]] = {}
+    for detail_value in details:
+        detail = _object_dict(detail_value)
+        if detail is None:
+            raise ValueError("Responses reasoning detail must be an object")
+        if detail.get("type") != "reasoning.encrypted":
+            continue
+        call_id = detail.get("id")
+        data = detail.get("data")
+        if not isinstance(call_id, str) or call_id not in call_ids:
+            raise ValueError("encrypted Responses reasoning detail has no matching tool call")
+        if not isinstance(data, str):
+            raise ValueError("encrypted Responses reasoning detail data must be JSON text")
+        try:
+            decoded = json.loads(data)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "encrypted Responses reasoning detail contains invalid JSON"
+            ) from error
+        decoded_items = decoded if isinstance(decoded, list) else [decoded]
+        if not decoded_items:
+            raise ValueError("encrypted Responses reasoning detail contains no reasoning items")
+        by_call.setdefault(call_id, []).extend(
+            _validated_reasoning_item(item) for item in decoded_items
+        )
+    return by_call
+
+
+def _chat_text(content: JsonValue) -> str | None:
+    """Flatten the text-only content forms emitted by OpenAI-compatible agent SDKs."""
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block_value in content:
+            block = _object_dict(block_value)
+            if block is None or not isinstance(block.get("text"), str):
+                raise ValueError("Responses adapter supports text chat content only")
+            parts.append(cast("str", block["text"]))
+        return "".join(parts)
+    raise ValueError("Responses adapter supports text chat content only")
+
+
+def _responses_tool_choice(choice: JsonValue) -> object:
+    """Translate Chat Completions tool choice into the Responses API shape."""
+    if isinstance(choice, str):
+        if choice not in ("auto", "none", "required"):
+            raise ValueError(f"unsupported Responses tool_choice {choice!r}")
+        return choice
+    choice_dict = _object_dict(choice)
+    if choice_dict is None or choice_dict.get("type") != "function":
+        raise ValueError("Responses tool_choice must name a function or use auto/none/required")
+    function = _object_dict(choice_dict.get("function"))
+    name = function.get("name") if function is not None else choice_dict.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("Responses function tool_choice requires a name")
+    return {"type": "function", "name": name}
+
+
+def _append_message_text(item: dict[str, object], parts: list[str]) -> None:
+    """Append native output-text blocks from one Responses message item."""
+    content = item.get("content")
+    if not isinstance(content, list):
+        raise ValueError("Responses message output content must be an array")
+    for block_value in content:
+        block = _object_dict(block_value)
+        if block is None:
+            raise ValueError("Responses message content block must be an object")
+        if block.get("type") == "output_text" and isinstance(block.get("text"), str):
+            parts.append(cast("str", block["text"]))
+        elif block.get("type") == "refusal" and isinstance(block.get("refusal"), str):
+            parts.append(cast("str", block["refusal"]))
+        else:
+            raise ValueError(f"unsupported Responses message block type {block.get('type')!r}")
+
+
+def _chat_tool_call(item: dict[str, object]) -> dict[str, object]:
+    """Map one native Responses function call while preserving its exact call id."""
+    call_id = item.get("call_id")
+    name = item.get("name")
+    arguments = item.get("arguments")
+    if not isinstance(call_id, str) or not call_id:
+        raise ValueError("Responses function_call is missing call_id")
+    if not isinstance(name, str) or not name:
+        raise ValueError("Responses function_call is missing name")
+    if not isinstance(arguments, str):
+        raise ValueError("Responses function_call arguments must be a JSON string")
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _validated_reasoning_item(value: object) -> dict[str, object]:
+    """Return the safe stateless subset of one encrypted Responses reasoning item."""
+    item = _object_dict(value)
+    if item is None or item.get("type") != "reasoning":
+        raise ValueError("encrypted Responses reasoning data is not a reasoning item")
+    item_id = item.get("id")
+    encrypted_content = item.get("encrypted_content")
+    summary = item.get("summary", [])
+    if not isinstance(item_id, str) or not item_id:
+        raise ValueError("encrypted Responses reasoning item is missing id")
+    if not isinstance(encrypted_content, str) or not encrypted_content:
+        raise ValueError("Responses reasoning item is missing encrypted_content")
+    if not isinstance(summary, list):
+        raise ValueError("Responses reasoning item summary must be an array")
+    return {
+        "type": "reasoning",
+        "id": item_id,
+        "summary": summary,
+        "encrypted_content": encrypted_content,
+    }
+
+
+def _encrypted_reasoning_detail(items: list[dict[str, object]], call_id: str) -> dict[str, str]:
+    """Pack ordered native reasoning items into Pi's one thoughtSignature per tool call."""
+    validated = [_validated_reasoning_item(item) for item in items]
+    return {
+        "type": "reasoning.encrypted",
+        "id": call_id,
+        "data": json.dumps(validated, separators=(",", ":"), sort_keys=True),
+    }
+
+
+def _require_completed_response(raw: dict[str, object]) -> None:
+    """Reject every non-completed top-level status before exposing partial tool calls."""
+    status = raw.get("status")
+    if status == "completed":
+        return
+    if status == "incomplete":
+        details = _object_dict(raw.get("incomplete_details"))
+        reason = details.get("reason") if details is not None else None
+        raise ValueError(
+            f"Responses API returned incomplete response: {reason or 'unknown reason'}"
+        )
+    error = _object_dict(raw.get("error"))
+    diagnostics: list[str] = []
+    if error is not None:
+        code = error.get("code")
+        message = error.get("message")
+        if isinstance(code, str) and code:
+            diagnostics.append(f"code={code}")
+        if isinstance(message, str) and message:
+            diagnostics.append(f"message={message}")
+    suffix = f" ({', '.join(diagnostics)})" if diagnostics else ""
+    raise ValueError(f"Responses API returned non-completed status {status!r}{suffix}")
+
+
+def _require_completed_output_item(item: dict[str, object]) -> None:
+    """Reject partial output items even on an otherwise malformed completed response."""
+    status = item.get("status")
+    if status not in (None, "completed"):
+        raise ValueError(
+            f"Responses API returned {item.get('type')!r} output with status {status!r}"
+        )
+
+
+def _finish_reason(raw: dict[str, object], *, has_tool_calls: bool) -> str:
+    """Map Responses status metadata to the OpenAI-compatible finish reason."""
+    del raw
+    return "tool_calls" if has_tool_calls else "stop"
+
+
+def _object_dict(value: object) -> dict[str, object] | None:
+    """Narrow a JSON object without imposing mutable mapping APIs on callers."""
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _usage_count(value: object) -> int:
+    """Read a non-boolean integer usage counter, defaulting absent values to zero."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _boolean_extra(request: ChatRequest, name: str, *, default: bool) -> bool:
+    """Read and validate one boolean extra from the forward-compatible request surface."""
+    value = (request.model_extra or {}).get(name, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"Responses {name} must be a boolean")
+    return value
+
+
+def _optional_boolean_extra(request: ChatRequest, name: str) -> bool | None:
+    """Read one optional boolean request extra."""
+    extras = request.model_extra or {}
+    if name not in extras or extras[name] is None:
+        return None
+    return _boolean_extra(request, name, default=False)
+
+
+def _optional_number_extra(request: ChatRequest, name: str) -> float | int | None:
+    """Read one optional non-boolean numeric request extra."""
+    value = (request.model_extra or {}).get(name)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Responses {name} must be numeric")
+    return value

--- a/wmh/providers/_responses_common_test.py
+++ b/wmh/providers/_responses_common_test.py
@@ -1,0 +1,435 @@
+"""Tests for provider-neutral structured Responses API translation."""
+
+import json
+
+import pytest
+from llm_waterfall import ChatRequest
+
+from wmh.providers._responses_common import (
+    responses_request,
+    responses_response,
+)
+
+
+def test_responses_request_translates_exact_pi_first_turn() -> None:
+    """The pi bridge request becomes a native, non-streaming Responses call."""
+    request = ChatRequest.model_validate(
+        {
+            "model": "worker",
+            "messages": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            ],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "store": False,
+            "max_completion_tokens": 4096,
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "parallel_tool_calls": True,
+            "tool_choice": "required",
+            "reasoning": {"effort": "minimal"},
+            "service_tier": "flex",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "read",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                            "required": ["path"],
+                        },
+                        "strict": False,
+                    },
+                }
+            ],
+        }
+    )
+
+    payload = responses_request(
+        request,
+        "gpt-5.5-deployment",
+        reasoning_effort="high",
+        service_tier="priority",
+    )
+
+    assert payload == {
+        "model": "gpt-5.5-deployment",
+        "input": [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "go"},
+        ],
+        "stream": False,
+        "store": False,
+        "max_output_tokens": 4096,
+        "parallel_tool_calls": True,
+        "tool_choice": "required",
+        "reasoning": {"effort": "high"},
+        "include": ["reasoning.encrypted_content"],
+        "service_tier": "priority",
+        "tools": [
+            {
+                "type": "function",
+                "name": "read_file",
+                "description": "read",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+                "strict": False,
+            }
+        ],
+    }
+    assert "messages" not in payload
+    assert "max_completion_tokens" not in payload
+    assert "stream_options" not in payload
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+
+
+def test_responses_request_translates_tool_result_turn_with_exact_call_id() -> None:
+    """A stateless replay preserves the assistant call and matching tool result."""
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "system"},
+                {"role": "developer", "content": "be concise"},
+                {"role": "user", "content": [{"type": "text", "text": "go"}]},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-abc",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"x"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "contents", "tool_call_id": "call-abc"},
+            ],
+            "max_tokens": 512,
+            "store": True,
+            "temperature": 0.25,
+            "top_p": 0.8,
+            "tool_choice": {"type": "function", "function": {"name": "read_file"}},
+        }
+    )
+
+    payload = responses_request(request, "gpt-5.5")
+
+    assert payload == {
+        "model": "gpt-5.5",
+        "input": [
+            {"role": "system", "content": "system"},
+            {"role": "developer", "content": "be concise"},
+            {"role": "user", "content": "go"},
+            {
+                "type": "function_call",
+                "call_id": "call-abc",
+                "name": "read_file",
+                "arguments": '{"path":"x"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call-abc",
+                "output": "contents",
+            },
+        ],
+        "stream": False,
+        "store": True,
+        "include": ["reasoning.encrypted_content"],
+        "max_output_tokens": 512,
+        "temperature": 0.25,
+        "top_p": 0.8,
+        "tool_choice": {"type": "function", "name": "read_file"},
+    }
+
+
+def test_responses_response_preserves_text_multiple_tools_usage_and_tier() -> None:
+    """Native Responses output maps back to one OpenAI-compatible chat choice."""
+    response = responses_response(
+        {
+            "id": "resp-1",
+            "model": "gpt-5.5-2026-05-01",
+            "status": "completed",
+            "service_tier": "priority",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "ciphertext-1",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {"type": "output_text", "text": "Checking "},
+                        {"type": "output_text", "text": "both."},
+                    ],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-a",
+                    "name": "read_file",
+                    "arguments": '{"path":"a"}',
+                    "status": "completed",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-b",
+                    "name": "read_file",
+                    "arguments": '{"path":"b"}',
+                    "status": "completed",
+                },
+            ],
+            "usage": {
+                "input_tokens": 321,
+                "output_tokens": 45,
+                "total_tokens": 366,
+            },
+        }
+    )
+
+    assert response.model == "gpt-5.5-2026-05-01"
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 321
+    assert response.usage.completion_tokens == 45
+    assert response.wire_payload()["service_tier"] == "priority"
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == "Checking both."
+    assert choice.message.tool_calls is not None
+    assert [call.id for call in choice.message.tool_calls] == ["call-a", "call-b"]
+    assert [call.function.name for call in choice.message.tool_calls] == [
+        "read_file",
+        "read_file",
+    ]
+    assert [call.function.arguments for call in choice.message.tool_calls] == [
+        '{"path":"a"}',
+        '{"path":"b"}',
+    ]
+    details = choice.message.model_extra
+    assert details is not None
+    assert details["reasoning_details"] == [
+        {
+            "type": "reasoning.encrypted",
+            "id": "call-a",
+            "data": json.dumps(
+                [
+                    {
+                        "type": "reasoning",
+                        "id": "reasoning-1",
+                        "summary": [],
+                        "encrypted_content": "ciphertext-1",
+                    }
+                ],
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        }
+    ]
+
+
+def test_ordered_encrypted_reasoning_round_trips_through_pi_chat_history() -> None:
+    """A stateless second turn replays every ordered reasoning item through Pi once."""
+    first = responses_response(
+        {
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "ciphertext-1",
+                },
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-2",
+                    "summary": [{"type": "summary_text", "text": "second"}],
+                    "encrypted_content": "ciphertext-2",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-a",
+                    "name": "read_file",
+                    "arguments": '{"path":"a"}',
+                    "status": "completed",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-b",
+                    "name": "read_file",
+                    "arguments": '{"path":"b"}',
+                    "status": "completed",
+                },
+            ],
+        }
+    )
+    wire_choices = first.wire_payload()["choices"]
+    assert isinstance(wire_choices, list)
+    wire_choice = wire_choices[0]
+    assert isinstance(wire_choice, dict)
+    assistant = wire_choice["message"]
+    assert isinstance(assistant, dict)
+    reasoning_details = assistant["reasoning_details"]
+    assert isinstance(reasoning_details, list)
+    assert len(reasoning_details) == 1
+    detail = reasoning_details[0]
+    assert isinstance(detail, dict)
+    data = detail["data"]
+    assert isinstance(data, str)
+    assert [item["id"] for item in json.loads(data)] == ["reasoning-1", "reasoning-2"]
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "inspect"},
+                assistant,
+                {"role": "tool", "tool_call_id": "call-a", "content": "A"},
+                {"role": "tool", "tool_call_id": "call-b", "content": "B"},
+            ],
+            "store": False,
+        }
+    )
+
+    payload = responses_request(request, "gpt-5.5", reasoning_effort="high")
+
+    assert payload["input"] == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": ""},
+        {
+            "type": "reasoning",
+            "id": "reasoning-1",
+            "summary": [],
+            "encrypted_content": "ciphertext-1",
+        },
+        {
+            "type": "reasoning",
+            "id": "reasoning-2",
+            "summary": [{"type": "summary_text", "text": "second"}],
+            "encrypted_content": "ciphertext-2",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call-a",
+            "name": "read_file",
+            "arguments": '{"path":"a"}',
+        },
+        {
+            "type": "function_call",
+            "call_id": "call-b",
+            "name": "read_file",
+            "arguments": '{"path":"b"}',
+        },
+        {"type": "function_call_output", "call_id": "call-a", "output": "A"},
+        {"type": "function_call_output", "call_id": "call-b", "output": "B"},
+    ]
+    assert payload["include"] == ["reasoning.encrypted_content"]
+
+
+def test_duplicate_parallel_reasoning_details_replay_once() -> None:
+    """Pi/provider compatibility duplicates cannot multiply a large encrypted trace."""
+    reasoning = {
+        "type": "reasoning",
+        "id": "reasoning-1",
+        "summary": [],
+        "encrypted_content": "ciphertext-1",
+    }
+    data = json.dumps(reasoning, separators=(",", ":"), sort_keys=True)
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-a",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        },
+                        {
+                            "id": "call-b",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        },
+                    ],
+                    "reasoning_details": [
+                        {"type": "reasoning.encrypted", "id": "call-a", "data": data},
+                        {"type": "reasoning.encrypted", "id": "call-b", "data": data},
+                    ],
+                }
+            ]
+        }
+    )
+
+    payload = responses_request(request, "gpt-5.5", reasoning_effort="high")
+
+    inputs = payload["input"]
+    assert isinstance(inputs, list)
+    assert sum(item == reasoning for item in inputs) == 1
+
+
+@pytest.mark.parametrize("status", [None, "queued", "in_progress", "cancelled", "unknown"])
+def test_non_completed_responses_fail_closed(status: str | None) -> None:
+    with pytest.raises(ValueError, match="non-completed status"):
+        responses_response({"status": status, "output": []})
+
+
+def test_failed_response_includes_provider_diagnostics() -> None:
+    with pytest.raises(ValueError, match="code=bad_request, message=invalid tool"):
+        responses_response(
+            {
+                "status": "failed",
+                "error": {"code": "bad_request", "message": "invalid tool"},
+                "output": [],
+            }
+        )
+
+
+def test_incomplete_response_never_exposes_a_partial_tool_call() -> None:
+    with pytest.raises(ValueError, match="incomplete response: max_output_tokens"):
+        responses_response(
+            {
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call-1",
+                        "name": "write_file",
+                        "arguments": "{",
+                        "status": "incomplete",
+                    }
+                ],
+            }
+        )
+
+
+def test_completed_response_rejects_an_incomplete_output_item() -> None:
+    with pytest.raises(ValueError, match="output with status 'incomplete'"):
+        responses_response(
+            {
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call-1",
+                        "name": "write_file",
+                        "arguments": "{",
+                        "status": "incomplete",
+                    }
+                ],
+            }
+        )
+
+
+def test_completed_response_requires_recognized_output() -> None:
+    with pytest.raises(ValueError, match="without a message or function call"):
+        responses_response({"status": "completed", "output": []})

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -22,6 +22,7 @@ from wmh.providers.base import (
     Message,
     ProviderConfig,
     VerifyResult,
+    normalize_chat_temperature,
     verify_via_ping,
 )
 
@@ -35,6 +36,7 @@ class AzureOpenAIProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: AzureOpenAI | None = None
+        self._forward_temperature = config.resolved_chat_forward_temperature()
 
     def _get_client(self) -> AzureOpenAI:
         # Lazy: construct on first use. api_version must be supplied by config; the endpoint and
@@ -100,6 +102,10 @@ class AzureOpenAIProvider:
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         """Run a full structured request on the configured Azure deployment."""
+        request = normalize_chat_temperature(
+            request,
+            forward_temperature=self._forward_temperature,
+        )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,
             self._deployment(),

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -105,6 +105,29 @@ class ProviderConfig(BaseModel):
             fallback=self.chat_max_tokens_field,
         )
 
+    def resolved_chat_forward_temperature(self) -> bool:
+        """Return whether this configured model accepts chat temperature."""
+        # Local import avoids a module cycle: the model catalog imports ProviderKind above.
+        from wmh.providers.models import resolve_provider_model
+
+        # Explicit OpenAI-compatible endpoints are user-owned sampling servers even when their
+        # configured model label happens to match a built-in reasoning model.
+        if self.kind is ProviderKind.OPENAI and self.endpoint is not None:
+            return True
+        model = self.model_type or self.model
+        return resolve_provider_model(self.kind, model).forward_temperature
+
+
+def normalize_chat_temperature(
+    request: ChatRequest,
+    *,
+    forward_temperature: bool,
+) -> ChatRequest:
+    """Apply one model's sampling capability without mutating the provider-neutral request."""
+    if forward_temperature or request.temperature is None:
+        return request
+    return request.model_copy(update={"temperature": None})
+
 
 @runtime_checkable
 class Embedder(Protocol):

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -16,6 +16,7 @@ from wmh.providers.base import (
     ProviderConfig,
     TokenUsage,
     VerifyResult,
+    normalize_chat_temperature,
     verify_via_ping,
 )
 
@@ -81,6 +82,10 @@ class BedrockProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: BaseClient | None = None
+        # Model capability lives in WMH's canonical catalog. Subclasses may
+        # override this per concrete deployment, but every Bedrock request path
+        # consumes the same provider-boundary flag.
+        self._forward_temperature = config.resolved_chat_forward_temperature()
 
     def _get_client(self) -> BaseClient:
         # Lazy: import boto3 and open the client only on first use. region falls back to
@@ -151,7 +156,11 @@ class BedrockProvider:
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         """Run a full structured agent request through Bedrock Converse."""
-        raw = self._get_client().converse(**converse_request(request, self.config.model))
+        normalized = normalize_chat_temperature(
+            request,
+            forward_temperature=self._forward_temperature,
+        )
+        raw = self._get_client().converse(**converse_request(normalized, self.config.model))
         return converse_response(raw, self.config.model)
 
     def _complete_converse(

--- a/wmh/providers/bedrock_test.py
+++ b/wmh/providers/bedrock_test.py
@@ -6,7 +6,7 @@ import io
 import json
 from typing import TYPE_CHECKING, cast
 
-from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind
 from wmh.providers.bedrock import BedrockProvider, _is_nova
 
 if TYPE_CHECKING:
@@ -25,6 +25,21 @@ class _StubClient:
         self.model_id = modelId
         self.body = json.loads(body)
         return {"body": io.BytesIO(json.dumps(self._response).encode("utf-8"))}
+
+
+class _StubConverseClient:
+    """Captures structured Converse requests and returns one text response."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    def converse(self, **kwargs: object) -> dict[str, object]:
+        self.requests.append(kwargs)
+        return {
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 2, "outputTokens": 1},
+        }
 
 
 def test_is_nova_matches_nova_model_ids_only() -> None:
@@ -79,3 +94,51 @@ def test_nova_complete_omits_empty_system() -> None:
     provider.complete("", [Message(role="user", content="hi")])
     assert stub.body is not None
     assert "system" not in stub.body
+
+
+def test_structured_chat_normalizes_temperature_for_unsupported_model() -> None:
+    provider = BedrockProvider(
+        ProviderConfig(
+            kind=ProviderKind.BEDROCK,
+            model_type="claude-opus-4-8",
+            model="us.anthropic.claude-opus-4-8",
+        )
+    )
+    stub = _StubConverseClient()
+    provider._client = cast("BaseClient", stub)
+    request = ChatRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.3,
+            "max_completion_tokens": 64,
+        }
+    )
+
+    provider.complete_chat(request)
+
+    assert request.temperature == 0.3  # normalization does not mutate the reusable request
+    assert stub.requests[0]["inferenceConfig"] == {"maxTokens": 64}
+
+
+def test_structured_chat_preserves_temperature_for_supported_model() -> None:
+    provider = BedrockProvider(
+        ProviderConfig(
+            kind=ProviderKind.BEDROCK,
+            model_type="claude-sonnet-4-6",
+            model="us.anthropic.claude-sonnet-4-6",
+        )
+    )
+    stub = _StubConverseClient()
+    provider._client = cast("BaseClient", stub)
+
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0.3,
+                "max_completion_tokens": 64,
+            }
+        )
+    )
+
+    assert stub.requests[0]["inferenceConfig"] == {"maxTokens": 64, "temperature": 0.3}

--- a/wmh/providers/models.py
+++ b/wmh/providers/models.py
@@ -14,8 +14,10 @@ class ProviderModel(BaseModel):
     ``model_type`` is the provider-independent identity used in product and
     configuration surfaces. ``model_id`` is the provider-specific value sent
     over the wire. ``chat_max_tokens_field`` records which output-token field
-    the model accepts on OpenAI-compatible chat requests. Keeping these
-    together prevents provider details from leaking into product catalogs.
+    the model accepts on OpenAI-compatible chat requests. ``forward_temperature``
+    records whether structured chat requests may send the sampling parameter at
+    all. Keeping these together prevents provider details from leaking into
+    product catalogs.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -24,24 +26,57 @@ class ProviderModel(BaseModel):
     model_type: str
     model_id: str
     chat_max_tokens_field: ChatMaxTokensField = "max_completion_tokens"
+    forward_temperature: bool = True
 
 
 _MODELS: tuple[ProviderModel, ...] = (
-    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.5", model_id="gpt-5.5"),
-    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.5-pro", model_id="gpt-5.5-pro"),
-    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.4", model_id="gpt-5.4"),
-    ProviderModel(provider=ProviderKind.OPENAI, model_type="gpt-5.4-mini", model_id="gpt-5.4-mini"),
-    ProviderModel(provider=ProviderKind.OPENAI_RESPONSES, model_type="gpt-5.5", model_id="gpt-5.5"),
+    ProviderModel(
+        provider=ProviderKind.OPENAI,
+        model_type="gpt-5.5",
+        model_id="gpt-5.5",
+        forward_temperature=False,
+    ),
+    ProviderModel(
+        provider=ProviderKind.OPENAI,
+        model_type="gpt-5.5-pro",
+        model_id="gpt-5.5-pro",
+        forward_temperature=False,
+    ),
+    ProviderModel(
+        provider=ProviderKind.OPENAI,
+        model_type="gpt-5.4",
+        model_id="gpt-5.4",
+        forward_temperature=False,
+    ),
+    ProviderModel(
+        provider=ProviderKind.OPENAI,
+        model_type="gpt-5.4-mini",
+        model_id="gpt-5.4-mini",
+        forward_temperature=False,
+    ),
+    ProviderModel(
+        provider=ProviderKind.OPENAI_RESPONSES,
+        model_type="gpt-5.5",
+        model_id="gpt-5.5",
+        forward_temperature=False,
+    ),
     ProviderModel(
         provider=ProviderKind.OPENAI_RESPONSES,
         model_type="gpt-5.5-pro",
         model_id="gpt-5.5-pro",
+        forward_temperature=False,
     ),
-    ProviderModel(provider=ProviderKind.OPENAI_RESPONSES, model_type="gpt-5.4", model_id="gpt-5.4"),
+    ProviderModel(
+        provider=ProviderKind.OPENAI_RESPONSES,
+        model_type="gpt-5.4",
+        model_id="gpt-5.4",
+        forward_temperature=False,
+    ),
     ProviderModel(
         provider=ProviderKind.OPENAI_RESPONSES,
         model_type="gpt-5.4-mini",
         model_id="gpt-5.4-mini",
+        forward_temperature=False,
     ),
     ProviderModel(
         provider=ProviderKind.ANTHROPIC,
@@ -67,6 +102,9 @@ _MODELS: tuple[ProviderModel, ...] = (
         provider=ProviderKind.BEDROCK,
         model_type="claude-opus-4-8",
         model_id="us.anthropic.claude-opus-4-8",
+        # Opus 4.8 dropped sampling parameters. Bedrock rejects a forwarded
+        # temperature with a ValidationException instead of ignoring it.
+        forward_temperature=False,
     ),
     ProviderModel(
         provider=ProviderKind.BEDROCK,
@@ -97,12 +135,23 @@ _MODELS: tuple[ProviderModel, ...] = (
     # Azure uses deployment names at runtime. These defaults deliberately
     # match the canonical type; callers with custom deployment names override
     # ProviderConfig.deployment without changing model identity.
-    ProviderModel(provider=ProviderKind.AZURE_OPENAI, model_type="gpt-5.5", model_id="gpt-5.5"),
-    ProviderModel(provider=ProviderKind.AZURE_OPENAI, model_type="gpt-5.4", model_id="gpt-5.4"),
+    ProviderModel(
+        provider=ProviderKind.AZURE_OPENAI,
+        model_type="gpt-5.5",
+        model_id="gpt-5.5",
+        forward_temperature=False,
+    ),
+    ProviderModel(
+        provider=ProviderKind.AZURE_OPENAI,
+        model_type="gpt-5.4",
+        model_id="gpt-5.4",
+        forward_temperature=False,
+    ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,
         model_type="gpt-5.4-mini",
         model_id="gpt-5.4-mini",
+        forward_temperature=False,
     ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,

--- a/wmh/providers/models_test.py
+++ b/wmh/providers/models_test.py
@@ -14,6 +14,26 @@ def test_same_model_type_resolves_to_provider_specific_ids() -> None:
     assert bedrock.model_id == "us.anthropic.claude-opus-4-8"
 
 
+def test_model_catalog_owns_temperature_compatibility() -> None:
+    """Sampling compatibility follows the canonical model across callers."""
+    opus = resolve_provider_model(ProviderKind.BEDROCK, "claude-opus-4-8")
+    opus_runtime_id = resolve_provider_model(ProviderKind.BEDROCK, "us.anthropic.claude-opus-4-8")
+    sonnet = resolve_provider_model(ProviderKind.BEDROCK, "claude-sonnet-4-6")
+
+    assert opus.forward_temperature is False
+    assert opus_runtime_id.forward_temperature is False
+    assert sonnet.forward_temperature is True
+    assert resolve_provider_model(ProviderKind.OPENAI, "gpt-5.5").forward_temperature is False
+    assert (
+        resolve_provider_model(ProviderKind.AZURE_OPENAI, "gpt-5.4-mini").forward_temperature
+        is False
+    )
+    assert (
+        resolve_provider_model(ProviderKind.AZURE_OPENAI, "deepseek-v4-pro").forward_temperature
+        is True
+    )
+
+
 def test_runtime_id_resolves_back_to_canonical_model_type() -> None:
     """Known provider ids never become a second public model identity."""
     resolved = resolve_provider_model(
@@ -58,6 +78,16 @@ def test_unknown_custom_model_round_trips() -> None:
     assert resolved.model_type == "my-fine-tune"
     assert resolved.model_id == "my-fine-tune"
     assert resolved.chat_max_tokens_field == "max_completion_tokens"
+
+
+def test_explicit_openai_compatible_endpoint_keeps_sampling_capability() -> None:
+    config = ProviderConfig(
+        kind=ProviderKind.OPENAI,
+        model="gpt-5.5",
+        endpoint="http://localhost:8001/v1",
+    )
+
+    assert config.resolved_chat_forward_temperature() is True
 
 
 def test_provider_config_resolves_model_contract_before_custom_deployment() -> None:

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -20,6 +20,7 @@ from wmh.providers.base import (
     Message,
     ProviderConfig,
     VerifyResult,
+    normalize_chat_temperature,
     verify_via_ping,
 )
 
@@ -33,6 +34,7 @@ class OpenAIProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: OpenAI | None = None
+        self._forward_temperature = config.resolved_chat_forward_temperature()
 
     def _get_client(self) -> OpenAI:
         # Lazy: don't import the SDK or read the key env vars until first use.
@@ -85,6 +87,10 @@ class OpenAIProvider:
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         """Run a full structured request on the configured OpenAI-compatible backend."""
+        request = normalize_chat_temperature(
+            request,
+            forward_temperature=self._forward_temperature,
+        )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,
             self.config.model,

--- a/wmh/providers/openai_responses.py
+++ b/wmh/providers/openai_responses.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
 
-from wmh.providers import _openai_common
+from wmh.providers import _openai_common, _responses_common
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
+    ChatRequest,
+    ChatResponse,
     Completion,
     Message,
     ProviderConfig,
@@ -77,6 +79,16 @@ class OpenAIResponsesProvider:
                 store=False,
             )
         return Completion(text=_response_text(response), usage=_usage_from_response(response))
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        """Run a full structured request through the native Responses API."""
+        return _responses_common.complete_chat(
+            self._get_client().responses,
+            self.config.model,
+            request,
+            reasoning_effort=self.config.reasoning_effort,
+            allow_sampling=False,
+        )
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed text through OpenAI's embeddings API.

--- a/wmh/providers/openai_responses_test.py
+++ b/wmh/providers/openai_responses_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from llm_waterfall import ChatRequest
 
 from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, ProviderConfig, ProviderKind
 from wmh.providers.openai_responses import OpenAIResponsesProvider
@@ -24,6 +25,24 @@ class _FakeResponsesResponse:
         self.output_text = output_text
         self.usage = usage
         self.output = output or []
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        """Return the native Responses shape used by structured completion tests."""
+        assert mode == "json"
+        return {
+            "model": "gpt-5.5-2026-05-01",
+            "status": "completed",
+            "service_tier": "priority",
+            "output": self.output,
+            "usage": (
+                {
+                    "input_tokens": self.usage.input_tokens,
+                    "output_tokens": self.usage.output_tokens,
+                }
+                if self.usage is not None
+                else None
+            ),
+        }
 
 
 class _FakeResponses:
@@ -141,6 +160,89 @@ def test_reasoning_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     provider.complete("", [Message(role="user", content="ping")])
 
     assert "reasoning" not in responses.last_kwargs
+
+
+def test_complete_chat_uses_native_responses_resource_without_legacy_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _FakeResponsesResponse(
+        "",
+        _FakeUsage(17, 9),
+        output=[
+            {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "read_file",
+                "arguments": '{"path":"README.md"}',
+            }
+        ],
+    )
+    responses = _FakeResponses(response)
+    provider = OpenAIResponsesProvider(_config())
+    fake = type("ResponsesOnlyClient", (), {"responses": responses})()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    completion = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "model": "worker",
+                "messages": [{"role": "user", "content": "inspect"}],
+                "max_completion_tokens": 2048,
+                "store": False,
+            }
+        )
+    )
+
+    assert responses.last_kwargs == {
+        "model": "gpt-5.4-mini",
+        "input": [{"role": "user", "content": "inspect"}],
+        "stream": False,
+        "store": False,
+        "max_output_tokens": 2048,
+        "reasoning": {"effort": "low"},
+        "include": ["reasoning.encrypted_content"],
+    }
+    assert completion.choices[0].finish_reason == "tool_calls"
+    assert completion.choices[0].message.tool_calls is not None
+    assert completion.choices[0].message.tool_calls[0].id == "call-1"
+    assert completion.token_usage().input_tokens == 17
+    assert completion.wire_payload()["service_tier"] == "priority"
+
+
+def test_complete_chat_never_forwards_sampling_for_gpt5_without_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _FakeResponsesResponse(
+        "",
+        _FakeUsage(3, 2),
+        output=[
+            {
+                "type": "message",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "ok"}],
+            }
+        ],
+    )
+    responses = _FakeResponses(response)
+    provider = OpenAIResponsesProvider(
+        ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="gpt-5.5")
+    )
+    fake = type("ResponsesOnlyClient", (), {"responses": responses})()
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "go"}],
+                "temperature": 0.2,
+                "top_p": 0.8,
+            }
+        )
+    )
+
+    assert "temperature" not in responses.last_kwargs
+    assert "top_p" not in responses.last_kwargs
+    assert responses.last_kwargs["include"] == ["reasoning.encrypted_content"]
 
 
 def test_embed_uses_openai_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
-from wmh.providers.base import Message, ProviderConfig, ProviderKind
+from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind
 
 
 class _FakeMessage:
@@ -28,6 +28,22 @@ class _FakeChatResponse:
     def __init__(self, content: str, usage: _FakeUsage) -> None:
         self.choices = [_FakeChoice(content)]
         self.usage = usage
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": self.choices[0].message.content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+            },
+        }
 
 
 class _FakeChatCompletions:
@@ -96,6 +112,33 @@ def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> 
     # On Azure the `model` arg carries the deployment name, not the base model id.
     assert chat.last_kwargs["model"] == "gpt55-deploy"
     assert chat.last_kwargs["max_completion_tokens"] == 16
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expects_temperature"),
+    [("gpt-5.5", False), ("deepseek-v4-pro", True)],
+)
+def test_structured_chat_applies_model_temperature_capability(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    expects_temperature: bool,
+) -> None:
+    config = _config().model_copy(update={"model_type": model_type, "model": model_type})
+    provider = AzureOpenAIProvider(config)
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(1, 1)))
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat))
+
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "go"}],
+                "temperature": 0.3,
+                "max_completion_tokens": 64,
+            }
+        )
+    )
+
+    assert ("temperature" in chat.last_kwargs) is expects_temperature
 
 
 def test_missing_deployment_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/providers/tests/openai_test.py
+++ b/wmh/providers/tests/openai_test.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    ChatRequest,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+)
 from wmh.providers.openai import OpenAIProvider
 
 
@@ -28,6 +34,22 @@ class _FakeChatResponse:
     def __init__(self, content: str, usage: _FakeUsage) -> None:
         self.choices = [_FakeChoice(content)]
         self.usage = usage
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": self.choices[0].message.content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+            },
+        }
 
 
 class _FakeChatCompletions:
@@ -223,3 +245,32 @@ def test_custom_endpoint_forwards_temperature_but_openai_does_not(
         monkeypatch.setattr(provider, "_get_client", lambda fake=fake: fake)
         provider.complete("sys", [Message(role="user", content="hi")], temperature=0.3)
         assert ("temperature" in chat.last_kwargs) is expects_temperature
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expects_temperature"),
+    [(None, False), ("http://localhost:8001/v1", True)],
+)
+def test_structured_chat_applies_temperature_capability_before_wire(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str | None,
+    expects_temperature: bool,
+) -> None:
+    provider = OpenAIProvider(
+        ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5", endpoint=endpoint)
+    )
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(1, 1)))
+    fake = _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([])))
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "go"}],
+                "temperature": 0.3,
+                "max_completion_tokens": 64,
+            }
+        )
+    )
+
+    assert ("temperature" in chat.last_kwargs) is expects_temperature


### PR DESCRIPTION
## Summary

- add a clean `wmh.agents` package with independent Default and Meta pi-agent definitions
- run the meta improver as an ordinary editable `HarnessDoc` through the shared `AgentProject` / `LiveSession` runtime
- give every optimizer run one persistent E2B project with a filesystem containing parent source, evidence, judged proposals, and compact lineage history
- keep that project and its ordinary pi runner alive while scoping the model transcript to one outer project turn, so filesystem memory persists without unbounded context growth
- align project-tool actions with an agent's explicit turn budget and require early parseable proposal checkpoints, so later rounds cannot spend the whole turn reading before producing output
- generate a configurable sibling proposal batch per round, independently from evaluation `k`
- rotate and size-weight failure clusters after a real evaluable batch expansion, so one exhausted/environment-limited task cannot consume the run
- give Meta bounded task-level traces, final answers, judge reasons, all-task scorecards, and persisted screen/full evaluation feedback
- preflight every project-written delta through the full typed `HarnessDoc` boundary and give invalid slots up to two bounded repair turns before search
- restrict each Meta turn's `write_file` authority to its exact current output slots, keeping parents, evidence, evaluations, and prior proposals immutable
- gate candidates lexicographically on task success and assertion-level partial credit across screen, suite, full, holdout, and confirmation tiers
- preserve provider, runner, proposal-contract, persistence, cancellation, worker-token, and E2B teardown failures instead of collapsing them into generic skips
- treat the exact HTTP/2 remote StreamReset raised by E2B `send_stdin` as a transport failure, retire the uncertain sandbox, and replay the episode once on a fresh sandbox without retrying provider-side or ambiguous protocol errors

## Why the search policy changed

The clean 8x3 diagnostic run `b322d26c-a86b-40bb-991e-3a33e6ec0b63` contained six separate one-task failure clusters, but the old search always selected `clusters[0]`. Because no child passed, all eight rounds targeted the same worldtimeapi task, whose simulated endpoint reset every connection. That spent 72 screen rollouts on one environment-limited task while five other clusters were never proposed against. One of those starved tasks already received valid JokeAPI JSON and only needed parsing/formatting help.

Cluster priority is now `task_count / (1 + useful_batches_on_parent_cluster)`, with stable deterministic ties. A batch only consumes an allocation when at least one child passes duplicate, delta-application, and backend-runtime validation and can actually enter evaluation. Proposer failures, unusable output, duplicates, stale preconditions, and backend-invalid deltas leave the cluster eligible.

## Architecture

The meta improver is not a special runtime. It is another project agent with its own editable prompt, tools, turn cap, source, temperature, and output-token surfaces, running through the same session runtime as every other agent. The optimizer only wires that ordinary agent into the delta loop, leaving its own harness eligible for optimization later.

The project filesystem is the durable memory. AgentProject reuses the same E2B sandbox, Agent, and live pi runner, but each outer project task starts with a clean model transcript. This matches the reference harness's fresh proposer invocation in one persistent working directory and avoids replaying every earlier file read until pi clamps the next output allowance to one token. Tool calls within a task still share their full transcript. All three pi bridges also forward real provider usage so pi's context accounting does not fall back to character estimates.

The project is the proposer data plane:

- content-addressed parent projections and a small root manifest
- exact pathful source mirror plus bounded per-surface chunks
- evidence, proposal, and evaluation manifests
- compact judged history without recursively duplicating prior context
- path-contained `read_file`, exact per-turn `write_file` grants, and `submit`; no shell escape surface

Proposal batch size controls sibling ideas generated in one agent turn. `k` independently controls repeated evaluation passes. The implementation was checked against [stanford-iris-lab/meta-harness](https://github.com/stanford-iris-lab/meta-harness) at reference commit `44b9942127847f7421db70d8c7e48407f09a3c70`, preserving its persistent proposal-history and explicit output gates while using WMH's shared project-agent runtime.

## Runtime, cancellation, and accounting

- missing replace/remove preconditions are filled mechanically from the exact serialized parent
- typed proposal preflight catches malformed skills, no-ops, equivalent children, unsupported runtime kinds, and backend-incompatible runtime switches before evaluator budget is spent
- valid siblings are protected byte-for-byte while only invalid slots receive actionable validation reports and repair turns; durable writes can still be salvaged after a lost runner frame
- OpenAI Responses tool turns preserve encrypted reasoning replay and fail closed on incomplete response status
- all runtimes honor the harness's temperature, turn, output-token, and skill surfaces
- project-agent turns bound transcript growth without restarting the sandbox/runner, and pi receives exact provider usage for context accounting
- project proposal failures retain their exact final preflight reason instead of collapsing to a generic unusable reply
- provider capability normalization drops unsupported temperature fields at the shared WMH boundary
- durable task, judge, evidence, and proposal text is canonicalized for UTF-8/E2B/Postgres safety without changing content hashes
- cancellation drains concurrent cells, closes the evaluator pool and Meta project, and propagates as cancellation rather than proposal failure
- `RuntimeCancelled` carries partial in-flight worker tokens; concurrent evaluation sums completed and interrupted cells exactly once; `HarnessSearchCancelled` combines all completed waves with the interrupted wave and finalized sandbox usage
- E2B cleanup remains fail closed: a lease is billable/live until deletion is confirmed
- an E2B `httpcore.RemoteProtocolError` is recoverable only when it crosses the sandbox `send_stdin` boundary with the exact remote StreamReset shape; the existing single-replay path then preserves single-send semantics by discarding the first sandbox rather than resending into an uncertain runner

## Validation

Exact WMH head: `f241f907574f8740f1067585b48f125b265f7c52`

- `uv run pytest -q`: 1,747 passed, 18 skipped
- executable two-turn live-runner transcript-scope regression: passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run ty check`: passed
- `git diff --check`: passed
- exact-head hosted checks and Greptile passed with zero unresolved threads

Platform PR [#313](https://github.com/experientiallabs/platform/pull/313) pins this exact commit from Platform head `5bb876e4e272e2ce6380298abeeee852ffada6b5`.

## Deployed evidence so far

- cancellation run `17ed4c5e-8c68-43b3-aab3-8b432ea00849`: one Meta project plus 20 evaluator sandboxes observed by run tag, all 20 linked rollouts terminalized without errors, the Modal worker exited cleanly, exact usage persisted, and every E2B resource was released
- clean systems run `b322d26c-a86b-40bb-991e-3a33e6ec0b63`: exactly 24/24 ordered proposal records, no proposer/runtime/contract/persistence errors, 132 linked rollouts terminal, and all 85 run-owned E2B resources released; it exposed the cluster-starvation policy because accepted remained zero
- rotation probe `90a9ebe2-784d-4e02-ad44-ab689a372036`: reached ordinary screening, then exposed a skill missing required frontmatter; fail-fast cancellation left all 22 linked rollouts terminal/error-free, the worker clean, and no tagged E2B resource active. The new typed preflight/repair path directly covers that proposal defect.
- exact-head rotation proof `7bdfcb6b-3eb3-4a81-bd7f-cdbb3bdcde88`: 6/6 ordered proposals with no skips/errors, distinct round targets, 46 clean linked rollouts, a clean Modal exit, and all 42 observed run-owned E2B resources released (1 Meta, 41 evaluators across waves)
- exact-head cancellation proof `768c67a9-14e6-49e3-bc71-3f9ea10ac852`: cancelled a live 20-cell wave; all 20 linked rollouts terminalized error-free, agent state restored, Modal exited cleanly, and all 21 observed resources were released in 13.668 seconds
- diagnostic improvement run `03fba8b0-93a7-40f5-96e0-048ee9b6cba0`: rounds 1-4 produced valid candidates and improved 78.33% to 96.67%, then the accumulated Meta transcript crossed pi's 128k declared context and pi clamped rounds 5-8 to `max_output_tokens=1`; all 852 linked rollouts and E2B resources still terminalized cleanly. This run is not final proof; the turn-scoped transcript and usage-forwarding fix directly addresses its twelve skipped proposals.
- exact-head diagnostic `39d414a5-778a-47e2-aef0-2e4b0d2af9ae`: round 1 was clean, but round 2 spent its project-action allowance exploring and left all three proposal slots invalid; the verifier cancelled immediately. All 189 rollouts, both Modal calls, and every run-owned E2B resource terminated cleanly. The final head aligns Meta's action/turn budgets, checkpoints parseable drafts before deeper reads, and preserves exact validation errors; this run is failure evidence, not final proof.
- checkpoint regression probe `f0a737fa-e2e7-4624-8407-88ecaa424104`: 2 rounds x 3 proposals with the ordinary Meta project produced 6/6 valid ordered outcomes (2 scored, 4 screened), including the richer-history second round that previously failed. All 66 rollouts completed without errors, the worker exited cleanly, and exact observed usage matched 1 Meta plus 41 evaluator sandboxes with none remaining.
- long-horizon diagnostic `55550cc9-758e-49e0-b0fd-52cacf49083c`: the first seven rounds produced 21/21 valid proposal outcomes and three accepted champions, improving 70% to 83.33%, before round 8 hit `httpcore.RemoteProtocolError: <StreamReset ... remote_reset:True>` specifically in E2B `commands.send_stdin`. The traceback proved an evaluator transport gap rather than a Meta/provider/proposal failure. All 1,530 linked rollouts terminalized without errors and all 498 run-owned E2B resources were released; attributable cost was $288.264904. The exact final head adds the narrow fresh-sandbox replay for this transport shape.
- full exact-head acceptance run `77a4f8f9-c467-4e54-84ef-debaaeccc00c`: all 8 rounds and 24 ordered proposals completed with 16 scored, 8 screened, 0 skipped, and 4 accepted; the ordinary Meta project improved the Default agent from 70% to 90%. Round 8 proposal 1 crossed the exact prior StreamReset boundary. All 1,452 linked rollouts completed without errors, the worker exited cleanly, and exact accounting observed one Meta plus 429 evaluator sandboxes with zero unexpected or remaining resources. Runtime was 5,874.024 seconds and attributable cost was $258.275916.
- exact-head cancellation run `0f7c70cf-b225-4424-8610-20b07c6711e0`: cancellation was issued only after 20/20 rollouts, one Meta sandbox, and 20 evaluator sandboxes were simultaneously live. In 7.954 seconds all 20 rollouts were terminal and error-free, the Platform worker exited cleanly, the agent returned to its exact pre-run state, and two consecutive inventories found zero remaining resources; attributable cost was $0.654349.
- earlier signal run `1a400812-75f3-4a66-a5b4-763e2b32885f`: seed 71.67% to an accepted 86.67% candidate, but intentionally not counted as final proof because a later transcript contained Postgres-invalid Unicode; recursive normalization now covers that failure

The exact-head Preview Integration and definitive Default-agent 8x3/cancellation proofs are owned by Platform PR #313. A separate Platform-only patch retries bounded provider capacity/transient failures for its worker and run-private simulator/judge; that downstream concern does not change WMH's transport or agent abstractions.

## Follow-up note

Persist the completed Meta project filesystem as a run-owned artifact so proposal context and raw history remain inspectable and can seed later optimizer runs. This is intentionally deferred from this PR but kept in context as the next extension. Before Meta edits its own harness, put executable agent code behind an OS-level read-only/output-only boundary or a second sandbox so self-modified code cannot bypass project-file grants.
