### PR TITLE
feat: configure evaluator episode timeouts

### DIFF
--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -49,6 +49,10 @@ from wmh.harness.project_proposer import (
     CandidateProposer,
     ProjectCandidateProposer,
 )
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    validate_episode_timeout_s,
+)
 from wmh.harness.source_tree import HarnessSourceTree
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import ProviderConfig, ToolCallingProvider
@@ -130,6 +134,12 @@ def optimize_harness(
         max=MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         help="Maximum seconds for one command in the Harbor-owned task environment.",
     ),
+    episode_timeout_sec: float = typer.Option(
+        DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        "--episode-timeout",
+        min=0.001,
+        help="Maximum seconds for one evaluated E2B harness episode.",
+    ),
     project_timeout_sec: float = typer.Option(
         DEFAULT_PROJECT_TIMEOUT_S,
         "--project-timeout",
@@ -188,6 +198,15 @@ def optimize_harness(
         )
     if not reward_key:
         raise typer.BadParameter("--reward-key must be nonempty")
+    try:
+        episode_timeout_sec = validate_episode_timeout_s(episode_timeout_sec)
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--episode-timeout") from error
+    if harness_backend == "local" and episode_timeout_sec != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+        raise typer.BadParameter(
+            "--episode-timeout requires --harness-backend e2b",
+            param_hint="--episode-timeout",
+        )
 
     job_config = load_harbor_config(Path(harbor_config))
     task_ids = load_task_ids(Path(task_ids_file))
@@ -211,7 +230,8 @@ def optimize_harness(
     _console.print(
         f"fixed search: 1 seed + {iterations} proposal slot(s), {len(task_ids)} task(s), "
         f"{attempts} attempt(s) -> up to {score_cells} requested score cells; "
-        f"ceiling={max_score_cells}; evaluated Pi backend={harness_backend}; proposer project=e2b"
+        f"ceiling={max_score_cells}; evaluated Pi backend={harness_backend}; "
+        f"episode timeout={episode_timeout_sec:g}s; proposer project=e2b"
     )
     if not yes:
         if not _console.is_terminal:
@@ -243,6 +263,7 @@ def optimize_harness(
         max_history_bytes=max_history_bytes,
         resume=resume,
         max_new_boundaries=max_new_boundaries,
+        episode_timeout_sec=episode_timeout_sec,
     )
     if isinstance(outcome, HarnessOptimizeProgress):
         completed = len(outcome.result.iterations) + 1
@@ -282,6 +303,7 @@ def _execute_optimization(
     max_history_bytes: int,
     resume: bool,
     max_new_boundaries: int | None = None,
+    episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
 ) -> HarnessOptimizeOutcome | HarnessOptimizeProgress:
     """Resolve one immutable scorer request, execute it, and publish evidence before winner."""
     if max_new_boundaries is not None and (
@@ -314,6 +336,7 @@ def _execute_optimization(
                 provider_config=agent_config,
                 reward_key=reward_key,
                 environment_command_timeout_sec=environment_command_timeout_sec,
+                episode_timeout_sec=episode_timeout_sec,
                 harness_backend=harness_backend,
                 e2b_template=e2b_template if harness_backend == "e2b" else None,
             )
@@ -355,6 +378,7 @@ def _execute_optimization(
             harness_backend=harness_backend,
             e2b_template=e2b_template or None,
             environment_command_timeout_sec=environment_command_timeout_sec,
+            episode_timeout_sec=episode_timeout_sec,
             project_timeout_sec=project_timeout_sec,
             max_source_files=DEFAULT_SOURCE_TREE_MAX_FILES,
             max_source_bytes=DEFAULT_SOURCE_TREE_MAX_BYTES,

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -262,6 +262,7 @@ def _checkpoint_identity(
         harness_backend="local",
         e2b_template=None,
         environment_command_timeout_sec=300,
+        episode_timeout_sec=300,
         project_timeout_sec=900,
         max_source_files=module.DEFAULT_SOURCE_TREE_MAX_FILES,
         max_source_bytes=module.DEFAULT_SOURCE_TREE_MAX_BYTES,
@@ -378,6 +379,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
         harness_backend="e2b",
         e2b_template="template-x",
         environment_command_timeout_sec=300,
+        episode_timeout_sec=12_000,
         project_timeout_sec=900,
         max_history_candidates=20,
         max_history_bytes=1_000_000,
@@ -389,6 +391,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     assert scorer_call["provider_config"] == agent_config
     assert scorer_call["harness_backend"] == "e2b"
     assert scorer_call["e2b_template"] == "template-x"
+    assert scorer_call["episode_timeout_sec"] == 12_000
     assert cast(JobConfig, scorer_call["job_config"]).jobs_dir == run_dir / "harbor"
     assert len(project_calls) == 3
     assert len({id(project) for project in projects}) == 3
@@ -417,6 +420,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     assert outcome.saved.doc_hash == result.best.candidate.doc_hash
     assert (root / "harnesses/selected/aliases.toml").exists()
     assert json.loads((run_dir / "inputs.json").read_text())["iterations"] == 3
+    assert json.loads((run_dir / "inputs.json").read_text())["episode_timeout_sec"] == 12_000
     written = json.loads((run_dir / "outcome.json").read_text())
     assert written["best_candidate_id"] == "candidate-0000"
     assert written["project_sandbox_usage"] == {"count": 3, "seconds": 37.5}
@@ -502,6 +506,7 @@ def test_execute_stops_ready_then_resumes_without_publishing_partial_work(
         "harness_backend": "local",
         "e2b_template": None,
         "environment_command_timeout_sec": 300,
+        "episode_timeout_sec": 300.0,
         "project_timeout_sec": 900,
         "max_history_candidates": 20,
         "max_history_bytes": 1_000_000,
@@ -612,6 +617,7 @@ def test_execute_resumes_ready_seed_at_next_slot_without_rescoring(
         harness_backend="local",
         e2b_template=None,
         environment_command_timeout_sec=300,
+        episode_timeout_sec=300,
         project_timeout_sec=900,
         max_source_files=module.DEFAULT_SOURCE_TREE_MAX_FILES,
         max_source_bytes=module.DEFAULT_SOURCE_TREE_MAX_BYTES,
@@ -727,6 +733,82 @@ def test_execute_resumes_ready_seed_at_next_slot_without_rescoring(
     assert propose_calls == [("candidate-0000",)]
     assert len(outcome.result.iterations) == 1
     assert outcome.result.iterations[0].error is not None
+
+
+def test_resume_rejects_episode_timeout_drift_before_any_score_or_project_spend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_dir = tmp_path / "run"
+    root = tmp_path / ".wmh"
+    seed = _source("seed")
+    request = _request()
+    job_config = _job_config(tmp_path)
+    meta_config, agent_config = _configs()
+    identity = _checkpoint_identity(
+        run_dir=run_dir,
+        root=root,
+        job_config=job_config,
+        seed=seed,
+        request=request,
+        iterations=1,
+        max_score_cells=2,
+        meta_config=meta_config,
+        agent_config=agent_config,
+    ).model_copy(
+        update={
+            "harness_backend": "e2b",
+            "e2b_template": "template",
+            "episode_timeout_sec": 300,
+        }
+    )
+    with PopulationCheckpointStore.create(run_dir, identity=identity, seed=seed):
+        pass
+
+    class FakeScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> FakeScorer:
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return request
+
+        def score(self, *_args: object, **_kwargs: object) -> HarnessScore:
+            raise AssertionError("identity drift must fail before scoring")
+
+    class NoProject:
+        @classmethod
+        def create(cls, **_kwargs: object) -> None:
+            raise AssertionError("identity drift must fail before project creation")
+
+    monkeypatch.setattr(module, "HarborScorer", FakeScorer)
+    monkeypatch.setattr(module, "AgentProject", NoProject)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+
+    with pytest.raises(PopulationCheckpointError, match="episode_timeout_sec"):
+        _execute_optimization(
+            name="selected",
+            root=str(root),
+            run_dir=run_dir,
+            job_config=job_config,
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            max_score_cells=2,
+            seed=None,
+            seed_reference=None,
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="e2b",
+            e2b_template="template",
+            environment_command_timeout_sec=300,
+            episode_timeout_sec=12_000,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+            resume=True,
+        )
 
 
 def test_execute_resumes_mixed_prefix_at_next_id_without_replaying_scores(
@@ -1225,6 +1307,7 @@ def test_execute_resumes_exact_publication_after_alias_before_complete(
         "harness_backend": "local",
         "e2b_template": None,
         "environment_command_timeout_sec": 300,
+        "episode_timeout_sec": 300.0,
         "project_timeout_sec": 900,
         "max_history_candidates": 20,
         "max_history_bytes": 1_000_000,
@@ -1625,6 +1708,10 @@ def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
             "1",
             "--max-score-cells",
             "3",
+            "--harness-backend",
+            "e2b",
+            "--episode-timeout",
+            "12000",
             "--max-new-boundaries",
             "1",
             "--result-out",
@@ -1637,6 +1724,9 @@ def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
 
     assert partial.exit_code == 0, partial.output
     assert calls[-1]["max_new_boundaries"] == 1
+    assert calls[-1]["harness_backend"] == "e2b"
+    assert calls[-1]["episode_timeout_sec"] == 12_000
+    assert "episode timeout=12000s" in " ".join(partial.output.split())
     assert "checkpointed" in partial.output
     assert "no winner published" in partial.output
     assert "--resume --result-out" in partial.output
@@ -1703,3 +1793,5 @@ def test_cli_help_preserves_model_roles_seed_syntax_and_local_output_wording() -
     assert "models.agent" in invoked.output
     assert "name@ref" in invoked.output
     assert "Local run directory" in invoked.output
+    assert "--episode-timeout" in invoked.output
+    assert "seconds" in invoked.output

--- a/wmh/cli/harness_score.py
+++ b/wmh/cli/harness_score.py
@@ -21,6 +21,10 @@ from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    validate_episode_timeout_s,
+)
 from wmh.harness.score_archive import write_score_archive
 from wmh.harness.score_batch import (
     HarnessScoreBatch,
@@ -94,6 +98,12 @@ def score_harness_command(
         max=MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         help="Maximum seconds for one command in the Harbor-owned task environment.",
     ),
+    episode_timeout_sec: float = typer.Option(
+        DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        "--episode-timeout",
+        min=0.001,
+        help="Maximum seconds for one evaluated E2B harness episode.",
+    ),
     result_out: str | None = typer.Option(
         None,
         "--result-out",
@@ -116,6 +126,15 @@ def score_harness_command(
         )
     if not reward_key:
         raise typer.BadParameter("--reward-key must be nonempty")
+    try:
+        episode_timeout_sec = validate_episode_timeout_s(episode_timeout_sec)
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--episode-timeout") from error
+    if harness_backend == "local" and episode_timeout_sec != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+        raise typer.BadParameter(
+            "--episode-timeout requires --harness-backend e2b",
+            param_hint="--episode-timeout",
+        )
 
     targets = _resolve_targets(
         root,
@@ -135,7 +154,8 @@ def score_harness_command(
     _console.print(
         f"scoring {len(targets)} harness(es), {len(task_ids)} task(s), "
         f"{attempts} attempt(s) -> {score_cells} requested score cells; "
-        f"evaluated harness backend={harness_backend}"
+        f"evaluated harness backend={harness_backend}; "
+        f"episode timeout={episode_timeout_sec:g}s"
     )
     if not yes:
         if not _console.is_terminal:
@@ -154,6 +174,7 @@ def score_harness_command(
         harness_backend=cast("Literal['local', 'e2b']", harness_backend),
         e2b_template=(effective_e2b_template or "") if harness_backend == "e2b" else None,
         environment_command_timeout_sec=environment_command_timeout_sec,
+        episode_timeout_sec=episode_timeout_sec,
     )
     for entry in outcome.result.entries:
         _console.print(
@@ -176,6 +197,7 @@ def _execute_scoring(
     harness_backend: Literal["local", "e2b"],
     e2b_template: str | None,
     environment_command_timeout_sec: int,
+    episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
 ) -> HarnessScoreOutcome:
     """Resolve one immutable scorer request, score every target, and archive evidence."""
     validate_score_targets(targets)
@@ -192,6 +214,7 @@ def _execute_scoring(
             provider_config=agent_config,
             reward_key=reward_key,
             environment_command_timeout_sec=environment_command_timeout_sec,
+            episode_timeout_sec=episode_timeout_sec,
             harness_backend=harness_backend,
             e2b_template=e2b_template if harness_backend == "e2b" else None,
         )
@@ -199,13 +222,14 @@ def _execute_scoring(
     request = scorer.request(attempts=attempts)
     run_dir.mkdir(parents=True, exist_ok=False)
     inputs: JsonObject = {
-        "schema_version": 1,
+        "schema_version": 2,
         "score_request": request.model_dump(mode="json"),
         "harbor_job_template": effective_job_config.model_dump(mode="json"),
         "agent_provider": agent_config.model_dump(mode="json"),
         "harness_backend": harness_backend,
         "e2b_template": e2b_template or None,
         "environment_command_timeout_sec": environment_command_timeout_sec,
+        "episode_timeout_sec": episode_timeout_sec,
         "targets": [
             {
                 "label": target.label,

--- a/wmh/cli/harness_score_test.py
+++ b/wmh/cli/harness_score_test.py
@@ -185,6 +185,7 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
         harness_backend="e2b",
         e2b_template="template-x",
         environment_command_timeout_sec=240,
+        episode_timeout_sec=12_000,
     )
 
     [scorer_call] = scorer_calls
@@ -192,13 +193,16 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
     assert scorer_call["provider_config"] == agent_config
     assert scorer_call["harness_backend"] == "e2b"
     assert scorer_call["e2b_template"] == "template-x"
+    assert scorer_call["episode_timeout_sec"] == 12_000
     [scored_call] = scored_calls
     assert scored_call[1] == (target,)
     assert scored_call[2] is request
     assert archived == [(run_dir / "scores", outcome.result)]
     assert outcome.archive_manifest == run_dir / "scores/manifest.json"
     inputs = json.loads((run_dir / "inputs.json").read_text(encoding="utf-8"))
+    assert inputs["schema_version"] == 2
     assert inputs["score_request"] == request.model_dump(mode="json")
+    assert inputs["episode_timeout_sec"] == 12_000
     assert inputs["targets"] == [
         {
             "document_hash": target.harness.doc_hash,
@@ -310,6 +314,37 @@ def test_cli_resolves_default_then_immutable_stored_version_with_agent_role(
     assert agent_config.kind is ProviderKind.ANTHROPIC
     assert "models.meta" not in invoked.output
 
+    e2b_invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "score",
+            "--include-default",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--attempts",
+            "1",
+            "--harness-backend",
+            "e2b",
+            "--episode-timeout",
+            "12000",
+            "--result-out",
+            str(tmp_path / "e2b-run"),
+            "--root",
+            str(root),
+            "--yes",
+        ],
+    )
+
+    assert e2b_invoked.exit_code == 0, e2b_invoked.output
+    assert calls[-1]["harness_backend"] == "e2b"
+    assert calls[-1]["episode_timeout_sec"] == 12_000
+    assert "episode timeout=12000s" in e2b_invoked.output
+
 
 def test_cli_requires_a_target_before_model_or_scorer_resolution(tmp_path: Path) -> None:
     config_path, task_ids_path = _write_inputs(tmp_path)
@@ -373,3 +408,5 @@ def test_cli_help_is_proposer_free_and_requires_only_agent_role() -> None:
     assert "models.meta" not in invoked.output
     assert "proposer" not in invoked.output.lower()
     assert "world model" not in invoked.output.lower()
+    assert "--episode-timeout" in invoked.output
+    assert "seconds" in invoked.output

--- a/wmh/evals/harbor/agent.py
+++ b/wmh/evals/harbor/agent.py
@@ -19,11 +19,15 @@ from harbor.models.task.config import MCPServerConfig
 from wmh.core.types import Action, ActionKind, JsonObject, Observation
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.environment import is_env_action
-from wmh.harness.runtime import RunResult
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    RunResult,
+    validate_episode_timeout_s,
+)
 from wmh.providers.base import ProviderConfig
 from wmh.providers.registry import get_provider
 
-WMH_HARBOR_AGENT_VERSION = "2"
+WMH_HARBOR_AGENT_VERSION = "3"
 WMH_HARBOR_AGENT_IMPORT_PATH = "wmh.evals.harbor.agent:WmhHarborAgent"
 # Keep every task command finite and leave cleanup headroom beneath the local Pi process cap. The
 # local shim also joins active request handlers, so a late-starting command cannot outlive runtime
@@ -121,6 +125,7 @@ class WmhHarborAgent(BaseAgent):
         provider_config: JsonObject,
         harness_backend: Literal["local", "e2b"] = "local",
         e2b_template: str | None = None,
+        episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
     ) -> None:
         if extra_env:
             raise ValueError("WMH Harbor evaluation does not inject agent environment variables")
@@ -136,6 +141,15 @@ class WmhHarborAgent(BaseAgent):
             raise ValueError("harness_backend must be local or e2b")
         if harness_backend == "local" and e2b_template is not None:
             raise ValueError("e2b_template requires harness_backend='e2b'")
+        try:
+            self._episode_timeout_sec = validate_episode_timeout_s(episode_timeout_sec)
+        except ValueError as error:
+            raise ValueError("episode_timeout_sec must be a finite positive number") from error
+        if (
+            harness_backend == "local"
+            and self._episode_timeout_sec != DEFAULT_EVAL_EPISODE_TIMEOUT_S
+        ):
+            raise ValueError("episode_timeout_sec requires harness_backend='e2b'")
         self._harness = HarnessDoc.model_validate(harness)
         self._provider_config = ProviderConfig.model_validate(provider_config)
         expected_model_name = f"{self._provider_config.kind.value}/{self._provider_config.model}"
@@ -174,6 +188,9 @@ class WmhHarborAgent(BaseAgent):
             backend=self._harness_backend,
             e2b_template=self._e2b_template,
             pi_transport=self._pi_transport,
+            episode_timeout_s=(
+                self._episode_timeout_sec if self._harness_backend == "e2b" else None
+            ),
             # A real task environment is mutable, so an E2B transport failure must not replay
             # the whole episode against already-mutated state. Local Pi has no replay wrapper.
             transport_retries=0 if self._harness_backend == "e2b" else None,

--- a/wmh/evals/harbor/agent_test.py
+++ b/wmh/evals/harbor/agent_test.py
@@ -148,6 +148,8 @@ def test_repeated_cancellation_cannot_detach_abort_drain_or_close(
         model_name="bedrock/worker-model",
         harness=HarnessDoc.baseline().model_dump(mode="json"),
         provider_config=_provider_config().model_dump(mode="json"),
+        harness_backend="e2b",
+        episode_timeout_sec=12_000,
     )
 
     async def run() -> None:
@@ -389,6 +391,7 @@ def test_agent_runs_the_exact_candidate_and_persists_its_trace(
         *,
         backend: str = "local",
         e2b_template: str | None = None,
+        episode_timeout_s: float | None = None,
         transport_retries: int | None = None,
         **_kwargs: object,
     ) -> _Runtime:
@@ -396,6 +399,7 @@ def test_agent_runs_the_exact_candidate_and_persists_its_trace(
         observed["provider"] = actual_provider
         observed["backend"] = backend
         observed["template"] = e2b_template
+        observed["episode_timeout_s"] = episode_timeout_s
         observed["transport_retries"] = transport_retries
         return _Runtime()
 
@@ -408,6 +412,7 @@ def test_agent_runs_the_exact_candidate_and_persists_its_trace(
         provider_config=_provider_config().model_dump(mode="json"),
         harness_backend="e2b",
         e2b_template="runner-template",
+        episode_timeout_sec=12_000,
     )
     context = AgentContext()
 
@@ -424,6 +429,7 @@ def test_agent_runs_the_exact_candidate_and_persists_its_trace(
         "provider": provider,
         "backend": "e2b",
         "template": "runner-template",
+        "episode_timeout_s": 12_000,
         "transport_retries": 0,
         "task_id": observed["task_id"],
         "instruction": "solve it",

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -41,6 +41,10 @@ from wmh.evals.harbor.tasks import (
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import resolve_e2b_template
 from wmh.harness.pi_runtime import PI_RUNNER_DIR, PI_RUNNER_HOST
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    validate_episode_timeout_s,
+)
 from wmh.harness.scoring import (
     ArtifactReader,
     EvaluationArtifact,
@@ -55,7 +59,7 @@ from wmh.providers.base import ProviderConfig
 _INDEX_PATH = "raw/index.json"
 _REQUIRED_JOB_FILES = frozenset({"config.json", "lock.json", "result.json", "job.log"})
 _REQUIRED_TRIAL_FILES = frozenset({"config.json", "lock.json", "result.json", "trial.log"})
-_HARBOR_SCORER_VERSION = "2"
+_HARBOR_SCORER_VERSION = "3"
 _CHECKSUM_PATTERN = r"^[0-9a-f]{64}$"
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
@@ -91,6 +95,14 @@ class HarborJobRunner:
             return executor.submit(lambda: asyncio.run(run_job())).result()
 
 
+def _validate_episode_timeout_sec(value: object) -> float:
+    """Validate the scorer-facing spelling while sharing the runtime's numeric contract."""
+    try:
+        return validate_episode_timeout_s(value)
+    except ValueError as error:
+        raise ValueError("episode_timeout_sec must be a finite positive number") from error
+
+
 class HarborScorer:
     """Evaluate exact harness candidates through Harbor's official verifier lifecycle."""
 
@@ -102,6 +114,7 @@ class HarborScorer:
         provider_config: ProviderConfig,
         reward_key: str,
         environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         harness_backend: Literal["local", "e2b"] = "local",
         e2b_template: str | None = None,
         runner: HarborRunner | None = None,
@@ -157,6 +170,9 @@ class HarborScorer:
             raise ValueError("harness_backend must be local or e2b")
         if harness_backend == "local" and e2b_template is not None:
             raise ValueError("e2b_template requires harness_backend='e2b'")
+        episode_timeout_sec = _validate_episode_timeout_sec(episode_timeout_sec)
+        if harness_backend == "local" and episode_timeout_sec != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+            raise ValueError("episode_timeout_sec requires harness_backend='e2b'")
         effective_agent_concurrency = template.n_concurrent or job_config.n_concurrent_trials
         if harness_backend == "local" and effective_agent_concurrency > 1:
             raise ValueError(
@@ -179,6 +195,7 @@ class HarborScorer:
         )
         self._reward_key = reward_key
         self._environment_command_timeout_sec = environment_command_timeout_sec
+        self._episode_timeout_sec = episode_timeout_sec
         self._harness_backend = harness_backend
         if harness_backend == "local":
             self._local_runner_identity = {
@@ -204,6 +221,7 @@ class HarborScorer:
         provider_config: ProviderConfig,
         reward_key: str,
         environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         harness_backend: Literal["local", "e2b"] = "local",
         e2b_template: str | None = None,
         runner: HarborRunner | None = None,
@@ -211,6 +229,9 @@ class HarborScorer:
         """Resolve exact task bytes before constructing a scorer that can incur spend."""
         if len(job_config.datasets) != 1 or job_config.tasks:
             raise ValueError("HarborScorer requires exactly one dataset and no direct tasks")
+        episode_timeout_sec = _validate_episode_timeout_sec(episode_timeout_sec)
+        if harness_backend == "local" and episode_timeout_sec != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+            raise ValueError("episode_timeout_sec requires harness_backend='e2b'")
         task_set = await resolve_harbor_task_set(job_config.datasets[0], task_ids)
         return cls(
             job_config=job_config,
@@ -218,6 +239,7 @@ class HarborScorer:
             provider_config=provider_config,
             reward_key=reward_key,
             environment_command_timeout_sec=environment_command_timeout_sec,
+            episode_timeout_sec=episode_timeout_sec,
             harness_backend=harness_backend,
             e2b_template=e2b_template,
             runner=runner,
@@ -286,6 +308,7 @@ class HarborScorer:
             "e2b_template": self._e2b_template,
             "local_runner": self._local_runner_identity,
             "environment_command_timeout_sec": self._environment_command_timeout_sec,
+            "episode_timeout_sec": self._episode_timeout_sec,
         }
         return ScoreContext(
             task_set_digest=_digest_json(task_payload),
@@ -372,6 +395,7 @@ class HarborScorer:
                     "harness_backend": self._harness_backend,
                     "e2b_template": self._e2b_template,
                     "command_timeout_sec": self._environment_command_timeout_sec,
+                    "episode_timeout_sec": self._episode_timeout_sec,
                 },
             },
             deep=True,

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -50,6 +50,7 @@ from wmh.evals.harbor.scorer import (
 )
 from wmh.evals.harbor.tasks import ResolvedHarborTaskSet, resolve_harbor_task_set
 from wmh.harness.doc import HarnessDoc
+from wmh.harness.pi_e2b import DEFAULT_EVAL_EPISODE_TIMEOUT_S
 from wmh.harness.scoring import ScoreRequest, score_harness
 from wmh.providers.base import ProviderConfig, ProviderKind
 
@@ -153,6 +154,7 @@ def _executed_agent(
     harness_backend: str,
     e2b_template: str | None = None,
     environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+    episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
 ) -> AgentConfig:
     return job_config.agents[0].model_copy(
         update={
@@ -168,6 +170,7 @@ def _executed_agent(
                 "harness_backend": harness_backend,
                 "e2b_template": e2b_template,
                 "command_timeout_sec": environment_command_timeout_sec,
+                "episode_timeout_sec": float(episode_timeout_sec),
             },
         },
         deep=True,
@@ -188,6 +191,7 @@ def _trial(
     harness_backend: Literal["local", "e2b"] = "local",
     e2b_template: str | None = None,
     environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+    episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
 ) -> TrialResult:
     candidate = candidate or HarnessDoc.baseline()
     provider = provider or _provider()
@@ -215,6 +219,7 @@ def _trial(
             harness_backend=harness_backend,
             e2b_template=e2b_template,
             environment_command_timeout_sec=environment_command_timeout_sec,
+            episode_timeout_sec=episode_timeout_sec,
         ),
         environment=job_config.environment,
         verifier=job_config.verifier,
@@ -346,6 +351,7 @@ def _scorer(
     harness_backend: Literal["local", "e2b"] = "local",
     e2b_template: str | None = None,
     environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+    episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
 ) -> tuple[HarborScorer, _Runner]:
     job_config = job_config or _job_config(tmp_path)
     dataset_path = job_config.datasets[0].path
@@ -359,6 +365,7 @@ def _scorer(
         provider_config=provider or _provider(),
         reward_key=reward_key,
         environment_command_timeout_sec=environment_command_timeout_sec,
+        episode_timeout_sec=episode_timeout_sec,
         harness_backend=harness_backend,
         e2b_template=e2b_template,
         runner=runner,
@@ -854,6 +861,94 @@ def test_environment_command_timeout_is_injected_and_execution_drift_is_rejected
             drift_scorer,
             HarnessDoc.baseline(),
             request=drift_scorer.request(attempts=1),
+        )
+
+
+def test_episode_timeout_is_evidence_bound_injected_and_drift_checked(tmp_path: Path) -> None:
+    timeout_sec = 12_000
+    job_dir = tmp_path / "completed-job"
+    trials = [
+        _trial(
+            job_dir,
+            task_id,
+            1,
+            score=1,
+            harness_backend="e2b",
+            e2b_template="",
+            episode_timeout_sec=timeout_sec,
+        )
+        for task_id in ("task-a", "task-b")
+    ]
+    scorer, runner = _scorer(
+        tmp_path,
+        _run(tmp_path, trials),
+        harness_backend="e2b",
+        e2b_template="",
+        episode_timeout_sec=timeout_sec,
+    )
+
+    score_harness(scorer, HarnessDoc.baseline(), request=scorer.request(attempts=1))
+
+    assert runner.configs[0].agents[0].kwargs["episode_timeout_sec"] == timeout_sec
+    assert (
+        scorer.context().execution_config_digest
+        != _scorer(
+            tmp_path / "default",
+            _run(tmp_path / "default", []),
+            harness_backend="e2b",
+            e2b_template="",
+        )[0]
+        .context()
+        .execution_config_digest
+    )
+
+    drift_path = tmp_path / "drift"
+    drift_job_dir = drift_path / "completed-job"
+    drift_trials = [
+        _trial(
+            drift_job_dir,
+            task_id,
+            1,
+            score=1,
+            harness_backend="e2b",
+            e2b_template="",
+            episode_timeout_sec=timeout_sec - 1,
+        )
+        for task_id in ("task-a", "task-b")
+    ]
+    drift_scorer, _ = _scorer(
+        drift_path,
+        _run(drift_path, drift_trials),
+        harness_backend="e2b",
+        e2b_template="",
+        episode_timeout_sec=timeout_sec,
+    )
+    with pytest.raises(ValueError, match="different agent config|execution config"):
+        score_harness(
+            drift_scorer,
+            HarnessDoc.baseline(),
+            request=drift_scorer.request(attempts=1),
+        )
+
+
+@pytest.mark.parametrize("invalid", [True, 0, -1, float("inf")])
+def test_scorer_rejects_invalid_episode_timeout(tmp_path: Path, invalid: object) -> None:
+    with pytest.raises(ValueError, match="episode_timeout_sec"):
+        _scorer(
+            tmp_path,
+            _run(tmp_path, []),
+            harness_backend="e2b",
+            episode_timeout_sec=cast("float", invalid),
+        )
+
+
+def test_scorer_rejects_nondefault_episode_timeout_for_local_backend(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="episode_timeout_sec requires harness_backend='e2b'"):
+        _scorer(
+            tmp_path,
+            _run(tmp_path, []),
+            harness_backend="local",
+            episode_timeout_sec=12_000,
         )
 
 

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -1100,6 +1100,9 @@ class _FakePool:
         self.close_failures = 0
         _FakePool.instances.append(self)
 
+    def assert_episode_timeout(self, episode_timeout_s: float) -> None:
+        assert episode_timeout_s == 300
+
     def usage(self) -> SandboxUsage:
         return SandboxUsage(count=len(self.channels), seconds=1.5 * len(self.channels))
 

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -39,11 +39,13 @@ from wmh.harness.code_runtime import (
     compile_harness_code,
 )
 from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
     DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_MAX_TURNS,
     DEFAULT_SYSTEM_PROMPT,
     AgentRuntime,
     Runtime,
+    validate_episode_timeout_s,
 )
 from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import DEFAULT_TOOLS, READ_SKILL, render_tools, resolve_tools
@@ -273,6 +275,7 @@ class HarnessDoc(BaseModel):
         e2b_template: str | None = None,
         e2b_pool: E2BSandboxPool | None = None,
         pi_transport: Literal["ssh", "link"] | None = None,
+        episode_timeout_s: float | None = None,
         transport_retries: int | None = None,
         should_cancel: Callable[[], bool] | None = None,
     ) -> Runtime:
@@ -290,6 +293,8 @@ class HarnessDoc(BaseModel):
         `code:runtime` surface drives episodes with the harness's own in-process program; with
         neither, the fixed baseline loop runs. `transport_retries` controls whole-episode replay
         only for the E2B pi-node backend; omitting it preserves that runtime's one-retry default.
+        `episode_timeout_s` controls the E2B pi-node episode wall budget; omitting it preserves
+        the 300-second default, and other execution modes reject it instead of silently ignoring it.
         All expose the same
         `run(task_id, instruction, environment) -> RunResult` shape closed-loop eval drives.
         """
@@ -304,6 +309,10 @@ class HarnessDoc(BaseModel):
         if pi_transport not in (None, "ssh", "link"):
             raise ValueError("pi_transport must be ssh or link")
         runtime_kind = self.runtime_kind()
+        if episode_timeout_s is not None:
+            episode_timeout_s = validate_episode_timeout_s(episode_timeout_s)
+            if backend != "e2b" or runtime_kind != "pi-node":
+                raise ValueError("episode_timeout_s applies only to e2b pi-node execution")
         if pi_transport is not None and (backend != "local" or runtime_kind != "pi-node"):
             raise ValueError("pi_transport applies only to local pi-node execution")
         if transport_retries is not None and (backend != "e2b" or runtime_kind != "pi-node"):
@@ -345,6 +354,11 @@ class HarnessDoc(BaseModel):
                     pool=e2b_pool,
                     max_turns=self.max_turns(),
                     max_output_tokens=self.max_output_tokens(),
+                    episode_timeout_s=(
+                        DEFAULT_EVAL_EPISODE_TIMEOUT_S
+                        if episode_timeout_s is None
+                        else episode_timeout_s
+                    ),
                     transport_retries=(1 if transport_retries is None else transport_retries),
                     should_cancel=should_cancel,
                 )

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -348,3 +348,23 @@ def test_transport_retries_reaches_e2b_pi_runtime() -> None:
     assert isinstance(runtime, E2BPiRuntime)
     assert runtime._transport_retries == 0  # noqa: SLF001 - pins public policy passthrough
     pool.close()
+
+
+def test_episode_timeout_reaches_e2b_pi_runtime_and_rejects_local_noop() -> None:
+    from wmh.harness.pi_e2b import E2BPiRuntime
+
+    runtime = _pi_doc().runtime(
+        _stub_provider(),
+        backend="e2b",
+        episode_timeout_s=12_000,
+    )
+
+    assert isinstance(runtime, E2BPiRuntime)
+    assert runtime._episode_timeout_s == 12_000  # noqa: SLF001 - public policy passthrough
+    runtime.close()
+    with pytest.raises(ValueError, match="episode_timeout_s applies only to e2b pi-node"):
+        _pi_doc().runtime(
+            _stub_provider(),
+            backend="local",
+            episode_timeout_s=12_000,
+        )

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -1356,10 +1356,12 @@ class E2BSandboxPool:
         )
 
     def _start_runner(self, sandbox: SandboxHandle) -> E2BStdioChannel:
-        # The creation factory gives bootstrap and startup the configured lease. Reset only after
-        # the hello handshake so the next episode receives the full budget; subsequent in-flight
-        # heartbeats keep extending it while the episode is active.
+        # Template-less bootstrap can consume most of the creation lease. Reset immediately before
+        # starting the runner so startup + hello get the configured budget, then reset again after
+        # hello so the next episode gets that full budget too. Subsequent in-flight heartbeats keep
+        # extending the lease while the episode is active.
         timeout = self._sandbox_timeout_s
+        sandbox.set_timeout(timeout)
         # timeout=0 = no command-connection limit (SDK-documented): the runner must outlive every
         # episode on this sandbox; the sandbox's own lifetime is the real bound.
         handle = sandbox.commands.run(START_CMD, background=True, stdin=True, timeout=0)

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -56,11 +56,13 @@ from wmh.harness.e2b_sandbox import (
 from wmh.harness.environment import AgentEnvironment
 from wmh.harness.runner_link import RunnerLink, WorkerFn
 from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
     DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_MAX_TURNS,
     RunResult,
     RuntimeCancelled,
     StopReason,
+    validate_episode_timeout_s,
 )
 from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import ToolSpec
@@ -123,17 +125,21 @@ _DURABLE_STDOUT_SILENCE_GRACE_S = 45.0
 # and therefore leave renewal disabled.
 TRANSPORT_KEEPALIVE_TYPE = "transport_keepalive"
 _SANDBOX_TIMEOUT_REFRESH_S = 300.0
-# Renewal must not turn mutated agent code into an unbounded cost leak. A legitimate slow episode
-# may cross the base 15-minute lease, but one cell still gets a hard one-hour sandbox lifetime.
+# Renewal must not turn mutated agent code into an unbounded cost leak. The default hard lifetime
+# is one hour; a longer episode budget adds one default lease for in-flight work and cleanup.
 MAX_EVAL_EPISODE_LIFETIME_S = 3_600.0
-# A score cell must finish much sooner than the E2B lease-renewal safety cap. This wall budget is
-# host-enforced by RunnerLink and may be exceeded only by one already-running provider/tool call.
-DEFAULT_EVAL_EPISODE_TIMEOUT_S = 300.0
 _MAX_RETIRE_WORKERS = 16
 
 _HTTPCORE_REMOTE_STREAM_RESET = re.compile(
     r"<StreamReset stream_id:\d+, error_code:\d+, remote_reset:True>"
 )
+
+
+def _episode_lease_lifetime_s(episode_timeout_s: float) -> float:
+    """Keep the legacy default, or cover one synchronous call plus cleanup after the watchdog."""
+    if episode_timeout_s <= DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+        return DEFAULT_SANDBOX_TIMEOUT_S
+    return episode_timeout_s + DEFAULT_SANDBOX_TIMEOUT_S
 
 
 class _Eof:
@@ -1136,12 +1142,24 @@ class E2BSandboxPool:
         metadata: dict[str, str] | None = None,
         sandbox_factory: SandboxFactory | None = None,
         hello_timeout: float = HELLO_TIMEOUT_S,
+        episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
     ) -> None:
+        self._episode_timeout_s = validate_episode_timeout_s(episode_timeout_s)
+        lease_lifetime_s = _episode_lease_lifetime_s(self._episode_timeout_s)
+        self._sandbox_timeout_s = max(
+            math.ceil(DEFAULT_SANDBOX_TIMEOUT_S),
+            math.ceil(lease_lifetime_s),
+        )
+        self._max_episode_lifetime_s = max(
+            MAX_EVAL_EPISODE_LIFETIME_S,
+            lease_lifetime_s,
+        )
         self._template = resolve_e2b_template(template)
         self._factory = sandbox_factory or default_sandbox_factory(
             api_key=api_key,
             template=self._template if self._template is not None else "",
             metadata=metadata,
+            timeout=self._sandbox_timeout_s,
         )
         self._hello_timeout = hello_timeout
         self._lock = threading.Lock()
@@ -1176,7 +1194,7 @@ class E2BSandboxPool:
                     break
                 sandbox, channel = self._idle.pop()
             try:
-                sandbox.set_timeout(int(DEFAULT_SANDBOX_TIMEOUT_S))
+                sandbox.set_timeout(self._sandbox_timeout_s)
             except Exception:  # noqa: BLE001 - a dead idle sandbox is expected after long gaps
                 self._retire(sandbox)
                 continue
@@ -1206,6 +1224,20 @@ class E2BSandboxPool:
                 return sandbox, channel
         self._retire(sandbox)  # closed while we were bootstrapping: don't leak the sandbox
         raise RuntimeError("E2BSandboxPool is closed")
+
+    def assert_episode_timeout(self, episode_timeout_s: float) -> None:
+        """Reject a runtime budget that this shared pool cannot keep alive."""
+        requested = validate_episode_timeout_s(episode_timeout_s)
+        required_lifetime = _episode_lease_lifetime_s(requested)
+        required_lease = max(math.ceil(DEFAULT_SANDBOX_TIMEOUT_S), math.ceil(required_lifetime))
+        if (
+            self._sandbox_timeout_s < required_lease
+            or self._max_episode_lifetime_s < required_lifetime
+        ):
+            raise ValueError(
+                "shared E2BSandboxPool episode timeout is too small; construct the pool "
+                f"with episode_timeout_s >= {requested:g}"
+            )
 
     def release(self, sandbox: SandboxHandle, channel: E2BStdioChannel, *, healthy: bool) -> None:
         """Return a sandbox for reuse, or discard it after a failed episode."""
@@ -1324,11 +1356,10 @@ class E2BSandboxPool:
         )
 
     def _start_runner(self, sandbox: SandboxHandle) -> E2BStdioChannel:
-        # Bootstrap can consume much of the creation-time lease on a template-less sandbox. Reset
-        # it immediately before the long-lived runner starts; subsequent in-flight heartbeats keep
-        # extending it while an episode is active.
-        timeout = int(DEFAULT_SANDBOX_TIMEOUT_S)
-        sandbox.set_timeout(timeout)
+        # The creation factory gives bootstrap and startup the configured lease. Reset only after
+        # the hello handshake so the next episode receives the full budget; subsequent in-flight
+        # heartbeats keep extending it while the episode is active.
+        timeout = self._sandbox_timeout_s
         # timeout=0 = no command-connection limit (SDK-documented): the runner must outlive every
         # episode on this sandbox; the sandbox's own lifetime is the real bound.
         handle = sandbox.commands.run(START_CMD, background=True, stdin=True, timeout=0)
@@ -1337,8 +1368,10 @@ class E2BSandboxPool:
             sandbox,
             cast("CommandHandle", handle),
             sandbox_timeout_s=timeout,
+            max_episode_lifetime_s=self._max_episode_lifetime_s,
         )
         self._await_hello(channel)
+        sandbox.set_timeout(timeout)
         return channel
 
     def _await_hello(self, channel: E2BStdioChannel) -> None:
@@ -1396,8 +1429,7 @@ class E2BPiRuntime:
             raise ValueError("max_output_tokens must be >= 1")
         if not 0.0 <= temperature <= 2.0:
             raise ValueError("temperature must be in [0, 2]")
-        if episode_timeout_s <= 0:
-            raise ValueError("episode_timeout_s must be positive")
+        episode_timeout_s = validate_episode_timeout_s(episode_timeout_s)
         if (
             isinstance(transport_retries, bool)
             or not isinstance(transport_retries, int)
@@ -1418,9 +1450,16 @@ class E2BPiRuntime:
         self._should_cancel = should_cancel
         self._aborted = threading.Event()
         self._owns_pool = pool is None
-        self._pool = pool or E2BSandboxPool(
-            template=template, api_key=api_key, hello_timeout=hello_timeout
-        )
+        if pool is None:
+            self._pool = E2BSandboxPool(
+                template=template,
+                api_key=api_key,
+                hello_timeout=hello_timeout,
+                episode_timeout_s=episode_timeout_s,
+            )
+        else:
+            pool.assert_episode_timeout(episode_timeout_s)
+            self._pool = pool
 
     def run(self, task_id: str, instruction: str, environment: AgentEnvironment) -> RunResult:
         if self._cancel_requested():

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -1049,7 +1049,90 @@ def test_pool_acquire_without_hello_raises_with_stderr_and_kills_the_sandbox(
     with pytest.raises(RuntimeError, match="no hello") as excinfo:
         pool.acquire()
     assert "SyntaxError: unexpected token" in str(excinfo.value)
+    assert fake.timeouts == [900]  # startup was protected; no post-hello reset was possible
     assert fake.kills == 1  # a sandbox that failed bootstrap never leaks
+
+
+def test_pool_resets_lease_before_runner_start_and_after_hello(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cold-start work and the first episode each receive a fresh sandbox lease."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    handle = _ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True)
+    fake = FakeSandbox(handle)
+    events: list[str] = []
+
+    original_set_timeout = fake.set_timeout
+
+    def recording_set_timeout(timeout: int) -> None:
+        events.append("set_timeout")
+        original_set_timeout(timeout)
+
+    original_run = fake.commands.run
+
+    def recording_run(
+        cmd: str,
+        background: bool | None = None,
+        *,
+        envs: dict[str, str] | None = None,
+        stdin: bool | None = None,
+        timeout: float | None = None,
+    ) -> object:
+        if background:
+            events.append("runner_start")
+        return original_run(cmd, background, envs=envs, stdin=stdin, timeout=timeout)
+
+    monkeypatch.setattr(fake, "set_timeout", recording_set_timeout)
+    monkeypatch.setattr(fake.commands, "run", recording_run)
+    pool = E2BSandboxPool(sandbox_factory=lambda: fake)
+    original_await_hello = pool._await_hello  # noqa: SLF001 - ordering contract under test
+
+    def recording_await_hello(channel: E2BStdioChannel) -> None:
+        events.append("await_hello")
+        original_await_hello(channel)
+        events.append("hello")
+
+    monkeypatch.setattr(pool, "_await_hello", recording_await_hello)
+
+    pool.acquire()
+
+    assert events == ["set_timeout", "runner_start", "await_hello", "hello", "set_timeout"]
+    assert fake.timeouts == [900, 900]
+    pool.close()
+
+
+@pytest.mark.parametrize(
+    ("failed_reset", "runner_starts"),
+    [(1, False), (2, True)],
+)
+def test_pool_reset_failure_retires_cold_start_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_reset: int,
+    runner_starts: bool,
+) -> None:
+    """Neither the pre-start nor post-hello lease reset may leak its sandbox on failure."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    handle = _ScriptedHandle(_stdout_events([{"type": "hello"}]), hold_open=True)
+    fake = FakeSandbox(handle)
+    reset_attempts = 0
+
+    def failing_set_timeout(timeout: int) -> None:
+        nonlocal reset_attempts
+        assert timeout == 900
+        reset_attempts += 1
+        if reset_attempts == failed_reset:
+            raise RuntimeError("lease reset failed")
+        fake.timeouts.append(timeout)
+
+    monkeypatch.setattr(fake, "set_timeout", failing_set_timeout)
+    pool = E2BSandboxPool(sandbox_factory=lambda: fake)
+
+    with pytest.raises(RuntimeError, match="lease reset failed"):
+        pool.acquire()
+
+    assert bool(fake.commands.background_cmds) is runner_starts
+    assert reset_attempts == failed_reset
+    assert fake.kills == 1
 
 
 def test_pool_with_template_skips_installs_but_still_writes_runner_files() -> None:
@@ -1300,11 +1383,11 @@ def test_acquire_extends_the_lifetime_of_a_reused_sandbox(
     pool = E2BSandboxPool(sandbox_factory=factory)
     sandbox, channel = pool.acquire()
     [fake] = made
-    assert fake.timeouts == [900]  # reset after bootstrap and hello, just before episode use
+    assert fake.timeouts == [900, 900]  # protect startup, then refresh after hello for episode use
     pool.release(sandbox, channel, healthy=True)
     again, _ = pool.acquire()
     assert again is sandbox
-    assert fake.timeouts == [900, 900]  # the reuse extended the countdown again
+    assert fake.timeouts == [900, 900, 900]  # the reuse extended the countdown again
     pool.close()
 
 
@@ -1328,14 +1411,14 @@ def test_explicit_episode_timeout_sizes_private_pool_creation_and_reuse(
     [fake] = made
     assert factory_calls == [{"api_key": None, "template": "", "metadata": None, "timeout": 12_900}]
     assert runtime._episode_timeout_s == 12_000  # noqa: SLF001 - watchdog stays exact
-    assert fake.timeouts == [12_900]
+    assert fake.timeouts == [12_900, 12_900]
     assert channel._max_episode_lifetime_s == 12_900  # noqa: SLF001 - overrun headroom
 
     pool.release(sandbox, channel, healthy=True)
     reused, reused_channel = pool.acquire()
     assert reused is sandbox
     assert reused_channel is channel
-    assert fake.timeouts == [12_900, 12_900]
+    assert fake.timeouts == [12_900, 12_900, 12_900]
     runtime.close()
 
 

--- a/wmh/harness/pi_e2b_test.py
+++ b/wmh/harness/pi_e2b_test.py
@@ -647,6 +647,32 @@ def test_transport_keepalive_stops_renewing_at_the_episode_deadline(
     assert fake.timeouts == [300]  # the final refresh expires exactly at the hard deadline
 
 
+def test_long_episode_keepalive_preserves_cleanup_headroom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 12000s watchdog keeps the sandbox alive through the 12900s overrun deadline."""
+    now = [100.0]
+    monkeypatch.setattr(pi_e2b_module.time, "monotonic", lambda: now[0])
+    keepalive: JsonObject = {"type": TRANSPORT_KEEPALIVE_TYPE}
+    handle = _ScriptedHandle([], hold_open=True)
+    fake = FakeSandbox(handle)
+    channel = _channel(
+        fake,
+        handle,
+        sandbox_timeout_s=12_900,
+        timeout_refresh_interval_s=300,
+        max_episode_lifetime_s=12_900,
+    )
+
+    channel.send({"type": "episode_start"})
+    assert channel._episode_renewal_deadline_at == 13_000  # noqa: SLF001 - absolute cap
+    now[0] += 300
+    channel._decode_line(_line(keepalive))  # noqa: SLF001 - exact transport path
+
+    assert fake.timeouts == [12_600]
+    assert now[0] + fake.timeouts[-1] == 13_000
+
+
 def test_transport_keepalive_refresh_failure_is_nonfatal_and_retried(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -875,7 +901,9 @@ def test_pool_default_factory_tags_initial_and_replacement_sandboxes(
 
     assert replacement is made[1]
     assert len(made) == 2
-    assert factory_calls == [{"api_key": "key", "template": "tmpl", "metadata": metadata}]
+    assert factory_calls == [
+        {"api_key": "key", "template": "tmpl", "metadata": metadata, "timeout": 900}
+    ]
     pool.close()
 
 
@@ -1272,12 +1300,80 @@ def test_acquire_extends_the_lifetime_of_a_reused_sandbox(
     pool = E2BSandboxPool(sandbox_factory=factory)
     sandbox, channel = pool.acquire()
     [fake] = made
-    assert fake.timeouts == [900]  # reset after bootstrap, immediately before the runner starts
+    assert fake.timeouts == [900]  # reset after bootstrap and hello, just before episode use
     pool.release(sandbox, channel, healthy=True)
     again, _ = pool.acquire()
     assert again is sandbox
     assert fake.timeouts == [900, 900]  # the reuse extended the countdown again
     pool.close()
+
+
+def test_explicit_episode_timeout_sizes_private_pool_creation_and_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long episode budget reaches Sandbox.create, the runner lease, and warm reuse."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, made = _factory_for([[{"type": "hello"}]])
+    factory_calls: list[dict[str, object]] = []
+
+    def recording_default_factory(**kwargs: object) -> SandboxFactory:
+        factory_calls.append(kwargs)
+        return factory
+
+    monkeypatch.setattr(pi_e2b_module, "default_sandbox_factory", recording_default_factory)
+    runtime = _runtime(episode_timeout_s=12_000)
+    pool = runtime._pool  # noqa: SLF001 - verifies the runtime-owned lease contract
+
+    sandbox, channel = pool.acquire()
+    [fake] = made
+    assert factory_calls == [{"api_key": None, "template": "", "metadata": None, "timeout": 12_900}]
+    assert runtime._episode_timeout_s == 12_000  # noqa: SLF001 - watchdog stays exact
+    assert fake.timeouts == [12_900]
+    assert channel._max_episode_lifetime_s == 12_900  # noqa: SLF001 - overrun headroom
+
+    pool.release(sandbox, channel, healthy=True)
+    reused, reused_channel = pool.acquire()
+    assert reused is sandbox
+    assert reused_channel is channel
+    assert fake.timeouts == [12_900, 12_900]
+    runtime.close()
+
+
+def test_default_episode_timeout_preserves_existing_private_pool_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting the option keeps the existing 300s episode and 900s sandbox defaults."""
+    monkeypatch.delenv(E2B_TEMPLATE_ENV, raising=False)
+    factory, _made = _factory_for([[{"type": "hello"}]])
+    factory_calls: list[dict[str, object]] = []
+
+    def recording_default_factory(**kwargs: object) -> SandboxFactory:
+        factory_calls.append(kwargs)
+        return factory
+
+    monkeypatch.setattr(pi_e2b_module, "default_sandbox_factory", recording_default_factory)
+    runtime = _runtime()
+
+    assert runtime._episode_timeout_s == 300  # noqa: SLF001 - compatibility contract
+    assert factory_calls == [{"api_key": None, "template": "", "metadata": None, "timeout": 900}]
+    runtime.close()
+
+
+def test_shared_pool_rejects_an_episode_budget_above_its_lease_capacity() -> None:
+    """A shared default pool cannot silently undercut a 12000-second runtime promise."""
+    factory, _made = _factory_for([[{"type": "hello"}]])
+    default_pool = E2BSandboxPool(sandbox_factory=factory)
+    with pytest.raises(ValueError, match="shared E2BSandboxPool episode timeout is too small"):
+        _runtime(pool=default_pool, episode_timeout_s=12_000)
+    default_pool.close()
+
+    sized_pool = E2BSandboxPool(
+        sandbox_factory=factory,
+        episode_timeout_s=12_000,
+    )
+    runtime = _runtime(pool=sized_pool, episode_timeout_s=12_000)
+    assert runtime._pool is sized_pool  # noqa: SLF001 - accepted capacity is reused exactly
+    sized_pool.close()
 
 
 def test_acquire_replaces_a_dead_idle_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/harness/population_checkpoint.py
+++ b/wmh/harness/population_checkpoint.py
@@ -29,12 +29,12 @@ from wmh.harness.project_proposer import (
     EvaluatedCandidate,
     validate_candidate_turn,
 )
-from wmh.harness.runtime import TokenUsage
+from wmh.harness.runtime import TokenUsage, validate_episode_timeout_s
 from wmh.harness.scoring import HarnessScore, HarnessScoreReport, ScoreRequest
 from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
 from wmh.providers.base import ProviderConfig
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
 _CHECKPOINT_DIR = "checkpoint"
 _IDENTITY_FILE = "identity.json"
@@ -60,7 +60,7 @@ class PopulationCheckpointIdentity(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[1] = _SCHEMA_VERSION
+    schema_version: Literal[2] = _SCHEMA_VERSION
     output_name: str = Field(min_length=1, max_length=512)
     artifact_root: str = Field(min_length=1)
     seed_reference: str | None = None
@@ -76,6 +76,7 @@ class PopulationCheckpointIdentity(BaseModel):
     harness_backend: Literal["local", "e2b"]
     e2b_template: str | None = None
     environment_command_timeout_sec: int = Field(strict=True, ge=1)
+    episode_timeout_sec: float = Field(gt=0)
     project_timeout_sec: float = Field(gt=0)
     max_source_files: int = Field(strict=True, ge=1)
     max_source_bytes: int = Field(strict=True, ge=1)
@@ -88,6 +89,11 @@ class PopulationCheckpointIdentity(BaseModel):
         if isinstance(value, bool):
             raise ValueError("checkpoint counts must be integers, not booleans")
         return value
+
+    @field_validator("episode_timeout_sec", mode="before")
+    @classmethod
+    def _validate_episode_timeout(cls, value: object) -> float:
+        return validate_episode_timeout_s(value)
 
     @model_validator(mode="after")
     def _validate_score_cell_plan(self) -> PopulationCheckpointIdentity:
@@ -149,7 +155,7 @@ class PopulationCheckpointControl(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[1] = _SCHEMA_VERSION
+    schema_version: Literal[2] = _SCHEMA_VERSION
     identity_hash: str = Field(pattern=_SHA256_PATTERN)
     state: Literal["ready", "in_progress", "complete"]
     committed_step: int = Field(strict=True, ge=-1)
@@ -218,7 +224,7 @@ class _FileRecord(BaseModel):
 class _SeedManifest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[1] = _SCHEMA_VERSION
+    schema_version: Literal[2] = _SCHEMA_VERSION
     source_tree_hash: str
     files: tuple[_FileRecord, ...]
 
@@ -226,7 +232,7 @@ class _SeedManifest(BaseModel):
 class _BoundaryManifest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[1] = _SCHEMA_VERSION
+    schema_version: Literal[2] = _SCHEMA_VERSION
     index: int = Field(strict=True, ge=0)
     previous_manifest_hash: str | None = Field(default=None, pattern=_SHA256_PATTERN)
     outcome: Literal["seed", "scored", "invalid"]

--- a/wmh/harness/population_checkpoint_test.py
+++ b/wmh/harness/population_checkpoint_test.py
@@ -198,6 +198,7 @@ def _identity(root: Path, seed: HarnessSourceTree) -> PopulationCheckpointIdenti
         harness_backend="e2b",
         e2b_template="template",
         environment_command_timeout_sec=300,
+        episode_timeout_sec=300,
         project_timeout_sec=900,
         max_source_files=100,
         max_source_bytes=1_000_000,

--- a/wmh/harness/runtime.py
+++ b/wmh/harness/runtime.py
@@ -11,6 +11,7 @@ the same types the rest of the harness uses.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable
 from enum import StrEnum
 from typing import Protocol, runtime_checkable
@@ -46,6 +47,9 @@ DEFAULT_MAX_TURNS = 20  # small shell tasks converge well before this; raise for
 # Per-call output budget used by the pi runtimes. This remains separate from the turn cap: a
 # reasoning model can exhaust one response before it emits a tool call even when many turns remain.
 DEFAULT_MAX_OUTPUT_TOKENS = 4096
+# Host-enforced wall budget for one evaluated harness episode. Backends may carry additional
+# resource leases, but none may undercut this budget once a caller selects a larger value.
+DEFAULT_EVAL_EPISODE_TIMEOUT_S = 300.0
 
 # Per-observation cap in the judge-facing transcript. Generous rather than tight: gold evidence
 # routinely lives deep in long outputs (`cat` of a produced file, `ls -R`), and truncating it away
@@ -56,6 +60,16 @@ _NUDGE = (
     "[ERROR] that reply was not a single valid JSON tool call. Reply with EXACTLY one JSON "
     'object: {"tool": "<tool name>", "arguments": {...}}'
 )
+
+
+def validate_episode_timeout_s(value: object) -> float:
+    """Return one finite positive episode timeout, rejecting booleans and non-numbers."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("episode_timeout_s must be a finite positive number")
+    timeout = float(value)
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("episode_timeout_s must be a finite positive number")
+    return timeout
 
 
 class HarnessSearchCancelled(RuntimeError):


### PR DESCRIPTION
Depends on #230.

## Summary
- expose an explicit episode timeout on Harbor-backed harness score and optimize commands
- bind the timeout into scorer evidence, run inputs, and crash-safe optimization identity
- propagate the budget through the Harbor agent bridge and HarnessDoc into E2B Pi execution
- size sandbox creation, reuse, and renewal with bounded synchronous-call and cleanup headroom while preserving the existing defaults
- reject local no-op configuration and shared pools that cannot sustain the requested budget

## Validation
- 2214 passed, 19 skipped
- focused timeout and checkpoint suite: 194 passed
- create harness suite: 57 passed
- Ruff check and format clean
- ty clean
- live score and optimize help verified