### PR TITLE
Add [models.agent] role so harness search can target a distinct agent

### DIFF
--- a/docs/reference/closed_loop.md
+++ b/docs/reference/closed_loop.md
@@ -16,11 +16,27 @@ wmh eval tasks.jsonl --mode closed-loop --name <world-model> --k 3 --out sim_rep
 - `tasks.jsonl` — one task per line: `{"task_id": ..., "instruction": ..., "gold": ["...", ...]}`.
   `gold` is a list of plain-English assertions that define success (post-conditions on the final
   state, checked semantically).
-- The **agent is fixed** (a minimal 4-tool loop: `bash`, `read_file`, `write_file`, `submit`) so any
-  score movement is attributable to the world model, not the agent.
+- The agent scaffold is fixed for a run. Without `--harness`, it is a minimal 4-tool loop:
+  `bash`, `read_file`, `write_file`, and `submit`. Pass `--harness <name>[@ref]` to evaluate a
+  stored harness version.
+- By default, the agent and world model share a provider. Configure `[models.agent]` in
+  `.wmh/settings.toml` to evaluate with a distinct agent provider. `wmh harness create` and the
+  reproduction command it prints resolve the same role.
 - Every task runs **k=3 passes** (the repo's eval-reporting convention); the score is the fraction of
   passes whose transcript satisfies every gold assertion, judged by an LLM judge that never trusts
   the agent's own claim of success.
+
+For example, a self-hosted OpenAI-compatible agent can be pinned independently of the world model:
+
+```toml
+[models.agent]
+provider = "openai"
+model = "Qwen/Qwen3.5-9B"
+endpoint = "http://127.0.0.1:8002/v1"
+```
+
+The configured provider kind and model are included in the saved report label. Keep the full
+settings file with experiment artifacts when endpoint or deployment identity matters.
 
 ## Comparing two reports (`wmh eval agreement`)
 

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -885,9 +885,10 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     - `wmh eval <trace files...>`: ad hoc replay scoring (open-loop, teacher-forced — the
       default mode).
     - `wmh eval <tasks.jsonl> --mode closed-loop`: a live agent runs tasks WITH the world model
-      as its environment; `--harness-backend e2b` moves the pi-node harness process into pooled
-      E2B sandboxes (the env stays the world model, all cells in parallel); score task success
-      against gold assertions (see docs/reference/closed_loop.md).
+      as its environment. `[models.agent]` selects a distinct agent provider when configured;
+      otherwise the agent shares the world model's provider. `--harness-backend e2b` moves the
+      pi-node harness process into pooled E2B sandboxes while the environment stays the world
+      model. Score task success against gold assertions (see docs/reference/closed_loop.md).
     - `wmh eval list`: list named suites under `examples/<task>/evals/`.
     - `wmh eval run <suite>`: run a suite and save a local JSON result.
     - `wmh eval results optional-suite`: summarize local suite results.

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -781,7 +781,7 @@ def test_download_multi_skips_a_404_and_fetches_the_rest(monkeypatch, tmp_path: 
 
     def fetch(name, force=False, on_progress=None):  # noqa: ANN001, ANN202
         if name == "broken":
-            raise urllib.error.HTTPError("https://hub/x", 404, "nf", None, None)  # type: ignore[arg-type]
+            raise urllib.error.HTTPError("https://hub/x", 404, "nf", None, None)  # ty: ignore[invalid-argument-type]
         fetched.append(name)
         return tmp_path
 

--- a/wmh/cli/eval_closed_loop.py
+++ b/wmh/cli/eval_closed_loop.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from wmh.cli.model_roles import resolve_opt_in_model_provider
 from wmh.config import WorldModelStore
 from wmh.engine import load_world_model
 from wmh.evals.agreement import compute_agreement
@@ -45,7 +46,9 @@ def run_closed_loop(
     `--harness <name>[@ref]` runs a stored harness version (ref = version or alias; default is
     the champion alias); without it the built-in baseline loop runs. `max_turns=None` means "the
     harness's own cap" (or the default for the baseline); an explicit value overrides either —
-    never silently ignored. The environment is ALWAYS the world-model simulation;
+    never silently ignored. `[models.agent]` selects the agent model for either path; when unset,
+    the agent shares the world model's provider. The environment is ALWAYS the world-model
+    simulation;
     `--harness-backend e2b` only moves the pi-node harness PROCESS into pooled E2B sandboxes
     (tool calls stay answered by the world model host-side), running all (task, attempt) cells
     at once unless `--eval-concurrency` caps them.
@@ -65,6 +68,7 @@ def run_closed_loop(
     except (FileNotFoundError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
     world_model, provider = load_world_model(model_dir)
+    agent_provider, agent_model = resolve_opt_in_model_provider(root, "agent", provider)
 
     loaded_harness = _load_harness(harness, root)
     if loaded_harness is None and harness_backend == "e2b":
@@ -77,13 +81,22 @@ def run_closed_loop(
         if loaded_harness is not None
         else "baseline"
     )
+    agent_identity = (
+        f"{agent_provider.config.kind.value}:{agent_model}" if agent_model is not None else None
+    )
+    report_agent_label = (
+        f"{agent_label}[agent={agent_identity}]" if agent_identity is not None else agent_label
+    )
+    agent_note = (
+        f" using agent model [bold]{agent_identity}[/bold]" if agent_identity is not None else ""
+    )
     versus = (
         f"world model [bold]{model_dir.name}[/bold]"
         if harness_backend == "local"
         else f"world model [bold]{model_dir.name}[/bold] (pi harness in pooled E2B sandboxes)"
     )
     console.print(
-        f"closed-loop: harness [bold]{agent_label}[/bold] vs {versus} "
+        f"closed-loop: harness [bold]{agent_label}[/bold]{agent_note} vs {versus} "
         f"on {len(tasks)} task(s), k={k}…"
     )
 
@@ -112,21 +125,21 @@ def run_closed_loop(
             loaded_harness = _with_max_turns(loaded_harness, max_turns)
         try:
             runtime = loaded_harness.runtime(
-                provider,
+                agent_provider,
                 backend=harness_backend,
                 e2b_template=e2b_template,
             )
         except ValueError as exc:  # e.g. e2b on a non-pi-node harness -> usage error
             raise typer.BadParameter(str(exc)) from exc
     else:
-        runtime = AgentRuntime(provider, max_turns=max_turns or DEFAULT_MAX_TURNS)
+        runtime = AgentRuntime(agent_provider, max_turns=max_turns or DEFAULT_MAX_TURNS)
     try:
         evaluation = ClosedLoopEval(
             tasks,
             world_model,
-            provider,
+            agent_provider,
             GoldJudge(provider),
-            label=f"{agent_label}@{model_dir.name}",
+            label=f"{report_agent_label}@{model_dir.name}",
             k=k,
             concurrency=(
                 eval_concurrency

--- a/wmh/cli/eval_closed_loop_test.py
+++ b/wmh/cli/eval_closed_loop_test.py
@@ -15,16 +15,18 @@ import pytest
 from typer.testing import CliRunner, Result
 
 from wmh.cli import app
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
 from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
 from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.doc import RUNTIME_KIND_ID, TOOL_POLICY_ID, HarnessDoc, Surface, SurfaceKind
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.pi_e2b import E2BPiRuntime
-from wmh.harness.runtime import RunResult, Runtime
+from wmh.harness.runtime import AgentRuntime, RunResult, Runtime
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 eval_cl_module = importlib.import_module("wmh.cli.eval_closed_loop")
+model_roles_module = importlib.import_module("wmh.cli.model_roles")
 
 runner = CliRunner()
 
@@ -34,7 +36,8 @@ _Progress = Callable[[str, int, GoldVerdict], None] | None
 class _Provider:
     """A do-nothing provider: scoring is faked, so no LLM role is ever exercised."""
 
-    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
+    def __init__(self, config: ProviderConfig | None = None) -> None:
+        self.config = config or ProviderConfig(kind=ProviderKind.BEDROCK, model="m")
 
     def complete(self, system: str, messages: list[Message], **kw: object) -> Completion:
         raise NotImplementedError
@@ -101,13 +104,14 @@ def _invoke(tmp_path: Path, *extra: str) -> Result:
 def _patch_seams(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> object:
     """Fake the world-model store/loader and `ClosedLoopEval`, recording the eval's wiring."""
     wm = object()
+    world_provider = _Provider()
 
     class _FakeEval:
         def __init__(
             self,
             tasks: list[TaskSpec],
             world_model: object,
-            provider: object,
+            agent_provider: object,
             judge: GoldJudge,
             *,
             label: str,
@@ -119,6 +123,7 @@ def _patch_seams(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> ob
             seen.update(
                 {
                     "world_model": world_model,
+                    "agent_provider": agent_provider,
                     "label": label,
                     "concurrency": concurrency,
                     "runtime": runtime,
@@ -131,8 +136,9 @@ def _patch_seams(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> ob
             return _report(self._label, self._k)
 
     monkeypatch.setattr(eval_cl_module, "WorldModelStore", _FakeStore)
-    monkeypatch.setattr(eval_cl_module, "load_world_model", lambda d: (wm, _Provider()))
+    monkeypatch.setattr(eval_cl_module, "load_world_model", lambda d: (wm, world_provider))
     monkeypatch.setattr(eval_cl_module, "ClosedLoopEval", _FakeEval)
+    seen["world_provider"] = world_provider
     return wm
 
 
@@ -146,11 +152,58 @@ def test_eval_local_default_scores_the_world_model_sequentially(
 
     assert result.exit_code == 0, result.output
     assert seen["world_model"] is wm
+    assert seen["agent_provider"] is seen["world_provider"]
+    runtime = seen["runtime"]
+    assert isinstance(runtime, AgentRuntime)
+    assert runtime._provider is seen["world_provider"]
     assert seen["label"] == "baseline@wm-alpha"  # the label always names the model
     assert seen["concurrency"] == 1  # local default: the sequential loop, unchanged
     flat = " ".join(result.output.split())
     assert "world model" in flat and "wm-alpha" in flat
     assert "OVERALL" in result.output
+
+
+def test_eval_agent_role_from_settings_drives_the_agent_under_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`[models.agent]` must survive the create-to-eval reproduction path."""
+    seen: dict[str, object] = {}
+    _patch_seams(monkeypatch, seen)
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                agent=ModelRole(
+                    provider="openai",
+                    model="Qwen/Qwen3.5-9B",
+                    endpoint="http://127.0.0.1:8002/v1",
+                )
+            )
+        ),
+        tmp_path / ".wmh",
+    )
+    agent_sentinel = _Provider(
+        ProviderConfig(
+            kind=ProviderKind.OPENAI,
+            model="Qwen/Qwen3.5-9B",
+            endpoint="http://127.0.0.1:8002/v1",
+        )
+    )
+
+    def fake_get_provider(_config: ProviderConfig) -> _Provider:
+        return agent_sentinel
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
+
+    result = _invoke(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    assert seen["agent_provider"] is agent_sentinel
+    runtime = seen["runtime"]
+    assert isinstance(runtime, AgentRuntime)
+    assert runtime._provider is agent_sentinel
+    assert seen["label"] == "baseline[agent=openai:Qwen/Qwen3.5-9B]@wm-alpha"
+    flat = " ".join(result.output.split())
+    assert "agent model openai:Qwen/Qwen3.5-9B" in flat
 
 
 def test_eval_always_requires_a_world_model(tmp_path: Path) -> None:

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -6,20 +6,22 @@ default). `init` writes the baseline as v1; `list`/`show` inspect what exists; `
 for a better harness by **inverting the world model** — delta variants are scored closed-loop
 against it and gated on non-regression, so the environment model the traces built now steers what
 the agent's scaffold should be. Run one closed-loop with
-`wmh eval closed-loop <tasks> --harness <name>[@ref]`.
+`wmh eval <tasks> --mode closed-loop --harness <name>[@ref]`.
 """
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
+from wmh.cli.model_roles import resolve_opt_in_model_provider
 from wmh.config import ARTIFACT_DIR, WorldModelStore
-from wmh.config.settings import load_settings
 from wmh.config.store import validate_name
 from wmh.engine import load_world_model
 from wmh.engine.world_model import WorldModel
@@ -30,8 +32,7 @@ from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
 from wmh.harness.proposer import ProviderDeltaProposer
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
-from wmh.providers.base import Provider, ProviderConfig, ProviderKind
-from wmh.providers.registry import get_provider
+from wmh.providers.base import Provider
 
 harness_app = typer.Typer(
     help="Named, versioned agent harnesses (.wmh/harnesses): create, init, list, show.",
@@ -152,13 +153,14 @@ def create(
     An LLM meta-agent proposes typed deltas against the harness document (surface-keyed ops with
     preconditions), each applied child is scored closed-loop (k passes per task) and gated on
     non-regression (regression suite, then full split, then the optional held-out split). The
-    The proposer's model resolves from `.wmh/settings.toml` `[models.meta]` when set (pick a
-    long-context, long-output model; a proposal carries whole replacement surfaces), and falls
-    back to the world model's provider otherwise. The
-    environment is ALWAYS the world-model simulation; `--harness-backend` only picks where the
-    harness PROCESS runs: `local` (the default) keeps it in/from this process, `e2b` runs the
-    real pi agent inside pooled E2B sandboxes (pi-node seeds only), its tool calls still answered
-    by the world model host-side — all (task, attempt) cells in parallel unless
+    agent-under-test resolves from `.wmh/settings.toml` `[models.agent]` when set and otherwise
+    uses the world model's provider. The proposer's model resolves from `[models.meta]` when set;
+    use a long-context, long-output model because a proposal carries whole replacement surfaces.
+    Otherwise the proposer also uses the world model's provider. The environment is ALWAYS the
+    world-model simulation; `--harness-backend` only picks where the harness PROCESS runs:
+    `local` (the default) keeps it in/from this process, `e2b` runs the real pi agent inside
+    pooled E2B sandboxes (pi-node seeds only), its tool calls still answered by the world model
+    host-side, with all (task, attempt) cells in parallel unless
     --eval-concurrency caps them. The champion is saved as a new immutable version with the
     `champion` alias. Interactive at a TTY: missing inputs are prompted for (the backend stays
     flag-only).
@@ -194,7 +196,8 @@ def create(
     seed_doc = _resolve_seed(store, seed)
     # The world model IS the environment on every backend, so it is always required.
     world_model, provider, model_name = _load_world_model(model, root)
-    meta_provider, meta_model = _meta_provider_from_settings(root, provider)
+    meta_provider, meta_model = resolve_opt_in_model_provider(root, "meta", provider)
+    agent_provider, agent_model = resolve_opt_in_model_provider(root, "agent", provider)
 
     candidate_count = iterations * proposal_batch_size
     rollouts = (candidate_count + 1) * k * len(tasks)
@@ -209,12 +212,17 @@ def create(
     meta_note = (
         f" (proposer: {meta_model} from settings models.meta)" if meta_model is not None else ""
     )
+    agent_note = (
+        f" (agent-under-test: {agent_model} from settings models.agent)"
+        if agent_model is not None
+        else ""
+    )
     _console.print(
         f"searching from [bold]{seed_doc.name}[/bold] against world model "
         f"[bold]{model_name}[/bold]: {iterations} iteration(s), "
         f"{proposal_batch_size} proposal(s)/iteration, k={k}, {len(tasks)} task(s) "
         f"-> up to ~{rollouts} rollouts{holdout_note} + {candidate_count} proposals"
-        f"{meta_note}{backend_note}"
+        f"{meta_note}{agent_note}{backend_note}"
     )
     if interactive and not yes and not Confirm.ask("Proceed?", default=True):
         raise typer.Exit(0)
@@ -255,7 +263,7 @@ def create(
         seed_doc,
         tasks,
         world_model,
-        provider,
+        agent_provider,
         ProviderDeltaProposer(meta_provider),
         GoldJudge(provider),
         iterations=iterations,
@@ -276,9 +284,30 @@ def create(
         f"success_rate={result.best_score:.3f}: {len(result.archive.deltas)} delta(s) audited, "
         f"{selected} selected, {result.skipped} skipped -> {store.dir_for(name)}"
     )
-    backend_hint = " --harness-backend e2b" if harness_backend == "e2b" else ""
+    run_argv = [
+        "wmh",
+        "eval",
+        tasks_file,
+        "--mode",
+        "closed-loop",
+        "--name",
+        model_name,
+        "--root",
+        root,
+        "--k",
+        str(k),
+        "--harness",
+        f"{name}@{saved.version}",
+    ]
+    if harness_backend == "e2b":
+        run_argv.extend(("--harness-backend", "e2b"))
+    if eval_concurrency is not None:
+        run_argv.extend(("--eval-concurrency", str(eval_concurrency)))
+    if harness_backend == "e2b" and e2b_template is not None:
+        run_argv.extend(("--e2b-template", e2b_template))
     _console.print(
-        f"  run it: [bold]wmh eval closed-loop {tasks_file} --harness {name}{backend_hint}[/bold]"
+        f"  run it: [bold]{escape(shlex.join(run_argv))}[/bold]",
+        soft_wrap=True,
     )
     if archive_out:
         Path(archive_out).write_text(result.archive.model_dump_json(indent=2), encoding="utf-8")
@@ -300,47 +329,6 @@ def _resolve_seed(store: HarnessStore, seed: str | None) -> HarnessDoc:
         return store.load(base, ref or None)
     except (FileNotFoundError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc
-
-
-# Azure OpenAI chat completions need an API version on every call; when the meta role
-# does not pin one in settings, this current stable version applies (override with
-# `api_version` under [models.meta]).
-_DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
-
-
-def _meta_provider_from_settings(root: str, fallback: Provider) -> tuple[Provider, str | None]:
-    """The delta proposer's provider: `[models.meta]` from settings, else the fallback.
-
-    The meta role is opt-in (see `ModelsSettings.resolve`): users who want a specific
-    long-context proposer set it in `.wmh/settings.toml`; everyone else keeps the world
-    model's provider, the pre-roles behavior. Returns the provider plus the configured model
-    name (None when falling back) for the run banner.
-    """
-    configured = load_settings(root).models.resolve("meta")
-    if configured is None:
-        return fallback, None
-    try:
-        kind = ProviderKind(configured.provider)
-    except ValueError:
-        kinds = ", ".join(k.value for k in ProviderKind)
-        raise typer.BadParameter(
-            f"settings [models.meta] has unknown provider {configured.provider!r}; "
-            f"choose one of: {kinds}"
-        ) from None
-    api_version = configured.api_version
-    if api_version is None and kind is ProviderKind.AZURE_OPENAI:
-        # The Azure provider refuses to run without one; a bare [models.meta] azure entry
-        # must still produce usable proposals, not a proposer error every iteration.
-        api_version = _DEFAULT_AZURE_API_VERSION
-    config = ProviderConfig(
-        kind=kind,
-        model=configured.model,
-        region=configured.region,
-        endpoint=configured.endpoint,
-        deployment=configured.deployment,
-        api_version=api_version,
-    )
-    return get_provider(config), configured.model
 
 
 def _load_world_model(name: str | None, root: str) -> tuple[WorldModel, Provider, str]:
@@ -373,4 +361,6 @@ def init_harness(
     _console.print(
         f"[green]wrote[/green] {name} v{doc.version} (champion) -> {store.dir_for(name)}"
     )
-    _console.print(f"run it: [bold]wmh eval closed-loop <tasks.jsonl> --harness {name}[/bold]")
+    _console.print(
+        f"run it: [bold]wmh eval <tasks.jsonl> --mode closed-loop --harness {name}[/bold]"
+    )

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -9,6 +9,7 @@ advertises. Flag validation, task loading, and the harness store are real.
 from __future__ import annotations
 
 import importlib
+import shlex
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 # The Typer object `harness_app` shadows the submodule name on plain attribute access; go
 # through importlib to monkeypatch module globals (same pattern as app_test.py).
 harness_app_module = importlib.import_module("wmh.cli.harness_app")
+model_roles_module = importlib.import_module("wmh.cli.model_roles")
 
 runner = CliRunner()
 
@@ -146,19 +148,45 @@ def test_create_e2b_wires_backend_flags_and_still_loads_the_world_model(
     assert "9 rollouts" in flat
     assert "pooled E2B sandboxes" in flat
     assert "world model" in flat and "wm-alpha" in flat
-    assert "--harness-backend e2b" in flat  # the run-it hint carries the backend through
+    expected = shlex.join(
+        [
+            "wmh",
+            "eval",
+            _tasks_file(tmp_path),
+            "--mode",
+            "closed-loop",
+            "--name",
+            "wm-alpha",
+            "--root",
+            str(tmp_path / ".wmh"),
+            "--k",
+            "3",
+            "--harness",
+            "made@1",
+            "--harness-backend",
+            "e2b",
+            "--eval-concurrency",
+            "4",
+            "--e2b-template",
+            "tmpl-x",
+        ]
+    )
+    assert expected in flat
+    assert "wmh eval closed-loop" not in flat
 
 
 def test_create_default_local_loads_the_world_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("WMH_E2B_TEMPLATE", raising=False)  # --e2b-template defaults from it
+    project_root = tmp_path / "project with spaces"
+    project_root.mkdir()
     recorder = _CreateRecorder()
     wm = object()
     monkeypatch.setattr(harness_app_module, "create_harness", recorder)
     loads = _patch_load(monkeypatch, wm, _Provider())
 
-    result = _invoke(tmp_path)
+    result = _invoke(project_root)
 
     assert result.exit_code == 0, result.output
     assert loads == [None]  # default: resolve the only built model
@@ -170,6 +198,24 @@ def test_create_default_local_loads_the_world_model(
     flat = " ".join(result.output.split())
     assert "world model" in flat and "wm-alpha" in flat
     assert "sandbox" not in flat  # no sandbox note on the local path
+    expected = shlex.join(
+        [
+            "wmh",
+            "eval",
+            _tasks_file(project_root),
+            "--mode",
+            "closed-loop",
+            "--name",
+            "wm-alpha",
+            "--root",
+            str(project_root / ".wmh"),
+            "--k",
+            "3",
+            "--harness",
+            "made@1",
+        ]
+    )
+    assert expected in flat
     assert "--harness-backend" not in flat  # and the run-it hint stays plain
 
 
@@ -196,13 +242,11 @@ def test_create_meta_role_from_settings_drives_the_proposer(
         root,
     )
     meta_sentinel = _Provider()
-    configs: list[ProviderConfig] = []
 
-    def fake_get_provider(config: ProviderConfig) -> _Provider:
-        configs.append(config)
+    def fake_get_provider(_config: ProviderConfig) -> _Provider:
         return meta_sentinel
 
-    monkeypatch.setattr(harness_app_module, "get_provider", fake_get_provider)
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
 
     result = _invoke(tmp_path)
 
@@ -211,48 +255,65 @@ def test_create_meta_role_from_settings_drives_the_proposer(
     assert call["provider"] is anchored  # agent + judge stay on the world model's provider
     assert isinstance(call["proposer"], ProviderDeltaProposer)
     assert call["proposer"].provider is meta_sentinel
-    [config] = configs
-    assert config.kind is ProviderKind.AZURE_OPENAI
-    assert config.model == "gpt-5.5"
-    assert config.deployment == "gpt-5-5"
-    # A bare azure meta role still runs: the Azure provider refuses a None api_version,
-    # so the default applies when settings do not pin one.
-    assert config.api_version == "2024-05-01-preview"
     flat = " ".join(result.output.split())
     assert "proposer: gpt-5.5 from settings models.meta" in flat  # the banner names it
 
 
-def test_create_meta_role_api_version_override_wins(
+def test_create_agent_role_from_settings_drives_the_agent_under_test(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An explicit api_version in [models.meta] overrides the azure default."""
+    """`[models.agent]` selects the agent-under-test provider, distinct from the world model."""
     recorder = _CreateRecorder()
+    anchored = _Provider()  # the world model's serve provider
     monkeypatch.setattr(harness_app_module, "create_harness", recorder)
-    _patch_load(monkeypatch, object(), _Provider())
+    _patch_load(monkeypatch, object(), anchored)
     save_settings(
         ProjectSettings(
             models=ModelsSettings(
-                meta=ModelRole(
-                    provider="azure",
-                    model="gpt-5.5",
-                    endpoint="https://x.example",
-                    deployment="gpt-5-5",
-                    api_version="2025-01-01",
+                agent=ModelRole(
+                    provider="openai",
+                    model="Qwen/Qwen3.5-9B",
+                    endpoint="http://127.0.0.1:8002/v1",
                 )
             )
         ),
         tmp_path / ".wmh",
     )
-    configs: list[ProviderConfig] = []
-    monkeypatch.setattr(
-        harness_app_module, "get_provider", lambda config: configs.append(config) or _Provider()
-    )
+    agent_sentinel = _Provider()
+
+    def fake_get_provider(_config: ProviderConfig) -> _Provider:
+        return agent_sentinel
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
 
     result = _invoke(tmp_path)
 
     assert result.exit_code == 0, result.output
-    [config] = configs
-    assert config.api_version == "2025-01-01"
+    [call] = recorder.calls
+    # The agent-under-test is the configured provider; the proposer (meta unset) and judge
+    # keep the world model's provider.
+    assert call["provider"] is agent_sentinel
+    assert isinstance(call["proposer"], ProviderDeltaProposer)
+    assert call["proposer"].provider is anchored
+    flat = " ".join(result.output.split())
+    assert "agent-under-test: Qwen/Qwen3.5-9B from settings models.agent" in flat
+
+
+def test_create_agent_defaults_to_the_world_model_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without `[models.agent]` the agent-under-test stays on the world model's provider."""
+    recorder = _CreateRecorder()
+    anchored = _Provider()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    _patch_load(monkeypatch, object(), anchored)
+
+    result = _invoke(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    [call] = recorder.calls
+    assert call["provider"] is anchored
+    assert "models.agent" not in result.output
 
 
 def test_create_meta_defaults_to_the_world_model_provider(

--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -1,0 +1,60 @@
+"""Provider resolution for opt-in model roles shared by CLI workflows."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import typer
+
+from wmh.config.settings import load_settings
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind
+from wmh.providers.registry import get_provider
+
+OptInModelRole = Literal["agent", "meta"]
+
+# Azure OpenAI chat completions need an API version on every call. When an opt-in role does not
+# pin one in settings, this shared default API version applies.
+_DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
+
+
+def resolve_opt_in_model_provider(
+    root: str,
+    role: OptInModelRole,
+    fallback: Provider,
+) -> tuple[Provider, str | None]:
+    """Resolve one opt-in model role, or return the caller's fallback provider.
+
+    Args:
+        root: Project artifact root containing ``settings.toml``.
+        role: The opt-in role to resolve.
+        fallback: Provider retained when the role is not configured.
+
+    Returns:
+        The resolved provider and configured model name, or the fallback and ``None``.
+
+    Raises:
+        typer.BadParameter: The configured provider kind is unknown.
+    """
+    configured = load_settings(root).models.resolve(role)
+    if configured is None:
+        return fallback, None
+    try:
+        kind = ProviderKind(configured.provider)
+    except ValueError:
+        kinds = ", ".join(kind.value for kind in ProviderKind)
+        raise typer.BadParameter(
+            f"settings [models.{role}] has unknown provider {configured.provider!r}; "
+            f"choose one of: {kinds}"
+        ) from None
+    api_version = configured.api_version
+    if api_version is None and kind is ProviderKind.AZURE_OPENAI:
+        api_version = _DEFAULT_AZURE_API_VERSION
+    config = ProviderConfig(
+        kind=kind,
+        model=configured.model,
+        region=configured.region,
+        endpoint=configured.endpoint,
+        deployment=configured.deployment,
+        api_version=api_version,
+    )
+    return get_provider(config), configured.model

--- a/wmh/cli/model_roles_test.py
+++ b/wmh/cli/model_roles_test.py
@@ -1,0 +1,153 @@
+"""Tests for shared CLI resolution of opt-in model providers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+import wmh.cli.model_roles as model_roles_module
+from wmh.cli.model_roles import OptInModelRole, resolve_opt_in_model_provider
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    VerifyResult,
+)
+
+
+class _Provider:
+    """A provider identity used without making model calls."""
+
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="fallback")
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        raise NotImplementedError
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+def _settings_for_role(role: OptInModelRole, configured: ModelRole) -> ProjectSettings:
+    """Build settings with exactly one opt-in role configured."""
+    models = (
+        ModelsSettings(agent=configured) if role == "agent" else ModelsSettings(meta=configured)
+    )
+    return ProjectSettings(models=models)
+
+
+@pytest.mark.parametrize("role", ["agent", "meta"])
+def test_unset_opt_in_role_keeps_the_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, role: OptInModelRole
+) -> None:
+    fallback = _Provider()
+
+    def unexpected_provider(_config: ProviderConfig) -> _Provider:
+        raise AssertionError("unset roles must not construct a provider")
+
+    monkeypatch.setattr(model_roles_module, "get_provider", unexpected_provider)
+
+    provider, model = resolve_opt_in_model_provider(str(tmp_path / ".wmh"), role, fallback)
+
+    assert provider is fallback
+    assert model is None
+
+
+def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                agent=ModelRole(
+                    provider="azure",
+                    model="gpt-5.5",
+                    region="us-east-2",
+                    endpoint="https://x.example",
+                    deployment="gpt-5-5",
+                )
+            )
+        ),
+        root,
+    )
+    sentinel = _Provider()
+    configs: list[ProviderConfig] = []
+
+    def fake_get_provider(config: ProviderConfig) -> _Provider:
+        configs.append(config)
+        return sentinel
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
+
+    provider, model = resolve_opt_in_model_provider(str(root), "agent", _Provider())
+
+    assert provider is sentinel
+    assert model == "gpt-5.5"
+    [config] = configs
+    assert config.kind is ProviderKind.AZURE_OPENAI
+    assert config.model == "gpt-5.5"
+    assert config.region == "us-east-2"
+    assert config.endpoint == "https://x.example"
+    assert config.deployment == "gpt-5-5"
+    assert config.api_version == "2024-05-01-preview"
+
+
+def test_explicit_api_version_overrides_the_azure_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(
+                    provider="azure",
+                    model="gpt-5.5",
+                    deployment="gpt-5-5",
+                    api_version="2025-01-01",
+                )
+            )
+        ),
+        root,
+    )
+    configs: list[ProviderConfig] = []
+
+    def fake_get_provider(config: ProviderConfig) -> _Provider:
+        configs.append(config)
+        return _Provider()
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
+
+    resolve_opt_in_model_provider(str(root), "meta", _Provider())
+
+    [config] = configs
+    assert config.api_version == "2025-01-01"
+
+
+@pytest.mark.parametrize("role", ["agent", "meta"])
+def test_unknown_provider_names_the_configured_role(tmp_path: Path, role: OptInModelRole) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        _settings_for_role(role, ModelRole(provider="bogus", model="m")),
+        root,
+    )
+
+    with pytest.raises(
+        typer.BadParameter,
+        match=rf"settings \[models\.{role}\] has unknown provider 'bogus'",
+    ):
+        resolve_opt_in_model_provider(str(root), role, _Provider())

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -35,35 +35,40 @@ class ModelRole(BaseModel):
 class ModelsSettings(BaseModel):
     """Role-based model defaults for this project (`.wmh/settings.toml`, `[models.<role>]`).
 
-    Four roles keep the surface small: `worker` does quality-critical generation (scenario
+    Five roles keep the surface small: `worker` does quality-critical generation (scenario
     synthesis, cluster naming, agent rollouts); `judge` grades (checklist judging, inline
     validity gates) and should be a different model family from `worker` so the grader carries
     no self-preference bias toward the generator's outputs; `summary` does high-volume cheap
     extraction (trace facets/digests); `meta` is the harness-search delta proposer, which
     needs a long-context, long-output model (one proposal holds every harness surface in its
-    prompt and replies with a complete replacement surface). Unset `judge`/`summary` fall back
-    to `worker`; explicit CLI flags override everything.
+    prompt and replies with a complete replacement surface); `agent` is the agent-under-test
+    whose harness `wmh harness create` searches. Set it to optimize a harness for a model
+    distinct from the world model's serve provider (e.g. a small self-hosted agent against a
+    frontier-served world model). Unset `judge`/`summary` fall back to `worker`; each command
+    documents which explicit model flags and opt-in roles it uses.
     """
 
     worker: ModelRole | None = None
     judge: ModelRole | None = None
     summary: ModelRole | None = None
     meta: ModelRole | None = None
+    agent: ModelRole | None = None
 
     def resolve(self, role: str) -> ModelRole | None:
         """The configured role, with unset `judge`/`summary` falling back to `worker`.
 
-        `meta` deliberately does NOT fall back to `worker`: the scenario worker is picked for
-        generation quality per token, not for the proposer's long-context/long-output needs,
-        so an unset `meta` returns None and the caller keeps its own default (`wmh harness
-        create` uses the world model's provider).
+        `meta` and `agent` deliberately do NOT fall back to `worker`: each is picked for a
+        need the scenario worker does not serve (the proposer's long-context/long-output
+        surface; the agent-under-test's own identity), so when unset they return None and the
+        caller keeps its own default (`wmh harness create` and closed-loop eval use the world
+        model's provider for the opt-in roles when unset).
         """
-        if role not in ("worker", "judge", "summary", "meta"):
+        if role not in ("worker", "judge", "summary", "meta", "agent"):
             raise ValueError(
-                f"unknown model role {role!r}; expected worker, judge, summary, or meta"
+                f"unknown model role {role!r}; expected worker, judge, summary, meta, or agent"
             )
         configured: ModelRole | None = getattr(self, role)
-        if role == "meta":
+        if role in ("meta", "agent"):
             return configured
         return configured or self.worker
 

--- a/wmh/config/settings_test.py
+++ b/wmh/config/settings_test.py
@@ -104,6 +104,19 @@ def test_meta_role_resolves_when_configured_and_never_falls_back_to_worker() -> 
     assert ModelsSettings(worker=worker, meta=meta).resolve("meta") is meta
 
 
+def test_agent_role_resolves_when_configured_and_never_falls_back_to_worker() -> None:
+    """The agent-under-test role is opt-in: unset agent means the caller's default.
+
+    `wmh harness create` optimizes a harness for a specific agent model, which may differ
+    from the world model's serve model; an unset agent must keep the world-model-provider
+    default rather than silently inheriting the scenario worker.
+    """
+    worker = ModelRole(provider="azure", model="gpt-5.4")
+    agent = ModelRole(provider="openai", model="Qwen/Qwen3.5-9B", endpoint="http://x/v1")
+    assert ModelsSettings(worker=worker).resolve("agent") is None
+    assert ModelsSettings(worker=worker, agent=agent).resolve("agent") is agent
+
+
 def test_meta_role_round_trips_through_toml(tmp_path: Path) -> None:
     root = tmp_path / ".wmh"
     settings = ProjectSettings(


### PR DESCRIPTION
## Problem

`wmh harness create` optimizes a harness for an agent whose environment is the world model. `create_harness()` already takes the agent-under-test as a **separate** `agent_provider` argument — but the CLI (`harness_app.py`) passed the *world model's own serve provider* for it. So you could only search a harness for the same model that serves the world model.

That blocks a core use case: optimize a harness for a **small self-hosted agent** (e.g. a 9B on vLLM) against a **frontier-served world model** (e.g. Claude on Bedrock). The two providers must differ.

## Fix

Add an opt-in `[models.agent]` settings role, mirroring the existing `[models.meta]` proposer role exactly:

- `ModelsSettings.agent` field + `resolve("agent")` support; like `meta`, it does **not** fall back to `worker`.
- CLI `_agent_provider_from_settings()` builds the agent provider from `[models.agent]`, defaulting to the world model's provider when unset — so **existing runs are unchanged**.
- The run banner names the configured agent model when set.

## Tests

- `settings_test.py`: `agent` resolves when configured, never falls back to worker; unknown roles rejected.
- `harness_app_test.py`: `[models.agent]` drives the `agent_provider` passed to `create_harness` (proposer/judge stay on the world model's provider); unset keeps the world-model provider.
- `ruff format`, `ruff check`, `ty check` clean on touched files; 20/20 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)