### PR TITLE
fix(bedrock): omit empty cache usage telemetry

### DIFF
--- a/packages/llm-waterfall/llm_waterfall/bedrock_chat.py
+++ b/packages/llm-waterfall/llm_waterfall/bedrock_chat.py
@@ -288,6 +288,18 @@ def bedrock_converse_response(
                     f"{translated_name!r}",
                 )
             translated_usage[translated_name] = value
+        # Converse can materialize optional cache telemetry even when no caching occurred.
+        # Normalize only exact no-op provider values. Positive, malformed, and unknown values
+        # remain visible so downstream pricing continues to fail closed.
+        for provider_name in ("cacheReadInputTokens", "cacheWriteInputTokens"):
+            if provider_name not in usage_data:
+                continue
+            value = usage_data[provider_name]
+            if type(value) is int and value == 0:
+                translated_usage.pop(usage_names[provider_name])
+        cache_details = usage_data.get("cacheDetails")
+        if type(cache_details) is list and not cache_details:
+            translated_usage.pop("cacheDetails")
         result["usage"] = translated_usage
     try:
         return ChatResponse.model_validate(result)

--- a/packages/llm-waterfall/llm_waterfall/bedrock_chat_test.py
+++ b/packages/llm-waterfall/llm_waterfall/bedrock_chat_test.py
@@ -6,6 +6,7 @@ import json
 from typing import cast
 
 import pytest
+from pydantic import JsonValue
 
 from llm_waterfall.bedrock_chat import (
     BedrockResponseTranslationError,
@@ -16,6 +17,10 @@ from llm_waterfall.bedrock_chat import (
 from llm_waterfall.types import ChatRequest, ResponseTranslationFailure
 
 _MODEL = "us.anthropic.claude-opus-4-6-v1"
+
+
+class _EmptyCacheDetails(list[JsonValue]):
+    """List subtype that must not be mistaken for the SDK's exact empty list."""
 
 
 def _tool_request() -> ChatRequest:
@@ -442,6 +447,62 @@ def test_usage_preserves_provider_dimensions_for_downstream_pricing() -> None:
     }
 
 
+def test_usage_omits_only_zero_or_empty_bedrock_cache_placeholders() -> None:
+    response = bedrock_converse_response(
+        {
+            "output": {"message": {"role": "assistant", "content": [{"text": "done"}]}},
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 2,
+                "totalTokens": 12,
+                "cacheReadInputTokens": 0,
+                "cacheWriteInputTokens": 0,
+                "cacheDetails": [],
+            },
+        },
+        _MODEL,
+    )
+
+    assert response.usage is not None
+    assert response.usage.model_extra == {"total_tokens": 12}
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "value", "translated_name"),
+    [
+        ("cacheReadInputTokens", 1, "cache_read_input_tokens"),
+        ("cacheWriteInputTokens", 1, "cache_write_input_tokens"),
+        ("cacheReadInputTokens", False, "cache_read_input_tokens"),
+        ("cacheWriteInputTokens", 0.0, "cache_write_input_tokens"),
+        ("cacheDetails", [{"inputTokens": 1, "ttl": "5m"}], "cacheDetails"),
+        ("cacheDetails", {}, "cacheDetails"),
+        ("cacheDetails", None, "cacheDetails"),
+        ("cacheDetails", _EmptyCacheDetails(), "cacheDetails"),
+    ],
+)
+def test_usage_preserves_nonempty_or_malformed_bedrock_cache_dimensions(
+    provider_name: str,
+    value: JsonValue,
+    translated_name: str,
+) -> None:
+    response = bedrock_converse_response(
+        {
+            "output": {"message": {"role": "assistant", "content": [{"text": "done"}]}},
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 2,
+                provider_name: value,
+            },
+        },
+        _MODEL,
+    )
+
+    assert response.usage is not None
+    assert response.usage.model_extra == {translated_name: value}
+
+
 def test_partial_usage_fails_closed() -> None:
     with pytest.raises(ValueError, match="must include inputTokens and outputTokens"):
         bedrock_converse_response(
@@ -495,6 +556,23 @@ def test_usage_alias_collision_fails_closed(
                 "output": {"message": {"role": "assistant", "content": []}},
                 "stopReason": "end_turn",
                 "usage": usage,
+            },
+            _MODEL,
+        )
+
+
+def test_zero_cache_alias_collision_fails_before_normalization() -> None:
+    with pytest.raises(ValueError, match="duplicate ChatUsage field"):
+        bedrock_converse_response(
+            {
+                "output": {"message": {"role": "assistant", "content": []}},
+                "stopReason": "end_turn",
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 4,
+                    "cacheReadInputTokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
             },
             _MODEL,
         )

--- a/wmh/tracking/budget_test.py
+++ b/wmh/tracking/budget_test.py
@@ -12,10 +12,11 @@ import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 import pytest
 from llm_waterfall import ChatRequest, ChatResponse
+from llm_waterfall.bedrock_chat import bedrock_converse_response
 from llm_waterfall.types import (
     ChatChoice,
     ChatMessage,
@@ -23,16 +24,18 @@ from llm_waterfall.types import (
 )
 from openai.types.completion_usage import CompletionUsage
 from openai.types.responses.response_usage import ResponseUsage
-from pydantic import ValidationError
+from pydantic import JsonValue, ValidationError
 
 from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
     ProviderKind,
+    SingleDispatchProvider,
     TokenUsage,
     VerifyResult,
 )
+from wmh.providers.bedrock import BedrockProvider
 from wmh.providers.receipt import (
     ProviderResponseIdentity,
     build_chat_provider_receipt,
@@ -1581,7 +1584,7 @@ def test_exposed_policy_is_a_defensive_deep_copy(tmp_path: Path) -> None:
 
 
 class _FakeToolProvider:
-    paid_request_attempts = 1
+    paid_request_attempts: Literal[1] = 1
 
     def __init__(
         self,
@@ -1637,7 +1640,7 @@ class _FakeToolProvider:
 
 def _budgeted_provider(
     tmp_path: Path,
-    provider: _FakeToolProvider,
+    provider: SingleDispatchProvider,
     *,
     ids: Iterator[str],
     response_identity: ProviderResponseIdentity | None = None,
@@ -1755,6 +1758,148 @@ def test_budgeted_provider_reserves_before_call_and_settles_exact_usage(tmp_path
     assert reservation.status is ReservationStatus.SETTLED
     assert reservation.charged_nano_usd == 11 * 2 + 7 * 5
     assert reservation.max_nano_usd > reservation.charged_nano_usd
+
+
+def test_live_shaped_bedrock_submit_with_zero_cache_usage_settles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LiveShapedBedrockClient:
+        def converse(self, **_kwargs: object) -> dict[str, object]:
+            return {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "toolUse": {
+                                    "toolUseId": "call-1",
+                                    "name": "submit",
+                                    "input": {"answer": "ok"},
+                                    "type": "tool_use",
+                                }
+                            }
+                        ],
+                    }
+                },
+                "stopReason": "tool_use",
+                "usage": {
+                    "inputTokens": 2,
+                    "outputTokens": 1,
+                    "totalTokens": 3,
+                    "cacheReadInputTokens": 0,
+                    "cacheWriteInputTokens": 0,
+                },
+                "ResponseMetadata": {"RequestId": "bedrock-request-1"},
+            }
+
+    raw_provider = BedrockProvider(
+        ProviderConfig(
+            kind=ProviderKind.BEDROCK,
+            model="model-1",
+            region="test-region",
+        )
+    )
+    client = LiveShapedBedrockClient()
+    monkeypatch.setattr(raw_provider, "_get_client", lambda: client)
+    provider, ledger = _budgeted_provider(
+        tmp_path,
+        raw_provider,
+        ids=iter(["bedrock-zero-cache"]),
+    )
+
+    returned = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "solve"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "submit",
+                            "description": "return the answer",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "max_completion_tokens": 20,
+            }
+        )
+    )
+
+    assert returned.choices[0].message.tool_calls is not None
+    assert returned.choices[0].message.tool_calls[0].function.name == "submit"
+    assert returned.usage is not None
+    assert returned.usage.model_extra == {"total_tokens": 3}
+    assert returned.provider_receipt is not None
+    assert returned.provider_receipt.provider_request_id == "bedrock-request-1"
+    [reservation] = ledger.reservations()
+    assert reservation.status is ReservationStatus.SETTLED
+    assert reservation.charged_nano_usd == 2 * 2 + 1 * 5
+
+
+@pytest.mark.parametrize(
+    ("usage_dimension", "dimension_name"),
+    [
+        ({"cacheReadInputTokens": 1}, "cache_read_input_tokens"),
+        ({"cacheWriteInputTokens": 1}, "cache_write_input_tokens"),
+        ({"cacheReadInputTokens": False}, "cache_read_input_tokens"),
+        ({"cacheWriteInputTokens": 0.0}, "cache_write_input_tokens"),
+        ({"cacheDetails": [{"inputTokens": 1, "ttl": "5m"}]}, "cacheDetails"),
+        ({"cacheDetails": {}}, "cacheDetails"),
+        ({"cacheDetails": None}, "cacheDetails"),
+    ],
+)
+def test_bedrock_submit_rejects_nonzero_nonempty_or_malformed_cache_usage(
+    tmp_path: Path,
+    usage_dimension: dict[str, JsonValue],
+    dimension_name: str,
+) -> None:
+    response = bedrock_converse_response(
+        {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "call-1",
+                                "name": "submit",
+                                "input": {"answer": "ok"},
+                                "type": "tool_use",
+                            }
+                        }
+                    ],
+                }
+            },
+            "stopReason": "tool_use",
+            "usage": {
+                "inputTokens": 2,
+                "outputTokens": 1,
+                "totalTokens": 3,
+                **usage_dimension,
+            },
+        },
+        "model-1",
+        advertised_client_tools=frozenset({"submit"}),
+    )
+    provider, ledger = _budgeted_provider(
+        tmp_path,
+        _FakeToolProvider(chat_response=response),
+        ids=iter(["bedrock-unsupported-cache"]),
+    )
+
+    with pytest.raises(UnpricedProviderUsageError, match=dimension_name):
+        provider.complete_chat(
+            ChatRequest(
+                messages=[ChatMessage(role="user", content="solve")],
+                max_completion_tokens=20,
+            )
+        )
+
+    [reservation] = ledger.reservations()
+    assert reservation.status is ReservationStatus.FORFEITED
+    assert reservation.failure_type == "UnpricedUsage"
 
 
 def test_budgeted_chat_forfeits_before_settlement_on_unpriced_usage_dimensions(


### PR DESCRIPTION
## Disposition

This branch is superseded and is not intended for merge. Exact head preserved: 584bb5765bccc6b1742163b36f52dd5d0f7f4819. No branch was deleted.