### PR TITLE
Resume durable live channels across sandbox pauses

### DIFF
--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -487,21 +487,32 @@ class E2BDurableChannel:
                     self._resume_condition.notify_all()
                 raise
             now = time.monotonic()
+            fatal_during_connect: str | None = None
             with self._resume_condition:
-                self._sandbox = sandbox
-                self._handle = handle
-                self._stream_dead_at = None
-                self._stream_death_probe_done = False
-                self._stream_error = None
-                self._last_stdout_at = now
-                self._head_failure_since = None
-                self._last_head_failure_at = None
-                self._next_pid_check_at = now + self._pid_probe_interval_s
-                self._pid_dead_at = None
-                self._last_outbox_error = None
-                self._missing_since.clear()
+                fatal_during_connect = self._fatal_error
+                if fatal_during_connect is None:
+                    self._sandbox = sandbox
+                    self._handle = handle
+                    self._stream_dead_at = None
+                    self._stream_death_probe_done = False
+                    self._stream_error = None
+                    self._last_stdout_at = now
+                    self._head_failure_since = None
+                    self._last_head_failure_at = None
+                    self._next_pid_check_at = now + self._pid_probe_interval_s
+                    self._pid_dead_at = None
+                    self._last_outbox_error = None
+                    self._missing_since.clear()
                 self._resuming = False
                 self._resume_condition.notify_all()
+            if fatal_during_connect is not None:
+                disconnect = getattr(handle, "disconnect", None)
+                if callable(disconnect):
+                    with contextlib.suppress(Exception):
+                        disconnect()
+                raise RuntimeError(
+                    f"durable runner channel failed while resuming: {fatal_during_connect}"
+                )
             reader = self._new_reader(handle, generation=generation)
             self._reader = reader
 

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -438,6 +438,7 @@ class E2BDurableChannel:
         self._next_pid_check_at = time.monotonic() + pid_probe_interval_s
         self._pid_dead_at: float | None = None
         self._last_outbox_error: str | None = None
+        self._stream_generation = 0
         self._file_request_timeout_s = file_request_timeout_s
         self._frame_request_timeout_s = frame_request_timeout_s
         self._poll_interval_s = poll_interval_s
@@ -449,10 +450,56 @@ class E2BDurableChannel:
         self._send_ack_timeout_s = send_ack_timeout_s
         self._close_request_timeout_s = close_request_timeout_s
         self._stdout_silence_grace_s = stdout_silence_grace_s
-        self._reader = threading.Thread(
-            target=self._read_events, name="e2b-durable-reader", daemon=True
-        )
+        self._reader = self._new_reader(handle, generation=self._stream_generation)
         self._reader.start()
+
+    def resume(self, sandbox: SandboxHandle, *, timeout: float | None = 0) -> None:
+        """Reconnect this channel to its preserved runner after an E2B sandbox resume.
+
+        E2B keeps the runner process and filesystem outbox in a memory-preserving pause, but the
+        old command output stream is gone. Reusing this channel preserves both transport sequence
+        cursors while replacing only that notification stream. The durable outbox remains the
+        source of truth for frames produced while the stream was detached.
+
+        Args:
+            sandbox: The reconnected handle for the same memory-preserved sandbox.
+            timeout: E2B command-stream timeout. Zero keeps the live stream attached indefinitely.
+        """
+        with self._send_lock, self._close_lock:
+            if self._closed.is_set():
+                raise RuntimeError("a closed durable runner channel cannot be resumed")
+            with self._state_lock:
+                if self._fatal_error is not None:
+                    raise RuntimeError(
+                        f"a failed durable runner channel cannot be resumed: {self._fatal_error}"
+                    )
+
+            handle = sandbox.commands.connect(self._pid, timeout=timeout)
+            previous_handle = self._handle
+            self._sandbox = sandbox
+            self._handle = handle
+            now = time.monotonic()
+            with self._state_lock:
+                self._stream_generation += 1
+                generation = self._stream_generation
+                self._stream_dead_at = None
+                self._stream_death_probe_done = False
+                self._stream_error = None
+                self._last_stdout_at = now
+                self._head_failure_since = None
+                self._last_head_failure_at = None
+                self._next_pid_check_at = now + self._pid_probe_interval_s
+                self._pid_dead_at = None
+                self._last_outbox_error = None
+                self._missing_since.clear()
+            reader = self._new_reader(handle, generation=generation)
+            self._reader = reader
+
+            disconnect = getattr(previous_handle, "disconnect", None)
+            if callable(disconnect):
+                with contextlib.suppress(Exception):
+                    disconnect()
+            reader.start()
 
     def send(self, frame: JsonObject) -> None:
         """Deliver one host frame once, retrying the same sequence until its durable ack."""
@@ -681,12 +728,23 @@ class E2BDurableChannel:
         message = self._fatal_error or "pi live runner process exited"
         raise RuntimeError(f"{message}{self._stderr_suffix()}")
 
-    def _read_events(self) -> None:
+    def _new_reader(self, handle: CommandHandle, *, generation: int) -> threading.Thread:
+        return threading.Thread(
+            target=self._read_events,
+            args=(handle, generation),
+            name="e2b-durable-reader",
+            daemon=True,
+        )
+
+    def _read_events(self, handle: CommandHandle, generation: int) -> None:
         pending = ""
         try:
-            for stdout, stderr, _pty in self._handle:
+            for stdout, stderr, _pty in handle:
                 if self._closed.is_set():
                     return
+                with self._state_lock:
+                    if generation != self._stream_generation:
+                        return
                 if stderr:
                     for line in stderr.splitlines():
                         if line.strip():
@@ -697,17 +755,22 @@ class E2BDurableChannel:
                 pending += stdout
                 while "\n" in pending:
                     line, pending = pending.split("\n", 1)
-                    self._decode_stdout_line(line)
+                    self._decode_stdout_line(line, generation=generation)
         except Exception as exc:  # noqa: BLE001 - stdout is only a fallible notification path
-            self._stream_error = f"[channel] output stream failed: {exc}"
-            self._stderr.append(self._stream_error)
+            with self._state_lock:
+                if generation == self._stream_generation and not self._closed.is_set():
+                    self._stream_error = f"[channel] output stream failed: {exc}"
+                    self._stderr.append(self._stream_error)
         else:
-            self._stream_error = "[channel] output stream ended"
+            with self._state_lock:
+                if generation == self._stream_generation and not self._closed.is_set():
+                    self._stream_error = "[channel] output stream ended"
         finally:
-            if not self._closed.is_set():
-                self._stream_dead_at = time.monotonic()
+            with self._state_lock:
+                if generation == self._stream_generation and not self._closed.is_set():
+                    self._stream_dead_at = time.monotonic()
 
-    def _decode_stdout_line(self, line: str) -> None:
+    def _decode_stdout_line(self, line: str, *, generation: int) -> None:
         text = line.strip()
         if not text:
             return
@@ -722,6 +785,8 @@ class E2BDurableChannel:
         if envelope is None:
             if isinstance(value, dict):
                 with self._state_lock:
+                    if generation != self._stream_generation:
+                        return
                     self._mark_fatal_locked(
                         "durable runner emitted an unsequenced or malformed semantic frame"
                     )
@@ -730,6 +795,8 @@ class E2BDurableChannel:
             return
         seq, frame = envelope
         with self._state_lock:
+            if generation != self._stream_generation:
+                return
             if seq <= self._last_seq:
                 return
             self._pending.setdefault(seq, frame)

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -416,6 +416,7 @@ class E2BDurableChannel:
         self._durable_stderr = ""
         self._frames: queue.Queue[JsonObject | _Eof] = queue.Queue()
         self._state_lock = threading.Lock()
+        self._resume_condition = threading.Condition(self._state_lock)
         self._send_lock = threading.Lock()
         self._close_lock = threading.Lock()
         self._ack_condition = threading.Condition()
@@ -439,6 +440,7 @@ class E2BDurableChannel:
         self._pid_dead_at: float | None = None
         self._last_outbox_error: str | None = None
         self._stream_generation = 0
+        self._resuming = False
         self._file_request_timeout_s = file_request_timeout_s
         self._frame_request_timeout_s = frame_request_timeout_s
         self._poll_interval_s = poll_interval_s
@@ -468,20 +470,26 @@ class E2BDurableChannel:
         with self._send_lock, self._close_lock:
             if self._closed.is_set():
                 raise RuntimeError("a closed durable runner channel cannot be resumed")
-            with self._state_lock:
+            with self._resume_condition:
                 if self._fatal_error is not None:
                     raise RuntimeError(
                         f"a failed durable runner channel cannot be resumed: {self._fatal_error}"
                     )
-
-            handle = sandbox.commands.connect(self._pid, timeout=timeout)
-            previous_handle = self._handle
-            self._sandbox = sandbox
-            self._handle = handle
-            now = time.monotonic()
-            with self._state_lock:
+                self._resuming = True
                 self._stream_generation += 1
                 generation = self._stream_generation
+                previous_handle = self._handle
+            try:
+                handle = sandbox.commands.connect(self._pid, timeout=timeout)
+            except BaseException:
+                with self._resume_condition:
+                    self._resuming = False
+                    self._resume_condition.notify_all()
+                raise
+            now = time.monotonic()
+            with self._resume_condition:
+                self._sandbox = sandbox
+                self._handle = handle
                 self._stream_dead_at = None
                 self._stream_death_probe_done = False
                 self._stream_error = None
@@ -492,6 +500,8 @@ class E2BDurableChannel:
                 self._pid_dead_at = None
                 self._last_outbox_error = None
                 self._missing_since.clear()
+                self._resuming = False
+                self._resume_condition.notify_all()
             reader = self._new_reader(handle, generation=generation)
             self._reader = reader
 
@@ -580,6 +590,11 @@ class E2BDurableChannel:
             return None
         deadline = None if timeout is None else time.monotonic() + timeout
         while True:
+            if not self._wait_for_resume(deadline):
+                raise TimeoutError(
+                    f"no frame from the pi runner within {timeout}s"
+                    f"{self._stderr_suffix(include_durable=False)}"
+                )
             item = self._get_queued_nowait()
             if item is not None:
                 return self._unwrap_item(item)
@@ -642,6 +657,19 @@ class E2BDurableChannel:
             except queue.Empty:
                 continue
             return self._unwrap_item(item)
+
+    def _wait_for_resume(self, deadline: float | None) -> bool:
+        """Block unary reads while a new sandbox attachment is being established."""
+        with self._resume_condition:
+            while self._resuming and not self._closed.is_set():
+                if deadline is None:
+                    self._resume_condition.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._resume_condition.wait(timeout=remaining)
+            return not self._resuming
 
     def close(self) -> None:
         """Logically close immediately and retire the runner in bounded background cleanup."""
@@ -745,13 +773,14 @@ class E2BDurableChannel:
                 with self._state_lock:
                     if generation != self._stream_generation:
                         return
-                if stderr:
-                    for line in stderr.splitlines():
-                        if line.strip():
-                            self._stderr.append(line)
+                    if stderr:
+                        for stderr_line in stderr.splitlines():
+                            if stderr_line.strip():
+                                self._stderr.append(stderr_line)
+                    if stdout:
+                        self._last_stdout_at = time.monotonic()
                 if not stdout:
                     continue
-                self._last_stdout_at = time.monotonic()
                 pending += stdout
                 while "\n" in pending:
                     line, pending = pending.split("\n", 1)
@@ -777,7 +806,9 @@ class E2BDurableChannel:
         try:
             value = json.loads(base64.b64decode(text, validate=True))
         except ValueError:
-            self._stderr.append(f"[stdout] {text}")
+            with self._state_lock:
+                if generation == self._stream_generation:
+                    self._stderr.append(f"[stdout] {text}")
             return
         if isinstance(value, dict) and value.get("type") == TRANSPORT_KEEPALIVE_TYPE:
             return  # deliberately unsequenced and never persisted by the durable runner
@@ -791,7 +822,9 @@ class E2BDurableChannel:
                         "durable runner emitted an unsequenced or malformed semantic frame"
                     )
                 return
-            self._stderr.append(f"[stdout] invalid durable envelope: {text}")
+            with self._state_lock:
+                if generation == self._stream_generation:
+                    self._stderr.append(f"[stdout] invalid durable envelope: {text}")
             return
         seq, frame = envelope
         with self._state_lock:
@@ -818,42 +851,51 @@ class E2BDurableChannel:
     ) -> None:
         if self._closed.is_set():
             return
+        with self._state_lock:
+            if self._resuming:
+                return
+            generation = self._stream_generation
+            sandbox = self._sandbox
         # Head is tiny and latency-sensitive. Exact frames use a separate, gzip-enabled budget:
         # an LLM request can carry the agent's entire context and must not be misclassified as
         # unavailable merely because it cannot fit inside this short polling interval.
         unary_timeout = max(0.001, request_timeout)
         try:
-            raw_head = self._sandbox.files.read(
+            raw_head = sandbox.files.read(
                 f"{self._outbox_root}/head", request_timeout=unary_timeout
             )
             head = int(raw_head.strip())
             if head < 0:
                 raise ValueError("negative sequence")
         except Exception as exc:  # noqa: BLE001 - startup/momentary unary read misses are normal
-            self._last_outbox_error = f"head read failed: {exc}"
-            now = time.monotonic()
-            # Treat only uninterrupted failures as one outage. AgentProject does not pump this
-            # channel while it is idle between proposal iterations, so a long idle gap must not make
-            # the next isolated read failure look ancient.
-            if self._last_head_failure_at is None or now - self._last_head_failure_at > max(
-                1.0, self._poll_interval_s * 4
-            ):
-                self._head_failure_since = now
-            self._last_head_failure_at = now
-            head_failure_since = self._head_failure_since or now
-            output_unavailable = self._stream_dead_at is not None or (
-                now - self._last_stdout_at >= self._stdout_silence_grace_s
-            )
-            if output_unavailable and now - head_failure_since >= self._frame_read_grace_s:
-                with self._state_lock:
+            with self._state_lock:
+                if generation != self._stream_generation or self._resuming:
+                    return
+                self._last_outbox_error = f"head read failed: {exc}"
+                now = time.monotonic()
+                # Treat only uninterrupted failures as one outage. AgentProject does not pump this
+                # channel while it is idle between proposal iterations, so a long idle gap must not
+                # make the next isolated read failure look ancient.
+                if self._last_head_failure_at is None or now - self._last_head_failure_at > max(
+                    1.0, self._poll_interval_s * 4
+                ):
+                    self._head_failure_since = now
+                self._last_head_failure_at = now
+                head_failure_since = self._head_failure_since or now
+                output_unavailable = self._stream_dead_at is not None or (
+                    now - self._last_stdout_at >= self._stdout_silence_grace_s
+                )
+                if output_unavailable and now - head_failure_since >= self._frame_read_grace_s:
                     self._mark_fatal_locked(
                         "durable outbox head unavailable after "
                         f"{self._frame_read_grace_s:g}s: {self._last_outbox_error}"
                     )
             return
-        self._head_failure_since = None
-        self._last_head_failure_at = None
         with self._state_lock:
+            if generation != self._stream_generation or self._resuming:
+                return
+            self._head_failure_since = None
+            self._last_head_failure_at = None
             self._known_head = max(self._known_head, head)
             self._drain_committed_locked(
                 request_timeout=(
@@ -962,48 +1004,78 @@ class E2BDurableChannel:
             return None
 
     def _classify_runner_liveness(self, *, request_timeout: float) -> None:
-        dead_at = self._stream_dead_at
-        if self._closed.is_set():
-            return
-        now = time.monotonic()
-        stream_failure_is_due = (
-            dead_at is not None
-            and not self._stream_death_probe_done
-            and now - dead_at >= self._stream_death_grace_s
-        )
-        if not stream_failure_is_due and now < self._next_pid_check_at:
-            return
-        if stream_failure_is_due:
-            self._stream_death_probe_done = True
-        self._next_pid_check_at = now + self._pid_probe_interval_s
+        with self._state_lock:
+            if self._closed.is_set() or self._resuming:
+                return
+            generation = self._stream_generation
+            sandbox = self._sandbox
+            dead_at = self._stream_dead_at
+            now = time.monotonic()
+            stream_failure_is_due = (
+                dead_at is not None
+                and not self._stream_death_probe_done
+                and now - dead_at >= self._stream_death_grace_s
+            )
+            if not stream_failure_is_due and now < self._next_pid_check_at:
+                return
+            if stream_failure_is_due:
+                self._stream_death_probe_done = True
+            self._next_pid_check_at = now + self._pid_probe_interval_s
         try:
-            processes = self._sandbox.commands.list(request_timeout=request_timeout)
+            processes = sandbox.commands.list(request_timeout=request_timeout)
         except Exception as exc:  # noqa: BLE001 - a failed probe is not proof of process death
             message = f"[channel] runner liveness probe failed: {exc}"
-            if not self._stderr or self._stderr[-1] != message:
-                self._stderr.append(message)
+            with self._state_lock:
+                if generation != self._stream_generation or self._resuming:
+                    return
+                if not self._stderr or self._stderr[-1] != message:
+                    self._stderr.append(message)
             return
-        if any(process.pid == self._pid for process in processes):
-            self._pid_dead_at = None
-            return
-        # `recv` polls disk before every liveness probe. Keep doing so for a bounded grace after the
-        # PID disappears, allowing a final frame and head update to become visible before EOF.
-        if self._pid_dead_at is None:
-            self._pid_dead_at = now
-            return
-        if now - self._pid_dead_at < self._frame_read_grace_s:
-            return
-        self._refresh_durable_stderr(request_timeout)
         with self._state_lock:
+            if generation != self._stream_generation or self._resuming:
+                return
+            if any(process.pid == self._pid for process in processes):
+                self._pid_dead_at = None
+                return
+            # `recv` polls disk before every liveness probe. Keep doing so for a bounded grace after
+            # the PID disappears, allowing a final frame and head update to become visible before
+            # EOF.
+            if self._pid_dead_at is None:
+                self._pid_dead_at = now
+                return
+            if now - self._pid_dead_at < self._frame_read_grace_s:
+                return
+        self._refresh_durable_stderr(
+            request_timeout,
+            generation=generation,
+            sandbox=sandbox,
+        )
+        with self._state_lock:
+            if generation != self._stream_generation or self._resuming:
+                return
             detail = f" after {self._stream_error}" if self._stream_error else ""
             self._mark_fatal_locked(f"pi live runner process exited{detail}")
 
-    def _refresh_durable_stderr(self, request_timeout: float) -> None:
+    def _refresh_durable_stderr(
+        self,
+        request_timeout: float,
+        *,
+        generation: int | None = None,
+        sandbox: SandboxHandle | None = None,
+    ) -> None:
+        if generation is None or sandbox is None:
+            with self._state_lock:
+                if self._resuming:
+                    return
+                generation = self._stream_generation
+                sandbox = self._sandbox
         try:
-            stderr = self._sandbox.files.read(self._stderr_path, request_timeout=request_timeout)
-            self._durable_stderr = "\n".join(stderr.splitlines()[-self._stderr_lines :])
+            stderr = sandbox.files.read(self._stderr_path, request_timeout=request_timeout)
         except Exception:  # noqa: BLE001 - diagnostics must never mask the transport error
-            pass
+            return
+        with self._state_lock:
+            if generation == self._stream_generation and not self._resuming:
+                self._durable_stderr = "\n".join(stderr.splitlines()[-self._stderr_lines :])
 
     @staticmethod
     def _parse_envelope(value: object) -> tuple[int, JsonObject] | None:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -188,6 +188,8 @@ class _FakeCommands:
     ) -> None:
         self._handle = handle
         self._reconnect_handles = list(reconnect_handles or [])
+        self.connect_started = threading.Event()
+        self.connect_gate: threading.Event | None = None
         self.calls: list[str] = []  # foreground commands, in order (installs, ...)
         self.background_cmds: list[str] = []
         self.background_envs: list[dict[str, str] | None] = []
@@ -221,6 +223,9 @@ class _FakeCommands:
 
     def connect(self, pid: int, *, timeout: float | None = None) -> object:
         self.connects.append((pid, timeout))
+        self.connect_started.set()
+        if self.connect_gate is not None:
+            self.connect_gate.wait(2.0)
         if not self._reconnect_handles:
             raise RuntimeError("process connection unavailable")
         return self._reconnect_handles.pop(0)
@@ -1637,6 +1642,57 @@ def test_durable_channel_resume_preserves_both_sequence_cursors() -> None:
     ]
     assert [wire["transport_in_seq"] for wire in wires] == [1, 2]
     assert fake.durable_dispatches == [first, second]
+
+
+def test_durable_channel_resume_fences_a_concurrent_old_liveness_probe() -> None:
+    """A recv racing reconnect cannot poison the resumed channel with the old PID state."""
+    hello: JsonObject = {"type": "hello"}
+    handle = _DisconnectingHandle(_stdout_events([_envelope(1, hello)]))
+    resumed = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle, reconnect_handles=[resumed])
+    _store_outbox(fake, [hello])
+    channel = _durable_channel(fake, handle, frame_read_grace_s=0.01)
+    assert channel.recv(timeout=0.5) == hello
+    deadline = time.monotonic() + 0.5
+    while channel._stream_dead_at is None and time.monotonic() < deadline:  # noqa: SLF001
+        time.sleep(0.001)
+    assert channel._stream_dead_at is not None  # noqa: SLF001
+
+    release_connect = threading.Event()
+    fake.commands.connect_gate = release_connect
+    fake.commands.running_pids.clear()
+    resume_errors: list[Exception] = []
+    recv_errors: list[Exception] = []
+
+    def resume() -> None:
+        try:
+            channel.resume(fake)
+        except Exception as error:  # noqa: BLE001 - asserted below
+            resume_errors.append(error)
+
+    def recv() -> None:
+        try:
+            channel.recv(timeout=0.1)
+        except Exception as error:  # noqa: BLE001 - asserted below
+            recv_errors.append(error)
+
+    resume_thread = threading.Thread(target=resume)
+    resume_thread.start()
+    assert fake.commands.connect_started.wait(0.5)
+    recv_thread = threading.Thread(target=recv)
+    recv_thread.start()
+    time.sleep(0.04)
+    fake.commands.running_pids.add(_PID)
+    release_connect.set()
+    resume_thread.join(timeout=0.5)
+    recv_thread.join(timeout=0.5)
+
+    assert not resume_thread.is_alive()
+    assert not recv_thread.is_alive()
+    assert resume_errors == []
+    assert len(recv_errors) == 1
+    assert isinstance(recv_errors[0], TimeoutError)
+    assert channel._fatal_error is None  # noqa: SLF001
 
 
 def test_durable_channel_retries_a_transiently_missing_committed_frame() -> None:

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -1695,6 +1695,37 @@ def test_durable_channel_resume_fences_a_concurrent_old_liveness_probe() -> None
     assert channel._fatal_error is None  # noqa: SLF001
 
 
+def test_durable_channel_resume_rejects_a_fatal_state_set_during_connect() -> None:
+    """The post-connect guard cannot return a newly attached but poisoned channel."""
+    handle = _ScriptedHandle([], hold_open=True)
+    resumed = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle, reconnect_handles=[resumed])
+    _store_outbox(fake, [])
+    channel = _durable_channel(fake, handle)
+    release_connect = threading.Event()
+    fake.commands.connect_gate = release_connect
+    resume_errors: list[Exception] = []
+
+    def resume() -> None:
+        try:
+            channel.resume(fake)
+        except Exception as error:  # noqa: BLE001 - asserted below
+            resume_errors.append(error)
+
+    resume_thread = threading.Thread(target=resume)
+    resume_thread.start()
+    assert fake.commands.connect_started.wait(0.5)
+    with channel._state_lock:  # noqa: SLF001
+        channel._mark_fatal_locked("simulated concurrent fatal state")  # noqa: SLF001
+    release_connect.set()
+    resume_thread.join(timeout=0.5)
+
+    assert not resume_thread.is_alive()
+    assert len(resume_errors) == 1
+    assert "simulated concurrent fatal state" in str(resume_errors[0])
+    assert resumed.disconnects == 1
+
+
 def test_durable_channel_retries_a_transiently_missing_committed_frame() -> None:
     hello: JsonObject = {"type": "hello"}
     ready: JsonObject = {"type": "state", "status": "ready"}

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -1620,9 +1620,13 @@ def test_durable_channel_resume_preserves_both_sequence_cursors() -> None:
 
     fake.files.store[_frame_path(4)] = json.dumps(_envelope(4, running))
     fake.files.store[f"{_OUTBOX}/head"] = "4"
+    previous_reader = channel._reader  # noqa: SLF001
     channel.resume(fake)
 
     assert fake.commands.connects == [(_PID, 0)]
+    previous_reader.join(timeout=0.5)
+    assert not previous_reader.is_alive()
+    assert channel._stream_dead_at is None  # noqa: SLF001
     assert channel.recv(timeout=0.5) == running
     second: JsonObject = {"type": "user_message", "text": "second"}
     channel.send(second)

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -1599,6 +1599,42 @@ def test_durable_channel_recovers_after_stdout_drops() -> None:
     assert "Server disconnected" in channel.stderr_tail()
 
 
+def test_durable_channel_resume_preserves_both_sequence_cursors() -> None:
+    """A memory-preserving sandbox resume reattaches without replaying either direction."""
+    hello: JsonObject = {"type": "hello"}
+    idle: JsonObject = {"type": "state", "status": "idle"}
+    running: JsonObject = {"type": "state", "status": "running"}
+    handle = _ScriptedHandle(
+        _stdout_events([_envelope(1, hello), _envelope(2, idle)]),
+        hold_open=True,
+    )
+    resumed = _ScriptedHandle(_stdout_events([_envelope(4, running)]), hold_open=True)
+    fake = FakeSandbox(handle, reconnect_handles=[resumed])
+    _store_outbox(fake, [hello, idle])
+    channel = _durable_channel(fake, handle)
+
+    assert channel.recv(timeout=0.5) == hello
+    assert channel.recv(timeout=0.5) == idle
+    first: JsonObject = {"type": "user_message", "text": "first"}
+    channel.send(first)
+
+    fake.files.store[_frame_path(4)] = json.dumps(_envelope(4, running))
+    fake.files.store[f"{_OUTBOX}/head"] = "4"
+    channel.resume(fake)
+
+    assert fake.commands.connects == [(_PID, 0)]
+    assert channel.recv(timeout=0.5) == running
+    second: JsonObject = {"type": "user_message", "text": "second"}
+    channel.send(second)
+
+    wires = [
+        cast("JsonObject", json.loads(base64.b64decode(data.strip())))
+        for _pid, data in fake.commands.stdin
+    ]
+    assert [wire["transport_in_seq"] for wire in wires] == [1, 2]
+    assert fake.durable_dispatches == [first, second]
+
+
 def test_durable_channel_retries_a_transiently_missing_committed_frame() -> None:
     hello: JsonObject = {"type": "hello"}
     ready: JsonObject = {"type": "state", "status": "ready"}


### PR DESCRIPTION
## Summary
- add a resume API to E2BDurableChannel that reconnects only the E2B notification stream
- preserve inbound acknowledgements and outbound delivery cursors across memory-preserving sandbox pauses
- fence obsolete reader, outbox, and liveness work by stream generation
- park concurrent recv calls until reconnect completes, and reject any fatal state that appears during connect

## Regression coverage
- sequence cursors survive pause and resume without replay
- an obsolete reader cannot poison the replacement stream
- a concurrent old-PID liveness probe cannot fail the resumed channel
- a fatal state injected during connect rejects and closes the new attachment

## Validation
- uv run ruff check .
- uv run ty check
- uv run pytest -q (1756 passed, 18 skipped)

Platform integration: experientiallabs/platform#334