### PR TITLE
Score complete harnesses through Harbor

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -40,6 +40,7 @@ from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app
 from wmh.cli.harness_optimize import register as register_harness_optimize_commands
+from wmh.cli.harness_score import register as register_harness_score_commands
 from wmh.cli.platform_cmds import register as register_platform_commands
 from wmh.cli.ui import (
     BuildParams,
@@ -142,6 +143,7 @@ app.add_typer(config_app, name="config")
 app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
 register_harness_optimize_commands(harness_app)
+register_harness_score_commands(harness_app)
 app.add_typer(harness_app, name="harness")
 register_platform_commands(app)
 register_agent_session_commands(app)

--- a/wmh/cli/harbor_inputs.py
+++ b/wmh/cli/harbor_inputs.py
@@ -1,0 +1,58 @@
+"""Shared local CLI loading and publication for exact Harbor scorer inputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+import yaml
+from harbor.models.job.config import JobConfig
+from pydantic import JsonValue, ValidationError
+
+from wmh.harness.scoring import ScoreRequest
+
+
+def load_harbor_config(path: Path) -> JobConfig:
+    """Load one Harbor JobConfig from JSON or YAML with an actionable CLI error."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return JobConfig.model_validate(raw)
+    except (OSError, yaml.YAMLError, ValidationError, ValueError, TypeError) as error:
+        raise typer.BadParameter(f"cannot load Harbor config from {path}: {error}") from error
+
+
+def load_task_ids(path: Path) -> tuple[str, ...]:
+    """Load one exact ordered task identity list using canonical score validation."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise typer.BadParameter(f"cannot load task IDs from {path}: {error}") from error
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise typer.BadParameter("task ID file must contain one JSON string list")
+    try:
+        validated = ScoreRequest.model_validate(
+            {
+                "context": {
+                    "task_set_digest": "sha256:" + "0" * 64,
+                    "evaluator_digest": "sha256:" + "0" * 64,
+                    "execution_config_digest": "sha256:" + "0" * 64,
+                },
+                "task_ids": raw,
+                "attempts": 1,
+            }
+        )
+    except ValidationError as error:
+        raise typer.BadParameter(f"invalid task ID file: {error}") from error
+    return validated.task_ids
+
+
+def write_json_atomic(path: Path, value: JsonValue) -> None:
+    """Write deterministic JSON through a same-directory atomic rename."""
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.parent.mkdir(parents=True, exist_ok=True)
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -2,10 +2,11 @@
 
 A harness is the scaffold an agent runs with: prompt surfaces, a tool policy, loop parameters, and
 skills, stored as immutable numbered versions with movable aliases (`champion` is what runs by
-default). `init` writes the baseline as v1; `list`/`show` inspect what exists; `create` searches
-for a better harness by **inverting the world model** — delta variants are scored closed-loop
-against it and gated on non-regression, so the environment model the traces built now steers what
-the agent's scaffold should be. Run one closed-loop with
+default). `init` writes the baseline as v1; `list`/`show` inspect what exists; `score` evaluates
+complete harnesses with an external scorer; `create` searches for a better harness by **inverting
+the world model**. Delta variants are scored closed-loop against it and gated on non-regression,
+so the environment model the traces built now steers what the agent's scaffold should be. Run one
+closed-loop with
 `wmh eval <tasks> --mode closed-loop --harness <name>[@ref]`.
 """
 
@@ -35,7 +36,7 @@ from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import Provider
 
 harness_app = typer.Typer(
-    help="Named, versioned agent harnesses: create, optimize, initialize, list, and inspect.",
+    help="Named agent harnesses: initialize, inspect, create, optimize, and score.",
     no_args_is_help=True,
 )
 _console = Console()

--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -3,25 +3,24 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 from uuid import uuid4
 
 import typer
-import yaml
 from harbor.models.job.config import JobConfig
-from pydantic import ValidationError
 from rich.console import Console
 from rich.prompt import Confirm
 
 from wmh.agents.default import default_agent
 from wmh.agents.optimizer import optimizer_agent
 from wmh.agents.project import DEFAULT_PROJECT_TIMEOUT_S, AgentProject
+from wmh.cli.harbor_inputs import load_harbor_config, load_task_ids, write_json_atomic
 from wmh.cli.model_roles import resolve_required_model_config
 from wmh.config import ARTIFACT_DIR
 from wmh.config.store import validate_name
+from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.doc import HarnessDoc
@@ -33,7 +32,6 @@ from wmh.harness.project_proposer import (
     DEFAULT_MAX_HISTORY_CANDIDATES,
     ProjectCandidateProposer,
 )
-from wmh.harness.scoring import ScoreRequest
 from wmh.harness.source_tree import HarnessSourceTree
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import ProviderConfig, ToolCallingProvider
@@ -145,8 +143,8 @@ def optimize_harness(
     if not reward_key:
         raise typer.BadParameter("--reward-key must be nonempty")
 
-    job_config = _load_harbor_config(Path(harbor_config))
-    task_ids = _load_task_ids(Path(task_ids_file))
+    job_config = load_harbor_config(Path(harbor_config))
+    task_ids = load_task_ids(Path(task_ids_file))
     meta_config = resolve_required_model_config(root, "meta")
     agent_config = resolve_required_model_config(root, "agent")
     seed_source = _resolve_seed_source(root, seed)
@@ -233,30 +231,28 @@ def _execute_optimization(
         )
     )
     request = scorer.request(attempts=attempts)
+    inputs: JsonObject = {
+        "schema_version": 1,
+        "seed_source_tree_hash": seed.tree_hash,
+        "iterations": iterations,
+        "score_request": request.model_dump(mode="json"),
+        "harbor_job_template": effective_job_config.model_dump(mode="json"),
+        "meta_provider": meta_config.model_dump(mode="json"),
+        "agent_provider": agent_config.model_dump(mode="json"),
+        "harness_backend": harness_backend,
+        "e2b_template": e2b_template or None,
+        "environment_command_timeout_sec": environment_command_timeout_sec,
+        "project_timeout_sec": project_timeout_sec,
+        "max_history_candidates": max_history_candidates,
+        "max_history_bytes": max_history_bytes,
+    }
     meta_provider = get_provider(meta_config)
     if not isinstance(meta_provider, ToolCallingProvider):
         raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
     # Only claim the requested output path after all read-only setup validation succeeds. Once
     # execution can incur spend, an incomplete directory remains deliberate failure evidence.
     run_dir.mkdir(parents=True, exist_ok=False)
-    _write_json_atomic(
-        run_dir / "inputs.json",
-        {
-            "schema_version": 1,
-            "seed_source_tree_hash": seed.tree_hash,
-            "iterations": iterations,
-            "score_request": request.model_dump(mode="json"),
-            "harbor_job_template": effective_job_config.model_dump(mode="json"),
-            "meta_provider": meta_config.model_dump(mode="json"),
-            "agent_provider": agent_config.model_dump(mode="json"),
-            "harness_backend": harness_backend,
-            "e2b_template": e2b_template or None,
-            "environment_command_timeout_sec": environment_command_timeout_sec,
-            "project_timeout_sec": project_timeout_sec,
-            "max_history_candidates": max_history_candidates,
-            "max_history_bytes": max_history_bytes,
-        },
-    )
+    write_json_atomic(run_dir / "inputs.json", inputs)
     with AgentProject.create(
         timeout=project_timeout_sec,
         template=e2b_template,
@@ -279,19 +275,17 @@ def _execute_optimization(
     archive_manifest = write_population_archive(run_dir / "population", result)
     selected = result.best.candidate.model_copy(update={"name": name, "version": 0})
     saved = HarnessStore(root).save_version(selected, alias=CHAMPION_ALIAS)
-    _write_json_atomic(
-        run_dir / "outcome.json",
-        {
-            "schema_version": 1,
-            "best_candidate_id": result.best.candidate_id,
-            "best_score": result.best_score,
-            "best_document_hash": result.best.candidate.doc_hash,
-            "saved_harness": saved.name,
-            "saved_version": saved.version,
-            "archive_manifest": archive_manifest.relative_to(run_dir).as_posix(),
-            "project_sandbox_usage": project_usage.model_dump(mode="json"),
-        },
-    )
+    outcome: JsonObject = {
+        "schema_version": 1,
+        "best_candidate_id": result.best.candidate_id,
+        "best_score": result.best_score,
+        "best_document_hash": result.best.candidate.doc_hash,
+        "saved_harness": saved.name,
+        "saved_version": saved.version,
+        "archive_manifest": archive_manifest.relative_to(run_dir).as_posix(),
+        "project_sandbox_usage": project_usage.model_dump(mode="json"),
+    }
+    write_json_atomic(run_dir / "outcome.json", outcome)
     return HarnessOptimizeOutcome(
         result=result,
         saved=saved,
@@ -299,39 +293,6 @@ def _execute_optimization(
         archive_manifest=archive_manifest,
         project_usage=project_usage,
     )
-
-
-def _load_harbor_config(path: Path) -> JobConfig:
-    try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        return JobConfig.model_validate(raw)
-    except (OSError, yaml.YAMLError, ValidationError, ValueError, TypeError) as error:
-        raise typer.BadParameter(f"cannot load Harbor config from {path}: {error}") from error
-
-
-def _load_task_ids(path: Path) -> tuple[str, ...]:
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise typer.BadParameter(f"cannot load task IDs from {path}: {error}") from error
-    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
-        raise typer.BadParameter("task ID file must contain one JSON string list")
-    try:
-        # Reuse the canonical task identity validation without inventing a parallel CLI policy.
-        validated = ScoreRequest.model_validate(
-            {
-                "context": {
-                    "task_set_digest": "sha256:" + "0" * 64,
-                    "evaluator_digest": "sha256:" + "0" * 64,
-                    "execution_config_digest": "sha256:" + "0" * 64,
-                },
-                "task_ids": raw,
-                "attempts": 1,
-            }
-        )
-    except ValidationError as error:
-        raise typer.BadParameter(f"invalid task ID file: {error}") from error
-    return validated.task_ids
 
 
 def _resolve_seed_source(root: str, seed: str | None) -> HarnessSourceTree:
@@ -342,13 +303,3 @@ def _resolve_seed_source(root: str, seed: str | None) -> HarnessSourceTree:
         return HarnessSourceTree.from_doc(HarnessStore(root).load(name, ref or None))
     except (FileNotFoundError, ValueError) as error:
         raise typer.BadParameter(str(error)) from error
-
-
-def _write_json_atomic(path: Path, value: object) -> None:
-    temporary = path.with_name(f"{path.name}.tmp")
-    temporary.parent.mkdir(parents=True, exist_ok=True)
-    temporary.write_text(
-        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    temporary.replace(path)

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -506,7 +506,7 @@ def test_cli_rejects_nonexact_task_id_manifests(tmp_path: Path, payload: str) ->
     path.write_text(payload, encoding="utf-8")
 
     with pytest.raises(typer.BadParameter):
-        module._load_task_ids(path)
+        module.load_task_ids(path)
 
 
 def test_cli_help_preserves_model_roles_seed_syntax_and_local_output_wording() -> None:

--- a/wmh/cli/harness_score.py
+++ b/wmh/cli/harness_score.py
@@ -1,0 +1,261 @@
+"""Local CLI composition for evaluator-driven multi-harness scoring."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+from uuid import uuid4
+
+import typer
+from harbor.models.job.config import JobConfig
+from rich.console import Console
+from rich.prompt import Confirm
+
+from wmh.agents.default import default_agent
+from wmh.cli.harbor_inputs import load_harbor_config, load_task_ids, write_json_atomic
+from wmh.cli.model_roles import resolve_required_model_config
+from wmh.config import ARTIFACT_DIR
+from wmh.core.types import JsonObject
+from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
+from wmh.evals.harbor.scorer import HarborScorer
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
+from wmh.harness.score_archive import write_score_archive
+from wmh.harness.score_batch import (
+    HarnessScoreBatch,
+    HarnessScoreTarget,
+    score_harnesses,
+    validate_score_targets,
+)
+from wmh.harness.store import HarnessStore
+from wmh.providers.base import ProviderConfig
+
+_console = Console()
+_HARNESSES_OPTION = typer.Option(
+    None,
+    "--harness",
+    help="Stored harness name@ref to score; repeat for several, in order.",
+)
+
+
+@dataclass(frozen=True)
+class HarnessScoreOutcome:
+    """Completed local multi-harness score artifacts."""
+
+    result: HarnessScoreBatch
+    run_dir: Path
+    archive_manifest: Path
+
+
+def register(app: typer.Typer) -> None:
+    """Register evaluator-driven scoring under ``wmh harness``."""
+    app.command("score")(score_harness_command)
+
+
+def score_harness_command(
+    include_default: bool = typer.Option(
+        False,
+        "--include-default",
+        help="Score WMH's built-in default harness first.",
+    ),
+    harnesses: list[str] | None = _HARNESSES_OPTION,
+    harbor_config: str = typer.Option(
+        ...,
+        "--harbor-config",
+        help="Harbor JobConfig template as JSON or YAML.",
+    ),
+    task_ids_file: str = typer.Option(
+        ...,
+        "--task-ids",
+        help="JSON file containing the exact ordered task-ID string list.",
+    ),
+    reward_key: str = typer.Option(
+        ...,
+        "--reward-key",
+        help="Official Harbor verifier reward field to score.",
+    ),
+    attempts: int = typer.Option(..., min=1, help="Attempts per exact task and harness."),
+    harness_backend: str = typer.Option(
+        "local",
+        "--harness-backend",
+        help="Where each evaluated harness process runs: local or e2b. The CLI remains local.",
+    ),
+    e2b_template: str | None = typer.Option(
+        None,
+        "--e2b-template",
+        envvar=E2B_TEMPLATE_ENV,
+        help="Optional template for evaluated harness processes using E2B.",
+    ),
+    environment_command_timeout_sec: int = typer.Option(
+        MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        "--environment-command-timeout",
+        min=1,
+        max=MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        help="Maximum seconds for one command in the Harbor-owned task environment.",
+    ),
+    result_out: str | None = typer.Option(
+        None,
+        "--result-out",
+        help="Local run directory (default: <root>/runs/<opaque-id>).",
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project artifact root and harness store."),
+    yes: bool = typer.Option(False, "--yes", help="Acknowledge the displayed execution matrix."),
+) -> None:
+    """Score complete harnesses against one exact ground-truth scorer request.
+
+    The command host is always the local WMH process. Evaluated harness processes use
+    ``--harness-backend``; Harbor's JobConfig independently owns task environment backend and
+    concurrency. ``models.agent`` must be configured in the selected project's
+    ``settings.toml``. Stored aliases are resolved to immutable versions before any scoring.
+    The command reports every declared harness and does not select or publish one.
+    """
+    if harness_backend not in ("local", "e2b"):
+        raise typer.BadParameter(
+            f"unknown --harness-backend {harness_backend!r}; choose local or e2b"
+        )
+    if not reward_key:
+        raise typer.BadParameter("--reward-key must be nonempty")
+
+    targets = _resolve_targets(
+        root,
+        include_default=include_default,
+        harnesses=tuple(harnesses or ()),
+    )
+    validate_score_targets(targets)
+    job_config = load_harbor_config(Path(harbor_config))
+    task_ids = load_task_ids(Path(task_ids_file))
+    agent_config = resolve_required_model_config(root, "agent")
+    effective_e2b_template = resolve_e2b_template(e2b_template)
+    run_dir = Path(result_out) if result_out is not None else Path(root) / "runs" / uuid4().hex
+    if run_dir.exists():
+        raise typer.BadParameter(f"result directory already exists: {run_dir}")
+
+    score_cells = len(targets) * len(task_ids) * attempts
+    _console.print(
+        f"scoring {len(targets)} harness(es), {len(task_ids)} task(s), "
+        f"{attempts} attempt(s) -> {score_cells} requested score cells; "
+        f"evaluated harness backend={harness_backend}"
+    )
+    if not yes:
+        if not _console.is_terminal:
+            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+        if not Confirm.ask("Proceed?", default=False):
+            raise typer.Exit(0)
+
+    outcome = _execute_scoring(
+        run_dir=run_dir,
+        job_config=job_config,
+        task_ids=task_ids,
+        reward_key=reward_key,
+        attempts=attempts,
+        targets=targets,
+        agent_config=agent_config,
+        harness_backend=cast("Literal['local', 'e2b']", harness_backend),
+        e2b_template=(effective_e2b_template or "") if harness_backend == "e2b" else None,
+        environment_command_timeout_sec=environment_command_timeout_sec,
+    )
+    for entry in outcome.result.entries:
+        _console.print(
+            f"  [bold]{entry.target.label}[/bold]: "
+            f"score={entry.score.report.score:.6f}, "
+            f"pass_rate={entry.score.report.pass_rate:.6f}"
+        )
+    _console.print(f"[green]scored[/green] evidence -> {outcome.run_dir}")
+
+
+def _execute_scoring(
+    *,
+    run_dir: Path,
+    job_config: JobConfig,
+    task_ids: tuple[str, ...],
+    reward_key: str,
+    attempts: int,
+    targets: tuple[HarnessScoreTarget, ...],
+    agent_config: ProviderConfig,
+    harness_backend: Literal["local", "e2b"],
+    e2b_template: str | None,
+    environment_command_timeout_sec: int,
+) -> HarnessScoreOutcome:
+    """Resolve one immutable scorer request, score every target, and archive evidence."""
+    validate_score_targets(targets)
+    effective_job_config = JobConfig.model_validate(
+        job_config.model_copy(
+            update={"jobs_dir": run_dir / "harbor"},
+            deep=True,
+        ).model_dump(mode="python")
+    )
+    scorer = asyncio.run(
+        HarborScorer.create(
+            job_config=effective_job_config,
+            task_ids=task_ids,
+            provider_config=agent_config,
+            reward_key=reward_key,
+            environment_command_timeout_sec=environment_command_timeout_sec,
+            harness_backend=harness_backend,
+            e2b_template=e2b_template if harness_backend == "e2b" else None,
+        )
+    )
+    request = scorer.request(attempts=attempts)
+    run_dir.mkdir(parents=True, exist_ok=False)
+    inputs: JsonObject = {
+        "schema_version": 1,
+        "score_request": request.model_dump(mode="json"),
+        "harbor_job_template": effective_job_config.model_dump(mode="json"),
+        "agent_provider": agent_config.model_dump(mode="json"),
+        "harness_backend": harness_backend,
+        "e2b_template": e2b_template or None,
+        "environment_command_timeout_sec": environment_command_timeout_sec,
+        "targets": [
+            {
+                "label": target.label,
+                "name": target.harness.name,
+                "version": target.harness.version,
+                "document_hash": target.harness.doc_hash,
+                "source_tree_hash": target.source.tree_hash,
+            }
+            for target in targets
+        ],
+    }
+    write_json_atomic(run_dir / "inputs.json", inputs)
+    result = score_harnesses(scorer, targets, request=request)
+    archive_manifest = write_score_archive(run_dir / "scores", result)
+    return HarnessScoreOutcome(
+        result=result,
+        run_dir=run_dir,
+        archive_manifest=archive_manifest,
+    )
+
+
+def _resolve_targets(
+    root: str,
+    *,
+    include_default: bool,
+    harnesses: tuple[str, ...],
+) -> tuple[HarnessScoreTarget, ...]:
+    if not include_default and not harnesses:
+        raise typer.BadParameter("pass --include-default or at least one --harness")
+    targets: list[HarnessScoreTarget] = []
+    if include_default:
+        harness = default_agent()
+        targets.append(
+            HarnessScoreTarget(
+                label="default",
+                harness=harness,
+            )
+        )
+    store = HarnessStore(root)
+    for reference in harnesses:
+        name, _, ref = reference.partition("@")
+        try:
+            version = store.resolve_version(name, ref or None)
+            harness = store.load(name, f"v{version}")
+        except (FileNotFoundError, ValueError) as error:
+            raise typer.BadParameter(str(error)) from error
+        targets.append(
+            HarnessScoreTarget(
+                label=f"{name}@v{version}",
+                harness=harness,
+            )
+        )
+    return tuple(targets)

--- a/wmh/cli/harness_score_test.py
+++ b/wmh/cli/harness_score_test.py
@@ -1,0 +1,375 @@
+"""CLI composition tests for proposer-free multi-harness scoring."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+from harbor.models.environment_type import EnvironmentType
+from harbor.models.job.config import DatasetConfig, JobConfig, RetryConfig
+from harbor.models.trial.config import AgentConfig, EnvironmentConfig
+from typer.testing import CliRunner
+
+from wmh.cli import app
+from wmh.cli.harness_score import HarnessScoreOutcome, _execute_scoring
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.harness.score_batch import HarnessScoreBatch, HarnessScoreTarget, ScoredHarness
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+module = importlib.import_module("wmh.cli.harness_score")
+runner = CliRunner()
+_DIGEST = "sha256:" + "a" * 64
+
+
+class _Reader:
+    def read_bytes(self, path: str) -> bytes:
+        assert path == "raw/result.json"
+        return b"{}"
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST,
+            evaluator_digest=_DIGEST,
+            execution_config_digest=_DIGEST,
+        ),
+        task_ids=("task-a",),
+        attempts=1,
+    )
+
+
+def _score(target: HarnessScoreTarget, request: ScoreRequest) -> HarnessScore:
+    artifact = EvaluationArtifact.from_bytes(path="raw/result.json", content=b"{}")
+    return HarnessScore(
+        report=HarnessScoreReport(
+            source_run_id=f"run-{target.label}",
+            candidate_doc_hash=target.harness.doc_hash,
+            request=request,
+            cells=(
+                ScoreCell(
+                    task_id="task-a",
+                    attempt=1,
+                    score=1.0,
+                    passed=True,
+                    artifact_paths=("raw/result.json",),
+                ),
+            ),
+            artifacts=(artifact,),
+        ),
+        artifacts=_Reader(),
+    )
+
+
+def _batch(targets: tuple[HarnessScoreTarget, ...]) -> HarnessScoreBatch:
+    request = _request()
+    return HarnessScoreBatch(
+        request=request,
+        entries=tuple(
+            ScoredHarness(target=target, score=_score(target, request)) for target in targets
+        ),
+    )
+
+
+def _job_config(tmp_path: Path) -> JobConfig:
+    return JobConfig(
+        job_name="template",
+        jobs_dir=tmp_path / "unused",
+        n_attempts=1,
+        n_concurrent_trials=2,
+        retry=RetryConfig(max_retries=0),
+        environment=EnvironmentConfig(type=EnvironmentType.DOCKER),
+        agents=[AgentConfig(n_concurrent=1)],
+        datasets=[DatasetConfig(path=tmp_path / "tasks")],
+    )
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    config_path = tmp_path / "harbor.yaml"
+    config_path.write_text(_job_config(tmp_path).model_dump_json(), encoding="utf-8")
+    task_ids_path = tmp_path / "task-ids.json"
+    task_ids_path.write_text('["task-a"]\n', encoding="utf-8")
+    return config_path, task_ids_path
+
+
+def _agent_settings(root: Path) -> None:
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                agent=ModelRole(provider="anthropic", model="agent-model"),
+            )
+        ),
+        root,
+    )
+
+
+def test_execute_resolves_one_scorer_request_and_neutral_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request = _request()
+    scorer_calls: list[dict[str, object]] = []
+
+    class FakeScorer:
+        @classmethod
+        async def create(cls, **kwargs: object) -> FakeScorer:
+            scorer_calls.append(kwargs)
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return request
+
+    target = HarnessScoreTarget(
+        label="candidate@v1",
+        harness=_source("p").to_doc("candidate"),
+    )
+    scored_calls: list[tuple[object, tuple[HarnessScoreTarget, ...], ScoreRequest]] = []
+
+    def fake_score_harnesses(
+        scorer: object,
+        targets: tuple[HarnessScoreTarget, ...],
+        *,
+        request: ScoreRequest,
+    ) -> HarnessScoreBatch:
+        scored_calls.append((scorer, targets, request))
+        return _batch(targets)
+
+    archived: list[tuple[Path, HarnessScoreBatch]] = []
+
+    def fake_archive(path: Path, batch: HarnessScoreBatch) -> Path:
+        archived.append((path, batch))
+        path.mkdir(parents=True)
+        manifest = path / "manifest.json"
+        manifest.write_text("{}\n", encoding="utf-8")
+        return manifest
+
+    monkeypatch.setattr(module, "HarborScorer", FakeScorer)
+    monkeypatch.setattr(module, "score_harnesses", fake_score_harnesses)
+    monkeypatch.setattr(module, "write_score_archive", fake_archive)
+    run_dir = tmp_path / "run"
+    agent_config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model="agent-model")
+
+    outcome = _execute_scoring(
+        run_dir=run_dir,
+        job_config=_job_config(tmp_path),
+        task_ids=("task-a",),
+        reward_key="reward",
+        attempts=1,
+        targets=(target,),
+        agent_config=agent_config,
+        harness_backend="e2b",
+        e2b_template="template-x",
+        environment_command_timeout_sec=240,
+    )
+
+    [scorer_call] = scorer_calls
+    assert cast(JobConfig, scorer_call["job_config"]).jobs_dir == run_dir / "harbor"
+    assert scorer_call["provider_config"] == agent_config
+    assert scorer_call["harness_backend"] == "e2b"
+    assert scorer_call["e2b_template"] == "template-x"
+    [scored_call] = scored_calls
+    assert scored_call[1] == (target,)
+    assert scored_call[2] is request
+    assert archived == [(run_dir / "scores", outcome.result)]
+    assert outcome.archive_manifest == run_dir / "scores/manifest.json"
+    inputs = json.loads((run_dir / "inputs.json").read_text(encoding="utf-8"))
+    assert inputs["score_request"] == request.model_dump(mode="json")
+    assert inputs["targets"] == [
+        {
+            "document_hash": target.harness.doc_hash,
+            "label": "candidate@v1",
+            "name": "candidate",
+            "source_tree_hash": target.source.tree_hash,
+            "version": 0,
+        }
+    ]
+    assert "meta_provider" not in inputs
+
+
+def test_execute_does_not_claim_result_directory_when_scorer_setup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class BrokenScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> BrokenScorer:
+            raise RuntimeError("task resolution failed")
+
+    monkeypatch.setattr(module, "HarborScorer", BrokenScorer)
+    run_dir = tmp_path / "run"
+    target = HarnessScoreTarget(
+        label="candidate@v1",
+        harness=_source("p").to_doc("candidate"),
+    )
+
+    with pytest.raises(RuntimeError, match="task resolution failed"):
+        _execute_scoring(
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            attempts=1,
+            targets=(target,),
+            agent_config=ProviderConfig(
+                kind=ProviderKind.ANTHROPIC,
+                model="agent-model",
+            ),
+            harness_backend="local",
+            e2b_template=None,
+            environment_command_timeout_sec=240,
+        )
+
+    assert not run_dir.exists()
+
+
+def test_cli_resolves_default_then_immutable_stored_version_with_agent_role(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    _agent_settings(root)
+    store = HarnessStore(root)
+    store.save_version(_source("v1").to_doc("stored"))
+    selected = store.save_version(
+        _source("v2").to_doc("stored"),
+        alias=CHAMPION_ALIAS,
+    )
+    config_path, task_ids_path = _write_inputs(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    def fake_execute(**kwargs: object) -> HarnessScoreOutcome:
+        calls.append(kwargs)
+        targets = cast(tuple[HarnessScoreTarget, ...], kwargs["targets"])
+        run_dir = cast(Path, kwargs["run_dir"])
+        return HarnessScoreOutcome(
+            result=_batch(targets),
+            run_dir=run_dir,
+            archive_manifest=run_dir / "scores/manifest.json",
+        )
+
+    monkeypatch.setattr(module, "_execute_scoring", fake_execute)
+    monkeypatch.setenv("WMH_E2B_TEMPLATE", "template-from-env")
+    result_out = tmp_path / "run"
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "score",
+            "--include-default",
+            "--harness",
+            "stored@champion",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--attempts",
+            "1",
+            "--result-out",
+            str(result_out),
+            "--root",
+            str(root),
+            "--yes",
+        ],
+    )
+
+    assert invoked.exit_code == 0, invoked.output
+    [call] = calls
+    targets = cast(tuple[HarnessScoreTarget, ...], call["targets"])
+    assert [target.label for target in targets] == ["default", "stored@v2"]
+    assert targets[1].harness.version == 2
+    assert targets[1].harness.doc_hash == selected.doc_hash
+    assert call["harness_backend"] == "local"
+    assert call["e2b_template"] is None
+    agent_config = cast(ProviderConfig, call["agent_config"])
+    assert agent_config.kind is ProviderKind.ANTHROPIC
+    assert "models.meta" not in invoked.output
+
+
+def test_cli_requires_a_target_before_model_or_scorer_resolution(tmp_path: Path) -> None:
+    config_path, task_ids_path = _write_inputs(tmp_path)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "score",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--attempts",
+            "1",
+            "--root",
+            str(tmp_path / ".wmh"),
+            "--yes",
+        ],
+    )
+
+    assert invoked.exit_code == 2
+    assert "--include-default or at least one --harness" in invoked.output
+
+
+def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Path) -> None:
+    root = tmp_path / ".wmh"
+    _agent_settings(root)
+    config_path, task_ids_path = _write_inputs(tmp_path)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "score",
+            "--include-default",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--attempts",
+            "1",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert invoked.exit_code == 2
+    assert "pass --yes" in invoked.output
+
+
+def test_cli_help_is_proposer_free_and_requires_only_agent_role() -> None:
+    invoked = runner.invoke(app, ["harness", "score", "--help"])
+
+    assert invoked.exit_code == 0, invoked.output
+    assert "models.agent" in invoked.output
+    assert "models.meta" not in invoked.output
+    assert "proposer" not in invoked.output.lower()
+    assert "world model" not in invoked.output.lower()

--- a/wmh/harness/archive_io.py
+++ b/wmh/harness/archive_io.py
@@ -1,0 +1,55 @@
+"""Shared integrity-preserving I/O for local harness evidence archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from wmh.harness.scoring import HarnessScore
+from wmh.harness.source_tree import HarnessSourceTree
+
+
+def write_source_tree(destination: Path, source: HarnessSourceTree) -> None:
+    """Materialize one portable source tree, including an empty root."""
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in source.files:
+        target = destination / item.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(item.content, encoding="utf-8")
+
+
+def copy_score_artifacts(destination: Path, score: HarnessScore) -> None:
+    """Copy every score artifact after verifying its declared size and digest."""
+    destination.mkdir(parents=True, exist_ok=True)
+    for artifact in score.report.artifacts:
+        content = score.artifacts.read_bytes(artifact.path)
+        if len(content) != artifact.size_bytes:
+            raise ValueError(f"artifact {artifact.path!r} size differs from its score manifest")
+        digest = "sha256:" + hashlib.sha256(content).hexdigest()
+        if digest != artifact.content_hash:
+            raise ValueError(f"artifact {artifact.path!r} content differs from its score manifest")
+        target = destination / artifact.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def write_text(path: Path, content: str) -> None:
+    """Write UTF-8 text after creating its parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def relative_path(root: Path, path: Path) -> str:
+    """Return one canonical archive-relative POSIX path."""
+    return path.relative_to(root).as_posix()
+
+
+def publish_json_manifest(path: Path, value: JsonValue) -> Path:
+    """Publish deterministic JSON atomically as an archive completion marker."""
+    temporary = path.with_name(f"{path.name}.tmp")
+    write_text(temporary, json.dumps(value, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+    return path

--- a/wmh/harness/population_archive.py
+++ b/wmh/harness/population_archive.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from pathlib import Path
 
+from wmh.core.types import JsonObject
+from wmh.harness.archive_io import (
+    copy_score_artifacts,
+    publish_json_manifest,
+    relative_path,
+    write_source_tree,
+    write_text,
+)
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import PopulationOptimizationResult
 from wmh.harness.runtime import TokenUsage
-from wmh.harness.source_tree import HarnessSourceTree
 
 _SCHEMA_VERSION = 1
 
@@ -37,7 +43,7 @@ def write_population_archive(
         raise ValueError("population archive candidates use different score requests")
 
     root.mkdir(parents=True)
-    population_entries: list[dict[str, object]] = []
+    population_entries: list[JsonObject] = []
     population_ids: set[str] = set()
     for index, evaluated in enumerate(result.population):
         if evaluated.candidate_id in population_ids:
@@ -45,41 +51,30 @@ def write_population_archive(
         population_ids.add(evaluated.candidate_id)
         candidate_dir = root / "population" / f"{index:04d}"
         source_dir = candidate_dir / "source"
-        _write_source_tree(source_dir, evaluated.source)
+        write_source_tree(source_dir, evaluated.source)
         report_path = candidate_dir / "score.json"
-        _write_text(report_path, evaluated.score.report.model_dump_json(indent=2))
+        write_text(report_path, evaluated.score.report.model_dump_json(indent=2))
         artifacts_dir = candidate_dir / "artifacts"
-        for artifact in evaluated.score.report.artifacts:
-            content = evaluated.score.artifacts.read_bytes(artifact.path)
-            if len(content) != artifact.size_bytes:
-                raise ValueError(f"artifact {artifact.path!r} size differs from its score manifest")
-            digest = "sha256:" + hashlib.sha256(content).hexdigest()
-            if digest != artifact.content_hash:
-                raise ValueError(
-                    f"artifact {artifact.path!r} content differs from its score manifest"
-                )
-            target = artifacts_dir / artifact.path
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_bytes(content)
+        copy_score_artifacts(artifacts_dir, evaluated.score)
         population_entries.append(
             {
                 "index": index,
                 "candidate_id": evaluated.candidate_id,
                 "document_hash": evaluated.candidate.doc_hash,
                 "source_tree_hash": evaluated.source.tree_hash,
-                "source_path": _relative(root, source_dir),
-                "score_path": _relative(root, report_path),
-                "artifacts_path": _relative(root, artifacts_dir),
+                "source_path": relative_path(root, source_dir),
+                "score_path": relative_path(root, report_path),
+                "artifacts_path": relative_path(root, artifacts_dir),
             }
         )
 
-    iteration_entries: list[dict[str, object]] = []
+    iteration_entries: list[JsonObject] = []
     for expected_index, iteration in enumerate(result.iterations, 1):
         if iteration.index != expected_index:
             raise ValueError("population archive iterations must be contiguous and one-indexed")
         iteration_dir = root / "iterations" / f"{iteration.index:04d}"
         events_path = iteration_dir / "events.json"
-        entry: dict[str, object] = {}
+        entry: JsonObject = {}
         if iteration.error is not None:
             events = iteration.error.events
             usage = iteration.error.worker_usage
@@ -90,14 +85,14 @@ def write_population_archive(
                     "outcome": "invalid",
                     "error": str(iteration.error),
                     "worker_usage": _usage(usage),
-                    "events_path": _relative(root, events_path),
+                    "events_path": relative_path(root, events_path),
                 }
             )
             if iteration.error.source is not None:
                 source_dir = iteration_dir / "source"
-                _write_source_tree(source_dir, iteration.error.source)
+                write_source_tree(source_dir, iteration.error.source)
                 entry["source_tree_hash"] = iteration.error.source.tree_hash
-                entry["source_path"] = _relative(root, source_dir)
+                entry["source_path"] = relative_path(root, source_dir)
         else:
             assert iteration.proposal is not None
             assert iteration.evaluation is not None
@@ -110,14 +105,14 @@ def write_population_archive(
                     "document_hash": iteration.proposal.candidate.doc_hash,
                     "source_tree_hash": iteration.proposal.source.tree_hash,
                     "worker_usage": _usage(iteration.proposal.worker_usage),
-                    "events_path": _relative(root, events_path),
+                    "events_path": relative_path(root, events_path),
                 }
             )
         _write_events(events_path, events)
         iteration_entries.append(entry)
 
     manifest_path = root / "manifest.json"
-    manifest = {
+    manifest: JsonObject = {
         "schema_version": _SCHEMA_VERSION,
         "score_request": request.model_dump(mode="json"),
         "best_candidate_id": result.best.candidate_id,
@@ -125,33 +120,19 @@ def write_population_archive(
         "population": population_entries,
         "iterations": iteration_entries,
     }
-    manifest_temp = manifest_path.with_name(f"{manifest_path.name}.tmp")
-    _write_text(manifest_temp, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
-    manifest_temp.replace(manifest_path)
-    return manifest_path
-
-
-def _write_source_tree(destination: Path, source: HarnessSourceTree) -> None:
-    destination.mkdir(parents=True, exist_ok=True)
-    for item in source.files:
-        target = destination / item.path
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(item.content, encoding="utf-8")
+    return publish_json_manifest(manifest_path, manifest)
 
 
 def _write_events(path: Path, events: tuple[SessionEvent, ...]) -> None:
     payload = [{"kind": event.kind, "payload": event.payload} for event in events]
-    _write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
-def _usage(usage: TokenUsage | None) -> dict[str, int] | None:
-    return usage.model_dump(mode="json") if usage is not None else None
-
-
-def _write_text(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
-
-
-def _relative(root: Path, path: Path) -> str:
-    return path.relative_to(root).as_posix()
+def _usage(usage: TokenUsage | None) -> JsonObject | None:
+    if usage is None:
+        return None
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "calls": usage.calls,
+    }

--- a/wmh/harness/score_archive.py
+++ b/wmh/harness/score_archive.py
@@ -1,0 +1,69 @@
+"""Durable, neutral evidence for one completed multi-harness score batch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wmh.core.types import JsonObject
+from wmh.harness.archive_io import (
+    copy_score_artifacts,
+    publish_json_manifest,
+    relative_path,
+    write_source_tree,
+    write_text,
+)
+from wmh.harness.score_batch import HarnessScoreBatch
+
+_SCHEMA_VERSION = 1
+
+
+def write_score_archive(
+    destination: str | Path,
+    batch: HarnessScoreBatch,
+) -> Path:
+    """Write sources, reports, and verified artifacts without selecting a winner.
+
+    The destination must not exist. ``manifest.json`` is written last and is the completion
+    marker. An interrupted copy remains inspectable but cannot be mistaken for a complete batch.
+    """
+    root = Path(destination)
+    if root.exists():
+        raise FileExistsError(f"score archive destination already exists: {root}")
+    root.mkdir(parents=True)
+
+    entries: list[JsonObject] = []
+    for index, evaluated in enumerate(batch.entries):
+        entry_dir = root / "entries" / f"{index:04d}"
+        source_dir = entry_dir / "source"
+        write_source_tree(source_dir, evaluated.target.source)
+        document_path = entry_dir / "document.json"
+        write_text(document_path, evaluated.target.harness.model_dump_json(indent=2))
+        report_path = entry_dir / "score.json"
+        write_text(report_path, evaluated.score.report.model_dump_json(indent=2))
+        artifacts_dir = entry_dir / "artifacts"
+        copy_score_artifacts(artifacts_dir, evaluated.score)
+        entries.append(
+            {
+                "index": index,
+                "label": evaluated.target.label,
+                "name": evaluated.target.harness.name,
+                "version": evaluated.target.harness.version,
+                "document_hash": evaluated.target.harness.doc_hash,
+                "source_tree_hash": evaluated.target.source.tree_hash,
+                "source_path": relative_path(root, source_dir),
+                "document_path": relative_path(root, document_path),
+                "score_path": relative_path(root, report_path),
+                "artifacts_path": relative_path(root, artifacts_dir),
+                "score": evaluated.score.report.score,
+                "pass_rate": evaluated.score.report.pass_rate,
+                "report_hash": evaluated.score.report.report_hash,
+            }
+        )
+
+    manifest_path = root / "manifest.json"
+    manifest: JsonObject = {
+        "schema_version": _SCHEMA_VERSION,
+        "score_request": batch.request.model_dump(mode="json"),
+        "entries": entries,
+    }
+    return publish_json_manifest(manifest_path, manifest)

--- a/wmh/harness/score_archive_test.py
+++ b/wmh/harness/score_archive_test.py
@@ -1,0 +1,176 @@
+"""Tests for neutral, self-contained multi-harness score archives."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.score_archive import write_score_archive
+from wmh.harness.score_batch import HarnessScoreBatch, HarnessScoreTarget, ScoredHarness
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_DIGEST = "sha256:" + "a" * 64
+_ARTIFACT_PATH = "raw/evidence.bin"
+
+
+@dataclass(frozen=True)
+class _Reader:
+    content: bytes
+
+    def read_bytes(self, path: str) -> bytes:
+        assert path == _ARTIFACT_PATH
+        return self.content
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST,
+            evaluator_digest=_DIGEST,
+            execution_config_digest=_DIGEST,
+        ),
+        task_ids=("task-a",),
+        attempts=1,
+    )
+
+
+def _entry(label: str, prompt: str, value: float, request: ScoreRequest) -> ScoredHarness:
+    source = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["bash", "submit"]\n',
+            ),
+        )
+    )
+    harness = source.to_doc(label.replace("@", "-"))
+    content = f"evidence:{label}".encode()
+    artifact = EvaluationArtifact.from_bytes(path=_ARTIFACT_PATH, content=content)
+    report = HarnessScoreReport(
+        source_run_id=f"run-{label}",
+        candidate_doc_hash=harness.doc_hash,
+        request=request,
+        cells=(
+            ScoreCell(
+                task_id="task-a",
+                attempt=1,
+                score=value,
+                passed=value == 1.0,
+                artifact_paths=(_ARTIFACT_PATH,),
+            ),
+        ),
+        artifacts=(artifact,),
+    )
+    return ScoredHarness(
+        target=HarnessScoreTarget(label=label, harness=harness),
+        score=HarnessScore(report=report, artifacts=_Reader(content)),
+    )
+
+
+def _batch() -> HarnessScoreBatch:
+    request = _request()
+    return HarnessScoreBatch(
+        request=request,
+        entries=(
+            _entry("default", "base", 0.0, request),
+            _entry("candidate@v2", "changed", 1.0, request),
+        ),
+    )
+
+
+def test_archive_copies_ordered_sources_reports_and_verified_artifacts(tmp_path: Path) -> None:
+    destination = tmp_path / "scores"
+
+    manifest_path = write_score_archive(destination, _batch())
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert "best" not in manifest
+    assert "winner" not in manifest
+    assert [entry["label"] for entry in manifest["entries"]] == [
+        "default",
+        "candidate@v2",
+    ]
+    assert [entry["score"] for entry in manifest["entries"]] == [0.0, 1.0]
+    assert (destination / "entries/0001/source/SYSTEM.md").read_text() == "changed"
+    document = json.loads((destination / "entries/0001/document.json").read_text(encoding="utf-8"))
+    report = json.loads((destination / "entries/0001/score.json").read_text(encoding="utf-8"))
+    assert document["name"] == "candidate-v2"
+    authoritative = HarnessDoc.model_validate(document)
+    assert authoritative.doc_hash == report["candidate_doc_hash"]
+    assert manifest["entries"][1]["document_path"] == "entries/0001/document.json"
+    exported = HarnessSourceTree(
+        files=tuple(
+            HarnessSourceFile(
+                path=path.relative_to(destination / "entries/0001/source").as_posix(),
+                content=path.read_text(encoding="utf-8"),
+            )
+            for path in sorted((destination / "entries/0001/source").rglob("*"))
+            if path.is_file()
+        )
+    )
+    assert exported.to_doc(authoritative.name).doc_hash != authoritative.doc_hash
+    assert (destination / "entries/0001/artifacts/raw/evidence.bin").read_bytes() == (
+        b"evidence:candidate@v2"
+    )
+    assert report["request"] == manifest["score_request"]
+
+
+def test_archive_never_overwrites_an_existing_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "scores"
+    destination.mkdir()
+    sentinel = destination / "keep.txt"
+    sentinel.write_text("owned", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        write_score_archive(destination, _batch())
+
+    assert sentinel.read_text(encoding="utf-8") == "owned"
+
+
+def test_archive_manifest_is_absent_when_atomic_publication_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "scores"
+
+    def fail_replace(self: Path, target: Path) -> Path:
+        del self, target
+        raise OSError("publication interrupted")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="publication interrupted"):
+        write_score_archive(destination, _batch())
+
+    assert not (destination / "manifest.json").exists()
+    assert (destination / "manifest.json.tmp").exists()
+
+
+def test_archive_rejects_artifact_bytes_that_differ_from_manifest(tmp_path: Path) -> None:
+    batch = _batch()
+    first = batch.entries[0]
+    broken = ScoredHarness(
+        target=first.target,
+        score=HarnessScore(report=first.score.report, artifacts=_Reader(b"different")),
+    )
+    broken_batch = HarnessScoreBatch(
+        request=batch.request,
+        entries=(broken, *batch.entries[1:]),
+    )
+
+    with pytest.raises(ValueError, match="differs from its score manifest"):
+        write_score_archive(tmp_path / "scores", broken_batch)
+
+    assert not (tmp_path / "scores/manifest.json").exists()

--- a/wmh/harness/score_batch.py
+++ b/wmh/harness/score_batch.py
@@ -1,0 +1,94 @@
+"""Ordered scoring of complete harnesses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from wmh.core.text import validate_durable_text
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.scoring import (
+    HarnessScore,
+    HarnessScorer,
+    ScoreRequest,
+    score_harness,
+)
+from wmh.harness.source_tree import HarnessSourceTree
+
+MAX_SCORE_TARGET_LABEL_CHARS = 512
+
+
+@dataclass(frozen=True)
+class HarnessScoreTarget:
+    """A labeled immutable harness document to evaluate once."""
+
+    label: str
+    harness: HarnessDoc
+    source: HarnessSourceTree = field(init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            not self.label
+            or len(self.label) > MAX_SCORE_TARGET_LABEL_CHARS
+            or "\n" in self.label
+            or "\r" in self.label
+        ):
+            raise ValueError(
+                "score target label must be one line containing "
+                f"1 to {MAX_SCORE_TARGET_LABEL_CHARS} characters"
+            )
+        validate_durable_text(self.label, field="score target label")
+        object.__setattr__(self, "source", HarnessSourceTree.from_doc(self.harness))
+
+
+@dataclass(frozen=True)
+class ScoredHarness:
+    """One target paired with its evaluator-owned score evidence."""
+
+    target: HarnessScoreTarget
+    score: HarnessScore
+
+    def __post_init__(self) -> None:
+        if self.score.report.candidate_doc_hash != self.target.harness.doc_hash:
+            raise ValueError("scored harness report does not match its target document")
+
+
+@dataclass(frozen=True)
+class HarnessScoreBatch:
+    """Ordered results evaluated against one exact score request."""
+
+    request: ScoreRequest
+    entries: tuple[ScoredHarness, ...]
+
+    def __post_init__(self) -> None:
+        validate_score_targets(tuple(entry.target for entry in self.entries))
+        for entry in self.entries:
+            if entry.score.report.request != self.request:
+                raise ValueError("scored harness entries use different score requests")
+
+
+def validate_score_targets(targets: tuple[HarnessScoreTarget, ...]) -> None:
+    """Reject an empty or ambiguously labeled target sequence before evaluation."""
+    if not targets:
+        raise ValueError("at least one harness score target is required")
+    labels = [target.label for target in targets]
+    duplicates = sorted({label for label in labels if labels.count(label) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate score target label(s): {duplicates}")
+
+
+def score_harnesses(
+    scorer: HarnessScorer,
+    targets: tuple[HarnessScoreTarget, ...],
+    *,
+    request: ScoreRequest,
+) -> HarnessScoreBatch:
+    """Score complete harnesses sequentially in their declared order."""
+    validate_score_targets(targets)
+    entries = tuple(
+        ScoredHarness(
+            target=target,
+            score=score_harness(scorer, target.harness, request=request),
+        )
+        for target in targets
+    )
+    return HarnessScoreBatch(request=request, entries=entries)

--- a/wmh/harness/score_batch_test.py
+++ b/wmh/harness/score_batch_test.py
@@ -1,0 +1,153 @@
+"""Tests for ordered scoring of complete harnesses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.score_batch import HarnessScoreTarget, score_harnesses
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_DIGEST = "sha256:" + "a" * 64
+
+
+@dataclass(frozen=True)
+class _Reader:
+    content: bytes
+
+    def read_bytes(self, path: str) -> bytes:
+        assert path == "raw/evidence.json"
+        return self.content
+
+
+def _request() -> ScoreRequest:
+    return ScoreRequest(
+        context=ScoreContext(
+            task_set_digest=_DIGEST,
+            evaluator_digest=_DIGEST,
+            execution_config_digest=_DIGEST,
+        ),
+        task_ids=("task-a",),
+        attempts=1,
+    )
+
+
+def _target(label: str, prompt: str) -> HarnessScoreTarget:
+    source = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["bash", "submit"]\n',
+            ),
+        )
+    )
+    return HarnessScoreTarget(
+        label=label,
+        harness=source.to_doc(label.replace("@", "-")),
+    )
+
+
+class _Scorer:
+    def __init__(self, request: ScoreRequest) -> None:
+        self.request = request
+        self.calls: list[str] = []
+
+    def score(self, candidate: object, *, request: ScoreRequest) -> HarnessScore:
+        from wmh.harness.doc import HarnessDoc
+
+        assert isinstance(candidate, HarnessDoc)
+        assert request is self.request
+        self.calls.append(candidate.name)
+        content = candidate.name.encode()
+        artifact = EvaluationArtifact.from_bytes(
+            path="raw/evidence.json",
+            content=content,
+            media_type="application/json",
+        )
+        report = HarnessScoreReport(
+            source_run_id=f"run-{candidate.name}",
+            candidate_doc_hash=candidate.doc_hash,
+            request=request,
+            cells=(
+                ScoreCell(
+                    task_id="task-a",
+                    attempt=1,
+                    score=float(len(self.calls) - 1),
+                    passed=len(self.calls) == 2,
+                    artifact_paths=("raw/evidence.json",),
+                ),
+            ),
+            artifacts=(artifact,),
+        )
+        return HarnessScore(report=report, artifacts=_Reader(content))
+
+
+def test_score_harnesses_preserves_declared_order_and_one_request() -> None:
+    request = _request()
+    scorer = _Scorer(request)
+    targets = (_target("first", "one"), _target("second@v2", "two"))
+
+    result = score_harnesses(scorer, targets, request=request)
+
+    assert scorer.calls == ["first", "second-v2"]
+    assert [entry.target.label for entry in result.entries] == ["first", "second@v2"]
+    assert [entry.score.report.score for entry in result.entries] == [0.0, 1.0]
+    assert all(entry.score.report.request is not request for entry in result.entries)
+    assert all(entry.score.report.request == request for entry in result.entries)
+
+
+def test_score_harnesses_rejects_duplicate_labels_before_spend() -> None:
+    request = _request()
+    scorer = _Scorer(request)
+
+    with pytest.raises(ValueError, match="duplicate score target label"):
+        score_harnesses(
+            scorer,
+            (_target("same", "one"), _target("same", "two")),
+            request=request,
+        )
+
+    assert scorer.calls == []
+
+
+def test_score_target_exports_source_from_the_authoritative_document() -> None:
+    target = _target("source", "one")
+
+    assert target.source == HarnessSourceTree.from_doc(target.harness)
+
+
+def test_score_target_rejects_unexportable_document_during_resolution() -> None:
+    harness = HarnessDoc(
+        name="invalid-export",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            Surface(
+                id="code:reserved",
+                kind=SurfaceKind.CODE,
+                path="SYSTEM.md",
+                content="conflict",
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="collides with a reserved file"):
+        HarnessScoreTarget(label="invalid-export", harness=harness)
+
+
+@pytest.mark.parametrize("label", ["", "bad\nlabel"])
+def test_score_target_rejects_unsafe_labels(label: str) -> None:
+    source = _target("valid", "one").source
+
+    with pytest.raises(ValueError, match="label"):
+        HarnessScoreTarget(label=label, harness=source.to_doc("valid"))


### PR DESCRIPTION
## Summary

- add a local wmh harness score command for immutable complete-harness source trees evaluated through Harbor
- support local and E2B evaluated-process backends while Harbor continues to own task environments and concurrency
- write replayable typed input and score archives, and share atomic archive I/O with harness optimization
- preserve neutral scoring evidence without selecting or publishing a winner

## Validation

- uv run --extra dev pytest -q (2163 passed, 19 skipped)
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev ty check