### PR TITLE
Export persistent meta agent projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ vendored pi source and `LiveSession` runtime. `AgentProject` gives an agent a pe
 filesystem while starting a fresh session for each turn. `ProjectDeltaProposer` uses that ordinary
 agent/project pair to retain every earlier proposal and generate a sibling batch from one selected
 parent per search round. Proposal batch size controls search breadth; `k` independently controls
-the number of evaluation passes per scenario.
+the number of evaluation passes per scenario. Before teardown, callers can use
+`AgentProject.export_archive()` to download the complete regular-file project as one deterministic
+gzip tar archive for durable storage or later inspection.
 
 ## Providers
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import Protocol
+from typing import Literal, Protocol, cast
 
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
@@ -26,14 +26,23 @@ from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
+MAX_PROJECT_ARCHIVE_BYTES = 50 * 1024 * 1024
 _OUTPUT_CAP = 16_000
 _PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
+_PROJECT_ARCHIVE_PATH = "/home/user/.wmh-agent-project.tar.gz"
+_PROJECT_ARCHIVE_TIMEOUT_S = 300
 
 
 class ChannelFactory(Protocol):
     """Start one fresh runner channel in a project's sandbox."""
 
     def __call__(self, sandbox: SandboxHandle, workspace: str) -> Channel: ...
+
+
+class _BinarySandboxFiles(Protocol):
+    """Binary E2B file read used for one project archive download."""
+
+    def read(self, path: str, *, format: Literal["bytes"]) -> bytes | bytearray: ...
 
 
 @dataclass(frozen=True)
@@ -98,6 +107,43 @@ class AgentProject:
     def read_text(self, path: str) -> str:
         """Read one project-relative file."""
         return self._sandbox.files.read(self._absolute_path(path))
+
+    def export_archive(self) -> bytes:
+        """Export the complete project workspace as a deterministic gzip tar archive.
+
+        The sandbox performs one filesystem walk and one binary download, avoiding a network
+        round trip per proposal file. Only regular files and directories enter the archive;
+        links and special files are excluded. Metadata that would vary between runs is normalized.
+
+        Returns:
+            Portable gzip tar bytes with paths relative to the project workspace.
+
+        Raises:
+            RuntimeError: If the project has already been closed.
+            ValueError: If the compressed archive exceeds the portable size limit.
+        """
+        if self._finished_at is not None:
+            raise RuntimeError("cannot export a closed project")
+        workspace = shlex.quote(self.workspace)
+        archive_path = shlex.quote(_PROJECT_ARCHIVE_PATH)
+        self._sandbox.commands.run(
+            f"cd {workspace} && "
+            "find . -mindepth 1 -xdev \\( -type f -o -type d \\) -print0 | "
+            "sort -z | "
+            "tar --null --no-recursion --format=ustar --mtime=@0 --owner=0 --group=0 "
+            f"--numeric-owner -cf - --files-from=- | gzip -n > {archive_path}",
+            timeout=_PROJECT_ARCHIVE_TIMEOUT_S,
+        )
+        files = cast("_BinarySandboxFiles", self._sandbox.files)
+        try:
+            content = bytes(files.read(_PROJECT_ARCHIVE_PATH, format="bytes"))
+        finally:
+            self._sandbox.commands.run(f"rm -f {archive_path}", timeout=30)
+        if len(content) > MAX_PROJECT_ARCHIVE_BYTES:
+            raise ValueError(
+                f"project archive exceeds {MAX_PROJECT_ARCHIVE_BYTES} bytes: {len(content)}"
+            )
+        return content
 
     def run(
         self,

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -127,7 +127,7 @@ class AgentProject:
         workspace = shlex.quote(self.workspace)
         archive_path = shlex.quote(_PROJECT_ARCHIVE_PATH)
         self._sandbox.commands.run(
-            f"cd {workspace} && "
+            f"set -eo pipefail; cd {workspace} && "
             "find . -mindepth 1 -xdev \\( -type f -o -type d \\) -print0 | "
             "sort -z | "
             "tar --null --no-recursion --format=ustar --mtime=@0 --owner=0 --group=0 "

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Literal, overload
+
 import pytest
 from llm_waterfall import ChatResponse
 
+import wmh.agents.project as project_module
 from wmh.agents.default import default_agent
 from wmh.agents.meta import meta_agent
 from wmh.agents.project import AgentProject
@@ -14,14 +17,25 @@ from wmh.providers.base import ProviderConfig, ProviderKind
 
 class _Files:
     def __init__(self) -> None:
-        self.values: dict[str, str] = {}
+        self.values: dict[str, str | bytes] = {}
 
     def write(self, path: str, data: str) -> object:
         self.values[path] = data
         return None
 
-    def read(self, path: str) -> str:
-        return self.values[path]
+    @overload
+    def read(self, path: str) -> str: ...
+
+    @overload
+    def read(self, path: str, *, format: Literal["bytes"]) -> bytes: ...
+
+    def read(self, path: str, *, format: Literal["bytes"] | None = None) -> str | bytes:
+        value = self.values[path]
+        if format == "bytes":
+            assert isinstance(value, bytes)
+            return value
+        assert isinstance(value, str)
+        return value
 
 
 class _Output:
@@ -158,3 +172,39 @@ def test_project_rejects_agents_with_uncontained_tools() -> None:
     )
     assert outcome.is_error is True
     assert outcome.content == "tool 'bash' not available"
+
+
+def test_project_exports_one_deterministic_regular_file_archive() -> None:
+    """One sandbox command archives project files without following links."""
+    sandbox = _Sandbox()
+    sandbox.files.values["/home/user/.wmh-agent-project.tar.gz"] = b"archive-bytes"
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    content = project.export_archive()
+
+    assert content == b"archive-bytes"
+    archive_command, cleanup_command = sandbox.commands.runs[-2:]
+    assert archive_command.startswith("cd /home/user/project && find . -mindepth 1 -xdev")
+    assert "-type f -o -type d" in archive_command
+    assert "sort -z" in archive_command
+    assert "--no-recursion" in archive_command
+    assert "--mtime=@0" in archive_command
+    assert "gzip -n" in archive_command
+    assert cleanup_command == "rm -f /home/user/.wmh-agent-project.tar.gz"
+
+
+def test_project_archive_rejects_oversize_and_closed_projects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Archives stay within the portable limit and must precede teardown."""
+    sandbox = _Sandbox()
+    sandbox.files.values["/home/user/.wmh-agent-project.tar.gz"] = b"large"
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    monkeypatch.setattr(project_module, "MAX_PROJECT_ARCHIVE_BYTES", 4)
+
+    with pytest.raises(ValueError, match="archive exceeds 4 bytes"):
+        project.export_archive()
+
+    project.close()
+    with pytest.raises(RuntimeError, match="closed project"):
+        project.export_archive()

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -184,7 +184,9 @@ def test_project_exports_one_deterministic_regular_file_archive() -> None:
 
     assert content == b"archive-bytes"
     archive_command, cleanup_command = sandbox.commands.runs[-2:]
-    assert archive_command.startswith("cd /home/user/project && find . -mindepth 1 -xdev")
+    assert archive_command.startswith(
+        "set -eo pipefail; cd /home/user/project && find . -mindepth 1 -xdev"
+    )
     assert "-type f -o -type d" in archive_command
     assert "sort -z" in archive_command
     assert "--no-recursion" in archive_command


### PR DESCRIPTION
## Summary

- add `AgentProject.export_archive()` for exporting the persistent proposer workspace before sandbox teardown
- build the archive in one sandbox command to avoid per-file E2B round trips
- make archives deterministic by sorting members and normalizing timestamps, owners, and gzip metadata
- exclude links and special files, enforce project containment, and cap compressed archives at 50 MiB
- propagate every archive-pipeline failure instead of returning a partial gzip
- document the portable project archive contract

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -q` (1244 passed, 18 skipped)

## Dependency

Stacked on #152.

Platform consumer: experientiallabs/platform#315.

## Backend-connected preview

WMH is the storage-agnostic library layer, so its runnable preview is deployed from the Platform consumer PR:

- Webapp: https://world-model-ickwm29h9-experiential-labs.vercel.app
- Backend: https://bespoke-ai-agents--explabs-platform-pr-315-fastapi-app.modal.run
- Preview workflow: https://github.com/experientiallabs/platform/actions/runs/29384730584
- Deployed Platform commit: `c562896bb3db67d31c654df51898d2e74a15965c`