### PR TITLE
Add Harbor ground-truth harness scorer

### DIFF
--- a/docs/reference/ground_truth_harness_eval.md
+++ b/docs/reference/ground_truth_harness_eval.md
@@ -230,6 +230,77 @@ host variable references in task and verifier environment maps, Docker Compose s
 Compose environment files. The audit reports variable names and source locations only. It never
 resolves or logs credential values.
 
+### Python scoring boundary
+
+`HarborHarnessScorer` is the synchronous bridge from one explicit Harbor task selection to the
+generic harness-search score contract. The dataset selection and `task_ids` must be the same
+ordered, literal list. Globs, exclusions, random task limits, request-time subsets, and
+request-time attempt changes are rejected. Scored search accepts only local dataset paths that WMH
+can inspect before Harbor job creation. Harbor 0.18 dereferences symlinks while copying remote/Git
+tasks, before WMH can validate the downloaded tree, so registry, package, and remote acquisition
+remain evaluator-only until a symlink-preserving acquisition boundary lands. Dataset-qualified task
+keys from a frozen qualification
+manifest bind each selection to its Harbor source, identity, and task checksum across candidates.
+Qualification also freezes the executed environment definition. Local runs attest the Docker
+daemon platform plus every Compose service's immutable image ID and image platform. Ephemeral
+container, trial, and project identities are deliberately excluded. Every scored attempt must
+reproduce the per-task qualification digest.
+
+Harbor 0.18 does not expose the immutable E2B build ID that `Sandbox.create` actually resolved.
+Looking up the mutable `default` tag after sandbox creation cannot close the alias race, even when
+the current tag and sandbox timestamps are retained. The evaluator therefore keeps E2B selectable
+for acceleration and parity diagnostics, but `HarborHarnessScorer` rejects E2B scored search until
+the integration creates sandboxes from an immutable build reference and surfaces that identity.
+
+```python
+from harbor.models.job.config import DatasetConfig
+
+from wmh.evals.harbor.config import HarborJobSpec
+from wmh.evals.harbor.scorer import HarborHarnessScorer
+from wmh.harness.scoring import ScoreRequest
+
+task_ids = ("task-a", "task-b")
+# Dataset-qualified task keys come from the frozen Harbor qualification manifest.
+qualified_task_keys = {
+    trial.task_identity: trial.cell.task_key for trial in qualification.result.trials
+}
+task_keys = tuple(qualified_task_keys[task_id] for task_id in task_ids)
+qualified_environment_digests = {}
+for task_id in task_ids:
+    digests = {
+        trial.task_environment_digest
+        for trial in qualification.result.trials
+        if trial.task_identity == task_id
+    }
+    if None in digests or len(digests) != 1:
+        raise ValueError(f"qualification did not freeze one environment for {task_id!r}")
+    qualified_environment_digests[task_id] = digests.pop()
+task_environment_digests = tuple(
+    qualified_environment_digests[task_id] for task_id in task_ids
+)
+job = HarborJobSpec(
+    job_name="discovery",
+    jobs_dir=".wmh/evals/harbor",
+    datasets=[DatasetConfig(path="/frozen/tasks", task_names=list(task_ids))],
+    n_attempts=2,
+)
+with HarborHarnessScorer(
+    job_spec=job,
+    provider_config=worker_provider,
+    reference_harness=baseline,
+    task_ids=task_ids,
+    task_keys=task_keys,
+    task_environment_digests=task_environment_digests,
+    reward_key="reward",
+) as scorer:
+    report = scorer.score(candidate, request=ScoreRequest(purpose="full"))
+```
+
+When this scorer is passed to `search_harness`, set `screen_proposals=False` and
+`confirm_narrow_vetoes=False`. Every candidate then receives exactly the frozen matrix. The
+reference harness fixes runtime kind, turns, output tokens, temperature, effective tools, and the
+per-turn deadline. A candidate that changes that compute envelope is ineligible.
+
 This static check is a narrow credential boundary, not proof that an arbitrary Harbor task is safe.
 A malicious Dockerfile, Compose mount, image, script, or verifier can attack the host through other
 channels. Every scored dataset must therefore be frozen by content, reviewed as executable code,
@@ -755,6 +826,8 @@ The reusable evaluation slice provides:
 - immutable run manifests, task-lock digests, stale-run rejection, and strict result ingestion;
 - an exclusive per-job resume lease and atomic replacement of Harbor's live root result;
 - a benchmark-neutral `wmh harness eval` command and canonical result JSON;
+- a synchronous `HarborHarnessScorer` that requires an exact literal task matrix, rejects compute
+  drift, and projects only complete binary verifier evidence into generic harness scores;
 - typed completed, failed, unknown, and cancelled candidate evidence without arbitrary Harbor
   metadata passthrough;
 - pre-environment rejection of task-authored imports of credential-like host variables;
@@ -793,8 +866,18 @@ The following remain required work before experiment launch:
   host devices, Docker socket access, build SSH forwarding, and any `HOST_*_PATH` or equivalent
   evidence-path escape; apply it before provider or E2B credentials are loaded and before any paid
   local task starts;
-- add deadline-aware provider calls, an explicitly frozen paper-strength timeout stack, and a
-  probed Azure/Bedrock failure taxonomy;
+- add deadline-aware, interruptible provider calls, prove provider and Harbor subprocess cleanup,
+  freeze the timeout stack, and probe the Azure/Bedrock failure taxonomy;
+- classify candidate-authored request, context, and tool-schema 4xx failures as candidate zero
+  while retaining authentication, routing, transport, throttling, and service failures as
+  infrastructure; otherwise one invalid proposal can veto the optimizer;
+- classify candidate-caused task-container destruction or resource exhaustion as candidate zero,
+  with separate run-health evidence for ambiguous failures, instead of treating every task-tool
+  transport exception as infrastructure;
+- create E2B sandboxes from an immutable build reference and surface the exact resolved build ID
+  before admitting E2B scores; keep E2B acceleration diagnostic-only until that boundary lands;
+- make remote, registry, and package task acquisition preserve symlinks for pre-read validation,
+  or keep scored search restricted to preflighted local dataset paths;
 - add and fund a generic Claude Code control only if making a matched headline-uplift claim;
 - perform real local/E2B parity canaries on a machine with Docker and valid E2B credentials;
 - run leakage audits and the paid Azure/Bedrock matrices.

--- a/wmh/evals/benchmark.py
+++ b/wmh/evals/benchmark.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 RewardValue = float | int
 Rewards = dict[str, RewardValue]
 _SHA256_DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
+MAX_BENCHMARK_TASK_INSTRUCTION_CHARS = 8_000
 
 
 class BenchmarkTaskEnvironment(StrEnum):
@@ -256,6 +257,14 @@ class BenchmarkTrialResult(BaseModel):
     task_identity: str = Field(min_length=1)
     task_checksum: str = Field(min_length=1)
     source: str | None = None
+    task_instruction: str = Field(default="", max_length=MAX_BENCHMARK_TASK_INSTRUCTION_CHARS)
+    task_environment_digest: str | None = Field(
+        default=None,
+        pattern=_SHA256_DIGEST_PATTERN,
+        description=(
+            "Opaque digest of the immutable executed task-environment definition and bytes"
+        ),
+    )
     status: BenchmarkTrialStatus
     rewards: Rewards | None = None
     error: BenchmarkError | None = None

--- a/wmh/evals/benchmark.py
+++ b/wmh/evals/benchmark.py
@@ -9,11 +9,12 @@ benchmark-specific headline key.
 from __future__ import annotations
 
 import math
+import re
 from collections import Counter
 from collections.abc import Iterable
 from enum import StrEnum
 from statistics import fmean
-from typing import Self
+from typing import Self, TypeGuard
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -21,6 +22,11 @@ RewardValue = float | int
 Rewards = dict[str, RewardValue]
 _SHA256_DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
 MAX_BENCHMARK_TASK_INSTRUCTION_CHARS = 8_000
+
+
+def is_sha256_digest(value: object) -> TypeGuard[str]:
+    """Return whether ``value`` is one canonical lowercase sha256 digest."""
+    return isinstance(value, str) and re.fullmatch(_SHA256_DIGEST_PATTERN, value) is not None
 
 
 class BenchmarkTaskEnvironment(StrEnum):

--- a/wmh/evals/benchmark_test.py
+++ b/wmh/evals/benchmark_test.py
@@ -21,6 +21,7 @@ from wmh.evals.benchmark import (
     BenchmarkTrialStatus,
     BenchmarkUsage,
     BenchmarkUsageStatus,
+    is_sha256_digest,
 )
 
 _RUN_CONFIG_DIGEST = "sha256:" + "a" * 64
@@ -35,6 +36,20 @@ _IDENTITY = BenchmarkRunIdentity(
     runner_image="runner-image",
     run_config_digest=_RUN_CONFIG_DIGEST,
 )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("sha256:" + "a" * 64, True),
+        ("sha256:" + "A" * 64, False),
+        ("sha256:" + "a" * 63, False),
+        ("md5:" + "a" * 64, False),
+        (None, False),
+    ],
+)
+def test_sha256_digest_validation(value: object, expected: bool) -> None:
+    assert is_sha256_digest(value) is expected
 
 
 def _cell(task_name: str, attempt: int = 1, *, task_key: str | None = None) -> BenchmarkCell:

--- a/wmh/evals/harbor/agent.py
+++ b/wmh/evals/harbor/agent.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import logging
 import math
 import os
+import re
 import shlex
 import tempfile
 import threading
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path, PurePosixPath
-from typing import Final, cast
+from typing import Final, Protocol, cast
 
 from harbor.agents.base import BaseAgent
 from harbor.environments.base import BaseEnvironment, ExecResult
@@ -49,8 +53,13 @@ _TOOL_COMMAND_BYTES = 32 * 1024
 _TOOL_PATH_BYTES = 4 * 1024
 _TOOL_CONTENT_BYTES = 64 * 1024
 _RUNNER_CLEANUP_TIMEOUT_S = 30.0
+_ENVIRONMENT_ATTESTATION_TIMEOUT_S = 30
+_MAX_ENVIRONMENT_ATTESTATION_OUTPUT_BYTES = 64 * 1024
+_MAX_ENVIRONMENT_CONTAINERS = 64
 _TRACE_FILE = "wmh-events.jsonl"
-WMH_PI_AGENT_VERSION: Final = "0.1.0"
+# Bump whenever trusted host/runtime semantics change. Harbor run identity binds this value, so
+# completed artifacts cannot be reused across evaluator behavior changes.
+WMH_PI_AGENT_VERSION: Final = "0.2.0"
 _TRUNCATION_MARKER = "\n... [output truncated] ...\n"
 _TOOL_EXEC_HEAD_BYTES = _TOOL_OUTPUT_CHARS - len(_TRUNCATION_MARKER.encode())
 _BOUNDED_EXEC_SCRIPT = f"""\
@@ -98,6 +107,38 @@ class WmhPiCleanupError(RuntimeError):
 
 class _CandidateToolArgumentError(ValueError):
     """Candidate-supplied tool arguments failed a bounded validation rule."""
+
+
+@dataclass(frozen=True)
+class _TaskEnvironmentAttestation:
+    digest: str
+    evidence: JsonObject
+
+
+class _DockerEnvironmentView(Protocol):
+    async def _run_docker_compose_command(
+        self,
+        command: list[str],
+        check: bool = True,
+        timeout_sec: int | None = None,
+        stdin_data: bytes | None = None,
+        on_output: object | None = None,
+    ) -> ExecResult: ...
+
+
+class _E2BSandboxInfoView(Protocol):
+    template_id: str
+    cpu_count: int
+    memory_mb: int
+    started_at: datetime
+
+
+class _E2BSandboxView(Protocol):
+    async def get_info(self) -> _E2BSandboxInfoView: ...
+
+
+class _E2BEnvironmentView(Protocol):
+    _sandbox: _E2BSandboxView | None
 
 
 class HarborToolExecutor:
@@ -320,6 +361,7 @@ class WmhPiAgent(BaseAgent):
         self._provider = provider
         self._runner_image = runner_image
         self._turn_timeout_s = turn_timeout_s
+        self._task_environment_attestation: _TaskEnvironmentAttestation | None = None
 
     @staticmethod
     def name() -> str:
@@ -329,8 +371,13 @@ class WmhPiAgent(BaseAgent):
         return WMH_PI_AGENT_VERSION
 
     async def setup(self, environment: BaseEnvironment) -> None:
-        """No task-side setup is required because pi runs in its own isolated container."""
-        _ = environment
+        """Freeze the immutable environment actually started for this trial."""
+        try:
+            self._task_environment_attestation = await _attest_task_environment(environment)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - environment details may contain credentials or paths
+            raise WmhPiEnvironmentError("task environment attestation failed") from None
 
     async def run(
         self,
@@ -339,11 +386,16 @@ class WmhPiAgent(BaseAgent):
         context: AgentContext,
     ) -> None:
         """Run one pi turn, preserving candidate failures for Harbor's native verifier."""
+        attestation = self._task_environment_attestation
+        if attestation is None:
+            raise WmhPiEnvironmentError("task environment attestation is unavailable")
         identity_metadata = cast(
             "JsonObject",
             {
                 "harness_hash": self._harness.execution_hash,
                 "runner_image": self._runner_image,
+                "task_environment_digest": attestation.digest,
+                "task_environment_attestation": attestation.evidence,
             },
         )
         _populate_context(context, TokenUsage(), identity_metadata)
@@ -446,6 +498,270 @@ class WmhPiAgent(BaseAgent):
                 temporary_path.unlink(missing_ok=True)
         except OSError:
             raise WmhPiRunnerError("WMH pi trace persistence failed") from None
+
+
+async def _attest_task_environment(
+    environment: BaseEnvironment,
+) -> _TaskEnvironmentAttestation:
+    environment_type = environment.type()
+    backend = getattr(environment_type, "value", environment_type)
+    if backend == "docker":
+        evidence = await _attest_docker_environment(cast("_DockerEnvironmentView", environment))
+    elif backend == "e2b":
+        evidence = await _attest_e2b_environment(
+            environment,
+            cast("_E2BEnvironmentView", environment),
+        )
+    else:
+        raise RuntimeError("unsupported task environment backend")
+    canonical = json.dumps(
+        evidence,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode()
+    if len(canonical) > _MAX_ENVIRONMENT_ATTESTATION_OUTPUT_BYTES:
+        raise RuntimeError("task environment attestation exceeds its evidence limit")
+    return _TaskEnvironmentAttestation(
+        digest="sha256:" + hashlib.sha256(canonical).hexdigest(),
+        evidence=evidence,
+    )
+
+
+async def _attest_docker_environment(
+    environment: _DockerEnvironmentView,
+) -> JsonObject:
+    result = await environment._run_docker_compose_command(
+        ["ps", "--all", "--quiet"],
+        timeout_sec=_ENVIRONMENT_ATTESTATION_TIMEOUT_S,
+    )
+    container_ids = _bounded_lines(result.stdout, label="Docker Compose container identities")
+    if not container_ids or len(container_ids) > _MAX_ENVIRONMENT_CONTAINERS:
+        raise RuntimeError("Docker Compose returned an invalid container set")
+    if len(set(container_ids)) != len(container_ids):
+        raise RuntimeError("Docker Compose returned duplicate container identities")
+    if any(re.fullmatch(r"[0-9a-f]{12,64}", value) is None for value in container_ids):
+        raise RuntimeError("Docker Compose returned an invalid container identity")
+
+    daemon_platform = _single_platform(
+        await _run_host_command(
+            "docker",
+            "info",
+            "--format",
+            "{{.OSType}}/{{.Architecture}}",
+        ),
+        label="Docker daemon platform",
+    )
+    services: list[tuple[str, int, str, str]] = []
+    replicas: set[tuple[str, int]] = set()
+    for container_id in container_ids:
+        identity = await _run_host_command(
+            "docker",
+            "container",
+            "inspect",
+            "--format",
+            '{{index .Config.Labels "com.docker.compose.service"}}\t'
+            '{{index .Config.Labels "com.docker.compose.container-number"}}\t'
+            "{{.Image}}\t{{.State.Status}}\t"
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+            container_id,
+        )
+        parts = identity.strip().split("\t")
+        if len(parts) != 5:
+            raise RuntimeError("Docker returned malformed container identity evidence")
+        service, raw_replica, image_id, status, health = parts
+        if re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", service) is None:
+            raise RuntimeError("Docker returned an invalid Compose service identity")
+        if re.fullmatch(r"[1-9][0-9]{0,5}", raw_replica) is None:
+            raise RuntimeError("Docker returned an invalid Compose replica identity")
+        replica = int(raw_replica)
+        replica_key = (service, replica)
+        if replica_key in replicas:
+            raise RuntimeError("Docker returned a duplicate Compose replica identity")
+        replicas.add(replica_key)
+        if re.fullmatch(r"sha256:[0-9a-f]{64}", image_id) is None:
+            raise RuntimeError("Docker returned a mutable or invalid image identity")
+        if status != "running" or health not in {"none", "healthy"}:
+            raise RuntimeError("Docker Compose service is not running and healthy")
+        image_platform = _single_platform(
+            await _run_host_command(
+                "docker",
+                "image",
+                "inspect",
+                "--format",
+                "{{.Os}}/{{.Architecture}}",
+                image_id,
+            ),
+            label="Docker image platform",
+        )
+        services.append((service, replica, image_id, image_platform))
+
+    return cast(
+        "JsonObject",
+        {
+            "schema_version": 1,
+            "backend": "docker",
+            "daemon_platform": daemon_platform,
+            "services": [
+                {
+                    "service": service,
+                    "replica": replica,
+                    "image_id": image_id,
+                    "image_platform": image_platform,
+                }
+                for service, replica, image_id, image_platform in sorted(services)
+            ],
+        },
+    )
+
+
+async def _attest_e2b_environment(
+    environment: BaseEnvironment,
+    view: _E2BEnvironmentView,
+) -> JsonObject:
+    sandbox = view._sandbox
+    if sandbox is None:
+        raise RuntimeError("E2B sandbox is unavailable")
+    info = await sandbox.get_info()
+    template_id = _bounded_identity(info.template_id, label="E2B template identity")
+    cpu_count = info.cpu_count
+    memory_mb = info.memory_mb
+    if (
+        isinstance(cpu_count, bool)
+        or not isinstance(cpu_count, int)
+        or cpu_count < 1
+        or isinstance(memory_mb, bool)
+        or not isinstance(memory_mb, int)
+        or memory_mb < 1
+    ):
+        raise RuntimeError("E2B returned invalid sandbox resource evidence")
+    tags = await _get_e2b_template_tags(template_id)
+    default_tags = [
+        (build_id, created_at) for tag, build_id, created_at in tags if tag == "default"
+    ]
+    if len(default_tags) != 1:
+        raise RuntimeError("E2B template default tag did not resolve to one immutable build")
+    raw_build_id, tag_created_at = default_tags[0]
+    if (
+        not isinstance(info.started_at, datetime)
+        or info.started_at.tzinfo is None
+        or not isinstance(tag_created_at, datetime)
+        or tag_created_at.tzinfo is None
+        or tag_created_at > info.started_at
+    ):
+        raise RuntimeError("E2B template tag changed after the sandbox started")
+    build_id = _bounded_identity(raw_build_id, label="E2B build identity")
+    platform_result = await environment.exec(
+        "/bin/uname -s && /bin/uname -m",
+        timeout_sec=_ENVIRONMENT_ATTESTATION_TIMEOUT_S,
+    )
+    if platform_result.return_code != 0:
+        raise RuntimeError("E2B sandbox platform attestation failed")
+    platform_lines = _bounded_lines(
+        platform_result.stdout,
+        label="E2B sandbox platform",
+    )
+    if len(platform_lines) != 2:
+        raise RuntimeError("E2B returned malformed sandbox platform evidence")
+    platform = "/".join(part.lower() for part in platform_lines)
+    if re.fullmatch(r"[a-z0-9_.-]{1,64}/[a-z0-9_.-]{1,64}", platform) is None:
+        raise RuntimeError("E2B returned invalid sandbox platform evidence")
+    return cast(
+        "JsonObject",
+        {
+            "schema_version": 1,
+            "backend": "e2b",
+            "template_id": template_id,
+            "build_id": build_id,
+            "platform": platform,
+            "cpu_count": cpu_count,
+            "memory_mb": memory_mb,
+        },
+    )
+
+
+async def _get_e2b_template_tags(
+    template_id: str,
+) -> tuple[tuple[str, str, datetime], ...]:
+    from e2b import AsyncTemplate
+
+    tags = await AsyncTemplate.get_tags(template_id)
+    return tuple((tag.tag, tag.build_id, tag.created_at) for tag in tags)
+
+
+async def _run_host_command(*command: str) -> str:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, _stderr = await asyncio.wait_for(
+            process.communicate(),
+            timeout=_ENVIRONMENT_ATTESTATION_TIMEOUT_S,
+        )
+    except TimeoutError:
+        await _kill_and_wait_process(process)
+        raise RuntimeError("task environment host attestation command timed out") from None
+    except asyncio.CancelledError:
+        await _kill_and_wait_process(process)
+        raise
+    if process.returncode != 0:
+        raise RuntimeError("task environment host attestation command failed")
+    if len(stdout) > _MAX_ENVIRONMENT_ATTESTATION_OUTPUT_BYTES:
+        raise RuntimeError("task environment host attestation output exceeds its limit")
+    try:
+        return stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        raise RuntimeError("task environment host attestation output is not UTF-8") from None
+
+
+async def _kill_and_wait_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is None:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+    cleanup = asyncio.create_task(process.wait())
+    while not cleanup.done():
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            continue
+    await cleanup
+
+
+def _bounded_lines(value: str | None, *, label: str) -> list[str]:
+    if value is None:
+        return []
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        raise RuntimeError(f"{label} is not valid UTF-8") from None
+    if len(encoded) > _MAX_ENVIRONMENT_ATTESTATION_OUTPUT_BYTES:
+        raise RuntimeError(f"{label} exceeds its evidence limit")
+    lines = [line.strip() for line in value.splitlines() if line.strip()]
+    if any(len(line.encode()) > 512 for line in lines):
+        raise RuntimeError(f"{label} contains an oversized value")
+    return lines
+
+
+def _single_platform(value: str, *, label: str) -> str:
+    lines = _bounded_lines(value, label=label)
+    if len(lines) != 1:
+        raise RuntimeError(f"{label} must contain one value")
+    platform = lines[0].lower()
+    if re.fullmatch(r"[a-z0-9_.-]{1,64}/[a-z0-9_.-]{1,64}", platform) is None:
+        raise RuntimeError(f"{label} is invalid")
+    return platform
+
+
+def _bounded_identity(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or re.fullmatch(r"[A-Za-z0-9_.:-]{1,512}", value) is None:
+        raise RuntimeError(f"{label} is invalid")
+    return value
 
 
 async def _cancel_and_wait_runner(runner_factory: LocalContainerRunnerFactory) -> None:

--- a/wmh/evals/harbor/agent.py
+++ b/wmh/evals/harbor/agent.py
@@ -115,6 +115,11 @@ class _TaskEnvironmentAttestation:
     evidence: JsonObject
 
 
+# Harbor 0.18 exposes no public API for the exact Docker Compose project or the E2B sandbox that
+# actually ran. WMH pins Harbor to that exact version and centralizes the two private members in
+# these protocol views. Missing members fail agent setup, before any provider request is admitted,
+# rather than silently producing an unattested score. Replace these views when Harbor adds a public
+# immutable environment-identity API.
 class _DockerEnvironmentView(Protocol):
     async def _run_docker_compose_command(
         self,

--- a/wmh/evals/harbor/agent_test.py
+++ b/wmh/evals/harbor/agent_test.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import json
 import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -12,6 +15,7 @@ from typing import cast
 import pytest
 from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
+from harbor.models.environment_type import EnvironmentType
 
 import wmh.evals.harbor.agent as mod
 from wmh.core.types import JsonObject
@@ -25,6 +29,33 @@ from wmh.harness.pi_runner import (
 )
 from wmh.harness.runner_link import TokenUsage
 from wmh.providers.base import ProviderConfig, ProviderKind
+
+_TASK_ENVIRONMENT_ATTESTATION = cast(
+    "JsonObject",
+    {
+        "schema_version": 1,
+        "backend": "docker",
+        "daemon_platform": "linux/amd64",
+        "services": [
+            {
+                "service": "main",
+                "replica": 1,
+                "image_id": "sha256:" + "c" * 64,
+                "image_platform": "linux/amd64",
+            }
+        ],
+    },
+)
+_TASK_ENVIRONMENT_DIGEST = (
+    "sha256:"
+    + hashlib.sha256(
+        json.dumps(
+            _TASK_ENVIRONMENT_ATTESTATION,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+)
 
 
 class _Provider:
@@ -62,12 +93,17 @@ class _Environment:
 def _agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> mod.WmhPiAgent:
     monkeypatch.setattr(mod, "get_provider", lambda _config: _Provider())
     config = ProviderConfig(kind=ProviderKind.BEDROCK, model="model")
-    return mod.WmhPiAgent(
+    agent = mod.WmhPiAgent(
         logs_dir=tmp_path / "agent",
         model_name="bedrock/model",
         harness=cast("JsonObject", pi_node_baseline("candidate").model_dump(mode="json")),
         provider_config=cast("JsonObject", config.model_dump(mode="json")),
     )
+    agent._task_environment_attestation = mod._TaskEnvironmentAttestation(
+        digest=_TASK_ENVIRONMENT_DIGEST,
+        evidence=_TASK_ENVIRONMENT_ATTESTATION,
+    )
+    return agent
 
 
 def _deadline(seconds: float = 300.0) -> mod.ToolExecutionDeadline:
@@ -127,6 +163,298 @@ def test_agent_rejects_environment_injection_before_task_execution(
         )
 
     assert secret not in str(caught.value)
+
+
+def test_setup_attests_all_local_compose_images_without_ephemeral_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(tmp_path, monkeypatch)
+
+    class DockerEnvironment(_Environment):
+        @staticmethod
+        def type() -> EnvironmentType:
+            return EnvironmentType.DOCKER
+
+        async def _run_docker_compose_command(
+            self,
+            command: list[str],
+            check: bool = True,
+            timeout_sec: int | None = None,
+            stdin_data: bytes | None = None,
+            on_output: object | None = None,
+        ) -> ExecResult:
+            _ = check, timeout_sec, stdin_data, on_output
+            assert command == ["ps", "--all", "--quiet"]
+            return ExecResult(stdout="b" * 64 + "\n" + "a" * 64 + "\n", return_code=0)
+
+    async def host_command(*command: str) -> str:
+        joined = " ".join(command)
+        if command[1] == "info":
+            return "linux/amd64\n"
+        if command[1:3] == ("container", "inspect"):
+            container_id = command[-1]
+            if container_id == "a" * 64:
+                return "main\t1\tsha256:" + "1" * 64 + "\trunning\thealthy\n"
+            return "proxy\t1\tsha256:" + "2" * 64 + "\trunning\tnone\n"
+        if command[1:3] == ("image", "inspect"):
+            return "linux/amd64\n"
+        raise AssertionError(f"unexpected host command: {joined}")
+
+    monkeypatch.setattr(mod, "_run_host_command", host_command)
+    asyncio.run(agent.setup(cast("BaseEnvironment", DockerEnvironment())))
+
+    attestation = agent._task_environment_attestation
+    assert attestation is not None
+    assert attestation.evidence["services"] == [
+        {
+            "service": "main",
+            "replica": 1,
+            "image_id": "sha256:" + "1" * 64,
+            "image_platform": "linux/amd64",
+        },
+        {
+            "service": "proxy",
+            "replica": 1,
+            "image_id": "sha256:" + "2" * 64,
+            "image_platform": "linux/amd64",
+        },
+    ]
+    assert "a" * 64 not in json.dumps(attestation.evidence)
+    assert "b" * 64 not in json.dumps(attestation.evidence)
+
+
+def test_local_attestation_binds_compose_replica_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DockerEnvironment(_Environment):
+        def __init__(self, container_ids: tuple[str, ...]) -> None:
+            super().__init__()
+            self.container_ids = container_ids
+
+        @staticmethod
+        def type() -> EnvironmentType:
+            return EnvironmentType.DOCKER
+
+        async def _run_docker_compose_command(
+            self,
+            command: list[str],
+            check: bool = True,
+            timeout_sec: int | None = None,
+            stdin_data: bytes | None = None,
+            on_output: object | None = None,
+        ) -> ExecResult:
+            _ = command, check, timeout_sec, stdin_data, on_output
+            return ExecResult(stdout="\n".join(self.container_ids) + "\n", return_code=0)
+
+    first_id = "a" * 64
+    second_id = "b" * 64
+
+    async def host_command(*command: str) -> str:
+        if command[1] == "info" or command[1:3] == ("image", "inspect"):
+            return "linux/amd64\n"
+        replica = "1" if command[-1] == first_id else "2"
+        return f"main\t{replica}\tsha256:{'1' * 64}\trunning\thealthy\n"
+
+    monkeypatch.setattr(mod, "_run_host_command", host_command)
+    one = asyncio.run(
+        mod._attest_task_environment(cast("BaseEnvironment", DockerEnvironment((first_id,))))
+    )
+    two = asyncio.run(
+        mod._attest_task_environment(
+            cast("BaseEnvironment", DockerEnvironment((first_id, second_id)))
+        )
+    )
+
+    assert one.digest != two.digest
+
+
+@pytest.mark.parametrize(
+    ("status", "health"),
+    [("exited", "none"), ("running", "unhealthy")],
+)
+def test_local_attestation_rejects_non_running_or_unhealthy_service(
+    status: str,
+    health: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container_id = "a" * 64
+
+    class DockerEnvironment(_Environment):
+        async def _run_docker_compose_command(
+            self,
+            command: list[str],
+            check: bool = True,
+            timeout_sec: int | None = None,
+            stdin_data: bytes | None = None,
+            on_output: object | None = None,
+        ) -> ExecResult:
+            _ = command, check, timeout_sec, stdin_data, on_output
+            return ExecResult(stdout=container_id + "\n", return_code=0)
+
+    async def host_command(*command: str) -> str:
+        if command[1] == "info" or command[1:3] == ("image", "inspect"):
+            return "linux/amd64\n"
+        return f"main\t1\tsha256:{'1' * 64}\t{status}\t{health}\n"
+
+    monkeypatch.setattr(mod, "_run_host_command", host_command)
+
+    with pytest.raises(RuntimeError, match="not running and healthy"):
+        asyncio.run(mod._attest_docker_environment(DockerEnvironment()))
+
+
+def test_setup_attests_e2b_template_build_resources_and_platform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(tmp_path, monkeypatch)
+
+    class Sandbox:
+        async def get_info(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                template_id="template-immutable",
+                cpu_count=4,
+                memory_mb=8192,
+                started_at=datetime(2026, 7, 18, 12, 0, tzinfo=UTC),
+            )
+
+    class E2BEnvironment(_Environment):
+        _sandbox = Sandbox()
+        _template_name = "mutable-alias-not-hashed"
+
+        @staticmethod
+        def type() -> EnvironmentType:
+            return EnvironmentType.E2B
+
+        async def exec(
+            self,
+            command: str,
+            cwd: str | None = None,
+            env: dict[str, str] | None = None,
+            timeout_sec: int | None = None,
+            user: str | int | None = None,
+        ) -> ExecResult:
+            _ = cwd, env, user
+            assert command == "/bin/uname -s && /bin/uname -m"
+            assert timeout_sec == mod._ENVIRONMENT_ATTESTATION_TIMEOUT_S
+            return ExecResult(stdout="Linux\nx86_64\n", return_code=0)
+
+    async def tags(_template_id: str) -> tuple[tuple[str, str, datetime], ...]:
+        return (
+            (
+                "default",
+                "build-immutable",
+                datetime(2026, 7, 18, 11, 59, tzinfo=UTC),
+            ),
+        )
+
+    monkeypatch.setattr(mod, "_get_e2b_template_tags", tags)
+    asyncio.run(agent.setup(cast("BaseEnvironment", E2BEnvironment())))
+
+    attestation = agent._task_environment_attestation
+    assert attestation is not None
+    assert attestation.evidence == {
+        "schema_version": 1,
+        "backend": "e2b",
+        "template_id": "template-immutable",
+        "build_id": "build-immutable",
+        "platform": "linux/x86_64",
+        "cpu_count": 4,
+        "memory_mb": 8192,
+    }
+    assert "mutable-alias-not-hashed" not in json.dumps(attestation.evidence)
+
+
+def test_setup_rejects_e2b_default_tag_repointed_after_sandbox_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(tmp_path, monkeypatch)
+    started_at = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+
+    class Sandbox:
+        async def get_info(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                template_id="template-immutable",
+                cpu_count=2,
+                memory_mb=4096,
+                started_at=started_at,
+            )
+
+    class E2BEnvironment(_Environment):
+        _sandbox = Sandbox()
+
+        @staticmethod
+        def type() -> EnvironmentType:
+            return EnvironmentType.E2B
+
+    async def tags(_template_id: str) -> tuple[tuple[str, str, datetime], ...]:
+        return (("default", "repointed-build", started_at + timedelta(seconds=1)),)
+
+    monkeypatch.setattr(mod, "_get_e2b_template_tags", tags)
+
+    with pytest.raises(mod.WmhPiEnvironmentError, match="attestation failed"):
+        asyncio.run(agent.setup(cast("BaseEnvironment", E2BEnvironment())))
+
+
+def test_setup_attestation_failure_is_sanitized_environment_infrastructure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(tmp_path, monkeypatch)
+    secret = "host-path-secret-sentinel"
+
+    async def fail(_environment: BaseEnvironment) -> mod._TaskEnvironmentAttestation:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(mod, "_attest_task_environment", fail)
+
+    with pytest.raises(mod.WmhPiEnvironmentError, match="attestation failed") as caught:
+        asyncio.run(agent.setup(cast("BaseEnvironment", _Environment())))
+
+    assert secret not in str(caught.value)
+
+
+def test_cancelled_host_attestation_kills_and_reaps_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Process:
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.killed = False
+            self.waited = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            self.started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            self.waited = True
+            return -9
+
+    async def scenario() -> None:
+        process = Process()
+
+        async def create(*_args: object, **_kwargs: object) -> Process:
+            return process
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", create)
+        task = asyncio.create_task(mod._run_host_command("docker", "info"))
+        await process.started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert process.killed is True
+        assert process.waited is True
+
+    asyncio.run(scenario())
 
 
 def test_tool_executor_bridges_bash_read_and_write_without_plaintext_content() -> None:
@@ -459,6 +787,8 @@ def test_success_populates_usage_and_backend_identity(
     assert context.metadata["candidate_failure"] is False
     assert context.metadata["runner_image"] == mod.PI_CONTAINER_IMAGE
     assert context.metadata["harness_hash"] == agent._harness.execution_hash
+    assert context.metadata["task_environment_digest"] == _TASK_ENVIRONMENT_DIGEST
+    assert context.metadata["task_environment_attestation"] == _TASK_ENVIRONMENT_ATTESTATION
 
 
 def test_infrastructure_error_does_not_persist_raw_provider_secret(

--- a/wmh/evals/harbor/evaluator.py
+++ b/wmh/evals/harbor/evaluator.py
@@ -36,7 +36,9 @@ from harbor.registry.client.package import PackageDatasetClient
 from harbor.tasks.client import TaskIdType
 from pydantic import ValidationError
 
+from wmh.core.text import normalize_durable_text
 from wmh.evals.benchmark import (
+    MAX_BENCHMARK_TASK_INSTRUCTION_CHARS,
     BenchmarkCell,
     BenchmarkRunIdentity,
     BenchmarkTaskEnvironment,
@@ -70,6 +72,8 @@ from wmh.harness.pi_local import (
 from wmh.providers.base import ProviderConfig
 
 _MANIFEST_FILENAME = "wmh-manifest.json"
+_MAX_TASK_HOST_TEXT_BYTES = 1024 * 1024
+_MAX_EXTRA_INSTRUCTION_FILES = 16
 _JOB_ROOT_FILES = frozenset(
     {_MANIFEST_FILENAME, "config.json", "job.log", "lock.json", "result.json"}
 )
@@ -114,16 +118,18 @@ class _PreparedTrial:
     task_identity: str
     task_checksum: str
     task_source: str | None
+    task_instruction: str
     trial_lock_digest: str
 
     @property
-    def immutable_key(self) -> tuple[str, str, str, str, str | None, str]:
+    def immutable_key(self) -> tuple[str, str, str, str, str | None, str, str]:
         return (
             self.task_key,
             self.task_name,
             self.task_identity,
             self.task_checksum,
             self.task_source,
+            self.task_instruction,
             self.trial_lock_digest,
         )
 
@@ -180,6 +186,7 @@ class HarborEvaluator:
             expected_agent_digest=agent_digest,
             expected_job_config=job_config,
         )
+        _preflight_local_task_trees(job_config)
         await asyncio.to_thread(_preflight_task_environment, job_config)
         await self._ensure_runner_ready()
 
@@ -198,11 +205,11 @@ class HarborEvaluator:
                 raise ValueError(
                     "Harbor resolved zero trials; refusing to publish an empty evaluation"
                 )
-            job_lock = _build_prepared_job_lock(job)
             tasks = _load_and_validate_tasks(
                 job,
                 environment_backend=self._spec.environment_backend,
             )
+            job_lock = _build_prepared_job_lock(job)
             prepared_trials = _prepare_trials(
                 job,
                 job_lock,
@@ -393,6 +400,95 @@ def _build_prepared_job_lock(job: Job) -> JobLock:
     return lock
 
 
+def _preflight_local_task_trees(config: JobConfig) -> None:
+    """Reject unsafe local task paths before Harbor can inspect task configuration."""
+    for dataset in config.datasets:
+        if not dataset.is_local():
+            continue
+        if dataset.path is None:
+            raise RuntimeError("local Harbor dataset is missing its path")
+        root = dataset.path.expanduser()
+        if root.is_symlink():
+            raise UnsupportedHarborTaskError(
+                f"local dataset root cannot be a symbolic link: {root}"
+            )
+        if not root.is_dir():
+            continue
+        for task_dir in sorted(root.iterdir(), key=lambda path: path.name):
+            if task_dir.is_symlink():
+                raise UnsupportedHarborTaskError(
+                    f"local task root cannot be a symbolic link: {task_dir}"
+                )
+            if not task_dir.is_dir():
+                continue
+            config_path = task_dir / "task.toml"
+            if not (config_path.exists() or config_path.is_symlink()):
+                continue
+            _validate_task_tree_for_host_reads(task_dir, extra_instruction_paths=())
+
+
+def _validate_task_tree_for_host_reads(
+    task_dir: Path,
+    *,
+    extra_instruction_paths: tuple[Path, ...] | list[Path],
+) -> None:
+    """Require a regular, symlink-free task tree before trusted host reads or hashes it."""
+    requested_root = task_dir.expanduser()
+    if requested_root.is_symlink():
+        raise UnsupportedHarborTaskError(
+            f"Harbor task root cannot be a symbolic link: {requested_root}"
+        )
+    if not requested_root.is_dir():
+        raise UnsupportedHarborTaskError(f"Harbor task root is not a directory: {requested_root}")
+    for path in requested_root.rglob("*"):
+        if path.is_symlink():
+            raise UnsupportedHarborTaskError(
+                f"Harbor task tree cannot contain a symbolic link: {path}"
+            )
+        if not path.is_dir() and not path.is_file():
+            raise UnsupportedHarborTaskError(
+                f"Harbor task tree can contain only regular files and directories: {path}"
+            )
+
+    root = requested_root.resolve()
+    _require_bounded_host_text_file(root / "task.toml", label="task configuration")
+    _require_bounded_host_text_file(root / "instruction.md", label="task instruction")
+    if len(extra_instruction_paths) > _MAX_EXTRA_INSTRUCTION_FILES:
+        raise UnsupportedHarborTaskError(
+            "Harbor task has too many extra instruction files for bounded host ingestion"
+        )
+    for path in extra_instruction_paths:
+        requested = path.expanduser()
+        if requested.is_symlink():
+            raise UnsupportedHarborTaskError(
+                f"extra task instruction cannot be a symbolic link: {requested}"
+            )
+        try:
+            resolved = requested.resolve(strict=True)
+        except OSError as exc:
+            raise UnsupportedHarborTaskError(
+                f"extra task instruction is unavailable: {requested}"
+            ) from exc
+        if not resolved.is_relative_to(root):
+            raise UnsupportedHarborTaskError(
+                f"extra task instruction must remain inside the task root: {requested}"
+            )
+        _require_bounded_host_text_file(resolved, label="extra task instruction")
+
+
+def _require_bounded_host_text_file(path: Path, *, label: str) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise UnsupportedHarborTaskError(f"{label} must be a regular file: {path}")
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise UnsupportedHarborTaskError(f"{label} is unavailable: {path}") from exc
+    if size > _MAX_TASK_HOST_TEXT_BYTES:
+        raise UnsupportedHarborTaskError(
+            f"{label} exceeds the {_MAX_TASK_HOST_TEXT_BYTES}-byte host-read limit: {path}"
+        )
+
+
 def harbor_run_config_digest(spec: HarborJobSpec, agent_config_digest: str) -> str:
     """Hash logical run semantics and controlled concurrency without leaking host paths.
 
@@ -439,6 +535,10 @@ def _load_and_validate_tasks(
             raise RuntimeError(
                 f"Harbor did not retain the prepared task {task_id.get_name()!r}"
             ) from None
+        _validate_task_tree_for_host_reads(
+            download.path,
+            extra_instruction_paths=trial_config.extra_instruction_paths,
+        )
         task = Task(
             download.path,
             extra_instruction_paths=trial_config.extra_instruction_paths,
@@ -523,10 +623,23 @@ def _prepare_trials(
                 task_identity=task_identity,
                 task_checksum=trial_lock.task.digest,
                 task_source=trial_lock.task.source,
+                task_instruction=_bound_task_instruction(task.instruction),
                 trial_lock_digest=harbor_trial_lock_digest(trial_lock),
             )
         )
     return prepared_trials
+
+
+def _bound_task_instruction(instruction: str) -> str:
+    """Retain deterministic proposer evidence without growing the trusted manifest unboundedly."""
+    normalized = normalize_durable_text(instruction)
+    if len(normalized) <= MAX_BENCHMARK_TASK_INSTRUCTION_CHARS:
+        return normalized
+    marker = f"\n...[task instruction truncated; original_chars={len(normalized)}]...\n"
+    retained = MAX_BENCHMARK_TASK_INSTRUCTION_CHARS - len(marker)
+    head = retained // 2
+    tail = retained - head
+    return normalized[:head] + marker + normalized[-tail:]
 
 
 def _build_manifest(
@@ -555,6 +668,7 @@ def _build_manifest(
                 task_identity=prepared.task_identity,
                 task_checksum=prepared.task_checksum,
                 task_source=prepared.task_source,
+                task_instruction=prepared.task_instruction,
                 trial_lock_digest=prepared.trial_lock_digest,
             )
         )
@@ -597,10 +711,10 @@ def _restore_manifest_trial_names(
         entry for entry in manifest.entries if entry.trial_name not in completed_names
     ]
     prepared_by_key: defaultdict[
-        tuple[str, str, str, str, str | None, str], list[_PreparedTrial]
+        tuple[str, str, str, str, str | None, str, str], list[_PreparedTrial]
     ] = defaultdict(list)
     entries_by_key: defaultdict[
-        tuple[str, str, str, str, str | None, str], list[HarborTrialManifestEntry]
+        tuple[str, str, str, str, str | None, str, str], list[HarborTrialManifestEntry]
     ] = defaultdict(list)
     for prepared in remaining_prepared:
         prepared_by_key[prepared.immutable_key].append(prepared)
@@ -635,13 +749,14 @@ def _restore_manifest_trial_names(
 
 def _manifest_entry_immutable_key(
     entry: HarborTrialManifestEntry,
-) -> tuple[str, str, str, str, str | None, str]:
+) -> tuple[str, str, str, str, str | None, str, str]:
     return (
         entry.cell.task_key,
         entry.cell.task_name,
         entry.task_identity,
         entry.task_checksum,
         entry.task_source,
+        entry.task_instruction,
         entry.trial_lock_digest,
     )
 

--- a/wmh/evals/harbor/evaluator_test.py
+++ b/wmh/evals/harbor/evaluator_test.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -37,6 +39,30 @@ from wmh.evals.harbor.results import (
 )
 from wmh.harness.pi_runner import pi_node_baseline
 from wmh.providers.base import ProviderConfig, ProviderKind
+
+_TASK_ENVIRONMENT_ATTESTATION = {
+    "schema_version": 1,
+    "backend": "docker",
+    "daemon_platform": "linux/amd64",
+    "services": [
+        {
+            "service": "main",
+            "replica": 1,
+            "image_id": "sha256:" + "c" * 64,
+            "image_platform": "linux/amd64",
+        }
+    ],
+}
+_TASK_ENVIRONMENT_DIGEST = (
+    "sha256:"
+    + hashlib.sha256(
+        json.dumps(
+            _TASK_ENVIRONMENT_ATTESTATION,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+)
 
 
 def _write_task(
@@ -331,6 +357,7 @@ def test_evaluate_pins_agent_persists_exact_lock_manifest_and_qualifies_task_key
     assert len(manifest.entries) == 4
     assert {entry.cell.task_name for entry in manifest.entries} == {"shared-task"}
     assert {entry.task_source for entry in manifest.entries} == {"dataset-a", "dataset-b"}
+    assert {entry.task_instruction for entry in manifest.entries} == {"Solve the task.\n"}
     assert len({entry.cell.task_key for entry in manifest.entries}) == 2
     for source in ("dataset-a", "dataset-b"):
         assert sorted(
@@ -664,7 +691,7 @@ def _materialize_job(
             config=trial_config,
             agent_info=AgentInfo(
                 name="wmh-pi",
-                version="0.1.0",
+                version=mod.WMH_PI_AGENT_VERSION,
                 model_info=ModelInfo(name="model", provider="bedrock"),
             ),
             agent_result=AgentContext(
@@ -673,6 +700,8 @@ def _materialize_job(
                 metadata={
                     "harness_hash": candidate_hash,
                     "runner_image": mod.PI_CONTAINER_IMAGE,
+                    "task_environment_digest": _TASK_ENVIRONMENT_DIGEST,
+                    "task_environment_attestation": _TASK_ENVIRONMENT_ATTESTATION,
                 },
             ),
             verifier_result=VerifierResult(rewards={"score": 1}),
@@ -753,6 +782,26 @@ def test_complete_matching_job_is_reused_without_rerunning_completed_trials(
     assert remaining == [0]
     assert resumed.result == first.result
     assert readiness_images == [mod.PI_CONTAINER_IMAGE]
+
+
+def test_agent_runtime_version_change_rejects_stale_completed_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = tmp_path / "dataset"
+    _write_task(dataset)
+    candidate = pi_node_baseline("candidate")
+    evaluator = mod.HarborEvaluator(_spec(tmp_path, dataset), _provider())
+
+    async def first_run(job: Job) -> None:
+        _materialize_completed_job(job, candidate.execution_hash)
+
+    monkeypatch.setattr(Job, "run", first_run)
+    asyncio.run(evaluator.evaluate(candidate))
+
+    monkeypatch.setattr(mod, "WMH_PI_AGENT_VERSION", "next-runtime-version")
+    with pytest.raises(mod.StaleHarborJobError, match="manifest"):
+        asyncio.run(evaluator.evaluate(candidate))
 
 
 @pytest.mark.parametrize("tamper", ["malformed", "mismatched"])
@@ -1122,6 +1171,7 @@ def test_existing_trial_evidence_must_be_regular_files(
         task_identity="task",
         task_checksum="sha256:" + "a" * 64,
         task_source="dataset",
+        task_instruction="Instruction for task.",
         trial_lock_digest=trial_config_digest,
     )
     manifest = HarborTrialManifest(
@@ -1220,6 +1270,80 @@ def test_multi_step_task_is_rejected_before_manifest_or_run(
         asyncio.run(evaluator.evaluate(pi_node_baseline("candidate")))
 
     assert not (tmp_path / "jobs" / "evaluation" / mod._MANIFEST_FILENAME).exists()
+
+
+@pytest.mark.parametrize("linked_name", ["instruction.md", "task.toml"])
+def test_local_task_host_read_symlink_is_rejected_before_harbor_job_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    linked_name: str,
+) -> None:
+    dataset = tmp_path / "dataset"
+    task_dir = _write_task(dataset)
+    sentinel = "host-secret-sentinel-must-not-surface"
+    outside = tmp_path / f"outside-{linked_name}"
+    outside.write_text(
+        f"# {sentinel}\n" if linked_name == "task.toml" else sentinel,
+        encoding="utf-8",
+    )
+    linked = task_dir / linked_name
+    linked.unlink()
+    linked.symlink_to(outside)
+
+    async def unexpected_create(_cls: type[Job], _config: JobConfig) -> Job:
+        raise AssertionError("unsafe task tree must fail before Harbor inspects it")
+
+    monkeypatch.setattr(Job, "create", classmethod(unexpected_create))
+    evaluator = mod.HarborEvaluator(_spec(tmp_path, dataset), _provider())
+
+    with pytest.raises(mod.UnsupportedHarborTaskError, match="symbolic link") as caught:
+        asyncio.run(evaluator.evaluate(pi_node_baseline("candidate")))
+
+    assert sentinel not in str(caught.value)
+    assert not (tmp_path / "jobs" / "evaluation" / mod._MANIFEST_FILENAME).exists()
+
+
+@pytest.mark.parametrize("unsafe_entry", ["task-root", "instruction.md", "task.toml"])
+def test_unselected_local_sibling_is_preflighted_before_harbor_scans_dataset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_entry: str,
+) -> None:
+    dataset = tmp_path / "dataset"
+    _write_task(dataset, "selected")
+    sibling = _write_task(dataset, "unselected")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "task.toml").write_text("", encoding="utf-8")
+    (outside / "instruction.md").write_text("host-secret-sentinel", encoding="utf-8")
+    if unsafe_entry == "task-root":
+        for path in sorted(sibling.rglob("*"), reverse=True):
+            if path.is_dir():
+                path.rmdir()
+            else:
+                path.unlink()
+        sibling.rmdir()
+        sibling.symlink_to(outside, target_is_directory=True)
+    else:
+        linked = sibling / unsafe_entry
+        linked.unlink()
+        linked.symlink_to(outside / unsafe_entry)
+
+    async def unexpected_create(_cls: type[Job], _config: JobConfig) -> Job:
+        raise AssertionError("unsafe sibling must fail before Harbor scans local tasks")
+
+    monkeypatch.setattr(Job, "create", classmethod(unexpected_create))
+    spec = _spec(tmp_path, dataset).model_copy(
+        update={
+            "datasets": [
+                DatasetConfig(path=dataset, task_names=["selected"]),
+            ]
+        }
+    )
+    evaluator = mod.HarborEvaluator(spec, _provider())
+
+    with pytest.raises(mod.UnsupportedHarborTaskError, match="symbolic link"):
+        asyncio.run(evaluator.evaluate(pi_node_baseline("candidate")))
 
 
 @pytest.mark.parametrize("keep_dockerfile", [False, True])

--- a/wmh/evals/harbor/results.py
+++ b/wmh/evals/harbor/results.py
@@ -33,6 +33,7 @@ from wmh.evals.benchmark import (
     BenchmarkUsage,
     BenchmarkUsageStatus,
     aggregate_benchmark_usage,
+    is_sha256_digest,
 )
 from wmh.evals.harbor.config import _require_supported_harbor_version
 from wmh.harness.doc import HarnessDoc
@@ -519,7 +520,7 @@ def _parse_task_environment_attestation(
 ) -> str:
     digest = metadata.get(_TASK_ENVIRONMENT_DIGEST_KEY)
     attestation = metadata.get(_TASK_ENVIRONMENT_ATTESTATION_KEY)
-    if not isinstance(digest, str) or not _is_sha256_digest(digest):
+    if not is_sha256_digest(digest):
         raise ValueError("Harbor agent metadata omits a valid task environment digest")
     if not isinstance(attestation, dict):
         raise ValueError("Harbor agent metadata omits task environment attestation evidence")
@@ -541,15 +542,6 @@ def _parse_task_environment_attestation(
     if actual != digest:
         raise ValueError("Harbor task environment attestation does not match its digest")
     return digest
-
-
-def _is_sha256_digest(value: str) -> bool:
-    encoded = value.removeprefix("sha256:")
-    return (
-        value.startswith("sha256:")
-        and len(encoded) == 64
-        and all(character in "0123456789abcdef" for character in encoded)
-    )
 
 
 def _parse_candidate_outcome(metadata: dict[str, object]) -> BenchmarkCandidateOutcome:

--- a/wmh/evals/harbor/results.py
+++ b/wmh/evals/harbor/results.py
@@ -17,6 +17,7 @@ from harbor.models.trial.result import ExceptionInfo, TrialResult
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from wmh.evals.benchmark import (
+    MAX_BENCHMARK_TASK_INSTRUCTION_CHARS,
     BenchmarkCandidateFailureReason,
     BenchmarkCandidateOutcome,
     BenchmarkCandidateStage,
@@ -115,6 +116,15 @@ _CANDIDATE_OUTCOME_METADATA_KEYS = frozenset(
         "terminal_reason",
     }
 )
+_TASK_ENVIRONMENT_DIGEST_KEY = "task_environment_digest"
+_TASK_ENVIRONMENT_ATTESTATION_KEY = "task_environment_attestation"
+_MAX_TASK_ENVIRONMENT_ATTESTATION_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True)
+class _TrustedRunEvidence:
+    candidate_outcome: BenchmarkCandidateOutcome
+    task_environment_digest: str | None
 
 
 class HarborTrialManifestEntry(BaseModel):
@@ -125,6 +135,7 @@ class HarborTrialManifestEntry(BaseModel):
     task_identity: str = Field(min_length=1)
     task_checksum: str = Field(min_length=1)
     task_source: str | None
+    task_instruction: str = Field(max_length=MAX_BENCHMARK_TASK_INSTRUCTION_CHARS)
     trial_lock_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
 
     @field_validator("trial_name")
@@ -282,6 +293,7 @@ def _load_manifest_entry(
                 task_identity=entry.task_identity,
                 task_checksum=entry.task_checksum,
                 source=entry.task_source,
+                task_instruction=entry.task_instruction,
                 status=BenchmarkTrialStatus.INCOMPLETE,
             ),
             HarborTrialLocator(
@@ -316,12 +328,12 @@ def _load_manifest_entry(
     _validate_locked_config(result.config, trial_lock)
     _validate_trial_job_provenance(result.config, root=root, job_id=job_id)
     _validate_trial_identity(result, entry)
-    candidate_outcome = _validate_run_identity(
+    run_evidence = _validate_run_identity(
         result,
         manifest.identity,
         manifest.agent_config_digest,
     )
-    return _convert_trial(result, entry, candidate_outcome), locator
+    return _convert_trial(result, entry, run_evidence), locator
 
 
 def _load_incomplete_trial(
@@ -338,6 +350,7 @@ def _load_incomplete_trial(
             task_identity=entry.task_identity,
             task_checksum=entry.task_checksum,
             source=entry.task_source,
+            task_instruction=entry.task_instruction,
             status=BenchmarkTrialStatus.INCOMPLETE,
         )
     if not config_path.is_file():
@@ -363,6 +376,7 @@ def _load_incomplete_trial(
         task_identity=entry.task_identity,
         task_checksum=entry.task_checksum,
         source=entry.task_source,
+        task_instruction=entry.task_instruction,
         status=BenchmarkTrialStatus.INCOMPLETE,
     )
 
@@ -427,7 +441,7 @@ def _validate_run_identity(
     result: TrialResult,
     expected: BenchmarkRunIdentity,
     expected_agent_config_digest: str,
-) -> BenchmarkCandidateOutcome:
+) -> _TrustedRunEvidence:
     actual_agent = result.agent_info
     if actual_agent.name != expected.agent_name or actual_agent.version != expected.agent_version:
         raise ValueError(
@@ -460,6 +474,7 @@ def _validate_run_identity(
         step.agent_result for step in result.step_results or [] if step.agent_result is not None
     )
     outcomes: list[BenchmarkCandidateOutcome] = []
+    environment_digests: list[str] = []
     for context in contexts:
         metadata = context.metadata or {}
         candidate_hash = metadata.get("harness_hash")
@@ -473,13 +488,68 @@ def _validate_run_identity(
             raise ValueError(
                 f"manifest expected runner image {expected.runner_image!r}, found {runner_image!r}"
             )
+        environment_digests.append(
+            _parse_task_environment_attestation(
+                metadata,
+                expected_backend=expected.task_environment.value,
+            )
+        )
         outcomes.append(_parse_candidate_outcome(metadata))
     if not outcomes:
-        return BenchmarkCandidateOutcome()
+        return _TrustedRunEvidence(
+            candidate_outcome=BenchmarkCandidateOutcome(),
+            task_environment_digest=None,
+        )
     first = outcomes[0]
     if any(outcome != first for outcome in outcomes[1:]):
         raise ValueError("Harbor step contexts contain inconsistent candidate outcome metadata")
-    return first
+    first_environment_digest = environment_digests[0]
+    if any(digest != first_environment_digest for digest in environment_digests[1:]):
+        raise ValueError("Harbor step contexts contain inconsistent task environment metadata")
+    return _TrustedRunEvidence(
+        candidate_outcome=first,
+        task_environment_digest=first_environment_digest,
+    )
+
+
+def _parse_task_environment_attestation(
+    metadata: dict[str, object],
+    *,
+    expected_backend: str,
+) -> str:
+    digest = metadata.get(_TASK_ENVIRONMENT_DIGEST_KEY)
+    attestation = metadata.get(_TASK_ENVIRONMENT_ATTESTATION_KEY)
+    if not isinstance(digest, str) or not _is_sha256_digest(digest):
+        raise ValueError("Harbor agent metadata omits a valid task environment digest")
+    if not isinstance(attestation, dict):
+        raise ValueError("Harbor agent metadata omits task environment attestation evidence")
+    if attestation.get("schema_version") != 1 or attestation.get("backend") != expected_backend:
+        raise ValueError("Harbor task environment attestation names the wrong backend or schema")
+    try:
+        canonical = json.dumps(
+            attestation,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError):
+        raise ValueError("Harbor task environment attestation is not canonical JSON") from None
+    if len(canonical) > _MAX_TASK_ENVIRONMENT_ATTESTATION_BYTES:
+        raise ValueError("Harbor task environment attestation exceeds its evidence limit")
+    actual = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    if actual != digest:
+        raise ValueError("Harbor task environment attestation does not match its digest")
+    return digest
+
+
+def _is_sha256_digest(value: str) -> bool:
+    encoded = value.removeprefix("sha256:")
+    return (
+        value.startswith("sha256:")
+        and len(encoded) == 64
+        and all(character in "0123456789abcdef" for character in encoded)
+    )
 
 
 def _parse_candidate_outcome(metadata: dict[str, object]) -> BenchmarkCandidateOutcome:
@@ -571,7 +641,7 @@ def _validate_agent_config_identity(
 def _convert_trial(
     result: TrialResult,
     entry: HarborTrialManifestEntry,
-    candidate_outcome: BenchmarkCandidateOutcome,
+    run_evidence: _TrustedRunEvidence,
 ) -> BenchmarkTrialResult:
     error = _convert_exception(result.exception_info)
     has_rewards = result.verifier_result is not None and result.verifier_result.rewards is not None
@@ -598,10 +668,12 @@ def _convert_trial(
         task_identity=entry.task_identity,
         task_checksum=entry.task_checksum,
         source=entry.task_source,
+        task_instruction=entry.task_instruction,
+        task_environment_digest=run_evidence.task_environment_digest,
         status=status,
         rewards=rewards,
         error=error,
-        candidate_outcome=candidate_outcome,
+        candidate_outcome=run_evidence.candidate_outcome,
         usage=BenchmarkUsage(
             input_tokens=n_input,
             input_tokens_status=_usage_status(
@@ -683,6 +755,7 @@ def _malformed_trial(
         task_identity=entry.task_identity,
         task_checksum=entry.task_checksum,
         source=entry.task_source,
+        task_instruction=entry.task_instruction,
         status=BenchmarkTrialStatus.INFRASTRUCTURE_ERROR,
         error=BenchmarkError(
             kind=BenchmarkFailureKind.MALFORMED_RESULT,

--- a/wmh/evals/harbor/results_test.py
+++ b/wmh/evals/harbor/results_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -41,6 +43,29 @@ _NOW = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
 _TASK_CHECKSUM = "sha256:" + "b" * 64
 _TASK_SOURCE = "example-benchmark"
 _HARNESS = pi_node_baseline("candidate")
+_TASK_ENVIRONMENT_ATTESTATION = {
+    "schema_version": 1,
+    "backend": "docker",
+    "daemon_platform": "linux/amd64",
+    "services": [
+        {
+            "service": "main",
+            "replica": 1,
+            "image_id": "sha256:" + "c" * 64,
+            "image_platform": "linux/amd64",
+        }
+    ],
+}
+_TASK_ENVIRONMENT_DIGEST = (
+    "sha256:"
+    + hashlib.sha256(
+        json.dumps(
+            _TASK_ENVIRONMENT_ATTESTATION,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+)
 
 
 def _agent_config() -> AgentConfig:
@@ -138,6 +163,8 @@ def _trial(
             metadata={
                 "harness_hash": _HARNESS.execution_hash,
                 "runner_image": "runner-image",
+                "task_environment_digest": _TASK_ENVIRONMENT_DIGEST,
+                "task_environment_attestation": _TASK_ENVIRONMENT_ATTESTATION,
                 **(candidate_metadata or {}),
             },
         ),
@@ -225,6 +252,7 @@ def _manifest_entry(
         task_identity=task_name,
         task_checksum=_TASK_CHECKSUM,
         task_source=_TASK_SOURCE,
+        task_instruction=f"Instruction for {task_name}.",
         trial_lock_digest=resolved_trial_lock_digest,
     )
 
@@ -246,6 +274,9 @@ def test_load_uses_exact_manifest_and_preserves_rewards_usage_and_missing_cells(
         ("failed", 1, failed.trial_name),
         ("missing", 1, "missing__harbor"),
     )
+    for entry in manifest.entries:
+        if entry.cell.task_name == "scored":
+            entry.task_instruction = "Score this task."
 
     loaded = load_harbor_job_result(job_dir, manifest)
     result = loaded.result
@@ -256,6 +287,10 @@ def test_load_uses_exact_manifest_and_preserves_rewards_usage_and_missing_cells(
     assert result.n_infrastructure_errors == 1
     assert result.n_incomplete == 1
     trials = {trial.cell.task_name: trial for trial in result.trials}
+    assert trials["scored"].task_instruction == "Score this task."
+    assert trials["scored"].task_environment_digest == _TASK_ENVIRONMENT_DIGEST
+    assert trials["failed"].task_environment_digest == _TASK_ENVIRONMENT_DIGEST
+    assert trials["missing"].task_environment_digest is None
     manifest_config_digests = {
         entry.cell.task_name: entry.trial_lock_digest for entry in manifest.entries
     }
@@ -631,11 +666,50 @@ def test_malformed_candidate_outcome_metadata_is_rejected(
         load_harbor_job_result(job_dir, _manifest("job", ("task", 1, trial.trial_name)))
 
 
+@pytest.mark.parametrize(
+    ("candidate_metadata", "message"),
+    [
+        ({"task_environment_digest": None}, "valid task environment digest"),
+        (
+            {"task_environment_digest": "sha256:" + "f" * 64},
+            "does not match its digest",
+        ),
+        (
+            {
+                "task_environment_attestation": {
+                    **_TASK_ENVIRONMENT_ATTESTATION,
+                    "backend": "e2b",
+                }
+            },
+            "wrong backend or schema",
+        ),
+    ],
+)
+def test_task_environment_attestation_must_be_complete_bound_and_backend_correct(
+    tmp_path: Path,
+    candidate_metadata: dict[str, object],
+    message: str,
+) -> None:
+    trial = _trial(
+        tmp_path,
+        "task",
+        rewards={"reward": 1},
+        candidate_metadata=candidate_metadata,
+    )
+    job_dir = tmp_path / "job"
+    _write_job(job_dir, [trial], expected=1)
+
+    with pytest.raises(ValueError, match=message):
+        load_harbor_job_result(job_dir, _manifest("job", ("task", 1, trial.trial_name)))
+
+
 def test_inconsistent_step_candidate_outcomes_are_rejected(tmp_path: Path) -> None:
     trial = _trial(tmp_path, "task", rewards={"reward": 1})
     identity = {
         "harness_hash": _HARNESS.execution_hash,
         "runner_image": "runner-image",
+        "task_environment_digest": _TASK_ENVIRONMENT_DIGEST,
+        "task_environment_attestation": _TASK_ENVIRONMENT_ATTESTATION,
     }
     trial.agent_result = None
     trial.step_results = [
@@ -950,6 +1024,7 @@ def test_manifest_rejects_duplicate_and_traversing_cells() -> None:
         task_identity="task",
         task_checksum=_TASK_CHECKSUM,
         task_source=_TASK_SOURCE,
+        task_instruction="Instruction for task.",
         trial_lock_digest=trial_config_digest,
     )
     with pytest.raises(ValidationError, match="duplicate manifest benchmark cell"):
@@ -972,6 +1047,7 @@ def test_manifest_rejects_duplicate_and_traversing_cells() -> None:
             task_identity="task",
             task_checksum=_TASK_CHECKSUM,
             task_source=_TASK_SOURCE,
+            task_instruction="Instruction for task.",
             trial_lock_digest=trial_config_digest,
         )
 

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -28,6 +28,7 @@ from wmh.evals.benchmark import (
     BenchmarkTrialResult,
     BenchmarkTrialStatus,
     Rewards,
+    is_sha256_digest,
 )
 from wmh.evals.harbor.agent import WMH_PI_AGENT_VERSION
 from wmh.evals.harbor.config import HarborEnvironmentBackend, HarborJobSpec
@@ -152,7 +153,7 @@ class HarborHarnessScorer:
         if len(set(frozen_task_keys)) != len(frozen_task_keys):
             raise ValueError("task_keys must be unique")
         for task_key in frozen_task_keys:
-            if not _is_sha256_digest(task_key):
+            if not is_sha256_digest(task_key):
                 raise ValueError(
                     "each task_key must be a sha256 digest from a Harbor qualification manifest"
                 )
@@ -160,7 +161,7 @@ class HarborHarnessScorer:
         if len(frozen_environment_digests) != len(frozen_task_ids):
             raise ValueError("task_environment_digests must contain exactly one digest per task_id")
         for environment_digest in frozen_environment_digests:
-            if not _is_sha256_digest(environment_digest):
+            if not is_sha256_digest(environment_digest):
                 raise ValueError(
                     "each task_environment_digest must be a sha256 digest from a Harbor "
                     "qualification run"
@@ -735,6 +736,7 @@ def _read_trace(
                 sort_keys=True,
                 separators=(",", ":"),
                 ensure_ascii=False,
+                allow_nan=False,
             )
         )
     canonical = "\n".join(canonical_lines)
@@ -896,13 +898,3 @@ def _rewards_digest(rewards: Rewards | None) -> str:
         allow_nan=False,
     )
     return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
-
-
-def _is_sha256_digest(value: str) -> bool:
-    prefix = "sha256:"
-    digest = value.removeprefix(prefix)
-    return (
-        value.startswith(prefix)
-        and len(digest) == 64
-        and all(character in "0123456789abcdef" for character in digest)
-    )

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -1,0 +1,908 @@
+"""Project strict Harbor task matrices into benchmark-neutral harness scores."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ValidationError as PydanticValidationError
+
+from wmh.core.text import normalize_durable_text, validate_durable_text
+from wmh.core.types import JsonObject
+from wmh.evals.benchmark import (
+    BenchmarkCandidateFailureReason,
+    BenchmarkCandidateOutcome,
+    BenchmarkCandidateStatus,
+    BenchmarkCell,
+    BenchmarkFailureKind,
+    BenchmarkRunResult,
+    BenchmarkTaskEnvironment,
+    BenchmarkTrialResult,
+    BenchmarkTrialStatus,
+    Rewards,
+)
+from wmh.evals.harbor.agent import WMH_PI_AGENT_VERSION
+from wmh.evals.harbor.config import HarborEnvironmentBackend, HarborJobSpec
+from wmh.evals.harbor.evaluator import HarborEvaluator
+from wmh.evals.harbor.results import HarborTrialLocator, LoadedHarborJobResult
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import EventKind
+from wmh.harness.pi_local import PI_CONTAINER_IMAGE, validate_pi_container_image
+from wmh.harness.scoring import (
+    MAX_TASK_EVIDENCE_CHARS,
+    HarnessScoreReport,
+    ScoreCapabilities,
+    ScoreRequest,
+    TaskScore,
+)
+from wmh.harness.tools import READ_SKILL
+from wmh.providers.base import ProviderConfig
+
+MAX_HARBOR_TASK_EVIDENCE_CHARS = MAX_TASK_EVIDENCE_CHARS
+_MAX_TRACE_FILE_BYTES = 16 * 1024 * 1024
+_TRACE_FILENAME = "wmh-events.jsonl"
+_AsyncRunner = asyncio.Runner
+
+
+class HarborAgentComputeEnvelope(BaseModel):
+    """Candidate-controlled compute settings held fixed across every scored harness."""
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    runtime_kind: str
+    max_turns: int = Field(ge=1)
+    max_output_tokens: int = Field(ge=1)
+    temperature: float = Field(ge=0.0, le=2.0)
+    effective_tools: tuple[str, ...]
+    turn_timeout_s: float = Field(gt=0.0)
+
+
+class _TraceRecord(BaseModel):
+    """One trusted WMH agent trace event, with no backend-defined extra fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: EventKind
+    payload: JsonObject
+
+
+class _EvaluationCellIdentity(BaseModel):
+    """Canonical score evidence that one evaluation ID commits to."""
+
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
+
+    cell: BenchmarkCell
+    task_identity: str
+    task_checksum: str
+    source: str | None
+    task_instruction_digest: str
+    task_environment_digest: str
+    status: BenchmarkTrialStatus
+    rewards_digest: str
+    verifier_reward: float = Field(ge=0.0, le=1.0)
+    score: float = Field(ge=0.0, le=1.0)
+    candidate_outcome: BenchmarkCandidateOutcome
+    error_kind: BenchmarkFailureKind | None
+    trace_digest: str
+
+
+@dataclass(frozen=True)
+class _TraceEvidence:
+    text: str
+    digest: str
+
+
+@dataclass(frozen=True)
+class _ScoredTrial:
+    trial: BenchmarkTrialResult
+    verifier_reward: float
+    score: float
+    trace: _TraceEvidence
+
+
+class HarborHarnessScorer:
+    """Score harnesses through one frozen, exact Harbor task matrix.
+
+    The scorer deliberately advertises no subset or attempt override support. Search callers must
+    disable screening and confirmation requests, so every candidate runs the same task cells.
+    """
+
+    capabilities = ScoreCapabilities(task_subsets=False, attempt_overrides=False)
+
+    def __init__(
+        self,
+        *,
+        job_spec: HarborJobSpec,
+        provider_config: ProviderConfig,
+        reference_harness: HarnessDoc,
+        task_ids: tuple[str, ...],
+        task_keys: tuple[str, ...],
+        task_environment_digests: tuple[str, ...],
+        reward_key: str,
+        runner_image: str = PI_CONTAINER_IMAGE,
+        turn_timeout_s: float = 300.0,
+    ) -> None:
+        """Freeze task selection, provider route, backend, image, and agent compute."""
+        validate_pi_container_image(runner_image)
+        if not math.isfinite(turn_timeout_s) or turn_timeout_s <= 0:
+            raise ValueError("turn_timeout_s must be finite and positive")
+        if not reward_key.strip():
+            raise ValueError("reward_key must be non-empty")
+        validate_durable_text(reward_key, field="Harbor reward key")
+        frozen_task_ids = tuple(task_ids)
+        if not frozen_task_ids:
+            raise ValueError("task_ids must be non-empty")
+        if len(set(frozen_task_ids)) != len(frozen_task_ids):
+            raise ValueError("task_ids must be unique")
+        for task_id in frozen_task_ids:
+            if not task_id or len(task_id) > 512:
+                raise ValueError("each task_id must contain between 1 and 512 characters")
+            validate_durable_text(task_id, field="Harbor task id")
+        frozen_task_keys = tuple(task_keys)
+        if len(frozen_task_keys) != len(frozen_task_ids):
+            raise ValueError("task_keys must contain exactly one key per task_id")
+        if len(set(frozen_task_keys)) != len(frozen_task_keys):
+            raise ValueError("task_keys must be unique")
+        for task_key in frozen_task_keys:
+            if not _is_sha256_digest(task_key):
+                raise ValueError(
+                    "each task_key must be a sha256 digest from a Harbor qualification manifest"
+                )
+        frozen_environment_digests = tuple(task_environment_digests)
+        if len(frozen_environment_digests) != len(frozen_task_ids):
+            raise ValueError("task_environment_digests must contain exactly one digest per task_id")
+        for environment_digest in frozen_environment_digests:
+            if not _is_sha256_digest(environment_digest):
+                raise ValueError(
+                    "each task_environment_digest must be a sha256 digest from a Harbor "
+                    "qualification run"
+                )
+
+        spec = HarborJobSpec.model_validate(job_spec.model_dump())
+        spec = spec.model_copy(
+            update={"jobs_dir": spec.jobs_dir.expanduser().resolve()},
+            deep=True,
+        )
+        _validate_job_prefix(spec.job_name)
+        _validate_exact_dataset_selection(spec, frozen_task_ids)
+        if spec.environment_backend is HarborEnvironmentBackend.E2B:
+            raise ValueError(
+                "HarborHarnessScorer cannot validate E2B runs until Harbor exposes the immutable "
+                "build ID used to create each sandbox; use local Docker for scored search"
+            )
+        provider = ProviderConfig.model_validate(provider_config.model_dump())
+        envelope = _compute_envelope(reference_harness, turn_timeout_s=turn_timeout_s)
+        if envelope.runtime_kind != "pi-node":
+            raise ValueError(
+                "HarborHarnessScorer requires a pi-node reference harness, got "
+                f"{envelope.runtime_kind!r}"
+            )
+
+        self._job_spec = spec
+        self._provider_config = provider
+        self._task_ids = frozen_task_ids
+        self._task_keys = frozen_task_keys
+        self._task_environment_digests = frozen_environment_digests
+        self._reward_key = reward_key
+        self._runner_image = runner_image
+        self._compute_envelope = envelope
+        self._runner: asyncio.Runner | None = None
+        self._closed = False
+
+    @property
+    def task_ids(self) -> tuple[str, ...]:
+        """Return the exact ordered task identities frozen by this scorer."""
+        return self._task_ids
+
+    @property
+    def default_attempts(self) -> int:
+        """Return the immutable number of attempts in every scored task cell."""
+        return self._job_spec.n_attempts
+
+    @property
+    def compute_envelope(self) -> HarborAgentComputeEnvelope:
+        """Return the immutable candidate-controlled compute envelope."""
+        return self._compute_envelope
+
+    @property
+    def task_keys(self) -> tuple[str, ...]:
+        """Return the dataset-qualified content identities paired with ``task_ids``."""
+        return self._task_keys
+
+    @property
+    def task_environment_digests(self) -> tuple[str, ...]:
+        """Return the executed task-environment identities frozen by qualification."""
+        return self._task_environment_digests
+
+    @property
+    def environment_backend(self) -> HarborEnvironmentBackend:
+        """Return the frozen Harbor task-environment backend."""
+        return self._job_spec.environment_backend
+
+    def validate_candidate(self, candidate: HarnessDoc) -> str | None:
+        """Reject candidates that change the frozen runtime or agent compute envelope."""
+        try:
+            actual = _compute_envelope(
+                candidate,
+                turn_timeout_s=self._compute_envelope.turn_timeout_s,
+            )
+        except (TypeError, ValueError) as exc:
+            return f"candidate compute envelope is invalid: {exc}"
+        if actual != self._compute_envelope:
+            return (
+                "candidate changes the frozen Harbor agent compute envelope; only harness "
+                "source may vary between candidates"
+            )
+        return None
+
+    def before_proposal_batch(self) -> None:
+        """Release the idle event loop before a potentially long proposal call."""
+        self._require_open()
+        self._release_runner()
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScoreReport:
+        """Evaluate one candidate and fail closed on any non-scoreable Harbor cell."""
+        self._require_open()
+        if request.task_ids is not None:
+            raise ValueError("HarborHarnessScorer does not support task subset requests")
+        if request.attempts is not None:
+            raise ValueError("HarborHarnessScorer does not support attempt override requests")
+        rejection = self.validate_candidate(candidate)
+        if rejection is not None:
+            raise ValueError(rejection)
+
+        job_name = self._job_name(candidate)
+        spec = self._job_spec.model_copy(update={"job_name": job_name}, deep=True)
+        evaluator = HarborEvaluator(
+            spec,
+            self._provider_config.model_copy(deep=True),
+            runner_image=self._runner_image,
+            turn_timeout_s=self._compute_envelope.turn_timeout_s,
+        )
+        try:
+            loaded = self._run_evaluation(evaluator, candidate)
+            return self._project(candidate, spec, loaded, request=request)
+        except BaseException:
+            self._release_runner()
+            raise
+
+    def close(self) -> None:
+        """Close the owned event loop; repeated calls are safe."""
+        if self._closed:
+            return
+        self._closed = True
+        self._release_runner()
+
+    def __enter__(self) -> Self:
+        self._require_open()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def _run_evaluation(
+        self,
+        evaluator: HarborEvaluator,
+        candidate: HarnessDoc,
+    ) -> LoadedHarborJobResult:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "HarborHarnessScorer.score cannot run inside a running event loop; "
+                "call the synchronous search API from a worker thread"
+            )
+        if self._runner is None:
+            self._runner = _AsyncRunner()
+        try:
+            return self._runner.run(evaluator.evaluate(candidate))
+        except BaseException:
+            self._release_runner()
+            raise
+
+    def _project(
+        self,
+        candidate: HarnessDoc,
+        spec: HarborJobSpec,
+        loaded: LoadedHarborJobResult,
+        *,
+        request: ScoreRequest,
+    ) -> HarnessScoreReport:
+        result = loaded.result
+        _validate_run_identity(
+            result,
+            candidate=candidate,
+            spec=spec,
+            provider_config=self._provider_config,
+            runner_image=self._runner_image,
+        )
+        ordered = _validate_and_order_matrix(
+            loaded,
+            task_ids=self._task_ids,
+            task_keys=self._task_keys,
+            task_environment_digests=self._task_environment_digests,
+            attempts=self.default_attempts,
+            reward_key=self._reward_key,
+        )
+        per_task: dict[str, TaskScore] = {}
+        identity_cells: list[_EvaluationCellIdentity] = []
+        for task_id in self._task_ids:
+            trials = ordered[task_id]
+            scores = [item.score for item in trials]
+            task_score = fmean(scores)
+            description = trials[0].trial.task_instruction
+            mechanisms = _failure_mechanisms(trials)
+            evidence = _render_task_evidence(trials)
+            per_task[task_id] = TaskScore(
+                task_id=task_id,
+                score=task_score,
+                secondary_score=task_score,
+                passed=all(score == 1.0 for score in scores),
+                description=description,
+                mechanisms=mechanisms,
+                evidence=evidence,
+            )
+            for item in trials:
+                trial = item.trial
+                identity_cells.append(
+                    _EvaluationCellIdentity(
+                        cell=trial.cell,
+                        task_identity=trial.task_identity,
+                        task_checksum=trial.task_checksum,
+                        source=trial.source,
+                        task_instruction_digest=_sha256_text(trial.task_instruction),
+                        task_environment_digest=_required_task_environment_digest(trial),
+                        status=trial.status,
+                        rewards_digest=_rewards_digest(trial.rewards),
+                        verifier_reward=item.verifier_reward,
+                        score=item.score,
+                        candidate_outcome=trial.candidate_outcome,
+                        error_kind=trial.error.kind if trial.error is not None else None,
+                        trace_digest=item.trace.digest,
+                    )
+                )
+
+        aggregate = fmean(task.score for task in per_task.values())
+        evaluation_id = _evaluation_id(
+            result=result,
+            request=request,
+            reward_key=self._reward_key,
+            task_ids=self._task_ids,
+            task_keys=self._task_keys,
+            task_environment_digests=self._task_environment_digests,
+            attempts=self.default_attempts,
+            compute_envelope=self._compute_envelope,
+            cells=identity_cells,
+        )
+        return HarnessScoreReport(
+            evaluation_id=evaluation_id,
+            label=result.job_name,
+            score=aggregate,
+            secondary_score=aggregate,
+            attempts=self.default_attempts,
+            per_task=per_task,
+        )
+
+    def _release_runner(self) -> None:
+        runner = self._runner
+        self._runner = None
+        if runner is not None:
+            runner.close()
+
+    def _job_name(self, candidate: HarnessDoc) -> str:
+        payload = {
+            "schema_version": 1,
+            "job_spec": {
+                **self._job_spec.model_dump(
+                    mode="json",
+                    exclude={"jobs_dir", "datasets"},
+                ),
+                "datasets": [
+                    {"task_names": list(dataset.task_names or [])}
+                    for dataset in self._job_spec.datasets
+                ],
+            },
+            "provider_config": self._provider_config.model_dump(mode="json"),
+            "candidate": candidate.model_dump(mode="json"),
+            "task_ids": list(self._task_ids),
+            "task_keys": list(self._task_keys),
+            "task_environment_digests": list(self._task_environment_digests),
+            "reward_key": self._reward_key,
+            "runner_image": self._runner_image,
+            "compute_envelope": self._compute_envelope.model_dump(mode="json"),
+            "agent_version": WMH_PI_AGENT_VERSION,
+        }
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        return "wmh-score-" + hashlib.sha256(canonical.encode()).hexdigest()
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("HarborHarnessScorer is closed")
+
+
+def _compute_envelope(
+    harness: HarnessDoc,
+    *,
+    turn_timeout_s: float,
+) -> HarborAgentComputeEnvelope:
+    tools = harness.tools()
+    if harness.skills() and READ_SKILL.name not in tools:
+        tools.append(READ_SKILL.name)
+    return HarborAgentComputeEnvelope(
+        runtime_kind=harness.runtime_kind(),
+        max_turns=harness.max_turns(),
+        max_output_tokens=harness.max_output_tokens(),
+        temperature=harness.temperature(),
+        effective_tools=tuple(tools),
+        turn_timeout_s=turn_timeout_s,
+    )
+
+
+def _validate_job_prefix(job_name: str) -> None:
+    if (
+        job_name in {".", ".."}
+        or "\0" in job_name
+        or Path(job_name).is_absolute()
+        or "/" in job_name
+        or "\\" in job_name
+    ):
+        raise ValueError("Harbor scorer job_name must be a single safe path component")
+    if len(job_name.encode()) > 200:
+        raise ValueError("Harbor scorer job_name must be at most 200 UTF-8 bytes")
+
+
+def _validate_exact_dataset_selection(spec: HarborJobSpec, task_ids: tuple[str, ...]) -> None:
+    selected: list[str] = []
+    for dataset in spec.datasets:
+        if not dataset.is_local():
+            raise ValueError(
+                "HarborHarnessScorer requires preflightable local dataset paths; remote, "
+                "registry, and package acquisition are not safe scoring inputs"
+            )
+        if dataset.task_names is None:
+            raise ValueError("HarborHarnessScorer requires explicit task_names on every dataset")
+        if dataset.exclude_task_names is not None or dataset.n_tasks is not None:
+            raise ValueError(
+                "HarborHarnessScorer forbids exclude_task_names and n_tasks; use one exact "
+                "task_names list"
+            )
+        for task_name in dataset.task_names:
+            if any(marker in task_name for marker in ("*", "?", "[", "]")):
+                raise ValueError("HarborHarnessScorer task_names cannot contain glob patterns")
+            selected.append(task_name)
+    if tuple(selected) != task_ids:
+        raise ValueError("Harbor dataset task_names must exactly match task_ids in order")
+
+
+def _validate_run_identity(
+    result: BenchmarkRunResult,
+    *,
+    candidate: HarnessDoc,
+    spec: HarborJobSpec,
+    provider_config: ProviderConfig,
+    runner_image: str,
+) -> None:
+    if result.job_name != spec.job_name:
+        raise ValueError(
+            f"Harbor result job name {result.job_name!r} does not match {spec.job_name!r}"
+        )
+    expected_environment = (
+        BenchmarkTaskEnvironment.E2B
+        if spec.environment_backend is HarborEnvironmentBackend.E2B
+        else BenchmarkTaskEnvironment.DOCKER
+    )
+    identity = result.identity
+    mismatches: list[str] = []
+    if identity.candidate_hash != candidate.execution_hash:
+        mismatches.append("candidate hash")
+    if identity.agent_name != "wmh-pi" or identity.agent_version != WMH_PI_AGENT_VERSION:
+        mismatches.append("agent")
+    if (
+        identity.provider != provider_config.kind.value
+        or identity.model_name != provider_config.model
+    ):
+        mismatches.append("provider route")
+    if identity.task_environment is not expected_environment:
+        mismatches.append("task backend")
+    if identity.runner_image != runner_image:
+        mismatches.append("runner image")
+    if mismatches:
+        raise ValueError(f"Harbor result identity mismatches frozen scorer: {sorted(mismatches)}")
+
+
+def _validate_and_order_matrix(
+    loaded: LoadedHarborJobResult,
+    *,
+    task_ids: tuple[str, ...],
+    task_keys: tuple[str, ...],
+    task_environment_digests: tuple[str, ...],
+    attempts: int,
+    reward_key: str,
+) -> dict[str, list[_ScoredTrial]]:
+    result = loaded.result
+    expected_keys = [(cell.task_key, cell.attempt) for cell in result.expected_cells]
+    observed_keys = [(trial.cell.task_key, trial.cell.attempt) for trial in result.trials]
+    duplicate_expected = sorted(key for key, count in Counter(expected_keys).items() if count > 1)
+    if duplicate_expected:
+        raise ValueError(f"duplicate expected Harbor cell(s): {duplicate_expected}")
+    duplicate_observed = sorted(key for key, count in Counter(observed_keys).items() if count > 1)
+    if duplicate_observed:
+        raise ValueError(f"duplicate observed Harbor cell(s): {duplicate_observed}")
+    if set(expected_keys) != set(observed_keys):
+        missing = sorted(set(expected_keys) - set(observed_keys))
+        extra = sorted(set(observed_keys) - set(expected_keys))
+        raise ValueError(
+            f"Harbor result cells differ from its plan: missing={missing}, extra={extra}"
+        )
+    expected_by_key = {(cell.task_key, cell.attempt): cell for cell in result.expected_cells}
+    for trial in result.trials:
+        key = (trial.cell.task_key, trial.cell.attempt)
+        if trial.cell != expected_by_key[key]:
+            raise ValueError(f"observed Harbor cell identity differs from plan: {key}")
+
+    locator_keys = [(locator.cell.task_key, locator.cell.attempt) for locator in loaded.locators]
+    duplicate_locators = sorted(key for key, count in Counter(locator_keys).items() if count > 1)
+    if duplicate_locators:
+        raise ValueError(f"duplicate Harbor result locator(s): {duplicate_locators}")
+    if set(locator_keys) != set(observed_keys):
+        missing = sorted(set(observed_keys) - set(locator_keys))
+        extra = sorted(set(locator_keys) - set(observed_keys))
+        raise ValueError(
+            f"Harbor result locators differ from cells: missing={missing}, extra={extra}"
+        )
+    locators = {
+        (locator.cell.task_key, locator.cell.attempt): locator for locator in loaded.locators
+    }
+    for trial in result.trials:
+        key = (trial.cell.task_key, trial.cell.attempt)
+        if locators[key].cell != trial.cell:
+            raise ValueError(f"Harbor locator cell identity differs from trial: {key}")
+
+    by_task: defaultdict[str, list[BenchmarkTrialResult]] = defaultdict(list)
+    for trial in result.trials:
+        by_task[trial.task_identity].append(trial)
+    expected_identities = set(task_ids)
+    found_identities = set(by_task)
+    if found_identities != expected_identities:
+        missing = sorted(expected_identities - found_identities)
+        extra = sorted(found_identities - expected_identities)
+        raise ValueError(
+            f"Harbor task identities differ from frozen scorer: missing={missing}, extra={extra}"
+        )
+
+    ordered: dict[str, list[_ScoredTrial]] = {}
+    expected_attempts = list(range(1, attempts + 1))
+    expected_keys_by_task = dict(zip(task_ids, task_keys, strict=True))
+    expected_environment_by_task = dict(zip(task_ids, task_environment_digests, strict=True))
+    for task_id in task_ids:
+        trials = sorted(by_task[task_id], key=lambda trial: trial.cell.attempt)
+        found_attempts = [trial.cell.attempt for trial in trials]
+        if found_attempts != expected_attempts:
+            raise ValueError(
+                f"Harbor task {task_id!r} attempts differ from frozen scorer: "
+                f"expected={expected_attempts}, found={found_attempts}"
+            )
+        _validate_task_attempt_identity(
+            task_id,
+            trials,
+            expected_task_key=expected_keys_by_task[task_id],
+            expected_environment_digest=expected_environment_by_task[task_id],
+        )
+        scored: list[_ScoredTrial] = []
+        for trial in trials:
+            if trial.status is not BenchmarkTrialStatus.SCORED:
+                detail = trial.error.kind.value if trial.error is not None else trial.status.value
+                raise ValueError(
+                    f"Harbor task {task_id!r} attempt {trial.cell.attempt} is not scored: {detail}"
+                )
+            if (
+                trial.error is not None
+                and trial.error.kind is not BenchmarkFailureKind.TASK_TIMEOUT
+            ):
+                raise ValueError(
+                    f"Harbor task {task_id!r} attempt {trial.cell.attempt} carries "
+                    f"infrastructure error {trial.error.kind.value!r} despite scored status"
+                )
+            if trial.candidate_outcome.status is BenchmarkCandidateStatus.UNKNOWN and not (
+                trial.error is not None and trial.error.kind is BenchmarkFailureKind.TASK_TIMEOUT
+            ):
+                raise ValueError(
+                    f"Harbor task {task_id!r} attempt {trial.cell.attempt} lacks trusted "
+                    "candidate outcome metadata"
+                )
+            if trial.rewards is None or reward_key not in trial.rewards:
+                raise ValueError(
+                    f"Harbor task {task_id!r} attempt {trial.cell.attempt} omits binary reward "
+                    f"{reward_key!r}"
+                )
+            raw_reward = trial.rewards[reward_key]
+            if isinstance(raw_reward, bool) or raw_reward not in (0, 0.0, 1, 1.0):
+                raise ValueError(
+                    f"Harbor task {task_id!r} attempt {trial.cell.attempt} reward "
+                    f"{reward_key!r} must be binary, got {raw_reward!r}"
+                )
+            locator = locators[(trial.cell.task_key, trial.cell.attempt)]
+            scored.append(
+                _ScoredTrial(
+                    trial=trial,
+                    verifier_reward=float(raw_reward),
+                    score=_analysis_score(trial, verifier_reward=float(raw_reward)),
+                    trace=_read_trace(
+                        loaded,
+                        locator,
+                        allow_missing=(
+                            trial.error is not None
+                            and trial.error.kind is BenchmarkFailureKind.TASK_TIMEOUT
+                        ),
+                    ),
+                )
+            )
+        ordered[task_id] = scored
+    return ordered
+
+
+def _validate_task_attempt_identity(
+    task_id: str,
+    trials: list[BenchmarkTrialResult],
+    *,
+    expected_task_key: str,
+    expected_environment_digest: str,
+) -> None:
+    for trial in trials:
+        if trial.task_instruction != normalize_durable_text(trial.task_instruction):
+            raise ValueError(f"Harbor task {task_id!r} instruction is not durable text")
+    identities = {
+        (
+            trial.cell.task_key,
+            trial.cell.task_name,
+            trial.task_identity,
+            trial.task_checksum,
+            trial.source,
+            trial.task_instruction,
+            trial.task_environment_digest,
+            trial.cell.config_digest,
+        )
+        for trial in trials
+    }
+    if len(identities) != 1:
+        raise ValueError(f"Harbor task {task_id!r} attempts have inconsistent identity")
+    if trials[0].cell.task_key != expected_task_key:
+        raise ValueError(
+            f"Harbor task {task_id!r} key differs from the frozen qualification manifest"
+        )
+    if _required_task_environment_digest(trials[0]) != expected_environment_digest:
+        raise ValueError(
+            f"Harbor task {task_id!r} environment differs from the frozen qualification run"
+        )
+
+
+def _read_trace(
+    loaded: LoadedHarborJobResult,
+    locator: HarborTrialLocator,
+    *,
+    allow_missing: bool,
+) -> _TraceEvidence:
+    relative_path = locator.trial_dir / _TRACE_FILENAME
+    trace_path = loaded.resolve_path(relative_path)
+    if not trace_path.exists():
+        if not allow_missing:
+            raise ValueError(f"completed Harbor trial is missing its WMH trace: {relative_path}")
+        return _TraceEvidence(text="(trace unavailable)", digest="missing")
+    if not trace_path.is_file():
+        raise ValueError(f"Harbor trace must be a regular file: {relative_path}")
+    with trace_path.open("rb") as handle:
+        payload = handle.read(_MAX_TRACE_FILE_BYTES + 1)
+    if len(payload) > _MAX_TRACE_FILE_BYTES:
+        raise ValueError(
+            f"Harbor trace exceeds the {_MAX_TRACE_FILE_BYTES}-byte evidence limit: {relative_path}"
+        )
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"Harbor trace is not valid UTF-8: {relative_path}") from exc
+    canonical_lines: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line:
+            raise ValueError(
+                f"Harbor trace contains an empty JSONL record at line {line_number}: "
+                f"{relative_path}"
+            )
+        try:
+            record = _TraceRecord.model_validate_json(line)
+        except PydanticValidationError as exc:
+            raise ValueError(
+                f"Harbor trace contains an invalid event at line {line_number}: {relative_path}"
+            ) from exc
+        canonical_lines.append(
+            json.dumps(
+                record.model_dump(mode="json"),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        )
+    canonical = "\n".join(canonical_lines)
+    return _TraceEvidence(
+        text=normalize_durable_text(canonical) if canonical else "(trace contained no events)",
+        digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _failure_mechanisms(trials: list[_ScoredTrial]) -> tuple[str, ...]:
+    mechanisms: set[str] = set()
+    for item in trials:
+        if item.score == 1.0:
+            continue
+        outcome = item.trial.candidate_outcome
+        if outcome.status is BenchmarkCandidateStatus.FAILED:
+            reason = outcome.failure_reason
+            labels = {
+                BenchmarkCandidateFailureReason.TIMEOUT: "candidate timeout",
+                BenchmarkCandidateFailureReason.RESOURCE_LIMIT: "candidate resource limit",
+                BenchmarkCandidateFailureReason.RUNTIME_ERROR: "candidate runtime error",
+                None: "candidate failure",
+            }
+            mechanisms.add(labels[reason])
+        elif (
+            item.trial.error is not None
+            and item.trial.error.kind is BenchmarkFailureKind.TASK_TIMEOUT
+        ):
+            mechanisms.add("agent task timeout")
+        else:
+            mechanisms.add("ground-truth reward below one")
+    return tuple(sorted(mechanisms))
+
+
+def _render_task_evidence(trials: list[_ScoredTrial]) -> str:
+    separator_chars = 2 * (len(trials) - 1)
+    per_attempt_limit = max(
+        0,
+        (MAX_HARBOR_TASK_EVIDENCE_CHARS - separator_chars) // len(trials),
+    )
+    sections: list[str] = []
+    for item in trials:
+        trial = item.trial
+        outcome = trial.candidate_outcome
+        details = [
+            f"## Attempt {trial.cell.attempt}",
+            f"score={item.score:.1f}",
+            f"verifier_reward={item.verifier_reward:.1f}",
+            f"candidate_status={outcome.status.value}",
+        ]
+        if outcome.failure_reason is not None:
+            details.append(f"candidate_failure_reason={outcome.failure_reason.value}")
+        if outcome.terminal_reason is not None:
+            details.append(f"candidate_terminal_reason={outcome.terminal_reason.value}")
+        if trial.error is not None:
+            details.append(f"trial_error={trial.error.kind.value}")
+        details.extend([f"trace_digest={item.trace.digest}", item.trace.text])
+        sections.append(
+            _bound_text(
+                "\n".join(details),
+                limit=per_attempt_limit,
+                label=f"attempt {trial.cell.attempt} evidence",
+            )
+        )
+    return _bound_text(
+        "\n\n".join(sections),
+        limit=MAX_HARBOR_TASK_EVIDENCE_CHARS,
+        label="task evidence",
+    )
+
+
+def _bound_text(value: str, *, limit: int, label: str) -> str:
+    if len(value) <= limit:
+        return value
+    marker = f"\n...[{label} truncated; original_chars={len(value)}]...\n"
+    retained = limit - len(marker)
+    if retained <= 0:
+        return marker[:limit]
+    head = retained // 2
+    tail = retained - head
+    return value[:head] + marker + value[-tail:]
+
+
+def _analysis_score(trial: BenchmarkTrialResult, *, verifier_reward: float) -> float:
+    """Apply the frozen primary rule while retaining Harbor's reward as diagnostic evidence."""
+    if trial.candidate_outcome.status is BenchmarkCandidateStatus.FAILED:
+        return 0.0
+    if trial.error is not None and trial.error.kind is BenchmarkFailureKind.TASK_TIMEOUT:
+        return 0.0
+    return verifier_reward
+
+
+def _evaluation_id(
+    *,
+    result: BenchmarkRunResult,
+    request: ScoreRequest,
+    reward_key: str,
+    task_ids: tuple[str, ...],
+    task_keys: tuple[str, ...],
+    task_environment_digests: tuple[str, ...],
+    attempts: int,
+    compute_envelope: HarborAgentComputeEnvelope,
+    cells: list[_EvaluationCellIdentity],
+) -> str:
+    payload = {
+        "schema_version": 1,
+        "job_name": result.job_name,
+        "run_identity": result.identity.model_dump(mode="json"),
+        "score_request": request.model_dump(mode="json"),
+        "reward_key": reward_key,
+        "task_ids": list(task_ids),
+        "task_keys": list(task_keys),
+        "task_environment_digests": list(task_environment_digests),
+        "attempts": attempts,
+        "compute_envelope": compute_envelope.model_dump(mode="json"),
+        "cells": [cell.model_dump(mode="json") for cell in cells],
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return "harbor-sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _required_task_environment_digest(trial: BenchmarkTrialResult) -> str:
+    digest = trial.task_environment_digest
+    if digest is None:
+        raise ValueError(
+            f"Harbor task {trial.task_identity!r} attempt {trial.cell.attempt} omits trusted "
+            "task environment identity"
+        )
+    return digest
+
+
+def _rewards_digest(rewards: Rewards | None) -> str:
+    if rewards is None:
+        raise ValueError("scored Harbor trial is missing its reward mapping")
+    for key, value in rewards.items():
+        if (
+            not isinstance(key, str)
+            or isinstance(value, bool)
+            or not isinstance(value, (int, float))
+        ):
+            raise ValueError("Harbor reward mappings must contain string keys and numeric values")
+        if not math.isfinite(value):
+            raise ValueError("Harbor reward mappings must contain only finite values")
+    canonical = json.dumps(
+        rewards,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _is_sha256_digest(value: str) -> bool:
+    prefix = "sha256:"
+    digest = value.removeprefix(prefix)
+    return (
+        value.startswith(prefix)
+        and len(digest) == 64
+        and all(character in "0123456789abcdef" for character in digest)
+    )

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -1,0 +1,863 @@
+"""Adversarial tests for projecting Harbor runs into generic harness scores."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from harbor.models.job.config import DatasetConfig
+
+import wmh.evals.harbor.scorer as mod
+from wmh.evals.benchmark import (
+    BenchmarkCandidateFailureReason,
+    BenchmarkCandidateOutcome,
+    BenchmarkCandidateStage,
+    BenchmarkCandidateStatus,
+    BenchmarkCell,
+    BenchmarkError,
+    BenchmarkFailureKind,
+    BenchmarkRunIdentity,
+    BenchmarkRunResult,
+    BenchmarkTaskEnvironment,
+    BenchmarkTrialResult,
+    BenchmarkTrialStatus,
+)
+from wmh.evals.harbor.config import HarborEnvironmentBackend, HarborJobSpec
+from wmh.evals.harbor.results import HarborTrialLocator, LoadedHarborJobResult
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.pi_local import PI_CONTAINER_IMAGE
+from wmh.harness.pi_runner import pi_node_baseline
+from wmh.harness.scoring import ScoreRequest
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+_TASK_IDS = ("alpha", "beta")
+_TASK_KEYS = ("sha256:" + "a" * 64, "sha256:" + "b" * 64)
+_TASK_ENVIRONMENT_DIGESTS = ("sha256:" + "c" * 64, "sha256:" + "d" * 64)
+_CONFIG_DIGEST = "sha256:" + "1" * 64
+_RUN_DIGEST = "sha256:" + "2" * 64
+
+
+@dataclass(frozen=True)
+class _ResultOptions:
+    rewards: dict[tuple[str, int], float] | None = None
+    diagnostic_reward: float | None = None
+    trace_suffix: str = ""
+    status: BenchmarkTrialStatus = BenchmarkTrialStatus.SCORED
+    candidate_outcome: BenchmarkCandidateOutcome | None = None
+    task_ids: tuple[str, ...] = _TASK_IDS
+    task_environment_digests: tuple[str, ...] = _TASK_ENVIRONMENT_DIGESTS
+    task_timeout: bool = False
+
+
+def _provider() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.BEDROCK,
+        model="worker-model",
+        region="us-west-2",
+    )
+
+
+def _spec(
+    tmp_path: Path,
+    *,
+    backend: HarborEnvironmentBackend = HarborEnvironmentBackend.LOCAL,
+) -> HarborJobSpec:
+    return HarborJobSpec(
+        job_name="search-train",
+        jobs_dir=tmp_path / "jobs",
+        datasets=[DatasetConfig(path=tmp_path / "dataset", task_names=list(_TASK_IDS))],
+        n_attempts=2,
+        n_concurrent_trials=2,
+        agent_n_concurrent=1,
+        environment_backend=backend,
+    )
+
+
+def _cell(task_id: str, attempt: int) -> BenchmarkCell:
+    task_key = dict(zip(_TASK_IDS, _TASK_KEYS, strict=True)).get(
+        task_id,
+        "sha256:" + "c" * 64,
+    )
+    return BenchmarkCell(
+        task_key=task_key,
+        task_name=f"display-{task_id}",
+        attempt=attempt,
+        config_digest=_CONFIG_DIGEST,
+    )
+
+
+def _candidate_failure() -> BenchmarkCandidateOutcome:
+    return BenchmarkCandidateOutcome(
+        status=BenchmarkCandidateStatus.FAILED,
+        stage=BenchmarkCandidateStage.EXECUTION,
+        failure_reason=BenchmarkCandidateFailureReason.TIMEOUT,
+    )
+
+
+def _loaded_result(
+    tmp_path: Path,
+    candidate: HarnessDoc,
+    spec: HarborJobSpec,
+    *,
+    rewards: dict[tuple[str, int], float] | None = None,
+    trace_suffix: str = "",
+    status: BenchmarkTrialStatus = BenchmarkTrialStatus.SCORED,
+    candidate_outcome: BenchmarkCandidateOutcome | None = None,
+    task_ids: tuple[str, ...] = _TASK_IDS,
+    task_keys: tuple[str, ...] = _TASK_KEYS,
+    task_environment_digests: tuple[str, ...] = _TASK_ENVIRONMENT_DIGESTS,
+    task_timeout: bool = False,
+    diagnostic_reward: float | None = None,
+) -> LoadedHarborJobResult:
+    environment_digest_by_task = dict(zip(_TASK_IDS, task_environment_digests, strict=True))
+    selected_rewards = rewards or {
+        ("alpha", 1): 1.0,
+        ("alpha", 2): 0.0,
+        ("beta", 1): 1.0,
+        ("beta", 2): 1.0,
+    }
+    job_dir = spec.jobs_dir / spec.job_name
+    job_dir.mkdir(parents=True, exist_ok=True)
+    trials: list[BenchmarkTrialResult] = []
+    locators: list[HarborTrialLocator] = []
+    expected: list[BenchmarkCell] = []
+    for task_id in task_ids:
+        for attempt in range(1, spec.n_attempts + 1):
+            cell = _cell(task_id, attempt)
+            expected.append(cell)
+            error = None
+            trial_rewards = {"reward": selected_rewards.get((task_id, attempt), 0.0)}
+            if diagnostic_reward is not None:
+                trial_rewards["diagnostic"] = diagnostic_reward
+            if task_timeout:
+                error = BenchmarkError(
+                    kind=BenchmarkFailureKind.TASK_TIMEOUT,
+                    type="AgentTimeoutError",
+                    message="agent execution exceeded the task time limit",
+                )
+            if status is not BenchmarkTrialStatus.SCORED:
+                trial_rewards = None
+                error = BenchmarkError(
+                    kind=BenchmarkFailureKind.ENVIRONMENT,
+                    type="EnvironmentStartTimeoutError",
+                    message="task environment infrastructure failed",
+                )
+            trials.append(
+                BenchmarkTrialResult(
+                    cell=cell,
+                    task_identity=task_id,
+                    task_checksum="sha256:" + "a" * 64,
+                    source="benchmark",
+                    task_instruction=f"Instruction for {task_id}.",
+                    task_environment_digest=environment_digest_by_task.get(
+                        task_id,
+                        "sha256:" + "e" * 64,
+                    ),
+                    status=status,
+                    rewards=trial_rewards,
+                    error=error,
+                    candidate_outcome=candidate_outcome
+                    or BenchmarkCandidateOutcome(status=BenchmarkCandidateStatus.COMPLETED),
+                )
+            )
+            trial_dir = Path(f"trial-{task_id}-{attempt}")
+            absolute_trial_dir = job_dir / trial_dir
+            absolute_trial_dir.mkdir(exist_ok=True)
+            trace_path = absolute_trial_dir / "wmh-events.jsonl"
+            trace_path.unlink(missing_ok=True)
+            trace_path.write_text(
+                '{"kind":"assistant_message","payload":{"text":"'
+                f"answer-{task_id}-{attempt}{trace_suffix}"
+                '"}}\n',
+                encoding="utf-8",
+            )
+            locators.append(
+                HarborTrialLocator(
+                    cell=cell,
+                    trial_dir=trial_dir,
+                    result_path=trial_dir / "result.json",
+                    artifacts_dir=trial_dir / "artifacts",
+                )
+            )
+    return LoadedHarborJobResult(
+        result=BenchmarkRunResult(
+            job_name=spec.job_name,
+            identity=BenchmarkRunIdentity(
+                candidate_hash=candidate.execution_hash,
+                agent_name="wmh-pi",
+                agent_version=mod.WMH_PI_AGENT_VERSION,
+                provider="bedrock",
+                model_name="worker-model",
+                task_environment=(
+                    BenchmarkTaskEnvironment.E2B
+                    if spec.environment_backend is HarborEnvironmentBackend.E2B
+                    else BenchmarkTaskEnvironment.DOCKER
+                ),
+                runner_image=PI_CONTAINER_IMAGE,
+                run_config_digest=_RUN_DIGEST,
+            ),
+            expected_cells=expected,
+            trials=trials,
+        ),
+        job_dir=job_dir,
+        locators=tuple(locators),
+    )
+
+
+def _install_fake_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    result_options: _ResultOptions | None = None,
+) -> list[tuple[HarborJobSpec, ProviderConfig, str, float]]:
+    captured: list[tuple[HarborJobSpec, ProviderConfig, str, float]] = []
+    options = result_options or _ResultOptions()
+
+    class FakeEvaluator:
+        def __init__(
+            self,
+            spec: HarborJobSpec,
+            provider_config: ProviderConfig,
+            *,
+            runner_image: str,
+            turn_timeout_s: float,
+        ) -> None:
+            captured.append((spec, provider_config, runner_image, turn_timeout_s))
+            self._spec = spec
+
+        async def evaluate(self, candidate: HarnessDoc) -> LoadedHarborJobResult:
+            return _loaded_result(
+                tmp_path,
+                candidate,
+                self._spec,
+                rewards=options.rewards,
+                trace_suffix=options.trace_suffix,
+                status=options.status,
+                candidate_outcome=options.candidate_outcome,
+                task_ids=options.task_ids,
+                task_environment_digests=options.task_environment_digests,
+                task_timeout=options.task_timeout,
+                diagnostic_reward=options.diagnostic_reward,
+            )
+
+    monkeypatch.setattr(mod, "HarborEvaluator", FakeEvaluator)
+    return captured
+
+
+def _scorer(
+    tmp_path: Path,
+    *,
+    job_spec: HarborJobSpec | None = None,
+    provider_config: ProviderConfig | None = None,
+    reference_harness: HarnessDoc | None = None,
+    task_ids: tuple[str, ...] = _TASK_IDS,
+    task_keys: tuple[str, ...] = _TASK_KEYS,
+    task_environment_digests: tuple[str, ...] = _TASK_ENVIRONMENT_DIGESTS,
+    reward_key: str = "reward",
+    runner_image: str = PI_CONTAINER_IMAGE,
+    turn_timeout_s: float = 300.0,
+) -> mod.HarborHarnessScorer:
+    return mod.HarborHarnessScorer(
+        job_spec=job_spec or _spec(tmp_path),
+        provider_config=provider_config or _provider(),
+        reference_harness=reference_harness or pi_node_baseline("baseline"),
+        task_ids=task_ids,
+        task_keys=task_keys,
+        task_environment_digests=task_environment_digests,
+        reward_key=reward_key,
+        runner_image=runner_image,
+        turn_timeout_s=turn_timeout_s,
+    )
+
+
+def _full_request() -> ScoreRequest:
+    return ScoreRequest(purpose="full")
+
+
+def test_projects_exact_binary_task_means_and_bounded_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _install_fake_evaluator(monkeypatch, tmp_path)
+    candidate = pi_node_baseline("candidate")
+
+    with _scorer(tmp_path) as scorer:
+        report = scorer.score(candidate, request=_full_request())
+
+    assert scorer.capabilities.task_subsets is False
+    assert scorer.capabilities.attempt_overrides is False
+    assert scorer.default_attempts == 2
+    assert scorer.task_ids == _TASK_IDS
+    assert scorer.task_keys == _TASK_KEYS
+    assert scorer.task_environment_digests == _TASK_ENVIRONMENT_DIGESTS
+    assert report.attempts == 2
+    assert report.score == pytest.approx(0.75)
+    assert report.secondary_score == report.score
+    assert list(report.per_task) == list(_TASK_IDS)
+    assert report.per_task["alpha"].score == 0.5
+    assert report.per_task["alpha"].passed is False
+    assert report.per_task["beta"].score == 1.0
+    assert report.per_task["beta"].passed is True
+    assert report.per_task["alpha"].secondary_score == 0.5
+    assert report.per_task["alpha"].description == "Instruction for alpha."
+    assert "answer-alpha-1" in report.per_task["alpha"].evidence
+    assert "answer-alpha-2" in report.per_task["alpha"].evidence
+    assert "ground-truth reward below one" in report.per_task["alpha"].mechanisms
+    assert captured[0][0].environment_backend is HarborEnvironmentBackend.LOCAL
+
+
+def test_score_job_identity_binds_full_candidate_route_and_qualification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _install_fake_evaluator(monkeypatch, tmp_path)
+    candidate = pi_node_baseline("seed")
+    renamed = candidate.model_copy(update={"name": "no-op-child", "version": 7})
+    assert candidate.execution_hash == renamed.execution_hash
+
+    with _scorer(tmp_path) as scorer:
+        first_name = scorer._job_name(candidate)
+        second_name = scorer._job_name(renamed)
+        scorer.score(candidate, request=_full_request())
+        scorer.score(renamed, request=_full_request())
+    assert first_name != second_name
+    assert captured[0][0].job_name == first_name
+    assert captured[1][0].job_name == second_name
+
+    azure = ProviderConfig(kind=ProviderKind.AZURE_OPENAI, model="worker-model")
+    with (
+        _scorer(tmp_path, provider_config=azure) as route_scorer,
+        _scorer(
+            tmp_path,
+            task_environment_digests=(
+                "sha256:" + "e" * 64,
+                _TASK_ENVIRONMENT_DIGESTS[1],
+            ),
+        ) as environment_scorer,
+        _scorer(
+            tmp_path,
+            task_keys=("sha256:" + "e" * 64, _TASK_KEYS[1]),
+        ) as task_key_scorer,
+        _scorer(tmp_path, reward_key="other-reward") as reward_scorer,
+    ):
+        assert route_scorer._job_name(candidate) != first_name
+        assert environment_scorer._job_name(candidate) != first_name
+        assert task_key_scorer._job_name(candidate) != first_name
+        assert reward_scorer._job_name(candidate) != first_name
+    assert captured[0][0].job_name.startswith("wmh-score-")
+    assert len(captured[0][0].job_name) == len("wmh-score-") + 64
+    assert captured[0][1] == _provider()
+    assert captured[0][2] == PI_CONTAINER_IMAGE
+    assert captured[0][3] == 300.0
+
+
+@pytest.mark.parametrize(
+    "score_request",
+    [
+        ScoreRequest(purpose="screen", task_ids=("alpha",)),
+        ScoreRequest(purpose="full", attempts=2),
+    ],
+)
+def test_rejects_unsupported_score_request_without_evaluating(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    score_request: ScoreRequest,
+) -> None:
+    captured = _install_fake_evaluator(monkeypatch, tmp_path)
+
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="does not support"):
+        scorer.score(pi_node_baseline("candidate"), request=score_request)
+
+    assert captured == []
+
+
+@pytest.mark.parametrize("task_ids", [("alpha",), ("alpha", "gamma")])
+def test_rejects_missing_or_extra_task_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    task_ids: tuple[str, ...],
+) -> None:
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(task_ids=task_ids),
+    )
+
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="task identities"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_rejects_duplicate_attempt_even_if_result_model_validation_was_bypassed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = pi_node_baseline("candidate")
+
+    class FakeEvaluator:
+        def __init__(self, spec: HarborJobSpec, *_args: object, **_kwargs: object) -> None:
+            self._spec = spec
+
+        async def evaluate(self, _candidate: HarnessDoc) -> LoadedHarborJobResult:
+            loaded = _loaded_result(tmp_path, candidate, self._spec)
+            duplicated = loaded.result.trials[0].model_copy(deep=True)
+            trials = [duplicated, *loaded.result.trials]
+            malformed = BenchmarkRunResult.model_construct(
+                job_name=loaded.result.job_name,
+                identity=loaded.result.identity,
+                expected_cells=loaded.result.expected_cells,
+                trials=trials,
+                usage=loaded.result.usage,
+            )
+            return LoadedHarborJobResult(
+                result=malformed,
+                job_dir=loaded.job_dir,
+                locators=loaded.locators,
+            )
+
+    monkeypatch.setattr(mod, "HarborEvaluator", FakeEvaluator)
+
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="duplicate observed"):
+        scorer.score(candidate, request=_full_request())
+
+
+def test_rejects_task_content_key_drift_from_qualification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    changed_keys = ("sha256:" + "c" * 64, "sha256:" + "d" * 64)
+
+    with (
+        _scorer(tmp_path, task_keys=changed_keys) as scorer,
+        pytest.raises(
+            ValueError,
+            match="frozen qualification manifest",
+        ),
+    ):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_rejects_task_environment_drift_from_qualification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    changed = ("sha256:" + "e" * 64, "sha256:" + "f" * 64)
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(task_environment_digests=changed),
+    )
+
+    with (
+        _scorer(tmp_path) as scorer,
+        pytest.raises(
+            ValueError,
+            match="frozen qualification run",
+        ),
+    ):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_scored_candidate_failure_is_data_but_infrastructure_is_invalid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(candidate_outcome=_candidate_failure()),
+    )
+    with _scorer(tmp_path) as scorer:
+        report = scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert report.score == 0.0
+    assert report.secondary_score == 0.0
+    assert report.per_task["alpha"].secondary_score == 0.0
+    assert report.per_task["beta"].secondary_score == 0.0
+    assert "candidate timeout" in report.per_task["alpha"].mechanisms
+    assert "candidate timeout" in report.per_task["beta"].mechanisms
+    assert "verifier_reward=1.0" in report.per_task["beta"].evidence
+    assert "score=0.0" in report.per_task["beta"].evidence
+
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(task_timeout=True),
+    )
+    with _scorer(tmp_path) as scorer:
+        timeout_report = scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert timeout_report.score == 0.0
+    assert timeout_report.secondary_score == 0.0
+    assert timeout_report.per_task["alpha"].secondary_score == 0.0
+    assert timeout_report.per_task["beta"].secondary_score == 0.0
+    assert "agent task timeout" in timeout_report.per_task["beta"].mechanisms
+    assert "verifier_reward=1.0" in timeout_report.per_task["beta"].evidence
+
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(status=BenchmarkTrialStatus.INFRASTRUCTURE_ERROR),
+    )
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="not scored"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_scored_status_cannot_hide_infrastructure_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = pi_node_baseline("candidate")
+
+    class ForgedEvaluator:
+        def __init__(self, spec: HarborJobSpec, *_args: object, **_kwargs: object) -> None:
+            self._spec = spec
+
+        async def evaluate(self, _candidate: HarnessDoc) -> LoadedHarborJobResult:
+            loaded = _loaded_result(tmp_path, candidate, self._spec)
+            forged_error = BenchmarkError(
+                kind=BenchmarkFailureKind.PROVIDER,
+                type="ApiInternalServerError",
+                message="model provider infrastructure failed",
+            )
+            forged_trial = loaded.result.trials[0].model_copy(
+                update={"error": forged_error},
+                deep=True,
+            )
+            forged_result = loaded.result.model_copy(
+                update={"trials": [forged_trial, *loaded.result.trials[1:]]},
+                deep=True,
+            )
+            return LoadedHarborJobResult(
+                result=forged_result,
+                job_dir=loaded.job_dir,
+                locators=loaded.locators,
+            )
+
+    monkeypatch.setattr(mod, "HarborEvaluator", ForgedEvaluator)
+
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="infrastructure error"):
+        scorer.score(candidate, request=_full_request())
+
+
+def test_evaluation_id_changes_with_reward_or_trace_and_is_deterministic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = pi_node_baseline("candidate")
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    with _scorer(tmp_path) as scorer:
+        first = scorer.score(candidate, request=_full_request())
+        repeated = scorer.score(candidate, request=_full_request())
+    assert repeated.evaluation_id == first.evaluation_id
+
+    changed_rewards = {
+        ("alpha", 1): 0.0,
+        ("alpha", 2): 0.0,
+        ("beta", 1): 1.0,
+        ("beta", 2): 1.0,
+    }
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(rewards=changed_rewards),
+    )
+    with _scorer(tmp_path) as scorer:
+        reward_changed = scorer.score(candidate, request=_full_request())
+    assert reward_changed.evaluation_id != first.evaluation_id
+
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(trace_suffix="-changed"),
+    )
+    with _scorer(tmp_path) as scorer:
+        trace_changed = scorer.score(candidate, request=_full_request())
+    assert trace_changed.evaluation_id != first.evaluation_id
+
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(diagnostic_reward=0.25),
+    )
+    with _scorer(tmp_path) as scorer:
+        diagnostic_changed = scorer.score(candidate, request=_full_request())
+    assert diagnostic_changed.score == first.score
+    assert diagnostic_changed.evaluation_id != first.evaluation_id
+
+
+def test_evaluation_id_binds_request_and_report_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = pi_node_baseline("candidate")
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    with _scorer(tmp_path) as scorer:
+        seed = scorer.score(candidate, request=ScoreRequest(purpose="seed"))
+        full = scorer.score(candidate, request=_full_request())
+    assert seed.evaluation_id != full.evaluation_id
+
+    renamed_spec = _spec(tmp_path).model_copy(update={"job_name": "other-prefix"}, deep=True)
+    with _scorer(tmp_path, job_spec=renamed_spec) as scorer:
+        renamed = scorer.score(candidate, request=_full_request())
+    assert renamed.label != full.label
+    assert renamed.evaluation_id != full.evaluation_id
+
+
+def test_trace_read_is_contained_and_rendering_is_capped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text('{"kind":"error","payload":{"message":"escape"}}\n', encoding="utf-8")
+
+    class SymlinkEvaluator:
+        def __init__(self, spec: HarborJobSpec, *_args: object, **_kwargs: object) -> None:
+            self._spec = spec
+
+        async def evaluate(self, candidate: HarnessDoc) -> LoadedHarborJobResult:
+            loaded = _loaded_result(tmp_path, candidate, self._spec)
+            trace = loaded.job_dir / loaded.locators[0].trial_dir / "wmh-events.jsonl"
+            trace.unlink()
+            trace.symlink_to(outside)
+            return loaded
+
+    monkeypatch.setattr(mod, "HarborEvaluator", SymlinkEvaluator)
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="cannot be a symlink"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+    huge_suffix = "x" * 40_000
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(trace_suffix=huge_suffix),
+    )
+    with _scorer(tmp_path) as scorer:
+        report = scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert len(report.per_task["alpha"].evidence) <= mod.MAX_HARBOR_TASK_EVIDENCE_CHARS
+    assert "truncated" in report.per_task["alpha"].evidence
+
+
+def test_trace_records_are_strictly_typed_before_reaching_proposer_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class InvalidTraceEvaluator:
+        def __init__(self, spec: HarborJobSpec, *_args: object, **_kwargs: object) -> None:
+            self._spec = spec
+
+        async def evaluate(self, candidate: HarnessDoc) -> LoadedHarborJobResult:
+            loaded = _loaded_result(tmp_path, candidate, self._spec)
+            trace = loaded.job_dir / loaded.locators[0].trial_dir / "wmh-events.jsonl"
+            trace.write_text('{"kind":"backend-secret","payload":{}}\n', encoding="utf-8")
+            return loaded
+
+    monkeypatch.setattr(mod, "HarborEvaluator", InvalidTraceEvaluator)
+
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="invalid event"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_missing_trace_is_allowed_only_for_harbor_task_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MissingTraceEvaluator:
+        task_timeout = False
+        candidate_failure = False
+
+        def __init__(self, spec: HarborJobSpec, *_args: object, **_kwargs: object) -> None:
+            self._spec = spec
+
+        async def evaluate(self, candidate: HarnessDoc) -> LoadedHarborJobResult:
+            loaded = _loaded_result(
+                tmp_path,
+                candidate,
+                self._spec,
+                task_timeout=self.task_timeout,
+                candidate_outcome=_candidate_failure() if self.candidate_failure else None,
+            )
+            for locator in loaded.locators:
+                (loaded.job_dir / locator.trial_dir / "wmh-events.jsonl").unlink()
+            return loaded
+
+    monkeypatch.setattr(mod, "HarborEvaluator", MissingTraceEvaluator)
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="missing its WMH trace"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+    MissingTraceEvaluator.candidate_failure = True
+    with _scorer(tmp_path) as scorer, pytest.raises(ValueError, match="missing its WMH trace"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+    MissingTraceEvaluator.candidate_failure = False
+    MissingTraceEvaluator.task_timeout = True
+    with _scorer(tmp_path) as scorer:
+        report = scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert report.score == 0.0
+    assert "trace unavailable" in report.per_task["alpha"].evidence
+
+
+def test_candidate_compute_envelope_is_frozen_while_source_may_change(tmp_path: Path) -> None:
+    baseline = pi_node_baseline("baseline")
+    scorer = _scorer(tmp_path)
+    code = baseline.code_files()[0]
+    changed_code = code.model_copy(update={"content": f"{code.content}\n// candidate edit\n"})
+    source_changed = HarnessDoc(
+        name="source-changed",
+        surfaces=[
+            changed_code if surface.id == code.id else surface for surface in baseline.surfaces
+        ],
+    )
+    assert scorer.validate_candidate(source_changed) is None
+
+    max_turns = baseline.surface("param:max-turns")
+    assert max_turns is not None
+    compute_changed = HarnessDoc(
+        name="compute-changed",
+        surfaces=[
+            Surface(
+                id=max_turns.id,
+                kind=SurfaceKind.PARAM,
+                content=str(baseline.max_turns() + 1),
+            )
+            if surface.id == max_turns.id
+            else surface
+            for surface in baseline.surfaces
+        ],
+    )
+    reason = scorer.validate_candidate(compute_changed)
+    assert reason is not None
+    assert "compute envelope" in reason
+    scorer.close()
+
+
+def test_e2b_scoring_is_gated_until_harbor_exposes_immutable_spawn_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    spec = _spec(tmp_path, backend=HarborEnvironmentBackend.E2B)
+    with pytest.raises(ValueError, match="immutable build ID"):
+        _scorer(tmp_path, job_spec=spec)
+
+
+def test_runner_cleanup_on_success_error_and_construction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[FakeRunner] = []
+
+    class FakeRunner:
+        def __init__(self) -> None:
+            self.closed = False
+            created.append(self)
+
+        def run(
+            self,
+            coroutine: Coroutine[object, object, LoadedHarborJobResult],
+        ) -> LoadedHarborJobResult:
+            return asyncio.run(coroutine)
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(mod, "_AsyncRunner", FakeRunner)
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    with _scorer(tmp_path) as scorer:
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+        assert created[-1].closed is False
+        scorer.before_proposal_batch()
+        assert created[-1].closed is True
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert created[-1].closed is True
+
+    class FailingEvaluator:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def evaluate(self, _candidate: HarnessDoc) -> LoadedHarborJobResult:
+            raise RuntimeError("evaluation failed")
+
+    monkeypatch.setattr(mod, "HarborEvaluator", FailingEvaluator)
+    with _scorer(tmp_path) as scorer, pytest.raises(RuntimeError, match="evaluation failed"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert created[-1].closed is True
+
+    _install_fake_evaluator(
+        monkeypatch,
+        tmp_path,
+        result_options=_ResultOptions(status=BenchmarkTrialStatus.INFRASTRUCTURE_ERROR),
+    )
+    scorer = _scorer(tmp_path)
+    with pytest.raises(ValueError, match="not scored"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+    assert created[-1].closed is True
+    scorer.close()
+
+    before = len(created)
+    invalid_spec = _spec(tmp_path).model_copy(
+        update={"datasets": [DatasetConfig(path=tmp_path / "dataset")]}
+    )
+    with pytest.raises(ValueError, match="explicit task_names"):
+        _scorer(tmp_path, job_spec=invalid_spec)
+    assert len(created) == before
+
+
+def test_constructor_requires_exact_explicit_unique_task_selection(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="exactly match task_ids"):
+        _scorer(tmp_path, task_ids=("beta", "alpha"))
+    with pytest.raises(ValueError, match="unique"):
+        _scorer(tmp_path, task_ids=("alpha", "alpha"))
+    with pytest.raises(ValueError, match="one key per task_id"):
+        _scorer(tmp_path, task_keys=(_TASK_KEYS[0],))
+    with pytest.raises(ValueError, match="one digest per task_id"):
+        _scorer(tmp_path, task_environment_digests=(_TASK_ENVIRONMENT_DIGESTS[0],))
+    with pytest.raises(ValueError, match="qualification manifest"):
+        _scorer(tmp_path, task_keys=(_TASK_KEYS[0], "not-a-digest"))
+    remote = _spec(tmp_path).model_copy(
+        update={
+            "datasets": [
+                DatasetConfig(
+                    repo="https://example.invalid/tasks.git",
+                    task_names=list(_TASK_IDS),
+                )
+            ]
+        }
+    )
+    with pytest.raises(ValueError, match="preflightable local dataset"):
+        _scorer(tmp_path, job_spec=remote)
+    wildcard = _spec(tmp_path).model_copy(
+        update={"datasets": [DatasetConfig(path=tmp_path / "dataset", task_names=["alpha*"])]}
+    )
+    with pytest.raises(ValueError, match="glob"):
+        _scorer(
+            tmp_path,
+            job_spec=wildcard,
+            task_ids=("alpha*",),
+            task_keys=(_TASK_KEYS[0],),
+            task_environment_digests=(_TASK_ENVIRONMENT_DIGESTS[0],),
+        )
+
+
+def test_closed_scorer_rejects_further_use(tmp_path: Path) -> None:
+    scorer = _scorer(tmp_path)
+    scorer.close()
+    scorer.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+
+def test_scoring_from_running_event_loop_fails_without_leaking_coroutine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_evaluator(monkeypatch, tmp_path)
+    scorer = _scorer(tmp_path)
+
+    async def call_sync_api() -> None:
+        with pytest.raises(RuntimeError, match="running event loop"):
+            scorer.score(pi_node_baseline("candidate"), request=_full_request())
+
+    asyncio.run(call_sync_api())
+    scorer.close()

--- a/wmh/harness/live_session.py
+++ b/wmh/harness/live_session.py
@@ -177,6 +177,8 @@ class LiveSession:
         else:
             self._worker_fn = None
         self._actions_per_turn = actions_per_turn
+        if turn_cap < 1:
+            raise ValueError("turn_cap must be >= 1")
         self._turn_cap = turn_cap
         if max_output_tokens < 1:
             raise ValueError("max_output_tokens must be >= 1")
@@ -194,6 +196,8 @@ class LiveSession:
         self._closed = False
         self._failure_message: str | None = None
         self._actions_this_turn = 0
+        self._llm_calls_this_message = 0
+        self._has_user_message = False
         self._aborting = False
         self._pending_ping: str | None = None
         self.worker_usage = TokenUsage()
@@ -302,6 +306,8 @@ class LiveSession:
                 return
             if isinstance(intent, _UserMessage):
                 self._actions_this_turn = 0
+                self._llm_calls_this_message = 0
+                self._has_user_message = True
                 # NB: do not clear `_aborting` here — a new message can be drained before
                 # the cancelled turn's in-flight submit frame is read, and clearing now
                 # would let that stale submit emit. The runner's next `state` frame (the
@@ -346,6 +352,8 @@ class LiveSession:
     def _answer_llm(self, frame: JsonObject) -> None:
         req_id = frame.get("req_id")
         body = frame.get("openai_body")
+        if not self._reserve_llm_call(req_id):
+            return
         if self._worker_fn is None:
             self._emit("error", {"message": "live session has no worker configured"})
             self._safe_send(
@@ -353,8 +361,21 @@ class LiveSession:
             )
             return
         try:
-            request_body = dict(body) if isinstance(body, dict) else {}
-            request_body["temperature"] = self._temperature
+            # The runner owns conversation and tool policy, but the trusted host owns every
+            # generation/compute control. An allowlist prevents candidate source from smuggling
+            # provider-specific extras such as ``n`` or reasoning effort through ChatRequest's
+            # intentionally forward-compatible extra-field support.
+            request_body = (
+                {key: body[key] for key in ("messages", "tools", "tool_choice") if key in body}
+                if isinstance(body, dict)
+                else {}
+            )
+            request_body.update(
+                {
+                    "temperature": self._temperature,
+                    "max_completion_tokens": self._max_output_tokens,
+                }
+            )
             request = ChatRequest.model_validate(request_body)
             completion = self._worker_fn(request)
             self._meter(completion)
@@ -366,8 +387,29 @@ class LiveSession:
             self._emit("error", {"message": f"worker LLM error: {exc}"})
             self._safe_send({"type": "llm_response", "req_id": req_id, "error": str(exc)})
 
+    def _reserve_llm_call(self, req_id: JsonValue) -> bool:
+        if not self._has_user_message:
+            message = "worker LLM request arrived before a user message"
+            self._emit("error", {"message": message})
+            self._safe_send({"type": "llm_response", "req_id": req_id, "error": message})
+            return False
+        if self._llm_calls_this_message >= self._turn_cap:
+            message = f"worker LLM call budget exhausted ({self._turn_cap} calls)"
+            self._aborting = True
+            self._emit("error", {"message": message})
+            self._safe_send({"type": "llm_response", "req_id": req_id, "error": message})
+            self._safe_send({"type": "abort", "reason": "llm_call_budget_exhausted"})
+            return False
+        self._llm_calls_this_message += 1
+        return True
+
     def _answer_tool(self, frame: JsonObject) -> None:
         req_id = frame.get("req_id")
+        if not self._has_user_message:
+            message = "tool request arrived before a user message"
+            self._emit("error", {"message": message})
+            self._respond_tool(req_id, message, is_error=True)
+            return
         name = frame.get("name")
         name = name if isinstance(name, str) else ""
         args = frame.get("arguments")

--- a/wmh/harness/live_session_test.py
+++ b/wmh/harness/live_session_test.py
@@ -178,6 +178,7 @@ def test_submit_tool_response_is_answered_without_executor() -> None:
 
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=execute, on_event=lambda e: None)
     session.start()
+    session.send_user_message("submit the answer")
     _drain(session)
     assert calls == []  # submit never routes to the real executor
     resp = next(f for f in channel.sent if f["type"] == "tool_response")
@@ -259,6 +260,7 @@ def test_read_skill_answered_from_bodies() -> None:
         skill_bodies={"deploy": "run ./deploy.sh"},
     )
     session.start()
+    session.send_user_message("load the skill")
     raw_tools = channel.sent[0]["tools"]
     assert isinstance(raw_tools, list)
     advertised = {tool["name"] for tool in raw_tools if isinstance(tool, dict) and "name" in tool}
@@ -296,9 +298,155 @@ def test_harness_temperature_overrides_live_runner_request() -> None:
         temperature=0.35,
     )
     session.start()
+    session.send_user_message("do the task")
     _drain(session)
 
     assert [request.temperature for request in requests] == [0.35]
+
+
+def test_harness_output_budget_overrides_and_canonicalizes_runner_request() -> None:
+    requests: list[ChatRequest] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "llm_request",
+                "req_id": 1,
+                "openai_body": {
+                    "messages": [],
+                    "max_tokens": 999_999,
+                    "max_completion_tokens": 888_888,
+                    "n": 7,
+                    "top_p": 0.99,
+                    "reasoning_effort": "high",
+                    "service_tier": "priority",
+                },
+            },
+        ]
+    )
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        requests.append(request)
+        return _completion()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=worker,
+        max_output_tokens=2048,
+    )
+    session.start()
+    session.send_user_message("do the task")
+    _drain(session)
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.max_tokens is None
+    assert request.max_completion_tokens == 2048
+    assert request.model_extra == {}
+    assert request.provider_payload("model", max_tokens_field="max_tokens")["max_tokens"] == 2048
+
+
+def test_host_rejects_llm_calls_beyond_the_per_message_turn_cap() -> None:
+    calls: list[ChatRequest] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+            {"type": "llm_request", "req_id": 2, "openai_body": {"messages": []}},
+            {"type": "llm_request", "req_id": 3, "openai_body": {"messages": []}},
+        ]
+    )
+
+    def worker(request: ChatRequest) -> ChatResponse:
+        calls.append(request)
+        return _completion()
+
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=worker,
+        turn_cap=2,
+    )
+    session.start()
+    session.send_user_message("do the task")
+    _drain(session)
+
+    assert len(calls) == 2
+    responses = [frame for frame in channel.sent if frame["type"] == "llm_response"]
+    assert [frame["req_id"] for frame in responses] == [1, 2, 3]
+    assert "budget exhausted" in str(responses[-1]["error"])
+    assert {"type": "abort", "reason": "llm_call_budget_exhausted"} in channel.sent
+
+
+def test_host_rejects_llm_calls_before_a_user_message() -> None:
+    calls: list[ChatRequest] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {"type": "llm_request", "req_id": 1, "openai_body": {"messages": []}},
+        ]
+    )
+    session = LiveSession(
+        channel,
+        tools=[],
+        execute_tool=_no_tool,
+        on_event=lambda event: None,
+        worker_fn=lambda request: calls.append(request) or _completion(),
+    )
+    session.start()
+    _drain(session)
+
+    assert calls == []
+    response = next(frame for frame in channel.sent if frame["type"] == "llm_response")
+    assert "before a user message" in str(response["error"])
+
+
+def test_host_rejects_tool_and_submit_calls_before_a_user_message() -> None:
+    calls: list[str] = []
+    events: list[SessionEvent] = []
+    channel = ScriptedChannel(
+        [
+            {"type": "state", "status": "idle"},
+            {
+                "type": "tool_request",
+                "req_id": 1,
+                "name": "bash",
+                "arguments": {"command": "touch /workspace/forged"},
+            },
+            {
+                "type": "tool_request",
+                "req_id": 2,
+                "name": "submit",
+                "arguments": {"answer": "forged"},
+            },
+        ]
+    )
+
+    def execute(name: str, args: JsonObject, emit) -> ToolOutcome:  # noqa: ANN001
+        _ = args, emit
+        calls.append(name)
+        return ToolOutcome(content="unexpected")
+
+    session = LiveSession(
+        channel,
+        tools=[BASH, SUBMIT],
+        execute_tool=execute,
+        on_event=events.append,
+    )
+    session.start()
+    _drain(session)
+
+    assert calls == []
+    assert all(event.kind not in {"tool_call", "submit"} for event in events)
+    responses = [frame for frame in channel.sent if frame["type"] == "tool_response"]
+    assert [frame["req_id"] for frame in responses] == [1, 2]
+    assert all(frame["is_error"] is True for frame in responses)
+    assert all("before a user message" in str(frame["content"]) for frame in responses)
 
 
 def test_worker_error_is_reported_not_raised() -> None:
@@ -319,6 +467,7 @@ def test_worker_error_is_reported_not_raised() -> None:
         channel, tools=[], execute_tool=_no_tool, on_event=events.append, worker_fn=boom
     )
     session.start()
+    session.send_user_message("do the task")
     _drain(session)
     assert any(e.kind == "error" for e in events)
     resp = next(f for f in channel.sent if f["type"] == "llm_response")
@@ -344,6 +493,7 @@ def test_unknown_tool_is_rejected() -> None:
     )
     session = LiveSession(channel, tools=[BASH], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("try the tool")
     _drain(session)
     result = next(e for e in events if e.kind == "tool_result")
     assert result.payload["is_error"] is True
@@ -367,6 +517,7 @@ def test_interrupt_suppresses_a_racing_submit_event() -> None:
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
     events.clear()
+    session.send_user_message("solve the task")
     session.interrupt()  # user hits Stop while the submit is racing
     _drain(session)
     # The abort was sent; the racing submit is answered but NOT surfaced as a submit event.
@@ -388,6 +539,7 @@ def test_submit_after_state_boundary_is_not_suppressed() -> None:
     events: list[SessionEvent] = []
     session = LiveSession(channel, tools=[SUBMIT], execute_tool=_no_tool, on_event=events.append)
     session.start()
+    session.send_user_message("solve the task")
     session.interrupt()
     events.clear()
     _drain(session)
@@ -449,6 +601,7 @@ def test_aborting_skips_real_tool_execution() -> None:
 
     session = LiveSession(channel, tools=[BASH], execute_tool=execute, on_event=lambda e: None)
     session.start()
+    session.send_user_message("modify the task")
     session.interrupt()  # user hits Stop while a bash request is already queued
     _drain(session)
     assert ran == []  # the tool never executed against the live sandbox


### PR DESCRIPTION
## Scope

This branch explored a Harbor adapter for the generic harness scoring interface, including normalized rewards, per-task evidence, and evaluator result mapping.

## Disposition

The implementation depends on broader superseded infrastructure. It is closed without merge, and the reusable adapter will be rebuilt as a focused current-main change.