### PR TITLE
Add feedback-directed one-step harness improvement (wmh harness improve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ sibling batch from the frozen current champion, evaluates every sibling against 
 snapshot, and selects at most one gate-eligible winner. Proposal batch size controls search
 breadth; `k` independently controls the number of evaluation passes per scenario.
 
+### Improve a harness from feedback
+
+One piece of feedback ("you should have access to my GitHub") can drive a single, gated
+improvement step: the feedback becomes the proposer's directive AND is synthesized into
+must-pass verification tasks (tasks the current champion already passes are dropped first).
+
+```bash
+uv run wmh harness improve my-agent --feedback "you should have access to my GitHub" \
+  --tasks tasks.jsonl --model my-world-model
+```
+
+The candidate is promoted (saved as a new champion version) only when it clears both gates: the
+standard suite score stays within a 10 percent margin of the seed (`--margin`), and every
+synthesized feedback verification task passes a strict majority of its attempts.
+
 ## Agentic mode: knowledge base, reasoning, web grounding
 
 Beyond retrieval, a world model can act like an *agent* about its own environment (all opt-in):

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -39,6 +39,7 @@ import wmh.providers as providers
 from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app
+from wmh.cli.harness_improve import register as register_harness_improve_commands
 from wmh.cli.harness_optimize import register as register_harness_optimize_commands
 from wmh.cli.harness_score import register as register_harness_score_commands
 from wmh.cli.platform_cmds import register as register_platform_commands
@@ -142,6 +143,7 @@ app.add_typer(examples_app, name="examples")
 app.add_typer(config_app, name="config")
 app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
+register_harness_improve_commands(harness_app)
 register_harness_optimize_commands(harness_app)
 register_harness_score_commands(harness_app)
 app.add_typer(harness_app, name="harness")

--- a/wmh/cli/harness_improve.py
+++ b/wmh/cli/harness_improve.py
@@ -1,0 +1,399 @@
+"""Local CLI composition for feedback-directed one-step harness improvement."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+from uuid import uuid4
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+from rich.prompt import Confirm
+
+from wmh.agents.default import default_agent
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import DEFAULT_PROJECT_TIMEOUT_S, AgentProject
+from wmh.cli.harbor_inputs import write_json_atomic
+from wmh.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
+from wmh.config import ARTIFACT_DIR, ArtifactPaths, WorldModelStore
+from wmh.config.store import validate_name
+from wmh.core.types import JsonObject
+from wmh.engine import load_world_model
+from wmh.engine.knowledge import KnowledgeBase
+from wmh.evals.gold import GoldJudge
+from wmh.evals.tasks import TaskSpec, load_tasks
+from wmh.evals.world_model_scorer import WorldModelScorer
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
+from wmh.harness.improve import (
+    DEFAULT_SUITE_MARGIN,
+    ImproveGate,
+    ImproveOutcome,
+    improve_harness,
+    verification_results,
+)
+from wmh.harness.population_archive import write_population_archive
+from wmh.harness.project_proposer import CandidateProposer, ProjectCandidateProposer
+from wmh.harness.source_tree import HarnessSourceTree
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.providers.base import Provider, ProviderConfig, ToolCallingProvider
+from wmh.providers.registry import get_provider
+from wmh.scenarios.feedback import synthesize_verification_tasks
+
+_console = Console()
+
+
+@dataclass(frozen=True)
+class ImproveAlreadySatisfied:
+    """QA outcome: the seed already passes every synthesized verification task."""
+
+    dropped: tuple[str, ...]
+    run_dir: Path
+
+
+@dataclass(frozen=True)
+class HarnessImproveOutcome:
+    """Completed local improve-run artifacts and the optional published version."""
+
+    outcome: ImproveOutcome
+    saved: HarnessDoc | None
+    run_dir: Path
+    dropped: tuple[str, ...]
+
+
+def register(app: typer.Typer) -> None:
+    """Register feedback-directed improvement under ``wmh harness``."""
+    app.command("improve")(improve_harness_command)
+
+
+def improve_harness_command(
+    name: str = typer.Argument(..., help="Harness name to improve; accepted winners save here."),
+    feedback: str | None = typer.Option(
+        None,
+        "--feedback",
+        help="One piece of user feedback naming the capability the harness should gain.",
+    ),
+    feedback_file: str | None = typer.Option(
+        None,
+        "--feedback-file",
+        help="Read the feedback text from this file instead of --feedback.",
+    ),
+    tasks_file: str = typer.Option(
+        ...,
+        "--tasks",
+        help="JSONL standard suite the improved harness must not regress on.",
+    ),
+    model: str = typer.Option(
+        ...,
+        "--model",
+        help="World model that simulates the environment for every evaluation.",
+    ),
+    verification_count: int = typer.Option(
+        3,
+        "--verification-count",
+        min=1,
+        help="Maximum number of must-pass verification tasks synthesized from the feedback.",
+    ),
+    margin: float = typer.Option(
+        DEFAULT_SUITE_MARGIN,
+        "--margin",
+        help="Allowed relative suite regression, a fraction in [0, 1).",
+    ),
+    iterations: int = typer.Option(1, min=1, help="Fixed number of singular proposal slots."),
+    attempts: int = typer.Option(3, min=1, help="Attempts per exact task and candidate."),
+    harness_backend: str = typer.Option(
+        "local",
+        "--harness-backend",
+        help="Where each evaluated harness process runs: local or e2b.",
+    ),
+    e2b_template: str | None = typer.Option(
+        None,
+        "--e2b-template",
+        envvar=E2B_TEMPLATE_ENV,
+        help="Optional template for the E2B proposer project and evaluated processes.",
+    ),
+    seed: str | None = typer.Option(
+        None,
+        "--seed",
+        help="Stored harness name@ref to improve; default is NAME's champion when it exists, "
+        "else the complete built-in Pi agent.",
+    ),
+    seed_knowledge: bool = typer.Option(
+        True,
+        "--seed-knowledge/--no-seed-knowledge",
+        help="Write the synthesized environment knowledge into the world model's knowledge dir.",
+    ),
+    result_out: str | None = typer.Option(
+        None,
+        "--result-out",
+        help="Local run directory (default: <root>/runs/<opaque-id>).",
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project artifact root and harness store."),
+    yes: bool = typer.Option(False, "--yes", help="Acknowledge the displayed execution matrix."),
+) -> None:
+    """Improve a harness from one piece of feedback, gated on the suite plus verification.
+
+    The feedback becomes the proposer directive and is synthesized (via settings
+    ``models.meta``, which also drives the proposer) into must-pass verification tasks; tasks
+    the seed already passes are dropped before any optimization spend. Candidates are scored
+    closed-loop against the world model (the agent under test resolves from settings
+    ``models.agent`` when set, else the world model's provider). A candidate is promoted only
+    when its standard suite score stays within ``--margin`` of the seed AND every surviving
+    verification task passes a strict majority of attempts.
+    """
+    try:
+        validate_name(name)
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if (feedback is None) == (feedback_file is None):
+        raise typer.BadParameter("provide exactly one of --feedback or --feedback-file")
+    if feedback_file is not None:
+        try:
+            feedback = Path(feedback_file).read_text(encoding="utf-8")
+        except OSError as error:
+            raise typer.BadParameter(
+                f"cannot read --feedback-file {feedback_file!r}: {error}"
+            ) from error
+    assert feedback is not None
+    if not feedback.strip():
+        raise typer.BadParameter("the feedback text is empty")
+    if harness_backend not in ("local", "e2b"):
+        raise typer.BadParameter(
+            f"unknown --harness-backend {harness_backend!r}; choose local or e2b"
+        )
+    try:
+        gate = ImproveGate(suite_margin=margin)
+    except ValidationError as error:
+        raise typer.BadParameter(
+            f"--margin must be a fraction in [0, 1): {error}", param_hint="--margin"
+        ) from error
+    try:
+        suite_tasks = load_tasks(tasks_file)
+    except (OSError, ValueError) as error:
+        raise typer.BadParameter(f"cannot load tasks from {tasks_file!r}: {error}") from error
+    meta_config = resolve_required_model_config(root, "meta")
+    effective_e2b_template = resolve_e2b_template(e2b_template)
+    run_dir = Path(result_out) if result_out is not None else Path(root) / "runs" / uuid4().hex
+    if run_dir.exists():
+        raise typer.BadParameter(f"result directory already exists: {run_dir}")
+
+    planned_cells = (iterations + 1) * (len(suite_tasks) + verification_count) * attempts
+    qa_cells = verification_count * attempts
+    _console.print(
+        f"feedback improvement: 1 seed + {iterations} proposal slot(s), {len(suite_tasks)} "
+        f"suite task(s) + up to {verification_count} verification task(s), {attempts} "
+        f"attempt(s) -> up to {planned_cells} score cells (+ up to {qa_cells} seed QA cells); "
+        f"gate: suite within {gate.suite_margin:.0%} of seed, every verification task passes; "
+        f"evaluated harness backend={harness_backend}; proposer project=e2b"
+    )
+    if not yes:
+        if not _console.is_terminal:
+            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+        if not Confirm.ask("Proceed?", default=False):
+            raise typer.Exit(0)
+
+    result = _execute_improvement(
+        name=name,
+        root=root,
+        run_dir=run_dir,
+        feedback=feedback,
+        suite_tasks=suite_tasks,
+        model=model,
+        verification_count=verification_count,
+        gate=gate,
+        iterations=iterations,
+        attempts=attempts,
+        harness_backend=cast("Literal['local', 'e2b']", harness_backend),
+        e2b_template=effective_e2b_template,
+        seed_reference=seed,
+        seed_knowledge=seed_knowledge,
+        meta_config=meta_config,
+    )
+    if isinstance(result, ImproveAlreadySatisfied):
+        dropped = ", ".join(result.dropped)
+        _console.print(
+            f"[yellow]feedback appears already satisfied[/yellow]: the seed harness already "
+            f"passes all {len(result.dropped)} synthesized verification task(s) ({dropped}); "
+            "no optimization was run"
+        )
+        raise typer.Exit(1)
+    outcome = result.outcome
+    if outcome.accepted:
+        assert result.saved is not None
+        assert outcome.candidate_suite_score is not None
+        passed = sum(1 for item in outcome.verification if item.passed)
+        _console.print(
+            f"[green]improved[/green] [bold]{name}[/bold] v{result.saved.version} (champion) "
+            f"suite={outcome.candidate_suite_score:.6f} (seed {outcome.seed_suite_score:.6f}); "
+            f"verification {passed}/{len(outcome.verification)} passed; "
+            f"evidence -> {result.run_dir}"
+        )
+        return
+    _console.print(
+        f"[yellow]rejected[/yellow] [bold]{name}[/bold]: {outcome.reason}; "
+        f"evidence -> {result.run_dir}"
+    )
+
+
+def _execute_improvement(
+    *,
+    name: str,
+    root: str,
+    run_dir: Path,
+    feedback: str,
+    suite_tasks: list[TaskSpec],
+    model: str,
+    verification_count: int,
+    gate: ImproveGate,
+    iterations: int,
+    attempts: int,
+    harness_backend: Literal["local", "e2b"],
+    e2b_template: str | None,
+    seed_reference: str | None,
+    seed_knowledge: bool,
+    meta_config: ProviderConfig,
+) -> HarnessImproveOutcome | ImproveAlreadySatisfied:
+    """Synthesize the gate, QA it against the seed, run one improvement, and publish evidence."""
+    meta_provider = get_provider(meta_config)
+    if not isinstance(meta_provider, ToolCallingProvider):
+        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
+    if not isinstance(meta_provider, Provider):
+        raise typer.BadParameter("settings [models.meta] provider lacks plain completions")
+    world_store = WorldModelStore(root)
+    try:
+        model_dir = world_store.resolve(model)
+    except (FileNotFoundError, ValueError) as error:
+        raise typer.BadParameter(str(error)) from error
+    world_model, wm_provider = load_world_model(model_dir)
+    agent_provider, _agent_model = resolve_opt_in_model_provider(root, "agent", wm_provider)
+    judge = GoldJudge(wm_provider)
+    seed_source = _resolve_seed_source(root, name=name, seed=seed_reference)
+    seed_doc = seed_source.to_doc("seed")
+
+    synthesis = synthesize_verification_tasks(
+        feedback,
+        provider=meta_provider,
+        count=verification_count,
+    )
+    collisions = sorted(
+        {task.task_id for task in synthesis.tasks} & {task.task_id for task in suite_tasks}
+    )
+    if collisions:
+        raise ValueError(
+            f"synthesized verification task id(s) collide with the suite: {collisions}"
+        )
+
+    def build_scorer(tasks: list[TaskSpec]) -> WorldModelScorer:
+        return WorldModelScorer(
+            world_model=world_model,
+            tasks=tasks,
+            agent_provider=agent_provider,
+            judge=judge,
+            model_identity={"world_model": model_dir.name},
+            harness_backend=harness_backend,
+            # "" freezes template absence for e2b (never an env re-read after this snapshot).
+            e2b_template=(e2b_template or "") if harness_backend == "e2b" else None,
+            eval_concurrency=1 if harness_backend == "local" else 0,
+        )
+
+    # QA: a verification task the seed already passes verifies nothing new; drop it before it
+    # can make the gate pass vacuously.
+    qa_scorer = build_scorer(list(synthesis.tasks))
+    qa_score = qa_scorer.score(seed_doc, request=qa_scorer.request(attempts=attempts))
+    qa_outcomes = verification_results(qa_score.report, [task.task_id for task in synthesis.tasks])
+    dropped = tuple(item.task_id for item in qa_outcomes if item.passed)
+    surviving = [task for task in synthesis.tasks if task.task_id not in set(dropped)]
+    if not surviving:
+        return ImproveAlreadySatisfied(dropped=dropped, run_dir=run_dir)
+
+    knowledge_file: str | None = None
+    if seed_knowledge and synthesis.knowledge_notes:
+        knowledge_file = _write_feedback_knowledge(
+            model_dir, feedback=feedback, notes=synthesis.knowledge_notes
+        )
+        _console.print(f"wrote environment knowledge -> {model_dir / 'knowledge'}/{knowledge_file}")
+
+    scorer = build_scorer([*suite_tasks, *surviving])
+    optimizer = optimizer_agent()
+    with AgentProject.create(
+        timeout=DEFAULT_PROJECT_TIMEOUT_S,
+        template=e2b_template,
+        metadata={"wmh_component": "harness_improve"},
+    ) as project:
+
+        def proposer_factory(directive: str) -> CandidateProposer:
+            return ProjectCandidateProposer(
+                project,
+                optimizer,
+                meta_provider,
+                directive=directive,
+            )
+
+        outcome = improve_harness(
+            seed=seed_source,
+            feedback=feedback,
+            suite_tasks=suite_tasks,
+            verification_tasks=surviving,
+            scorer=scorer,
+            proposer_factory=proposer_factory,
+            iterations=iterations,
+            attempts=attempts,
+            gate=gate,
+        )
+
+    write_population_archive(run_dir / "population", outcome.result)
+    payload: JsonObject = {
+        "schema_version": 1,
+        "accepted": outcome.accepted,
+        "reason": outcome.reason,
+        "feedback": feedback,
+        "seed_suite_score": outcome.seed_suite_score,
+        "candidate_suite_score": outcome.candidate_suite_score,
+        "selected_candidate_id": (
+            outcome.selected.candidate_id if outcome.selected is not None else None
+        ),
+        "verification": [item.model_dump(mode="json") for item in outcome.verification],
+        "suite_task_ids": [task.task_id for task in suite_tasks],
+        "verification_task_ids": [task.task_id for task in surviving],
+        "dropped_verification_task_ids": list(dropped),
+        "suite_margin": gate.suite_margin,
+        "knowledge_file": knowledge_file,
+    }
+    write_json_atomic(run_dir / "improve-outcome.json", payload)
+
+    saved: HarnessDoc | None = None
+    if outcome.accepted:
+        assert outcome.selected is not None
+        selected_doc = outcome.selected.candidate.model_copy(update={"name": name, "version": 0})
+        saved = HarnessStore(root).save_version(selected_doc, alias=CHAMPION_ALIAS)
+    return HarnessImproveOutcome(
+        outcome=outcome,
+        saved=saved,
+        run_dir=run_dir,
+        dropped=dropped,
+    )
+
+
+def _write_feedback_knowledge(model_dir: Path, *, feedback: str, notes: str) -> str:
+    """Write the synthesized environment facts as one new feedback-keyed knowledge file."""
+    digest = hashlib.sha256(feedback.encode("utf-8")).hexdigest()[:12]
+    file_name = f"feedback-{digest}.md"
+    KnowledgeBase(ArtifactPaths(model_dir).knowledge).write_file(file_name, notes.rstrip() + "\n")
+    return file_name
+
+
+def _resolve_seed_source(root: str, *, name: str, seed: str | None) -> HarnessSourceTree:
+    """Resolve the seed: an explicit ref, NAME's champion when it exists, else the Pi baseline."""
+    store = HarnessStore(root)
+    if seed is not None:
+        base, _, ref = seed.partition("@")
+        try:
+            return HarnessSourceTree.from_doc(store.load(base, ref or None))
+        except (FileNotFoundError, ValueError) as error:
+            raise typer.BadParameter(str(error)) from error
+    if store.exists(name):
+        return HarnessSourceTree.from_doc(store.load(name))
+    return HarnessSourceTree.from_doc(default_agent())

--- a/wmh/cli/harness_improve_test.py
+++ b/wmh/cli/harness_improve_test.py
@@ -1,0 +1,367 @@
+"""CLI tests for feedback-directed harness improvement (execution seam monkeypatched)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import cast
+
+import pytest
+from typer.testing import CliRunner
+
+from wmh.cli import app
+from wmh.cli.harness_improve import HarnessImproveOutcome, ImproveAlreadySatisfied
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.harness.improve import ImproveGate, ImproveOutcome, VerificationResult
+from wmh.harness.population import PopulationOptimizationResult
+from wmh.harness.project_proposer import EvaluatedCandidate
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.providers.base import ProviderConfig
+
+module = importlib.import_module("wmh.cli.harness_improve")
+runner = CliRunner()
+_DIGEST = "sha256:" + "a" * 64
+
+
+class _Reader:
+    def read_bytes(self, path: str) -> bytes:
+        assert path == "raw/result.json"
+        return b"{}"
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _evaluated(candidate_id: str, source: HarnessSourceTree) -> EvaluatedCandidate:
+    artifact = EvaluationArtifact.from_bytes(path="raw/result.json", content=b"{}")
+    report = HarnessScoreReport(
+        source_run_id=f"run-{candidate_id}",
+        candidate_doc_hash=source.to_doc(candidate_id).doc_hash,
+        request=ScoreRequest(
+            context=ScoreContext(
+                task_set_digest=_DIGEST,
+                evaluator_digest=_DIGEST,
+                execution_config_digest=_DIGEST,
+            ),
+            task_ids=("suite-a", "feedback-verify-01"),
+            attempts=1,
+        ),
+        cells=(
+            ScoreCell(
+                task_id="suite-a",
+                attempt=1,
+                score=0.8,
+                passed=True,
+                summary="suite",
+                artifact_paths=("raw/result.json",),
+            ),
+            ScoreCell(
+                task_id="feedback-verify-01",
+                attempt=1,
+                score=1.0,
+                passed=True,
+                summary="verify",
+                artifact_paths=("raw/result.json",),
+            ),
+        ),
+        artifacts=(artifact,),
+    )
+    return EvaluatedCandidate(
+        candidate_id=candidate_id,
+        source=source,
+        score=HarnessScore(report=report, artifacts=_Reader()),
+    )
+
+
+def _accepted_outcome() -> ImproveOutcome:
+    evaluated = _evaluated("candidate-0000", _source("seed"))
+    result = PopulationOptimizationResult(
+        population=(evaluated,),
+        iterations=(),
+        best=evaluated,
+    )
+    return ImproveOutcome(
+        accepted=True,
+        reason="candidate-0000 passed the gate",
+        seed_suite_score=0.7,
+        candidate_suite_score=0.8,
+        verification=(
+            VerificationResult(
+                task_id="feedback-verify-01",
+                passed=True,
+                pass_count=1,
+                attempts=1,
+            ),
+        ),
+        selected=evaluated,
+        result=result,
+    )
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(provider="openai_responses", model="meta-model"),
+            )
+        ),
+        root,
+    )
+    tasks_path = tmp_path / "suite.jsonl"
+    tasks_path.write_text(
+        '{"task_id": "suite-a", "instruction": "do a", "gold": ["done"]}\n',
+        encoding="utf-8",
+    )
+    return root, tasks_path
+
+
+def test_cli_requires_exactly_one_feedback_source(tmp_path: Path) -> None:
+    _root, tasks_path = _write_inputs(tmp_path)
+
+    neither = runner.invoke(
+        app,
+        ["harness", "improve", "helper", "--tasks", str(tasks_path), "--model", "wm"],
+    )
+    assert neither.exit_code == 2
+    assert "exactly one of --feedback or --feedback-file" in neither.output
+
+    feedback_file = tmp_path / "feedback.txt"
+    feedback_file.write_text("give me GitHub access\n", encoding="utf-8")
+    both = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--feedback",
+            "text",
+            "--feedback-file",
+            str(feedback_file),
+        ],
+    )
+    assert both.exit_code == 2
+    assert "exactly one of --feedback or --feedback-file" in both.output
+
+
+def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Path) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--feedback",
+            "give me GitHub access",
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert invoked.exit_code == 2
+    assert "pass --yes" in invoked.output
+
+
+def test_cli_composes_inputs_and_prints_the_accepted_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    feedback_file = tmp_path / "feedback.txt"
+    feedback_file.write_text("give me GitHub access\n", encoding="utf-8")
+    result_out = tmp_path / "improve-run"
+    calls: list[dict[str, object]] = []
+    outcome = _accepted_outcome()
+
+    def fake_execute(**kwargs: object) -> HarnessImproveOutcome:
+        calls.append(kwargs)
+        assert outcome.selected is not None
+        saved = outcome.selected.candidate.model_copy(update={"name": "helper", "version": 4})
+        return HarnessImproveOutcome(
+            outcome=outcome,
+            saved=saved,
+            run_dir=cast(Path, kwargs["run_dir"]),
+            dropped=("feedback-verify-02",),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_execute)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--feedback-file",
+            str(feedback_file),
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--verification-count",
+            "2",
+            "--margin",
+            "0.2",
+            "--iterations",
+            "3",
+            "--attempts",
+            "5",
+            "--harness-backend",
+            "e2b",
+            "--seed",
+            "other@2",
+            "--no-seed-knowledge",
+            "--result-out",
+            str(result_out),
+            "--root",
+            str(root),
+            "--yes",
+        ],
+    )
+
+    assert invoked.exit_code == 0, invoked.output
+    normalized = " ".join(invoked.output.split())
+    assert "improved" in normalized
+    assert "v4" in normalized
+    assert "verification 1/1 passed" in normalized
+    [call] = calls
+    assert call["name"] == "helper"
+    assert call["feedback"] == "give me GitHub access\n"
+    assert call["model"] == "wm"
+    assert call["verification_count"] == 2
+    assert call["gate"] == ImproveGate(suite_margin=0.2)
+    assert call["iterations"] == 3
+    assert call["attempts"] == 5
+    assert call["harness_backend"] == "e2b"
+    assert call["seed_reference"] == "other@2"
+    assert call["seed_knowledge"] is False
+    assert call["run_dir"] == result_out
+    assert cast(ProviderConfig, call["meta_config"]).model == "meta-model"
+
+
+def test_cli_reports_rejection_and_already_satisfied_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    rejected = ImproveOutcome(
+        accepted=False,
+        reason="suite regression beyond margin: best candidate candidate-0001 scored 0.5",
+        seed_suite_score=0.8,
+        candidate_suite_score=None,
+        verification=(),
+        selected=None,
+        result=_accepted_outcome().result,
+    )
+
+    def fake_rejected(**kwargs: object) -> HarnessImproveOutcome:
+        return HarnessImproveOutcome(
+            outcome=rejected,
+            saved=None,
+            run_dir=cast(Path, kwargs["run_dir"]),
+            dropped=(),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_rejected)
+    argv = [
+        "harness",
+        "improve",
+        "helper",
+        "--feedback",
+        "give me GitHub access",
+        "--tasks",
+        str(tasks_path),
+        "--model",
+        "wm",
+        "--root",
+        str(root),
+        "--yes",
+    ]
+
+    invoked = runner.invoke(app, argv)
+    assert invoked.exit_code == 0, invoked.output
+    assert "rejected" in invoked.output
+    assert "suite regression beyond margin" in invoked.output
+
+    def fake_satisfied(**kwargs: object) -> ImproveAlreadySatisfied:
+        return ImproveAlreadySatisfied(
+            dropped=("feedback-verify-01",),
+            run_dir=cast(Path, kwargs["run_dir"]),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_satisfied)
+    satisfied = runner.invoke(app, argv)
+    assert satisfied.exit_code == 1
+    assert "already satisfied" in satisfied.output
+    assert "feedback-verify-01" in satisfied.output
+
+
+def test_cli_rejects_invalid_margin_backend_and_existing_result_dir(tmp_path: Path) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    base = [
+        "harness",
+        "improve",
+        "helper",
+        "--feedback",
+        "give me GitHub access",
+        "--tasks",
+        str(tasks_path),
+        "--model",
+        "wm",
+        "--root",
+        str(root),
+        "--yes",
+    ]
+
+    bad_margin = runner.invoke(app, [*base, "--margin", "1.0"])
+    assert bad_margin.exit_code == 2
+    assert "--margin" in bad_margin.output
+
+    bad_backend = runner.invoke(app, [*base, "--harness-backend", "cloud"])
+    assert bad_backend.exit_code == 2
+    assert "cloud" in bad_backend.output
+
+    taken = tmp_path / "taken"
+    taken.mkdir()
+    existing = runner.invoke(app, [*base, "--result-out", str(taken)])
+    assert existing.exit_code == 2
+    assert "already exists" in existing.output
+
+
+def test_cli_help_names_the_gate_and_feedback_inputs() -> None:
+    invoked = runner.invoke(app, ["harness", "improve", "--help"])
+
+    assert invoked.exit_code == 0, invoked.output
+    # The 80-column help panel truncates long option names, so assert stable prefixes.
+    assert "--feedback" in invoked.output
+    assert "--feedback-file" in invoked.output
+    assert "--verification" in invoked.output
+    assert "--margin" in invoked.output
+    assert "--seed-knowled" in invoked.output
+    assert "models.meta" in invoked.output
+    assert "name@ref" in invoked.output

--- a/wmh/evals/world_model_scorer.py
+++ b/wmh/evals/world_model_scorer.py
@@ -1,0 +1,427 @@
+"""Closed-loop world-model projection into immutable WMH harness scores.
+
+The world-model sibling of :class:`wmh.evals.harbor.scorer.HarborScorer`: the real harness
+process runs (in-process by default, in E2B sandboxes for pi-node candidates) while every
+environment response is simulated by the world model, and a :class:`GoldJudge` grades each
+rollout transcript against the task's gold assertions. Rollouts reuse the merged lane's
+closed-loop machinery (`wmh.evals.closed_loop.evaluate_closed_loop`, the same composition
+`wmh.harness.create._score` uses) rather than reimplementing them, and the result is projected
+into the evaluator-neutral `HarnessScore` evidence that `score_harness` verifies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping, Sequence
+from typing import Literal, Protocol
+from uuid import uuid4
+
+from wmh.core.types import JsonObject
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, evaluate_closed_loop
+from wmh.evals.gold import GoldJudge, GoldVerdict
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.e2b_sandbox import resolve_e2b_template
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    HarnessSearchCancelled,
+    Runtime,
+    RuntimeCancelled,
+    TokenUsage,
+    validate_episode_timeout_s,
+)
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.providers.base import Provider
+
+_WORLD_MODEL_SCORER_VERSION = "1"
+# Cell summaries index into the full artifact; keep them far below MAX_CELL_SUMMARY_CHARS.
+_SUMMARY_RATIONALE_CHARS = 1_000
+
+
+class ClosedLoopEvaluate(Protocol):
+    """The exact rollout seam `evaluate_closed_loop` satisfies.
+
+    The scorer owns the runtime and the projection; the seam owns rollouts and judging. Tests
+    inject a fake here so no provider, world model, or sandbox is exercised.
+    """
+
+    def __call__(
+        self,
+        tasks: list[TaskSpec],
+        world_model: WorldModel,
+        agent_provider: Provider,
+        judge: GoldJudge,
+        *,
+        label: str,
+        k: int,
+        concurrency: int,
+        runtime: Runtime,
+        should_cancel: Callable[[], bool] | None,
+    ) -> ClosedLoopReport: ...
+
+
+class InMemoryArtifactReader:
+    """Serve evaluator-owned artifact bytes from an in-memory `path -> bytes` map."""
+
+    def __init__(self, contents: Mapping[str, bytes]) -> None:
+        self._contents = dict(contents)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return one artifact's exact bytes; unknown paths are a hard error."""
+        content = self._contents.get(path)
+        if content is None:
+            raise KeyError(f"unknown artifact path {path!r}")
+        return content
+
+
+class WorldModelScorer:
+    """Evaluate exact harness candidates closed-loop against a simulated environment.
+
+    Each `score` call builds the candidate's runtime (`candidate.runtime(agent_provider)` for
+    local execution, or the E2B pi-node runtime backed by a per-call sandbox pool for
+    `harness_backend='e2b'`), runs `request.attempts` passes per requested task with the world
+    model answering every environment action, and judges each rollout with the configured
+    `GoldJudge`. Every (task, attempt) cell carries exactly one JSON transcript artifact at
+    `rollouts/task-{index:04d}/attempt-{n}.json`, where `index` is the task's 1-based position
+    in `request.task_ids` (task ids may contain characters that are unsafe in artifact paths,
+    so they are never embedded in the path).
+
+    `model_identity` is the caller-supplied world-model identity (typically the model name plus
+    a build fingerprint) committed into the evaluator digest; `judge_identity` names the judge
+    the same way and defaults to the judge's class name only, so callers who care about judge
+    replayability should pass the judge model identity explicitly.
+
+    `last_worker_usage` is per-score-call state: it is reset when `score` starts and afterwards
+    holds that call's aggregated self-metered worker token spend (`None` when the runtime does
+    not self-meter, exactly as `ClosedLoopReport.worker_usage` reports it). On cancellation it
+    holds the partial spend carried by the cancelled wave. Callers metering spend must read it
+    after every call; a later call overwrites it.
+    """
+
+    def __init__(
+        self,
+        *,
+        world_model: WorldModel,
+        tasks: Sequence[TaskSpec],
+        agent_provider: Provider,
+        judge: GoldJudge,
+        model_identity: JsonObject,
+        judge_identity: JsonObject | None = None,
+        harness_backend: Literal["local", "e2b"] = "local",
+        e2b_template: str | None = None,
+        eval_concurrency: int,
+        episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        should_cancel: Callable[[], bool] | None = None,
+        evaluate: ClosedLoopEvaluate | None = None,
+    ) -> None:
+        task_list = [TaskSpec.model_validate(task.model_dump(mode="python")) for task in tasks]
+        if not task_list:
+            raise ValueError("tasks must be nonempty")
+        ids = [task.task_id for task in task_list]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate task_id(s): {duplicates}")
+        if harness_backend not in ("local", "e2b"):
+            raise ValueError("harness_backend must be local or e2b")
+        if harness_backend == "local" and e2b_template is not None:
+            raise ValueError("e2b_template requires harness_backend='e2b'")
+        if (
+            isinstance(eval_concurrency, bool)
+            or not isinstance(eval_concurrency, int)
+            or eval_concurrency < 0
+        ):
+            raise ValueError("eval_concurrency must be an integer >= 0 (0 runs every cell at once)")
+        episode_timeout_s = validate_episode_timeout_s(episode_timeout_s)
+        if harness_backend == "local" and episode_timeout_s != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+            raise ValueError("episode_timeout_s requires harness_backend='e2b'")
+        self._world_model = world_model
+        self._tasks = tuple(task_list)
+        self._tasks_by_id = {task.task_id: task for task in task_list}
+        self._agent_provider = agent_provider
+        self._judge = judge
+        self._model_identity = _frozen_identity(model_identity, field="model_identity")
+        self._judge_identity = _frozen_identity(
+            judge_identity if judge_identity is not None else {"class": type(judge).__name__},
+            field="judge_identity",
+        )
+        self._harness_backend: Literal["local", "e2b"] = harness_backend
+        if harness_backend == "e2b":
+            # Resolve once so the execution digest and the per-call pool agree even when the
+            # template comes from $WMH_E2B_TEMPLATE; "" pins "resolved to nothing" (the pool's
+            # own resolution treats "" as an explicit no-template, never an env fallback).
+            effective_template = resolve_e2b_template(e2b_template)
+            self._e2b_template = effective_template if effective_template is not None else ""
+        else:
+            self._e2b_template = None
+        self._eval_concurrency = eval_concurrency
+        self._episode_timeout_s = episode_timeout_s
+        self._should_cancel = should_cancel
+        self._evaluate: ClosedLoopEvaluate = (
+            evaluate if evaluate is not None else evaluate_closed_loop
+        )
+        # Per-score-call worker spend (see the class docstring).
+        self.last_worker_usage: TokenUsage | None = None
+
+    def context(self) -> ScoreContext:
+        """Build the frozen content identities this scorer evaluates under."""
+        task_payload = {
+            "tasks": [
+                {
+                    "task_id": task.task_id,
+                    "instruction": task.instruction,
+                    "gold": list(task.gold),
+                }
+                for task in sorted(self._tasks, key=lambda task: task.task_id)
+            ]
+        }
+        evaluator_payload = {
+            "scorer_version": _WORLD_MODEL_SCORER_VERSION,
+            "world_model": self._model_identity,
+            "judge": self._judge_identity,
+        }
+        execution_payload = {
+            "harness_backend": self._harness_backend,
+            "e2b_template": self._e2b_template,
+            "eval_concurrency": self._eval_concurrency,
+            "episode_timeout_s": self._episode_timeout_s,
+            "agent_provider": self._agent_provider.config.model_dump(mode="json"),
+        }
+        return ScoreContext(
+            task_set_digest=_digest_json(task_payload),
+            evaluator_digest=_digest_json(evaluator_payload),
+            execution_config_digest=_digest_json(execution_payload),
+        )
+
+    def request(self, *, attempts: int) -> ScoreRequest:
+        """Build the full-suite score request (every configured task, in configured order)."""
+        return ScoreRequest(
+            context=self.context(),
+            task_ids=tuple(task.task_id for task in self._tasks),
+            attempts=attempts,
+        )
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+        """Run and project one candidate, raising unless every requested cell is scoreable.
+
+        `request.task_ids` may be any ordered subset of the configured tasks (screening lanes
+        score failure clusters); ids this scorer does not serve, or a request minted under a
+        different configuration, raise before any rollout spend.
+        """
+        _check_cancelled(self._should_cancel)
+        if request.context != self.context():
+            raise ValueError("score request context differs from this scorer's configuration")
+        unknown = sorted(set(request.task_ids) - set(self._tasks_by_id))
+        if unknown:
+            raise ValueError(f"score request names task(s) this scorer does not serve: {unknown}")
+        ordered_tasks = [self._tasks_by_id[task_id] for task_id in request.task_ids]
+        self.last_worker_usage = None
+        report = self._evaluate_candidate(candidate, ordered_tasks, request)
+        self.last_worker_usage = report.worker_usage
+        cells, manifests, contents = self._project(report, ordered_tasks, request)
+        score_report = HarnessScoreReport(
+            source_run_id=f"wm-{candidate.doc_hash[:12]}-{uuid4().hex[:12]}",
+            candidate_doc_hash=candidate.doc_hash,
+            request=request,
+            cells=tuple(cells),
+            artifacts=tuple(manifests),
+        )
+        return HarnessScore(report=score_report, artifacts=InMemoryArtifactReader(contents))
+
+    def _evaluate_candidate(
+        self,
+        candidate: HarnessDoc,
+        tasks: list[TaskSpec],
+        request: ScoreRequest,
+    ) -> ClosedLoopReport:
+        """Build the candidate's runtime for the configured backend and run the rollout seam."""
+        if self._harness_backend == "local":
+            if self._eval_concurrency != 1 and candidate.runtime_kind() == "pi-node":
+                # Local pi runtimes are single-episode resources (one runner port/workdir or one
+                # RunnerLink channel): parallel cells would collide. Checked per-candidate
+                # because runtime kind is a document surface (create.py precedent).
+                raise ValueError(
+                    "pi-node harnesses run one episode at a time under harness_backend='local' "
+                    "(single runner port/channel); use eval_concurrency=1 or "
+                    "harness_backend='e2b'"
+                )
+            return self._run(candidate, tasks, request, candidate.runtime(self._agent_provider))
+        if candidate.runtime_kind() != "pi-node":
+            raise ValueError(
+                "harness_backend='e2b' runs the pi-node harness process in sandboxes; "
+                f"candidate runtime kind is {candidate.runtime_kind()!r}, which already runs "
+                "in-process; use harness_backend='local'"
+            )
+        # Lazy: the e2b backend is an optional extra; local scoring must import none of it.
+        from wmh.harness.pi_e2b import E2BSandboxPool
+
+        # v1 pool lifecycle: one pool per score call, closed before the score returns, so no
+        # sandbox lease outlives the evaluation that owns it.
+        pool = E2BSandboxPool(
+            template=self._e2b_template,
+            episode_timeout_s=self._episode_timeout_s,
+        )
+        try:
+            runtime = candidate.runtime(
+                self._agent_provider,
+                backend="e2b",
+                e2b_pool=pool,
+                episode_timeout_s=self._episode_timeout_s,
+                should_cancel=self._should_cancel,
+            )
+            return self._run(candidate, tasks, request, runtime)
+        finally:
+            pool.close()
+
+    def _run(
+        self,
+        candidate: HarnessDoc,
+        tasks: list[TaskSpec],
+        request: ScoreRequest,
+        runtime: Runtime,
+    ) -> ClosedLoopReport:
+        """Run k=attempts closed-loop passes per task, preserving cancelled-wave spend."""
+        try:
+            return self._evaluate(
+                list(tasks),
+                self._world_model,
+                self._agent_provider,
+                self._judge,
+                label=candidate.name,
+                k=request.attempts,
+                concurrency=self._eval_concurrency,
+                runtime=runtime,
+                should_cancel=self._should_cancel,
+            )
+        except RuntimeCancelled as exc:
+            # Cancelled cells are not scoreable outcomes: convert at the scorer boundary
+            # (create.py precedent) and keep the partial wave's spend meterable.
+            self.last_worker_usage = exc.worker_usage
+            raise HarnessSearchCancelled(
+                "harness score cancelled", worker_usage=exc.worker_usage
+            ) from exc
+
+    def _project(
+        self,
+        report: ClosedLoopReport,
+        tasks: list[TaskSpec],
+        request: ScoreRequest,
+    ) -> tuple[list[ScoreCell], list[EvaluationArtifact], dict[str, bytes]]:
+        """Map the closed-loop report onto the exact requested cell matrix, fail-closed."""
+        extra = sorted(set(report.per_task) - set(request.task_ids))
+        if extra:
+            raise ValueError(f"closed-loop report contains unrequested task(s): {extra}")
+        cells: list[ScoreCell] = []
+        manifests: list[EvaluationArtifact] = []
+        contents: dict[str, bytes] = {}
+        for index, task in enumerate(tasks, 1):
+            outcome = report.per_task.get(task.task_id)
+            if outcome is None:
+                raise ValueError(f"closed-loop report is missing task {task.task_id!r}")
+            if (
+                outcome.passes != request.attempts
+                or len(outcome.verdicts) != request.attempts
+                or len(outcome.attempts) != request.attempts
+            ):
+                raise ValueError(
+                    f"closed-loop report for task {task.task_id!r} does not carry exactly "
+                    f"{request.attempts} judged attempt(s)"
+                )
+            for attempt in range(1, request.attempts + 1):
+                verdict = outcome.verdicts[attempt - 1]
+                evidence = outcome.attempts[attempt - 1]
+                path = f"rollouts/task-{index:04d}/attempt-{attempt}.json"
+                content = _artifact_content(task, verdict, evidence)
+                manifests.append(
+                    EvaluationArtifact.from_text(
+                        path=path, content=content, media_type="application/json"
+                    )
+                )
+                contents[path] = content.encode("utf-8")
+                cells.append(
+                    ScoreCell(
+                        task_id=task.task_id,
+                        attempt=attempt,
+                        score=verdict.fraction,
+                        passed=verdict.passed,
+                        summary=_cell_summary(verdict, evidence),
+                        artifact_paths=(path,),
+                    )
+                )
+        return cells, manifests, contents
+
+
+def _artifact_content(task: TaskSpec, verdict: GoldVerdict, evidence: RolloutEvidence) -> str:
+    """Serialize one judged rollout as deterministic JSON evidence."""
+    payload = {
+        "schema_version": 1,
+        "task_id": task.task_id,
+        "instruction": task.instruction,
+        "gold": list(task.gold),
+        "verdict": {
+            "passed": verdict.passed,
+            "fraction": verdict.fraction,
+            "rationale": verdict.rationale,
+            "assertions": [
+                {"assertion": item.assertion, "passed": item.passed, "why": item.why}
+                for item in verdict.assertions
+            ],
+        },
+        "rollout": {
+            "answer": evidence.answer,
+            "transcript": evidence.transcript,
+            "stop_reason": evidence.stop_reason.value,
+            "turns": evidence.turns,
+        },
+    }
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    )
+
+
+def _cell_summary(verdict: GoldVerdict, evidence: RolloutEvidence) -> str:
+    """One short diagnostic line per cell; the full evidence lives in the artifact."""
+    rationale = verdict.rationale
+    if len(rationale) > _SUMMARY_RATIONALE_CHARS:
+        rationale = rationale[:_SUMMARY_RATIONALE_CHARS] + " ..."
+    return (
+        f"passed={verdict.passed} fraction={verdict.fraction:.3f} "
+        f"stop={evidence.stop_reason.value} turns={evidence.turns}: {rationale}"
+    )
+
+
+def _frozen_identity(value: JsonObject, *, field: str) -> JsonObject:
+    """Snapshot one caller-supplied identity object, proving it is durable JSON."""
+    if not value:
+        raise ValueError(f"{field} must be a nonempty JSON object")
+    try:
+        encoded = json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{field} must be JSON-serializable") from error
+    frozen = json.loads(encoded)
+    if not isinstance(frozen, dict):
+        raise ValueError(f"{field} must be a JSON object")
+    return frozen
+
+
+def _digest_json(value: object) -> str:
+    """Digest one JSON-native payload deterministically (sorted keys, exact separators)."""
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness score cancelled")

--- a/wmh/evals/world_model_scorer_test.py
+++ b/wmh/evals/world_model_scorer_test.py
@@ -1,0 +1,566 @@
+"""Hermetic WorldModelScorer tests: fake providers and a stubbed rollout seam, no network.
+
+Two layers, mirroring the closed-loop test idioms: the round-trip test drives the REAL
+`evaluate_closed_loop` machinery with one `RoleProvider` playing agent, world model, and judge
+(the `closed_loop_test` pattern), while the projection tests inject a `FakeEvaluate` seam so the
+scorer's request validation, cell mapping, and artifact evidence are pinned without any rollout.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Literal
+
+import pytest
+
+from wmh.core.types import JsonObject
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, TaskOutcome
+from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
+from wmh.evals.tasks import TaskSpec
+from wmh.evals.world_model_scorer import (
+    ClosedLoopEvaluate,
+    InMemoryArtifactReader,
+    WorldModelScorer,
+)
+from wmh.harness.doc import RUNTIME_KIND_ID, TOOL_POLICY_ID, HarnessDoc, Surface, SurfaceKind
+from wmh.harness.runtime import (
+    DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    Runtime,
+    StopReason,
+    TokenUsage,
+)
+from wmh.harness.scoring import HarnessScore, ScoreRequest, score_harness
+from wmh.providers.base import Completion, Message, Provider, ProviderConfig, ProviderKind
+from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+class RoleProvider:
+    """Plays agent, world model, and gold judge, keyed off the system prompt."""
+
+    def __init__(self, *, judge_passes: bool = True, model: str = "m") -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model=model)
+        self._judge_passes = judge_passes
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        if "grade whether an agent completed a task" in system:
+            passed = "true" if self._judge_passes else "false"
+            return Completion(
+                text='{"assertions": [{"assertion": "did it", "passed": '
+                + passed
+                + ', "why": "x"}], "passed": '
+                + passed
+                + "}"
+            )
+        if system.startswith("You are a capable command-line agent"):
+            return Completion(
+                text='{"tool": "submit", "arguments": {"answer": "the answer is 42"}}'
+            )
+        # world model
+        return Completion(text='{"output": "ok", "is_error": false}')
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201 - test fake never calls it
+        raise NotImplementedError
+
+
+def _wm(provider: RoleProvider) -> WorldModel:
+    return WorldModel(provider, EmbeddingRetriever(HashingEmbedder(dim=16)))
+
+
+def _tasks() -> list[TaskSpec]:
+    return [
+        TaskSpec(task_id="q1", instruction="answer it", gold=["did it"]),
+        TaskSpec(task_id="q2", instruction="answer it again", gold=["did it"]),
+    ]
+
+
+def _seam_tasks() -> list[TaskSpec]:
+    return [
+        TaskSpec(task_id="a", instruction="do a", gold=["g"]),
+        TaskSpec(task_id="b", instruction="do b", gold=["g"]),
+        TaskSpec(task_id="c", instruction="do c", gold=["g"]),
+    ]
+
+
+def _make_scorer(
+    *,
+    provider: RoleProvider | None = None,
+    tasks: list[TaskSpec] | None = None,
+    model_identity: JsonObject | None = None,
+    judge_identity: JsonObject | None = None,
+    harness_backend: Literal["local", "e2b"] = "local",
+    e2b_template: str | None = None,
+    eval_concurrency: int = 1,
+    episode_timeout_s: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    should_cancel: Callable[[], bool] | None = None,
+    evaluate: ClosedLoopEvaluate | None = None,
+) -> WorldModelScorer:
+    resolved = provider if provider is not None else RoleProvider()
+    return WorldModelScorer(
+        world_model=_wm(resolved),
+        tasks=tasks if tasks is not None else _tasks(),
+        agent_provider=resolved,
+        judge=GoldJudge(resolved),
+        model_identity=(
+            model_identity
+            if model_identity is not None
+            else {"world_model": "wm-test", "build": "fingerprint-1"}
+        ),
+        judge_identity=judge_identity,
+        harness_backend=harness_backend,
+        e2b_template=e2b_template,
+        eval_concurrency=eval_concurrency,
+        episode_timeout_s=episode_timeout_s,
+        should_cancel=should_cancel,
+        evaluate=evaluate,
+    )
+
+
+class FakeEvaluate:
+    """Rollout seam stub: records every call and fabricates a `ClosedLoopReport` per plan."""
+
+    def __init__(
+        self,
+        *,
+        fractions: dict[str, list[float]] | None = None,
+        worker_usage: TokenUsage | None = None,
+        drop_last_verdict: bool = False,
+        wrong_passes: bool = False,
+        extra_task_id: str | None = None,
+    ) -> None:
+        self.fractions = fractions
+        self.worker_usage = worker_usage
+        self.drop_last_verdict = drop_last_verdict
+        self.wrong_passes = wrong_passes
+        self.extra_task_id = extra_task_id
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(
+        self,
+        tasks: list[TaskSpec],
+        world_model: WorldModel,
+        agent_provider: Provider,
+        judge: GoldJudge,
+        *,
+        label: str,
+        k: int,
+        concurrency: int,
+        runtime: Runtime,
+        should_cancel: Callable[[], bool] | None,
+    ) -> ClosedLoopReport:
+        self.calls.append(
+            {
+                "task_ids": [task.task_id for task in tasks],
+                "label": label,
+                "k": k,
+                "concurrency": concurrency,
+                "runtime": runtime,
+            }
+        )
+        per_task = {task.task_id: self._outcome(task, k) for task in tasks}
+        if self.extra_task_id is not None:
+            extra = TaskSpec(task_id=self.extra_task_id, instruction="extra", gold=["g"])
+            per_task[extra.task_id] = self._outcome(extra, k)
+        return ClosedLoopReport(
+            label=label,
+            success_rate=0.0,
+            mean_fraction=0.0,
+            k=k,
+            per_task=per_task,
+            worker_usage=self.worker_usage,
+        )
+
+    def _outcome(self, task: TaskSpec, k: int) -> TaskOutcome:
+        fracs = (self.fractions or {}).get(task.task_id, [1.0] * k)
+        verdicts = [
+            GoldVerdict(
+                passed=fraction == 1.0,
+                fraction=fraction,
+                assertions=[AssertionResult(assertion="g", passed=fraction == 1.0, why="w")],
+                rationale=f"{task.task_id} attempt {attempt} rationale",
+            )
+            for attempt, fraction in enumerate(fracs, 1)
+        ]
+        if self.drop_last_verdict:
+            verdicts = verdicts[:-1]
+        attempts = [
+            RolloutEvidence(
+                answer=f"answer-{task.task_id}-{attempt}",
+                transcript=f"[1] tool_call: bash cmd-{task.task_id}-{attempt}\n    -> ok",
+                stop_reason=StopReason.SUBMITTED,
+                turns=attempt,
+            )
+            for attempt in range(1, len(fracs) + 1)
+        ]
+        return TaskOutcome(
+            task_id=task.task_id,
+            success_rate=sum(1.0 for verdict in verdicts if verdict.passed) / max(len(fracs), 1),
+            mean_fraction=sum(verdict.fraction for verdict in verdicts) / max(len(fracs), 1),
+            passes=k - 1 if self.wrong_passes else k,
+            verdicts=verdicts,
+            attempts=attempts,
+        )
+
+
+def _pi_node_doc() -> HarnessDoc:
+    return HarnessDoc(
+        name="pi",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
+            Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+        ],
+    )
+
+
+# -- digests and requests ---------------------------------------------------------------------
+
+
+def test_context_and_request_are_deterministic_across_instances() -> None:
+    first = _make_scorer()
+    second = _make_scorer()
+    assert first.context() == second.context()
+    assert first.request(attempts=2) == second.request(attempts=2)
+    assert first.request(attempts=2).task_ids == ("q1", "q2")
+
+
+def test_task_set_digest_ignores_task_order_but_request_preserves_it() -> None:
+    forward = _make_scorer(tasks=_tasks())
+    reversed_tasks = _make_scorer(tasks=list(reversed(_tasks())))
+    assert forward.context() == reversed_tasks.context()
+    assert reversed_tasks.request(attempts=1).task_ids == ("q2", "q1")
+
+
+def test_digests_isolate_tasks_evaluator_and_execution() -> None:
+    base = _make_scorer().context()
+
+    changed_tasks = _make_scorer(
+        tasks=[
+            TaskSpec(task_id="q1", instruction="a DIFFERENT instruction", gold=["did it"]),
+            TaskSpec(task_id="q2", instruction="answer it again", gold=["did it"]),
+        ]
+    ).context()
+    assert changed_tasks.task_set_digest != base.task_set_digest
+    assert changed_tasks.evaluator_digest == base.evaluator_digest
+    assert changed_tasks.execution_config_digest == base.execution_config_digest
+
+    changed_model = _make_scorer(model_identity={"world_model": "wm-test", "build": "v2"}).context()
+    assert changed_model.evaluator_digest != base.evaluator_digest
+    assert changed_model.task_set_digest == base.task_set_digest
+    assert changed_model.execution_config_digest == base.execution_config_digest
+
+    changed_judge = _make_scorer(judge_identity={"judge_model": "other"}).context()
+    assert changed_judge.evaluator_digest != base.evaluator_digest
+    assert changed_judge.task_set_digest == base.task_set_digest
+    assert changed_judge.execution_config_digest == base.execution_config_digest
+
+    for variant in (
+        _make_scorer(eval_concurrency=4),
+        _make_scorer(provider=RoleProvider(model="other-model")),
+        _make_scorer(harness_backend="e2b", e2b_template="tpl", eval_concurrency=0),
+        _make_scorer(
+            harness_backend="e2b",
+            e2b_template="tpl",
+            eval_concurrency=0,
+            episode_timeout_s=120.0,
+        ),
+    ):
+        context = variant.context()
+        assert context.execution_config_digest != base.execution_config_digest
+        assert context.task_set_digest == base.task_set_digest
+        assert context.evaluator_digest == base.evaluator_digest
+
+
+# -- end to end through the real closed-loop machinery -----------------------------------------
+
+
+def test_score_round_trips_through_score_harness_with_real_rollouts() -> None:
+    scorer = _make_scorer()
+    candidate = HarnessDoc.baseline("candidate")
+    request = scorer.request(attempts=2)
+
+    scored = score_harness(scorer, candidate, request=request)
+
+    assert scored.report.candidate_doc_hash == candidate.doc_hash
+    assert scored.report.request == request
+    assert [
+        (cell.task_id, cell.attempt, cell.score, cell.passed) for cell in scored.report.cells
+    ] == [
+        ("q1", 1, 1.0, True),
+        ("q1", 2, 1.0, True),
+        ("q2", 1, 1.0, True),
+        ("q2", 2, 1.0, True),
+    ]
+    assert scored.report.score == 1.0
+    assert scored.report.pass_rate == 1.0
+    assert [artifact.path for artifact in scored.report.artifacts] == [
+        "rollouts/task-0001/attempt-1.json",
+        "rollouts/task-0001/attempt-2.json",
+        "rollouts/task-0002/attempt-1.json",
+        "rollouts/task-0002/attempt-2.json",
+    ]
+    assert all(artifact.media_type == "application/json" for artifact in scored.report.artifacts)
+    # Every cell references exactly its own transcript artifact and no orphans exist
+    # (HarnessScoreReport validation), so the mapping below is total.
+    by_cell = {(cell.task_id, cell.attempt): cell.artifact_paths for cell in scored.report.cells}
+    assert by_cell[("q2", 2)] == ("rollouts/task-0002/attempt-2.json",)
+
+    payload = json.loads(scored.artifacts.read_bytes("rollouts/task-0001/attempt-1.json").decode())
+    assert payload["task_id"] == "q1"
+    assert payload["instruction"] == "answer it"
+    assert payload["gold"] == ["did it"]
+    assert payload["verdict"]["passed"] is True
+    assert payload["verdict"]["fraction"] == 1.0
+    assert payload["verdict"]["assertions"] == [{"assertion": "did it", "passed": True, "why": "x"}]
+    assert "submit" in payload["rollout"]["transcript"]
+    assert payload["rollout"]["answer"] == "the answer is 42"
+    assert payload["rollout"]["stop_reason"] == "submitted"
+    # The fixed AgentRuntime is provider-wrapped, so nothing self-meters worker tokens.
+    assert scorer.last_worker_usage is None
+
+
+def test_failed_judgement_maps_to_zero_scores() -> None:
+    scorer = _make_scorer(provider=RoleProvider(judge_passes=False))
+    scored = score_harness(scorer, HarnessDoc.baseline(), request=scorer.request(attempts=1))
+    assert scored.report.score == 0.0
+    assert all(not cell.passed for cell in scored.report.cells)
+
+
+# -- cell mapping through the stubbed seam ------------------------------------------------------
+
+
+def test_cells_map_fraction_passed_and_one_indexed_attempts() -> None:
+    fake = FakeEvaluate(fractions={"a": [1.0, 0.5], "b": [0.0, 1.0], "c": [1.0, 1.0]})
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    candidate = HarnessDoc.baseline("candidate")
+    request = scorer.request(attempts=2)
+
+    scored = score_harness(scorer, candidate, request=request)
+
+    assert [
+        (cell.task_id, cell.attempt, cell.score, cell.passed) for cell in scored.report.cells
+    ] == [
+        ("a", 1, 1.0, True),
+        ("a", 2, 0.5, False),
+        ("b", 1, 0.0, False),
+        ("b", 2, 1.0, True),
+        ("c", 1, 1.0, True),
+        ("c", 2, 1.0, True),
+    ]
+    assert scored.report.score == pytest.approx(4.5 / 6)
+    half_credit = next(
+        cell for cell in scored.report.cells if (cell.task_id, cell.attempt) == ("a", 2)
+    )
+    assert "fraction=0.500" in half_credit.summary
+    assert "a attempt 2 rationale" in half_credit.summary
+    assert len(half_credit.summary) < 16_000
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["k"] == 2
+    assert fake.calls[0]["concurrency"] == 1
+    assert fake.calls[0]["label"] == "candidate"
+
+
+def test_subset_and_reordered_task_ids_score_only_requested_tasks() -> None:
+    fake = FakeEvaluate(fractions={"c": [1.0], "a": [0.0]})
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    request = ScoreRequest(context=scorer.context(), task_ids=("c", "a"), attempts=1)
+
+    scored = score_harness(scorer, HarnessDoc.baseline(), request=request)
+
+    assert fake.calls[0]["task_ids"] == ["c", "a"]  # request order, not configured order
+    assert [(cell.task_id, cell.score) for cell in scored.report.cells] == [
+        ("a", 0.0),
+        ("c", 1.0),
+    ]
+    # Artifact indices follow the request's 1-based positions: task-0001 is "c".
+    assert [artifact.path for artifact in scored.report.artifacts] == [
+        "rollouts/task-0001/attempt-1.json",
+        "rollouts/task-0002/attempt-1.json",
+    ]
+    first = json.loads(scored.artifacts.read_bytes("rollouts/task-0001/attempt-1.json").decode())
+    second = json.loads(scored.artifacts.read_bytes("rollouts/task-0002/attempt-1.json").decode())
+    assert first["task_id"] == "c"
+    assert second["task_id"] == "a"
+
+
+def test_artifact_contents_are_deterministic_json_evidence() -> None:
+    fake = FakeEvaluate(fractions={"a": [0.5]})
+    scorer = _make_scorer(tasks=_seam_tasks()[:1], evaluate=fake)
+    scored = score_harness(scorer, HarnessDoc.baseline(), request=scorer.request(attempts=1))
+
+    raw = scored.artifacts.read_bytes("rollouts/task-0001/attempt-1.json")
+    payload = json.loads(raw.decode())
+    assert payload == {
+        "schema_version": 1,
+        "task_id": "a",
+        "instruction": "do a",
+        "gold": ["g"],
+        "verdict": {
+            "passed": False,
+            "fraction": 0.5,
+            "rationale": "a attempt 1 rationale",
+            "assertions": [{"assertion": "g", "passed": False, "why": "w"}],
+        },
+        "rollout": {
+            "answer": "answer-a-1",
+            "transcript": "[1] tool_call: bash cmd-a-1\n    -> ok",
+            "stop_reason": "submitted",
+            "turns": 1,
+        },
+    }
+    # Deterministic serialization: sorted keys, exact separators.
+    assert raw.decode() == json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+# -- request and report validation --------------------------------------------------------------
+
+
+def test_unknown_task_ids_raise_before_any_rollout() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    request = ScoreRequest(context=scorer.context(), task_ids=("a", "zz"), attempts=1)
+    with pytest.raises(ValueError, match="does not serve"):
+        scorer.score(HarnessDoc.baseline(), request=request)
+    assert fake.calls == []
+
+
+def test_stale_request_from_another_configuration_raises_before_any_rollout() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    other = _make_scorer(
+        tasks=_seam_tasks(),
+        model_identity={"world_model": "different", "build": "v9"},
+    )
+    with pytest.raises(ValueError, match="context differs"):
+        scorer.score(HarnessDoc.baseline(), request=other.request(attempts=1))
+    assert fake.calls == []
+
+
+@pytest.mark.parametrize("defect", ["drop_last_verdict", "wrong_passes", "extra_task_id"])
+def test_malformed_closed_loop_reports_are_rejected(defect: str) -> None:
+    fake = FakeEvaluate(
+        drop_last_verdict=defect == "drop_last_verdict",
+        wrong_passes=defect == "wrong_passes",
+        extra_task_id="zz" if defect == "extra_task_id" else None,
+    )
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    with pytest.raises(ValueError, match="closed-loop report"):
+        scorer.score(HarnessDoc.baseline(), request=scorer.request(attempts=2))
+
+
+def test_score_harness_rejects_a_tampered_candidate_hash() -> None:
+    class TamperingScorer:
+        """Delegates to a real scorer, then rewrites the report's candidate identity."""
+
+        def __init__(self, inner: WorldModelScorer) -> None:
+            self._inner = inner
+
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            scored = self._inner.score(candidate, request=request)
+            # doc_hash covers surfaces, not the display name, so the tampered identity must
+            # come from a document whose surfaces genuinely differ.
+            other = HarnessDoc(
+                name="other",
+                surfaces=[
+                    Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="another prompt")
+                ],
+            )
+            tampered = scored.report.model_copy(update={"candidate_doc_hash": other.doc_hash})
+            return HarnessScore(report=tampered, artifacts=scored.artifacts)
+
+    inner = _make_scorer(tasks=_seam_tasks(), evaluate=FakeEvaluate())
+    scorer = TamperingScorer(inner)
+    candidate = HarnessDoc.baseline("candidate")
+    request = inner.request(attempts=1)
+    with pytest.raises(ValueError, match="does not match the harness"):
+        score_harness(scorer, candidate, request=request)
+
+
+def test_local_pi_node_candidates_require_sequential_cells() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(tasks=_seam_tasks(), eval_concurrency=2, evaluate=fake)
+    with pytest.raises(ValueError, match="one episode at a time"):
+        scorer.score(_pi_node_doc(), request=scorer.request(attempts=1))
+    assert fake.calls == []
+
+
+def test_e2b_backend_rejects_in_process_candidates_before_any_sandbox() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(
+        harness_backend="e2b",
+        e2b_template="tpl",
+        eval_concurrency=0,
+        tasks=_seam_tasks(),
+        evaluate=fake,
+    )
+    with pytest.raises(ValueError, match="already runs in-process"):
+        scorer.score(HarnessDoc.baseline(), request=scorer.request(attempts=1))
+    assert fake.calls == []
+
+
+# -- worker usage --------------------------------------------------------------------------------
+
+
+def test_worker_usage_is_per_score_call_state() -> None:
+    fake = FakeEvaluate(worker_usage=TokenUsage(input_tokens=10, output_tokens=3, calls=2))
+    scorer = _make_scorer(tasks=_seam_tasks(), evaluate=fake)
+    request = scorer.request(attempts=1)
+
+    scorer.score(HarnessDoc.baseline(), request=request)
+    assert scorer.last_worker_usage == TokenUsage(input_tokens=10, output_tokens=3, calls=2)
+
+    fake.worker_usage = None  # a later call overwrites: no stale spend survives
+    scorer.score(HarnessDoc.baseline(), request=request)
+    assert scorer.last_worker_usage is None
+
+
+# -- constructor validation ----------------------------------------------------------------------
+
+
+def test_constructor_rejects_bad_configuration() -> None:
+    with pytest.raises(ValueError, match="tasks must be nonempty"):
+        _make_scorer(tasks=[])
+    with pytest.raises(ValueError, match="duplicate task_id"):
+        _make_scorer(tasks=[_tasks()[0], _tasks()[0]])
+    with pytest.raises(ValueError, match="e2b_template requires"):
+        _make_scorer(e2b_template="tpl")
+    with pytest.raises(ValueError, match="episode_timeout_s requires"):
+        _make_scorer(episode_timeout_s=10.0)
+    with pytest.raises(ValueError, match="finite positive"):
+        _make_scorer(
+            harness_backend="e2b", e2b_template="tpl", eval_concurrency=0, episode_timeout_s=-1.0
+        )
+    with pytest.raises(ValueError, match="eval_concurrency"):
+        _make_scorer(eval_concurrency=-1)
+    with pytest.raises(ValueError, match="eval_concurrency"):
+        _make_scorer(eval_concurrency=True)
+    with pytest.raises(ValueError, match="model_identity"):
+        _make_scorer(model_identity={})
+
+
+def test_scorer_snapshots_tasks_against_caller_mutation() -> None:
+    tasks = _tasks()
+    scorer = _make_scorer(tasks=tasks)
+    before = scorer.context()
+    tasks[0].instruction = "mutated after construction"
+    assert scorer.context() == before
+
+
+def test_in_memory_reader_serves_exact_bytes_and_rejects_unknown_paths() -> None:
+    reader = InMemoryArtifactReader({"rollouts/x.json": b"{}"})
+    assert reader.read_bytes("rollouts/x.json") == b"{}"
+    with pytest.raises(KeyError, match="unknown artifact path"):
+        reader.read_bytes("rollouts/missing.json")

--- a/wmh/harness/improve.py
+++ b/wmh/harness/improve.py
@@ -1,0 +1,291 @@
+"""Feedback-directed one-step harness improvement behind an explicit promotion gate.
+
+One piece of user feedback ("you should have access to my GitHub") drives one
+:class:`~wmh.harness.population.HarnessPopulationOptimizer` run: the feedback text becomes the
+proposer directive, and the must-pass verification tasks synthesized from it
+(`wmh.scenarios.feedback.synthesize_verification_tasks`) join the standard suite in one exact
+score request. Promotion is decided here, never by the optimizer's blended ``result.best``
+(which averages suite and verification cells together): a candidate is promotable only when its
+standard-suite mean stays within :class:`ImproveGate.suite_margin` of the seed AND a strict
+majority of attempts passes on every verification task. Among gate-passing candidates the
+highest suite score wins, with the earliest candidate breaking ties.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.population import HarnessPopulationOptimizer, PopulationOptimizationResult
+from wmh.harness.project_proposer import CandidateProposer, EvaluatedCandidate
+from wmh.harness.scoring import HarnessScore, HarnessScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceTree
+
+DEFAULT_SUITE_MARGIN = 0.10
+
+
+class ImproveGate(BaseModel):
+    """Relative regression budget on the standard suite (verification tasks get none).
+
+    A candidate's suite mean must be at least ``(1 - suite_margin) * seed_suite_mean``. The
+    margin is a fraction in ``[0, 1)``: 0 demands no regression at all, and values at or above
+    1 would accept a zero-scoring candidate, so they are rejected.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    suite_margin: float = Field(default=DEFAULT_SUITE_MARGIN, ge=0.0, lt=1.0)
+
+
+_DEFAULT_GATE = ImproveGate()
+
+
+class VerificationResult(BaseModel):
+    """Majority-rule outcome for one verification task across all its attempts."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str
+    passed: bool
+    pass_count: int
+    attempts: int
+
+
+class ImproveScorer(Protocol):
+    """The scorer seam ``improve_harness`` needs: request minting plus candidate scoring.
+
+    ``wmh.evals.world_model_scorer.WorldModelScorer`` satisfies this protocol directly.
+    """
+
+    def request(self, *, attempts: int) -> ScoreRequest: ...
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore: ...
+
+
+@dataclass(frozen=True)
+class ImproveOutcome:
+    """The gate's promotion decision plus the complete evaluated population evidence.
+
+    ``candidate_suite_score`` and ``verification`` describe the selected candidate; they are
+    ``None`` and empty when no candidate passed the gate (the rejection reason still carries the
+    best candidate's numbers).
+    """
+
+    accepted: bool
+    reason: str
+    seed_suite_score: float
+    candidate_suite_score: float | None
+    verification: tuple[VerificationResult, ...]
+    selected: EvaluatedCandidate | None
+    result: PopulationOptimizationResult
+
+
+def suite_score(report: HarnessScoreReport, suite_task_ids: Collection[str]) -> float:
+    """Return the mean cell score restricted to the standard-suite tasks.
+
+    Args:
+        report: One complete candidate scorecard.
+        suite_task_ids: The task ids that constitute the standard suite.
+
+    Returns:
+        The mean of ``cell.score`` over every cell whose task id is in ``suite_task_ids``.
+
+    Raises:
+        ValueError: When no cell in the report matches ``suite_task_ids``.
+    """
+    wanted = set(suite_task_ids)
+    scores = [cell.score for cell in report.cells if cell.task_id in wanted]
+    if not scores:
+        raise ValueError("score report contains no cells for the given suite task ids")
+    return fmean(scores)
+
+
+def verification_results(
+    report: HarnessScoreReport,
+    verification_task_ids: Sequence[str],
+) -> tuple[VerificationResult, ...]:
+    """Apply the strict-majority pass rule to each verification task, in the given order.
+
+    A task passes only when strictly more than half of its attempts have ``cell.passed`` True:
+    2 of 3 passes, while exactly half (for example 1 of 2) does not.
+
+    Args:
+        report: One complete candidate scorecard containing the verification cells.
+        verification_task_ids: The verification task ids, in reporting order.
+
+    Returns:
+        One :class:`VerificationResult` per requested task id.
+
+    Raises:
+        ValueError: When a named task has no cells in the report.
+    """
+    results: list[VerificationResult] = []
+    for task_id in verification_task_ids:
+        cells = [cell for cell in report.cells if cell.task_id == task_id]
+        if not cells:
+            raise ValueError(f"score report contains no cells for verification task {task_id!r}")
+        pass_count = sum(1 for cell in cells if cell.passed)
+        results.append(
+            VerificationResult(
+                task_id=task_id,
+                passed=pass_count * 2 > len(cells),
+                pass_count=pass_count,
+                attempts=len(cells),
+            )
+        )
+    return tuple(results)
+
+
+def improve_harness(
+    *,
+    seed: HarnessSourceTree,
+    feedback: str,
+    suite_tasks: Sequence[TaskSpec],
+    verification_tasks: Sequence[TaskSpec],
+    scorer: ImproveScorer,
+    proposer_factory: Callable[[str], CandidateProposer],
+    iterations: int = 1,
+    attempts: int = 3,
+    gate: ImproveGate = _DEFAULT_GATE,
+    should_cancel: Callable[[], bool] | None = None,
+    on_boundary: Callable[[PopulationOptimizationResult], None] | None = None,
+) -> ImproveOutcome:
+    """Run one feedback-directed population step and gate promotion explicitly.
+
+    The scorer must already be configured with the suite tasks followed by the verification
+    tasks, in that exact order; the minted request is asserted against that contract before any
+    spend. The feedback text is handed verbatim to ``proposer_factory`` as the proposal
+    directive.
+
+    Args:
+        seed: The champion source tree every proposal slot starts from.
+        feedback: The user's feedback; becomes the proposer directive.
+        suite_tasks: The standard suite, gated on the relative margin.
+        verification_tasks: The synthesized must-pass tasks, gated on strict majority.
+        scorer: Scorer configured over ``suite_tasks + verification_tasks`` in order.
+        proposer_factory: Builds the candidate proposer from the feedback directive.
+        iterations: Fixed number of proposal slots.
+        attempts: Attempts per task and candidate.
+        gate: The suite regression budget.
+        should_cancel: Optional cooperative cancellation callback.
+        on_boundary: Optional durable-boundary callback forwarded to the optimizer.
+
+    Returns:
+        The promotion decision with the full population evidence. ``result.best`` (the
+        optimizer's blended winner) is deliberately ignored for promotion.
+
+    Raises:
+        ValueError: On blank feedback, an empty task set, non-disjoint or duplicate task ids
+            across the two sets, or a scorer request that does not match the declared task
+            order.
+    """
+    if not feedback.strip():
+        raise ValueError("feedback must be a nonempty description of the desired improvement")
+    suite_ids = tuple(task.task_id for task in suite_tasks)
+    verification_ids = tuple(task.task_id for task in verification_tasks)
+    if not suite_ids:
+        raise ValueError("suite_tasks must be nonempty")
+    if not verification_ids:
+        raise ValueError("verification_tasks must be nonempty")
+    combined = suite_ids + verification_ids
+    if len(set(combined)) != len(combined):
+        raise ValueError("suite and verification task ids must be unique and disjoint")
+
+    request = scorer.request(attempts=attempts)
+    if request.task_ids != combined:
+        raise ValueError(
+            "scorer request task ids must be exactly the suite tasks followed by the "
+            "verification tasks, in order"
+        )
+
+    result = HarnessPopulationOptimizer(proposer_factory(feedback), scorer).optimize(
+        seed=seed,
+        request=request,
+        iterations=iterations,
+        should_cancel=should_cancel,
+        on_boundary=on_boundary,
+    )
+    seed_suite = suite_score(result.population[0].score.report, suite_ids)
+    floor = (1.0 - gate.suite_margin) * seed_suite
+    candidates = result.population[1:]
+    if not candidates:
+        return ImproveOutcome(
+            accepted=False,
+            reason=(
+                "no valid proposals: every proposal slot failed to produce a scoreable candidate"
+            ),
+            seed_suite_score=seed_suite,
+            candidate_suite_score=None,
+            verification=(),
+            selected=None,
+            result=result,
+        )
+
+    graded = [
+        (
+            candidate,
+            suite_score(candidate.score.report, suite_ids),
+            verification_results(candidate.score.report, verification_ids),
+        )
+        for candidate in candidates
+    ]
+    # The population is ordered by ascending candidate_id, so replacing only on a strictly
+    # higher suite score keeps the earliest candidate on ties.
+    selected: tuple[EvaluatedCandidate, float, tuple[VerificationResult, ...]] | None = None
+    for candidate, candidate_suite, verification in graded:
+        if candidate_suite < floor or not all(item.passed for item in verification):
+            continue
+        if selected is None or candidate_suite > selected[1]:
+            selected = (candidate, candidate_suite, verification)
+    if selected is not None:
+        candidate, candidate_suite, verification = selected
+        return ImproveOutcome(
+            accepted=True,
+            reason=(
+                f"candidate {candidate.candidate_id} passed the gate: suite "
+                f"{candidate_suite:.6f} vs seed {seed_suite:.6f} (floor {floor:.6f} at margin "
+                f"{gate.suite_margin:.0%}); all {len(verification)} verification task(s) passed"
+            ),
+            seed_suite_score=seed_suite,
+            candidate_suite_score=candidate_suite,
+            verification=verification,
+            selected=candidate,
+            result=result,
+        )
+
+    # No candidate passed. Diagnose using the best candidate by suite score (ties keep the
+    # earliest, because max returns the first maximal element).
+    best_candidate, best_suite, best_verification = max(graded, key=lambda entry: entry[1])
+    if best_suite < floor:
+        reason = (
+            f"suite regression beyond margin: best candidate {best_candidate.candidate_id} "
+            f"scored {best_suite:.6f} on the suite, below the floor {floor:.6f} "
+            f"({1.0 - gate.suite_margin:.2f} x seed {seed_suite:.6f}, margin "
+            f"{gate.suite_margin:.0%})"
+        )
+    else:
+        failing = ", ".join(
+            f"{item.task_id} ({item.pass_count}/{item.attempts} passed)"
+            for item in best_verification
+            if not item.passed
+        )
+        reason = (
+            f"verification tasks failed: candidate {best_candidate.candidate_id} (suite "
+            f"{best_suite:.6f} vs seed {seed_suite:.6f}) did not reach a strict majority on "
+            f"{failing}"
+        )
+    return ImproveOutcome(
+        accepted=False,
+        reason=reason,
+        seed_suite_score=seed_suite,
+        candidate_suite_score=None,
+        verification=(),
+        selected=None,
+        result=result,
+    )

--- a/wmh/harness/improve_test.py
+++ b/wmh/harness/improve_test.py
@@ -1,0 +1,502 @@
+"""Behavioral tests for the feedback-directed one-step improvement gate."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+
+import pytest
+
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.improve import (
+    ImproveGate,
+    improve_harness,
+    suite_score,
+    verification_results,
+)
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.project_proposer import (
+    CandidateProposal,
+    CandidateProposalError,
+    CandidateProposer,
+    EvaluatedCandidate,
+)
+from wmh.harness.runtime import TokenUsage
+from wmh.harness.scoring import (
+    EvaluationArtifact,
+    HarnessScore,
+    HarnessScoreReport,
+    ScoreCell,
+    ScoreContext,
+    ScoreRequest,
+)
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+_RAW_PATH = "raw/trace.json"
+
+# One preplanned score call: task_id -> one (score, passed) pair per attempt.
+_CellPlan = Mapping[str, Sequence[tuple[float, bool]]]
+
+
+class _Reader:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def read_bytes(self, path: str) -> bytes:
+        assert path == _RAW_PATH
+        return self.content
+
+
+class _Scorer:
+    """Yields one preplanned per-task cell matrix per score call (seed first)."""
+
+    def __init__(
+        self,
+        task_ids: Sequence[str],
+        attempts: int,
+        outcomes: Sequence[_CellPlan],
+    ) -> None:
+        self._task_ids = tuple(task_ids)
+        self._attempts = attempts
+        self.outcomes = list(outcomes)
+        self.calls: list[HarnessDoc] = []
+
+    def request(self, *, attempts: int) -> ScoreRequest:
+        return ScoreRequest(
+            context=ScoreContext(
+                task_set_digest=_DIGEST_A,
+                evaluator_digest=_DIGEST_B,
+                execution_config_digest=_DIGEST_C,
+            ),
+            task_ids=self._task_ids,
+            attempts=attempts,
+        )
+
+    def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+        self.calls.append(candidate)
+        per_task = self.outcomes.pop(0)
+        raw = f'{{"candidate":"{candidate.doc_hash}"}}\n'.encode()
+        artifact = EvaluationArtifact.from_bytes(
+            path=_RAW_PATH,
+            content=raw,
+            media_type="application/json",
+        )
+        cells: list[ScoreCell] = []
+        for task_id in request.task_ids:
+            attempt_outcomes = per_task[task_id]
+            assert len(attempt_outcomes) == request.attempts
+            for attempt, (score, passed) in enumerate(attempt_outcomes, start=1):
+                cells.append(
+                    ScoreCell(
+                        task_id=task_id,
+                        attempt=attempt,
+                        score=score,
+                        passed=passed,
+                        summary="planned cell",
+                        artifact_paths=(_RAW_PATH,),
+                    )
+                )
+        report = HarnessScoreReport(
+            source_run_id=f"run-{len(self.calls)}",
+            candidate_doc_hash=candidate.doc_hash,
+            request=request,
+            cells=tuple(cells),
+            artifacts=(artifact,),
+        )
+        return HarnessScore(report=report, artifacts=_Reader(raw))
+
+
+class _Proposer:
+    def __init__(self, outcomes: Sequence[CandidateProposal | CandidateProposalError]) -> None:
+        self.outcomes = list(outcomes)
+        self.histories: list[tuple[EvaluatedCandidate, ...]] = []
+
+    def propose(
+        self,
+        history: Sequence[EvaluatedCandidate],
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        del should_cancel
+        self.histories.append(tuple(history))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, CandidateProposalError):
+            raise outcome
+        return outcome
+
+
+def _factory(proposer: CandidateProposer) -> tuple[Callable[[str], CandidateProposer], list[str]]:
+    directives: list[str] = []
+
+    def factory(directive: str) -> CandidateProposer:
+        directives.append(directive)
+        return proposer
+
+    return factory, directives
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content=('[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n'),
+            ),
+        )
+    )
+
+
+def _proposal(candidate_id: str, prompt: str) -> CandidateProposal:
+    source = _source(prompt)
+    return CandidateProposal(
+        candidate_id=candidate_id,
+        source=source,
+        candidate=source.to_doc(candidate_id),
+        events=(SessionEvent(kind="submit", payload={"answer": "done"}),),
+        worker_usage=TokenUsage(input_tokens=10, output_tokens=5, calls=1),
+    )
+
+
+def _tasks(ids: Sequence[str]) -> tuple[TaskSpec, ...]:
+    return tuple(
+        TaskSpec(task_id=task_id, instruction=f"do {task_id}", gold=["g"]) for task_id in ids
+    )
+
+
+def _uniform(task_outcomes: Mapping[str, tuple[float, bool]], attempts: int) -> _CellPlan:
+    return {task_id: [outcome] * attempts for task_id, outcome in task_outcomes.items()}
+
+
+_SUITE = _tasks(["suite-a", "suite-b"])
+_VERIFY = _tasks(["verify-1"])
+_ALL_IDS = ("suite-a", "suite-b", "verify-1")
+
+
+def test_gate_accepts_candidate_within_margin_with_all_verification_passing() -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            {
+                "suite-a": [(0.75, True)] * 3,
+                "suite-b": [(0.75, True)] * 3,
+                "verify-1": [(1.0, True), (1.0, True), (0.0, False)],  # 2 of 3: strict majority
+            },
+        ],
+    )
+    factory, directives = _factory(_Proposer([_proposal("candidate-0001", "improved")]))
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="the agent should have access to my GitHub",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=1,
+        attempts=3,
+    )
+
+    assert directives == ["the agent should have access to my GitHub"]
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+    assert outcome.seed_suite_score == pytest.approx(0.8)
+    assert outcome.candidate_suite_score == pytest.approx(0.75)
+    [verification] = outcome.verification
+    assert verification.task_id == "verify-1"
+    assert verification.passed is True
+    assert verification.pass_count == 2
+    assert verification.attempts == 3
+    assert "candidate-0001" in outcome.reason
+
+
+def test_gate_rejects_suite_regression_beyond_margin() -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            # Suite mean 0.6 is below the floor 0.72 = 0.9 * 0.8 even though verification passes.
+            _uniform({"suite-a": (0.6, True), "suite-b": (0.6, True), "verify-1": (1.0, True)}, 3),
+        ],
+    )
+    factory, _directives = _factory(_Proposer([_proposal("candidate-0001", "regressed")]))
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="add GitHub access",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=1,
+        attempts=3,
+    )
+
+    assert outcome.accepted is False
+    assert outcome.selected is None
+    assert outcome.candidate_suite_score is None
+    assert outcome.verification == ()
+    assert "suite regression beyond margin" in outcome.reason
+    assert "margin" in outcome.reason
+    assert "0.600000" in outcome.reason
+    assert "0.720000" in outcome.reason
+
+
+def test_gate_rejects_when_a_verification_task_fails_majority() -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            {
+                "suite-a": [(0.9, True)] * 3,
+                "suite-b": [(0.9, True)] * 3,
+                "verify-1": [(1.0, True), (0.0, False), (0.0, False)],  # 1 of 3: no majority
+            },
+        ],
+    )
+    factory, _directives = _factory(_Proposer([_proposal("candidate-0001", "half done")]))
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="add GitHub access",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=1,
+        attempts=3,
+    )
+
+    assert outcome.accepted is False
+    assert outcome.selected is None
+    assert "verification tasks failed" in outcome.reason
+    assert "verify-1" in outcome.reason
+    assert "1/3" in outcome.reason
+
+
+def test_selection_prefers_highest_suite_score_over_optimizer_blended_best() -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        1,
+        [
+            _uniform({"suite-a": (0.5, True), "suite-b": (0.5, True), "verify-1": (0.0, False)}, 1),
+            # Blended mean 0.666 but the best suite score (0.9).
+            _uniform({"suite-a": (0.9, True), "suite-b": (0.9, True), "verify-1": (0.2, True)}, 1),
+            # Blended mean 0.8 (the optimizer's best) but a lower suite score (0.7).
+            _uniform({"suite-a": (0.7, True), "suite-b": (0.7, True), "verify-1": (1.0, True)}, 1),
+        ],
+    )
+    factory, _directives = _factory(
+        _Proposer(
+            [
+                _proposal("candidate-0001", "high suite"),
+                _proposal("candidate-0002", "high verification"),
+            ]
+        )
+    )
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="add GitHub access",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=2,
+        attempts=1,
+    )
+
+    assert outcome.result.best.candidate_id == "candidate-0002"
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+    assert outcome.candidate_suite_score == pytest.approx(0.9)
+
+
+def test_selection_tie_on_suite_score_keeps_the_earliest_candidate() -> None:
+    plan = _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (1.0, True)}, 1)
+    scorer = _Scorer(
+        _ALL_IDS,
+        1,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 1),
+            plan,
+            plan,
+        ],
+    )
+    factory, _directives = _factory(
+        _Proposer(
+            [
+                _proposal("candidate-0001", "first tie"),
+                _proposal("candidate-0002", "second tie"),
+            ]
+        )
+    )
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="add GitHub access",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=2,
+        attempts=1,
+    )
+
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+
+
+def test_seed_only_population_reports_no_valid_proposals() -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+        ],
+    )
+    factory, _directives = _factory(
+        _Proposer([CandidateProposalError("candidate-0001", "agent turn did not submit")])
+    )
+
+    outcome = improve_harness(
+        seed=_source("seed"),
+        feedback="add GitHub access",
+        suite_tasks=_SUITE,
+        verification_tasks=_VERIFY,
+        scorer=scorer,
+        proposer_factory=factory,
+        iterations=1,
+        attempts=3,
+    )
+
+    assert outcome.accepted is False
+    assert "no valid proposals" in outcome.reason
+    assert outcome.selected is None
+    assert outcome.candidate_suite_score is None
+    assert outcome.verification == ()
+    assert [item.candidate_id for item in outcome.result.population] == ["candidate-0000"]
+    assert outcome.seed_suite_score == pytest.approx(0.8)
+
+
+def _report(task_ids: Sequence[str], attempts: int, plan: _CellPlan) -> HarnessScoreReport:
+    scorer = _Scorer(task_ids, attempts, [plan])
+    candidate = _source("unit").to_doc("candidate-0000")
+    return scorer.score(candidate, request=scorer.request(attempts=attempts)).report
+
+
+def test_suite_score_means_only_matching_cells_and_rejects_empty_selection() -> None:
+    report = _report(
+        ("suite-a", "suite-b", "verify-1"),
+        2,
+        {
+            "suite-a": [(1.0, True), (0.0, False)],
+            "suite-b": [(0.5, True), (0.5, True)],
+            "verify-1": [(0.0, False), (0.0, False)],
+        },
+    )
+
+    assert suite_score(report, ("suite-a", "suite-b")) == pytest.approx(0.5)
+    assert suite_score(report, ("suite-a",)) == pytest.approx(0.5)
+    with pytest.raises(ValueError, match="no cells"):
+        suite_score(report, ("absent-task",))
+    with pytest.raises(ValueError, match="no cells"):
+        suite_score(report, ())
+
+
+def test_verification_results_apply_the_strict_majority_rule() -> None:
+    half = _report(("verify-1",), 2, {"verify-1": [(1.0, True), (0.0, False)]})
+    [result] = verification_results(half, ("verify-1",))
+    assert result.passed is False  # exactly half (1 of 2) is not a strict majority
+    assert result.pass_count == 1
+    assert result.attempts == 2
+
+    majority = _report(
+        ("verify-1",),
+        3,
+        {"verify-1": [(1.0, True), (1.0, True), (0.0, False)]},
+    )
+    [result] = verification_results(majority, ("verify-1",))
+    assert result.passed is True
+    assert result.pass_count == 2
+    assert result.attempts == 3
+
+    with pytest.raises(ValueError, match="absent-task"):
+        verification_results(majority, ("absent-task",))
+
+
+def test_improve_validates_task_sets_and_request_before_any_proposal() -> None:
+    factory, directives = _factory(_Proposer([]))
+    valid_scorer = _Scorer(_ALL_IDS, 1, [])
+
+    with pytest.raises(ValueError, match="disjoint"):
+        improve_harness(
+            seed=_source("seed"),
+            feedback="add GitHub access",
+            suite_tasks=_SUITE,
+            verification_tasks=_tasks(["suite-a"]),
+            scorer=valid_scorer,
+            proposer_factory=factory,
+            attempts=1,
+        )
+    with pytest.raises(ValueError, match="suite_tasks must be nonempty"):
+        improve_harness(
+            seed=_source("seed"),
+            feedback="add GitHub access",
+            suite_tasks=(),
+            verification_tasks=_VERIFY,
+            scorer=valid_scorer,
+            proposer_factory=factory,
+            attempts=1,
+        )
+    with pytest.raises(ValueError, match="verification_tasks must be nonempty"):
+        improve_harness(
+            seed=_source("seed"),
+            feedback="add GitHub access",
+            suite_tasks=_SUITE,
+            verification_tasks=(),
+            scorer=valid_scorer,
+            proposer_factory=factory,
+            attempts=1,
+        )
+    with pytest.raises(ValueError, match="feedback"):
+        improve_harness(
+            seed=_source("seed"),
+            feedback="   ",
+            suite_tasks=_SUITE,
+            verification_tasks=_VERIFY,
+            scorer=valid_scorer,
+            proposer_factory=factory,
+            attempts=1,
+        )
+
+    reordered_scorer = _Scorer(("verify-1", "suite-a", "suite-b"), 1, [])
+    with pytest.raises(ValueError, match="suite tasks followed by the verification tasks"):
+        improve_harness(
+            seed=_source("seed"),
+            feedback="add GitHub access",
+            suite_tasks=_SUITE,
+            verification_tasks=_VERIFY,
+            scorer=reordered_scorer,
+            proposer_factory=factory,
+            attempts=1,
+        )
+    assert directives == []
+
+
+def test_margin_gate_validates_its_fraction() -> None:
+    assert ImproveGate().suite_margin == pytest.approx(0.10)
+    assert ImproveGate(suite_margin=0.0).suite_margin == 0.0
+    for invalid in (-0.1, 1.0, 1.5):
+        with pytest.raises(ValueError):
+            ImproveGate(suite_margin=invalid)

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -26,6 +26,7 @@ from wmh.providers.base import ToolCallingProvider
 DEFAULT_MAX_HISTORY_CANDIDATES = 1_024
 DEFAULT_MAX_HISTORY_BYTES = 512 * 1024 * 1024
 MAX_HISTORY_ARTIFACT_PATH_BYTES = 1_024
+MAX_DIRECTIVE_CHARS = 20_000
 
 
 class CandidateProject(Protocol):
@@ -172,6 +173,7 @@ class ProjectCandidateProposer:
         agent: HarnessDoc,
         provider: ToolCallingProvider,
         *,
+        directive: str = "",
         max_source_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
         max_source_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
         max_history_candidates: int = DEFAULT_MAX_HISTORY_CANDIDATES,
@@ -181,6 +183,11 @@ class ProjectCandidateProposer:
         _require_positive_int(max_source_bytes, field="max_source_bytes")
         _require_positive_int(max_history_candidates, field="max_history_candidates")
         _require_positive_int(max_history_bytes, field="max_history_bytes")
+        if directive:
+            validate_durable_text(directive, field="proposal directive")
+            if len(directive) > MAX_DIRECTIVE_CHARS:
+                raise ValueError(f"proposal directive exceeds {MAX_DIRECTIVE_CHARS} characters")
+        self._directive = directive
         self._project = project
         self._agent = agent
         self._provider = provider
@@ -220,6 +227,7 @@ class ProjectCandidateProposer:
                 proposal_dir=proposal_dir,
                 history_count=history_count,
                 previous_proposal_id=(f"candidate-{index - 1:04d}" if index > 1 else None),
+                directive=self._directive,
             )
             if turn.request != expected_request:
                 raise ValueError(f"restored request differs for {candidate_id}")
@@ -285,6 +293,7 @@ class ProjectCandidateProposer:
             proposal_dir=proposal_dir,
             history_count=len(frozen_history),
             previous_proposal_id=previous_proposal_id,
+            directive=self._directive,
         )
         self._project.write_text(f"{proposal_dir}/REQUEST.md", request)
         self._proposal_count = next_proposal_count
@@ -596,6 +605,7 @@ def _proposal_request(
     proposal_dir: str,
     history_count: int,
     previous_proposal_id: str | None,
+    directive: str = "",
 ) -> str:
     previous_trace = (
         f"The immediately preceding coding-turn trace is "
@@ -604,13 +614,19 @@ def _proposal_request(
         if previous_proposal_id is not None
         else "There is no earlier coding turn in this project."
     )
+    directive_block = (
+        "\nThe user directing this optimization gave the following feedback. Treat it as the"
+        f" primary objective of this candidate:\n\n{directive}\n"
+        if directive
+        else ""
+    )
     return f"""Produce exactly one complete harness candidate: {candidate_id}.
 
 Read `history/manifest.json`. It indexes all {history_count} evaluated candidates, their complete
 source directories, full score reports, and raw evaluator artifacts. Earlier coding-turn traces
 remain under `proposals/`. {previous_trace} Use the full population as evidence. Do not select or
 assume a host-designated source to extend.
-
+{directive_block}
 Your only candidate output is this initially empty directory:
 `{absolute_stage}`
 

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -413,6 +413,65 @@ def test_project_proposer_restore_rejects_tampered_request_without_an_agent_run(
     assert restored_project.run_calls == []
 
 
+def test_project_proposer_threads_directive_into_request_and_restore() -> None:
+    directive = "User feedback: the agent must gain read access to my GitHub issues."
+    project = _FakeProject([_source("improved")])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(
+        project, optimizer_agent(), _provider(), directive=directive
+    )
+    seed = _evaluated("candidate-0000")
+
+    proposal = proposer.propose((seed,))
+
+    assert directive in proposal.request
+    assert directive in project.run_calls[0].instruction
+    assert directive in project.files["proposals/candidate-0001/REQUEST.md"]
+
+    restored_project = _FakeProject([_source("unused")])
+    restored = ProjectCandidateProposer(
+        restored_project, optimizer_agent(), _provider(), directive=directive
+    )
+    restored.restore(
+        (seed, _evaluated("candidate-0001", source=proposal.source)),
+        (proposal,),
+    )
+    assert restored_project.files["proposals/candidate-0001/REQUEST.md"] == proposal.request
+
+
+def test_project_proposer_restore_rejects_a_different_directive() -> None:
+    project = _FakeProject([_source("improved")])
+    project.run_behavior = _emit_bash_activity
+    proposer = ProjectCandidateProposer(
+        project, optimizer_agent(), _provider(), directive="original directive"
+    )
+    seed = _evaluated("candidate-0000")
+    proposal = proposer.propose((seed,))
+
+    restored_project = _FakeProject([_source("unused")])
+    restored = ProjectCandidateProposer(restored_project, optimizer_agent(), _provider())
+
+    with pytest.raises(ValueError, match="request differs"):
+        restored.restore(
+            (seed, _evaluated("candidate-0001", source=proposal.source)),
+            (proposal,),
+        )
+
+    assert restored_project.run_calls == []
+
+
+def test_project_proposer_rejects_invalid_directive() -> None:
+    with pytest.raises(ValueError, match="directive"):
+        ProjectCandidateProposer(
+            _FakeProject([]), optimizer_agent(), _provider(), directive="bad\x00directive"
+        )
+
+    with pytest.raises(ValueError, match="directive"):
+        ProjectCandidateProposer(
+            _FakeProject([]), optimizer_agent(), _provider(), directive="x" * 20_001
+        )
+
+
 @pytest.mark.parametrize(
     ("field", "value", "match"),
     [

--- a/wmh/scenarios/feedback.py
+++ b/wmh/scenarios/feedback.py
@@ -1,0 +1,177 @@
+"""Feedback-directed verification tasks: turn one piece of user feedback into a must-pass gate.
+
+One piece of natural-language feedback about an agent ("you should have access to my GitHub")
+names a capability the current harness lacks. An LLM converts that feedback into a small set of
+verification `TaskSpec`s that exercise the NEW capability directly, plus the knowledge notes the
+world-model environment needs to simulate it plausibly. The tasks are the acceptance gate for a
+feedback-directed one-step harness improvement: they run closed-loop against the world model and
+are judged by their gold assertions, so an improvement only counts when the new capability
+demonstrably works.
+
+Unlike the trace-driven `ScenarioSynthesizer` (which degrades gracefully because a corpus has
+thousands of traces), a gate synthesized from one sentence of feedback has no fallback that is
+still meaningful: an unusable reply is retried once with the validation error, then raised.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from wmh.core.parsing import extract_json_object
+from wmh.evals.tasks import TaskSpec
+from wmh.providers.base import Message, Provider
+
+FEEDBACK_SYNTHESIS_SYSTEM = """You design verification tasks for an AI agent. A user gave one
+piece of feedback naming a capability the agent should have but currently lacks. Write tasks
+that PROVE the new capability works once the agent's harness is improved.
+
+Respond with ONLY a JSON object, no prose around it:
+{{"tasks": [{{"task_id": "feedback-verify-01", "instruction": "<self-contained task a user would
+give the agent>", "gold": ["<concrete assertion>", "..."]}}, ...],
+ "knowledge_notes": "<markdown facts the environment simulator needs>"}}
+
+Rules:
+- Produce between 1 and {count} tasks.
+- Each instruction is a self-contained task a real user would give the agent, and it must
+  exercise the NEW capability the feedback asks for. Never write a meta-task about editing the
+  agent's configuration, prompt, or tools: the task is what a user asks AFTER the capability
+  exists.
+- Each gold list holds 2 to 5 concrete, outcome-focused assertions that a judge can check from
+  the run transcript alone: the agent invoked the new capability, it surfaced the correct data,
+  and it did not fabricate results it never retrieved.
+- Tasks must differ from each other. When the task budget allows more than one, cover the happy
+  path plus at least one edge or error path (for example: authentication missing, or the
+  requested entity does not exist).
+- knowledge_notes gives the world-model environment simulator the facts it needs to answer the
+  new tool calls consistently: tool or API names, request/response shapes, and realistic sample
+  entities with concrete names, ids, and values that the gold assertions can reference. Use an
+  empty string only when the environment truly needs nothing new.
+- task_id values must be unique, contain only characters safe in kebab-case or snake_case, and
+  start with "feedback-verify-"."""
+
+
+class FeedbackSynthesis(BaseModel):
+    """Verification tasks plus the environment knowledge needed to simulate the new capability.
+
+    `knowledge_notes` is markdown destined for the world-model environment's knowledge base: the
+    tool names, request/response shapes, and sample entities the simulator needs to answer the
+    new capability's tool calls consistently. Empty when nothing is needed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tasks: tuple[TaskSpec, ...]
+    knowledge_notes: str = ""
+
+
+class _RawTask(BaseModel):
+    task_id: str
+    instruction: str
+    gold: list[str] = Field(default_factory=list)
+
+
+class _RawFeedbackSynthesis(BaseModel):
+    tasks: list[_RawTask] = Field(default_factory=list)
+    knowledge_notes: str = ""
+
+
+def synthesize_verification_tasks(
+    feedback: str,
+    *,
+    provider: Provider,
+    count: int = 3,
+    environment_context: str = "",
+) -> FeedbackSynthesis:
+    """Synthesize the must-pass verification tasks for one piece of user feedback.
+
+    Args:
+        feedback: One piece of natural-language user feedback about the agent, naming the
+            capability it should gain (e.g. "you should have access to my GitHub").
+        provider: LLM provider used to write the tasks.
+        count: Maximum number of tasks to synthesize (the model returns 1 to `count`).
+        environment_context: Optional caller-supplied prose about the environment (e.g. a
+            knowledge-base excerpt) that grounds the tasks in existing entities.
+
+    Returns:
+        The validated tasks plus the knowledge notes the environment simulator needs.
+
+    Raises:
+        ValueError: When `feedback` is blank, `count` is not positive, or the model failed to
+            produce a valid reply after one retry. There is no silent fallback: these tasks gate
+            a harness change, so a degraded task set must fail loudly, not pass vacuously.
+    """
+    if not feedback.strip():
+        raise ValueError("feedback must be a nonempty description of the desired capability")
+    if count < 1:
+        raise ValueError(f"count must be at least 1, got {count}")
+    system = FEEDBACK_SYNTHESIS_SYSTEM.format(count=count)
+    request = _render_request(feedback, environment_context)
+    completion = provider.complete(
+        system,
+        [Message(role="user", content=request)],
+        temperature=0.0,
+        max_tokens=4096,
+    )
+    try:
+        return _parse_synthesis(completion.text, count=count)
+    except ValueError as first_error:
+        retry_request = (
+            f"{request}\n\nYour previous reply was rejected: {first_error}\n"
+            "Reply again with ONLY the corrected JSON object."
+        )
+        completion = provider.complete(
+            system,
+            [Message(role="user", content=retry_request)],
+            temperature=0.0,
+            max_tokens=4096,
+        )
+        try:
+            return _parse_synthesis(completion.text, count=count)
+        except ValueError as second_error:
+            raise ValueError(
+                "could not synthesize verification tasks from the feedback after one retry: "
+                f"{second_error}"
+            ) from second_error
+
+
+def _render_request(feedback: str, environment_context: str) -> str:
+    """Render the user message: the feedback, grounded by any caller-supplied context."""
+    sections = [f"User feedback about the agent:\n{feedback.strip()}"]
+    if environment_context.strip():
+        sections.append(f"Known environment context:\n{environment_context.strip()}")
+    return "\n\n".join(sections)
+
+
+def _parse_synthesis(text: str, *, count: int) -> FeedbackSynthesis:
+    """Parse and validate one model reply; raise ValueError describing the first defect found."""
+    raw = extract_json_object(text)
+    if raw is None:
+        raise ValueError("reply contains no JSON object")
+    try:
+        parsed = _RawFeedbackSynthesis.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ValueError(f"reply JSON does not match the contract: {exc}") from exc
+    if not 1 <= len(parsed.tasks) <= count:
+        raise ValueError(f"expected between 1 and {count} tasks, got {len(parsed.tasks)}")
+    tasks: list[TaskSpec] = []
+    seen_ids: set[str] = set()
+    for index, raw_task in enumerate(parsed.tasks, start=1):
+        try:
+            spec = TaskSpec(
+                task_id=raw_task.task_id.strip(),
+                instruction=raw_task.instruction.strip(),
+                gold=[assertion.strip() for assertion in raw_task.gold if assertion.strip()],
+            )
+        except ValidationError as exc:
+            raise ValueError(f"task {index} is not a valid TaskSpec: {exc}") from exc
+        if not spec.task_id:
+            raise ValueError(f"task {index} has an empty task_id")
+        if not spec.instruction:
+            raise ValueError(f"task {spec.task_id!r} has an empty instruction")
+        if not spec.gold:
+            raise ValueError(f"task {spec.task_id!r} has no gold assertions")
+        if spec.task_id in seen_ids:
+            raise ValueError(f"duplicate task_id {spec.task_id!r}")
+        seen_ids.add(spec.task_id)
+        tasks.append(spec)
+    return FeedbackSynthesis(tasks=tuple(tasks), knowledge_notes=parsed.knowledge_notes.strip())

--- a/wmh/scenarios/feedback_test.py
+++ b/wmh/scenarios/feedback_test.py
@@ -1,0 +1,169 @@
+"""Tests for feedback-directed verification tasks (strict parse, retry once, no fallback)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.core.types import JsonValue
+from wmh.evals.tasks import TaskSpec
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.scenarios.feedback import FeedbackSynthesis, synthesize_verification_tasks
+
+
+class FakeProvider:
+    """Returns queued completion texts in order; records every prompt for assertions."""
+
+    def __init__(self, replies: list[str]) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model="m")
+        self._replies = list(replies)
+        self.systems: list[str] = []
+        self.requests: list[str] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.systems.append(system)
+        self.requests.append(messages[0].content)
+        if not self._replies:
+            raise AssertionError("provider called more times than replies were queued")
+        return Completion(text=self._replies.pop(0))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def _task(task_id: str, instruction: str = "List my open GitHub PRs.") -> dict[str, JsonValue]:
+    return {
+        "task_id": task_id,
+        "instruction": instruction,
+        "gold": [
+            "The agent called the GitHub API to list pull requests",
+            "The agent reported PR #42 'Fix login bug' from acme/webapp",
+        ],
+    }
+
+
+def _reply(tasks: list[dict[str, JsonValue]], **extra: JsonValue) -> str:
+    payload: dict[str, JsonValue] = {"tasks": tasks, "knowledge_notes": "GitHub notes"}
+    payload.update(extra)
+    return json.dumps(payload)
+
+
+def test_happy_path_parses_into_feedback_synthesis() -> None:
+    reply = _reply(
+        [
+            _task("feedback-verify-01"),
+            _task("feedback-verify-02", "Look up nonexistent repo acme/ghost."),
+        ],
+        knowledge_notes="## GitHub\n- repo acme/webapp has PR #42 'Fix login bug'",
+    )
+    provider = FakeProvider(["Here you go:\n```json\n" + reply + "\n```"])
+    result = synthesize_verification_tasks(
+        "you should have access to my GitHub",
+        provider=provider,
+        count=3,
+        environment_context="The user works in the acme org.",
+    )
+    assert isinstance(result, FeedbackSynthesis)
+    assert isinstance(result.tasks, tuple)
+    assert [t.task_id for t in result.tasks] == ["feedback-verify-01", "feedback-verify-02"]
+    assert all(isinstance(t, TaskSpec) for t in result.tasks)
+    assert result.tasks[0].instruction == "List my open GitHub PRs."
+    assert len(result.tasks[0].gold) == 2
+    assert result.knowledge_notes == "## GitHub\n- repo acme/webapp has PR #42 'Fix login bug'"
+    # One clean call: the feedback, the caller's context, and the count all reached the model.
+    assert len(provider.requests) == 1
+    assert "you should have access to my GitHub" in provider.requests[0]
+    assert "The user works in the acme org." in provider.requests[0]
+    assert "between 1 and 3 tasks" in provider.systems[0]
+
+
+def test_unparseable_reply_retries_once_then_raises() -> None:
+    provider = FakeProvider(["not json at all", "still not json"])
+    with pytest.raises(ValueError, match="after one retry.*no JSON object"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    # The retry carries the first validation error back to the model.
+    assert "rejected" in provider.requests[1]
+    assert "no JSON object" in provider.requests[1]
+
+
+def test_duplicate_task_ids_trigger_retry_then_succeed() -> None:
+    bad = _reply([_task("feedback-verify-01"), _task("feedback-verify-01")])
+    good = _reply([_task("feedback-verify-01")])
+    provider = FakeProvider([bad, good])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    assert "duplicate task_id 'feedback-verify-01'" in provider.requests[1]
+    assert [t.task_id for t in result.tasks] == ["feedback-verify-01"]
+
+
+def test_empty_gold_triggers_retry_then_raises_when_still_invalid() -> None:
+    empty = _task("feedback-verify-01")
+    empty["gold"] = []
+    whitespace = _task("feedback-verify-01")
+    whitespace["gold"] = ["   ", ""]
+    provider = FakeProvider([_reply([empty]), _reply([whitespace])])
+    with pytest.raises(ValueError, match="no gold assertions"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+
+
+def test_empty_instruction_triggers_retry() -> None:
+    bad = _reply([_task("feedback-verify-01", instruction="   ")])
+    good = _reply([_task("feedback-verify-01")])
+    provider = FakeProvider([bad, good])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    assert "empty instruction" in provider.requests[1]
+    assert result.tasks[0].instruction == "List my open GitHub PRs."
+
+
+def test_count_is_enforced_and_named_in_the_prompt() -> None:
+    three = _reply([_task(f"feedback-verify-0{i}") for i in (1, 2, 3)])
+    two = _reply([_task("feedback-verify-01"), _task("feedback-verify-02")])
+    provider = FakeProvider([three, two])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider, count=2)
+    assert len(result.tasks) == 2
+    assert "between 1 and 2 tasks" in provider.systems[0]
+    assert "expected between 1 and 2 tasks, got 3" in provider.requests[1]
+
+
+def test_zero_tasks_is_invalid() -> None:
+    provider = FakeProvider([_reply([]), _reply([])])
+    with pytest.raises(ValueError, match="between 1 and 3 tasks, got 0"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+
+
+def test_knowledge_notes_defaults_to_empty_when_omitted() -> None:
+    reply = json.dumps({"tasks": [_task("feedback-verify-01")]})
+    provider = FakeProvider([reply])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert result.knowledge_notes == ""
+
+
+def test_blank_feedback_and_bad_count_raise_without_calling_provider() -> None:
+    provider = FakeProvider([])
+    with pytest.raises(ValueError, match="nonempty"):
+        synthesize_verification_tasks("   ", provider=provider)
+    with pytest.raises(ValueError, match="count must be at least 1"):
+        synthesize_verification_tasks("add GitHub access", provider=provider, count=0)
+    assert provider.requests == []
+
+
+def test_result_model_is_frozen() -> None:
+    provider = FakeProvider([_reply([_task("feedback-verify-01")])])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    with pytest.raises(ValidationError):
+        result.knowledge_notes = "mutated"  # type: ignore[misc]


### PR DESCRIPTION
## What

One gated self-edit of a harness from a single piece of user feedback, with the world model as both scenario author and execution environment. Stacked on the harness-optimization track (base: #231).

- `wmh/scenarios/feedback.py`: synthesizes must-pass verification `TaskSpec`s (plus knowledge notes that seed the world model's knowledge base so it can simulate the new capability) from natural-language feedback, with strict code-side validation and one retry.
- `wmh/evals/world_model_scorer.py`: `WorldModelScorer`, the world-model sibling of `HarborScorer`. Implements the immutable `HarnessScorer` protocol: real harness process (local or E2B), environment responses simulated by the world model, cells = task x attempt with assertion-fraction scores, content-addressed rollout transcripts as artifacts.
- `wmh/harness/project_proposer.py`: `ProjectCandidateProposer` gains a keyword-only `directive` woven into its immutable request template; restore recomputes with the same directive, so a resume under a different directive fails loudly.
- `wmh/harness/improve.py`: `improve_harness` runs a fixed-slot population step and applies an explicit promotion gate, deliberately ignoring the optimizer's blended `result.best`: standard suite within a relative margin of the seed champion (default 10 percent) AND every verification task passes a strict majority of attempts. Rejections carry precise reasons.
- `wmh/cli/harness_improve.py`: `wmh harness improve NAME --feedback ... --tasks suite.jsonl --model WM`. Seed QA drops verification tasks the champion already passes (exits 1 with no optimization spend when the feedback appears already satisfied); evidence is a population archive plus `improve-outcome.json`; accepted winners publish with the champion alias. Improve runs are not checkpointed.

## Why

The platform's auto-optimize feature (companion platform PR) lets a user attach an Auto-optimize badge in the live-session chat; their next message becomes this feedback. The world model gates the self-edit: no regression beyond the margin, and the new requirement must demonstrably pass.

## Validation

Full gate green on the stack tip: `uv run ruff format` / `ruff check` / `ty check` clean, `pytest -q`: 2266 passed, 19 skipped. 52 new tests across the five touched surfaces, all hermetic (no network, no E2B, no providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)