### PR TITLE
Optimize complete harnesses from the CLI

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -39,6 +39,7 @@ import wmh.providers as providers
 from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app
+from wmh.cli.harness_optimize import register as register_harness_optimize_commands
 from wmh.cli.platform_cmds import register as register_platform_commands
 from wmh.cli.ui import (
     BuildParams,
@@ -140,6 +141,7 @@ app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")
 app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
+register_harness_optimize_commands(harness_app)
 app.add_typer(harness_app, name="harness")
 register_platform_commands(app)
 register_agent_session_commands(app)

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -35,7 +35,7 @@ from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import Provider
 
 harness_app = typer.Typer(
-    help="Named, versioned agent harnesses (.wmh/harnesses): create, init, list, show.",
+    help="Named, versioned agent harnesses: create, optimize, initialize, list, and inspect.",
     no_args_is_help=True,
 )
 _console = Console()

--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -215,7 +215,6 @@ def _execute_optimization(
     max_history_bytes: int,
 ) -> HarnessOptimizeOutcome:
     """Resolve one immutable scorer request, execute it, and publish evidence before winner."""
-    run_dir.mkdir(parents=True, exist_ok=False)
     effective_job_config = JobConfig.model_validate(
         job_config.model_copy(
             update={"jobs_dir": run_dir / "harbor"},
@@ -234,6 +233,12 @@ def _execute_optimization(
         )
     )
     request = scorer.request(attempts=attempts)
+    meta_provider = get_provider(meta_config)
+    if not isinstance(meta_provider, ToolCallingProvider):
+        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
+    # Only claim the requested output path after all read-only setup validation succeeds. Once
+    # execution can incur spend, an incomplete directory remains deliberate failure evidence.
+    run_dir.mkdir(parents=True, exist_ok=False)
     _write_json_atomic(
         run_dir / "inputs.json",
         {
@@ -252,10 +257,6 @@ def _execute_optimization(
             "max_history_bytes": max_history_bytes,
         },
     )
-
-    meta_provider = get_provider(meta_config)
-    if not isinstance(meta_provider, ToolCallingProvider):
-        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
     with AgentProject.create(
         timeout=project_timeout_sec,
         template=e2b_template,

--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -1,0 +1,353 @@
+"""Local CLI composition for scorer-driven complete-harness optimization."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+from uuid import uuid4
+
+import typer
+import yaml
+from harbor.models.job.config import JobConfig
+from pydantic import ValidationError
+from rich.console import Console
+from rich.prompt import Confirm
+
+from wmh.agents.default import default_agent
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import DEFAULT_PROJECT_TIMEOUT_S, AgentProject
+from wmh.cli.model_roles import resolve_required_model_config
+from wmh.config import ARTIFACT_DIR
+from wmh.config.store import validate_name
+from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
+from wmh.evals.harbor.scorer import HarborScorer
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage, resolve_e2b_template
+from wmh.harness.population import HarnessPopulationOptimizer, PopulationOptimizationResult
+from wmh.harness.population_archive import write_population_archive
+from wmh.harness.project_proposer import (
+    DEFAULT_MAX_HISTORY_BYTES,
+    DEFAULT_MAX_HISTORY_CANDIDATES,
+    ProjectCandidateProposer,
+)
+from wmh.harness.scoring import ScoreRequest
+from wmh.harness.source_tree import HarnessSourceTree
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.providers.base import ProviderConfig, ToolCallingProvider
+from wmh.providers.registry import get_provider
+
+_console = Console()
+
+
+@dataclass(frozen=True)
+class HarnessOptimizeOutcome:
+    """Completed local run artifacts and the published local harness version."""
+
+    result: PopulationOptimizationResult
+    saved: HarnessDoc
+    run_dir: Path
+    archive_manifest: Path
+    project_usage: SandboxUsage
+
+
+def register(app: typer.Typer) -> None:
+    """Register scorer-driven optimization under ``wmh harness``."""
+    app.command("optimize")(optimize_harness)
+
+
+def optimize_harness(
+    name: str = typer.Argument(..., help="Name used to save the selected harness version."),
+    harbor_config: str = typer.Option(
+        ...,
+        "--harbor-config",
+        help="Harbor JobConfig template as JSON or YAML.",
+    ),
+    task_ids_file: str = typer.Option(
+        ...,
+        "--task-ids",
+        help="JSON file containing the exact ordered task-ID string list.",
+    ),
+    reward_key: str = typer.Option(
+        ...,
+        "--reward-key",
+        help="Official Harbor verifier reward field to optimize.",
+    ),
+    iterations: int = typer.Option(..., min=1, help="Fixed number of singular proposal slots."),
+    attempts: int = typer.Option(..., min=1, help="Attempts per exact task and candidate."),
+    seed: str | None = typer.Option(
+        None,
+        "--seed",
+        help="Stored harness name@ref; default is the complete built-in Pi agent.",
+    ),
+    harness_backend: str = typer.Option(
+        "local",
+        "--harness-backend",
+        help="Where each evaluated Pi process runs: local or e2b. The CLI remains local.",
+    ),
+    e2b_template: str | None = typer.Option(
+        None,
+        "--e2b-template",
+        envvar=E2B_TEMPLATE_ENV,
+        help="Optional template for E2B project and evaluated Pi processes.",
+    ),
+    environment_command_timeout_sec: int = typer.Option(
+        MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        "--environment-command-timeout",
+        min=1,
+        max=MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        help="Maximum seconds for one command in the Harbor-owned task environment.",
+    ),
+    project_timeout_sec: float = typer.Option(
+        DEFAULT_PROJECT_TIMEOUT_S,
+        "--project-timeout",
+        min=1,
+        help="Lifetime in seconds for the proposer project's E2B sandbox.",
+    ),
+    max_history_candidates: int = typer.Option(
+        DEFAULT_MAX_HISTORY_CANDIDATES,
+        "--max-history-candidates",
+        min=1,
+        help="Maximum evaluated candidates materialized into proposer history.",
+    ),
+    max_history_bytes: int = typer.Option(
+        DEFAULT_MAX_HISTORY_BYTES,
+        "--max-history-bytes",
+        min=1,
+        help="Maximum complete source, score, and artifact bytes in proposer history.",
+    ),
+    result_out: str | None = typer.Option(
+        None,
+        "--result-out",
+        help="Local run directory (default: <root>/runs/<opaque-id>).",
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project artifact root and harness store."),
+    yes: bool = typer.Option(False, "--yes", help="Acknowledge the displayed execution matrix."),
+) -> None:
+    """Optimize complete harness source against one exact ground-truth scorer request.
+
+    The command host is always the local WMH process. The proposer project runs in E2B; evaluated
+    Pi processes use ``--harness-backend``; Harbor's own JobConfig independently owns task
+    environment backend and concurrency. Both ``models.meta`` and ``models.agent`` must be
+    configured in the selected project's ``settings.toml``. This command has no world-model
+    fallback and performs no held-out selection.
+    """
+    try:
+        validate_name(name)
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if harness_backend not in ("local", "e2b"):
+        raise typer.BadParameter(
+            f"unknown --harness-backend {harness_backend!r}; choose local or e2b"
+        )
+    if not reward_key:
+        raise typer.BadParameter("--reward-key must be nonempty")
+
+    job_config = _load_harbor_config(Path(harbor_config))
+    task_ids = _load_task_ids(Path(task_ids_file))
+    meta_config = resolve_required_model_config(root, "meta")
+    agent_config = resolve_required_model_config(root, "agent")
+    seed_source = _resolve_seed_source(root, seed)
+    effective_e2b_template = resolve_e2b_template(e2b_template)
+    run_dir = Path(result_out) if result_out is not None else Path(root) / "runs" / uuid4().hex
+    if run_dir.exists():
+        raise typer.BadParameter(f"result directory already exists: {run_dir}")
+
+    score_cells = (iterations + 1) * len(task_ids) * attempts
+    _console.print(
+        f"fixed search: 1 seed + {iterations} proposal slot(s), {len(task_ids)} task(s), "
+        f"{attempts} attempt(s) -> up to {score_cells} requested score cells; "
+        f"evaluated Pi backend={harness_backend}; proposer project=e2b"
+    )
+    if not yes:
+        if not _console.is_terminal:
+            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+        if not Confirm.ask("Proceed?", default=False):
+            raise typer.Exit(0)
+
+    outcome = _execute_optimization(
+        name=name,
+        root=root,
+        run_dir=run_dir,
+        job_config=job_config,
+        task_ids=task_ids,
+        reward_key=reward_key,
+        iterations=iterations,
+        attempts=attempts,
+        seed=seed_source,
+        meta_config=meta_config,
+        agent_config=agent_config,
+        harness_backend=cast("Literal['local', 'e2b']", harness_backend),
+        # An explicit empty string freezes template absence so lower layers cannot re-read a
+        # concurrently changed environment after the input snapshot is written.
+        e2b_template=effective_e2b_template or "",
+        environment_command_timeout_sec=environment_command_timeout_sec,
+        project_timeout_sec=project_timeout_sec,
+        max_history_candidates=max_history_candidates,
+        max_history_bytes=max_history_bytes,
+    )
+    _console.print(
+        f"[green]optimized[/green] [bold]{name}[/bold] v{outcome.saved.version} "
+        f"score={outcome.result.best_score:.6f}; evidence -> {outcome.run_dir}"
+    )
+
+
+def _execute_optimization(
+    *,
+    name: str,
+    root: str,
+    run_dir: Path,
+    job_config: JobConfig,
+    task_ids: tuple[str, ...],
+    reward_key: str,
+    iterations: int,
+    attempts: int,
+    seed: HarnessSourceTree,
+    meta_config: ProviderConfig,
+    agent_config: ProviderConfig,
+    harness_backend: Literal["local", "e2b"],
+    e2b_template: str | None,
+    environment_command_timeout_sec: int,
+    project_timeout_sec: float,
+    max_history_candidates: int,
+    max_history_bytes: int,
+) -> HarnessOptimizeOutcome:
+    """Resolve one immutable scorer request, execute it, and publish evidence before winner."""
+    run_dir.mkdir(parents=True, exist_ok=False)
+    effective_job_config = JobConfig.model_validate(
+        job_config.model_copy(
+            update={"jobs_dir": run_dir / "harbor"},
+            deep=True,
+        ).model_dump(mode="python")
+    )
+    scorer = asyncio.run(
+        HarborScorer.create(
+            job_config=effective_job_config,
+            task_ids=task_ids,
+            provider_config=agent_config,
+            reward_key=reward_key,
+            environment_command_timeout_sec=environment_command_timeout_sec,
+            harness_backend=harness_backend,
+            e2b_template=e2b_template if harness_backend == "e2b" else None,
+        )
+    )
+    request = scorer.request(attempts=attempts)
+    _write_json_atomic(
+        run_dir / "inputs.json",
+        {
+            "schema_version": 1,
+            "seed_source_tree_hash": seed.tree_hash,
+            "iterations": iterations,
+            "score_request": request.model_dump(mode="json"),
+            "harbor_job_template": effective_job_config.model_dump(mode="json"),
+            "meta_provider": meta_config.model_dump(mode="json"),
+            "agent_provider": agent_config.model_dump(mode="json"),
+            "harness_backend": harness_backend,
+            "e2b_template": e2b_template or None,
+            "environment_command_timeout_sec": environment_command_timeout_sec,
+            "project_timeout_sec": project_timeout_sec,
+            "max_history_candidates": max_history_candidates,
+            "max_history_bytes": max_history_bytes,
+        },
+    )
+
+    meta_provider = get_provider(meta_config)
+    if not isinstance(meta_provider, ToolCallingProvider):
+        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
+    with AgentProject.create(
+        timeout=project_timeout_sec,
+        template=e2b_template,
+        metadata={"wmh_component": "harness_optimize"},
+    ) as project:
+        proposer = ProjectCandidateProposer(
+            project,
+            optimizer_agent(),
+            meta_provider,
+            max_history_candidates=max_history_candidates,
+            max_history_bytes=max_history_bytes,
+        )
+        result = HarnessPopulationOptimizer(proposer, scorer).optimize(
+            seed=seed,
+            request=request,
+            iterations=iterations,
+        )
+    project_usage = project.usage()
+
+    archive_manifest = write_population_archive(run_dir / "population", result)
+    selected = result.best.candidate.model_copy(update={"name": name, "version": 0})
+    saved = HarnessStore(root).save_version(selected, alias=CHAMPION_ALIAS)
+    _write_json_atomic(
+        run_dir / "outcome.json",
+        {
+            "schema_version": 1,
+            "best_candidate_id": result.best.candidate_id,
+            "best_score": result.best_score,
+            "best_document_hash": result.best.candidate.doc_hash,
+            "saved_harness": saved.name,
+            "saved_version": saved.version,
+            "archive_manifest": archive_manifest.relative_to(run_dir).as_posix(),
+            "project_sandbox_usage": project_usage.model_dump(mode="json"),
+        },
+    )
+    return HarnessOptimizeOutcome(
+        result=result,
+        saved=saved,
+        run_dir=run_dir,
+        archive_manifest=archive_manifest,
+        project_usage=project_usage,
+    )
+
+
+def _load_harbor_config(path: Path) -> JobConfig:
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return JobConfig.model_validate(raw)
+    except (OSError, yaml.YAMLError, ValidationError, ValueError, TypeError) as error:
+        raise typer.BadParameter(f"cannot load Harbor config from {path}: {error}") from error
+
+
+def _load_task_ids(path: Path) -> tuple[str, ...]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise typer.BadParameter(f"cannot load task IDs from {path}: {error}") from error
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise typer.BadParameter("task ID file must contain one JSON string list")
+    try:
+        # Reuse the canonical task identity validation without inventing a parallel CLI policy.
+        validated = ScoreRequest.model_validate(
+            {
+                "context": {
+                    "task_set_digest": "sha256:" + "0" * 64,
+                    "evaluator_digest": "sha256:" + "0" * 64,
+                    "execution_config_digest": "sha256:" + "0" * 64,
+                },
+                "task_ids": raw,
+                "attempts": 1,
+            }
+        )
+    except ValidationError as error:
+        raise typer.BadParameter(f"invalid task ID file: {error}") from error
+    return validated.task_ids
+
+
+def _resolve_seed_source(root: str, seed: str | None) -> HarnessSourceTree:
+    if seed is None:
+        return HarnessSourceTree.from_doc(default_agent())
+    name, _, ref = seed.partition("@")
+    try:
+        return HarnessSourceTree.from_doc(HarnessStore(root).load(name, ref or None))
+    except (FileNotFoundError, ValueError) as error:
+        raise typer.BadParameter(str(error)) from error
+
+
+def _write_json_atomic(path: Path, value: object) -> None:
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.parent.mkdir(parents=True, exist_ok=True)
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -304,6 +304,83 @@ def test_execute_closes_project_and_never_publishes_winner_after_optimizer_error
     assert not (tmp_path / "local-run/outcome.json").exists()
 
 
+def test_execute_does_not_claim_result_directory_when_scorer_setup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class BrokenScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> BrokenScorer:
+            raise ValueError("invalid scorer configuration")
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", BrokenScorer)
+    run_dir = tmp_path / "local-run"
+
+    with pytest.raises(ValueError, match="invalid scorer configuration"):
+        _execute_optimization(
+            name="unpublished",
+            root=str(tmp_path / ".wmh"),
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            seed=_source("seed"),
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="local",
+            e2b_template=None,
+            environment_command_timeout_sec=240,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+        )
+
+    assert not run_dir.exists()
+
+
+def test_execute_does_not_claim_result_directory_for_non_tool_meta_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> FakeScorer:
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return _request()
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", FakeScorer)
+    monkeypatch.setattr(module, "get_provider", lambda config: object())
+    run_dir = tmp_path / "local-run"
+
+    with pytest.raises(typer.BadParameter, match="structured tool calling"):
+        _execute_optimization(
+            name="unpublished",
+            root=str(tmp_path / ".wmh"),
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            seed=_source("seed"),
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="local",
+            e2b_template=None,
+            environment_command_timeout_sec=240,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+        )
+
+    assert not run_dir.exists()
+
+
 def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -1,0 +1,442 @@
+"""CLI and resource-lifecycle tests for scorer-driven harness optimization."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+import typer
+from harbor.models.environment_type import EnvironmentType
+from harbor.models.job.config import DatasetConfig, JobConfig, RetryConfig
+from harbor.models.trial.config import AgentConfig, EnvironmentConfig
+from typer.testing import CliRunner
+
+from wmh.cli import app
+from wmh.cli.harness_optimize import HarnessOptimizeOutcome, _execute_optimization
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.population import PopulationOptimizationResult
+from wmh.harness.project_proposer import EvaluatedCandidate, ProjectCandidateProposer
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+module = importlib.import_module("wmh.cli.harness_optimize")
+runner = CliRunner()
+_DIGEST = "sha256:" + "a" * 64
+
+
+class _Reader:
+    def read_bytes(self, path: str) -> bytes:
+        assert path == "raw/result.json"
+        return b"{}"
+
+
+class _ToolProvider:
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+
+    def complete_chat(self, request: object) -> object:
+        raise NotImplementedError
+
+
+class _Project:
+    def __init__(self) -> None:
+        self.workspace = "/workspace/project"
+        self.closed = False
+
+    def __enter__(self) -> _Project:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.closed = True
+
+    def usage(self) -> SandboxUsage:
+        return SandboxUsage(count=1, seconds=12.5)
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST,
+            evaluator_digest=_DIGEST,
+            execution_config_digest=_DIGEST,
+        ),
+        task_ids=("task-a",),
+        attempts=1,
+    )
+
+
+def _result() -> PopulationOptimizationResult:
+    source = _source("selected")
+    candidate_id = "candidate-0000"
+    artifact = EvaluationArtifact.from_bytes(path="raw/result.json", content=b"{}")
+    report = HarnessScoreReport(
+        source_run_id="run-1",
+        candidate_doc_hash=source.to_doc(candidate_id).doc_hash,
+        request=_request(),
+        cells=(
+            ScoreCell(
+                task_id="task-a",
+                attempt=1,
+                score=1.0,
+                passed=True,
+                summary="official result",
+                artifact_paths=("raw/result.json",),
+            ),
+        ),
+        artifacts=(artifact,),
+    )
+    evaluated = EvaluatedCandidate(
+        candidate_id=candidate_id,
+        source=source,
+        score=HarnessScore(report=report, artifacts=_Reader()),
+    )
+    return PopulationOptimizationResult(population=(evaluated,), iterations=(), best=evaluated)
+
+
+def _job_config(tmp_path: Path) -> JobConfig:
+    return JobConfig(
+        job_name="template",
+        jobs_dir=tmp_path / "unused",
+        n_attempts=1,
+        n_concurrent_trials=2,
+        retry=RetryConfig(max_retries=0),
+        environment=EnvironmentConfig(type=EnvironmentType.DOCKER),
+        agents=[AgentConfig(n_concurrent=1)],
+        datasets=[DatasetConfig(path=tmp_path / "tasks")],
+    )
+
+
+def _configs() -> tuple[ProviderConfig, ProviderConfig]:
+    return (
+        ProviderConfig(
+            kind=ProviderKind.OPENAI_RESPONSES,
+            model="meta-model",
+            reasoning_effort="high",
+        ),
+        ProviderConfig(kind=ProviderKind.ANTHROPIC, model="agent-model"),
+    )
+
+
+def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = _request()
+    scorer_calls: list[dict[str, object]] = []
+
+    class FakeScorer:
+        @classmethod
+        async def create(cls, **kwargs: object) -> FakeScorer:
+            scorer_calls.append(kwargs)
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return request
+
+    project = _Project()
+    project_calls: list[dict[str, object]] = []
+
+    class FakeProjectFactory:
+        @classmethod
+        def create(cls, **kwargs: object) -> _Project:
+            project_calls.append(kwargs)
+            return project
+
+    optimizer_calls: list[dict[str, object]] = []
+    result = _result()
+
+    class FakeOptimizer:
+        def __init__(self, proposer: object, scorer: object) -> None:
+            optimizer_calls.append({"proposer": proposer, "scorer": scorer})
+
+        def optimize(self, **kwargs: object) -> PopulationOptimizationResult:
+            optimizer_calls[-1].update(kwargs)
+            return result
+
+    archived: list[tuple[Path, PopulationOptimizationResult]] = []
+
+    def fake_archive(path: Path, value: PopulationOptimizationResult) -> Path:
+        archived.append((path, value))
+        path.mkdir(parents=True)
+        manifest = path / "manifest.json"
+        manifest.write_text("{}\n", encoding="utf-8")
+        return manifest
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", FakeScorer)
+    monkeypatch.setattr(module, "AgentProject", FakeProjectFactory)
+    monkeypatch.setattr(module, "HarnessPopulationOptimizer", FakeOptimizer)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+    monkeypatch.setattr(module, "write_population_archive", fake_archive)
+    run_dir = tmp_path / "local-run"
+    root = tmp_path / ".wmh"
+    seed = _source("seed")
+
+    outcome = _execute_optimization(
+        name="selected",
+        root=str(root),
+        run_dir=run_dir,
+        job_config=_job_config(tmp_path),
+        task_ids=("task-a",),
+        reward_key="reward",
+        iterations=3,
+        attempts=1,
+        seed=seed,
+        meta_config=meta_config,
+        agent_config=agent_config,
+        harness_backend="e2b",
+        e2b_template="template-x",
+        environment_command_timeout_sec=300,
+        project_timeout_sec=900,
+        max_history_candidates=20,
+        max_history_bytes=1_000_000,
+    )
+
+    [scorer_call] = scorer_calls
+    assert scorer_call["task_ids"] == ("task-a",)
+    assert scorer_call["provider_config"] == agent_config
+    assert scorer_call["harness_backend"] == "e2b"
+    assert scorer_call["e2b_template"] == "template-x"
+    assert cast(JobConfig, scorer_call["job_config"]).jobs_dir == run_dir / "harbor"
+    [project_call] = project_calls
+    assert project_call["template"] == "template-x"
+    assert project_call["timeout"] == 900
+    assert project.closed is True
+    [optimizer_call] = optimizer_calls
+    assert cast(FakeScorer, optimizer_call["scorer"]).request(attempts=1) == request
+    assert optimizer_call["seed"] == seed
+    assert optimizer_call["request"] == request
+    assert optimizer_call["iterations"] == 3
+    proposer = cast(ProjectCandidateProposer, optimizer_call["proposer"])
+    assert proposer._max_history_candidates == 20
+    assert proposer._max_history_bytes == 1_000_000
+    assert archived == [(run_dir / "population", result)]
+    assert outcome.saved.name == "selected"
+    assert outcome.saved.version == 1
+    assert outcome.saved.doc_hash == result.best.candidate.doc_hash
+    assert (root / "harnesses/selected/aliases.toml").exists()
+    assert json.loads((run_dir / "inputs.json").read_text())["iterations"] == 3
+    written = json.loads((run_dir / "outcome.json").read_text())
+    assert written["best_candidate_id"] == "candidate-0000"
+    assert written["project_sandbox_usage"] == {"count": 1, "seconds": 12.5}
+
+
+def test_execute_closes_project_and_never_publishes_winner_after_optimizer_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> FakeScorer:
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return _request()
+
+    project = _Project()
+
+    class FakeProjectFactory:
+        @classmethod
+        def create(cls, **_kwargs: object) -> _Project:
+            return project
+
+    class BrokenOptimizer:
+        def __init__(self, proposer: object, scorer: object) -> None:
+            del proposer, scorer
+
+        def optimize(self, **_kwargs: object) -> PopulationOptimizationResult:
+            raise RuntimeError("scorer unavailable")
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", FakeScorer)
+    monkeypatch.setattr(module, "AgentProject", FakeProjectFactory)
+    monkeypatch.setattr(module, "HarnessPopulationOptimizer", BrokenOptimizer)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+    root = tmp_path / ".wmh"
+
+    with pytest.raises(RuntimeError, match="scorer unavailable"):
+        _execute_optimization(
+            name="unpublished",
+            root=str(root),
+            run_dir=tmp_path / "local-run",
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            seed=_source("seed"),
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="local",
+            e2b_template=None,
+            environment_command_timeout_sec=300,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+        )
+
+    assert project.closed is True
+    assert not (root / "harnesses/unpublished").exists()
+    assert not (tmp_path / "local-run/outcome.json").exists()
+
+
+def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(
+                    provider="openai_responses",
+                    model="meta-model",
+                    reasoning_effort="high",
+                ),
+                agent=ModelRole(provider="anthropic", model="agent-model"),
+            )
+        ),
+        root,
+    )
+    config_path = tmp_path / "harbor.yaml"
+    config_path.write_text(_job_config(tmp_path).model_dump_json(), encoding="utf-8")
+    task_ids_path = tmp_path / "task-ids.json"
+    task_ids_path.write_text('["task-a"]\n', encoding="utf-8")
+    calls: list[dict[str, object]] = []
+    fake_result = _result()
+
+    def fake_execute(**kwargs: object) -> HarnessOptimizeOutcome:
+        calls.append(kwargs)
+        saved = fake_result.best.candidate.model_copy(update={"name": "selected", "version": 1})
+        run_dir = cast(Path, kwargs["run_dir"])
+        return HarnessOptimizeOutcome(
+            result=fake_result,
+            saved=saved,
+            run_dir=run_dir,
+            archive_manifest=run_dir / "population/manifest.json",
+            project_usage=_Project().usage(),
+        )
+
+    monkeypatch.setattr(module, "_execute_optimization", fake_execute)
+    monkeypatch.setenv("WMH_E2B_TEMPLATE", "template-from-env")
+    result_out = tmp_path / "local-run"
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "optimize",
+            "selected",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--iterations",
+            "2",
+            "--attempts",
+            "1",
+            "--result-out",
+            str(result_out),
+            "--root",
+            str(root),
+            "--yes",
+        ],
+    )
+
+    assert invoked.exit_code == 0, invoked.output
+    [call] = calls
+    assert call["harness_backend"] == "local"
+    assert call["iterations"] == 2
+    assert call["task_ids"] == ("task-a",)
+    assert call["e2b_template"] == "template-from-env"
+    assert cast(ProviderConfig, call["meta_config"]).reasoning_effort == "high"
+    assert cast(ProviderConfig, call["agent_config"]).kind is ProviderKind.ANTHROPIC
+    seed = call["seed"]
+    assert isinstance(seed, HarnessSourceTree)
+    assert seed.to_doc("seed").runtime_kind() == "pi-node"
+    assert len(seed.to_doc("seed").code_files()) > 1
+
+
+def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(provider="openai_responses", model="meta-model"),
+                agent=ModelRole(provider="anthropic", model="agent-model"),
+            )
+        ),
+        root,
+    )
+    config_path = tmp_path / "harbor.json"
+    config_path.write_text(_job_config(tmp_path).model_dump_json(), encoding="utf-8")
+    task_ids_path = tmp_path / "task-ids.json"
+    task_ids_path.write_text('["task-a"]\n', encoding="utf-8")
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "optimize",
+            "selected",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--iterations",
+            "1",
+            "--attempts",
+            "1",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert invoked.exit_code == 2
+    assert "pass --yes" in invoked.output
+
+
+@pytest.mark.parametrize("payload", ['["same", "same"]', '{"task": "a"}', "not-json"])
+def test_cli_rejects_nonexact_task_id_manifests(tmp_path: Path, payload: str) -> None:
+    path = tmp_path / "task-ids.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(typer.BadParameter):
+        module._load_task_ids(path)
+
+
+def test_cli_help_preserves_model_roles_seed_syntax_and_local_output_wording() -> None:
+    invoked = runner.invoke(app, ["harness", "optimize", "--help"])
+
+    assert invoked.exit_code == 0, invoked.output
+    assert "models.meta" in invoked.output
+    assert "models.agent" in invoked.output
+    assert "name@ref" in invoked.output
+    assert "Local run directory" in invoked.output

--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import typer
 
-from wmh.config.settings import load_settings
+from wmh.config.settings import ModelRole, load_settings
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.providers.registry import get_provider
 
@@ -35,9 +35,26 @@ def resolve_opt_in_model_provider(
     Raises:
         typer.BadParameter: The configured provider kind is unknown.
     """
-    configured = load_settings(root).models.resolve(role)
-    if configured is None:
+    config = _resolve_model_config(root, role)
+    if config is None:
         return fallback, None
+    return get_provider(config), config.model
+
+
+def resolve_required_model_config(root: str, role: OptInModelRole) -> ProviderConfig:
+    """Resolve one explicitly configured opt-in model role into provider-neutral config."""
+    config = _resolve_model_config(root, role)
+    if config is None:
+        raise typer.BadParameter(f"settings [models.{role}] must be configured")
+    return config
+
+
+def _resolve_model_config(root: str, role: OptInModelRole) -> ProviderConfig | None:
+    configured = load_settings(root).models.resolve(role)
+    return None if configured is None else _model_config(configured, role=role)
+
+
+def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderConfig:
     try:
         kind = ProviderKind(configured.provider)
     except ValueError:
@@ -49,12 +66,12 @@ def resolve_opt_in_model_provider(
     api_version = configured.api_version
     if api_version is None and kind is ProviderKind.AZURE_OPENAI:
         api_version = _DEFAULT_AZURE_API_VERSION
-    config = ProviderConfig(
+    return ProviderConfig(
         kind=kind,
         model=configured.model,
         region=configured.region,
         endpoint=configured.endpoint,
         deployment=configured.deployment,
         api_version=api_version,
+        reasoning_effort=configured.reasoning_effort,
     )
-    return get_provider(config), configured.model

--- a/wmh/cli/model_roles_test.py
+++ b/wmh/cli/model_roles_test.py
@@ -8,7 +8,11 @@ import pytest
 import typer
 
 import wmh.cli.model_roles as model_roles_module
-from wmh.cli.model_roles import OptInModelRole, resolve_opt_in_model_provider
+from wmh.cli.model_roles import (
+    OptInModelRole,
+    resolve_opt_in_model_provider,
+    resolve_required_model_config,
+)
 from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
@@ -80,6 +84,7 @@ def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
                     region="us-east-2",
                     endpoint="https://x.example",
                     deployment="gpt-5-5",
+                    reasoning_effort="high",
                 )
             )
         ),
@@ -105,6 +110,16 @@ def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
     assert config.endpoint == "https://x.example"
     assert config.deployment == "gpt-5-5"
     assert config.api_version == "2024-05-01-preview"
+    assert config.reasoning_effort == "high"
+
+
+@pytest.mark.parametrize("role", ["agent", "meta"])
+def test_required_model_config_rejects_an_unset_role(tmp_path: Path, role: OptInModelRole) -> None:
+    with pytest.raises(
+        typer.BadParameter,
+        match=rf"settings \[models\.{role}\] must be configured",
+    ):
+        resolve_required_model_config(str(tmp_path / ".wmh"), role)
 
 
 def test_explicit_api_version_overrides_the_azure_default(

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -30,6 +30,7 @@ class ModelRole(BaseModel):
     endpoint: str | None = None  # Azure OpenAI / custom base URL
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version (azure roles get a default)
+    reasoning_effort: str | None = None  # structured reasoning effort, when supported
 
 
 class ModelsSettings(BaseModel):

--- a/wmh/harness/population_archive.py
+++ b/wmh/harness/population_archive.py
@@ -1,0 +1,157 @@
+"""Durable, self-contained evidence for one completed population optimization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.population import PopulationOptimizationResult
+from wmh.harness.runtime import TokenUsage
+from wmh.harness.source_tree import HarnessSourceTree
+
+_SCHEMA_VERSION = 1
+
+
+def write_population_archive(
+    destination: str | Path,
+    result: PopulationOptimizationResult,
+) -> Path:
+    """Write verified reports, artifacts, sources, and proposal outcomes once.
+
+    The destination must not exist. ``manifest.json`` is written last, so its presence is the
+    completion marker; an interrupted copy leaves inspectable evidence but cannot be mistaken for
+    a complete archive.
+    """
+    root = Path(destination)
+    if root.exists():
+        raise FileExistsError(f"population archive destination already exists: {root}")
+    if not result.population:
+        raise ValueError("population archive requires an evaluated seed")
+    if result.best not in result.population:
+        raise ValueError("population archive winner is not in its evaluated population")
+
+    request = result.population[0].score.report.request
+    if any(item.score.report.request != request for item in result.population[1:]):
+        raise ValueError("population archive candidates use different score requests")
+
+    root.mkdir(parents=True)
+    population_entries: list[dict[str, object]] = []
+    population_ids: set[str] = set()
+    for index, evaluated in enumerate(result.population):
+        if evaluated.candidate_id in population_ids:
+            raise ValueError("population archive contains duplicate candidate identities")
+        population_ids.add(evaluated.candidate_id)
+        candidate_dir = root / "population" / f"{index:04d}"
+        source_dir = candidate_dir / "source"
+        _write_source_tree(source_dir, evaluated.source)
+        report_path = candidate_dir / "score.json"
+        _write_text(report_path, evaluated.score.report.model_dump_json(indent=2))
+        artifacts_dir = candidate_dir / "artifacts"
+        for artifact in evaluated.score.report.artifacts:
+            content = evaluated.score.artifacts.read_bytes(artifact.path)
+            if len(content) != artifact.size_bytes:
+                raise ValueError(f"artifact {artifact.path!r} size differs from its score manifest")
+            digest = "sha256:" + hashlib.sha256(content).hexdigest()
+            if digest != artifact.content_hash:
+                raise ValueError(
+                    f"artifact {artifact.path!r} content differs from its score manifest"
+                )
+            target = artifacts_dir / artifact.path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+        population_entries.append(
+            {
+                "index": index,
+                "candidate_id": evaluated.candidate_id,
+                "document_hash": evaluated.candidate.doc_hash,
+                "source_tree_hash": evaluated.source.tree_hash,
+                "source_path": _relative(root, source_dir),
+                "score_path": _relative(root, report_path),
+                "artifacts_path": _relative(root, artifacts_dir),
+            }
+        )
+
+    iteration_entries: list[dict[str, object]] = []
+    for expected_index, iteration in enumerate(result.iterations, 1):
+        if iteration.index != expected_index:
+            raise ValueError("population archive iterations must be contiguous and one-indexed")
+        iteration_dir = root / "iterations" / f"{iteration.index:04d}"
+        events_path = iteration_dir / "events.json"
+        entry: dict[str, object] = {}
+        if iteration.error is not None:
+            events = iteration.error.events
+            usage = iteration.error.worker_usage
+            entry.update(
+                {
+                    "index": iteration.index,
+                    "candidate_id": iteration.error.candidate_id,
+                    "outcome": "invalid",
+                    "error": str(iteration.error),
+                    "worker_usage": _usage(usage),
+                    "events_path": _relative(root, events_path),
+                }
+            )
+            if iteration.error.source is not None:
+                source_dir = iteration_dir / "source"
+                _write_source_tree(source_dir, iteration.error.source)
+                entry["source_tree_hash"] = iteration.error.source.tree_hash
+                entry["source_path"] = _relative(root, source_dir)
+        else:
+            assert iteration.proposal is not None
+            assert iteration.evaluation is not None
+            events = iteration.proposal.events
+            entry.update(
+                {
+                    "index": iteration.index,
+                    "candidate_id": iteration.proposal.candidate_id,
+                    "outcome": "scored",
+                    "document_hash": iteration.proposal.candidate.doc_hash,
+                    "source_tree_hash": iteration.proposal.source.tree_hash,
+                    "worker_usage": _usage(iteration.proposal.worker_usage),
+                    "events_path": _relative(root, events_path),
+                }
+            )
+        _write_events(events_path, events)
+        iteration_entries.append(entry)
+
+    manifest_path = root / "manifest.json"
+    manifest = {
+        "schema_version": _SCHEMA_VERSION,
+        "score_request": request.model_dump(mode="json"),
+        "best_candidate_id": result.best.candidate_id,
+        "best_score": result.best_score,
+        "population": population_entries,
+        "iterations": iteration_entries,
+    }
+    manifest_temp = manifest_path.with_name(f"{manifest_path.name}.tmp")
+    _write_text(manifest_temp, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    manifest_temp.replace(manifest_path)
+    return manifest_path
+
+
+def _write_source_tree(destination: Path, source: HarnessSourceTree) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in source.files:
+        target = destination / item.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(item.content, encoding="utf-8")
+
+
+def _write_events(path: Path, events: tuple[SessionEvent, ...]) -> None:
+    payload = [{"kind": event.kind, "payload": event.payload} for event in events]
+    _write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _usage(usage: TokenUsage | None) -> dict[str, int] | None:
+    return usage.model_dump(mode="json") if usage is not None else None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _relative(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()

--- a/wmh/harness/population_archive_test.py
+++ b/wmh/harness/population_archive_test.py
@@ -1,0 +1,231 @@
+"""Tests for complete, append-only population result archives."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.population import PopulationIteration, PopulationOptimizationResult
+from wmh.harness.population_archive import write_population_archive
+from wmh.harness.project_proposer import (
+    CandidateProposal,
+    CandidateProposalError,
+    EvaluatedCandidate,
+)
+from wmh.harness.runtime import TokenUsage
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_DIGEST = "sha256:" + "a" * 64
+_ARTIFACT_PATH = "raw/evidence.bin"
+
+
+class _Reader:
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    def read_bytes(self, path: str) -> bytes:
+        assert path == _ARTIFACT_PATH
+        return self._content
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["bash", "submit"]\n',
+            ),
+        )
+    )
+
+
+def _score(candidate_id: str, source: HarnessSourceTree, value: float) -> HarnessScore:
+    request = ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST,
+            evaluator_digest=_DIGEST,
+            execution_config_digest=_DIGEST,
+        ),
+        task_ids=("task-a",),
+        attempts=1,
+    )
+    content = f"evidence for {candidate_id}".encode()
+    artifact = EvaluationArtifact.from_bytes(path=_ARTIFACT_PATH, content=content)
+    report = HarnessScoreReport(
+        source_run_id=f"run-{candidate_id}",
+        candidate_doc_hash=source.to_doc(candidate_id).doc_hash,
+        request=request,
+        cells=(
+            ScoreCell(
+                task_id="task-a",
+                attempt=1,
+                score=value,
+                passed=value == 1.0,
+                summary="official result",
+                artifact_paths=(_ARTIFACT_PATH,),
+            ),
+        ),
+        artifacts=(artifact,),
+    )
+    return HarnessScore(report=report, artifacts=_Reader(content))
+
+
+def _evaluated(candidate_id: str, prompt: str, score: float) -> EvaluatedCandidate:
+    source = _source(prompt)
+    return EvaluatedCandidate(
+        candidate_id=candidate_id,
+        source=source,
+        score=_score(candidate_id, source, score),
+    )
+
+
+def test_archive_copies_sources_reports_artifacts_and_proposal_events(tmp_path: Path) -> None:
+    seed = _evaluated("candidate-0000", "seed", 0.0)
+    candidate = _evaluated("candidate-0001", "candidate", 1.0)
+    proposal = CandidateProposal(
+        candidate_id=candidate.candidate_id,
+        source=candidate.source,
+        candidate=candidate.candidate,
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(input_tokens=10, output_tokens=4, calls=1),
+    )
+    result = PopulationOptimizationResult(
+        population=(seed, candidate),
+        iterations=(PopulationIteration(index=1, proposal=proposal, evaluation=candidate),),
+        best=candidate,
+    )
+
+    destination = tmp_path / "archive"
+    manifest_path = write_population_archive(destination, result)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["best_candidate_id"] == "candidate-0001"
+    assert manifest["best_score"] == 1.0
+    assert [entry["candidate_id"] for entry in manifest["population"]] == [
+        "candidate-0000",
+        "candidate-0001",
+    ]
+    assert (destination / "population/0001/source/SYSTEM.md").read_text() == "candidate"
+    assert (destination / "population/0001/artifacts/raw/evidence.bin").read_bytes() == (
+        b"evidence for candidate-0001"
+    )
+    events = json.loads((destination / "iterations/0001/events.json").read_text(encoding="utf-8"))
+    assert events == [{"kind": "submit", "payload": {"answer": "done"}}]
+    assert manifest["iterations"][0]["worker_usage"]["calls"] == 1
+
+
+def test_archive_preserves_invalid_iteration_source_and_unknown_usage(tmp_path: Path) -> None:
+    seed = _evaluated("candidate-0000", "seed", 0.5)
+    invalid_source = _source("invalid but captured")
+    error = CandidateProposalError(
+        "candidate-0001",
+        "did not submit",
+        source=invalid_source,
+        events=(SessionEvent(kind="error", payload={"message": "stopped"}),),
+        worker_usage=None,
+    )
+    result = PopulationOptimizationResult(
+        population=(seed,),
+        iterations=(PopulationIteration(index=1, error=error),),
+        best=seed,
+    )
+
+    destination = tmp_path / "archive"
+    manifest_path = write_population_archive(destination, result)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    [iteration] = manifest["iterations"]
+    assert iteration["outcome"] == "invalid"
+    assert iteration["worker_usage"] is None
+    assert "did not submit" in iteration["error"]
+    assert (destination / "iterations/0001/source/SYSTEM.md").read_text() == (
+        "invalid but captured"
+    )
+
+
+def test_archive_materializes_an_empty_invalid_source_directory(tmp_path: Path) -> None:
+    seed = _evaluated("candidate-0000", "seed", 0.5)
+    error = CandidateProposalError(
+        "candidate-0001",
+        "empty snapshot",
+        source=HarnessSourceTree(files=()),
+    )
+    result = PopulationOptimizationResult(
+        population=(seed,),
+        iterations=(PopulationIteration(index=1, error=error),),
+        best=seed,
+    )
+
+    destination = tmp_path / "archive"
+    manifest_path = write_population_archive(destination, result)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    [iteration] = manifest["iterations"]
+    assert iteration["source_path"] == "iterations/0001/source"
+    assert (destination / "iterations/0001/source").is_dir()
+    assert list((destination / "iterations/0001/source").iterdir()) == []
+
+
+def test_archive_never_overwrites_an_existing_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "archive"
+    destination.mkdir()
+    sentinel = destination / "keep.txt"
+    sentinel.write_text("owned", encoding="utf-8")
+    seed = _evaluated("candidate-0000", "seed", 0.5)
+    result = PopulationOptimizationResult(population=(seed,), iterations=(), best=seed)
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        write_population_archive(destination, result)
+
+    assert sentinel.read_text(encoding="utf-8") == "owned"
+
+
+def test_archive_manifest_is_absent_when_atomic_publication_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "archive"
+    seed = _evaluated("candidate-0000", "seed", 0.5)
+    result = PopulationOptimizationResult(population=(seed,), iterations=(), best=seed)
+
+    def fail_replace(self: Path, target: Path) -> Path:
+        del self, target
+        raise OSError("publication interrupted")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="publication interrupted"):
+        write_population_archive(destination, result)
+
+    assert not (destination / "manifest.json").exists()
+    assert (destination / "manifest.json.tmp").exists()
+
+
+def test_archive_rejects_artifact_bytes_that_differ_from_manifest(tmp_path: Path) -> None:
+    seed = _evaluated("candidate-0000", "seed", 0.5)
+    broken_score = HarnessScore(
+        report=seed.score.report,
+        artifacts=_Reader(b"different bytes"),
+    )
+    broken = EvaluatedCandidate(
+        candidate_id=seed.candidate_id,
+        source=seed.source,
+        score=broken_score,
+    )
+    result = PopulationOptimizationResult(population=(broken,), iterations=(), best=broken)
+
+    with pytest.raises(ValueError, match="differs from its score manifest"):
+        write_population_archive(tmp_path / "archive", result)
+
+    assert not (tmp_path / "archive/manifest.json").exists()


### PR DESCRIPTION
## Summary

- add a local wmh harness optimize command over complete source candidates
- compose Harbor scoring, an E2B project proposer, and fixed population optimization
- keep evaluated harness execution local by default with E2B as an explicit alternative
- archive complete score evidence before publishing the selected harness locally
- require explicit meta and agent model roles and an acknowledged execution matrix

## Validation

- uv run pytest wmh/cli/harness_optimize_test.py wmh/cli/model_roles_test.py wmh/harness/population_archive_test.py -q
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run pytest -q