### PR TITLE
Make optimizer iterations batch atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ on the results (`worker_usage`, `sandbox_usage`).
 `wmh.agents` exposes the default agent and a separately customizable meta agent over the same
 vendored pi source and `LiveSession` runtime. `AgentProject` gives an agent a persistent E2B
 filesystem while starting a fresh session for each turn. `ProjectDeltaProposer` uses that ordinary
-agent/project pair to retain every earlier proposal and generate a sibling batch from one selected
-parent per search round. Proposal batch size controls search breadth; `k` independently controls
-the number of evaluation passes per scenario.
+agent/project pair to retain every earlier proposal. Each optimization iteration generates a
+sibling batch from the frozen current champion, evaluates every sibling against that same
+snapshot, and selects at most one gate-eligible winner. Proposal batch size controls search
+breadth; `k` independently controls the number of evaluation passes per scenario.
 
 ## Agentic mode: knowledge base, reasoning, web grounding
 

--- a/wmh/agents/meta.py
+++ b/wmh/agents/meta.py
@@ -6,7 +6,7 @@ from wmh.harness.doc import MAX_OUTPUT_TOKENS_ID, MAX_TURNS_ID, TOOL_POLICY_ID, 
 META_AGENT_PROMPT = """You are the meta agent inside an optimizer project. Improve agent harnesses;
 do not solve their benchmark tasks yourself.
 
-The project filesystem is your durable memory. Each round provides a current parent document,
+The project filesystem is your durable memory. Each iteration provides a current parent document,
 failure evidence, and the complete judged history. Earlier proposal files remain under proposals/.
 Parent/evidence/history manifests point to bounded content files; read those files selectively and
 follow their exact paths with read_file. Treat context/, evaluations/, and earlier proposals as
@@ -20,7 +20,7 @@ and rewrite every invalid slot before any optional exploration.
 Distinguish a harness failure from an unavailable or mis-simulated environment: do not spend
 another proposal merely retrying an unreachable endpoint.
 Inspect earlier proposals and evaluations, learn from accepted and rejected attempts, and produce
-the exact number of independent proposals requested for the round.
+the exact number of independent proposals requested for the iteration.
 
 The harness's real source-code surfaces are the primary search space. Prefer a focused structural
 code change when the failure is in control flow, context handling, tool dispatch, verification,
@@ -28,9 +28,9 @@ recovery, or output parsing. Use a skill for a reusable technique, tool policy f
 and params for genuine sampling/budget issues. Prompt wording is the weakest lever. Every proposal
 must target the supplied parent, change one mechanism, preserve unrelated behavior, and state a
 falsifiable expected effect. Compact exact edits are preferred for large source files. Never
-overwrite an earlier round.
+overwrite an earlier iteration.
 
-Use read_file and write_file to work in the project. The user message for each round gives the
+Use read_file and write_file to work in the project. The user message for each iteration gives the
 required input and output paths and the proposal schema. Write every requested proposal before
 calling submit. Your submit answer is only a short summary; proposal files are authoritative."""
 

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -25,7 +25,7 @@ from wmh.engine import load_world_model
 from wmh.engine.world_model import WorldModel
 from wmh.evals.gold import GoldJudge
 from wmh.evals.tasks import TaskSpec, load_tasks
-from wmh.harness.create import create_harness
+from wmh.harness.create import ProposalRecord, create_harness
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
 from wmh.harness.proposer import ProviderDeltaProposer
@@ -211,24 +211,44 @@ def create(
     )
     _console.print(
         f"searching from [bold]{seed_doc.name}[/bold] against world model "
-        f"[bold]{model_name}[/bold]: {iterations} round(s), "
-        f"{proposal_batch_size} proposal(s)/round, k={k}, {len(tasks)} task(s) "
+        f"[bold]{model_name}[/bold]: {iterations} iteration(s), "
+        f"{proposal_batch_size} proposal(s)/iteration, k={k}, {len(tasks)} task(s) "
         f"-> up to ~{rollouts} rollouts{holdout_note} + {candidate_count} proposals"
         f"{meta_note}{backend_note}"
     )
     if interactive and not yes and not Confirm.ask("Proceed?", default=True):
         raise typer.Exit(0)
 
-    def _progress(iteration: int, variant: str, score: float, accepted: bool) -> None:
+    def _progress(iteration: int, variant: str, score: float, changed: bool) -> None:
         tag = "seed" if iteration == 0 else f"iter {iteration}"
-        gate = "[green]accepted[/green]" if accepted else "[yellow]rejected[/yellow]"
-        _console.print(f"  [{tag}] {variant}: success_rate={score:.3f} {gate}")
+        state = (
+            "seed"
+            if iteration == 0
+            else "[green]selected[/green]"
+            if changed
+            else "[yellow]unchanged[/yellow]"
+        )
+        _console.print(f"  [{tag}] {variant}: success_rate={score:.3f} {state}")
 
     def _note(message: str) -> None:
-        # Iterations that die before scoring (unusable/invalid/screened proposals) emit no
-        # _progress event; without this a run whose proposals all fail looks frozen after
-        # the seed line.
+        # Dead proposals narrate here; scored proposals use the structured callback below.
         _console.print(f"  [dim]{message}[/dim]")
+
+    def _proposal(record: ProposalRecord) -> None:
+        if record.outcome != "scored":
+            return
+        assert record.candidate is not None and record.score is not None
+        state = (
+            "[green]selected[/green]"
+            if record.selected
+            else "[cyan]eligible, not selected[/cyan]"
+            if record.gate_eligible
+            else "[yellow]rejected by gate[/yellow]"
+        )
+        _console.print(
+            f"  [iteration {record.iteration} proposal {record.proposal_index}] "
+            f"{record.candidate}: success_rate={record.score:.3f} {state}"
+        )
 
     result = create_harness(
         name,
@@ -247,13 +267,14 @@ def create(
         e2b_template=e2b_template,
         on_progress=_progress,
         on_note=_note,
+        on_proposal=_proposal,
     )
     saved = store.save_version(result.best, alias=CHAMPION_ALIAS)
-    accepted = len(result.archive.accepted())
+    selected = len(result.archive.accepted())
     _console.print(
         f"[green]created[/green] [bold]{name}[/bold] v{saved.version} (champion) "
         f"success_rate={result.best_score:.3f}: {len(result.archive.deltas)} delta(s) audited, "
-        f"{accepted} accepted, {result.skipped} skipped -> {store.dir_for(name)}"
+        f"{selected} selected, {result.skipped} skipped -> {store.dir_for(name)}"
     )
     backend_hint = " --harness-backend e2b" if harness_backend == "e2b" else ""
     _console.print(

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -1,10 +1,10 @@
 """`wmh harness create`: budgeted search over harness deltas, gated by non-regression.
 
-The loop: select a parent from the accepted pool (stepping-stone weighting — good scores favored,
-already-expanded parents discounted), cluster the parent's failures into mechanisms, ask the
-proposer for a sibling batch of `HarnessDelta` objects against a size-weighted, expansion-
-discounted cluster, apply each atomically, score each child closed-loop against the world model,
-and gate acceptance:
+Each iteration freezes the current champion, clusters its failures into mechanisms, and asks the
+proposer for a sibling batch of `HarnessDelta` objects against one size-weighted,
+expansion-discounted cluster. Every sibling is applied and evaluated against that same frozen
+champion. After the full batch resolves, at most one gate-eligible sibling becomes the next
+iteration's champion:
 
 - **Tier 1 — regression suite**: the child's score on the suite (tasks the search has already
   mastered) must not drop below the champion's. Newly-passing tasks promote into the suite on
@@ -13,21 +13,20 @@ and gate acceptance:
 - **Tier 3 — held-out (optional)**: with a holdout task file, the child must also be no worse than
   the champion on tasks the proposer never saw evidence from.
 
-Ties pass every tier: with k passes per task, scores are coarse, and "no worse" is the contract.
-Every proposed delta — accepted, rejected, or invalid-before-eval — is recorded in the archive
-with its verdict, so the archive is a queryable lineage of audited updates, not a pile of
-snapshots. Parent SELECTION is deterministic — a blake2b hash of the iteration index replaces RNG
-(per the repo's no-entropy rule) — but the run as a whole is only as reproducible as its
-providers: proposals and rollouts sample real models at temperature.
+Ties pass every gate tier: with k passes per task, scores are coarse, and "no worse" is the
+eligibility contract. When multiple siblings are eligible, full success wins, then assertion
+fraction, then lower proposal index. Every proposed delta, whether selected, rejected, or invalid
+before eval, is recorded in the archive with its verdict. The run as a whole is only as
+reproducible as its providers because proposals and rollouts sample real models at temperature.
 """
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from wmh.engine.world_model import WorldModel
 from wmh.evals.closed_loop import DEFAULT_K, ClosedLoopReport, evaluate_closed_loop
@@ -51,10 +50,6 @@ if TYPE_CHECKING:
     # the pool is actually constructed.
     from wmh.harness.pi_e2b import E2BSandboxPool
 
-# Selection floor: a zero-scoring variant keeps a small chance of being expanded, so early
-# pools with no successes still make progress instead of dividing by zero interest.
-_SELECTION_FLOOR = 0.05
-
 # Non-regression tolerance: fmean over identical verdicts must compare equal, never fail a gate
 # on float noise.
 _TIE_EPS = 1e-9
@@ -63,16 +58,8 @@ ALL_PASS_MECHANISM = "none: all tasks pass"
 
 FailureClusterKey = tuple[str, str, tuple[str, ...]]
 
-# Reports progress as (iteration, variant name, success_rate, accepted); iteration 0 is the seed.
+# Reports (iteration, champion name, success rate, changed); iteration 0 is the seed.
 CreateProgress = Callable[[int, str, float, bool], None]
-
-
-class PoolEntry(BaseModel):
-    """One accepted variant, as the parent-selection pool sees it."""
-
-    doc_hash: str
-    name: str
-    success_rate: float
 
 
 class DeltaArchive(BaseModel):
@@ -103,21 +90,18 @@ class DeltaArchive(BaseModel):
         return docs[doc_hash]
 
 
-class IterationRecord(BaseModel):
-    """One proposal attempt, scored or dead, in order: the complete search history.
+class ProposalRecord(BaseModel):
+    """One proposal in an iteration's sibling batch, in stable proposal order.
 
-    Every search round proposes a sibling batch from one selected parent. A dead attempt
-    (every outcome but "scored") ends early: the proposal died before a full-split eval,
-    the search moves straight to the next sibling, and the record here is what remains of it.
-    Callers render these as records and plot points, so a run full of dead proposals shows its
-    work instead of looking like it never iterated. `champion_score` is the champion's
-    full-suite rate when the iteration resolved: the honest y-level for plotting a dead
-    iteration (the line it failed to move).
+    A dead proposal (every outcome but ``scored``) ends before a full-split evaluation. Scored
+    proposals distinguish gate eligibility from final selection: several siblings may satisfy
+    the frozen non-regression gate, but only the best eligible sibling is selected. The
+    ``champion_score`` is always the frozen pre-iteration champion score, which is the comparison
+    baseline and the honest plotting level for a dead proposal.
     """
 
-    iteration: int
-    round: int
-    proposal_index: int
+    iteration: int = Field(ge=1)
+    proposal_index: int = Field(ge=1)
     outcome: Literal["scored", "screened", "invalid", "unusable", "proposer_error"]
     candidate: str | None = None
     candidate_doc_hash: str | None = None
@@ -127,13 +111,28 @@ class IterationRecord(BaseModel):
     ops: list[str] = Field(default_factory=list)  # "replace prompt:main" style summaries
     rationales: list[str] = Field(default_factory=list)
     reason: str | None = None
-    score: float | None = None  # full-suite success rate; scored attempts only
-    accepted: bool | None = None  # gate verdict; scored attempts only
+    score: float | None = None  # full-suite success rate; scored proposals only
+    gate_eligible: bool | None = None  # frozen non-regression gate; scored proposals only
+    selected: bool = False  # true only for the iteration winner
     screen_child: float | None = None  # trigger-cluster means; screened attempts only
     screen_parent: float | None = None
     screen_child_fraction: float | None = None  # denser assertion-level screen signal
     screen_parent_fraction: float | None = None
-    champion_score: float | None = None
+    champion_score: float
+
+    @model_validator(mode="after")
+    def _validate_state(self) -> ProposalRecord:
+        """Reject impossible scored, dead, and selected record combinations."""
+        if self.outcome == "scored":
+            if self.score is None or self.gate_eligible is None:
+                raise ValueError("scored proposals require score and gate_eligible")
+            if self.candidate is None or self.candidate_doc_hash is None or self.delta_id is None:
+                raise ValueError("scored proposals require candidate and delta identities")
+        elif self.score is not None or self.gate_eligible is not None or self.selected:
+            raise ValueError("dead proposals cannot carry score, gate eligibility, or selection")
+        if self.selected and not self.gate_eligible:
+            raise ValueError("selected proposals must be gate eligible")
+        return self
 
 
 class CreateResult(BaseModel):
@@ -145,11 +144,11 @@ class CreateResult(BaseModel):
     reports: dict[str, ClosedLoopReport] = Field(default_factory=dict)  # by doc_hash
     holdout_reports: dict[str, ClosedLoopReport] = Field(default_factory=dict)  # by doc_hash
     suite: list[str] = Field(default_factory=list)  # final regression suite (task ids)
-    skipped: int = 0  # iterations whose proposal was unusable or invalid (they end early)
-    iteration_records: list[IterationRecord] = Field(default_factory=list)  # every iteration
+    skipped: int = 0  # proposals unusable or invalid before evaluation
+    proposal_records: list[ProposalRecord] = Field(default_factory=list)
     screened: int = 0  # deltas rejected at the cheap trigger-cluster screen (no full eval spent)
     confirmations: int = 0  # narrow vetoes retried at higher k (see `narrow_failing_tiers`)
-    rounds: int = 0
+    iterations: int = 0
     proposal_batch_size: int = 1
     # Spend meters over the WHOLE search (seed, screens, full splits, holdout, confirmations).
     # worker_usage: worker-LLM tokens from self-metering runtimes (the pi worker path; None on
@@ -157,6 +156,18 @@ class CreateResult(BaseModel):
     # lifetime seconds (None on the local backend).
     worker_usage: TokenUsage | None = None
     sandbox_usage: SandboxUsage | None = None
+
+
+@dataclass
+class _ScoredProposal:
+    """One fully scored sibling awaiting iteration-level winner selection."""
+
+    proposal_index: int
+    child: HarnessDoc
+    delta: HarnessDelta
+    report: ClosedLoopReport
+    gate: GateRecord
+    record: ProposalRecord
 
 
 def cluster_failures(report: ClosedLoopReport, tasks: list[TaskSpec]) -> list[FailureSignature]:
@@ -230,7 +241,7 @@ def select_failure_cluster(
 ) -> FailureSignature:
     """Choose a high-impact cluster without getting trapped on one exhausted failure.
 
-    A cluster's priority is ``task_count / (1 + prior_rounds_on_this_parent)``. Large mechanisms
+    A cluster's priority is ``task_count / (1 + prior_iterations_on_this_parent)``. Large mechanisms
     still receive proportionally more search budget, but equally sized singleton failures rotate
     after one batch instead of a deterministic ``clusters[0]`` absorbing the entire run. The
     stable mechanism/task ordering resolves exact ties without entropy.
@@ -240,9 +251,9 @@ def select_failure_cluster(
 
     def _priority(cluster: FailureSignature) -> tuple[float, str, tuple[str, ...]]:
         key = _failure_cluster_key(parent_doc_hash, cluster)
-        rounds = expansion_counts.get(key, 0)
+        prior_iterations = expansion_counts.get(key, 0)
         return (
-            -(len(cluster.task_ids) / (1 + rounds)),
+            -(len(cluster.task_ids) / (1 + prior_iterations)),
             cluster.mechanism,
             tuple(cluster.task_ids),
         )
@@ -252,31 +263,6 @@ def select_failure_cluster(
 
 def _failure_cluster_key(parent_doc_hash: str, cluster: FailureSignature) -> FailureClusterKey:
     return parent_doc_hash, cluster.mechanism, tuple(cluster.task_ids)
-
-
-def select_parent(
-    entries: list[PoolEntry], children_counts: dict[str, int], seed: int
-) -> PoolEntry:
-    """Pick the next parent by stepping-stone weighting, deterministically.
-
-    Weight = (success_rate + floor) / (1 + children_count): better variants are favored, but each
-    expansion discounts a parent so the search spreads over the pool instead of hill-climbing one
-    lineage. The "random" point is blake2b(seed) mapped to [0, 1) over the cumulative weights —
-    reproducible, no RNG.
-    """
-    if not entries:
-        raise ValueError("cannot select a parent from an empty pool")
-    weights = [
-        (entry.success_rate + _SELECTION_FLOOR) / (1 + children_counts.get(entry.doc_hash, 0))
-        for entry in entries
-    ]
-    point = _fraction(str(seed)) * sum(weights)
-    cumulative = 0.0
-    for entry, weight in zip(entries, weights, strict=True):
-        cumulative += weight
-        if point < cumulative:
-            return entry
-    return entries[-1]  # floating-point edge: the point landed exactly on the total
 
 
 def narrow_failing_tiers(
@@ -416,22 +402,22 @@ def create_harness(
     e2b_metadata: dict[str, str] | None = None,
     on_progress: CreateProgress | None = None,
     on_note: Callable[[str], None] | None = None,
-    on_iteration: Callable[[IterationRecord], None] | None = None,
+    on_proposal: Callable[[ProposalRecord], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
     on_sandbox_usage: Callable[[SandboxUsage], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
     """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
 
-    Scores the seed first, then runs `iterations` proposal rounds. Each round asks the proposer
-    for `proposal_batch_size` sibling deltas against one selected parent before any sibling is
-    evaluated. A dead proposal (unusable/invalid proposal, or one
-    screened out on its own trigger cluster) ends early and cheaply: it is counted
-    (`skipped`/`screened`), recorded in `iteration_records`, narrated via `on_note`, and
-    the search moves straight to the next iteration. Never fatal. `on_accept` fires the
-    moment a delta is accepted, with the new champion doc, its delta (verdict attached),
-    and its full-suite score, so callers can persist champions in real time instead of
-    waiting for the search to finish.
+    Scores the seed first, then runs ``iterations`` proposal batches. Each iteration asks the
+    proposer for ``proposal_batch_size`` siblings against the frozen champion, evaluates every
+    sibling against that same snapshot, and selects at most one winner. A dead proposal
+    (unusable, invalid, or screened out on its trigger cluster) ends early and cheaply. It is
+    counted, recorded in ``proposal_records``, and narrated via ``on_note`` without aborting its
+    siblings. ``on_proposal`` receives every final record in stable proposal order after
+    selection. ``on_progress`` receives the seed plus exactly one champion point per iteration,
+    including an unchanged point when no proposal wins. ``on_accept`` fires at most once per
+    iteration with the selected champion, its final delta verdict, and its full-suite score.
 
     ``on_sandbox_usage`` fires after the shared E2B pool is successfully closed on every exit
     path, including failures and cancellation, so callers can persist already-incurred evaluator
@@ -450,7 +436,7 @@ def create_harness(
     tool calls still answered by the world model host-side. One `E2BSandboxPool` is shared across
     score waves within a proposal batch, then its idle runners are retired before the next batch's
     proposer call. This amortizes bootstrap work across sibling proposals without carrying E2B
-    command streams through the potentially long proposal gap between rounds. `eval_concurrency`
+    command streams through the potentially long proposal gap between iterations. `eval_concurrency`
     is how many (task, attempt) cells run at once; `None` means the backend default — 1
     (sequential) for local, 0 (every cell at once, one pooled sandbox each) for e2b.
     `e2b_template` names a prebaked sandbox template (node 22 + the pi runner deps) so e2b
@@ -461,7 +447,7 @@ def create_harness(
     2-3 failing tasks its delta claims to fix, k passes). The screen is lexicographic: full-task
     success first, then assertion-level partial credit, so a real partial fix is not flattened
     into a binary tie. If neither signal improves, the delta is rejected and archived for a
-    fraction of a full eval's cost, and no `on_progress` event fires. Repeated batches discount
+    fraction of a full eval's cost. Repeated iterations discount
     their cluster on that parent, preventing one environment-limited singleton from absorbing the
     whole run. Held-out evals run only for children that pass tiers 1-2, so a bad delta costs at
     most one full-split eval. Every judged delta (screened, rejected, or accepted) is fed back to
@@ -509,7 +495,6 @@ def create_harness(
         reports: dict[str, ClosedLoopReport] = {}
         holdout_reports: dict[str, ClosedLoopReport] = {}
         archive = DeltaArchive(seed=seed_doc)
-        children_counts: dict[str, int] = {}
         failure_cluster_expansions: dict[FailureClusterKey, int] = {}
         skipped = 0
         screened = 0
@@ -577,13 +562,6 @@ def create_harness(
         if on_progress is not None:
             on_progress(0, seed_doc.name, seed_report.success_rate, True)
 
-        pool = [
-            PoolEntry(
-                doc_hash=seed_doc.doc_hash,
-                name=seed_doc.name,
-                success_rate=seed_report.success_rate,
-            )
-        ]
         champion_hash = seed_doc.doc_hash
         best_full = seed_report.success_rate
         # The regression suite: tasks the champion lineage has fully passed. Wins promote in
@@ -594,270 +572,207 @@ def create_harness(
             if seed_report.per_task[task.task_id].success_rate >= 1.0 - _TIE_EPS
         )
 
-        iteration_records: list[IterationRecord] = []
+        proposal_records: list[ProposalRecord] = []
 
-        def _dead(record: IterationRecord, note: str) -> None:
-            # A dead iteration is a first-class search event: recorded, streamed, narrated.
-            # It ends early (no full eval was spent) and the search moves straight on.
-            iteration_records.append(record)
-            if on_iteration is not None:
-                on_iteration(record)
-            _note(note)
-
-        proposal_queue: list[
-            tuple[
-                HarnessDoc,
-                ClosedLoopReport,
-                FailureSignature,
-                HarnessDelta | ProposalFailure | None,
-            ]
-        ] = []
-        batch_cluster_key: FailureClusterKey | None = None
-        batch_cluster_expansion_recorded = False
-        total_attempts = iterations * proposal_batch_size
-        for i in range(1, total_attempts + 1):
-            _check_cancelled()
-            round_index = ((i - 1) // proposal_batch_size) + 1
-            proposal_index = ((i - 1) % proposal_batch_size) + 1
-            champion_score = reports[champion_hash].success_rate
-            if proposal_index == 1:
-                # The previous round's eval runners would otherwise sit idle through this
-                # potentially long proposer call. Retire only idle runners now; subsequent score
-                # waves for this batch still share the newly warmed pool.
-                if sandbox_pool is not None:
-                    sandbox_pool.retire_idle()
-                parent_entry = select_parent(pool, children_counts, seed=round_index)
-                parent = docs[parent_entry.doc_hash]
-                parent_report = reports[parent_entry.doc_hash]
-                clusters = cluster_failures(parent_report, tasks)
-                batch_cluster_key = None
-                batch_cluster_expansion_recorded = False
-                if clusters:
-                    trigger = select_failure_cluster(
-                        clusters,
-                        failure_cluster_expansions,
-                        parent_doc_hash=parent.doc_hash,
-                    )
-                    batch_cluster_key = _failure_cluster_key(parent.doc_hash, trigger)
-                else:
-                    trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
-                evidence = render_evidence(trigger, parent_report, tasks)
-                try:
-                    batch = proposer.propose_batch(
-                        parent,
-                        trigger,
-                        evidence,
-                        history=archive.deltas,
-                        count=proposal_batch_size,
-                        should_cancel=should_cancel,
-                    )
-                    if len(batch) != proposal_batch_size:
-                        raise ValueError(
-                            f"proposer returned {len(batch)} proposals; "
-                            f"expected {proposal_batch_size}"
-                        )
-                except HarnessSearchCancelled:
-                    raise
-                except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
-                    batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
-                _check_cancelled()
-                proposal_queue.extend((parent, parent_report, trigger, delta) for delta in batch)
-
-            parent, parent_report, trigger, delta = proposal_queue.pop(0)
-            label = _proposal_label(
-                round_index,
-                proposal_index,
-                rounds=iterations,
-                batch_size=proposal_batch_size,
+        def _stage_dead(records: list[ProposalRecord], record: ProposalRecord) -> None:
+            """Stage one dead proposal for ordered publication after batch selection."""
+            records.append(record)
+            _note(
+                _dead_proposal_note(
+                    record,
+                    iterations=iterations,
+                    batch_size=proposal_batch_size,
+                )
             )
-            if isinstance(delta, ProposalFailure):
-                skipped += 1
-                _dead(
-                    IterationRecord(
-                        iteration=i,
-                        round=round_index,
-                        proposal_index=proposal_index,
-                        outcome="proposer_error",
-                        trigger=trigger,
-                        reason=delta.reason,
-                        champion_score=champion_score,
-                    ),
-                    f"{label}: proposer call failed ({delta.reason}); skipped",
+
+        for iteration_index in range(1, iterations + 1):
+            _check_cancelled()
+            # Eval runners from the previous iteration would otherwise sit idle through the
+            # potentially long proposer call. Sibling score waves still share the newly warmed
+            # pool for this whole iteration.
+            if sandbox_pool is not None:
+                sandbox_pool.retire_idle()
+
+            frozen_champion_hash = champion_hash
+            parent = docs[frozen_champion_hash]
+            parent_report = reports[frozen_champion_hash]
+            frozen_champion_score = parent_report.success_rate
+            frozen_best_full = best_full
+            frozen_suite = list(suite)
+            frozen_champion_holdout = holdout_reports.get(frozen_champion_hash)
+            clusters = cluster_failures(parent_report, tasks)
+            batch_cluster_key: FailureClusterKey | None = None
+            batch_cluster_expansion_recorded = False
+            if clusters:
+                trigger = select_failure_cluster(
+                    clusters,
+                    failure_cluster_expansions,
+                    parent_doc_hash=parent.doc_hash,
                 )
-                continue
-            if delta is None:
-                skipped += 1
-                _dead(
-                    IterationRecord(
-                        iteration=i,
-                        round=round_index,
-                        proposal_index=proposal_index,
-                        outcome="unusable",
-                        trigger=trigger,
-                        reason="unparseable or truncated meta reply",
-                        champion_score=champion_score,
-                    ),
-                    f"{label}: proposal unusable (unparseable or truncated meta reply); skipped",
-                )
-                continue
-            ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
-            rationales = [op.rationale[:1_000] for op in delta.ops]
-            expected_effect = delta.expected_effect[:1_000]
-            if any(d.delta_id == delta.delta_id for d in archive.deltas):
-                # The proposer re-proposed a delta this run already judged. Re-evaluating it
-                # would spend a screen (or worse) to learn a known verdict; skip without spend.
-                # The duplicate is NOT re-archived; the original carries the verdict.
-                skipped += 1
-                _dead(
-                    IterationRecord(
-                        iteration=i,
-                        round=round_index,
-                        proposal_index=proposal_index,
-                        outcome="invalid",
-                        delta_id=delta.delta_id,
-                        trigger=delta.trigger,
-                        expected_effect=expected_effect,
-                        ops=ops_summary,
-                        rationales=rationales,
-                        reason="duplicate of an already-judged delta",
-                        champion_score=champion_score,
-                    ),
-                    f"{label}: proposal duplicates an already-judged delta; skipped",
-                )
-                continue
+                batch_cluster_key = _failure_cluster_key(parent.doc_hash, trigger)
+            else:
+                trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
+            evidence = render_evidence(trigger, parent_report, tasks)
             try:
-                child_name = (
-                    f"{name}-g{round_index}"
-                    if proposal_batch_size == 1
-                    else f"{name}-g{round_index}-p{proposal_index}"
+                batch = proposer.propose_batch(
+                    parent,
+                    trigger,
+                    evidence,
+                    history=archive.deltas,
+                    count=proposal_batch_size,
+                    should_cancel=should_cancel,
                 )
-                child = apply_delta(parent, delta, child_name)
-            except ValueError as exc:
-                delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {exc}")
-                archive.deltas.append(delta)
-                skipped += 1
-                _dead(
-                    IterationRecord(
-                        iteration=i,
-                        round=round_index,
-                        proposal_index=proposal_index,
-                        outcome="invalid",
-                        delta_id=delta.delta_id,
-                        trigger=delta.trigger,
-                        expected_effect=expected_effect,
-                        ops=ops_summary,
-                        rationales=rationales,
-                        reason=f"invalid before eval: {exc}",
-                        champion_score=champion_score,
-                    ),
-                    f"{label}: delta invalid before eval ({exc}); skipped",
-                )
-                continue
-            if harness_backend == "e2b" and child.runtime_kind() != "pi-node":
-                # A delta that abandons the pi-node runtime cannot execute on this backend:
-                # `doc.runtime(backend="e2b")` would raise mid-score and abort the whole search.
-                # Reject-and-archive it like any other invalid-before-eval proposal.
-                delta.verdict = GateRecord(
-                    accepted=False,
-                    reason=(
-                        f"invalid before eval: runtime kind {child.runtime_kind()!r} cannot "
-                        "run on harness_backend='e2b' (pi-node only)"
-                    ),
-                )
-                archive.deltas.append(delta)
-                skipped += 1
-                _dead(
-                    IterationRecord(
-                        iteration=i,
-                        round=round_index,
-                        proposal_index=proposal_index,
-                        outcome="invalid",
-                        candidate=child.name,
-                        candidate_doc_hash=child.doc_hash,
-                        delta_id=delta.delta_id,
-                        trigger=delta.trigger,
-                        expected_effect=expected_effect,
-                        ops=ops_summary,
-                        rationales=rationales,
-                        reason=str(delta.verdict.reason),
-                        champion_score=champion_score,
-                    ),
-                    f"{label}: delta abandoned the pi-node runtime "
-                    "(e2b runs pi-node only); skipped",
-                )
-                continue
-
-            # Discount the selected cluster only when this batch produces its first child that can
-            # actually enter evaluation. Parsed-but-duplicate, inapplicable, or backend-invalid
-            # deltas teach the search nothing about that failure mechanism. Sibling proposals share
-            # one batch expansion, so later evaluable children must not discount it again.
-            if batch_cluster_key is not None and not batch_cluster_expansion_recorded:
-                failure_cluster_expansions[batch_cluster_key] = (
-                    failure_cluster_expansions.get(batch_cluster_key, 0) + 1
-                )
-                batch_cluster_expansion_recorded = True
-
-            # Only an evaluable child counts as a real expansion. Provider faults,
-            # unusable replies, duplicates, and invalid deltas leave the parent fresh.
-            children_counts[parent.doc_hash] = children_counts.get(parent.doc_hash, 0) + 1
-
-            # Cheap screen: before a full-split eval, the delta must improve the very cluster it
-            # was proposed to fix. Compare task success first, then assertion-level partial credit:
-            # a 0%-to-75% assertion lift must not be flattened into the same "0 vs 0" as no effect.
-            screen_child_value: float | None = None
-            screen_parent_value: float | None = None
-            screen_child_fraction_value: float | None = None
-            screen_parent_fraction_value: float | None = None
-            screen_tasks = [t for t in tasks if t.task_id in set(trigger.task_ids)]
-            if screen_tasks:
-                screen_report = _score(child, screen_tasks)
-                parent_mean = _suite_rate(parent_report, sorted(trigger.task_ids))
-                child_mean = _suite_rate(screen_report, sorted(trigger.task_ids))
-                parent_fraction = _suite_fraction(parent_report, sorted(trigger.task_ids))
-                child_fraction = _suite_fraction(screen_report, sorted(trigger.task_ids))
-                screen_child_value = child_mean
-                screen_parent_value = parent_mean
-                screen_child_fraction_value = child_fraction
-                screen_parent_fraction_value = parent_fraction
-                success_regressed = child_mean < parent_mean - _TIE_EPS
-                success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
-                fraction_did_not_improve = child_fraction <= parent_fraction + _TIE_EPS
-                feedback_error = _record_proposer_evaluation(
-                    proposer,
-                    delta,
-                    stage="screen",
-                    report=screen_report,
-                    tasks=screen_tasks,
-                    summary=(
-                        f"trigger success {child_mean:.3f} vs parent {parent_mean:.3f}; "
-                        f"assertion fraction {child_fraction:.3f} vs parent "
-                        f"{parent_fraction:.3f}"
-                    ),
-                )
-                if feedback_error is not None:
-                    _note(
-                        f"{label}: screen feedback could not be persisted "
-                        f"({feedback_error}); continuing"
+                if len(batch) != proposal_batch_size:
+                    raise ValueError(
+                        f"proposer returned {len(batch)} proposals; expected {proposal_batch_size}"
                     )
-                if success_regressed or (success_tied and fraction_did_not_improve):
+            except HarnessSearchCancelled:
+                raise
+            except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
+                batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
+            _check_cancelled()
+
+            batch_records: list[ProposalRecord] = []
+            batch_deltas: list[HarnessDelta] = []
+            scored_proposals: list[_ScoredProposal] = []
+            seen_delta_ids = {delta.delta_id for delta in archive.deltas}
+            seen_child_hashes = {
+                delta.child_doc_hash for delta in archive.deltas if delta.child_doc_hash is not None
+            }
+
+            for proposal_index, delta in enumerate(batch, 1):
+                _check_cancelled()
+                label = _proposal_label(
+                    iteration_index,
+                    proposal_index,
+                    iterations=iterations,
+                    batch_size=proposal_batch_size,
+                )
+                if isinstance(delta, ProposalFailure):
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="proposer_error",
+                            trigger=trigger,
+                            reason=delta.reason,
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+                if delta is None:
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="unusable",
+                            trigger=trigger,
+                            reason="unparseable or truncated meta reply",
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+                ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
+                rationales = [op.rationale[:1_000] for op in delta.ops]
+                expected_effect = delta.expected_effect[:1_000]
+                if delta.delta_id in seen_delta_ids:
+                    # The proposer re-proposed a delta this run already judged. Re-evaluating it
+                    # would spend a screen (or worse) to learn a known verdict; skip without spend.
+                    # Preserve this proposal as a distinct rejected archive entry so history remains
+                    # complete, including duplicates inside the current sibling batch.
+                    delta.verdict = GateRecord(
+                        accepted=False,
+                        reason="invalid before eval: duplicate of an already-proposed delta",
+                    )
+                    batch_deltas.append(delta)
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="invalid",
+                            delta_id=delta.delta_id,
+                            trigger=delta.trigger,
+                            expected_effect=expected_effect,
+                            ops=ops_summary,
+                            rationales=rationales,
+                            reason="duplicate of an already-proposed delta",
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+                seen_delta_ids.add(delta.delta_id)
+                batch_deltas.append(delta)
+                try:
+                    child_name = f"{name}-i{iteration_index}-p{proposal_index}"
+                    child = apply_delta(parent, delta, child_name)
+                except ValueError as exc:
+                    delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {exc}")
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="invalid",
+                            delta_id=delta.delta_id,
+                            trigger=delta.trigger,
+                            expected_effect=expected_effect,
+                            ops=ops_summary,
+                            rationales=rationales,
+                            reason=f"invalid before eval: {exc}",
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+                if child.doc_hash in seen_child_hashes:
+                    delta.verdict = GateRecord(
+                        accepted=False,
+                        reason="invalid before eval: duplicate of an already-proposed child",
+                    )
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="invalid",
+                            candidate=child.name,
+                            candidate_doc_hash=child.doc_hash,
+                            delta_id=delta.delta_id,
+                            trigger=delta.trigger,
+                            expected_effect=expected_effect,
+                            ops=ops_summary,
+                            rationales=rationales,
+                            reason="duplicate of an already-proposed child",
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+                seen_child_hashes.add(child.doc_hash)
+                if harness_backend == "e2b" and child.runtime_kind() != "pi-node":
+                    # A delta that abandons the pi-node runtime cannot execute on this backend:
+                    # `doc.runtime(backend="e2b")` would raise mid-score and abort the whole search.
+                    # Reject-and-archive it like any other invalid-before-eval proposal.
                     delta.verdict = GateRecord(
                         accepted=False,
                         reason=(
-                            f"screened out: trigger success {child_mean:.2f} vs parent "
-                            f"{parent_mean:.2f}; assertion fraction {child_fraction:.2f} vs "
-                            f"parent {parent_fraction:.2f} over {len(screen_tasks)} task(s), "
-                            f"k={k}; "
-                            "the delta did not improve its own target"
+                            f"invalid before eval: runtime kind {child.runtime_kind()!r} cannot "
+                            "run on harness_backend='e2b' (pi-node only)"
                         ),
                     )
-                    archive.deltas.append(delta)
-                    screened += 1
-                    _dead(
-                        IterationRecord(
-                            iteration=i,
-                            round=round_index,
+                    skipped += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
                             proposal_index=proposal_index,
-                            outcome="screened",
+                            outcome="invalid",
                             candidate=child.name,
                             candidate_doc_hash=child.doc_hash,
                             delta_id=delta.delta_id,
@@ -866,154 +781,292 @@ def create_harness(
                             ops=ops_summary,
                             rationales=rationales,
                             reason=str(delta.verdict.reason),
-                            screen_child=child_mean,
-                            screen_parent=parent_mean,
-                            screen_child_fraction=child_fraction,
-                            screen_parent_fraction=parent_fraction,
-                            champion_score=champion_score,
+                            champion_score=frozen_champion_score,
                         ),
-                        f"{label}: screened out: trigger success "
-                        f"{child_mean:.2f} vs parent {parent_mean:.2f}; assertion fraction "
-                        f"{child_fraction:.2f} vs parent {parent_fraction:.2f}",
                     )
                     continue
 
-            child_report = _score(child, tasks)
-            pre_verdict = gate_delta(
-                delta,
-                child=child_report,
-                champion=reports[champion_hash],
-                best_full=best_full,
-                suite=suite,
-            )
-            # The held-out tier is measured for every candidate that could still be accepted —
-            # including candidates whose suite/full veto is narrow enough for a confirmation
-            # re-run. A confirmation may overturn a veto; it must never bypass the held-out tier.
-            could_accept = pre_verdict.accepted or (
-                confirm_narrow_vetoes
-                and narrow_failing_tiers(pre_verdict, k=k, n_suite=len(suite), n_holdout=0)
-                is not None
-            )
-            if holdout and could_accept:
-                child_holdout = _score(child, holdout)
-                holdout_reports[child.doc_hash] = child_holdout
-                if champion_hash not in holdout_reports:
-                    holdout_reports[champion_hash] = _score(docs[champion_hash], holdout)
-                verdict = gate_delta(
+                # Discount the selected cluster only when this batch produces its first child
+                # that can enter evaluation. Parsed-but-duplicate, inapplicable, or
+                # backend-invalid deltas teach the search nothing about that failure mechanism.
+                # Siblings share one expansion, so later children must not discount it again.
+                if batch_cluster_key is not None and not batch_cluster_expansion_recorded:
+                    failure_cluster_expansions[batch_cluster_key] = (
+                        failure_cluster_expansions.get(batch_cluster_key, 0) + 1
+                    )
+                    batch_cluster_expansion_recorded = True
+
+                # Before a full-split eval, the delta must improve its target cluster. Compare
+                # task success first, then assertion-level partial credit, so a 0%-to-75%
+                # assertion lift is not flattened into the same "0 vs 0" as no effect.
+                screen_child_value: float | None = None
+                screen_parent_value: float | None = None
+                screen_child_fraction_value: float | None = None
+                screen_parent_fraction_value: float | None = None
+                screen_tasks = [t for t in tasks if t.task_id in set(trigger.task_ids)]
+                if screen_tasks:
+                    screen_report = _score(child, screen_tasks)
+                    parent_mean = _suite_rate(parent_report, sorted(trigger.task_ids))
+                    child_mean = _suite_rate(screen_report, sorted(trigger.task_ids))
+                    parent_fraction = _suite_fraction(parent_report, sorted(trigger.task_ids))
+                    child_fraction = _suite_fraction(screen_report, sorted(trigger.task_ids))
+                    screen_child_value = child_mean
+                    screen_parent_value = parent_mean
+                    screen_child_fraction_value = child_fraction
+                    screen_parent_fraction_value = parent_fraction
+                    success_regressed = child_mean < parent_mean - _TIE_EPS
+                    success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
+                    fraction_did_not_improve = child_fraction <= parent_fraction + _TIE_EPS
+                    feedback_error = _record_proposer_evaluation(
+                        proposer,
+                        delta,
+                        stage="screen",
+                        report=screen_report,
+                        tasks=screen_tasks,
+                        summary=(
+                            f"trigger success {child_mean:.3f} vs parent {parent_mean:.3f}; "
+                            f"assertion fraction {child_fraction:.3f} vs parent "
+                            f"{parent_fraction:.3f}"
+                        ),
+                    )
+                    if feedback_error is not None:
+                        _note(
+                            f"{label}: screen feedback could not be persisted "
+                            f"({feedback_error}); continuing"
+                        )
+                    if success_regressed or (success_tied and fraction_did_not_improve):
+                        delta.verdict = GateRecord(
+                            accepted=False,
+                            reason=(
+                                f"screened out: trigger success {child_mean:.2f} vs parent "
+                                f"{parent_mean:.2f}; assertion fraction {child_fraction:.2f} vs "
+                                f"parent {parent_fraction:.2f} over {len(screen_tasks)} task(s), "
+                                f"k={k}; "
+                                "the delta did not improve its own target"
+                            ),
+                        )
+                        screened += 1
+                        _stage_dead(
+                            batch_records,
+                            ProposalRecord(
+                                iteration=iteration_index,
+                                proposal_index=proposal_index,
+                                outcome="screened",
+                                candidate=child.name,
+                                candidate_doc_hash=child.doc_hash,
+                                delta_id=delta.delta_id,
+                                trigger=delta.trigger,
+                                expected_effect=expected_effect,
+                                ops=ops_summary,
+                                rationales=rationales,
+                                reason=str(delta.verdict.reason),
+                                screen_child=child_mean,
+                                screen_parent=parent_mean,
+                                screen_child_fraction=child_fraction,
+                                screen_parent_fraction=parent_fraction,
+                                champion_score=frozen_champion_score,
+                            ),
+                        )
+                        continue
+
+                child_report = _score(child, tasks)
+                pre_verdict = gate_delta(
                     delta,
                     child=child_report,
-                    champion=reports[champion_hash],
-                    best_full=best_full,
-                    suite=suite,
-                    child_holdout=child_holdout,
-                    champion_holdout=holdout_reports[champion_hash],
+                    champion=parent_report,
+                    best_full=frozen_best_full,
+                    suite=frozen_suite,
                 )
-            else:
-                verdict = pre_verdict
-            tiers = (
-                narrow_failing_tiers(verdict, k=k, n_suite=len(suite), n_holdout=len(holdout or []))
-                if confirm_narrow_vetoes
+                # The held-out tier is measured for every candidate that could still be accepted,
+                # including candidates whose suite/full veto is narrow enough for a confirmation
+                # re-run. A confirmation may overturn a veto, but never bypass the held-out tier.
+                could_accept = pre_verdict.accepted or (
+                    confirm_narrow_vetoes
+                    and narrow_failing_tiers(
+                        pre_verdict, k=k, n_suite=len(frozen_suite), n_holdout=0
+                    )
+                    is not None
+                )
+                if holdout and could_accept:
+                    child_holdout = _score(child, holdout)
+                    holdout_reports[child.doc_hash] = child_holdout
+                    if frozen_champion_holdout is None:
+                        frozen_champion_holdout = _score(parent, holdout)
+                        holdout_reports[frozen_champion_hash] = frozen_champion_holdout
+                    verdict = gate_delta(
+                        delta,
+                        child=child_report,
+                        champion=parent_report,
+                        best_full=frozen_best_full,
+                        suite=frozen_suite,
+                        child_holdout=child_holdout,
+                        champion_holdout=frozen_champion_holdout,
+                    )
+                else:
+                    verdict = pre_verdict
+                tiers = (
+                    narrow_failing_tiers(
+                        verdict,
+                        k=k,
+                        n_suite=len(frozen_suite),
+                        n_holdout=len(holdout or []),
+                    )
+                    if confirm_narrow_vetoes
+                    else None
+                )
+                if tiers:
+                    confirmations += 1
+                    confirmed_ok = True
+                    notes: list[str] = []
+                    for tier in tiers:
+                        tier_tasks = (
+                            [t for t in tasks if t.task_id in set(frozen_suite)]
+                            if tier == "suite"
+                            else list(holdout or [])
+                        )
+                        child_re = _score(child, tier_tasks, k_override=2 * k)
+                        champ_re = _score(parent, tier_tasks, k_override=2 * k)
+                        re_delta = child_re.success_rate - champ_re.success_rate
+                        re_fraction_delta = child_re.mean_fraction - champ_re.mean_fraction
+                        notes.append(
+                            f"{tier} re-measured at k={2 * k}: success {re_delta:+.3f}, "
+                            f"assertion fraction {re_fraction_delta:+.3f}"
+                        )
+                        if re_delta < -_TIE_EPS or (
+                            abs(re_delta) <= _TIE_EPS and re_fraction_delta < -_TIE_EPS
+                        ):
+                            confirmed_ok = False
+                    outcome = "veto overturned" if confirmed_ok else "regression confirmed"
+                    verdict = GateRecord(
+                        suite_delta=verdict.suite_delta,
+                        suite_fraction_delta=verdict.suite_fraction_delta,
+                        full_delta=verdict.full_delta,
+                        full_fraction_delta=verdict.full_fraction_delta,
+                        holdout_delta=verdict.holdout_delta,
+                        holdout_fraction_delta=verdict.holdout_fraction_delta,
+                        accepted=confirmed_ok,
+                        reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
+                        + verdict.reason,
+                    )
+                docs[child.doc_hash] = child
+                reports[child.doc_hash] = child_report
+                record = ProposalRecord(
+                    iteration=iteration_index,
+                    proposal_index=proposal_index,
+                    outcome="scored",
+                    candidate=child.name,
+                    candidate_doc_hash=child.doc_hash,
+                    delta_id=delta.delta_id,
+                    trigger=delta.trigger,
+                    expected_effect=expected_effect,
+                    ops=ops_summary,
+                    rationales=rationales,
+                    reason=str(verdict.reason),
+                    score=child_report.success_rate,
+                    gate_eligible=verdict.accepted,
+                    screen_child=screen_child_value,
+                    screen_parent=screen_parent_value,
+                    screen_child_fraction=screen_child_fraction_value,
+                    screen_parent_fraction=screen_parent_fraction_value,
+                    champion_score=frozen_champion_score,
+                )
+                batch_records.append(record)
+                scored_proposals.append(
+                    _ScoredProposal(
+                        proposal_index=proposal_index,
+                        child=child,
+                        delta=delta,
+                        report=child_report,
+                        gate=verdict,
+                        record=record,
+                    )
+                )
+
+            _check_cancelled()
+            eligible = [candidate for candidate in scored_proposals if candidate.gate.accepted]
+            winner = (
+                max(
+                    eligible,
+                    key=lambda candidate: (
+                        candidate.report.success_rate,
+                        candidate.report.mean_fraction,
+                        -candidate.proposal_index,
+                    ),
+                )
+                if eligible
                 else None
             )
-            if tiers:
-                confirmations += 1
-                confirmed_ok = True
-                notes: list[str] = []
-                for tier in tiers:
-                    tier_tasks = (
-                        [t for t in tasks if t.task_id in set(suite)]
-                        if tier == "suite"
-                        else list(holdout or [])
+            for candidate in scored_proposals:
+                gate_eligible = candidate.gate.accepted
+                if winner is candidate:
+                    final_gate = candidate.gate
+                elif gate_eligible:
+                    assert winner is not None
+                    final_gate = candidate.gate.model_copy(
+                        update={
+                            "accepted": False,
+                            "reason": (
+                                "gate eligible but not selected: "
+                                f"proposal {winner.proposal_index} ranked higher by full success, "
+                                "assertion fraction, then proposal order | " + candidate.gate.reason
+                            ),
+                        }
                     )
-                    child_re = _score(child, tier_tasks, k_override=2 * k)
-                    champ_re = _score(docs[champion_hash], tier_tasks, k_override=2 * k)
-                    re_delta = child_re.success_rate - champ_re.success_rate
-                    re_fraction_delta = child_re.mean_fraction - champ_re.mean_fraction
-                    notes.append(
-                        f"{tier} re-measured at k={2 * k}: success {re_delta:+.3f}, "
-                        f"assertion fraction {re_fraction_delta:+.3f}"
+                else:
+                    final_gate = candidate.gate
+                candidate.delta.verdict = final_gate
+                candidate.record.gate_eligible = gate_eligible
+                candidate.record.selected = winner is candidate
+                candidate.record.reason = final_gate.reason
+
+            # Full-stage history must describe final selection, not preliminary gate eligibility.
+            # Persist it before the atomic commit so cancellation cannot publish a partial winner.
+            for candidate in scored_proposals:
+                assert candidate.delta.verdict is not None
+                feedback_error = _record_proposer_evaluation(
+                    proposer,
+                    candidate.delta,
+                    stage="full",
+                    report=candidate.report,
+                    tasks=tasks,
+                    summary=candidate.delta.verdict.reason,
+                )
+                if feedback_error is not None:
+                    _note(
+                        f"iteration {iteration_index}/{iterations} proposal "
+                        f"{candidate.proposal_index}/{proposal_batch_size}: full feedback could "
+                        f"not be persisted ({feedback_error}); continuing"
                     )
-                    if re_delta < -_TIE_EPS or (
-                        abs(re_delta) <= _TIE_EPS and re_fraction_delta < -_TIE_EPS
-                    ):
-                        confirmed_ok = False
-                outcome = "veto overturned" if confirmed_ok else "regression confirmed"
-                verdict = GateRecord(
-                    suite_delta=verdict.suite_delta,
-                    suite_fraction_delta=verdict.suite_fraction_delta,
-                    full_delta=verdict.full_delta,
-                    full_fraction_delta=verdict.full_fraction_delta,
-                    holdout_delta=verdict.holdout_delta,
-                    holdout_fraction_delta=verdict.holdout_fraction_delta,
-                    accepted=confirmed_ok,
-                    reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
-                    + verdict.reason,
-                )
-            if verdict.accepted:
-                # Scoring checks cancellation on return, but gating and confirmation bookkeeping
-                # happen afterward. Check again at the acceptance commit boundary so a cancelled
-                # child never enters lineage or reaches the persistence callback.
-                _check_cancelled()
-            feedback_error = _record_proposer_evaluation(
-                proposer,
-                delta,
-                stage="full",
-                report=child_report,
-                tasks=tasks,
-                summary=verdict.reason,
-            )
-            if feedback_error is not None:
-                _note(
-                    f"{label}: full feedback could not be persisted ({feedback_error}); continuing"
-                )
-            delta.verdict = verdict
-            archive.deltas.append(delta)
-            docs[child.doc_hash] = child
-            reports[child.doc_hash] = child_report
-            if verdict.accepted:
-                pool.append(
-                    PoolEntry(
-                        doc_hash=child.doc_hash,
-                        name=child.name,
-                        success_rate=child_report.success_rate,
-                    )
-                )
-                champion_hash = child.doc_hash
-                best_full = max(best_full, child_report.success_rate)
+
+            # One commit boundary for the whole iteration. Diagnostic notes may already have
+            # streamed, but cancellation before this point publishes no archive lineage,
+            # champion, suite, acceptance/proposal callback, or champion checkpoint.
+            _check_cancelled()
+            archive.deltas.extend(batch_deltas)
+            if winner is not None:
+                champion_hash = winner.child.doc_hash
+                best_full = max(best_full, winner.report.success_rate)
                 promoted = {
                     task_id
-                    for task_id, outcome in child_report.per_task.items()
+                    for task_id, outcome in winner.report.per_task.items()
                     if outcome.success_rate >= 1.0 - _TIE_EPS
                 }
                 suite = sorted(set(suite) | promoted)
                 if on_accept is not None:
-                    on_accept(child, delta, child_report.success_rate)
-            record = IterationRecord(
-                iteration=i,
-                round=round_index,
-                proposal_index=proposal_index,
-                outcome="scored",
-                candidate=child.name,
-                candidate_doc_hash=child.doc_hash,
-                delta_id=delta.delta_id,
-                trigger=delta.trigger,
-                expected_effect=expected_effect,
-                ops=ops_summary,
-                rationales=rationales,
-                reason=str(verdict.reason),
-                score=child_report.success_rate,
-                accepted=verdict.accepted,
-                screen_child=screen_child_value,
-                screen_parent=screen_parent_value,
-                screen_child_fraction=screen_child_fraction_value,
-                screen_parent_fraction=screen_parent_fraction_value,
-                champion_score=reports[champion_hash].success_rate,
-            )
-            iteration_records.append(record)
-            if on_iteration is not None:
-                on_iteration(record)
+                    on_accept(winner.child, winner.delta, winner.report.success_rate)
+
+            proposal_records.extend(batch_records)
+            if on_proposal is not None:
+                for record in batch_records:
+                    on_proposal(record)
             if on_progress is not None:
-                on_progress(i, child.name, child_report.success_rate, verdict.accepted)
+                champion = docs[champion_hash]
+                on_progress(
+                    iteration_index,
+                    champion.name,
+                    reports[champion_hash].success_rate,
+                    winner is not None,
+                )
 
         _check_cancelled()
         best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
@@ -1025,10 +1078,10 @@ def create_harness(
             holdout_reports=holdout_reports,
             suite=suite,
             skipped=skipped,
-            iteration_records=iteration_records,
+            proposal_records=proposal_records,
             screened=screened,
             confirmations=confirmations,
-            rounds=iterations,
+            iterations=iterations,
             proposal_batch_size=proposal_batch_size,
             worker_usage=combine_usage(worker_usages),
         )
@@ -1108,14 +1161,28 @@ def _record_proposer_evaluation(
     return None
 
 
-def _proposal_label(round_index: int, proposal_index: int, *, rounds: int, batch_size: int) -> str:
-    """Human-readable attempt identity that stays concise for singleton batches."""
+def _proposal_label(
+    iteration_index: int, proposal_index: int, *, iterations: int, batch_size: int
+) -> str:
+    """Human-readable proposal identity that stays concise for singleton batches."""
     if batch_size == 1:
-        return f"iteration {round_index}/{rounds}"
-    return f"round {round_index}/{rounds} proposal {proposal_index}/{batch_size}"
+        return f"iteration {iteration_index}/{iterations}"
+    return f"iteration {iteration_index}/{iterations} proposal {proposal_index}/{batch_size}"
 
 
-def _fraction(text: str) -> float:
-    """Stable hash of `text` mapped to [0, 1) — the repo's RNG-free randomness convention."""
-    digest = hashlib.blake2b(text.encode("utf-8"), digest_size=8).digest()
-    return int.from_bytes(digest, "big") / 2**64
+def _dead_proposal_note(record: ProposalRecord, *, iterations: int, batch_size: int) -> str:
+    """Render one dead proposal for the lightweight narration callback."""
+    label = _proposal_label(
+        record.iteration,
+        record.proposal_index,
+        iterations=iterations,
+        batch_size=batch_size,
+    )
+    reason = record.reason or "no reason reported"
+    if record.outcome == "proposer_error":
+        return f"{label}: proposer call failed ({reason}); skipped"
+    if record.outcome == "unusable":
+        return f"{label}: proposal unusable ({reason}); skipped"
+    if record.outcome == "invalid":
+        return f"{label}: {reason}; skipped"
+    return f"{label}: {reason}"

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -418,6 +418,9 @@ def create_harness(
     selection. ``on_progress`` receives the seed plus exactly one champion point per iteration,
     including an unchanged point when no proposal wins. ``on_accept`` fires at most once per
     iteration with the selected champion, its final delta verdict, and its full-suite score.
+    ``on_note`` is an eager diagnostic stream, so dead-proposal and feedback-error notes may fire
+    while siblings are still evaluating. ``on_proposal`` waits for batch selection and then fires
+    in stable proposal order. The iteration's ``on_progress`` checkpoint follows those records.
 
     ``on_sandbox_usage`` fires after the shared E2B pool is successfully closed on every exit
     path, including failures and cancellation, so callers can persist already-incurred evaluator

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -2154,3 +2154,26 @@ def test_skipped_proposals_narrate_through_on_note() -> None:
         "iteration 3/3",
     ]
     assert all("proposal unusable" in note for note in notes)
+
+
+def test_dead_notes_precede_final_proposal_records_and_iteration_checkpoint() -> None:
+    """Eager diagnostics precede the batch's ordered records and champion checkpoint."""
+    events: list[str] = []
+
+    result = _run(
+        RoleProvider(meta_reply="truncated garbage that is not json"),
+        proposal_batch_size=2,
+        on_progress=lambda iteration, name, score, changed: events.append(f"progress:{iteration}"),
+        on_note=lambda message: events.append(f"note:{message.split(':', 1)[0]}"),
+        on_proposal=lambda record: events.append(f"proposal:{record.proposal_index}"),
+    )
+
+    assert result.skipped == 2
+    assert events == [
+        "progress:0",
+        "note:iteration 1/1 proposal 1/2",
+        "note:iteration 1/1 proposal 2/2",
+        "proposal:1",
+        "proposal:2",
+        "progress:1",
+    ]

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -26,15 +26,15 @@ from wmh.harness import create as create_module
 from wmh.harness.create import (
     CreateResult,
     HarnessSearchCancelled,
-    PoolEntry,
+    ProposalRecord,
     cluster_failures,
     create_harness,
     select_failure_cluster,
-    select_parent,
 )
 from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.mutate import parse_delta
 from wmh.harness.proposer import ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runtime import Runtime
 from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind
@@ -150,6 +150,7 @@ def _run(
     holdout: list[TaskSpec] | None = None,
     on_progress: Callable[[int, str, float, bool], None] | None = None,
     on_note: Callable[[str], None] | None = None,
+    on_proposal: Callable[[ProposalRecord], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
@@ -167,6 +168,7 @@ def _run(
         holdout=holdout,
         on_progress=on_progress,
         on_note=on_note,
+        on_proposal=on_proposal,
         on_accept=on_accept,
         should_cancel=should_cancel,
     )
@@ -182,7 +184,7 @@ def test_create_accepts_improving_delta_and_promotes_suite() -> None:
     assert result.best_score == 1.0
     assert result.best.name == "winner"
     assert result.best.system_prompt() == _CAREFUL_PROMPT
-    assert progress == [(0, "seed", 0.0, True), (1, "winner-g1", 1.0, True)]
+    assert progress == [(0, "seed", 0.0, True), (1, "winner-i1-p1", 1.0, True)]
 
     [delta] = result.archive.deltas
     assert delta.verdict is not None and delta.verdict.accepted
@@ -240,7 +242,7 @@ def test_create_skips_unusable_proposals() -> None:
     assert result.archive.deltas == []  # nothing to audit: no delta object ever existed
     assert result.best.name == "winner"  # even a search with no children yields the renamed seed
     # Every iteration is recorded even when its proposal dies before producing anything.
-    assert [(r.iteration, r.outcome) for r in result.iteration_records] == [
+    assert [(r.iteration, r.outcome) for r in result.proposal_records] == [
         (1, "unusable"),
         (2, "unusable"),
     ]
@@ -557,28 +559,6 @@ def test_create_does_not_discount_a_cluster_when_every_delta_is_invalid() -> Non
     assert "[other] t2" in provider.meta_users[1]
 
 
-# -- parent selection --------------------------------------------------------------------------
-
-
-def _entry(doc_hash: str, success_rate: float) -> PoolEntry:
-    return PoolEntry(doc_hash=doc_hash, name=doc_hash, success_rate=success_rate)
-
-
-def test_select_parent_is_deterministic_and_discounts_expanded_parents() -> None:
-    entries = [_entry("a", 0.5), _entry("b", 1.0)]
-    assert select_parent(entries, {}, seed=7) == select_parent(entries, {}, seed=7)
-    picks_fresh = [select_parent(entries, {}, seed=s).doc_hash for s in range(50)]
-    picks_worn = [select_parent(entries, {"b": 9}, seed=s).doc_hash for s in range(50)]
-    # Both variants are reachable, and expanding a parent shrinks its share of selections.
-    assert set(picks_fresh) == {"a", "b"}
-    assert picks_worn.count("b") < picks_fresh.count("b")
-
-
-def test_select_parent_rejects_empty_pool() -> None:
-    with pytest.raises(ValueError, match="empty"):
-        select_parent([], {}, seed=1)
-
-
 # -- staged verification: screening + history ---------------------------------------------------
 
 
@@ -598,13 +578,13 @@ def test_screen_rejects_delta_that_does_not_improve_its_trigger() -> None:
     assert delta.verdict is not None and not delta.verdict.accepted
     assert delta.verdict.reason.startswith("screened out")
     # The dead iteration is still a first-class record, with its screen means attached.
-    [record] = result.iteration_records
+    [record] = result.proposal_records
     assert record.iteration == 1 and record.outcome == "screened"
     assert record.screen_child is not None and record.screen_parent is not None
-    # The cheap screen replaced the full eval: only the seed has a full-split report,
-    # and no child progress event ever fired.
+    # The cheap screen replaced the full eval: only the seed has a full-split report. The
+    # iteration still emits one unchanged champion checkpoint.
     assert len(result.reports) == 1
-    assert [e[0] for e in progress] == [0]
+    assert progress == [(0, "seed", 0.0, True), (1, "seed", 0.0, False)]
 
 
 def test_screen_uses_assertion_fraction_to_admit_partial_improvement() -> None:
@@ -661,7 +641,7 @@ def test_screen_uses_assertion_fraction_to_admit_partial_improvement() -> None:
     )
 
     assert result.screened == 0
-    [record] = result.iteration_records
+    [record] = result.proposal_records
     assert record.outcome == "scored"
     assert record.screen_child == record.screen_parent == 0.0
     assert record.screen_parent_fraction == 0.0
@@ -792,7 +772,7 @@ def test_feedback_persistence_failure_does_not_abort_scored_search() -> None:
     )
 
     assert result.best_score == 1.0
-    assert len(result.iteration_records) == 1
+    assert len(result.proposal_records) == 1
     assert any("screen feedback could not be persisted" in note for note in notes)
     assert any("full feedback could not be persisted" in note for note in notes)
 
@@ -985,7 +965,7 @@ def test_flaky_holdout_veto_is_overturned_by_confirmation() -> None:
 
 
 def test_wide_holdout_regression_skips_confirmation() -> None:
-    # Same setup as the round-2 holdout test: the child ALWAYS fails held-out. -1.0 is far
+    # Same setup as the second-iteration holdout test: the child ALWAYS fails held-out. -1.0 is far
     # beyond the narrow margin, so no re-measurement is spent and the plain rejection stands.
     seed = HarnessDoc.baseline("seed")
 
@@ -1456,7 +1436,7 @@ def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(
         harness_backend="e2b",
     )
 
-    assert result.rounds == 2 and len(result.iteration_records) == 6
+    assert result.iterations == 2 and len(result.proposal_records) == 6
     [pool] = fake_pool_cls.instances
     assert pool.retire_idle_calls == 2  # once per batch, never between its three siblings
 
@@ -1673,7 +1653,7 @@ def test_proposer_call_failure_skips_the_iteration_not_the_run() -> None:
     assert len(notes) == 2
     assert all("proposer call failed" in note for note in notes)
     assert all("max_tokens above model output limit" in note for note in notes)
-    assert [(r.iteration, r.outcome) for r in result.iteration_records] == [
+    assert [(r.iteration, r.outcome) for r in result.proposal_records] == [
         (1, "proposer_error"),
         (2, "proposer_error"),
     ]
@@ -1701,8 +1681,99 @@ class _SequencedMetaProvider(RoleProvider):
         return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
 
 
+class _RankedMetaProvider(_SequencedMetaProvider):
+    """Give weak and strong proposal prompts distinct, deterministic task scores."""
+
+    def __init__(self, replies: list[str]) -> None:
+        super().__init__(replies)
+        self._judge_fn = lambda user: (
+            "done-strong" in user or ("done-weak" in user and "task one" in user)
+        )
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        special = (
+            "grade whether an agent completed a task",
+            "meta-agent improving an agent harness",
+            "You ARE the environment",
+        )
+        if not any(marker in system for marker in special):
+            if "strong agent" in system:
+                answer = "done-strong"
+            elif "weak agent" in system:
+                answer = "done-weak"
+            else:
+                answer = "done"
+            return Completion(text=json.dumps({"tool": "submit", "arguments": {"answer": answer}}))
+        return super().complete(
+            system,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+
+class _ParentRecordingProposer:
+    """Propose against the live parent and remember each iteration's parent hash."""
+
+    def __init__(self) -> None:
+        self.parent_hashes: list[str] = []
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> list[HarnessDelta | ProposalFailure | None]:
+        del evidence, history, should_cancel
+        self.parent_hashes.append(parent.doc_hash)
+        prompt = f"{_CAREFUL_PROMPT} Iteration {len(self.parent_hashes)}."
+        proposal = parse_delta(parent, trigger, _meta_reply(parent, prompt))
+        assert proposal is not None and count == 1
+        return [proposal]
+
+
+class _FeedbackRecordingProposer:
+    """Return scripted siblings and retain the final evaluation feedback for each."""
+
+    def __init__(self, prompts: list[str]) -> None:
+        self.prompts = prompts
+        self.feedback: list[tuple[str, str, str]] = []
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> list[HarnessDelta | ProposalFailure | None]:
+        del evidence, history, should_cancel
+        assert count == len(self.prompts)
+        proposals: list[HarnessDelta | ProposalFailure | None] = [
+            parse_delta(parent, trigger, _meta_reply(parent, prompt)) for prompt in self.prompts
+        ]
+        assert all(proposal is not None for proposal in proposals)
+        return proposals
+
+    def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
+        self.feedback.append((delta.delta_id, stage, content))
+
+
 def test_proposal_batch_is_generated_before_siblings_are_evaluated() -> None:
-    """One round expands one parent into independently tracked sibling candidates."""
+    """One iteration expands one parent into independently tracked sibling candidates."""
     seed = HarnessDoc.baseline("seed")
     provider = _SequencedMetaProvider(
         [
@@ -1714,15 +1785,310 @@ def test_proposal_batch_is_generated_before_siblings_are_evaluated() -> None:
     result = _run(provider, iterations=1, proposal_batch_size=2)
 
     assert len(provider.meta_users) == 2
-    assert [(record.round, record.proposal_index) for record in result.iteration_records] == [
+    assert [(record.iteration, record.proposal_index) for record in result.proposal_records] == [
         (1, 1),
         (1, 2),
     ]
-    assert [record.candidate for record in result.iteration_records] == [
-        "winner-g1-p1",
-        "winner-g1-p2",
+    assert [record.candidate for record in result.proposal_records] == [
+        "winner-i1-p1",
+        "winner-i1-p2",
     ]
     assert len(result.archive.deltas) == 2
+
+
+def test_iteration_batch_commits_one_winner_and_one_progress_point() -> None:
+    """Three eligible siblings yield one deterministic winner and one champion update."""
+    seed = HarnessDoc.baseline("seed")
+    provider = _SequencedMetaProvider(
+        [_meta_reply(seed, f"{_CAREFUL_PROMPT} Candidate {index}.") for index in range(1, 4)]
+    )
+    progress: list[tuple[int, str, float, bool]] = []
+    proposals: list[ProposalRecord] = []
+    crowned: list[str] = []
+
+    result = create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=1,
+        proposal_batch_size=3,
+        on_progress=lambda i, n, r, a: progress.append((i, n, r, a)),
+        on_proposal=proposals.append,
+        on_accept=lambda doc, delta, score: crowned.append(doc.name),
+    )
+
+    assert result.iterations == 1
+    assert len(result.proposal_records) == 3
+    assert [(record.iteration, record.proposal_index) for record in result.proposal_records] == [
+        (1, 1),
+        (1, 2),
+        (1, 3),
+    ]
+    assert [record.gate_eligible for record in result.proposal_records] == [True, True, True]
+    assert [record.selected for record in result.proposal_records] == [True, False, False]
+    assert len(proposals) == 3
+    assert crowned == ["winner-i1-p1"]
+    assert progress == [
+        (0, "seed", 0.0, True),
+        (1, "winner-i1-p1", 1.0, True),
+    ]
+    assert [delta.verdict.accepted for delta in result.archive.deltas if delta.verdict] == [
+        True,
+        False,
+        False,
+    ]
+
+
+def test_duplicate_sibling_is_archived_without_duplicate_evaluation() -> None:
+    """The search boundary rejects duplicate sibling deltas before spending another screen."""
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
+
+    result = _run(provider, iterations=1, proposal_batch_size=2)
+
+    assert result.skipped == 1
+    assert len(result.archive.deltas) == 2
+    assert [record.outcome for record in result.proposal_records] == ["scored", "invalid"]
+    assert [record.selected for record in result.proposal_records] == [True, False]
+    assert "already-proposed" in (result.proposal_records[1].reason or "")
+    assert len(result.reports) == 2  # seed plus the first sibling, never the duplicate
+
+
+def test_cancellation_during_later_sibling_commits_no_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later-sibling cancellation cannot publish an earlier sibling as the winner."""
+    seed = HarnessDoc.baseline("seed")
+    provider = _SequencedMetaProvider(
+        [
+            _meta_reply(seed, _CAREFUL_PROMPT),
+            _meta_reply(seed, f"{_CAREFUL_PROMPT} Another candidate."),
+        ]
+    )
+    cancelled = False
+    gate_delta = create_module.gate_delta
+
+    def cancel_after_first_gate(
+        delta: HarnessDelta,
+        *,
+        child: ClosedLoopReport,
+        champion: ClosedLoopReport,
+        best_full: float,
+        suite: list[str],
+        child_holdout: ClosedLoopReport | None = None,
+        champion_holdout: ClosedLoopReport | None = None,
+    ) -> GateRecord:
+        nonlocal cancelled
+        verdict = gate_delta(
+            delta,
+            child=child,
+            champion=champion,
+            best_full=best_full,
+            suite=suite,
+            child_holdout=child_holdout,
+            champion_holdout=champion_holdout,
+        )
+        cancelled = True
+        return verdict
+
+    monkeypatch.setattr(create_module, "gate_delta", cancel_after_first_gate)
+    progress: list[tuple[int, str, float, bool]] = []
+    crowned: list[str] = []
+    proposals: list[ProposalRecord] = []
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        _run(
+            provider,
+            proposal_batch_size=2,
+            should_cancel=lambda: cancelled,
+            on_progress=lambda i, n, r, a: progress.append((i, n, r, a)),
+            on_accept=lambda doc, delta, score: crowned.append(doc.doc_hash),
+            on_proposal=proposals.append,
+        )
+
+    assert progress == [(0, "seed", 0.0, True)]
+    assert crowned == []
+    assert proposals == []
+
+
+@pytest.mark.parametrize(
+    ("prompts", "selected"),
+    [
+        (["You are a weak agent.", "You are a strong agent."], [False, True]),
+        (["You are a strong agent.", "You are a weak agent."], [True, False]),
+    ],
+)
+def test_iteration_selects_best_eligible_score_independent_of_proposal_order(
+    prompts: list[str], selected: list[bool]
+) -> None:
+    """Full success outranks assertion fraction and proposal order within a frozen batch."""
+    seed = HarnessDoc.baseline("seed")
+    provider = _RankedMetaProvider([_meta_reply(seed, prompt) for prompt in prompts])
+    tasks = [
+        TaskSpec(task_id="t1", instruction="task one", gold=["the work completed"]),
+        TaskSpec(task_id="t2", instruction="task two", gold=["the work completed"]),
+    ]
+    crowned: list[str] = []
+
+    result = create_harness(
+        "winner",
+        seed,
+        tasks,
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=1,
+        proposal_batch_size=2,
+        k=1,
+        on_accept=lambda doc, delta, score: crowned.append(doc.system_prompt()),
+    )
+
+    assert result.best_score == 1.0
+    assert result.best.system_prompt() == "You are a strong agent."
+    assert [record.gate_eligible for record in result.proposal_records] == [True, True]
+    assert [record.selected for record in result.proposal_records] == selected
+    assert crowned == ["You are a strong agent."]
+    accepted = result.archive.accepted()
+    assert len(accepted) == 1
+    winner_hash = next(
+        record.candidate_doc_hash for record in result.proposal_records if record.selected
+    )
+    assert accepted[0].child_doc_hash == winner_hash
+    assert winner_hash is not None
+    assert result.archive.reconstruct(winner_hash).system_prompt() == "You are a strong agent."
+    loser_hash = next(
+        record.candidate_doc_hash for record in result.proposal_records if not record.selected
+    )
+    assert loser_hash is not None
+    with pytest.raises(ValueError, match="not in this archive"):
+        result.archive.reconstruct(loser_hash)
+    loser_delta = next(
+        delta
+        for delta in result.archive.deltas
+        if delta.verdict is not None and not delta.verdict.accepted
+    )
+    assert loser_delta.verdict is not None
+    assert "gate eligible but not selected" in loser_delta.verdict.reason
+
+
+def test_full_feedback_records_final_batch_selection() -> None:
+    """Eligible losers teach the proposer that ranking, not the gate, rejected them."""
+    provider = _RankedMetaProvider([])
+    proposer = _FeedbackRecordingProposer(["You are a weak agent.", "You are a strong agent."])
+    tasks = [
+        TaskSpec(task_id="t1", instruction="task one", gold=["the work completed"]),
+        TaskSpec(task_id="t2", instruction="task two", gold=["the work completed"]),
+    ]
+
+    result = create_harness(
+        "winner",
+        HarnessDoc.baseline("seed"),
+        tasks,
+        _wm(provider),
+        provider,
+        proposer,
+        GoldJudge(provider),
+        iterations=1,
+        proposal_batch_size=2,
+        k=1,
+    )
+
+    loser = next(
+        delta
+        for delta in result.archive.deltas
+        if delta.verdict is not None and not delta.verdict.accepted
+    )
+    winner = result.archive.accepted()[0]
+    loser_feedback = next(
+        content
+        for delta_id, stage, content in proposer.feedback
+        if delta_id == loser.delta_id and stage == "full"
+    )
+    winner_feedback = next(
+        content
+        for delta_id, stage, content in proposer.feedback
+        if delta_id == winner.delta_id and stage == "full"
+    )
+    assert "gate eligible but not selected" in loser_feedback
+    assert "gate eligible but not selected" not in winner_feedback
+
+
+def test_sibling_holdout_gates_use_frozen_iteration_champion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selected-looking first sibling cannot become the second sibling's gate baseline."""
+    seed = HarnessDoc.baseline("seed")
+    provider = _SequencedMetaProvider(
+        [
+            _meta_reply(seed, _CAREFUL_PROMPT),
+            _meta_reply(seed, f"{_CAREFUL_PROMPT} Another candidate."),
+        ]
+    )
+    provider._judge_fn = lambda user: (
+        True if "the holdout task" in user else "done-verified" in user
+    )
+    holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["still works"])]
+    gate_delta = create_module.gate_delta
+    holdout_gate_champions: list[tuple[float, float]] = []
+
+    def capture_gate_baselines(
+        delta: HarnessDelta,
+        *,
+        child: ClosedLoopReport,
+        champion: ClosedLoopReport,
+        best_full: float,
+        suite: list[str],
+        child_holdout: ClosedLoopReport | None = None,
+        champion_holdout: ClosedLoopReport | None = None,
+    ) -> GateRecord:
+        if child_holdout is not None and champion_holdout is not None:
+            holdout_gate_champions.append((champion.success_rate, champion_holdout.success_rate))
+        return gate_delta(
+            delta,
+            child=child,
+            champion=champion,
+            best_full=best_full,
+            suite=suite,
+            child_holdout=child_holdout,
+            champion_holdout=champion_holdout,
+        )
+
+    monkeypatch.setattr(create_module, "gate_delta", capture_gate_baselines)
+
+    result = _run(provider, proposal_batch_size=2, holdout=holdout)
+
+    assert holdout_gate_champions == [(0.0, 1.0), (0.0, 1.0)]
+    assert [record.gate_eligible for record in result.proposal_records] == [True, True]
+    assert [record.selected for record in result.proposal_records] == [True, False]
+
+
+def test_next_iteration_proposes_from_previous_iteration_winner() -> None:
+    """The selected winner is the next parent, with no stepping-stone parent pool."""
+    seed = HarnessDoc.baseline("seed")
+    provider = RoleProvider()
+    proposer = _ParentRecordingProposer()
+
+    result = create_harness(
+        "winner",
+        seed,
+        _tasks(),
+        _wm(provider),
+        provider,
+        proposer,
+        GoldJudge(provider),
+        iterations=2,
+        proposal_batch_size=1,
+    )
+
+    assert len(result.archive.accepted()) == 2
+    first_winner_hash = result.proposal_records[0].candidate_doc_hash
+    assert proposer.parent_hashes == [seed.doc_hash, first_winner_hash]
+    assert [record.selected for record in result.proposal_records] == [True, True]
 
 
 def test_on_accept_delivers_the_new_champion_the_moment_it_is_crowned() -> None:
@@ -1760,38 +2126,19 @@ def test_dead_iteration_ends_early_and_the_search_moves_on() -> None:
     assert result.skipped == 1
     assert result.best_score == 1.0
     assert result.best.system_prompt() == _CAREFUL_PROMPT
-    assert [e[0] for e in progress] == [0, 2]  # the dead iteration fires no progress event
-    assert [(r.iteration, r.outcome) for r in result.iteration_records] == [
+    assert [e[0] for e in progress] == [0, 1, 2]
+    assert progress[1] == (1, "seed", 0.0, False)
+    assert [(r.iteration, r.outcome) for r in result.proposal_records] == [
         (1, "unusable"),
         (2, "scored"),
     ]
-    scored = result.iteration_records[-1]
-    assert scored.accepted is True and scored.score == 1.0
-    assert scored.candidate == "winner-g2"
+    scored = result.proposal_records[-1]
+    assert scored.selected is True and scored.score == 1.0
+    assert scored.candidate == "winner-i2-p1"
 
 
-def test_dead_proposals_do_not_discount_the_selected_parent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Selection freshness changes only after a valid child is constructed."""
-    observed_counts: list[dict[str, int]] = []
-
-    def capture_selection(
-        entries: list[PoolEntry], children_counts: dict[str, int], seed: int
-    ) -> PoolEntry:
-        del seed
-        observed_counts.append(dict(children_counts))
-        return entries[0]
-
-    monkeypatch.setattr(create_module, "select_parent", capture_selection)
-    result = _run(RoleProvider(meta_reply="not json"), iterations=2)
-
-    assert result.skipped == 2
-    assert observed_counts == [{}, {}]
-
-
-def test_skipped_iterations_narrate_through_on_note() -> None:
-    """Every iteration whose proposal dies before scoring reports itself.
+def test_skipped_proposals_narrate_through_on_note() -> None:
+    """Every proposal that dies before scoring narrates itself.
 
     Regression: a run whose proposals were all unusable (e.g. truncated meta replies on huge
     pi code surfaces) emitted NO progress events at all; five iterations looked like one.
@@ -1801,10 +2148,9 @@ def test_skipped_iterations_narrate_through_on_note() -> None:
     result = _run(provider, iterations=3, on_note=notes.append)
 
     assert result.skipped == 3
-    assert len(notes) == 3
-    assert all("proposal unusable" in note for note in notes)
     assert [note.split(":")[0] for note in notes] == [
         "iteration 1/3",
         "iteration 2/3",
         "iteration 3/3",
     ]
+    assert all("proposal unusable" in note for note in notes)

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -766,7 +766,7 @@ class E2BDurableChannel:
             self._last_outbox_error = f"head read failed: {exc}"
             now = time.monotonic()
             # Treat only uninterrupted failures as one outage. AgentProject does not pump this
-            # channel while it is idle between proposal rounds, so a long idle gap must not make
+            # channel while it is idle between proposal iterations, so a long idle gap must not make
             # the next isolated read failure look ancient.
             if self._last_head_failure_at is None or now - self._last_head_failure_at > max(
                 1.0, self._poll_interval_s * 4
@@ -967,8 +967,9 @@ class E2BSandboxPool:
     The bootstrap (runner files + node 22 + pi's npm deps unless a template prebakes them) is
     doc-independent — a mutated harness's code surfaces travel per-episode in
     `episode_start.files` — so one pool serves a whole search. `create_harness` retires the idle
-    pool at each round boundary before the proposer runs, preventing long proposer/evaluation gaps
-    from leaving stale E2B command streams alive; score waves for sibling proposals in that round
+    pool at each iteration boundary before the proposer runs, preventing long
+    proposer/evaluation gaps from leaving stale E2B command streams alive; score waves for
+    sibling proposals in that iteration
     still reuse warm sandboxes instead of re-paying installs. Concurrent episodes acquire distinct
     sandboxes; a sandbox whose episode raised is discarded (the runner process is in an unknown
     state — reuse could cross frames between episodes). `close()` kills everything; the pool lock

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -801,7 +801,7 @@ def test_pool_reuses_a_healthy_sandbox_without_rebootstrap(
 def test_pool_retire_idle_rotates_only_free_sandboxes_and_preserves_usage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A round boundary kills idle streams, leaves in-flight work, and meters both lifetimes."""
+    """An iteration boundary kills idle streams and meters both runner lifetimes."""
     monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
     now = [10.0]
     monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])

--- a/wmh/harness/proposer.py
+++ b/wmh/harness/proposer.py
@@ -130,7 +130,7 @@ class ProjectDeltaProposer:
         self._project = project
         self._agent = agent
         self._provider = provider
-        self._round = 0
+        self._iteration = 0
         self._evaluation_dirs: dict[str, str] = {}
         self._proposal_files: dict[str, str] = {}
         self._parent_manifests: dict[str, JsonObject] = {}
@@ -152,10 +152,10 @@ class ProjectDeltaProposer:
             raise ValueError(f"proposal count must be positive, got {count}")
         self._should_cancel = should_cancel
         _check_cancelled(should_cancel)
-        self._round += 1
-        round_dir = f"round-{self._round:04d}"
-        context_dir = f"context/{round_dir}"
-        proposal_dir = f"proposals/{round_dir}"
+        self._iteration += 1
+        iteration_dir = f"iteration-{self._iteration:04d}"
+        context_dir = f"context/{iteration_dir}"
+        proposal_dir = f"proposals/{iteration_dir}"
         parent_context = self._parent_manifests.get(parent.doc_hash)
         if parent_context is None:
             parent_context = _materialize_parent(
@@ -415,7 +415,7 @@ class ProjectDeltaProposer:
                 )
                 self._evaluation_dirs.setdefault(
                     stamped.delta_id,
-                    f"evaluations/{round_dir}/proposal-{index:02d}",
+                    f"evaluations/{iteration_dir}/proposal-{index:02d}",
                 )
             elif terminal_error is not None:
                 proposals.append(ProposalFailure(reason=str(terminal_error)))
@@ -431,7 +431,7 @@ class ProjectDeltaProposer:
         return proposals
 
     def record_evaluation(self, delta: HarnessDelta, *, stage: str, content: str) -> None:
-        """Persist one candidate's judged evidence for later project-agent rounds."""
+        """Persist one candidate's judged evidence for later project-agent iterations."""
         should_cancel = self._should_cancel
         _check_cancelled(should_cancel)
         root = self._evaluation_dirs.get(
@@ -487,7 +487,7 @@ def _read_project_text(
     *,
     should_cancel: Callable[[], bool] | None,
 ) -> str:
-    """Read one project output without hiding cancellation behind the next round."""
+    """Read one project output without hiding cancellation behind the next iteration."""
     _check_cancelled(should_cancel)
     content = project.read_text(path)
     _check_cancelled(should_cancel)
@@ -641,7 +641,7 @@ def _project_history_entry(
 ) -> JsonObject:
     """Compact judged metadata while raw proposals retain exact replacement payloads.
 
-    Re-serializing every prior full code surface into every later round makes persistent history
+    Re-serializing every prior full code surface into every later iteration makes persistent history
     quadratic in run length. The project already owns each raw proposal file, so history carries
     queryable identities, rationales, sizes, and verdicts plus a direct pointer to the exact bytes.
     """
@@ -681,10 +681,10 @@ def _project_history_entry(
 def _stamp_project_preconditions(
     parent: HarnessDoc, proposal: HarnessDelta | None
 ) -> HarnessDelta | None:
-    """Stamp missing concurrency metadata from the exact project-round parent.
+    """Stamp missing concurrency metadata from the exact project-iteration parent.
 
     The ordinary agent still chooses every semantic operation. The host owns this mechanical
-    identity field because it wrote the immutable parent snapshot for the same synchronous round.
+    identity field because it wrote the immutable parent snapshot for the same iteration.
     An explicitly supplied but incorrect hash is preserved so normal validation rejects it.
     """
     if proposal is None:
@@ -869,11 +869,11 @@ def _project_repair_request(
         if preserve_runtime_kind
         else "produce a valid resolved runtime kind"
     )
-    return f"""Repair exactly {len(errors)} invalid proposal slot(s) from this round.
+    return f"""Repair exactly {len(errors)} invalid proposal slot(s) from this iteration.
 This is repair turn {repair_turn} of {_MAX_PROJECT_REPAIR_TURNS}.
 
 Read the host validation report: {workspace}/{validation_path}
-It contains the exact error for each invalid slot. Re-read the original round request at
+It contains the exact error for each invalid slot. Re-read the original iteration request at
 {workspace}/{request_path} and its supplied parent manifests as needed, then rewrite ONLY these
 invalid files:
 {invalid_outputs}
@@ -913,7 +913,10 @@ def _project_request(
             "the search backend makes the final executability decision."
         )
     )
-    return f"""Produce exactly {count} independent harness proposals for this optimization round.
+    heading = (
+        f"Produce exactly {count} independent harness proposals for this optimization iteration."
+    )
+    return f"""{heading}
 
 Read:
 - parent manifest: {absolute_context}/parent.json
@@ -927,7 +930,7 @@ Read:
 - earlier raw proposals, when useful: {workspace}/proposals/
 - earlier candidate evaluation manifests and traces: {workspace}/evaluations/
 
-Write exactly these files, without changing earlier rounds:
+Write exactly these files, without changing earlier iterations:
 {outputs}
 
 Each file must be one JSON object:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -136,9 +136,9 @@ class _Project:
         del agent, provider, should_cancel, writable_files
         self.runs += 1
         assert f"exactly {len(self.outputs)}" in instruction
-        round_dir = f"round-{self.runs:04d}"
+        iteration_dir = f"iteration-{self.runs:04d}"
         for index, output in enumerate(self.outputs, start=1):
-            self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
+            self.files[f"proposals/{iteration_dir}/proposal-{index:02d}.json"] = output
         return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
 
 
@@ -176,9 +176,9 @@ class _InterruptedProject(_Project):
     ) -> AgentProjectRun:
         del agent, provider, instruction, should_cancel, writable_files
         self.runs += 1
-        round_dir = f"round-{self.runs:04d}"
+        iteration_dir = f"iteration-{self.runs:04d}"
         for index, output in enumerate(self.outputs, start=1):
-            self.files[f"proposals/{round_dir}/proposal-{index:02d}.json"] = output
+            self.files[f"proposals/{iteration_dir}/proposal-{index:02d}.json"] = output
         raise RuntimeError("Server disconnected after durable writes")
 
 
@@ -200,7 +200,7 @@ class _FailedProject(_Project):
 
 
 class _RepairingProject(_Project):
-    """Drive one proposal round with explicit per-turn rewrites of the same slot files."""
+    """Drive one proposal iteration with explicit per-turn rewrites of the same slot files."""
 
     def __init__(
         self,
@@ -237,7 +237,7 @@ class _RepairingProject(_Project):
             writes = self.repairs[repair_index] if repair_index < len(self.repairs) else {}
             writes = {**self.extra_rewrites, **writes}
         for index, output in writes.items():
-            self.files[f"proposals/round-0001/proposal-{index:02d}.json"] = output
+            self.files[f"proposals/iteration-0001/proposal-{index:02d}.json"] = output
         if self.runs == 1 and self.initial_error is not None:
             raise RuntimeError(self.initial_error)
         return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
@@ -247,7 +247,7 @@ class _RestoreFailingProject(_RepairingProject):
     """Lose the durable-write channel while the host restores a valid sibling."""
 
     def write_text(self, path: str, content: str) -> None:
-        if self.runs >= 2 and path == "proposals/round-0001/proposal-01.json":
+        if self.runs >= 2 and path == "proposals/iteration-0001/proposal-01.json":
             raise RuntimeError("valid sibling restoration failed")
         super().write_text(path, content)
 
@@ -358,7 +358,7 @@ def test_project_proposer_checks_cancellation_between_context_writes() -> None:
     assert project.runs == 0
 
 
-def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
+def test_project_proposer_uses_one_agent_turn_and_keeps_iteration_files() -> None:
     parent = HarnessDoc.baseline("parent")
     project = _Project([_payload(parent, "careful"), _payload(parent, "verify")])
     provider = _Provider("unused")
@@ -379,19 +379,19 @@ def test_project_proposer_uses_one_agent_turn_and_keeps_round_files() -> None:
     assert len(proposals) == 2
     assert len(second) == 2
     assert all(proposal is not None for proposal in proposals)
-    assert "context/round-0001/parent.json" in project.files
-    assert "context/round-0001/evidence.json" in project.files
-    assert "context/round-0001/history.json" in project.files
-    assert "context/round-0002/history.json" in project.files
-    assert "proposal-01.json" in project.files["context/round-0002/REQUEST.md"]
-    assert "failure evidence manifest" in project.files["context/round-0002/REQUEST.md"]
-    assert "content_files in listed order" in project.files["context/round-0002/REQUEST.md"]
+    assert "context/iteration-0001/parent.json" in project.files
+    assert "context/iteration-0001/evidence.json" in project.files
+    assert "context/iteration-0001/history.json" in project.files
+    assert "context/iteration-0002/history.json" in project.files
+    assert "proposal-01.json" in project.files["context/iteration-0002/REQUEST.md"]
+    assert "failure evidence manifest" in project.files["context/iteration-0002/REQUEST.md"]
+    assert "content_files in listed order" in project.files["context/iteration-0002/REQUEST.md"]
     assert all(project.files[path] == content for path, content in first_files.items())
     assert {path for path in project.files if path.startswith("parents/")} == {
         path for path in first_files if path.startswith("parents/")
     }
-    parent_context = json.loads(project.files["context/round-0001/parent.json"])
-    surface_manifests = _parent_surface_manifests(project, "context/round-0001/parent.json")
+    parent_context = json.loads(project.files["context/iteration-0001/parent.json"])
+    surface_manifests = _parent_surface_manifests(project, "context/iteration-0001/parent.json")
     assert parent_context["doc_hash"] == parent.doc_hash
     assert {
         surface["id"]: surface["content_hash"] for surface in surface_manifests
@@ -431,8 +431,8 @@ def test_project_parent_manifest_splits_large_surfaces_below_read_cap() -> None:
         parent, _trigger(), "inspect failures", history=[], count=1
     )
 
-    manifest_text = project.files["context/round-0001/parent.json"]
-    surfaces = _parent_surface_manifests(project, "context/round-0001/parent.json")
+    manifest_text = project.files["context/iteration-0001/parent.json"]
+    surfaces = _parent_surface_manifests(project, "context/iteration-0001/parent.json")
     code_surface = next(surface for surface in surfaces if surface["id"] == "code:large")
     relative_files = [
         path.removeprefix(f"{project.workspace}/")
@@ -456,9 +456,9 @@ def test_real_pi_parent_manifest_itself_fits_one_project_read() -> None:
         parent, _trigger(), "inspect failures", history=[], count=1
     )
 
-    manifest_text = project.files["context/round-0001/parent.json"]
+    manifest_text = project.files["context/iteration-0001/parent.json"]
     manifest = json.loads(manifest_text)
-    surfaces = _parent_surface_manifests(project, "context/round-0001/parent.json")
+    surfaces = _parent_surface_manifests(project, "context/iteration-0001/parent.json")
     assert len(manifest_text) < 16_000
     assert manifest["surface_count"] == len(parent.surfaces)
     assert len(surfaces) == len(parent.surfaces)
@@ -490,9 +490,11 @@ def test_project_context_preserves_evidence_and_compacts_judged_history() -> Non
     proposer.propose_batch(parent, _trigger(), evidence, history=history, count=1)
 
     evidence_manifest, evidence_chunks = _manifest_content(
-        project, "context/round-0002/evidence.json"
+        project, "context/iteration-0002/evidence.json"
     )
-    history_manifest, history_chunks = _manifest_content(project, "context/round-0002/history.json")
+    history_manifest, history_chunks = _manifest_content(
+        project, "context/iteration-0002/history.json"
+    )
     reconstructed_history = "".join(history_chunks)
     judged_history = json.loads(reconstructed_history)
 
@@ -510,7 +512,7 @@ def test_project_context_preserves_evidence_and_compacts_judged_history() -> Non
     assert all("content" not in entry["ops"][0] for entry in judged_history)
     assert all(entry["ops"][0]["content_length"] == len(large_change) for entry in judged_history)
     assert judged_history[0]["proposal_file"] is None
-    assert judged_history[1]["proposal_file"].endswith("/proposals/round-0001/proposal-01.json")
+    assert judged_history[1]["proposal_file"].endswith("/proposals/iteration-0001/proposal-01.json")
 
 
 def test_project_proposer_persists_candidate_evaluation_beside_its_proposal() -> None:
@@ -525,7 +527,7 @@ def test_project_proposer_persists_candidate_evaluation_beside_its_proposal() ->
 
     proposer.record_evaluation(proposal, stage="screen", content=evidence)
 
-    manifest_path = "evaluations/round-0001/proposal-01/screen.json"
+    manifest_path = "evaluations/iteration-0001/proposal-01/screen.json"
     manifest, chunks = _manifest_content(project, manifest_path)
     assert manifest["delta_id"] == proposal.delta_id
     assert manifest["stage"] == "screen"
@@ -598,22 +600,22 @@ def test_project_proposer_repairs_skill_frontmatter_and_protects_valid_sibling()
     assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
     assert project.write_grants == [
         (
-            "proposals/round-0001/proposal-01.json",
-            "proposals/round-0001/proposal-02.json",
+            "proposals/iteration-0001/proposal-01.json",
+            "proposals/iteration-0001/proposal-02.json",
         ),
-        ("proposals/round-0001/proposal-02.json",),
+        ("proposals/iteration-0001/proposal-02.json",),
     ]
-    assert project.files["proposals/round-0001/proposal-01.json"] == valid_raw
+    assert project.files["proposals/iteration-0001/proposal-01.json"] == valid_raw
     assert "name: <slug>" in project.instructions[0]
     assert "rewrite ONLY these" in project.instructions[1]
     assert "invalid files:" in project.instructions[1]
-    assert "proposals/round-0001/proposal-02.json" in project.instructions[1]
+    assert "proposals/iteration-0001/proposal-02.json" in project.instructions[1]
     assert "Do not rewrite them" in project.instructions[1]
     first_report = json.loads(
-        project.files["context/round-0001/proposal-validation-attempt-01.json"]
+        project.files["context/iteration-0001/proposal-validation-attempt-01.json"]
     )
     final_report = json.loads(
-        project.files["context/round-0001/proposal-validation-attempt-02.json"]
+        project.files["context/iteration-0001/proposal-validation-attempt-02.json"]
     )
     assert first_report["valid_slots"] == [1]
     assert "skill file has no frontmatter" in first_report["errors"][0]["reason"]
@@ -665,7 +667,7 @@ def test_project_proposer_repairs_history_and_sibling_duplicates() -> None:
     assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
     delta_ids = [proposal.delta_id for proposal in proposals if isinstance(proposal, HarnessDelta)]
     assert len(delta_ids) == len(set(delta_ids)) == 3
-    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-01.json"])
+    report = json.loads(project.files["context/iteration-0001/proposal-validation-attempt-01.json"])
     reasons = [error["reason"] for error in report["errors"]]
     assert any("duplicates valid sibling proposal-01" in reason for reason in reasons)
     assert any("already present in judged history" in reason for reason in reasons)
@@ -724,7 +726,7 @@ def test_project_proposer_repairs_semantically_identical_children_and_no_ops() -
     )
 
     assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
-    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-01.json"])
+    report = json.loads(project.files["context/iteration-0001/proposal-validation-attempt-01.json"])
     reasons = [error["reason"] for error in report["errors"]]
     assert any("duplicates valid sibling proposal-01" in reason for reason in reasons)
     assert any("semantic no-op" in reason for reason in reasons)
@@ -742,7 +744,7 @@ def test_project_proposer_never_returns_a_delta_that_remains_invalid_after_two_r
     assert project.runs == 3
     assert "skill file has no frontmatter" in _proposal_failure_reason(proposals[0])
     final_report = json.loads(
-        project.files["context/round-0001/proposal-validation-attempt-03.json"]
+        project.files["context/iteration-0001/proposal-validation-attempt-03.json"]
     )
     assert final_report["valid_slots"] == []
     assert "skill file has no frontmatter" in final_report["errors"][0]["reason"]
@@ -769,7 +771,7 @@ def test_project_proposer_repairs_partial_durable_outputs_after_runner_disconnec
     assert project.runs == 2
     assert all(isinstance(proposal, HarnessDelta) for proposal in proposals)
     final_report = json.loads(
-        project.files["context/round-0001/proposal-validation-attempt-02.json"]
+        project.files["context/iteration-0001/proposal-validation-attempt-02.json"]
     )
     assert final_report["valid_slots"] == [1, 2]
     assert final_report["errors"] == []
@@ -804,7 +806,7 @@ def test_project_proposer_rejects_a_runtime_kind_switch_when_fixed_before_search
     assert "must preserve the parent's runtime kind 'kit-python'" in _proposal_failure_reason(
         proposals[0]
     )
-    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
+    report = json.loads(project.files["context/iteration-0001/proposal-validation-attempt-03.json"])
     assert "must preserve the parent's runtime kind 'kit-python'" in report["errors"][0]["reason"]
 
 
@@ -860,7 +862,7 @@ def test_project_proposer_repairs_an_unknown_runtime_kind_before_search() -> Non
     )
 
     assert "unsupported runtime kind 'pi-nod'" in _proposal_failure_reason(proposals[0])
-    report = json.loads(project.files["context/round-0001/proposal-validation-attempt-03.json"])
+    report = json.loads(project.files["context/iteration-0001/proposal-validation-attempt-03.json"])
     assert "unsupported runtime kind 'pi-nod'" in report["errors"][0]["reason"]
 
 


### PR DESCRIPTION
## Summary

- Treat one optimizer iteration as one proposal batch.
- Freeze the current champion, regression suite, and holdout comparator for every sibling in the batch.
- Select at most one gate-eligible winner by full success, assertion fraction, then proposal order.
- Carry only that winner into the next iteration while preserving every proposal and its final feedback.
- Replace proposal-attempt iteration records with explicit `ProposalRecord(iteration, proposal_index)` history.
- Rename persistent Meta project paths and optimizer copy from rounds to iterations.

## Stack

- Stacked on `agent/meta-harness-agents` / #152.
- Independent of the Bedrock provider fix in #160.
- Platform companion #332 pins exact head `e7f8d5715179ca6699a8ffd907bdea1cf94b3bfd` and provides the grouped iteration UI.

## Selection contract

Each iteration generates `proposal_batch_size` siblings from the current champion. Screening, full gating, holdout checks, and confirmation compare every sibling against the same frozen iteration-start state. After all proposals resolve, at most one winner updates the archive lineage, champion, suite, persistence callback, and progress checkpoint. Cancellation before that commit boundary promotes nothing.

Every proposal remains in stable iteration/proposal order with explicit gate eligibility and selection state. Eligible nonwinners retain their scores and receive final not-selected feedback, but never become accepted archive lineage.

`on_note` is eager diagnostic narration. Final `on_proposal` callbacks wait for batch selection, fire in stable order, and are followed by the iteration's single `on_progress` champion checkpoint.

## Validation

- `uv run pytest -q`: 1,752 passed, 18 skipped
- Callback-order follow-up: 57 focused tests passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `git diff --check`
- Independent modified-surface audit: 158 tests passed
- Greptile: passed at 5/5 confidence, zero unresolved threads

## Reference alignment

This matches the Meta Harness outer-loop unit: one iteration proposes and evaluates a candidate batch before updating the incumbent or frontier. The product keeps a scalar champion, so only the best eligible sibling is selected while all proposal evidence remains available to Meta.

Reference: https://github.com/stanford-iris-lab/meta-harness/blob/main/reference_examples/text_classification/meta_harness.py#L444-L568

## Workspace compatibility

No old `round-NNNN` compatibility shim is needed. Meta projects are fresh, run-owned workspaces; cross-worker or cross-deployment optimizer resume does not exist. Transport recovery replays the in-memory file mirror inside the same `AgentProject`, while fresh runs receive fresh projects. Supporting only old directory names would imply unsafe partial recovery without restoring the archive, reports, suite, proposer counters, or project mirror.
