### PR TITLE
Add an immutable harness scoring protocol

### DIFF
--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -56,6 +56,10 @@ if TYPE_CHECKING:
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
+# The canonical document identity is a lowercase hexadecimal 16-byte BLAKE2b digest.
+DOC_HASH_DIGEST_BYTES = 16
+DOC_HASH_PATTERN = rf"^[0-9a-f]{{{DOC_HASH_DIGEST_BYTES * 2}}}$"
+
 # Well-known surface ids. The tool policy and scalar parameters are singletons; prompt and skill
 # surfaces may be added freely (an update can split `prompt:core` into finer sections).
 TOOL_POLICY_ID = "tool_policy:main"
@@ -433,4 +437,4 @@ def code_baseline(name: str = "baseline") -> HarnessDoc:
 
 
 def _digest(text: str) -> str:
-    return hashlib.blake2b(text.encode("utf-8"), digest_size=16).hexdigest()
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=DOC_HASH_DIGEST_BYTES).hexdigest()

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -1,0 +1,348 @@
+"""Immutable, evaluator-neutral score evidence for harness optimization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Protocol, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from wmh.core.text import validate_durable_text
+from wmh.harness.doc import HarnessDoc
+
+_SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
+_SAFE_ARTIFACT_PART = r"^[A-Za-z0-9._-]+$"
+MAX_CELL_SUMMARY_CHARS = 16_000
+
+
+class ScoreContext(BaseModel):
+    """Content identities that make one evaluation request replayable."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_set_digest: str = Field(strict=True, pattern=_SHA256_PATTERN)
+    evaluator_digest: str = Field(strict=True, pattern=_SHA256_PATTERN)
+    execution_config_digest: str = Field(strict=True, pattern=_SHA256_PATTERN)
+
+    @property
+    def context_hash(self) -> str:
+        """Return a stable identity for the complete scoring context."""
+        return _sha256(self.model_dump_json())
+
+
+class ScoreRequest(BaseModel):
+    """One exact task-by-attempt matrix evaluated under a frozen context."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    context: ScoreContext
+    task_ids: tuple[str, ...]
+    attempts: int = Field(strict=True, ge=1)
+
+    @field_validator("attempts", mode="before")
+    @classmethod
+    def _reject_boolean_attempts(cls, value: object) -> object:
+        if isinstance(value, bool):
+            raise ValueError("attempts must be an integer, not boolean")
+        return value
+
+    @field_validator("task_ids")
+    @classmethod
+    def _validate_task_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("task_ids must be nonempty")
+        if len(set(value)) != len(value):
+            raise ValueError("task_ids must be unique")
+        for task_id in value:
+            if not task_id:
+                raise ValueError("task_ids must not contain empty values")
+            if len(task_id) > 512:
+                raise ValueError("task_ids must not contain values longer than 512 characters")
+            validate_durable_text(task_id, field="task id")
+        return value
+
+
+class EvaluationArtifact(BaseModel):
+    """Content-addressed reference to evaluator-owned raw evidence."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    path: str = Field(strict=True)
+    content_hash: str = Field(strict=True, pattern=_SHA256_PATTERN)
+    size_bytes: int = Field(strict=True, ge=0)
+    media_type: str = Field(default="text/plain", strict=True, min_length=1, max_length=256)
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, value: str) -> str:
+        _validate_artifact_path(value)
+        return value
+
+    @field_validator("size_bytes", mode="before")
+    @classmethod
+    def _reject_boolean_size(cls, value: object) -> object:
+        if isinstance(value, bool):
+            raise ValueError("artifact size must be an integer, not boolean")
+        return value
+
+    @field_validator("media_type")
+    @classmethod
+    def _validate_media_type(cls, value: str) -> str:
+        validate_durable_text(value, field="artifact media type")
+        return value
+
+    @classmethod
+    def from_text(
+        cls,
+        *,
+        path: str,
+        content: str,
+        media_type: str = "text/plain",
+    ) -> Self:
+        """Build a manifest entry without retaining the potentially large content."""
+        validate_durable_text(content, field=f"artifact {path!r} content")
+        return cls.from_bytes(path=path, content=content.encode("utf-8"), media_type=media_type)
+
+    @classmethod
+    def from_bytes(
+        cls,
+        *,
+        path: str,
+        content: bytes,
+        media_type: str = "application/octet-stream",
+    ) -> Self:
+        """Build a manifest entry for arbitrary evaluator evidence without retaining it."""
+        return cls(
+            path=path,
+            content_hash=_sha256_bytes(content),
+            size_bytes=len(content),
+            media_type=media_type,
+        )
+
+
+class ScoreCell(BaseModel):
+    """Normalized score and evidence index for one task attempt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
+
+    task_id: str = Field(strict=True, min_length=1, max_length=512)
+    attempt: int = Field(strict=True, ge=1)
+    score: float = Field(strict=True, ge=0.0, le=1.0, allow_inf_nan=False)
+    # The evaluator owns pass semantics. Optimization ranks by ``score``; ``passed`` is retained
+    # as diagnostic and reporting evidence rather than silently deriving a second objective.
+    passed: bool = Field(strict=True)
+    summary: str = Field(default="", strict=True, max_length=MAX_CELL_SUMMARY_CHARS)
+    artifact_paths: tuple[str, ...] = Field(min_length=1)
+
+    @field_validator("attempt", mode="before")
+    @classmethod
+    def _reject_boolean_attempt(cls, value: object) -> object:
+        if isinstance(value, bool):
+            raise ValueError("attempt must be an integer, not boolean")
+        return value
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _reject_boolean_score(cls, value: object) -> object:
+        if isinstance(value, bool):
+            raise ValueError("score must be numeric, not boolean")
+        return value
+
+    @field_validator("task_id", "summary")
+    @classmethod
+    def _validate_text(cls, value: str, info: object) -> str:
+        field_name = getattr(info, "field_name", "score cell")
+        validate_durable_text(value, field=str(field_name))
+        return value
+
+    @field_validator("artifact_paths")
+    @classmethod
+    def _validate_artifact_paths(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("artifact_paths must be unique")
+        for path in value:
+            _validate_artifact_path(path)
+        return tuple(sorted(value))
+
+
+class HarnessScoreReport(BaseModel):
+    """Canonical scorecard for one exact candidate and evaluation request."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
+
+    source_run_id: str = Field(strict=True, min_length=1, max_length=1024)
+    candidate_execution_hash: str = Field(strict=True, pattern=r"^[0-9a-f]{32}$")
+    request: ScoreRequest
+    cells: tuple[ScoreCell, ...]
+    artifacts: tuple[EvaluationArtifact, ...]
+
+    @field_validator("source_run_id", "candidate_execution_hash")
+    @classmethod
+    def _validate_identity_text(cls, value: str, info: object) -> str:
+        field_name = getattr(info, "field_name", "score identity")
+        validate_durable_text(value, field=str(field_name))
+        return value
+
+    @field_validator("cells")
+    @classmethod
+    def _canonicalize_cells(cls, value: tuple[ScoreCell, ...]) -> tuple[ScoreCell, ...]:
+        return tuple(sorted(value, key=lambda cell: (cell.task_id, cell.attempt)))
+
+    @field_validator("artifacts")
+    @classmethod
+    def _canonicalize_artifacts(
+        cls, value: tuple[EvaluationArtifact, ...]
+    ) -> tuple[EvaluationArtifact, ...]:
+        return tuple(sorted(value, key=lambda artifact: artifact.path))
+
+    @model_validator(mode="after")
+    def _validate_matrix_and_artifacts(self) -> Self:
+        observed = [(cell.task_id, cell.attempt) for cell in self.cells]
+        duplicates = sorted(key for key, count in Counter(observed).items() if count > 1)
+        if duplicates:
+            raise ValueError(f"duplicate score cell(s): {duplicates}")
+        expected = {
+            (task_id, attempt)
+            for task_id in self.request.task_ids
+            for attempt in range(1, self.request.attempts + 1)
+        }
+        missing = sorted(expected - set(observed))
+        extra = sorted(set(observed) - expected)
+        if missing or extra:
+            raise ValueError(f"score cells do not match request: missing={missing}, extra={extra}")
+
+        paths = [artifact.path for artifact in self.artifacts]
+        duplicate_paths = sorted(path for path, count in Counter(paths).items() if count > 1)
+        if duplicate_paths:
+            raise ValueError(f"duplicate artifact path(s): {duplicate_paths}")
+        known_paths = set(paths)
+        missing_paths = sorted(
+            {path for cell in self.cells for path in cell.artifact_paths if path not in known_paths}
+        )
+        if missing_paths:
+            raise ValueError(f"score cells reference missing artifact(s): {missing_paths}")
+        return self
+
+    @property
+    def score(self) -> float:
+        """Return the primary optimization objective over the complete matrix."""
+        return fmean(cell.score for cell in self.cells)
+
+    @property
+    def pass_rate(self) -> float:
+        """Return the evaluator-authoritative pass fraction for reporting."""
+        return fmean(1.0 if cell.passed else 0.0 for cell in self.cells)
+
+    @property
+    def report_hash(self) -> str:
+        """Commit to source run, candidate, context, cells, and artifact manifests."""
+        payload = self.model_dump(mode="json")
+        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        return _sha256(encoded)
+
+
+class ArtifactReader(Protocol):
+    """Read evaluator-owned raw evidence by safe relative path."""
+
+    def read_bytes(self, path: str) -> bytes: ...
+
+
+@dataclass(frozen=True)
+class HarnessScore:
+    """A durable score report paired with its non-inline raw artifact reader."""
+
+    report: HarnessScoreReport
+    artifacts: ArtifactReader
+
+
+class HarnessScorer(Protocol):
+    """Synchronous evaluator injected into a harness optimization loop."""
+
+    def score(
+        self,
+        candidate: HarnessDoc,
+        *,
+        request: ScoreRequest,
+    ) -> HarnessScore: ...
+
+
+def score_harness(
+    scorer: HarnessScorer,
+    candidate: HarnessDoc,
+    *,
+    request: ScoreRequest,
+) -> HarnessScore:
+    """Score once, reject identity drift, and detach immutable trusted metadata."""
+    scored = scorer.score(candidate, request=request)
+    if scored.report.candidate_execution_hash != candidate.execution_hash:
+        raise ValueError(
+            "scorer returned a candidate execution hash that does not match the scored harness"
+        )
+    if scored.report.request != request:
+        raise ValueError("scorer returned a different score request than the caller supplied")
+    snapshot = HarnessScoreReport.model_validate(scored.report.model_dump(mode="python"))
+    artifacts = _VerifiedArtifactReader(snapshot.artifacts, scored.artifacts)
+    artifacts.verify_all()
+    return HarnessScore(report=snapshot, artifacts=artifacts)
+
+
+class _VerifiedArtifactReader:
+    """Check evaluator-owned bytes against the immutable manifest on every read."""
+
+    def __init__(
+        self,
+        manifest: Sequence[EvaluationArtifact],
+        source: ArtifactReader,
+    ) -> None:
+        self._manifest = {artifact.path: artifact for artifact in manifest}
+        self._source = source
+
+    def verify_all(self) -> None:
+        """Fail before publication when any manifest entry is absent or changed."""
+        for path in sorted(self._manifest):
+            self.read_bytes(path)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read and verify one artifact."""
+        artifact = self._manifest.get(path)
+        if artifact is None:
+            raise ValueError(f"artifact {path!r} is not present in the score manifest")
+        content = self._source.read_bytes(path)
+        if not isinstance(content, bytes):
+            raise TypeError(f"artifact {path!r} reader returned non-bytes content")
+        if len(content) != artifact.size_bytes:
+            raise ValueError(
+                f"artifact {path!r} size differs from its manifest: "
+                f"expected {artifact.size_bytes}, got {len(content)}"
+            )
+        digest = _sha256_bytes(content)
+        if digest != artifact.content_hash:
+            raise ValueError(
+                f"artifact {path!r} digest differs from its manifest: "
+                f"expected {artifact.content_hash}, got {digest}"
+            )
+        return content
+
+
+def _validate_artifact_path(path: str) -> None:
+    if not path or path.startswith("/") or "\\" in path:
+        raise ValueError(f"artifact path must be a safe relative POSIX path, got {path!r}")
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"artifact path must be canonical and traversal-free, got {path!r}")
+    if any(re.fullmatch(_SAFE_ARTIFACT_PART, part) is None for part in parts):
+        raise ValueError(f"artifact path contains unsupported characters: {path!r}")
+
+
+def _sha256(value: str) -> str:
+    return _sha256_bytes(value.encode("utf-8"))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -14,7 +14,7 @@ from typing import Protocol, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from wmh.core.text import validate_durable_text
-from wmh.harness.doc import HarnessDoc
+from wmh.harness.doc import DOC_HASH_PATTERN, HarnessDoc
 
 _SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
 _SAFE_ARTIFACT_PART = r"^[A-Za-z0-9._-]+$"
@@ -177,12 +177,12 @@ class HarnessScoreReport(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
 
     source_run_id: str = Field(strict=True, min_length=1, max_length=1024)
-    candidate_execution_hash: str = Field(strict=True, pattern=r"^[0-9a-f]{32}$")
+    candidate_doc_hash: str = Field(strict=True, pattern=DOC_HASH_PATTERN)
     request: ScoreRequest
     cells: tuple[ScoreCell, ...]
     artifacts: tuple[EvaluationArtifact, ...]
 
-    @field_validator("source_run_id", "candidate_execution_hash")
+    @field_validator("source_run_id", "candidate_doc_hash")
     @classmethod
     def _validate_identity_text(cls, value: str, info: object) -> str:
         field_name = getattr(info, "field_name", "score identity")
@@ -227,6 +227,10 @@ class HarnessScoreReport(BaseModel):
         )
         if missing_paths:
             raise ValueError(f"score cells reference missing artifact(s): {missing_paths}")
+        referenced_paths = {path for cell in self.cells for path in cell.artifact_paths}
+        orphan_paths = sorted(known_paths - referenced_paths)
+        if orphan_paths:
+            raise ValueError(f"score report contains unreferenced artifact(s): {orphan_paths}")
         return self
 
     @property
@@ -280,9 +284,9 @@ def score_harness(
 ) -> HarnessScore:
     """Score once, reject identity drift, and detach immutable trusted metadata."""
     scored = scorer.score(candidate, request=request)
-    if scored.report.candidate_execution_hash != candidate.doc_hash:
+    if scored.report.candidate_doc_hash != candidate.doc_hash:
         raise ValueError(
-            "scorer returned a candidate execution hash that does not match the scored harness"
+            "scorer returned a candidate document hash that does not match the harness"
         )
     if scored.report.request != request:
         raise ValueError("scorer returned a different score request than the caller supplied")

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -280,7 +280,7 @@ def score_harness(
 ) -> HarnessScore:
     """Score once, reject identity drift, and detach immutable trusted metadata."""
     scored = scorer.score(candidate, request=request)
-    if scored.report.candidate_execution_hash != candidate.execution_hash:
+    if scored.report.candidate_execution_hash != candidate.doc_hash:
         raise ValueError(
             "scorer returned a candidate execution hash that does not match the scored harness"
         )

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -1,0 +1,419 @@
+"""Tests for benchmark-neutral harness scoring contracts."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.harness.doc import HarnessDoc, SurfaceKind
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+    score_harness,
+)
+
+_TASK_SET_DIGEST = "sha256:" + "a" * 64
+_EVALUATOR_DIGEST = "sha256:" + "b" * 64
+_EXECUTION_CONFIG_DIGEST = "sha256:" + "c" * 64
+_RAW_PATH = "raw/evidence.txt"
+
+
+class _ArtifactReader:
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+
+    def read_bytes(self, path: str) -> bytes:
+        return self.files[path]
+
+
+def _context() -> ScoreContext:
+    return ScoreContext(
+        task_set_digest=_TASK_SET_DIGEST,
+        evaluator_digest=_EVALUATOR_DIGEST,
+        execution_config_digest=_EXECUTION_CONFIG_DIGEST,
+    )
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(context=_context(), task_ids=("task-a", "task-b"), attempts=2)
+
+
+def _cells() -> tuple[ScoreCell, ...]:
+    return (
+        ScoreCell(
+            task_id="task-a",
+            attempt=1,
+            score=1.0,
+            passed=True,
+            summary="completed",
+            artifact_paths=(_RAW_PATH,),
+        ),
+        ScoreCell(
+            task_id="task-a",
+            attempt=2,
+            score=0.0,
+            passed=False,
+            artifact_paths=(_RAW_PATH,),
+        ),
+        ScoreCell(
+            task_id="task-b",
+            attempt=1,
+            score=0.5,
+            passed=False,
+            artifact_paths=(_RAW_PATH,),
+        ),
+        ScoreCell(
+            task_id="task-b",
+            attempt=2,
+            score=1.0,
+            passed=True,
+            artifact_paths=(_RAW_PATH,),
+        ),
+    )
+
+
+def _score(candidate: HarnessDoc, *, content: str = "raw trace\n") -> HarnessScore:
+    artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content=content)
+    report = HarnessScoreReport(
+        source_run_id="run-1",
+        candidate_execution_hash=candidate.execution_hash,
+        request=_request(),
+        cells=_cells(),
+        artifacts=(artifact,),
+    )
+    return HarnessScore(
+        report=report,
+        artifacts=_ArtifactReader({_RAW_PATH: content.encode("utf-8")}),
+    )
+
+
+@pytest.mark.parametrize("task_ids", [(), ("task-a", "task-a")])
+def test_score_request_rejects_empty_or_duplicate_tasks(task_ids: tuple[str, ...]) -> None:
+    with pytest.raises(ValidationError, match="task_ids"):
+        ScoreRequest(context=_context(), task_ids=task_ids, attempts=1)
+
+
+def test_score_request_rejects_task_ids_that_cells_cannot_represent() -> None:
+    with pytest.raises(ValidationError, match="512"):
+        ScoreRequest(context=_context(), task_ids=("x" * 513,), attempts=1)
+
+
+@pytest.mark.parametrize(
+    "model,value",
+    [
+        (ScoreContext, _context().model_dump()),
+        (ScoreRequest, _request().model_dump()),
+        (
+            EvaluationArtifact,
+            EvaluationArtifact.from_text(path=_RAW_PATH, content="raw trace\n").model_dump(),
+        ),
+        (ScoreCell, _cells()[0].model_dump()),
+    ],
+)
+def test_public_score_models_reject_unknown_fields(
+    model: type[ScoreContext | ScoreRequest | EvaluationArtifact | ScoreCell],
+    value: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        model.model_validate({**value, "unexpected": "value"})
+
+
+def test_score_report_rejects_unknown_fields_and_invalid_candidate_hash() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    report = _score(candidate).report
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        HarnessScoreReport.model_validate({**report.model_dump(), "unexpected": "value"})
+    with pytest.raises(ValidationError, match="candidate_execution_hash"):
+        HarnessScoreReport.model_validate(
+            {**report.model_dump(), "candidate_execution_hash": "not-a-hash"}
+        )
+
+
+def test_score_models_reject_stringified_or_integer_typed_measurements() -> None:
+    request = _request().model_dump()
+    cell = _cells()[0].model_dump()
+    artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content="raw trace\n").model_dump()
+
+    with pytest.raises(ValidationError, match="attempts"):
+        ScoreRequest.model_validate({**request, "attempts": "2"})
+    with pytest.raises(ValidationError, match="attempt"):
+        ScoreCell.model_validate({**cell, "attempt": "1"})
+    with pytest.raises(ValidationError, match="score"):
+        ScoreCell.model_validate({**cell, "score": "1.0"})
+    with pytest.raises(ValidationError, match="passed"):
+        ScoreCell.model_validate({**cell, "passed": 1})
+    with pytest.raises(ValidationError, match="size_bytes"):
+        EvaluationArtifact.model_validate({**artifact, "size_bytes": "10"})
+
+
+@pytest.mark.parametrize(
+    "cells,match",
+    [
+        (_cells()[:-1], "missing"),
+        (
+            (
+                *_cells(),
+                ScoreCell(
+                    task_id="task-c",
+                    attempt=1,
+                    score=0.0,
+                    passed=False,
+                    artifact_paths=(_RAW_PATH,),
+                ),
+            ),
+            "extra",
+        ),
+        ((_cells()[0], *_cells()), "duplicate"),
+    ],
+)
+def test_score_report_requires_the_exact_task_attempt_matrix(
+    cells: tuple[ScoreCell, ...], match: str
+) -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content="raw trace\n")
+
+    with pytest.raises(ValidationError, match=match):
+        HarnessScoreReport(
+            source_run_id="run-1",
+            candidate_execution_hash=candidate.execution_hash,
+            request=_request(),
+            cells=cells,
+            artifacts=(artifact,),
+        )
+
+
+@pytest.mark.parametrize("path", ["", ".", "/absolute.txt", "../escape.txt", "a/../b"])
+def test_artifact_manifest_rejects_unsafe_or_noncanonical_paths(path: str) -> None:
+    with pytest.raises(ValidationError, match="path"):
+        EvaluationArtifact.from_text(path=path, content="raw trace")
+
+
+def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content="raw trace\n")
+    unreferenced = _cells()[0].model_copy(update={"artifact_paths": ("missing.txt",)})
+    no_evidence = _cells()[0].model_copy(update={"artifact_paths": ()})
+
+    with pytest.raises(ValidationError, match="artifact_paths"):
+        ScoreCell.model_validate(no_evidence.model_dump())
+
+    with pytest.raises(ValidationError, match="missing artifact"):
+        HarnessScoreReport(
+            source_run_id="run-1",
+            candidate_execution_hash=candidate.execution_hash,
+            request=_request(),
+            cells=(unreferenced, *_cells()[1:]),
+            artifacts=(artifact,),
+        )
+
+    with pytest.raises(ValidationError, match="duplicate artifact"):
+        HarnessScoreReport(
+            source_run_id="run-1",
+            candidate_execution_hash=candidate.execution_hash,
+            request=_request(),
+            cells=_cells(),
+            artifacts=(artifact, artifact),
+        )
+
+
+@pytest.mark.parametrize("score", [True, -0.01, 1.01, float("nan"), float("inf")])
+def test_score_cell_rejects_boolean_nonfinite_or_out_of_range_scores(
+    score: float | bool,
+) -> None:
+    with pytest.raises(ValidationError, match="score"):
+        ScoreCell(
+            task_id="task",
+            attempt=1,
+            score=score,
+            passed=False,
+            artifact_paths=(_RAW_PATH,),
+        )
+
+
+def test_raw_artifacts_are_hash_bound_and_read_without_truncation() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    content = "event\n" * 100_000
+
+    class Scorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del request
+            return _score(candidate, content=content)
+
+    scored = score_harness(
+        Scorer(),
+        candidate,
+        request=_request(),
+    )
+
+    assert scored.artifacts.read_bytes(_RAW_PATH) == content.encode("utf-8")
+    assert scored.report.artifacts[0].content_hash.startswith("sha256:")
+    assert scored.report.artifacts[0].size_bytes == len(content.encode("utf-8"))
+    assert content not in scored.report.model_dump_json()
+
+
+def test_artifact_manifest_and_reader_preserve_arbitrary_bytes() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    path = "raw/blob.bin"
+    content = b"\x00\xffbinary\x00"
+    artifact = EvaluationArtifact.from_bytes(path=path, content=content)
+    cells = tuple(cell.model_copy(update={"artifact_paths": (path,)}) for cell in _cells())
+    report = HarnessScoreReport(
+        source_run_id="run-1",
+        candidate_execution_hash=candidate.execution_hash,
+        request=_request(),
+        cells=cells,
+        artifacts=(artifact,),
+    )
+
+    class Scorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del candidate, request
+            return HarnessScore(report=report, artifacts=_ArtifactReader({path: content}))
+
+    scored = score_harness(Scorer(), candidate, request=_request())
+
+    assert scored.artifacts.read_bytes(path) == content
+
+
+def test_report_identity_is_canonical_and_commits_to_all_evidence() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    scored = _score(candidate)
+    report = scored.report
+    reordered = HarnessScoreReport(
+        source_run_id=report.source_run_id,
+        candidate_execution_hash=report.candidate_execution_hash,
+        request=report.request,
+        cells=tuple(reversed(report.cells)),
+        artifacts=tuple(reversed(report.artifacts)),
+    )
+    changed_cell = report.model_copy(
+        update={
+            "cells": (
+                report.cells[0].model_copy(update={"score": 0.75}),
+                *report.cells[1:],
+            )
+        }
+    )
+    changed_content = "different\n"
+    changed_artifact = report.model_copy(
+        update={
+            "artifacts": (EvaluationArtifact.from_text(path=_RAW_PATH, content=changed_content),)
+        }
+    )
+    changed_run = report.model_copy(update={"source_run_id": "run-2"})
+
+    assert reordered.cells == report.cells
+    assert reordered.artifacts == report.artifacts
+    assert reordered.report_hash == report.report_hash
+    assert changed_cell.report_hash != report.report_hash
+    assert changed_artifact.report_hash != report.report_hash
+    assert changed_run.report_hash != report.report_hash
+    assert report.score == pytest.approx(0.625)
+    # `passed` is evaluator-authoritative diagnostic evidence. Search ranks by `score`, not this.
+    assert report.pass_rate == pytest.approx(0.5)
+
+
+def test_score_harness_rejects_candidate_request_or_artifact_identity_drift() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    other = HarnessDoc(
+        name="other",
+        surfaces=[
+            surface.model_copy(update={"content": "changed"})
+            if surface.kind is SurfaceKind.PROMPT
+            else surface
+            for surface in candidate.surfaces
+        ],
+    )
+
+    class WrongCandidateScorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del candidate, request
+            return _score(other)
+
+    with pytest.raises(ValueError, match="candidate execution hash"):
+        score_harness(WrongCandidateScorer(), candidate, request=_request())
+
+    class WrongRequestScorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del request
+            scored = _score(candidate)
+            wrong = scored.report.model_copy(
+                update={
+                    "request": ScoreRequest(context=_context(), task_ids=("task-a",), attempts=1)
+                }
+            )
+            return HarnessScore(report=wrong, artifacts=scored.artifacts)
+
+    with pytest.raises(ValueError, match="score request"):
+        score_harness(WrongRequestScorer(), candidate, request=_request())
+
+    class MutatedArtifactScorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del request
+            scored = _score(candidate)
+            source = _ArtifactReader({_RAW_PATH: b"mutated!!\n"})
+            return HarnessScore(report=scored.report, artifacts=source)
+
+    with pytest.raises(ValueError, match="artifact.*digest"):
+        score_harness(MutatedArtifactScorer(), candidate, request=_request())
+
+
+def test_score_harness_returns_a_detached_deeply_immutable_snapshot() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    original = _score(candidate)
+
+    class Scorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            assert candidate.execution_hash == original.report.candidate_execution_hash
+            assert request == _request()
+            return original
+
+    snapshot = score_harness(Scorer(), candidate, request=_request())
+
+    assert snapshot.report == original.report
+    assert snapshot.report is not original.report
+    assert snapshot.report.cells is not original.report.cells
+    with pytest.raises(ValidationError, match="frozen"):
+        snapshot.report.source_run_id = "changed"
+    with pytest.raises(ValidationError, match="frozen"):
+        snapshot.report.cells[0].summary = "changed"
+    with pytest.raises(ValidationError, match="frozen"):
+        snapshot.report.artifacts[0].path = "changed.txt"
+    with pytest.raises(ValidationError, match="frozen"):
+        snapshot.report.request.attempts = 3
+    with pytest.raises(ValidationError, match="frozen"):
+        snapshot.report.request.context.task_set_digest = _EVALUATOR_DIGEST
+    with pytest.raises(FrozenInstanceError):
+        snapshot.report = original.report  # ty: ignore[invalid-assignment]
+
+
+def test_score_harness_detects_artifact_mutation_after_snapshot() -> None:
+    candidate = HarnessDoc.baseline("candidate")
+    content = "raw trace\n"
+    artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content=content)
+    source = _ArtifactReader({_RAW_PATH: content.encode("utf-8")})
+    report = HarnessScoreReport(
+        source_run_id="run-1",
+        candidate_execution_hash=candidate.execution_hash,
+        request=_request(),
+        cells=_cells(),
+        artifacts=(artifact,),
+    )
+
+    class Scorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            del candidate, request
+            return HarnessScore(report=report, artifacts=source)
+
+    snapshot = score_harness(Scorer(), candidate, request=_request())
+    source.files[_RAW_PATH] = b"mutated!!\n"
+
+    with pytest.raises(ValueError, match="artifact.*digest"):
+        snapshot.artifacts.read_bytes(_RAW_PATH)

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -82,7 +82,7 @@ def _score(candidate: HarnessDoc, *, content: str = "raw trace\n") -> HarnessSco
     artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content=content)
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.doc_hash,
+        candidate_doc_hash=candidate.doc_hash,
         request=_request(),
         cells=_cells(),
         artifacts=(artifact,),
@@ -130,9 +130,9 @@ def test_score_report_rejects_unknown_fields_and_invalid_candidate_hash() -> Non
 
     with pytest.raises(ValidationError, match="extra_forbidden"):
         HarnessScoreReport.model_validate({**report.model_dump(), "unexpected": "value"})
-    with pytest.raises(ValidationError, match="candidate_execution_hash"):
+    with pytest.raises(ValidationError, match="candidate_doc_hash"):
         HarnessScoreReport.model_validate(
-            {**report.model_dump(), "candidate_execution_hash": "not-a-hash"}
+            {**report.model_dump(), "candidate_doc_hash": "not-a-hash"}
         )
 
 
@@ -182,7 +182,7 @@ def test_score_report_requires_the_exact_task_attempt_matrix(
     with pytest.raises(ValidationError, match=match):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.doc_hash,
+            candidate_doc_hash=candidate.doc_hash,
             request=_request(),
             cells=cells,
             artifacts=(artifact,),
@@ -198,6 +198,7 @@ def test_artifact_manifest_rejects_unsafe_or_noncanonical_paths(path: str) -> No
 def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
     candidate = HarnessDoc.baseline("candidate")
     artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content="raw trace\n")
+    orphan = EvaluationArtifact.from_text(path="raw/orphan.txt", content="orphan\n")
     unreferenced = _cells()[0].model_copy(update={"artifact_paths": ("missing.txt",)})
     no_evidence = _cells()[0].model_copy(update={"artifact_paths": ()})
 
@@ -207,7 +208,7 @@ def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
     with pytest.raises(ValidationError, match="missing artifact"):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.doc_hash,
+            candidate_doc_hash=candidate.doc_hash,
             request=_request(),
             cells=(unreferenced, *_cells()[1:]),
             artifacts=(artifact,),
@@ -216,10 +217,19 @@ def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
     with pytest.raises(ValidationError, match="duplicate artifact"):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.doc_hash,
+            candidate_doc_hash=candidate.doc_hash,
             request=_request(),
             cells=_cells(),
             artifacts=(artifact, artifact),
+        )
+
+    with pytest.raises(ValidationError, match="unreferenced artifact"):
+        HarnessScoreReport(
+            source_run_id="run-1",
+            candidate_doc_hash=candidate.doc_hash,
+            request=_request(),
+            cells=_cells(),
+            artifacts=(artifact, orphan),
         )
 
 
@@ -266,7 +276,7 @@ def test_artifact_manifest_and_reader_preserve_arbitrary_bytes() -> None:
     cells = tuple(cell.model_copy(update={"artifact_paths": (path,)}) for cell in _cells())
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.doc_hash,
+        candidate_doc_hash=candidate.doc_hash,
         request=_request(),
         cells=cells,
         artifacts=(artifact,),
@@ -288,7 +298,7 @@ def test_report_identity_is_canonical_and_commits_to_all_evidence() -> None:
     report = scored.report
     reordered = HarnessScoreReport(
         source_run_id=report.source_run_id,
-        candidate_execution_hash=report.candidate_execution_hash,
+        candidate_doc_hash=report.candidate_doc_hash,
         request=report.request,
         cells=tuple(reversed(report.cells)),
         artifacts=tuple(reversed(report.artifacts)),
@@ -337,7 +347,7 @@ def test_score_harness_rejects_candidate_request_or_artifact_identity_drift() ->
             del candidate, request
             return _score(other)
 
-    with pytest.raises(ValueError, match="candidate execution hash"):
+    with pytest.raises(ValueError, match="candidate document hash"):
         score_harness(WrongCandidateScorer(), candidate, request=_request())
 
     class WrongRequestScorer:
@@ -371,7 +381,7 @@ def test_score_harness_returns_a_detached_deeply_immutable_snapshot() -> None:
 
     class Scorer:
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
-            assert candidate.doc_hash == original.report.candidate_execution_hash
+            assert candidate.doc_hash == original.report.candidate_doc_hash
             assert request == _request()
             return original
 
@@ -401,7 +411,7 @@ def test_score_harness_detects_artifact_mutation_after_snapshot() -> None:
     source = _ArtifactReader({_RAW_PATH: content.encode("utf-8")})
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.doc_hash,
+        candidate_doc_hash=candidate.doc_hash,
         request=_request(),
         cells=_cells(),
         artifacts=(artifact,),

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -82,7 +82,7 @@ def _score(candidate: HarnessDoc, *, content: str = "raw trace\n") -> HarnessSco
     artifact = EvaluationArtifact.from_text(path=_RAW_PATH, content=content)
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.execution_hash,
+        candidate_execution_hash=candidate.doc_hash,
         request=_request(),
         cells=_cells(),
         artifacts=(artifact,),
@@ -182,7 +182,7 @@ def test_score_report_requires_the_exact_task_attempt_matrix(
     with pytest.raises(ValidationError, match=match):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.execution_hash,
+            candidate_execution_hash=candidate.doc_hash,
             request=_request(),
             cells=cells,
             artifacts=(artifact,),
@@ -207,7 +207,7 @@ def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
     with pytest.raises(ValidationError, match="missing artifact"):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.execution_hash,
+            candidate_execution_hash=candidate.doc_hash,
             request=_request(),
             cells=(unreferenced, *_cells()[1:]),
             artifacts=(artifact,),
@@ -216,7 +216,7 @@ def test_score_report_requires_raw_evidence_and_unique_artifact_paths() -> None:
     with pytest.raises(ValidationError, match="duplicate artifact"):
         HarnessScoreReport(
             source_run_id="run-1",
-            candidate_execution_hash=candidate.execution_hash,
+            candidate_execution_hash=candidate.doc_hash,
             request=_request(),
             cells=_cells(),
             artifacts=(artifact, artifact),
@@ -266,7 +266,7 @@ def test_artifact_manifest_and_reader_preserve_arbitrary_bytes() -> None:
     cells = tuple(cell.model_copy(update={"artifact_paths": (path,)}) for cell in _cells())
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.execution_hash,
+        candidate_execution_hash=candidate.doc_hash,
         request=_request(),
         cells=cells,
         artifacts=(artifact,),
@@ -371,7 +371,7 @@ def test_score_harness_returns_a_detached_deeply_immutable_snapshot() -> None:
 
     class Scorer:
         def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
-            assert candidate.execution_hash == original.report.candidate_execution_hash
+            assert candidate.doc_hash == original.report.candidate_execution_hash
             assert request == _request()
             return original
 
@@ -401,7 +401,7 @@ def test_score_harness_detects_artifact_mutation_after_snapshot() -> None:
     source = _ArtifactReader({_RAW_PATH: content.encode("utf-8")})
     report = HarnessScoreReport(
         source_run_id="run-1",
-        candidate_execution_hash=candidate.execution_hash,
+        candidate_execution_hash=candidate.doc_hash,
         request=_request(),
         cells=_cells(),
         artifacts=(artifact,),


### PR DESCRIPTION
## Summary

- define evaluator-neutral score requests and exact task-attempt reports
- bind reports to candidate execution identity and content-addressed evidence
- validate scorer output and verify artifact bytes before returning trusted evidence

## Verification

- `.venv/bin/pytest wmh/harness/scoring_test.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ty check`