### PR TITLE
fix(engine): prevent trace state corruption by deep copying seed_state

### DIFF
--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -183,9 +183,9 @@ class WorldModel:
         required for evaluation rollouts, whose PREDICTED observations must not become demos for
         later rollouts (order-dependent, self-reinforcing scores otherwise)."""
         session = Session(
-            id=uuid.uuid4().hex, 
-            task=task, 
-            state=seed_state.model_copy(deep=True) if seed_state else EnvState(), 
+            id=uuid.uuid4().hex,
+            task=task,
+            state=seed_state.model_copy(deep=True) if seed_state else EnvState(),
             enrich=enrich
         )
         self._sessions[session.id] = session

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -183,7 +183,10 @@ class WorldModel:
         required for evaluation rollouts, whose PREDICTED observations must not become demos for
         later rollouts (order-dependent, self-reinforcing scores otherwise)."""
         session = Session(
-            id=uuid.uuid4().hex, task=task, state=seed_state or EnvState(), enrich=enrich
+            id=uuid.uuid4().hex, 
+            task=task, 
+            state=seed_state.model_copy(deep=True) if seed_state else EnvState(), 
+            enrich=enrich
         )
         self._sessions[session.id] = session
         tracker = RunTracker(run_id=session.id, kind="serve")

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -35,6 +35,24 @@ def test_world_model_new_session_works() -> None:
     assert WorldModel.get_session(wm, session.id) is session
 
 
+def test_new_session_seed_state_is_isolated() -> None:
+    """AGENTS.md Rule 10: Mutating the session state must not leak back into the original seed."""
+    wm = WorldModel.__new__(WorldModel)
+    wm._telemetry_root = Path(".wmh")
+    wm._sessions = {}
+    wm._trackers = {}
+    
+    seed = EnvState(scratchpad="original")
+    session = WorldModel.new_session(wm, task="hi", seed_state=seed)
+    
+    # Mutate the session state directly (simulating _update_state)
+    session.state.scratchpad += " + mutated"
+    
+    # Original seed must be unchanged
+    assert seed.scratchpad == "original"
+    assert session.state.scratchpad == "original + mutated"
+
+
 class FakeProvider:
     """Returns a canned world-model JSON completion; captures the last prompt for assertions."""
 


### PR DESCRIPTION
Fixes #169
# Description

## Summary

Fixes a critical issue in WorldModel.new_session where seeding a session with an existing state caused in-place mutations to leak back into the original trace object in memory.

## Description

In wmh/engine/world_model.py, the new_session method accepts an optional seed_state (an EnvState Pydantic model) and assigns it directly to the new session's state. Because Pydantic does not deep-copy the object during direct assignment, session.state holds a shared reference to the passed seed_state (which typically comes from a trace loaded into memory, e.g., trace.steps[0].state_before).

As the session advances, _update_state mutates session.state in-place (appending notes to the scratchpad or updating the profile). Because of the shared reference, this permanently corrupted the in-memory golden trace object. If an evaluation loops over the same trace multiple times, subsequent evaluations would start with a polluted initial state containing the accumulated scratchpad notes from previous runs, destroying episode isolation.

This PR fixes the issue by explicitly deep-copying the seed state before assigning it to the session using `seed_state.model_copy(deep=True)`.

## Checklist

- [x] Ensure session.state holds an independent deep copy of seed_state.
- [x] Prevented cross-episode state leakage and trace object pollution.