### PR TITLE
Support Azure structured reasoning

### DIFF
--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from openai import AzureOpenAI, OpenAI
 
 
+_STRUCTURED_VERIFY_MAX_TOKENS = 256
 _STRUCTURED_TOOL_PING = ChatRequest.model_validate(
     {
         "messages": [{"role": "user", "content": "Call health_check exactly once."}],
@@ -49,7 +50,9 @@ _STRUCTURED_TOOL_PING = ChatRequest.model_validate(
             }
         ],
         "tool_choice": "required",
-        "max_completion_tokens": 2048,
+        # Verification exercises one required zero-argument call. Keep routine checks bounded
+        # while leaving enough output space for a short reasoning prelude and the tool payload.
+        "max_completion_tokens": _STRUCTURED_VERIFY_MAX_TOKENS,
         "store": False,
     }
 )

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
-from wmh.providers import _openai_common
+from wmh.providers import _openai_common, _responses_common
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
     ChatRequest,
@@ -27,7 +27,32 @@ from wmh.providers.base import (
 )
 
 if TYPE_CHECKING:
-    from openai import AzureOpenAI
+    from openai import AzureOpenAI, OpenAI
+
+
+_STRUCTURED_TOOL_PING = ChatRequest.model_validate(
+    {
+        "messages": [{"role": "user", "content": "Call health_check exactly once."}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "health_check",
+                    "description": "Verify structured tool-call availability.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            }
+        ],
+        "tool_choice": "required",
+        "max_completion_tokens": 2048,
+        "store": False,
+    }
+)
 
 
 class AzureOpenAIProvider:
@@ -36,7 +61,22 @@ class AzureOpenAIProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: AzureOpenAI | None = None
+        self._responses_client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
+
+    def _resolved_endpoint(self) -> tuple[str, bool]:
+        """Return the endpoint and whether it came from untrusted model configuration."""
+        env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+        endpoint = self.config.endpoint or env_endpoint
+        if not endpoint:
+            raise ValueError(
+                "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
+                "AZURE_OPENAI_ENDPOINT."
+            )
+        is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
+            self.config.endpoint, env_endpoint
+        )
+        return endpoint, is_config_endpoint
 
     def _get_client(self) -> AzureOpenAI:
         # Lazy: construct on first use. api_version must be supplied by config; the endpoint and
@@ -47,22 +87,13 @@ class AzureOpenAIProvider:
             if self.config.api_version is None:
                 raise ValueError("AzureOpenAIProvider requires config.api_version to be set.")
 
-            env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
-            endpoint = self.config.endpoint or env_endpoint
-            if not endpoint:
-                raise ValueError(
-                    "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
-                    "AZURE_OPENAI_ENDPOINT."
-                )
+            endpoint, is_config_endpoint = self._resolved_endpoint()
 
             from openai import AzureOpenAI
 
             # Compare canonically so a trailing slash or host-casing difference between the config
             # value and the trusted env endpoint doesn't misclassify the same Azure resource as an
             # untrusted host (which would strip the real key and break the call).
-            is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
-                self.config.endpoint, env_endpoint
-            )
             if is_config_endpoint:
                 # A config-controlled endpoint (config.toml can come from an untrusted model
                 # bundle) is an untrusted host. NEVER let the SDK fall back to the real
@@ -81,6 +112,31 @@ class AzureOpenAIProvider:
                     azure_endpoint=endpoint,
                 )
         return self._client
+
+    def _get_responses_client(self) -> OpenAI:
+        """Create the Azure v1 client used by configured structured reasoning calls."""
+        if self._responses_client is None:
+            endpoint, is_config_endpoint = self._resolved_endpoint()
+            if is_config_endpoint:
+                api_key = os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed"
+            else:
+                api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "AzureOpenAIProvider needs AZURE_OPENAI_API_KEY for the v1 Responses API."
+                    )
+
+            from openai import OpenAI
+
+            self._responses_client = OpenAI(
+                api_key=api_key,
+                base_url=_responses_base_url(endpoint),
+                timeout=240.0,
+                # A lost SDK response may already be billed. Keep one WMH proposer turn equal to
+                # one provider dispatch so usage and the operator's hard budget stay observable.
+                max_retries=0,
+            )
+        return self._responses_client
 
     def _deployment(self) -> str:
         # On Azure, the `model` arg to the API is the deployment name, not the base model id.
@@ -106,6 +162,14 @@ class AzureOpenAIProvider:
             request,
             forward_temperature=self._forward_temperature,
         )
+        if self.config.reasoning_effort is not None:
+            return _responses_common.complete_chat(
+                self._get_responses_client().responses,
+                self._deployment(),
+                request,
+                reasoning_effort=self.config.reasoning_effort,
+                allow_sampling=False,
+            )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,
             self._deployment(),
@@ -123,6 +187,22 @@ class AzureOpenAIProvider:
         )
 
     def verify(self) -> VerifyResult:
+        if self.config.reasoning_effort is not None:
+            try:
+                response = self.complete_chat(_STRUCTURED_TOOL_PING)
+                calls = response.choices[0].message.tool_calls if response.choices else None
+                if calls is None or len(calls) != 1 or calls[0].function.name != "health_check":
+                    raise ValueError(
+                        "structured provider verification returned no single health_check call"
+                    )
+            except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
+                return VerifyResult(
+                    ok=False,
+                    kind=self.config.kind,
+                    model=self.config.model,
+                    detail=str(exc),
+                )
+            return VerifyResult(ok=True, kind=self.config.kind, model=self.config.model)
         return verify_via_ping(self)
 
 
@@ -143,3 +223,12 @@ def _same_endpoint(a: str, b: str | None) -> bool:
         pb.path.rstrip("/"),
         pb.query,
     )
+
+
+def _responses_base_url(endpoint: str) -> str:
+    """Normalize an Azure resource endpoint onto its native v1 route."""
+    parsed = urlsplit(endpoint)
+    path = parsed.path.rstrip("/")
+    if not path.lower().endswith("/openai/v1"):
+        path = f"{path}/openai/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, f"{path}/", parsed.query, ""))

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -358,6 +358,7 @@ def test_reasoning_verify_probes_the_structured_tool_route(
     assert len(responses.calls) == 1
     assert responses.calls[0]["reasoning"] == {"effort": "high"}
     assert responses.calls[0]["tool_choice"] == "required"
+    assert responses.calls[0]["max_output_tokens"] == 256
 
 
 def test_missing_deployment_raises(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -61,6 +61,49 @@ class _FakeChat:
         self.completions = completions
 
 
+class _FakeResponsesResponse:
+    def __init__(self, tool_name: str = "bash") -> None:
+        self.tool_name = tool_name
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "model": "gpt-5.5-2026-06-01",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "ciphertext-1",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": self.tool_name,
+                    "arguments": '{"command":"pwd"}',
+                    "status": "completed",
+                },
+            ],
+            "usage": {"input_tokens": 11, "output_tokens": 7},
+        }
+
+
+class _FakeResponses:
+    def __init__(self, tool_name: str = "bash") -> None:
+        self.tool_name = tool_name
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> _FakeResponsesResponse:
+        self.calls.append(kwargs)
+        return _FakeResponsesResponse(self.tool_name)
+
+
+class _FakeResponsesClient:
+    def __init__(self, responses: _FakeResponses) -> None:
+        self.responses = responses
+
+
 class _FakeEmbeddingItem:
     def __init__(self, embedding: list[float]) -> None:
         self.embedding = embedding
@@ -97,6 +140,10 @@ def _config() -> ProviderConfig:
         deployment="gpt55-deploy",
         api_version="2024-10-21",
     )
+
+
+def _reasoning_config() -> ProviderConfig:
+    return _config().model_copy(update={"reasoning_effort": "high"})
 
 
 def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -139,6 +186,178 @@ def test_structured_chat_applies_model_temperature_capability(
     )
 
     assert ("temperature" in chat.last_kwargs) is expects_temperature
+
+
+def test_structured_reasoning_uses_azure_v1_and_replays_tool_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses()
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning tools must not use chat")),
+    )
+
+    first = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "inspect"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "description": "run a command",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "temperature": 0.3,
+                "top_p": 0.7,
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+
+    assert responses.calls[0] == {
+        "model": "gpt55-deploy",
+        "input": [{"role": "user", "content": "inspect"}],
+        "stream": False,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "max_output_tokens": 4096,
+        "tools": [
+            {
+                "type": "function",
+                "name": "bash",
+                "description": "run a command",
+                "parameters": {"type": "object"},
+            }
+        ],
+        "reasoning": {"effort": "high"},
+    }
+    assert first.choices[0].finish_reason == "tool_calls"
+    assert first.choices[0].message.tool_calls is not None
+    assert first.choices[0].message.tool_calls[0].function.name == "bash"
+    assert first.token_usage().input_tokens == 11
+    assert first.token_usage().output_tokens == 7
+
+    assistant = first.choices[0].message.model_dump(mode="json", exclude_none=True)
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "user", "content": "inspect"},
+                    assistant,
+                    {"role": "tool", "tool_call_id": "call-1", "content": "/workspace"},
+                ],
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+
+    assert len(responses.calls) == 2
+    assert responses.calls[1]["input"] == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": ""},
+        {
+            "type": "reasoning",
+            "id": "reasoning-1",
+            "summary": [],
+            "encrypted_content": "ciphertext-1",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "bash",
+            "arguments": '{"command":"pwd"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": "/workspace",
+        },
+    ]
+    assert responses.calls[1]["reasoning"] == {"effort": "high"}
+
+
+def test_responses_client_uses_trusted_key_and_normalized_v1_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://Trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _reasoning_config().model_copy(update={"endpoint": "https://trusted.openai.azure.com/"})
+    )
+
+    first = provider._get_responses_client()
+    second = provider._get_responses_client()
+
+    assert first is second
+    assert constructed == [
+        {
+            "api_key": "az-real-secret",
+            "base_url": "https://trusted.openai.azure.com/openai/v1/",
+            "timeout": 240.0,
+            "max_retries": 0,
+        }
+    ]
+
+
+def test_untrusted_responses_endpoint_never_receives_real_azure_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _reasoning_config().model_copy(update={"endpoint": "https://untrusted.example"})
+    )
+
+    provider._get_responses_client()
+
+    assert constructed[0]["api_key"] == "endpoint-token"
+    assert constructed[0]["base_url"] == "https://untrusted.example/openai/v1/"
+
+
+def test_reasoning_verify_probes_the_structured_tool_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses(tool_name="health_check")
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+
+    result = provider.verify()
+
+    assert result.ok is True
+    assert len(responses.calls) == 1
+    assert responses.calls[0]["reasoning"] == {"effort": "high"}
+    assert responses.calls[0]["tool_choice"] == "required"
 
 
 def test_missing_deployment_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -333,3 +552,68 @@ def test_live_verify() -> None:  # pragma: no cover - network
         )
     )
     assert provider.verify().ok is True
+
+
+@pytest.mark.skipif(
+    __import__("os").environ.get("WMH_RUN_LIVE_AZURE_REASONING_TEST") != "1"
+    or not {"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"}.issubset(__import__("os").environ),
+    reason="live Azure reasoning replay requires explicit opt-in and credentials",
+)
+def test_live_reasoning_tool_replay() -> None:  # pragma: no cover - network
+    """Canary the exact structured high-reasoning route used by a project agent."""
+    import os
+
+    provider = AzureOpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-5.5"),
+            reasoning_effort="high",
+        )
+    )
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "health_check",
+            "description": "Return a bounded provider health-check result.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+    first = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Call health_check exactly once."}],
+                "tools": [tool],
+                "tool_choice": "required",
+                "max_completion_tokens": 4096,
+                "store": False,
+            }
+        )
+    )
+    calls = first.choices[0].message.tool_calls if first.choices else None
+    assert calls is not None and len(calls) == 1
+    assert calls[0].function.name == "health_check"
+
+    assistant = first.choices[0].message.model_dump(mode="json", exclude_none=True)
+    second = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "user", "content": "Call health_check exactly once."},
+                    assistant,
+                    {"role": "tool", "tool_call_id": calls[0].id, "content": '{"ok":true}'},
+                    {"role": "user", "content": "Reply with exactly: ok"},
+                ],
+                "max_completion_tokens": 4096,
+                "store": False,
+            }
+        )
+    )
+    assert second.choices
+    assert second.choices[0].finish_reason == "stop"


### PR DESCRIPTION
## Summary

- route configured Azure reasoning requests through the native Responses v1 API
- preserve structured tools, tool results, encrypted reasoning replay, and usage
- keep trusted and config-controlled endpoint credentials isolated
- disable provider retries so each caller dispatch remains observable

## Validation

- uv run pytest wmh/providers/tests/azure_openai_test.py -q
- uv run ruff check wmh/providers/azure_openai.py wmh/providers/tests/azure_openai_test.py
- uv run ruff format --check wmh/providers/azure_openai.py wmh/providers/tests/azure_openai_test.py
- uv run ty check