### PR TITLE
Detached hosted-agent sessions for wmh run

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,15 @@ carried over), then continue with `-s`/`-a`/`--end` as above.
 The current-session reference (and, with `-u`, a synchronization checkpoint) lives in WMH user
 state under `~/.wmh/sessions/`, not in your repository. Every send/attach/end first catches up:
 workspace changes the agent made while nothing was attached are applied locally, and local edits
-made since the checkpoint are uploaded, before the command proceeds. Detaching (Ctrl-D,
-`:detach`, or a second Ctrl-C) never ends the hosted session; only `--end` or the interactive
-`:end` command does. Detached sessions still observe the platform's idle timeout: an idle
-session eventually ends on its own, and the next `wmh run --end` reconciles its final workspace.
+made since the checkpoint are uploaded, before the command proceeds. In a detached-started or
+attached session (`-a`), leaving never ends the run: `:detach`, Ctrl-D, and a second Ctrl-C all
+leave it alive, and only `wmh run --end` or the interactive `:end` command terminates it. A
+plain interactive `wmh run <agent-id>` keeps its original semantics: `:quit`, `:end`, Ctrl-D,
+and a double Ctrl-C end the session, while `:detach` promotes it. Lines starting with a colon
+are reserved for commands and are never sent to the agent as chat. Detached sessions still
+observe the platform's idle timeout: an idle session eventually ends on its own, and the next
+`wmh run --end` reconciles its final workspace (even when the local checkpoint or directory is
+gone, in which case the final archive is saved as a recovery file instead of synced).
 
 For a deployment-protected preview whose public discovery route is not available to a
 non-browser client, pair its browser and backend URLs explicitly:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ wmh run <agent-id> -u . --task "fix the failing tests"
 wmh run --task "fix the failing tests"   # built-in pi harness, also platform-backed when logged in
 ```
 
+Hosted agent sessions can also run detached: start one, return to your shell, and keep working
+with it from later commands (or from the web app, where it remains an ordinary live session):
+
+```bash
+wmh run <agent-id> -d                    # start hosted, remember as the current session, return
+wmh run <agent-id> -u . --detach         # same, with workspace upload + live sync
+wmh run -s "Do this task"                # send a message, stream that turn until idle, exit
+wmh run -a                               # attach interactively; :detach leaves it running
+wmh run --end                            # end it explicitly, with the final workspace sync
+wmh run --session <session-id> --send "Do this task"   # address a specific session
+```
+
+The current-session reference (and, with `-u`, a synchronization checkpoint) lives in WMH user
+state under `~/.wmh/sessions/`, not in your repository. Every send/attach/end first catches up:
+workspace changes the agent made while nothing was attached are applied locally, and local edits
+made since the checkpoint are uploaded, before the command proceeds. Detaching (Ctrl-D,
+`:detach`, or a second Ctrl-C) never ends the hosted session; only `--end` or the interactive
+`:end` command does. Detached sessions still observe the platform's idle timeout: an idle
+session eventually ends on its own, and the next `wmh run --end` reconciles its final workspace.
+
 For a deployment-protected preview whose public discovery route is not available to a
 non-browser client, pair its browser and backend URLs explicitly:
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ wmh run --end                            # end it explicitly, with the final wor
 wmh run --session <session-id> --send "Do this task"   # address a specific session
 ```
 
+An interactive `wmh run <agent-id>` can also be promoted mid-session: type `:detach` to leave
+the hosted session running as the current detached session (with `-u`, the sync checkpoint is
+carried over), then continue with `-s`/`-a`/`--end` as above.
+
 The current-session reference (and, with `-u`, a synchronization checkpoint) lives in WMH user
 state under `~/.wmh/sessions/`, not in your repository. Every send/attach/end first catches up:
 workspace changes the agent made while nothing was attached are applied locally, and local edits

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import threading
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Protocol
 
@@ -42,7 +43,12 @@ from wmh.cli.hosted_session import (
     SessionAction,
     patch_revision,
 )
-from wmh.cli.session_state import SessionStateStore
+from wmh.cli.session_state import (
+    DetachedSessionState,
+    SessionStateError,
+    SessionStateStore,
+    WorkspaceCheckpoint,
+)
 from wmh.cli.workspace_sync import (
     WorkspaceSnapshot,
     WorkspaceSyncError,
@@ -57,7 +63,7 @@ from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import render_tools, resolve_tools
 from wmh.harness.workspace_patch import WorkspacePatchError
 from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
-from wmh.platform.credentials import load_credentials
+from wmh.platform.credentials import PlatformCredentials, load_credentials
 from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
 from wmh.providers.models import resolve_provider_model
 from wmh.providers.registry import get_provider
@@ -444,23 +450,35 @@ class RemoteAgentCommandReader(threading.Thread):
         self._agent_id = agent_id
         self._session_id = session_id
         self.eof = threading.Event()
+        self.detach = threading.Event()
 
     def run(self) -> None:
-        """Map stdin lines to hosted steer, interrupt, and end commands."""
+        """Map stdin lines to hosted steer, interrupt, detach, and end commands."""
         try:
             for raw in sys.stdin:
                 line = raw.strip()
-                if line in {":quit", ":q", ":exit"}:
+                if line in {":quit", ":q", ":exit", ":end"}:
                     self._post("end")
+                    return
+                if line == ":detach":
+                    self.detach.set()
                     return
                 if line == ":stop":
                     self._post("interrupt")
+                elif line.startswith(":"):
+                    # An unknown command must never reach the agent as chat.
+                    _console.print(
+                        f"[yellow]unknown command {line}; use :stop, :detach, or :quit[/yellow]"
+                    )
                 elif line:
                     self._post("user_message", text=line)
         except (OSError, PlatformError):
             pass
         finally:
-            self.eof.set()
+            # EOF keeps its plain-run meaning (end once the run settles); a
+            # detach stopped reading deliberately and must not look like EOF.
+            if not self.detach.is_set():
+                self.eof.set()
 
     def _post(self, kind: str, *, text: str | None = None) -> None:
         """Post one command through the authenticated platform client."""
@@ -477,14 +495,20 @@ class RemoteAgentDriver:
         name: str,
         jail_root: Path | None,
         task: str | None,
+        *,
+        credentials: PlatformCredentials,
+        state_store: SessionStateStore,
     ) -> None:
-        """Store the resolved agent and optional local workspace transport root."""
+        """Store the resolved agent, workspace root, and detach-promotion state."""
         self._client = client
         self._target_id = target_id
         self._name = name
         self._jail = jail_root
         self._task = task
+        self._credentials = credentials
+        self._store = state_store
         self._interrupts = 0
+        self._cursor = 0
 
     def run(self) -> None:
         """Run and stream one E2B session, syncing local files only when requested."""
@@ -510,13 +534,17 @@ class RemoteAgentDriver:
             quit_detail = "end and sync back" if initial is not None else "end"
             _console.print(
                 f"[green]E2B session started[/green] for [bold]{self._name}[/bold]. "
-                "Type to steer, [bold]:stop[/bold] to interrupt, "
-                f"[bold]:quit[/bold] to {quit_detail}."
+                "Type to steer, [bold]:stop[/bold] to interrupt, [bold]:detach[/bold] to "
+                f"leave it running, [bold]:quit[/bold] to {quit_detail}."
             )
             reader = RemoteAgentCommandReader(self._client, self._target_id, session.id)
             reader.start()
             stdin_eof = getattr(reader, "eof", threading.Event())
-            terminal = self._poll(session.id, workspace, stdin_eof)
+            detach = getattr(reader, "detach", threading.Event())
+            terminal = self._poll(session.id, workspace, stdin_eof, detach)
+            if terminal is None:
+                self._promote(session.id, workspace)
+                return
             workspace_conflicts = False
             if workspace is not None:
                 workspace_conflicts = bool(workspace.finalize().conflicts)
@@ -525,20 +553,70 @@ class RemoteAgentDriver:
                 raise typer.Exit(code=1)
             if workspace_conflicts:
                 raise typer.Exit(code=2)
-        except (WorkspacePatchError, WorkspaceSyncError) as error:
+        except (WorkspacePatchError, WorkspaceSyncError, SessionStateError) as error:
             raise typer.BadParameter(str(error)) from error
         except PlatformError as error:
             raise typer.BadParameter(str(error)) from error
         finally:
             self._client.close()
 
+    def _promote(self, session_id: str, workspace: LiveWorkspace | None) -> None:
+        """Persist the live session as the current detached session and exit.
+
+        The transcript cursor and (with -u) the last synchronized snapshot are
+        checkpointed exactly as a `--detach` start would have left them, so the
+        next send/attach/end catches up from here. No final workspace sync
+        runs: the session stays alive.
+        """
+        checkpoint: WorkspaceCheckpoint | None = None
+        base_archive: bytes | None = None
+        if workspace is not None and self._jail is not None:
+            checkpoint = WorkspaceCheckpoint(
+                root=str(self._jail), conflicts=tuple(sorted(workspace.conflicts))
+            )
+            base_archive = workspace.synchronized.archive
+        state = DetachedSessionState(
+            api_url=str(self._credentials.api_url),
+            web_url=self._credentials.web_url,
+            agent_id=self._target_id,
+            agent_name=self._name,
+            session_id=session_id,
+            created_at=datetime.now(tz=UTC).isoformat(),
+            cursor=self._cursor,
+            workspace=checkpoint,
+        )
+        try:
+            self._store.save(state, base_archive=base_archive)
+            self._store.set_current(session_id)
+        except SessionStateError as error:
+            # The hosted session keeps running; the user must get an
+            # addressable reference even though the local save failed.
+            msg = (
+                f"session {session_id} is still running on the platform, but its local "
+                f"reference could not be saved: {error}. Control it with "
+                f"`wmh run --session {session_id} --attach` or end it with "
+                f"`wmh run --session {session_id} --end`"
+            )
+            raise typer.BadParameter(msg) from error
+        _console.print(
+            f"[green]detached[/green]; session {session_id} stays alive as the "
+            "current session.\n"
+            'Send a message with [bold]wmh run -s "..."[/bold], attach with '
+            "[bold]wmh run -a[/bold], end with [bold]wmh run --end[/bold]."
+        )
+
     def _poll(
         self,
         session_id: str,
         workspace: LiveWorkspace | None,
         stdin_eof: threading.Event,
-    ) -> RemoteAgentSession:
-        """Render new transcript events until output export makes the row terminal."""
+        detach: threading.Event,
+    ) -> RemoteAgentSession | None:
+        """Render transcript events until the row is terminal or the user detaches.
+
+        Returns:
+            The terminal session record, or ``None`` when the user detached.
+        """
         cursor = 0
         last_workspace_push = time.monotonic()
         sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
@@ -576,8 +654,11 @@ class RemoteAgentDriver:
                                 )
                                 end_sent = True
                 cursor = page.last_seq
+                self._cursor = cursor
                 if page.status in {"ended", "failed"}:
                     return self._client.get_agent_session(self._target_id, session_id)
+                if detach.is_set():
+                    return None
                 now = time.monotonic()
                 if stdin_eof.is_set() and self._task is None and not end_sent:
                     self._client.post_agent_session_command(self._target_id, session_id, "end")
@@ -640,6 +721,12 @@ class RemoteWorldModelDriver:
             if line in {":quit", ":q", ":exit"}:
                 _console.print("[dim]bye[/dim]")
                 return
+            if line == ":detach":
+                _console.print(
+                    "[yellow]world-model sessions are interactive only; :detach works "
+                    "for hosted agent sessions. Use :quit to leave.[/yellow]"
+                )
+                continue
             if line in {":help", ":h"}:
                 _console.print(
                     'Tool call: [cyan]name {"arg": "value"}[/cyan]. '
@@ -962,7 +1049,15 @@ def _build_driver(
                 jail_root=jail_root,
                 task=task,
             )
-        return RemoteAgentDriver(client, resolved.id, resolved.name, jail_root, task)
+        return RemoteAgentDriver(
+            client,
+            resolved.id,
+            resolved.name,
+            jail_root,
+            task,
+            credentials=credentials,
+            state_store=SessionStateStore(),
+        )
     except PlatformError as error:
         client.close()
         raise typer.BadParameter(str(error)) from error

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -491,9 +491,7 @@ class RemoteAgentCommandReader(threading.Thread):
                 self._agent_id, self._session_id, kind, text=text
             )
         except PlatformError as error:
-            _console.print(
-                f"[red]{kind} failed:[/red] {error} (still attached; try again)"
-            )
+            _console.print(f"[red]{kind} failed:[/red] {error} (still attached; try again)")
             return False
         return True
 
@@ -683,12 +681,21 @@ class RemoteAgentDriver:
             except KeyboardInterrupt:
                 self._interrupts += 1
                 kind = "interrupt" if self._interrupts == 1 else "end"
-                _console.print(
-                    "\n[yellow]interrupting (press Ctrl-C again to end)[/yellow]"
-                    if kind == "interrupt"
-                    else "\n[yellow]ending session[/yellow]"
-                )
-                self._client.post_agent_session_command(self._target_id, session_id, kind)
+                # The next Ctrl-C frequently lands inside this handler (the
+                # print or the HTTP post); escalate to the end action instead
+                # of crashing out with the session still live.
+                try:
+                    _console.print(
+                        "\n[yellow]interrupting (press Ctrl-C again to end)[/yellow]"
+                        if kind == "interrupt"
+                        else "\n[yellow]ending session[/yellow]"
+                    )
+                    self._client.post_agent_session_command(self._target_id, session_id, kind)
+                except KeyboardInterrupt:
+                    self._interrupts += 1
+                    with contextlib.suppress(KeyboardInterrupt, PlatformError):
+                        _console.print("\n[yellow]ending session[/yellow]")
+                        self._client.post_agent_session_command(self._target_id, session_id, "end")
                 continue
 
 

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -458,12 +458,12 @@ class RemoteAgentCommandReader(threading.Thread):
             for raw in sys.stdin:
                 line = raw.strip()
                 if line in {":quit", ":q", ":exit", ":end"}:
-                    self._post("end")
-                    return
-                if line == ":detach":
+                    if self._post("end"):
+                        return
+                elif line == ":detach":
                     self.detach.set()
                     return
-                if line == ":stop":
+                elif line == ":stop":
                     self._post("interrupt")
                 elif line.startswith(":"):
                     # An unknown command must never reach the agent as chat.
@@ -472,7 +472,7 @@ class RemoteAgentCommandReader(threading.Thread):
                     )
                 elif line:
                     self._post("user_message", text=line)
-        except (OSError, PlatformError):
+        except OSError:
             pass
         finally:
             # EOF keeps its plain-run meaning (end once the run settles); a
@@ -480,9 +480,22 @@ class RemoteAgentCommandReader(threading.Thread):
             if not self.detach.is_set():
                 self.eof.set()
 
-    def _post(self, kind: str, *, text: str | None = None) -> None:
-        """Post one command through the authenticated platform client."""
-        self._client.post_agent_session_command(self._agent_id, self._session_id, kind, text=text)
+    def _post(self, kind: str, *, text: str | None = None) -> bool:
+        """Post one command; a transient failure warns and keeps the reader alive.
+
+        Returns:
+            Whether the command was accepted.
+        """
+        try:
+            self._client.post_agent_session_command(
+                self._agent_id, self._session_id, kind, text=text
+            )
+        except PlatformError as error:
+            _console.print(
+                f"[red]{kind} failed:[/red] {error} (still attached; try again)"
+            )
+            return False
+        return True
 
 
 class RemoteAgentDriver:

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -571,6 +571,10 @@ class RemoteAgentDriver:
         finally:
             self._client.close()
 
+    def _advance_cursor(self, seq: int) -> None:
+        """Mark one transcript event as processed."""
+        self._cursor = seq
+
     def _promote(self, session_id: str, workspace: LiveWorkspace | None) -> None:
         """Persist the live session as the current detached session and exit.
 
@@ -628,7 +632,6 @@ class RemoteAgentDriver:
         Returns:
             The terminal session record, or ``None`` when the user detached.
         """
-        cursor = 0
         last_workspace_push = time.monotonic()
         sink = TerminalEventSink(recorder=None, on_running=lambda _running: None)
         saw_running = False
@@ -636,7 +639,7 @@ class RemoteAgentDriver:
         while True:
             try:
                 page = self._client.list_agent_session_events(
-                    self._target_id, session_id, after=cursor
+                    self._target_id, session_id, after=self._cursor
                 )
                 for event in page.events:
                     if event.kind == "workspace_patch":
@@ -644,7 +647,13 @@ class RemoteAgentDriver:
                             raise WorkspaceSyncError(
                                 "received a workspace patch without --upload-dir"
                             )
-                        workspace.apply_remote_patch(patch_revision(event))
+                        # Advance before the ack posts: once the object is
+                        # acknowledged (hence deleted), neither an interrupt
+                        # resume nor a :detach promotion may re-request it.
+                        workspace.apply_remote_patch(
+                            patch_revision(event),
+                            before_ack=lambda seq=event.seq: self._advance_cursor(seq),
+                        )
                     elif event.kind == "status":
                         detail = event.payload.get("message") or event.payload.get("status")
                         if detail:
@@ -664,8 +673,10 @@ class RemoteAgentDriver:
                                     self._target_id, session_id, "end"
                                 )
                                 end_sent = True
-                cursor = page.last_seq
-                self._cursor = cursor
+                    # Per event, not per page: a Ctrl-C mid-page must resume
+                    # (and promote) after the events already processed.
+                    self._cursor = event.seq
+                self._cursor = page.last_seq
                 if page.status in {"ended", "failed"}:
                     return self._client.get_agent_session(self._target_id, session_id)
                 if detach.is_set():

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -664,7 +664,7 @@ class RemoteAgentDriver:
                     self._client.post_agent_session_command(self._target_id, session_id, "end")
                     end_sent = True
                 if workspace is not None and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
-                    workspace.push_local()
+                    workspace.try_push_local()
                     last_workspace_push = now
                 time.sleep(0.5)
             except KeyboardInterrupt:

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -35,13 +35,18 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from wmh.cli.hosted_session import (
+    DetachedCommandDriver,
+    DetachedStartDriver,
+    LiveWorkspace,
+    SessionAction,
+    patch_revision,
+)
+from wmh.cli.session_state import SessionStateStore
 from wmh.cli.workspace_sync import (
     WorkspaceSnapshot,
     WorkspaceSyncError,
-    apply_workspace_patch,
     snapshot_workspace,
-    sync_workspace,
-    write_conflict_archive,
 )
 from wmh.engine.play import parse_action
 from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
@@ -50,7 +55,7 @@ from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import render_tools, resolve_tools
-from wmh.harness.workspace_patch import WorkspacePatchError, build_workspace_patch
+from wmh.harness.workspace_patch import WorkspacePatchError
 from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmh.platform.credentials import load_credentials
 from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
@@ -480,7 +485,6 @@ class RemoteAgentDriver:
         self._jail = jail_root
         self._task = task
         self._interrupts = 0
-        self._live_conflicts: set[str] = set()
 
     def run(self) -> None:
         """Run and stream one E2B session, syncing local files only when requested."""
@@ -498,6 +502,11 @@ class RemoteAgentDriver:
                 workspace=initial.archive if initial is not None else None,
                 instruction=self._task,
             )
+            workspace: LiveWorkspace | None = None
+            if self._jail is not None and initial is not None:
+                workspace = LiveWorkspace(
+                    self._client, self._target_id, session.id, self._jail, initial
+                )
             quit_detail = "end and sync back" if initial is not None else "end"
             _console.print(
                 f"[green]E2B session started[/green] for [bold]{self._name}[/bold]. "
@@ -507,34 +516,10 @@ class RemoteAgentDriver:
             reader = RemoteAgentCommandReader(self._client, self._target_id, session.id)
             reader.start()
             stdin_eof = getattr(reader, "eof", threading.Event())
-            terminal, synchronized = self._poll(session.id, initial, stdin_eof)
-            jail_root = self._jail
+            terminal = self._poll(session.id, workspace, stdin_eof)
             workspace_conflicts = False
-            if jail_root is not None and synchronized is not None:
-                with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
-                    final_archive = self._client.download_agent_workspace(
-                        self._target_id, session.id
-                    )
-                    result = sync_workspace(
-                        jail_root,
-                        synchronized,
-                        final_archive,
-                        protected_paths=frozenset(self._live_conflicts),
-                    )
-                if result.conflicts:
-                    workspace_conflicts = True
-                    recovery = write_conflict_archive(jail_root, session.id, final_archive)
-                    self._client.acknowledge_agent_workspace(self._target_id, session.id)
-                    paths = ", ".join(result.conflicts)
-                    _console.print(
-                        f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
-                        f"The full E2B result is saved at [bold]{recovery}[/bold]."
-                    )
-                else:
-                    self._client.acknowledge_agent_workspace(self._target_id, session.id)
-                    _console.print(
-                        f"[green]workspace synced[/green] ({len(result.applied)} changed paths)"
-                    )
+            if workspace is not None:
+                workspace_conflicts = bool(workspace.finalize().conflicts)
             if terminal.status == "failed":
                 _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
                 raise typer.Exit(code=1)
@@ -550,9 +535,9 @@ class RemoteAgentDriver:
     def _poll(
         self,
         session_id: str,
-        synchronized: WorkspaceSnapshot | None,
+        workspace: LiveWorkspace | None,
         stdin_eof: threading.Event,
-    ) -> tuple[RemoteAgentSession, WorkspaceSnapshot | None]:
+    ) -> RemoteAgentSession:
         """Render new transcript events until output export makes the row terminal."""
         cursor = 0
         last_workspace_push = time.monotonic()
@@ -566,11 +551,11 @@ class RemoteAgentDriver:
                 )
                 for event in page.events:
                     if event.kind == "workspace_patch":
-                        if synchronized is None:
+                        if workspace is None:
                             raise WorkspaceSyncError(
                                 "received a workspace patch without --upload-dir"
                             )
-                        synchronized = self._apply_remote_patch(session_id, event, synchronized)
+                        workspace.apply_remote_patch(patch_revision(event))
                     elif event.kind == "status":
                         detail = event.payload.get("message") or event.payload.get("status")
                         if detail:
@@ -592,16 +577,13 @@ class RemoteAgentDriver:
                                 end_sent = True
                 cursor = page.last_seq
                 if page.status in {"ended", "failed"}:
-                    return (
-                        self._client.get_agent_session(self._target_id, session_id),
-                        synchronized,
-                    )
+                    return self._client.get_agent_session(self._target_id, session_id)
                 now = time.monotonic()
                 if stdin_eof.is_set() and self._task is None and not end_sent:
                     self._client.post_agent_session_command(self._target_id, session_id, "end")
                     end_sent = True
-                if synchronized is not None and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
-                    synchronized = self._push_local_patch(session_id, synchronized)
+                if workspace is not None and now - last_workspace_push >= _WORKSPACE_SYNC_TICK_S:
+                    workspace.push_local()
                     last_workspace_push = now
                 time.sleep(0.5)
             except KeyboardInterrupt:
@@ -614,57 +596,6 @@ class RemoteAgentDriver:
                 )
                 self._client.post_agent_session_command(self._target_id, session_id, kind)
                 continue
-
-    def _apply_remote_patch(
-        self,
-        session_id: str,
-        event: object,
-        synchronized: WorkspaceSnapshot,
-    ) -> WorkspaceSnapshot:
-        """Download and apply one announced E2B patch, then advance the local base."""
-        jail_root = self._jail
-        if jail_root is None:
-            raise WorkspaceSyncError("workspace sync is not enabled")
-        payload = getattr(event, "payload", {})
-        revision_value = payload.get("revision") if isinstance(payload, dict) else None
-        if not isinstance(revision_value, str) or not revision_value:
-            raise WorkspaceSyncError("workspace patch event has no revision")
-        content = self._client.download_agent_workspace_patch(
-            self._target_id, session_id, revision_value
-        )
-        result = apply_workspace_patch(jail_root, content)
-        self._live_conflicts.update(result.conflicts)
-        self._client.acknowledge_agent_workspace_patch(self._target_id, session_id, revision_value)
-        if result.applied:
-            _console.print(f"[dim]workspace updated ({len(result.applied)} changed paths)[/dim]")
-        if result.conflicts:
-            paths = ", ".join(result.conflicts)
-            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
-        return snapshot_workspace(jail_root)
-
-    def _push_local_patch(
-        self, session_id: str, synchronized: WorkspaceSnapshot
-    ) -> WorkspaceSnapshot:
-        """Send local edits made since the last synchronized snapshot."""
-        jail_root = self._jail
-        if jail_root is None:
-            return synchronized
-        try:
-            current = snapshot_workspace(jail_root)
-        except WorkspaceSyncError:
-            return synchronized
-        content = build_workspace_patch(synchronized.archive, current.archive)
-        if content is None:
-            return synchronized
-        result = self._client.upload_agent_workspace_patch(self._target_id, session_id, content)
-        self._live_conflicts.update(result.conflicts)
-        if result.conflicts:
-            paths = ", ".join(result.conflicts)
-            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
-        # A conflicted path was rejected by E2B, so ``current`` cannot become
-        # the synchronized base. Keep the prior base and conservatively retry
-        # accepted sibling paths until the conflict is reconciled at teardown.
-        return synchronized if result.conflicts else current
 
 
 class RemoteWorldModelDriver:
@@ -766,6 +697,21 @@ _PROVIDER_OPT = typer.Option(
 _MODEL_OPT = typer.Option("--model", help="Worker model for the built-in local pi harness.")
 _TASK_OPT = typer.Option("--task", "--instruction", help="Opening task for either execution kind.")
 _YES_OPT = typer.Option("--yes", help="Skip the local-execution consent prompt.")
+_DETACH_OPT = typer.Option(
+    "-d", "--detach", help="Start the hosted agent session and return, leaving it running."
+)
+_SEND_OPT = typer.Option(
+    "-s", "--send", help="Send one message to the current (or --session) session and stream it."
+)
+_ATTACH_OPT = typer.Option(
+    "-a", "--attach", help="Attach interactively to the current (or --session) session."
+)
+_END_OPT = typer.Option(
+    "--end", help="End the current (or --session) session after a final workspace sync."
+)
+_SESSION_OPT = typer.Option(
+    "--session", help="Hosted session id to address instead of the current session."
+)
 
 
 def register(app: typer.Typer) -> None:
@@ -780,8 +726,30 @@ def register(app: typer.Typer) -> None:
         model: Annotated[str | None, _MODEL_OPT] = None,
         task: Annotated[str | None, _TASK_OPT] = None,
         yes: Annotated[bool, _YES_OPT] = False,
+        detach: Annotated[bool, _DETACH_OPT] = False,
+        send: Annotated[str | None, _SEND_OPT] = None,
+        attach: Annotated[bool, _ATTACH_OPT] = False,
+        end: Annotated[bool, _END_OPT] = False,
+        session: Annotated[str | None, _SESSION_OPT] = None,
     ) -> None:
         """Run a platform world model/agent by id, or the built-in pi harness."""
+        action = _session_action(send=send, attach=attach, end=end)
+        if action is not None:
+            _reject_run_options_for_session_commands(
+                target=target,
+                directory=directory,
+                upload_directory=upload_directory,
+                provider=provider,
+                model=model,
+                task=task,
+                detach=detach,
+            )
+            _build_session_command_driver(action=action, text=send, session_override=session).run()
+            return
+        if session is not None:
+            raise typer.BadParameter("--session requires --send, --attach, or --end")
+        if detach and target is None:
+            raise typer.BadParameter("--detach requires a platform agent id")
         if target is None and upload_directory is not None:
             raise typer.BadParameter("--upload-dir is only supported for platform agent ids")
         if target is not None and directory is not None:
@@ -812,8 +780,79 @@ def register(app: typer.Typer) -> None:
             model=model,
             task=task,
             confirm_local=confirm_local,
+            detach=detach,
         )
         driver.run()
+
+
+def _session_action(*, send: str | None, attach: bool, end: bool) -> SessionAction | None:
+    """The single detached-session action requested, or ``None`` for a plain run."""
+    chosen: list[SessionAction] = []
+    if send is not None:
+        chosen.append("send")
+    if attach:
+        chosen.append("attach")
+    if end:
+        chosen.append("end")
+    if not chosen:
+        return None
+    if len(chosen) > 1:
+        raise typer.BadParameter("--send, --attach, and --end are mutually exclusive")
+    return chosen[0]
+
+
+def _reject_run_options_for_session_commands(
+    *,
+    target: str | None,
+    directory: str | None,
+    upload_directory: str | None,
+    provider: str | None,
+    model: str | None,
+    task: str | None,
+    detach: bool,
+) -> None:
+    """Keep run-start options off the commands that address an existing session."""
+    if detach:
+        raise typer.BadParameter(
+            "--detach starts a new session; it cannot be combined with --send/--attach/--end"
+        )
+    if target is not None:
+        raise typer.BadParameter(
+            "--send/--attach/--end address an existing session; omit the agent id "
+            "(use --session <session-id> to pick one)"
+        )
+    if upload_directory is not None or directory is not None:
+        raise typer.BadParameter(
+            "workspace sync is chosen when the session starts "
+            "(`wmh run <agent-id> -u PATH --detach`); it cannot be changed afterwards"
+        )
+    if provider is not None or model is not None:
+        raise typer.BadParameter(
+            "hosted sessions use platform credentials; --provider/--model are not accepted"
+        )
+    if task is not None:
+        raise typer.BadParameter(
+            "--task only applies when starting a run; use --send to message the session"
+        )
+
+
+def _build_session_command_driver(
+    *, action: SessionAction, text: str | None, session_override: str | None
+) -> DetachedCommandDriver:
+    """Assemble the authenticated driver behind --send/--attach/--end."""
+    credentials = load_credentials()
+    if not credentials.is_complete():
+        raise typer.BadParameter("run `wmh login` to use hosted agent sessions")
+    client = PlatformClient(str(credentials.api_url), str(credentials.token))
+    return DetachedCommandDriver(
+        client=client,
+        credentials=credentials,
+        state_store=SessionStateStore(),
+        action=action,
+        text=text,
+        session_override=session_override,
+        sink=TerminalEventSink(recorder=None, on_running=lambda _running: None),
+    )
 
 
 def _confirm_local_execution(jail_root: Path, *, target: str | None, yes: bool) -> None:
@@ -837,7 +876,8 @@ def _build_driver(
     model: str | None,
     task: str | None,
     confirm_local: Callable[[], None] | None = None,
-) -> LocalLiveDriver | RemoteAgentDriver | RemoteWorldModelDriver:
+    detach: bool = False,
+) -> LocalLiveDriver | RemoteAgentDriver | RemoteWorldModelDriver | DetachedStartDriver:
     """Resolve the target kind once and assemble its execution driver."""
     credentials = load_credentials()
     logged_in = credentials.is_complete()
@@ -903,10 +943,25 @@ def _build_driver(
     try:
         resolved = client.resolve_run_target(target)
         if resolved.kind == "world_model":
+            if detach:
+                client.close()
+                raise typer.BadParameter(
+                    "world-model sessions are interactive only; --detach needs an agent id"
+                )
             if jail_root is not None:
                 client.close()
                 raise typer.BadParameter("--upload-dir is only supported for agent ids")
             return RemoteWorldModelDriver(client, resolved.id, resolved.name, task)
+        if detach:
+            return DetachedStartDriver(
+                client=client,
+                credentials=credentials,
+                state_store=SessionStateStore(),
+                target_id=resolved.id,
+                name=resolved.name,
+                jail_root=jail_root,
+                task=task,
+            )
         return RemoteAgentDriver(client, resolved.id, resolved.name, jail_root, task)
     except PlatformError as error:
         client.close()

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -1137,3 +1137,52 @@ def test_reader_keeps_reading_after_a_failed_steer_post(
     assert reader.eof.is_set()
     assert not reader.detach.is_set()
     assert "failed" in capsys.readouterr().out
+
+
+def test_second_interrupt_during_the_plain_handler_still_ends(tmp_path: Path) -> None:
+    """A Ctrl-C landing inside the plain-run interrupt handler escalates to end."""
+
+    class _Client:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+            self.polls = 0
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "sess-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            self.polls += 1
+            if self.polls == 1:
+                raise KeyboardInterrupt
+            return type("Page", (), {"events": [], "last_seq": 0, "status": "ended"})()
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            _ = text
+            self.commands.append(kind)
+            if kind == "interrupt":
+                raise KeyboardInterrupt
+
+        def get_agent_session(self, *_args: object) -> object:
+            return type("Session", (), {"status": "ended", "error": None})()
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _NoReader:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    client = _Client()
+    driver, _store = _plain_driver(client, tmp_path)
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(mod, "RemoteAgentCommandReader", _NoReader)
+        driver.run()
+
+    assert client.commands == ["interrupt", "end"]
+    assert client.closed

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -780,13 +780,13 @@ def test_run_session_flag_combinations_are_validated(monkeypatch: pytest.MonkeyP
 
 def test_run_dispatches_session_commands(monkeypatch: pytest.MonkeyPatch) -> None:
     """--send/--attach/--end route to the detached command driver, unified in run."""
-    captured: list[dict[str, object]] = []
+    captured: list[dict[str, str | None]] = []
 
     class _Driver:
         def run(self) -> None:
             pass
 
-    def build(**kwargs: object) -> _Driver:
+    def build(**kwargs: str | None) -> _Driver:
         captured.append(kwargs)
         return _Driver()
 

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -718,7 +718,7 @@ def test_remote_agent_driver_applies_live_workspace_patch(
             event = type(
                 "Event",
                 (),
-                {"kind": "workspace_patch", "payload": {"revision": "patch-1"}},
+                {"seq": 1, "kind": "workspace_patch", "payload": {"revision": "patch-1"}},
             )()
             return type("Page", (), {"events": [event], "last_seq": 1, "status": "ended"})()
 
@@ -1186,3 +1186,92 @@ def test_second_interrupt_during_the_plain_handler_still_ends(tmp_path: Path) ->
 
     assert client.commands == ["interrupt", "end"]
     assert client.closed
+
+
+def test_plain_run_interrupt_around_a_patch_ack_promotes_a_fresh_cursor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Ctrl-C during the patch ack must not leave a cursor that re-fetches it.
+
+    The resumed loop (and a later :detach promotion) must poll past the
+    processed patch event: its object is acknowledged, so re-requesting it
+    would 404 and abort the next detached command.
+    """
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = mod.snapshot_workspace(root)
+    remote = io.BytesIO()
+    with tarfile.open(fileobj=remote, mode="w:gz") as archive:
+        body = b"during"
+        info = tarfile.TarInfo("answer.txt")
+        info.size = len(body)
+        info.mode = 0o644
+        archive.addfile(info, io.BytesIO(body))
+    patch = build_workspace_patch(base.archive, remote.getvalue())
+    assert patch is not None
+
+    class _Client:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+            self.acks = 0
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "sess-1"})()
+
+        def list_agent_session_events(
+            self, _agent_id: str, _session_id: str, *, after: int
+        ) -> object:
+            self.calls.append(f"events after={after}")
+            if after == 0:
+                event = type(
+                    "Event",
+                    (),
+                    {"seq": 1, "kind": "workspace_patch", "payload": {"revision": "p1"}},
+                )()
+                return type("Page", (), {"events": [event], "last_seq": 1, "status": "running"})()
+            return type("Page", (), {"events": [], "last_seq": after, "status": "running"})()
+
+        def download_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: str
+        ) -> bytes:
+            self.calls.append(f"patch:{revision}")
+            if revision != "p1" or self.acks:
+                pytest.fail("an acknowledged patch must never be re-requested")
+            return patch
+
+        def acknowledge_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: str
+        ) -> None:
+            _ = revision
+            self.acks += 1
+            raise KeyboardInterrupt
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            _ = kind, text
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _DetachAfterResume:
+        def __init__(self, *_args: object) -> None:
+            self.eof = threading.Event()
+            self.detach = threading.Event()
+            self.detach.set()
+
+        def start(self) -> None:
+            pass
+
+    client = _Client()
+    driver, store = _plain_driver(client, tmp_path, jail_root=root)
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _DetachAfterResume)
+    driver.run()
+
+    assert client.calls.count("patch:p1") == 1
+    assert "events after=1" in client.calls
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 1

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import io
 import tarfile
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -17,6 +18,8 @@ from typer.testing import CliRunner
 import wmh.cli.agent_session as mod
 import wmh.cli.hosted_session as hosted_mod
 from wmh.cli import app
+from wmh.cli.session_state import DetachedSessionState, SessionStateError, SessionStateStore
+from wmh.cli.workspace_sync import snapshot_from_archive
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.workspace_patch import build_workspace_patch
 from wmh.platform.credentials import PlatformCredentials
@@ -549,7 +552,13 @@ def test_remote_agent_driver_syncs_final_e2b_workspace(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, "fix it"
+        cast("mod.PlatformClient", client),
+        "agent-1",
+        "Agent",
+        tmp_path,
+        "fix it",
+        credentials=PlatformCredentials(api_url="https://api.test", token="xpl_test"),
+        state_store=SessionStateStore(tmp_path / ".state"),
     ).run()
 
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "after"
@@ -606,7 +615,13 @@ def test_failed_hosted_session_is_not_hidden_by_workspace_conflicts(
 
     with pytest.raises(typer.Exit) as raised:
         mod.RemoteAgentDriver(
-            cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, "fix it"
+            cast("mod.PlatformClient", client),
+            "agent-1",
+            "Agent",
+            tmp_path,
+            "fix it",
+            credentials=PlatformCredentials(api_url="https://api.test", token="xpl_test"),
+            state_store=SessionStateStore(tmp_path / ".state"),
         ).run()
 
     assert raised.value.exit_code == 1
@@ -661,7 +676,13 @@ def test_remote_agent_driver_without_upload_never_reads_local_workspace(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client), "agent-1", "Agent", None, "work remotely"
+        cast("mod.PlatformClient", client),
+        "agent-1",
+        "Agent",
+        None,
+        "work remotely",
+        credentials=PlatformCredentials(api_url="https://api.test", token="xpl_test"),
+        state_store=SessionStateStore(tmp_path / ".state"),
     ).run()
 
     assert client.created_workspaces == [None]
@@ -734,7 +755,13 @@ def test_remote_agent_driver_applies_live_workspace_patch(
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
 
     mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", client), "agent-1", "Agent", tmp_path, None
+        cast("mod.PlatformClient", client),
+        "agent-1",
+        "Agent",
+        tmp_path,
+        None,
+        credentials=PlatformCredentials(api_url="https://api.test", token="xpl_test"),
+        state_store=SessionStateStore(tmp_path / ".state"),
     ).run()
 
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "during"
@@ -840,3 +867,240 @@ def test_build_driver_detach_rejects_world_models(monkeypatch: pytest.MonkeyPatc
             task=None,
             detach=True,
         )
+
+
+# -- plain-run :detach promotion ---------------------------------------------------------------
+
+
+class _DetachedReader:
+    """A reader stub whose user immediately detaches (never EOF, never end)."""
+
+    def __init__(self, *_args: object) -> None:
+        self.eof = threading.Event()
+        self.detach = threading.Event()
+        self.detach.set()
+
+    def start(self) -> None:
+        pass
+
+
+def _plain_driver(
+    client: object,
+    tmp_path: Path,
+    *,
+    jail_root: Path | None = None,
+    task: str | None = None,
+) -> tuple[mod.RemoteAgentDriver, SessionStateStore]:
+    """A plain hosted driver wired to an injectable session-state store."""
+    store = SessionStateStore(tmp_path / "state")
+    driver = mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", client),
+        "agent-1",
+        "Agent",
+        jail_root,
+        task,
+        credentials=PlatformCredentials(
+            api_url="https://api.test", web_url="https://platform.test", token="xpl_test"
+        ),
+        state_store=store,
+    )
+    return driver, store
+
+
+def test_reader_detach_skips_eof_end_and_guards_unknown_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """:detach stops reading without ending; unknown :commands never become chat."""
+
+    class _Client:
+        def __init__(self) -> None:
+            self.posted: list[tuple[str, str | None]] = []
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            self.posted.append((kind, text))
+
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":detach\n"))
+    client = _Client()
+    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+    reader.run()
+    assert reader.detach.is_set()
+    assert not reader.eof.is_set()
+    assert client.posted == []
+
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":frob\nhello\n:end\n"))
+    client = _Client()
+    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+    reader.run()
+    assert client.posted == [("user_message", "hello"), ("end", None)]
+    assert not reader.detach.is_set()
+
+
+def test_plain_run_detach_promotes_session_without_ending(tmp_path: Path) -> None:
+    """:detach in a plain run persists the current-session reference and exits."""
+
+    class _Client:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "sess-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            event = type(
+                "Event", (), {"seq": 3, "kind": "assistant_message", "payload": {"text": "hi"}}
+            )()
+            return type("Page", (), {"events": [event], "last_seq": 3, "status": "running"})()
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            _ = text
+            self.commands.append(kind)
+
+        def download_agent_workspace(self, *_args: object) -> bytes:
+            pytest.fail("a detach promotion must not run the final workspace sync")
+
+        def close(self) -> None:
+            self.closed = True
+
+    client = _Client()
+    driver, store = _plain_driver(client, tmp_path)
+    with pytest.MonkeyPatch.context() as patcher:
+        patcher.setattr(mod, "RemoteAgentCommandReader", _DetachedReader)
+        driver.run()
+
+    assert client.commands == []
+    assert client.closed
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.api_url == "https://api.test"
+    assert state.agent_id == "agent-1"
+    assert state.session_id == "sess-1"
+    assert state.cursor == 3
+    assert state.workspace is None
+    assert store.current_session_id() == "sess-1"
+
+
+def test_plain_run_detach_with_workspace_checkpoints_without_final_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Promotion persists the synced checkpoint; no finalize, patches stay acked."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = mod.snapshot_workspace(root)
+    remote = io.BytesIO()
+    with tarfile.open(fileobj=remote, mode="w:gz") as archive:
+        body = b"during"
+        info = tarfile.TarInfo("answer.txt")
+        info.size = len(body)
+        info.mode = 0o644
+        archive.addfile(info, io.BytesIO(body))
+    patch = build_workspace_patch(base.archive, remote.getvalue())
+    assert patch is not None
+
+    class _Client:
+        def __init__(self) -> None:
+            self.patch_acks: list[str] = []
+            self.closed = False
+
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "sess-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            event = type(
+                "Event", (), {"seq": 1, "kind": "workspace_patch", "payload": {"revision": "p1"}}
+            )()
+            return type("Page", (), {"events": [event], "last_seq": 1, "status": "running"})()
+
+        def download_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: str
+        ) -> bytes:
+            assert revision == "p1"
+            return patch
+
+        def acknowledge_agent_workspace_patch(
+            self, _agent_id: str, _session_id: str, revision: str
+        ) -> None:
+            self.patch_acks.append(revision)
+
+        def download_agent_workspace(self, *_args: object) -> bytes:
+            pytest.fail("a detach promotion must not run the final workspace sync")
+
+        def acknowledge_agent_workspace(self, *_args: object) -> None:
+            pytest.fail("a detach promotion must not acknowledge the final workspace")
+
+        def close(self) -> None:
+            self.closed = True
+
+    client = _Client()
+    driver, store = _plain_driver(client, tmp_path, jail_root=root)
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _DetachedReader)
+    driver.run()
+
+    assert client.patch_acks == ["p1"]
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "during"
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 1
+    assert state.workspace is not None
+    assert state.workspace.root == str(root)
+    checkpoint = snapshot_from_archive(store.load_base_archive(state))
+    assert checkpoint.files == mod.snapshot_workspace(root).files
+
+
+def test_plain_run_detach_state_failure_names_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed promotion save still hands the user the session id."""
+
+    class _FailingStore(SessionStateStore):
+        def save(
+            self, state: DetachedSessionState, *, base_archive: bytes | None = None
+        ) -> DetachedSessionState:
+            raise SessionStateError("disk full")
+
+    class _Client:
+        def create_agent_session(self, *_args: object, **_kwargs: object) -> object:
+            return type("Session", (), {"id": "sess-1"})()
+
+        def list_agent_session_events(self, *_args: object, **_kwargs: object) -> object:
+            return type("Page", (), {"events": [], "last_seq": 0, "status": "running"})()
+
+        def close(self) -> None:
+            pass
+
+    driver = mod.RemoteAgentDriver(
+        cast("mod.PlatformClient", _Client()),
+        "agent-1",
+        "Agent",
+        None,
+        None,
+        credentials=PlatformCredentials(api_url="https://api.test", token="xpl_test"),
+        state_store=_FailingStore(tmp_path / "state"),
+    )
+    monkeypatch.setattr(mod, "RemoteAgentCommandReader", _DetachedReader)
+    with pytest.raises(typer.BadParameter, match="sess-1"):
+        driver.run()
+
+
+def test_world_model_loop_rejects_detach(monkeypatch: pytest.MonkeyPatch) -> None:
+    """:detach in a world-model REPL warns instead of stepping the model."""
+
+    class _Client:
+        def step_world_model_session(self, *_args: object, **_kwargs: object) -> object:
+            pytest.fail(":detach must never reach the world model as an action")
+
+        def close(self) -> None:
+            pass
+
+    lines = iter([":detach", ":quit"])
+    monkeypatch.setattr(mod._console, "input", lambda *_a, **_k: next(lines))
+    driver = mod.RemoteWorldModelDriver(
+        cast("mod.PlatformClient", _Client()), "wm-1", "Model", None
+    )
+
+    driver._loop("sess-1")

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -15,6 +15,7 @@ from llm_waterfall.types import ChatChoice, ChatMessage, ChatRequest, ChatRespon
 from typer.testing import CliRunner
 
 import wmh.cli.agent_session as mod
+import wmh.cli.hosted_session as hosted_mod
 from wmh.cli import app
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.workspace_patch import build_workspace_patch
@@ -490,27 +491,6 @@ def test_local_driver_returns_nonzero_when_the_runner_fails(
     assert channel.closed
 
 
-def test_conflicted_local_patch_does_not_advance_the_synchronized_base(tmp_path: Path) -> None:
-    """A rejected same-file edit remains outside the platform-accepted snapshot."""
-    path = tmp_path / "answer.txt"
-    path.write_text("before", encoding="utf-8")
-    initial = mod.snapshot_workspace(tmp_path)
-    path.write_text("local", encoding="utf-8")
-
-    class _Client:
-        def upload_agent_workspace_patch(self, *_args: object, **_kwargs: object) -> object:
-            return type("Result", (), {"conflicts": ("answer.txt",)})()
-
-    driver = mod.RemoteAgentDriver(
-        cast("mod.PlatformClient", _Client()), "agent-1", "Agent", tmp_path, "work"
-    )
-
-    synchronized = driver._push_local_patch("session-1", initial)
-
-    assert synchronized is initial
-    assert driver._live_conflicts == {"answer.txt"}
-
-
 def test_remote_agent_driver_syncs_final_e2b_workspace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -617,7 +597,7 @@ def test_failed_hosted_session_is_not_hidden_by_workspace_conflicts(
     client = _HostedClient()
     monkeypatch.setattr(mod, "RemoteAgentCommandReader", _NoReader)
     monkeypatch.setattr(
-        mod,
+        hosted_mod,
         "sync_workspace",
         lambda *_args, **_kwargs: type(
             "Result", (), {"applied": (), "conflicts": ("answer.txt",)}
@@ -760,3 +740,103 @@ def test_remote_agent_driver_applies_live_workspace_patch(
     assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "during"
     assert client.patch_acks == ["patch-1"]
     assert client.closed
+
+
+# -- detached session flags -------------------------------------------------------------------
+
+
+def test_run_session_flag_combinations_are_validated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The detached options keep one unambiguous meaning per invocation."""
+    monkeypatch.setattr(
+        mod, "_build_session_command_driver", lambda **_kw: pytest.fail("must not build")
+    )
+    monkeypatch.setattr(mod, "_build_driver", lambda **_kw: pytest.fail("must not build"))
+    runner = CliRunner()
+
+    exclusive = runner.invoke(app, ["run", "-s", "hi", "-a"])
+    assert exclusive.exit_code != 0
+    assert "mutually exclusive" in exclusive.output
+
+    dangling_session = runner.invoke(app, ["run", "--session", "sess-1"])
+    assert dangling_session.exit_code != 0
+    assert "--session" in dangling_session.output
+
+    send_with_target = runner.invoke(app, ["run", "agent-1", "-s", "hi"])
+    assert send_with_target.exit_code != 0
+
+    detach_without_target = runner.invoke(app, ["run", "-d"])
+    assert detach_without_target.exit_code != 0
+    assert "agent id" in detach_without_target.output
+
+    send_with_upload = runner.invoke(app, ["run", "-s", "hi", "-u", "."])
+    assert send_with_upload.exit_code != 0
+
+    send_with_task = runner.invoke(app, ["run", "-s", "hi", "--task", "x"])
+    assert send_with_task.exit_code != 0
+
+    detach_with_send = runner.invoke(app, ["run", "agent-1", "-d", "-s", "hi"])
+    assert detach_with_send.exit_code != 0
+
+
+def test_run_dispatches_session_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--send/--attach/--end route to the detached command driver, unified in run."""
+    captured: list[dict[str, object]] = []
+
+    class _Driver:
+        def run(self) -> None:
+            pass
+
+    def build(**kwargs: object) -> _Driver:
+        captured.append(kwargs)
+        return _Driver()
+
+    monkeypatch.setattr(mod, "_build_session_command_driver", build)
+    runner = CliRunner()
+
+    assert runner.invoke(app, ["run", "--send", "do it"]).exit_code == 0
+    assert runner.invoke(app, ["run", "-a", "--session", "sess-2"]).exit_code == 0
+    assert runner.invoke(app, ["run", "--end"]).exit_code == 0
+
+    assert captured == [
+        {"action": "send", "text": "do it", "session_override": None},
+        {"action": "attach", "text": None, "session_override": "sess-2"},
+        {"action": "end", "text": None, "session_override": None},
+    ]
+
+
+def test_build_driver_detach_returns_start_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--detach on an agent id builds the detached start driver, not the streamer."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    driver = mod._build_driver(
+        target="a1",
+        jail_root=None,
+        provider=None,
+        model=None,
+        task="do it",
+        detach=True,
+    )
+
+    assert isinstance(driver, hosted_mod.DetachedStartDriver)
+
+
+def test_build_driver_detach_rejects_world_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """World-model sessions are interactive only; --detach names agents."""
+    creds = PlatformCredentials(api_url="https://api.test", token="xpl_test")
+    monkeypatch.setattr(mod, "load_credentials", lambda: creds)
+    client = _FakeClient()
+    client.target_kind = "world_model"
+    monkeypatch.setattr(mod, "PlatformClient", lambda *_a, **_k: client)
+
+    with pytest.raises(typer.BadParameter, match="agent"):
+        mod._build_driver(
+            target="wm-1",
+            jail_root=None,
+            provider=None,
+            model=None,
+            task=None,
+            detach=True,
+        )

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -22,6 +22,7 @@ from wmh.cli.session_state import DetachedSessionState, SessionStateError, Sessi
 from wmh.cli.workspace_sync import snapshot_from_archive
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.workspace_patch import build_workspace_patch
+from wmh.platform.client import PlatformError
 from wmh.platform.credentials import PlatformCredentials
 
 if TYPE_CHECKING:
@@ -1104,3 +1105,35 @@ def test_world_model_loop_rejects_detach(monkeypatch: pytest.MonkeyPatch) -> Non
     )
 
     driver._loop("sess-1")
+
+
+def test_reader_keeps_reading_after_a_failed_steer_post(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A transient post failure warns and keeps the session attached, never ends it."""
+
+    class _FlakyClient:
+        def __init__(self) -> None:
+            self.posted: list[tuple[str, str | None]] = []
+            self.failed_once = False
+
+        def post_agent_session_command(
+            self, _agent_id: str, _session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            if kind == "user_message" and not self.failed_once:
+                self.failed_once = True
+                raise PlatformError("backend unavailable", status_code=503)
+            self.posted.append((kind, text))
+
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO("hello\n:stop\n"))
+    client = _FlakyClient()
+    reader = mod.RemoteAgentCommandReader(cast("mod.PlatformClient", client), "a", "s")
+
+    reader.run()
+
+    # The failed steer was reported, the reader kept going, and only true
+    # stdin EOF set the eof flag; nothing ended or detached the session.
+    assert client.posted == [("interrupt", None)]
+    assert reader.eof.is_set()
+    assert not reader.detach.is_set()
+    assert "failed" in capsys.readouterr().out

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -39,6 +39,7 @@ from wmh.cli.session_state import (
 from wmh.cli.workspace_sync import (
     WorkspaceSnapshot,
     WorkspaceSyncError,
+    apply_patch_to_snapshot,
     apply_workspace_patch,
     snapshot_from_archive,
     snapshot_workspace,
@@ -114,7 +115,13 @@ class LiveWorkspace:
         )
         result = apply_workspace_patch(self.root, content)
         self.conflicts.update(result.conflicts)
-        self.synchronized = snapshot_workspace(self.root)
+        # Advance the base by base+patch, never by re-reading the directory:
+        # a disk snapshot here would absorb not-yet-uploaded local edits into
+        # the base, so they would never upload (and the final sync could even
+        # delete them). Conflicted paths stay at their base state.
+        self.synchronized = apply_patch_to_snapshot(
+            self.synchronized, content, conflicts=result.conflicts
+        )
         if before_ack is not None:
             before_ack()
         self._client.acknowledge_agent_workspace_patch(self._agent_id, self._session_id, revision)
@@ -491,12 +498,12 @@ class DetachedCommandDriver:
     def _send(self, stream: _Stream) -> None:
         """Catch up, deliver one message, and stream its turn until idle."""
         text = self._text if self._text is not None else ""
+        self._push_workspace(stream)
         if self._catch_up(stream) == "terminal":
             self._finish_terminal(
                 stream, failure_note="the session ended before the message could be sent"
             )
             return
-        self._push_workspace(stream)
         self._client.post_agent_session_command(
             stream.state.agent_id, stream.state.session_id, "user_message", text=text
         )
@@ -514,10 +521,10 @@ class DetachedCommandDriver:
 
     def _attach(self, stream: _Stream) -> None:
         """Catch up, then stream interactively until the user detaches or ends."""
+        self._push_workspace(stream)
         if self._catch_up(stream) == "terminal":
             self._finish_terminal(stream)
             return
-        self._push_workspace(stream)
         stream.render = True
         reader = AttachedCommandReader(self._client, stream.state.agent_id, stream.state.session_id)
         reader.start()
@@ -535,8 +542,8 @@ class DetachedCommandDriver:
 
     def _end(self, stream: _Stream) -> None:
         """Catch up, push local edits, end the session, and run the final sync."""
+        self._push_workspace(stream)
         if self._catch_up(stream) != "terminal":
-            self._push_workspace(stream)
             remote = self._client.end_agent_session(stream.state.agent_id, stream.state.session_id)
             if remote.status not in TERMINAL_STATUSES:
                 outcome = self._stream_until(stream, stop=lambda: False)
@@ -610,8 +617,7 @@ class DetachedCommandDriver:
                     return "stopped"
                 now = time.monotonic()
                 if stream.workspace is not None and now - last_push >= _WORKSPACE_SYNC_TICK_S:
-                    stream.workspace.push_local()
-                    self._persist(stream, stream.cursor)
+                    self._push_workspace(stream)
                     last_push = now
                 if now - last_probe >= _STALE_PROBE_S:
                     # The detail read lazily reconciles a dead driver so the
@@ -675,10 +681,20 @@ class DetachedCommandDriver:
     # -- checkpointing -----------------------------------------------------------------------
 
     def _push_workspace(self, stream: _Stream) -> None:
-        """Upload local edits made since the checkpoint, then persist it."""
+        """Upload local edits made since the checkpoint, then persist it.
+
+        A workspace whose sandbox is not accepting patches yet (booting, or
+        winding down) is tolerated: the streaming loop retries every tick, and
+        an end falls back to the conflict-preserving final sync.
+        """
         if stream.workspace is None:
             return
-        stream.workspace.push_local()
+        try:
+            stream.workspace.push_local()
+        except PlatformError as error:
+            if error.status_code not in {409, 503}:
+                raise
+            _console.print("[dim]local changes will sync once the workspace is running[/dim]")
         self._persist(stream, stream.cursor)
 
     def _persist(self, stream: _Stream, cursor: int) -> None:

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -1,0 +1,702 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Detached lifecycle and workspace transport for hosted E2B agent sessions.
+
+``wmh run <agent-id> --detach`` starts a normal platform-owned agent session
+and returns immediately, remembering it as the current session in WMH user
+state. Later ``wmh run --send/--attach/--end`` invocations address that
+session (or any accessible session via ``--session <id>``) through the same
+authenticated platform protocol the web app uses: durable transcript polling,
+queued commands, live workspace patches, and the final workspace handoff.
+
+No local process runs between invocations, so a persisted checkpoint (the
+transcript cursor plus the last synchronized workspace snapshot) lets the next
+command catch up on hosted workspace patches and upload local edits before
+proceeding. Sessions remain ordinary platform records: they stay visible and
+controllable from the web application throughout.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import typer
+from rich.console import Console
+
+from wmh.cli.session_state import (
+    DetachedSessionState,
+    SessionStateError,
+    SessionStateStore,
+    WorkspaceCheckpoint,
+)
+from wmh.cli.workspace_sync import (
+    WorkspaceSnapshot,
+    WorkspaceSyncError,
+    apply_workspace_patch,
+    snapshot_from_archive,
+    snapshot_workspace,
+    sync_workspace,
+    write_conflict_archive,
+)
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.workspace_patch import WorkspacePatchError, build_workspace_patch
+from wmh.platform.client import PlatformClient, PlatformError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from wmh.cli.workspace_sync import SyncResult
+    from wmh.platform.client import (
+        RemoteAgentEventPage,
+        RemoteAgentSession,
+        RemoteAgentSessionEvent,
+    )
+    from wmh.platform.credentials import PlatformCredentials
+
+_console = Console()
+
+TERMINAL_STATUSES = frozenset({"ended", "failed"})
+SessionAction = Literal["send", "attach", "end"]
+
+_POLL_INTERVAL_S = 0.5
+_WORKSPACE_SYNC_TICK_S = 1.0
+# A session whose driver died keeps answering `running` on the events poll;
+# the detail read reconciles it server-side, so probe it occasionally.
+_STALE_PROBE_S = 30.0
+
+
+def patch_revision(event: RemoteAgentSessionEvent) -> str:
+    """Extract the patch revision announced by one ``workspace_patch`` event."""
+    revision = event.payload.get("revision")
+    if not isinstance(revision, str) or not revision:
+        raise WorkspaceSyncError("workspace patch event has no revision")
+    return revision
+
+
+class LiveWorkspace:
+    """Bidirectional file transport between one local root and a hosted session."""
+
+    def __init__(
+        self,
+        client: PlatformClient,
+        agent_id: str,
+        session_id: str,
+        root: Path,
+        synchronized: WorkspaceSnapshot,
+        conflicts: Iterable[str] = (),
+    ) -> None:
+        """Bind the transport to its synchronized base snapshot and known conflicts."""
+        self._client = client
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self.root = root
+        self.synchronized = synchronized
+        self.conflicts: set[str] = set(conflicts)
+
+    def apply_remote_patch(
+        self, revision: str, *, before_ack: Callable[[], None] | None = None
+    ) -> None:
+        """Download and apply one announced E2B patch, then advance the local base.
+
+        ``before_ack`` runs after the local base advanced but before the patch
+        is acknowledged: a detached checkpoint persisted there guarantees an
+        acknowledged (hence deleted) patch is never needed again.
+        """
+        content = self._client.download_agent_workspace_patch(
+            self._agent_id, self._session_id, revision
+        )
+        result = apply_workspace_patch(self.root, content)
+        self.conflicts.update(result.conflicts)
+        self.synchronized = snapshot_workspace(self.root)
+        if before_ack is not None:
+            before_ack()
+        self._client.acknowledge_agent_workspace_patch(self._agent_id, self._session_id, revision)
+        if result.applied:
+            _console.print(f"[dim]workspace updated ({len(result.applied)} changed paths)[/dim]")
+        if result.conflicts:
+            paths = ", ".join(result.conflicts)
+            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
+
+    def push_local(self) -> bool:
+        """Send local edits made since the last synchronized snapshot.
+
+        Returns:
+            Whether the synchronized base advanced (all changes were accepted).
+        """
+        try:
+            current = snapshot_workspace(self.root)
+        except WorkspaceSyncError:
+            return False
+        content = build_workspace_patch(self.synchronized.archive, current.archive)
+        if content is None:
+            return False
+        result = self._client.upload_agent_workspace_patch(
+            self._agent_id, self._session_id, content
+        )
+        self.conflicts.update(result.conflicts)
+        if result.conflicts:
+            paths = ", ".join(result.conflicts)
+            _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
+            # A conflicted path was rejected by E2B, so ``current`` cannot become
+            # the synchronized base. Keep the prior base and conservatively retry
+            # accepted sibling paths until the conflict is reconciled at teardown.
+            return False
+        self.synchronized = current
+        return True
+
+    def finalize(self) -> SyncResult:
+        """Reconcile the terminal session's final E2B workspace into the root.
+
+        Applies the three-way merge against the last synchronized snapshot,
+        preserves conflicting local paths (plus the full result under
+        ``.wmh-conflicts/``), and acknowledges the handoff so the platform can
+        remove its private archive objects.
+        """
+        with _console.status("[dim]syncing E2B workspace back...[/dim]", spinner="dots"):
+            final_archive = self._client.download_agent_workspace(self._agent_id, self._session_id)
+            result = sync_workspace(
+                self.root,
+                self.synchronized,
+                final_archive,
+                protected_paths=frozenset(self.conflicts),
+            )
+        if result.conflicts:
+            recovery = write_conflict_archive(self.root, self._session_id, final_archive)
+            self._client.acknowledge_agent_workspace(self._agent_id, self._session_id)
+            paths = ", ".join(result.conflicts)
+            _console.print(
+                f"[red]workspace conflicts preserved locally[/red]: {paths}\n"
+                f"The full E2B result is saved at [bold]{recovery}[/bold]."
+            )
+        else:
+            self._client.acknowledge_agent_workspace(self._agent_id, self._session_id)
+            _console.print(f"[green]workspace synced[/green] ({len(result.applied)} changed paths)")
+        return result
+
+
+class DetachedStartDriver:
+    """Start a hosted agent session, persist its reference, and return."""
+
+    def __init__(
+        self,
+        *,
+        client: PlatformClient,
+        credentials: PlatformCredentials,
+        state_store: SessionStateStore,
+        target_id: str,
+        name: str,
+        jail_root: Path | None,
+        task: str | None,
+    ) -> None:
+        """Store the resolved agent target and optional workspace root."""
+        self._client = client
+        self._credentials = credentials
+        self._store = state_store
+        self._target_id = target_id
+        self._name = name
+        self._jail = jail_root
+        self._task = task
+
+    def run(self) -> None:
+        """Create the session, persist the reference and checkpoint, and exit."""
+        try:
+            initial: WorkspaceSnapshot | None = None
+            if self._jail is not None:
+                with _console.status("[dim]snapshotting local workspace...[/dim]", spinner="dots"):
+                    initial = snapshot_workspace(self._jail)
+                _console.print(
+                    f"[dim]uploading {len(initial.files)} files to the platform "
+                    "E2B workspace...[/dim]"
+                )
+            session = self._client.create_agent_session(
+                self._target_id,
+                workspace=initial.archive if initial is not None else None,
+                instruction=self._task,
+            )
+            workspace: WorkspaceCheckpoint | None = None
+            if self._jail is not None:
+                workspace = WorkspaceCheckpoint(root=str(self._jail))
+            state = DetachedSessionState(
+                api_url=str(self._credentials.api_url),
+                web_url=self._credentials.web_url,
+                agent_id=self._target_id,
+                agent_name=self._name,
+                session_id=session.id,
+                created_at=datetime.now(tz=UTC).isoformat(),
+                workspace=workspace,
+            )
+            self._store.save(state, base_archive=initial.archive if initial is not None else None)
+            self._store.set_current(session.id)
+            _console.print(
+                f"[green]detached E2B session started[/green] for [bold]{self._name}[/bold]\n"
+                f"  agent    {self._target_id}\n"
+                f"  session  {session.id}\n"
+                'Send a message with [bold]wmh run -s "..."[/bold], attach with '
+                "[bold]wmh run -a[/bold], end with [bold]wmh run --end[/bold]."
+            )
+        except (WorkspacePatchError, WorkspaceSyncError, SessionStateError) as error:
+            raise typer.BadParameter(str(error)) from error
+        except PlatformError as error:
+            raise typer.BadParameter(str(error)) from error
+        finally:
+            self._client.close()
+
+
+class AttachedCommandReader(threading.Thread):
+    """Terminal input for an attached session: steer, interrupt, detach, or end."""
+
+    def __init__(self, client: PlatformClient, agent_id: str, session_id: str) -> None:
+        """Read stdin on a daemon thread; commands post through the platform."""
+        super().__init__(daemon=True)
+        self._client = client
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self.detach = threading.Event()
+
+    def run(self) -> None:
+        """Map lines to hosted commands; leaving the terminal detaches, never ends."""
+        try:
+            for raw in sys.stdin:
+                if self.detach.is_set():
+                    return
+                line = raw.strip()
+                if line in {":detach", ":quit", ":q", ":exit"}:
+                    self.detach.set()
+                    return
+                if line == ":end":
+                    self._client.end_agent_session(self._agent_id, self._session_id)
+                elif line == ":stop":
+                    self._post("interrupt")
+                elif line:
+                    self._post("user_message", text=line)
+        except (OSError, PlatformError):
+            pass
+        finally:
+            # Closed stdin means the terminal went away, not that the hosted
+            # session should end. Ending stays explicit (:end or --end).
+            self.detach.set()
+
+    def _post(self, kind: str, *, text: str | None = None) -> None:
+        """Post one command through the authenticated platform client."""
+        self._client.post_agent_session_command(self._agent_id, self._session_id, kind, text=text)
+
+
+@dataclass
+class _Stream:
+    """Mutable streaming state threaded through the detached event loop."""
+
+    state: DetachedSessionState
+    persisted: bool
+    workspace: LiveWorkspace | None
+    render: bool
+    cursor: int = 0
+    pending_text: str | None = None
+    message_seen: bool = False
+    turn_idle: bool = False
+    foreign_patch_noted: bool = False
+
+
+class DetachedCommandDriver:
+    """Send to, attach to, or end one hosted session from its stored reference."""
+
+    def __init__(
+        self,
+        *,
+        client: PlatformClient,
+        credentials: PlatformCredentials,
+        state_store: SessionStateStore,
+        action: SessionAction,
+        text: str | None,
+        session_override: str | None,
+        sink: Callable[[SessionEvent], None],
+    ) -> None:
+        """Bind one action to the resolved credentials, state store, and renderer."""
+        self._client = client
+        self._credentials = credentials
+        self._store = state_store
+        self._action = action
+        self._text = text
+        self._session_override = session_override
+        self._sink = sink
+        self._interrupts = 0
+        self._persisted_snapshot: WorkspaceSnapshot | None = None
+
+    def run(self) -> None:
+        """Resolve the session, catch up, and run the requested action."""
+        try:
+            self._run()
+        except (WorkspacePatchError, WorkspaceSyncError, SessionStateError) as error:
+            raise typer.BadParameter(str(error)) from error
+        except PlatformError as error:
+            raise typer.BadParameter(str(error)) from error
+        finally:
+            self._client.close()
+
+    # -- resolution --------------------------------------------------------------------------
+
+    def _run(self) -> None:
+        state, persisted, remote = self._resolve()
+        if remote.status in TERMINAL_STATUSES:
+            self._handle_already_terminal(state, persisted, remote)
+            return
+        workspace = self._load_workspace(state, persisted)
+        stream = _Stream(
+            state=state,
+            persisted=persisted,
+            workspace=workspace,
+            render=persisted,
+            cursor=state.cursor,
+        )
+        match self._action:
+            case "send":
+                self._send(stream)
+            case "attach":
+                self._attach(stream)
+            case "end":
+                self._end(stream)
+
+    def _resolve(self) -> tuple[DetachedSessionState, bool, RemoteAgentSession]:
+        """Resolve the addressed session to state, persistence, and remote record."""
+        api_url = str(self._credentials.api_url)
+        override = self._session_override
+        if override is not None:
+            stored = self._store.load(override)
+            if stored is None:
+                return self._resolve_remote(override, api_url)
+            state = stored
+        else:
+            current = self._store.current_session_id()
+            if current is None:
+                raise typer.BadParameter(
+                    "no current session: start one with `wmh run <agent-id> --detach`, "
+                    "or address one with --session <session-id>"
+                )
+            loaded = self._store.load(current)
+            if loaded is None:
+                raise typer.BadParameter(
+                    f"the current session pointer references {current} but its state is "
+                    "gone; start a new session with `wmh run <agent-id> --detach`"
+                )
+            state = loaded
+        if state.api_url != api_url:
+            stored_home = state.web_url or state.api_url
+            active_home = self._credentials.web_url or api_url
+            raise typer.BadParameter(
+                f"session {state.session_id} belongs to {stored_home}, but this login "
+                f"points at {active_home}; run `wmh login --url {stored_home}` to switch, "
+                "or start a new session here with `wmh run <agent-id> --detach`"
+            )
+        try:
+            remote = self._client.get_agent_session(state.agent_id, state.session_id)
+        except PlatformError as error:
+            if error.status_code == 404:
+                raise typer.BadParameter(
+                    f"session {state.session_id} was not found on "
+                    f"{state.web_url or state.api_url}; it may have been removed, or "
+                    "this login may lack access (check `wmh status`)"
+                ) from error
+            raise
+        return state, True, remote
+
+    def _resolve_remote(
+        self, session_id: str, api_url: str
+    ) -> tuple[DetachedSessionState, bool, RemoteAgentSession]:
+        """Resolve a session id with no local state through the platform."""
+        try:
+            remote = self._client.resolve_agent_session(session_id)
+        except PlatformError as error:
+            if error.status_code == 404:
+                raise typer.BadParameter(
+                    f"session {session_id} was not found on "
+                    f"{self._credentials.web_url or api_url}; check --session and that "
+                    "your login (`wmh status`) can access it"
+                ) from error
+            raise
+        name = remote.agent_id
+        with contextlib.suppress(PlatformError):
+            target = self._client.resolve_run_target(remote.agent_id)
+            name = target.display_name or target.name
+        state = DetachedSessionState(
+            api_url=api_url,
+            web_url=self._credentials.web_url,
+            agent_id=remote.agent_id,
+            agent_name=name,
+            session_id=session_id,
+            created_at=datetime.now(tz=UTC).isoformat(),
+        )
+        return state, False, remote
+
+    def _handle_already_terminal(
+        self, state: DetachedSessionState, persisted: bool, remote: RemoteAgentSession
+    ) -> None:
+        """Reconcile (--end) or explain (send/attach) an already-finished session."""
+        if self._action != "end":
+            detail = (
+                "reconcile its final workspace and clear it"
+                if persisted and state.workspace is not None
+                else "clear it"
+            )
+            raise typer.BadParameter(
+                f"session {state.session_id} is already {remote.status}; run "
+                f"`wmh run --session {state.session_id} --end` to {detail}, or start a "
+                f"new session with `wmh run {state.agent_id} --detach`"
+            )
+        workspace = self._load_workspace(state, persisted)
+        stream = _Stream(
+            state=state,
+            persisted=persisted,
+            workspace=workspace,
+            render=False,
+            cursor=state.cursor,
+        )
+        self._finish_terminal(stream)
+
+    def _load_workspace(self, state: DetachedSessionState, persisted: bool) -> LiveWorkspace | None:
+        """Rehydrate the workspace transport from the persisted checkpoint."""
+        if not persisted or state.workspace is None:
+            return None
+        root = Path(state.workspace.root)
+        if not root.is_dir():
+            if self._action == "end":
+                _console.print(
+                    f"[yellow]the synchronized workspace {root} no longer exists; ending "
+                    "without a final sync[/yellow]"
+                )
+                return None
+            raise typer.BadParameter(
+                f"the synchronized workspace {root} no longer exists; restore it, or end "
+                f"the session with `wmh run --session {state.session_id} --end`"
+            )
+        base = self._store.load_base_archive(state)
+        synchronized = snapshot_from_archive(base)
+        self._persisted_snapshot = synchronized
+        return LiveWorkspace(
+            self._client,
+            state.agent_id,
+            state.session_id,
+            root,
+            synchronized,
+            conflicts=state.workspace.conflicts,
+        )
+
+    # -- actions -----------------------------------------------------------------------------
+
+    def _send(self, stream: _Stream) -> None:
+        """Catch up, deliver one message, and stream its turn until idle."""
+        text = self._text if self._text is not None else ""
+        if self._catch_up(stream) == "terminal":
+            self._finish_terminal(
+                stream, failure_note="the session ended before the message could be sent"
+            )
+            return
+        self._push_workspace(stream)
+        self._client.post_agent_session_command(
+            stream.state.agent_id, stream.state.session_id, "user_message", text=text
+        )
+        stream.pending_text = text
+        stream.render = True
+        outcome = self._stream_until(stream, stop=lambda: stream.turn_idle)
+        if outcome == "terminal":
+            self._finish_terminal(stream)
+            return
+        self._persist(stream, stream.cursor)
+        if outcome == "detached":
+            _console.print("[dim]detached; the session stays alive[/dim]")
+            return
+        _console.print(f"[dim]turn finished; session {stream.state.session_id} stays alive[/dim]")
+
+    def _attach(self, stream: _Stream) -> None:
+        """Catch up, then stream interactively until the user detaches or ends."""
+        if self._catch_up(stream) == "terminal":
+            self._finish_terminal(stream)
+            return
+        self._push_workspace(stream)
+        stream.render = True
+        reader = AttachedCommandReader(self._client, stream.state.agent_id, stream.state.session_id)
+        reader.start()
+        _console.print(
+            f"[green]attached[/green] to [bold]{stream.state.agent_name}[/bold] "
+            f"({stream.state.session_id}). Type to steer, [bold]:stop[/bold] to interrupt, "
+            "[bold]:detach[/bold] to leave it running, [bold]:end[/bold] to end it."
+        )
+        outcome = self._stream_until(stream, stop=reader.detach.is_set)
+        if outcome == "terminal":
+            self._finish_terminal(stream)
+            return
+        self._persist(stream, stream.cursor)
+        _console.print("[dim]detached; the session stays alive[/dim]")
+
+    def _end(self, stream: _Stream) -> None:
+        """Catch up, push local edits, end the session, and run the final sync."""
+        if self._catch_up(stream) != "terminal":
+            self._push_workspace(stream)
+            remote = self._client.end_agent_session(stream.state.agent_id, stream.state.session_id)
+            if remote.status not in TERMINAL_STATUSES:
+                outcome = self._stream_until(stream, stop=lambda: False)
+                if outcome == "detached":
+                    self._persist(stream, stream.cursor)
+                    _console.print(
+                        "[yellow]end requested; leaving before the final sync (rerun "
+                        "`wmh run --end` to finish)[/yellow]"
+                    )
+                    raise typer.Exit(code=1)
+        self._finish_terminal(stream)
+
+    def _finish_terminal(self, stream: _Stream, *, failure_note: str | None = None) -> None:
+        """Run the final workspace handoff, clear local state, and report the outcome."""
+        conflicted = False
+        if stream.workspace is not None:
+            try:
+                result = stream.workspace.finalize()
+                conflicted = bool(result.conflicts)
+            except PlatformError as error:
+                if error.status_code != 404:
+                    # Keep local state so `wmh run --end` can retry the handoff.
+                    raise
+                _console.print(
+                    "[yellow]no final workspace archive is available; it may already "
+                    "have been synchronized[/yellow]"
+                )
+        terminal = self._client.get_agent_session(stream.state.agent_id, stream.state.session_id)
+        if stream.persisted:
+            self._store.delete(stream.state.session_id)
+        if failure_note is not None:
+            _console.print(f"[red]{failure_note}[/red]")
+        if terminal.status == "failed":
+            _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
+            raise typer.Exit(code=1)
+        _console.print(f"[dim]session ended ({terminal.ended_reason or terminal.status})[/dim]")
+        if failure_note is not None:
+            raise typer.Exit(code=1)
+        if conflicted:
+            raise typer.Exit(code=2)
+
+    # -- event loop --------------------------------------------------------------------------
+
+    def _catch_up(self, stream: _Stream) -> str:
+        """Apply everything durable that happened while no CLI process ran.
+
+        Returns:
+            ``"terminal"`` when the session finished, otherwise ``"ready"``.
+        """
+        while True:
+            page = self._poll(stream)
+            if page.status in TERMINAL_STATUSES:
+                return "terminal"
+            if not page.events:
+                return "ready"
+
+    def _stream_until(self, stream: _Stream, *, stop: Callable[[], bool]) -> str:
+        """Poll, render, and synchronize until ``stop``, terminal state, or detach.
+
+        Returns:
+            ``"terminal"``, ``"stopped"``, or ``"detached"`` (double Ctrl-C).
+        """
+        last_push = time.monotonic()
+        last_probe = time.monotonic()
+        while True:
+            try:
+                page = self._poll(stream)
+                if page.status in TERMINAL_STATUSES:
+                    return "terminal"
+                if stop():
+                    return "stopped"
+                now = time.monotonic()
+                if stream.workspace is not None and now - last_push >= _WORKSPACE_SYNC_TICK_S:
+                    stream.workspace.push_local()
+                    self._persist(stream, stream.cursor)
+                    last_push = now
+                if now - last_probe >= _STALE_PROBE_S:
+                    # The detail read lazily reconciles a dead driver so the
+                    # next events poll reports the truthful terminal status.
+                    with contextlib.suppress(PlatformError):
+                        self._client.get_agent_session(
+                            stream.state.agent_id, stream.state.session_id
+                        )
+                    last_probe = now
+                time.sleep(_POLL_INTERVAL_S)
+            except KeyboardInterrupt:
+                self._interrupts += 1
+                if self._interrupts == 1:
+                    _console.print("\n[yellow]interrupting (press Ctrl-C again to detach)[/yellow]")
+                    with contextlib.suppress(PlatformError):
+                        self._client.post_agent_session_command(
+                            stream.state.agent_id, stream.state.session_id, "interrupt"
+                        )
+                else:
+                    return "detached"
+
+    def _poll(self, stream: _Stream) -> RemoteAgentEventPage:
+        """Fetch one page after the cursor, process it, and persist the checkpoint."""
+        page = self._client.list_agent_session_events(
+            stream.state.agent_id, stream.state.session_id, after=stream.cursor
+        )
+        for event in page.events:
+            self._handle_event(stream, event)
+        stream.cursor = page.last_seq
+        self._persist(stream, page.last_seq)
+        return page
+
+    def _handle_event(self, stream: _Stream, event: RemoteAgentSessionEvent) -> None:
+        """Apply one durable event: workspace transport, turn tracking, rendering."""
+        if event.kind == "workspace_patch":
+            if stream.workspace is None:
+                if not stream.foreign_patch_noted:
+                    _console.print(
+                        "[dim](workspace patches are synchronized by the launching CLI; "
+                        "skipping)[/dim]"
+                    )
+                    stream.foreign_patch_noted = True
+                return
+            stream.workspace.apply_remote_patch(
+                patch_revision(event), before_ack=lambda: self._persist(stream, event.seq)
+            )
+            return
+        if event.kind == "status":
+            detail = event.payload.get("message") or event.payload.get("status")
+            if detail and stream.render:
+                _console.print(f"[dim]({detail})[/dim]")
+            return
+        if event.kind == "user_message" and stream.pending_text is not None:
+            if event.payload.get("text") == stream.pending_text:
+                stream.message_seen = True
+        if event.kind == "state" and stream.message_seen and event.payload.get("status") == "idle":
+            stream.turn_idle = True
+        if stream.render:
+            self._sink(SessionEvent(kind=event.kind, payload=event.payload))
+
+    # -- checkpointing -----------------------------------------------------------------------
+
+    def _push_workspace(self, stream: _Stream) -> None:
+        """Upload local edits made since the checkpoint, then persist it."""
+        if stream.workspace is None:
+            return
+        stream.workspace.push_local()
+        self._persist(stream, stream.cursor)
+
+    def _persist(self, stream: _Stream, cursor: int) -> None:
+        """Advance the durable checkpoint (cursor, conflicts, base snapshot)."""
+        if not stream.persisted:
+            return
+        state = stream.state
+        workspace_state = state.workspace
+        archive: bytes | None = None
+        if stream.workspace is not None and workspace_state is not None:
+            workspace_state = workspace_state.model_copy(
+                update={"conflicts": tuple(sorted(stream.workspace.conflicts))}
+            )
+            if stream.workspace.synchronized is not self._persisted_snapshot:
+                archive = stream.workspace.synchronized.archive
+        if cursor == state.cursor and workspace_state == state.workspace and archive is None:
+            return
+        updated = state.model_copy(update={"cursor": cursor, "workspace": workspace_state})
+        stream.state = self._store.save(updated, base_archive=archive)
+        if stream.workspace is not None:
+            self._persisted_snapshot = stream.workspace.synchronized

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -114,7 +114,7 @@ class LiveWorkspace:
             self._agent_id, self._session_id, revision
         )
         result = apply_workspace_patch(self.root, content)
-        self.conflicts.update(result.conflicts)
+        new_conflicts = self._record_conflicts(result.conflicts)
         # Advance the base by base+patch, never by re-reading the directory:
         # a disk snapshot here would absorb not-yet-uploaded local edits into
         # the base, so they would never upload (and the final sync could even
@@ -127,8 +127,8 @@ class LiveWorkspace:
         self._client.acknowledge_agent_workspace_patch(self._agent_id, self._session_id, revision)
         if result.applied:
             _console.print(f"[dim]workspace updated ({len(result.applied)} changed paths)[/dim]")
-        if result.conflicts:
-            paths = ", ".join(result.conflicts)
+        if new_conflicts:
+            paths = ", ".join(new_conflicts)
             _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
 
     def push_local(self) -> bool:
@@ -147,16 +147,23 @@ class LiveWorkspace:
         result = self._client.upload_agent_workspace_patch(
             self._agent_id, self._session_id, content
         )
-        self.conflicts.update(result.conflicts)
-        if result.conflicts:
-            paths = ", ".join(result.conflicts)
+        new_conflicts = self._record_conflicts(result.conflicts)
+        if new_conflicts:
+            paths = ", ".join(new_conflicts)
             _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
+        if result.conflicts:
             # A conflicted path was rejected by E2B, so ``current`` cannot become
             # the synchronized base. Keep the prior base and conservatively retry
             # accepted sibling paths until the conflict is reconciled at teardown.
             return False
         self.synchronized = current
         return True
+
+    def _record_conflicts(self, conflicts: Iterable[str]) -> list[str]:
+        """Track conflicts, returning only ones not already reported."""
+        fresh = [path for path in conflicts if path not in self.conflicts]
+        self.conflicts.update(conflicts)
+        return fresh
 
     def finalize(self) -> SyncResult:
         """Reconcile the terminal session's final E2B workspace into the root.
@@ -239,8 +246,21 @@ class DetachedStartDriver:
                 created_at=datetime.now(tz=UTC).isoformat(),
                 workspace=workspace,
             )
-            self._store.save(state, base_archive=initial.archive if initial is not None else None)
-            self._store.set_current(session.id)
+            try:
+                self._store.save(
+                    state, base_archive=initial.archive if initial is not None else None
+                )
+                self._store.set_current(session.id)
+            except SessionStateError as error:
+                # The hosted session is already running; the user must get an
+                # addressable reference even though the local save failed.
+                msg = (
+                    f"session {session.id} is running on the platform, but its local "
+                    f"reference could not be saved: {error}. Control it with "
+                    f"`wmh run --session {session.id} --attach` or end it with "
+                    f"`wmh run --session {session.id} --end`"
+                )
+                raise typer.BadParameter(msg) from error
             _console.print(
                 f"[green]detached E2B session started[/green] for [bold]{self._name}[/bold]\n"
                 f"  agent    {self._target_id}\n"
@@ -266,6 +286,7 @@ class AttachedCommandReader(threading.Thread):
         self._agent_id = agent_id
         self._session_id = session_id
         self.detach = threading.Event()
+        self.end_failed = False
 
     def run(self) -> None:
         """Map lines to hosted commands; leaving the terminal detaches, never ends."""
@@ -278,7 +299,16 @@ class AttachedCommandReader(threading.Thread):
                     self.detach.set()
                     return
                 if line == ":end":
-                    self._client.end_agent_session(self._agent_id, self._session_id)
+                    # A failed end must be reported, never silently converted
+                    # into a detach that leaves the session running.
+                    try:
+                        self._client.end_agent_session(self._agent_id, self._session_id)
+                    except PlatformError as error:
+                        self.end_failed = True
+                        _console.print(
+                            f"[red]end failed:[/red] {error} "
+                            "(retry [bold]:end[/bold], or run `wmh run --end` later)"
+                        )
                 elif line == ":stop":
                     self._post("interrupt")
                 elif line:

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -370,6 +370,7 @@ class _Stream:
     workspace: LiveWorkspace | None
     render: bool
     cursor: int = 0
+    pending_ack: str | None = None
     pending_text: str | None = None
     message_seen: bool = False
     turn_idle: bool = False
@@ -400,6 +401,7 @@ class DetachedCommandDriver:
         self._sink = sink
         self._interrupts = 0
         self._persisted_snapshot: WorkspaceSnapshot | None = None
+        self._salvage_reason: str | None = None
 
     def run(self) -> None:
         """Resolve the session, catch up, and run the requested action."""
@@ -426,7 +428,9 @@ class DetachedCommandDriver:
             workspace=workspace,
             render=persisted,
             cursor=state.cursor,
+            pending_ack=state.workspace.pending_ack if state.workspace is not None else None,
         )
+        self._retry_pending_ack(stream)
         match self._action:
             case "send":
                 self._send(stream)
@@ -528,7 +532,9 @@ class DetachedCommandDriver:
             workspace=workspace,
             render=False,
             cursor=state.cursor,
+            pending_ack=state.workspace.pending_ack if state.workspace is not None else None,
         )
+        self._retry_pending_ack(stream)
         self._finish_terminal(stream)
 
     def _load_workspace(self, state: DetachedSessionState, persisted: bool) -> LiveWorkspace | None:
@@ -538,16 +544,22 @@ class DetachedCommandDriver:
         root = Path(state.workspace.root)
         if not root.is_dir():
             if self._action == "end":
-                _console.print(
-                    f"[yellow]the synchronized workspace {root} no longer exists; ending "
-                    "without a final sync[/yellow]"
-                )
+                self._salvage_reason = f"the synchronized workspace {root} no longer exists"
                 return None
             raise typer.BadParameter(
-                f"the synchronized workspace {root} no longer exists; restore it, or end "
-                f"the session with `wmh run --session {state.session_id} --end`"
+                f"the synchronized workspace {root} no longer exists; restore it, or run "
+                f"`wmh run --session {state.session_id} --end` to save the final "
+                "workspace without a local sync"
             )
-        base = self._store.load_base_archive(state)
+        try:
+            base = self._store.load_base_archive(state)
+        except SessionStateError as error:
+            # `--end` still completes the handoff without a local sync; the
+            # stored error messages point other actions at exactly that.
+            if self._action == "end":
+                self._salvage_reason = str(error)
+                return None
+            raise
         synchronized = snapshot_from_archive(base)
         self._persisted_snapshot = synchronized
         return LiveWorkspace(
@@ -637,6 +649,12 @@ class DetachedCommandDriver:
                     "[yellow]no final workspace archive is available; it may already "
                     "have been synchronized[/yellow]"
                 )
+        elif (
+            stream.persisted
+            and stream.state.workspace is not None
+            and self._salvage_reason is not None
+        ):
+            self._salvage_final_workspace(stream)
         terminal = self._client.get_agent_session(stream.state.agent_id, stream.state.session_id)
         if stream.persisted:
             self._store.delete(stream.state.session_id)
@@ -650,6 +668,61 @@ class DetachedCommandDriver:
             raise typer.Exit(code=1)
         if conflicted:
             raise typer.Exit(code=2)
+
+    def _salvage_final_workspace(self, stream: _Stream) -> None:
+        """Save the final archive without a local sync when the checkpoint is unusable.
+
+        The handoff is still acknowledged so the platform can remove its
+        private archive object; the user's data lands as a recovery archive
+        (under the workspace root when it exists, else in WMH state, where it
+        survives the state cleanup).
+        """
+        state = stream.state
+        try:
+            content = self._client.download_agent_workspace(state.agent_id, state.session_id)
+        except PlatformError as error:
+            if error.status_code != 404:
+                # Keep local state so `wmh run --end` can retry the handoff.
+                raise
+            _console.print(
+                "[yellow]no final workspace archive is available; it may already "
+                "have been synchronized[/yellow]"
+            )
+            return
+        workspace_state = state.workspace
+        root = Path(workspace_state.root) if workspace_state is not None else None
+        if root is not None and root.is_dir():
+            recovery = write_conflict_archive(root, state.session_id, content)
+        else:
+            recovery = self._store.write_recovery_archive(state.session_id, content)
+        self._client.acknowledge_agent_workspace(state.agent_id, state.session_id)
+        _console.print(
+            f"[yellow]final workspace saved without a local sync "
+            f"({self._salvage_reason}).[/yellow]\n"
+            f"The full E2B result is at [bold]{recovery}[/bold]."
+        )
+
+    def _retry_pending_ack(self, stream: _Stream) -> None:
+        """Deliver a patch acknowledgement a previous invocation could not send."""
+        workspace_state = stream.state.workspace
+        if (
+            not stream.persisted
+            or workspace_state is None
+            or workspace_state.pending_ack is None
+        ):
+            return
+        revision = workspace_state.pending_ack
+        try:
+            self._client.acknowledge_agent_workspace_patch(
+                stream.state.agent_id, stream.state.session_id, revision
+            )
+        except PlatformError as error:
+            # 404 means the object is already gone (acknowledged after all, or
+            # removed with the session); anything else stays retryable.
+            if error.status_code != 404:
+                raise
+        stream.pending_ack = None
+        self._persist(stream, stream.cursor)
 
     # -- event loop --------------------------------------------------------------------------
 
@@ -727,9 +800,16 @@ class DetachedCommandDriver:
                     )
                     stream.foreign_patch_noted = True
                 return
-            stream.workspace.apply_remote_patch(
-                patch_revision(event), before_ack=lambda: self._persist(stream, event.seq)
-            )
+            revision = patch_revision(event)
+
+            def checkpoint_before_ack() -> None:
+                stream.cursor = event.seq
+                stream.pending_ack = revision
+                self._persist(stream, event.seq)
+
+            stream.workspace.apply_remote_patch(revision, before_ack=checkpoint_before_ack)
+            stream.pending_ack = None
+            self._persist(stream, stream.cursor)
             return
         if event.kind == "status":
             detail = event.payload.get("message") or event.payload.get("status")
@@ -760,12 +840,15 @@ class DetachedCommandDriver:
         state = stream.state
         workspace_state = state.workspace
         archive: bytes | None = None
-        if stream.workspace is not None and workspace_state is not None:
-            workspace_state = workspace_state.model_copy(
-                update={"conflicts": tuple(sorted(stream.workspace.conflicts))}
-            )
-            if stream.workspace.synchronized is not self._persisted_snapshot:
-                archive = stream.workspace.synchronized.archive
+        if workspace_state is not None:
+            update: dict[str, tuple[str, ...] | str | None] = {
+                "pending_ack": stream.pending_ack
+            }
+            if stream.workspace is not None:
+                update["conflicts"] = tuple(sorted(stream.workspace.conflicts))
+                if stream.workspace.synchronized is not self._persisted_snapshot:
+                    archive = stream.workspace.synchronized.archive
+            workspace_state = workspace_state.model_copy(update=update)
         if cursor == state.cursor and workspace_state == state.workspace and archive is None:
             return
         updated = state.model_copy(update={"cursor": cursor, "workspace": workspace_state})

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -837,6 +837,11 @@ class DetachedCommandDriver:
                 _console.print(f"[dim]({detail})[/dim]")
             return
         if event.kind == "user_message" and stream.pending_text is not None:
+            # Turn attribution matches the echoed text among events after the
+            # send-time cursor. The command API cannot correlate a command id
+            # to its transcript echo, so an identical message posted by
+            # another actor in the same window can end the stream one turn
+            # early; the session itself is unaffected (a known approximation).
             if event.payload.get("text") == stream.pending_text:
                 stream.message_seen = True
         if event.kind == "state" and stream.message_seen and event.payload.get("status") == "idle":

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -655,15 +655,31 @@ class DetachedCommandDriver:
             and self._salvage_reason is not None
         ):
             self._salvage_final_workspace(stream)
-        terminal = self._client.get_agent_session(stream.state.agent_id, stream.state.session_id)
+        terminal: RemoteAgentSession | None
+        try:
+            terminal = self._client.get_agent_session(
+                stream.state.agent_id, stream.state.session_id
+            )
+        except PlatformError as error:
+            # The record (or its agent) can vanish between the handoff and
+            # this read; local state must still be cleared, or it is stuck
+            # with no CLI path to remove it.
+            if error.status_code != 404:
+                raise
+            terminal = None
         if stream.persisted:
             self._store.delete(stream.state.session_id)
         if failure_note is not None:
             _console.print(f"[red]{failure_note}[/red]")
-        if terminal.status == "failed":
+        if terminal is not None and terminal.status == "failed":
             _console.print(f"[red]session failed: {terminal.error or 'unknown error'}[/red]")
             raise typer.Exit(code=1)
-        _console.print(f"[dim]session ended ({terminal.ended_reason or terminal.status})[/dim]")
+        detail = (
+            terminal.ended_reason or terminal.status
+            if terminal is not None
+            else "no longer visible on the platform"
+        )
+        _console.print(f"[dim]session ended ({detail})[/dim]")
         if failure_note is not None:
             raise typer.Exit(code=1)
         if conflicted:

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -311,6 +311,11 @@ class AttachedCommandReader(threading.Thread):
                         )
                 elif line == ":stop":
                     self._post("interrupt")
+                elif line.startswith(":"):
+                    # An unknown command must never reach the agent as chat.
+                    _console.print(
+                        f"[yellow]unknown command {line}; use :stop, :detach, or :end[/yellow]"
+                    )
                 elif line:
                     self._post("user_message", text=line)
         except (OSError, PlatformError):

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -39,6 +39,7 @@ from wmh.cli.session_state import (
 from wmh.cli.workspace_sync import (
     WorkspaceSnapshot,
     WorkspaceSyncError,
+    advance_snapshot_paths,
     apply_patch_to_snapshot,
     apply_workspace_patch,
     snapshot_from_archive,
@@ -152,9 +153,13 @@ class LiveWorkspace:
             paths = ", ".join(new_conflicts)
             _console.print(f"[yellow]workspace sync conflict[/yellow]: {paths}")
         if result.conflicts:
-            # A conflicted path was rejected by E2B, so ``current`` cannot become
-            # the synchronized base. Keep the prior base and conservatively retry
-            # accepted sibling paths until the conflict is reconciled at teardown.
+            # A conflicted path was rejected by E2B, so ``current`` cannot
+            # become the synchronized base for it; accepted sibling paths did
+            # land, so they advance individually.
+            if result.applied:
+                self.synchronized = advance_snapshot_paths(
+                    self.synchronized, current, result.applied
+                )
             return False
         self.synchronized = current
         return True

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -159,6 +159,21 @@ class LiveWorkspace:
         self.synchronized = current
         return True
 
+    def try_push_local(self) -> bool:
+        """Push local edits, tolerating a workspace that cannot accept patches yet.
+
+        A sandbox that is still booting (or winding down) answers 409/503; the
+        caller's sync loop retries on its next tick, and an end falls back to
+        the conflict-preserving final sync. Anything else still raises.
+        """
+        try:
+            return self.push_local()
+        except PlatformError as error:
+            if error.status_code not in {409, 503}:
+                raise
+            _console.print("[dim]local changes will sync once the workspace is running[/dim]")
+            return False
+
     def _record_conflicts(self, conflicts: Iterable[str]) -> list[str]:
         """Track conflicts, returning only ones not already reported."""
         fresh = [path for path in conflicts if path not in self.conflicts]
@@ -716,20 +731,10 @@ class DetachedCommandDriver:
     # -- checkpointing -----------------------------------------------------------------------
 
     def _push_workspace(self, stream: _Stream) -> None:
-        """Upload local edits made since the checkpoint, then persist it.
-
-        A workspace whose sandbox is not accepting patches yet (booting, or
-        winding down) is tolerated: the streaming loop retries every tick, and
-        an end falls back to the conflict-preserving final sync.
-        """
+        """Upload local edits made since the checkpoint, then persist it."""
         if stream.workspace is None:
             return
-        try:
-            stream.workspace.push_local()
-        except PlatformError as error:
-            if error.status_code not in {409, 503}:
-                raise
-            _console.print("[dim]local changes will sync once the workspace is running[/dim]")
+        stream.workspace.try_push_local()
         self._persist(stream, stream.cursor)
 
     def _persist(self, stream: _Stream, cursor: int) -> None:

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -306,7 +306,7 @@ class AttachedCommandReader(threading.Thread):
         self._agent_id = agent_id
         self._session_id = session_id
         self.detach = threading.Event()
-        self.end_failed = False
+        self.ended = threading.Event()
 
     def run(self) -> None:
         """Map lines to hosted commands; leaving the terminal detaches, never ends."""
@@ -320,15 +320,19 @@ class AttachedCommandReader(threading.Thread):
                     return
                 if line == ":end":
                     # A failed end must be reported, never silently converted
-                    # into a detach that leaves the session running.
+                    # into a detach that leaves the session running; after a
+                    # successful end the driver streams to the final handoff,
+                    # so a following EOF must not look like a detach either.
                     try:
                         self._client.end_agent_session(self._agent_id, self._session_id)
                     except PlatformError as error:
-                        self.end_failed = True
                         _console.print(
                             f"[red]end failed:[/red] {error} "
                             "(retry [bold]:end[/bold], or run `wmh run --end` later)"
                         )
+                    else:
+                        self.ended.set()
+                        return
                 elif line == ":stop":
                     self._post("interrupt")
                 elif line.startswith(":"):
@@ -338,16 +342,23 @@ class AttachedCommandReader(threading.Thread):
                     )
                 elif line:
                     self._post("user_message", text=line)
-        except (OSError, PlatformError):
+        except OSError:
             pass
         finally:
             # Closed stdin means the terminal went away, not that the hosted
-            # session should end. Ending stays explicit (:end or --end).
-            self.detach.set()
+            # session should end. Ending stays explicit (:end or --end); after
+            # one, the driver keeps streaming to the final handoff.
+            if not self.ended.is_set():
+                self.detach.set()
 
     def _post(self, kind: str, *, text: str | None = None) -> None:
-        """Post one command through the authenticated platform client."""
-        self._client.post_agent_session_command(self._agent_id, self._session_id, kind, text=text)
+        """Post one command; a transient failure warns and keeps the reader alive."""
+        try:
+            self._client.post_agent_session_command(
+                self._agent_id, self._session_id, kind, text=text
+            )
+        except PlatformError as error:
+            _console.print(f"[red]{kind} failed:[/red] {error} (still attached; try again)")
 
 
 @dataclass

--- a/wmh/cli/hosted_session.py
+++ b/wmh/cli/hosted_session.py
@@ -705,11 +705,7 @@ class DetachedCommandDriver:
     def _retry_pending_ack(self, stream: _Stream) -> None:
         """Deliver a patch acknowledgement a previous invocation could not send."""
         workspace_state = stream.state.workspace
-        if (
-            not stream.persisted
-            or workspace_state is None
-            or workspace_state.pending_ack is None
-        ):
+        if not stream.persisted or workspace_state is None or workspace_state.pending_ack is None:
             return
         revision = workspace_state.pending_ack
         try:
@@ -769,13 +765,17 @@ class DetachedCommandDriver:
                 time.sleep(_POLL_INTERVAL_S)
             except KeyboardInterrupt:
                 self._interrupts += 1
-                if self._interrupts == 1:
+                if self._interrupts >= 2:
+                    return "detached"
+                # The next Ctrl-C frequently lands inside this handler (the
+                # print or the HTTP post); it must detach, not crash out.
+                try:
                     _console.print("\n[yellow]interrupting (press Ctrl-C again to detach)[/yellow]")
                     with contextlib.suppress(PlatformError):
                         self._client.post_agent_session_command(
                             stream.state.agent_id, stream.state.session_id, "interrupt"
                         )
-                else:
+                except KeyboardInterrupt:
                     return "detached"
 
     def _poll(self, stream: _Stream) -> RemoteAgentEventPage:
@@ -785,6 +785,10 @@ class DetachedCommandDriver:
         )
         for event in page.events:
             self._handle_event(stream, event)
+            # Advance per event, not only per page: a Ctrl-C landing mid-page
+            # must resume after the events already processed (re-fetching a
+            # patch event whose object was acknowledged would 404).
+            stream.cursor = event.seq
         stream.cursor = page.last_seq
         self._persist(stream, page.last_seq)
         return page
@@ -841,9 +845,7 @@ class DetachedCommandDriver:
         workspace_state = state.workspace
         archive: bytes | None = None
         if workspace_state is not None:
-            update: dict[str, tuple[str, ...] | str | None] = {
-                "pending_ack": stream.pending_ack
-            }
+            update: dict[str, tuple[str, ...] | str | None] = {"pending_ack": stream.pending_ack}
             if stream.workspace is not None:
                 update["conflicts"] = tuple(sorted(stream.workspace.conflicts))
                 if stream.workspace.synchronized is not self._persisted_snapshot:

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -853,3 +853,104 @@ def test_try_push_local_tolerates_a_workspace_that_is_not_ready(tmp_path: Path) 
     )
     with pytest.raises(PlatformError):
         failing.try_push_local()
+
+
+def test_contested_path_survives_push_rejection_catchup_and_finalize(tmp_path: Path) -> None:
+    """The full disputed ordering, end to end: a both-sides-edited file is never lost.
+
+    Composes the pieces the ordering debate touched: a detached checkpoint with
+    X at base content B, a local edit to U while detached, and a pending hosted
+    patch moving the same X from B to A. The send flow pushes first (rejected
+    with a content conflict), catch-up applies the patch (local conflict, file
+    kept), and the end flow's finalize preserves U locally, saves A in the
+    recovery archive, and signals the conflict with exit code 2.
+    """
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("B", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"A"}))
+    assert patch is not None
+    (root / "answer.txt").write_text("U", encoding="utf-8")
+
+    send_client = _FakeClient()
+    send_client.session_states = [_session(workspace_sync=True)]
+    send_client.upload_result = WorkspacePatchResult(applied=[], conflicts=["answer.txt"])
+    send_client.patches["patch-1"] = patch
+    send_client.pages = [
+        _page([_event(1, "workspace_patch", revision="patch-1")], 1, "running"),
+        _page([], 1, "running"),
+        _page(
+            [_event(2, "user_message", text="hi"), _event(3, "state", status="idle")],
+            3,
+            "running",
+        ),
+    ]
+
+    _command_driver(send_client, store, action="send", text="hi").run()
+
+    # The rejected push ran before the patch download (the disputed ordering).
+    assert send_client.calls.index("upload_patch") < send_client.calls.index("patch:patch-1")
+    assert send_client.patch_acks == ["patch-1"]
+    # The local edit is untouched, recorded as a conflict, and the base kept B.
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "U"
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.workspace is not None
+    assert state.workspace.conflicts == ("answer.txt",)
+    checkpoint = snapshot_from_archive(store.load_base_archive(state))
+    assert checkpoint.files["answer.txt"] == base.files["answer.txt"]
+
+    end_client = _FakeClient()
+    end_client.session_states = [
+        _session(workspace_sync=True),
+        _session("ended", workspace_sync=True),
+    ]
+    end_client.upload_result = WorkspacePatchResult(applied=[], conflicts=["answer.txt"])
+    end_client.final_archive = _archive({"answer.txt": b"A"})
+    end_client.pages = [
+        _page([], 3, "running"),
+        _page([], 3, "ended"),
+    ]
+
+    with pytest.raises(typer.Exit) as raised:
+        _command_driver(end_client, store, action="end").run()
+
+    assert raised.value.exit_code == 2
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "U"
+    recovery = root / ".wmh-conflicts" / "sess-1.tar.gz"
+    assert recovery.is_file()
+    with tarfile.open(recovery) as archive:
+        member = archive.extractfile("answer.txt")
+        assert member is not None
+        assert member.read() == b"A"
+    assert end_client.final_acked
+    assert store.load("sess-1") is None
+
+
+def test_partially_conflicted_push_advances_accepted_sibling_paths(tmp_path: Path) -> None:
+    """Accepted siblings of a rejected path advance the base; only the conflict stays.
+
+    Keeping the whole base stale would re-push the accepted paths later against
+    a base the sandbox has moved past, manufacturing conflicts if they change
+    again locally.
+    """
+    (tmp_path / "answer.txt").write_text("B", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("O", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    (tmp_path / "answer.txt").write_text("U", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("O2", encoding="utf-8")
+    client = _FakeClient()
+    client.upload_result = WorkspacePatchResult(applied=["other.txt"], conflicts=["answer.txt"])
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+
+    changed = workspace.push_local()
+
+    assert not changed
+    assert workspace.conflicts == {"answer.txt"}
+    disk = snapshot_workspace(tmp_path)
+    assert workspace.synchronized.files["other.txt"] == disk.files["other.txt"]
+    assert workspace.synchronized.files["answer.txt"] == base.files["answer.txt"]

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -1308,3 +1308,43 @@ def test_second_interrupt_during_the_handler_detaches_cleanly(tmp_path: Path) ->
     assert client.end_calls == []
     # The session reference survives the detach for the next command.
     assert store.load("sess-1") is not None
+
+
+def test_end_tolerates_a_sandbox_that_ended_mid_command(tmp_path: Path) -> None:
+    """A session ending between pre-check and push still reaches the final handoff.
+
+    The platform's patch-upload route answers 409 ("workspace is not running")
+    for any non-running session, which the tolerant push defers; the catch-up
+    then observes the terminal state and the finalize path runs normally.
+    """
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    (root / "answer.txt").write_text("local edit while detached", encoding="utf-8")
+
+    class _EndedSandboxClient(_FakeClient):
+        def upload_agent_workspace_patch(
+            self, agent_id: str, session_id: str, content: bytes
+        ) -> WorkspacePatchResult:
+            raise PlatformError("workspace is not running", status_code=409)
+
+    client = _EndedSandboxClient()
+    client.session_states = [
+        _session(workspace_sync=True),
+        _session("ended", workspace_sync=True),
+    ]
+    client.final_archive = _archive({"answer.txt": b"final"})
+    client.pages = [_page([], 0, "ended")]
+
+    with pytest.raises(typer.Exit) as raised:
+        _command_driver(client, store, action="end").run()
+
+    # The local edit conflicts with the final content and is preserved; the
+    # handoff still completed (download, recovery archive, ack, cleanup).
+    assert raised.value.exit_code == 2
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "local edit while detached"
+    assert (root / ".wmh-conflicts" / "sess-1.tar.gz").is_file()
+    assert client.final_acked
+    assert store.load("sess-1") is None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -773,7 +773,7 @@ def test_attached_reader_reports_a_failed_end_and_keeps_reading(
     # The reader kept consuming input after the failed end (the :stop landed),
     # and only stdin EOF flipped the detach event.
     assert client.commands == [("interrupt", None)]
-    assert reader.end_failed
+    assert not reader.ended.is_set()
     assert reader.detach.is_set()
 
 
@@ -954,3 +954,70 @@ def test_partially_conflicted_push_advances_accepted_sibling_paths(tmp_path: Pat
     disk = snapshot_workspace(tmp_path)
     assert workspace.synchronized.files["other.txt"] == disk.files["other.txt"]
     assert workspace.synchronized.files["answer.txt"] == base.files["answer.txt"]
+
+
+def test_attached_reader_keeps_reading_after_a_failed_steer_post(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A transient steer failure warns and keeps reading; it never becomes a detach."""
+
+    class _FlakyClient(_FakeClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failed_once = False
+
+        def post_agent_session_command(
+            self, agent_id: str, session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            if kind == "user_message" and not self.failed_once:
+                self.failed_once = True
+                raise PlatformError("backend unavailable", status_code=503)
+            super().post_agent_session_command(agent_id, session_id, kind, text=text)
+
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO("hello\n:stop\n"))
+    client = _FlakyClient()
+    reader = mod.AttachedCommandReader(cast("mod.PlatformClient", client), "a", "s")
+
+    reader.run()
+
+    assert client.commands == [("interrupt", None)]
+    assert reader.detach.is_set()  # via true EOF only, after both lines were read
+    assert not reader.ended.is_set()
+    assert "failed" in capsys.readouterr().out
+
+
+def test_attached_reader_end_success_stops_reading_without_detach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful :end must not fall through to an EOF-driven detach."""
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":end\nnever sent\n"))
+    client = _FakeClient()
+    reader = mod.AttachedCommandReader(cast("mod.PlatformClient", client), "a", "s")
+
+    reader.run()
+
+    assert client.end_calls == [("a", "s")]
+    assert reader.ended.is_set()
+    assert not reader.detach.is_set()
+    assert client.commands == []
+
+
+def test_attach_end_command_runs_the_final_handoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """printf ':end' | wmh run -a must finalize and clean up, not report a detach."""
+    store = _store_with_session(tmp_path)
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":end\n"))
+    client = _FakeClient()
+    client.session_states = [_session("running"), _session("ended")]
+    client.pages = [
+        _page([], 0, "running"),
+        _page([], 0, "ending"),
+        _page([], 0, "ended"),
+    ]
+
+    _command_driver(client, store, action="attach").run()
+
+    assert client.end_calls == [("agent-1", "sess-1")]
+    assert store.load("sess-1") is None
+    assert store.current_session_id() is None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -819,3 +819,37 @@ def test_end_reruns_cleanly_while_the_session_is_ending(tmp_path: Path) -> None:
 
     assert client.end_calls == [("agent-1", "sess-1")]
     assert store.load("sess-1") is None
+
+
+def test_try_push_local_tolerates_a_workspace_that_is_not_ready(tmp_path: Path) -> None:
+    """A booting or winding-down sandbox defers the push; real failures still raise."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    (tmp_path / "answer.txt").write_text("local", encoding="utf-8")
+
+    class _NotReadyClient(_FakeClient):
+        def __init__(self, status_code: int) -> None:
+            super().__init__()
+            self.status_code = status_code
+
+        def upload_agent_workspace_patch(
+            self, agent_id: str, session_id: str, content: bytes
+        ) -> WorkspacePatchResult:
+            raise PlatformError("workspace is not running", status_code=self.status_code)
+
+    for status_code in (409, 503):
+        workspace = mod.LiveWorkspace(
+            cast("mod.PlatformClient", _NotReadyClient(status_code)),
+            "agent-1",
+            "sess-1",
+            tmp_path,
+            base,
+        )
+        assert workspace.try_push_local() is False
+        assert workspace.synchronized is base
+
+    failing = mod.LiveWorkspace(
+        cast("mod.PlatformClient", _NotReadyClient(500)), "agent-1", "sess-1", tmp_path, base
+    )
+    with pytest.raises(PlatformError):
+        failing.try_push_local()

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -1,0 +1,700 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for detached hosted-session flows: start, send, attach, end, catch-up."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+import typer
+
+import wmh.cli.hosted_session as mod
+from wmh.cli.session_state import DetachedSessionState, SessionStateStore, WorkspaceCheckpoint
+from wmh.cli.workspace_sync import snapshot_from_archive, snapshot_workspace
+from wmh.harness.workspace_patch import build_workspace_patch
+from wmh.platform.client import (
+    PlatformError,
+    RemoteAgentEventPage,
+    RemoteAgentSession,
+    RemoteAgentSessionEvent,
+    WorkspacePatchResult,
+)
+from wmh.platform.credentials import PlatformCredentials
+
+if TYPE_CHECKING:
+    from wmh.core.types import JsonValue
+
+API_URL = "https://api.test"
+WEB_URL = "https://platform.test"
+
+
+def _credentials() -> PlatformCredentials:
+    return PlatformCredentials(api_url=API_URL, web_url=WEB_URL, token="xpl_secret")
+
+
+def _session(status: str = "running", *, workspace_sync: bool = False) -> RemoteAgentSession:
+    return RemoteAgentSession(
+        id="sess-1",
+        agent_id="agent-1",
+        status=status,
+        workspace_sync=workspace_sync,
+        launched_from="cli",
+    )
+
+
+def _event(seq: int, kind: str, **payload: JsonValue) -> RemoteAgentSessionEvent:
+    return RemoteAgentSessionEvent.model_validate(
+        {"seq": seq, "kind": kind, "payload": dict(payload)}
+    )
+
+
+def _page(
+    events: list[RemoteAgentSessionEvent], last_seq: int, status: str
+) -> RemoteAgentEventPage:
+    return RemoteAgentEventPage(events=events, last_seq=last_seq, status=status)
+
+
+def _archive(files: dict[str, bytes]) -> bytes:
+    """A regular-file-only gzip tar simulating a hosted workspace archive."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for path, content in files.items():
+            info = tarfile.TarInfo(path)
+            info.size = len(content)
+            info.mode = 0o644
+            archive.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+class _FakeClient:
+    """A scriptable platform client covering the hosted-session protocol."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.commands: list[tuple[str, str | None]] = []
+        self.end_calls: list[tuple[str, str]] = []
+        self.pages: list[RemoteAgentEventPage] = []
+        self.session_states: list[RemoteAgentSession] = [_session()]
+        self.resolved: RemoteAgentSession | None = None
+        self.end_result: RemoteAgentSession | None = None
+        self.created: RemoteAgentSession | None = None
+        self.created_workspace: bytes | None = None
+        self.created_instruction: str | None = None
+        self.patches: dict[str, bytes] = {}
+        self.patch_acks: list[str] = []
+        self.upload_result = WorkspacePatchResult(applied=[], conflicts=[])
+        self.uploaded_patches: list[bytes] = []
+        self.final_archive: bytes | None = None
+        self.final_acked = False
+        self.closed = False
+
+    def create_agent_session(
+        self, agent_id: str, *, workspace: bytes | None, instruction: str | None = None
+    ) -> RemoteAgentSession:
+        self.calls.append(f"create {agent_id}")
+        self.created_workspace = workspace
+        self.created_instruction = instruction
+        created = self.created or _session("starting")
+        return created
+
+    def get_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+        self.calls.append(f"get {agent_id}/{session_id}")
+        if len(self.session_states) > 1:
+            return self.session_states.pop(0)
+        return self.session_states[0]
+
+    def resolve_agent_session(self, session_id: str) -> RemoteAgentSession:
+        self.calls.append(f"resolve {session_id}")
+        if self.resolved is None:
+            raise PlatformError(f"Session not found: {session_id}", status_code=404)
+        return self.resolved
+
+    def resolve_run_target(self, target_id: str) -> object:
+        self.calls.append(f"target {target_id}")
+        return SimpleNamespace(display_name=None, name="remote-agent")
+
+    def list_agent_session_events(
+        self, agent_id: str, session_id: str, *, after: int
+    ) -> RemoteAgentEventPage:
+        self.calls.append(f"events after={after}")
+        if self.pages:
+            return self.pages.pop(0)
+        return _page([], after, self.session_states[-1].status)
+
+    def post_agent_session_command(
+        self, agent_id: str, session_id: str, kind: str, *, text: str | None = None
+    ) -> None:
+        self.calls.append(f"command:{kind}")
+        self.commands.append((kind, text))
+
+    def end_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+        self.calls.append(f"end {agent_id}/{session_id}")
+        self.end_calls.append((agent_id, session_id))
+        return self.end_result or _session("ending")
+
+    def download_agent_workspace_patch(
+        self, agent_id: str, session_id: str, revision: str
+    ) -> bytes:
+        self.calls.append(f"patch:{revision}")
+        return self.patches[revision]
+
+    def acknowledge_agent_workspace_patch(
+        self, agent_id: str, session_id: str, revision: str
+    ) -> None:
+        self.calls.append(f"patch-ack:{revision}")
+        self.patch_acks.append(revision)
+
+    def upload_agent_workspace_patch(
+        self, agent_id: str, session_id: str, content: bytes
+    ) -> WorkspacePatchResult:
+        self.calls.append("upload_patch")
+        self.uploaded_patches.append(content)
+        return self.upload_result
+
+    def download_agent_workspace(self, agent_id: str, session_id: str) -> bytes:
+        self.calls.append("final_download")
+        if self.final_archive is None:
+            raise PlatformError("workspace not found", status_code=404)
+        return self.final_archive
+
+    def acknowledge_agent_workspace(self, agent_id: str, session_id: str) -> None:
+        self.calls.append("final_ack")
+        self.final_acked = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _store_with_session(
+    tmp_path: Path,
+    *,
+    workspace_root: Path | None = None,
+    base_archive: bytes | None = None,
+) -> SessionStateStore:
+    """A state store holding sess-1 as the current session."""
+    store = SessionStateStore(tmp_path / "state")
+    workspace = None
+    if workspace_root is not None:
+        workspace = WorkspaceCheckpoint(root=str(workspace_root))
+    state = DetachedSessionState(
+        api_url=API_URL,
+        web_url=WEB_URL,
+        agent_id="agent-1",
+        agent_name="Agent",
+        session_id="sess-1",
+        created_at="2026-07-15T00:00:00+00:00",
+        workspace=workspace,
+    )
+    store.save(state, base_archive=base_archive)
+    store.set_current("sess-1")
+    return store
+
+
+def _command_driver(
+    client: _FakeClient,
+    store: SessionStateStore,
+    *,
+    action: mod.SessionAction,
+    text: str | None = None,
+    session_override: str | None = None,
+    sink: list[object] | None = None,
+) -> mod.DetachedCommandDriver:
+    events = sink if sink is not None else []
+    return mod.DetachedCommandDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        action=action,
+        text=text,
+        session_override=session_override,
+        sink=events.append,
+    )
+
+
+# -- LiveWorkspace ---------------------------------------------------------------------------
+
+
+def test_conflicted_local_push_does_not_advance_the_base(tmp_path: Path) -> None:
+    """A rejected same-file edit remains outside the platform-accepted snapshot."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    (tmp_path / "answer.txt").write_text("local", encoding="utf-8")
+    client = _FakeClient()
+    client.upload_result = WorkspacePatchResult(applied=[], conflicts=["answer.txt"])
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+
+    changed = workspace.push_local()
+
+    assert not changed
+    assert workspace.synchronized is base
+    assert workspace.conflicts == {"answer.txt"}
+
+
+def test_accepted_local_push_advances_the_base(tmp_path: Path) -> None:
+    """An accepted patch makes the current local snapshot the new synchronized base."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    (tmp_path / "answer.txt").write_text("local", encoding="utf-8")
+    client = _FakeClient()
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+
+    changed = workspace.push_local()
+
+    assert changed
+    assert len(client.uploaded_patches) == 1
+    assert workspace.synchronized.files == snapshot_workspace(tmp_path).files
+
+
+def test_remote_patch_applies_locally_and_checkpoints_before_ack(tmp_path: Path) -> None:
+    """The durable checkpoint lands between local apply and the remote acknowledgement."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+    client = _FakeClient()
+    client.patches["patch-1"] = patch
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+    order: list[str] = []
+
+    workspace.apply_remote_patch("patch-1", before_ack=lambda: order.append("checkpoint"))
+    order.extend(f"ack:{revision}" for revision in client.patch_acks)
+
+    assert order == ["checkpoint", "ack:patch-1"]
+    assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "during"
+    assert workspace.synchronized.files == snapshot_workspace(tmp_path).files
+
+
+def test_finalize_preserves_conflicts_and_acknowledges(tmp_path: Path) -> None:
+    """Final sync keeps conflicting local work, saves the recovery archive, and acks."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    (tmp_path / "answer.txt").write_text("local", encoding="utf-8")
+    client = _FakeClient()
+    client.final_archive = _archive({"answer.txt": b"remote"})
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+
+    result = workspace.finalize()
+
+    assert result.conflicts == ("answer.txt",)
+    assert (tmp_path / "answer.txt").read_text(encoding="utf-8") == "local"
+    assert (tmp_path / ".wmh-conflicts" / "sess-1.tar.gz").is_file()
+    assert client.final_acked
+
+
+# -- DetachedStartDriver ---------------------------------------------------------------------
+
+
+def test_detached_start_persists_reference_and_returns(tmp_path: Path) -> None:
+    """--detach creates a normal hosted session, records it, and never ends it."""
+    store = SessionStateStore(tmp_path / "state")
+    client = _FakeClient()
+    mod.DetachedStartDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        target_id="agent-1",
+        name="Agent",
+        jail_root=None,
+        task="open task",
+    ).run()
+
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.api_url == API_URL
+    assert state.web_url == WEB_URL
+    assert state.agent_id == "agent-1"
+    assert state.cursor == 0
+    assert state.workspace is None
+    assert store.current_session_id() == "sess-1"
+    assert client.created_instruction == "open task"
+    assert client.created_workspace is None
+    assert client.commands == []
+    assert client.end_calls == []
+    assert client.closed
+
+
+def test_detached_start_uploads_workspace_and_checkpoints_the_base(tmp_path: Path) -> None:
+    """-u at detach time uploads the snapshot and persists it as the sync base."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    store = SessionStateStore(tmp_path / "state")
+    client = _FakeClient()
+
+    mod.DetachedStartDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        target_id="agent-1",
+        name="Agent",
+        jail_root=root,
+        task=None,
+    ).run()
+
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.workspace is not None
+    assert state.workspace.root == str(root)
+    assert client.created_workspace is not None
+    assert store.load_base_archive(state) == client.created_workspace
+    assert snapshot_from_archive(client.created_workspace).files == snapshot_workspace(root).files
+
+
+# -- DetachedCommandDriver: send ---------------------------------------------------------------
+
+
+def test_send_streams_one_turn_and_leaves_the_session_alive(tmp_path: Path) -> None:
+    """--send posts one user_message, streams to idle, and exits without ending."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.pages = [
+        _page([], 0, "running"),
+        _page(
+            [
+                _event(1, "user_message", text="Do this task"),
+                _event(2, "state", status="running"),
+                _event(3, "assistant_message", text="done"),
+                _event(4, "state", status="idle"),
+            ],
+            4,
+            "running",
+        ),
+    ]
+    rendered: list[object] = []
+
+    _command_driver(client, store, action="send", text="Do this task", sink=rendered).run()
+
+    assert client.commands == [("user_message", "Do this task")]
+    assert client.end_calls == []
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 4
+    assert any(getattr(event, "kind", None) == "assistant_message" for event in rendered)
+    assert client.closed
+
+
+def test_send_ignores_idle_left_over_from_a_previous_turn(tmp_path: Path) -> None:
+    """Turn completion counts only after the sent message appears in the transcript."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.pages = [
+        _page([], 0, "running"),
+        _page([_event(1, "state", status="idle")], 1, "running"),
+        _page(
+            [_event(2, "user_message", text="hi"), _event(3, "state", status="idle")],
+            3,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi").run()
+
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 3
+
+
+def test_send_catches_up_remote_patches_before_messaging(tmp_path: Path) -> None:
+    """Patches hosted while detached land locally (and are acked) before the send."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+    client = _FakeClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.patches["patch-1"] = patch
+    client.pages = [
+        _page([_event(1, "workspace_patch", revision="patch-1")], 1, "running"),
+        _page([], 1, "running"),
+        _page(
+            [_event(2, "user_message", text="hi"), _event(3, "state", status="idle")],
+            3,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi").run()
+
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "during"
+    assert client.patch_acks == ["patch-1"]
+    patch_index = client.calls.index("patch:patch-1")
+    command_index = client.calls.index("command:user_message")
+    assert patch_index < command_index
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 3
+    assert snapshot_from_archive(store.load_base_archive(state)).files == base_files(root)
+
+
+def base_files(root: Path) -> dict[str, object]:
+    """The current on-disk manifest, for checkpoint equality assertions."""
+    return dict(snapshot_workspace(root).files)
+
+
+def test_send_uploads_local_changes_before_the_message(tmp_path: Path) -> None:
+    """Local edits made while detached reach the sandbox before the agent reads the task."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    (root / "answer.txt").write_text("edited while detached", encoding="utf-8")
+    client = _FakeClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.pages = [
+        _page([], 0, "running"),
+        _page(
+            [_event(1, "user_message", text="hi"), _event(2, "state", status="idle")],
+            2,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi").run()
+
+    assert len(client.uploaded_patches) == 1
+    assert client.calls.index("upload_patch") < client.calls.index("command:user_message")
+    state = store.load("sess-1")
+    assert state is not None
+    assert snapshot_from_archive(store.load_base_archive(state)).files == base_files(root)
+
+
+def test_send_to_terminal_session_is_actionable(tmp_path: Path) -> None:
+    """A dead current session tells the user how to reconcile it, keeping state."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.session_states = [_session("ended")]
+
+    with pytest.raises(typer.BadParameter, match="--end"):
+        _command_driver(client, store, action="send", text="hi").run()
+
+    assert store.load("sess-1") is not None
+    assert client.commands == []
+
+
+def test_send_without_current_session_is_actionable(tmp_path: Path) -> None:
+    """No stored session points the user at --detach and --session."""
+    store = SessionStateStore(tmp_path / "state")
+    client = _FakeClient()
+
+    with pytest.raises(typer.BadParameter, match="--detach"):
+        _command_driver(client, store, action="send", text="hi").run()
+
+
+def test_dangling_current_pointer_is_actionable(tmp_path: Path) -> None:
+    """A pointer whose state file is gone explains how to start over."""
+    store = SessionStateStore(tmp_path / "state")
+    store.set_current("sess-ghost")
+    client = _FakeClient()
+
+    with pytest.raises(typer.BadParameter, match="--detach"):
+        _command_driver(client, store, action="send", text="hi").run()
+
+
+def test_platform_url_mismatch_is_actionable(tmp_path: Path) -> None:
+    """A session from another platform names both URLs and the fix."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    driver = mod.DetachedCommandDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=PlatformCredentials(
+            api_url="https://api.elsewhere", web_url="https://elsewhere.test", token="xpl_2"
+        ),
+        state_store=store,
+        action="send",
+        text="hi",
+        session_override=None,
+        sink=lambda _event: None,
+    )
+
+    with pytest.raises(typer.BadParameter, match="wmh login"):
+        driver.run()
+
+
+def test_session_override_resolves_remotely_when_unknown_locally(tmp_path: Path) -> None:
+    """--session with a foreign id uses the platform resolution route, ephemerally."""
+    store = SessionStateStore(tmp_path / "state")
+    client = _FakeClient()
+    client.resolved = RemoteAgentSession(
+        id="sess-9",
+        agent_id="agent-2",
+        status="running",
+        workspace_sync=False,
+        launched_from="web",
+    )
+    client.pages = [
+        _page([], 0, "running"),
+        _page(
+            [_event(1, "user_message", text="hi"), _event(2, "state", status="idle")],
+            2,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi", session_override="sess-9").run()
+
+    assert "resolve sess-9" in client.calls
+    assert client.commands == [("user_message", "hi")]
+    assert store.load("sess-9") is None
+
+
+def test_unknown_session_override_is_actionable(tmp_path: Path) -> None:
+    """A miss on the resolution route mentions the session id and the login."""
+    store = SessionStateStore(tmp_path / "state")
+    client = _FakeClient()
+
+    with pytest.raises(typer.BadParameter, match="sess-9"):
+        _command_driver(client, store, action="send", text="hi", session_override="sess-9").run()
+
+
+# -- DetachedCommandDriver: attach -------------------------------------------------------------
+
+
+class _InstantDetachReader:
+    """A reader whose user immediately detaches (never ends)."""
+
+    def __init__(self, *_args: object) -> None:
+        self.detach = threading.Event()
+        self.detach.set()
+
+    def start(self) -> None:
+        pass
+
+
+def test_attach_detaches_without_ending(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Leaving an attachment persists the cursor and leaves the session running."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.pages = [
+        _page([], 0, "running"),
+        _page([_event(1, "assistant_message", text="hello")], 1, "running"),
+    ]
+    monkeypatch.setattr(mod, "AttachedCommandReader", _InstantDetachReader)
+
+    _command_driver(client, store, action="attach").run()
+
+    assert client.commands == []
+    assert client.end_calls == []
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.cursor == 1
+    assert store.current_session_id() == "sess-1"
+
+
+def test_attach_to_terminal_session_is_actionable(tmp_path: Path) -> None:
+    """Attaching to a finished session explains the --end reconciliation path."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.session_states = [_session("failed")]
+
+    with pytest.raises(typer.BadParameter, match="--end"):
+        _command_driver(client, store, action="attach").run()
+
+
+def test_attach_finishes_cleanly_when_the_session_ends_remotely(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A session ended from the web while attached tears down local state."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.session_states = [_session("running"), _session("ended")]
+    client.pages = [
+        _page([], 0, "running"),
+        _page([_event(1, "state", status="idle")], 1, "ended"),
+    ]
+
+    class _NeverDetachReader:
+        def __init__(self, *_args: object) -> None:
+            self.detach = threading.Event()
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(mod, "AttachedCommandReader", _NeverDetachReader)
+
+    _command_driver(client, store, action="attach").run()
+
+    assert store.load("sess-1") is None
+    assert store.current_session_id() is None
+
+
+# -- DetachedCommandDriver: end ----------------------------------------------------------------
+
+
+def test_end_syncs_final_workspace_and_clears_state(tmp_path: Path) -> None:
+    """--end pushes local edits, ends, applies the final archive, acks, and cleans up."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    client = _FakeClient()
+    client.session_states = [
+        _session(workspace_sync=True),
+        _session("ended", workspace_sync=True),
+    ]
+    client.final_archive = _archive({"answer.txt": b"after"})
+    client.pages = [
+        _page([], 0, "running"),
+        _page([], 0, "ended"),
+    ]
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.end_calls == [("agent-1", "sess-1")]
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "after"
+    assert client.final_acked
+    assert store.load("sess-1") is None
+    assert store.current_session_id() is None
+
+
+def test_end_on_already_terminal_session_reconciles_and_clears(tmp_path: Path) -> None:
+    """--end on a session that died while detached still syncs and clears state."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    client = _FakeClient()
+    client.session_states = [
+        _session("ended", workspace_sync=True),
+        _session("ended", workspace_sync=True),
+    ]
+    client.final_archive = _archive({"answer.txt": b"after"})
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.end_calls == []
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "after"
+    assert client.final_acked
+    assert store.load("sess-1") is None
+
+
+def test_failed_session_end_exits_nonzero_after_cleanup(tmp_path: Path) -> None:
+    """A failed session's end reports the error and exits 1, with state removed."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.session_states = [_session("failed"), _session("failed")]
+
+    with pytest.raises(typer.Exit) as raised:
+        _command_driver(client, store, action="end").run()
+
+    assert raised.value.exit_code == 1
+    assert store.load("sess-1") is None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import io
+import shutil
 import tarfile
 import threading
 from pathlib import Path
@@ -1021,3 +1022,189 @@ def test_attach_end_command_runs_the_final_handoff(
     assert client.end_calls == [("agent-1", "sess-1")]
     assert store.load("sess-1") is None
     assert store.current_session_id() is None
+
+
+def _workspace_session_store(tmp_path: Path) -> tuple[SessionStateStore, Path, bytes]:
+    """A current detached session with a checkpointed workspace root."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    return store, root, base.archive
+
+
+def _terminal_end_client(final_archive: bytes | None) -> _FakeClient:
+    """A client for an end flow that reaches the terminal state in one page."""
+    client = _FakeClient()
+    client.session_states = [
+        _session(workspace_sync=True),
+        _session("ended", workspace_sync=True),
+    ]
+    client.final_archive = final_archive
+    client.pages = [
+        _page([], 0, "running"),
+        _page([], 0, "ended"),
+    ]
+    return client
+
+
+def test_end_with_missing_base_archive_salvages_the_final_workspace(tmp_path: Path) -> None:
+    """--end without a usable checkpoint still saves the archive and acknowledges."""
+    store, root, _base = _workspace_session_store(tmp_path)
+    (archive_path,) = (tmp_path / "state").glob("sess-1.workspace-*.tar.gz")
+    archive_path.unlink()
+    client = _terminal_end_client(_archive({"answer.txt": b"final"}))
+
+    _command_driver(client, store, action="end").run()
+
+    assert "final_download" in client.calls
+    assert client.final_acked
+    recovery = root / ".wmh-conflicts" / "sess-1.tar.gz"
+    assert recovery.is_file()
+    with tarfile.open(recovery) as archive:
+        member = archive.extractfile("answer.txt")
+        assert member is not None
+        assert member.read() == b"final"
+    # No local sync ran: the working tree is untouched.
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "before"
+    assert store.load("sess-1") is None
+
+
+def test_end_with_corrupt_base_archive_salvages_the_final_workspace(tmp_path: Path) -> None:
+    """A checkpoint that fails its integrity check degrades to the same salvage."""
+    store, root, _base = _workspace_session_store(tmp_path)
+    (archive_path,) = (tmp_path / "state").glob("sess-1.workspace-*.tar.gz")
+    archive_path.write_bytes(b"tampered")
+    client = _terminal_end_client(_archive({"answer.txt": b"final"}))
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.final_acked
+    assert (root / ".wmh-conflicts" / "sess-1.tar.gz").is_file()
+    assert store.load("sess-1") is None
+
+
+def test_end_with_missing_root_salvages_to_the_state_directory(tmp_path: Path) -> None:
+    """With the synced directory gone, the archive lands in WMH state and survives."""
+    store, root, _base = _workspace_session_store(tmp_path)
+    shutil.rmtree(root)
+    client = _terminal_end_client(_archive({"answer.txt": b"final"}))
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.final_acked
+    recovery = tmp_path / "state" / "sess-1.recovered.tar.gz"
+    assert recovery.is_file()
+    # State cleanup must not take the user's data with it.
+    assert store.load("sess-1") is None
+    assert recovery.is_file()
+    with tarfile.open(recovery) as archive:
+        member = archive.extractfile("answer.txt")
+        assert member is not None
+        assert member.read() == b"final"
+
+
+def test_send_with_missing_base_archive_points_at_end(tmp_path: Path) -> None:
+    """Non-end actions on an unusable checkpoint point at the now-working --end."""
+    store, _root, _base = _workspace_session_store(tmp_path)
+    (archive_path,) = (tmp_path / "state").glob("sess-1.workspace-*.tar.gz")
+    archive_path.unlink()
+    client = _FakeClient()
+    client.session_states = [_session(workspace_sync=True)]
+
+    with pytest.raises(typer.BadParameter, match="--end"):
+        _command_driver(client, store, action="send", text="hi").run()
+
+    assert store.load("sess-1") is not None
+
+
+def test_failed_patch_ack_is_retried_on_the_next_command(tmp_path: Path) -> None:
+    """A patch whose acknowledgement failed is re-acked before the next catch-up."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+
+    class _AckFailsClient(_FakeClient):
+        def acknowledge_agent_workspace_patch(
+            self, agent_id: str, session_id: str, revision: str
+        ) -> None:
+            raise PlatformError("backend unavailable", status_code=503)
+
+    first = _AckFailsClient()
+    first.session_states = [_session(workspace_sync=True)]
+    first.patches["patch-1"] = patch
+    first.pages = [_page([_event(1, "workspace_patch", revision="patch-1")], 1, "running")]
+
+    with pytest.raises(typer.BadParameter):
+        _command_driver(first, store, action="send", text="hi").run()
+
+    # The patch landed locally and the checkpoint remembers the unsent ack.
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "during"
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.workspace is not None
+    assert state.workspace.pending_ack == "patch-1"
+
+    second = _FakeClient()
+    second.session_states = [_session(workspace_sync=True)]
+    second.pages = [
+        _page([], 1, "running"),
+        _page(
+            [_event(2, "user_message", text="hi"), _event(3, "state", status="idle")],
+            3,
+            "running",
+        ),
+    ]
+
+    _command_driver(second, store, action="send", text="hi").run()
+
+    assert second.patch_acks == ["patch-1"]
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.workspace is not None
+    assert state.workspace.pending_ack is None
+
+
+def test_pending_ack_tolerates_an_already_removed_patch(tmp_path: Path) -> None:
+    """A 404 on the ack retry means the object is gone; the marker still clears."""
+    root = tmp_path / "work"
+    root.mkdir()
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    state = store.load("sess-1")
+    assert state is not None
+    assert state.workspace is not None
+    store.save(
+        state.model_copy(
+            update={"workspace": state.workspace.model_copy(update={"pending_ack": "patch-9"})}
+        )
+    )
+
+    class _GoneClient(_FakeClient):
+        def acknowledge_agent_workspace_patch(
+            self, agent_id: str, session_id: str, revision: str
+        ) -> None:
+            raise PlatformError("workspace patch not found", status_code=404)
+
+    client = _GoneClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.pages = [
+        _page([], 0, "running"),
+        _page(
+            [_event(1, "user_message", text="hi"), _event(2, "state", status="idle")],
+            2,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi").run()
+
+    reloaded = store.load("sess-1")
+    assert reloaded is not None
+    assert reloaded.workspace is not None
+    assert reloaded.workspace.pending_ack is None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -1348,3 +1348,35 @@ def test_end_tolerates_a_sandbox_that_ended_mid_command(tmp_path: Path) -> None:
     assert (root / ".wmh-conflicts" / "sess-1.tar.gz").is_file()
     assert client.final_acked
     assert store.load("sess-1") is None
+
+
+def test_finish_terminal_survives_a_vanished_session_record(tmp_path: Path) -> None:
+    """A 404 on the post-handoff status read must not strand local state forever."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+
+    class _VanishingClient(_FakeClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.gets = 0
+
+        def get_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+            self.gets += 1
+            if self.gets > 1:
+                raise PlatformError(f"Agent not found: {agent_id}", status_code=404)
+            return super().get_agent_session(agent_id, session_id)
+
+    client = _VanishingClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.final_archive = _archive({"answer.txt": b"final"})
+    client.pages = [_page([], 0, "ended")]
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.final_acked
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "final"
+    assert store.load("sess-1") is None
+    assert store.current_session_id() is None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -1208,3 +1208,103 @@ def test_pending_ack_tolerates_an_already_removed_patch(tmp_path: Path) -> None:
     assert reloaded is not None
     assert reloaded.workspace is not None
     assert reloaded.workspace.pending_ack is None
+
+
+def test_interrupt_mid_page_does_not_refetch_processed_events(tmp_path: Path) -> None:
+    """Resuming after Ctrl-C polls past processed events, so acked patches never 404."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+    client = _FakeClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.patches["patch-1"] = patch
+    client.pages = [
+        _page([], 0, "running"),
+        _page(
+            [
+                _event(1, "workspace_patch", revision="patch-1"),
+                _event(2, "assistant_message", text="mid-turn"),
+            ],
+            2,
+            "running",
+        ),
+        _page(
+            [
+                _event(2, "assistant_message", text="mid-turn"),
+                _event(3, "user_message", text="hi"),
+                _event(4, "state", status="idle"),
+            ],
+            4,
+            "running",
+        ),
+    ]
+    interrupted = False
+
+    def sink(event: object) -> None:
+        nonlocal interrupted
+        if getattr(event, "kind", "") == "assistant_message" and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+
+    driver = mod.DetachedCommandDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        action="send",
+        text="hi",
+        session_override=None,
+        sink=sink,
+    )
+    driver.run()
+
+    # The patch downloaded exactly once and the resume polled past its event.
+    assert client.calls.count("patch:patch-1") == 1
+    assert "events after=1" in client.calls
+    assert ("interrupt", None) in client.commands
+
+
+def test_second_interrupt_during_the_handler_detaches_cleanly(tmp_path: Path) -> None:
+    """A Ctrl-C landing inside the interrupt handler detaches instead of crashing."""
+    store = _store_with_session(tmp_path)
+
+    class _InterruptRacedClient(_FakeClient):
+        def post_agent_session_command(
+            self, agent_id: str, session_id: str, kind: str, *, text: str | None = None
+        ) -> None:
+            super().post_agent_session_command(agent_id, session_id, kind, text=text)
+            if kind == "interrupt":
+                raise KeyboardInterrupt
+
+    client = _InterruptRacedClient()
+    client.pages = [
+        _page([], 0, "running"),
+        _page([_event(1, "assistant_message", text="working")], 1, "running"),
+    ]
+    interrupted = False
+
+    def sink(event: object) -> None:
+        nonlocal interrupted
+        if not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+
+    driver = mod.DetachedCommandDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        action="send",
+        text="hi",
+        session_override=None,
+        sink=sink,
+    )
+    driver.run()
+
+    assert ("interrupt", None) in client.commands
+    assert not any(kind == "end" for kind, _ in client.commands)
+    assert client.end_calls == []
+    # The session reference survives the detach for the next command.
+    assert store.load("sess-1") is not None

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -16,7 +16,7 @@ import typer
 
 import wmh.cli.hosted_session as mod
 from wmh.cli.session_state import DetachedSessionState, SessionStateStore, WorkspaceCheckpoint
-from wmh.cli.workspace_sync import snapshot_from_archive, snapshot_workspace
+from wmh.cli.workspace_sync import FileState, snapshot_from_archive, snapshot_workspace
 from wmh.harness.workspace_patch import build_workspace_patch
 from wmh.platform.client import (
     PlatformError,
@@ -443,7 +443,7 @@ def test_send_catches_up_remote_patches_before_messaging(tmp_path: Path) -> None
     assert snapshot_from_archive(store.load_base_archive(state)).files == base_files(root)
 
 
-def base_files(root: Path) -> dict[str, object]:
+def base_files(root: Path) -> dict[str, FileState]:
     """The current on-disk manifest, for checkpoint equality assertions."""
     return dict(snapshot_workspace(root).files)
 

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -698,3 +698,58 @@ def test_failed_session_end_exits_nonzero_after_cleanup(tmp_path: Path) -> None:
 
     assert raised.value.exit_code == 1
     assert store.load("sess-1") is None
+
+
+def test_remote_patch_does_not_absorb_unpushed_local_edits(tmp_path: Path) -> None:
+    """A local edit made while detached must still upload after a patch lands.
+
+    Reproduces the preview bug: advancing the base by re-snapshotting the local
+    directory swallowed unpushed local files, so they never reached the sandbox
+    and the final sync could even delete them.
+    """
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+    (tmp_path / "local-only.txt").write_text("unpushed", encoding="utf-8")
+    client = _FakeClient()
+    client.patches["patch-1"] = patch
+    workspace = mod.LiveWorkspace(
+        cast("mod.PlatformClient", client), "agent-1", "sess-1", tmp_path, base
+    )
+
+    workspace.apply_remote_patch("patch-1")
+
+    assert "local-only.txt" not in workspace.synchronized.files
+    assert workspace.push_local()
+    assert len(client.uploaded_patches) == 1
+
+
+def test_attach_uploads_local_edits_before_rebasing_on_remote_patches(tmp_path: Path) -> None:
+    """Catch-up pushes local changes first so a pending patch cannot swallow them."""
+    root = tmp_path / "work"
+    root.mkdir()
+    (root / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(root)
+    store = _store_with_session(tmp_path, workspace_root=root, base_archive=base.archive)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": b"during"}))
+    assert patch is not None
+    (root / "local-only.txt").write_text("created while detached", encoding="utf-8")
+    client = _FakeClient()
+    client.session_states = [_session(workspace_sync=True)]
+    client.patches["patch-1"] = patch
+    client.pages = [
+        _page([_event(1, "workspace_patch", revision="patch-1")], 1, "running"),
+        _page([], 1, "running"),
+        _page(
+            [_event(2, "user_message", text="hi"), _event(3, "state", status="idle")],
+            3,
+            "running",
+        ),
+    ]
+
+    _command_driver(client, store, action="send", text="hi").run()
+
+    assert len(client.uploaded_patches) >= 1
+    assert client.calls.index("upload_patch") < client.calls.index("patch:patch-1")
+    assert (root / "answer.txt").read_text(encoding="utf-8") == "during"

--- a/wmh/cli/hosted_session_test.py
+++ b/wmh/cli/hosted_session_test.py
@@ -753,3 +753,69 @@ def test_attach_uploads_local_edits_before_rebasing_on_remote_patches(tmp_path: 
     assert len(client.uploaded_patches) >= 1
     assert client.calls.index("upload_patch") < client.calls.index("patch:patch-1")
     assert (root / "answer.txt").read_text(encoding="utf-8") == "during"
+
+
+def test_attached_reader_reports_a_failed_end_and_keeps_reading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed :end must be reported, not silently converted into a detach."""
+    monkeypatch.setattr(mod.sys, "stdin", io.StringIO(":end\n:stop\n"))
+
+    class _FailingEndClient(_FakeClient):
+        def end_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+            raise PlatformError("backend unavailable", status_code=503)
+
+    client = _FailingEndClient()
+    reader = mod.AttachedCommandReader(cast("mod.PlatformClient", client), "agent-1", "sess-1")
+
+    reader.run()
+
+    # The reader kept consuming input after the failed end (the :stop landed),
+    # and only stdin EOF flipped the detach event.
+    assert client.commands == [("interrupt", None)]
+    assert reader.end_failed
+    assert reader.detach.is_set()
+
+
+def test_detached_start_state_failure_names_the_running_session(
+    tmp_path: Path,
+) -> None:
+    """A state-write failure after creation must hand the user the session id."""
+
+    class _FailingSaveStore(SessionStateStore):
+        def save(
+            self, state: DetachedSessionState, *, base_archive: bytes | None = None
+        ) -> DetachedSessionState:
+            raise mod.SessionStateError("disk full")
+
+    store = _FailingSaveStore(tmp_path / "state")
+    client = _FakeClient()
+    driver = mod.DetachedStartDriver(
+        client=cast("mod.PlatformClient", client),
+        credentials=_credentials(),
+        state_store=store,
+        target_id="agent-1",
+        name="Agent",
+        jail_root=None,
+        task=None,
+    )
+
+    with pytest.raises(typer.BadParameter, match="sess-1"):
+        driver.run()
+
+
+def test_end_reruns_cleanly_while_the_session_is_ending(tmp_path: Path) -> None:
+    """--end on a session already winding down still reaches the final handoff."""
+    store = _store_with_session(tmp_path)
+    client = _FakeClient()
+    client.session_states = [_session("ending"), _session("ended")]
+    client.end_result = _session("ending")
+    client.pages = [
+        _page([], 0, "ending"),
+        _page([], 0, "ended"),
+    ]
+
+    _command_driver(client, store, action="end").run()
+
+    assert client.end_calls == [("agent-1", "sess-1")]
+    assert store.load("sess-1") is None

--- a/wmh/cli/session_state.py
+++ b/wmh/cli/session_state.py
@@ -47,6 +47,9 @@ class WorkspaceCheckpoint(BaseModel):
     root: str
     base_sha256: str = ""
     conflicts: tuple[str, ...] = ()
+    # A patch applied locally whose acknowledgement did not reach the platform
+    # yet; the next command retries it so the server object never leaks.
+    pending_ack: str | None = None
 
 
 class DetachedSessionState(BaseModel):
@@ -139,6 +142,17 @@ class SessionStateStore:
             )
             raise SessionStateError(msg)
         return content
+
+    def write_recovery_archive(self, session_id: str, content: bytes) -> Path:
+        """Save a final workspace archive that could not be synchronized locally.
+
+        The file deliberately survives :meth:`delete`: it is the user's data,
+        not session state.
+        """
+        self._ensure_directory()
+        path = self._directory / f"{self._validated(session_id)}.recovered.tar.gz"
+        self._write_bytes(path, content)
+        return path
 
     def delete(self, session_id: str) -> None:
         """Remove the state, its checkpoint archives, and a matching current pointer."""

--- a/wmh/cli/session_state.py
+++ b/wmh/cli/session_state.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Persisted local references to detached hosted agent sessions.
+
+``wmh run <agent-id> --detach`` leaves a platform-owned E2B session running
+with no local process attached. The CLI remembers how to address it again
+(platform URL, agent id, session id) plus the workspace-sync checkpoint in the
+user-global WMH state directory (``$WMH_HOME`` or ``~/.wmh``), never inside
+the directory being synchronized. Writes are atomic and owner-only; the state
+directory is injectable so tests never touch real user state.
+
+The workspace base archive is stored content-addressed next to the JSON state
+and referenced by digest: the archive lands first and the state referencing it
+lands last, so a crash between the two writes leaves the previous checkpoint
+intact instead of a dangling pointer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tempfile
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+
+from wmh.platform.credentials import wmh_home
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SESSIONS_DIRNAME = "sessions"
+_CURRENT_FILENAME = "current"
+# Session ids come from the platform (UUIDs); refuse anything that could
+# escape the state directory when used as a file-name component.
+_SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class SessionStateError(RuntimeError):
+    """Detached-session state on disk is missing, unsafe, or corrupted."""
+
+
+class WorkspaceCheckpoint(BaseModel):
+    """Synchronization checkpoint between one local directory and the session."""
+
+    root: str
+    base_sha256: str = ""
+    conflicts: tuple[str, ...] = ()
+
+
+class DetachedSessionState(BaseModel):
+    """One hosted agent session the CLI can send to, attach to, or end later."""
+
+    api_url: str
+    web_url: str | None = None
+    agent_id: str
+    agent_name: str
+    session_id: str
+    created_at: str
+    cursor: int = 0
+    workspace: WorkspaceCheckpoint | None = None
+
+
+class SessionStateStore:
+    """Atomic, owner-only persistence for detached session references."""
+
+    def __init__(self, directory: Path | None = None) -> None:
+        """Store state under ``directory`` (default: the user-global WMH home)."""
+        self._directory = directory if directory is not None else wmh_home() / SESSIONS_DIRNAME
+
+    # -- session records ---------------------------------------------------------------------
+
+    def save(
+        self, state: DetachedSessionState, *, base_archive: bytes | None = None
+    ) -> DetachedSessionState:
+        """Persist one session's state, optionally with a new workspace base archive.
+
+        Returns:
+            The state as persisted (with ``base_sha256`` updated when an
+            archive was written).
+
+        Raises:
+            SessionStateError: If an archive is given without workspace
+                metadata, the id is unsafe, or a state path is a symlink.
+        """
+        self._ensure_directory()
+        session_id = self._validated(state.session_id)
+        if base_archive is not None:
+            if state.workspace is None:
+                msg = "a workspace base archive requires workspace checkpoint metadata"
+                raise SessionStateError(msg)
+            digest = hashlib.sha256(base_archive, usedforsecurity=False).hexdigest()
+            self._write_bytes(self._archive_path(session_id, digest), base_archive)
+            state = state.model_copy(
+                update={"workspace": state.workspace.model_copy(update={"base_sha256": digest})}
+            )
+        payload = state.model_dump_json(indent=2)
+        self._write_bytes(self._state_path(session_id), payload.encode("utf-8"))
+        self._prune_archives(state)
+        return state
+
+    def load(self, session_id: str) -> DetachedSessionState | None:
+        """Read one session's state; ``None`` when nothing is stored for the id."""
+        path = self._state_path(self._validated(session_id))
+        if not path.exists():
+            return None
+        try:
+            return DetachedSessionState.model_validate_json(path.read_text(encoding="utf-8"))
+        except (ValidationError, ValueError, OSError) as error:
+            msg = (
+                f"session state at {path} is unreadable; delete it and start a new "
+                "session with `wmh run <agent-id> --detach`"
+            )
+            raise SessionStateError(msg) from error
+
+    def load_base_archive(self, state: DetachedSessionState) -> bytes:
+        """Read and integrity-check the persisted workspace base archive."""
+        workspace = state.workspace
+        if workspace is None or not workspace.base_sha256:
+            msg = f"session {state.session_id} has no workspace checkpoint"
+            raise SessionStateError(msg)
+        path = self._archive_path(self._validated(state.session_id), workspace.base_sha256)
+        try:
+            content = path.read_bytes()
+        except OSError as error:
+            msg = (
+                f"workspace checkpoint archive is missing at {path}; end the session "
+                f"with `wmh run --session {state.session_id} --end` and recover from "
+                "the final workspace download"
+            )
+            raise SessionStateError(msg) from error
+        digest = hashlib.sha256(content, usedforsecurity=False).hexdigest()
+        if digest != workspace.base_sha256:
+            msg = (
+                f"workspace checkpoint archive at {path} failed its integrity check; "
+                f"delete it and end the session with `wmh run --session "
+                f"{state.session_id} --end`"
+            )
+            raise SessionStateError(msg)
+        return content
+
+    def delete(self, session_id: str) -> None:
+        """Remove the state, its checkpoint archives, and a matching current pointer."""
+        session_id = self._validated(session_id)
+        self._state_path(session_id).unlink(missing_ok=True)
+        for archive in self._directory.glob(f"{session_id}.workspace-*.tar.gz"):
+            archive.unlink(missing_ok=True)
+        if self.current_session_id() == session_id:
+            (self._directory / _CURRENT_FILENAME).unlink(missing_ok=True)
+
+    # -- current pointer ---------------------------------------------------------------------
+
+    def set_current(self, session_id: str) -> None:
+        """Publish ``session_id`` as the session bare send/attach/end commands use."""
+        self._ensure_directory()
+        content = f"{self._validated(session_id)}\n".encode()
+        self._write_bytes(self._directory / _CURRENT_FILENAME, content)
+
+    def current_session_id(self) -> str | None:
+        """The current session id, or ``None`` when no pointer is set."""
+        path = self._directory / _CURRENT_FILENAME
+        if not path.exists():
+            return None
+        value = path.read_text(encoding="utf-8").strip()
+        return value or None
+
+    # -- internals ---------------------------------------------------------------------------
+
+    def _ensure_directory(self) -> None:
+        """Create the state directory and keep it owner-only."""
+        self._directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(self._directory, 0o700)
+
+    def _state_path(self, session_id: str) -> Path:
+        return self._directory / f"{session_id}.json"
+
+    def _archive_path(self, session_id: str, digest: str) -> Path:
+        return self._directory / f"{session_id}.workspace-{digest[:16]}.tar.gz"
+
+    def _prune_archives(self, state: DetachedSessionState) -> None:
+        """Drop archives the just-written state no longer references."""
+        keep: str | None = None
+        if state.workspace is not None and state.workspace.base_sha256:
+            keep = self._archive_path(state.session_id, state.workspace.base_sha256).name
+        for candidate in self._directory.glob(f"{state.session_id}.workspace-*.tar.gz"):
+            if candidate.name != keep:
+                candidate.unlink(missing_ok=True)
+
+    def _validated(self, session_id: str) -> str:
+        """Reject ids that are unsafe as file-name components."""
+        if _SESSION_ID.fullmatch(session_id) is None:
+            msg = f"invalid session id: {session_id!r}"
+            raise SessionStateError(msg)
+        return session_id
+
+    def _write_bytes(self, path: Path, content: bytes) -> None:
+        """Write through a 0600 temporary file and swap into place atomically."""
+        if path.is_symlink():
+            msg = f"refusing to write session state through the symlink {path}; remove the link"
+            raise SessionStateError(msg)
+        fd, tmp_name = tempfile.mkstemp(dir=self._directory, prefix=f"{path.name}.")
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+            os.replace(tmp_name, path)
+        except BaseException:
+            os.unlink(tmp_name)
+            raise

--- a/wmh/cli/session_state.py
+++ b/wmh/cli/session_state.py
@@ -17,6 +17,7 @@ intact instead of a dangling pointer.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import re
@@ -182,9 +183,25 @@ class SessionStateStore:
     # -- internals ---------------------------------------------------------------------------
 
     def _ensure_directory(self) -> None:
-        """Create the state directory and keep it owner-only."""
-        self._directory.mkdir(parents=True, exist_ok=True)
-        os.chmod(self._directory, 0o700)
+        """Create every missing directory level owner-only from the start.
+
+        ``mkdir(parents=True)`` would create intermediate levels with the
+        umask default, leaving a window (and, for ``~/.wmh``, a permanent
+        0755) around checkpoint archives that contain the user's source
+        tree. A umask can only narrow 0o700, so creating each level with
+        that mode closes the race; pre-existing directories are left alone.
+        """
+        missing: list[Path] = []
+        current = self._directory
+        while not current.exists():
+            missing.append(current)
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
+        for directory in reversed(missing):
+            with contextlib.suppress(FileExistsError):
+                directory.mkdir(mode=0o700)
 
     def _state_path(self, session_id: str) -> Path:
         return self._directory / f"{session_id}.json"
@@ -219,5 +236,8 @@ class SessionStateStore:
                 handle.write(content)
             os.replace(tmp_name, path)
         except BaseException:
-            os.unlink(tmp_name)
+            # The replace may already have consumed the temp file; a missing
+            # file must not mask the original exception (e.g. an interrupt).
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
             raise

--- a/wmh/cli/session_state_test.py
+++ b/wmh/cli/session_state_test.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Tests for persisted detached-session references and workspace checkpoints."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from wmh.cli.session_state import (
+    DetachedSessionState,
+    SessionStateError,
+    SessionStateStore,
+    WorkspaceCheckpoint,
+)
+
+
+def _state(
+    session_id: str = "sess-1", *, workspace: WorkspaceCheckpoint | None = None
+) -> DetachedSessionState:
+    """A representative detached-session reference."""
+    return DetachedSessionState(
+        api_url="https://api.test",
+        web_url="https://platform.test",
+        agent_id="agent-1",
+        agent_name="Support Agent",
+        session_id=session_id,
+        created_at="2026-07-15T00:00:00+00:00",
+        workspace=workspace,
+    )
+
+
+def test_save_and_load_round_trip(tmp_path: Path) -> None:
+    """A saved reference loads back typed and equal."""
+    store = SessionStateStore(tmp_path)
+    saved = store.save(_state())
+
+    loaded = store.load("sess-1")
+
+    assert loaded == saved
+    assert loaded is not None
+    assert loaded.agent_id == "agent-1"
+    assert loaded.cursor == 0
+    assert loaded.workspace is None
+
+
+def test_load_missing_session_returns_none(tmp_path: Path) -> None:
+    """An unknown session id is a clean miss, not an error."""
+    assert SessionStateStore(tmp_path).load("sess-unknown") is None
+
+
+def test_state_files_are_owner_only(tmp_path: Path) -> None:
+    """The state directory and its files never leak to other users."""
+    directory = tmp_path / "sessions"
+    store = SessionStateStore(directory)
+    store.save(_state())
+    store.set_current("sess-1")
+
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    assert stat.S_IMODE((directory / "sess-1.json").stat().st_mode) == 0o600
+    assert stat.S_IMODE((directory / "current").stat().st_mode) == 0o600
+
+
+def test_current_pointer_round_trip(tmp_path: Path) -> None:
+    """set_current publishes the pointer that later commands resolve."""
+    store = SessionStateStore(tmp_path)
+    assert store.current_session_id() is None
+
+    store.save(_state("sess-1"))
+    store.set_current("sess-1")
+    assert store.current_session_id() == "sess-1"
+
+    store.save(_state("sess-2"))
+    store.set_current("sess-2")
+    assert store.current_session_id() == "sess-2"
+
+
+def test_delete_removes_state_archives_and_matching_pointer(tmp_path: Path) -> None:
+    """Deleting a session clears every file it owns, including a matching pointer."""
+    store = SessionStateStore(tmp_path)
+    workspace = WorkspaceCheckpoint(root="/tmp/project")
+    store.save(_state(workspace=workspace), base_archive=b"archive-bytes")
+    store.set_current("sess-1")
+
+    store.delete("sess-1")
+
+    assert store.load("sess-1") is None
+    assert store.current_session_id() is None
+    assert list(tmp_path.glob("sess-1*")) == []
+
+
+def test_delete_keeps_a_pointer_to_another_session(tmp_path: Path) -> None:
+    """Deleting a non-current session must not clear the current pointer."""
+    store = SessionStateStore(tmp_path)
+    store.save(_state("sess-1"))
+    store.save(_state("sess-2"))
+    store.set_current("sess-2")
+
+    store.delete("sess-1")
+
+    assert store.current_session_id() == "sess-2"
+
+
+def test_base_archive_round_trip_and_integrity(tmp_path: Path) -> None:
+    """The workspace base archive persists content-addressed and verifies on load."""
+    store = SessionStateStore(tmp_path)
+    saved = store.save(
+        _state(workspace=WorkspaceCheckpoint(root="/tmp/project")),
+        base_archive=b"archive-bytes",
+    )
+
+    assert saved.workspace is not None
+    assert saved.workspace.base_sha256
+    assert store.load_base_archive(saved) == b"archive-bytes"
+
+    reloaded = store.load("sess-1")
+    assert reloaded is not None
+    assert reloaded.workspace == saved.workspace
+
+
+def test_tampered_base_archive_fails_integrity(tmp_path: Path) -> None:
+    """A modified checkpoint archive is rejected, never silently used as a base."""
+    store = SessionStateStore(tmp_path)
+    saved = store.save(
+        _state(workspace=WorkspaceCheckpoint(root="/tmp/project")),
+        base_archive=b"archive-bytes",
+    )
+    (archive_path,) = tmp_path.glob("sess-1.workspace-*.tar.gz")
+    archive_path.write_bytes(b"tampered")
+
+    with pytest.raises(SessionStateError, match="integrity"):
+        store.load_base_archive(saved)
+
+
+def test_new_base_archive_replaces_the_previous_one(tmp_path: Path) -> None:
+    """Checkpoint updates leave exactly one archive on disk (the referenced one)."""
+    store = SessionStateStore(tmp_path)
+    state = _state(workspace=WorkspaceCheckpoint(root="/tmp/project"))
+    first = store.save(state, base_archive=b"first")
+    second = store.save(first, base_archive=b"second")
+
+    archives = list(tmp_path.glob("sess-1.workspace-*.tar.gz"))
+    assert len(archives) == 1
+    assert store.load_base_archive(second) == b"second"
+
+
+def test_save_base_archive_requires_workspace_metadata(tmp_path: Path) -> None:
+    """An archive without checkpoint metadata would be unreachable; refuse it."""
+    store = SessionStateStore(tmp_path)
+    with pytest.raises(SessionStateError, match="workspace"):
+        store.save(_state(), base_archive=b"orphan")
+
+
+def test_corrupted_state_file_is_an_actionable_error(tmp_path: Path) -> None:
+    """A broken state file names its path so the user can remove it."""
+    store = SessionStateStore(tmp_path)
+    store.save(_state())
+    (tmp_path / "sess-1.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SessionStateError, match="sess-1.json"):
+        store.load("sess-1")
+
+
+def test_unsafe_session_ids_are_rejected(tmp_path: Path) -> None:
+    """A session id is a file-name component; traversal never leaves the directory."""
+    store = SessionStateStore(tmp_path)
+    with pytest.raises(SessionStateError, match="session id"):
+        store.load("../escape")
+    with pytest.raises(SessionStateError, match="session id"):
+        store.set_current("a/b")
+
+
+def test_symlinked_state_file_is_refused(tmp_path: Path) -> None:
+    """A symlink at the state path must never be written through."""
+    store = SessionStateStore(tmp_path)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    (tmp_path / "sess-1.json").symlink_to(outside)
+
+    with pytest.raises(SessionStateError, match="symlink"):
+        store.save(_state())

--- a/wmh/cli/session_state_test.py
+++ b/wmh/cli/session_state_test.py
@@ -181,3 +181,37 @@ def test_symlinked_state_file_is_refused(tmp_path: Path) -> None:
 
     with pytest.raises(SessionStateError, match="symlink"):
         store.save(_state())
+
+
+def test_atomic_write_cleanup_preserves_the_original_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupt racing os.replace must not be masked by the temp-file cleanup."""
+    import wmh.cli.session_state as session_state_module
+
+    real_replace = session_state_module.os.replace
+
+    def replace_then_interrupt(src: str, dst: str) -> None:
+        real_replace(src, dst)
+        raise KeyboardInterrupt
+
+    store = SessionStateStore(tmp_path)
+    monkeypatch.setattr(session_state_module.os, "replace", replace_then_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        store.save(_state())
+
+
+def test_state_directories_are_created_owner_only_at_every_level(tmp_path: Path) -> None:
+    """Every directory level the store creates is 0700 from the start."""
+    pre_existing = tmp_path / "home"
+    pre_existing.mkdir(mode=0o755)
+    directory = pre_existing / ".wmh" / "sessions"
+    store = SessionStateStore(directory)
+
+    store.save(_state())
+
+    assert stat.S_IMODE((pre_existing / ".wmh").stat().st_mode) == 0o700
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    # A directory the store did not create keeps its owner-chosen mode.
+    assert stat.S_IMODE(pre_existing.stat().st_mode) == 0o755

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import io
 import os
@@ -330,11 +331,26 @@ def apply_workspace_patch(root: Path, content: bytes) -> SyncResult:
 
 
 def write_conflict_archive(root: Path, session_id: str, content: bytes) -> Path:
-    """Preserve a downloaded result archive when automatic reconciliation conflicts."""
+    """Preserve a downloaded result archive when automatic reconciliation conflicts.
+
+    The archive is the only remaining copy of the agent's work once the
+    handoff is acknowledged, so it lands atomically: a crash mid-write leaves
+    the previous file (or nothing), never a truncated archive.
+    """
     directory = root.resolve() / ".wmh-conflicts"
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / f"{session_id}.tar.gz"
-    path.write_bytes(content)
+    fd, tmp_name = tempfile.mkstemp(dir=directory, prefix=f"{path.name}.")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+        os.replace(tmp_name, path)
+    except BaseException:
+        # The replace may already have consumed the temp file; a missing file
+        # must not mask the original exception.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
     return path
 
 

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -14,8 +14,12 @@ import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
 
 from wmh.harness.workspace_patch import PatchFileState, parse_workspace_patch
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 MAX_WORKSPACE_ARCHIVE_BYTES = 50 * 1024 * 1024
 MAX_WORKSPACE_UNPACKED_BYTES = 512 * 1024 * 1024
@@ -115,10 +119,52 @@ def snapshot_from_archive(content: bytes) -> WorkspaceSnapshot:
     Raises:
         WorkspaceSyncError: If the bytes are not a safe regular-file archive.
     """
+    files = {
+        path: FileState(
+            sha256=hashlib.sha256(body, usedforsecurity=False).hexdigest(),
+            mode=stat.S_IMODE(mode),
+        )
+        for path, (body, mode) in _archive_files(content).items()
+    }
+    return WorkspaceSnapshot(archive=content, files=files)
+
+
+def apply_patch_to_snapshot(
+    snapshot: WorkspaceSnapshot, content: bytes, *, conflicts: Iterable[str] = ()
+) -> WorkspaceSnapshot:
+    """Advance a synchronized base by the patch operations that landed locally.
+
+    The base must reflect only synchronized content. Re-reading the local
+    directory here would absorb not-yet-uploaded local edits into the base,
+    so they would never upload and the final sync could even delete them.
+    Conflicted paths keep their base state: the disagreement stays visible to
+    both sides until the terminal reconciliation.
+
+    Raises:
+        WorkspaceSyncError: If the patch or the rebuilt base violates limits.
+    """
+    try:
+        patch = parse_workspace_patch(content)
+    except Exception as error:  # noqa: BLE001 - normalize to the sync error surface
+        raise WorkspaceSyncError(f"workspace patch is invalid: {error}") from error
+    rejected = set(conflicts)
+    files = _archive_files(snapshot.archive)
+    for operation in patch.operations:
+        if operation.path in rejected:
+            continue
+        if operation.after is None:
+            files.pop(operation.path, None)
+        else:
+            files[operation.path] = (patch.files[operation.path], operation.after.mode)
+    return _snapshot_from_files(files)
+
+
+def _archive_files(content: bytes) -> dict[str, tuple[bytes, int]]:
+    """Read a checkpoint archive's regular files as ``{path: (bytes, mode)}``."""
     if len(content) > MAX_WORKSPACE_ARCHIVE_BYTES:
         msg = f"workspace archive exceeds {MAX_WORKSPACE_ARCHIVE_BYTES} compressed bytes"
         raise WorkspaceSyncError(msg)
-    files: dict[str, FileState] = {}
+    files: dict[str, tuple[bytes, int]] = {}
     total = 0
     try:
         with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
@@ -144,16 +190,40 @@ def snapshot_from_archive(content: bytes) -> WorkspaceSnapshot:
                     raise WorkspaceSyncError(f"workspace file has no content: {member.name}")
                 with source:
                     body = source.read()
-                files[relative] = FileState(
-                    sha256=hashlib.sha256(body, usedforsecurity=False).hexdigest(),
-                    mode=stat.S_IMODE(member.mode),
-                )
+                files[relative] = (body, stat.S_IMODE(member.mode))
     except WorkspaceSyncError:
         raise
     except (tarfile.TarError, OSError, EOFError) as error:
         msg = "workspace must be a valid gzip tar archive"
         raise WorkspaceSyncError(msg) from error
-    return WorkspaceSnapshot(archive=content, files=files)
+    return files
+
+
+def _snapshot_from_files(files: dict[str, tuple[bytes, int]]) -> WorkspaceSnapshot:
+    """Build a deterministic snapshot archive plus manifest from file contents."""
+    total = sum(len(body) for body, _mode in files.values())
+    if total > MAX_WORKSPACE_UNPACKED_BYTES:
+        msg = f"workspace files exceed {MAX_WORKSPACE_UNPACKED_BYTES} uncompressed bytes"
+        raise WorkspaceSyncError(msg)
+    buffer = io.BytesIO()
+    manifest: dict[str, FileState] = {}
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for path in sorted(files):
+            body, mode = files[path]
+            info = tarfile.TarInfo(path)
+            info.size = len(body)
+            info.mode = stat.S_IMODE(mode)
+            info.mtime = 0
+            archive.addfile(info, io.BytesIO(body))
+            manifest[path] = FileState(
+                sha256=hashlib.sha256(body, usedforsecurity=False).hexdigest(),
+                mode=stat.S_IMODE(mode),
+            )
+    content = buffer.getvalue()
+    if len(content) > MAX_WORKSPACE_ARCHIVE_BYTES:
+        msg = f"workspace archive exceeds {MAX_WORKSPACE_ARCHIVE_BYTES} compressed bytes"
+        raise WorkspaceSyncError(msg)
+    return WorkspaceSnapshot(archive=content, files=manifest)
 
 
 def sync_workspace(

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -105,6 +105,57 @@ def snapshot_workspace(root: Path) -> WorkspaceSnapshot:
     return WorkspaceSnapshot(archive=content, files=files)
 
 
+def snapshot_from_archive(content: bytes) -> WorkspaceSnapshot:
+    """Rehydrate a snapshot (archive plus manifest) from persisted archive bytes.
+
+    Detached sessions persist their last synchronized archive between CLI
+    invocations; the manifest is recomputed from the archive itself so the
+    checkpoint has a single source of truth.
+
+    Raises:
+        WorkspaceSyncError: If the bytes are not a safe regular-file archive.
+    """
+    if len(content) > MAX_WORKSPACE_ARCHIVE_BYTES:
+        msg = f"workspace archive exceeds {MAX_WORKSPACE_ARCHIVE_BYTES} compressed bytes"
+        raise WorkspaceSyncError(msg)
+    files: dict[str, FileState] = {}
+    total = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            members = archive.getmembers()
+            if len(members) > MAX_WORKSPACE_ENTRIES:
+                msg = f"workspace archive has more than {MAX_WORKSPACE_ENTRIES} entries"
+                raise WorkspaceSyncError(msg)
+            for member in members:
+                relative = _normalized_name(member.name)
+                if member.isdir():
+                    continue
+                if not member.isfile():
+                    msg = f"workspace entry must be a regular file or directory: {member.name}"
+                    raise WorkspaceSyncError(msg)
+                if relative in files:
+                    raise WorkspaceSyncError(f"duplicate workspace path: {relative}")
+                total += member.size
+                if total > MAX_WORKSPACE_UNPACKED_BYTES:
+                    msg = f"workspace expands beyond {MAX_WORKSPACE_UNPACKED_BYTES} bytes"
+                    raise WorkspaceSyncError(msg)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise WorkspaceSyncError(f"workspace file has no content: {member.name}")
+                with source:
+                    body = source.read()
+                files[relative] = FileState(
+                    sha256=hashlib.sha256(body, usedforsecurity=False).hexdigest(),
+                    mode=stat.S_IMODE(member.mode),
+                )
+    except WorkspaceSyncError:
+        raise
+    except (tarfile.TarError, OSError, EOFError) as error:
+        msg = "workspace must be a valid gzip tar archive"
+        raise WorkspaceSyncError(msg) from error
+    return WorkspaceSnapshot(archive=content, files=files)
+
+
 def sync_workspace(
     root: Path,
     initial: WorkspaceSnapshot,

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -159,6 +159,26 @@ def apply_patch_to_snapshot(
     return _snapshot_from_files(files)
 
 
+def advance_snapshot_paths(
+    base: WorkspaceSnapshot, current: WorkspaceSnapshot, paths: Iterable[str]
+) -> WorkspaceSnapshot:
+    """Advance only ``paths`` of the base to their state in ``current``.
+
+    A partially-accepted upload moves the sandbox for the accepted paths only.
+    Advancing the whole base would hide the rejected paths' divergence, while
+    advancing nothing re-pushes the accepted paths against a stale base later,
+    which can manufacture conflicts if they change again locally in between.
+    """
+    files = _archive_files(base.archive)
+    replacements = _archive_files(current.archive)
+    for path in paths:
+        if path in replacements:
+            files[path] = replacements[path]
+        else:
+            files.pop(path, None)
+    return _snapshot_from_files(files)
+
+
 def _archive_files(content: bytes) -> dict[str, tuple[bytes, int]]:
     """Read a checkpoint archive's regular files as ``{path: (bytes, mode)}``."""
     if len(content) > MAX_WORKSPACE_ARCHIVE_BYTES:
@@ -252,14 +272,13 @@ def sync_workspace(
                 continue
             target = resolved / relative
             now = current.get(relative)
-            if (
-                relative in protected_paths
-                or _has_non_file_collision(target, now)
-                or (now != before and now != after)
-            ):
-                conflicts.append(relative)
-                continue
+            # Local and remote agreeing (content and mode) is synchronization,
+            # not a conflict, even for a path protected by an earlier live
+            # disagreement that has since reconverged.
             if now == after:
+                continue
+            if relative in protected_paths or _has_non_file_collision(target, now) or now != before:
+                conflicts.append(relative)
                 continue
             try:
                 if after is None:

--- a/wmh/cli/workspace_sync.py
+++ b/wmh/cli/workspace_sync.py
@@ -272,12 +272,18 @@ def sync_workspace(
                 continue
             target = resolved / relative
             now = current.get(relative)
+            # A directory/link/special file occupying the path is always a
+            # conflict: the manifests cannot see it, so no equality below is
+            # trustworthy.
+            if _has_non_file_collision(target, now):
+                conflicts.append(relative)
+                continue
             # Local and remote agreeing (content and mode) is synchronization,
             # not a conflict, even for a path protected by an earlier live
             # disagreement that has since reconverged.
             if now == after:
                 continue
-            if relative in protected_paths or _has_non_file_collision(target, now) or now != before:
+            if relative in protected_paths or now != before:
                 conflicts.append(relative)
                 continue
             try:

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -242,3 +242,17 @@ def test_sync_never_conflicts_a_path_that_converged(tmp_path: Path) -> None:
     assert result.conflicts == ()
     assert result.applied == ()
     assert (tmp_path / "same.txt").read_text(encoding="utf-8") == "A"
+
+
+def test_sync_conflicts_when_remote_deletion_meets_a_local_directory(tmp_path: Path) -> None:
+    """A non-file occupying a remotely-deleted path is a conflict, not convergence."""
+    (tmp_path / "same.txt").write_text("B", encoding="utf-8")
+    initial = snapshot_workspace(tmp_path)
+    (tmp_path / "same.txt").unlink()
+    (tmp_path / "same.txt").mkdir()
+    final = _archive({})
+
+    result = sync_workspace(tmp_path, initial, final)
+
+    assert result.conflicts == ("same.txt",)
+    assert (tmp_path / "same.txt").is_dir()

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -256,3 +256,21 @@ def test_sync_conflicts_when_remote_deletion_meets_a_local_directory(tmp_path: P
 
     assert result.conflicts == ("same.txt",)
     assert (tmp_path / "same.txt").is_dir()
+
+
+def test_conflict_archive_write_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A crash mid-write must not leave a truncated recovery archive behind."""
+    import wmh.cli.workspace_sync as workspace_sync_module
+
+    def failing_replace(_src: str, _dst: str) -> None:
+        raise OSError("simulated crash at the swap")
+
+    monkeypatch.setattr(workspace_sync_module.os, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="simulated"):
+        write_conflict_archive(tmp_path, "sess-1", b"archive-bytes")
+
+    directory = tmp_path / ".wmh-conflicts"
+    # Neither a partial target nor a stray temporary file survives the crash.
+    assert not (directory / "sess-1.tar.gz").exists()
+    assert [p for p in directory.iterdir()] == []

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -12,6 +12,7 @@ import pytest
 
 from wmh.cli.workspace_sync import (
     WorkspaceSyncError,
+    apply_patch_to_snapshot,
     apply_workspace_patch,
     snapshot_from_archive,
     snapshot_workspace,
@@ -193,3 +194,37 @@ def test_snapshot_from_archive_rejects_unsafe_entries(tmp_path: Path) -> None:
         archive.addfile(info)
     with pytest.raises(WorkspaceSyncError, match="regular file"):
         snapshot_from_archive(buffer.getvalue())
+
+
+def test_apply_patch_to_snapshot_advances_base_without_reading_disk(tmp_path: Path) -> None:
+    """The synchronized base advances by base+patch, never by re-reading local files."""
+    (tmp_path / "answer.txt").write_text("before", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    patch = build_workspace_patch(base.archive, _archive({"answer.txt": (b"during", 0o644)}))
+    assert patch is not None
+    # A local, not-yet-uploaded edit must stay out of the advanced base.
+    (tmp_path / "local-only.txt").write_text("unpushed", encoding="utf-8")
+
+    advanced = apply_patch_to_snapshot(base, patch, conflicts=())
+
+    assert set(advanced.files) == {"answer.txt"}
+    assert advanced.files["answer.txt"] != base.files["answer.txt"]
+    restored = snapshot_from_archive(advanced.archive)
+    assert restored.files == advanced.files
+
+
+def test_apply_patch_to_snapshot_keeps_conflicted_paths_at_their_base(tmp_path: Path) -> None:
+    """A locally-conflicted operation leaves the base unchanged for that path."""
+    (tmp_path / "same.txt").write_text("before", encoding="utf-8")
+    (tmp_path / "other.txt").write_text("keep", encoding="utf-8")
+    base = snapshot_workspace(tmp_path)
+    patch = build_workspace_patch(
+        base.archive,
+        _archive({"same.txt": (b"remote", 0o644), "other.txt": (b"changed", 0o644)}),
+    )
+    assert patch is not None
+
+    advanced = apply_patch_to_snapshot(base, patch, conflicts=("same.txt",))
+
+    assert advanced.files["same.txt"] == base.files["same.txt"]
+    assert advanced.files["other.txt"] != base.files["other.txt"]

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -228,3 +228,17 @@ def test_apply_patch_to_snapshot_keeps_conflicted_paths_at_their_base(tmp_path: 
 
     assert advanced.files["same.txt"] == base.files["same.txt"]
     assert advanced.files["other.txt"] != base.files["other.txt"]
+
+
+def test_sync_never_conflicts_a_path_that_converged(tmp_path: Path) -> None:
+    """Local and remote agreeing is synchronization, even for a protected path."""
+    (tmp_path / "same.txt").write_text("B", encoding="utf-8")
+    initial = snapshot_workspace(tmp_path)
+    (tmp_path / "same.txt").write_text("A", encoding="utf-8")
+    final = _archive({"same.txt": (b"A", 0o644)})
+
+    result = sync_workspace(tmp_path, initial, final, protected_paths=frozenset({"same.txt"}))
+
+    assert result.conflicts == ()
+    assert result.applied == ()
+    assert (tmp_path / "same.txt").read_text(encoding="utf-8") == "A"

--- a/wmh/cli/workspace_sync_test.py
+++ b/wmh/cli/workspace_sync_test.py
@@ -13,6 +13,7 @@ import pytest
 from wmh.cli.workspace_sync import (
     WorkspaceSyncError,
     apply_workspace_patch,
+    snapshot_from_archive,
     snapshot_workspace,
     sync_workspace,
     write_conflict_archive,
@@ -157,3 +158,38 @@ def test_sync_rejects_traversal_and_links(tmp_path: Path) -> None:
         archive.addfile(info)
     with pytest.raises(WorkspaceSyncError, match="regular file or directory"):
         sync_workspace(tmp_path, initial, buffer.getvalue())
+
+
+def test_snapshot_from_archive_rehydrates_the_manifest(tmp_path: Path) -> None:
+    """A persisted checkpoint archive restores the exact snapshot it was saved from."""
+    (tmp_path / "a.txt").write_text("alpha", encoding="utf-8")
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "b.py").write_text("print('b')", encoding="utf-8")
+    original = snapshot_workspace(tmp_path)
+
+    restored = snapshot_from_archive(original.archive)
+
+    assert restored.files == original.files
+    assert restored.archive == original.archive
+
+
+def test_snapshot_from_archive_rejects_malformed_bytes() -> None:
+    """Corrupted checkpoint bytes are a clean error, never a silent empty base."""
+    with pytest.raises(WorkspaceSyncError, match="gzip tar"):
+        snapshot_from_archive(b"not a tar archive")
+
+
+def test_snapshot_from_archive_rejects_unsafe_entries(tmp_path: Path) -> None:
+    """Traversal and non-regular entries cannot enter a rehydrated manifest."""
+    with pytest.raises(WorkspaceSyncError, match="unsafe"):
+        snapshot_from_archive(_archive({"../escape": (b"bad", 0o644)}))
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo("link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        archive.addfile(info)
+    with pytest.raises(WorkspaceSyncError, match="regular file"):
+        snapshot_from_archive(buffer.getvalue())

--- a/wmh/platform/client.py
+++ b/wmh/platform/client.py
@@ -126,6 +126,7 @@ class RemoteAgentSession(BaseModel):
     workspace_sync: bool
     launched_from: str
     starting_detail: str | None = None
+    ended_reason: str | None = None
     error: str | None = None
 
 
@@ -291,6 +292,18 @@ class PlatformClient:
     def get_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
         """Read current hosted agent session state."""
         response = self._client.get(f"/api/agents/{agent_id}/sessions/{session_id}")
+        self._raise_for_error(response)
+        return RemoteAgentSession.model_validate(response.json())
+
+    def resolve_agent_session(self, session_id: str) -> RemoteAgentSession:
+        """Resolve a bare session id to its owning agent and current state."""
+        response = self._client.get(f"/api/agent-sessions/{session_id}")
+        self._raise_for_error(response)
+        return RemoteAgentSession.model_validate(response.json())
+
+    def end_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
+        """Request an end, reconciling directly when the hosted driver is gone."""
+        response = self._client.post(f"/api/agents/{agent_id}/sessions/{session_id}/end")
         self._raise_for_error(response)
         return RemoteAgentSession.model_validate(response.json())
 

--- a/wmh/platform/client_test.py
+++ b/wmh/platform/client_test.py
@@ -226,6 +226,51 @@ def test_hosted_agent_session_without_workspace_posts_create_directly() -> None:
     assert seen == ["POST /api/agents/agent-1/sessions"]
 
 
+def test_detached_session_resolution_and_end_routes() -> None:
+    """A bare session id resolves to its agent, and end uses the reconciling route."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(f"{request.method} {request.url.path}")
+        if request.url.path == "/api/agent-sessions/sess-9":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "sess-9",
+                    "agent_id": "agent-2",
+                    "status": "running",
+                    "workspace_sync": False,
+                    "launched_from": "cli",
+                },
+            )
+        assert request.url.path == "/api/agents/agent-2/sessions/sess-9/end"
+        return httpx.Response(
+            202,
+            json={
+                "id": "sess-9",
+                "agent_id": "agent-2",
+                "status": "failed",
+                "workspace_sync": False,
+                "launched_from": "cli",
+                "ended_reason": "stalled",
+                "error": "driver heartbeat went stale",
+            },
+        )
+
+    with _client(handler) as client:
+        resolved = client.resolve_agent_session("sess-9")
+        ended = client.end_agent_session(resolved.agent_id, resolved.id)
+
+    assert resolved.agent_id == "agent-2"
+    assert resolved.status == "running"
+    assert ended.status == "failed"
+    assert ended.ended_reason == "stalled"
+    assert seen == [
+        "GET /api/agent-sessions/sess-9",
+        "POST /api/agents/agent-2/sessions/sess-9/end",
+    ]
+
+
 def test_hosted_agent_session_accepts_future_launch_origins() -> None:
     """A compatible platform origin extension does not break session decoding."""
     session = RemoteAgentSession.model_validate(


### PR DESCRIPTION
## What

`wmh run` gains a detached lifecycle for platform-owned E2B agent sessions, keeping `run` as the single unified execution command (bare `wmh run` still launches the built-in local pi harness):

```bash
wmh run <agent-id> -d            # start hosted, remember as the current session, return
wmh run <agent-id> -u . --detach # same, with workspace upload + live sync
wmh run <agent-id>               # plain interactive run; :detach promotes it to detached mid-session
wmh run -s "Do this task"        # send a message, stream that turn until idle, exit
wmh run -a                       # attach interactively; :detach leaves it running
wmh run --end                    # end explicitly, with the final workspace sync
wmh run --session <id> --send "Do this task"   # address a specific session
```

- Detached sessions are ordinary platform session records created through the existing authenticated session API: they stay visible and controllable from the web app, and the CLI reuses the same durable transcript poll / command queue / workspace patch protocol. No parallel executor.
- Session selection is explicit: commands address a stored (platform URL, agent id, session id) reference, current-pointer or `--session` override, never "the agent's active session", so it stays correct under future concurrent sessions.
- The current-session reference and workspace checkpoint persist in WMH user state (`~/.wmh/sessions/`, `$WMH_HOME` aware) as typed pydantic state with atomic owner-only writes and an injectable state directory. Actionable errors cover: no current session, terminal sessions, authorization failures (404-masked), and sessions belonging to a different platform URL.
- Workspace sync without a daemon: every send/attach/end first applies hosted patches accumulated while detached (checkpoint persisted between local apply and patch ack, so an acked patch is never needed again), uploads local edits since the checkpoint, then continues live sync while streaming. `--end` runs the final three-way sync, preserves the existing conflict behavior and `.wmh-conflicts/` recovery archive, and acknowledges the handoff before deleting local state.
- Exiting an attachment detaches (Ctrl-D, `:detach`, second Ctrl-C); only `--end` or the interactive `:end` ends it. The plain interactive run keeps its original semantics (`:quit`, `:end`, Ctrl-D, double Ctrl-C end the session) and gains `:detach`, which promotes the live session to the current detached session, carrying the workspace checkpoint and transcript cursor over. Lines starting with a colon are reserved for commands and are never forwarded to the agent as chat. No hidden reliance on stdin EOF ending hosted sessions, and hosted readers survive transient post failures (a warning, not a silent end/detach).
- `wmh run --end` completes the handoff even when the local checkpoint is unusable (missing/corrupt base archive, deleted workspace root): it downloads the final archive, saves it as a recovery file (`.wmh-conflicts/` under the root, else `~/.wmh/sessions/<id>.recovered.tar.gz`, which survives state cleanup), acknowledges, and only then clears state. Patch acknowledgements are durable via a pending-ack checkpoint marker retried on the next command.
- A plain interactive hosted run can be promoted mid-session: `:detach` persists the same current-session reference and workspace checkpoint a `-d` start writes (skipping the final sync-back) and exits with the session running. Plain-run `:quit` and Ctrl-D keep ending the session; unknown `:` commands in hosted readers warn instead of being forwarded to the agent as chat.
- The shared `LiveWorkspace` transport now also backs the attached `RemoteAgentDriver`, so attached and detached paths use one implementation.

## Platform dependency

Depends on experientiallabs/platform#320, which adds `GET /api/agent-sessions/{session_id}` (server-owned, tenant-scoped resolution of a bare session id) and admits org API keys to it and to the reconciling `POST .../sessions/{session_id}/end` route. Only `--session <unknown-id>` and end-with-stale-driver need the new surface; everything else uses already-deployed routes.

## Validation

- `uv run ruff check .`, `uv run ruff format .`, `uv run ty check`: clean
- `uv run pytest -q`: 1477 passed, 18 skipped
- New tests: session-state persistence (atomicity, permissions, integrity, pruning), LiveWorkspace transport (conflict-holding, checkpoint-before-ack ordering, finalize/recovery), detached start, send catch-up ordering (patches applied and local edits uploaded before the message), turn-idle detection ignoring stale idle events, attach detach-without-end, remote end while attached, end final-sync + state cleanup, terminal/stale/foreign-URL/no-current error paths, CLI flag matrix.
- A composed regression test (`test_contested_path_survives_push_rejection_catchup_and_finalize`) covers the contested-file case end to end: local and hosted edits to the same path while detached, rejected push, remote patch conflict, checkpoint record, recovery archive, exit code 2.
- Manual exercise against a platform preview (detached start, send to idle, attach/detach without ending, web coexistence, detached-workspace reconciliation, explicit end with final sync, stale/terminal handling, mid-session promotion): results posted in the PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

