### PR TITLE
Add complete project source snapshots

### DIFF
--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import shlex
 import time
@@ -10,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Protocol
 from uuid import uuid4
+
+from pydantic import BaseModel
 
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
@@ -31,6 +34,7 @@ from wmh.harness.live_session import (
 from wmh.harness.pi_e2b import start_live_runner
 from wmh.harness.runner_link import Channel, TokenUsage
 from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.source_tree import MAX_SOURCE_PATH_BYTES, HarnessSourceFile, HarnessSourceTree
 from wmh.harness.tools import resolve_tools
 from wmh.providers.base import ToolCallingProvider
 
@@ -38,6 +42,8 @@ PROJECT_WORKSPACE = "/home/user/project"
 PROJECT_SCRATCH_DIR = ".scratch"
 PROJECT_SHELL_USER = "wmh-project-shell"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
+DEFAULT_SOURCE_TREE_MAX_FILES = 1_024
+DEFAULT_SOURCE_TREE_MAX_BYTES = 8 * 1024 * 1024
 _BASH_TIMEOUT_S = 60.0
 _BASH_PROCESS_TIMEOUT_S = 50
 _SHELL_QUIESCENCE_TIMEOUT_S = 10.0
@@ -95,6 +101,89 @@ process.stdin.on("end", () => {{
 }});
 """
 
+_SNAPSHOT_SOURCE_TREE_SCRIPT = r"""
+import base64
+import json
+import os
+import stat
+import sys
+
+
+def fail(message):
+    sys.stderr.write(message + "\n")
+    raise SystemExit(2)
+
+
+root = sys.argv[1]
+max_files = int(sys.argv[2])
+max_bytes = int(sys.argv[3])
+max_path_bytes = int(sys.argv[4])
+try:
+    root_stat = os.lstat(root)
+except FileNotFoundError:
+    fail("source stage does not exist")
+if not stat.S_ISDIR(root_stat.st_mode):
+    fail("source stage is not a directory")
+
+files = []
+total_bytes = 0
+entries = 0
+max_entries = max_files * 4
+for current, directories, names in os.walk(root, topdown=True, followlinks=False):
+    directories.sort()
+    names.sort()
+    for name in directories:
+        entries += 1
+        if entries > max_entries:
+            fail("source stage exceeds entry-count bound")
+        path = os.path.join(current, name)
+        if not stat.S_ISDIR(os.lstat(path).st_mode):
+            fail("non-regular entry in source stage: " + os.path.relpath(path, root))
+    for name in names:
+        entries += 1
+        if entries > max_entries:
+            fail("source stage exceeds entry-count bound")
+        path = os.path.join(current, name)
+        relative = os.path.relpath(path, root).replace(os.sep, "/")
+        if len(relative.encode("utf-8")) > max_path_bytes:
+            fail("source entry exceeds path-length bound")
+        before = os.lstat(path)
+        if not stat.S_ISREG(before.st_mode):
+            fail("non-regular entry in source stage: " + relative)
+        if len(files) >= max_files:
+            fail("source stage exceeds file-count bound")
+        if before.st_size > max_bytes - total_bytes:
+            fail("source stage exceeds byte bound")
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as source:
+            opened = os.fstat(source.fileno())
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_dev != before.st_dev
+                or opened.st_ino != before.st_ino
+            ):
+                fail("source entry changed while opening: " + relative)
+            content = source.read(max_bytes - total_bytes + 1)
+        if len(content) > max_bytes - total_bytes:
+            fail("source stage exceeds byte bound")
+        try:
+            content.decode("utf-8")
+        except UnicodeDecodeError:
+            fail("source entry is not UTF-8: " + relative)
+        total_bytes += len(content)
+        files.append(
+            {
+                "path": relative,
+                "content_base64": base64.b64encode(content).decode("ascii"),
+            }
+        )
+
+json.dump({"files": files}, sys.stdout, ensure_ascii=False, separators=(",", ":"))
+"""
+
 
 class ChannelFactory(Protocol):
     """Start one fresh runner channel in a project's sandbox."""
@@ -109,6 +198,27 @@ class AgentProjectRun:
     answer: str
     events: tuple[SessionEvent, ...]
     worker_usage: TokenUsage
+
+
+@dataclass(frozen=True)
+class ProjectSourceStage:
+    """One writable source-tree stage bound to a specific project sandbox generation."""
+
+    path: str
+    sandbox_generation: int
+
+
+class _EncodedSourceFile(BaseModel):
+    """One regular snapshot file encoded for bounded JSON transport."""
+
+    path: str
+    content_base64: str
+
+
+class _EncodedSourceSnapshot(BaseModel):
+    """The trusted sandbox script's fixed-expansion wire representation."""
+
+    files: tuple[_EncodedSourceFile, ...]
 
 
 class _ProjectAgentTurnError(RuntimeError):
@@ -144,6 +254,10 @@ class AgentProject:
         self._active_sandbox_started_at = time.monotonic()
         self._retired_sandbox_seconds = 0.0
         self._sandbox_count = 1
+        self._sandbox_generation = 1
+        self._next_source_stage = 1
+        self._source_stages: dict[str, ProjectSourceStage] = {}
+        self._snapshotted_source_stages: set[str] = set()
         # A lease remains live until E2B confirms its kill. Replacement failures retain both
         # handles here so usage keeps accruing and close() can retry every unproven teardown.
         self._live_sandboxes: dict[int, tuple[SandboxHandle, float]] = {
@@ -235,6 +349,106 @@ class AgentProject:
                 "publish agent output through write_file"
             )
         return self._file_contents[relative]
+
+    def stage_source_tree(
+        self,
+        tree: HarnessSourceTree,
+        *,
+        max_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+    ) -> ProjectSourceStage:
+        """Materialize one editable tree in a fresh, sandbox-generation-bound scratch path."""
+        if self._closing:
+            raise RuntimeError("cannot stage a source tree in a closed project")
+        self._ensure_project_shell_healthy()
+        if self._active_event_sink is not None:
+            raise RuntimeError("cannot stage a source tree while a project agent turn is running")
+        tree.validate_bounds(max_files=max_files, max_bytes=max_bytes)
+        self._prepare_shell_workspace()
+        stage_name = f"stage-{self._next_source_stage:06d}"
+        self._next_source_stage += 1
+        relative = f"{PROJECT_SCRATCH_DIR}/source-stages/{stage_name}"
+        absolute = self._absolute_path(relative)
+        self._sandbox.commands.run(f"mkdir -p {shlex.quote(absolute)}", timeout=30)
+        for item in tree.files:
+            self._write_sandbox_file(
+                self._sandbox,
+                f"{absolute}/{item.path}",
+                item.content,
+            )
+        self._sandbox.commands.run(
+            f"chown -R {PROJECT_SHELL_USER}:{PROJECT_SHELL_USER} {shlex.quote(absolute)} "
+            f"&& find {shlex.quote(absolute)} -type d -exec chmod 700 {{}} + "
+            f"&& find {shlex.quote(absolute)} -type f -exec chmod 600 {{}} +",
+            user="root",
+            timeout=30,
+        )
+        stage = ProjectSourceStage(
+            path=relative,
+            sandbox_generation=self._sandbox_generation,
+        )
+        self._source_stages[stage.path] = stage
+        return stage
+
+    def snapshot_source_tree(
+        self,
+        stage: ProjectSourceStage,
+        *,
+        max_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+    ) -> HarnessSourceTree:
+        """Revoke proposer processes and capture one stage as bounded immutable host data."""
+        if self._closing:
+            raise RuntimeError("cannot snapshot a source tree in a closed project")
+        self._ensure_project_shell_healthy()
+        if self._active_event_sink is not None:
+            raise RuntimeError(
+                "cannot snapshot a source tree while a project agent turn is running"
+            )
+        known = self._source_stages.get(stage.path)
+        if known is not stage:
+            raise ValueError("source stage does not belong to this project")
+        if stage.path in self._snapshotted_source_stages:
+            raise RuntimeError(f"source stage {stage.path!r} has already been snapshotted")
+        if stage.sandbox_generation != self._sandbox_generation:
+            raise RuntimeError(
+                f"source stage {stage.path!r} was lost when the project sandbox was replaced"
+            )
+        _validate_source_tree_bounds(max_files=max_files, max_bytes=max_bytes)
+
+        # No more model or tool frames may arrive once capture starts. Any shell process that
+        # escaped an individual Bash command still runs as the dedicated unprivileged user. Stop
+        # that entire user, kill it, and prove it absent before the trusted regular-file walk.
+        self._snapshotted_source_stages.add(stage.path)
+        self._close_agent_session()
+        absolute = self._absolute_path(stage.path)
+        command = _source_tree_snapshot_command(
+            absolute,
+            shell_user=self._shell_user,
+            max_files=max_files,
+            max_bytes=max_bytes,
+        )
+        try:
+            result = self._sandbox.commands.run(command, user="root", timeout=60.0)
+        except Exception as error:  # noqa: BLE001 - E2B raises command failures
+            detail = str(getattr(error, "stderr", "") or error)
+            raise RuntimeError(
+                f"project source snapshot failed: {_capped(detail).content}"
+            ) from error
+        exit_code = int(getattr(result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            stderr = str(getattr(result, "stderr", "") or "snapshot command failed")
+            raise RuntimeError(f"project source snapshot failed: {_capped(stderr).content}")
+        try:
+            tree = _decode_source_tree_snapshot(str(getattr(result, "stdout", "")))
+        except ValueError as error:
+            raise RuntimeError("project source snapshot returned an invalid source tree") from error
+        tree.validate_bounds(max_files=max_files, max_bytes=max_bytes)
+        if stage.sandbox_generation != self._sandbox_generation:
+            raise RuntimeError(
+                f"source stage {stage.path!r} was lost when the project sandbox was replaced"
+            )
+        return tree
 
     def run(
         self,
@@ -644,6 +858,7 @@ class AgentProject:
         self._close_agent_session()
         self._active_sandbox_started_at = replacement_started_at
         self._sandbox = replacement
+        self._sandbox_generation += 1
         self._network_locked_sandbox_id = None
         self._shell_ready_sandbox_id = None
         if self._owns_sandbox:
@@ -665,8 +880,8 @@ class AgentProject:
         The project tree is owned by the ordinary sandbox user and is readable but not writable
         by the dedicated project-shell user. Shell commands start in a sticky scratch directory
         and receive an empty environment, no network, no privilege escalation, and bounded process
-        and output streams. Durable outputs must cross the separate exact-file ``write_file``
-        grant.
+        and output streams. Durable outputs cross a trusted source snapshot or the separate
+        exact-file ``write_file`` grant.
         """
         filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
         script = (
@@ -778,7 +993,7 @@ class AgentProject:
             raise RuntimeError(stderr)
 
     def _ensure_project_shell_healthy(self) -> None:
-        """Reject further agent work after unproven shell cleanup."""
+        """Reject further agent or source-stage work after unproven shell cleanup."""
         if self._shell_quiescence_error is not None:
             raise RuntimeError(
                 "project shell is tainted after cleanup failure; close it and create a new "
@@ -813,6 +1028,28 @@ class AgentProject:
         return frozenset(self._relative_path(self._absolute_path(path)) for path in writable_files)
 
 
+def _validate_source_tree_bounds(*, max_files: int, max_bytes: int) -> None:
+    """Validate source snapshot limits before interpolating them into the trusted command."""
+    if isinstance(max_files, bool) or not isinstance(max_files, int) or max_files < 1:
+        raise ValueError("max_files must be a positive integer")
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+        raise ValueError("max_bytes must be a positive integer")
+
+
+def _decode_source_tree_snapshot(payload: str) -> HarnessSourceTree:
+    """Decode bounded base64 JSON from the trusted snapshot script."""
+    encoded = _EncodedSourceSnapshot.model_validate_json(payload)
+    files: list[HarnessSourceFile] = []
+    for item in encoded.files:
+        try:
+            content_bytes = base64.b64decode(item.content_base64, validate=True)
+            content = content_bytes.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ValueError(f"invalid encoded snapshot content for {item.path!r}") from error
+        files.append(HarnessSourceFile(path=item.path, content=content))
+    return HarnessSourceTree(files=tuple(files))
+
+
 def _project_shell_quiescence_command(shell_user: str) -> str:
     """Build the root-only stop, kill, and absence-proof command."""
     return (
@@ -831,6 +1068,21 @@ def _project_shell_quiescence_command(shell_user: str) -> str:
         "  echo 'could not prove project shell quiescence' >&2\n"
         "  exit 70\n"
         "fi\n"
+    )
+
+
+def _source_tree_snapshot_command(
+    absolute: str,
+    *,
+    shell_user: str,
+    max_files: int,
+    max_bytes: int,
+) -> str:
+    """Build the root-only quiescence and regular-file capture command."""
+    return (
+        _project_shell_quiescence_command(shell_user) + "# wmh-project-source-snapshot\n"
+        f"python3 -c {shlex.quote(_SNAPSHOT_SOURCE_TREE_SCRIPT)} "
+        f"{shlex.quote(absolute)} {max_files} {max_bytes} {MAX_SOURCE_PATH_BYTES}\n"
     )
 
 

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -376,13 +376,24 @@ class AgentProject:
                 f"{absolute}/{item.path}",
                 item.content,
             )
-        self._sandbox.commands.run(
-            f"chown -R {PROJECT_SHELL_USER}:{PROJECT_SHELL_USER} {shlex.quote(absolute)} "
+        permission_result = self._sandbox.commands.run(
+            f"chown -R {self._shell_user}:{self._shell_user} {shlex.quote(absolute)} "
             f"&& find {shlex.quote(absolute)} -type d -exec chmod 700 {{}} + "
             f"&& find {shlex.quote(absolute)} -type f -exec chmod 600 {{}} +",
             user="root",
             timeout=30,
         )
+        exit_code = int(getattr(permission_result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            detail = str(
+                getattr(permission_result, "stderr", "")
+                or getattr(permission_result, "stdout", "")
+                or "stage permission command returned no output"
+            )
+            raise RuntimeError(
+                f"project source stage permission setup failed with exit {exit_code}: "
+                f"{_capped(detail).content}"
+            )
         stage = ProjectSourceStage(
             path=relative,
             sandbox_generation=self._sandbox_generation,

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from llm_waterfall import ChatResponse
 
@@ -14,6 +20,7 @@ from wmh.harness.doc import TOOL_POLICY_ID, HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxCleanupError, SandboxUsage
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 
@@ -59,6 +66,41 @@ class _Commands:
     def send_stdin(self, pid: int, data: str, request_timeout: float | None = None) -> object:
         del pid, data, request_timeout
         return None
+
+
+class _SourceTreeCommands(_Commands):
+    """Script the trusted snapshot response while recording its E2B command contract."""
+
+    def __init__(self, files: _Files) -> None:
+        super().__init__(files)
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.snapshot_payload = _snapshot_payload(
+            HarnessSourceTree(files=(HarnessSourceFile(path="SYSTEM.md", content="candidate"),))
+        )
+
+    def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+        del background
+        self.runs.append(cmd)
+        self.calls.append((cmd, dict(kwargs)))
+        if "wmh-project-source-snapshot" in cmd:
+            return _Output(stdout=self.snapshot_payload)
+        return _Output()
+
+
+def _snapshot_payload(tree: HarnessSourceTree) -> str:
+    return json.dumps(
+        {
+            "files": [
+                {
+                    "path": item.path,
+                    "content_base64": base64.b64encode(item.content.encode("utf-8")).decode(
+                        "ascii"
+                    ),
+                }
+                for item in tree.files
+            ]
+        }
+    )
 
 
 class _Sandbox:
@@ -1434,6 +1476,8 @@ def test_project_bash_cleanup_failure_taints_the_project() -> None:
     assert "project shell is tainted" in blocked.content
     with pytest.raises(RuntimeError, match="project shell is tainted"):
         project.run(meta_agent(), _Provider(), "continue", timeout=1)
+    with pytest.raises(RuntimeError, match="project shell is tainted"):
+        project.stage_source_tree(HarnessSourceTree(files=()))
 
 
 def test_project_bash_cleanup_failure_stops_before_another_provider_call() -> None:
@@ -1617,3 +1661,221 @@ def test_project_rejects_agents_with_uncontained_tools() -> None:
 
     with pytest.raises(ValueError, match="uncontained tools: read_skill"):
         project.run(uncontained, _Provider(), "escape", timeout=1)
+
+
+def test_project_stages_and_snapshots_a_complete_source_tree_once() -> None:
+    """The host captures current stage bytes only after revoking proposer processes."""
+    sandbox = _Sandbox()
+    commands = _SourceTreeCommands(sandbox.files)
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    seed = HarnessSourceTree.from_doc(HarnessDoc.baseline("seed"))
+    candidate = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="candidate"),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["submit"]\nmax_turns = 8\n',
+            ),
+            HarnessSourceFile(path="src/new.ts", content="export const value = 1;\n"),
+        )
+    )
+    commands.snapshot_payload = _snapshot_payload(candidate)
+
+    stage = project.stage_source_tree(seed)
+    captured = project.snapshot_source_tree(stage)
+
+    assert stage.path == ".scratch/source-stages/stage-000001"
+    assert captured == candidate
+    assert captured.to_doc("candidate").system_prompt() == "candidate"
+    assert (
+        sandbox.files.values["/home/user/project/.scratch/source-stages/stage-000001/SYSTEM.md"]
+        == seed.file_map()["SYSTEM.md"]
+    )
+    snapshot_command, snapshot_options = next(
+        call for call in commands.calls if "wmh-project-source-snapshot" in call[0]
+    )
+    assert snapshot_options == {"user": "root", "timeout": 60.0}
+    assert f"pkill -STOP -u {PROJECT_SHELL_USER}" in snapshot_command
+    assert f"pkill -KILL -u {PROJECT_SHELL_USER}" in snapshot_command
+    assert f"pgrep -u {PROJECT_SHELL_USER}" in snapshot_command
+    with pytest.raises(RuntimeError, match="already been snapshotted"):
+        project.snapshot_source_tree(stage)
+
+
+def test_project_snapshot_preserves_candidate_deletions() -> None:
+    sandbox = _Sandbox()
+    commands = _SourceTreeCommands(sandbox.files)
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    seed = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="seed"),
+            HarnessSourceFile(path="src/removed.ts", content="remove me"),
+        )
+    )
+    commands.snapshot_payload = _snapshot_payload(
+        HarnessSourceTree(files=(HarnessSourceFile(path="SYSTEM.md", content="candidate"),))
+    )
+
+    captured = project.snapshot_source_tree(project.stage_source_tree(seed))
+
+    assert captured.file_map() == {"SYSTEM.md": "candidate"}
+
+
+def test_project_snapshot_cannot_salvage_a_stage_lost_on_sandbox_replacement() -> None:
+    original = _Sandbox()
+    replacement = _Sandbox()
+    original.commands = _SourceTreeCommands(original.files)
+    replacement.commands = _SourceTreeCommands(replacement.files)
+    project = AgentProject(
+        original,
+        channel_factory=lambda sandbox, workspace: _Channel(),
+        sandbox_factory=lambda: replacement,
+    )
+    stage = project.stage_source_tree(HarnessSourceTree.from_doc(HarnessDoc.baseline("seed")))
+    project.write_text("submissions/ready.txt", "ready")
+
+    project._replace_sandbox()  # noqa: SLF001 - exercise the recovery boundary directly
+
+    assert project.read_text("submissions/ready.txt") == "ready"
+    with pytest.raises(RuntimeError, match="lost when the project sandbox was replaced"):
+        project.snapshot_source_tree(stage)
+
+
+def test_project_rejects_an_equal_looking_stage_handle_from_another_project() -> None:
+    first_sandbox = _Sandbox()
+    first_sandbox.commands = _SourceTreeCommands(first_sandbox.files)
+    second_sandbox = _Sandbox()
+    second_sandbox.commands = _SourceTreeCommands(second_sandbox.files)
+    first = AgentProject(first_sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    second = AgentProject(second_sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    empty = HarnessSourceTree(files=())
+
+    first_stage = first.stage_source_tree(empty)
+    second_stage = second.stage_source_tree(empty)
+
+    assert first_stage == second_stage
+    with pytest.raises(ValueError, match="does not belong to this project"):
+        second.snapshot_source_tree(first_stage)
+
+
+def test_project_source_stage_does_not_require_a_host_selected_starting_tree() -> None:
+    sandbox = _Sandbox()
+    sandbox.commands = _SourceTreeCommands(sandbox.files)
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    stage = project.stage_source_tree(HarnessSourceTree(files=()))
+
+    assert stage.path == ".scratch/source-stages/stage-000001"
+
+
+def test_project_snapshot_failure_consumes_the_stage() -> None:
+    class _FailingSnapshotCommands(_SourceTreeCommands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            if "wmh-project-source-snapshot" in cmd:
+                raise RuntimeError("capture failed")
+            return super().run(cmd, background, **kwargs)
+
+    sandbox = _Sandbox()
+    sandbox.commands = _FailingSnapshotCommands(sandbox.files)
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    stage = project.stage_source_tree(HarnessSourceTree(files=()))
+
+    with pytest.raises(RuntimeError, match="capture failed"):
+        project.snapshot_source_tree(stage)
+    with pytest.raises(RuntimeError, match="already been snapshotted"):
+        project.snapshot_source_tree(stage)
+
+
+def test_project_snapshot_rechecks_file_and_byte_bounds_host_side() -> None:
+    sandbox = _Sandbox()
+    commands = _SourceTreeCommands(sandbox.files)
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+    stage = project.stage_source_tree(HarnessSourceTree.from_doc(HarnessDoc.baseline("seed")))
+    commands.snapshot_payload = _snapshot_payload(
+        HarnessSourceTree(
+            files=(
+                HarnessSourceFile(path="SYSTEM.md", content="candidate"),
+                HarnessSourceFile(path="src/a.ts", content="a"),
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="more than 1 files"):
+        project.snapshot_source_tree(stage, max_files=1)
+
+    second_stage = project.stage_source_tree(
+        HarnessSourceTree.from_doc(HarnessDoc.baseline("second"))
+    )
+    with pytest.raises(ValueError, match="more than 4 bytes"):
+        project.snapshot_source_tree(second_stage, max_bytes=4)
+
+
+def _run_snapshot_script(
+    root: Path,
+    *,
+    max_files: int = 20,
+    max_bytes: int = 10_000,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            project_module._SNAPSHOT_SOURCE_TREE_SCRIPT,  # noqa: SLF001
+            str(root),
+            str(max_files),
+            str(max_bytes),
+            str(project_module.MAX_SOURCE_PATH_BYTES),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_snapshot_script_captures_only_regular_utf8_files(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "SYSTEM.md").write_text("candidate", encoding="utf-8")
+    (tmp_path / "src" / "agent.ts").write_text("export {};\n", encoding="utf-8")
+
+    result = _run_snapshot_script(tmp_path)
+
+    assert result.returncode == 0
+    tree = project_module._decode_source_tree_snapshot(result.stdout)  # noqa: SLF001
+    assert tree.file_map() == {
+        "SYSTEM.md": "candidate",
+        "src/agent.ts": "export {};\n",
+    }
+
+
+def test_snapshot_script_rejects_symlinks(tmp_path: Path) -> None:
+    (tmp_path / "SYSTEM.md").write_text("candidate", encoding="utf-8")
+    (tmp_path / "link").symlink_to(tmp_path / "SYSTEM.md")
+
+    result = _run_snapshot_script(tmp_path)
+
+    assert result.returncode != 0
+    assert "non-regular entry" in result.stderr
+
+
+def test_snapshot_script_rejects_non_utf8_files(tmp_path: Path) -> None:
+    (tmp_path / "SYSTEM.md").write_bytes(b"\xff")
+
+    result = _run_snapshot_script(tmp_path)
+
+    assert result.returncode != 0
+    assert "not UTF-8" in result.stderr
+
+
+def test_snapshot_script_bounds_empty_directory_walks(tmp_path: Path) -> None:
+    current = tmp_path
+    for index in range(81):
+        current = current / f"d{index}"
+        current.mkdir()
+
+    result = _run_snapshot_script(tmp_path, max_files=20)
+
+    assert result.returncode != 0
+    assert "entry-count bound" in result.stderr

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1692,15 +1692,45 @@ def test_project_stages_and_snapshots_a_complete_source_tree_once() -> None:
         sandbox.files.values["/home/user/project/.scratch/source-stages/stage-000001/SYSTEM.md"]
         == seed.file_map()["SYSTEM.md"]
     )
+    permission_command, permission_options = next(
+        call for call in commands.calls if call[0].startswith("chown -R ")
+    )
+    assert permission_options == {"user": "root", "timeout": 30}
+    assert (
+        f"chown -R {project._shell_user}:{project._shell_user} "  # noqa: SLF001
+        "/home/user/project/.scratch/source-stages/stage-000001"
+    ) in permission_command
     snapshot_command, snapshot_options = next(
         call for call in commands.calls if "wmh-project-source-snapshot" in call[0]
     )
     assert snapshot_options == {"user": "root", "timeout": 60.0}
-    assert f"pkill -STOP -u {PROJECT_SHELL_USER}" in snapshot_command
-    assert f"pkill -KILL -u {PROJECT_SHELL_USER}" in snapshot_command
-    assert f"pgrep -u {PROJECT_SHELL_USER}" in snapshot_command
+    assert f"pkill -STOP -u {project._shell_user}" in snapshot_command  # noqa: SLF001
+    assert f"pkill -KILL -u {project._shell_user}" in snapshot_command  # noqa: SLF001
+    assert f"pgrep -u {project._shell_user}" in snapshot_command  # noqa: SLF001
     with pytest.raises(RuntimeError, match="already been snapshotted"):
         project.snapshot_source_tree(stage)
+
+
+def test_project_source_stage_permission_nonzero_exit_fails_closed() -> None:
+    class _PermissionFails(_SourceTreeCommands):
+        def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+            if cmd.startswith("chown -R "):
+                self.runs.append(cmd)
+                self.calls.append((cmd, dict(kwargs)))
+                return _Output(stderr="chown rejected the project shell user", exit_code=13)
+            return super().run(cmd, background, **kwargs)
+
+    sandbox = _Sandbox()
+    commands = _PermissionFails(sandbox.files)
+    sandbox.commands = commands
+    project = AgentProject(sandbox, channel_factory=lambda sandbox, workspace: _Channel())
+
+    with pytest.raises(RuntimeError, match="stage permission setup failed with exit 13"):
+        project.stage_source_tree(HarnessSourceTree(files=()))
+
+    permission_command = next(command for command in commands.runs if command.startswith("chown"))
+    assert f"{project._shell_user}:{project._shell_user}" in permission_command  # noqa: SLF001
+    assert project._source_stages == {}  # noqa: SLF001
 
 
 def test_project_snapshot_preserves_candidate_deletions() -> None:

--- a/wmh/harness/source_tree.py
+++ b/wmh/harness/source_tree.py
@@ -1,0 +1,260 @@
+"""Portable source trees for editing and reconstructing complete harnesses."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import tomllib
+from pathlib import PurePosixPath
+
+import tomli_w
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from wmh.core.text import validate_durable_text
+from wmh.harness.doc import (
+    CODE_RUNTIME_ID,
+    MAX_OUTPUT_TOKENS_ID,
+    MAX_TURNS_ID,
+    RUNTIME_KIND_ID,
+    TEMPERATURE_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.pi_vendor import code_surface_id
+from wmh.harness.skills import Skill
+
+SYSTEM_FILE = "SYSTEM.md"
+CONFIG_FILE = "config.toml"
+RUNTIME_FILE = "runtime.py"
+SKILLS_DIR = "skills"
+
+_STORE_METADATA_FILES = frozenset({"doc.json", "aliases.toml"})
+_RESERVED_RENDER_FILES = frozenset({SYSTEM_FILE, CONFIG_FILE, RUNTIME_FILE})
+_SOURCE_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
+_TREE_HASH_BYTES = 16
+MAX_SOURCE_PATH_BYTES = 1_024
+
+
+class HarnessSourceFile(BaseModel):
+    """One UTF-8 text file at a canonical path inside a harness source tree."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    content: str
+
+    @model_validator(mode="after")
+    def _validate_file(self) -> HarnessSourceFile:
+        candidate = PurePosixPath(self.path)
+        if (
+            candidate.is_absolute()
+            or not candidate.parts
+            or candidate.as_posix() != self.path
+            or ".." in candidate.parts
+            or not _SOURCE_PATH_RE.fullmatch(self.path)
+            or len(self.path.encode("utf-8")) > MAX_SOURCE_PATH_BYTES
+        ):
+            raise ValueError(f"source path {self.path!r} must be a canonical relative POSIX path")
+        validate_durable_text(self.content, field=f"source file {self.path!r}")
+        return self
+
+
+class HarnessSourceTree(BaseModel):
+    """A complete editable file representation that can be parsed into a HarnessDoc."""
+
+    model_config = ConfigDict(frozen=True)
+
+    files: tuple[HarnessSourceFile, ...]
+
+    @field_validator("files")
+    @classmethod
+    def _canonical_files(
+        cls, files: tuple[HarnessSourceFile, ...]
+    ) -> tuple[HarnessSourceFile, ...]:
+        paths = [item.path for item in files]
+        duplicates = sorted({path for path in paths if paths.count(path) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate source path(s): {duplicates}")
+        metadata = sorted(path for path in paths if path in _STORE_METADATA_FILES)
+        if metadata:
+            raise ValueError(f"source tree cannot contain store metadata file(s): {metadata}")
+        return tuple(sorted(files, key=lambda item: item.path))
+
+    @classmethod
+    def from_doc(cls, doc: HarnessDoc) -> HarnessSourceTree:
+        """Render a harness into the exact source files an external editor should see."""
+        files: dict[str, str] = {
+            SYSTEM_FILE: doc.system_prompt(),
+            CONFIG_FILE: tomli_w.dumps(
+                {
+                    "harness": {
+                        "tools": doc.tools(),
+                        "max_turns": doc.max_turns(),
+                        "max_output_tokens": doc.max_output_tokens(),
+                        "temperature": doc.temperature(),
+                        "runtime_kind": doc.runtime_kind(),
+                    }
+                }
+            ),
+        }
+        for skill in doc.skills():
+            files[f"{SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
+        runtime = doc.surface(CODE_RUNTIME_ID)
+        if runtime is not None:
+            files[RUNTIME_FILE] = runtime.content
+        for surface in doc.code_files():
+            assert surface.path is not None
+            if surface.path in _RESERVED_RENDER_FILES or surface.path.startswith(f"{SKILLS_DIR}/"):
+                raise ValueError(
+                    f"code surface path {surface.path!r} collides with a reserved file"
+                )
+            files[surface.path] = surface.content
+        return cls(
+            files=tuple(
+                HarnessSourceFile(path=path, content=content) for path, content in files.items()
+            )
+        )
+
+    def to_doc(self, name: str) -> HarnessDoc:
+        """Parse the complete source tree into one validated harness document."""
+        files = self.file_map()
+        if SYSTEM_FILE not in files:
+            raise ValueError(f"harness source tree is missing required {SYSTEM_FILE}")
+        surfaces = [
+            Surface(
+                id="prompt:core",
+                kind=SurfaceKind.PROMPT,
+                content=files[SYSTEM_FILE],
+            )
+        ]
+        config_text = files.get(CONFIG_FILE)
+        if config_text is not None:
+            parsed_config = tomllib.loads(config_text)
+            unknown_tables = sorted(set(parsed_config) - {"harness"})
+            if unknown_tables:
+                raise ValueError(
+                    f"{CONFIG_FILE} contains unknown top-level table(s): {unknown_tables}"
+                )
+            config = parsed_config.get("harness", {})
+            if not isinstance(config, dict):
+                raise ValueError(f"{CONFIG_FILE} [harness] must be a table")
+            allowed_fields = {
+                "tools",
+                "max_turns",
+                "max_output_tokens",
+                "temperature",
+                "runtime_kind",
+            }
+            unknown_fields = sorted(set(config) - allowed_fields)
+            if unknown_fields:
+                raise ValueError(
+                    f"{CONFIG_FILE} [harness] contains unknown field(s): {unknown_fields}"
+                )
+            tools = config.get("tools")
+            if tools is not None:
+                if not isinstance(tools, list) or not all(isinstance(item, str) for item in tools):
+                    raise ValueError(f"{CONFIG_FILE} harness.tools must be an array of strings")
+                surfaces.append(
+                    Surface(
+                        id=TOOL_POLICY_ID,
+                        kind=SurfaceKind.TOOL_POLICY,
+                        content="\n".join(tools),
+                    )
+                )
+            scalar_fields = (
+                ("max_turns", MAX_TURNS_ID),
+                ("max_output_tokens", MAX_OUTPUT_TOKENS_ID),
+                ("temperature", TEMPERATURE_ID),
+            )
+            for field, surface_id in scalar_fields:
+                if field in config:
+                    surfaces.append(
+                        Surface(
+                            id=surface_id,
+                            kind=SurfaceKind.PARAM,
+                            content=str(config[field]),
+                        )
+                    )
+            runtime_kind = config.get("runtime_kind")
+            if runtime_kind is not None and not isinstance(runtime_kind, str):
+                raise ValueError(f"{CONFIG_FILE} harness.runtime_kind must be a string")
+            if runtime_kind and runtime_kind != "kit-python":
+                surfaces.append(
+                    Surface(
+                        id=RUNTIME_KIND_ID,
+                        kind=SurfaceKind.PARAM,
+                        content=str(runtime_kind),
+                    )
+                )
+        runtime = files.get(RUNTIME_FILE)
+        if runtime is not None:
+            surfaces.append(Surface(id=CODE_RUNTIME_ID, kind=SurfaceKind.CODE, content=runtime))
+        for item in self.files:
+            path = PurePosixPath(item.path)
+            if path.parts[0] != SKILLS_DIR:
+                continue
+            if len(path.parts) != 2 or path.suffix != ".md":
+                raise ValueError(f"skill source path {item.path!r} must be skills/<skill-name>.md")
+            skill = Skill.from_markdown(item.content)
+            if path.stem != skill.name:
+                raise ValueError(
+                    f"skill source path {item.path!r} does not match declared name {skill.name!r}"
+                )
+            surfaces.append(
+                Surface(
+                    id=f"skill:{skill.name}",
+                    kind=SurfaceKind.SKILL,
+                    content=skill.to_markdown(),
+                )
+            )
+        for item in self.files:
+            if item.path in _RESERVED_RENDER_FILES or item.path.startswith(f"{SKILLS_DIR}/"):
+                continue
+            surfaces.append(
+                Surface(
+                    id=code_surface_id(item.path),
+                    kind=SurfaceKind.CODE,
+                    path=item.path,
+                    content=item.content,
+                )
+            )
+        return HarnessDoc(name=name, surfaces=surfaces)
+
+    def file_map(self) -> dict[str, str]:
+        """Return a new path-to-content mapping in canonical path order."""
+        return {item.path: item.content for item in self.files}
+
+    @property
+    def total_bytes(self) -> int:
+        """Return the UTF-8 payload size across all source files."""
+        return sum(len(item.content.encode("utf-8")) for item in self.files)
+
+    @property
+    def tree_hash(self) -> str:
+        """Return a content address covering every source path and byte."""
+        digest = hashlib.blake2b(digest_size=_TREE_HASH_BYTES)
+        for item in self.files:
+            path = item.path.encode("utf-8")
+            content = item.content.encode("utf-8")
+            digest.update(len(path).to_bytes(4, "big"))
+            digest.update(path)
+            digest.update(len(content).to_bytes(8, "big"))
+            digest.update(content)
+        return digest.hexdigest()
+
+    def validate_bounds(self, *, max_files: int, max_bytes: int) -> None:
+        """Reject a tree that exceeds explicit file-count or UTF-8 byte bounds."""
+        if isinstance(max_files, bool) or not isinstance(max_files, int) or max_files < 1:
+            raise ValueError("max_files must be a positive integer")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+        if len(self.files) > max_files:
+            raise ValueError(
+                f"source tree has {len(self.files)} files, more than {max_files} files allowed"
+            )
+        if self.total_bytes > max_bytes:
+            raise ValueError(
+                f"source tree has {self.total_bytes} bytes, more than {max_bytes} bytes allowed"
+            )

--- a/wmh/harness/source_tree_test.py
+++ b/wmh/harness/source_tree_test.py
@@ -1,0 +1,136 @@
+"""Tests for the portable, editable harness source-tree representation."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.harness.doc import (
+    MAX_OUTPUT_TOKENS_ID,
+    RUNTIME_KIND_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.pi_vendor import pi_agent_code_surfaces
+from wmh.harness.skills import Skill
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+
+def _pi_document() -> HarnessDoc:
+    skill = Skill(name="inspect-code", description="Inspect code", body="Use rg before editing.")
+    return HarnessDoc(
+        name="pi",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="Work carefully."),
+            Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
+            Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="8192"),
+            Surface(
+                id="skill:inspect-code",
+                kind=SurfaceKind.SKILL,
+                content=skill.to_markdown(),
+            ),
+            *pi_agent_code_surfaces(),
+        ],
+    )
+
+
+def test_source_tree_round_trips_a_complete_pathful_harness() -> None:
+    """The public call site carries every executable file without store metadata."""
+    original = _pi_document()
+
+    tree = HarnessSourceTree.from_doc(original)
+    restored = tree.to_doc("restored")
+
+    paths = set(tree.file_map())
+    assert "SYSTEM.md" in paths
+    assert "config.toml" in paths
+    assert "skills/inspect-code.md" in paths
+    assert "doc.json" not in paths
+    assert restored.system_prompt() == original.system_prompt()
+    assert restored.tools() == original.tools()
+    assert restored.runtime_kind() == original.runtime_kind()
+    assert restored.max_output_tokens() == original.max_output_tokens()
+    assert [skill.name for skill in restored.skills()] == ["inspect-code"]
+    assert {(item.path, item.content) for item in restored.code_files()} == {
+        (item.path, item.content) for item in original.code_files()
+    }
+
+
+def test_source_tree_reparse_preserves_deletions_and_rewrites() -> None:
+    original = HarnessSourceTree.from_doc(_pi_document())
+    deleted_path = next(item.path for item in original.files if item.path.startswith("src/"))
+    rewritten = HarnessSourceTree(
+        files=tuple(
+            item.model_copy(update={"content": "Changed prompt."})
+            if item.path == "SYSTEM.md"
+            else item
+            for item in original.files
+            if item.path != deleted_path
+        )
+    )
+
+    candidate = rewritten.to_doc("candidate")
+
+    assert candidate.system_prompt() == "Changed prompt."
+    assert deleted_path not in {item.path for item in candidate.code_files()}
+    assert len(candidate.code_files()) == len(_pi_document().code_files()) - 1
+    assert rewritten.tree_hash != original.tree_hash
+
+
+@pytest.mark.parametrize("path", ["doc.json", "aliases.toml"])
+def test_source_tree_rejects_store_authority_files(path: str) -> None:
+    with pytest.raises(ValueError, match="store metadata"):
+        HarnessSourceTree(files=(HarnessSourceFile(path=path, content="{}"),))
+
+
+@pytest.mark.parametrize("path", ["/absolute.ts", "../escape.ts", "src/../escape.ts", "src\\x.ts"])
+def test_source_tree_rejects_noncanonical_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="canonical relative POSIX path"):
+        HarnessSourceTree(files=(HarnessSourceFile(path=path, content="x"),))
+
+
+def test_source_tree_rejects_duplicate_paths() -> None:
+    with pytest.raises(ValueError, match="duplicate source path"):
+        HarnessSourceTree(
+            files=(
+                HarnessSourceFile(path="SYSTEM.md", content="one"),
+                HarnessSourceFile(path="SYSTEM.md", content="two"),
+            )
+        )
+
+
+def test_source_tree_rejects_unparsed_skill_namespace_files() -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="skills/nested/ignored.md", content="ignored"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="skill source path"):
+        tree.to_doc("invalid")
+
+
+@pytest.mark.parametrize(
+    "config, error",
+    [
+        ("[provider]\nmodel = 'mutable'\n", "unknown top-level"),
+        ("[harness]\ntools = ['submit']\nmodel = 'mutable'\n", "unknown field"),
+        ("[harness]\nruntime_kind = false\n", "runtime_kind must be a string"),
+    ],
+)
+def test_source_tree_rejects_config_that_would_not_affect_the_parsed_harness(
+    config: str,
+    error: str,
+) -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="config.toml", content=config),
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        tree.to_doc("invalid")

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -26,32 +26,14 @@ from pathlib import Path
 import tomli_w
 
 from wmh.config.store import validate_name
-from wmh.harness.doc import (
-    CODE_RUNTIME_ID,
-    MAX_OUTPUT_TOKENS_ID,
-    MAX_TURNS_ID,
-    RUNTIME_KIND_ID,
-    TEMPERATURE_ID,
-    TOOL_POLICY_ID,
-    HarnessDoc,
-    Surface,
-    SurfaceKind,
-)
-from wmh.harness.pi_vendor import code_surface_id
-from wmh.harness.skills import Skill
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
 
 HARNESSES_DIR = "harnesses"
 CHAMPION_ALIAS = "champion"
 
 _DOC_FILE = "doc.json"
-_SYSTEM_FILE = "SYSTEM.md"
-_CONFIG_FILE = "config.toml"
-_RUNTIME_FILE = "runtime.py"
-_SKILLS_DIR = "skills"
 _ALIASES_FILE = "aliases.toml"
-
-# Top-level render filenames a pathful code surface must not shadow (skills/ is guarded by prefix).
-_RESERVED_FILES = frozenset({_DOC_FILE, _SYSTEM_FILE, _CONFIG_FILE, _RUNTIME_FILE})
 
 
 class HarnessStore:
@@ -162,34 +144,7 @@ class HarnessStore:
 
 def _render(doc: HarnessDoc) -> dict[str, str]:
     """Render the document to its file export (relative path -> content)."""
-    files = {
-        _SYSTEM_FILE: doc.system_prompt(),
-        _CONFIG_FILE: tomli_w.dumps(
-            {
-                "harness": {
-                    "tools": doc.tools(),
-                    "max_turns": doc.max_turns(),
-                    "max_output_tokens": doc.max_output_tokens(),
-                    "temperature": doc.temperature(),
-                    "runtime_kind": doc.runtime_kind(),
-                }
-            }
-        ),
-    }
-    for skill in doc.skills():
-        files[f"{_SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
-    code = doc.surface(CODE_RUNTIME_ID)
-    if code is not None:
-        files[_RUNTIME_FILE] = code.content
-    # Pathful code surfaces (a pi-node harness's vendored source) render to their own paths, so
-    # the export is the harness's real directory tree — what the agent view browses and what an
-    # execution sandbox downloads. Their `code_surface_id` is recovered from the path on reparse.
-    for surface in doc.code_files():
-        assert surface.path is not None  # code_files() only returns pathful surfaces
-        if surface.path in _RESERVED_FILES or surface.path.startswith(f"{_SKILLS_DIR}/"):
-            raise ValueError(f"code surface path {surface.path!r} collides with a reserved file")
-        files[surface.path] = surface.content
-    return files
+    return HarnessSourceTree.from_doc(doc).file_map()
 
 
 def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
@@ -198,87 +153,14 @@ def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
     The whole `SYSTEM.md` becomes one `prompt:core` surface — section boundaries are not
     recoverable from a rendered prompt, which is exactly why `doc.json` is the authoritative form.
     """
-    system_path = directory / _SYSTEM_FILE
-    if not system_path.exists():
-        raise ValueError(f"harness dir {directory} has neither {_DOC_FILE} nor {_SYSTEM_FILE}")
-    surfaces = [
-        Surface(
-            id="prompt:core",
-            kind=SurfaceKind.PROMPT,
-            content=system_path.read_text(encoding="utf-8"),
-        )
-    ]
-    config_path = directory / _CONFIG_FILE
-    if config_path.exists():
-        config = tomllib.loads(config_path.read_text(encoding="utf-8")).get("harness", {})
-        if "tools" in config:
-            surfaces.append(
-                Surface(
-                    id=TOOL_POLICY_ID,
-                    kind=SurfaceKind.TOOL_POLICY,
-                    content="\n".join(str(t) for t in config["tools"]),
-                )
-            )
-        if "max_turns" in config:
-            surfaces.append(
-                Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(config["max_turns"]))
-            )
-        if "max_output_tokens" in config:
-            surfaces.append(
-                Surface(
-                    id=MAX_OUTPUT_TOKENS_ID,
-                    kind=SurfaceKind.PARAM,
-                    content=str(config["max_output_tokens"]),
-                )
-            )
-        if "temperature" in config:
-            surfaces.append(
-                Surface(
-                    id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(config["temperature"])
-                )
-            )
-        # runtime_kind classifies the harness (pi-node vs in-process); a default "kit-python" is
-        # implicit, so only a non-default value needs its own surface on reconstruction.
-        if config.get("runtime_kind") and config["runtime_kind"] != "kit-python":
-            surfaces.append(
-                Surface(
-                    id=RUNTIME_KIND_ID,
-                    kind=SurfaceKind.PARAM,
-                    content=str(config["runtime_kind"]),
-                )
-            )
-    runtime_path = directory / _RUNTIME_FILE
-    if runtime_path.exists():
-        surfaces.append(
-            Surface(
-                id=CODE_RUNTIME_ID,
-                kind=SurfaceKind.CODE,
-                content=runtime_path.read_text(encoding="utf-8"),
-            )
-        )
-    skills_dir = directory / _SKILLS_DIR
-    if skills_dir.exists():
-        for path in sorted(skills_dir.glob("*.md")):
-            skill = Skill.from_markdown(path.read_text(encoding="utf-8"))
-            surfaces.append(
-                Surface(
-                    id=f"skill:{skill.name}", kind=SurfaceKind.SKILL, content=skill.to_markdown()
-                )
-            )
-    # Everything else under the dir is a pathful code surface (a pi-node harness's source tree):
-    # the inverse of `_render`'s per-path write, keyed back to its `code_surface_id`.
+    files: list[HarnessSourceFile] = []
     for path in sorted(directory.rglob("*")):
         if not path.is_file():
             continue
         rel = path.relative_to(directory).as_posix()
-        if rel in _RESERVED_FILES or rel == _ALIASES_FILE or rel.startswith(f"{_SKILLS_DIR}/"):
+        if rel in {_DOC_FILE, _ALIASES_FILE}:
             continue
-        surfaces.append(
-            Surface(
-                id=code_surface_id(rel),
-                kind=SurfaceKind.CODE,
-                path=rel,
-                content=path.read_text(encoding="utf-8"),
-            )
-        )
-    return HarnessDoc(name=name, surfaces=surfaces)
+        files.append(HarnessSourceFile(path=rel, content=path.read_text(encoding="utf-8")))
+    if not files:
+        raise ValueError(f"harness dir {directory} has neither {_DOC_FILE} nor SYSTEM.md")
+    return HarnessSourceTree(files=tuple(files)).to_doc(name)


### PR DESCRIPTION
## Summary

- add an immutable complete harness source-tree representation
- capture validated project workspace snapshots after an agent turn
- share source-tree serialization with the harness store
- reject unsafe paths and preserve deterministic source identity

## Validation

- uv run pytest wmh/agents/project_test.py wmh/harness/source_tree_test.py wmh/harness/store_test.py -q
- uv run ruff check wmh/agents/project.py wmh/harness/source_tree.py wmh/harness/store.py
- uv run ruff format --check wmh/agents/project.py wmh/harness/source_tree.py wmh/harness/store.py
- uv run ty check