### PR TITLE
feat(providers): honor Azure reasoning profiles

### DIFF
--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -16,6 +16,7 @@ OptInModelRole = Literal["agent", "meta"]
 # Azure OpenAI chat completions need an API version on every call. When an opt-in role does not
 # pin one in settings, this shared default API version applies.
 _DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
+_AZURE_REASONING_RESPONSES_API_VERSION = "v1"
 
 
 def resolve_opt_in_model_provider(
@@ -50,6 +51,11 @@ def resolve_opt_in_model_provider(
     api_version = configured.api_version
     if api_version is None and kind is ProviderKind.AZURE_OPENAI:
         api_version = _DEFAULT_AZURE_API_VERSION
+    responses_api_version = (
+        _AZURE_REASONING_RESPONSES_API_VERSION
+        if kind is ProviderKind.AZURE_OPENAI and configured.reasoning_effort is not None
+        else None
+    )
     model = resolve_provider_model(kind, configured.model)
     config = ProviderConfig(
         kind=kind,
@@ -60,5 +66,6 @@ def resolve_opt_in_model_provider(
         deployment=configured.deployment,
         api_version=api_version,
         reasoning_effort=configured.reasoning_effort,
+        responses_api_version=responses_api_version,
     )
     return get_provider(config), configured.model

--- a/wmh/cli/model_roles_test.py
+++ b/wmh/cli/model_roles_test.py
@@ -172,6 +172,43 @@ def test_meta_role_resolves_canonical_bedrock_model_and_reasoning_effort(
     assert config.reasoning_effort == "max"
 
 
+def test_meta_role_resolves_azure_reasoning_to_explicit_v1_responses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(
+                    provider="azure",
+                    model="gpt-5.5",
+                    endpoint="https://example.openai.azure.com",
+                    deployment="gpt55-deploy",
+                    api_version="2024-10-21",
+                    reasoning_effort="high",
+                )
+            )
+        ),
+        root,
+    )
+    configs: list[ProviderConfig] = []
+
+    def fake_get_provider(config: ProviderConfig) -> _Provider:
+        configs.append(config)
+        return _Provider()
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
+
+    _, configured_model = resolve_opt_in_model_provider(str(root), "meta", _Provider())
+
+    assert configured_model == "gpt-5.5"
+    [config] = configs
+    assert config.reasoning_effort == "high"
+    assert config.api_version == "2024-10-21"
+    assert config.responses_api_version == "v1"
+    assert config.model_dump(mode="json")["responses_api_version"] == "v1"
+
+
 def test_proposer_reasoning_setting_does_not_mutate_unset_agent_worker(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -53,6 +53,7 @@ def complete(
     messages: list[Message],
     max_tokens: int,
     temperature: float | None = None,
+    reasoning_effort: str | None = None,
 ) -> Completion:
     """Run one chat completion and map it onto our `Completion`.
 
@@ -60,31 +61,27 @@ def complete(
     `temperature` is sent ONLY when given: GPT 5.5's reasoning models reject non-default sampling
     params (callers pass None), while OpenAI-compatible servers (vLLM policies) need it.
     """
-    if temperature is None:
-        response = chat_completions.create(
-            model=model,
-            messages=to_messages(system, messages),
-            max_completion_tokens=max_tokens,
-        )
-    else:
-        try:
-            response = chat_completions.create(
-                model=model,
-                messages=to_messages(system, messages),
-                max_completion_tokens=max_tokens,
-                temperature=temperature,
-            )
-        except BadRequestError as exc:
-            # Reasoning-model deployments (GPT-5.x behind Azure/custom endpoints) reject any
-            # non-default temperature with a 400 unsupported_value. The caller can't know which
-            # models sample; degrade to the model's default rather than failing the request.
-            if "temperature" not in str(exc):
-                raise
-            response = chat_completions.create(
-                model=model,
-                messages=to_messages(system, messages),
-                max_completion_tokens=max_tokens,
-            )
+    payload: dict[str, object] = {
+        "model": model,
+        "messages": to_messages(system, messages),
+        "max_completion_tokens": max_tokens,
+    }
+    if temperature is not None:
+        payload["temperature"] = temperature
+    if reasoning_effort is not None:
+        # This is provider-owned configuration, never a caller-controlled request extra.
+        payload["reasoning_effort"] = reasoning_effort
+    resource = cast("Any", chat_completions)
+    try:
+        response = resource.create(**payload)
+    except BadRequestError as exc:
+        # Reasoning-model deployments (GPT-5.x behind Azure/custom endpoints) reject any
+        # non-default temperature with a 400 unsupported_value. The caller can't know which
+        # models sample; degrade to the model's default rather than failing the request.
+        if temperature is None or "temperature" not in str(exc):
+            raise
+        payload.pop("temperature")
+        response = resource.create(**payload)
     if not response.choices:
         # Content filtering (and some error modes) can return zero choices; surface it clearly
         # rather than letting choices[0] raise a bare IndexError.

--- a/wmh/providers/_responses_common.py
+++ b/wmh/providers/_responses_common.py
@@ -209,10 +209,18 @@ def responses_response(
 
     usage = _object_dict(raw.get("usage"))
     if usage is not None:
-        response["usage"] = {
+        translated_usage: dict[str, object] = {
             "prompt_tokens": _usage_count(usage.get("input_tokens")),
             "completion_tokens": _usage_count(usage.get("output_tokens")),
         }
+        translated_usage.update(
+            {
+                name: value
+                for name, value in usage.items()
+                if name not in {"input_tokens", "output_tokens"}
+            }
+        )
+        response["usage"] = translated_usage
 
     service_tier = raw.get("service_tier")
     if isinstance(service_tier, str):

--- a/wmh/providers/_responses_common.py
+++ b/wmh/providers/_responses_common.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from llm_waterfall import ChatReasoningDetail, ChatRequest, ChatResponse
 from pydantic import JsonValue
@@ -19,6 +19,7 @@ from pydantic import JsonValue
 from wmh.providers.receipt import ProviderRequestPayload, build_chat_provider_receipt
 
 _RESPONSES_REASONING_ENVELOPE_FORMAT = "openai.responses.output.v1"
+ResponsesSnapshotProvider = Literal["openai_responses", "azure"]
 
 
 def responses_request(
@@ -28,6 +29,7 @@ def responses_request(
     reasoning_effort: str | None = None,
     service_tier: str | None = None,
     allow_sampling: bool = True,
+    snapshot_provider: ResponsesSnapshotProvider = "openai_responses",
 ) -> dict[str, object]:
     """Translate one structured chat request into a native Responses API payload.
 
@@ -49,7 +51,7 @@ def responses_request(
     """
     payload: dict[str, object] = {
         "model": model,
-        "input": _responses_input(request, model),
+        "input": _responses_input(request, model, snapshot_provider=snapshot_provider),
         # pi asks its OpenAI-compatible endpoint for a stream. The Python runtime needs one
         # complete Response object, so the provider boundary deliberately terminates streaming.
         "stream": False,
@@ -105,6 +107,8 @@ def responses_request(
 def responses_response(
     raw: dict[str, object],
     requested_model: str | None = None,
+    *,
+    snapshot_provider: ResponsesSnapshotProvider = "openai_responses",
 ) -> ChatResponse:
     """Translate one native Responses object into the structured chat response contract.
 
@@ -176,7 +180,11 @@ def responses_response(
             {
                 "type": "reasoning.encrypted",
                 "id": first_call_id,
-                "data": _encode_responses_snapshot(native_items, origin_model),
+                "data": _encode_responses_snapshot(
+                    native_items,
+                    origin_model,
+                    snapshot_provider=snapshot_provider,
+                ),
             }
         ]
 
@@ -222,6 +230,7 @@ def complete_chat(
     allow_sampling: bool = True,
     receipt_provider: str | None = None,
     provider_request_id_headers: tuple[str, ...] = (),
+    snapshot_provider: ResponsesSnapshotProvider = "openai_responses",
 ) -> ChatResponse:
     """Run a structured chat turn against an OpenAI SDK Responses resource.
 
@@ -250,11 +259,12 @@ def complete_chat(
         reasoning_effort=reasoning_effort,
         service_tier=service_tier,
         allow_sampling=allow_sampling,
+        snapshot_provider=snapshot_provider,
     )
     if receipt_provider is None:
         sdk_response = resource.create(**payload)
         raw = cast("dict[str, object]", sdk_response.model_dump(mode="json"))
-        return responses_response(raw, model)
+        return responses_response(raw, model, snapshot_provider=snapshot_provider)
     if not provider_request_id_headers:
         raise ValueError("Responses receipt requires at least one provider request id header")
 
@@ -263,7 +273,11 @@ def complete_chat(
     sdk_response = raw_api_response.parse()
     finished_at = time.time()
     raw = cast("dict[str, object]", sdk_response.model_dump(mode="json"))
-    response = responses_response(raw, model).model_copy(update={"provider_receipt": None})
+    response = responses_response(
+        raw,
+        model,
+        snapshot_provider=snapshot_provider,
+    ).model_copy(update={"provider_receipt": None})
     provider_request_id = next(
         (
             value
@@ -310,7 +324,12 @@ def complete_chat(
     return response.model_copy(update={"provider_receipt": receipt})
 
 
-def _responses_input(request: ChatRequest, model: str) -> list[dict[str, object]]:
+def _responses_input(
+    request: ChatRequest,
+    model: str,
+    *,
+    snapshot_provider: ResponsesSnapshotProvider,
+) -> list[dict[str, object]]:
     """Translate ordered chat history into stateless Responses input items."""
     items: list[dict[str, object]] = []
     for message in request.messages:
@@ -329,7 +348,13 @@ def _responses_input(request: ChatRequest, model: str) -> list[dict[str, object]
         if message.reasoning_details:
             if message.role != "assistant":
                 raise ValueError("Responses reasoning details must belong to an assistant message")
-            items.extend(_signed_responses_snapshot(message, model))
+            items.extend(
+                _signed_responses_snapshot(
+                    message,
+                    model,
+                    snapshot_provider=snapshot_provider,
+                )
+            )
             continue
 
         text = _chat_text(message.content)
@@ -352,7 +377,12 @@ def _responses_input(request: ChatRequest, model: str) -> list[dict[str, object]
     return items
 
 
-def _signed_responses_snapshot(message: object, model: str) -> list[dict[str, object]]:
+def _signed_responses_snapshot(
+    message: object,
+    model: str,
+    *,
+    snapshot_provider: ResponsesSnapshotProvider,
+) -> list[dict[str, object]]:
     """Decode and validate one exact provider-output snapshot before stateless replay."""
     details = getattr(message, "reasoning_details", None)
     if not isinstance(details, list) or len(details) != 1:
@@ -372,7 +402,7 @@ def _signed_responses_snapshot(message: object, model: str) -> list[dict[str, ob
         raise ValueError("invalid or foreign Responses reasoning envelope")
     if (
         envelope.get("format") != _RESPONSES_REASONING_ENVELOPE_FORMAT
-        or envelope.get("provider") != "openai_responses"
+        or envelope.get("provider") != snapshot_provider
     ):
         raise ValueError("invalid or foreign Responses reasoning envelope")
     origin_model = envelope.get("model")
@@ -430,13 +460,18 @@ def _signed_responses_snapshot(message: object, model: str) -> list[dict[str, ob
     return native_items
 
 
-def _encode_responses_snapshot(items: list[dict[str, object]], model: str) -> str:
+def _encode_responses_snapshot(
+    items: list[dict[str, object]],
+    model: str,
+    *,
+    snapshot_provider: ResponsesSnapshotProvider,
+) -> str:
     """Encode ordered Responses output items into Pi's opaque reasoning-detail field."""
     try:
         return json.dumps(
             {
                 "format": _RESPONSES_REASONING_ENVELOPE_FORMAT,
-                "provider": "openai_responses",
+                "provider": snapshot_provider,
                 "model": _openai_model_family(model),
                 "output": items,
             },

--- a/wmh/providers/_responses_common.py
+++ b/wmh/providers/_responses_common.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from typing import Any, cast
 
 from llm_waterfall import ChatReasoningDetail, ChatRequest, ChatResponse
 from pydantic import JsonValue
+
+from wmh.providers.receipt import ProviderRequestPayload, build_chat_provider_receipt
 
 _RESPONSES_REASONING_ENVELOPE_FORMAT = "openai.responses.output.v1"
 
@@ -158,7 +161,12 @@ def responses_response(
         message["tool_calls"] = tool_calls
     if has_reasoning and tool_calls:
         response_model = raw.get("model")
-        origin_model = response_model if isinstance(response_model, str) else requested_model
+        # Bind opaque state to the provider-controlled requested route. A service may report a
+        # dated snapshot (OpenAI) or a base model family behind a deployment alias (Azure); both
+        # must replay through the same requested route, not be rejected as a foreign model.
+        origin_model = requested_model or (
+            response_model if isinstance(response_model, str) else None
+        )
         if not isinstance(origin_model, str) or not origin_model:
             raise ValueError("Responses reasoning output is missing its originating model")
         first_call_id = cast("str", tool_calls[0]["id"])
@@ -184,6 +192,12 @@ def responses_response(
     model = raw.get("model")
     if isinstance(model, str):
         response["model"] = model
+    response_id = raw.get("id")
+    if isinstance(response_id, str):
+        response["id"] = response_id
+    system_fingerprint = raw.get("system_fingerprint")
+    if isinstance(system_fingerprint, str):
+        response["system_fingerprint"] = system_fingerprint
 
     usage = _object_dict(raw.get("usage"))
     if usage is not None:
@@ -206,6 +220,8 @@ def complete_chat(
     reasoning_effort: str | None = None,
     service_tier: str | None = None,
     allow_sampling: bool = True,
+    receipt_provider: str | None = None,
+    provider_request_id_headers: tuple[str, ...] = (),
 ) -> ChatResponse:
     """Run a structured chat turn against an OpenAI SDK Responses resource.
 
@@ -216,6 +232,10 @@ def complete_chat(
         reasoning_effort: Provider-controlled reasoning effort.
         service_tier: Provider-controlled service tier.
         allow_sampling: Whether compatible non-reasoning models may receive sampling fields.
+        receipt_provider: Provider identity for a sanitized receipt. When set, the adapter uses
+            the SDK raw-response surface and attaches a receipt if required metadata is present.
+        provider_request_id_headers: Ordered response-header names that may carry the provider's
+            request identity.
 
     Returns:
         Provider-neutral structured chat response.
@@ -224,17 +244,70 @@ def complete_chat(
     # releases. The payload is validated by the narrow translation above, so keep that churn at
     # this one SDK boundary instead of leaking Any through the runtime contract.
     resource = cast("Any", responses)
-    sdk_response = resource.create(
-        **responses_request(
-            request,
-            model,
-            reasoning_effort=reasoning_effort,
-            service_tier=service_tier,
-            allow_sampling=allow_sampling,
-        )
+    payload = responses_request(
+        request,
+        model,
+        reasoning_effort=reasoning_effort,
+        service_tier=service_tier,
+        allow_sampling=allow_sampling,
     )
+    if receipt_provider is None:
+        sdk_response = resource.create(**payload)
+        raw = cast("dict[str, object]", sdk_response.model_dump(mode="json"))
+        return responses_response(raw, model)
+    if not provider_request_id_headers:
+        raise ValueError("Responses receipt requires at least one provider request id header")
+
+    started_at = time.time()
+    raw_api_response = resource.with_raw_response.create(**payload)
+    sdk_response = raw_api_response.parse()
+    finished_at = time.time()
     raw = cast("dict[str, object]", sdk_response.model_dump(mode="json"))
-    return responses_response(raw, model)
+    response = responses_response(raw, model).model_copy(update={"provider_receipt": None})
+    provider_request_id = next(
+        (
+            value
+            for header in provider_request_id_headers
+            if isinstance((value := raw_api_response.headers.get(header)), str) and value
+        ),
+        None,
+    )
+    response_id = raw.get("id")
+    response_model = raw.get("model")
+    system_fingerprint = raw.get("system_fingerprint")
+    max_output_tokens = payload.get("max_output_tokens")
+    temperature = payload.get("temperature")
+    if (
+        provider_request_id is None
+        or not isinstance(response_id, str)
+        or not response_id
+        or not isinstance(response_model, str)
+        or not response_model
+        or (system_fingerprint is not None and not isinstance(system_fingerprint, str))
+        or isinstance(max_output_tokens, bool)
+        or not isinstance(max_output_tokens, int)
+        or max_output_tokens < 1
+        or (
+            temperature is not None
+            and (isinstance(temperature, bool) or not isinstance(temperature, (int, float)))
+        )
+    ):
+        return response
+    receipt = build_chat_provider_receipt(
+        provider=receipt_provider,
+        provider_request_id=provider_request_id,
+        response_id=response_id,
+        requested_model=model,
+        response_model=response_model,
+        system_fingerprint=system_fingerprint,
+        request_payload=cast("ProviderRequestPayload", payload),
+        temperature=float(temperature) if temperature is not None else None,
+        max_tokens=max_output_tokens,
+        max_tokens_field="max_output_tokens",
+        started_at_unix_s=started_at,
+        finished_at_unix_s=finished_at,
+    )
+    return response.model_copy(update={"provider_receipt": receipt})
 
 
 def _responses_input(request: ChatRequest, model: str) -> list[dict[str, object]]:

--- a/wmh/providers/_responses_common.py
+++ b/wmh/providers/_responses_common.py
@@ -19,6 +19,7 @@ from pydantic import JsonValue
 from wmh.providers.receipt import ProviderRequestPayload, build_chat_provider_receipt
 
 _RESPONSES_REASONING_ENVELOPE_FORMAT = "openai.responses.output.v1"
+_CHAT_USAGE_RESERVED_FIELDS = frozenset({"prompt_tokens", "completion_tokens"})
 ResponsesSnapshotProvider = Literal["openai_responses", "azure"]
 
 
@@ -209,6 +210,10 @@ def responses_response(
 
     usage = _object_dict(raw.get("usage"))
     if usage is not None:
+        reserved_fields = _CHAT_USAGE_RESERVED_FIELDS.intersection(usage)
+        if reserved_fields:
+            names = ", ".join(sorted(reserved_fields))
+            raise ValueError(f"Responses API usage contains reserved ChatUsage field(s): {names}")
         translated_usage: dict[str, object] = {
             "prompt_tokens": _usage_count(usage.get("input_tokens")),
             "completion_tokens": _usage_count(usage.get("output_tokens")),

--- a/wmh/providers/_responses_common_test.py
+++ b/wmh/providers/_responses_common_test.py
@@ -196,6 +196,8 @@ def test_responses_response_preserves_text_multiple_tools_usage_and_tier() -> No
                 "input_tokens": 321,
                 "output_tokens": 45,
                 "total_tokens": 366,
+                "input_tokens_details": {"cached_tokens": 12},
+                "output_tokens_details": {"reasoning_tokens": 20},
             },
         }
     )
@@ -204,6 +206,11 @@ def test_responses_response_preserves_text_multiple_tools_usage_and_tier() -> No
     assert response.usage is not None
     assert response.usage.prompt_tokens == 321
     assert response.usage.completion_tokens == 45
+    assert response.usage.model_extra == {
+        "total_tokens": 366,
+        "input_tokens_details": {"cached_tokens": 12},
+        "output_tokens_details": {"reasoning_tokens": 20},
+    }
     assert response.wire_payload()["service_tier"] == "priority"
     choice = response.choices[0]
     assert choice.finish_reason == "tool_calls"
@@ -256,6 +263,29 @@ def test_responses_response_preserves_text_multiple_tools_usage_and_tier() -> No
             "status": "completed",
         },
     ]
+
+
+@pytest.mark.parametrize("reserved_name", ["prompt_tokens", "completion_tokens"])
+def test_responses_response_rejects_reserved_usage_aliases(reserved_name: str) -> None:
+    """Native usage aliases cannot overwrite translated canonical counters."""
+    with pytest.raises(ValueError, match="reserved ChatUsage field"):
+        responses_response(
+            {
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "done"}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 4,
+                    reserved_name: 0,
+                },
+            }
+        )
 
 
 def test_ordered_encrypted_reasoning_round_trips_through_pi_chat_history() -> None:

--- a/wmh/providers/_responses_common_test.py
+++ b/wmh/providers/_responses_common_test.py
@@ -1,6 +1,7 @@
 """Tests for provider-neutral structured Responses API translation."""
 
 import json
+from typing import Literal
 
 import pytest
 from llm_waterfall import ChatRequest
@@ -356,6 +357,49 @@ def test_ordered_encrypted_reasoning_round_trips_through_pi_chat_history() -> No
         {"type": "function_call_output", "call_id": "call-b", "output": "B"},
     ]
     assert payload["include"] == ["reasoning.encrypted_content"]
+
+
+@pytest.mark.parametrize(
+    ("origin_provider", "replay_provider"),
+    [("azure", "openai_responses"), ("openai_responses", "azure")],
+)
+def test_encrypted_reasoning_cannot_replay_across_response_providers(
+    origin_provider: Literal["azure", "openai_responses"],
+    replay_provider: Literal["azure", "openai_responses"],
+) -> None:
+    first = responses_response(
+        {
+            "model": "gpt-5.5",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "provider-bound-ciphertext",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "read_file",
+                    "arguments": '{"path":"README.md"}',
+                    "status": "completed",
+                },
+            ],
+        },
+        "gpt-5.5",
+        snapshot_provider=origin_provider,
+    )
+    assistant = first.choices[0].message.model_dump(mode="json", exclude_none=True)
+    request = ChatRequest.model_validate({"messages": [assistant]})
+
+    with pytest.raises(ValueError, match="invalid or foreign Responses reasoning envelope"):
+        responses_request(
+            request,
+            "gpt-5.5",
+            reasoning_effort="high",
+            snapshot_provider=replay_provider,
+        )
 
 
 def test_duplicate_parallel_reasoning_details_fail_closed() -> None:

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -171,6 +171,12 @@ class AzureOpenAIProvider:
             usage_payload = response.usage.model_dump(mode="json")
             usage_payload.pop("prompt_tokens", None)
             usage_payload.pop("completion_tokens", None)
+            reserved_usage_names = {"input_tokens", "output_tokens"}.intersection(usage_payload)
+            if reserved_usage_names:
+                reserved_name = min(reserved_usage_names)
+                raise ValueError(
+                    f"Azure usage contains reserved TokenUsage field {reserved_name!r}"
+                )
             completion_fields["usage"] = TokenUsage.model_validate(
                 {
                     "input_tokens": response.usage.prompt_tokens,

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -162,6 +162,7 @@ class AzureOpenAIProvider:
                 allow_sampling=False,
                 receipt_provider=self.config.kind.value,
                 provider_request_id_headers=("apim-request-id", "x-request-id"),
+                snapshot_provider="azure",
             )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -21,6 +21,7 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    TokenUsage,
     VerifyResult,
     normalize_chat_temperature,
     verify_via_ping,
@@ -138,6 +139,34 @@ class AzureOpenAIProvider:
         temperature: float = 0.7,
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
+        if self.config.reasoning_effort is not None:
+            request_messages: list[dict[str, str]] = []
+            if system:
+                request_messages.append({"role": "system", "content": system})
+            request_messages.extend(
+                {"role": message.role, "content": message.content} for message in messages
+            )
+            response = self.complete_chat(
+                ChatRequest.model_validate(
+                    {
+                        "messages": request_messages,
+                        "max_completion_tokens": max_tokens,
+                    }
+                )
+            )
+            if not response.choices:
+                raise ValueError(f"{self._deployment()} returned no choices")
+            content = response.choices[0].message.content
+            if not isinstance(content, str):
+                raise ValueError(f"{self._deployment()} returned no text completion")
+            usage = response.token_usage()
+            return Completion(
+                text=content,
+                usage=TokenUsage(
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                ),
+            )
         return _openai_common.complete(
             self._get_client().chat.completions,
             self._deployment(),

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -159,14 +159,26 @@ class AzureOpenAIProvider:
             content = response.choices[0].message.content
             if not isinstance(content, str):
                 raise ValueError(f"{self._deployment()} returned no text completion")
-            usage = response.token_usage()
-            return Completion(
-                text=content,
-                usage=TokenUsage(
-                    input_tokens=usage.input_tokens,
-                    output_tokens=usage.output_tokens,
-                ),
+            completion_fields: dict[str, object] = {
+                "text": content,
+                "model": response.model,
+                "system_fingerprint": response.system_fingerprint,
+            }
+            if response.usage is None:
+                # A paid response without provider usage must remain distinguishable from a
+                # genuine zero-token response so the hard-budget boundary can forfeit it.
+                return Completion.model_validate(completion_fields)
+            usage_payload = response.usage.model_dump(mode="json")
+            usage_payload.pop("prompt_tokens", None)
+            usage_payload.pop("completion_tokens", None)
+            completion_fields["usage"] = TokenUsage.model_validate(
+                {
+                    "input_tokens": response.usage.prompt_tokens,
+                    "output_tokens": response.usage.completion_tokens,
+                    **usage_payload,
+                }
             )
+            return Completion.model_validate(completion_fields)
         return _openai_common.complete(
             self._get_client().chat.completions,
             self._deployment(),

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -13,7 +13,7 @@ import os
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlsplit
 
-from wmh.providers import _openai_common
+from wmh.providers import _openai_common, _responses_common
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
     ChatRequest,
@@ -24,10 +24,11 @@ from wmh.providers.base import (
     VerifyResult,
     normalize_chat_temperature,
     verify_via_ping,
+    verify_via_structured_tool_ping,
 )
 
 if TYPE_CHECKING:
-    from openai import AzureOpenAI
+    from openai import AzureOpenAI, OpenAI
 
 
 class AzureOpenAIProvider:
@@ -38,33 +39,37 @@ class AzureOpenAIProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: AzureOpenAI | None = None
+        self._responses_client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
+
+    def _resolved_endpoint(self) -> tuple[str, bool]:
+        """Return the endpoint and whether it is controlled by untrusted config."""
+        if self.config.api_version is None:
+            raise ValueError("AzureOpenAIProvider requires config.api_version to be set.")
+
+        env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+        endpoint = self.config.endpoint or env_endpoint
+        if not endpoint:
+            raise ValueError(
+                "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
+                "AZURE_OPENAI_ENDPOINT."
+            )
+        is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
+            self.config.endpoint, env_endpoint
+        )
+        return endpoint, is_config_endpoint
 
     def _get_client(self) -> AzureOpenAI:
         # Lazy: construct on first use. api_version must be supplied by config; the endpoint and
         # api_key are resolved with a trust check (see below), never blindly from the environment.
         if self._client is None:
-            # Validate config before reaching for the SDK, so a config error doesn't depend on the
-            # optional `openai` extra being installed.
-            if self.config.api_version is None:
-                raise ValueError("AzureOpenAIProvider requires config.api_version to be set.")
-
-            env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
-            endpoint = self.config.endpoint or env_endpoint
-            if not endpoint:
-                raise ValueError(
-                    "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
-                    "AZURE_OPENAI_ENDPOINT."
-                )
+            endpoint, is_config_endpoint = self._resolved_endpoint()
 
             from openai import AzureOpenAI
 
             # Compare canonically so a trailing slash or host-casing difference between the config
             # value and the trusted env endpoint doesn't misclassify the same Azure resource as an
             # untrusted host (which would strip the real key and break the call).
-            is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
-                self.config.endpoint, env_endpoint
-            )
             if is_config_endpoint:
                 # A config-controlled endpoint (config.toml can come from an untrusted model
                 # bundle) is an untrusted host. NEVER let the SDK fall back to the real
@@ -86,6 +91,39 @@ class AzureOpenAIProvider:
                 )
         return self._client
 
+    def _get_responses_client(self) -> OpenAI:
+        """Create the Azure v1 client used when a reasoning profile is configured.
+
+        Azure's Chat Completions endpoint rejects reasoning effort together with function tools
+        for GPT-5.5. Its v1 Responses endpoint supports both. Client construction preserves the
+        same trusted-endpoint credential boundary as :meth:`_get_client`.
+        """
+        if self._responses_client is None:
+            endpoint, is_config_endpoint = self._resolved_endpoint()
+            responses_api_version = self.config.responses_api_version
+            if responses_api_version != "v1":
+                raise ValueError(
+                    "AzureOpenAIProvider reasoning calls require responses_api_version='v1'."
+                )
+            if is_config_endpoint:
+                api_key = os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed"
+            else:
+                api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "AzureOpenAIProvider needs AZURE_OPENAI_API_KEY for the v1 Responses API."
+                    )
+
+            from openai import OpenAI
+
+            self._responses_client = OpenAI(
+                api_key=api_key,
+                base_url=_responses_base_url(endpoint),
+                default_query={"api-version": responses_api_version},
+                max_retries=0,
+            )
+        return self._responses_client
+
     def _deployment(self) -> str:
         # On Azure, the `model` arg to the API is the deployment name, not the base model id.
         if self.config.deployment is None:
@@ -101,7 +139,12 @@ class AzureOpenAIProvider:
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
         return _openai_common.complete(
-            self._get_client().chat.completions, self._deployment(), system, messages, max_tokens
+            self._get_client().chat.completions,
+            self._deployment(),
+            system,
+            messages,
+            max_tokens,
+            reasoning_effort=self.config.reasoning_effort,
         )
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
@@ -110,6 +153,16 @@ class AzureOpenAIProvider:
             request,
             forward_temperature=self._forward_temperature,
         )
+        if self.config.reasoning_effort is not None:
+            return _responses_common.complete_chat(
+                self._get_responses_client().responses,
+                self._deployment(),
+                request,
+                reasoning_effort=self.config.reasoning_effort,
+                allow_sampling=False,
+                receipt_provider=self.config.kind.value,
+                provider_request_id_headers=("apim-request-id", "x-request-id"),
+            )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,
             self._deployment(),
@@ -129,6 +182,8 @@ class AzureOpenAIProvider:
         )
 
     def verify(self) -> VerifyResult:
+        if self.config.reasoning_effort is not None:
+            return verify_via_structured_tool_ping(self)
         return verify_via_ping(self)
 
 
@@ -149,3 +204,11 @@ def _same_endpoint(a: str, b: str | None) -> bool:
         pb.path.rstrip("/"),
         pb.query,
     )
+
+
+def _responses_base_url(endpoint: str) -> str:
+    """Normalize an Azure resource endpoint onto its native v1 route."""
+    root = endpoint.rstrip("/")
+    if root.lower().endswith("/openai/v1"):
+        return f"{root}/"
+    return f"{root}/openai/v1/"

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -297,6 +297,8 @@ def verify_via_structured_tool_ping(provider: SingleDispatchProvider) -> VerifyR
     """Verify the operative structured tool route with exactly one bounded dispatch."""
 
     def call() -> object:
+        if provider.paid_request_attempts != 1:
+            raise ValueError("structured provider verification requires one paid request attempt")
         response = provider.complete_chat(_STRUCTURED_TOOL_PING)
         if not response.choices:
             raise ValueError("structured provider verification returned no choices")

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 from typing import Literal, Protocol, Self, runtime_checkable
 
@@ -91,6 +92,12 @@ class ProviderConfig(BaseModel):
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version
     reasoning_effort: ReasoningEffort | None = None
+    # Azure reasoning/tool calls use the native Responses route alongside the dated Chat API.
+    # Omit this field from unrelated persisted configs so existing identities remain stable.
+    responses_api_version: Literal["v1"] | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
     # The serialized default stays stable for persisted configs. When callers do not explicitly
     # set this field, built-in models resolve it from the canonical ProviderModel catalog.
     chat_max_tokens_field: ChatMaxTokensField = "max_completion_tokens"
@@ -98,6 +105,18 @@ class ProviderConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_reasoning_effort(self) -> Self:
         """Reject settings that the selected provider and model cannot honor."""
+        if self.responses_api_version is not None and (
+            self.kind is not ProviderKind.AZURE_OPENAI or self.reasoning_effort is None
+        ):
+            raise ValueError(
+                "responses_api_version is supported only by Azure reasoning configuration"
+            )
+        if (
+            self.kind is ProviderKind.AZURE_OPENAI
+            and self.reasoning_effort is not None
+            and self.responses_api_version != "v1"
+        ):
+            raise ValueError("Azure reasoning configuration requires responses_api_version='v1'")
         if self.reasoning_effort is None:
             return self
         from wmh.providers.models import resolve_provider_model
@@ -222,9 +241,33 @@ _PING_MESSAGES: list[Message] = [Message(role="user", content="ping")]
 
 # Ping output budget. Reasoning models (GPT-5.x) spend output tokens on reasoning before any
 # visible text, and OpenAI 400s ("max_tokens or model output limit was reached") when the budget
-# can't cover it — which reads like bad credentials. Non-reasoning models stop after a token or
-# two regardless, so the headroom costs nothing there.
+# can't cover it. Non-reasoning models stop after a token or two regardless, so the headroom costs
+# nothing there.
 PING_MAX_TOKENS = 2048
+
+_STRUCTURED_TOOL_PING = ChatRequest.model_validate(
+    {
+        "messages": [{"role": "user", "content": "Call health_check exactly once."}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "health_check",
+                    "description": "Verify structured tool-call availability.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            }
+        ],
+        "tool_choice": "required",
+        "max_completion_tokens": PING_MAX_TOKENS,
+        "store": False,
+    }
+)
 
 # Belt-and-suspenders for the above: if a reasoning model spends even the larger ping budget on
 # reasoning before emitting output, the resulting error still PROVES the model is reachable (auth
@@ -243,16 +286,48 @@ def verify_via_ping(provider: Provider) -> VerifyResult:
     Every backend's verify() is identical apart from its kind/model (both on the config), so they
     all delegate here. Never raises — `verify_all` relies on that to not crash startup.
     """
-    cfg = provider.config
+    return _verify_call(
+        provider.config,
+        lambda: provider.complete("", _PING_MESSAGES, max_tokens=PING_MAX_TOKENS),
+        accept_output_limit_reachability=True,
+    )
+
+
+def verify_via_structured_tool_ping(provider: SingleDispatchProvider) -> VerifyResult:
+    """Verify the operative structured tool route with exactly one bounded dispatch."""
+
+    def call() -> object:
+        response = provider.complete_chat(_STRUCTURED_TOOL_PING)
+        if not response.choices:
+            raise ValueError("structured provider verification returned no choices")
+        calls = response.choices[0].message.tool_calls or []
+        if not any(call.function.name == "health_check" for call in calls):
+            raise ValueError("structured provider verification returned no health_check call")
+        if response.provider_receipt is None:
+            raise ValueError("structured provider verification returned no provider receipt")
+        return response
+
+    return _verify_call(provider.config, call, accept_output_limit_reachability=False)
+
+
+def _verify_call(
+    config: ProviderConfig,
+    call: Callable[[], object],
+    *,
+    accept_output_limit_reachability: bool,
+) -> VerifyResult:
+    """Run one verification dispatch with shared reasoning-limit semantics."""
     try:
-        provider.complete("", _PING_MESSAGES, max_tokens=PING_MAX_TOKENS)
+        call()
     except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
         # A max-tokens/output-limit error confirms reachability: the request reached the model
         # (auth + model id are valid) and only failed because a reasoning model consumed the 1-token
         # ping budget before producing output. Anything else (auth, missing model, network) is a
         # real failure.
         msg = str(exc).lower()
-        if any(marker in msg for marker in _REACHABLE_ERROR_MARKERS):
-            return VerifyResult(ok=True, kind=cfg.kind, model=cfg.model)
-        return VerifyResult(ok=False, kind=cfg.kind, model=cfg.model, detail=str(exc))
-    return VerifyResult(ok=True, kind=cfg.kind, model=cfg.model)
+        if accept_output_limit_reachability and any(
+            marker in msg for marker in _REACHABLE_ERROR_MARKERS
+        ):
+            return VerifyResult(ok=True, kind=config.kind, model=config.model)
+        return VerifyResult(ok=False, kind=config.kind, model=config.model, detail=str(exc))
+    return VerifyResult(ok=True, kind=config.kind, model=config.model)

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -47,6 +47,10 @@ class Message(BaseModel):
 
 
 class TokenUsage(BaseModel):
+    # Providers may report separately billed usage dimensions. Preserve them so the hard-budget
+    # boundary can price a registered inclusive subset or fail closed on an unknown dimension.
+    model_config = ConfigDict(extra="allow")
+
     input_tokens: int = 0
     output_tokens: int = 0
 
@@ -58,6 +62,9 @@ class Completion(BaseModel):
     # the call. None (the norm) means "the configured model" — metering falls back to config.
     # min_length=1 keeps "" impossible, so `completion.model or config.model` is exact.
     model: str | None = Field(default=None, min_length=1)
+    # OpenAI-compatible providers can report a backend fingerprint independently of the served
+    # model. Preserve explicit absence so a frozen scored route can distinguish it from a value.
+    system_fingerprint: str | None = Field(default=None, min_length=1, max_length=512)
 
 
 DEFAULT_MAX_TOKENS = 8192

--- a/wmh/providers/base_test.py
+++ b/wmh/providers/base_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from wmh.providers.base import (
     PING_MAX_TOKENS,
     Completion,
@@ -86,3 +88,28 @@ def test_verify_reports_real_failures() -> None:
     result = verify_via_ping(_RaisingProvider(exc))
     assert not result.ok
     assert "401" in (result.detail or "")
+
+
+def test_responses_api_version_is_omitted_from_unrelated_config_identity() -> None:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="zai.glm-5")
+
+    assert "responses_api_version" not in config.model_dump(mode="json")
+
+
+def test_responses_api_version_is_rejected_outside_azure() -> None:
+    with pytest.raises(ValueError, match="only by Azure reasoning"):
+        ProviderConfig(
+            kind=ProviderKind.OPENAI_RESPONSES,
+            model="gpt-5.5",
+            reasoning_effort="high",
+            responses_api_version="v1",
+        )
+
+
+def test_responses_api_version_is_rejected_for_unprofiled_azure() -> None:
+    with pytest.raises(ValueError, match="only by Azure reasoning"):
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            responses_api_version="v1",
+        )

--- a/wmh/providers/models.py
+++ b/wmh/providers/models.py
@@ -176,18 +176,21 @@ _MODELS: tuple[ProviderModel, ...] = (
         model_type="gpt-5.5",
         model_id="gpt-5.5",
         forward_temperature=False,
+        reasoning_efforts=_OPENAI_GPT_54_55_REASONING_EFFORTS,
     ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,
         model_type="gpt-5.4",
         model_id="gpt-5.4",
         forward_temperature=False,
+        reasoning_efforts=_OPENAI_GPT_54_55_REASONING_EFFORTS,
     ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,
         model_type="gpt-5.4-mini",
         model_id="gpt-5.4-mini",
         forward_temperature=False,
+        reasoning_efforts=_OPENAI_GPT_54_55_REASONING_EFFORTS,
     ),
     ProviderModel(
         provider=ProviderKind.AZURE_OPENAI,

--- a/wmh/providers/receipt.py
+++ b/wmh/providers/receipt.py
@@ -181,11 +181,15 @@ def validate_chat_provider_receipt(
     expected_temperature = (
         requested_temperature if provider_config.resolved_chat_forward_temperature() else None
     )
-    expected_max_tokens_field = (
-        "inferenceConfig.maxTokens"
-        if provider_config.kind is ProviderKind.BEDROCK
-        else provider_config.resolved_chat_max_tokens_field()
-    )
+    if provider_config.kind is ProviderKind.BEDROCK:
+        expected_max_tokens_field = "inferenceConfig.maxTokens"
+    elif (
+        provider_config.kind is ProviderKind.AZURE_OPENAI
+        and provider_config.reasoning_effort is not None
+    ):
+        expected_max_tokens_field = "max_output_tokens"
+    else:
+        expected_max_tokens_field = provider_config.resolved_chat_max_tokens_field()
     if receipt.provider != provider_config.kind.value:
         raise ValueError("provider receipt disagrees with the frozen provider")
     if receipt.requested_model != requested_chat_model(provider_config):

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import cast
+
 import httpx
 import pytest
-from openai import AzureOpenAI
+from openai import AzureOpenAI, OpenAI
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
 from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind
+from wmh.providers.receipt import validate_chat_provider_receipt
 
 
 class _FakeMessage:
@@ -100,6 +104,86 @@ class _FakeChat:
         self.completions = completions
 
 
+class _FakeResponsesResponse:
+    def __init__(self, tool_name: str = "bash") -> None:
+        self.tool_name = tool_name
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "id": "response-azure-1",
+            "model": "gpt-5.5-2026-06-01",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "ciphertext-1",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": self.tool_name,
+                    "arguments": '{"command":"pwd"}',
+                },
+            ],
+            "usage": {"input_tokens": 11, "output_tokens": 7},
+        }
+
+
+class _FakeResponses:
+    def __init__(
+        self,
+        *,
+        tool_name: str = "bash",
+        headers: dict[str, str] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.tool_name = tool_name
+        self.headers = (
+            {"apim-request-id": "provider-request-azure-responses-1"}
+            if headers is None
+            else headers
+        )
+        self.error = error
+        self.last_kwargs: dict[str, object] = {}
+        self.calls: list[dict[str, object]] = []
+        self.with_raw_response = _FakeResponsesWithRawResponse(self)
+
+    def create(self, **kwargs: object) -> _FakeResponsesResponse:
+        self.last_kwargs = kwargs
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return _FakeResponsesResponse(self.tool_name)
+
+
+class _FakeResponsesRawResponse:
+    def __init__(self, response: _FakeResponsesResponse, headers: dict[str, str]) -> None:
+        self._response = response
+        self.headers = headers
+
+    def parse(self) -> _FakeResponsesResponse:
+        return self._response
+
+
+class _FakeResponsesWithRawResponse:
+    def __init__(self, responses: _FakeResponses) -> None:
+        self._responses = responses
+
+    def create(self, **kwargs: object) -> _FakeResponsesRawResponse:
+        return _FakeResponsesRawResponse(
+            self._responses.create(**kwargs),
+            self._responses.headers,
+        )
+
+
+class _FakeResponsesClient:
+    def __init__(self, responses: _FakeResponses) -> None:
+        self.responses = responses
+
+
 class _FakeEmbeddingItem:
     def __init__(self, embedding: list[float]) -> None:
         self.embedding = embedding
@@ -138,6 +222,30 @@ def _config() -> ProviderConfig:
     )
 
 
+def _reasoning_config() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        endpoint="https://example.openai.azure.com",
+        deployment="gpt55-deploy",
+        api_version="2024-10-21",
+        reasoning_effort="high",
+        responses_api_version="v1",
+    )
+
+
+def test_reasoning_config_requires_explicit_responses_api_version() -> None:
+    with pytest.raises(ValueError, match="responses_api_version"):
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            endpoint="https://example.openai.azure.com",
+            deployment="gpt55-deploy",
+            api_version="2024-10-21",
+            reasoning_effort="high",
+        )
+
+
 def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> None:
     chat = _FakeChatCompletions(_FakeChatResponse("yo", _FakeUsage(3, 2)))
     provider = AzureOpenAIProvider(_config())
@@ -151,6 +259,17 @@ def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> 
     # On Azure the `model` arg carries the deployment name, not the base model id.
     assert chat.last_kwargs["model"] == "gpt55-deploy"
     assert chat.last_kwargs["max_completion_tokens"] == 16
+
+
+def test_complete_binds_configured_reasoning_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    chat = _FakeChatCompletions(_FakeChatResponse("yo", _FakeUsage(3, 2)))
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat))
+
+    provider.complete("sys", [Message(role="user", content="hi")], max_tokens=16)
+
+    assert chat.last_kwargs["reasoning_effort"] == "high"
+    assert "temperature" not in chat.last_kwargs
 
 
 def test_complete_preserves_missing_usage_for_budget_forfeit(
@@ -199,6 +318,253 @@ def test_structured_chat_applies_model_temperature_capability(
     assert response.provider_receipt.response_model == "gpt-5.5-2026-06-01"
     assert response.provider_receipt.system_fingerprint == "fp-azure-1"
     assert response.provider_receipt.temperature == (0.3 if expects_temperature else None)
+
+
+def test_structured_gpt55_reasoning_uses_azure_v1_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses()
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning tools must not use chat")),
+    )
+
+    response = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "inspect"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "description": "run a command",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "temperature": 0.3,
+                "top_p": 0.7,
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+
+    assert responses.last_kwargs == {
+        "model": "gpt55-deploy",
+        "input": [{"role": "user", "content": "inspect"}],
+        "stream": False,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "max_output_tokens": 4096,
+        "tools": [
+            {
+                "type": "function",
+                "name": "bash",
+                "description": "run a command",
+                "parameters": {"type": "object"},
+            }
+        ],
+        "reasoning": {"effort": "high"},
+    }
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.tool_calls is not None
+    assert response.choices[0].message.tool_calls[0].function.name == "bash"
+    assert response.token_usage().input_tokens == 11
+    assert response.token_usage().output_tokens == 7
+    assert response.provider_receipt is not None
+    assert response.provider_receipt.provider == "azure"
+    assert response.provider_receipt.provider_request_id == ("provider-request-azure-responses-1")
+    assert response.provider_receipt.response_id == "response-azure-1"
+    assert response.provider_receipt.requested_model == "gpt55-deploy"
+    assert response.provider_receipt.response_model == "gpt-5.5-2026-06-01"
+    assert response.provider_receipt.max_tokens_field == "max_output_tokens"
+    validate_chat_provider_receipt(
+        response.provider_receipt,
+        provider_config=provider.config,
+        requested_temperature=0.3,
+        max_tokens=4096,
+    )
+
+    assistant = response.choices[0].message.model_dump(mode="json", exclude_none=True)
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "user", "content": "inspect"},
+                    assistant,
+                    {"role": "tool", "tool_call_id": "call-1", "content": "/workspace"},
+                ],
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+    assert len(responses.calls) == 2
+    replay_input = responses.last_kwargs["input"]
+    assert isinstance(replay_input, list)
+    assert replay_input[-1] == {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": "/workspace",
+    }
+
+
+def test_responses_client_uses_trusted_azure_key_and_normalized_v1_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://Trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _endpoint_config("https://trusted.openai.azure.com/").model_copy(
+            update={"reasoning_effort": "high", "responses_api_version": "v1"}
+        )
+    )
+
+    first = provider._get_responses_client()
+    second = provider._get_responses_client()
+
+    assert first is second
+    assert constructed == [
+        {
+            "api_key": "az-real-secret",
+            "base_url": "https://trusted.openai.azure.com/openai/v1/",
+            "default_query": {"api-version": "v1"},
+            "max_retries": 0,
+        }
+    ]
+
+
+def test_untrusted_responses_endpoint_never_receives_real_azure_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _endpoint_config("https://untrusted.example").model_copy(
+            update={"reasoning_effort": "high", "responses_api_version": "v1"}
+        )
+    )
+
+    provider._get_responses_client()
+
+    assert constructed == [
+        {
+            "api_key": "endpoint-token",
+            "base_url": "https://untrusted.example/openai/v1/",
+            "default_query": {"api-version": "v1"},
+            "max_retries": 0,
+        }
+    ]
+
+
+def test_reasoning_transport_sends_explicit_v1_query_and_receipt_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"apim-request-id": "azure-v1-request-1"},
+            json={
+                "id": "resp-azure-v1-1",
+                "model": "gpt-5.5-2026-06-01",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "id": "reasoning-1",
+                        "summary": [],
+                        "encrypted_content": "ciphertext-1",
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call-1",
+                        "name": "bash",
+                        "arguments": '{"command":"pwd"}',
+                        "status": "completed",
+                    },
+                ],
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    real_openai = OpenAI
+
+    def build_openai(**kwargs: object) -> OpenAI:
+        api_key = kwargs.get("api_key")
+        base_url = kwargs.get("base_url")
+        default_query = kwargs.get("default_query")
+        max_retries = kwargs.get("max_retries")
+        assert isinstance(api_key, str)
+        assert isinstance(base_url, str)
+        assert isinstance(default_query, Mapping)
+        assert isinstance(max_retries, int)
+        return real_openai(
+            api_key=api_key,
+            base_url=base_url,
+            default_query=cast("Mapping[str, object]", default_query),
+            max_retries=max_retries,
+            http_client=http_client,
+        )
+
+    monkeypatch.setattr("openai.OpenAI", build_openai)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "dummy-test-key")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    provider = AzureOpenAIProvider(_reasoning_config())
+    try:
+        response = provider.complete_chat(
+            ChatRequest.model_validate(
+                {
+                    "messages": [{"role": "user", "content": "inspect"}],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                    "max_completion_tokens": 64,
+                }
+            )
+        )
+    finally:
+        if provider._responses_client is not None:
+            provider._responses_client.close()
+
+    assert len(requests) == 1
+    assert str(requests[0].url) == (
+        "https://example.openai.azure.com/openai/v1/responses?api-version=v1"
+    )
+    assert response.provider_receipt is not None
+    assert response.provider_receipt.provider_request_id == "azure-v1-request-1"
 
 
 def test_structured_chat_uses_azure_apim_request_id_from_real_sdk_transport() -> None:
@@ -328,6 +694,59 @@ def test_verify_reports_failure_without_raising(monkeypatch: pytest.MonkeyPatch)
     assert result.ok is False
     assert "bad endpoint" in result.detail
     assert result.kind is ProviderKind.AZURE_OPENAI
+
+
+def test_reasoning_verify_probes_one_structured_responses_tool_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses(tool_name="health_check")
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("verify must probe Responses")),
+    )
+
+    result = provider.verify()
+
+    assert result.ok is True
+    assert len(responses.calls) == 1
+    assert responses.last_kwargs["reasoning"] == {"effort": "high"}
+    assert responses.last_kwargs["tool_choice"] == "required"
+    tools = responses.last_kwargs["tools"]
+    assert isinstance(tools, list)
+    first_tool = tools[0]
+    assert isinstance(first_tool, dict)
+    assert cast("dict[str, object]", first_tool)["name"] == "health_check"
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        _FakeResponses(tool_name="health_check", headers={}),
+        _FakeResponses(error=RuntimeError("Unsupported parameter: max_output_tokens")),
+    ],
+)
+def test_reasoning_verify_rejects_missing_receipt_and_output_parameter_error(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: _FakeResponses,
+) -> None:
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+
+    result = provider.verify()
+
+    assert result.ok is False
+    assert len(responses.calls) == 1
 
 
 def _endpoint_config(endpoint: str) -> ProviderConfig:

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -731,6 +731,23 @@ def test_reasoning_verify_probes_one_structured_responses_tool_call(
     assert cast("dict[str, object]", first_tool)["name"] == "health_check"
 
 
+def test_reasoning_verify_rejects_multi_dispatch_provider_before_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(provider, "paid_request_attempts", 2)
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: (_ for _ in ()).throw(AssertionError("invalid capability must not dispatch")),
+    )
+
+    result = provider.verify()
+
+    assert result.ok is False
+    assert result.detail == "structured provider verification requires one paid request attempt"
+
+
 @pytest.mark.parametrize(
     "responses",
     [

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -11,7 +11,14 @@ import pytest
 from openai import AzureOpenAI, OpenAI
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
-from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind, TokenUsage
+from wmh.providers.base import (
+    ChatRequest,
+    ChatResponse,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+)
 from wmh.providers.receipt import validate_chat_provider_receipt
 
 
@@ -349,6 +356,36 @@ def test_complete_binds_configured_reasoning_effort(monkeypatch: pytest.MonkeyPa
     ]
     assert responses.last_kwargs["max_output_tokens"] == 16
     assert "temperature" not in responses.last_kwargs
+
+
+@pytest.mark.parametrize("reserved_name", ["input_tokens", "output_tokens"])
+def test_reasoning_complete_rejects_reserved_usage_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+    reserved_name: str,
+) -> None:
+    """Structured response extras cannot overwrite canonical billing counters."""
+    response = ChatResponse.model_validate(
+        {
+            "model": "gpt-5.5-2026-06-01",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "yo"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 11,
+                "completion_tokens": 7,
+                reserved_name: 0,
+            },
+        }
+    )
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(provider, "complete_chat", lambda request: response)
+
+    with pytest.raises(ValueError, match="reserved TokenUsage field"):
+        provider.complete("sys", [Message(role="user", content="hi")], max_tokens=16)
 
 
 def test_complete_preserves_missing_usage_for_budget_forfeit(

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -11,7 +11,7 @@ import pytest
 from openai import AzureOpenAI, OpenAI
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
-from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind, TokenUsage
 from wmh.providers.receipt import validate_chat_provider_receipt
 
 
@@ -106,29 +106,43 @@ class _FakeChat:
 
 
 class _FakeResponsesResponse:
-    def __init__(self, tool_name: str = "bash") -> None:
+    def __init__(self, tool_name: str = "bash", text: str | None = None) -> None:
         self.tool_name = tool_name
+        self.text = text
 
     def model_dump(self, *, mode: str) -> dict[str, object]:
         assert mode == "json"
-        return {
-            "id": "response-azure-1",
-            "model": "gpt-5.5-2026-06-01",
-            "status": "completed",
-            "output": [
-                {
-                    "type": "reasoning",
-                    "id": "reasoning-1",
-                    "summary": [],
-                    "encrypted_content": "ciphertext-1",
-                },
+        output: list[dict[str, object]] = [
+            {
+                "type": "reasoning",
+                "id": "reasoning-1",
+                "summary": [],
+                "encrypted_content": "ciphertext-1",
+            }
+        ]
+        if self.text is None:
+            output.append(
                 {
                     "type": "function_call",
                     "call_id": "call-1",
                     "name": self.tool_name,
                     "arguments": '{"command":"pwd"}',
-                },
-            ],
+                }
+            )
+        else:
+            output.append(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": self.text}],
+                }
+            )
+        return {
+            "id": "response-azure-1",
+            "model": "gpt-5.5-2026-06-01",
+            "status": "completed",
+            "output": output,
             "usage": {"input_tokens": 11, "output_tokens": 7},
         }
 
@@ -138,10 +152,12 @@ class _FakeResponses:
         self,
         *,
         tool_name: str = "bash",
+        text: str | None = None,
         headers: dict[str, str] | None = None,
         error: Exception | None = None,
     ) -> None:
         self.tool_name = tool_name
+        self.text = text
         self.headers = (
             {"apim-request-id": "provider-request-azure-responses-1"}
             if headers is None
@@ -157,7 +173,7 @@ class _FakeResponses:
         self.calls.append(kwargs)
         if self.error is not None:
             raise self.error
-        return _FakeResponsesResponse(self.tool_name)
+        return _FakeResponsesResponse(self.tool_name, self.text)
 
 
 class _FakeResponsesRawResponse:
@@ -263,14 +279,30 @@ def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_complete_binds_configured_reasoning_effort(monkeypatch: pytest.MonkeyPatch) -> None:
-    chat = _FakeChatCompletions(_FakeChatResponse("yo", _FakeUsage(3, 2)))
+    responses = _FakeResponses(text="yo")
     provider = AzureOpenAIProvider(_reasoning_config())
-    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(chat))
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning text must use Responses")),
+    )
 
-    provider.complete("sys", [Message(role="user", content="hi")], max_tokens=16)
+    completion = provider.complete("sys", [Message(role="user", content="hi")], max_tokens=16)
 
-    assert chat.last_kwargs["reasoning_effort"] == "high"
-    assert "temperature" not in chat.last_kwargs
+    assert completion.text == "yo"
+    assert completion.usage == TokenUsage(input_tokens=11, output_tokens=7)
+    assert responses.last_kwargs["reasoning"] == {"effort": "high"}
+    assert responses.last_kwargs["input"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+    assert responses.last_kwargs["max_output_tokens"] == 16
+    assert "temperature" not in responses.last_kwargs
 
 
 def test_complete_preserves_missing_usage_for_budget_forfeit(

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import cast
 
@@ -394,6 +395,11 @@ def test_structured_gpt55_reasoning_uses_azure_v1_responses(
     )
 
     assistant = response.choices[0].message.model_dump(mode="json", exclude_none=True)
+    reasoning_details = assistant["reasoning_details"]
+    assert isinstance(reasoning_details, list)
+    reasoning_data = reasoning_details[0]["data"]
+    assert isinstance(reasoning_data, str)
+    assert json.loads(reasoning_data)["provider"] == "azure"
     provider.complete_chat(
         ChatRequest.model_validate(
             {

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -106,9 +106,18 @@ class _FakeChat:
 
 
 class _FakeResponsesResponse:
-    def __init__(self, tool_name: str = "bash", text: str | None = None) -> None:
+    def __init__(
+        self,
+        tool_name: str = "bash",
+        text: str | None = None,
+        *,
+        usage: dict[str, object] | None = None,
+        system_fingerprint: str | None = None,
+    ) -> None:
         self.tool_name = tool_name
         self.text = text
+        self.usage = usage or {"input_tokens": 11, "output_tokens": 7}
+        self.system_fingerprint = system_fingerprint
 
     def model_dump(self, *, mode: str) -> dict[str, object]:
         assert mode == "json"
@@ -138,13 +147,16 @@ class _FakeResponsesResponse:
                     "content": [{"type": "output_text", "text": self.text}],
                 }
             )
-        return {
+        response: dict[str, object] = {
             "id": "response-azure-1",
             "model": "gpt-5.5-2026-06-01",
             "status": "completed",
             "output": output,
-            "usage": {"input_tokens": 11, "output_tokens": 7},
+            "usage": self.usage,
         }
+        if self.system_fingerprint is not None:
+            response["system_fingerprint"] = self.system_fingerprint
+        return response
 
 
 class _FakeResponses:
@@ -153,11 +165,15 @@ class _FakeResponses:
         *,
         tool_name: str = "bash",
         text: str | None = None,
+        usage: dict[str, object] | None = None,
+        system_fingerprint: str | None = None,
         headers: dict[str, str] | None = None,
         error: Exception | None = None,
     ) -> None:
         self.tool_name = tool_name
         self.text = text
+        self.usage = usage
+        self.system_fingerprint = system_fingerprint
         self.headers = (
             {"apim-request-id": "provider-request-azure-responses-1"}
             if headers is None
@@ -173,7 +189,12 @@ class _FakeResponses:
         self.calls.append(kwargs)
         if self.error is not None:
             raise self.error
-        return _FakeResponsesResponse(self.tool_name, self.text)
+        return _FakeResponsesResponse(
+            self.tool_name,
+            self.text,
+            usage=self.usage,
+            system_fingerprint=self.system_fingerprint,
+        )
 
 
 class _FakeResponsesRawResponse:
@@ -242,6 +263,7 @@ def _config() -> ProviderConfig:
 def _reasoning_config() -> ProviderConfig:
     return ProviderConfig(
         kind=ProviderKind.AZURE_OPENAI,
+        model_type="gpt-5.5",
         model="gpt-5.5",
         endpoint="https://example.openai.azure.com",
         deployment="gpt55-deploy",
@@ -249,6 +271,16 @@ def _reasoning_config() -> ProviderConfig:
         reasoning_effort="high",
         responses_api_version="v1",
     )
+
+
+def _reasoning_response_usage() -> dict[str, object]:
+    return {
+        "input_tokens": 11,
+        "output_tokens": 7,
+        "total_tokens": 18,
+        "input_tokens_details": {"cached_tokens": 3},
+        "output_tokens_details": {"reasoning_tokens": 5},
+    }
 
 
 def test_reasoning_config_requires_explicit_responses_api_version() -> None:
@@ -279,7 +311,11 @@ def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_complete_binds_configured_reasoning_effort(monkeypatch: pytest.MonkeyPatch) -> None:
-    responses = _FakeResponses(text="yo")
+    responses = _FakeResponses(
+        text="yo",
+        usage=_reasoning_response_usage(),
+        system_fingerprint="fp-azure-responses-1",
+    )
     provider = AzureOpenAIProvider(_reasoning_config())
     monkeypatch.setattr(
         provider,
@@ -295,7 +331,17 @@ def test_complete_binds_configured_reasoning_effort(monkeypatch: pytest.MonkeyPa
     completion = provider.complete("sys", [Message(role="user", content="hi")], max_tokens=16)
 
     assert completion.text == "yo"
-    assert completion.usage == TokenUsage(input_tokens=11, output_tokens=7)
+    assert completion.model == "gpt-5.5-2026-06-01"
+    assert completion.system_fingerprint == "fp-azure-responses-1"
+    assert completion.usage == TokenUsage.model_validate(
+        {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "input_tokens_details": {"cached_tokens": 3},
+            "output_tokens_details": {"reasoning_tokens": 5},
+        }
+    )
     assert responses.last_kwargs["reasoning"] == {"effort": "high"}
     assert responses.last_kwargs["input"] == [
         {"role": "system", "content": "sys"},

--- a/wmh/providers/waterfall.py
+++ b/wmh/providers/waterfall.py
@@ -75,6 +75,11 @@ def to_backend(config: ProviderConfig, *, profile: str | None = None) -> Backend
             f"provider kind {config.kind.value!r} has no llm-waterfall backend; supported: "
             f"{', '.join(sorted(k.value for k in _SUPPORTED_KINDS))}"
         )
+    if config.kind is ProviderKind.AZURE_OPENAI and config.reasoning_effort is not None:
+        raise ValueError(
+            "Azure reasoning profiles require the native AzureOpenAIProvider Responses route; "
+            "llm-waterfall Azure backends use Chat Completions and cannot preserve this profile"
+        )
     return Backend(
         provider,
         config.model,

--- a/wmh/providers/waterfall_test.py
+++ b/wmh/providers/waterfall_test.py
@@ -137,6 +137,21 @@ def test_to_backend_preserves_reasoning_effort() -> None:
     assert to_backend(config).reasoning_effort == "max"
 
 
+def test_to_backend_rejects_azure_reasoning_profile_instead_of_dropping_it() -> None:
+    config = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        endpoint="https://example.openai.azure.com",
+        deployment="gpt55-deploy",
+        api_version="2024-10-21",
+        reasoning_effort="high",
+        responses_api_version="v1",
+    )
+
+    with pytest.raises(ValueError, match="native AzureOpenAIProvider Responses route"):
+        to_backend(config)
+
+
 def test_to_backend_rejects_kinds_without_real_adapters() -> None:
     # openai_responses has no package equivalent (the package speaks chat-completions).
     with pytest.raises(ValueError, match="no llm-waterfall backend"):


### PR DESCRIPTION
## Scope

This branch explored reusable Azure reasoning support:

- Responses API routing when reasoning is enabled
- reasoning profile propagation through provider configuration
- provider-bound replay of signed reasoning state
- structured tool-call compatibility

## Disposition

The branch is stacked on superseded work and is closed without merge. The focused provider changes will be rebuilt on current main.