### PR TITLE
Fix Bedrock tool-history requests with none choice

### DIFF
--- a/wmh/providers/_bedrock_chat.py
+++ b/wmh/providers/_bedrock_chat.py
@@ -13,6 +13,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
     """Translate the provider-neutral structured contract to Bedrock Converse."""
     system: list[dict[str, str]] = []
     messages: list[dict[str, object]] = []
+    has_tool_history = False
 
     def push(role: str, content: list[dict[str, object]]) -> None:
         if messages and messages[-1]["role"] == role:
@@ -28,6 +29,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
                 system.append({"text": text})
             continue
         if message.role == "tool":
+            has_tool_history = True
             push(
                 "user",
                 [
@@ -45,6 +47,7 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
         if text:
             blocks.append({"text": text})
         for tool_call in message.tool_calls or []:
+            has_tool_history = True
             try:
                 arguments = json.loads(tool_call.function.arguments)
             except ValueError:
@@ -91,7 +94,10 @@ def converse_request(request: ChatRequest, model: str) -> dict[str, object]:
             function = choice.get("function")
             if isinstance(function, dict) and isinstance(function.get("name"), str):
                 tool_config["toolChoice"] = {"tool": {"name": function["name"]}}
-        if choice != "none":
+        if choice != "none" or has_tool_history:
+            # Converse requires toolConfig whenever replayed history contains
+            # toolUse/toolResult blocks. Bedrock has no exact "none" choice, so
+            # retain the available tools in auto mode for those follow-up turns.
             result["toolConfig"] = tool_config
     return result
 

--- a/wmh/providers/_bedrock_chat_test.py
+++ b/wmh/providers/_bedrock_chat_test.py
@@ -80,6 +80,74 @@ def test_converse_round_trip_preserves_tools_results_and_usage() -> None:
     assert response.token_usage().input_tokens == 42
 
 
+def test_converse_omits_tools_for_initial_none_choice() -> None:
+    request = ChatRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "answer without tools"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "description": "run a command",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        }
+    )
+
+    wire = converse_request(request, "model-id")
+
+    assert "toolConfig" not in wire
+
+
+def test_converse_retains_tools_for_none_choice_with_tool_history() -> None:
+    request = ChatRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"command":"ls"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "a.txt"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "description": "run a command",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "none",
+        }
+    )
+
+    wire = converse_request(request, "model-id")
+
+    tool_config = wire["toolConfig"]
+    assert isinstance(tool_config, dict)
+    tool_config_data = cast("dict[str, object]", tool_config)
+    assert "toolChoice" not in tool_config_data
+    assert cast("list[dict[str, object]]", tool_config_data["tools"])[0]["toolSpec"] == {
+        "name": "bash",
+        "description": "run a command",
+        "inputSchema": {"json": {"type": "object"}},
+    }
+
+
 @pytest.mark.parametrize("stop_reason", ["content_filtered", "guardrail_intervened"])
 def test_converse_response_preserves_filtered_stops(stop_reason: str) -> None:
     """Blocked Bedrock turns cannot look like successful assistant stops."""


### PR DESCRIPTION
## Disposition

This branch is superseded and is not intended for merge. Exact head preserved: 357abe474697925e4785cda96f5c337803af53bb. No branch was deleted.