### PR TITLE
Canonicalize Harbor checkpoint inputs across processes

### DIFF
--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -32,6 +32,7 @@ from wmh.config import ARTIFACT_DIR
 from wmh.config.store import validate_name
 from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
+from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage, resolve_e2b_template
@@ -371,7 +372,7 @@ def _execute_optimization(
             iterations=iterations,
             planned_score_cells=planned_score_cells,
             max_score_cells=max_score_cells,
-            harbor_job_template=effective_job_config.model_dump(mode="json"),
+            harbor_job_template=canonical_harbor_job_config(effective_job_config),
             meta_provider=meta_config,
             agent_provider=agent_config,
             optimizer_document_hash=optimizer.doc_hash,

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
+import os
+import subprocess
+import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import cast
@@ -13,6 +17,7 @@ import typer
 from harbor.models.environment_type import EnvironmentType
 from harbor.models.job.config import DatasetConfig, JobConfig, RetryConfig
 from harbor.models.trial.config import AgentConfig, EnvironmentConfig
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from wmh.cli import app
@@ -22,6 +27,7 @@ from wmh.cli.harness_optimize import (
     _execute_optimization,
 )
 from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
 from wmh.harness.live_session import SessionEvent
@@ -217,6 +223,34 @@ def _job_config(tmp_path: Path) -> JobConfig:
     )
 
 
+def _raw_job_config_for_hash_seed(hash_seed: int) -> dict[str, object]:
+    """Harbor's JSON-mode set ordering from a genuinely distinct interpreter seed."""
+    script = """
+from harbor.models.job.config import JobConfig, RetryConfig
+
+config = JobConfig(
+    job_name="template",
+    jobs_dir="run/harbor",
+    retry=RetryConfig(
+        max_retries=0,
+        include_exceptions={"ZetaError", "AlphaError"},
+    ),
+    artifacts=["second", "first"],
+)
+print(config.model_dump_json())
+"""
+    environment = os.environ.copy()
+    environment["PYTHONHASHSEED"] = str(hash_seed)
+    output = subprocess.check_output(
+        [sys.executable, "-c", script],
+        env=environment,
+        text=True,
+    )
+    value = json.loads(output)
+    assert isinstance(value, dict)
+    return cast("dict[str, object]", value)
+
+
 def _configs() -> tuple[ProviderConfig, ProviderConfig]:
     return (
         ProviderConfig(
@@ -281,6 +315,117 @@ def _commit_ready_boundary(
     checkpoint.before_step(len(result.iterations))
     checkpoint.commit_boundary(result)
     checkpoint.finish_project_segment(usage)
+
+
+def test_harbor_job_identity_and_resume_are_stable_across_process_hash_seeds(
+    tmp_path: Path,
+) -> None:
+    """Harbor set order cannot fork an otherwise identical durable optimization."""
+    raw_templates = [_raw_job_config_for_hash_seed(seed) for seed in (0, 1, 42)]
+    raw_retry_orders = {
+        json.dumps(cast("dict[str, object]", template["retry"]), separators=(",", ":"))
+        for template in raw_templates
+    }
+    assert len(raw_retry_orders) > 1  # prove the subprocesses exercised the original defect
+
+    canonical_templates = [canonical_harbor_job_config(template) for template in raw_templates]
+    assert canonical_templates[0] == canonical_templates[1] == canonical_templates[2]
+    retry = cast("dict[str, object]", canonical_templates[0]["retry"])
+    assert retry["include_exceptions"] == ["AlphaError", "ZetaError"]
+    assert retry["exclude_exceptions"] == sorted(cast("list[str]", retry["exclude_exceptions"]))
+    assert canonical_templates[0]["artifacts"] == ["second", "first"]
+    ordered = JobConfig(
+        job_name="ordered",
+        agents=[
+            AgentConfig(import_path="agents.First"),
+            AgentConfig(import_path="agents.Second"),
+        ],
+        datasets=[DatasetConfig(path=Path("second")), DatasetConfig(path=Path("first"))],
+        artifacts=["second", "first"],
+    )
+    ordered_payload = canonical_harbor_job_config(ordered)
+    ordered_agents = cast("list[dict[str, object]]", ordered_payload["agents"])
+    ordered_datasets = cast("list[dict[str, object]]", ordered_payload["datasets"])
+    assert [agent["import_path"] for agent in ordered_agents] == [
+        "agents.First",
+        "agents.Second",
+    ]
+    assert [dataset["path"] for dataset in ordered_datasets] == ["second", "first"]
+    assert ordered_payload["artifacts"] == ["second", "first"]
+    reordered = ordered.model_copy(
+        update={
+            "agents": list(reversed(ordered.agents)),
+            "datasets": list(reversed(ordered.datasets)),
+            "artifacts": list(reversed(ordered.artifacts)),
+        },
+        deep=True,
+    )
+    assert canonical_harbor_job_config(reordered) != ordered_payload
+
+    unknown_top_level = {**raw_templates[0], "unknown_identity_input": True}
+    unknown_nested = json.loads(json.dumps(raw_templates[0]))
+    cast("dict[str, object]", unknown_nested["retry"])["unknown_retry_input"] = True
+    with pytest.raises(ValidationError):
+        canonical_harbor_job_config(unknown_top_level)
+    with pytest.raises(ValidationError):
+        canonical_harbor_job_config(unknown_nested)
+
+    run_dir = tmp_path / "run"
+    root = tmp_path / ".wmh"
+    seed = _source("seed")
+    meta_config, agent_config = _configs()
+    base_identity = _checkpoint_identity(
+        run_dir=run_dir,
+        root=root,
+        job_config=_job_config(tmp_path),
+        seed=seed,
+        request=_request(),
+        iterations=1,
+        max_score_cells=2,
+        meta_config=meta_config,
+        agent_config=agent_config,
+    )
+    # model_copy intentionally bypasses validation to reproduce a checkpoint written by the
+    # pre-fix process, whose Harbor JSON list retained that process's arbitrary set order.
+    legacy_identity = base_identity.model_copy(update={"harbor_job_template": raw_templates[0]})
+    expected_identity = PopulationCheckpointIdentity.model_validate(
+        {
+            **base_identity.model_dump(mode="json"),
+            "harbor_job_template": raw_templates[1],
+        }
+    )
+    serialized_identities = [
+        json.dumps(
+            PopulationCheckpointIdentity.model_validate(
+                {
+                    **base_identity.model_dump(mode="json"),
+                    "harbor_job_template": template,
+                }
+            ).model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        for template in raw_templates
+    ]
+    assert len(set(serialized_identities)) == 1
+    assert len({hashlib.sha256(value).hexdigest() for value in serialized_identities}) == 1
+
+    with PopulationCheckpointStore.create(
+        run_dir,
+        identity=legacy_identity,
+        seed=seed,
+    ) as checkpoint:
+        _commit_ready_boundary(
+            checkpoint,
+            _result(seed),
+            usage=SandboxUsage(count=1, seconds=1.0),
+        )
+    identity_path = run_dir / "checkpoint/identity.json"
+    raw_identity_before_resume = identity_path.read_bytes()
+    with PopulationCheckpointStore.open(run_dir) as resumed:
+        resumed.assert_identity(expected_identity)
+        assert resumed.control.committed_step == 0
+    assert identity_path.read_bytes() == raw_identity_before_resume
 
 
 def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
@@ -419,8 +564,11 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     assert outcome.saved.version == 1
     assert outcome.saved.doc_hash == result.best.candidate.doc_hash
     assert (root / "harnesses/selected/aliases.toml").exists()
-    assert json.loads((run_dir / "inputs.json").read_text())["iterations"] == 3
-    assert json.loads((run_dir / "inputs.json").read_text())["episode_timeout_sec"] == 12_000
+    inputs = json.loads((run_dir / "inputs.json").read_text())
+    assert inputs["iterations"] == 3
+    assert inputs["episode_timeout_sec"] == 12_000
+    retry = inputs["harbor_job_template"]["retry"]
+    assert retry["exclude_exceptions"] == sorted(retry["exclude_exceptions"])
     written = json.loads((run_dir / "outcome.json").read_text())
     assert written["best_candidate_id"] == "candidate-0000"
     assert written["project_sandbox_usage"] == {"count": 3, "seconds": 37.5}

--- a/wmh/cli/harness_score.py
+++ b/wmh/cli/harness_score.py
@@ -19,6 +19,7 @@ from wmh.cli.model_roles import resolve_required_model_config
 from wmh.config import ARTIFACT_DIR
 from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
+from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
 from wmh.harness.runtime import (
@@ -224,7 +225,7 @@ def _execute_scoring(
     inputs: JsonObject = {
         "schema_version": 2,
         "score_request": request.model_dump(mode="json"),
-        "harbor_job_template": effective_job_config.model_dump(mode="json"),
+        "harbor_job_template": canonical_harbor_job_config(effective_job_config),
         "agent_provider": agent_config.model_dump(mode="json"),
         "harness_backend": harness_backend,
         "e2b_template": e2b_template or None,

--- a/wmh/cli/harness_score_test.py
+++ b/wmh/cli/harness_score_test.py
@@ -203,6 +203,8 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
     assert inputs["schema_version"] == 2
     assert inputs["score_request"] == request.model_dump(mode="json")
     assert inputs["episode_timeout_sec"] == 12_000
+    retry = inputs["harbor_job_template"]["retry"]
+    assert retry["exclude_exceptions"] == sorted(retry["exclude_exceptions"])
     assert inputs["targets"] == [
         {
             "document_hash": target.harness.doc_hash,

--- a/wmh/evals/harbor/canonical.py
+++ b/wmh/evals/harbor/canonical.py
@@ -1,0 +1,77 @@
+"""Canonical JSON projection for Harbor models with set-valued fields."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import date, datetime, time
+from enum import Enum
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+from harbor.models.job.config import JobConfig
+from pydantic import BaseModel
+
+from wmh.core.types import JsonObject
+
+
+def normalize_harbor_json(value: object) -> object:
+    """Return JSON-shaped Harbor data while preserving sequence and set semantics.
+
+    Pydantic's JSON mode turns sets into process-order lists. Normalize from Python mode instead:
+    ordered lists and tuples retain their order, while sets become canonically sorted lists.
+    """
+    if isinstance(value, BaseModel):
+        return normalize_harbor_json(value.model_dump(mode="python"))
+    if isinstance(value, Mapping):
+        return {
+            str(key): normalize_harbor_json(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (set, frozenset)):
+        normalized = [normalize_harbor_json(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ),
+        )
+    if isinstance(value, (list, tuple)):
+        return [normalize_harbor_json(item) for item in value]
+    if isinstance(value, Enum):
+        return normalize_harbor_json(value.value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    return value
+
+
+def canonical_harbor_job_config(value: object) -> JsonObject:
+    """Validate and emit one stable, JSON-safe Harbor ``JobConfig`` payload.
+
+    Re-validation restores Harbor's set types when reading a pre-canonical checkpoint, allowing
+    the same projection to compare old and new process orderings without rewriting evidence.
+    """
+    # A checkpoint payload may predate this projection. Reject unknown fields instead of letting
+    # Harbor's default ``extra=ignore`` erase input drift and make two identities compare equal.
+    config = (
+        value if isinstance(value, JobConfig) else JobConfig.model_validate(value, extra="forbid")
+    )
+    encoded = json.dumps(
+        normalize_harbor_json(config.model_dump(mode="python")),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    payload = json.loads(encoded)
+    if not isinstance(payload, dict):  # pragma: no cover - JobConfig always has an object root
+        raise TypeError("canonical Harbor JobConfig must be a JSON object")
+    return cast("JsonObject", payload)

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -11,8 +11,6 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from datetime import date, datetime, time
-from enum import Enum
 from pathlib import Path
 from typing import Literal, Protocol, Self, TypeVar
 from uuid import UUID, uuid4
@@ -33,6 +31,7 @@ from wmh.evals.harbor.agent import (
     WMH_HARBOR_AGENT_VERSION,
     WmhHarborAgent,
 )
+from wmh.evals.harbor.canonical import normalize_harbor_json
 from wmh.evals.harbor.tasks import (
     HarborTaskIdentity,
     ResolvedHarborTaskSet,
@@ -674,44 +673,12 @@ def _read_json(path: Path) -> object:
 
 def _canonical_model(model: BaseModel) -> str:
     return json.dumps(
-        _normalize_json(model.model_dump(mode="python")),
+        normalize_harbor_json(model.model_dump(mode="python")),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
         allow_nan=False,
     )
-
-
-def _normalize_json(value: object) -> object:
-    if isinstance(value, BaseModel):
-        return _normalize_json(value.model_dump(mode="python"))
-    if isinstance(value, Mapping):
-        return {
-            str(key): _normalize_json(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
-        }
-    if isinstance(value, (set, frozenset)):
-        normalized = [_normalize_json(item) for item in value]
-        return sorted(
-            normalized,
-            key=lambda item: json.dumps(
-                item,
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=False,
-            ),
-        )
-    if isinstance(value, (list, tuple)):
-        return [_normalize_json(item) for item in value]
-    if isinstance(value, Enum):
-        return _normalize_json(value.value)
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, (datetime, date, time)):
-        return value.isoformat()
-    return value
 
 
 def _validate_trial_lock(lock: TrialLock, trial: TrialResult) -> None:
@@ -877,7 +844,7 @@ def _trial_summary(trial: TrialResult) -> str:
 
 def _digest_json(value: object) -> str:
     encoded = json.dumps(
-        _normalize_json(value),
+        normalize_harbor_json(value),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,

--- a/wmh/harness/population_checkpoint.py
+++ b/wmh/harness/population_checkpoint.py
@@ -15,6 +15,7 @@ from filelock import BaseFileLock, FileLock, Timeout
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 from wmh.core.types import JsonObject
+from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.harness.archive_io import copy_score_artifacts, write_source_tree, write_text
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxUsage
@@ -94,6 +95,11 @@ class PopulationCheckpointIdentity(BaseModel):
     @classmethod
     def _validate_episode_timeout(cls, value: object) -> float:
         return validate_episode_timeout_s(value)
+
+    @field_validator("harbor_job_template", mode="before")
+    @classmethod
+    def _canonicalize_harbor_job_template(cls, value: object) -> JsonObject:
+        return canonical_harbor_job_config(value)
 
     @model_validator(mode="after")
     def _validate_score_cell_plan(self) -> PopulationCheckpointIdentity:


### PR DESCRIPTION
## Summary
- serialize Harbor job templates from Python-mode models so set-valued retry fields are stable across interpreter hash seeds while ordered lists retain their order
- use the same canonical payload for score evidence and optimizer checkpoint identity
- strictly reject unknown Harbor fields and normalize pre-canonical ready checkpoint identities in memory without rewriting their raw identity bytes

## Stacking
- stacked on #231
- keep open and unmerged pending approval

## Validation
- cross-process `PYTHONHASHSEED` regression plus pre-canonical ready-checkpoint resume identity coverage
- focused Harbor/score/optimize/checkpoint suite: 78 passed
- complete suite: 2218 passed, 19 skipped
- Ruff check and format: pass
- ty: pass
- `git diff --check`: pass