### PR TITLE
Include code paths in harness execution identity

### DIFF
--- a/wmh/harness/delta_test.py
+++ b/wmh/harness/delta_test.py
@@ -83,6 +83,35 @@ def test_apply_replaces_content_and_records_child_hash() -> None:
     assert child.surface(TOOL_POLICY_ID) == parent.surface(TOOL_POLICY_ID)
 
 
+def test_apply_treats_a_code_path_change_as_a_distinct_child() -> None:
+    base = HarnessDoc.baseline("parent")
+    code = Surface(
+        id="code:worker",
+        kind=SurfaceKind.CODE,
+        content="export const value = 1;",
+        path="src/worker.ts",
+    )
+    parent = HarnessDoc(name="parent", surfaces=[*base.surfaces, code])
+    ops = [
+        SurfaceOp(
+            op="replace",
+            surface_id=code.id,
+            content=code.content,
+            path="src/renamed-worker.ts",
+            rationale="move the executable module",
+        )
+    ]
+    delta = _delta(ops, parent=parent, preconditions={code.id: code.content_hash})
+
+    child = apply_delta(parent, delta, "child")
+
+    child_code = child.surface(code.id)
+    assert child_code is not None
+    assert child_code.path == "src/renamed-worker.ts"
+    assert child.doc_hash != parent.doc_hash
+    assert delta.child_doc_hash == child.doc_hash
+
+
 def test_apply_add_and_remove() -> None:
     parent = _parent()
     old = parent.surface("skill:old-skill")

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -182,8 +182,21 @@ class HarnessDoc(BaseModel):
 
     @property
     def doc_hash(self) -> str:
-        """Content identity of the whole document (order-independent via canonical sort)."""
-        joined = "\n".join(f"{s.id}\x00{s.content_hash}" for s in self.surfaces)
+        """Execution identity of the whole document (order-independent via canonical sort)."""
+        return self.execution_hash
+
+    @property
+    def execution_hash(self) -> str:
+        """Identity of every surface field that can change materialized execution.
+
+        Display metadata and validation-only budgets do not affect execution. A code surface's
+        destination path does, even when its id and content stay unchanged.
+        """
+        joined = "\n".join(
+            f"{surface.id}\x00{surface.content_hash}"
+            + (f"\x00path={surface.path}" if surface.path is not None else "")
+            for surface in self.surfaces
+        )
         return _digest(joined)
 
     # -- derived, validated views ------------------------------------------------------------

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -182,11 +182,6 @@ class HarnessDoc(BaseModel):
 
     @property
     def doc_hash(self) -> str:
-        """Execution identity of the whole document (order-independent via canonical sort)."""
-        return self.execution_hash
-
-    @property
-    def execution_hash(self) -> str:
         """Identity of every surface field that can change materialized execution.
 
         Display metadata and validation-only budgets do not affect execution. A code surface's

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -65,6 +65,40 @@ def test_doc_hash_is_content_and_order_independent() -> None:
     assert doc3.doc_hash != doc1.doc_hash
 
 
+def test_execution_hash_includes_materialized_paths_and_ignores_display_metadata() -> None:
+    first = HarnessDoc(
+        name="first",
+        version=1,
+        surfaces=[
+            Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
+            Surface(
+                id="code:worker",
+                kind=SurfaceKind.CODE,
+                content="export const value = 1;",
+                path="src/worker.ts",
+            ),
+        ],
+    )
+    renamed = first.model_copy(update={"name": "renamed", "version": 99})
+    moved = HarnessDoc(
+        name="moved",
+        surfaces=[
+            Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
+            Surface(
+                id="code:worker",
+                kind=SurfaceKind.CODE,
+                content="export const value = 1;",
+                path="src/moved.ts",
+            ),
+        ],
+    )
+
+    assert renamed.execution_hash == first.execution_hash
+    assert renamed.doc_hash == first.doc_hash
+    assert moved.doc_hash != first.doc_hash
+    assert moved.execution_hash != first.execution_hash
+
+
 def test_duplicate_surface_ids_rejected() -> None:
     a = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="A")
     with pytest.raises(ValidationError, match="duplicate surface id"):

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -65,7 +65,7 @@ def test_doc_hash_is_content_and_order_independent() -> None:
     assert doc3.doc_hash != doc1.doc_hash
 
 
-def test_execution_hash_includes_materialized_paths_and_ignores_display_metadata() -> None:
+def test_doc_hash_includes_materialized_paths_and_ignores_display_metadata() -> None:
     first = HarnessDoc(
         name="first",
         version=1,
@@ -93,10 +93,8 @@ def test_execution_hash_includes_materialized_paths_and_ignores_display_metadata
         ],
     )
 
-    assert renamed.execution_hash == first.execution_hash
     assert renamed.doc_hash == first.doc_hash
     assert moved.doc_hash != first.doc_hash
-    assert moved.execution_hash != first.execution_hash
 
 
 def test_duplicate_surface_ids_rejected() -> None:


### PR DESCRIPTION
## Summary

- include materialized surface paths in `HarnessDoc` execution identity
- preserve the existing identity for pathless surfaces
- treat path-only code moves as distinct delta children

## Verification

- `.venv/bin/pytest wmh/harness/doc_test.py wmh/harness/delta_test.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ty check`