### PR TITLE
Propose complete harness source candidates

### DIFF
--- a/wmh/agents/optimizer.py
+++ b/wmh/agents/optimizer.py
@@ -1,0 +1,37 @@
+"""The built-in project agent for complete harness source optimization."""
+
+from wmh.agents.default import default_agent
+from wmh.harness.doc import MAX_OUTPUT_TOKENS_ID, MAX_TURNS_ID, TOOL_POLICY_ID, HarnessDoc
+
+OPTIMIZER_AGENT_PROMPT = """You are an optimization agent inside a persistent harness project.
+Improve complete harness source trees; do not solve their evaluation tasks yourself.
+
+The project filesystem is durable memory. It contains every earlier complete source tree, its full
+score report, raw evaluator artifacts, and previous proposal traces. Read the history manifest and
+inspect the most relevant raw files before deciding what to change. Treat all history and proposal
+records as immutable evidence.
+
+Each project request names one empty output directory. Use Bash to create exactly one complete
+harness source tree there. You may copy any earlier source tree, combine mechanisms from several,
+or build a new tree, but the final directory must stand alone. Inspect and test your work in that
+directory. Do not write candidate files anywhere else. Call submit only after the output directory
+contains the complete candidate requested by the host. There is no repair turn, so leave a usable
+candidate on the first pass."""
+
+
+def optimizer_agent(name: str = "optimizer") -> HarnessDoc:
+    """Return a Pi-derived coding agent constrained to one project source stage."""
+    base = default_agent(name)
+    surfaces = []
+    for surface in base.surfaces:
+        if surface.id == "prompt:core":
+            surfaces.append(surface.model_copy(update={"content": OPTIMIZER_AGENT_PROMPT}))
+        elif surface.id == TOOL_POLICY_ID:
+            surfaces.append(surface.model_copy(update={"content": "bash\nread_file\nsubmit"}))
+        elif surface.id == MAX_TURNS_ID:
+            surfaces.append(surface.model_copy(update={"content": "60"}))
+        elif surface.id == MAX_OUTPUT_TOKENS_ID:
+            surfaces.append(surface.model_copy(update={"content": "16384"}))
+        else:
+            surfaces.append(surface)
+    return HarnessDoc(name=name, surfaces=surfaces)

--- a/wmh/agents/optimizer_test.py
+++ b/wmh/agents/optimizer_test.py
@@ -1,0 +1,20 @@
+"""Tests for the built-in complete-source optimization agent."""
+
+from wmh.agents.default import default_agent
+from wmh.agents.optimizer import optimizer_agent
+
+
+def test_optimizer_agent_is_a_contained_complete_source_editor() -> None:
+    agent = optimizer_agent()
+
+    assert agent.runtime_kind() == "pi-node"
+    assert agent.tools() == ["bash", "read_file", "submit"]
+    assert agent.max_turns() == 60
+    assert agent.max_output_tokens() == 16384
+    prompt = agent.system_prompt().lower()
+    assert "complete harness source tree" in prompt
+    assert "do not solve" in prompt
+    assert "parent" not in prompt
+    assert {surface.path: surface.content for surface in agent.code_files()} == {
+        surface.path: surface.content for surface in default_agent().code_files()
+    }

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -35,6 +35,8 @@ class CandidateProject(Protocol):
 
     def write_text(self, path: str, content: str) -> None: ...
 
+    def read_text(self, path: str) -> str: ...
+
     def stage_source_tree(
         self,
         tree: HarnessSourceTree,
@@ -195,7 +197,11 @@ class ProjectCandidateProposer:
         if len(fingerprints) < len(self._history_fingerprints):
             raise ValueError("candidate proposal history must preserve its append-only prefix")
 
-        self._materialize_history(frozen_history, start=len(self._history_fingerprints))
+        self._materialize_history(
+            frozen_history,
+            fingerprints=fingerprints,
+            start=len(self._history_fingerprints),
+        )
         self._history_fingerprints = fingerprints
         self._write_history_manifest(frozen_history)
         self._check_cancelled(should_cancel)
@@ -329,11 +335,13 @@ class ProjectCandidateProposer:
         self,
         history: Sequence[EvaluatedCandidate],
         *,
+        fingerprints: Sequence[str],
         start: int,
     ) -> None:
         """Append every new complete candidate and exact artifact byte to the project."""
         for index, evaluated in enumerate(history[start:], start=start):
             directory = f"history/candidate-{index:04d}"
+            self._bind_history_slot(directory, fingerprints[index])
             self._write_source_tree(f"{directory}/source", evaluated.source)
             self._project.write_text(
                 f"{directory}/evaluation/report.json",
@@ -357,6 +365,20 @@ class ProjectCandidateProposer:
             self._project.write_text(
                 f"{directory}/evaluation/artifacts.json",
                 _json(artifact_manifest),
+            )
+
+    def _bind_history_slot(self, directory: str, fingerprint: str) -> None:
+        """Bind one history index before non-atomic writes so retries cannot mix candidates."""
+        identity_path = f"{directory}/fingerprint.txt"
+        try:
+            existing = self._project.read_text(identity_path)
+        except FileNotFoundError:
+            self._project.write_text(identity_path, fingerprint)
+            return
+        if existing != fingerprint:
+            raise ValueError(
+                f"{directory} is already bound to another candidate after a partial write; "
+                "retry with the original history or create a fresh project"
             )
 
     def _write_history_manifest(self, history: Sequence[EvaluatedCandidate]) -> None:

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -1,0 +1,493 @@
+"""Agentic proposal of complete harness source trees from scored project history."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from wmh.agents.project import (
+    DEFAULT_SOURCE_TREE_MAX_BYTES,
+    DEFAULT_SOURCE_TREE_MAX_FILES,
+    AgentProjectRun,
+    ProjectSourceStage,
+)
+from wmh.core.text import validate_durable_text
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
+from wmh.harness.scoring import EvaluationArtifact, HarnessScore
+from wmh.harness.source_tree import HarnessSourceTree
+from wmh.providers.base import ToolCallingProvider
+
+DEFAULT_MAX_HISTORY_CANDIDATES = 1_024
+DEFAULT_MAX_HISTORY_BYTES = 512 * 1024 * 1024
+MAX_HISTORY_ARTIFACT_PATH_BYTES = 1_024
+
+
+class CandidateProject(Protocol):
+    """Project operations required to propose one complete source candidate."""
+
+    workspace: str
+
+    def write_text(self, path: str, content: str) -> None: ...
+
+    def stage_source_tree(
+        self,
+        tree: HarnessSourceTree,
+        *,
+        max_files: int,
+        max_bytes: int,
+    ) -> ProjectSourceStage: ...
+
+    def snapshot_source_tree(
+        self,
+        stage: ProjectSourceStage,
+        *,
+        max_files: int,
+        max_bytes: int,
+    ) -> HarnessSourceTree: ...
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        on_event: Callable[[SessionEvent], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
+    ) -> AgentProjectRun: ...
+
+
+@dataclass(frozen=True)
+class EvaluatedCandidate:
+    """One complete source candidate paired with its immutable raw score evidence."""
+
+    candidate_id: str
+    source: HarnessSourceTree
+    score: HarnessScore
+
+    def __post_init__(self) -> None:
+        if not self.candidate_id or len(self.candidate_id) > 512:
+            raise ValueError("candidate_id must contain between 1 and 512 characters")
+        validate_durable_text(self.candidate_id, field="candidate id")
+        candidate = self.source.to_doc(self.candidate_id)
+        if candidate.doc_hash != self.score.report.candidate_doc_hash:
+            raise ValueError(
+                "score document hash does not match the evaluated candidate source tree"
+            )
+
+    @property
+    def candidate(self) -> HarnessDoc:
+        """Reparse the complete source into its validated harness document."""
+        return self.source.to_doc(self.candidate_id)
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the immutable identity used to enforce append-only project history."""
+        for artifact in self.score.report.artifacts:
+            _verified_artifact_content(self.score, artifact)
+        payload = {
+            "candidate_id": self.candidate_id,
+            "doc_hash": self.candidate.doc_hash,
+            "report_hash": self.score.report.report_hash,
+            "source_tree_hash": self.source.tree_hash,
+        }
+        encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class CandidateProposal:
+    """One complete, host-captured and reparsed candidate proposal."""
+
+    candidate_id: str
+    source: HarnessSourceTree
+    candidate: HarnessDoc
+    events: tuple[SessionEvent, ...]
+    worker_usage: TokenUsage
+
+
+class CandidateProposalError(RuntimeError):
+    """One proposal turn that did not publish a new valid complete candidate."""
+
+    def __init__(
+        self,
+        candidate_id: str,
+        reason: str,
+        *,
+        source: HarnessSourceTree | None = None,
+        events: Sequence[SessionEvent] = (),
+        worker_usage: TokenUsage | None = None,
+    ) -> None:
+        super().__init__(f"{candidate_id}: {reason}")
+        self.candidate_id = candidate_id
+        self.source = source
+        self.events = tuple(events)
+        self.worker_usage = worker_usage
+
+
+class CandidateProposer(Protocol):
+    """Produce exactly one complete candidate from append-only evaluated history."""
+
+    def propose(
+        self,
+        history: Sequence[EvaluatedCandidate],
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal: ...
+
+
+class ProjectCandidateProposer:
+    """Run one contained coding turn against complete scored project history."""
+
+    def __init__(
+        self,
+        project: CandidateProject,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        *,
+        max_source_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_source_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+        max_history_candidates: int = DEFAULT_MAX_HISTORY_CANDIDATES,
+        max_history_bytes: int = DEFAULT_MAX_HISTORY_BYTES,
+    ) -> None:
+        _require_positive_int(max_source_files, field="max_source_files")
+        _require_positive_int(max_source_bytes, field="max_source_bytes")
+        _require_positive_int(max_history_candidates, field="max_history_candidates")
+        _require_positive_int(max_history_bytes, field="max_history_bytes")
+        self._project = project
+        self._agent = agent
+        self._provider = provider
+        self._max_source_files = max_source_files
+        self._max_source_bytes = max_source_bytes
+        self._max_history_candidates = max_history_candidates
+        self._max_history_bytes = max_history_bytes
+        self._history_fingerprints: tuple[str, ...] = ()
+        self._proposal_count = 0
+
+    def propose(
+        self,
+        history: Sequence[EvaluatedCandidate],
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        """Produce one new source tree without selecting or materializing a host parent."""
+        self._check_cancelled(should_cancel)
+        frozen_history = tuple(history)
+        if not frozen_history:
+            raise ValueError("candidate proposal history must include an evaluated seed")
+        candidate_ids = [item.candidate_id for item in frozen_history]
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("candidate proposal history contains duplicate candidate_id values")
+        score_request = frozen_history[0].score.report.request
+        if any(item.score.report.request != score_request for item in frozen_history[1:]):
+            raise ValueError("all candidate history entries must use the same score request")
+        self._validate_history_bounds(frozen_history)
+        fingerprints = tuple(item.fingerprint for item in frozen_history)
+        if fingerprints[: len(self._history_fingerprints)] != self._history_fingerprints:
+            raise ValueError("candidate proposal history must preserve its append-only prefix")
+        if len(fingerprints) < len(self._history_fingerprints):
+            raise ValueError("candidate proposal history must preserve its append-only prefix")
+
+        self._materialize_history(frozen_history, start=len(self._history_fingerprints))
+        self._history_fingerprints = fingerprints
+        self._write_history_manifest(frozen_history)
+        self._check_cancelled(should_cancel)
+
+        previous_proposal_id = (
+            f"candidate-{self._proposal_count:04d}" if self._proposal_count > 0 else None
+        )
+        next_proposal_count = self._proposal_count + 1
+        candidate_id = f"candidate-{next_proposal_count:04d}"
+        proposal_dir = f"proposals/{candidate_id}"
+        stage = self._project.stage_source_tree(
+            HarnessSourceTree(files=()),
+            max_files=self._max_source_files,
+            max_bytes=self._max_source_bytes,
+        )
+        absolute_stage = f"{self._project.workspace}/{stage.path}"
+        request = _proposal_request(
+            candidate_id=candidate_id,
+            absolute_stage=absolute_stage,
+            proposal_dir=proposal_dir,
+            history_count=len(frozen_history),
+            previous_proposal_id=previous_proposal_id,
+        )
+        self._project.write_text(f"{proposal_dir}/REQUEST.md", request)
+        self._proposal_count = next_proposal_count
+
+        events: list[SessionEvent] = []
+        run_error: str | None = None
+        run_result: AgentProjectRun | None = None
+        try:
+            run_result = self._project.run(
+                self._agent,
+                self._provider,
+                request,
+                on_event=events.append,
+                should_cancel=should_cancel,
+                writable_files=(),
+                retry_recoverable=False,
+            )
+        except HarnessSearchCancelled:
+            self._write_events(proposal_dir, events)
+            raise
+        except Exception as error:  # noqa: BLE001 - persist the failed turn before rejecting it
+            run_error = str(error)
+        self._write_events(proposal_dir, events)
+        self._check_cancelled(should_cancel)
+
+        source: HarnessSourceTree | None = None
+        snapshot_error: str | None = None
+        try:
+            source = self._project.snapshot_source_tree(
+                stage,
+                max_files=self._max_source_files,
+                max_bytes=self._max_source_bytes,
+            )
+        except Exception as error:  # noqa: BLE001 - preserve a failed proposal as one iteration
+            snapshot_error = str(error)
+
+        if source is not None:
+            self._write_source_tree(f"{proposal_dir}/source", source)
+
+        validation_errors: list[str] = []
+        if not any(event.kind == "submit" for event in events):
+            validation_errors.append("agent turn did not submit a completed candidate")
+        if snapshot_error is not None:
+            validation_errors.append(f"source snapshot failed: {snapshot_error}")
+        if run_error is not None:
+            validation_errors.append(f"agent turn failed: {run_error}")
+
+        candidate: HarnessDoc | None = None
+        if source is not None:
+            try:
+                candidate = source.to_doc(candidate_id)
+            except (TypeError, ValueError) as error:
+                validation_errors.append(str(error))
+
+        worker_usage = run_result.worker_usage if run_result is not None else None
+        self._write_status(
+            proposal_dir,
+            candidate_id=candidate_id,
+            source=source,
+            candidate=candidate,
+            agent_error=run_error,
+            validation_errors=validation_errors,
+        )
+        if validation_errors or source is None or candidate is None:
+            reason = "; ".join(validation_errors) or "candidate source was not captured"
+            raise CandidateProposalError(
+                candidate_id,
+                reason,
+                source=source,
+                events=events,
+                worker_usage=worker_usage,
+            )
+        assert run_result is not None
+        return CandidateProposal(
+            candidate_id=candidate_id,
+            source=source,
+            candidate=candidate,
+            events=tuple(events),
+            worker_usage=run_result.worker_usage,
+        )
+
+    def _validate_history_bounds(self, history: Sequence[EvaluatedCandidate]) -> None:
+        """Reject unbounded evaluator-controlled history before reading or writing its bytes."""
+        if len(history) > self._max_history_candidates:
+            raise ValueError(
+                f"candidate history exceeds max_history_candidates={self._max_history_candidates}"
+            )
+        total_bytes = 0
+        for evaluated in history:
+            evaluated.source.validate_bounds(
+                max_files=self._max_source_files,
+                max_bytes=self._max_source_bytes,
+            )
+            total_bytes += evaluated.source.total_bytes
+            total_bytes += len(evaluated.score.report.model_dump_json().encode("utf-8"))
+            for artifact in evaluated.score.report.artifacts:
+                if len(artifact.path.encode("utf-8")) > MAX_HISTORY_ARTIFACT_PATH_BYTES:
+                    raise ValueError(
+                        f"artifact path exceeds {MAX_HISTORY_ARTIFACT_PATH_BYTES} bytes: "
+                        f"{artifact.path!r}"
+                    )
+                total_bytes += artifact.size_bytes
+        if total_bytes > self._max_history_bytes:
+            raise ValueError(
+                f"candidate history exceeds max_history_bytes={self._max_history_bytes}"
+            )
+
+    def _materialize_history(
+        self,
+        history: Sequence[EvaluatedCandidate],
+        *,
+        start: int,
+    ) -> None:
+        """Append every new complete candidate and exact artifact byte to the project."""
+        for index, evaluated in enumerate(history[start:], start=start):
+            directory = f"history/candidate-{index:04d}"
+            self._write_source_tree(f"{directory}/source", evaluated.source)
+            self._project.write_text(
+                f"{directory}/evaluation/report.json",
+                evaluated.score.report.model_dump_json(indent=2),
+            )
+            artifact_manifest: list[dict[str, str | int]] = []
+            for artifact in evaluated.score.report.artifacts:
+                content = _verified_artifact_content(evaluated.score, artifact)
+                project_path, encoding, rendered = _render_artifact(directory, artifact, content)
+                self._project.write_text(project_path, rendered)
+                artifact_manifest.append(
+                    {
+                        "artifact_path": artifact.path,
+                        "content_hash": artifact.content_hash,
+                        "encoding": encoding,
+                        "media_type": artifact.media_type,
+                        "project_path": project_path,
+                        "size_bytes": artifact.size_bytes,
+                    }
+                )
+            self._project.write_text(
+                f"{directory}/evaluation/artifacts.json",
+                _json(artifact_manifest),
+            )
+
+    def _write_history_manifest(self, history: Sequence[EvaluatedCandidate]) -> None:
+        candidates = []
+        for index, evaluated in enumerate(history):
+            directory = f"history/candidate-{index:04d}"
+            candidates.append(
+                {
+                    "candidate_id": evaluated.candidate_id,
+                    "doc_hash": evaluated.candidate.doc_hash,
+                    "evaluation_artifacts": f"{directory}/evaluation/artifacts.json",
+                    "score": evaluated.score.report.score,
+                    "score_report": f"{directory}/evaluation/report.json",
+                    "source_dir": f"{directory}/source",
+                    "source_tree_hash": evaluated.source.tree_hash,
+                }
+            )
+        self._project.write_text(
+            "history/manifest.json",
+            _json(
+                {
+                    "candidate_count": len(candidates),
+                    "candidates": candidates,
+                    "proposal_history_dir": "proposals",
+                }
+            ),
+        )
+
+    def _write_source_tree(self, directory: str, source: HarnessSourceTree) -> None:
+        for item in source.files:
+            self._project.write_text(f"{directory}/{item.path}", item.content)
+
+    def _write_events(self, proposal_dir: str, events: Sequence[SessionEvent]) -> None:
+        self._project.write_text(
+            f"{proposal_dir}/events.json",
+            _json([{"kind": event.kind, "payload": event.payload} for event in events]),
+        )
+
+    def _write_status(
+        self,
+        proposal_dir: str,
+        *,
+        candidate_id: str,
+        source: HarnessSourceTree | None,
+        candidate: HarnessDoc | None,
+        agent_error: str | None,
+        validation_errors: Sequence[str],
+    ) -> None:
+        self._project.write_text(
+            f"{proposal_dir}/status.json",
+            _json(
+                {
+                    "agent_error": agent_error,
+                    "candidate_doc_hash": candidate.doc_hash if candidate is not None else None,
+                    "candidate_id": candidate_id,
+                    "source_tree_hash": source.tree_hash if source is not None else None,
+                    "valid": not validation_errors and candidate is not None,
+                    "validation_error": "; ".join(validation_errors) or None,
+                }
+            ),
+        )
+
+    @staticmethod
+    def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+        if should_cancel is not None and should_cancel():
+            raise HarnessSearchCancelled("harness search cancelled")
+
+
+def _proposal_request(
+    *,
+    candidate_id: str,
+    absolute_stage: str,
+    proposal_dir: str,
+    history_count: int,
+    previous_proposal_id: str | None,
+) -> str:
+    previous_trace = (
+        f"The immediately preceding coding-turn trace is "
+        f"`proposals/{previous_proposal_id}/events.json`; its captured source and status are "
+        f"in the same directory."
+        if previous_proposal_id is not None
+        else "There is no earlier coding turn in this project."
+    )
+    return f"""Produce exactly one complete harness candidate: {candidate_id}.
+
+Read `history/manifest.json`. It indexes all {history_count} evaluated candidates, their complete
+source directories, full score reports, and raw evaluator artifacts. Earlier coding-turn traces
+remain under `proposals/`. {previous_trace} Use the full population as evidence. Do not select or
+assume a host-designated source to extend.
+
+Your only candidate output is this initially empty directory:
+`{absolute_stage}`
+
+Use Bash to inspect immutable project evidence and to copy, create, edit, delete, and test files
+inside that directory. Leave one complete standalone harness source tree there. Do not modify
+`history/`, `proposals/`, or any other project path. When the candidate is complete, call submit.
+The host snapshots the directory once after this turn and will not ask for a repair.
+
+This turn's immutable request and trace are stored under `{proposal_dir}/`.
+"""
+
+
+def _verified_artifact_content(score: HarnessScore, artifact: EvaluationArtifact) -> bytes:
+    content = score.artifacts.read_bytes(artifact.path)
+    digest = "sha256:" + hashlib.sha256(content).hexdigest()
+    if len(content) != artifact.size_bytes or digest != artifact.content_hash:
+        raise ValueError(f"artifact content differs from its manifest for {artifact.path!r}")
+    return content
+
+
+def _render_artifact(
+    directory: str,
+    artifact: EvaluationArtifact,
+    content: bytes,
+) -> tuple[str, str, str]:
+    try:
+        rendered = content.decode("utf-8")
+        validate_durable_text(rendered, field=f"artifact {artifact.path!r}")
+    except (UnicodeDecodeError, ValueError):
+        return (
+            f"{directory}/evaluation/artifacts-base64/{artifact.path}.b64",
+            "base64",
+            base64.b64encode(content).decode("ascii"),
+        )
+    return f"{directory}/evaluation/artifacts/{artifact.path}", "utf-8", rendered
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _require_positive_int(value: int, *, field: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -1,0 +1,552 @@
+"""Behavioral tests for complete-source project candidate proposal."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable, Collection
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import AgentProjectRun, ProjectSourceStage
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.project_proposer import (
+    CandidateProposalError,
+    EvaluatedCandidate,
+    ProjectCandidateProposer,
+)
+from wmh.harness.runtime import HarnessSearchCancelled, TokenUsage
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.providers.base import ToolCallingProvider
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+
+
+class _BytesReader:
+    def __init__(self, content: dict[str, bytes]) -> None:
+        self.content = content
+
+    def read_bytes(self, path: str) -> bytes:
+        return self.content[path]
+
+
+@dataclass
+class _RunCall:
+    instruction: str
+    writable_files: tuple[str, ...]
+    retry_recoverable: bool
+
+
+class _FakeProject:
+    workspace = "/home/user/project"
+
+    def __init__(self, snapshots: list[HarnessSourceTree]) -> None:
+        self.files: dict[str, str] = {}
+        self.snapshots = snapshots
+        self.staged: list[HarnessSourceTree] = []
+        self.snapshot_calls: list[ProjectSourceStage] = []
+        self.run_calls: list[_RunCall] = []
+        self.emit_submit = True
+        self.run_behavior: (
+            Callable[[_FakeProject, tuple[str, ...], Callable[[SessionEvent], None] | None], None]
+            | None
+        ) = None
+
+    def write_text(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    def read_text(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    def stage_source_tree(
+        self,
+        tree: HarnessSourceTree,
+        *,
+        max_files: int,
+        max_bytes: int,
+    ) -> ProjectSourceStage:
+        del max_files, max_bytes
+        self.staged.append(tree)
+        return ProjectSourceStage(
+            path=f".scratch/source-stages/stage-{len(self.staged):06d}",
+            sandbox_generation=1,
+        )
+
+    def snapshot_source_tree(
+        self,
+        stage: ProjectSourceStage,
+        *,
+        max_files: int,
+        max_bytes: int,
+    ) -> HarnessSourceTree:
+        del max_files, max_bytes
+        self.snapshot_calls.append(stage)
+        return self.snapshots.pop(0)
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        on_event: Callable[[SessionEvent], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
+    ) -> AgentProjectRun:
+        del agent, provider, should_cancel
+        granted = tuple(writable_files or ())
+        self.run_calls.append(
+            _RunCall(
+                instruction=instruction,
+                writable_files=granted,
+                retry_recoverable=retry_recoverable,
+            )
+        )
+        if self.run_behavior is not None:
+            self.run_behavior(self, granted, on_event)
+        event = SessionEvent(kind="submit", payload={"answer": "candidate complete"})
+        if self.emit_submit and on_event is not None:
+            on_event(event)
+        return AgentProjectRun(
+            answer="candidate complete",
+            events=((event,) if self.emit_submit else ()),
+            worker_usage=TokenUsage(input_tokens=11, output_tokens=7, calls=1),
+        )
+
+
+def _source(prompt: str = "base") -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _evaluated(
+    candidate_id: str = "seed",
+    *,
+    source: HarnessSourceTree | None = None,
+    artifacts: dict[str, bytes] | None = None,
+) -> EvaluatedCandidate:
+    tree = source or _source()
+    candidate = tree.to_doc(candidate_id)
+    raw = artifacts or {
+        "traces/task.jsonl": b'{"tool":"bash","ok":true}\n',
+        "screens/final.bin": b"\x00\xff",
+    }
+    manifest = tuple(
+        EvaluationArtifact.from_bytes(path=path, content=content) for path, content in raw.items()
+    )
+    request = ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST_A,
+            evaluator_digest=_DIGEST_B,
+            execution_config_digest=_DIGEST_C,
+        ),
+        task_ids=("task-1",),
+        attempts=1,
+    )
+    report = HarnessScoreReport(
+        source_run_id=f"run-{candidate_id}",
+        candidate_doc_hash=candidate.doc_hash,
+        request=request,
+        cells=(
+            ScoreCell(
+                task_id="task-1",
+                attempt=1,
+                score=0.5,
+                passed=False,
+                summary="raw result",
+                artifact_paths=tuple(raw),
+            ),
+        ),
+        artifacts=manifest,
+    )
+    return EvaluatedCandidate(
+        candidate_id=candidate_id,
+        source=tree,
+        score=HarnessScore(report=report, artifacts=_BytesReader(raw)),
+    )
+
+
+def _provider() -> ToolCallingProvider:
+    return cast(ToolCallingProvider, object())
+
+
+def _emit_bash_activity(
+    project: _FakeProject,
+    granted: tuple[str, ...],
+    on_event: Callable[[SessionEvent], None] | None,
+) -> None:
+    del project
+    assert granted == ()
+    if on_event is not None:
+        on_event(SessionEvent(kind="tool_call", payload={"name": "bash"}))
+
+
+def test_evaluated_candidate_rejects_score_identity_drift() -> None:
+    evaluated = _evaluated()
+    changed = _source("changed")
+
+    with pytest.raises(ValueError, match="score document hash"):
+        EvaluatedCandidate(
+            candidate_id="seed",
+            source=changed,
+            score=evaluated.score,
+        )
+
+
+def test_project_proposer_materializes_complete_history_and_returns_one_candidate() -> None:
+    candidate_source = _source("improved")
+    project = _FakeProject([candidate_source])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    result = proposer.propose((_evaluated(),))
+
+    assert result.candidate_id == "candidate-0001"
+    assert result.source == candidate_source
+    assert result.candidate.system_prompt() == "improved"
+    assert result.worker_usage == TokenUsage(input_tokens=11, output_tokens=7, calls=1)
+    assert len(project.run_calls) == 1
+    assert project.staged == [HarnessSourceTree(files=())]
+    assert len(project.snapshot_calls) == 1
+    assert project.run_calls[0].writable_files == ()
+    assert project.run_calls[0].retry_recoverable is False
+    assert "/home/user/project/.scratch/source-stages/stage-000001" in (
+        project.run_calls[0].instruction
+    )
+
+    manifest = json.loads(project.files["history/manifest.json"])
+    assert manifest["candidate_count"] == 1
+    assert manifest["candidates"][0]["candidate_id"] == "seed"
+    assert manifest["candidates"][0]["source_dir"] == "history/candidate-0000/source"
+    assert project.files["history/candidate-0000/source/SYSTEM.md"] == "base"
+    report = json.loads(project.files["history/candidate-0000/evaluation/report.json"])
+    assert report["candidate_doc_hash"] == _source().to_doc("seed").doc_hash
+    assert (
+        project.files["history/candidate-0000/evaluation/artifacts/traces/task.jsonl"]
+        == '{"tool":"bash","ok":true}\n'
+    )
+    encoded = project.files[
+        "history/candidate-0000/evaluation/artifacts-base64/screens/final.bin.b64"
+    ]
+    assert base64.b64decode(encoded) == b"\x00\xff"
+    assert project.files["proposals/candidate-0001/source/SYSTEM.md"] == "improved"
+    events = json.loads(project.files["proposals/candidate-0001/events.json"])
+    assert [event["kind"] for event in events] == ["tool_call", "submit"]
+
+
+def test_project_proposer_history_is_append_only_and_previous_trace_remains_visible() -> None:
+    first_source = _source("first")
+    second_source = _source("second")
+    project = _FakeProject([first_source, second_source])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+    seed = _evaluated()
+
+    first = proposer.propose((seed,))
+    scored_first = _evaluated("first", source=first.source)
+    second = proposer.propose((seed, scored_first))
+
+    assert second.candidate_id == "candidate-0002"
+    assert len(project.run_calls) == 2
+    assert "proposals/candidate-0001/events.json" in project.run_calls[1].instruction
+    manifest = json.loads(project.files["history/manifest.json"])
+    assert [item["candidate_id"] for item in manifest["candidates"]] == ["seed", "first"]
+    assert project.files["proposals/candidate-0001/source/SYSTEM.md"] == "first"
+
+    with pytest.raises(ValueError, match="append-only prefix"):
+        proposer.propose((scored_first, seed))
+    assert len(project.run_calls) == 2
+
+
+def test_pre_turn_stage_failure_does_not_advance_proposal_identity() -> None:
+    class _StageFailsOnceProject(_FakeProject):
+        def __init__(self) -> None:
+            super().__init__([_source("first")])
+            self.stage_attempts = 0
+
+        def stage_source_tree(
+            self,
+            tree: HarnessSourceTree,
+            *,
+            max_files: int,
+            max_bytes: int,
+        ) -> ProjectSourceStage:
+            self.stage_attempts += 1
+            if self.stage_attempts == 1:
+                raise RuntimeError("stage unavailable")
+            return super().stage_source_tree(
+                tree,
+                max_files=max_files,
+                max_bytes=max_bytes,
+            )
+
+    project = _StageFailsOnceProject()
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+    seed = _evaluated()
+
+    with pytest.raises(RuntimeError, match="stage unavailable"):
+        proposer.propose((seed,))
+
+    assert project.run_calls == []
+    assert not any(path.startswith("proposals/") for path in project.files)
+
+    result = proposer.propose((seed,))
+
+    assert result.candidate_id == "candidate-0001"
+    assert "There is no earlier coding turn" in project.run_calls[0].instruction
+    assert "proposals/candidate-0001/events.json" not in project.run_calls[0].instruction
+
+
+def test_append_only_history_binds_source_score_and_artifact_content() -> None:
+    project = _FakeProject([_source("first")])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+    seed = _evaluated()
+    proposer.propose((seed,))
+
+    changed_source = _evaluated("seed", source=_source("changed seed"))
+    with pytest.raises(ValueError, match="append-only prefix"):
+        proposer.propose((changed_source,))
+    assert len(project.run_calls) == 1
+
+    corrupt_reader = EvaluatedCandidate(
+        candidate_id=seed.candidate_id,
+        source=seed.source,
+        score=HarnessScore(
+            report=seed.score.report,
+            artifacts=_BytesReader(
+                {
+                    "traces/task.jsonl": b"changed",
+                    "screens/final.bin": b"\x00\xff",
+                }
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="artifact content differs"):
+        proposer.propose((corrupt_reader,))
+    assert len(project.run_calls) == 1
+
+
+def test_history_rejects_a_second_evaluation_matrix_before_project_writes() -> None:
+    seed = _evaluated()
+    second = _evaluated("second", source=_source("second"))
+    changed_request = second.score.report.request.model_copy(
+        update={
+            "context": second.score.report.request.context.model_copy(
+                update={"execution_config_digest": "sha256:" + "d" * 64}
+            )
+        }
+    )
+    changed_report = second.score.report.model_copy(update={"request": changed_request})
+    mixed = EvaluatedCandidate(
+        candidate_id=second.candidate_id,
+        source=second.source,
+        score=HarnessScore(report=changed_report, artifacts=second.score.artifacts),
+    )
+    project = _FakeProject([_source("unused")])
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    with pytest.raises(ValueError, match="same score request"):
+        proposer.propose((seed, mixed))
+
+    assert project.files == {}
+    assert project.run_calls == []
+
+
+def test_history_is_bounded_before_materializing_evaluator_controlled_files() -> None:
+    seed = _evaluated()
+    second = _evaluated("second", source=_source("second"))
+    project = _FakeProject([_source("unused")])
+    proposer = ProjectCandidateProposer(
+        project,
+        optimizer_agent(),
+        _provider(),
+        max_history_candidates=1,
+    )
+
+    with pytest.raises(ValueError, match="max_history_candidates"):
+        proposer.propose((seed, second))
+    assert project.files == {}
+
+    byte_bounded = ProjectCandidateProposer(
+        project,
+        optimizer_agent(),
+        _provider(),
+        max_history_bytes=1,
+    )
+    with pytest.raises(ValueError, match="max_history_bytes"):
+        byte_bounded.propose((seed,))
+    assert project.files == {}
+    assert project.run_calls == []
+
+
+def test_invalid_candidate_consumes_turn_without_repair_or_fallback() -> None:
+    invalid = HarnessSourceTree(files=(HarnessSourceFile(path="notes.txt", content="partial"),))
+    valid = _source("later")
+    project = _FakeProject([invalid, valid])
+    project.emit_submit = False
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+    seed = _evaluated()
+
+    with pytest.raises(CandidateProposalError, match="submit") as raised:
+        proposer.propose((seed,))
+
+    assert raised.value.candidate_id == "candidate-0001"
+    assert raised.value.source == invalid
+    assert len(project.run_calls) == 1
+    assert project.staged == [HarnessSourceTree(files=())]
+    assert project.files["proposals/candidate-0001/source/notes.txt"] == "partial"
+
+    project.emit_submit = True
+    project.run_behavior = _emit_bash_activity
+    result = proposer.propose((seed,))
+    assert result.candidate_id == "candidate-0002"
+    assert result.candidate.system_prompt() == "later"
+    assert len(project.run_calls) == 2
+    assert "proposals/candidate-0001/events.json" in project.run_calls[1].instruction
+
+
+def test_complete_duplicate_is_returned_without_a_host_novelty_gate() -> None:
+    seed = _evaluated()
+    duplicate_project = _FakeProject([seed.source])
+    duplicate_project.run_behavior = _emit_bash_activity
+    duplicate_proposer = ProjectCandidateProposer(duplicate_project, optimizer_agent(), _provider())
+
+    duplicate = duplicate_proposer.propose((seed,))
+
+    assert duplicate.source == seed.source
+    assert duplicate.candidate.doc_hash == seed.candidate.doc_hash
+    assert len(duplicate_project.run_calls) == 1
+
+
+def test_repeated_invalid_source_remains_an_invalid_consumed_turn() -> None:
+    seed = _evaluated()
+    failed = HarnessSourceTree(
+        files=(HarnessSourceFile(path="notes.txt", content="same failed source"),)
+    )
+    failed_project = _FakeProject([failed, failed])
+    failed_project.run_behavior = _emit_bash_activity
+    failed_proposer = ProjectCandidateProposer(failed_project, optimizer_agent(), _provider())
+    with pytest.raises(CandidateProposalError, match="missing required SYSTEM.md"):
+        failed_proposer.propose((seed,))
+
+    with pytest.raises(CandidateProposalError, match="missing required SYSTEM.md"):
+        failed_proposer.propose((seed,))
+
+    assert len(failed_project.run_calls) == 2
+
+
+def test_submitted_snapshot_fails_closed_when_agent_run_errors() -> None:
+    project = _FakeProject([_source("durable")])
+
+    def fail_after_ready(
+        project: _FakeProject,
+        granted: tuple[str, ...],
+        on_event: Callable[[SessionEvent], None] | None,
+    ) -> None:
+        _emit_bash_activity(project, granted, on_event)
+        if on_event is not None:
+            on_event(SessionEvent(kind="submit", payload={"answer": "candidate complete"}))
+        raise RuntimeError("terminal frame lost")
+
+    project.run_behavior = fail_after_ready
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    with pytest.raises(CandidateProposalError, match="agent turn failed") as raised:
+        proposer.propose((_evaluated(),))
+
+    assert raised.value.source == _source("durable")
+    assert raised.value.worker_usage is None
+    status = json.loads(project.files["proposals/candidate-0001/status.json"])
+    assert status["agent_error"] == "terminal frame lost"
+    assert status["valid"] is False
+
+
+def test_invalid_tree_is_not_repaired_and_preserves_raw_source_and_trace() -> None:
+    invalid = HarnessSourceTree(
+        files=(HarnessSourceFile(path="config.toml", content="[harness]\n"),)
+    )
+    project = _FakeProject([invalid])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    with pytest.raises(CandidateProposalError, match="missing required SYSTEM.md") as raised:
+        proposer.propose((_evaluated(),))
+
+    assert raised.value.source == invalid
+    assert len(project.run_calls) == 1
+    assert len(project.snapshot_calls) == 1
+    assert project.files["proposals/candidate-0001/source/config.toml"] == "[harness]\n"
+    status = json.loads(project.files["proposals/candidate-0001/status.json"])
+    assert status["valid"] is False
+    assert "missing required SYSTEM.md" in status["validation_error"]
+
+
+def test_cancellation_propagates_without_snapshotting_a_candidate() -> None:
+    project = _FakeProject([_source("unused")])
+
+    def cancel(
+        project: _FakeProject,
+        granted: tuple[str, ...],
+        on_event: Callable[[SessionEvent], None] | None,
+    ) -> None:
+        del project, granted, on_event
+        raise HarnessSearchCancelled("stop")
+
+    project.run_behavior = cancel
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    with pytest.raises(HarnessSearchCancelled, match="stop"):
+        proposer.propose((_evaluated(),))
+
+    assert len(project.run_calls) == 1
+    assert project.snapshot_calls == []
+
+
+def test_history_artifact_content_is_verified_before_agent_exposure() -> None:
+    evaluated = _evaluated()
+    corrupt = EvaluatedCandidate(
+        candidate_id=evaluated.candidate_id,
+        source=evaluated.source,
+        score=HarnessScore(
+            report=evaluated.score.report,
+            artifacts=_BytesReader(
+                {
+                    "traces/task.jsonl": b"changed",
+                    "screens/final.bin": b"\x00\xff",
+                }
+            ),
+        ),
+    )
+    project = _FakeProject([_source("unused")])
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+
+    with pytest.raises(ValueError, match="artifact content differs"):
+        proposer.propose((corrupt,))
+
+    assert project.run_calls == []

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -282,6 +282,39 @@ def test_project_proposer_history_is_append_only_and_previous_trace_remains_visi
     assert len(project.run_calls) == 2
 
 
+def test_partial_history_write_cannot_be_reused_for_a_different_candidate() -> None:
+    class _HistoryWriteFailsOnceProject(_FakeProject):
+        def __init__(self) -> None:
+            super().__init__([_source("proposal")])
+            self.failed = False
+
+        def write_text(self, path: str, content: str) -> None:
+            if path.endswith("evaluation/report.json") and not self.failed:
+                self.failed = True
+                raise RuntimeError("history write interrupted")
+            super().write_text(path, content)
+
+    project = _HistoryWriteFailsOnceProject()
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(project, optimizer_agent(), _provider())
+    original = _evaluated("original", source=_source("original"))
+
+    with pytest.raises(RuntimeError, match="history write interrupted"):
+        proposer.propose((original,))
+
+    assert project.files["history/candidate-0000/source/SYSTEM.md"] == "original"
+    changed = _evaluated("changed", source=_source("changed"))
+    with pytest.raises(ValueError, match="already bound to another candidate"):
+        proposer.propose((changed,))
+    assert project.files["history/candidate-0000/source/SYSTEM.md"] == "original"
+    assert project.run_calls == []
+
+    recovered = proposer.propose((original,))
+
+    assert recovered.candidate_id == "candidate-0001"
+    assert len(project.run_calls) == 1
+
+
 def test_pre_turn_stage_failure_does_not_advance_proposal_identity() -> None:
     class _StageFailsOnceProject(_FakeProject):
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- add a project-backed candidate proposer for complete harness source trees
- materialize bounded evaluated history with full score evidence
- validate submitted source before returning a candidate
- retain proposal events, usage, and invalid-source evidence for callers

## Validation

- uv run pytest wmh/agents/optimizer_test.py wmh/harness/project_proposer_test.py -q
- uv run ruff check wmh/agents/optimizer.py wmh/harness/project_proposer.py
- uv run ruff format --check wmh/agents/optimizer.py wmh/harness/project_proposer.py
- uv run ty check