### PR TITLE
Use canonical production domain for login

### DIFF
--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -200,4 +200,4 @@ def test_bare_login_targets_the_hosted_platform(monkeypatch: pytest.MonkeyPatch)
     result = runner.invoke(app, ["login", "--token", "xpl_new"])
 
     assert result.exit_code == 0, result.output
-    assert seen["web_url"] == "https://experiential-platform-web.vercel.app"
+    assert seen["web_url"] == "https://platform.experientiallabs.ai"

--- a/wmh/platform/credentials.py
+++ b/wmh/platform/credentials.py
@@ -25,7 +25,7 @@ CREDENTIALS_FILENAME = "credentials.toml"
 
 # The hosted platform a bare `wmh login` connects to; `--url` (previews,
 # self-hosted, the local stack) and saved credentials both take precedence.
-DEFAULT_WEB_URL = "https://experiential-platform-web.vercel.app"
+DEFAULT_WEB_URL = "https://platform.experientiallabs.ai"
 
 
 class PlatformCredentials(BaseModel):


### PR DESCRIPTION
## Summary

- make bare `wmh login` target `https://platform.experientiallabs.ai`
- update the regression test for the hosted-platform default

## Root cause

WMH still defaulted to the retired Vercel deployment URL, so users had to pass `--url` even though the canonical production domain advertises the correct Modal backend.

## User impact

After this change, users can run `wmh login` without specifying the production URL. Explicit URLs continue to override the default for previews and self-hosted deployments.

## Validation

- `uv run pytest -q` (1216 passed, 18 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- live discovery resolved `https://platform.experientiallabs.ai` to the production Modal backend