### PR TITLE
wmh run: host-answered github_search connector tool

### DIFF
--- a/docs/reference/connect-library.md
+++ b/docs/reference/connect-library.md
@@ -94,3 +94,22 @@ The Notion connector's remote-MCP path uses the `mcp` client SDK, packaged as th
 inside that path only, so `import wmh.connect` and every other connector's `pull` work without
 the extra installed. Notion also accepts a pasted integration secret, which uses the REST API and
 needs no extra.
+
+## Live agent tool: `github_search` in `wmh run`
+
+Beyond building bundles programmatically, GitHub is exposed as a live tool the built-in agent
+can call during `wmh run`. When a GitHub credential resolves on the machine running the CLI (a
+`WMH_GITHUB_TOKEN` in the environment, or a stored connector credential), `wmh run` adds a
+`github_search` tool to the agent's tool set; when none resolves it is omitted, so the agent is
+never handed a tool that would always error.
+
+```bash
+export WMH_GITHUB_TOKEN=ghp_...
+wmh run --task "summarize the open bugs in octocat/hello"
+```
+
+The tool is answered host-side: the CLI process resolves the token, runs the connector `pull`,
+and returns the rendered items as the tool observation. On `--harness-backend e2b` the executor
+still runs in the CLI process (the sandbox only carries frames), so the token never enters the
+sandbox. Arguments: `target` (`owner/repo`, required), `query`, `since`; results are capped for
+one live call.

--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -55,11 +55,16 @@ from wmh.cli.workspace_sync import (
     snapshot_workspace,
 )
 from wmh.engine.play import parse_action
+from wmh.harness.connector_tools import (
+    GITHUB_SEARCH,
+    github_search_available,
+    github_search_fetch,
+)
 from wmh.harness.doc import RUNTIME_KIND_ID, HarnessDoc, Surface, SurfaceKind
 from wmh.harness.live_session import LiveSession, SessionEvent, ToolOutcome
 from wmh.harness.pi_local import LocalStdioChannel, start_local_live_runner
 from wmh.harness.pi_vendor import pi_agent_code_surfaces
-from wmh.harness.tools import READ_SKILL, resolve_tools
+from wmh.harness.tools import READ_SKILL, ToolSpec, resolve_tools
 from wmh.harness.workspace_patch import WorkspacePatchError
 from wmh.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmh.platform.credentials import PlatformCredentials, load_credentials
@@ -101,17 +106,24 @@ def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
     return ToolOutcome(content=capped, is_error=is_error, truncated=True)
 
 
-def _assemble(doc: HarnessDoc) -> tuple[str, list, dict[str, str], dict[str, str]]:
+def _assemble(
+    doc: HarnessDoc, *, extra_tools: list[ToolSpec] | None = None
+) -> tuple[str, list[ToolSpec], dict[str, str], dict[str, str]]:
     """Derive the LiveSession inputs from a HarnessDoc (mirrors the hosted driver).
 
     Returns the assembled system prompt (prompt + rendered tools + skills index),
     the resolved tool specs, the code surfaces as {path: content} (the agent's own
     code, materialized into the local runner), and skill bodies answered host-side.
+
+    ``extra_tools`` are host-answered tools (e.g. ``github_search``) the driver
+    injects beyond the doc's closed-set tools; they are appended as ToolSpec
+    objects so they are offered to the agent without passing through the
+    closed-set ``resolve_tools`` gate.
     """
     tool_names = doc.tools()
     if doc.skills() and READ_SKILL.name not in tool_names:
         tool_names.append(READ_SKILL.name)
-    tool_specs = resolve_tools(tool_names)
+    tool_specs = [*resolve_tools(tool_names), *(extra_tools or [])]
     system = doc.assembled_prompt()
     files = {surface.path: surface.content for surface in doc.code_files() if surface.path}
     skill_bodies = {skill.name: skill.body for skill in doc.skills()}
@@ -341,7 +353,9 @@ class LocalLiveDriver:
 
     def run(self) -> None:
         """Boot the local runner, drive the session, and always tear down."""
-        system, tool_specs, files, skill_bodies = _assemble(self._doc)
+        system, tool_specs, files, skill_bodies = _assemble(
+            self._doc, extra_tools=self._connector_tools()
+        )
         _console.print("[dim]starting the built-in pi harness locally...[/dim]")
         session: LiveSession | None = None
         reason = "user_ended"
@@ -388,10 +402,25 @@ class LocalLiveDriver:
         if error is not None:
             raise typer.Exit(code=1)
 
+    def _connector_tools(self) -> list[ToolSpec]:
+        """Offer github_search only when a GitHub credential resolves host-side.
+
+        Availability is decided on the machine running the CLI, never in the
+        sandbox; an agent is never handed a tool that would always error.
+        """
+        return [GITHUB_SEARCH] if github_search_available() else []
+
     def _execute(
         self, name: str, args: JsonObject, emit: Callable[[str, str], None]
     ) -> ToolOutcome:
-        """Run one tool locally (each tool blocks the session pump)."""
+        """Run one tool locally (each tool blocks the session pump).
+
+        github_search is answered host-side here, with a token resolved from the
+        environment, so on the e2b backend it never enters the sandbox; every
+        other tool runs against the local jail.
+        """
+        if name == GITHUB_SEARCH.name:
+            return github_search_fetch(args)
         return self._executor(name, args, emit)
 
     def _loop(self, session: LiveSession, stdin_eof: threading.Event) -> None:

--- a/wmh/cli/agent_session_test.py
+++ b/wmh/cli/agent_session_test.py
@@ -20,13 +20,15 @@ import wmh.cli.hosted_session as hosted_mod
 from wmh.cli import app
 from wmh.cli.session_state import DetachedSessionState, SessionStateError, SessionStateStore
 from wmh.cli.workspace_sync import snapshot_from_archive
-from wmh.harness.live_session import SessionEvent
+from wmh.harness.live_session import SessionEvent, ToolOutcome
 from wmh.harness.workspace_patch import build_workspace_patch
 from wmh.platform.client import PlatformError
 from wmh.platform.credentials import PlatformCredentials
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from wmh.core.types import JsonObject
 
 
 def _noop_emit(_stream: str, _chunk: str) -> None:
@@ -1275,3 +1277,67 @@ def test_plain_run_interrupt_around_a_patch_ack_promotes_a_fresh_cursor(
     state = store.load("sess-1")
     assert state is not None
     assert state.cursor == 1
+
+
+# -- github_search connector tool (host-answered) --------------------------------------------------
+
+
+@pytest.fixture
+def _isolated_connector_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate connector credential resolution so the host env decides tool availability."""
+    monkeypatch.setenv("WMH_CONNECTORS_PATH", str(tmp_path / "connectors.toml"))
+    monkeypatch.delenv("WMH_GITHUB_TOKEN", raising=False)
+
+
+def _local_driver(tmp_path: Path) -> mod.LocalLiveDriver:
+    """A minimal LocalLiveDriver for exercising tool selection and dispatch."""
+    return mod.LocalLiveDriver(
+        jail_root=tmp_path,
+        doc=mod._pi_node_baseline(),
+        provider=None,
+        worker_fn=None,
+        recorder=None,
+        instruction=None,
+    )
+
+
+@pytest.mark.usefixtures("_isolated_connector_creds")
+def test_github_search_offered_only_when_a_token_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """github_search is absent without a credential and present once one resolves host-side."""
+    driver = _local_driver(tmp_path)
+    assert [tool.name for tool in driver._connector_tools()] == []
+    monkeypatch.setenv("WMH_GITHUB_TOKEN", "gho_test")
+    assert [tool.name for tool in driver._connector_tools()] == ["github_search"]
+
+
+def test_assemble_appends_connector_tools() -> None:
+    """Injected connector tools are offered to the agent beyond the doc's closed-set tools."""
+    from wmh.harness.connector_tools import GITHUB_SEARCH
+
+    _system, tool_specs, _files, _skills = mod._assemble(
+        mod._pi_node_baseline(), extra_tools=[GITHUB_SEARCH]
+    )
+    assert "github_search" in [tool.name for tool in tool_specs]
+
+
+def test_execute_dispatches_github_search_to_the_host_side_fetch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """github_search is answered by the host-side fetch, never the local jail executor."""
+    driver = _local_driver(tmp_path)
+    sentinel = ToolOutcome(content="rendered items")
+
+    def _fake_fetch(_args: JsonObject) -> ToolOutcome:
+        return sentinel
+
+    monkeypatch.setattr(mod, "github_search_fetch", _fake_fetch)
+
+    def _fail(*_a: object, **_k: object) -> ToolOutcome:
+        raise AssertionError("github_search must not reach the local filesystem executor")
+
+    monkeypatch.setattr(driver, "_executor", _fail)
+
+    outcome = driver._execute("github_search", {"target": "o/r", "query": "x"}, _noop_emit)
+    assert outcome is sentinel

--- a/wmh/harness/connector_tools.py
+++ b/wmh/harness/connector_tools.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from wmh.connect import (
     ConnectError,
-    ConnectorAuth,
     PullQuery,
     get_connector,
     load_connector_auth,
@@ -150,7 +149,13 @@ def github_search_fetch(args: JsonObject) -> ToolOutcome:
         return ToolOutcome(
             content="github_search needs a 'target' repository as 'owner/repo'", is_error=True
         )
-    auth = _resolve_auth()
+    try:
+        auth = load_connector_auth(_CONNECTOR)
+    except ConnectError as error:
+        # A credential is present but unusable (e.g. a malformed stored file):
+        # surface the real reason, not the "not configured" message. This is the
+        # error github_search_available promises the fetch will report.
+        return ToolOutcome(content=f"github_search credential is invalid: {error}", is_error=True)
     if auth is None:
         hint = " or ".join(f"${var}" for var in token_env_vars(_CONNECTOR))
         return ToolOutcome(
@@ -171,11 +176,3 @@ def github_search_fetch(args: JsonObject) -> ToolOutcome:
     except ConnectError as error:
         return ToolOutcome(content=f"github_search failed: {error}", is_error=True)
     return ToolOutcome(content=_render_items(items))
-
-
-def _resolve_auth() -> ConnectorAuth | None:
-    """The host-side GitHub credential, or None when a corrupt stored one still cannot be used."""
-    try:
-        return load_connector_auth(_CONNECTOR)
-    except ConnectError:
-        return None

--- a/wmh/harness/connector_tools.py
+++ b/wmh/harness/connector_tools.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+
+"""Host-answered connector tools for a live agent session.
+
+A live session's tools are answered by the HOST (the CLI process, or the platform runner), never
+by the sandbox: the `ToolExecutor` runs where credentials live, so the agent can reach a service
+without the token ever entering the runner. This module packages the GitHub connector as one such
+tool, `github_search`: a `ToolSpec` object the caller appends to the session's tool list, a cheap
+availability check, and a fetch that resolves the token host-side, pulls via `wmh.connect`, and
+renders the result into one capped observation.
+
+Placement note: this lives with the harness (not `wmh.connect`) because the shape it produces is
+harness machinery, a `ToolSpec` plus a `ToolOutcome`. `wmh.connect` stays a standalone context
+library with no dependency on the harness; the arrow points harness -> connect, never back.
+"""
+
+from __future__ import annotations
+
+from wmh.connect import (
+    ConnectError,
+    ConnectorAuth,
+    PullQuery,
+    get_connector,
+    load_connector_auth,
+    token_env_vars,
+)
+from wmh.connect.types import ContextItem
+from wmh.core.types import JsonObject, JsonValue
+from wmh.harness.live_session import ToolOutcome
+from wmh.harness.tools import ToolSpec
+
+_CONNECTOR = "github"
+
+# One github_search observation is capped so a large repo pull cannot blow up the agent's context.
+# The connector does not cap individual item bodies, so this cap governs the whole rendering: whole
+# items are dropped from the tail, and a single item larger than the cap is hard-truncated.
+_OBSERVATION_CAP_CHARS = 24_000
+# The most items one search may pull, regardless of the model-supplied `limit`: a live agent is
+# reading, not archiving, so a tight cap keeps one tool call cheap and the observation bounded.
+_MAX_LIMIT = 30
+_DEFAULT_LIMIT = 10
+
+GITHUB_SEARCH = ToolSpec(
+    name="github_search",
+    description=(
+        "Search a GitHub repository's issues, pull requests, and README, newest first. "
+        "Answered by the host from its configured GitHub credential; the repo must be one that "
+        "credential can see."
+    ),
+    arguments={
+        "target": "the repository as 'owner/repo' (required)",
+        "query": "optional GitHub issue-search text (e.g. 'label:bug crash'); omit for the "
+        "newest issues and pull requests",
+        "since": "optional ISO-8601 lower bound on item update time (e.g. '2026-01-01')",
+        "limit": f"optional max items to return (1-{_MAX_LIMIT}, default {_DEFAULT_LIMIT})",
+    },
+)
+
+
+def github_search_available() -> bool:
+    """Whether a GitHub credential resolves host-side, so the tool would not always error.
+
+    True when a token resolves from the environment (`WMH_GITHUB_TOKEN`) or from the stored
+    connector credential file. The tool is offered to an agent only when this holds.
+    """
+    try:
+        return load_connector_auth(_CONNECTOR) is not None
+    except ConnectError:
+        # A corrupt stored credential still means "configured"; the fetch surfaces the real
+        # error rather than silently hiding a tool the user meant to have.
+        return True
+
+
+def _coerce_limit(raw: JsonValue | None) -> int:
+    """Clamp a model-supplied limit into `[1, _MAX_LIMIT]`, defaulting when absent or invalid."""
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return _DEFAULT_LIMIT
+    value = int(raw)
+    if value < 1:
+        return _DEFAULT_LIMIT
+    return min(value, _MAX_LIMIT)
+
+
+def _opt_arg(raw: JsonValue | None) -> str | None:
+    """A tool argument as a non-empty stripped string, else None."""
+    if not isinstance(raw, str):
+        return None
+    stripped = raw.strip()
+    return stripped or None
+
+
+def _render_items(items: list[ContextItem]) -> str:
+    """Render pulled items into one capped observation, newest first, truncation made visible.
+
+    Each item becomes a compact block (title, a kind/state/date/url fact line, then its body).
+    When the assembled text would exceed the observation cap, whole items are dropped from the
+    tail and a final "... n more items omitted" line keeps the truncation loud, never silent.
+    """
+    if not items:
+        return "no matching issues, pull requests, or README found"
+    blocks = [_render_item(item) for item in items]
+    full = "\n\n".join(blocks)
+    if len(full) <= _OBSERVATION_CAP_CHARS:
+        return full
+    for kept in range(len(blocks) - 1, 0, -1):
+        omitted = len(blocks) - kept
+        candidate = "\n\n".join([*blocks[:kept], f"... {omitted} more items omitted"])
+        if len(candidate) <= _OBSERVATION_CAP_CHARS:
+            return candidate
+    # Even the first item alone is over budget; return it hard-truncated with a loud marker,
+    # reserving room for that marker so the whole observation still fits the cap.
+    marker = f"\n... item truncated and {len(blocks) - 1} more items omitted"
+    head = blocks[0][: max(0, _OBSERVATION_CAP_CHARS - len(marker))]
+    return f"{head}{marker}"
+
+
+def _render_item(item: ContextItem) -> str:
+    """One item block: its title, a kind/state/date/url fact line, then its body."""
+    facts: list[str] = [item.kind.value]
+    state = item.metadata.get("state")
+    if isinstance(state, str) and state:
+        facts.append(state)
+    if item.updated_at:
+        facts.append(f"updated {item.updated_at}")
+    if item.url:
+        facts.append(item.url)
+    block = f"### {item.title}\n{' | '.join(facts)}"
+    body = item.body.strip()
+    if body:
+        block += f"\n\n{body}"
+    return block
+
+
+def github_search_fetch(args: JsonObject) -> ToolOutcome:
+    """Answer one `github_search` call host-side, returning the rendered observation.
+
+    Resolves the GitHub token from the host environment / stored credential, builds a capped
+    `PullQuery`, pulls via `wmh.connect.get_connector("github")`, and renders the items into one
+    capped observation. A missing credential or a `ConnectError` becomes a clean `is_error`
+    `ToolOutcome`; connector internals never leak to the agent.
+
+    Args:
+        args: The model-supplied tool arguments (`target`, optional `query`/`since`/`limit`).
+
+    Returns:
+        A `ToolOutcome`: the rendered observation on success, or an actionable error on failure.
+    """
+    target = _opt_arg(args.get("target"))
+    if target is None:
+        return ToolOutcome(
+            content="github_search needs a 'target' repository as 'owner/repo'", is_error=True
+        )
+    auth = _resolve_auth()
+    if auth is None:
+        hint = " or ".join(f"${var}" for var in token_env_vars(_CONNECTOR))
+        return ToolOutcome(
+            content=(
+                f"github_search is not configured: set {hint} on the machine running the "
+                "CLI before starting the session"
+            ),
+            is_error=True,
+        )
+    query = PullQuery(
+        target=target,
+        query=_opt_arg(args.get("query")),
+        since=_opt_arg(args.get("since")),
+        limit=_coerce_limit(args.get("limit")),
+    )
+    try:
+        items = get_connector(_CONNECTOR).pull(auth, query)
+    except ConnectError as error:
+        return ToolOutcome(content=f"github_search failed: {error}", is_error=True)
+    return ToolOutcome(content=_render_items(items))
+
+
+def _resolve_auth() -> ConnectorAuth | None:
+    """The host-side GitHub credential, or None when a corrupt stored one still cannot be used."""
+    try:
+        return load_connector_auth(_CONNECTOR)
+    except ConnectError:
+        return None

--- a/wmh/harness/connector_tools_test.py
+++ b/wmh/harness/connector_tools_test.py
@@ -1,0 +1,201 @@
+"""Tests for the host-answered github_search connector tool.
+
+No network: the connector's `pull` is faked (or raised through) and credentials are resolved from
+an isolated env/store, so every path (render, no-token, ConnectError, cap) is exercised offline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.connect.credentials import ENV_CONNECTORS_PATH
+from wmh.connect.types import ConnectError, ConnectorAuth, ContextItem, ItemKind, PullQuery
+from wmh.core.types import JsonObject
+from wmh.harness import connector_tools as mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_creds(tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate credential resolution: empty tmp store, no GitHub env token by default."""
+    monkeypatch.setenv(ENV_CONNECTORS_PATH, str(tmp_path) + "/connectors.toml")  # type: ignore[operator]
+    monkeypatch.delenv("WMH_GITHUB_TOKEN", raising=False)
+
+
+class _FakeConnector:
+    """A stand-in github connector recording the pull it received and returning fixed items."""
+
+    name = "github"
+    label = "GitHub"
+
+    def __init__(self, items: list[ContextItem]) -> None:
+        self._items = items
+        self.received: PullQuery | None = None
+
+    def pull(self, auth: ConnectorAuth, query: PullQuery) -> list[ContextItem]:
+        """Record the query and return the fixed items (no network)."""
+        _ = auth
+        self.received = query
+        return self._items
+
+
+class _RaisingConnector:
+    """A github connector whose pull raises a ConnectError, to test error mapping."""
+
+    name = "github"
+    label = "GitHub"
+
+    def pull(self, auth: ConnectorAuth, query: PullQuery) -> list[ContextItem]:
+        """Always raise a ConnectError (with a token-shaped detail we assert is NOT leaked raw)."""
+        _ = (auth, query)
+        raise ConnectError("github rejected the stored credential during the pull (HTTP 401)")
+
+
+def _item(number: int, *, body: str = "body text", state: str = "open") -> ContextItem:
+    """One issue-kind ContextItem for rendering tests."""
+    return ContextItem(
+        id=f"octocat/hello#{number}",
+        source="github",
+        kind=ItemKind.ISSUE,
+        title=f"#{number} a bug",
+        body=body,
+        url=f"https://github.com/octocat/hello/issues/{number}",
+        updated_at="2026-07-01T00:00:00Z",
+        metadata={"state": state},
+    )
+
+
+def _use_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make a GitHub credential resolve host-side via the env token."""
+    monkeypatch.setenv("WMH_GITHUB_TOKEN", "gho_test")
+
+
+# -- availability ----------------------------------------------------------------------------------
+
+
+def test_available_is_false_without_any_credential() -> None:
+    assert mod.github_search_available() is False
+
+
+def test_available_is_true_with_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    assert mod.github_search_available() is True
+
+
+# -- fetch: success --------------------------------------------------------------------------------
+
+
+def test_fetch_renders_items_into_one_observation(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    fake = _FakeConnector([_item(1), _item(2)])
+    monkeypatch.setattr(mod, "get_connector", lambda _name: fake)
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is False
+    assert "#1 a bug" in outcome.content
+    assert "#2 a bug" in outcome.content
+    assert "issue | open" in outcome.content
+    assert "https://github.com/octocat/hello/issues/1" in outcome.content
+    assert fake.received is not None
+    assert fake.received.target == "octocat/hello"
+
+
+def test_fetch_passes_query_and_since_and_caps_the_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    fake = _FakeConnector([_item(1)])
+    monkeypatch.setattr(mod, "get_connector", lambda _name: fake)
+
+    args: JsonObject = {
+        "target": "octocat/hello",
+        "query": "label:bug",
+        "since": "2026-01-01",
+        "limit": 999,
+    }
+    mod.github_search_fetch(args)
+
+    assert fake.received is not None
+    assert fake.received.query == "label:bug"
+    assert fake.received.since == "2026-01-01"
+    assert fake.received.limit == mod._MAX_LIMIT
+
+
+def test_fetch_defaults_the_limit_when_missing_or_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_token(monkeypatch)
+    fake = _FakeConnector([_item(1)])
+    monkeypatch.setattr(mod, "get_connector", lambda _name: fake)
+
+    mod.github_search_fetch({"target": "octocat/hello", "limit": "not-a-number"})
+
+    assert fake.received is not None
+    assert fake.received.limit == mod._DEFAULT_LIMIT
+
+
+def test_fetch_reports_no_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    monkeypatch.setattr(mod, "get_connector", lambda _name: _FakeConnector([]))
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is False
+    assert "no matching" in outcome.content
+
+
+def test_fetch_caps_the_observation_and_makes_truncation_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_token(monkeypatch)
+    big = "x" * 20_000
+    items = [_item(n, body=big) for n in range(5)]
+    monkeypatch.setattr(mod, "get_connector", lambda _name: _FakeConnector(items))
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is False
+    assert len(outcome.content) <= mod._OBSERVATION_CAP_CHARS
+    assert "items omitted" in outcome.content
+
+
+def test_fetch_caps_a_single_oversized_item(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    # One item whose body alone exceeds the cap, so the hard-truncate branch runs.
+    big = "x" * (mod._OBSERVATION_CAP_CHARS * 2)
+    monkeypatch.setattr(mod, "get_connector", lambda _name: _FakeConnector([_item(1, body=big)]))
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is False
+    assert len(outcome.content) <= mod._OBSERVATION_CAP_CHARS
+    assert "item truncated" in outcome.content
+
+
+# -- fetch: errors ---------------------------------------------------------------------------------
+
+
+def test_fetch_without_a_target_is_a_clean_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+
+    outcome = mod.github_search_fetch({})
+
+    assert outcome.is_error is True
+    assert "target" in outcome.content
+
+
+def test_fetch_without_a_credential_is_a_clean_error() -> None:
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is True
+    assert "WMH_GITHUB_TOKEN" in outcome.content
+
+
+def test_fetch_maps_connect_error_to_a_clean_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_token(monkeypatch)
+    monkeypatch.setattr(mod, "get_connector", lambda _name: _RaisingConnector())
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is True
+    assert outcome.content.startswith("github_search failed:")
+    # The env token itself must never appear in the observation.
+    assert "gho_test" not in outcome.content

--- a/wmh/harness/connector_tools_test.py
+++ b/wmh/harness/connector_tools_test.py
@@ -187,6 +187,27 @@ def test_fetch_without_a_credential_is_a_clean_error() -> None:
 
     assert outcome.is_error is True
     assert "WMH_GITHUB_TOKEN" in outcome.content
+    assert "not configured" in outcome.content
+
+
+def test_fetch_with_a_corrupt_credential_surfaces_the_real_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present-but-unusable credential reports the invalid-credential error, not 'not configured'.
+
+    This is what github_search_available promises when it offers the tool despite a ConnectError.
+    """
+
+    def _raise(_connector: str) -> object:
+        raise ConnectError("stored github credential is malformed")
+
+    monkeypatch.setattr(mod, "load_connector_auth", _raise)
+
+    outcome = mod.github_search_fetch({"target": "octocat/hello"})
+
+    assert outcome.is_error is True
+    assert "credential is invalid" in outcome.content
+    assert "not configured" not in outcome.content
 
 
 def test_fetch_maps_connect_error_to_a_clean_outcome(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Wires a **`github_search`** tool into `wmh run` so the built-in pi agent can pull GitHub context mid-run. It's the CLI counterpart to platform#340 (same host-answered tool in the hosted runner), consuming the `wmh.connect` library from #174.

```bash
export WMH_GITHUB_TOKEN=ghp_...
wmh run --task "summarize the open bugs in octocat/hello"
```

## How (and why no secret reaches the sandbox)

Answered **host-side**: `wmh run`'s `LocalLiveDriver` (in the CLI process) resolves the GitHub token from the environment, runs `wmh.connect` `get_connector("github").pull(...)`, and returns the rendered `ContextItem`s as the observation. On `--harness-backend e2b` the executor runs in the CLI process (the sandbox only carries frames), so `WMH_GITHUB_TOKEN` **never enters the sandbox**. Bare-local has no sandbox; the token stays local as usual.

- `wmh/harness/connector_tools.py` — `GITHUB_SEARCH` ToolSpec; `github_search_available()`; `github_search_fetch()` rendering items into a capped observation, missing-token / `ConnectError` → clean `is_error` outcome (token never in the observation).
- `wmh/cli/agent_session.py` — `_assemble` gains `extra_tools` (appended as ToolSpec objects past the closed-set `resolve_tools` gate); `LocalLiveDriver` offers `github_search` only when a token resolves and dispatches it to the host-side fetch before the local jail executor.

## Test plan

Full gate green: ruff, ty, pytest (1,965 passed). Inline tests (no network): render + capping, missing-token / `ConnectError` clean errors, token never in observation; tool offered iff a credential resolves; `_execute` dispatches `github_search` host-side, never the jail executor.

## Scope

GitHub only, mirroring #340; Google/Slack/Notion/Brave are the same additive pattern. Token from `WMH_GITHUB_TOKEN`; no `wmh connect` CLI is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)