### PR TITLE
fix(environment-capture): properly kill orphaned child processes on ex…

### DIFF
--- a/packages/environment-capture/environment_capture/localexec.py
+++ b/packages/environment-capture/environment_capture/localexec.py
@@ -92,6 +92,10 @@ class LocalBashEnv:
         if self.contain and command_targets_host(command):
             return ExecResult(output=_BLOCKED_MESSAGE, returncode=1)
         try:
+            kwargs = {}
+            if os.name == "posix":
+                kwargs["start_new_session"] = True
+                
             process = subprocess.Popen(
                 ["bash", "-c", command],
                 cwd=self.workspace,
@@ -100,16 +104,19 @@ class LocalBashEnv:
                 text=True,
                 errors="replace",  # binary output becomes a real observation, not a crash
                 env=_scrubbed_env(),  # never expose the capture process's provider credentials
-                start_new_session=True,
+                **kwargs
             )
             stdout, stderr = process.communicate(timeout=self.timeout_s)
             returncode = process.returncode
         except subprocess.TimeoutExpired:
             if os.name == "posix":
-                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                os.killpg(process.pid, signal.SIGKILL)
             else:
                 subprocess.run(["taskkill", "/F", "/T", "/PID", str(process.pid)], capture_output=True)
-            process.communicate()
+            try:
+                process.communicate(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
             return ExecResult(
                 output=f"command timed out after {self.timeout_s}s",
                 returncode=_TIMEOUT_RETURNCODE,

--- a/packages/environment-capture/environment_capture/localexec.py
+++ b/packages/environment-capture/environment_capture/localexec.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 from pathlib import Path
@@ -91,24 +92,32 @@ class LocalBashEnv:
         if self.contain and command_targets_host(command):
             return ExecResult(output=_BLOCKED_MESSAGE, returncode=1)
         try:
-            completed = subprocess.run(
+            process = subprocess.Popen(
                 ["bash", "-c", command],
                 cwd=self.workspace,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
                 errors="replace",  # binary output becomes a real observation, not a crash
-                timeout=self.timeout_s,
                 env=_scrubbed_env(),  # never expose the capture process's provider credentials
+                start_new_session=True,
             )
+            stdout, stderr = process.communicate(timeout=self.timeout_s)
+            returncode = process.returncode
         except subprocess.TimeoutExpired:
+            if os.name == "posix":
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            else:
+                subprocess.run(["taskkill", "/F", "/T", "/PID", str(process.pid)], capture_output=True)
+            process.communicate()
             return ExecResult(
                 output=f"command timed out after {self.timeout_s}s",
                 returncode=_TIMEOUT_RETURNCODE,
             )
-        output = completed.stdout
-        if completed.stderr:
-            output = f"{output}{completed.stderr}" if output else completed.stderr
-        return ExecResult(output=output.rstrip("\n"), returncode=completed.returncode)
+        output = stdout
+        if stderr:
+            output = f"{output}{stderr}" if output else stderr
+        return ExecResult(output=output.rstrip("\n"), returncode=returncode)
 
     def close(self) -> None:
         if self._cleanup:

--- a/packages/environment-capture/environment_capture/localexec_test.py
+++ b/packages/environment-capture/environment_capture/localexec_test.py
@@ -40,6 +40,32 @@ def test_timeout_returns_error_result(tmp_path: Path) -> None:
         env.close()
 
 
+def test_timeout_kills_orphaned_child_processes(tmp_path: Path) -> None:
+    """A command that times out must not leave orphaned child processes running in the background."""
+    env = LocalBashEnv(workspace=tmp_path, timeout_s=1)
+    script = tmp_path / "spin.py"
+    script.write_text(
+        "import time\n"
+        "while True:\n"
+        "    with open('ping.txt', 'a') as f: f.write('x\\n')\n"
+        "    time.sleep(0.1)\n"
+    )
+    try:
+        result = env.execute("python spin.py")
+        assert result.returncode != 0
+        assert "timed out" in result.output
+        
+        # Verify the background process is dead by checking if ping.txt stops growing.
+        import time
+        ping_file = tmp_path / "ping.txt"
+        size_before = ping_file.stat().st_size if ping_file.exists() else 0
+        time.sleep(0.4)
+        size_after = ping_file.stat().st_size if ping_file.exists() else 0
+        assert size_before == size_after, "Background process is still running and writing to file!"
+    finally:
+        env.close()
+
+
 def test_state_does_not_leak_between_commands(tmp_path: Path) -> None:
     (tmp_path / "sub").mkdir()
     env = LocalBashEnv(workspace=tmp_path)


### PR DESCRIPTION
Fixes #168
## Summary

Fixes a critical issue in LocalBashEnv where execution timeouts leaked orphaned child processes into the host system.

## Description

Previously, LocalBashEnv.execute() used subprocess.run(timeout=...) to bound agent execution time. When a timeout triggered, Python would send a SIGKILL to the direct child process (bash). However, bash does not propagate SIGKILL to its running children, meaning any long-running tasks or infinite loops spawned by the agent (e.g., python server.py, sleep 1000) became orphaned and ran indefinitely in the background. In benchmark suites, this caused rapid resource exhaustion and port collisions (e.g., Address already in use).

This PR fixes the issue by managing the process group directly:

- Replaced subprocess.run with subprocess.Popen and start_new_session=True to place the execution in a new process group.
- On TimeoutExpired, we now forcefully terminate the entire process tree using os.killpg on POSIX systems, or taskkill /F /T as a fallback for Windows native environments.
- Handled standard pipes manually to preserve the original unified stdout/stderr output format.

## Checklist

- [x] Tested that sleep 100 correctly terminates the entire process tree on timeout.
- [x] Added cross-platform process group cleanup (POSIX + Windows).