### PR TITLE
feat(serve): rate-limited public play + catalog replay precompute

### DIFF
--- a/packages/environment-capture/scripts/precompute_public_scenarios.py
+++ b/packages/environment-capture/scripts/precompute_public_scenarios.py
@@ -1,0 +1,124 @@
+"""Precompute example open-loop reconstructions for the public world models.
+
+The platform's unauthenticated catalog shows, per model, a few hard-coded "reconstruction"
+scenarios: a recorded action, the real observation the environment produced, and the world
+model's predicted observation. Recomputing these live on every page view would be slow and
+costly, so we run them once here and vendor the result into the platform frontend build.
+
+Each step's golden data comes from the model's own indexed corpus (`sample_steps`), and the
+prediction from `step_open_loop` (teacher-forced: predict, then advance from ground truth). The
+headline fidelity shown in the UI is the model's official held-out score from its card, not
+recomputed here, so self-retrieval on indexed steps never inflates the number a visitor sees.
+
+Run once, with the models' serve provider available (Bedrock):
+
+    uv run python packages/environment-capture/scripts/precompute_public_scenarios.py \
+        --out ../platform-public-catalog/apps/web/data/public-scenarios.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from wmh.config.card import load_card
+from wmh.core.render import render_action
+from wmh.engine.loader import load_world_model
+
+MODELS_GLOB = "*/models/*"
+SCENARIOS_PER_MODEL = 2
+STEPS_PER_SCENARIO = 3
+OBSERVATION_CLIP = 900
+
+
+def _clip(text: str) -> str:
+    flat = text.strip()
+    return flat if len(flat) <= OBSERVATION_CLIP else flat[: OBSERVATION_CLIP - 1] + "…"
+
+
+def _model_dirs(capture_root: Path) -> list[Path]:
+    return sorted(p for p in capture_root.glob(MODELS_GLOB) if (p / "config.toml").is_file())
+
+
+def precompute_model(model_dir: Path, *, scenarios: int, steps_per: int) -> dict | None:
+    """Build the vendored scenarios for one model, or None when it has too few indexed steps."""
+    card = load_card(model_dir)
+    if card is None:
+        return None
+    wm, _provider = load_world_model(model_dir)
+    total = scenarios * steps_per
+    sampled = wm.sample_steps(total)
+    if len(sampled) < steps_per:
+        return None
+
+    replayed: list[dict] = []
+    for step in sampled:
+        session = wm.new_session(task=step.task, seed_state=step.state_before, enrich=False)
+        predicted = wm.step_open_loop(session.id, step.action, step.observation)
+        replayed.append(
+            {
+                "action": _clip(render_action(step.action)),
+                "golden": _clip(step.observation.content or ""),
+                "predicted": _clip(predicted.content or ""),
+                "isErrorGolden": step.observation.is_error,
+                "isErrorPredicted": predicted.is_error,
+            }
+        )
+
+    grouped = [replayed[i : i + steps_per] for i in range(0, len(replayed), steps_per)]
+    out_scenarios = [
+        {"id": f"s{i}", "label": f"Reconstruction {i + 1}", "steps": group}
+        for i, group in enumerate(grouped)
+        if group
+    ]
+    # Suggested "example tool calls" for the live playground: the first distinct rendered actions.
+    suggestions: list[str] = []
+    for step in sampled:
+        label = _clip(render_action(step.action))
+        if label and label not in suggestions:
+            suggestions.append(label)
+        if len(suggestions) >= 4:
+            break
+
+    return {
+        "slug": card.name,
+        "fidelity": card.fidelity.score if card.fidelity else None,
+        "scenarios": out_scenarios,
+        "suggestions": suggestions,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="Path to write the vendored JSON.")
+    parser.add_argument("--only", default=None, help="Precompute a single model slug (for probes).")
+    parser.add_argument("--scenarios", type=int, default=SCENARIOS_PER_MODEL)
+    parser.add_argument("--steps", type=int, default=STEPS_PER_SCENARIO)
+    args = parser.parse_args()
+
+    capture_root = Path(__file__).resolve().parents[1]  # packages/environment-capture
+    out: list[dict] = []
+    for model_dir in _model_dirs(capture_root):
+        if args.only and model_dir.name != args.only:
+            continue
+        print(f"precomputing {model_dir.name} ...", flush=True)
+        try:
+            entry = precompute_model(model_dir, scenarios=args.scenarios, steps_per=args.steps)
+        except Exception as exc:  # noqa: BLE001 - one bad model must not sink the whole run
+            print(f"  skipped {model_dir.name}: {exc}", flush=True)
+            continue
+        if entry is None:
+            print(f"  skipped {model_dir.name}: no card or too few steps", flush=True)
+            continue
+        out.append(entry)
+        print(f"  {model_dir.name}: {len(entry['scenarios'])} scenarios", flush=True)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {len(out)} models to {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -107,6 +107,7 @@ from wmh.scenarios import (
     build_scenario_set,
     verify_scenarios,
 )
+from wmh.serving.public_play import PublicPlayLimiter, PublicPlayLimits
 from wmh.serving.server import create_app
 from wmh.telemetry import (
     BuildTelemetryStats,
@@ -746,18 +747,35 @@ def serve(
         help="Serve with the online extras on: the build-measured winning config when the "
         "artifact has one, otherwise every extra it supports. Default: pure RAG.",
     ),
+    public_play: bool = typer.Option(
+        False,
+        "--public-play",
+        help="Expose /public/... routes for anonymous play, capped by a shared step ceiling "
+        "(bounds total spend). For the public catalog; do not enable for private serving.",
+    ),
+    public_max_steps: int = typer.Option(
+        500, help="Global step ceiling for --public-play across all anonymous sessions."
+    ),
 ) -> None:
     """Run the local FastAPI backend so agents can step against world models over HTTP.
 
     Serves every built model by default, or just the `--name` ones, from one or more roots
     (e.g. `--root .wmh --root examples/tau-bench`). Routes are namespaced:
-    `/world_models/{name}/sessions` and `.../step`.
+    `/world_models/{name}/sessions` and `.../step`. With `--public-play`, adds capped
+    `/public/...` routes for the anonymous catalog.
     """
     names = list(name) if name else None
+    limiter = (
+        PublicPlayLimiter(PublicPlayLimits(max_total_steps=public_max_steps))
+        if public_play
+        else None
+    )
     # Bad --name input (unsafe segment, unknown model, nothing built) is a usage error,
     # not a traceback; load the models before uvicorn takes over the process.
     try:
-        server_app = create_app(list(root), names=names, max_fidelity=max_fidelity)
+        server_app = create_app(
+            list(root), names=names, max_fidelity=max_fidelity, public_play=limiter
+        )
     except (ValueError, FileNotFoundError) as err:
         raise typer.BadParameter(str(err)) from None
     uvicorn.run(server_app, host="127.0.0.1", port=port)

--- a/wmh/serving/public_play.py
+++ b/wmh/serving/public_play.py
@@ -1,0 +1,85 @@
+"""Rate-limiting and a hard spend ceiling for anonymous ("public") play.
+
+The public catalog lets logged-out visitors step a world model live. That spends real provider
+tokens with no account behind it, so the public play surface runs through this limiter: a global
+ceiling on total steps (which bounds total spend deterministically, since each step costs at most
+one model call), plus a per-session step cap and a cap on how many sessions may be opened. When a
+ceiling is hit the caller gets a typed refusal that the serving layer turns into HTTP 429.
+
+The limiter is process-local and in-memory: it protects a single public-play server instance. It
+never tracks user identity (there is none); the ceilings are the whole defense.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+
+class PublicPlayLimitError(Exception):
+    """A public-play ceiling was reached; the serving layer maps this to HTTP 429."""
+
+
+@dataclass(frozen=True)
+class PublicPlayLimits:
+    """Ceilings for the public play surface. Total spend is bounded by `max_total_steps`."""
+
+    max_total_steps: int = 500
+    max_steps_per_session: int = 20
+    max_sessions: int = 200
+
+
+class PublicPlayLimiter:
+    """Thread-safe ceilings shared across every public-play session on one server."""
+
+    def __init__(self, limits: PublicPlayLimits | None = None) -> None:
+        self._limits = limits or PublicPlayLimits()
+        self._total_steps = 0
+        self._sessions_opened = 0
+        self._session_steps: dict[str, int] = {}
+        self._session_model: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def open_session(self, model_name: str, session_id: str) -> None:
+        """Reserve a new public session, or refuse when the session ceiling is reached."""
+        with self._lock:
+            if self._sessions_opened >= self._limits.max_sessions:
+                raise PublicPlayLimitError(
+                    "The public demo is at capacity right now. Log in to keep playing."
+                )
+            self._sessions_opened += 1
+            self._session_steps[session_id] = 0
+            self._session_model[session_id] = model_name
+
+    def model_for_session(self, session_id: str) -> str | None:
+        """The model a public session belongs to, or None if the session is unknown here."""
+        with self._lock:
+            return self._session_model.get(session_id)
+
+    def charge_step(self, session_id: str) -> None:
+        """Count one step against the global and per-session ceilings, or refuse at the limit.
+
+        Charged BEFORE the model call so a refused step never spends anything.
+        """
+        with self._lock:
+            if session_id not in self._session_steps:
+                raise PublicPlayLimitError("Unknown or expired public session.")
+            if self._total_steps >= self._limits.max_total_steps:
+                raise PublicPlayLimitError(
+                    "The public demo has reached its usage limit. Log in to keep playing."
+                )
+            if self._session_steps[session_id] >= self._limits.max_steps_per_session:
+                raise PublicPlayLimitError(
+                    "This session has reached the public step limit. Log in to keep playing."
+                )
+            self._total_steps += 1
+            self._session_steps[session_id] += 1
+
+    def snapshot(self) -> dict[str, int]:
+        """Current counters, for observability and tests."""
+        with self._lock:
+            return {
+                "total_steps": self._total_steps,
+                "sessions_opened": self._sessions_opened,
+                "max_total_steps": self._limits.max_total_steps,
+            }

--- a/wmh/serving/public_play_test.py
+++ b/wmh/serving/public_play_test.py
@@ -1,0 +1,48 @@
+import pytest
+
+from wmh.serving.public_play import (
+    PublicPlayLimiter,
+    PublicPlayLimitError,
+    PublicPlayLimits,
+)
+
+
+def test_charges_steps_against_global_ceiling() -> None:
+    limiter = PublicPlayLimiter(PublicPlayLimits(max_total_steps=2, max_steps_per_session=10))
+    limiter.open_session("m", "s1")
+    limiter.charge_step("s1")
+    limiter.charge_step("s1")
+    with pytest.raises(PublicPlayLimitError):
+        limiter.charge_step("s1")
+    assert limiter.snapshot()["total_steps"] == 2
+
+
+def test_per_session_step_cap_is_independent() -> None:
+    limiter = PublicPlayLimiter(PublicPlayLimits(max_total_steps=100, max_steps_per_session=1))
+    limiter.open_session("m", "s1")
+    limiter.open_session("m", "s2")
+    limiter.charge_step("s1")
+    with pytest.raises(PublicPlayLimitError):
+        limiter.charge_step("s1")
+    # A different session still has its own budget.
+    limiter.charge_step("s2")
+
+
+def test_session_ceiling() -> None:
+    limiter = PublicPlayLimiter(PublicPlayLimits(max_sessions=1))
+    limiter.open_session("m", "s1")
+    with pytest.raises(PublicPlayLimitError):
+        limiter.open_session("m", "s2")
+
+
+def test_unknown_session_is_refused() -> None:
+    limiter = PublicPlayLimiter()
+    with pytest.raises(PublicPlayLimitError):
+        limiter.charge_step("nope")
+
+
+def test_model_for_session_roundtrips() -> None:
+    limiter = PublicPlayLimiter()
+    limiter.open_session("tau-bench", "s1")
+    assert limiter.model_for_session("s1") == "tau-bench"
+    assert limiter.model_for_session("missing") is None

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -33,6 +33,7 @@ from wmh.engine.loader import load_world_model
 from wmh.engine.world_model import WorldModel
 from wmh.optimize.reward import EpisodeScore
 from wmh.serving.builds import BuildManager, BuildRouteRequest, BuildSnapshot
+from wmh.serving.public_play import PublicPlayLimiter, PublicPlayLimitError
 from wmh.serving.traces_source import (
     TRACES_FILENAME,
     TracesDownloader,
@@ -184,6 +185,7 @@ def create_app(
     cards: dict[str, ModelCard | None] | None = None,
     build_manager: BuildManager | None = None,
     max_fidelity: bool = False,
+    public_play: PublicPlayLimiter | None = None,
 ) -> FastAPI:
     """Build the FastAPI app serving one or more named WorldModels.
 
@@ -375,6 +377,43 @@ def create_app(
     def step(world_model_name: str, session_id: str, req: StepRequest) -> StepResponse:
         wm = _model_or_404(world_model_name)
         _session_or_404(wm, session_id)
+        observation = wm.step(session_id, req.action)
+        return StepResponse(observation=observation, state=wm.get_session(session_id).state)
+
+    # -- public (anonymous) play -------------------------------------------------------------------
+    # A logged-out visitor can step a public model live. These routes exist only when the server is
+    # started with --public-play; a shared limiter caps total steps (bounding spend), per-session
+    # steps, and session count, returning 429 at the ceiling. Sessions are unenriched so anonymous
+    # play never feeds the shared retrieval buffer.
+    def _public_or_404() -> PublicPlayLimiter:
+        if public_play is None:
+            raise HTTPException(status_code=404, detail="public play is not enabled on this server")
+        return public_play
+
+    @app.post("/public/world_models/{world_model_name}/sessions", response_model=NewSessionResponse)
+    def public_new_session(world_model_name: str, req: NewSessionRequest) -> NewSessionResponse:
+        limiter = _public_or_404()
+        wm = _model_or_404(world_model_name)
+        session = wm.new_session(task=req.task, seed_state=req.seed_state, enrich=False)
+        try:
+            limiter.open_session(world_model_name, session.id)
+        except PublicPlayLimitError as exc:
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
+        return NewSessionResponse(session_id=session.id, state=session.state)
+
+    @app.post("/public/sessions/{session_id}/step", response_model=StepResponse)
+    def public_step(session_id: str, req: StepRequest) -> StepResponse:
+        limiter = _public_or_404()
+        name = limiter.model_for_session(session_id)
+        if name is None:
+            raise HTTPException(status_code=404, detail="unknown or expired public session")
+        wm = _model_or_404(name)
+        _session_or_404(wm, session_id)
+        try:
+            # Charged before the model call, so a refused step spends nothing.
+            limiter.charge_step(session_id)
+        except PublicPlayLimitError as exc:
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         observation = wm.step(session_id, req.action)
         return StepResponse(observation=observation, state=wm.get_session(session_id).state)
 

--- a/wmh/serving/server_test.py
+++ b/wmh/serving/server_test.py
@@ -14,6 +14,7 @@ from wmh.engine.world_model import WorldModel
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 from wmh.serving.builds import BuildManager
+from wmh.serving.public_play import PublicPlayLimiter, PublicPlayLimits
 from wmh.serving.server import _load_card_or_none, create_app, resolve_model_dirs
 
 
@@ -381,3 +382,45 @@ def test_traces_downloadable_when_card_declares_hub_source() -> None:
 def test_download_traces_400_without_source() -> None:
     resp = _client().post("/world_models/airline/traces/download")
     assert resp.status_code == 400
+
+
+def _public_client(limiter: PublicPlayLimiter) -> TestClient:
+    return TestClient(create_app(world_models={"airline": _world_model()}, public_play=limiter))
+
+
+def _message(text: str) -> dict:
+    return {"action": {"kind": "message", "content": text}}
+
+
+def test_public_play_disabled_returns_404() -> None:
+    # No limiter -> the /public routes do not serve.
+    resp = _client().post("/public/world_models/airline/sessions", json={})
+    assert resp.status_code == 404
+
+
+def test_public_play_session_and_step() -> None:
+    client = _public_client(PublicPlayLimiter(PublicPlayLimits(max_total_steps=5)))
+    session_id = client.post("/public/world_models/airline/sessions", json={}).json()["session_id"]
+    resp = client.post(f"/public/sessions/{session_id}/step", json=_message("hello"))
+    assert resp.status_code == 200
+    assert resp.json()["observation"]["content"] == "user found"
+
+
+def test_public_play_step_ceiling_returns_429() -> None:
+    client = _public_client(PublicPlayLimiter(PublicPlayLimits(max_total_steps=1)))
+    session_id = client.post("/public/world_models/airline/sessions", json={}).json()["session_id"]
+    assert client.post(f"/public/sessions/{session_id}/step", json=_message("a")).status_code == 200
+    capped = client.post(f"/public/sessions/{session_id}/step", json=_message("b"))
+    assert capped.status_code == 429
+
+
+def test_public_play_unknown_session_returns_404() -> None:
+    client = _public_client(PublicPlayLimiter())
+    resp = client.post("/public/sessions/nope/step", json=_message("a"))
+    assert resp.status_code == 404
+
+
+def test_public_play_session_ceiling_returns_429() -> None:
+    client = _public_client(PublicPlayLimiter(PublicPlayLimits(max_sessions=1)))
+    assert client.post("/public/world_models/airline/sessions", json={}).status_code == 200
+    assert client.post("/public/world_models/airline/sessions", json={}).status_code == 429


### PR DESCRIPTION
## What

The backend half of the platform's unauthenticated world-model catalog. Two additions to the wmh (engine/backend) side that the platform frontend connects to.

### Public (anonymous) play on `wmh serve`
Logged-out visitors can step a public model live. That spends real provider tokens with no account behind it, so it runs through a limiter (`wmh/serving/public_play.py`):
- a **global step ceiling** that bounds total spend deterministically (each step is at most one model call),
- a **per-session step cap**, and a **session-count cap**.

Enabled with `wmh serve --public-play [--public-max-steps N]`, which adds capped routes `POST /public/world_models/{name}/sessions` and `POST /public/sessions/{id}/step` (unenriched sessions; typed refusal -> HTTP 429). Without the flag the routes 404. The platform proxies these for anon play.

### Catalog replay precompute
`packages/environment-capture/scripts/precompute_public_scenarios.py` samples each public model's indexed steps and runs `step_open_loop` to record action + golden observation vs the model's predicted observation, plus a few suggested actions. Run once; the output is vendored into the platform build so replays never recompute. Headline fidelity shown in the UI stays the model's official held-out score (from its card), never the self-retrieval number.

## Verification

- `ruff check .` + `ruff format --check` clean; `ty check` clean on the diff (one pre-existing unrelated diagnostic in `app_test.py`).
- `pytest wmh/serving wmh/cli` -> 281 passed. New tests: limiter ceilings, and serving routes (session, step, per-session/global 429 ceilings, disabled -> 404).
- **Live**: `wmh serve --public-play --public-max-steps 2` -> open session -> step (200, real Bedrock observation) -> step (200) -> step (429 at the ceiling).

Pairs with the platform PR that adds the anon proxy routes + the catalog UI.