### PR TITLE
Make harness runtime execution policy explicit

### DIFF
--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -273,7 +273,7 @@ class HarnessDoc(BaseModel):
         e2b_template: str | None = None,
         e2b_pool: E2BSandboxPool | None = None,
         pi_transport: Literal["ssh", "link"] | None = None,
-        transport_retries: int = 1,
+        transport_retries: int | None = None,
         should_cancel: Callable[[], bool] | None = None,
     ) -> Runtime:
         """The configured agent runtime this document describes.
@@ -288,12 +288,14 @@ class HarnessDoc(BaseModel):
         npm deps) is already done; default is $WMH_E2B_TEMPLATE. Under `local`, "pi-node" uses
         the SSH shim (or the RunnerLink frame transport when PI_TRANSPORT=link); otherwise a
         `code:runtime` surface drives episodes with the harness's own in-process program; with
-        neither, the fixed baseline loop runs. All expose the same
+        neither, the fixed baseline loop runs. `transport_retries` controls whole-episode replay
+        only for the E2B pi-node backend; omitting it preserves that runtime's one-retry default.
+        All expose the same
         `run(task_id, instruction, environment) -> RunResult` shape closed-loop eval drives.
         """
         if backend not in ("local", "e2b"):
             raise ValueError(f"unknown backend {backend!r}; choose local or e2b")
-        if (
+        if transport_retries is not None and (
             isinstance(transport_retries, bool)
             or not isinstance(transport_retries, int)
             or transport_retries < 0
@@ -304,6 +306,8 @@ class HarnessDoc(BaseModel):
         runtime_kind = self.runtime_kind()
         if pi_transport is not None and (backend != "local" or runtime_kind != "pi-node"):
             raise ValueError("pi_transport applies only to local pi-node execution")
+        if transport_retries is not None and (backend != "e2b" or runtime_kind != "pi-node"):
+            raise ValueError("transport_retries applies only to e2b pi-node execution")
         if runtime_kind == "pi-node":
             skills = SkillLibrary(self.skills())
             code_files = {s.path: s.content for s in self.code_files() if s.path is not None}
@@ -341,7 +345,7 @@ class HarnessDoc(BaseModel):
                     pool=e2b_pool,
                     max_turns=self.max_turns(),
                     max_output_tokens=self.max_output_tokens(),
-                    transport_retries=transport_retries,
+                    transport_retries=(1 if transport_retries is None else transport_retries),
                     should_cancel=should_cancel,
                 )
             # PI_TRANSPORT=link routes pi to the RunnerLink frame transport (a persistent runner the

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -28,7 +28,7 @@ import os
 import re
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -272,6 +272,8 @@ class HarnessDoc(BaseModel):
         backend: str = "local",
         e2b_template: str | None = None,
         e2b_pool: E2BSandboxPool | None = None,
+        pi_transport: Literal["ssh", "link"] | None = None,
+        transport_retries: int = 1,
         should_cancel: Callable[[], bool] | None = None,
     ) -> Runtime:
         """The configured agent runtime this document describes.
@@ -291,7 +293,18 @@ class HarnessDoc(BaseModel):
         """
         if backend not in ("local", "e2b"):
             raise ValueError(f"unknown backend {backend!r}; choose local or e2b")
-        if self.runtime_kind() == "pi-node":
+        if (
+            isinstance(transport_retries, bool)
+            or not isinstance(transport_retries, int)
+            or transport_retries < 0
+        ):
+            raise ValueError("transport_retries must be a nonnegative integer")
+        if pi_transport not in (None, "ssh", "link"):
+            raise ValueError("pi_transport must be ssh or link")
+        runtime_kind = self.runtime_kind()
+        if pi_transport is not None and (backend != "local" or runtime_kind != "pi-node"):
+            raise ValueError("pi_transport applies only to local pi-node execution")
+        if runtime_kind == "pi-node":
             skills = SkillLibrary(self.skills())
             code_files = {s.path: s.content for s in self.code_files() if s.path is not None}
             tool_names = self.tools()
@@ -302,8 +315,11 @@ class HarnessDoc(BaseModel):
                 tool_names.append(READ_SKILL.name)
             tools = resolve_tools(tool_names)
             structured_provider = provider if isinstance(provider, ToolCallingProvider) else None
+            effective_pi_transport = pi_transport or (
+                "link" if os.environ.get("PI_TRANSPORT") == "link" else "ssh"
+            )
             if (
-                backend == "e2b" or os.environ.get("PI_TRANSPORT") == "link"
+                backend == "e2b" or effective_pi_transport == "link"
             ) and structured_provider is None:
                 raise TypeError(
                     "pi-node link/e2b execution needs a ToolCallingProvider; "
@@ -325,12 +341,13 @@ class HarnessDoc(BaseModel):
                     pool=e2b_pool,
                     max_turns=self.max_turns(),
                     max_output_tokens=self.max_output_tokens(),
+                    transport_retries=transport_retries,
                     should_cancel=should_cancel,
                 )
             # PI_TRANSPORT=link routes pi to the RunnerLink frame transport (a persistent runner the
             # host set via runner_link.set_active_channel) instead of the per-episode SSH shim; the
             # default (unset / "ssh") keeps PiRuntime. The worker LLM reads the same PI_AGENT_* env.
-            if os.environ.get("PI_TRANSPORT") == "link":
+            if effective_pi_transport == "link":
                 from wmh.harness.runner_link import (
                     RunnerLink,
                     active_channel,

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -312,3 +312,15 @@ def test_runtime_e2b_backend_rejects_in_process_runtime_kinds() -> None:
         HarnessDoc.baseline("b").runtime(provider, backend="e2b")
     with pytest.raises(ValueError, match="use backend='local'"):
         code_baseline("c").runtime(provider, backend="e2b")
+
+
+def test_pi_transport_rejects_execution_modes_where_it_has_no_effect() -> None:
+    provider = _stub_provider()
+    with pytest.raises(ValueError, match="only to local pi-node"):
+        _pi_doc().runtime(
+            provider,
+            backend="e2b",
+            pi_transport="ssh",
+        )
+    with pytest.raises(ValueError, match="only to local pi-node"):
+        HarnessDoc.baseline("b").runtime(provider, pi_transport="ssh")

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -324,3 +324,27 @@ def test_pi_transport_rejects_execution_modes_where_it_has_no_effect() -> None:
         )
     with pytest.raises(ValueError, match="only to local pi-node"):
         HarnessDoc.baseline("b").runtime(provider, pi_transport="ssh")
+
+
+def test_transport_retries_rejects_execution_modes_where_it_has_no_effect() -> None:
+    provider = _stub_provider()
+    with pytest.raises(ValueError, match="only to e2b pi-node"):
+        _pi_doc().runtime(provider, transport_retries=0)
+    with pytest.raises(ValueError, match="only to e2b pi-node"):
+        HarnessDoc.baseline("b").runtime(provider, transport_retries=0)
+
+
+def test_transport_retries_reaches_e2b_pi_runtime() -> None:
+    from wmh.harness.pi_e2b import E2BPiRuntime, E2BSandboxPool
+
+    pool = E2BSandboxPool()
+    runtime = _pi_doc().runtime(
+        _stub_provider(),
+        backend="e2b",
+        e2b_pool=pool,
+        transport_retries=0,
+    )
+
+    assert isinstance(runtime, E2BPiRuntime)
+    assert runtime._transport_retries == 0  # noqa: SLF001 - pins public policy passthrough
+    pool.close()

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -47,6 +47,13 @@ _KILL_DELAYS = (0.1, 0.5)
 _KILL_REQUEST_TIMEOUT_S = 5.0
 
 
+def resolve_e2b_template(template: str | None) -> str | None:
+    """Resolve the template once; an explicit empty string disables environment fallback."""
+    if template is None:
+        return os.environ.get(E2B_TEMPLATE_ENV) or None
+    return template or None
+
+
 class SandboxCleanupError(RuntimeError):
     """An E2B sandbox may still be live after bounded teardown retries."""
 
@@ -175,6 +182,8 @@ def default_sandbox_factory(
     session driver relies on this for cost-leak reconciliation.
     """
 
+    chosen_template = resolve_e2b_template(template)
+
     def make() -> SandboxHandle:
         try:
             from e2b import Sandbox
@@ -186,13 +195,19 @@ def default_sandbox_factory(
         key = api_key or os.environ.get(E2B_API_KEY_ENV)
         if not key:
             raise RuntimeError(f"set ${E2B_API_KEY_ENV} to run the harness in E2B sandboxes")
-        chosen = template or os.environ.get(E2B_TEMPLATE_ENV) or None
         if metadata:
             sandbox = Sandbox.create(
-                template=chosen, timeout=int(timeout), api_key=key, metadata=metadata
+                template=chosen_template,
+                timeout=int(timeout),
+                api_key=key,
+                metadata=metadata,
             )
         else:
-            sandbox = Sandbox.create(template=chosen, timeout=int(timeout), api_key=key)
+            sandbox = Sandbox.create(
+                template=chosen_template,
+                timeout=int(timeout),
+                api_key=key,
+            )
         # The SDK object satisfies the protocol slice structurally; cast rather than pin the
         # SDK's full (much wider) signatures into the protocol.
         return cast("SandboxHandle", sandbox)

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -19,6 +19,7 @@ from wmh.harness.e2b_sandbox import (
     create_sandbox,
     default_sandbox_factory,
     kill_sandbox,
+    resolve_e2b_template,
 )
 
 
@@ -280,6 +281,30 @@ def test_default_factory_passes_metadata_to_the_lazy_e2b_sdk(
             "metadata": metadata,
         }
     ]
+
+
+def test_default_factory_snapshots_template_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeSandbox()
+    calls: list[dict[str, object]] = []
+
+    class _SandboxSdk:
+        @staticmethod
+        def create(**kwargs: object) -> FakeSandbox:
+            calls.append(kwargs)
+            return fake
+
+    e2b = ModuleType("e2b")
+    e2b.__dict__["Sandbox"] = _SandboxSdk
+    monkeypatch.setitem(sys.modules, "e2b", e2b)
+    monkeypatch.setenv("WMH_E2B_TEMPLATE", "template-at-construction")
+    factory = default_sandbox_factory(api_key="key")
+    monkeypatch.setenv("WMH_E2B_TEMPLATE", "template-after-construction")
+
+    assert factory() is fake
+    assert calls[0]["template"] == "template-at-construction"
+    assert resolve_e2b_template("") is None
 
 
 def test_fake_sandbox_satisfies_the_sandbox_handle_protocol() -> None:

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -51,6 +51,7 @@ from wmh.harness.e2b_sandbox import (
     create_sandbox,
     default_sandbox_factory,
     kill_sandbox,
+    resolve_e2b_template,
 )
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.runner_link import RunnerLink, WorkerFn
@@ -1136,10 +1137,10 @@ class E2BSandboxPool:
         sandbox_factory: SandboxFactory | None = None,
         hello_timeout: float = HELLO_TIMEOUT_S,
     ) -> None:
-        self._template = template
+        self._template = resolve_e2b_template(template)
         self._factory = sandbox_factory or default_sandbox_factory(
             api_key=api_key,
-            template=template,
+            template=self._template if self._template is not None else "",
             metadata=metadata,
         )
         self._hello_timeout = hello_timeout
@@ -1313,7 +1314,7 @@ class E2BSandboxPool:
         """Upload the runner files; on template-less sandboxes also install node 22 + pi's deps."""
         for name in _RUNNER_FILES:
             sandbox.files.write(f"{RUNNER_WORKDIR}/{name}", _read_entry(name))
-        if self._template or os.environ.get(E2B_TEMPLATE_ENV):
+        if self._template:
             return  # the template prebakes node 22 + node_modules; only the runner files refresh
         sandbox.files.write(f"{RUNNER_WORKDIR}/package.json", _PACKAGE_JSON)
         sandbox.commands.run(NODE_INSTALL_CMD, timeout=INSTALL_TIMEOUT_S)
@@ -1386,6 +1387,7 @@ class E2BPiRuntime:
         temperature: float = 0.7,
         skills: SkillLibrary | None = None,
         episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        transport_retries: int = 1,
         should_cancel: Callable[[], bool] | None = None,
     ) -> None:
         if max_turns < 1:
@@ -1396,6 +1398,12 @@ class E2BPiRuntime:
             raise ValueError("temperature must be in [0, 2]")
         if episode_timeout_s <= 0:
             raise ValueError("episode_timeout_s must be positive")
+        if (
+            isinstance(transport_retries, bool)
+            or not isinstance(transport_retries, int)
+            or transport_retries < 0
+        ):
+            raise ValueError("transport_retries must be a nonnegative integer")
         self._provider = provider
         self._files = dict(files)
         self._tools = list(tools)
@@ -1406,6 +1414,7 @@ class E2BPiRuntime:
         self._temperature = temperature
         self._skills = skills if skills is not None else SkillLibrary()
         self._episode_timeout_s = episode_timeout_s
+        self._transport_retries = transport_retries
         self._should_cancel = should_cancel
         self._aborted = threading.Event()
         self._owns_pool = pool is None
@@ -1416,24 +1425,24 @@ class E2BPiRuntime:
     def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
         if self._cancel_requested():
             raise RuntimeCancelled("runtime episode cancelled")
-        try:
-            return self._run_episode(task_id, instruction, environment)
-        except RuntimeCancelled:
-            # RunnerLink owns the episode's authoritative partial worker meter.
-            # Preserve it instead of replacing the cancellation at this wrapper.
-            raise
-        except Exception as exc:
-            if self._cancel_requested():
-                raise RuntimeCancelled("runtime episode cancelled") from exc
-            if not _is_retryable_transport_error(exc):
+        transport_failures = 0
+        while True:
+            try:
+                return self._run_episode(task_id, instruction, environment)
+            except RuntimeCancelled:
+                # RunnerLink owns the episode's authoritative partial worker meter.
+                # Preserve it instead of replacing the cancellation at this wrapper.
                 raise
-            # Transport death (stream drop, sandbox lifetime, dead runner) — the failed
-            # attempt's sandbox was already discarded on release. Retry ONCE on a fresh
-            # sandbox: the environment session may replay the dead attempt's opening steps,
-            # which for the world-model sim beats failing a whole search wave over one
-            # dropped connection. pi-level failures come back as RunResults (episode_error),
-            # never as exceptions, so this retries infrastructure only.
-            return self._run_episode(task_id, instruction, environment)
+            except Exception as exc:
+                if self._cancel_requested():
+                    raise RuntimeCancelled("runtime episode cancelled") from exc
+                if not _is_retryable_transport_error(exc):
+                    raise
+                if transport_failures >= self._transport_retries:
+                    raise
+                # Whole-episode replay is an explicit runtime policy. Same-sequence durable
+                # transport recovery inside a channel is unaffected by this budget.
+                transport_failures += 1
 
     def _run_episode(
         self, task_id: str, instruction: str, environment: AgentEnvironment

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -507,6 +507,7 @@ def _runtime(
     temperature: float = 0.7,
     skills: SkillLibrary | None = None,
     episode_timeout_s: float = 300.0,
+    transport_retries: int = 1,
     should_cancel: Callable[[], bool] | None = None,
 ) -> E2BPiRuntime:
     return E2BPiRuntime(
@@ -522,6 +523,7 @@ def _runtime(
         temperature=temperature,
         skills=skills,
         episode_timeout_s=episode_timeout_s,
+        transport_retries=transport_retries,
         should_cancel=should_cancel,
     )
 
@@ -536,6 +538,12 @@ def _sent_frames(fake: FakeSandbox) -> list[JsonObject]:
         else value
         for value in decoded
     ]
+
+
+@pytest.mark.parametrize("value", [True, -1, 0.5])
+def test_transport_retry_budget_must_be_a_nonnegative_integer(value: object) -> None:
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        _runtime(transport_retries=cast("int", value))
 
 
 def _of_kind(fake: FakeSandbox, kind: str) -> list[JsonObject]:
@@ -1328,6 +1336,34 @@ def test_run_retries_once_on_a_fresh_sandbox_after_transport_death(
     assert result.answer == "recovered"
     assert len(made) == 2
     assert made[0].kills == 1  # the dead attempt's sandbox was discarded, not reused
+    pool.close()
+
+
+def test_zero_transport_retry_budget_never_replays_an_episode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for(
+        [
+            [{"type": "hello"}],
+            [
+                {"type": "hello"},
+                {"type": "done", "answer": "must not run"},
+            ],
+        ]
+    )
+
+    def dying_factory() -> FakeSandbox:
+        fake = factory()
+        fake.commands._handle._hold_open = False  # noqa: SLF001
+        return fake
+
+    pool = E2BSandboxPool(sandbox_factory=dying_factory)
+    with pytest.raises(RuntimeError, match="exited mid-episode"):
+        _runtime(pool=pool, transport_retries=0).run("t1", "do it", _RecordingEnv())
+
+    assert len(made) == 1
+    assert made[0].kills == 1
     pool.close()
 
 


### PR DESCRIPTION
## Summary

- let callers choose the Pi transport explicitly without depending on ambient process state
- resolve E2B templates once so execution identity stays stable across a run
- expose the transport retry budget while preserving the existing default behavior
- allow evaluators with mutable task environments to disable whole-episode replay

## Verification

- Ruff check and format check
- focused HarnessDoc, E2B sandbox, and Pi E2B runtime tests
- full stacked gate is reported on #221

## Stack

Built on #218. No merge requested.