### PR TITLE
Add fixed harness population optimization

### DIFF
--- a/wmh/harness/population.py
+++ b/wmh/harness/population.py
@@ -1,0 +1,147 @@
+"""Fixed-iteration optimization over complete scored harness candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from wmh.harness.project_proposer import (
+    CandidateProposal,
+    CandidateProposalError,
+    CandidateProposer,
+    EvaluatedCandidate,
+)
+from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.scoring import HarnessScorer, ScoreRequest, score_harness
+from wmh.harness.source_tree import HarnessSourceTree
+
+
+@dataclass(frozen=True)
+class PopulationIteration:
+    """One consumed proposal slot and its scored or invalid outcome."""
+
+    index: int
+    proposal: CandidateProposal | None = None
+    evaluation: EvaluatedCandidate | None = None
+    error: CandidateProposalError | None = None
+
+    def __post_init__(self) -> None:
+        if self.index < 1:
+            raise ValueError("population iteration index must be positive")
+        if self.error is not None:
+            if self.proposal is not None or self.evaluation is not None:
+                raise ValueError("an invalid population iteration cannot contain an evaluation")
+            return
+        if self.proposal is None or self.evaluation is None:
+            raise ValueError("a valid population iteration needs its proposal and evaluation")
+        if self.proposal.candidate_id != self.evaluation.candidate_id:
+            raise ValueError("population iteration proposal and evaluation identities differ")
+
+    @property
+    def candidate_id(self) -> str:
+        """Return the proposed identity for either a valid or invalid iteration."""
+        if self.error is not None:
+            return self.error.candidate_id
+        assert self.proposal is not None
+        return self.proposal.candidate_id
+
+
+@dataclass(frozen=True)
+class PopulationOptimizationResult:
+    """The full evaluated population, every consumed slot, and its score winner."""
+
+    population: tuple[EvaluatedCandidate, ...]
+    iterations: tuple[PopulationIteration, ...]
+    best: EvaluatedCandidate
+
+    @property
+    def best_score(self) -> float:
+        """Return the winner's primary score."""
+        return self.best.score.report.score
+
+
+class HarnessPopulationOptimizer:
+    """Score one seed and a fixed number of singular complete-source proposals."""
+
+    def __init__(self, proposer: CandidateProposer, scorer: HarnessScorer) -> None:
+        self._proposer = proposer
+        self._scorer = scorer
+
+    def optimize(
+        self,
+        *,
+        seed: HarnessSourceTree,
+        request: ScoreRequest,
+        iterations: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> PopulationOptimizationResult:
+        """Evaluate an append-only population and select by primary score only.
+
+        A :class:`CandidateProposalError` consumes its configured slot and leaves the evaluated
+        population unchanged. Scorer and infrastructure errors propagate because the optimizer
+        cannot safely reinterpret an incomplete evaluation as a candidate score.
+        """
+        if isinstance(iterations, bool) or not isinstance(iterations, int) or iterations < 1:
+            raise ValueError("iterations must be a positive integer")
+        _check_cancelled(should_cancel)
+        seed_id = "candidate-0000"
+        seed_candidate = seed.to_doc(seed_id)
+        seed_score = score_harness(self._scorer, seed_candidate, request=request)
+        population = [
+            EvaluatedCandidate(
+                candidate_id=seed_id,
+                source=seed,
+                score=seed_score,
+            )
+        ]
+        outcomes: list[PopulationIteration] = []
+
+        for index in range(1, iterations + 1):
+            _check_cancelled(should_cancel)
+            try:
+                proposal = self._proposer.propose(
+                    tuple(population),
+                    should_cancel=should_cancel,
+                )
+            except CandidateProposalError as error:
+                outcomes.append(PopulationIteration(index=index, error=error))
+                continue
+
+            known_ids = {item.candidate_id for item in population}
+            if proposal.candidate_id in known_ids:
+                raise ValueError(
+                    f"proposer reused evaluated candidate_id {proposal.candidate_id!r}"
+                )
+            if proposal.candidate.name != proposal.candidate_id:
+                raise ValueError("proposal document name does not match its candidate_id")
+            parsed = proposal.source.to_doc(proposal.candidate_id)
+            if parsed.doc_hash != proposal.candidate.doc_hash:
+                raise ValueError("proposal source does not match its candidate document")
+            _check_cancelled(should_cancel)
+            score = score_harness(self._scorer, parsed, request=request)
+            evaluated = EvaluatedCandidate(
+                candidate_id=proposal.candidate_id,
+                source=proposal.source,
+                score=score,
+            )
+            population.append(evaluated)
+            outcomes.append(
+                PopulationIteration(
+                    index=index,
+                    proposal=proposal,
+                    evaluation=evaluated,
+                )
+            )
+
+        _check_cancelled(should_cancel)
+        best = max(population, key=lambda item: item.score.report.score)
+        return PopulationOptimizationResult(
+            population=tuple(population),
+            iterations=tuple(outcomes),
+            best=best,
+        )
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness search cancelled")

--- a/wmh/harness/population_test.py
+++ b/wmh/harness/population_test.py
@@ -1,0 +1,390 @@
+"""Behavioral tests for fixed-iteration harness population optimization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import pytest
+
+from wmh.agents.default import default_agent
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.population import HarnessPopulationOptimizer
+from wmh.harness.project_proposer import (
+    CandidateProposal,
+    CandidateProposalError,
+    EvaluatedCandidate,
+)
+from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+_RAW_PATH = "raw/trace.json"
+
+
+class _Reader:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def read_bytes(self, path: str) -> bytes:
+        assert path == _RAW_PATH
+        return self.content
+
+
+class _Scorer:
+    def __init__(self, outcomes: Sequence[tuple[float, bool] | Exception]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[tuple[HarnessDoc, ScoreRequest]] = []
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+        self.calls.append((candidate, request))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        score, passed = outcome
+        raw = f'{{"candidate":"{candidate.doc_hash}"}}\n'.encode()
+        artifact = EvaluationArtifact.from_bytes(
+            path=_RAW_PATH,
+            content=raw,
+            media_type="application/json",
+        )
+        cells = tuple(
+            ScoreCell(
+                task_id=task_id,
+                attempt=attempt,
+                score=score,
+                passed=passed,
+                summary="official result",
+                artifact_paths=(_RAW_PATH,),
+            )
+            for task_id in request.task_ids
+            for attempt in range(1, request.attempts + 1)
+        )
+        report = HarnessScoreReport(
+            source_run_id=f"run-{len(self.calls)}",
+            candidate_doc_hash=candidate.doc_hash,
+            request=request,
+            cells=cells,
+            artifacts=(artifact,),
+        )
+        return HarnessScore(report=report, artifacts=_Reader(raw))
+
+
+class _Proposer:
+    def __init__(self, outcomes: Sequence[CandidateProposal | CandidateProposalError]) -> None:
+        self.outcomes = list(outcomes)
+        self.histories: list[tuple[EvaluatedCandidate, ...]] = []
+        self.cancel_callbacks: list[Callable[[], bool] | None] = []
+
+    def propose(
+        self,
+        history: Sequence[EvaluatedCandidate],
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        self.histories.append(tuple(history))
+        self.cancel_callbacks.append(should_cancel)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, CandidateProposalError):
+            raise outcome
+        return outcome
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST_A,
+            evaluator_digest=_DIGEST_B,
+            execution_config_digest=_DIGEST_C,
+        ),
+        task_ids=("task-a", "task-b"),
+        attempts=1,
+    )
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _proposal(candidate_id: str, prompt: str) -> CandidateProposal:
+    source = _source(prompt)
+    return CandidateProposal(
+        candidate_id=candidate_id,
+        source=source,
+        candidate=source.to_doc(candidate_id),
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(input_tokens=10, output_tokens=5, calls=1),
+    )
+
+
+def test_optimizer_scores_seed_then_each_valid_candidate_on_one_request() -> None:
+    invalid = CandidateProposalError(
+        "candidate-0002",
+        "source tree is incomplete",
+        events=(SessionEvent(kind="error", payload={"message": "incomplete"}),),
+        worker_usage=TokenUsage(input_tokens=4, output_tokens=2, calls=1),
+    )
+    proposer = _Proposer(
+        [
+            _proposal("candidate-0001", "first"),
+            invalid,
+            _proposal("candidate-0003", "third"),
+        ]
+    )
+    scorer = _Scorer([(0.2, False), (0.8, True), (0.4, False)])
+    request = _request()
+
+    result = HarnessPopulationOptimizer(proposer, scorer).optimize(
+        seed=_source("seed"),
+        request=request,
+        iterations=3,
+    )
+
+    assert len(proposer.histories) == 3
+    assert [[item.candidate_id for item in history] for history in proposer.histories] == [
+        ["candidate-0000"],
+        ["candidate-0000", "candidate-0001"],
+        ["candidate-0000", "candidate-0001"],
+    ]
+    assert [candidate.name for candidate, _request_arg in scorer.calls] == [
+        "candidate-0000",
+        "candidate-0001",
+        "candidate-0003",
+    ]
+    assert all(request_arg == request for _candidate, request_arg in scorer.calls)
+    assert [item.candidate_id for item in result.population] == [
+        "candidate-0000",
+        "candidate-0001",
+        "candidate-0003",
+    ]
+    assert len(result.iterations) == 3
+    assert result.iterations[0].evaluation is result.population[1]
+    assert result.iterations[1].error is invalid
+    assert result.iterations[1].evaluation is None
+    assert result.iterations[2].evaluation is result.population[2]
+    assert result.best.candidate_id == "candidate-0001"
+    assert result.best_score == pytest.approx(0.8)
+
+
+def test_optimizer_uses_primary_score_only_and_keeps_earliest_tie() -> None:
+    proposer = _Proposer(
+        [
+            _proposal("candidate-0001", "first"),
+            _proposal("candidate-0002", "second"),
+        ]
+    )
+    scorer = _Scorer([(0.1, False), (0.8, False), (0.8, True)])
+
+    result = HarnessPopulationOptimizer(proposer, scorer).optimize(
+        seed=_source("seed"),
+        request=_request(),
+        iterations=2,
+    )
+
+    assert result.population[1].score.report.pass_rate == 0.0
+    assert result.population[2].score.report.pass_rate == 1.0
+    assert result.best.candidate_id == "candidate-0001"
+
+
+def test_complete_duplicate_candidate_is_still_scored_and_retained() -> None:
+    seed = _source("same")
+    duplicate = CandidateProposal(
+        candidate_id="candidate-0001",
+        source=seed,
+        candidate=seed.to_doc("candidate-0001"),
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(calls=1),
+    )
+    proposer = _Proposer([duplicate])
+    scorer = _Scorer([(0.3, False), (0.6, True)])
+
+    result = HarnessPopulationOptimizer(proposer, scorer).optimize(
+        seed=seed,
+        request=_request(),
+        iterations=1,
+    )
+
+    assert len(scorer.calls) == 2
+    assert scorer.calls[0][0].doc_hash == scorer.calls[1][0].doc_hash
+    assert [item.candidate_id for item in result.population] == [
+        "candidate-0000",
+        "candidate-0001",
+    ]
+    assert result.best.candidate_id == "candidate-0001"
+
+
+def test_scorer_error_aborts_without_another_proposal_or_fabricated_score() -> None:
+    proposer = _Proposer(
+        [
+            _proposal("candidate-0001", "first"),
+            _proposal("candidate-0002", "unreached"),
+        ]
+    )
+    scorer = _Scorer([(0.2, False), RuntimeError("evaluator unavailable")])
+
+    with pytest.raises(RuntimeError, match="evaluator unavailable"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=2,
+        )
+
+    assert len(proposer.histories) == 1
+    assert len(scorer.calls) == 2
+
+
+def test_optimizer_rejects_proposal_identity_drift_before_scoring() -> None:
+    source = _source("source")
+    mismatched = CandidateProposal(
+        candidate_id="candidate-0001",
+        source=source,
+        candidate=_source("different").to_doc("candidate-0001"),
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(calls=1),
+    )
+    proposer = _Proposer([mismatched])
+    scorer = _Scorer([(0.2, False)])
+
+    with pytest.raises(ValueError, match="source does not match"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+        )
+
+    assert len(scorer.calls) == 1
+
+
+def test_optimizer_rejects_proposal_document_name_drift_before_scoring() -> None:
+    source = _source("source")
+    mismatched = CandidateProposal(
+        candidate_id="candidate-0001",
+        source=source,
+        candidate=source.to_doc("different-name"),
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(calls=1),
+    )
+    proposer = _Proposer([mismatched])
+    scorer = _Scorer([(0.2, False)])
+
+    with pytest.raises(ValueError, match="name does not match"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+        )
+
+    assert len(scorer.calls) == 1
+
+
+def test_optimizer_rejects_reused_candidate_id_before_scoring() -> None:
+    proposer = _Proposer([_proposal("candidate-0000", "new")])
+    scorer = _Scorer([(0.2, False)])
+
+    with pytest.raises(ValueError, match="candidate_id"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+        )
+
+    assert len(scorer.calls) == 1
+
+
+def test_optimizer_propagates_non_candidate_proposer_errors() -> None:
+    class BrokenProposer:
+        def propose(
+            self,
+            history: Sequence[EvaluatedCandidate],
+            *,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> CandidateProposal:
+            del history, should_cancel
+            raise RuntimeError("provider unavailable")
+
+    scorer = _Scorer([(0.2, False)])
+
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        HarnessPopulationOptimizer(BrokenProposer(), scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+        )
+
+    assert len(scorer.calls) == 1
+
+
+def test_optimizer_honors_cancellation_after_proposal_before_scoring() -> None:
+    checks = iter([False, False, True])
+    proposer = _Proposer([_proposal("candidate-0001", "first")])
+    scorer = _Scorer([(0.2, False)])
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+            should_cancel=lambda: next(checks),
+        )
+
+    assert len(proposer.histories) == 1
+    assert len(scorer.calls) == 1
+
+
+def test_optimizer_preserves_an_explicit_complete_default_pi_seed() -> None:
+    seed_doc = default_agent()
+    proposer = _Proposer([CandidateProposalError("candidate-0001", "invalid")])
+    scorer = _Scorer([(0.2, False)])
+
+    result = HarnessPopulationOptimizer(proposer, scorer).optimize(
+        seed=HarnessSourceTree.from_doc(seed_doc),
+        request=_request(),
+        iterations=1,
+    )
+
+    assert result.population[0].candidate.doc_hash == seed_doc.doc_hash
+    assert len(result.population[0].candidate.code_files()) == len(seed_doc.code_files())
+
+
+@pytest.mark.parametrize("iterations", [0, -1, True])
+def test_optimizer_requires_a_positive_fixed_iteration_count(iterations: int) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        HarnessPopulationOptimizer(_Proposer([]), _Scorer([])).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=iterations,
+        )
+
+
+def test_optimizer_honors_cancellation_before_scoring_seed() -> None:
+    proposer = _Proposer([])
+    scorer = _Scorer([])
+
+    with pytest.raises(HarnessSearchCancelled, match="cancelled"):
+        HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=_source("seed"),
+            request=_request(),
+            iterations=1,
+            should_cancel=lambda: True,
+        )
+
+    assert scorer.calls == []
+    assert proposer.histories == []


### PR DESCRIPTION
## Summary

- add a scorer-driven population optimizer over complete harness candidates
- evaluate the seed once and consume a fixed number of proposal slots
- preserve one immutable score request across the population
- select the highest primary score with deterministic tie handling

## Validation

- uv run pytest wmh/harness/population_test.py -q
- uv run ruff check wmh/harness/population.py wmh/harness/population_test.py
- uv run ruff format --check wmh/harness/population.py wmh/harness/population_test.py
- uv run ty check