### PR TITLE
Fix contained project shell launch on E2B

### DIFF
--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -41,6 +41,7 @@ from wmh.providers.base import ToolCallingProvider
 PROJECT_WORKSPACE = "/home/user/project"
 PROJECT_SCRATCH_DIR = ".scratch"
 PROJECT_SHELL_USER = "wmh-project-shell"
+PROJECT_SHELL_GROUP = "wmh-project-shell"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
 DEFAULT_SOURCE_TREE_MAX_FILES = 1_024
 DEFAULT_SOURCE_TREE_MAX_BYTES = 8 * 1024 * 1024
@@ -703,13 +704,25 @@ class AgentProject:
         if self._shell_ready_sandbox_id == id(self._sandbox):
             return
         scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
+        workspace_access = ""
+        if self.workspace == PROJECT_WORKSPACE:
+            workspace_parent = str(PurePosixPath(PROJECT_WORKSPACE).parent)
+            workspace_access = (
+                f"chgrp {PROJECT_SHELL_GROUP} {shlex.quote(workspace_parent)}\n"
+                f"chmod g=x {shlex.quote(workspace_parent)}\n"
+            )
         command = (
             "set -eu\n"
+            f"if ! getent group {PROJECT_SHELL_GROUP} >/dev/null 2>&1; then\n"
+            f"  groupadd --system {PROJECT_SHELL_GROUP}\n"
+            "fi\n"
             f"if ! id -u {self._shell_user} >/dev/null 2>&1; then\n"
             f"  useradd --system --user-group --no-create-home "
             f"--shell /usr/sbin/nologin {self._shell_user}\n"
             "fi\n"
             f"id -u {self._shell_user} >/dev/null\n"
+            f"usermod --append --groups {PROJECT_SHELL_GROUP} {self._shell_user}\n"
+            f"{workspace_access}"
             f"mkdir -p {shlex.quote(scratch)} && chmod 1777 {shlex.quote(scratch)}"
         )
         result = self._sandbox.commands.run(command, user="root", timeout=30)
@@ -897,6 +910,7 @@ class AgentProject:
         filter_command = f"node -e {shlex.quote(_BASH_FILTER_SCRIPT)}"
         script = (
             "set -o pipefail\n"
+            "umask 077\n"
             f"timeout --kill-after=3s {_BASH_PROCESS_TIMEOUT_S}s "
             f"bash --noprofile --norc -c {shlex.quote(command)} "
             f"2> >({filter_command} >&2) | {filter_command}\n"
@@ -904,11 +918,13 @@ class AgentProject:
             'exit "$status"'
         )
         scratch = f"{self.workspace}/{PROJECT_SCRATCH_DIR}"
+        shell_user = shlex.quote(self._shell_user)
         wrapped = (
             "env -i PATH=/usr/local/bin:/usr/bin:/bin "
             f"HOME={shlex.quote(scratch)} TMPDIR={shlex.quote(scratch)} "
-            f"USER={self._shell_user} LOGNAME={self._shell_user} "
-            "setpriv --no-new-privs --inh-caps=-all --ambient-caps=-all "
+            f"USER={shell_user} LOGNAME={shell_user} "
+            f"setpriv --reuid=$(id -u {shell_user}) --regid=$(id -g {shell_user}) "
+            "--init-groups --no-new-privs --inh-caps=-all --ambient-caps=-all "
             f"--bounding-set=-all bash --noprofile --norc -c {shlex.quote(script)}"
         )
         stdout = ""
@@ -919,7 +935,10 @@ class AgentProject:
             try:
                 result = self._sandbox.commands.run(
                     wrapped,
-                    user=self._shell_user,
+                    # E2B cannot start a command directly as a dynamically created system user.
+                    # Start the trusted wrapper as root, then drop uid, gid, groups, privileges,
+                    # and capabilities before the agent-controlled command reaches Bash.
+                    user="root",
                     cwd=scratch,
                     timeout=_BASH_TIMEOUT_S,
                 )

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1375,14 +1375,22 @@ def test_project_bash_runs_as_an_unprivileged_bounded_scratch_process() -> None:
     assert emitted == [("stdout", "inspected\n"), ("stderr", "warning\n")]
     agent_call, cleanup_call = commands.calls
     assert agent_call == {
-        "user": project._shell_user,  # noqa: SLF001 - assert per-project isolation identity
+        "user": "root",
         "cwd": "/home/user/project/.scratch",
         "timeout": 60.0,
     }
     assert cleanup_call == {"user": "root", "timeout": 10.0}
     command, cleanup_command = commands.runs
     assert command.startswith("env -i ")
-    assert "setpriv --no-new-privs" in command
+    assert f"setpriv --reuid=$(id -u {project._shell_user})" in command  # noqa: SLF001
+    assert f"--regid=$(id -g {project._shell_user})" in command  # noqa: SLF001
+    assert "--init-groups" in command
+    assert "--init-groups --no-new-privs" in command
+    assert "--inh-caps=-all" in command
+    assert "--ambient-caps=-all" in command
+    assert "--bounding-set=-all" in command
+    assert command.index("setpriv --reuid=") < command.index("bash --noprofile --norc -c")
+    assert "umask 077" in command
     assert "timeout --kill-after=3s 50s" in command
     assert "pwd && rg TODO ../candidates" in command
     assert "wmh-project-shell-quiescence" in cleanup_command
@@ -1610,12 +1618,37 @@ def test_project_accepts_bash_as_a_contained_agent_tool() -> None:
     shell_setup = next(
         command for command in sandbox.commands.runs if "useradd --system" in command
     )
+    assert "groupadd --system wmh-project-shell" in shell_setup
     assert "useradd --system --user-group --no-create-home" in shell_setup
     assert project._shell_user != PROJECT_SHELL_USER  # noqa: SLF001
     assert f"id -u {project._shell_user}" in shell_setup  # noqa: SLF001
-    assert shell_setup.count(project._shell_user) == 3  # noqa: SLF001
+    assert (  # noqa: SLF001
+        f"usermod --append --groups wmh-project-shell {project._shell_user}" in shell_setup
+    )
+    assert shell_setup.count(project._shell_user) == 4  # noqa: SLF001
+    assert "chgrp wmh-project-shell /home/user" in shell_setup
+    assert "chmod g=x /home/user" in shell_setup
     assert "mkdir -p /home/user/project/.scratch" in shell_setup
     assert "chmod 1777 /home/user/project/.scratch" in shell_setup
+
+
+def test_custom_project_workspace_does_not_repermission_its_parent() -> None:
+    sandbox = _Sandbox()
+    project = AgentProject(
+        sandbox,
+        workspace="/srv/wmh/project",
+        channel_factory=lambda sandbox, workspace: _Channel(),
+        owns_sandbox=False,
+    )
+
+    project._prepare_shell_workspace()  # noqa: SLF001
+
+    shell_setup = next(
+        command for command in sandbox.commands.runs if "useradd --system" in command
+    )
+    assert "chgrp wmh-project-shell /srv/wmh" not in shell_setup
+    assert "chmod g=x /srv/wmh" not in shell_setup
+    assert "mkdir -p /srv/wmh/project/.scratch" in shell_setup
 
 
 def test_project_shell_setup_nonzero_exit_fails_closed_and_remains_retryable() -> None:


### PR DESCRIPTION
## Summary

- launch the trusted AgentProject Bash wrapper as root, then drop to the unique project-shell uid/gid and supplementary groups before any agent-controlled command runs
- grant traversal-only access through the fixed E2B home boundary while preserving unique 0700/0600 source-stage ownership and cross-project isolation
- retain the empty environment, network lock, no-new-privileges and capability drops, bounded output/time, and per-user process quiescence

## Verification

- 59 focused AgentProject tests pass
- full suite: 2,219 passed, 19 skipped
- Ruff check and format, ty, diff, and credential-literal scan pass
- no-model E2B smoke proves non-root identity, read-only project evidence, writable isolated source stage, cross-user denial, network lock, process quiescence, and sandbox retirement

Stacked on #232. No merge requested.