### PR TITLE
Add contained project shell turns

### DIFF
--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -34,9 +34,13 @@ from wmh.harness.tools import resolve_tools
 from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
+PROJECT_SCRATCH_DIR = ".scratch"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
+_BASH_TIMEOUT_S = 60.0
+_BASH_PROCESS_TIMEOUT_S = 50
+_BASH_STREAM_CAP = 7_000
 _OUTPUT_CAP = 16_000
-_PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
+_PROJECT_TOOLS = frozenset({"bash", "read_file", "write_file", "submit"})
 _RECOVERABLE_SESSION_MARKERS = (
     "server disconnected",
     "connection reset",
@@ -53,6 +57,40 @@ _RECOVERABLE_SESSION_MARKERS = (
     "live session runner did not become ready",
     "channel send failed",
 )
+
+_BASH_FILTER_SCRIPT = f"""\
+const cap = {_BASH_STREAM_CAP};
+const half = Math.floor(cap / 2);
+let small = Buffer.alloc(0);
+let head = Buffer.alloc(0);
+let tail = Buffer.alloc(0);
+let total = 0;
+let truncated = false;
+process.stdin.on("data", (chunk) => {{
+  total += chunk.length;
+  if (!truncated) {{
+    small = Buffer.concat([small, chunk]);
+    if (small.length > cap) {{
+      truncated = true;
+      head = small.subarray(0, half);
+      tail = small.subarray(small.length - half);
+      small = Buffer.alloc(0);
+    }}
+  }} else {{
+    tail = Buffer.concat([tail, chunk]);
+    if (tail.length > half) tail = tail.subarray(tail.length - half);
+  }}
+}});
+process.stdin.on("end", () => {{
+  if (truncated) {{
+    process.stdout.write(head);
+    process.stdout.write(`\\n... ${{total - cap}} bytes truncated in sandbox ...\\n`);
+    process.stdout.write(tail);
+  }} else {{
+    process.stdout.write(small);
+  }}
+}});
+"""
 
 
 class ChannelFactory(Protocol):
@@ -118,6 +156,7 @@ class AgentProject:
         self._session_agent_hash: str | None = None
         self._session_provider: ToolCallingProvider | None = None
         self._network_locked_sandbox_id: int | None = None
+        self._shell_ready_sandbox_id: int | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
         # ``None`` preserves the historical unrestricted project-tool behavior. A concrete set is
         # one logical run's exact, project-relative write grant; it is cleared even when the turn
@@ -158,6 +197,7 @@ class AgentProject:
         if self._closing:
             raise RuntimeError("cannot write to a closed project")
         absolute = self._absolute_path(path)
+        self._reject_reserved_scratch(absolute)
         try:
             self._write_sandbox_file(self._sandbox, absolute, content)
         except Exception as error:
@@ -176,19 +216,18 @@ class AgentProject:
         self._file_contents[self._relative_path(absolute)] = content
 
     def read_text(self, path: str) -> str:
-        """Read one project-relative file."""
+        """Read one authoritative host or mediated-write project file."""
         if self._closing:
             raise RuntimeError("cannot read from a closed project")
         absolute = self._absolute_path(path)
+        self._reject_reserved_scratch(absolute)
         relative = self._relative_path(absolute)
-        try:
-            content = self._sandbox.files.read(absolute)
-        except Exception:
-            if relative in self._file_contents:
-                return self._file_contents[relative]
-            raise
-        self._file_contents[relative] = content
-        return content
+        if relative not in self._file_contents:
+            raise FileNotFoundError(
+                f"{relative!r} is not an authoritative project file; "
+                "publish agent output through write_file"
+            )
+        return self._file_contents[relative]
 
     def run(
         self,
@@ -363,6 +402,8 @@ class AgentProject:
             # Runner bootstrap has completed in channel_factory, but no agent-controlled source
             # has been imported yet. Remove egress before session_start materializes that code.
             self._lock_project_network()
+            if "bash" in agent.tools():
+                self._prepare_shell_workspace()
             skills = agent.skills()
             session = LiveSession(
                 channel,
@@ -409,6 +450,15 @@ class AgentProject:
             raise RuntimeError("owned project sandbox cannot disable internet access")
         update_network({"allow_internet_access": False})
         self._network_locked_sandbox_id = id(self._sandbox)
+
+    def _prepare_shell_workspace(self) -> None:
+        """Create the only project directory writable by unprivileged shell commands."""
+        if self._shell_ready_sandbox_id == id(self._sandbox):
+            return
+        scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
+        command = f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
+        self._sandbox.commands.run(command, timeout=30)
+        self._shell_ready_sandbox_id = id(self._sandbox)
 
     def _emit_session_event(self, event: SessionEvent) -> None:
         """Route session events to the currently active project turn."""
@@ -554,6 +604,7 @@ class AgentProject:
         self._active_sandbox_started_at = replacement_started_at
         self._sandbox = replacement
         self._network_locked_sandbox_id = None
+        self._shell_ready_sandbox_id = None
         if self._owns_sandbox:
             self._retire_sandbox(previous)
 
@@ -567,28 +618,74 @@ class AgentProject:
         _handle, started_at = self._live_sandboxes.pop(id(sandbox))
         self._retired_sandbox_seconds += max(0.0, retired_at - started_at)
 
+    def _run_bash(self, command: str, emit: Callable[[str, str], None]) -> ToolOutcome:
+        """Run one bounded command as an unprivileged user in disposable scratch space.
+
+        The project tree is owned by the ordinary sandbox user and is readable but not writable
+        by ``nobody``. Shell commands start in a sticky scratch directory and receive an empty
+        environment, no network, no privilege escalation, and bounded process and output streams.
+        Durable candidate outputs must cross the separate exact-file ``write_file`` grant.
+        """
+        filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
+        script = (
+            "set -o pipefail\n"
+            f"timeout --kill-after=3s {_BASH_PROCESS_TIMEOUT_S}s "
+            f"bash --noprofile --norc -c {shlex.quote(command)} "
+            f"2> >({filter_command} >&2) | {filter_command}\n"
+            "status=${PIPESTATUS[0]}\n"
+            'exit "$status"'
+        )
+        scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
+        wrapped = (
+            "env -i PATH=/usr/local/bin:/usr/bin:/bin "
+            f"HOME={shlex.quote(scratch)} TMPDIR={shlex.quote(scratch)} "
+            "USER=nobody LOGNAME=nobody "
+            "setpriv --no-new-privs --inh-caps=-all --ambient-caps=-all "
+            f"--bounding-set=-all bash --noprofile --norc -c {shlex.quote(script)}"
+        )
+        try:
+            result = self._sandbox.commands.run(
+                wrapped,
+                user="nobody",
+                cwd=scratch,
+                timeout=_BASH_TIMEOUT_S,
+            )
+            stdout = _bounded_bash_stream(str(getattr(result, "stdout", "") or ""))
+            stderr = _bounded_bash_stream(str(getattr(result, "stderr", "") or ""))
+            exit_code = int(getattr(result, "exit_code", 0) or 0)
+        except Exception as error:  # noqa: BLE001 - E2B reports non-zero exits as exceptions
+            stdout = _bounded_bash_stream(str(getattr(error, "stdout", "") or ""))
+            stderr = _bounded_bash_stream(str(getattr(error, "stderr", "") or str(error)))
+            exit_code = int(getattr(error, "exit_code", 1) or 1)
+
+        if stdout:
+            emit("stdout", stdout)
+        if stderr:
+            emit("stderr", stderr)
+        body = stdout + stderr
+        if exit_code != 0:
+            body = f"{body}\n[exit {exit_code}]"
+        return _capped(body, is_error=exit_code != 0)
+
     def _execute_tool(
         self,
         name: str,
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
-        del emit  # Project file tools return one bounded observation; they do not stream output.
         try:
+            if name == "bash":
+                return self._run_bash(str(arguments.get("command", "")), emit)
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
                 relative = self._relative_path(path)
-                try:
+                content = self._file_contents.get(relative)
+                if content is None:
                     content = self._sandbox.files.read(path)
-                except Exception:
-                    if relative not in self._file_contents:
-                        raise
-                    content = self._file_contents[relative]
-                else:
-                    self._file_contents[relative] = content
                 return _capped(content)
             if name == "write_file":
                 path = self._tool_path(str(arguments.get("path", "")))
+                self._reject_reserved_scratch(path)
                 relative = self._relative_path(path)
                 if (
                     self._active_writable_files is not None
@@ -604,6 +701,12 @@ class AgentProject:
         except Exception as error:  # noqa: BLE001 - tool errors are agent observations
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
         return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
+
+    def _reject_reserved_scratch(self, absolute: str) -> None:
+        """Keep Bash scratch outside the authoritative host-mediated file namespace."""
+        relative = PurePosixPath(self._relative_path(absolute))
+        if relative.parts[0] == PROJECT_SCRATCH_DIR:
+            raise ValueError(f"{PROJECT_SCRATCH_DIR!r} is reserved for bash scratch files")
 
     def _tool_path(self, path: str) -> str:
         """Resolve an agent-supplied path while containing it to the project."""
@@ -670,6 +773,20 @@ def _usage_delta(after: TokenUsage, before: TokenUsage) -> TokenUsage:
         input_tokens=after.input_tokens - before.input_tokens,
         output_tokens=after.output_tokens - before.output_tokens,
         calls=after.calls - before.calls,
+    )
+
+
+def _bounded_bash_stream(content: str) -> str:
+    """Keep both ends of one shell stream within the live-session event budget."""
+    if len(content) <= _BASH_STREAM_CAP or (
+        len(content) <= _BASH_STREAM_CAP + 512 and "bytes truncated in sandbox" in content
+    ):
+        return content
+    half = _BASH_STREAM_CAP // 2
+    omitted = len(content) - _BASH_STREAM_CAP
+    return (
+        f"{content[:half]}\n... {omitted} characters truncated by Bash boundary ...\n"
+        f"{content[-half:]}"
     )
 
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Protocol
+from uuid import uuid4
 
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
@@ -159,6 +160,9 @@ class AgentProject:
         self._session_provider: ToolCallingProvider | None = None
         self._network_locked_sandbox_id: int | None = None
         self._shell_ready_sandbox_id: int | None = None
+        # Shell cleanup is user-scoped. Give every project its own unprivileged identity so
+        # quiescing one project cannot stop commands owned by another project in a shared sandbox.
+        self._shell_user = f"{PROJECT_SHELL_USER}-{uuid4().hex[:12]}"
         self._shell_quiescence_error: str | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
         # ``None`` preserves the historical unrestricted project-tool behavior. A concrete set is
@@ -476,11 +480,11 @@ class AgentProject:
         scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
         command = (
             "set -eu\n"
-            f"if ! id -u {PROJECT_SHELL_USER} >/dev/null 2>&1; then\n"
+            f"if ! id -u {self._shell_user} >/dev/null 2>&1; then\n"
             f"  useradd --system --user-group --no-create-home "
-            f"--shell /usr/sbin/nologin {PROJECT_SHELL_USER}\n"
+            f"--shell /usr/sbin/nologin {self._shell_user}\n"
             "fi\n"
-            f"id -u {PROJECT_SHELL_USER} >/dev/null\n"
+            f"id -u {self._shell_user} >/dev/null\n"
             f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
         )
         self._sandbox.commands.run(command, user="root", timeout=30)
@@ -666,7 +670,7 @@ class AgentProject:
         wrapped = (
             "env -i PATH=/usr/local/bin:/usr/bin:/bin "
             f"HOME={shlex.quote(scratch)} TMPDIR={shlex.quote(scratch)} "
-            f"USER={PROJECT_SHELL_USER} LOGNAME={PROJECT_SHELL_USER} "
+            f"USER={self._shell_user} LOGNAME={self._shell_user} "
             "setpriv --no-new-privs --inh-caps=-all --ambient-caps=-all "
             f"--bounding-set=-all bash --noprofile --norc -c {shlex.quote(script)}"
         )
@@ -678,7 +682,7 @@ class AgentProject:
             try:
                 result = self._sandbox.commands.run(
                     wrapped,
-                    user=PROJECT_SHELL_USER,
+                    user=self._shell_user,
                     cwd=scratch,
                     timeout=_BASH_TIMEOUT_S,
                 )
@@ -753,7 +757,7 @@ class AgentProject:
     def _quiesce_project_shell(self) -> None:
         """Kill every dedicated shell-user process and fail if any process remains."""
         result = self._sandbox.commands.run(
-            _project_shell_quiescence_command(),
+            _project_shell_quiescence_command(self._shell_user),
             user="root",
             timeout=_SHELL_QUIESCENCE_TIMEOUT_S,
         )
@@ -798,21 +802,21 @@ class AgentProject:
         return frozenset(self._relative_path(self._absolute_path(path)) for path in writable_files)
 
 
-def _project_shell_quiescence_command() -> str:
+def _project_shell_quiescence_command(shell_user: str) -> str:
     """Build the root-only stop, kill, and absence-proof command."""
     return (
         "set -eu\n"
         "# wmh-project-shell-quiescence\n"
         "for attempt in 1 2 3; do\n"
-        f"  if ! pgrep -u {PROJECT_SHELL_USER} >/dev/null; then break; fi\n"
-        f"  pkill -STOP -u {PROJECT_SHELL_USER} || true\n"
+        f"  if ! pgrep -u {shell_user} >/dev/null; then break; fi\n"
+        f"  pkill -STOP -u {shell_user} || true\n"
         "done\n"
-        f"pkill -KILL -u {PROJECT_SHELL_USER} || true\n"
+        f"pkill -KILL -u {shell_user} || true\n"
         "for attempt in 1 2 3; do\n"
-        f"  if ! pgrep -u {PROJECT_SHELL_USER} >/dev/null; then break; fi\n"
+        f"  if ! pgrep -u {shell_user} >/dev/null; then break; fi\n"
         "  sleep 0.05\n"
         "done\n"
-        f"if pgrep -u {PROJECT_SHELL_USER} >/dev/null; then\n"
+        f"if pgrep -u {shell_user} >/dev/null; then\n"
         "  echo 'could not prove project shell quiescence' >&2\n"
         "  exit 70\n"
         "fi\n"

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -35,9 +35,11 @@ from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 PROJECT_SCRATCH_DIR = ".scratch"
+PROJECT_SHELL_USER = "wmh-project-shell"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
 _BASH_TIMEOUT_S = 60.0
 _BASH_PROCESS_TIMEOUT_S = 50
+_SHELL_QUIESCENCE_TIMEOUT_S = 10.0
 _BASH_STREAM_CAP = 7_000
 _OUTPUT_CAP = 16_000
 _PROJECT_TOOLS = frozenset({"bash", "read_file", "write_file", "submit"})
@@ -157,6 +159,7 @@ class AgentProject:
         self._session_provider: ToolCallingProvider | None = None
         self._network_locked_sandbox_id: int | None = None
         self._shell_ready_sandbox_id: int | None = None
+        self._shell_quiescence_error: str | None = None
         self._active_event_sink: Callable[[SessionEvent], None] | None = None
         # ``None`` preserves the historical unrestricted project-tool behavior. A concrete set is
         # one logical run's exact, project-relative write grant; it is cleared even when the turn
@@ -253,6 +256,7 @@ class AgentProject:
         """
         if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
+        self._ensure_project_shell_healthy()
         _check_cancelled(should_cancel)
         if self._active_event_sink is not None:
             raise RuntimeError("a project agent turn is already running")
@@ -354,6 +358,9 @@ class AgentProject:
                     self._close_agent_session()
                     raise TimeoutError(f"project agent did not finish within {timeout:g}s")
                 running = session.pump(timeout=min(0.5, remaining))
+                # A tool pump may fail to prove that detached shell processes were killed. Stop
+                # before the next frame can trigger another paid provider call or project tool.
+                self._ensure_project_shell_healthy()
                 # A pump can synchronously run one provider completion. Observe cancellation as
                 # soon as it returns, before consuming a second model or tool request.
                 self._cancel_turn_if_requested(session, should_cancel)
@@ -369,6 +376,7 @@ class AgentProject:
                 raise _ProjectAgentTurnError(
                     f"project agent turn ended with reason: {turn_terminal_reason}"
                 )
+            self._ensure_project_shell_healthy()
         finally:
             self._active_event_sink = None
         return AgentProjectRun(answer=answer, events=tuple(events), worker_usage=TokenUsage())
@@ -456,8 +464,16 @@ class AgentProject:
         if self._shell_ready_sandbox_id == id(self._sandbox):
             return
         scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
-        command = f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
-        self._sandbox.commands.run(command, timeout=30)
+        command = (
+            "set -eu\n"
+            f"if ! id -u {PROJECT_SHELL_USER} >/dev/null 2>&1; then\n"
+            f"  useradd --system --user-group --no-create-home "
+            f"--shell /usr/sbin/nologin {PROJECT_SHELL_USER}\n"
+            "fi\n"
+            f"id -u {PROJECT_SHELL_USER} >/dev/null\n"
+            f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
+        )
+        self._sandbox.commands.run(command, user="root", timeout=30)
         self._shell_ready_sandbox_id = id(self._sandbox)
 
     def _emit_session_event(self, event: SessionEvent) -> None:
@@ -622,9 +638,10 @@ class AgentProject:
         """Run one bounded command as an unprivileged user in disposable scratch space.
 
         The project tree is owned by the ordinary sandbox user and is readable but not writable
-        by ``nobody``. Shell commands start in a sticky scratch directory and receive an empty
-        environment, no network, no privilege escalation, and bounded process and output streams.
-        Durable candidate outputs must cross the separate exact-file ``write_file`` grant.
+        by the dedicated project-shell user. Shell commands start in a sticky scratch directory
+        and receive an empty environment, no network, no privilege escalation, and bounded process
+        and output streams. Durable outputs must cross the separate exact-file ``write_file``
+        grant.
         """
         filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
         script = (
@@ -639,24 +656,40 @@ class AgentProject:
         wrapped = (
             "env -i PATH=/usr/local/bin:/usr/bin:/bin "
             f"HOME={shlex.quote(scratch)} TMPDIR={shlex.quote(scratch)} "
-            "USER=nobody LOGNAME=nobody "
+            f"USER={PROJECT_SHELL_USER} LOGNAME={PROJECT_SHELL_USER} "
             "setpriv --no-new-privs --inh-caps=-all --ambient-caps=-all "
             f"--bounding-set=-all bash --noprofile --norc -c {shlex.quote(script)}"
         )
+        stdout = ""
+        stderr = ""
+        exit_code = 1
+        cleanup_error: str | None = None
         try:
-            result = self._sandbox.commands.run(
-                wrapped,
-                user="nobody",
-                cwd=scratch,
-                timeout=_BASH_TIMEOUT_S,
-            )
-            stdout = _bounded_bash_stream(str(getattr(result, "stdout", "") or ""))
-            stderr = _bounded_bash_stream(str(getattr(result, "stderr", "") or ""))
-            exit_code = int(getattr(result, "exit_code", 0) or 0)
-        except Exception as error:  # noqa: BLE001 - E2B reports non-zero exits as exceptions
-            stdout = _bounded_bash_stream(str(getattr(error, "stdout", "") or ""))
-            stderr = _bounded_bash_stream(str(getattr(error, "stderr", "") or str(error)))
-            exit_code = int(getattr(error, "exit_code", 1) or 1)
+            try:
+                result = self._sandbox.commands.run(
+                    wrapped,
+                    user=PROJECT_SHELL_USER,
+                    cwd=scratch,
+                    timeout=_BASH_TIMEOUT_S,
+                )
+                stdout = _bounded_bash_stream(str(getattr(result, "stdout", "") or ""))
+                stderr = _bounded_bash_stream(str(getattr(result, "stderr", "") or ""))
+                exit_code = int(getattr(result, "exit_code", 0) or 0)
+            except Exception as error:  # noqa: BLE001 - E2B non-zero exits raise
+                stdout = _bounded_bash_stream(str(getattr(error, "stdout", "") or ""))
+                stderr = _bounded_bash_stream(str(getattr(error, "stderr", "") or str(error)))
+                exit_code = int(getattr(error, "exit_code", 1) or 1)
+        finally:
+            try:
+                self._quiesce_project_shell()
+            except Exception as error:  # noqa: BLE001 - taint on unproven process cleanup
+                cleanup_error = _capped(str(error)).content
+                self._shell_quiescence_error = cleanup_error
+
+        if cleanup_error is not None:
+            suffix = f"could not prove project shell quiescence: {cleanup_error}"
+            stderr = f"{stderr}\n{suffix}" if stderr else suffix
+            exit_code = exit_code or 1
 
         if stdout:
             emit("stdout", stdout)
@@ -673,6 +706,11 @@ class AgentProject:
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
+        if self._shell_quiescence_error is not None:
+            return ToolOutcome(
+                content=f"project shell is tainted: {self._shell_quiescence_error}",
+                is_error=True,
+            )
         try:
             if name == "bash":
                 return self._run_bash(str(arguments.get("command", "")), emit)
@@ -702,6 +740,26 @@ class AgentProject:
             return ToolOutcome(content=f"{name} failed: {error}", is_error=True)
         return ToolOutcome(content=f"tool {name!r} not available", is_error=True)
 
+    def _quiesce_project_shell(self) -> None:
+        """Kill every dedicated shell-user process and fail if any process remains."""
+        result = self._sandbox.commands.run(
+            _project_shell_quiescence_command(),
+            user="root",
+            timeout=_SHELL_QUIESCENCE_TIMEOUT_S,
+        )
+        exit_code = int(getattr(result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            stderr = str(getattr(result, "stderr", "") or "quiescence command failed")
+            raise RuntimeError(stderr)
+
+    def _ensure_project_shell_healthy(self) -> None:
+        """Reject further agent work after unproven shell cleanup."""
+        if self._shell_quiescence_error is not None:
+            raise RuntimeError(
+                "project shell is tainted after cleanup failure; close it and create a new "
+                f"project: {self._shell_quiescence_error}"
+            )
+
     def _reject_reserved_scratch(self, absolute: str) -> None:
         """Keep Bash scratch outside the authoritative host-mediated file namespace."""
         relative = PurePosixPath(self._relative_path(absolute))
@@ -728,6 +786,27 @@ class AgentProject:
         if writable_files is None:
             return None
         return frozenset(self._relative_path(self._absolute_path(path)) for path in writable_files)
+
+
+def _project_shell_quiescence_command() -> str:
+    """Build the root-only stop, kill, and absence-proof command."""
+    return (
+        "set -eu\n"
+        "# wmh-project-shell-quiescence\n"
+        "for attempt in 1 2 3; do\n"
+        f"  if ! pgrep -u {PROJECT_SHELL_USER} >/dev/null; then break; fi\n"
+        f"  pkill -STOP -u {PROJECT_SHELL_USER} || true\n"
+        "done\n"
+        f"pkill -KILL -u {PROJECT_SHELL_USER} || true\n"
+        "for attempt in 1 2 3; do\n"
+        f"  if ! pgrep -u {PROJECT_SHELL_USER} >/dev/null; then break; fi\n"
+        "  sleep 0.05\n"
+        "done\n"
+        f"if pgrep -u {PROJECT_SHELL_USER} >/dev/null; then\n"
+        "  echo 'could not prove project shell quiescence' >&2\n"
+        "  exit 70\n"
+        "fi\n"
+    )
 
 
 def _start_channel(sandbox: SandboxHandle, workspace: str) -> Channel:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -487,7 +487,18 @@ class AgentProject:
             f"id -u {self._shell_user} >/dev/null\n"
             f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
         )
-        self._sandbox.commands.run(command, user="root", timeout=30)
+        result = self._sandbox.commands.run(command, user="root", timeout=30)
+        exit_code = int(getattr(result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            detail = str(
+                getattr(result, "stderr", "")
+                or getattr(result, "stdout", "")
+                or "shell setup command returned no output"
+            )
+            raise RuntimeError(
+                f"project shell workspace setup failed with exit {exit_code}: "
+                f"{_capped(detail).content}"
+            )
         self._shell_ready_sandbox_id = id(self._sandbox)
 
     def _emit_session_event(self, event: SessionEvent) -> None:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -242,6 +242,7 @@ class AgentProject:
         on_event: Callable[[SessionEvent], None] | None = None,
         should_cancel: Callable[[], bool] | None = None,
         writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
     ) -> AgentProjectRun:
         """Run one turn of an ordinary agent against this persistent project.
 
@@ -252,7 +253,9 @@ class AgentProject:
         agent's ``write_file`` tool access to exact project-relative files for
         this logical run. Omitting it preserves unrestricted project writes;
         an empty collection denies every agent write. Host ``write_text`` calls
-        are not constrained by an agent turn's grant.
+        are not constrained by an agent turn's grant. Set
+        ``retry_recoverable=False`` when one logical run must represent exactly
+        one agent attempt even if its runner transport fails after partial work.
         """
         if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
@@ -267,8 +270,9 @@ class AgentProject:
         write_grant = self._normalize_writable_files(writable_files)
         usage_before = self._total_worker_usage()
         self._active_writable_files = write_grant
+        max_attempts = 2 if retry_recoverable else 1
         try:
-            for attempt in range(2):
+            for attempt in range(max_attempts):
                 try:
                     result = self._run_turn(
                         agent,
@@ -287,7 +291,13 @@ class AgentProject:
                 except HarnessSearchCancelled:
                     raise
                 except Exception as error:
-                    if attempt > 0 or not _is_recoverable_session_error(error):
+                    recoverable = _is_recoverable_session_error(error)
+                    if not recoverable:
+                        raise
+                    if attempt + 1 >= max_attempts:
+                        # A transport-poisoned session is never reused by a later logical run,
+                        # even when this caller deliberately owns recovery at a higher level.
+                        self._close_agent_session()
                         raise
                     if self._sandbox_factory is None:
                         self._close_agent_session()

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1235,14 +1235,182 @@ def test_agent_file_tools_reject_paths_outside_the_project() -> None:
         assert "escapes project workspace" in outcome.content
 
 
-@pytest.mark.parametrize("tool", ["bash", "read_skill"])
-def test_project_rejects_agents_with_uncontained_tools(tool: str) -> None:
+def test_project_bash_runs_as_an_unprivileged_bounded_scratch_process() -> None:
+    """Shell exploration cannot run as the owner of authoritative project files."""
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    class _BashCommands(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[dict[str, object]] = []
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background
+            self.runs.append(cmd)
+            self.calls.append(dict(kwargs))
+            return _Output(stdout="inspected\n", stderr="warning\n")
+
+    commands = _BashCommands()
+    sandbox.commands = commands
+    emitted: list[tuple[str, str]] = []
+
+    outcome = project._execute_tool(
+        "bash",
+        {"command": "pwd && rg TODO ../candidates"},
+        lambda stream, data: emitted.append((stream, data)),
+    )
+
+    assert outcome.is_error is False
+    assert outcome.content == "inspected\nwarning\n"
+    assert emitted == [("stdout", "inspected\n"), ("stderr", "warning\n")]
+    [call] = commands.calls
+    assert call == {
+        "user": "nobody",
+        "cwd": "/home/user/project/.scratch",
+        "timeout": 60.0,
+    }
+    [command] = commands.runs
+    assert command.startswith("env -i ")
+    assert "setpriv --no-new-privs" in command
+    assert "timeout --kill-after=3s 50s" in command
+    assert "pwd && rg TODO ../candidates" in command
+
+
+def test_project_bash_bounds_streams_before_live_session_publication() -> None:
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    class _NoisyCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del cmd, background, kwargs
+            return _Output(stdout="x" * 20_000, stderr="warning")
+
+    sandbox.commands = _NoisyCommands()
+    emitted: list[tuple[str, str]] = []
+
+    outcome = project._execute_tool(
+        "bash", {"command": "generate-output"}, lambda stream, data: emitted.append((stream, data))
+    )
+
+    assert outcome.is_error is False
+    assert outcome.truncated is False
+    assert "13000 characters truncated by Bash boundary" in outcome.content
+    assert emitted[0][0] == "stdout"
+    assert len(emitted[0][1]) < 7_100
+    assert emitted[1] == ("stderr", "warning")
+
+
+def test_project_bash_surfaces_nonzero_exit_with_bounded_streams() -> None:
+    class _CommandError(RuntimeError):
+        stdout = "partial output"
+        stderr = "command failed"
+        exit_code = 7
+
+    class _FailingCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del cmd, background, kwargs
+            raise _CommandError("non-zero")
+
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    sandbox.commands = _FailingCommands()
+    emitted: list[tuple[str, str]] = []
+
+    outcome = project._execute_tool(
+        "bash", {"command": "fail"}, lambda stream, data: emitted.append((stream, data))
+    )
+
+    assert outcome.is_error is True
+    assert outcome.content == "partial outputcommand failed\n[exit 7]"
+    assert emitted == [("stdout", "partial output"), ("stderr", "command failed")]
+
+
+def test_project_bash_cannot_publish_or_mutate_authoritative_files() -> None:
+    """Only host and granted write_file calls cross the scratch authority boundary."""
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    project.write_text("evidence/input.txt", "trusted")
+
+    class _MutatingCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del cmd, background, kwargs
+            sandbox.files.values["/home/user/project/evidence/input.txt"] = "tampered"
+            sandbox.files.values["/home/user/project/candidate.json"] = "unmediated"
+            return _Output()
+
+    sandbox.commands = _MutatingCommands()
+
+    outcome = project._execute_tool("bash", {"command": "attack"}, lambda stream, data: None)
+
+    assert outcome.is_error is False
+    assert project.read_text("evidence/input.txt") == "trusted"
+    read = project._execute_tool(
+        "read_file", {"path": "evidence/input.txt"}, lambda stream, data: None
+    )
+    assert read.content == "trusted"
+    with pytest.raises(FileNotFoundError, match="authoritative project file"):
+        project.read_text("candidate.json")
+
+
+def test_project_rejects_mediated_writes_into_reserved_scratch() -> None:
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    outcome = project._execute_tool(
+        "write_file",
+        {"path": ".scratch/candidate.json", "content": "not authoritative"},
+        lambda stream, data: None,
+    )
+
+    assert outcome.is_error is True
+    assert "reserved for bash" in outcome.content
+
+
+def test_project_accepts_bash_as_a_contained_agent_tool() -> None:
+    base = meta_agent()
+    shell_agent = HarnessDoc(
+        name="shell-agent",
+        surfaces=[
+            surface.model_copy(update={"content": "bash\nsubmit"})
+            if surface.id == TOOL_POLICY_ID
+            else surface
+            for surface in base.surfaces
+        ],
+    )
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "submit",
+            "arguments": {"answer": "done"},
+        },
+        {"type": "state", "status": "idle", "reason": "completed"},
+    ]
+    sandbox = _Sandbox()
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    assert project.run(shell_agent, _Provider(), "inspect", timeout=1).answer == "done"
+    assert any(
+        command
+        == "mkdir -p /home/user/project/.scratch && chmod 1777 /home/user/project/.scratch"
+        for command in sandbox.commands.runs
+    )
+
+
+def test_project_rejects_agents_with_uncontained_tools() -> None:
     """The project still rejects capabilities outside its isolated tool allowlist."""
     base = meta_agent()
     uncontained = HarnessDoc(
         name="uncontained",
         surfaces=[
-            surface.model_copy(update={"content": f"{tool}\nsubmit"})
+            surface.model_copy(update={"content": "read_skill\nsubmit"})
             if surface.id == TOOL_POLICY_ID
             else surface
             for surface in base.surfaces
@@ -1250,5 +1418,5 @@ def test_project_rejects_agents_with_uncontained_tools(tool: str) -> None:
     )
     project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
 
-    with pytest.raises(ValueError, match=f"uncontained tools: {tool}"):
+    with pytest.raises(ValueError, match="uncontained tools: read_skill"):
         project.run(uncontained, _Provider(), "escape", timeout=1)

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1398,8 +1398,7 @@ def test_project_accepts_bash_as_a_contained_agent_tool() -> None:
 
     assert project.run(shell_agent, _Provider(), "inspect", timeout=1).answer == "done"
     assert any(
-        command
-        == "mkdir -p /home/user/project/.scratch && chmod 1777 /home/user/project/.scratch"
+        command == "mkdir -p /home/user/project/.scratch && chmod 1777 /home/user/project/.scratch"
         for command in sandbox.commands.runs
     )
 

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -7,7 +7,7 @@ from llm_waterfall import ChatResponse
 
 from wmh.agents import project as project_module
 from wmh.agents.meta import meta_agent
-from wmh.agents.project import AgentProject
+from wmh.agents.project import PROJECT_SHELL_USER, AgentProject
 from wmh.core.types import JsonObject
 from wmh.harness import e2b_sandbox as e2b_sandbox_module
 from wmh.harness.doc import TOOL_POLICY_ID, HarnessDoc
@@ -1264,17 +1264,21 @@ def test_project_bash_runs_as_an_unprivileged_bounded_scratch_process() -> None:
     assert outcome.is_error is False
     assert outcome.content == "inspected\nwarning\n"
     assert emitted == [("stdout", "inspected\n"), ("stderr", "warning\n")]
-    [call] = commands.calls
-    assert call == {
-        "user": "nobody",
+    agent_call, cleanup_call = commands.calls
+    assert agent_call == {
+        "user": PROJECT_SHELL_USER,
         "cwd": "/home/user/project/.scratch",
         "timeout": 60.0,
     }
-    [command] = commands.runs
+    assert cleanup_call == {"user": "root", "timeout": 10.0}
+    command, cleanup_command = commands.runs
     assert command.startswith("env -i ")
     assert "setpriv --no-new-privs" in command
     assert "timeout --kill-after=3s 50s" in command
     assert "pwd && rg TODO ../candidates" in command
+    assert "wmh-project-shell-quiescence" in cleanup_command
+    assert f"pkill -STOP -u {PROJECT_SHELL_USER}" in cleanup_command
+    assert f"pkill -KILL -u {PROJECT_SHELL_USER}" in cleanup_command
 
 
 def test_project_bash_bounds_streams_before_live_session_publication() -> None:
@@ -1309,7 +1313,9 @@ def test_project_bash_surfaces_nonzero_exit_with_bounded_streams() -> None:
 
     class _FailingCommands(_Commands):
         def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
-            del cmd, background, kwargs
+            del background, kwargs
+            if "wmh-project-shell-quiescence" in cmd:
+                return _Output()
             raise _CommandError("non-zero")
 
     sandbox = _Sandbox()
@@ -1324,6 +1330,85 @@ def test_project_bash_surfaces_nonzero_exit_with_bounded_streams() -> None:
     assert outcome.is_error is True
     assert outcome.content == "partial outputcommand failed\n[exit 7]"
     assert emitted == [("stdout", "partial output"), ("stderr", "command failed")]
+
+
+def test_project_bash_cleanup_failure_taints_the_project() -> None:
+    class _CleanupFailCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background, kwargs
+            if "wmh-project-shell-quiescence" in cmd:
+                raise RuntimeError("cleanup transport failed")
+            return _Output(stdout="command completed")
+
+    sandbox = _Sandbox()
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    sandbox.commands = _CleanupFailCommands()
+
+    outcome = project._execute_tool("bash", {"command": "setsid sleep 30 &"}, lambda *_: None)
+
+    assert outcome.is_error is True
+    assert "could not prove project shell quiescence" in outcome.content
+    blocked = project._execute_tool("bash", {"command": "true"}, lambda *_: None)
+    assert blocked.is_error is True
+    assert "project shell is tainted" in blocked.content
+    with pytest.raises(RuntimeError, match="project shell is tainted"):
+        project.run(meta_agent(), _Provider(), "continue", timeout=1)
+
+
+def test_project_bash_cleanup_failure_stops_before_another_provider_call() -> None:
+    class _CleanupFailCommands(_Commands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background, kwargs
+            if "wmh-project-shell-quiescence" in cmd:
+                raise RuntimeError("cleanup transport failed")
+            return _Output(stdout="command completed")
+
+    class _CountingProvider(_MeteredProvider):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete_chat(self, request: object) -> ChatResponse:
+            self.calls += 1
+            return super().complete_chat(request)
+
+    base = meta_agent()
+    shell_agent = HarnessDoc(
+        name="shell-agent",
+        surfaces=[
+            surface.model_copy(update={"content": "bash\nsubmit"})
+            if surface.id == TOOL_POLICY_ID
+            else surface
+            for surface in base.surfaces
+        ],
+    )
+    channel = _Channel()
+    channel.inbound = [
+        {"type": "state", "status": "idle"},
+        {"type": "state", "status": "running"},
+        {
+            "type": "tool_request",
+            "req_id": 1,
+            "name": "bash",
+            "arguments": {"command": "setsid sleep 30 &"},
+        },
+        {"type": "llm_request", "req_id": 2, "openai_body": {"messages": []}},
+    ]
+    sandbox = _Sandbox()
+    sandbox.commands = _CleanupFailCommands()
+    provider = _CountingProvider()
+    project = AgentProject(
+        sandbox,
+        channel_factory=lambda sandbox, workspace: channel,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(RuntimeError, match="project shell is tainted"):
+        project.run(shell_agent, provider, "inspect", timeout=1)
+
+    assert provider.calls == 0
+    assert channel.inbound == [
+        {"type": "llm_request", "req_id": 2, "openai_body": {"messages": []}}
+    ]
 
 
 def test_project_bash_cannot_publish_or_mutate_authoritative_files() -> None:
@@ -1397,10 +1482,13 @@ def test_project_accepts_bash_as_a_contained_agent_tool() -> None:
     )
 
     assert project.run(shell_agent, _Provider(), "inspect", timeout=1).answer == "done"
-    assert any(
-        command == "mkdir -p /home/user/project/.scratch && chmod 1777 /home/user/project/.scratch"
-        for command in sandbox.commands.runs
+    shell_setup = next(
+        command for command in sandbox.commands.runs if "useradd --system" in command
     )
+    assert "useradd --system --user-group --no-create-home" in shell_setup
+    assert PROJECT_SHELL_USER in shell_setup
+    assert "mkdir -p /home/user/project/.scratch" in shell_setup
+    assert "chmod 1777 /home/user/project/.scratch" in shell_setup
 
 
 def test_project_rejects_agents_with_uncontained_tools() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1333,7 +1333,7 @@ def test_project_bash_runs_as_an_unprivileged_bounded_scratch_process() -> None:
     assert emitted == [("stdout", "inspected\n"), ("stderr", "warning\n")]
     agent_call, cleanup_call = commands.calls
     assert agent_call == {
-        "user": PROJECT_SHELL_USER,
+        "user": project._shell_user,  # noqa: SLF001 - assert per-project isolation identity
         "cwd": "/home/user/project/.scratch",
         "timeout": 60.0,
     }
@@ -1344,8 +1344,22 @@ def test_project_bash_runs_as_an_unprivileged_bounded_scratch_process() -> None:
     assert "timeout --kill-after=3s 50s" in command
     assert "pwd && rg TODO ../candidates" in command
     assert "wmh-project-shell-quiescence" in cleanup_command
-    assert f"pkill -STOP -u {PROJECT_SHELL_USER}" in cleanup_command
-    assert f"pkill -KILL -u {PROJECT_SHELL_USER}" in cleanup_command
+    assert f"pkill -STOP -u {project._shell_user}" in cleanup_command  # noqa: SLF001
+    assert f"pkill -KILL -u {project._shell_user}" in cleanup_command  # noqa: SLF001
+
+
+def test_projects_sharing_a_sandbox_use_isolated_shell_cleanup_identities() -> None:
+    """Quiescing one project cannot target another project's shell processes."""
+    sandbox = _Sandbox()
+    first = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    second = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    assert first._shell_user != second._shell_user  # noqa: SLF001
+    first_cleanup = project_module._project_shell_quiescence_command(  # noqa: SLF001
+        first._shell_user  # noqa: SLF001
+    )
+    assert first._shell_user in first_cleanup  # noqa: SLF001
+    assert second._shell_user not in first_cleanup  # noqa: SLF001
 
 
 def test_project_bash_bounds_streams_before_live_session_publication() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1567,9 +1567,38 @@ def test_project_accepts_bash_as_a_contained_agent_tool() -> None:
         command for command in sandbox.commands.runs if "useradd --system" in command
     )
     assert "useradd --system --user-group --no-create-home" in shell_setup
-    assert PROJECT_SHELL_USER in shell_setup
+    assert project._shell_user != PROJECT_SHELL_USER  # noqa: SLF001
+    assert f"id -u {project._shell_user}" in shell_setup  # noqa: SLF001
+    assert shell_setup.count(project._shell_user) == 3  # noqa: SLF001
     assert "mkdir -p /home/user/project/.scratch" in shell_setup
     assert "chmod 1777 /home/user/project/.scratch" in shell_setup
+
+
+def test_project_shell_setup_nonzero_exit_fails_closed_and_remains_retryable() -> None:
+    class _SetupFails(_Commands):
+        def __init__(self) -> None:
+            super().__init__()
+            self.setup_calls = 0
+
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            del background, kwargs
+            self.runs.append(cmd)
+            if "useradd --system" in cmd:
+                self.setup_calls += 1
+                return _Output(stderr="useradd rejected the shell identity", exit_code=9)
+            return _Output()
+
+    sandbox = _Sandbox()
+    commands = _SetupFails()
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    for _attempt in range(2):
+        with pytest.raises(RuntimeError, match="workspace setup failed with exit 9"):
+            project._prepare_shell_workspace()  # noqa: SLF001
+
+    assert commands.setup_calls == 2
+    assert project._shell_ready_sandbox_id is None  # noqa: SLF001
 
 
 def test_project_rejects_agents_with_uncontained_tools() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -851,6 +851,73 @@ def test_project_restarts_one_live_session_after_transport_disconnect() -> None:
     assert [frame["type"] for frame in recovered.sent].count("user_message") == 1
 
 
+def test_project_can_disable_retry_after_partial_work_and_provider_call() -> None:
+    """One optimizer iteration never replays a partially written coding turn."""
+
+    class _DisconnectedAfterPartialWork(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+                {
+                    "type": "tool_request",
+                    "req_id": 1,
+                    "name": "write_file",
+                    "arguments": {
+                        "path": "/home/user/project/stages/candidate/SYSTEM.md",
+                        "content": "partial candidate",
+                    },
+                },
+                {"type": "llm_request", "req_id": 2, "openai_body": {"messages": []}},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("Server disconnected")
+
+    class _CountingProvider(_MeteredProvider):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete_chat(self, request: object) -> ChatResponse:
+            self.calls += 1
+            return super().complete_chat(request)
+
+    channel = _DisconnectedAfterPartialWork()
+    channel_starts = 0
+
+    def channel_factory(sandbox: object, workspace: str) -> _Channel:
+        nonlocal channel_starts
+        del sandbox, workspace
+        channel_starts += 1
+        return channel
+
+    provider = _CountingProvider()
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=channel_factory,
+        owns_sandbox=False,
+    )
+
+    with pytest.raises(RuntimeError, match="Server disconnected"):
+        project.run(
+            meta_agent(),
+            provider,
+            "produce one candidate",
+            timeout=1,
+            writable_files=["stages/candidate/SYSTEM.md"],
+            retry_recoverable=False,
+        )
+
+    assert provider.calls == 1
+    assert channel_starts == 1
+    assert [frame["type"] for frame in channel.sent].count("user_message") == 1
+    assert project.read_text("stages/candidate/SYSTEM.md") == "partial candidate"
+    assert channel.closed is True
+
+
 def test_project_retries_a_transient_channel_send_failure() -> None:
     """E2B stdin timeouts are transport failures even after LiveSession stringifies them."""
 

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -104,9 +104,14 @@ class SandboxCommands(Protocol):
         cmd: str,
         background: bool | None = None,
         *,
+        cwd: str | None = None,
         envs: dict[str, str] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        request_timeout: float | None = None,
         stdin: bool | None = None,
         timeout: float | None = None,
+        user: str | None = None,
     ) -> CommandOutput | CommandHandle: ...
 
     def connect(


### PR DESCRIPTION
## Summary

- add a contained shell session for project agents
- bind each agent turn to one terminal attempt
- isolate and quiesce subprocesses before returning control
- preserve deterministic cleanup across success and failure

## Validation

- uv run pytest wmh/agents/project_test.py -q
- uv run ruff check wmh/agents/project.py wmh/agents/project_test.py
- uv run ruff format --check wmh/agents/project.py wmh/agents/project_test.py
- uv run ty check