### PR TITLE
Generalize harness scoring for ground-truth search

### DIFF
--- a/docs/reference/harness_delta.md
+++ b/docs/reference/harness_delta.md
@@ -99,7 +99,7 @@ class GateRecord(BaseModel):
     full_delta: float            # full split: child − best-seen        (tier 2)
     full_secondary_delta: float   # secondary score when full score ties
     holdout_delta: float | None  # held-out split: child − champion     (tier 3; None = no holdout)
-    holdout_secondary_delta: float | None
+    holdout_secondary_delta: float | None  # secondary score when held-out score ties
     accepted: bool
     reason: str                  # accept/reject reasoning, incl. the expected-effect audit
 

--- a/docs/reference/harness_delta.md
+++ b/docs/reference/harness_delta.md
@@ -8,7 +8,8 @@ improve harnesses* is bounded by what the update object can express.
 
 Implementation: `wmh/harness/doc.py` (the document), `wmh/harness/delta.py` (the delta),
 `wmh/harness/mutate.py` (delta parsing), `wmh/harness/proposer.py` (proposal runtimes), and
-`wmh/harness/create.py` (clustering, gate, archive).
+`wmh/harness/scoring.py` plus `wmh/harness/create.py` (scoring contract, clustering, gate,
+archive).
 
 ---
 
@@ -95,11 +96,11 @@ class SurfaceOp(BaseModel):
 class GateRecord(BaseModel):
     """Filled at evaluation time; the delta carries its own verdict."""
     suite_delta: float           # regression suite: child − champion   (tier 1)
-    suite_secondary_delta: float  # secondary score when suite score ties
+    suite_secondary_delta: float | None  # present only for a declared secondary objective
     full_delta: float            # full split: child − best-seen        (tier 2)
-    full_secondary_delta: float   # secondary score when full score ties
+    full_secondary_delta: float | None  # present only for a declared secondary objective
     holdout_delta: float | None  # held-out split: child − champion     (tier 3; None = no holdout)
-    holdout_secondary_delta: float | None  # secondary score when held-out score ties
+    holdout_secondary_delta: float | None  # present only for a declared secondary objective
     accepted: bool
     reason: str                  # accept/reject reasoning, incl. the expected-effect audit
 
@@ -117,7 +118,31 @@ class HarnessDelta(BaseModel):
     verdict: GateRecord | None     # None until evaluated; the archive stores deltas, not snapshots
 ```
 
-### 2.3 Semantics
+### 2.3 Scoring contract
+
+`search_harness` owns proposal, gate, and acceptance policy. An injected `HarnessScorer` owns
+candidate eligibility and evaluation. The core scorer protocol has only `capabilities`,
+`default_attempts`, `validate_candidate`, and `score`. Resource cleanup at the proposal boundary
+is a separate optional `before_proposal_batch` callback, so a pure scorer does not need a lifecycle
+method. The world-model adapter uses that callback to retire idle sandbox resources.
+
+Every `TaskScore` carries a normalized primary score and an explicit positive
+`aggregate_weight`. `HarnessScoreReport.score` must equal the aggregate-weighted task mean. This
+keeps subset and full-split gates consistent while allowing benchmark-defined weighting rather
+than assuming every task contributes equally. Missing suite tasks, aggregate mismatches, or
+weight changes fail closed.
+
+The secondary objective is optional. A scorer that has one declares a stable `ScoreObjective` in
+`ScoreCapabilities`, repeats that identity on every report, and supplies a secondary score for
+the report and every task. A scorer without one supplies `None` throughout. The seed freezes the
+task identities, weights, and secondary-objective schema for its scorer role. Candidate, holdout,
+and confirmation reports must match the corresponding frozen schema. Lexicographic gates and
+sibling ranking consult the secondary score only when that objective was genuinely declared.
+Confirmation also requires the scorer to declare both attempt overrides and
+`mean_over_attempts`. Its narrow-veto threshold then uses the largest weighted aggregate impact
+that one normalized attempt can have, rather than assuming equal task weights.
+
+### 2.4 Semantics
 
 - **Application is atomic** (`apply_delta`): lineage hash, every precondition, and every op are
   validated against the parent doc — and the child re-validates as a whole `HarnessDoc` — before a
@@ -132,10 +157,11 @@ class HarnessDelta(BaseModel):
   fails the episode, not the eval).
 - **Verification is staged by cost**: before a full-split eval, a child is screened on its own
   trigger cluster — the failing tasks its delta claims to fix. The screen compares full-task
-  primary score first and secondary score second, so a partial fix is not flattened into
-  a binary tie. A delta that improves neither signal is rejected (and archived) for a fraction of
-  the price. The authoritative full gate repeats the same lexicographic contract across the whole
-  split: the primary score leads, and the secondary score cannot regress when the primary ties.
+  primary score first and, when declared, secondary score second, so a measured partial fix is
+  not flattened into a binary tie. A delta that improves no available signal is rejected and
+  archived for a fraction of the price. The authoritative full gate repeats the same contract
+  across the whole split: the primary score leads, and an available secondary score cannot regress
+  when the primary ties.
   Every judged delta is fed back to the proposer as trace-level history, so the search iterates
   instead of re-proposing rejected ideas.
 - **Search breadth is independent from evaluation depth**: `proposal_batch_size` asks the
@@ -145,7 +171,7 @@ class HarnessDelta(BaseModel):
   project while every turn runs through the same ordinary agent-session runtime.
 - **Acceptance is the gate, not "applied cleanly"** (`gate_delta`): regression-suite
   non-regression vs the champion → full-split never-worse-than-best → held-out non-regression vs
-  the champion (when a holdout split is given). Primary ties consult the secondary score;
+  the champion (when a holdout split is given). Primary ties consult a declared secondary score;
   a stepping stone may advance on dense signal but cannot hide a global dense regression. On
   accept, newly-passing tasks promote into the regression suite, so wins are locked in and later
   deltas cannot quietly trade them away. The verdict is written onto the delta.
@@ -165,7 +191,7 @@ class HarnessDelta(BaseModel):
   re-checked ("trigger cluster: 2/3 tasks now pass") and the result lands in `verdict.reason`.
   Over time this measures the proposer's *calibration*, not just its win rate.
 
-### 2.4 What the meta-agent emits
+### 2.5 What the meta-agent emits
 
 The proposal prompt (`MUTATE_SYSTEM`) asks for exactly `{expected_effect, preconditions, ops}` as
 JSON — trigger, lineage, and identity are filled by the caller from ground truth, never trusted
@@ -183,7 +209,7 @@ that fails atomic application is a counted skip that is still archived with its 
 2. **Merge.** Identity-keyed surfaces + content lineage make a surface-keyed three-way merge of
    two accepted lineages nearly free. Deferred to a follow-up.
 3. **Gate resolution.** With k=3 and small suites, binary per-task deltas are coarse (0, ⅓, ⅔, 1).
-   Secondary scores break otherwise-flat ties; if flappy accepts show up in practice,
+   A declared secondary score breaks otherwise-flat ties; if flappy accepts show up in practice,
    raise k on gate evals rather than adding arbitrary thresholds.
 4. **Suite demotion.** Newly-passing tasks promote into the regression suite; nothing ever leaves
    it. A permanently-flaky task could wedge the gate. Punted until observed.

--- a/docs/reference/harness_delta.md
+++ b/docs/reference/harness_delta.md
@@ -63,8 +63,8 @@ class HarnessDoc(BaseModel):
     name: str
     version: int                 # immutable, assigned by the store on save; 0 = unsaved
     surfaces: list[Surface]      # unique ids; canonical order
-    # doc_hash: computed over sorted (id, content_hash) pairs. "The score of harness X" is
-    # well-defined because X is this hash.
+    # doc_hash / execution_hash: computed over every sorted surface field that affects execution
+    # or materialization. Display-only document name and version are excluded.
 ```
 
 A document validates as a whole at construction — tools resolve, `submit` present, params in
@@ -106,7 +106,7 @@ class GateRecord(BaseModel):
 
 class HarnessDelta(BaseModel):
     delta_id: str                  # content-addressed: blake2b(parent hash + ops)
-    parent_doc_hash: str           # lineage by content, not name
+    parent_doc_hash: str           # lineage by execution-affecting content, not display name
     trigger: FailureSignature      # built by deterministic clustering, never free-typed
     preconditions: dict[str, str]  # surface_id -> expected content_hash of the PARENT surface the
                                    # meta-agent actually read. ANY mismatch rejects the WHOLE delta
@@ -129,8 +129,17 @@ method. The world-model adapter uses that callback to retire idle sandbox resour
 Every `TaskScore` carries a normalized primary score and an explicit positive
 `aggregate_weight`. `HarnessScoreReport.score` must equal the aggregate-weighted task mean. This
 keeps subset and full-split gates consistent while allowing benchmark-defined weighting rather
-than assuming every task contributes equally. Missing suite tasks, aggregate mismatches, or
-weight changes fail closed.
+than assuming every task contributes equally. Empty reports, missing suite tasks, nonfinite or
+nonpositive weights, aggregate mismatches, and weight changes fail closed. A frozen
+`PassCriterion` states the primary-score threshold for `TaskScore.passed`; report validation and
+search reject a boolean verdict that disagrees with the rule or a rule that changes mid-search.
+
+Each report carries structured `ScoreProvenance` for the exact task set, evaluator, and execution
+backend. It also carries the issued `ScoreRequest`, candidate `execution_hash`, and any
+evaluation-specific identity evidence. `evaluation_id` is constructed centrally as canonical
+SHA-256 over those fields plus the scores and proposer evidence. Callers cannot choose it. Display
+fields such as report label and harness name/version are excluded. Search rejects a report for a
+different request or candidate and freezes provenance independently for discovery and holdout.
 
 The secondary objective is optional. A scorer that has one declares a stable `ScoreObjective` in
 `ScoreCapabilities`, repeats that identity on every report, and supplies a secondary score for

--- a/docs/reference/harness_delta.md
+++ b/docs/reference/harness_delta.md
@@ -80,9 +80,9 @@ never to "whatever the harness currently is".
 ```python
 class FailureSignature(BaseModel):
     """Machine-clustered trigger: WHY this delta exists, queryably."""
-    mechanism: str               # e.g. the shared unmet assertion, or "none: all tasks pass"
+    mechanism: str               # e.g. a shared failure label, or "none: all tasks pass"
     task_ids: list[str]          # the cluster of failing tasks exhibiting it
-    unmet_assertions: list[str]  # deduped gold assertions the mechanism explains
+    mechanism_labels: list[str]  # deduped scorer labels the mechanism explains
 
 class SurfaceOp(BaseModel):
     op: Literal["add", "replace", "remove"]
@@ -95,11 +95,11 @@ class SurfaceOp(BaseModel):
 class GateRecord(BaseModel):
     """Filled at evaluation time; the delta carries its own verdict."""
     suite_delta: float           # regression suite: child − champion   (tier 1)
-    suite_fraction_delta: float  # assertion credit when suite success ties
+    suite_secondary_delta: float  # secondary score when suite score ties
     full_delta: float            # full split: child − best-seen        (tier 2)
-    full_fraction_delta: float   # assertion credit when full success ties
+    full_secondary_delta: float   # secondary score when full score ties
     holdout_delta: float | None  # held-out split: child − champion     (tier 3; None = no holdout)
-    holdout_fraction_delta: float | None
+    holdout_secondary_delta: float | None
     accepted: bool
     reason: str                  # accept/reject reasoning, incl. the expected-effect audit
 
@@ -132,10 +132,10 @@ class HarnessDelta(BaseModel):
   fails the episode, not the eval).
 - **Verification is staged by cost**: before a full-split eval, a child is screened on its own
   trigger cluster — the failing tasks its delta claims to fix. The screen compares full-task
-  success first and assertion-level partial credit second, so a partial fix is not flattened into
+  primary score first and secondary score second, so a partial fix is not flattened into
   a binary tie. A delta that improves neither signal is rejected (and archived) for a fraction of
   the price. The authoritative full gate repeats the same lexicographic contract across the whole
-  split: binary success remains primary, and assertion credit cannot regress when success ties.
+  split: the primary score leads, and the secondary score cannot regress when the primary ties.
   Every judged delta is fed back to the proposer as trace-level history, so the search iterates
   instead of re-proposing rejected ideas.
 - **Search breadth is independent from evaluation depth**: `proposal_batch_size` asks the
@@ -145,12 +145,12 @@ class HarnessDelta(BaseModel):
   project while every turn runs through the same ordinary agent-session runtime.
 - **Acceptance is the gate, not "applied cleanly"** (`gate_delta`): regression-suite
   non-regression vs the champion → full-split never-worse-than-best → held-out non-regression vs
-  the champion (when a holdout split is given). Binary ties consult assertion-level partial credit;
+  the champion (when a holdout split is given). Primary ties consult the secondary score;
   a stepping stone may advance on dense signal but cannot hide a global dense regression. On
   accept, newly-passing tasks promote into the regression suite, so wins are locked in and later
   deltas cannot quietly trade them away. The verdict is written onto the delta.
-- **The trigger is machine-made** (`cluster_failures`): failing tasks group by shared unmet gold
-  assertions (connected components; the most common unmet assertion labels the mechanism),
+- **The trigger is machine-made** (`cluster_score_failures`): failing tasks group by shared scorer
+  mechanism labels (connected components; the most common label names the mechanism),
   deterministically — no LLM, no entropy — so mechanism labels are comparable across deltas and
   runs. Selection weights cluster size but discounts rounds already spent on the same cluster and
   parent, so one environment-limited singleton cannot absorb the whole search. An all-pass parent
@@ -183,7 +183,7 @@ that fails atomic application is a counted skip that is still archived with its 
 2. **Merge.** Identity-keyed surfaces + content lineage make a surface-keyed three-way merge of
    two accepted lineages nearly free. Deferred to a follow-up.
 3. **Gate resolution.** With k=3 and small suites, binary per-task deltas are coarse (0, ⅓, ⅔, 1).
-   Assertion-level fractions break otherwise-flat ties; if flappy accepts show up in practice,
+   Secondary scores break otherwise-flat ties; if flappy accepts show up in practice,
    raise k on gate evals rather than adding arbitrary thresholds.
 4. **Suite demotion.** Newly-passing tasks promote into the regression suite; nothing ever leaves
    it. A permanently-flaky task could wedge the gate. Punted until observed.

--- a/wmh/engine/grounding.py
+++ b/wmh/engine/grounding.py
@@ -20,6 +20,7 @@ The default is `NullGrounder` — no network, tests and evals stay hermetic. Rea
 
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 import json
 import os
@@ -34,7 +35,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, Field, ValidationError
 
-from wmh.core.types import Action
+from wmh.core.types import Action, JsonObject
 
 GROUNDER_KINDS = ("none", "brave", "fetch")
 _BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
@@ -62,6 +63,10 @@ class NullGrounder:
 
     def ground(self, query: str) -> list[GroundingResult]:
         return []
+
+    def evaluation_context(self) -> JsonObject:
+        """Return the exact disabled-grounding configuration."""
+        return {"kind": "none"}
 
 
 # Injectable HTTP GET (url, headers) -> response body; lets tests exercise BraveGrounder offline.
@@ -154,6 +159,15 @@ class BraveGrounder:
                 f"Brave search response for {query!r} did not match the expected shape: {exc}"
             ) from exc
 
+    def evaluation_context(self) -> JsonObject:
+        """Return non-secret configuration that identifies this search evaluator."""
+        return {
+            "kind": "brave",
+            "api_key_sha256": hashlib.sha256(self._api_key.encode()).hexdigest(),
+            "count": self._count,
+            "fetch": _callable_identity(self._fetch),
+        }
+
 
 class FetchGrounder:
     """Keyless grounder for URL-shaped queries: GET the URL, return its (capped) body.
@@ -185,6 +199,26 @@ class FetchGrounder:
             results = [GroundingResult(title=url, url=url, snippet=body)]
         self._memo[url] = results
         return results
+
+    def evaluation_context(self) -> JsonObject:
+        """Return configuration and cached observations that affect fetch grounding."""
+        return {
+            "kind": "fetch",
+            "max_chars": self._max_chars,
+            "fetch": _callable_identity(self._fetch),
+            "memo": {
+                query: [result.model_dump(mode="json") for result in results]
+                for query, results in self._memo.items()
+            },
+        }
+
+
+def _callable_identity(value: FetchFn) -> JsonObject:
+    """Return a stable code identity for an injected fetch implementation."""
+    return {
+        "module": getattr(value, "__module__", ""),
+        "qualname": getattr(value, "__qualname__", type(value).__qualname__),
+    }
 
 
 # curl flags that mean the request mutates state (or uploads); those commands are never fetched.

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -12,10 +12,11 @@ import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from wmh.config import ArtifactPaths, load_config
 from wmh.core.parsing import dumps_observation_contract, parse_observation
-from wmh.core.types import Action, EnvState, Observation, Session, Step
+from wmh.core.types import Action, EnvState, JsonObject, Observation, Session, Step
 from wmh.engine.autoconfig import AutoFidelityReport
 from wmh.engine.grounding import Grounder, extract_get_url, get_grounder, render_grounding
 from wmh.engine.knowledge import KnowledgeBase
@@ -30,6 +31,22 @@ from wmh.tracking import MeteredProvider, Phase, RunRecord, RunTracker
 
 # Live web searches allowed per session (cache hits are free); keeps grounding cost bounded.
 DEFAULT_GROUND_BUDGET = 5
+
+
+@runtime_checkable
+class _EvaluationContextProvider(Protocol):
+    """Component that can expose exact non-secret evaluation configuration."""
+
+    def evaluation_context(self) -> JsonObject: ...
+
+
+def _provider_evaluation_context(provider: Provider) -> JsonObject:
+    """Return provider implementation and non-secret route configuration."""
+    provider_type = type(provider)
+    return {
+        "type": f"{provider_type.__module__}.{provider_type.__qualname__}",
+        "config": provider.config.model_dump(mode="json"),
+    }
 
 
 class _StepUsage:
@@ -214,6 +231,33 @@ class WorldModel:
     def knowledge(self) -> KnowledgeBase | None:
         """The cross-session knowledge base, or None when the artifact ships none."""
         return self._knowledge
+
+    def evaluation_context(self) -> JsonObject:
+        """Return the frozen non-secret state that determines evaluation observations."""
+        if not isinstance(self._retriever, _EvaluationContextProvider):
+            raise ValueError("world-model retriever does not expose exact evaluation context")
+        if self._grounder is None:
+            grounder: JsonObject = {"kind": "disabled"}
+        elif isinstance(self._grounder, _EvaluationContextProvider):
+            grounder = self._grounder.evaluation_context()
+        else:
+            raise ValueError("world-model grounder does not expose exact evaluation context")
+        return {
+            "kind": "world_model",
+            "provider": _provider_evaluation_context(self._provider),
+            "reward_provider": _provider_evaluation_context(self._reward_provider),
+            "retriever": self._retriever.evaluation_context(),
+            "env_prompt": self._env_prompt,
+            "top_k": self._top_k,
+            "max_retrieved_observation_chars": self._demo_obs_cap,
+            "knowledge": self._knowledge.files() if self._knowledge is not None else {},
+            "reasoning": self._reasoning,
+            "grounder": grounder,
+            "ground_budget": self._ground_budget,
+            "verify": self._verify,
+            "confidence": self._confidence,
+            "confidence_why": self._confidence_why,
+        }
 
     def end_session(self, session_id: str) -> RunRecord:
         """End `session_id`: stop its metering, drop it from the model, return the final usage.

--- a/wmh/evals/closed_loop.py
+++ b/wmh/evals/closed_loop.py
@@ -96,7 +96,7 @@ class TaskOutcome(BaseModel):
     task_id: str
     success_rate: float = 0.0  # fraction of k passes that fully passed gold
     mean_fraction: float = 0.0  # mean fraction-of-assertions across passes (partial credit)
-    passes: int = 0
+    passes: int = 0  # number of completed evaluation passes, not successful verdicts
     verdicts: list[GoldVerdict] = Field(default_factory=list)
     attempts: list[RolloutEvidence] = Field(default_factory=list)
 

--- a/wmh/evals/gold.py
+++ b/wmh/evals/gold.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from wmh.core.parsing import extract_json_object
 from wmh.core.text import normalize_durable_text
+from wmh.core.types import JsonObject
 from wmh.providers.base import Message, Provider
 
 GOLD_JUDGE_MARKER = "grade whether an agent completed a task"
@@ -69,6 +70,20 @@ class GoldJudge:
 
     def __init__(self, provider: Provider) -> None:
         self._provider = provider
+
+    def evaluation_context(self) -> JsonObject:
+        """Return the exact non-secret judge configuration used by score provenance."""
+        provider_type = type(self._provider)
+        return {
+            "kind": "gold_assertions",
+            "system_prompt": GOLD_JUDGE_SYSTEM,
+            "provider": {
+                "type": f"{provider_type.__module__}.{provider_type.__qualname__}",
+                "config": self._provider.config.model_dump(mode="json"),
+            },
+            "temperature": 0.0,
+            "max_tokens": 1024,
+        }
 
     def score(self, instruction: str, answer: str, transcript: str, gold: list[str]) -> GoldVerdict:
         if not gold:

--- a/wmh/evals/harbor/evaluator_test.py
+++ b/wmh/evals/harbor/evaluator_test.py
@@ -325,7 +325,7 @@ def test_evaluate_pins_agent_persists_exact_lock_manifest_and_qualifies_task_key
     assert result is sentinel
     manifest = cast("HarborTrialManifest", captured["manifest_at_run"])
     assert captured["loaded_manifest"] == manifest
-    assert candidate.doc_hash != candidate.execution_hash
+    assert candidate.doc_hash == candidate.execution_hash
     assert manifest.identity.candidate_hash == candidate.execution_hash
     assert manifest.identity.task_environment is BenchmarkTaskEnvironment.DOCKER
     assert len(manifest.entries) == 4

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -14,8 +14,8 @@ iteration's champion:
   the champion on tasks the proposer never saw evidence from.
 
 Ties pass every gate tier: with k passes per task, scores are coarse, and "no worse" is the
-eligibility contract. When multiple siblings are eligible, full success wins, then assertion
-fraction, then lower proposal index. Every proposed delta, whether selected, rejected, or invalid
+eligibility contract. When multiple siblings are eligible, full success wins, then secondary
+score, then lower proposal index. Every proposed delta, whether selected, rejected, or invalid
 before eval, is recorded in the archive with its verdict. The run as a whole is only as
 reproducible as its providers because proposals and rollouts sample real models at temperature.
 """

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -1292,9 +1292,9 @@ class _ClosedLoopHarnessScorer:
         validate_candidate: Callable[[HarnessDoc], str | None],
         provenance: ScoreProvenance,
     ) -> None:
-        self._tasks = list(tasks)
-        self._by_id = {task.task_id: task for task in tasks}
-        if len(self._by_id) != len(tasks):
+        self._tasks = [task.model_copy(deep=True) for task in tasks]
+        self._by_id = {task.task_id: task for task in self._tasks}
+        if len(self._by_id) != len(self._tasks):
             raise ValueError("closed-loop search task ids must be unique")
         self.default_attempts = default_attempts
         self._evaluate = evaluate
@@ -1472,9 +1472,11 @@ def _closed_loop_score_provenance(
     if harness_backend == "local":
         resolved_concurrency = eval_concurrency if eval_concurrency is not None else 1
         resolved_e2b_template = None
+        resolved_e2b_metadata: dict[str, str] = {}
     else:
         resolved_concurrency = eval_concurrency if eval_concurrency is not None else 0
         resolved_e2b_template = e2b_template or os.environ.get(E2B_TEMPLATE_ENV)
+        resolved_e2b_metadata = dict(sorted((e2b_metadata or {}).items()))
     return ScoreProvenance(
         task_set={"tasks": [task.model_dump(mode="json") for task in tasks]},
         evaluator={
@@ -1493,7 +1495,7 @@ def _closed_loop_score_provenance(
             "kind": harness_backend,
             "concurrency": resolved_concurrency,
             "e2b_template": resolved_e2b_template,
-            "e2b_metadata": dict(sorted((e2b_metadata or {}).items())),
+            "e2b_metadata": resolved_e2b_metadata,
         },
     )
 
@@ -1532,6 +1534,12 @@ def create_harness(
             f"runtime kind is {seed_doc.runtime_kind()!r}, which already runs in-process; "
             "use harness_backend='local'"
         )
+    if harness_backend == "e2b":
+        resolved_e2b_template = e2b_template or os.environ.get(E2B_TEMPLATE_ENV)
+        resolved_e2b_metadata = dict(sorted((e2b_metadata or {}).items()))
+    else:
+        resolved_e2b_template = None
+        resolved_e2b_metadata = {}
 
     discovery_provenance = _closed_loop_score_provenance(
         tasks,
@@ -1540,8 +1548,8 @@ def create_harness(
         judge=judge,
         harness_backend=harness_backend,
         eval_concurrency=eval_concurrency,
-        e2b_template=e2b_template,
-        e2b_metadata=e2b_metadata,
+        e2b_template=resolved_e2b_template,
+        e2b_metadata=resolved_e2b_metadata,
     )
     holdout_provenance = (
         _closed_loop_score_provenance(
@@ -1551,8 +1559,8 @@ def create_harness(
             judge=judge,
             harness_backend=harness_backend,
             eval_concurrency=eval_concurrency,
-            e2b_template=e2b_template,
-            e2b_metadata=e2b_metadata,
+            e2b_template=resolved_e2b_template,
+            e2b_metadata=resolved_e2b_metadata,
         )
         if holdout
         else None
@@ -1562,7 +1570,10 @@ def create_harness(
     if harness_backend == "e2b":
         from wmh.harness.pi_e2b import E2BSandboxPool as _Pool
 
-        sandbox_pool = _Pool(template=e2b_template, metadata=e2b_metadata)
+        sandbox_pool = _Pool(
+            template=resolved_e2b_template,
+            metadata=resolved_e2b_metadata,
+        )
 
     worker_usages: list[TokenUsage | None] = []
     cancelled: HarnessSearchCancelled | None = None

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -22,8 +22,10 @@ reproducible as its providers because proposals and rollouts sample real models 
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable
 from dataclasses import dataclass
+from math import isclose
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -35,13 +37,26 @@ from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_delta
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
-from wmh.harness.mutate import render_evidence
+from wmh.harness.mutate import render_task_attempt_evidence
 from wmh.harness.proposer import DeltaProposer, ProposalFailure
 from wmh.harness.runtime import (
     HarnessSearchCancelled,
     RuntimeCancelled,
     TokenUsage,
     combine_usage,
+)
+from wmh.harness.scoring import (
+    MAX_TASK_DESCRIPTION_CHARS,
+    MAX_TASK_EVIDENCE_CHARS,
+    HarnessScorer,
+    HarnessScoreReport,
+    ScoreCapabilities,
+    ScoreRequest,
+    TaskScore,
+    cluster_score_failures,
+    render_score_evidence,
+    suite_score,
+    suite_secondary_score,
 )
 from wmh.providers.base import Provider
 
@@ -116,8 +131,8 @@ class ProposalRecord(BaseModel):
     selected: bool = False  # true only for the iteration winner
     screen_child: float | None = None  # trigger-cluster means; screened attempts only
     screen_parent: float | None = None
-    screen_child_fraction: float | None = None  # denser assertion-level screen signal
-    screen_parent_fraction: float | None = None
+    screen_child_secondary: float | None = None  # denser secondary screen signal
+    screen_parent_secondary: float | None = None
     champion_score: float
 
     @model_validator(mode="after")
@@ -158,79 +173,33 @@ class CreateResult(BaseModel):
     sandbox_usage: SandboxUsage | None = None
 
 
+class SearchResult(BaseModel):
+    """Benchmark-neutral champion and audit record returned by ``search_harness``."""
+
+    best: HarnessDoc
+    best_score: float
+    archive: DeltaArchive
+    reports: dict[str, HarnessScoreReport] = Field(default_factory=dict)
+    holdout_reports: dict[str, HarnessScoreReport] = Field(default_factory=dict)
+    suite: list[str] = Field(default_factory=list)
+    skipped: int = 0
+    proposal_records: list[ProposalRecord] = Field(default_factory=list)
+    screened: int = 0
+    confirmations: int = 0
+    iterations: int = 0
+    proposal_batch_size: int = 1
+
+
 @dataclass
 class _ScoredProposal:
-    """One fully scored sibling awaiting iteration-level winner selection."""
+    """One neutral scored sibling awaiting iteration-level winner selection."""
 
     proposal_index: int
     child: HarnessDoc
     delta: HarnessDelta
-    report: ClosedLoopReport
+    report: HarnessScoreReport
     gate: GateRecord
     record: ProposalRecord
-
-
-def cluster_failures(report: ClosedLoopReport, tasks: list[TaskSpec]) -> list[FailureSignature]:
-    """Group failing tasks into mechanisms, deterministically — no LLM, no entropy.
-
-    Two failing tasks share a mechanism when they share an unmet gold assertion (connected
-    components over the task/assertion graph). The cluster's `mechanism` label is its most common
-    unmet assertion (ties broken lexicographically); clusters are ordered largest-first so the
-    size-weighted, expansion-discounted selector has a stable base order. A failing task whose
-    verdicts carry no per-assertion detail (an unparseable judge reply) forms its own cluster.
-    """
-    unmet_by_task: dict[str, list[str]] = {}
-    for task in tasks:
-        outcome = report.per_task.get(task.task_id)
-        if outcome is None or outcome.success_rate >= 1.0:
-            continue
-        seen: set[str] = set()
-        unmet: list[str] = []
-        for verdict in outcome.verdicts:
-            for result in verdict.assertions:
-                if not result.passed and result.assertion not in seen:
-                    seen.add(result.assertion)
-                    unmet.append(result.assertion)
-        unmet_by_task[task.task_id] = unmet
-
-    clusters: list[FailureSignature] = []
-    assigned: set[str] = set()
-    for task_id in sorted(unmet_by_task):
-        if task_id in assigned:
-            continue
-        # Flood-fill the component: tasks connected through shared unmet assertions.
-        member_ids = {task_id}
-        assertions = set(unmet_by_task[task_id])
-        grew = True
-        while grew:
-            grew = False
-            for other, other_unmet in unmet_by_task.items():
-                if other in member_ids or not assertions.intersection(other_unmet):
-                    continue
-                member_ids.add(other)
-                assertions.update(other_unmet)
-                grew = True
-        assigned.update(member_ids)
-        counts: dict[str, int] = {}
-        for member in member_ids:
-            for assertion in unmet_by_task[member]:
-                counts[assertion] = counts.get(assertion, 0) + 1
-        # Most common unmet assertion labels the cluster; max() keeps the first (lexicographically
-        # smallest) among ties because the candidates are pre-sorted.
-        mechanism = (
-            max(sorted(counts), key=lambda a: counts[a])
-            if counts
-            else "run failed without per-assertion verdicts"
-        )
-        clusters.append(
-            FailureSignature(
-                mechanism=mechanism,
-                task_ids=sorted(member_ids),
-                unmet_assertions=sorted(assertions),
-            )
-        )
-    clusters.sort(key=lambda c: (-len(c.task_ids), c.mechanism))
-    return clusters
 
 
 def select_failure_cluster(
@@ -285,13 +254,13 @@ def narrow_failing_tiers(
         return None
     # A confirmation may only revisit the explicitly returned binary vetoes. Do not let it erase
     # a separate tied-success dense veto on another tier.
-    if abs(verdict.suite_delta) <= _TIE_EPS and verdict.suite_fraction_delta < -_TIE_EPS:
+    if abs(verdict.suite_delta) <= _TIE_EPS and verdict.suite_secondary_delta < -_TIE_EPS:
         return None
     if (
         verdict.holdout_delta is not None
         and abs(verdict.holdout_delta) <= _TIE_EPS
-        and verdict.holdout_fraction_delta is not None
-        and verdict.holdout_fraction_delta < -_TIE_EPS
+        and verdict.holdout_secondary_delta is not None
+        and verdict.holdout_secondary_delta < -_TIE_EPS
     ):
         return None
     tiers: list[str] = []
@@ -309,59 +278,55 @@ def narrow_failing_tiers(
     return tiers or None
 
 
-def gate_delta(
+def gate_score_delta(
     delta: HarnessDelta,
     *,
-    child: ClosedLoopReport,
-    champion: ClosedLoopReport,
+    child: HarnessScoreReport,
+    champion: HarnessScoreReport,
     best_full: float,
     suite: list[str],
-    child_holdout: ClosedLoopReport | None = None,
-    champion_holdout: ClosedLoopReport | None = None,
+    child_holdout: HarnessScoreReport | None = None,
+    champion_holdout: HarnessScoreReport | None = None,
 ) -> GateRecord:
-    """Lexicographic success/partial-credit gate plus optional held-out acceptance.
-
-    End-to-end task success remains the primary objective. When a tier's binary score ties, its
-    assertion-level fraction must not regress. This admits useful partial-progress stepping
-    stones without promoting a target-local improvement that silently damages more work across
-    the full split.
-    """
-    suite_delta = _suite_rate(child, suite) - _suite_rate(champion, suite)
-    suite_fraction_delta = _suite_fraction(child, suite) - _suite_fraction(champion, suite)
-    full_delta = child.success_rate - best_full
-    full_fraction_delta = child.mean_fraction - champion.mean_fraction
+    """Apply the search's lexicographic non-regression gate to neutral scores."""
+    suite_delta = suite_score(child, suite) - suite_score(champion, suite)
+    suite_secondary_delta = suite_secondary_score(child, suite) - suite_secondary_score(
+        champion, suite
+    )
+    full_delta = child.score - best_full
+    full_secondary_delta = child.secondary_score - champion.secondary_score
     holdout_delta = (
-        child_holdout.success_rate - champion_holdout.success_rate
+        child_holdout.score - champion_holdout.score
         if child_holdout is not None and champion_holdout is not None
         else None
     )
-    holdout_fraction_delta = (
-        child_holdout.mean_fraction - champion_holdout.mean_fraction
+    holdout_secondary_delta = (
+        child_holdout.secondary_score - champion_holdout.secondary_score
         if child_holdout is not None and champion_holdout is not None
         else None
     )
     failures: list[str] = []
     if suite_delta < -_TIE_EPS:
         failures.append(f"suite regressed by {-suite_delta:.3f}")
-    elif abs(suite_delta) <= _TIE_EPS and suite_fraction_delta < -_TIE_EPS:
-        failures.append(f"suite assertion fraction regressed by {-suite_fraction_delta:.3f}")
+    elif abs(suite_delta) <= _TIE_EPS and suite_secondary_delta < -_TIE_EPS:
+        failures.append(f"suite secondary score regressed by {-suite_secondary_delta:.3f}")
     if full_delta < -_TIE_EPS:
-        failures.append(f"full split {child.success_rate:.3f} below best {best_full:.3f}")
-    elif abs(full_delta) <= _TIE_EPS and full_fraction_delta < -_TIE_EPS:
-        failures.append(f"full-split assertion fraction regressed by {-full_fraction_delta:.3f}")
+        failures.append(f"full split {child.score:.3f} below best {best_full:.3f}")
+    elif abs(full_delta) <= _TIE_EPS and full_secondary_delta < -_TIE_EPS:
+        failures.append(f"full-split secondary score regressed by {-full_secondary_delta:.3f}")
     if holdout_delta is not None and holdout_delta < -_TIE_EPS:
         failures.append(f"held-out regressed by {-holdout_delta:.3f}")
     elif (
         holdout_delta is not None
         and abs(holdout_delta) <= _TIE_EPS
-        and holdout_fraction_delta is not None
-        and holdout_fraction_delta < -_TIE_EPS
+        and holdout_secondary_delta is not None
+        and holdout_secondary_delta < -_TIE_EPS
     ):
-        failures.append(f"held-out assertion fraction regressed by {-holdout_fraction_delta:.3f}")
+        failures.append(f"held-out secondary score regressed by {-holdout_secondary_delta:.3f}")
     flipped = sum(
         1
         for task_id in delta.trigger.task_ids
-        if (outcome := child.per_task.get(task_id)) is not None and outcome.success_rate >= 1.0
+        if (task := child.per_task.get(task_id)) is not None and task.passed
     )
     effect = (
         f"trigger cluster: {flipped}/{len(delta.trigger.task_ids)} tasks now pass"
@@ -372,14 +337,916 @@ def gate_delta(
     reason = ("accepted; " if accepted else "rejected: " + "; ".join(failures) + "; ") + effect
     return GateRecord(
         suite_delta=suite_delta,
-        suite_fraction_delta=suite_fraction_delta,
+        suite_secondary_delta=suite_secondary_delta,
         full_delta=full_delta,
-        full_fraction_delta=full_fraction_delta,
+        full_secondary_delta=full_secondary_delta,
         holdout_delta=holdout_delta,
-        holdout_fraction_delta=holdout_fraction_delta,
+        holdout_secondary_delta=holdout_secondary_delta,
         accepted=accepted,
         reason=reason,
     )
+
+
+def _snapshot_score_report(report: HarnessScoreReport) -> HarnessScoreReport:
+    """Revalidate and detach a scorer-owned report before it enters search state."""
+    snapshot = HarnessScoreReport.model_validate(report.model_dump(mode="json"))
+    return snapshot.model_copy(
+        update={"per_task": dict(sorted(snapshot.per_task.items()))},
+        deep=True,
+    )
+
+
+def _score_report_fingerprint(report: HarnessScoreReport) -> str:
+    """Canonical content identity used to detect evaluation-id collisions."""
+    content = report.model_dump_json(exclude={"evaluation_id"})
+    return hashlib.blake2b(content.encode("utf-8"), digest_size=32).hexdigest()
+
+
+def search_harness(
+    name: str,
+    seed_doc: HarnessDoc,
+    scorer: HarnessScorer,
+    proposer: DeltaProposer,
+    *,
+    iterations: int = 5,
+    proposal_batch_size: int = 1,
+    screen_proposals: bool = True,
+    holdout_scorer: HarnessScorer | None = None,
+    confirm_narrow_vetoes: bool = True,
+    on_progress: CreateProgress | None = None,
+    on_note: Callable[[str], None] | None = None,
+    on_proposal: Callable[[ProposalRecord], None] | None = None,
+    on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+) -> SearchResult:
+    """Search over harness deltas using normalized scores from an injected evaluator.
+
+    The seed fixes the discovery task matrix and attempt count. Every candidate must return that
+    same matrix before it can enter the non-regression gate. Optional screening and confirmation
+    stages are admitted only when the scorer declares the required capabilities.
+
+    Args:
+        name: Name assigned to the final champion.
+        seed_doc: Initial harness document.
+        scorer: Discovery evaluator and candidate eligibility boundary.
+        proposer: Existing delta proposer fed bounded scorer evidence.
+        iterations: Number of proposal batches. Zero performs seed qualification only.
+        proposal_batch_size: Sibling proposals evaluated against each frozen champion.
+        screen_proposals: Whether to prefilter each child on its trigger task subset.
+        holdout_scorer: Optional independent evaluator used as a third gate tier.
+        confirm_narrow_vetoes: Whether capable scorers remeasure narrow gate vetoes.
+
+    Returns:
+        The champion, normalized reports, and complete delta audit record.
+
+    Raises:
+        ValueError: If scorer capabilities, task matrices, attempts, or identities drift.
+        HarnessSearchCancelled: If cancellation is requested at a search boundary.
+    """
+    if iterations < 0:
+        raise ValueError(f"iterations must be non-negative, got {iterations}")
+    if proposal_batch_size < 1:
+        raise ValueError(f"proposal_batch_size must be positive, got {proposal_batch_size}")
+    discovery_attempts = scorer.default_attempts
+    if discovery_attempts < 1:
+        raise ValueError("scorer.default_attempts must be positive")
+    if screen_proposals and not scorer.capabilities.task_subsets:
+        raise ValueError(
+            "scorer cannot evaluate task subsets; pass screen_proposals=False to avoid "
+            "unsupported paid screens"
+        )
+    if confirm_narrow_vetoes and not scorer.capabilities.attempt_overrides:
+        raise ValueError("scorer cannot override attempt counts; pass confirm_narrow_vetoes=False")
+    holdout_attempts = holdout_scorer.default_attempts if holdout_scorer is not None else None
+    if holdout_scorer is not None:
+        assert holdout_attempts is not None
+        if holdout_attempts < 1:
+            raise ValueError("holdout_scorer.default_attempts must be positive")
+        if confirm_narrow_vetoes and not holdout_scorer.capabilities.attempt_overrides:
+            raise ValueError(
+                "holdout scorer cannot override attempt counts; pass confirm_narrow_vetoes=False"
+            )
+        if confirm_narrow_vetoes and holdout_attempts != discovery_attempts:
+            raise ValueError(
+                "confirmation requires discovery and holdout scorers to use the same "
+                "default_attempts"
+            )
+    seed_error = scorer.validate_candidate(seed_doc)
+    if seed_error is not None:
+        raise ValueError(f"seed is not eligible for scoring: {seed_error}")
+    if holdout_scorer is not None:
+        holdout_seed_error = holdout_scorer.validate_candidate(seed_doc)
+        if holdout_seed_error is not None:
+            raise ValueError(f"holdout seed is not eligible for scoring: {holdout_seed_error}")
+
+    evaluations_by_id: dict[str, tuple[str, str, str]] = {}
+
+    def _check_cancelled() -> None:
+        if should_cancel is not None and should_cancel():
+            raise HarnessSearchCancelled("harness search cancelled")
+
+    def _note(message: str) -> None:
+        if on_note is not None:
+            on_note(message)
+
+    def _score(
+        active_scorer: HarnessScorer,
+        doc: HarnessDoc,
+        *,
+        purpose: Literal["seed", "screen", "full", "holdout", "confirmation"],
+        task_ids: list[str] | None = None,
+        attempts: int | None = None,
+        expected_task_ids: frozenset[str] | None = None,
+    ) -> HarnessScoreReport:
+        _check_cancelled()
+        request = ScoreRequest(
+            purpose=purpose,
+            task_ids=tuple(task_ids) if task_ids is not None else None,
+            attempts=attempts,
+        )
+        report = _snapshot_score_report(active_scorer.score(doc, request=request))
+        scorer_attempts = (
+            discovery_attempts
+            if active_scorer is scorer
+            else holdout_attempts
+            if active_scorer is holdout_scorer
+            else None
+        )
+        if scorer_attempts is None:
+            raise ValueError("search received a report from an unknown scorer")
+        expected_attempts = attempts or scorer_attempts
+        if report.attempts != expected_attempts:
+            raise ValueError(
+                f"scorer returned attempts={report.attempts}; expected attempts={expected_attempts}"
+            )
+        required_task_ids = frozenset(task_ids) if task_ids is not None else expected_task_ids
+        if required_task_ids is not None and set(report.per_task) != required_task_ids:
+            missing = sorted(required_task_ids - set(report.per_task))
+            extra = sorted(set(report.per_task) - required_task_ids)
+            raise ValueError(
+                f"scorer returned the wrong task set; missing={missing}, extra={extra}"
+            )
+        evaluation_record = (
+            doc.execution_hash,
+            request.model_dump_json(),
+            _score_report_fingerprint(report),
+        )
+        prior_record = evaluations_by_id.get(report.evaluation_id)
+        if prior_record is not None and prior_record != evaluation_record:
+            raise ValueError(
+                f"evaluation_id {report.evaluation_id!r} identifies a different report"
+            )
+        evaluations_by_id[report.evaluation_id] = evaluation_record
+        _check_cancelled()
+        return report
+
+    docs: dict[str, HarnessDoc] = {seed_doc.doc_hash: seed_doc}
+    reports: dict[str, HarnessScoreReport] = {}
+    holdout_reports: dict[str, HarnessScoreReport] = {}
+    archive = DeltaArchive(seed=seed_doc)
+    failure_cluster_expansions: dict[FailureClusterKey, int] = {}
+    skipped = 0
+    screened = 0
+    confirmations = 0
+
+    seed_report = _score(scorer, seed_doc, purpose="seed")
+    if not seed_report.per_task:
+        raise ValueError("seed score report contains no tasks")
+    discovery_task_ids = frozenset(seed_report.per_task)
+    reports[seed_doc.doc_hash] = seed_report
+    holdout_task_ids: frozenset[str] | None = None
+    if holdout_scorer is not None:
+        seed_holdout = _score(holdout_scorer, seed_doc, purpose="holdout")
+        if not seed_holdout.per_task:
+            raise ValueError("holdout seed score report contains no tasks")
+        holdout_task_ids = frozenset(seed_holdout.per_task)
+        holdout_reports[seed_doc.doc_hash] = seed_holdout
+    if on_progress is not None:
+        on_progress(0, seed_doc.name, seed_report.score, True)
+
+    champion_hash = seed_doc.doc_hash
+    best_full = seed_report.score
+    suite = sorted(task_id for task_id, task in seed_report.per_task.items() if task.passed)
+    proposal_records: list[ProposalRecord] = []
+
+    def _stage_dead(records: list[ProposalRecord], record: ProposalRecord) -> None:
+        records.append(record)
+        _note(
+            _dead_proposal_note(
+                record,
+                iterations=iterations,
+                batch_size=proposal_batch_size,
+            )
+        )
+
+    for iteration_index in range(1, iterations + 1):
+        _check_cancelled()
+        scorer.before_proposal_batch()
+        if holdout_scorer is not None and holdout_scorer is not scorer:
+            holdout_scorer.before_proposal_batch()
+        parent = docs[champion_hash]
+        parent_report = reports[champion_hash]
+        frozen_champion_hash = champion_hash
+        frozen_champion_score = parent_report.score
+        frozen_best_full = best_full
+        frozen_suite = list(suite)
+        frozen_champion_holdout = holdout_reports.get(frozen_champion_hash)
+        clusters = cluster_score_failures(parent_report)
+        batch_cluster_key: FailureClusterKey | None = None
+        batch_cluster_expansion_recorded = False
+        if clusters:
+            trigger = select_failure_cluster(
+                clusters,
+                failure_cluster_expansions,
+                parent_doc_hash=parent.doc_hash,
+            )
+            batch_cluster_key = _failure_cluster_key(parent.doc_hash, trigger)
+        else:
+            trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
+        evidence = render_score_evidence(trigger, parent_report)
+        try:
+            batch = proposer.propose_batch(
+                parent,
+                trigger,
+                evidence,
+                history=archive.deltas,
+                count=proposal_batch_size,
+                should_cancel=should_cancel,
+            )
+            if len(batch) != proposal_batch_size:
+                raise ValueError(
+                    f"proposer returned {len(batch)} proposals; expected {proposal_batch_size}"
+                )
+        except HarnessSearchCancelled:
+            raise
+        except Exception as error:  # noqa: BLE001
+            batch = [ProposalFailure(reason=str(error))] * proposal_batch_size
+        _check_cancelled()
+
+        batch_records: list[ProposalRecord] = []
+        batch_deltas: list[HarnessDelta] = []
+        scored_proposals: list[_ScoredProposal] = []
+        seen_delta_ids = {delta.delta_id for delta in archive.deltas}
+        seen_child_hashes = {
+            delta.child_doc_hash for delta in archive.deltas if delta.child_doc_hash is not None
+        }
+
+        for proposal_index, proposed in enumerate(batch, 1):
+            _check_cancelled()
+            label = _proposal_label(
+                iteration_index,
+                proposal_index,
+                iterations=iterations,
+                batch_size=proposal_batch_size,
+            )
+            if isinstance(proposed, ProposalFailure):
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="proposer_error",
+                        trigger=trigger,
+                        reason=proposed.reason,
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+            if proposed is None:
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="unusable",
+                        trigger=trigger,
+                        reason="unparseable or truncated meta reply",
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+            delta = proposed
+            ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
+            rationales = [op.rationale[:1_000] for op in delta.ops]
+            expected_effect = delta.expected_effect[:1_000]
+            if delta.delta_id in seen_delta_ids:
+                delta.verdict = GateRecord(
+                    accepted=False,
+                    reason="invalid before eval: duplicate of an already-proposed delta",
+                )
+                batch_deltas.append(delta)
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="invalid",
+                        delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
+                        ops=ops_summary,
+                        rationales=rationales,
+                        reason="duplicate of an already-proposed delta",
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+            seen_delta_ids.add(delta.delta_id)
+            batch_deltas.append(delta)
+            try:
+                child = apply_delta(
+                    parent,
+                    delta,
+                    f"{name}-i{iteration_index}-p{proposal_index}",
+                )
+            except ValueError as error:
+                delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {error}")
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="invalid",
+                        delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
+                        ops=ops_summary,
+                        rationales=rationales,
+                        reason=f"invalid before eval: {error}",
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+            if child.doc_hash in seen_child_hashes:
+                delta.verdict = GateRecord(
+                    accepted=False,
+                    reason="invalid before eval: duplicate of an already-proposed child",
+                )
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="invalid",
+                        candidate=child.name,
+                        candidate_doc_hash=child.doc_hash,
+                        delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
+                        ops=ops_summary,
+                        rationales=rationales,
+                        reason="duplicate of an already-proposed child",
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+            seen_child_hashes.add(child.doc_hash)
+            validation_error = scorer.validate_candidate(child)
+            if validation_error is None and holdout_scorer is not None:
+                validation_error = holdout_scorer.validate_candidate(child)
+            if validation_error is not None:
+                reason = f"invalid before eval: {validation_error}"
+                delta.verdict = GateRecord(accepted=False, reason=reason)
+                skipped += 1
+                _stage_dead(
+                    batch_records,
+                    ProposalRecord(
+                        iteration=iteration_index,
+                        proposal_index=proposal_index,
+                        outcome="invalid",
+                        candidate=child.name,
+                        candidate_doc_hash=child.doc_hash,
+                        delta_id=delta.delta_id,
+                        trigger=delta.trigger,
+                        expected_effect=expected_effect,
+                        ops=ops_summary,
+                        rationales=rationales,
+                        reason=reason,
+                        champion_score=frozen_champion_score,
+                    ),
+                )
+                continue
+
+            if batch_cluster_key is not None and not batch_cluster_expansion_recorded:
+                failure_cluster_expansions[batch_cluster_key] = (
+                    failure_cluster_expansions.get(batch_cluster_key, 0) + 1
+                )
+                batch_cluster_expansion_recorded = True
+
+            screen_child_value: float | None = None
+            screen_parent_value: float | None = None
+            screen_child_secondary: float | None = None
+            screen_parent_secondary: float | None = None
+            screen_task_ids = sorted(trigger.task_ids)
+            if screen_proposals and screen_task_ids:
+                screen_report = _score(
+                    scorer,
+                    child,
+                    purpose="screen",
+                    task_ids=screen_task_ids,
+                )
+                parent_mean = suite_score(parent_report, screen_task_ids)
+                child_mean = suite_score(screen_report, screen_task_ids)
+                parent_secondary = suite_secondary_score(parent_report, screen_task_ids)
+                child_secondary = suite_secondary_score(screen_report, screen_task_ids)
+                screen_child_value = child_mean
+                screen_parent_value = parent_mean
+                screen_child_secondary = child_secondary
+                screen_parent_secondary = parent_secondary
+                feedback_error = _record_score_evaluation(
+                    proposer,
+                    delta,
+                    stage="screen",
+                    report=screen_report,
+                    summary=(
+                        f"trigger score {child_mean:.3f} vs parent {parent_mean:.3f}; "
+                        f"secondary score {child_secondary:.3f} vs parent {parent_secondary:.3f}"
+                    ),
+                )
+                if feedback_error is not None:
+                    _note(
+                        f"{label}: screen feedback could not be persisted "
+                        f"({feedback_error}); continuing"
+                    )
+                success_regressed = child_mean < parent_mean - _TIE_EPS
+                success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
+                secondary_did_not_improve = child_secondary <= parent_secondary + _TIE_EPS
+                if success_regressed or (success_tied and secondary_did_not_improve):
+                    delta.verdict = GateRecord(
+                        accepted=False,
+                        reason=(
+                            f"screened out: trigger score {child_mean:.2f} vs parent "
+                            f"{parent_mean:.2f}; secondary score {child_secondary:.2f} vs "
+                            f"parent {parent_secondary:.2f} over {len(screen_task_ids)} "
+                            f"task(s), attempts={discovery_attempts}; the delta did not "
+                            "improve its own target"
+                        ),
+                    )
+                    screened += 1
+                    _stage_dead(
+                        batch_records,
+                        ProposalRecord(
+                            iteration=iteration_index,
+                            proposal_index=proposal_index,
+                            outcome="screened",
+                            candidate=child.name,
+                            candidate_doc_hash=child.doc_hash,
+                            delta_id=delta.delta_id,
+                            trigger=delta.trigger,
+                            expected_effect=expected_effect,
+                            ops=ops_summary,
+                            rationales=rationales,
+                            reason=delta.verdict.reason,
+                            screen_child=child_mean,
+                            screen_parent=parent_mean,
+                            screen_child_secondary=child_secondary,
+                            screen_parent_secondary=parent_secondary,
+                            champion_score=frozen_champion_score,
+                        ),
+                    )
+                    continue
+
+            child_report = _score(
+                scorer,
+                child,
+                purpose="full",
+                expected_task_ids=discovery_task_ids,
+            )
+            pre_verdict = gate_score_delta(
+                delta,
+                child=child_report,
+                champion=parent_report,
+                best_full=frozen_best_full,
+                suite=frozen_suite,
+            )
+            could_accept = pre_verdict.accepted or (
+                confirm_narrow_vetoes
+                and narrow_failing_tiers(
+                    pre_verdict,
+                    k=discovery_attempts,
+                    n_suite=len(frozen_suite),
+                    n_holdout=0,
+                )
+                is not None
+            )
+            if holdout_scorer is not None and could_accept:
+                child_holdout = _score(
+                    holdout_scorer,
+                    child,
+                    purpose="holdout",
+                    expected_task_ids=holdout_task_ids,
+                )
+                holdout_reports[child.doc_hash] = child_holdout
+                if frozen_champion_holdout is None:
+                    frozen_champion_holdout = _score(
+                        holdout_scorer,
+                        parent,
+                        purpose="holdout",
+                        expected_task_ids=holdout_task_ids,
+                    )
+                    holdout_reports[frozen_champion_hash] = frozen_champion_holdout
+                verdict = gate_score_delta(
+                    delta,
+                    child=child_report,
+                    champion=parent_report,
+                    best_full=frozen_best_full,
+                    suite=frozen_suite,
+                    child_holdout=child_holdout,
+                    champion_holdout=frozen_champion_holdout,
+                )
+            else:
+                verdict = pre_verdict
+            tiers = (
+                narrow_failing_tiers(
+                    verdict,
+                    k=discovery_attempts,
+                    n_suite=len(frozen_suite),
+                    n_holdout=(
+                        len(frozen_champion_holdout.per_task)
+                        if frozen_champion_holdout is not None
+                        else 0
+                    ),
+                )
+                if confirm_narrow_vetoes
+                else None
+            )
+            if tiers:
+                confirmations += 1
+                confirmed_ok = True
+                notes: list[str] = []
+                for tier in tiers:
+                    active_scorer = scorer if tier == "suite" else holdout_scorer
+                    assert active_scorer is not None
+                    task_ids = frozen_suite if tier == "suite" else None
+                    attempts = 2 * (
+                        discovery_attempts if tier == "suite" else holdout_attempts or 0
+                    )
+                    child_re = _score(
+                        active_scorer,
+                        child,
+                        purpose="confirmation",
+                        task_ids=task_ids,
+                        attempts=attempts,
+                        expected_task_ids=(
+                            discovery_task_ids if tier == "suite" else holdout_task_ids
+                        ),
+                    )
+                    champion_re = _score(
+                        active_scorer,
+                        parent,
+                        purpose="confirmation",
+                        task_ids=task_ids,
+                        attempts=attempts,
+                        expected_task_ids=(
+                            discovery_task_ids if tier == "suite" else holdout_task_ids
+                        ),
+                    )
+                    score_delta = child_re.score - champion_re.score
+                    secondary_delta = child_re.secondary_score - champion_re.secondary_score
+                    notes.append(
+                        f"{tier} re-measured at attempts={attempts}: score "
+                        f"{score_delta:+.3f}, secondary score {secondary_delta:+.3f}"
+                    )
+                    if score_delta < -_TIE_EPS or (
+                        abs(score_delta) <= _TIE_EPS and secondary_delta < -_TIE_EPS
+                    ):
+                        confirmed_ok = False
+                outcome = "veto overturned" if confirmed_ok else "regression confirmed"
+                verdict = GateRecord(
+                    suite_delta=verdict.suite_delta,
+                    suite_secondary_delta=verdict.suite_secondary_delta,
+                    full_delta=verdict.full_delta,
+                    full_secondary_delta=verdict.full_secondary_delta,
+                    holdout_delta=verdict.holdout_delta,
+                    holdout_secondary_delta=verdict.holdout_secondary_delta,
+                    accepted=confirmed_ok,
+                    reason=(
+                        f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
+                        f"{verdict.reason}"
+                    ),
+                )
+
+            docs[child.doc_hash] = child
+            reports[child.doc_hash] = child_report
+            record = ProposalRecord(
+                iteration=iteration_index,
+                proposal_index=proposal_index,
+                outcome="scored",
+                candidate=child.name,
+                candidate_doc_hash=child.doc_hash,
+                delta_id=delta.delta_id,
+                trigger=delta.trigger,
+                expected_effect=expected_effect,
+                ops=ops_summary,
+                rationales=rationales,
+                reason=verdict.reason,
+                score=child_report.score,
+                gate_eligible=verdict.accepted,
+                screen_child=screen_child_value,
+                screen_parent=screen_parent_value,
+                screen_child_secondary=screen_child_secondary,
+                screen_parent_secondary=screen_parent_secondary,
+                champion_score=frozen_champion_score,
+            )
+            batch_records.append(record)
+            scored_proposals.append(
+                _ScoredProposal(
+                    proposal_index=proposal_index,
+                    child=child,
+                    delta=delta,
+                    report=child_report,
+                    gate=verdict,
+                    record=record,
+                )
+            )
+
+        _check_cancelled()
+        eligible = [candidate for candidate in scored_proposals if candidate.gate.accepted]
+        winner = (
+            max(
+                eligible,
+                key=lambda candidate: (
+                    candidate.report.score,
+                    candidate.report.secondary_score,
+                    -candidate.proposal_index,
+                ),
+            )
+            if eligible
+            else None
+        )
+        for candidate in scored_proposals:
+            gate_eligible = candidate.gate.accepted
+            if winner is candidate:
+                final_gate = candidate.gate
+            elif gate_eligible:
+                assert winner is not None
+                final_gate = candidate.gate.model_copy(
+                    update={
+                        "accepted": False,
+                        "reason": (
+                            "gate eligible but not selected: "
+                            f"proposal {winner.proposal_index} ranked higher by full score, "
+                            "secondary score, then proposal order | " + candidate.gate.reason
+                        ),
+                    }
+                )
+            else:
+                final_gate = candidate.gate
+            candidate.delta.verdict = final_gate
+            candidate.record.gate_eligible = gate_eligible
+            candidate.record.selected = winner is candidate
+            candidate.record.reason = final_gate.reason
+
+        for candidate in scored_proposals:
+            assert candidate.delta.verdict is not None
+            feedback_error = _record_score_evaluation(
+                proposer,
+                candidate.delta,
+                stage="full",
+                report=candidate.report,
+                summary=candidate.delta.verdict.reason,
+            )
+            if feedback_error is not None:
+                _note(
+                    f"iteration {iteration_index}/{iterations} proposal "
+                    f"{candidate.proposal_index}/{proposal_batch_size}: full feedback could "
+                    f"not be persisted ({feedback_error}); continuing"
+                )
+
+        _check_cancelled()
+        archive.deltas.extend(batch_deltas)
+        if winner is not None:
+            champion_hash = winner.child.doc_hash
+            best_full = max(best_full, winner.report.score)
+            suite = sorted(
+                set(suite)
+                | {task_id for task_id, task in winner.report.per_task.items() if task.passed}
+            )
+            if on_accept is not None:
+                on_accept(winner.child, winner.delta, winner.report.score)
+
+        proposal_records.extend(batch_records)
+        if on_proposal is not None:
+            for record in batch_records:
+                on_proposal(record)
+        if on_progress is not None:
+            champion = docs[champion_hash]
+            on_progress(
+                iteration_index,
+                champion.name,
+                reports[champion_hash].score,
+                winner is not None,
+            )
+
+    _check_cancelled()
+    best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
+    return SearchResult(
+        best=best,
+        best_score=reports[champion_hash].score,
+        archive=archive,
+        reports={doc_hash: report.model_copy(deep=True) for doc_hash, report in reports.items()},
+        holdout_reports={
+            doc_hash: report.model_copy(deep=True) for doc_hash, report in holdout_reports.items()
+        },
+        suite=suite,
+        skipped=skipped,
+        proposal_records=proposal_records,
+        screened=screened,
+        confirmations=confirmations,
+        iterations=iterations,
+        proposal_batch_size=proposal_batch_size,
+    )
+
+
+ClosedLoopScoreFn = Callable[[HarnessDoc, list[TaskSpec], int], ClosedLoopReport]
+
+
+class _ClosedLoopHarnessScorer:
+    """Adapt the existing world-model evaluation into normalized search scores."""
+
+    capabilities = ScoreCapabilities(task_subsets=True, attempt_overrides=True)
+
+    def __init__(
+        self,
+        tasks: list[TaskSpec],
+        *,
+        default_attempts: int,
+        evaluate: ClosedLoopScoreFn,
+        validate_candidate: Callable[[HarnessDoc], str | None],
+        before_proposal_batch: Callable[[], None],
+    ) -> None:
+        self._tasks = list(tasks)
+        self._by_id = {task.task_id: task for task in tasks}
+        if len(self._by_id) != len(tasks):
+            raise ValueError("closed-loop search task ids must be unique")
+        self.default_attempts = default_attempts
+        self._evaluate = evaluate
+        self._validate = validate_candidate
+        self._before_proposal = before_proposal_batch
+        self.raw_reports: dict[str, ClosedLoopReport] = {}
+
+    def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+        return self._validate(candidate)
+
+    def before_proposal_batch(self) -> None:
+        self._before_proposal()
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+        if request.task_ids is None:
+            tasks = self._tasks
+        else:
+            unknown = sorted(set(request.task_ids) - set(self._by_id))
+            if unknown:
+                raise ValueError(f"score request contains unknown task ids: {unknown}")
+            selected = set(request.task_ids)
+            tasks = [task for task in self._tasks if task.task_id in selected]
+        attempts = request.attempts or self.default_attempts
+        raw = self._evaluate(candidate, tasks, attempts)
+        if raw.k != attempts:
+            raise ValueError(f"closed-loop evaluator returned k={raw.k} for attempts={attempts}")
+        _validate_closed_loop_report(tasks, raw, attempts=attempts)
+        if request.purpose in ("seed", "full", "holdout"):
+            self.raw_reports[candidate.doc_hash] = raw
+        return _closed_loop_score(candidate, tasks, raw, request)
+
+
+def _validate_closed_loop_report(
+    tasks: list[TaskSpec], report: ClosedLoopReport, *, attempts: int
+) -> None:
+    """Reject a raw scorecard unless its full task-attempt matrix is internally consistent."""
+    expected_task_ids = {task.task_id for task in tasks}
+    actual_task_ids = set(report.per_task)
+    if actual_task_ids != expected_task_ids:
+        missing = sorted(expected_task_ids - actual_task_ids)
+        extra = sorted(actual_task_ids - expected_task_ids)
+        raise ValueError(
+            f"closed-loop evaluator returned wrong task set; missing={missing}, extra={extra}"
+        )
+
+    success_rates: list[float] = []
+    secondary_scores: list[float] = []
+    for task_id in sorted(expected_task_ids):
+        outcome = report.per_task[task_id]
+        if outcome.task_id != task_id:
+            raise ValueError(
+                f"closed-loop report key {task_id!r} does not match task_id {outcome.task_id!r}"
+            )
+        if outcome.passes != attempts:
+            raise ValueError(
+                f"closed-loop task {task_id!r} returned passes={outcome.passes}; "
+                f"expected {attempts}"
+            )
+        if len(outcome.verdicts) != attempts:
+            raise ValueError(
+                f"closed-loop task {task_id!r} returned {len(outcome.verdicts)} verdicts; "
+                f"expected {attempts}"
+            )
+        if len(outcome.attempts) != attempts:
+            raise ValueError(
+                f"closed-loop task {task_id!r} returned {len(outcome.attempts)} evidence "
+                f"records; expected {attempts}"
+            )
+
+        success_rate = (
+            sum(1.0 if verdict.passed else 0.0 for verdict in outcome.verdicts) / attempts
+        )
+        secondary_score = sum(verdict.fraction for verdict in outcome.verdicts) / attempts
+        if not isclose(outcome.success_rate, success_rate, rel_tol=0.0, abs_tol=_TIE_EPS):
+            raise ValueError(
+                f"closed-loop task {task_id!r} success_rate={outcome.success_rate!r} is "
+                f"inconsistent with verdicts={success_rate!r}"
+            )
+        if not isclose(outcome.mean_fraction, secondary_score, rel_tol=0.0, abs_tol=_TIE_EPS):
+            raise ValueError(
+                f"closed-loop task {task_id!r} mean_fraction={outcome.mean_fraction!r} is "
+                f"inconsistent with verdicts={secondary_score!r}"
+            )
+        success_rates.append(success_rate)
+        secondary_scores.append(secondary_score)
+
+    aggregate_score = sum(success_rates) / len(success_rates) if success_rates else 0.0
+    aggregate_secondary = sum(secondary_scores) / len(secondary_scores) if secondary_scores else 0.0
+    if not isclose(report.success_rate, aggregate_score, rel_tol=0.0, abs_tol=_TIE_EPS):
+        raise ValueError(
+            f"closed-loop report success_rate={report.success_rate!r} is inconsistent with "
+            f"per-task mean={aggregate_score!r}"
+        )
+    if not isclose(report.mean_fraction, aggregate_secondary, rel_tol=0.0, abs_tol=_TIE_EPS):
+        raise ValueError(
+            f"closed-loop report mean_fraction={report.mean_fraction!r} is inconsistent with "
+            f"per-task mean={aggregate_secondary!r}"
+        )
+
+
+def _closed_loop_score(
+    candidate: HarnessDoc,
+    tasks: list[TaskSpec],
+    report: ClosedLoopReport,
+    request: ScoreRequest,
+) -> HarnessScoreReport:
+    """Project a gold-judged report onto the benchmark-neutral search contract."""
+    task_scores: dict[str, TaskScore] = {}
+    for task in tasks:
+        outcome = report.per_task.get(task.task_id)
+        if outcome is None:
+            raise ValueError(f"closed-loop report is missing task {task.task_id!r}")
+        mechanisms: list[str] = []
+        seen: set[str] = set()
+        for verdict in outcome.verdicts:
+            for assertion in verdict.assertions:
+                if not assertion.passed and assertion.assertion not in seen:
+                    seen.add(assertion.assertion)
+                    mechanisms.append(assertion.assertion)
+        description = _bounded_score_text(
+            task.instruction,
+            limit=MAX_TASK_DESCRIPTION_CHARS,
+            label="description",
+        )
+        evidence = _bounded_score_text(
+            render_task_attempt_evidence(outcome),
+            limit=MAX_TASK_EVIDENCE_CHARS,
+            label="evidence",
+        )
+        task_scores[task.task_id] = TaskScore(
+            task_id=task.task_id,
+            score=outcome.success_rate,
+            secondary_score=outcome.mean_fraction,
+            passed=outcome.success_rate >= 1.0 - _TIE_EPS,
+            description=description,
+            mechanisms=tuple(mechanisms),
+            evidence=evidence,
+        )
+    identity_input = "\x00".join(
+        (
+            candidate.execution_hash,
+            request.purpose,
+            str(report.k),
+            *(task.task_id for task in tasks),
+            report.model_dump_json(),
+        )
+    )
+    digest = hashlib.blake2b(identity_input.encode("utf-8"), digest_size=16).hexdigest()
+    return HarnessScoreReport(
+        evaluation_id=f"closed-loop:{digest}",
+        label=report.label,
+        score=report.success_rate,
+        secondary_score=report.mean_fraction,
+        attempts=report.k,
+        per_task=task_scores,
+    )
+
+
+def _bounded_score_text(value: str, *, limit: int, label: str) -> str:
+    """Bound one proposer-facing field while preserving an explicit truncation marker."""
+    if len(value) <= limit:
+        return value
+    marker = f"\n...[{label} truncated; original_chars={len(value)}]"
+    return value[: limit - len(marker)] + marker
 
 
 def create_harness(
@@ -407,693 +1274,137 @@ def create_harness(
     on_sandbox_usage: Callable[[SandboxUsage], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
 ) -> CreateResult:
-    """Search for a better harness under a fixed eval budget; the champion is renamed to `name`.
-
-    Scores the seed first, then runs ``iterations`` proposal batches. Each iteration asks the
-    proposer for ``proposal_batch_size`` siblings against the frozen champion, evaluates every
-    sibling against that same snapshot, and selects at most one winner. A dead proposal
-    (unusable, invalid, or screened out on its trigger cluster) ends early and cheaply. It is
-    counted, recorded in ``proposal_records``, and narrated via ``on_note`` without aborting its
-    siblings. ``on_proposal`` receives every final record in stable proposal order after
-    selection. ``on_progress`` receives the seed plus exactly one champion point per iteration,
-    including an unchanged point when no proposal wins. ``on_accept`` fires at most once per
-    iteration with the selected champion, its final delta verdict, and its full-suite score.
-    ``on_note`` is an eager diagnostic stream, so dead-proposal and feedback-error notes may fire
-    while siblings are still evaluating. ``on_proposal`` waits for batch selection and then fires
-    in stable proposal order. The iteration's ``on_progress`` checkpoint follows those records.
-
-    ``on_sandbox_usage`` fires after the shared E2B pool is successfully closed on every exit
-    path, including failures and cancellation, so callers can persist already-incurred evaluator
-    spend without requiring a partial result. An unproven close raises instead of publishing a
-    falsely final meter.
-    ``should_cancel`` is checked before and after every score wave, before each proposal slot,
-    and after each batched proposer call. E2B runtimes also poll it while waiting for runner
-    frames, so cancellation aborts the active wave without judging partial cells. A provider/tool
-    call already in progress remains bounded by that call's own timeout. Cancellation raises
-    :class:`HarnessSearchCancelled` while the normal ``finally`` path retires sandbox resources.
-
-    Every rollout scores against the world-model simulation — the environment is always sim.
-    `harness_backend` picks where the harness PROCESS executes: `local` (the default) runs it
-    in/from this process exactly as before; `e2b` runs the real pi agent inside E2B sandboxes
-    (pi-node seeds only — that harness's context management is the thing under search), with its
-    tool calls still answered by the world model host-side. One `E2BSandboxPool` is shared across
-    score waves within a proposal batch, then its idle runners are retired before the next batch's
-    proposer call. This amortizes bootstrap work across sibling proposals without carrying E2B
-    command streams through the potentially long proposal gap between iterations. `eval_concurrency`
-    is how many (task, attempt) cells run at once; `None` means the backend default — 1
-    (sequential) for local, 0 (every cell at once, one pooled sandbox each) for e2b.
-    `e2b_template` names a prebaked sandbox template (node 22 + the pi runner deps) so e2b
-    rollouts skip bootstrap installs. `e2b_metadata` tags every sandbox created by the shared
-    evaluation pool, including fresh replacements for retired runners.
-
-    Verification is staged by cost: a child is first SCREENED on its own trigger cluster (the
-    2-3 failing tasks its delta claims to fix, k passes). The screen is lexicographic: full-task
-    success first, then assertion-level partial credit, so a real partial fix is not flattened
-    into a binary tie. If neither signal improves, the delta is rejected and archived for a
-    fraction of a full eval's cost. Repeated iterations discount
-    their cluster on that parent, preventing one environment-limited singleton from absorbing the
-    whole run. Held-out evals run only for children that pass tiers 1-2, so a bad delta costs at
-    most one full-split eval. Every judged delta (screened, rejected, or accepted) is fed back to
-    the proposer as history, so it iterates instead of re-proposing rejected ideas.
-
-    Symmetrically, a REJECTION can be noise: with k passes over small tiers, one unlucky attempt
-    can veto a genuine win. When `confirm_narrow_vetoes` is set, a delta that strictly won the
-    full split but failed suite/holdout within `narrow_failing_tiers`' margin gets that tier
-    re-measured — child AND champion, at 2k — and the re-measurement decides. The verdict records
-    the retrial either way, so the archive shows which accepts needed confirmation.
-    """
+    """Run the existing world-model search through the benchmark-neutral scorer seam."""
     if harness_backend not in ("local", "e2b"):
         raise ValueError(f"unknown harness_backend {harness_backend!r}; choose local or e2b")
-    if proposal_batch_size < 1:
-        raise ValueError(f"proposal_batch_size must be positive, got {proposal_batch_size}")
     if harness_backend == "e2b" and seed_doc.runtime_kind() != "pi-node":
         raise ValueError(
             "harness_backend='e2b' runs the pi-node harness process in sandboxes; seed "
-            f"runtime kind is {seed_doc.runtime_kind()!r}, which already runs in-process — "
+            f"runtime kind is {seed_doc.runtime_kind()!r}, which already runs in-process; "
             "use harness_backend='local'"
         )
+
     sandbox_pool: E2BSandboxPool | None = None
     if harness_backend == "e2b":
-        # Lazy: the e2b backend is an optional extra; local searches must import none of it.
         from wmh.harness.pi_e2b import E2BSandboxPool as _Pool
 
         sandbox_pool = _Pool(template=e2b_template, metadata=e2b_metadata)
 
+    worker_usages: list[TokenUsage | None] = []
     cancelled: HarnessSearchCancelled | None = None
     result: CreateResult | None = None
-    try:
 
-        def _check_cancelled() -> None:
-            if should_cancel is not None and should_cancel():
-                raise HarnessSearchCancelled("harness search cancelled")
+    def _check_cancelled() -> None:
+        if should_cancel is not None and should_cancel():
+            raise HarnessSearchCancelled("harness search cancelled")
 
-        def _note(message: str) -> None:
-            # Narration for iterations that produce NO on_progress event (unusable/invalid/screened
-            # proposals): without it a run whose proposals all fail looks like it never iterated.
-            if on_note is not None:
-                on_note(message)
-
-        docs: dict[str, HarnessDoc] = {seed_doc.doc_hash: seed_doc}
-        worker_usages: list[TokenUsage | None] = []
-        reports: dict[str, ClosedLoopReport] = {}
-        holdout_reports: dict[str, ClosedLoopReport] = {}
-        archive = DeltaArchive(seed=seed_doc)
-        failure_cluster_expansions: dict[FailureClusterKey, int] = {}
-        skipped = 0
-        screened = 0
-        confirmations = 0
-
-        def _score(
-            doc: HarnessDoc, split: list[TaskSpec], *, k_override: int | None = None
-        ) -> ClosedLoopReport:
-            _check_cancelled()
-            k_eff = k if k_override is None else k_override
-            if harness_backend == "local":
-                concurrency = eval_concurrency if eval_concurrency is not None else 1
-                if concurrency != 1 and doc.runtime_kind() == "pi-node":
-                    # Local pi runtimes are single-episode resources (one runner port/workdir, or
-                    # one RunnerLink channel): parallel cells would collide. Checked per-doc because
-                    # a delta can flip param:runtime-kind mid-search.
-                    raise ValueError(
-                        "pi-node harnesses run one episode at a time under harness_backend='local' "
-                        "(single runner port/channel); use eval_concurrency=1 or "
-                        "harness_backend='e2b'"
-                    )
-                runtime = doc.runtime(agent_provider)
-            else:
-                # The pi process runs in pooled sandboxes; every cell at once by default. Tool calls
-                # still route to the world model — the environment is sim regardless of backend.
-                concurrency = eval_concurrency if eval_concurrency is not None else 0
-                runtime = doc.runtime(
-                    agent_provider,
-                    backend="e2b",
-                    e2b_pool=sandbox_pool,
-                    should_cancel=should_cancel,
-                )
-            try:
-                report = evaluate_closed_loop(
-                    split,
-                    world_model,
-                    agent_provider,
-                    judge,
-                    label=doc.name,
-                    k=k_eff,
-                    concurrency=concurrency,
-                    runtime=runtime,
-                    should_cancel=should_cancel,
-                )
-            except RuntimeCancelled as exc:
-                # Cancelled cells are not scoreable outcomes: do not judge them. Converting at the
-                # search boundary preserves the public cancellation contract while the surrounding
-                # finally closes the shared pool and retires every active evaluator sandbox.
-                raise HarnessSearchCancelled(
-                    "harness search cancelled", worker_usage=exc.worker_usage
-                ) from exc
-            # Tally the pi worker's self-metered tokens across every score wave (seed, screens,
-            # full splits, holdout, confirmations): its LLM calls bypass the Provider, so this is
-            # the only record. None on backends whose runtimes don't self-meter (local).
-            worker_usages.append(report.worker_usage)
-            # Append first so a cancellation that lands after evaluation but before
-            # the report is consumed still carries the completed wave's spend.
-            _check_cancelled()
-            return report
-
-        seed_report = _score(seed_doc, tasks)
-        reports[seed_doc.doc_hash] = seed_report
-        if holdout:
-            holdout_reports[seed_doc.doc_hash] = _score(seed_doc, holdout)
-        if on_progress is not None:
-            on_progress(0, seed_doc.name, seed_report.success_rate, True)
-
-        champion_hash = seed_doc.doc_hash
-        best_full = seed_report.success_rate
-        # The regression suite: tasks the champion lineage has fully passed. Wins promote in
-        # on accept.
-        suite = sorted(
-            task.task_id
-            for task in tasks
-            if seed_report.per_task[task.task_id].success_rate >= 1.0 - _TIE_EPS
-        )
-
-        proposal_records: list[ProposalRecord] = []
-
-        def _stage_dead(records: list[ProposalRecord], record: ProposalRecord) -> None:
-            """Stage one dead proposal for ordered publication after batch selection."""
-            records.append(record)
-            _note(
-                _dead_proposal_note(
-                    record,
-                    iterations=iterations,
-                    batch_size=proposal_batch_size,
-                )
+    def _validate_candidate(candidate: HarnessDoc) -> str | None:
+        if harness_backend == "e2b" and candidate.runtime_kind() != "pi-node":
+            return (
+                f"runtime kind {candidate.runtime_kind()!r} cannot run on "
+                "harness_backend='e2b' (pi-node only)"
             )
+        return None
 
-        for iteration_index in range(1, iterations + 1):
-            _check_cancelled()
-            # Eval runners from the previous iteration would otherwise sit idle through the
-            # potentially long proposer call. Sibling score waves still share the newly warmed
-            # pool for this whole iteration.
-            if sandbox_pool is not None:
-                sandbox_pool.retire_idle()
+    def _before_proposal_batch() -> None:
+        if sandbox_pool is not None:
+            sandbox_pool.retire_idle()
 
-            frozen_champion_hash = champion_hash
-            parent = docs[frozen_champion_hash]
-            parent_report = reports[frozen_champion_hash]
-            frozen_champion_score = parent_report.success_rate
-            frozen_best_full = best_full
-            frozen_suite = list(suite)
-            frozen_champion_holdout = holdout_reports.get(frozen_champion_hash)
-            clusters = cluster_failures(parent_report, tasks)
-            batch_cluster_key: FailureClusterKey | None = None
-            batch_cluster_expansion_recorded = False
-            if clusters:
-                trigger = select_failure_cluster(
-                    clusters,
-                    failure_cluster_expansions,
-                    parent_doc_hash=parent.doc_hash,
-                )
-                batch_cluster_key = _failure_cluster_key(parent.doc_hash, trigger)
-            else:
-                trigger = FailureSignature(mechanism=ALL_PASS_MECHANISM)
-            evidence = render_evidence(trigger, parent_report, tasks)
-            try:
-                batch = proposer.propose_batch(
-                    parent,
-                    trigger,
-                    evidence,
-                    history=archive.deltas,
-                    count=proposal_batch_size,
-                    should_cancel=should_cancel,
-                )
-                if len(batch) != proposal_batch_size:
-                    raise ValueError(
-                        f"proposer returned {len(batch)} proposals; expected {proposal_batch_size}"
-                    )
-            except HarnessSearchCancelled:
-                raise
-            except Exception as exc:  # noqa: BLE001 - provider/agent/transport failure
-                batch = [ProposalFailure(reason=str(exc))] * proposal_batch_size
-            _check_cancelled()
-
-            batch_records: list[ProposalRecord] = []
-            batch_deltas: list[HarnessDelta] = []
-            scored_proposals: list[_ScoredProposal] = []
-            seen_delta_ids = {delta.delta_id for delta in archive.deltas}
-            seen_child_hashes = {
-                delta.child_doc_hash for delta in archive.deltas if delta.child_doc_hash is not None
-            }
-
-            for proposal_index, delta in enumerate(batch, 1):
-                _check_cancelled()
-                label = _proposal_label(
-                    iteration_index,
-                    proposal_index,
-                    iterations=iterations,
-                    batch_size=proposal_batch_size,
-                )
-                if isinstance(delta, ProposalFailure):
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="proposer_error",
-                            trigger=trigger,
-                            reason=delta.reason,
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-                if delta is None:
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="unusable",
-                            trigger=trigger,
-                            reason="unparseable or truncated meta reply",
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-                ops_summary = [f"{op.op} {op.surface_id}" for op in delta.ops]
-                rationales = [op.rationale[:1_000] for op in delta.ops]
-                expected_effect = delta.expected_effect[:1_000]
-                if delta.delta_id in seen_delta_ids:
-                    # The proposer re-proposed a delta this run already judged. Re-evaluating it
-                    # would spend a screen (or worse) to learn a known verdict; skip without spend.
-                    # Preserve this proposal as a distinct rejected archive entry so history remains
-                    # complete, including duplicates inside the current sibling batch.
-                    delta.verdict = GateRecord(
-                        accepted=False,
-                        reason="invalid before eval: duplicate of an already-proposed delta",
-                    )
-                    batch_deltas.append(delta)
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="invalid",
-                            delta_id=delta.delta_id,
-                            trigger=delta.trigger,
-                            expected_effect=expected_effect,
-                            ops=ops_summary,
-                            rationales=rationales,
-                            reason="duplicate of an already-proposed delta",
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-                seen_delta_ids.add(delta.delta_id)
-                batch_deltas.append(delta)
-                try:
-                    child_name = f"{name}-i{iteration_index}-p{proposal_index}"
-                    child = apply_delta(parent, delta, child_name)
-                except ValueError as exc:
-                    delta.verdict = GateRecord(accepted=False, reason=f"invalid before eval: {exc}")
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="invalid",
-                            delta_id=delta.delta_id,
-                            trigger=delta.trigger,
-                            expected_effect=expected_effect,
-                            ops=ops_summary,
-                            rationales=rationales,
-                            reason=f"invalid before eval: {exc}",
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-                if child.doc_hash in seen_child_hashes:
-                    delta.verdict = GateRecord(
-                        accepted=False,
-                        reason="invalid before eval: duplicate of an already-proposed child",
-                    )
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="invalid",
-                            candidate=child.name,
-                            candidate_doc_hash=child.doc_hash,
-                            delta_id=delta.delta_id,
-                            trigger=delta.trigger,
-                            expected_effect=expected_effect,
-                            ops=ops_summary,
-                            rationales=rationales,
-                            reason="duplicate of an already-proposed child",
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-                seen_child_hashes.add(child.doc_hash)
-                if harness_backend == "e2b" and child.runtime_kind() != "pi-node":
-                    # A delta that abandons the pi-node runtime cannot execute on this backend:
-                    # `doc.runtime(backend="e2b")` would raise mid-score and abort the whole search.
-                    # Reject-and-archive it like any other invalid-before-eval proposal.
-                    delta.verdict = GateRecord(
-                        accepted=False,
-                        reason=(
-                            f"invalid before eval: runtime kind {child.runtime_kind()!r} cannot "
-                            "run on harness_backend='e2b' (pi-node only)"
-                        ),
-                    )
-                    skipped += 1
-                    _stage_dead(
-                        batch_records,
-                        ProposalRecord(
-                            iteration=iteration_index,
-                            proposal_index=proposal_index,
-                            outcome="invalid",
-                            candidate=child.name,
-                            candidate_doc_hash=child.doc_hash,
-                            delta_id=delta.delta_id,
-                            trigger=delta.trigger,
-                            expected_effect=expected_effect,
-                            ops=ops_summary,
-                            rationales=rationales,
-                            reason=str(delta.verdict.reason),
-                            champion_score=frozen_champion_score,
-                        ),
-                    )
-                    continue
-
-                # Discount the selected cluster only when this batch produces its first child
-                # that can enter evaluation. Parsed-but-duplicate, inapplicable, or
-                # backend-invalid deltas teach the search nothing about that failure mechanism.
-                # Siblings share one expansion, so later children must not discount it again.
-                if batch_cluster_key is not None and not batch_cluster_expansion_recorded:
-                    failure_cluster_expansions[batch_cluster_key] = (
-                        failure_cluster_expansions.get(batch_cluster_key, 0) + 1
-                    )
-                    batch_cluster_expansion_recorded = True
-
-                # Before a full-split eval, the delta must improve its target cluster. Compare
-                # task success first, then assertion-level partial credit, so a 0%-to-75%
-                # assertion lift is not flattened into the same "0 vs 0" as no effect.
-                screen_child_value: float | None = None
-                screen_parent_value: float | None = None
-                screen_child_fraction_value: float | None = None
-                screen_parent_fraction_value: float | None = None
-                screen_tasks = [t for t in tasks if t.task_id in set(trigger.task_ids)]
-                if screen_tasks:
-                    screen_report = _score(child, screen_tasks)
-                    parent_mean = _suite_rate(parent_report, sorted(trigger.task_ids))
-                    child_mean = _suite_rate(screen_report, sorted(trigger.task_ids))
-                    parent_fraction = _suite_fraction(parent_report, sorted(trigger.task_ids))
-                    child_fraction = _suite_fraction(screen_report, sorted(trigger.task_ids))
-                    screen_child_value = child_mean
-                    screen_parent_value = parent_mean
-                    screen_child_fraction_value = child_fraction
-                    screen_parent_fraction_value = parent_fraction
-                    success_regressed = child_mean < parent_mean - _TIE_EPS
-                    success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
-                    fraction_did_not_improve = child_fraction <= parent_fraction + _TIE_EPS
-                    feedback_error = _record_proposer_evaluation(
-                        proposer,
-                        delta,
-                        stage="screen",
-                        report=screen_report,
-                        tasks=screen_tasks,
-                        summary=(
-                            f"trigger success {child_mean:.3f} vs parent {parent_mean:.3f}; "
-                            f"assertion fraction {child_fraction:.3f} vs parent "
-                            f"{parent_fraction:.3f}"
-                        ),
-                    )
-                    if feedback_error is not None:
-                        _note(
-                            f"{label}: screen feedback could not be persisted "
-                            f"({feedback_error}); continuing"
-                        )
-                    if success_regressed or (success_tied and fraction_did_not_improve):
-                        delta.verdict = GateRecord(
-                            accepted=False,
-                            reason=(
-                                f"screened out: trigger success {child_mean:.2f} vs parent "
-                                f"{parent_mean:.2f}; assertion fraction {child_fraction:.2f} vs "
-                                f"parent {parent_fraction:.2f} over {len(screen_tasks)} task(s), "
-                                f"k={k}; "
-                                "the delta did not improve its own target"
-                            ),
-                        )
-                        screened += 1
-                        _stage_dead(
-                            batch_records,
-                            ProposalRecord(
-                                iteration=iteration_index,
-                                proposal_index=proposal_index,
-                                outcome="screened",
-                                candidate=child.name,
-                                candidate_doc_hash=child.doc_hash,
-                                delta_id=delta.delta_id,
-                                trigger=delta.trigger,
-                                expected_effect=expected_effect,
-                                ops=ops_summary,
-                                rationales=rationales,
-                                reason=str(delta.verdict.reason),
-                                screen_child=child_mean,
-                                screen_parent=parent_mean,
-                                screen_child_fraction=child_fraction,
-                                screen_parent_fraction=parent_fraction,
-                                champion_score=frozen_champion_score,
-                            ),
-                        )
-                        continue
-
-                child_report = _score(child, tasks)
-                pre_verdict = gate_delta(
-                    delta,
-                    child=child_report,
-                    champion=parent_report,
-                    best_full=frozen_best_full,
-                    suite=frozen_suite,
-                )
-                # The held-out tier is measured for every candidate that could still be accepted,
-                # including candidates whose suite/full veto is narrow enough for a confirmation
-                # re-run. A confirmation may overturn a veto, but never bypass the held-out tier.
-                could_accept = pre_verdict.accepted or (
-                    confirm_narrow_vetoes
-                    and narrow_failing_tiers(
-                        pre_verdict, k=k, n_suite=len(frozen_suite), n_holdout=0
-                    )
-                    is not None
-                )
-                if holdout and could_accept:
-                    child_holdout = _score(child, holdout)
-                    holdout_reports[child.doc_hash] = child_holdout
-                    if frozen_champion_holdout is None:
-                        frozen_champion_holdout = _score(parent, holdout)
-                        holdout_reports[frozen_champion_hash] = frozen_champion_holdout
-                    verdict = gate_delta(
-                        delta,
-                        child=child_report,
-                        champion=parent_report,
-                        best_full=frozen_best_full,
-                        suite=frozen_suite,
-                        child_holdout=child_holdout,
-                        champion_holdout=frozen_champion_holdout,
-                    )
-                else:
-                    verdict = pre_verdict
-                tiers = (
-                    narrow_failing_tiers(
-                        verdict,
-                        k=k,
-                        n_suite=len(frozen_suite),
-                        n_holdout=len(holdout or []),
-                    )
-                    if confirm_narrow_vetoes
-                    else None
-                )
-                if tiers:
-                    confirmations += 1
-                    confirmed_ok = True
-                    notes: list[str] = []
-                    for tier in tiers:
-                        tier_tasks = (
-                            [t for t in tasks if t.task_id in set(frozen_suite)]
-                            if tier == "suite"
-                            else list(holdout or [])
-                        )
-                        child_re = _score(child, tier_tasks, k_override=2 * k)
-                        champ_re = _score(parent, tier_tasks, k_override=2 * k)
-                        re_delta = child_re.success_rate - champ_re.success_rate
-                        re_fraction_delta = child_re.mean_fraction - champ_re.mean_fraction
-                        notes.append(
-                            f"{tier} re-measured at k={2 * k}: success {re_delta:+.3f}, "
-                            f"assertion fraction {re_fraction_delta:+.3f}"
-                        )
-                        if re_delta < -_TIE_EPS or (
-                            abs(re_delta) <= _TIE_EPS and re_fraction_delta < -_TIE_EPS
-                        ):
-                            confirmed_ok = False
-                    outcome = "veto overturned" if confirmed_ok else "regression confirmed"
-                    verdict = GateRecord(
-                        suite_delta=verdict.suite_delta,
-                        suite_fraction_delta=verdict.suite_fraction_delta,
-                        full_delta=verdict.full_delta,
-                        full_fraction_delta=verdict.full_fraction_delta,
-                        holdout_delta=verdict.holdout_delta,
-                        holdout_fraction_delta=verdict.holdout_fraction_delta,
-                        accepted=confirmed_ok,
-                        reason=f"confirmation re-run ({outcome}): {'; '.join(notes)} | initially: "
-                        + verdict.reason,
-                    )
-                docs[child.doc_hash] = child
-                reports[child.doc_hash] = child_report
-                record = ProposalRecord(
-                    iteration=iteration_index,
-                    proposal_index=proposal_index,
-                    outcome="scored",
-                    candidate=child.name,
-                    candidate_doc_hash=child.doc_hash,
-                    delta_id=delta.delta_id,
-                    trigger=delta.trigger,
-                    expected_effect=expected_effect,
-                    ops=ops_summary,
-                    rationales=rationales,
-                    reason=str(verdict.reason),
-                    score=child_report.success_rate,
-                    gate_eligible=verdict.accepted,
-                    screen_child=screen_child_value,
-                    screen_parent=screen_parent_value,
-                    screen_child_fraction=screen_child_fraction_value,
-                    screen_parent_fraction=screen_parent_fraction_value,
-                    champion_score=frozen_champion_score,
-                )
-                batch_records.append(record)
-                scored_proposals.append(
-                    _ScoredProposal(
-                        proposal_index=proposal_index,
-                        child=child,
-                        delta=delta,
-                        report=child_report,
-                        gate=verdict,
-                        record=record,
-                    )
-                )
-
-            _check_cancelled()
-            eligible = [candidate for candidate in scored_proposals if candidate.gate.accepted]
-            winner = (
-                max(
-                    eligible,
-                    key=lambda candidate: (
-                        candidate.report.success_rate,
-                        candidate.report.mean_fraction,
-                        -candidate.proposal_index,
-                    ),
-                )
-                if eligible
-                else None
-            )
-            for candidate in scored_proposals:
-                gate_eligible = candidate.gate.accepted
-                if winner is candidate:
-                    final_gate = candidate.gate
-                elif gate_eligible:
-                    assert winner is not None
-                    final_gate = candidate.gate.model_copy(
-                        update={
-                            "accepted": False,
-                            "reason": (
-                                "gate eligible but not selected: "
-                                f"proposal {winner.proposal_index} ranked higher by full success, "
-                                "assertion fraction, then proposal order | " + candidate.gate.reason
-                            ),
-                        }
-                    )
-                else:
-                    final_gate = candidate.gate
-                candidate.delta.verdict = final_gate
-                candidate.record.gate_eligible = gate_eligible
-                candidate.record.selected = winner is candidate
-                candidate.record.reason = final_gate.reason
-
-            # Full-stage history must describe final selection, not preliminary gate eligibility.
-            # Persist it before the atomic commit so cancellation cannot publish a partial winner.
-            for candidate in scored_proposals:
-                assert candidate.delta.verdict is not None
-                feedback_error = _record_proposer_evaluation(
-                    proposer,
-                    candidate.delta,
-                    stage="full",
-                    report=candidate.report,
-                    tasks=tasks,
-                    summary=candidate.delta.verdict.reason,
-                )
-                if feedback_error is not None:
-                    _note(
-                        f"iteration {iteration_index}/{iterations} proposal "
-                        f"{candidate.proposal_index}/{proposal_batch_size}: full feedback could "
-                        f"not be persisted ({feedback_error}); continuing"
-                    )
-
-            # One commit boundary for the whole iteration. Diagnostic notes may already have
-            # streamed, but cancellation before this point publishes no archive lineage,
-            # champion, suite, acceptance/proposal callback, or champion checkpoint.
-            _check_cancelled()
-            archive.deltas.extend(batch_deltas)
-            if winner is not None:
-                champion_hash = winner.child.doc_hash
-                best_full = max(best_full, winner.report.success_rate)
-                promoted = {
-                    task_id
-                    for task_id, outcome in winner.report.per_task.items()
-                    if outcome.success_rate >= 1.0 - _TIE_EPS
-                }
-                suite = sorted(set(suite) | promoted)
-                if on_accept is not None:
-                    on_accept(winner.child, winner.delta, winner.report.success_rate)
-
-            proposal_records.extend(batch_records)
-            if on_proposal is not None:
-                for record in batch_records:
-                    on_proposal(record)
-            if on_progress is not None:
-                champion = docs[champion_hash]
-                on_progress(
-                    iteration_index,
-                    champion.name,
-                    reports[champion_hash].success_rate,
-                    winner is not None,
-                )
-
+    def _evaluate(
+        candidate: HarnessDoc,
+        split: list[TaskSpec],
+        attempts: int,
+    ) -> ClosedLoopReport:
         _check_cancelled()
-        best = docs[champion_hash].model_copy(update={"name": name, "version": 0})
-        result = CreateResult(
-            best=best,
-            best_score=reports[champion_hash].success_rate,
-            archive=archive,
-            reports=reports,
-            holdout_reports=holdout_reports,
-            suite=suite,
-            skipped=skipped,
-            proposal_records=proposal_records,
-            screened=screened,
-            confirmations=confirmations,
+        if harness_backend == "local":
+            concurrency = eval_concurrency if eval_concurrency is not None else 1
+            if concurrency != 1 and candidate.runtime_kind() == "pi-node":
+                raise ValueError(
+                    "pi-node harnesses run one episode at a time under harness_backend='local' "
+                    "(single runner port/channel); use eval_concurrency=1 or "
+                    "harness_backend='e2b'"
+                )
+            runtime = candidate.runtime(agent_provider)
+        else:
+            concurrency = eval_concurrency if eval_concurrency is not None else 0
+            runtime = candidate.runtime(
+                agent_provider,
+                backend="e2b",
+                e2b_pool=sandbox_pool,
+                should_cancel=should_cancel,
+            )
+        try:
+            report = evaluate_closed_loop(
+                split,
+                world_model,
+                agent_provider,
+                judge,
+                label=candidate.name,
+                k=attempts,
+                concurrency=concurrency,
+                runtime=runtime,
+                should_cancel=should_cancel,
+            )
+        except RuntimeCancelled as error:
+            raise HarnessSearchCancelled(
+                "harness search cancelled", worker_usage=error.worker_usage
+            ) from error
+        worker_usages.append(report.worker_usage)
+        _check_cancelled()
+        return report
+
+    try:
+        scorer = _ClosedLoopHarnessScorer(
+            tasks,
+            default_attempts=k,
+            evaluate=_evaluate,
+            validate_candidate=_validate_candidate,
+            before_proposal_batch=_before_proposal_batch,
+        )
+        holdout_scorer = (
+            _ClosedLoopHarnessScorer(
+                holdout,
+                default_attempts=k,
+                evaluate=_evaluate,
+                validate_candidate=_validate_candidate,
+                before_proposal_batch=lambda: None,
+            )
+            if holdout
+            else None
+        )
+        search_result = search_harness(
+            name,
+            seed_doc,
+            scorer,
+            proposer,
             iterations=iterations,
             proposal_batch_size=proposal_batch_size,
+            screen_proposals=True,
+            holdout_scorer=holdout_scorer,
+            confirm_narrow_vetoes=confirm_narrow_vetoes,
+            on_progress=on_progress,
+            on_note=on_note,
+            on_proposal=on_proposal,
+            on_accept=on_accept,
+            should_cancel=should_cancel,
+        )
+        result = CreateResult(
+            best=search_result.best,
+            best_score=search_result.best_score,
+            archive=search_result.archive,
+            reports=scorer.raw_reports,
+            holdout_reports=(holdout_scorer.raw_reports if holdout_scorer is not None else {}),
+            suite=search_result.suite,
+            skipped=search_result.skipped,
+            proposal_records=search_result.proposal_records,
+            screened=search_result.screened,
+            confirmations=search_result.confirmations,
+            iterations=search_result.iterations,
+            proposal_batch_size=search_result.proposal_batch_size,
             worker_usage=combine_usage(worker_usages),
         )
         return result
     except HarnessSearchCancelled as error:
-        # A cancellation inside evaluation carries that wave's completed and
-        # partial cells. Waves that returned normally were appended above. The
-        # search exception is the authoritative aggregate for callers because
-        # cancellation intentionally has no partial CreateResult.
         error.worker_usage = combine_usage([*worker_usages, error.worker_usage])
         cancelled = error
         raise
@@ -1109,42 +1420,15 @@ def create_harness(
                 on_sandbox_usage(usage)
 
 
-def _suite_rate(report: ClosedLoopReport, suite: list[str]) -> float:
-    """Mean per-task success over the regression suite; an empty suite constrains nothing."""
-    if not suite:
-        return 1.0
-    rates = [
-        outcome.success_rate
-        for task_id in suite
-        if (outcome := report.per_task.get(task_id)) is not None
-    ]
-    # Dividing by len(suite), not len(rates): a suite task missing from the report counts as 0
-    # (fail-closed), though suite tasks are always a subset of the scored split in practice.
-    return sum(rates) / len(suite)
-
-
-def _suite_fraction(report: ClosedLoopReport, suite: list[str]) -> float:
-    """Mean assertion completion over a task subset; missing tasks fail closed."""
-    if not suite:
-        return 1.0
-    fractions = [
-        outcome.mean_fraction
-        for task_id in suite
-        if (outcome := report.per_task.get(task_id)) is not None
-    ]
-    return sum(fractions) / len(suite)
-
-
-def _record_proposer_evaluation(
+def _record_score_evaluation(
     proposer: DeltaProposer,
     delta: HarnessDelta,
     *,
     stage: str,
-    report: ClosedLoopReport,
-    tasks: list[TaskSpec],
+    report: HarnessScoreReport,
     summary: str,
 ) -> str | None:
-    """Best-effort durable trace feedback; evaluation correctness never depends on telemetry."""
+    """Persist neutral evaluation evidence when the proposer supports feedback."""
     recorder = getattr(proposer, "record_evaluation", None)
     if not callable(recorder):
         return None
@@ -1153,13 +1437,13 @@ def _record_proposer_evaluation(
         f"Delta: {delta.delta_id}\n\n"
         f"Expected effect: {delta.expected_effect}\n\n"
         f"Outcome: {summary}\n\n"
-        f"{render_evidence(delta.trigger, report, tasks)}"
+        f"{render_score_evidence(delta.trigger, report)}"
     )
     try:
         recorder(delta, stage=stage, content=content)
     except HarnessSearchCancelled:
         raise
-    except Exception as error:  # noqa: BLE001 - optional E2B feedback must not abort scored work
+    except Exception as error:  # noqa: BLE001
         return str(error)
     return None
 

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -13,11 +13,12 @@ iteration's champion:
 - **Tier 3 — held-out (optional)**: with a holdout task file, the child must also be no worse than
   the champion on tasks the proposer never saw evidence from.
 
-Ties pass every gate tier: with k passes per task, scores are coarse, and "no worse" is the
-eligibility contract. When multiple siblings are eligible, full success wins, then secondary
-score, then lower proposal index. Every proposed delta, whether selected, rejected, or invalid
-before eval, is recorded in the archive with its verdict. The run as a whole is only as
-reproducible as its providers because proposals and rollouts sample real models at temperature.
+Ties pass every gate tier: with repeated attempts per task, scores can be coarse, and "no worse"
+is the eligibility contract. When multiple siblings are eligible, the full primary score wins,
+then an available declared secondary score, then lower proposal index. Every proposed delta,
+whether selected, rejected, or invalid before eval, is recorded in the archive with its verdict.
+The run as a whole is only as reproducible as its providers because proposals and rollouts sample
+real models at temperature.
 """
 
 from __future__ import annotations
@@ -51,6 +52,7 @@ from wmh.harness.scoring import (
     HarnessScorer,
     HarnessScoreReport,
     ScoreCapabilities,
+    ScoreObjective,
     ScoreRequest,
     TaskScore,
     cluster_score_failures,
@@ -126,10 +128,10 @@ class ProposalRecord(BaseModel):
     ops: list[str] = Field(default_factory=list)  # "replace prompt:main" style summaries
     rationales: list[str] = Field(default_factory=list)
     reason: str | None = None
-    score: float | None = None  # full-suite success rate; scored proposals only
+    score: float | None = None  # full-split primary aggregate; scored proposals only
     gate_eligible: bool | None = None  # frozen non-regression gate; scored proposals only
     selected: bool = False  # true only for the iteration winner
-    screen_child: float | None = None  # trigger-cluster means; screened attempts only
+    screen_child: float | None = None  # trigger-cluster aggregates; screened attempts only
     screen_parent: float | None = None
     screen_child_secondary: float | None = None  # denser secondary screen signal
     screen_parent_secondary: float | None = None
@@ -202,6 +204,22 @@ class _ScoredProposal:
     record: ProposalRecord
 
 
+@dataclass(frozen=True)
+class _ScoreSchema:
+    """Frozen objective and task weights for one scorer role."""
+
+    secondary_objective: ScoreObjective | None
+    task_weights: tuple[tuple[str, float], ...]
+
+
+def _secondary_candidate_rank(candidate: _ScoredProposal) -> tuple[float, float, int]:
+    """Rank a candidate when its scorer declared the secondary objective."""
+    secondary_score = candidate.report.secondary_score
+    if secondary_score is None:
+        raise ValueError("declared secondary objective produced no candidate score")
+    return candidate.report.score, secondary_score, -candidate.proposal_index
+
+
 def select_failure_cluster(
     clusters: list[FailureSignature],
     expansion_counts: dict[FailureClusterKey, int],
@@ -237,24 +255,27 @@ def _failure_cluster_key(parent_doc_hash: str, cluster: FailureSignature) -> Fai
 def narrow_failing_tiers(
     verdict: GateRecord,
     *,
-    k: int,
-    n_suite: int,
-    n_holdout: int,
+    suite_attempt_impact: float | None,
+    holdout_attempt_impact: float | None,
     margin_attempts: int = 2,
 ) -> list[str] | None:
     """Which tiers vetoed this delta narrowly enough to deserve a re-measurement.
 
     Eligible only when the delta strictly won the full split: the question a confirmation
     answers is "was this win vetoed by measurement noise?", not "can a loser get lucky?".
-    A tier's veto is narrow when its regression is at most `margin_attempts` single-attempt
-    flips wide (one flip changes a tier mean by 1/(k*n)). Returns the narrowly-failing tier
-    names, or None when the delta is ineligible (no win, a wide veto, or no veto at all).
+    A tier's veto is narrow when its regression is at most ``margin_attempts`` maximum
+    single-attempt changes wide under the scorer's declared mean-over-attempts contract. Returns
+    the narrowly failing tier names, or None when the delta is ineligible.
     """
     if verdict.accepted or verdict.full_delta <= _TIE_EPS:
         return None
     # A confirmation may only revisit the explicitly returned binary vetoes. Do not let it erase
     # a separate tied-success dense veto on another tier.
-    if abs(verdict.suite_delta) <= _TIE_EPS and verdict.suite_secondary_delta < -_TIE_EPS:
+    if (
+        abs(verdict.suite_delta) <= _TIE_EPS
+        and verdict.suite_secondary_delta is not None
+        and verdict.suite_secondary_delta < -_TIE_EPS
+    ):
         return None
     if (
         verdict.holdout_delta is not None
@@ -265,17 +286,32 @@ def narrow_failing_tiers(
         return None
     tiers: list[str] = []
     if verdict.suite_delta < -_TIE_EPS:
-        if n_suite == 0 or verdict.suite_delta < -(margin_attempts / (k * n_suite)) - _TIE_EPS:
+        if (
+            suite_attempt_impact is None
+            or verdict.suite_delta < -(margin_attempts * suite_attempt_impact) - _TIE_EPS
+        ):
             return None
         tiers.append("suite")
     if verdict.holdout_delta is not None and verdict.holdout_delta < -_TIE_EPS:
         if (
-            n_holdout == 0
-            or verdict.holdout_delta < -(margin_attempts / (k * n_holdout)) - _TIE_EPS
+            holdout_attempt_impact is None
+            or verdict.holdout_delta < -(margin_attempts * holdout_attempt_impact) - _TIE_EPS
         ):
             return None
         tiers.append("holdout")
     return tiers or None
+
+
+def _max_primary_attempt_impact(
+    report: HarnessScoreReport,
+    task_ids: list[str],
+) -> float | None:
+    """Return the largest weighted aggregate change one normalized attempt can cause."""
+    if not task_ids:
+        return None
+    tasks = [report.per_task[task_id] for task_id in task_ids]
+    total_weight = sum(task.aggregate_weight for task in tasks)
+    return max(task.aggregate_weight / total_weight for task in tasks) / report.attempts
 
 
 def gate_score_delta(
@@ -289,30 +325,53 @@ def gate_score_delta(
     champion_holdout: HarnessScoreReport | None = None,
 ) -> GateRecord:
     """Apply the search's lexicographic non-regression gate to neutral scores."""
+    _validate_compatible_score_reports(child, champion, context="discovery")
     suite_delta = suite_score(child, suite) - suite_score(champion, suite)
-    suite_secondary_delta = suite_secondary_score(child, suite) - suite_secondary_score(
-        champion, suite
+    suite_secondary_delta = _optional_score_delta(
+        suite_secondary_score(child, suite),
+        suite_secondary_score(champion, suite),
+        context="discovery suite",
     )
     full_delta = child.score - best_full
-    full_secondary_delta = child.secondary_score - champion.secondary_score
+    full_secondary_delta = _optional_score_delta(
+        child.secondary_score,
+        champion.secondary_score,
+        context="discovery full split",
+    )
+    if (child_holdout is None) != (champion_holdout is None):
+        raise ValueError("holdout gate requires both child and champion reports")
+    if child_holdout is not None and champion_holdout is not None:
+        _validate_compatible_score_reports(child_holdout, champion_holdout, context="holdout")
     holdout_delta = (
         child_holdout.score - champion_holdout.score
         if child_holdout is not None and champion_holdout is not None
         else None
     )
     holdout_secondary_delta = (
-        child_holdout.secondary_score - champion_holdout.secondary_score
+        _optional_score_delta(
+            child_holdout.secondary_score,
+            champion_holdout.secondary_score,
+            context="holdout",
+        )
         if child_holdout is not None and champion_holdout is not None
         else None
     )
     failures: list[str] = []
     if suite_delta < -_TIE_EPS:
         failures.append(f"suite regressed by {-suite_delta:.3f}")
-    elif abs(suite_delta) <= _TIE_EPS and suite_secondary_delta < -_TIE_EPS:
+    elif (
+        abs(suite_delta) <= _TIE_EPS
+        and suite_secondary_delta is not None
+        and suite_secondary_delta < -_TIE_EPS
+    ):
         failures.append(f"suite secondary score regressed by {-suite_secondary_delta:.3f}")
     if full_delta < -_TIE_EPS:
         failures.append(f"full split {child.score:.3f} below best {best_full:.3f}")
-    elif abs(full_delta) <= _TIE_EPS and full_secondary_delta < -_TIE_EPS:
+    elif (
+        abs(full_delta) <= _TIE_EPS
+        and full_secondary_delta is not None
+        and full_secondary_delta < -_TIE_EPS
+    ):
         failures.append(f"full-split secondary score regressed by {-full_secondary_delta:.3f}")
     if holdout_delta is not None and holdout_delta < -_TIE_EPS:
         failures.append(f"held-out regressed by {-holdout_delta:.3f}")
@@ -347,6 +406,41 @@ def gate_score_delta(
     )
 
 
+def _validate_compatible_score_reports(
+    child: HarnessScoreReport,
+    champion: HarnessScoreReport,
+    *,
+    context: str,
+) -> None:
+    """Reject a gate comparison when task or objective schemas differ."""
+    if set(child.per_task) != set(champion.per_task):
+        raise ValueError(f"{context} reports contain different task identities")
+    for task_id in child.per_task:
+        child_weight = child.per_task[task_id].aggregate_weight
+        champion_weight = champion.per_task[task_id].aggregate_weight
+        if child_weight != champion_weight:
+            raise ValueError(
+                f"{context} aggregate weight for task {task_id!r} changed from "
+                f"{champion_weight!r} to {child_weight!r}"
+            )
+    if child.secondary_objective != champion.secondary_objective:
+        raise ValueError(f"{context} reports declare different secondary objectives")
+
+
+def _optional_score_delta(
+    child: float | None,
+    champion: float | None,
+    *,
+    context: str,
+) -> float | None:
+    """Subtract optional objective values only when both are genuinely available."""
+    if child is None and champion is None:
+        return None
+    if child is None or champion is None:
+        raise ValueError(f"{context} secondary score availability changed")
+    return child - champion
+
+
 def _snapshot_score_report(report: HarnessScoreReport) -> HarnessScoreReport:
     """Revalidate and detach a scorer-owned report before it enters search state."""
     snapshot = HarnessScoreReport.model_validate(report.model_dump(mode="json"))
@@ -378,6 +472,7 @@ def search_harness(
     on_proposal: Callable[[ProposalRecord], None] | None = None,
     on_accept: Callable[[HarnessDoc, HarnessDelta, float], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    before_proposal_batch: Callable[[], None] | None = None,
 ) -> SearchResult:
     """Search over harness deltas using normalized scores from an injected evaluator.
 
@@ -395,6 +490,7 @@ def search_harness(
         screen_proposals: Whether to prefilter each child on its trigger task subset.
         holdout_scorer: Optional independent evaluator used as a third gate tier.
         confirm_narrow_vetoes: Whether capable scorers remeasure narrow gate vetoes.
+        before_proposal_batch: Optional lifecycle callback run before each proposer batch.
 
     Returns:
         The champion, normalized reports, and complete delta audit record.
@@ -407,24 +503,40 @@ def search_harness(
         raise ValueError(f"iterations must be non-negative, got {iterations}")
     if proposal_batch_size < 1:
         raise ValueError(f"proposal_batch_size must be positive, got {proposal_batch_size}")
+    discovery_capabilities = ScoreCapabilities.model_validate(scorer.capabilities)
     discovery_attempts = scorer.default_attempts
     if discovery_attempts < 1:
         raise ValueError("scorer.default_attempts must be positive")
-    if screen_proposals and not scorer.capabilities.task_subsets:
+    if screen_proposals and not discovery_capabilities.task_subsets:
         raise ValueError(
             "scorer cannot evaluate task subsets; pass screen_proposals=False to avoid "
             "unsupported paid screens"
         )
-    if confirm_narrow_vetoes and not scorer.capabilities.attempt_overrides:
+    if confirm_narrow_vetoes and not discovery_capabilities.attempt_overrides:
         raise ValueError("scorer cannot override attempt counts; pass confirm_narrow_vetoes=False")
+    if confirm_narrow_vetoes and not discovery_capabilities.mean_over_attempts:
+        raise ValueError(
+            "scorer does not declare mean_over_attempts; pass confirm_narrow_vetoes=False"
+        )
+    holdout_capabilities = (
+        ScoreCapabilities.model_validate(holdout_scorer.capabilities)
+        if holdout_scorer is not None
+        else None
+    )
     holdout_attempts = holdout_scorer.default_attempts if holdout_scorer is not None else None
     if holdout_scorer is not None:
         assert holdout_attempts is not None
         if holdout_attempts < 1:
             raise ValueError("holdout_scorer.default_attempts must be positive")
-        if confirm_narrow_vetoes and not holdout_scorer.capabilities.attempt_overrides:
+        assert holdout_capabilities is not None
+        if confirm_narrow_vetoes and not holdout_capabilities.attempt_overrides:
             raise ValueError(
                 "holdout scorer cannot override attempt counts; pass confirm_narrow_vetoes=False"
+            )
+        if confirm_narrow_vetoes and not holdout_capabilities.mean_over_attempts:
+            raise ValueError(
+                "holdout scorer does not declare mean_over_attempts; pass "
+                "confirm_narrow_vetoes=False"
             )
         if confirm_narrow_vetoes and holdout_attempts != discovery_attempts:
             raise ValueError(
@@ -440,6 +552,7 @@ def search_harness(
             raise ValueError(f"holdout seed is not eligible for scoring: {holdout_seed_error}")
 
     evaluations_by_id: dict[str, tuple[str, str, str]] = {}
+    schemas_by_role: dict[Literal["discovery", "holdout"], _ScoreSchema] = {}
 
     def _check_cancelled() -> None:
         if should_cancel is not None and should_cancel():
@@ -453,6 +566,7 @@ def search_harness(
         active_scorer: HarnessScorer,
         doc: HarnessDoc,
         *,
+        role: Literal["discovery", "holdout"],
         purpose: Literal["seed", "screen", "full", "holdout", "confirmation"],
         task_ids: list[str] | None = None,
         attempts: int | None = None,
@@ -465,13 +579,10 @@ def search_harness(
             attempts=attempts,
         )
         report = _snapshot_score_report(active_scorer.score(doc, request=request))
-        scorer_attempts = (
-            discovery_attempts
-            if active_scorer is scorer
-            else holdout_attempts
-            if active_scorer is holdout_scorer
-            else None
-        )
+        expected_scorer = scorer if role == "discovery" else holdout_scorer
+        if active_scorer is not expected_scorer:
+            raise ValueError(f"search received a report from an unknown {role} scorer")
+        scorer_attempts = discovery_attempts if role == "discovery" else holdout_attempts
         if scorer_attempts is None:
             raise ValueError("search received a report from an unknown scorer")
         expected_attempts = attempts or scorer_attempts
@@ -486,6 +597,48 @@ def search_harness(
             raise ValueError(
                 f"scorer returned the wrong task set; missing={missing}, extra={extra}"
             )
+        capabilities = discovery_capabilities if role == "discovery" else holdout_capabilities
+        assert capabilities is not None
+        if report.secondary_objective != capabilities.secondary_objective:
+            actual = (
+                report.secondary_objective.objective_id
+                if report.secondary_objective is not None
+                else None
+            )
+            declared = (
+                capabilities.secondary_objective.objective_id
+                if capabilities.secondary_objective is not None
+                else None
+            )
+            if declared is None:
+                raise ValueError(
+                    f"{role} scorer returned secondary objective {actual!r}, but it was not "
+                    "declared in capabilities"
+                )
+            raise ValueError(
+                f"{role} scorer returned secondary objective {actual!r}; capabilities declare "
+                f"{declared!r}"
+            )
+        task_weights = tuple(
+            sorted((task_id, task.aggregate_weight) for task_id, task in report.per_task.items())
+        )
+        schema = schemas_by_role.get(role)
+        if schema is None:
+            schemas_by_role[role] = _ScoreSchema(
+                secondary_objective=report.secondary_objective,
+                task_weights=task_weights,
+            )
+        else:
+            expected_weights = dict(schema.task_weights)
+            for task_id, weight in task_weights:
+                expected_weight = expected_weights.get(task_id)
+                if expected_weight is None:
+                    raise ValueError(f"{role} scorer introduced unknown task {task_id!r}")
+                if weight != expected_weight:
+                    raise ValueError(
+                        f"{role} aggregate weight for task {task_id!r} changed from "
+                        f"{expected_weight!r} to {weight!r}"
+                    )
         evaluation_record = (
             doc.execution_hash,
             request.model_dump_json(),
@@ -509,14 +662,19 @@ def search_harness(
     screened = 0
     confirmations = 0
 
-    seed_report = _score(scorer, seed_doc, purpose="seed")
+    seed_report = _score(scorer, seed_doc, role="discovery", purpose="seed")
     if not seed_report.per_task:
         raise ValueError("seed score report contains no tasks")
     discovery_task_ids = frozenset(seed_report.per_task)
     reports[seed_doc.doc_hash] = seed_report
     holdout_task_ids: frozenset[str] | None = None
     if holdout_scorer is not None:
-        seed_holdout = _score(holdout_scorer, seed_doc, purpose="holdout")
+        seed_holdout = _score(
+            holdout_scorer,
+            seed_doc,
+            role="holdout",
+            purpose="holdout",
+        )
         if not seed_holdout.per_task:
             raise ValueError("holdout seed score report contains no tasks")
         holdout_task_ids = frozenset(seed_holdout.per_task)
@@ -541,9 +699,8 @@ def search_harness(
 
     for iteration_index in range(1, iterations + 1):
         _check_cancelled()
-        scorer.before_proposal_batch()
-        if holdout_scorer is not None and holdout_scorer is not scorer:
-            holdout_scorer.before_proposal_batch()
+        if before_proposal_batch is not None:
+            before_proposal_batch()
         parent = docs[champion_hash]
         parent_report = reports[champion_hash]
         frozen_champion_hash = champion_hash
@@ -747,6 +904,7 @@ def search_harness(
                 screen_report = _score(
                     scorer,
                     child,
+                    role="discovery",
                     purpose="screen",
                     task_ids=screen_task_ids,
                 )
@@ -758,14 +916,19 @@ def search_harness(
                 screen_parent_value = parent_mean
                 screen_child_secondary = child_secondary
                 screen_parent_secondary = parent_secondary
+                secondary_summary = (
+                    f"; secondary score {child_secondary:.3f} vs parent {parent_secondary:.3f}"
+                    if child_secondary is not None and parent_secondary is not None
+                    else ""
+                )
                 feedback_error = _record_score_evaluation(
                     proposer,
                     delta,
                     stage="screen",
                     report=screen_report,
                     summary=(
-                        f"trigger score {child_mean:.3f} vs parent {parent_mean:.3f}; "
-                        f"secondary score {child_secondary:.3f} vs parent {parent_secondary:.3f}"
+                        f"trigger score {child_mean:.3f} vs parent {parent_mean:.3f}"
+                        f"{secondary_summary}"
                     ),
                 )
                 if feedback_error is not None:
@@ -775,14 +938,22 @@ def search_harness(
                     )
                 success_regressed = child_mean < parent_mean - _TIE_EPS
                 success_tied = abs(child_mean - parent_mean) <= _TIE_EPS
-                secondary_did_not_improve = child_secondary <= parent_secondary + _TIE_EPS
+                secondary_did_not_improve = (
+                    child_secondary is None
+                    or parent_secondary is None
+                    or child_secondary <= parent_secondary + _TIE_EPS
+                )
                 if success_regressed or (success_tied and secondary_did_not_improve):
+                    secondary_reason = (
+                        f"; secondary score {child_secondary:.2f} vs parent {parent_secondary:.2f}"
+                        if child_secondary is not None and parent_secondary is not None
+                        else ""
+                    )
                     delta.verdict = GateRecord(
                         accepted=False,
                         reason=(
                             f"screened out: trigger score {child_mean:.2f} vs parent "
-                            f"{parent_mean:.2f}; secondary score {child_secondary:.2f} vs "
-                            f"parent {parent_secondary:.2f} over {len(screen_task_ids)} "
+                            f"{parent_mean:.2f}{secondary_reason} over {len(screen_task_ids)} "
                             f"task(s), attempts={discovery_attempts}; the delta did not "
                             "improve its own target"
                         ),
@@ -814,6 +985,7 @@ def search_harness(
             child_report = _score(
                 scorer,
                 child,
+                role="discovery",
                 purpose="full",
                 expected_task_ids=discovery_task_ids,
             )
@@ -828,9 +1000,11 @@ def search_harness(
                 confirm_narrow_vetoes
                 and narrow_failing_tiers(
                     pre_verdict,
-                    k=discovery_attempts,
-                    n_suite=len(frozen_suite),
-                    n_holdout=0,
+                    suite_attempt_impact=_max_primary_attempt_impact(
+                        parent_report,
+                        frozen_suite,
+                    ),
+                    holdout_attempt_impact=None,
                 )
                 is not None
             )
@@ -838,6 +1012,7 @@ def search_harness(
                 child_holdout = _score(
                     holdout_scorer,
                     child,
+                    role="holdout",
                     purpose="holdout",
                     expected_task_ids=holdout_task_ids,
                 )
@@ -846,6 +1021,7 @@ def search_harness(
                     frozen_champion_holdout = _score(
                         holdout_scorer,
                         parent,
+                        role="holdout",
                         purpose="holdout",
                         expected_task_ids=holdout_task_ids,
                     )
@@ -864,12 +1040,17 @@ def search_harness(
             tiers = (
                 narrow_failing_tiers(
                     verdict,
-                    k=discovery_attempts,
-                    n_suite=len(frozen_suite),
-                    n_holdout=(
-                        len(frozen_champion_holdout.per_task)
+                    suite_attempt_impact=_max_primary_attempt_impact(
+                        parent_report,
+                        frozen_suite,
+                    ),
+                    holdout_attempt_impact=(
+                        _max_primary_attempt_impact(
+                            frozen_champion_holdout,
+                            sorted(frozen_champion_holdout.per_task),
+                        )
                         if frozen_champion_holdout is not None
-                        else 0
+                        else None
                     ),
                 )
                 if confirm_narrow_vetoes
@@ -889,6 +1070,7 @@ def search_harness(
                     child_re = _score(
                         active_scorer,
                         child,
+                        role="discovery" if tier == "suite" else "holdout",
                         purpose="confirmation",
                         task_ids=task_ids,
                         attempts=attempts,
@@ -899,6 +1081,7 @@ def search_harness(
                     champion_re = _score(
                         active_scorer,
                         parent,
+                        role="discovery" if tier == "suite" else "holdout",
                         purpose="confirmation",
                         task_ids=task_ids,
                         attempts=attempts,
@@ -907,13 +1090,24 @@ def search_harness(
                         ),
                     )
                     score_delta = child_re.score - champion_re.score
-                    secondary_delta = child_re.secondary_score - champion_re.secondary_score
+                    secondary_delta = _optional_score_delta(
+                        child_re.secondary_score,
+                        champion_re.secondary_score,
+                        context=f"{tier} confirmation",
+                    )
+                    secondary_note = (
+                        f", secondary score {secondary_delta:+.3f}"
+                        if secondary_delta is not None
+                        else ""
+                    )
                     notes.append(
                         f"{tier} re-measured at attempts={attempts}: score "
-                        f"{score_delta:+.3f}, secondary score {secondary_delta:+.3f}"
+                        f"{score_delta:+.3f}{secondary_note}"
                     )
                     if score_delta < -_TIE_EPS or (
-                        abs(score_delta) <= _TIE_EPS and secondary_delta < -_TIE_EPS
+                        abs(score_delta) <= _TIE_EPS
+                        and secondary_delta is not None
+                        and secondary_delta < -_TIE_EPS
                     ):
                         confirmed_ok = False
                 outcome = "veto overturned" if confirmed_ok else "regression confirmed"
@@ -967,17 +1161,19 @@ def search_harness(
 
         _check_cancelled()
         eligible = [candidate for candidate in scored_proposals if candidate.gate.accepted]
-        winner = (
-            max(
+        if not eligible:
+            winner = None
+        elif discovery_capabilities.secondary_objective is not None:
+            winner = max(eligible, key=_secondary_candidate_rank)
+        else:
+            winner = max(
                 eligible,
-                key=lambda candidate: (
-                    candidate.report.score,
-                    candidate.report.secondary_score,
-                    -candidate.proposal_index,
-                ),
+                key=lambda candidate: (candidate.report.score, -candidate.proposal_index),
             )
-            if eligible
-            else None
+        ranking = (
+            "full score, secondary score, then proposal order"
+            if discovery_capabilities.secondary_objective is not None
+            else "full score, then proposal order"
         )
         for candidate in scored_proposals:
             gate_eligible = candidate.gate.accepted
@@ -990,8 +1186,8 @@ def search_harness(
                         "accepted": False,
                         "reason": (
                             "gate eligible but not selected: "
-                            f"proposal {winner.proposal_index} ranked higher by full score, "
-                            "secondary score, then proposal order | " + candidate.gate.reason
+                            f"proposal {winner.proposal_index} ranked higher by {ranking} | "
+                            + candidate.gate.reason
                         ),
                     }
                 )
@@ -1064,12 +1260,18 @@ def search_harness(
 
 
 ClosedLoopScoreFn = Callable[[HarnessDoc, list[TaskSpec], int], ClosedLoopReport]
+_ASSERTION_FRACTION_OBJECTIVE = ScoreObjective(objective_id="assertion_fraction")
 
 
 class _ClosedLoopHarnessScorer:
     """Adapt the existing world-model evaluation into normalized search scores."""
 
-    capabilities = ScoreCapabilities(task_subsets=True, attempt_overrides=True)
+    capabilities = ScoreCapabilities(
+        task_subsets=True,
+        attempt_overrides=True,
+        mean_over_attempts=True,
+        secondary_objective=_ASSERTION_FRACTION_OBJECTIVE,
+    )
 
     def __init__(
         self,
@@ -1078,7 +1280,6 @@ class _ClosedLoopHarnessScorer:
         default_attempts: int,
         evaluate: ClosedLoopScoreFn,
         validate_candidate: Callable[[HarnessDoc], str | None],
-        before_proposal_batch: Callable[[], None],
     ) -> None:
         self._tasks = list(tasks)
         self._by_id = {task.task_id: task for task in tasks}
@@ -1087,14 +1288,10 @@ class _ClosedLoopHarnessScorer:
         self.default_attempts = default_attempts
         self._evaluate = evaluate
         self._validate = validate_candidate
-        self._before_proposal = before_proposal_batch
         self.raw_reports: dict[str, ClosedLoopReport] = {}
 
     def validate_candidate(self, candidate: HarnessDoc) -> str | None:
         return self._validate(candidate)
-
-    def before_proposal_batch(self) -> None:
-        self._before_proposal()
 
     def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
         if request.task_ids is None:
@@ -1235,6 +1432,7 @@ def _closed_loop_score(
         evaluation_id=f"closed-loop:{digest}",
         label=report.label,
         score=report.success_rate,
+        secondary_objective=_ASSERTION_FRACTION_OBJECTIVE,
         secondary_score=report.mean_fraction,
         attempts=report.k,
         per_task=task_scores,
@@ -1359,7 +1557,6 @@ def create_harness(
             default_attempts=k,
             evaluate=_evaluate,
             validate_candidate=_validate_candidate,
-            before_proposal_batch=_before_proposal_batch,
         )
         holdout_scorer = (
             _ClosedLoopHarnessScorer(
@@ -1367,7 +1564,6 @@ def create_harness(
                 default_attempts=k,
                 evaluate=_evaluate,
                 validate_candidate=_validate_candidate,
-                before_proposal_batch=lambda: None,
             )
             if holdout
             else None
@@ -1387,6 +1583,7 @@ def create_harness(
             on_proposal=on_proposal,
             on_accept=on_accept,
             should_cancel=should_cancel,
+            before_proposal_batch=_before_proposal_batch,
         )
         result = CreateResult(
             best=search_result.best,

--- a/wmh/harness/create.py
+++ b/wmh/harness/create.py
@@ -23,7 +23,7 @@ real models at temperature.
 
 from __future__ import annotations
 
-import hashlib
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from math import isclose
@@ -37,7 +37,7 @@ from wmh.evals.gold import GoldJudge
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta, apply_delta
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage
 from wmh.harness.mutate import render_task_attempt_evidence
 from wmh.harness.proposer import DeltaProposer, ProposalFailure
 from wmh.harness.runtime import (
@@ -51,8 +51,10 @@ from wmh.harness.scoring import (
     MAX_TASK_EVIDENCE_CHARS,
     HarnessScorer,
     HarnessScoreReport,
+    PassCriterion,
     ScoreCapabilities,
     ScoreObjective,
+    ScoreProvenance,
     ScoreRequest,
     TaskScore,
     cluster_score_failures,
@@ -209,6 +211,8 @@ class _ScoreSchema:
     """Frozen objective and task weights for one scorer role."""
 
     secondary_objective: ScoreObjective | None
+    pass_criterion: PassCriterion
+    provenance: ScoreProvenance
     task_weights: tuple[tuple[str, float], ...]
 
 
@@ -413,6 +417,10 @@ def _validate_compatible_score_reports(
     context: str,
 ) -> None:
     """Reject a gate comparison when task or objective schemas differ."""
+    if child.pass_criterion != champion.pass_criterion:
+        raise ValueError(f"{context} reports declare different pass criteria")
+    if child.provenance != champion.provenance:
+        raise ValueError(f"{context} reports carry different evaluation provenance")
     if set(child.per_task) != set(champion.per_task):
         raise ValueError(f"{context} reports contain different task identities")
     for task_id in child.per_task:
@@ -443,17 +451,13 @@ def _optional_score_delta(
 
 def _snapshot_score_report(report: HarnessScoreReport) -> HarnessScoreReport:
     """Revalidate and detach a scorer-owned report before it enters search state."""
-    snapshot = HarnessScoreReport.model_validate(report.model_dump(mode="json"))
+    snapshot = HarnessScoreReport.model_validate(
+        report.model_dump(mode="json", exclude={"evaluation_id"})
+    )
     return snapshot.model_copy(
         update={"per_task": dict(sorted(snapshot.per_task.items()))},
         deep=True,
     )
-
-
-def _score_report_fingerprint(report: HarnessScoreReport) -> str:
-    """Canonical content identity used to detect evaluation-id collisions."""
-    content = report.model_dump_json(exclude={"evaluation_id"})
-    return hashlib.blake2b(content.encode("utf-8"), digest_size=32).hexdigest()
 
 
 def search_harness(
@@ -510,7 +514,7 @@ def search_harness(
     if screen_proposals and not discovery_capabilities.task_subsets:
         raise ValueError(
             "scorer cannot evaluate task subsets; pass screen_proposals=False to avoid "
-            "unsupported paid screens"
+            "unsupported screening evaluations"
         )
     if confirm_narrow_vetoes and not discovery_capabilities.attempt_overrides:
         raise ValueError("scorer cannot override attempt counts; pass confirm_narrow_vetoes=False")
@@ -551,7 +555,6 @@ def search_harness(
         if holdout_seed_error is not None:
             raise ValueError(f"holdout seed is not eligible for scoring: {holdout_seed_error}")
 
-    evaluations_by_id: dict[str, tuple[str, str, str]] = {}
     schemas_by_role: dict[Literal["discovery", "holdout"], _ScoreSchema] = {}
 
     def _check_cancelled() -> None:
@@ -579,6 +582,16 @@ def search_harness(
             attempts=attempts,
         )
         report = _snapshot_score_report(active_scorer.score(doc, request=request))
+        if report.candidate_execution_hash != doc.execution_hash:
+            raise ValueError(
+                f"{role} scorer returned candidate execution identity "
+                f"{report.candidate_execution_hash!r}; expected {doc.execution_hash!r}"
+            )
+        if report.request != request:
+            raise ValueError(
+                f"{role} scorer returned score request {report.request.model_dump(mode='json')!r}; "
+                f"expected {request.model_dump(mode='json')!r}"
+            )
         expected_scorer = scorer if role == "discovery" else holdout_scorer
         if active_scorer is not expected_scorer:
             raise ValueError(f"search received a report from an unknown {role} scorer")
@@ -626,9 +639,16 @@ def search_harness(
         if schema is None:
             schemas_by_role[role] = _ScoreSchema(
                 secondary_objective=report.secondary_objective,
+                pass_criterion=report.pass_criterion,
+                provenance=report.provenance,
                 task_weights=task_weights,
             )
         else:
+            if report.pass_criterion != schema.pass_criterion:
+                raise ValueError(f"{role} scorer changed its pass criterion")
+            for field in ("task_set", "evaluator", "backend"):
+                if getattr(report.provenance, field) != getattr(schema.provenance, field):
+                    raise ValueError(f"{role} scorer changed evaluation provenance field {field!r}")
             expected_weights = dict(schema.task_weights)
             for task_id, weight in task_weights:
                 expected_weight = expected_weights.get(task_id)
@@ -639,17 +659,6 @@ def search_harness(
                         f"{role} aggregate weight for task {task_id!r} changed from "
                         f"{expected_weight!r} to {weight!r}"
                     )
-        evaluation_record = (
-            doc.execution_hash,
-            request.model_dump_json(),
-            _score_report_fingerprint(report),
-        )
-        prior_record = evaluations_by_id.get(report.evaluation_id)
-        if prior_record is not None and prior_record != evaluation_record:
-            raise ValueError(
-                f"evaluation_id {report.evaluation_id!r} identifies a different report"
-            )
-        evaluations_by_id[report.evaluation_id] = evaluation_record
         _check_cancelled()
         return report
 
@@ -1261,6 +1270,7 @@ def search_harness(
 
 ClosedLoopScoreFn = Callable[[HarnessDoc, list[TaskSpec], int], ClosedLoopReport]
 _ASSERTION_FRACTION_OBJECTIVE = ScoreObjective(objective_id="assertion_fraction")
+_ALL_ATTEMPTS_PASS_CRITERION = PassCriterion(score_at_least=1.0)
 
 
 class _ClosedLoopHarnessScorer:
@@ -1280,6 +1290,7 @@ class _ClosedLoopHarnessScorer:
         default_attempts: int,
         evaluate: ClosedLoopScoreFn,
         validate_candidate: Callable[[HarnessDoc], str | None],
+        provenance: ScoreProvenance,
     ) -> None:
         self._tasks = list(tasks)
         self._by_id = {task.task_id: task for task in tasks}
@@ -1288,6 +1299,7 @@ class _ClosedLoopHarnessScorer:
         self.default_attempts = default_attempts
         self._evaluate = evaluate
         self._validate = validate_candidate
+        self._provenance = provenance
         self.raw_reports: dict[str, ClosedLoopReport] = {}
 
     def validate_candidate(self, candidate: HarnessDoc) -> str | None:
@@ -1309,7 +1321,7 @@ class _ClosedLoopHarnessScorer:
         _validate_closed_loop_report(tasks, raw, attempts=attempts)
         if request.purpose in ("seed", "full", "holdout"):
             self.raw_reports[candidate.doc_hash] = raw
-        return _closed_loop_score(candidate, tasks, raw, request)
+        return _closed_loop_score(candidate, tasks, raw, request, self._provenance)
 
 
 def _validate_closed_loop_report(
@@ -1385,6 +1397,7 @@ def _closed_loop_score(
     tasks: list[TaskSpec],
     report: ClosedLoopReport,
     request: ScoreRequest,
+    provenance: ScoreProvenance,
 ) -> HarnessScoreReport:
     """Project a gold-judged report onto the benchmark-neutral search contract."""
     task_scores: dict[str, TaskScore] = {}
@@ -1413,29 +1426,25 @@ def _closed_loop_score(
             task_id=task.task_id,
             score=outcome.success_rate,
             secondary_score=outcome.mean_fraction,
-            passed=outcome.success_rate >= 1.0 - _TIE_EPS,
+            passed=_ALL_ATTEMPTS_PASS_CRITERION.is_met(outcome.success_rate),
             description=description,
             mechanisms=tuple(mechanisms),
             evidence=evidence,
         )
-    identity_input = "\x00".join(
-        (
-            candidate.execution_hash,
-            request.purpose,
-            str(report.k),
-            *(task.task_id for task in tasks),
-            report.model_dump_json(),
-        )
-    )
-    digest = hashlib.blake2b(identity_input.encode("utf-8"), digest_size=16).hexdigest()
     return HarnessScoreReport(
-        evaluation_id=f"closed-loop:{digest}",
+        candidate_execution_hash=candidate.execution_hash,
+        request=request,
+        provenance=provenance,
+        pass_criterion=_ALL_ATTEMPTS_PASS_CRITERION,
         label=report.label,
         score=report.success_rate,
         secondary_objective=_ASSERTION_FRACTION_OBJECTIVE,
         secondary_score=report.mean_fraction,
         attempts=report.k,
         per_task=task_scores,
+        evaluation_evidence={
+            "closed_loop_report": report.model_dump(mode="json", exclude={"label"})
+        },
     )
 
 
@@ -1445,6 +1454,48 @@ def _bounded_score_text(value: str, *, limit: int, label: str) -> str:
         return value
     marker = f"\n...[{label} truncated; original_chars={len(value)}]"
     return value[: limit - len(marker)] + marker
+
+
+def _closed_loop_score_provenance(
+    tasks: list[TaskSpec],
+    *,
+    world_model: WorldModel,
+    agent_provider: Provider,
+    judge: GoldJudge,
+    harness_backend: Literal["local", "e2b"],
+    eval_concurrency: int | None,
+    e2b_template: str | None,
+    e2b_metadata: dict[str, str] | None,
+) -> ScoreProvenance:
+    """Build exact task, evaluator, and backend context for closed-loop scores."""
+    provider_type = type(agent_provider)
+    if harness_backend == "local":
+        resolved_concurrency = eval_concurrency if eval_concurrency is not None else 1
+        resolved_e2b_template = None
+    else:
+        resolved_concurrency = eval_concurrency if eval_concurrency is not None else 0
+        resolved_e2b_template = e2b_template or os.environ.get(E2B_TEMPLATE_ENV)
+    return ScoreProvenance(
+        task_set={"tasks": [task.model_dump(mode="json") for task in tasks]},
+        evaluator={
+            "kind": "closed_loop_gold",
+            "contract_version": 1,
+            "world_model": world_model.evaluation_context(),
+            "agent_provider": {
+                "type": f"{provider_type.__module__}.{provider_type.__qualname__}",
+                "config": agent_provider.config.model_dump(mode="json"),
+            },
+            "judge": judge.evaluation_context(),
+            "primary_score": "mean_binary_pass",
+            "secondary_score": _ASSERTION_FRACTION_OBJECTIVE.objective_id,
+        },
+        backend={
+            "kind": harness_backend,
+            "concurrency": resolved_concurrency,
+            "e2b_template": resolved_e2b_template,
+            "e2b_metadata": dict(sorted((e2b_metadata or {}).items())),
+        },
+    )
 
 
 def create_harness(
@@ -1481,6 +1532,31 @@ def create_harness(
             f"runtime kind is {seed_doc.runtime_kind()!r}, which already runs in-process; "
             "use harness_backend='local'"
         )
+
+    discovery_provenance = _closed_loop_score_provenance(
+        tasks,
+        world_model=world_model,
+        agent_provider=agent_provider,
+        judge=judge,
+        harness_backend=harness_backend,
+        eval_concurrency=eval_concurrency,
+        e2b_template=e2b_template,
+        e2b_metadata=e2b_metadata,
+    )
+    holdout_provenance = (
+        _closed_loop_score_provenance(
+            holdout,
+            world_model=world_model,
+            agent_provider=agent_provider,
+            judge=judge,
+            harness_backend=harness_backend,
+            eval_concurrency=eval_concurrency,
+            e2b_template=e2b_template,
+            e2b_metadata=e2b_metadata,
+        )
+        if holdout
+        else None
+    )
 
     sandbox_pool: E2BSandboxPool | None = None
     if harness_backend == "e2b":
@@ -1557,17 +1633,19 @@ def create_harness(
             default_attempts=k,
             evaluate=_evaluate,
             validate_candidate=_validate_candidate,
+            provenance=discovery_provenance,
         )
-        holdout_scorer = (
-            _ClosedLoopHarnessScorer(
+        if holdout:
+            assert holdout_provenance is not None
+            holdout_scorer = _ClosedLoopHarnessScorer(
                 holdout,
                 default_attempts=k,
                 evaluate=_evaluate,
                 validate_candidate=_validate_candidate,
+                provenance=holdout_provenance,
             )
-            if holdout
-            else None
-        )
+        else:
+            holdout_scorer = None
         search_result = search_harness(
             name,
             seed_doc,

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -19,16 +19,16 @@ from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import JsonObject
 from wmh.engine.world_model import WorldModel
-from wmh.evals.closed_loop import ClosedLoopReport, TaskOutcome
-from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, TaskOutcome
+from wmh.evals.gold import GoldJudge, GoldVerdict
 from wmh.evals.tasks import TaskSpec
 from wmh.harness import create as create_module
 from wmh.harness.create import (
     CreateResult,
     HarnessSearchCancelled,
     ProposalRecord,
-    cluster_failures,
     create_harness,
+    search_harness,
     select_failure_cluster,
 )
 from wmh.harness.delta import FailureSignature, GateRecord, HarnessDelta
@@ -36,7 +36,13 @@ from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.mutate import parse_delta
 from wmh.harness.proposer import ProposalFailure, ProviderDeltaProposer
-from wmh.harness.runtime import Runtime
+from wmh.harness.runtime import Runtime, StopReason
+from wmh.harness.scoring import (
+    HarnessScoreReport,
+    ScoreCapabilities,
+    ScoreRequest,
+    TaskScore,
+)
 from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
@@ -174,6 +180,352 @@ def _run(
     )
 
 
+class _NeutralScorer:
+    """A ground-truth-like scorer with no world-model dependencies."""
+
+    capabilities = ScoreCapabilities()
+    default_attempts = 2
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, ScoreRequest]] = []
+        self.before_proposal_calls = 0
+
+    def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+        return None
+
+    def before_proposal_batch(self) -> None:
+        self.before_proposal_calls += 1
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+        self.requests.append((candidate.doc_hash, request))
+        prompt = candidate.surface("prompt:core")
+        passed = prompt is not None and "careful agent" in prompt.content
+        score = 1.0 if passed else 0.0
+        return HarnessScoreReport(
+            evaluation_id=f"fake:{candidate.doc_hash}:{request.purpose}",
+            label=candidate.name,
+            score=score,
+            secondary_score=score,
+            attempts=self.default_attempts,
+            per_task={
+                "ground-truth-task": TaskScore(
+                    task_id="ground-truth-task",
+                    score=score,
+                    secondary_score=score,
+                    passed=passed,
+                    description="repair the repository",
+                    mechanisms=() if passed else ("missing verification",),
+                    evidence="verifier reward and execution trace",
+                )
+            },
+        )
+
+
+class _EvidenceRecordingProposer:
+    """Return one deterministic delta and retain the scorer evidence."""
+
+    def __init__(self) -> None:
+        self.evidence: list[str] = []
+
+    def propose_batch(
+        self,
+        parent: HarnessDoc,
+        trigger: FailureSignature,
+        evidence: str,
+        *,
+        history: list[HarnessDelta],
+        count: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> list[HarnessDelta | ProposalFailure | None]:
+        del history, should_cancel
+        assert count == 1
+        self.evidence.append(evidence)
+        proposal = parse_delta(parent, trigger, _meta_reply(parent, _CAREFUL_PROMPT))
+        assert proposal is not None
+        return [proposal]
+
+
+def test_search_harness_scores_with_no_world_model_or_gold_judge() -> None:
+    seed = HarnessDoc.baseline("seed")
+    scorer = _NeutralScorer()
+    proposer = _EvidenceRecordingProposer()
+
+    result = search_harness(
+        "winner",
+        seed,
+        scorer,
+        proposer,
+        iterations=1,
+        screen_proposals=False,
+        confirm_narrow_vetoes=False,
+    )
+
+    assert result.best_score == 1.0
+    assert result.best.name == "winner"
+    assert [request.purpose for _, request in scorer.requests] == ["seed", "full"]
+    assert scorer.before_proposal_calls == 1
+    assert "verifier reward and execution trace" in proposer.evidence[0]
+    assert result.suite == ["ground-truth-task"]
+
+
+def test_search_harness_rejects_unsupported_paid_stages_before_scoring() -> None:
+    scorer = _NeutralScorer()
+
+    with pytest.raises(ValueError, match="screen_proposals=False"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            scorer,
+            _EvidenceRecordingProposer(),
+            iterations=0,
+        )
+
+    assert scorer.requests == []
+
+
+def test_search_harness_rejects_negative_iterations() -> None:
+    scorer = _NeutralScorer()
+    with pytest.raises(ValueError, match="iterations must be non-negative"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            scorer,
+            _EvidenceRecordingProposer(),
+            iterations=-1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+    assert scorer.requests == []
+
+
+def test_search_harness_rejects_default_attempt_count_drift() -> None:
+    class WrongAttemptsScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            return report.model_copy(update={"attempts": self.default_attempts + 1})
+
+    with pytest.raises(ValueError, match="attempts=3.*expected attempts=2"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            WrongAttemptsScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_candidate_that_omits_a_discovery_task() -> None:
+    class OmittingScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            if request.purpose != "seed":
+                return report
+            required = TaskScore(
+                task_id="required-task",
+                score=0.0,
+                secondary_score=0.0,
+                passed=False,
+            )
+            return report.model_copy(
+                update={"per_task": {**report.per_task, required.task_id: required}}
+            )
+
+    with pytest.raises(ValueError, match="wrong task set.*required-task"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            OmittingScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_candidate_that_omits_a_holdout_task() -> None:
+    class OmittingHoldoutScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            if len(self.requests) != 1:
+                return report
+            required = TaskScore(
+                task_id="held-out-required",
+                score=0.0,
+                secondary_score=0.0,
+                passed=False,
+            )
+            return report.model_copy(
+                update={"per_task": {**report.per_task, required.task_id: required}}
+            )
+
+    with pytest.raises(ValueError, match="wrong task set.*held-out-required"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            _NeutralScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            holdout_scorer=OmittingHoldoutScorer(),
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_evaluation_identity_collision() -> None:
+    class CollidingScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            return report.model_copy(update={"evaluation_id": "reused-id"})
+
+    with pytest.raises(ValueError, match="evaluation_id 'reused-id'.*different report"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            CollidingScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_snapshots_and_canonicalizes_scorer_owned_reports() -> None:
+    class RetainingScorer(_NeutralScorer):
+        source_report: HarnessScoreReport | None = None
+
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            extra = TaskScore(
+                task_id="another-task",
+                score=0.0,
+                secondary_score=0.0,
+                passed=False,
+                evidence="another immutable trace",
+            )
+            self.source_report = report.model_copy(
+                update={
+                    "per_task": {
+                        "ground-truth-task": report.per_task["ground-truth-task"],
+                        "another-task": extra,
+                    }
+                }
+            )
+            return self.source_report
+
+    seed = HarnessDoc.baseline("seed")
+    scorer = RetainingScorer()
+    result = search_harness(
+        "winner",
+        seed,
+        scorer,
+        _EvidenceRecordingProposer(),
+        iterations=0,
+        screen_proposals=False,
+        confirm_narrow_vetoes=False,
+    )
+    source = scorer.source_report
+    assert source is not None
+    audited = result.reports[seed.doc_hash]
+    assert list(audited.per_task) == ["another-task", "ground-truth-task"]
+
+    source.score = 1.0
+    source.per_task["ground-truth-task"].score = 1.0
+    source.per_task["ground-truth-task"].evidence = "mutated after return"
+    source.per_task["late-task"] = TaskScore(
+        task_id="late-task",
+        score=1.0,
+        secondary_score=1.0,
+        passed=True,
+    )
+
+    assert audited.score == 0.0
+    assert audited.per_task["ground-truth-task"].score == 0.0
+    assert audited.per_task["ground-truth-task"].evidence == "verifier reward and execution trace"
+    assert "late-task" not in audited.per_task
+
+
+def test_search_harness_rejects_empty_seed_and_holdout_matrices() -> None:
+    class EmptyScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            return report.model_copy(update={"score": 0.0, "secondary_score": 0.0, "per_task": {}})
+
+    with pytest.raises(ValueError, match="seed score report contains no tasks"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            EmptyScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+    with pytest.raises(ValueError, match="holdout seed score report contains no tasks"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            _NeutralScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            holdout_scorer=EmptyScorer(),
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_validates_and_retires_both_scorers() -> None:
+    class RejectingHoldoutScorer(_NeutralScorer):
+        def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+            prompt = candidate.surface("prompt:core")
+            return (
+                "holdout runtime rejected candidate"
+                if prompt and "careful" in prompt.content
+                else None
+            )
+
+    discovery = _NeutralScorer()
+    holdout = RejectingHoldoutScorer()
+    result = search_harness(
+        "winner",
+        HarnessDoc.baseline("seed"),
+        discovery,
+        _EvidenceRecordingProposer(),
+        iterations=1,
+        screen_proposals=False,
+        holdout_scorer=holdout,
+        confirm_narrow_vetoes=False,
+    )
+
+    assert [request.purpose for _, request in discovery.requests] == ["seed"]
+    assert [request.purpose for _, request in holdout.requests] == ["holdout"]
+    assert discovery.before_proposal_calls == holdout.before_proposal_calls == 1
+    assert result.proposal_records[0].outcome == "invalid"
+    assert "holdout runtime rejected candidate" in (result.proposal_records[0].reason or "")
+
+
+def test_search_harness_validates_seed_against_holdout_before_scoring() -> None:
+    class RejectingHoldoutScorer(_NeutralScorer):
+        def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+            return "holdout runtime rejected seed"
+
+    discovery = _NeutralScorer()
+    holdout = RejectingHoldoutScorer()
+    with pytest.raises(ValueError, match="holdout seed is not eligible"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            discovery,
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            holdout_scorer=holdout,
+            confirm_narrow_vetoes=False,
+        )
+    assert discovery.requests == holdout.requests == []
+
+
 def test_create_accepts_improving_delta_and_promotes_suite() -> None:
     seed = HarnessDoc.baseline("seed")
     provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
@@ -307,17 +659,17 @@ def test_cancellation_wins_before_accepted_lineage_and_callback_mutate(
     provider = RoleProvider(meta_reply=_meta_reply(seed, _CAREFUL_PROMPT))
     cancelled = False
     crowned: list[str] = []
-    gate_delta = create_module.gate_delta
+    gate_delta = create_module.gate_score_delta
 
     def cancelling_gate(
         delta: HarnessDelta,
         *,
-        child: ClosedLoopReport,
-        champion: ClosedLoopReport,
+        child: HarnessScoreReport,
+        champion: HarnessScoreReport,
         best_full: float,
         suite: list[str],
-        child_holdout: ClosedLoopReport | None = None,
-        champion_holdout: ClosedLoopReport | None = None,
+        child_holdout: HarnessScoreReport | None = None,
+        champion_holdout: HarnessScoreReport | None = None,
     ) -> GateRecord:
         nonlocal cancelled
         verdict = gate_delta(
@@ -333,7 +685,7 @@ def test_cancellation_wins_before_accepted_lineage_and_callback_mutate(
             cancelled = True
         return verdict
 
-    monkeypatch.setattr(create_module, "gate_delta", cancelling_gate)
+    monkeypatch.setattr(create_module, "gate_score_delta", cancelling_gate)
 
     with pytest.raises(HarnessSearchCancelled, match="cancelled"):
         _run(
@@ -393,44 +745,6 @@ def test_holdout_regression_rejects_a_full_split_win() -> None:
 
 
 # -- deterministic failure clustering ---------------------------------------------------------
-
-
-def _failing(task_id: str, unmet: list[str]) -> TaskOutcome:
-    verdict = GoldVerdict(
-        passed=False,
-        fraction=0.0,
-        assertions=[AssertionResult(assertion=a, passed=False, why="w") for a in unmet],
-    )
-    return TaskOutcome(
-        task_id=task_id, success_rate=0.0, mean_fraction=0.0, passes=2, verdicts=[verdict, verdict]
-    )
-
-
-def test_cluster_failures_groups_by_shared_assertions() -> None:
-    report = ClosedLoopReport(
-        per_task={
-            "t1": _failing("t1", ["a", "b"]),
-            "t2": _failing("t2", ["b", "c"]),
-            "t3": _failing("t3", ["z"]),
-            "t4": TaskOutcome(task_id="t4", success_rate=1.0, mean_fraction=1.0, passes=2),
-            "t5": _failing("t5", []),  # unparseable judge: no per-assertion detail
-        }
-    )
-    tasks = [TaskSpec(task_id=t, instruction=t) for t in ("t1", "t2", "t3", "t4", "t5")]
-    clusters = cluster_failures(report, tasks)
-    assert [c.task_ids for c in clusters] == [["t1", "t2"], ["t5"], ["t3"]]
-    # t1+t2 connect through shared assertion "b", which also labels the mechanism.
-    assert clusters[0].mechanism == "b"
-    assert clusters[0].unmet_assertions == ["a", "b", "c"]
-    assert clusters[1].mechanism == "run failed without per-assertion verdicts"
-    assert clusters[2].mechanism == "z"
-
-
-def test_cluster_failures_empty_when_everything_passes() -> None:
-    report = ClosedLoopReport(
-        per_task={"t1": TaskOutcome(task_id="t1", success_rate=1.0, mean_fraction=1.0, passes=3)}
-    )
-    assert cluster_failures(report, [TaskSpec(task_id="t1", instruction="i")]) == []
 
 
 def test_select_failure_cluster_rotates_equally_sized_failures() -> None:
@@ -644,8 +958,8 @@ def test_screen_uses_assertion_fraction_to_admit_partial_improvement() -> None:
     [record] = result.proposal_records
     assert record.outcome == "scored"
     assert record.screen_child == record.screen_parent == 0.0
-    assert record.screen_parent_fraction == 0.0
-    assert record.screen_child_fraction == 0.5
+    assert record.screen_parent_secondary == 0.0
+    assert record.screen_child_secondary == 0.5
 
 
 def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regresses() -> None:
@@ -653,24 +967,28 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
     delta = HarnessDelta.model_construct(
         trigger=FailureSignature(mechanism="target", task_ids=["target"])
     )
-    champion = ClosedLoopReport(
-        success_rate=0.0,
-        mean_fraction=0.45,
+    champion = HarnessScoreReport(
+        evaluation_id="champion",
+        score=0.0,
+        secondary_score=0.45,
+        attempts=1,
         per_task={
-            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.0),
-            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.9),
+            "target": TaskScore(task_id="target", score=0.0, secondary_score=0.0, passed=False),
+            "other": TaskScore(task_id="other", score=0.0, secondary_score=0.9, passed=False),
         },
     )
-    child = ClosedLoopReport(
-        success_rate=0.0,
-        mean_fraction=0.25,
+    child = HarnessScoreReport(
+        evaluation_id="child",
+        score=0.0,
+        secondary_score=0.25,
+        attempts=1,
         per_task={
-            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.5),
-            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.0),
+            "target": TaskScore(task_id="target", score=0.0, secondary_score=0.5, passed=False),
+            "other": TaskScore(task_id="other", score=0.0, secondary_score=0.0, passed=False),
         },
     )
 
-    verdict = create_module.gate_delta(
+    verdict = create_module.gate_score_delta(
         delta,
         child=child,
         champion=champion,
@@ -680,32 +998,36 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
 
     assert verdict.accepted is False
     assert verdict.full_delta == 0.0
-    assert verdict.full_fraction_delta == pytest.approx(-0.2)
-    assert "full-split assertion fraction regressed" in verdict.reason
+    assert verdict.full_secondary_delta == pytest.approx(-0.2)
+    assert "full-split secondary score regressed" in verdict.reason
 
 
 def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() -> None:
     delta = HarnessDelta.model_construct(
         trigger=FailureSignature(mechanism="target", task_ids=["target"])
     )
-    champion = ClosedLoopReport(
-        success_rate=0.0,
-        mean_fraction=0.1,
+    champion = HarnessScoreReport(
+        evaluation_id="champion",
+        score=0.0,
+        secondary_score=0.1,
+        attempts=1,
         per_task={
-            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.0),
-            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.2),
+            "target": TaskScore(task_id="target", score=0.0, secondary_score=0.0, passed=False),
+            "other": TaskScore(task_id="other", score=0.0, secondary_score=0.2, passed=False),
         },
     )
-    child = ClosedLoopReport(
-        success_rate=0.0,
-        mean_fraction=0.35,
+    child = HarnessScoreReport(
+        evaluation_id="child",
+        score=0.0,
+        secondary_score=0.35,
+        attempts=1,
         per_task={
-            "target": TaskOutcome(task_id="target", success_rate=0.0, mean_fraction=0.5),
-            "other": TaskOutcome(task_id="other", success_rate=0.0, mean_fraction=0.2),
+            "target": TaskScore(task_id="target", score=0.0, secondary_score=0.5, passed=False),
+            "other": TaskScore(task_id="other", score=0.0, secondary_score=0.2, passed=False),
         },
     )
 
-    verdict = create_module.gate_delta(
+    verdict = create_module.gate_score_delta(
         delta,
         child=child,
         champion=champion,
@@ -714,7 +1036,7 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
     )
 
     assert verdict.accepted is True
-    assert verdict.full_fraction_delta == pytest.approx(0.25)
+    assert verdict.full_secondary_delta == pytest.approx(0.25)
 
 
 def test_search_records_screen_and_full_trace_feedback_for_project_proposers() -> None:
@@ -929,7 +1251,7 @@ def test_narrow_failing_tiers_eligibility() -> None:
         full_delta=0.05,
         suite_delta=-0.05,
         holdout_delta=0.0,
-        holdout_fraction_delta=-0.2,
+        holdout_secondary_delta=-0.2,
     )
     assert narrow_failing_tiers(dense_veto, k=5, n_suite=8, n_holdout=4) is None
     # Accepted verdicts are never retried.
@@ -1043,10 +1365,92 @@ def _pi_seed() -> HarnessDoc:
 
 
 def _canned_report(rate: float, *, k: int = 3) -> ClosedLoopReport:
-    outcome = TaskOutcome(task_id="t1", success_rate=rate, mean_fraction=rate, passes=k)
+    successes = round(rate * k)
+    if abs(successes / k - rate) > 1e-9:
+        raise ValueError(f"rate {rate} cannot be represented by k={k} binary verdicts")
+    verdicts = [
+        GoldVerdict(passed=index < successes, fraction=1.0 if index < successes else 0.0)
+        for index in range(k)
+    ]
+    attempts = [RolloutEvidence(stop_reason=StopReason.SUBMITTED) for _ in range(k)]
+    outcome = TaskOutcome(
+        task_id="t1",
+        success_rate=rate,
+        mean_fraction=rate,
+        passes=k,
+        verdicts=verdicts,
+        attempts=attempts,
+    )
     return ClosedLoopReport(
         label="x", success_rate=rate, mean_fraction=rate, k=k, per_task={"t1": outcome}
     )
+
+
+def _corrupt_closed_loop_report(kind: str) -> ClosedLoopReport:
+    """Return one malformed raw evaluator result for adapter fail-closed tests."""
+    report = _canned_report(1.0)
+    outcome = report.per_task["t1"].model_copy(deep=True)
+    if kind == "missing task":
+        return report.model_copy(update={"per_task": {}})
+    if kind == "extra task":
+        extra = outcome.model_copy(update={"task_id": "t2"})
+        return report.model_copy(update={"per_task": {"t1": outcome, "t2": extra}})
+    if kind == "mismatched task id":
+        outcome = outcome.model_copy(update={"task_id": "not-t1"})
+    elif kind == "wrong pass count":
+        outcome = outcome.model_copy(update={"passes": 2})
+    elif kind == "missing verdict":
+        outcome = outcome.model_copy(update={"verdicts": outcome.verdicts[:-1]})
+    elif kind == "missing evidence":
+        outcome = outcome.model_copy(update={"attempts": outcome.attempts[:-1]})
+    elif kind == "task score drift":
+        outcome = outcome.model_copy(update={"success_rate": 0.5})
+    elif kind == "task secondary drift":
+        outcome = outcome.model_copy(update={"mean_fraction": 0.5})
+    elif kind == "aggregate score drift":
+        return report.model_copy(update={"success_rate": 0.5})
+    elif kind == "aggregate secondary drift":
+        return report.model_copy(update={"mean_fraction": 0.5})
+    else:
+        raise AssertionError(f"unknown corruption {kind!r}")
+    return report.model_copy(update={"per_task": {"t1": outcome}})
+
+
+@pytest.mark.parametrize(
+    ("kind", "error"),
+    [
+        ("missing task", "wrong task set.*missing=\\['t1'\\]"),
+        ("extra task", "wrong task set.*extra=\\['t2'\\]"),
+        ("mismatched task id", "key 't1'.*task_id 'not-t1'"),
+        ("wrong pass count", "task 't1'.*passes=2.*expected 3"),
+        ("missing verdict", "task 't1'.*2 verdicts.*expected 3"),
+        ("missing evidence", "task 't1'.*2 evidence.*expected 3"),
+        ("task score drift", "task 't1'.*success_rate=0.5.*verdicts=1.0"),
+        ("task secondary drift", "task 't1'.*mean_fraction=0.5.*verdicts=1.0"),
+        ("aggregate score drift", "report success_rate=0.5.*per-task mean=1.0"),
+        ("aggregate secondary drift", "report mean_fraction=0.5.*per-task mean=1.0"),
+    ],
+)
+def test_closed_loop_adapter_rejects_incomplete_or_inconsistent_raw_reports(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    error: str,
+) -> None:
+    provider = RoleProvider()
+    malformed = _corrupt_closed_loop_report(kind)
+    monkeypatch.setattr(create_module, "evaluate_closed_loop", lambda *args, **kwargs: malformed)
+
+    with pytest.raises(ValueError, match=error):
+        create_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            _tasks(),
+            _wm(provider),
+            provider,
+            ProviderDeltaProposer(provider),
+            GoldJudge(provider),
+            iterations=0,
+        )
 
 
 class _ScriptedPoolChannel:
@@ -1290,6 +1694,37 @@ def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(
     assert observed_usage == [SandboxUsage(count=0, seconds=0.0)]
 
 
+@pytest.mark.parametrize("duplicate_split", ["discovery", "holdout"])
+def test_e2b_pool_is_closed_when_scorer_construction_rejects_duplicate_task_ids(
+    fake_pool_cls: type[_FakePool], duplicate_split: str
+) -> None:
+    """Task validation after pool creation remains inside the pool's lifecycle boundary."""
+    provider = RoleProvider()
+    duplicate_tasks = [*_tasks(), *_tasks()]
+    discovery = duplicate_tasks if duplicate_split == "discovery" else _tasks()
+    holdout = duplicate_tasks if duplicate_split == "holdout" else None
+    observed_usage: list[SandboxUsage] = []
+
+    with pytest.raises(ValueError, match="closed-loop search task ids must be unique"):
+        create_harness(
+            "winner",
+            _pi_seed(),
+            discovery,
+            _wm(provider),
+            provider,
+            ProviderDeltaProposer(provider),
+            GoldJudge(provider),
+            iterations=0,
+            holdout=holdout,
+            harness_backend="e2b",
+            on_sandbox_usage=observed_usage.append,
+        )
+
+    [pool] = fake_pool_cls.instances
+    assert pool.closes == 1
+    assert observed_usage == [SandboxUsage(count=0, seconds=0.0)]
+
+
 def test_e2b_cleanup_failure_replaces_cancellation_and_withholds_final_usage(
     monkeypatch: pytest.MonkeyPatch, fake_pool_cls: type[_FakePool]
 ) -> None:
@@ -1402,6 +1837,7 @@ def test_cancellation_carries_completed_and_partial_wave_worker_usage(
             ProviderDeltaProposer(provider),
             GoldJudge(provider),
             iterations=1,
+            k=2,
             harness_backend="e2b",
         )
 
@@ -1433,6 +1869,7 @@ def test_e2b_pool_retires_idle_runners_once_per_proposal_batch(
         GoldJudge(provider),
         iterations=2,
         proposal_batch_size=3,
+        k=2,
         harness_backend="e2b",
     )
 
@@ -1529,6 +1966,7 @@ def test_create_sums_worker_usage_across_score_waves(
         ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
+        k=2,
         harness_backend="e2b",
     )
 
@@ -1611,6 +2049,7 @@ def test_e2b_rejects_a_delta_that_abandons_the_pi_runtime(
         ProviderDeltaProposer(provider),
         GoldJudge(provider),
         iterations=1,
+        k=2,
         harness_backend="e2b",
     )
 
@@ -1870,17 +2309,17 @@ def test_cancellation_during_later_sibling_commits_no_iteration(
         ]
     )
     cancelled = False
-    gate_delta = create_module.gate_delta
+    gate_delta = create_module.gate_score_delta
 
     def cancel_after_first_gate(
         delta: HarnessDelta,
         *,
-        child: ClosedLoopReport,
-        champion: ClosedLoopReport,
+        child: HarnessScoreReport,
+        champion: HarnessScoreReport,
         best_full: float,
         suite: list[str],
-        child_holdout: ClosedLoopReport | None = None,
-        champion_holdout: ClosedLoopReport | None = None,
+        child_holdout: HarnessScoreReport | None = None,
+        champion_holdout: HarnessScoreReport | None = None,
     ) -> GateRecord:
         nonlocal cancelled
         verdict = gate_delta(
@@ -1895,7 +2334,7 @@ def test_cancellation_during_later_sibling_commits_no_iteration(
         cancelled = True
         return verdict
 
-    monkeypatch.setattr(create_module, "gate_delta", cancel_after_first_gate)
+    monkeypatch.setattr(create_module, "gate_score_delta", cancel_after_first_gate)
     progress: list[tuple[int, str, float, bool]] = []
     crowned: list[str] = []
     proposals: list[ProposalRecord] = []
@@ -2033,21 +2472,21 @@ def test_sibling_holdout_gates_use_frozen_iteration_champion(
         True if "the holdout task" in user else "done-verified" in user
     )
     holdout = [TaskSpec(task_id="h1", instruction="the holdout task", gold=["still works"])]
-    gate_delta = create_module.gate_delta
+    gate_delta = create_module.gate_score_delta
     holdout_gate_champions: list[tuple[float, float]] = []
 
     def capture_gate_baselines(
         delta: HarnessDelta,
         *,
-        child: ClosedLoopReport,
-        champion: ClosedLoopReport,
+        child: HarnessScoreReport,
+        champion: HarnessScoreReport,
         best_full: float,
         suite: list[str],
-        child_holdout: ClosedLoopReport | None = None,
-        champion_holdout: ClosedLoopReport | None = None,
+        child_holdout: HarnessScoreReport | None = None,
+        champion_holdout: HarnessScoreReport | None = None,
     ) -> GateRecord:
         if child_holdout is not None and champion_holdout is not None:
-            holdout_gate_champions.append((champion.success_rate, champion_holdout.success_rate))
+            holdout_gate_champions.append((champion.score, champion_holdout.score))
         return gate_delta(
             delta,
             child=child,
@@ -2058,7 +2497,7 @@ def test_sibling_holdout_gates_use_frozen_iteration_champion(
             champion_holdout=champion_holdout,
         )
 
-    monkeypatch.setattr(create_module, "gate_delta", capture_gate_baselines)
+    monkeypatch.setattr(create_module, "gate_score_delta", capture_gate_baselines)
 
     result = _run(provider, proposal_batch_size=2, holdout=holdout)
 

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -40,6 +40,7 @@ from wmh.harness.runtime import Runtime, StopReason
 from wmh.harness.scoring import (
     HarnessScoreReport,
     ScoreCapabilities,
+    ScoreObjective,
     ScoreRequest,
     TaskScore,
 )
@@ -47,6 +48,7 @@ from wmh.providers.base import Completion, Message, Provider, ProviderConfig, Pr
 from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
 _CAREFUL_PROMPT = "You are a careful agent. Verify the state of the system before submitting."
+_DENSE_OBJECTIVE = ScoreObjective(objective_id="assertion_fraction")
 
 
 def _meta_reply(parent: HarnessDoc, new_prompt: str) -> str:
@@ -188,13 +190,9 @@ class _NeutralScorer:
 
     def __init__(self) -> None:
         self.requests: list[tuple[str, ScoreRequest]] = []
-        self.before_proposal_calls = 0
 
     def validate_candidate(self, candidate: HarnessDoc) -> str | None:
         return None
-
-    def before_proposal_batch(self) -> None:
-        self.before_proposal_calls += 1
 
     def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
         self.requests.append((candidate.doc_hash, request))
@@ -205,13 +203,11 @@ class _NeutralScorer:
             evaluation_id=f"fake:{candidate.doc_hash}:{request.purpose}",
             label=candidate.name,
             score=score,
-            secondary_score=score,
             attempts=self.default_attempts,
             per_task={
                 "ground-truth-task": TaskScore(
                     task_id="ground-truth-task",
                     score=score,
-                    secondary_score=score,
                     passed=passed,
                     description="repair the repository",
                     mechanisms=() if passed else ("missing verification",),
@@ -245,10 +241,28 @@ class _EvidenceRecordingProposer:
         return [proposal]
 
 
+def _declare_secondary(
+    report: HarnessScoreReport,
+    objective: ScoreObjective,
+) -> HarnessScoreReport:
+    """Attach a real scorer-declared objective to a neutral test report."""
+    return report.model_copy(
+        update={
+            "secondary_objective": objective,
+            "secondary_score": report.score,
+            "per_task": {
+                task_id: task.model_copy(update={"secondary_score": task.score})
+                for task_id, task in report.per_task.items()
+            },
+        }
+    )
+
+
 def test_search_harness_scores_with_no_world_model_or_gold_judge() -> None:
     seed = HarnessDoc.baseline("seed")
     scorer = _NeutralScorer()
     proposer = _EvidenceRecordingProposer()
+    proposal_boundaries: list[str] = []
 
     result = search_harness(
         "winner",
@@ -258,12 +272,13 @@ def test_search_harness_scores_with_no_world_model_or_gold_judge() -> None:
         iterations=1,
         screen_proposals=False,
         confirm_narrow_vetoes=False,
+        before_proposal_batch=lambda: proposal_boundaries.append("released"),
     )
 
     assert result.best_score == 1.0
     assert result.best.name == "winner"
     assert [request.purpose for _, request in scorer.requests] == ["seed", "full"]
-    assert scorer.before_proposal_calls == 1
+    assert proposal_boundaries == ["released"]
     assert "verifier reward and execution trace" in proposer.evidence[0]
     assert result.suite == ["ground-truth-task"]
 
@@ -281,6 +296,22 @@ def test_search_harness_rejects_unsupported_paid_stages_before_scoring() -> None
         )
 
     assert scorer.requests == []
+
+
+def test_search_harness_requires_declared_attempt_mean_for_confirmation() -> None:
+    class OverrideOnlyScorer(_NeutralScorer):
+        capabilities = ScoreCapabilities(attempt_overrides=True)
+
+    with pytest.raises(ValueError, match="mean_over_attempts"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            OverrideOnlyScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            confirm_narrow_vetoes=True,
+        )
 
 
 def test_search_harness_rejects_negative_iterations() -> None:
@@ -316,6 +347,135 @@ def test_search_harness_rejects_default_attempt_count_drift() -> None:
         )
 
 
+def test_search_harness_rejects_an_undeclared_secondary_objective() -> None:
+    class UndeclaredSecondaryScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            return _declare_secondary(super().score(candidate, request=request), _DENSE_OBJECTIVE)
+
+    with pytest.raises(ValueError, match="secondary objective.*not declared"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            UndeclaredSecondaryScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_candidate_secondary_objective_drift() -> None:
+    other_objective = ScoreObjective(objective_id="different_dense_progress")
+
+    class DriftingSecondaryScorer(_NeutralScorer):
+        capabilities = ScoreCapabilities(secondary_objective=_DENSE_OBJECTIVE)
+
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            objective = other_objective if request.purpose == "full" else _DENSE_OBJECTIVE
+            return _declare_secondary(super().score(candidate, request=request), objective)
+
+    with pytest.raises(ValueError, match="secondary objective.*different_dense_progress"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            DriftingSecondaryScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_holdout_secondary_objective_drift() -> None:
+    other_objective = ScoreObjective(objective_id="different_holdout_progress")
+
+    class DriftingHoldoutScorer(_NeutralScorer):
+        capabilities = ScoreCapabilities(secondary_objective=_DENSE_OBJECTIVE)
+
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            objective = other_objective if report.score == 1.0 else _DENSE_OBJECTIVE
+            return _declare_secondary(report, objective)
+
+    with pytest.raises(ValueError, match="secondary objective.*different_holdout_progress"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            _NeutralScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            holdout_scorer=DriftingHoldoutScorer(),
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_confirmation_secondary_objective_drift() -> None:
+    other_objective = ScoreObjective(objective_id="different_confirmation_progress")
+
+    class DiscoveryScorer(_NeutralScorer):
+        capabilities = ScoreCapabilities(attempt_overrides=True, mean_over_attempts=True)
+        default_attempts = 5
+
+    class ConfirmationDriftScorer(_NeutralScorer):
+        capabilities = ScoreCapabilities(
+            attempt_overrides=True,
+            mean_over_attempts=True,
+            secondary_objective=_DENSE_OBJECTIVE,
+        )
+        default_attempts = 5
+
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            score = 0.8 if report.score == 1.0 else 1.0
+            task = report.per_task["ground-truth-task"].model_copy(
+                update={"score": score, "secondary_score": score, "passed": score == 1.0}
+            )
+            objective = other_objective if request.purpose == "confirmation" else _DENSE_OBJECTIVE
+            return report.model_copy(
+                update={
+                    "score": score,
+                    "secondary_objective": objective,
+                    "secondary_score": score,
+                    "attempts": request.attempts or self.default_attempts,
+                    "per_task": {task.task_id: task},
+                }
+            )
+
+    with pytest.raises(ValueError, match="secondary objective.*different_confirmation_progress"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            DiscoveryScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            holdout_scorer=ConfirmationDriftScorer(),
+            confirm_narrow_vetoes=True,
+        )
+
+
+def test_search_harness_rejects_candidate_aggregate_weight_drift() -> None:
+    class DriftingWeightScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            if request.purpose != "full":
+                return report
+            task = report.per_task["ground-truth-task"].model_copy(update={"aggregate_weight": 2.0})
+            return report.model_copy(update={"per_task": {task.task_id: task}})
+
+    with pytest.raises(ValueError, match="aggregate weight.*ground-truth-task"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            DriftingWeightScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
 def test_search_harness_rejects_candidate_that_omits_a_discovery_task() -> None:
     class OmittingScorer(_NeutralScorer):
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
@@ -325,7 +485,6 @@ def test_search_harness_rejects_candidate_that_omits_a_discovery_task() -> None:
             required = TaskScore(
                 task_id="required-task",
                 score=0.0,
-                secondary_score=0.0,
                 passed=False,
             )
             return report.model_copy(
@@ -353,7 +512,6 @@ def test_search_harness_rejects_candidate_that_omits_a_holdout_task() -> None:
             required = TaskScore(
                 task_id="held-out-required",
                 score=0.0,
-                secondary_score=0.0,
                 passed=False,
             )
             return report.model_copy(
@@ -400,7 +558,6 @@ def test_search_harness_snapshots_and_canonicalizes_scorer_owned_reports() -> No
             extra = TaskScore(
                 task_id="another-task",
                 score=0.0,
-                secondary_score=0.0,
                 passed=False,
                 evidence="another immutable trace",
             )
@@ -436,7 +593,6 @@ def test_search_harness_snapshots_and_canonicalizes_scorer_owned_reports() -> No
     source.per_task["late-task"] = TaskScore(
         task_id="late-task",
         score=1.0,
-        secondary_score=1.0,
         passed=True,
     )
 
@@ -450,7 +606,7 @@ def test_search_harness_rejects_empty_seed_and_holdout_matrices() -> None:
     class EmptyScorer(_NeutralScorer):
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
             report = super().score(candidate, request=request)
-            return report.model_copy(update={"score": 0.0, "secondary_score": 0.0, "per_task": {}})
+            return report.model_copy(update={"score": 0.0, "per_task": {}})
 
     with pytest.raises(ValueError, match="seed score report contains no tasks"):
         search_harness(
@@ -475,7 +631,7 @@ def test_search_harness_rejects_empty_seed_and_holdout_matrices() -> None:
         )
 
 
-def test_search_harness_validates_and_retires_both_scorers() -> None:
+def test_search_harness_validates_both_scorers_and_runs_injected_batch_boundary() -> None:
     class RejectingHoldoutScorer(_NeutralScorer):
         def validate_candidate(self, candidate: HarnessDoc) -> str | None:
             prompt = candidate.surface("prompt:core")
@@ -487,6 +643,7 @@ def test_search_harness_validates_and_retires_both_scorers() -> None:
 
     discovery = _NeutralScorer()
     holdout = RejectingHoldoutScorer()
+    proposal_boundaries: list[str] = []
     result = search_harness(
         "winner",
         HarnessDoc.baseline("seed"),
@@ -496,11 +653,12 @@ def test_search_harness_validates_and_retires_both_scorers() -> None:
         screen_proposals=False,
         holdout_scorer=holdout,
         confirm_narrow_vetoes=False,
+        before_proposal_batch=lambda: proposal_boundaries.append("released"),
     )
 
     assert [request.purpose for _, request in discovery.requests] == ["seed"]
     assert [request.purpose for _, request in holdout.requests] == ["holdout"]
-    assert discovery.before_proposal_calls == holdout.before_proposal_calls == 1
+    assert proposal_boundaries == ["released"]
     assert result.proposal_records[0].outcome == "invalid"
     assert "holdout runtime rejected candidate" in (result.proposal_records[0].reason or "")
 
@@ -970,6 +1128,7 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
     champion = HarnessScoreReport(
         evaluation_id="champion",
         score=0.0,
+        secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.45,
         attempts=1,
         per_task={
@@ -980,6 +1139,7 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
     child = HarnessScoreReport(
         evaluation_id="child",
         score=0.0,
+        secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.25,
         attempts=1,
         per_task={
@@ -1009,6 +1169,7 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
     champion = HarnessScoreReport(
         evaluation_id="champion",
         score=0.0,
+        secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.1,
         attempts=1,
         per_task={
@@ -1019,6 +1180,7 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
     child = HarnessScoreReport(
         evaluation_id="child",
         score=0.0,
+        secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.35,
         attempts=1,
         per_task={
@@ -1037,6 +1199,37 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
 
     assert verdict.accepted is True
     assert verdict.full_secondary_delta == pytest.approx(0.25)
+
+
+def test_gate_uses_only_primary_scores_when_no_secondary_objective_exists() -> None:
+    delta = HarnessDelta.model_construct(
+        trigger=FailureSignature(mechanism="target", task_ids=["target"])
+    )
+    champion = HarnessScoreReport(
+        evaluation_id="champion-primary-only",
+        score=0.0,
+        attempts=1,
+        per_task={"target": TaskScore(task_id="target", score=0.0, passed=False)},
+    )
+    child = HarnessScoreReport(
+        evaluation_id="child-primary-only",
+        score=0.0,
+        attempts=1,
+        per_task={"target": TaskScore(task_id="target", score=0.0, passed=False)},
+    )
+
+    verdict = create_module.gate_score_delta(
+        delta,
+        child=child,
+        champion=champion,
+        best_full=0.0,
+        suite=["target"],
+    )
+
+    assert verdict.accepted is True
+    assert verdict.suite_secondary_delta is None
+    assert verdict.full_secondary_delta is None
+    assert "secondary" not in verdict.reason
 
 
 def test_search_records_screen_and_full_trace_feedback_for_project_proposers() -> None:
@@ -1236,16 +1429,38 @@ def test_narrow_failing_tiers_eligibility() -> None:
 
     # Narrow holdout veto on a full-split win -> retry that tier.
     narrow = record(full_delta=0.05, holdout_delta=-0.1)
-    assert narrow_failing_tiers(narrow, k=5, n_suite=4, n_holdout=4) == ["holdout"]
+    assert narrow_failing_tiers(
+        narrow,
+        suite_attempt_impact=0.05,
+        holdout_attempt_impact=0.05,
+    ) == ["holdout"]
     # A wide veto is a real regression, not noise: ineligible.
     wide = record(full_delta=0.05, holdout_delta=-1.0)
-    assert narrow_failing_tiers(wide, k=5, n_suite=4, n_holdout=4) is None
+    assert (
+        narrow_failing_tiers(
+            wide,
+            suite_attempt_impact=0.05,
+            holdout_attempt_impact=0.05,
+        )
+        is None
+    )
     # No full-split win: nothing to confirm.
     no_win = record(full_delta=0.0, holdout_delta=-0.1)
-    assert narrow_failing_tiers(no_win, k=5, n_suite=4, n_holdout=4) is None
+    assert (
+        narrow_failing_tiers(
+            no_win,
+            suite_attempt_impact=0.05,
+            holdout_attempt_impact=0.05,
+        )
+        is None
+    )
     # Both tiers narrowly failing -> both retried.
     both = record(full_delta=0.05, suite_delta=-0.05, holdout_delta=-0.1)
-    assert narrow_failing_tiers(both, k=5, n_suite=8, n_holdout=4) == ["suite", "holdout"]
+    assert narrow_failing_tiers(
+        both,
+        suite_attempt_impact=0.025,
+        holdout_attempt_impact=0.05,
+    ) == ["suite", "holdout"]
     # Confirmation of one binary veto cannot erase a separate dense-signal veto.
     dense_veto = record(
         full_delta=0.05,
@@ -1253,10 +1468,49 @@ def test_narrow_failing_tiers_eligibility() -> None:
         holdout_delta=0.0,
         holdout_secondary_delta=-0.2,
     )
-    assert narrow_failing_tiers(dense_veto, k=5, n_suite=8, n_holdout=4) is None
+    assert (
+        narrow_failing_tiers(
+            dense_veto,
+            suite_attempt_impact=0.025,
+            holdout_attempt_impact=0.05,
+        )
+        is None
+    )
     # Accepted verdicts are never retried.
     ok = GateRecord(accepted=True, reason="r", full_delta=0.05)
-    assert narrow_failing_tiers(ok, k=5, n_suite=4, n_holdout=4) is None
+    assert (
+        narrow_failing_tiers(
+            ok,
+            suite_attempt_impact=0.05,
+            holdout_attempt_impact=0.05,
+        )
+        is None
+    )
+
+
+def test_confirmation_attempt_impact_uses_frozen_aggregate_weights() -> None:
+    report = HarnessScoreReport(
+        evaluation_id="weighted-confirmation",
+        score=0.75,
+        attempts=5,
+        per_task={
+            "light": TaskScore(
+                task_id="light",
+                score=0.0,
+                aggregate_weight=1.0,
+                passed=False,
+            ),
+            "heavy": TaskScore(
+                task_id="heavy",
+                score=1.0,
+                aggregate_weight=3.0,
+                passed=True,
+            ),
+        },
+    )
+
+    assert create_module._max_primary_attempt_impact(report, ["light", "heavy"]) == 0.15
+    assert create_module._max_primary_attempt_impact(report, ["light"]) == 0.2
 
 
 def test_flaky_holdout_veto_is_overturned_by_confirmation() -> None:

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -39,8 +39,10 @@ from wmh.harness.proposer import ProposalFailure, ProviderDeltaProposer
 from wmh.harness.runtime import Runtime, StopReason
 from wmh.harness.scoring import (
     HarnessScoreReport,
+    PassCriterion,
     ScoreCapabilities,
     ScoreObjective,
+    ScoreProvenance,
     ScoreRequest,
     TaskScore,
 )
@@ -49,6 +51,12 @@ from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
 
 _CAREFUL_PROMPT = "You are a careful agent. Verify the state of the system before submitting."
 _DENSE_OBJECTIVE = ScoreObjective(objective_id="assertion_fraction")
+_PASS_CRITERION = PassCriterion(score_at_least=1.0)
+_NEUTRAL_PROVENANCE = ScoreProvenance(
+    task_set={"tasks": [{"task_id": "ground-truth-task"}]},
+    evaluator={"kind": "test-neutral", "version": 1},
+    backend={"kind": "in_process", "config": {}},
+)
 
 
 def _meta_reply(parent: HarnessDoc, new_prompt: str) -> str:
@@ -200,7 +208,10 @@ class _NeutralScorer:
         passed = prompt is not None and "careful agent" in prompt.content
         score = 1.0 if passed else 0.0
         return HarnessScoreReport(
-            evaluation_id=f"fake:{candidate.doc_hash}:{request.purpose}",
+            candidate_execution_hash=candidate.execution_hash,
+            request=request,
+            provenance=_NEUTRAL_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
             label=candidate.name,
             score=score,
             attempts=self.default_attempts,
@@ -283,7 +294,65 @@ def test_search_harness_scores_with_no_world_model_or_gold_judge() -> None:
     assert result.suite == ["ground-truth-task"]
 
 
-def test_search_harness_rejects_unsupported_paid_stages_before_scoring() -> None:
+def test_search_harness_keeps_path_or_budget_only_children_distinct() -> None:
+    seed = HarnessDoc.baseline("seed")
+    core = seed.surface("prompt:core")
+    assert core is not None
+
+    class RebudgetingProposer:
+        def propose_batch(
+            self,
+            parent: HarnessDoc,
+            trigger: FailureSignature,
+            evidence: str,
+            *,
+            history: list[HarnessDelta],
+            count: int,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> list[HarnessDelta | ProposalFailure | None]:
+            del evidence, history, should_cancel
+            assert count == 1
+            proposal = parse_delta(
+                parent,
+                trigger,
+                json.dumps(
+                    {
+                        "expected_effect": "freeze a larger prompt budget",
+                        "preconditions": {"prompt:core": core.content_hash},
+                        "ops": [
+                            {
+                                "op": "replace",
+                                "surface_id": "prompt:core",
+                                "content": core.content,
+                                "budget": len(core.content) + 100,
+                                "rationale": "bind the materialized candidate budget",
+                            }
+                        ],
+                    }
+                ),
+            )
+            assert proposal is not None
+            return [proposal]
+
+    result = search_harness(
+        "winner",
+        seed,
+        _NeutralScorer(),
+        RebudgetingProposer(),
+        iterations=1,
+        screen_proposals=False,
+        confirm_narrow_vetoes=False,
+    )
+
+    [delta] = result.archive.deltas
+    assert delta.child_doc_hash is not None
+    assert delta.child_doc_hash != seed.doc_hash
+    assert set(result.reports) == {seed.doc_hash, delta.child_doc_hash}
+    winner_core = result.best.surface("prompt:core")
+    assert winner_core is not None and winner_core.budget == len(core.content) + 100
+
+
+def test_search_harness_rejects_unsupported_screening_before_scoring() -> None:
     scorer = _NeutralScorer()
 
     with pytest.raises(ValueError, match="screen_proposals=False"):
@@ -531,17 +600,166 @@ def test_search_harness_rejects_candidate_that_omits_a_holdout_task() -> None:
         )
 
 
-def test_search_harness_rejects_evaluation_identity_collision() -> None:
-    class CollidingScorer(_NeutralScorer):
+@pytest.mark.parametrize("mismatch", ["candidate", "request"])
+def test_search_harness_rejects_report_identity_mismatch(mismatch: str) -> None:
+    class MismatchedScorer(_NeutralScorer):
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
             report = super().score(candidate, request=request)
-            return report.model_copy(update={"evaluation_id": "reused-id"})
+            update = (
+                {"candidate_execution_hash": "f" * 32}
+                if mismatch == "candidate"
+                else {"request": ScoreRequest(purpose="confirmation")}
+            )
+            return report.model_copy(update=update)
 
-    with pytest.raises(ValueError, match="evaluation_id 'reused-id'.*different report"):
+    with pytest.raises(ValueError, match="candidate execution identity|score request"):
         search_harness(
             "winner",
             HarnessDoc.baseline("seed"),
-            CollidingScorer(),
+            MismatchedScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=0,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_closed_loop_provenance_binds_task_evaluator_and_backend_configuration() -> None:
+    provider = RoleProvider()
+    world_model = _wm(provider)
+    judge = GoldJudge(provider)
+    base = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=world_model,
+        agent_provider=provider,
+        judge=judge,
+        harness_backend="local",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
+
+    changed_task = create_module._closed_loop_score_provenance(
+        [TaskSpec(task_id="other", instruction="different", gold=["done"])],
+        world_model=world_model,
+        agent_provider=provider,
+        judge=judge,
+        harness_backend="local",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
+    changed_world_model = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=WorldModel(provider, EmbeddingRetriever(HashingEmbedder(dim=32))),
+        agent_provider=provider,
+        judge=judge,
+        harness_backend="local",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
+    alternate_provider = RoleProvider()
+    alternate_provider.config = alternate_provider.config.model_copy(update={"model": "other"})
+    changed_agent = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=world_model,
+        agent_provider=alternate_provider,
+        judge=judge,
+        harness_backend="local",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
+    changed_judge = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=world_model,
+        agent_provider=provider,
+        judge=GoldJudge(alternate_provider),
+        harness_backend="local",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
+    changed_backend = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=world_model,
+        agent_provider=provider,
+        judge=judge,
+        harness_backend="e2b",
+        eval_concurrency=4,
+        e2b_template="template-v2",
+        e2b_metadata={"run": "comparison"},
+    )
+
+    assert base.task_set == {"tasks": [task.model_dump(mode="json") for task in _tasks()]}
+    assert base.backend == {
+        "kind": "local",
+        "concurrency": 1,
+        "e2b_template": None,
+        "e2b_metadata": {},
+    }
+    assert (
+        len(
+            {
+                base.model_dump_json(),
+                changed_task.model_dump_json(),
+                changed_world_model.model_dump_json(),
+                changed_agent.model_dump_json(),
+                changed_judge.model_dump_json(),
+                changed_backend.model_dump_json(),
+            }
+        )
+        == 6
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("task_set", {"tasks": [{"task_id": "changed"}]}),
+        ("evaluator", {"kind": "changed", "version": 1}),
+        ("backend", {"kind": "changed", "config": {}}),
+    ],
+)
+def test_search_harness_rejects_evaluation_provenance_drift(
+    field: str,
+    value: JsonObject,
+) -> None:
+    class DriftingProvenanceScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            if request.purpose != "full":
+                return report
+            return report.model_copy(
+                update={"provenance": report.provenance.model_copy(update={field: value})}
+            )
+
+    with pytest.raises(ValueError, match=f"evaluation provenance.*{field}"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            DriftingProvenanceScorer(),
+            _EvidenceRecordingProposer(),
+            iterations=1,
+            screen_proposals=False,
+            confirm_narrow_vetoes=False,
+        )
+
+
+def test_search_harness_rejects_pass_criterion_drift() -> None:
+    class DriftingPassCriterionScorer(_NeutralScorer):
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+            report = super().score(candidate, request=request)
+            if request.purpose != "full":
+                return report
+            return report.model_copy(update={"pass_criterion": PassCriterion(score_at_least=0.5)})
+
+    with pytest.raises(ValueError, match="pass criterion"):
+        search_harness(
+            "winner",
+            HarnessDoc.baseline("seed"),
+            DriftingPassCriterionScorer(),
             _EvidenceRecordingProposer(),
             iterations=1,
             screen_proposals=False,
@@ -602,13 +820,13 @@ def test_search_harness_snapshots_and_canonicalizes_scorer_owned_reports() -> No
     assert "late-task" not in audited.per_task
 
 
-def test_search_harness_rejects_empty_seed_and_holdout_matrices() -> None:
+def test_search_harness_revalidates_empty_seed_and_holdout_matrices() -> None:
     class EmptyScorer(_NeutralScorer):
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
             report = super().score(candidate, request=request)
             return report.model_copy(update={"score": 0.0, "per_task": {}})
 
-    with pytest.raises(ValueError, match="seed score report contains no tasks"):
+    with pytest.raises(ValueError, match="at least 1 item"):
         search_harness(
             "winner",
             HarnessDoc.baseline("seed"),
@@ -618,7 +836,7 @@ def test_search_harness_rejects_empty_seed_and_holdout_matrices() -> None:
             screen_proposals=False,
             confirm_narrow_vetoes=False,
         )
-    with pytest.raises(ValueError, match="holdout seed score report contains no tasks"):
+    with pytest.raises(ValueError, match="at least 1 item"):
         search_harness(
             "winner",
             HarnessDoc.baseline("seed"),
@@ -1126,7 +1344,10 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
         trigger=FailureSignature(mechanism="target", task_ids=["target"])
     )
     champion = HarnessScoreReport(
-        evaluation_id="champion",
+        candidate_execution_hash="a" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.45,
@@ -1137,7 +1358,10 @@ def test_gate_rejects_target_partial_lift_when_full_split_partial_credit_regress
         },
     )
     child = HarnessScoreReport(
-        evaluation_id="child",
+        candidate_execution_hash="b" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.25,
@@ -1167,7 +1391,10 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
         trigger=FailureSignature(mechanism="target", task_ids=["target"])
     )
     champion = HarnessScoreReport(
-        evaluation_id="champion",
+        candidate_execution_hash="a" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.1,
@@ -1178,7 +1405,10 @@ def test_gate_accepts_binary_tie_with_nonregressing_global_partial_progress() ->
         },
     )
     child = HarnessScoreReport(
-        evaluation_id="child",
+        candidate_execution_hash="b" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         secondary_objective=_DENSE_OBJECTIVE,
         secondary_score=0.35,
@@ -1206,13 +1436,19 @@ def test_gate_uses_only_primary_scores_when_no_secondary_objective_exists() -> N
         trigger=FailureSignature(mechanism="target", task_ids=["target"])
     )
     champion = HarnessScoreReport(
-        evaluation_id="champion-primary-only",
+        candidate_execution_hash="a" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         attempts=1,
         per_task={"target": TaskScore(task_id="target", score=0.0, passed=False)},
     )
     child = HarnessScoreReport(
-        evaluation_id="child-primary-only",
+        candidate_execution_hash="b" * 32,
+        request=ScoreRequest(purpose="full"),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.0,
         attempts=1,
         per_task={"target": TaskScore(task_id="target", score=0.0, passed=False)},
@@ -1490,7 +1726,10 @@ def test_narrow_failing_tiers_eligibility() -> None:
 
 def test_confirmation_attempt_impact_uses_frozen_aggregate_weights() -> None:
     report = HarnessScoreReport(
-        evaluation_id="weighted-confirmation",
+        candidate_execution_hash="a" * 32,
+        request=ScoreRequest(purpose="confirmation", attempts=5),
+        provenance=_NEUTRAL_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=0.75,
         attempts=5,
         per_task={

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -624,7 +624,9 @@ def test_search_harness_rejects_report_identity_mismatch(mismatch: str) -> None:
         )
 
 
-def test_closed_loop_provenance_binds_task_evaluator_and_backend_configuration() -> None:
+def test_closed_loop_provenance_binds_task_evaluator_and_backend_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     provider = RoleProvider()
     world_model = _wm(provider)
     judge = GoldJudge(provider)
@@ -691,6 +693,17 @@ def test_closed_loop_provenance_binds_task_evaluator_and_backend_configuration()
         e2b_template="template-v2",
         e2b_metadata={"run": "comparison"},
     )
+    monkeypatch.setenv(create_module.E2B_TEMPLATE_ENV, "template-from-env")
+    environment_backend = create_module._closed_loop_score_provenance(
+        _tasks(),
+        world_model=world_model,
+        agent_provider=provider,
+        judge=judge,
+        harness_backend="e2b",
+        eval_concurrency=None,
+        e2b_template=None,
+        e2b_metadata=None,
+    )
 
     assert base.task_set == {"tasks": [task.model_dump(mode="json") for task in _tasks()]}
     assert base.backend == {
@@ -708,10 +721,31 @@ def test_closed_loop_provenance_binds_task_evaluator_and_backend_configuration()
                 changed_agent.model_dump_json(),
                 changed_judge.model_dump_json(),
                 changed_backend.model_dump_json(),
+                environment_backend.model_dump_json(),
             }
         )
-        == 6
+        == 7
     )
+    assert environment_backend.backend["e2b_template"] == "template-from-env"
+
+
+def test_closed_loop_scorer_snapshots_caller_owned_task_specs() -> None:
+    tasks = _tasks()
+    scorer = create_module._ClosedLoopHarnessScorer(
+        tasks,
+        default_attempts=1,
+        evaluate=lambda candidate, split, attempts: _canned_report(1.0, k=attempts),
+        validate_candidate=lambda candidate: None,
+        provenance=_NEUTRAL_PROVENANCE,
+    )
+    tasks[0].instruction = "mutated after scorer construction"
+
+    report = scorer.score(
+        HarnessDoc.baseline("seed"),
+        request=ScoreRequest(purpose="seed"),
+    )
+
+    assert report.per_task["t1"].description == "answer it"
 
 
 @pytest.mark.parametrize(
@@ -2158,6 +2192,39 @@ def test_e2b_backend_scores_against_the_world_model_through_the_shared_pool(
         response = channel.sent[1]
         # The WORLD MODEL answered the tool: "ok" is the RoleProvider env-role marker reply.
         assert response.get("content") == "ok" and response.get("is_error") is False
+
+
+def test_e2b_backend_freezes_environment_template_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_pool_cls: type[_FakePool],
+) -> None:
+    provider = RoleProvider()
+    metadata = {"purpose": "evaluation", "run": "frozen"}
+    monkeypatch.setenv(create_module.E2B_TEMPLATE_ENV, "template-from-env")
+    monkeypatch.setattr(
+        create_module,
+        "evaluate_closed_loop",
+        lambda *args, **kwargs: _canned_report(1.0, k=kwargs.get("k", 1)),
+    )
+
+    create_harness(
+        "winner",
+        _pi_seed(),
+        _tasks(),
+        _wm(provider),
+        provider,
+        ProviderDeltaProposer(provider),
+        GoldJudge(provider),
+        iterations=0,
+        k=1,
+        harness_backend="e2b",
+        e2b_metadata=metadata,
+    )
+
+    [pool] = fake_pool_cls.instances
+    assert pool.template == "template-from-env"
+    assert pool.metadata == {"purpose": "evaluation", "run": "frozen"}
+    assert pool.metadata is not metadata
 
 
 def test_e2b_pool_is_closed_exactly_once_when_the_search_raises(

--- a/wmh/harness/delta.py
+++ b/wmh/harness/delta.py
@@ -90,9 +90,9 @@ class GateRecord(BaseModel):
     """The acceptance verdict, filled at evaluation time and persisted on the delta."""
 
     suite_delta: float = 0.0  # regression suite: child - champion (tier 1; >= 0 to pass)
-    suite_secondary_delta: float = 0.0  # secondary score; vetoes only when suite score ties
+    suite_secondary_delta: float | None = None  # present only for a declared secondary objective
     full_delta: float = 0.0  # full split: child - best seen (tier 2; >= 0 to pass)
-    full_secondary_delta: float = 0.0  # secondary score; vetoes only when full score ties
+    full_secondary_delta: float | None = None  # present only for a declared secondary objective
     holdout_delta: float | None = None  # held-out split (tier 3; None when no holdout given)
     holdout_secondary_delta: float | None = None  # secondary held-out signal when score ties
     accepted: bool

--- a/wmh/harness/delta.py
+++ b/wmh/harness/delta.py
@@ -35,22 +35,22 @@ from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
 class FailureSignature(BaseModel):
     """The clustered failure mechanism a delta answers to: WHY it exists, queryably.
 
-    Built deterministically from a closed-loop report (`wmh.harness.create.cluster_failures`),
+    Built deterministically from a score report (`wmh.harness.scoring.cluster_score_failures`),
     never free-typed by the proposer — so the archive's mechanism labels are comparable across
     deltas and runs.
     """
 
-    mechanism: str  # e.g. the shared unmet assertion, or "none: all tasks pass"
+    mechanism: str  # e.g. the shared failure label, or "none: all tasks pass"
     task_ids: list[str] = Field(default_factory=list)  # the failing tasks exhibiting it
-    unmet_assertions: list[str] = Field(default_factory=list)  # deduped, order-stable
+    mechanism_labels: list[str] = Field(default_factory=list)  # deduped, order-stable
 
     @model_validator(mode="after")
     def _validate_text(self) -> FailureSignature:
         validate_durable_text(self.mechanism, field="failure mechanism")
         for task_id in self.task_ids:
             validate_durable_text(task_id, field="failure task id")
-        for assertion in self.unmet_assertions:
-            validate_durable_text(assertion, field="failure assertion")
+        for label in self.mechanism_labels:
+            validate_durable_text(label, field="failure mechanism label")
         return self
 
 
@@ -90,11 +90,11 @@ class GateRecord(BaseModel):
     """The acceptance verdict, filled at evaluation time and persisted on the delta."""
 
     suite_delta: float = 0.0  # regression suite: child - champion (tier 1; >= 0 to pass)
-    suite_fraction_delta: float = 0.0  # assertion credit; vetoes only when suite success ties
+    suite_secondary_delta: float = 0.0  # secondary score; vetoes only when suite score ties
     full_delta: float = 0.0  # full split: child - best seen (tier 2; >= 0 to pass)
-    full_fraction_delta: float = 0.0  # assertion credit; vetoes only when full success ties
+    full_secondary_delta: float = 0.0  # secondary score; vetoes only when full score ties
     holdout_delta: float | None = None  # held-out split (tier 3; None when no holdout given)
-    holdout_fraction_delta: float | None = None  # dense held-out signal when success ties
+    holdout_secondary_delta: float | None = None  # secondary held-out signal when score ties
     accepted: bool
     reason: str  # accept/reject reasoning, incl. whether `expected_effect` came true
 

--- a/wmh/harness/delta_test.py
+++ b/wmh/harness/delta_test.py
@@ -34,7 +34,7 @@ def _delta(
     return HarnessDelta(
         delta_id=compute_delta_id(parent.doc_hash, ops),
         parent_doc_hash=parent.doc_hash,
-        trigger=FailureSignature(mechanism="m", task_ids=["t1"], unmet_assertions=["a"]),
+        trigger=FailureSignature(mechanism="m", task_ids=["t1"], mechanism_labels=["a"]),
         preconditions=preconditions if preconditions is not None else {},
         ops=ops,
         expected_effect="t1 flips to pass",

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -9,9 +9,9 @@ Why surfaces instead of files:
 - **Identity.** Every surface has a stable id (`prompt:core`, `skill:count-words`). An update names
   its target; nothing is ever addressed by position or filename, so "which thing changed" is never
   inferred.
-- **Content addressing.** Each surface has a content hash, and the document has a hash over its
-  surfaces. "The score of harness X" is well-defined because X is a hash; an update can assert
-  exactly what it believes it is editing.
+- **Content addressing.** Each surface has a content hash, and the document has a hash over every
+  surface field that affects execution or materialization. "The score of harness X" is
+  well-defined because X is this identity; an update can assert exactly what it is editing.
 - **Typed validation.** A document validates as a whole (tools resolve, `submit` present, params in
   range, budgets respected) the moment it is constructed — an invalid harness cannot exist as a
   value, so nothing downstream re-checks.
@@ -183,13 +183,12 @@ class HarnessDoc(BaseModel):
 
     @property
     def doc_hash(self) -> str:
-        """Content identity of the whole document (order-independent via canonical sort)."""
-        joined = "\n".join(f"{s.id}\x00{s.content_hash}" for s in self.surfaces)
-        return _digest(joined)
+        """Canonical identity of every surface field that affects execution or materialization."""
+        return self.execution_hash
 
     @property
     def execution_hash(self) -> str:
-        """Identity of every surface field that can change materialization or execution."""
+        """Execution-affecting identity, excluding display-only document name and version."""
         payload = [surface.model_dump(mode="json") for surface in self.surfaces]
         canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
         return _digest(canonical)

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -65,8 +65,8 @@ def test_doc_hash_is_content_and_order_independent() -> None:
     assert doc3.doc_hash != doc1.doc_hash
 
 
-def test_execution_hash_includes_code_materialization_path() -> None:
-    prompt = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p")
+def test_document_identity_includes_materialization_path_and_budget() -> None:
+    prompt = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p", budget=10)
     code = Surface(
         id="code:agent",
         kind=SurfaceKind.CODE,
@@ -74,13 +74,20 @@ def test_execution_hash_includes_code_materialization_path() -> None:
         path="src/agent.ts",
     )
     original = HarnessDoc(name="candidate", surfaces=[prompt, code])
-    renamed = HarnessDoc(
+    moved = HarnessDoc(
         name="candidate",
         surfaces=[prompt, code.model_copy(update={"path": "src/not-agent.ts"})],
     )
+    rebudgeted = HarnessDoc(
+        name="candidate",
+        surfaces=[prompt.model_copy(update={"budget": 20}), code],
+    )
 
-    assert original.doc_hash == renamed.doc_hash
-    assert original.execution_hash != renamed.execution_hash
+    assert original.doc_hash == original.execution_hash
+    assert moved.doc_hash == moved.execution_hash
+    assert rebudgeted.doc_hash == rebudgeted.execution_hash
+    assert original.doc_hash != moved.doc_hash
+    assert original.doc_hash != rebudgeted.doc_hash
 
 
 def test_duplicate_surface_ids_rejected() -> None:

--- a/wmh/harness/mutate.py
+++ b/wmh/harness/mutate.py
@@ -21,9 +21,8 @@ from pydantic import BaseModel, Field, ValidationError
 
 from wmh.core.parsing import extract_json_object
 from wmh.core.text import normalize_durable_text
-from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence
+from wmh.evals.closed_loop import RolloutEvidence, TaskOutcome
 from wmh.evals.gold import GoldVerdict
-from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature, HarnessDelta, SurfaceOp, compute_delta_id
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
@@ -200,67 +199,15 @@ def _apply_edits(content: str, value: object) -> str:
     return content
 
 
-def render_evidence(
-    trigger: FailureSignature, report: ClosedLoopReport, tasks: list[TaskSpec]
-) -> str:
-    """Render one failure cluster (instructions + unmet assertions) as reflection fuel.
-
-    A trigger with no failing tasks (the all-pass case) gets an explicit "nothing failed" prompt
-    asking for a generalization/efficiency improvement — not a fake failure section that would
-    send the meta-agent chasing nonexistent problems.
-    """
-    if not trigger.task_ids:
-        return (
-            "The harness passed every task on every pass. There are no failures to fix. "
-            "Propose a change that should GENERALIZE or ECONOMIZE: a tighter, more transferable "
-            "prompt surface; a lower param:max-turns if runs finish early; or a reusable skill "
-            "distilled from what worked."
-        )
-    by_id = {task.task_id: task for task in tasks}
-    selected = set(trigger.task_ids)
-    scorecard = [
-        "## Evaluation scorecard",
-        "The selected failure is marked TARGET; preserve behavior on the other tasks.",
-    ]
-    for task in tasks:
-        outcome = report.per_task.get(task.task_id)
-        success = outcome.success_rate if outcome is not None else 0.0
-        fraction = outcome.mean_fraction if outcome is not None else 0.0
-        instruction = " ".join(normalize_durable_text(task.instruction).split())
-        if len(instruction) > 240:
-            instruction = f"{instruction[:237]}..."
-        marker = "TARGET" if task.task_id in selected else "other"
-        scorecard.append(
-            f"- [{marker}] {task.task_id}: success={success:.2f}, "
-            f"assertion_fraction={fraction:.2f} — {instruction}"
-        )
-    sections = [
-        "\n".join(scorecard),
-        f"## Selected failure\n\nFailure mechanism: {trigger.mechanism}",
-    ]
-    for task_id in trigger.task_ids:
-        task = by_id.get(task_id)
-        outcome = report.per_task.get(task_id)
-        instruction = (
-            normalize_durable_text(task.instruction) if task is not None else "(unknown task)"
-        )
-        rate = f"{outcome.success_rate:.2f} over {outcome.passes} passes" if outcome else "?"
-        fraction = f", assertion_fraction={outcome.mean_fraction:.2f}" if outcome else ""
-        task_section = [
-            f"### Task {task_id} (success_rate={rate}{fraction})",
-            f"Instruction: {instruction}",
-        ]
-        if outcome is not None:
-            for index, verdict in enumerate(outcome.verdicts, 1):
-                attempt = outcome.attempts[index - 1] if index <= len(outcome.attempts) else None
-                task_section.append(_render_attempt(index=index, attempt=attempt, verdict=verdict))
-        sections.append("\n\n".join(task_section))
-    unmet = "\n".join(f"- {a}" for a in trigger.unmet_assertions)
-    sections.append(
-        "Original trigger assertions from the parent (current attempt verdicts above are "
-        f"authoritative):\n{unmet or '- (none recorded)'}"
-    )
-    return "\n\n".join(sections)
+def render_task_attempt_evidence(outcome: TaskOutcome | None) -> str:
+    """Render the bounded attempts from one closed-loop task outcome."""
+    if outcome is None:
+        return ""
+    rendered: list[str] = []
+    for index, verdict in enumerate(outcome.verdicts, 1):
+        attempt = outcome.attempts[index - 1] if index <= len(outcome.attempts) else None
+        rendered.append(_render_attempt(index=index, attempt=attempt, verdict=verdict))
+    return "\n\n".join(rendered)
 
 
 def _render_attempt(*, index: int, attempt: RolloutEvidence | None, verdict: GoldVerdict) -> str:

--- a/wmh/harness/mutate_test.py
+++ b/wmh/harness/mutate_test.py
@@ -6,12 +6,11 @@ import json
 
 import pytest
 
-from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, TaskOutcome
+from wmh.evals.closed_loop import RolloutEvidence, TaskOutcome
 from wmh.evals.gold import AssertionResult, GoldVerdict
-from wmh.evals.tasks import TaskSpec
 from wmh.harness.delta import FailureSignature
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.mutate import parse_delta, propose_delta, render_evidence
+from wmh.harness.mutate import parse_delta, propose_delta, render_task_attempt_evidence
 from wmh.harness.runtime import StopReason
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
@@ -52,7 +51,7 @@ def _trigger() -> FailureSignature:
     return FailureSignature(
         mechanism="the file was created",
         task_ids=["t1"],
-        unmet_assertions=["the file was created"],
+        mechanism_labels=["the file was created"],
     )
 
 
@@ -179,85 +178,42 @@ def test_parse_delta_expands_compact_exact_replacement_edits() -> None:
     assert delta.ops[0].content == core.content.replace(old, "You are a careful agent")
 
 
-def test_render_evidence_shows_cluster_tasks_and_unmet_assertions() -> None:
-    report = ClosedLoopReport(
-        label="parent",
-        per_task={
-            "t1": TaskOutcome(task_id="t1", success_rate=0.0, mean_fraction=0.0, passes=2),
-            "t2": TaskOutcome(task_id="t2", success_rate=1.0, mean_fraction=1.0, passes=2),
-        },
-    )
-    tasks = [
-        TaskSpec(task_id="t1", instruction="create the file", gold=["the file was created"]),
-        TaskSpec(task_id="t2", instruction="easy one", gold=["done"]),
-    ]
-    evidence = render_evidence(_trigger(), report, tasks)
-    assert "the file was created" in evidence
-    assert "create the file" in evidence
-    assert "0.00 over 2 passes" in evidence
-    assert "[TARGET] t1" in evidence
-    assert "[other] t2" in evidence
-    assert "easy one" in evidence  # passing behavior remains visible in the compact scorecard
-
-
-def test_render_evidence_includes_execution_trace_answer_and_judge_reason() -> None:
-    report = ClosedLoopReport(
-        label="parent",
-        per_task={
-            "t1": TaskOutcome(
-                task_id="t1",
-                success_rate=0.0,
-                mean_fraction=0.5,
-                passes=1,
-                attempts=[
-                    RolloutEvidence(
-                        answer="I could not verify it",
-                        transcript="[1] tool_call: curl endpoint\n    -> connection reset",
-                        stop_reason=StopReason.SUBMITTED,
-                        turns=2,
-                    )
-                ],
-                verdicts=[
-                    GoldVerdict(
+def test_render_task_attempt_evidence_includes_trace_answer_and_judge_reason() -> None:
+    outcome = TaskOutcome(
+        task_id="t1",
+        success_rate=0.0,
+        mean_fraction=0.5,
+        passes=1,
+        attempts=[
+            RolloutEvidence(
+                answer="I could not verify it",
+                transcript="[1] tool_call: curl endpoint\n    -> connection reset",
+                stop_reason=StopReason.SUBMITTED,
+                turns=2,
+            )
+        ],
+        verdicts=[
+            GoldVerdict(
+                passed=False,
+                fraction=0.5,
+                assertions=[
+                    AssertionResult(
+                        assertion="the value was printed",
                         passed=False,
-                        fraction=0.5,
-                        assertions=[
-                            AssertionResult(
-                                assertion="the value was printed",
-                                passed=False,
-                                why="the final answer contained no value",
-                            )
-                        ],
+                        why="the final answer contained no value",
                     )
                 ],
             )
-        },
-    )
-    trigger = FailureSignature(
-        mechanism="the value was printed",
-        task_ids=["t1"],
-        unmet_assertions=["the value was printed"],
+        ],
     )
 
-    evidence = render_evidence(
-        trigger,
-        report,
-        [TaskSpec(task_id="t1", instruction="fetch the value", gold=["the value was printed"])],
-    )
+    evidence = render_task_attempt_evidence(outcome)
 
     assert "assertion_fraction=0.50" in evidence
     assert "Stop: submitted; turns=2" in evidence
     assert "I could not verify it" in evidence
     assert "connection reset" in evidence
     assert "the final answer contained no value" in evidence
-
-
-def test_all_pass_evidence_asks_for_generalization() -> None:
-    trigger = FailureSignature(mechanism="none: all tasks pass")
-    report = ClosedLoopReport(label="x", success_rate=1.0)
-    evidence = render_evidence(trigger, report, [TaskSpec(task_id="t", instruction="do it")])
-    assert "passed every task" in evidence
-    assert "GENERALIZE" in evidence
 
 
 def test_prompt_exposes_pi_code_files_as_editable_levers() -> None:

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from math import isclose
 from typing import Annotated, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -28,6 +29,18 @@ _MAX_MECHANISM_SUMMARY_CHARS = 16_000
 MechanismLabel = Annotated[str, Field(min_length=1, max_length=4_000)]
 
 
+class ScoreObjective(BaseModel):
+    """Stable identity for an optional normalized objective where higher is better."""
+
+    model_config = ConfigDict(frozen=True)
+
+    objective_id: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-z0-9][a-z0-9._-]*$",
+    )
+
+
 class ScoreCapabilities(BaseModel):
     """Optional score requests a scorer can execute."""
 
@@ -35,6 +48,9 @@ class ScoreCapabilities(BaseModel):
 
     task_subsets: bool = False
     attempt_overrides: bool = False
+    # Primary TaskScore.score is the arithmetic mean of normalized per-attempt scores.
+    mean_over_attempts: bool = False
+    secondary_objective: ScoreObjective | None = None
 
 
 class ScoreRequest(BaseModel):
@@ -58,13 +74,14 @@ class ScoreRequest(BaseModel):
 
 
 class TaskScore(BaseModel):
-    """One task's normalized score and proposer-facing evidence."""
+    """One task's normalized scores, aggregate weight, and proposer-facing evidence."""
 
     model_config = ConfigDict(allow_inf_nan=False)
 
     task_id: str = Field(min_length=1, max_length=512)
     score: float = Field(ge=0.0, le=1.0)
-    secondary_score: float = Field(ge=0.0, le=1.0)
+    secondary_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    aggregate_weight: float = Field(default=1.0, gt=0.0)
     passed: bool
     description: str = Field(default="", max_length=MAX_TASK_DESCRIPTION_CHARS)
     mechanisms: tuple[MechanismLabel, ...] = Field(default=(), max_length=MAX_MECHANISMS_PER_TASK)
@@ -72,14 +89,20 @@ class TaskScore(BaseModel):
 
 
 class HarnessScoreReport(BaseModel):
-    """A normalized scorecard over one candidate and one task split."""
+    """A normalized weighted scorecard over one candidate and one task split.
+
+    ``score`` is the aggregate-weighted mean of the primary per-task scores. A secondary score is
+    valid only when ``secondary_objective`` identifies it, and it uses the same frozen task
+    weights. Search checks that objective identity and weights stay fixed across evaluations.
+    """
 
     model_config = ConfigDict(allow_inf_nan=False)
 
     evaluation_id: str = Field(min_length=1, max_length=512, frozen=True)
     label: str = Field(default="", max_length=512)
     score: float = Field(default=0.0, ge=0.0, le=1.0)
-    secondary_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    secondary_objective: ScoreObjective | None = None
+    secondary_score: float | None = Field(default=None, ge=0.0, le=1.0)
     attempts: int = Field(ge=1)
     per_task: dict[str, TaskScore] = Field(default_factory=dict)
 
@@ -90,6 +113,41 @@ class HarnessScoreReport(BaseModel):
                 raise ValueError(
                     f"per_task key {task_id!r} does not match task_id {task.task_id!r}"
                 )
+        if not self.per_task:
+            return self
+
+        aggregate = _weighted_task_score(tuple(self.per_task.values()), secondary=False)
+        if not isclose(self.score, aggregate, rel_tol=0.0, abs_tol=1e-9):
+            raise ValueError(
+                f"score={self.score!r} is inconsistent with weighted task aggregate={aggregate!r}"
+            )
+
+        task_secondary = [task.secondary_score for task in self.per_task.values()]
+        if self.secondary_objective is None:
+            if self.secondary_score is not None or any(
+                value is not None for value in task_secondary
+            ):
+                raise ValueError("secondary scores require an explicit secondary objective")
+            return self
+        if self.secondary_score is None or any(value is None for value in task_secondary):
+            raise ValueError(
+                "a declared secondary objective requires a secondary score on the report and "
+                "every task"
+            )
+        secondary_aggregate = _weighted_task_score(
+            tuple(self.per_task.values()),
+            secondary=True,
+        )
+        if not isclose(
+            self.secondary_score,
+            secondary_aggregate,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(
+                f"secondary_score={self.secondary_score!r} is inconsistent with weighted task "
+                f"aggregate={secondary_aggregate!r}"
+            )
         return self
 
 
@@ -102,11 +160,26 @@ class HarnessScorer(Protocol):
     def validate_candidate(self, candidate: HarnessDoc) -> str | None:
         """Return a rejection reason, or None when the candidate is eligible."""
 
-    def before_proposal_batch(self) -> None:
-        """Release idle evaluation resources before a potentially long proposal call."""
-
     def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
         """Evaluate one candidate under the requested task and attempt selection."""
+
+
+def _weighted_task_score(tasks: tuple[TaskScore, ...], *, secondary: bool) -> float:
+    """Aggregate task scores using their explicit positive weights."""
+    total_weight = sum(task.aggregate_weight for task in tasks)
+    if secondary:
+        values = [task.secondary_score for task in tasks]
+        if any(value is None for value in values):
+            raise ValueError("secondary aggregation requires a score on every task")
+        return (
+            sum(
+                value * task.aggregate_weight
+                for task, value in zip(tasks, values, strict=True)
+                if value is not None
+            )
+            / total_weight
+        )
+    return sum(task.score * task.aggregate_weight for task in tasks) / total_weight
 
 
 def cluster_score_failures(report: HarnessScoreReport) -> list[FailureSignature]:
@@ -169,10 +242,10 @@ def render_score_evidence(trigger: FailureSignature, report: HarnessScoreReport)
         if len(description) > 240:
             description = f"{description[:237]}..."
         marker = "TARGET" if task_id in selected else "other"
-        scorecard.append(
-            f"- [{marker}] {task_id}: score={task.score:.2f}, "
-            f"secondary_score={task.secondary_score:.2f}: {description}"
-        )
+        score_summary = f"score={task.score:.2f}"
+        if task.secondary_score is not None:
+            score_summary += f", secondary_score={task.secondary_score:.2f}"
+        scorecard.append(f"- [{marker}] {task_id}: {score_summary}: {description}")
 
     scorecard_text = _bound_score_text(
         "\n".join(scorecard),
@@ -216,9 +289,11 @@ def render_score_evidence(trigger: FailureSignature, report: HarnessScoreReport)
                 f"### Task {task_id}\n\nInstruction: (unknown task)\n\nNo evidence recorded."
             )
         else:
+            score_summary = f"score={task.score:.2f}"
+            if task.secondary_score is not None:
+                score_summary += f", secondary_score={task.secondary_score:.2f}"
             section = [
-                f"### Task {task_id} (score={task.score:.2f}, "
-                f"secondary_score={task.secondary_score:.2f})",
+                f"### Task {task_id} ({score_summary})",
                 f"Instruction: {normalize_durable_text(task.description) or '(none)'}",
                 normalize_durable_text(task.evidence) if task.evidence else "No evidence recorded.",
             ]
@@ -251,20 +326,25 @@ def _bound_score_text(value: str, *, limit: int, label: str) -> str:
 
 
 def suite_score(report: HarnessScoreReport, suite: Sequence[str]) -> float:
-    """Return the mean primary score over a task subset, with missing tasks scored zero."""
-    if not suite:
-        return 1.0
-    scores = [task.score for task_id in suite if (task := report.per_task.get(task_id)) is not None]
-    return sum(scores) / len(suite)
+    """Return the explicit weighted primary aggregate over a task subset."""
+    tasks = _suite_tasks(report, suite)
+    return _weighted_task_score(tasks, secondary=False) if tasks else 1.0
 
 
-def suite_secondary_score(report: HarnessScoreReport, suite: Sequence[str]) -> float:
-    """Return the mean secondary score over a subset, with missing tasks scored zero."""
-    if not suite:
-        return 1.0
-    scores = [
-        task.secondary_score
-        for task_id in suite
-        if (task := report.per_task.get(task_id)) is not None
-    ]
-    return sum(scores) / len(suite)
+def suite_secondary_score(report: HarnessScoreReport, suite: Sequence[str]) -> float | None:
+    """Return the weighted secondary aggregate, or None when no objective is declared."""
+    if report.secondary_objective is None:
+        return None
+    tasks = _suite_tasks(report, suite)
+    return _weighted_task_score(tasks, secondary=True) if tasks else 1.0
+
+
+def _suite_tasks(report: HarnessScoreReport, suite: Sequence[str]) -> tuple[TaskScore, ...]:
+    """Resolve a unique subset and reject missing task identities."""
+    task_ids = tuple(suite)
+    if len(set(task_ids)) != len(task_ids):
+        raise ValueError("score suite task ids must be unique")
+    missing = sorted(set(task_ids) - set(report.per_task))
+    if missing:
+        raise ValueError(f"score suite contains missing task ids: {missing}")
+    return tuple(report.per_task[task_id] for task_id in task_ids)

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Sequence
 from math import isclose
 from typing import Annotated, Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 from wmh.core.text import normalize_durable_text
+from wmh.core.types import JsonObject
 from wmh.harness.delta import FailureSignature
 from wmh.harness.doc import HarnessDoc
 
@@ -39,6 +42,36 @@ class ScoreObjective(BaseModel):
         max_length=128,
         pattern=r"^[a-z0-9][a-z0-9._-]*$",
     )
+
+
+class PassCriterion(BaseModel):
+    """Immutable task pass rule over the normalized primary score."""
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    score_at_least: float = Field(ge=0.0, le=1.0)
+
+    def is_met(self, score: float) -> bool:
+        """Return whether one normalized primary task score passes this rule."""
+        return score >= self.score_at_least
+
+
+class ScoreProvenance(BaseModel):
+    """Frozen benchmark-neutral context that gives an evaluation its meaning."""
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False, extra="forbid")
+
+    task_set: JsonObject
+    evaluator: JsonObject
+    backend: JsonObject
+
+    @model_validator(mode="after")
+    def _validate_contexts(self) -> ScoreProvenance:
+        for field in ("task_set", "evaluator", "backend"):
+            if not getattr(self, field):
+                raise ValueError(f"{field} provenance must be nonempty")
+        _canonical_json(self.model_dump(mode="json"))
+        return self
 
 
 class ScoreCapabilities(BaseModel):
@@ -93,18 +126,49 @@ class HarnessScoreReport(BaseModel):
 
     ``score`` is the aggregate-weighted mean of the primary per-task scores. A secondary score is
     valid only when ``secondary_objective`` identifies it, and it uses the same frozen task
-    weights. Search checks that objective identity and weights stay fixed across evaluations.
+    weights. ``pass_criterion`` makes task verdicts derivable from primary scores. Canonical
+    identity binds the candidate execution hash, request, provenance, scores, and evidence while
+    excluding the display label. Search freezes this schema across evaluations.
     """
 
-    model_config = ConfigDict(allow_inf_nan=False)
+    model_config = ConfigDict(allow_inf_nan=False, extra="forbid")
 
-    evaluation_id: str = Field(min_length=1, max_length=512, frozen=True)
+    candidate_execution_hash: str = Field(pattern=r"^[0-9a-f]{32}$", frozen=True)
+    request: ScoreRequest
+    provenance: ScoreProvenance
+    pass_criterion: PassCriterion
     label: str = Field(default="", max_length=512)
     score: float = Field(default=0.0, ge=0.0, le=1.0)
     secondary_objective: ScoreObjective | None = None
     secondary_score: float | None = Field(default=None, ge=0.0, le=1.0)
     attempts: int = Field(ge=1)
-    per_task: dict[str, TaskScore] = Field(default_factory=dict)
+    per_task: dict[str, TaskScore] = Field(min_length=1)
+    evaluation_evidence: JsonObject = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ignore_supplied_evaluation_id(cls, value: object) -> object:
+        """Keep identity centrally derived while allowing serialized reports to round-trip."""
+        if isinstance(value, dict) and "evaluation_id" in value:
+            return {key: item for key, item in value.items() if key != "evaluation_id"}
+        return value
+
+    @computed_field
+    @property
+    def evaluation_id(self) -> str:
+        """Canonical identity of context, request, candidate execution, scores, and evidence."""
+        return canonical_evaluation_id(
+            candidate_execution_hash=self.candidate_execution_hash,
+            request=self.request,
+            provenance=self.provenance,
+            pass_criterion=self.pass_criterion,
+            score=self.score,
+            secondary_objective=self.secondary_objective,
+            secondary_score=self.secondary_score,
+            attempts=self.attempts,
+            per_task=self.per_task,
+            evaluation_evidence=self.evaluation_evidence,
+        )
 
     @model_validator(mode="after")
     def _validate_task_keys(self) -> HarnessScoreReport:
@@ -113,14 +177,18 @@ class HarnessScoreReport(BaseModel):
                 raise ValueError(
                     f"per_task key {task_id!r} does not match task_id {task.task_id!r}"
                 )
-        if not self.per_task:
-            return self
-
         aggregate = _weighted_task_score(tuple(self.per_task.values()), secondary=False)
         if not isclose(self.score, aggregate, rel_tol=0.0, abs_tol=1e-9):
             raise ValueError(
                 f"score={self.score!r} is inconsistent with weighted task aggregate={aggregate!r}"
             )
+        for task_id, task in self.per_task.items():
+            expected_passed = self.pass_criterion.is_met(task.score)
+            if task.passed != expected_passed:
+                raise ValueError(
+                    f"task {task_id!r} passed={task.passed!r} conflicts with pass criterion "
+                    f"score >= {self.pass_criterion.score_at_least!r}"
+                )
 
         task_secondary = [task.secondary_score for task in self.per_task.values()]
         if self.secondary_objective is None:
@@ -149,6 +217,53 @@ class HarnessScoreReport(BaseModel):
                 f"aggregate={secondary_aggregate!r}"
             )
         return self
+
+
+def canonical_evaluation_id(
+    *,
+    candidate_execution_hash: str,
+    request: ScoreRequest,
+    provenance: ScoreProvenance,
+    pass_criterion: PassCriterion,
+    score: float,
+    secondary_objective: ScoreObjective | None,
+    secondary_score: float | None,
+    attempts: int,
+    per_task: dict[str, TaskScore],
+    evaluation_evidence: JsonObject,
+) -> str:
+    """Build the shared content identity for one score report."""
+    payload = {
+        "schema_version": 1,
+        "candidate_execution_hash": candidate_execution_hash,
+        "request": request.model_dump(mode="json"),
+        "provenance": provenance.model_dump(mode="json"),
+        "pass_criterion": pass_criterion.model_dump(mode="json"),
+        "score": score,
+        "secondary_objective": (
+            secondary_objective.model_dump(mode="json") if secondary_objective is not None else None
+        ),
+        "secondary_score": secondary_score,
+        "attempts": attempts,
+        "per_task": {task_id: task.model_dump(mode="json") for task_id, task in per_task.items()},
+        "evaluation_evidence": evaluation_evidence,
+    }
+    canonical = _canonical_json(payload)
+    return "score-sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: JsonObject) -> str:
+    """Serialize a JSON object canonically and reject nonfinite numeric values."""
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"evaluation identity context is not canonical JSON: {error}") from error
 
 
 class HarnessScorer(Protocol):

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -1,0 +1,270 @@
+"""Benchmark-neutral score reports consumed by harness search."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Annotated, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from wmh.core.text import normalize_durable_text
+from wmh.harness.delta import FailureSignature
+from wmh.harness.doc import HarnessDoc
+
+ALL_PASS_EVIDENCE = (
+    "The harness passed every task on every pass. There are no failures to fix. "
+    "Propose a change that should GENERALIZE or ECONOMIZE: a tighter, more transferable "
+    "prompt surface; a lower param:max-turns if runs finish early; or a reusable skill "
+    "distilled from what worked."
+)
+
+MAX_TASK_DESCRIPTION_CHARS = 8_000
+MAX_TASK_EVIDENCE_CHARS = 64_000
+MAX_MECHANISMS_PER_TASK = 64
+MAX_RENDERED_SCORE_EVIDENCE_CHARS = 256_000
+_MAX_SCORECARD_CHARS = 32_000
+_MAX_FAILURE_HEADER_CHARS = 8_000
+_MAX_MECHANISM_SUMMARY_CHARS = 16_000
+MechanismLabel = Annotated[str, Field(min_length=1, max_length=4_000)]
+
+
+class ScoreCapabilities(BaseModel):
+    """Optional score requests a scorer can execute."""
+
+    model_config = ConfigDict(frozen=True)
+
+    task_subsets: bool = False
+    attempt_overrides: bool = False
+
+
+class ScoreRequest(BaseModel):
+    """One immutable scoring request issued by the search."""
+
+    model_config = ConfigDict(frozen=True)
+
+    purpose: Literal["seed", "screen", "full", "holdout", "confirmation"]
+    task_ids: tuple[str, ...] | None = None
+    attempts: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_task_ids(self) -> ScoreRequest:
+        if self.task_ids is None:
+            return self
+        if not self.task_ids:
+            raise ValueError("task_ids must be nonempty when requesting a subset")
+        if len(set(self.task_ids)) != len(self.task_ids):
+            raise ValueError("task_ids must be unique")
+        return self
+
+
+class TaskScore(BaseModel):
+    """One task's normalized score and proposer-facing evidence."""
+
+    model_config = ConfigDict(allow_inf_nan=False)
+
+    task_id: str = Field(min_length=1, max_length=512)
+    score: float = Field(ge=0.0, le=1.0)
+    secondary_score: float = Field(ge=0.0, le=1.0)
+    passed: bool
+    description: str = Field(default="", max_length=MAX_TASK_DESCRIPTION_CHARS)
+    mechanisms: tuple[MechanismLabel, ...] = Field(default=(), max_length=MAX_MECHANISMS_PER_TASK)
+    evidence: str = Field(default="", max_length=MAX_TASK_EVIDENCE_CHARS)
+
+
+class HarnessScoreReport(BaseModel):
+    """A normalized scorecard over one candidate and one task split."""
+
+    model_config = ConfigDict(allow_inf_nan=False)
+
+    evaluation_id: str = Field(min_length=1, max_length=512, frozen=True)
+    label: str = Field(default="", max_length=512)
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    secondary_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    attempts: int = Field(ge=1)
+    per_task: dict[str, TaskScore] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_task_keys(self) -> HarnessScoreReport:
+        for task_id, task in self.per_task.items():
+            if task_id != task.task_id:
+                raise ValueError(
+                    f"per_task key {task_id!r} does not match task_id {task.task_id!r}"
+                )
+        return self
+
+
+class HarnessScorer(Protocol):
+    """Synchronous candidate evaluator used by the harness search loop."""
+
+    capabilities: ScoreCapabilities
+    default_attempts: int
+
+    def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+        """Return a rejection reason, or None when the candidate is eligible."""
+
+    def before_proposal_batch(self) -> None:
+        """Release idle evaluation resources before a potentially long proposal call."""
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+        """Evaluate one candidate under the requested task and attempt selection."""
+
+
+def cluster_score_failures(report: HarnessScoreReport) -> list[FailureSignature]:
+    """Group failing tasks by shared mechanism labels, deterministically."""
+    mechanisms_by_task = {
+        task_id: list(dict.fromkeys(task.mechanisms))
+        for task_id, task in report.per_task.items()
+        if not task.passed
+    }
+    clusters: list[FailureSignature] = []
+    assigned: set[str] = set()
+    for task_id in sorted(mechanisms_by_task):
+        if task_id in assigned:
+            continue
+        member_ids = {task_id}
+        mechanisms = set(mechanisms_by_task[task_id])
+        grew = True
+        while grew:
+            grew = False
+            for other, other_mechanisms in mechanisms_by_task.items():
+                if other in member_ids or not mechanisms.intersection(other_mechanisms):
+                    continue
+                member_ids.add(other)
+                mechanisms.update(other_mechanisms)
+                grew = True
+        assigned.update(member_ids)
+        counts: dict[str, int] = {}
+        for member in member_ids:
+            for mechanism in mechanisms_by_task[member]:
+                counts[mechanism] = counts.get(mechanism, 0) + 1
+        label = (
+            max(sorted(counts), key=lambda mechanism: counts[mechanism])
+            if counts
+            else "run failed without mechanism details"
+        )
+        clusters.append(
+            FailureSignature(
+                mechanism=label,
+                task_ids=sorted(member_ids),
+                mechanism_labels=sorted(mechanisms),
+            )
+        )
+    clusters.sort(key=lambda cluster: (-len(cluster.task_ids), cluster.mechanism))
+    return clusters
+
+
+def render_score_evidence(trigger: FailureSignature, report: HarnessScoreReport) -> str:
+    """Render one selected failure under a deterministic whole-prompt character budget."""
+    if not trigger.task_ids:
+        return ALL_PASS_EVIDENCE
+
+    selected = set(trigger.task_ids)
+    scorecard = [
+        "## Evaluation scorecard",
+        "The selected failure is marked TARGET; preserve behavior on the other tasks.",
+    ]
+    for task_id in sorted(report.per_task):
+        task = report.per_task[task_id]
+        description = " ".join(normalize_durable_text(task.description).split())
+        if len(description) > 240:
+            description = f"{description[:237]}..."
+        marker = "TARGET" if task_id in selected else "other"
+        scorecard.append(
+            f"- [{marker}] {task_id}: score={task.score:.2f}, "
+            f"secondary_score={task.secondary_score:.2f}: {description}"
+        )
+
+    scorecard_text = _bound_score_text(
+        "\n".join(scorecard),
+        limit=_MAX_SCORECARD_CHARS,
+        label="scorecard",
+    )
+    failure_header = _bound_score_text(
+        f"## Selected failure\n\nFailure mechanism: {trigger.mechanism}",
+        limit=_MAX_FAILURE_HEADER_CHARS,
+        label="failure header",
+    )
+    mechanism_summary = _bound_score_text(
+        "Original trigger mechanisms from the parent (current attempt evidence above is "
+        "authoritative):\n"
+        + (
+            "\n".join(f"- {item}" for item in sorted(trigger.mechanism_labels))
+            or "- (none recorded)"
+        ),
+        limit=_MAX_MECHANISM_SUMMARY_CHARS,
+        label="mechanism summary",
+    )
+
+    selected_task_ids = sorted(dict.fromkeys(trigger.task_ids))
+    separator_chars = 2 * (len(selected_task_ids) + 2)
+    task_budget = max(
+        0,
+        (
+            MAX_RENDERED_SCORE_EVIDENCE_CHARS
+            - len(scorecard_text)
+            - len(failure_header)
+            - len(mechanism_summary)
+            - separator_chars
+        )
+        // len(selected_task_ids),
+    )
+    task_sections: list[str] = []
+    for task_id in selected_task_ids:
+        task = report.per_task.get(task_id)
+        if task is None:
+            task_section = (
+                f"### Task {task_id}\n\nInstruction: (unknown task)\n\nNo evidence recorded."
+            )
+        else:
+            section = [
+                f"### Task {task_id} (score={task.score:.2f}, "
+                f"secondary_score={task.secondary_score:.2f})",
+                f"Instruction: {normalize_durable_text(task.description) or '(none)'}",
+                normalize_durable_text(task.evidence) if task.evidence else "No evidence recorded.",
+            ]
+            task_section = "\n\n".join(section)
+        task_sections.append(
+            _bound_score_text(task_section, limit=task_budget, label=f"task {task_id}")
+        )
+
+    rendered = "\n\n".join([scorecard_text, failure_header, *task_sections, mechanism_summary])
+    return _bound_score_text(
+        rendered,
+        limit=MAX_RENDERED_SCORE_EVIDENCE_CHARS,
+        label="score evidence",
+    )
+
+
+def _bound_score_text(value: str, *, limit: int, label: str) -> str:
+    """Bound text deterministically while preserving both its opening and terminal evidence."""
+    if len(value) <= limit:
+        return value
+    if limit <= 0:
+        return ""
+    marker = f"\n...[{label} truncated; original_chars={len(value)}]...\n"
+    if len(marker) >= limit:
+        return marker[:limit]
+    retained = limit - len(marker)
+    head = retained // 2
+    tail = retained - head
+    return value[:head] + marker + value[-tail:]
+
+
+def suite_score(report: HarnessScoreReport, suite: Sequence[str]) -> float:
+    """Return the mean primary score over a task subset, with missing tasks scored zero."""
+    if not suite:
+        return 1.0
+    scores = [task.score for task_id in suite if (task := report.per_task.get(task_id)) is not None]
+    return sum(scores) / len(suite)
+
+
+def suite_secondary_score(report: HarnessScoreReport, suite: Sequence[str]) -> float:
+    """Return the mean secondary score over a subset, with missing tasks scored zero."""
+    if not suite:
+        return 1.0
+    scores = [
+        task.secondary_score
+        for task_id in suite
+        if (task := report.per_task.get(task_id)) is not None
+    ]
+    return sum(scores) / len(suite)

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -1,0 +1,222 @@
+"""Tests for benchmark-neutral harness scoring and search evidence."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.harness.delta import FailureSignature
+from wmh.harness.scoring import (
+    MAX_RENDERED_SCORE_EVIDENCE_CHARS,
+    MAX_TASK_DESCRIPTION_CHARS,
+    MAX_TASK_EVIDENCE_CHARS,
+    HarnessScoreReport,
+    ScoreRequest,
+    TaskScore,
+    cluster_score_failures,
+    render_score_evidence,
+    suite_score,
+    suite_secondary_score,
+)
+
+
+def _task(
+    task_id: str,
+    *,
+    score: float,
+    secondary: float | None = None,
+    mechanisms: tuple[str, ...] = (),
+    evidence: str = "",
+) -> TaskScore:
+    return TaskScore(
+        task_id=task_id,
+        score=score,
+        secondary_score=score if secondary is None else secondary,
+        passed=score == 1.0,
+        description=f"instruction for {task_id}",
+        mechanisms=mechanisms,
+        evidence=evidence,
+    )
+
+
+def _report(*tasks: TaskScore) -> HarnessScoreReport:
+    per_task = {task.task_id: task for task in tasks}
+    return HarnessScoreReport(
+        evaluation_id="eval-1",
+        label="candidate",
+        score=sum(task.score for task in tasks) / len(tasks),
+        secondary_score=sum(task.secondary_score for task in tasks) / len(tasks),
+        attempts=2,
+        per_task=per_task,
+    )
+
+
+def test_score_report_rejects_mismatched_task_key() -> None:
+    with pytest.raises(ValidationError, match="key 'wrong'.*task_id 'task'"):
+        HarnessScoreReport(
+            evaluation_id="eval-1",
+            score=0.0,
+            secondary_score=0.0,
+            attempts=1,
+            per_task={"wrong": _task("task", score=0.0)},
+        )
+
+
+@pytest.mark.parametrize("task_ids", [(), ("task", "task")])
+def test_score_request_rejects_empty_or_duplicate_subset(task_ids: tuple[str, ...]) -> None:
+    with pytest.raises(ValidationError, match="task_ids"):
+        ScoreRequest(purpose="screen", task_ids=task_ids)
+
+
+@pytest.mark.parametrize("value", [-0.01, 1.01, float("nan"), float("inf")])
+def test_score_report_rejects_non_normalized_scores(value: float) -> None:
+    with pytest.raises(ValidationError):
+        HarnessScoreReport(evaluation_id="eval-1", score=value, secondary_score=0.0, attempts=1)
+
+
+def test_score_report_requires_identity_and_bounds_proposer_evidence() -> None:
+    with pytest.raises(ValidationError, match="evaluation_id"):
+        HarnessScoreReport(evaluation_id="", attempts=1)
+    with pytest.raises(ValidationError, match="evidence"):
+        _report(_task("task", score=0.0, evidence="x" * 64_001))
+    report = _report(_task("task", score=0.0))
+    with pytest.raises(ValidationError, match="frozen"):
+        report.evaluation_id = "changed"
+
+
+def test_cluster_score_failures_uses_shared_mechanisms_and_singletons() -> None:
+    report = _report(
+        _task("t1", score=0.0, mechanisms=("a", "b")),
+        _task("t2", score=0.0, mechanisms=("b", "c")),
+        _task("t3", score=0.0, mechanisms=("z",)),
+        _task("t4", score=1.0),
+        _task("t5", score=0.0),
+    )
+
+    clusters = cluster_score_failures(report)
+
+    assert [cluster.task_ids for cluster in clusters] == [["t1", "t2"], ["t5"], ["t3"]]
+    assert clusters[0].mechanism == "b"
+    assert clusters[0].mechanism_labels == ["a", "b", "c"]
+    assert clusters[1].mechanism == "run failed without mechanism details"
+    assert clusters[2].mechanism == "z"
+
+
+def test_render_score_evidence_is_benchmark_neutral() -> None:
+    report = _report(
+        _task("pass", score=1.0, evidence="pass evidence"),
+        _task(
+            "fail",
+            score=0.0,
+            secondary=0.5,
+            mechanisms=("missing verification",),
+            evidence="attempt trace and verifier feedback",
+        ),
+    )
+    trigger = FailureSignature(
+        mechanism="missing verification",
+        task_ids=["fail"],
+        mechanism_labels=["missing verification"],
+    )
+
+    rendered = render_score_evidence(trigger, report)
+
+    assert "[other] pass: score=1.00, secondary_score=1.00" in rendered
+    assert "[TARGET] fail: score=0.00, secondary_score=0.50" in rendered
+    assert "Instruction: instruction for fail" in rendered
+    assert "attempt trace and verifier feedback" in rendered
+    assert "gold" not in rendered.lower()
+    assert "world model" not in rendered.lower()
+
+
+def test_render_score_evidence_handles_all_pass_parent() -> None:
+    report = _report(_task("pass", score=1.0))
+
+    rendered = render_score_evidence(FailureSignature(mechanism="none: all tasks pass"), report)
+
+    assert "passed every task" in rendered
+    assert "There are no failures to fix" in rendered
+
+
+def test_render_score_evidence_is_invariant_to_task_and_label_insertion_order() -> None:
+    first = _task(
+        "first",
+        score=0.0,
+        mechanisms=("shared", "alpha"),
+        evidence="first evidence",
+    )
+    second = _task(
+        "second",
+        score=0.0,
+        mechanisms=("shared", "beta"),
+        evidence="second evidence",
+    )
+    forward = _report(first, second)
+    reverse = HarnessScoreReport(
+        evaluation_id="eval-2",
+        score=forward.score,
+        secondary_score=forward.secondary_score,
+        attempts=forward.attempts,
+        per_task={"second": second, "first": first},
+    )
+
+    forward_text = render_score_evidence(
+        FailureSignature(
+            mechanism="shared",
+            task_ids=["first", "second"],
+            mechanism_labels=["alpha", "beta", "shared"],
+        ),
+        forward,
+    )
+    reverse_text = render_score_evidence(
+        FailureSignature(
+            mechanism="shared",
+            task_ids=["second", "first"],
+            mechanism_labels=["shared", "beta", "alpha"],
+        ),
+        reverse,
+    )
+
+    assert forward_text == reverse_text
+    assert forward_text.index("### Task first") < forward_text.index("### Task second")
+
+
+def test_render_score_evidence_bounds_a_maximal_connected_cluster() -> None:
+    tasks = tuple(
+        TaskScore(
+            task_id=f"task-{index:02}",
+            score=0.0,
+            secondary_score=0.0,
+            passed=False,
+            description=chr(65 + index % 26) * MAX_TASK_DESCRIPTION_CHARS,
+            mechanisms=("shared", f"mechanism-{index:02}"),
+            evidence=f"evidence-{index:02}:" + "x" * (MAX_TASK_EVIDENCE_CHARS - 12),
+        )
+        for index in range(30)
+    )
+    report = _report(*tasks)
+    task_ids = [task.task_id for task in reversed(tasks)]
+    trigger = FailureSignature(
+        mechanism="shared",
+        task_ids=task_ids,
+        mechanism_labels=["shared", *(f"mechanism-{index:02}" for index in range(30))],
+    )
+
+    rendered = render_score_evidence(trigger, report)
+
+    assert len(rendered) <= MAX_RENDERED_SCORE_EVIDENCE_CHARS
+    assert "truncated" in rendered
+    for task in tasks:
+        assert f"### Task {task.task_id}" in rendered
+
+
+def test_suite_scores_count_tasks_absent_from_a_subset_report_as_zero() -> None:
+    report = _report(
+        _task("t1", score=0.25, secondary=0.5),
+        _task("t2", score=0.75, secondary=1.0),
+    )
+
+    assert suite_score(report, ["t1", "t2", "missing"]) == pytest.approx(1 / 3)
+    assert suite_secondary_score(report, ["t1", "t2", "missing"]) == 0.5
+    assert suite_score(report, []) == 1.0
+    assert suite_secondary_score(report, []) == 1.0

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -11,7 +11,9 @@ from wmh.harness.scoring import (
     MAX_TASK_DESCRIPTION_CHARS,
     MAX_TASK_EVIDENCE_CHARS,
     HarnessScoreReport,
+    PassCriterion,
     ScoreObjective,
+    ScoreProvenance,
     ScoreRequest,
     TaskScore,
     cluster_score_failures,
@@ -19,6 +21,15 @@ from wmh.harness.scoring import (
     suite_score,
     suite_secondary_score,
 )
+
+_CANDIDATE_EXECUTION_HASH = "a" * 32
+_REQUEST = ScoreRequest(purpose="seed")
+_PROVENANCE = ScoreProvenance(
+    task_set={"tasks": [{"task_id": "fixture"}]},
+    evaluator={"kind": "fixture", "version": 1},
+    backend={"kind": "in_process", "config": {}},
+)
+_PASS_CRITERION = PassCriterion(score_at_least=1.0)
 
 
 def _task(
@@ -48,7 +59,10 @@ def _report(*tasks: TaskScore) -> HarnessScoreReport:
     secondary_values = [task.secondary_score for task in tasks]
     has_secondary = any(value is not None for value in secondary_values)
     return HarnessScoreReport(
-        evaluation_id="eval-1",
+        candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+        request=_REQUEST,
+        provenance=_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         label="candidate",
         score=sum(task.score * task.aggregate_weight for task in tasks) / total_weight,
         secondary_objective=(
@@ -72,7 +86,10 @@ def _report(*tasks: TaskScore) -> HarnessScoreReport:
 def test_score_report_rejects_mismatched_task_key() -> None:
     with pytest.raises(ValidationError, match="key 'wrong'.*task_id 'task'"):
         HarnessScoreReport(
-            evaluation_id="eval-1",
+            candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
             score=0.0,
             attempts=1,
             per_task={"wrong": _task("task", score=0.0)},
@@ -82,7 +99,10 @@ def test_score_report_rejects_mismatched_task_key() -> None:
 def test_score_report_requires_an_explicit_consistent_secondary_objective() -> None:
     with pytest.raises(ValidationError, match="secondary objective"):
         HarnessScoreReport(
-            evaluation_id="eval-1",
+            candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
             score=0.0,
             secondary_score=0.0,
             attempts=1,
@@ -90,7 +110,10 @@ def test_score_report_requires_an_explicit_consistent_secondary_objective() -> N
         )
     with pytest.raises(ValidationError, match="every task"):
         HarnessScoreReport(
-            evaluation_id="eval-1",
+            candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
             score=0.0,
             secondary_objective=ScoreObjective(objective_id="dense_progress"),
             secondary_score=0.0,
@@ -108,11 +131,108 @@ def test_score_report_enforces_declared_weighted_aggregate() -> None:
     assert report.score == 0.75
     with pytest.raises(ValidationError, match="weighted task aggregate"):
         HarnessScoreReport(
-            evaluation_id="eval-bad",
+            candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
             score=0.5,
             attempts=1,
             per_task={"light": light, "heavy": heavy},
         )
+
+
+@pytest.mark.parametrize("weight", [0.0, -1.0, float("nan"), float("inf")])
+def test_task_score_rejects_nonpositive_or_nonfinite_aggregate_weight(weight: float) -> None:
+    with pytest.raises(ValidationError, match="aggregate_weight"):
+        _task("task", score=0.0, aggregate_weight=weight)
+
+
+def test_score_report_rejects_an_empty_task_matrix() -> None:
+    with pytest.raises(ValidationError, match="per_task"):
+        HarnessScoreReport(
+            candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
+            score=0.0,
+            attempts=1,
+            per_task={},
+        )
+
+
+def test_score_report_enforces_its_explicit_pass_criterion() -> None:
+    criterion = PassCriterion(score_at_least=0.5)
+    passing = TaskScore(task_id="task", score=0.5, passed=True)
+
+    report = HarnessScoreReport(
+        candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+        request=_REQUEST,
+        provenance=_PROVENANCE,
+        pass_criterion=criterion,
+        score=0.5,
+        attempts=1,
+        per_task={"task": passing},
+    )
+
+    assert report.per_task["task"].passed is True
+    with pytest.raises(ValidationError, match="frozen"):
+        criterion.score_at_least = 0.25
+    with pytest.raises(ValidationError, match="pass criterion"):
+        HarnessScoreReport.model_validate(
+            {
+                **report.model_dump(mode="json", exclude={"evaluation_id"}),
+                "per_task": {
+                    "task": passing.model_copy(update={"passed": False}).model_dump(mode="json")
+                },
+            }
+        )
+
+
+def test_evaluation_identity_is_canonical_and_excludes_display_label() -> None:
+    report = _report(_task("task", score=0.0, evidence="trace one"))
+
+    assert report.evaluation_id.startswith("score-sha256:")
+    assert report.model_copy(update={"label": "renamed display label"}).evaluation_id == (
+        report.evaluation_id
+    )
+    assert report.model_copy(update={"candidate_execution_hash": "b" * 32}).evaluation_id != (
+        report.evaluation_id
+    )
+    assert (
+        report.model_copy(update={"request": ScoreRequest(purpose="full")}).evaluation_id
+        != report.evaluation_id
+    )
+    changed_contexts = {
+        "task_set": {"tasks": [{"task_id": "other"}]},
+        "evaluator": {"kind": "other", "version": 1},
+        "backend": {"kind": "isolated", "config": {}},
+    }
+    for field, value in changed_contexts.items():
+        changed = report.model_copy(
+            update={"provenance": _PROVENANCE.model_copy(update={field: value})}
+        )
+        assert changed.evaluation_id != report.evaluation_id
+    changed_evidence = _report(_task("task", score=0.0, evidence="trace two"))
+    assert changed_evidence.evaluation_id != report.evaluation_id
+
+
+def test_evaluation_identity_is_centrally_derived_and_serialization_round_trips() -> None:
+    report = _report(_task("task", score=0.0, evidence="trace"))
+    payload = report.model_dump(mode="json")
+    payload["evaluation_id"] = "caller-chosen"
+
+    restored = HarnessScoreReport.model_validate(payload)
+
+    assert restored.evaluation_id == report.evaluation_id
+    assert HarnessScoreReport.model_validate_json(report.model_dump_json()) == report
+
+
+@pytest.mark.parametrize("field", ["task_set", "evaluator", "backend"])
+def test_score_provenance_requires_each_frozen_context(field: str) -> None:
+    payload = _PROVENANCE.model_dump(mode="json")
+    payload[field] = {}
+    with pytest.raises(ValidationError, match=field):
+        ScoreProvenance.model_validate(payload)
 
 
 @pytest.mark.parametrize("task_ids", [(), ("task", "task")])
@@ -124,17 +244,24 @@ def test_score_request_rejects_empty_or_duplicate_subset(task_ids: tuple[str, ..
 @pytest.mark.parametrize("value", [-0.01, 1.01, float("nan"), float("inf")])
 def test_score_report_rejects_non_normalized_scores(value: float) -> None:
     with pytest.raises(ValidationError):
-        HarnessScoreReport(evaluation_id="eval-1", score=value, attempts=1)
+        _report(_task("task", score=value))
 
 
 def test_score_report_requires_identity_and_bounds_proposer_evidence() -> None:
-    with pytest.raises(ValidationError, match="evaluation_id"):
-        HarnessScoreReport(evaluation_id="", attempts=1)
+    with pytest.raises(ValidationError, match="candidate_execution_hash"):
+        HarnessScoreReport(
+            candidate_execution_hash="",
+            request=_REQUEST,
+            provenance=_PROVENANCE,
+            pass_criterion=_PASS_CRITERION,
+            attempts=1,
+            per_task={"task": _task("task", score=0.0)},
+        )
     with pytest.raises(ValidationError, match="evidence"):
         _report(_task("task", score=0.0, evidence="x" * 64_001))
     report = _report(_task("task", score=0.0))
-    with pytest.raises(ValidationError, match="frozen"):
-        report.evaluation_id = "changed"
+    with pytest.raises((AttributeError, ValidationError), match="evaluation_id|frozen|property"):
+        report.evaluation_id = "changed"  # ty: ignore[invalid-assignment]
 
 
 def test_cluster_score_failures_uses_shared_mechanisms_and_singletons() -> None:
@@ -206,7 +333,10 @@ def test_render_score_evidence_is_invariant_to_task_and_label_insertion_order() 
     )
     forward = _report(first, second)
     reverse = HarnessScoreReport(
-        evaluation_id="eval-2",
+        candidate_execution_hash=_CANDIDATE_EXECUTION_HASH,
+        request=_REQUEST,
+        provenance=_PROVENANCE,
+        pass_criterion=_PASS_CRITERION,
         score=forward.score,
         secondary_objective=forward.secondary_objective,
         secondary_score=forward.secondary_score,

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -11,6 +11,7 @@ from wmh.harness.scoring import (
     MAX_TASK_DESCRIPTION_CHARS,
     MAX_TASK_EVIDENCE_CHARS,
     HarnessScoreReport,
+    ScoreObjective,
     ScoreRequest,
     TaskScore,
     cluster_score_failures,
@@ -25,13 +26,15 @@ def _task(
     *,
     score: float,
     secondary: float | None = None,
+    aggregate_weight: float = 1.0,
     mechanisms: tuple[str, ...] = (),
     evidence: str = "",
 ) -> TaskScore:
     return TaskScore(
         task_id=task_id,
         score=score,
-        secondary_score=score if secondary is None else secondary,
+        secondary_score=secondary,
+        aggregate_weight=aggregate_weight,
         passed=score == 1.0,
         description=f"instruction for {task_id}",
         mechanisms=mechanisms,
@@ -41,11 +44,26 @@ def _task(
 
 def _report(*tasks: TaskScore) -> HarnessScoreReport:
     per_task = {task.task_id: task for task in tasks}
+    total_weight = sum(task.aggregate_weight for task in tasks)
+    secondary_values = [task.secondary_score for task in tasks]
+    has_secondary = any(value is not None for value in secondary_values)
     return HarnessScoreReport(
         evaluation_id="eval-1",
         label="candidate",
-        score=sum(task.score for task in tasks) / len(tasks),
-        secondary_score=sum(task.secondary_score for task in tasks) / len(tasks),
+        score=sum(task.score * task.aggregate_weight for task in tasks) / total_weight,
+        secondary_objective=(
+            ScoreObjective(objective_id="dense_progress") if has_secondary else None
+        ),
+        secondary_score=(
+            sum(
+                value * task.aggregate_weight
+                for task, value in zip(tasks, secondary_values, strict=True)
+                if value is not None
+            )
+            / total_weight
+            if has_secondary
+            else None
+        ),
         attempts=2,
         per_task=per_task,
     )
@@ -56,9 +74,44 @@ def test_score_report_rejects_mismatched_task_key() -> None:
         HarnessScoreReport(
             evaluation_id="eval-1",
             score=0.0,
-            secondary_score=0.0,
             attempts=1,
             per_task={"wrong": _task("task", score=0.0)},
+        )
+
+
+def test_score_report_requires_an_explicit_consistent_secondary_objective() -> None:
+    with pytest.raises(ValidationError, match="secondary objective"):
+        HarnessScoreReport(
+            evaluation_id="eval-1",
+            score=0.0,
+            secondary_score=0.0,
+            attempts=1,
+            per_task={"task": _task("task", score=0.0)},
+        )
+    with pytest.raises(ValidationError, match="every task"):
+        HarnessScoreReport(
+            evaluation_id="eval-1",
+            score=0.0,
+            secondary_objective=ScoreObjective(objective_id="dense_progress"),
+            secondary_score=0.0,
+            attempts=1,
+            per_task={"task": _task("task", score=0.0)},
+        )
+
+
+def test_score_report_enforces_declared_weighted_aggregate() -> None:
+    light = _task("light", score=0.0, aggregate_weight=1.0)
+    heavy = _task("heavy", score=1.0, aggregate_weight=3.0)
+
+    report = _report(light, heavy)
+
+    assert report.score == 0.75
+    with pytest.raises(ValidationError, match="weighted task aggregate"):
+        HarnessScoreReport(
+            evaluation_id="eval-bad",
+            score=0.5,
+            attempts=1,
+            per_task={"light": light, "heavy": heavy},
         )
 
 
@@ -71,7 +124,7 @@ def test_score_request_rejects_empty_or_duplicate_subset(task_ids: tuple[str, ..
 @pytest.mark.parametrize("value", [-0.01, 1.01, float("nan"), float("inf")])
 def test_score_report_rejects_non_normalized_scores(value: float) -> None:
     with pytest.raises(ValidationError):
-        HarnessScoreReport(evaluation_id="eval-1", score=value, secondary_score=0.0, attempts=1)
+        HarnessScoreReport(evaluation_id="eval-1", score=value, attempts=1)
 
 
 def test_score_report_requires_identity_and_bounds_proposer_evidence() -> None:
@@ -104,7 +157,7 @@ def test_cluster_score_failures_uses_shared_mechanisms_and_singletons() -> None:
 
 def test_render_score_evidence_is_benchmark_neutral() -> None:
     report = _report(
-        _task("pass", score=1.0, evidence="pass evidence"),
+        _task("pass", score=1.0, secondary=1.0, evidence="pass evidence"),
         _task(
             "fail",
             score=0.0,
@@ -155,6 +208,7 @@ def test_render_score_evidence_is_invariant_to_task_and_label_insertion_order() 
     reverse = HarnessScoreReport(
         evaluation_id="eval-2",
         score=forward.score,
+        secondary_objective=forward.secondary_objective,
         secondary_score=forward.secondary_score,
         attempts=forward.attempts,
         per_task={"second": second, "first": first},
@@ -210,13 +264,22 @@ def test_render_score_evidence_bounds_a_maximal_connected_cluster() -> None:
         assert f"### Task {task.task_id}" in rendered
 
 
-def test_suite_scores_count_tasks_absent_from_a_subset_report_as_zero() -> None:
+def test_suite_scores_use_weights_and_reject_missing_tasks() -> None:
     report = _report(
-        _task("t1", score=0.25, secondary=0.5),
-        _task("t2", score=0.75, secondary=1.0),
+        _task("t1", score=0.25, secondary=0.5, aggregate_weight=1.0),
+        _task("t2", score=0.75, secondary=1.0, aggregate_weight=3.0),
     )
 
-    assert suite_score(report, ["t1", "t2", "missing"]) == pytest.approx(1 / 3)
-    assert suite_secondary_score(report, ["t1", "t2", "missing"]) == 0.5
+    assert suite_score(report, ["t1", "t2"]) == pytest.approx(0.625)
+    assert suite_secondary_score(report, ["t1", "t2"]) == pytest.approx(0.875)
     assert suite_score(report, []) == 1.0
     assert suite_secondary_score(report, []) == 1.0
+    with pytest.raises(ValueError, match="missing task"):
+        suite_score(report, ["t1", "missing"])
+
+
+def test_suite_secondary_score_is_absent_without_a_declared_objective() -> None:
+    report = _report(_task("task", score=0.5))
+
+    assert suite_secondary_score(report, ["task"]) is None
+    assert suite_secondary_score(report, []) is None

--- a/wmh/retrieval/embedders.py
+++ b/wmh/retrieval/embedders.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from wmh.core.types import JsonObject
 from wmh.providers.base import EmbedderKind
 
 if TYPE_CHECKING:
@@ -44,6 +45,10 @@ class HashingEmbedder:
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         return [self._embed_one(text) for text in texts]
+
+    def evaluation_context(self) -> JsonObject:
+        """Return the exact deterministic embedder configuration."""
+        return {"kind": "hashing_character_trigrams", "dimension": self._dim, "ngram": _NGRAM}
 
     def _embed_one(self, text: str) -> list[float]:
         vec = np.zeros(self._dim, dtype=np.float64)

--- a/wmh/retrieval/retriever.py
+++ b/wmh/retrieval/retriever.py
@@ -11,6 +11,7 @@ steps (`add`).
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
@@ -19,8 +20,8 @@ import numpy as np
 from numpy.typing import NDArray
 
 from wmh.core.render import encode_action, encode_state_action
-from wmh.core.types import Action, EnvState, Observation, Step, Trace
-from wmh.providers.base import Embedder
+from wmh.core.types import Action, EnvState, JsonObject, Observation, Step, Trace
+from wmh.providers.base import Embedder, ProviderConfig
 
 # What text phi embeds per step: the full (state, action) summary, or the command-only action.
 RetrievalKey = Literal["state_action", "action"]
@@ -46,6 +47,13 @@ class Retriever(Protocol):
     def sample(self, n: int) -> list[Step]:
         """Return up to `n` steps from the buffer (e.g. to seed the demo agent)."""
         ...
+
+
+@runtime_checkable
+class _EvaluationContextProvider(Protocol):
+    """Optional exact configuration surface for evaluation provenance."""
+
+    def evaluation_context(self) -> JsonObject: ...
 
 
 class EmbeddingRetriever:
@@ -120,6 +128,40 @@ class EmbeddingRetriever:
     def sample(self, n: int) -> list[Step]:
         """Return the first up-to-`n` steps from the buffer (deterministic; no RNG needed)."""
         return self._steps[: max(0, n)]
+
+    def evaluation_context(self) -> JsonObject:
+        """Return embedder, corpus, and matrix identities that determine retrieval."""
+        if isinstance(self._provider, _EvaluationContextProvider):
+            embedder = self._provider.evaluation_context()
+        else:
+            config = getattr(self._provider, "config", None)
+            if not isinstance(config, ProviderConfig):
+                raise ValueError(
+                    "retriever embedder must expose evaluation_context() or ProviderConfig"
+                )
+            provider_type = type(self._provider)
+            embedder = {
+                "kind": "provider",
+                "type": f"{provider_type.__module__}.{provider_type.__qualname__}",
+                "config": config.model_dump(mode="json"),
+            }
+        matrix = self._matrix
+        matrix_identity: JsonObject
+        if matrix is None:
+            matrix_identity = {"shape": None, "sha256": None}
+        else:
+            canonical_matrix = np.ascontiguousarray(matrix, dtype="<f8")
+            matrix_identity = {
+                "shape": list(canonical_matrix.shape),
+                "sha256": hashlib.sha256(canonical_matrix.tobytes(order="C")).hexdigest(),
+            }
+        return {
+            "kind": "embedding_retriever",
+            "key_mode": self._key_mode,
+            "embedder": embedder,
+            "steps": [step.model_dump(mode="json") for step in self._steps],
+            "matrix": matrix_identity,
+        }
 
     def save(self, index_dir: str | Path) -> None:
         """Persist the buffer (embedding matrix + parallel steps) under `index_dir`.


### PR DESCRIPTION
## Scope

This branch explored reusable scorer injection for harness optimization:

- a generic scorer interface
- normalized candidate and per-task score reports
- an adapter for the existing evaluator
- explicit candidate execution identity

## Disposition

The branch also coupled the interface to the existing selection algorithm, so it is superseded by a smaller scorer boundary on current main. It is closed without merge.