### PR TITLE
Preserve tool calls through provider retries

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -87,7 +87,7 @@ from wmh.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmh.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmh.providers.base import Embedder, EmbedderKind, Provider
 from wmh.providers.models import resolve_provider_model
-from wmh.providers.retry import RetryingProvider
+from wmh.providers.retry import wrap_provider_with_retries
 from wmh.retrieval import HashingEmbedder, get_embedder
 from wmh.scenarios import (
     ChecklistJudge,
@@ -1160,7 +1160,7 @@ def scenarios_verify(
         store = WorldModelStore(root)
         model_dir = store.resolve(_resolve_name(store, name))
         override = _provider_config(provider or "bedrock", model or "claude-opus-4-8", region)
-        llm = RetryingProvider(providers.get_provider(override))
+        llm = wrap_provider_with_retries(providers.get_provider(override))
         world_model = WorldModel.load(str(model_dir), llm)
     else:
         world_model, _resolved_name, llm = _load_model(name, root)
@@ -1410,7 +1410,7 @@ def demo(
                 check=lambda cfg: verify_all([cfg])[0],
             )
             switched = _provider_config(provider_name, model_type, region)
-            provider = RetryingProvider(
+            provider = wrap_provider_with_retries(
                 providers.get_provider(switched), on_retry=_NARRATOR.on_retry, sleep=_NARRATOR.sleep
             )
             wm = WorldModel.load(str(model_dir), provider, telemetry_root=str(model_root))
@@ -1672,7 +1672,7 @@ def _load_model(name: str | None, root: str):  # noqa: ANN202 - (WorldModel, nam
     resolved_name = _resolve_name(store, name)
     model_dir = store.resolve(resolved_name)
     config = load_config(model_dir)
-    provider = RetryingProvider(
+    provider = wrap_provider_with_retries(
         providers.get_provider(config.serve_provider_config()),
         on_retry=_NARRATOR.on_retry,
         sleep=_NARRATOR.sleep,

--- a/wmh/providers/retry.py
+++ b/wmh/providers/retry.py
@@ -11,15 +11,19 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from typing import TypeVar
 
 from llm_waterfall import is_capacity_error
 
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
+    ChatRequest,
+    ChatResponse,
     Completion,
     Message,
     Provider,
     ProviderConfig,
+    ToolCallingProvider,
     VerifyResult,
 )
 
@@ -28,6 +32,7 @@ _DELAYS = (1.0, 3.0, 9.0)
 
 # on_retry(attempt_number, total_attempts, delay_seconds, error)
 RetryCallback = Callable[[int, int, float, Exception], None]
+_T = TypeVar("_T")
 
 
 class RetryingProvider:
@@ -71,7 +76,7 @@ class RetryingProvider:
     def verify(self) -> VerifyResult:
         return self._provider.verify()
 
-    def _retry(self, call):  # noqa: ANN001, ANN202 - generic over the wrapped call's return
+    def _retry(self, call: Callable[[], _T]) -> _T:
         total = len(self._delays)
         for attempt, delay in enumerate(self._delays, start=1):
             try:
@@ -83,3 +88,36 @@ class RetryingProvider:
                     self._on_retry(attempt, total, delay, exc)
                 self._sleep(delay)
         return call()  # final attempt: let any error propagate
+
+
+class RetryingToolCallingProvider(RetryingProvider):
+    """Capacity retries that preserve structured agent completions."""
+
+    def __init__(
+        self,
+        provider: Provider,
+        on_retry: RetryCallback | None = None,
+        *,
+        delays: tuple[float, ...] = _DELAYS,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        """Wrap a provider that implements both provider protocols.
+
+        Args:
+            provider: Provider with the structured ``complete_chat`` capability.
+            on_retry: Optional callback before each capacity-error backoff.
+            delays: Backoff seconds before successive attempts.
+            sleep: Sleep implementation, injectable for tests.
+
+        Raises:
+            TypeError: If ``provider`` lacks structured tool calling.
+        """
+        if not isinstance(provider, ToolCallingProvider):
+            msg = "RetryingToolCallingProvider requires a ToolCallingProvider"
+            raise TypeError(msg)
+        super().__init__(provider, on_retry=on_retry, delays=delays, sleep=sleep)
+        self._tool_calling_provider = provider
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        """Retry one structured completion when capacity classification allows it."""
+        return self._retry(lambda: self._tool_calling_provider.complete_chat(request))

--- a/wmh/providers/retry.py
+++ b/wmh/providers/retry.py
@@ -121,3 +121,19 @@ class RetryingToolCallingProvider(RetryingProvider):
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         """Retry one structured completion when capacity classification allows it."""
         return self._retry(lambda: self._tool_calling_provider.complete_chat(request))
+
+
+def wrap_provider_with_retries(
+    provider: Provider,
+    on_retry: RetryCallback | None = None,
+    *,
+    delays: tuple[float, ...] = _DELAYS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> RetryingProvider:
+    """Apply retries without changing the provider's runtime capabilities."""
+    wrapper = (
+        RetryingToolCallingProvider
+        if isinstance(provider, ToolCallingProvider)
+        else RetryingProvider
+    )
+    return wrapper(provider, on_retry=on_retry, delays=delays, sleep=sleep)

--- a/wmh/providers/retry_test.py
+++ b/wmh/providers/retry_test.py
@@ -13,7 +13,11 @@ from wmh.providers.base import (
     ProviderKind,
     ToolCallingProvider,
 )
-from wmh.providers.retry import RetryingProvider, RetryingToolCallingProvider
+from wmh.providers.retry import (
+    RetryingProvider,
+    RetryingToolCallingProvider,
+    wrap_provider_with_retries,
+)
 
 
 class _Throttle(Exception):
@@ -129,3 +133,13 @@ def test_tool_calling_retry_preserves_structured_surface() -> None:
     assert provider.calls == 2
     assert events == [(1, 3, 1.0)]
     assert slept == [1.0]
+
+
+def test_retry_factory_preserves_only_the_underlying_provider_capabilities() -> None:
+    structured = wrap_provider_with_retries(FlakyToolCallingProvider(failures=0))
+    text_only = wrap_provider_with_retries(FlakyProvider(failures=0))
+
+    assert isinstance(structured, RetryingToolCallingProvider)
+    assert isinstance(structured, ToolCallingProvider)
+    assert type(text_only) is RetryingProvider
+    assert not isinstance(text_only, ToolCallingProvider)

--- a/wmh/providers/retry_test.py
+++ b/wmh/providers/retry_test.py
@@ -4,8 +4,16 @@ from __future__ import annotations
 
 import pytest
 
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
-from wmh.providers.retry import RetryingProvider
+from wmh.providers.base import (
+    ChatRequest,
+    ChatResponse,
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    ToolCallingProvider,
+)
+from wmh.providers.retry import RetryingProvider, RetryingToolCallingProvider
 
 
 class _Throttle(Exception):
@@ -40,6 +48,28 @@ class FlakyProvider:
 
     def verify(self):  # noqa: ANN201
         raise NotImplementedError
+
+
+class FlakyToolCallingProvider(FlakyProvider):
+    """Raises capacity errors from structured calls, then succeeds."""
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        _ = request
+        self.calls += 1
+        if self.calls <= self._failures:
+            raise _Throttle()
+        return ChatResponse.model_validate(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "done"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+            }
+        )
 
 
 def test_retries_capacity_errors_with_backoff_and_narration() -> None:
@@ -79,3 +109,23 @@ def test_non_capacity_errors_propagate_immediately() -> None:
     with pytest.raises(Auth):
         retrying.complete("s", [Message(role="user", content="hi")])
     assert provider.calls == 1
+
+
+def test_tool_calling_retry_preserves_structured_surface() -> None:
+    events: list[tuple[int, int, float]] = []
+    slept: list[float] = []
+    provider = FlakyToolCallingProvider(failures=1)
+    retrying = RetryingToolCallingProvider(
+        provider,
+        on_retry=lambda attempt, total, delay, error: events.append((attempt, total, delay)),
+        sleep=slept.append,
+    )
+
+    assert isinstance(retrying, ToolCallingProvider)
+    response = retrying.complete_chat(ChatRequest())
+
+    assert response.token_usage().input_tokens == 11
+    assert response.token_usage().output_tokens == 7
+    assert provider.calls == 2
+    assert events == [(1, 3, 1.0)]
+    assert slept == [1.0]


### PR DESCRIPTION
## What changed

- add `RetryingToolCallingProvider` beside the existing text-completion retry wrapper
- preserve `complete_chat` for structured agent runtimes while reusing the same capacity classifier, retry callbacks, and bounded backoff
- type the shared retry loop generically

## Why

Wrapping a structured provider in `RetryingProvider` erased the `ToolCallingProvider` capability. Pi runtimes then failed before sending an agent-model request, which downstream evaluation could present as zero usage and zero quality.

Provider capability preservation and retry behavior belong in wmh rather than downstream applications.

## Validation

- new regression test observed failing before implementation
- `uv run pytest -q` (1175 passed, 18 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
