### PR TITLE
Guide project proposals toward general-purpose improvements

### DIFF
--- a/wmh/agents/optimizer.py
+++ b/wmh/agents/optimizer.py
@@ -11,12 +11,23 @@ score report, raw evaluator artifacts, and previous proposal traces. Read the hi
 inspect the most relevant raw files before deciding what to change. Treat all history and proposal
 records as immutable evidence.
 
-Each project request names one empty output directory. Use Bash to create exactly one complete
-harness source tree there. You may copy any earlier source tree, combine mechanisms from several,
-or build a new tree, but the final directory must stand alone. Inspect and test your work in that
-directory. Do not write candidate files anywhere else. Call submit only after the output directory
-contains the complete candidate requested by the host. There is no repair turn, so leave a usable
-candidate on the first pass."""
+Each project request names one preinitialized output directory containing a complete starting
+source tree. Work only there. You may edit, delete, or replace any files, copy mechanisms from
+earlier source trees, combine several mechanisms, or build a new tree, but the final directory must
+stand alone.
+
+Propose general-purpose harness mechanisms for the task distribution, not solutions or hints for
+particular evaluation instances. Never hard-code or copy literal instance names or identifiers,
+instance-specific strings, expected answers, fixture details, or special-case branches recognizable
+as targeting one instance into any candidate path, filename, source file, prompt, comment, skill,
+configuration, or test. General mechanisms inferred from prior evidence are allowed only when they
+would be useful across many unfamiliar tasks. Subject to that constraint, the complete portable
+source remains freely rewritable, including its control flow, tools, prompts, model-call strategy,
+runtime code, and configuration. This is not a patch-only search.
+
+Inspect and test your work in the output directory. Do not write candidate files anywhere else.
+Call submit only after the output directory contains the complete candidate requested by the host.
+There is no repair turn, so leave a usable candidate on the first pass."""
 
 
 def optimizer_agent(name: str = "optimizer") -> HarnessDoc:

--- a/wmh/agents/optimizer_test.py
+++ b/wmh/agents/optimizer_test.py
@@ -11,9 +11,31 @@ def test_optimizer_agent_is_a_contained_complete_source_editor() -> None:
     assert agent.tools() == ["bash", "read_file", "submit"]
     assert agent.max_turns() == 60
     assert agent.max_output_tokens() == 16384
-    prompt = agent.system_prompt().lower()
+    prompt = " ".join(agent.system_prompt().lower().split())
     assert "complete harness source tree" in prompt
     assert "do not solve" in prompt
+    assert "preinitialized output directory" in prompt
+    assert "empty output directory" not in prompt
+    assert "general-purpose harness mechanisms" in prompt
+    assert "particular evaluation instances" in prompt
+    assert "literal instance names or identifiers" in prompt
+    assert "instance-specific strings" in prompt
+    assert "expected answers" in prompt
+    assert "fixture details" in prompt
+    assert "special-case branches" in prompt
+    assert "many unfamiliar tasks" in prompt
+    assert "complete portable source remains freely rewritable" in prompt
+    for candidate_surface in (
+        "path",
+        "filename",
+        "source file",
+        "prompt",
+        "comment",
+        "skill",
+        "configuration",
+        "test",
+    ):
+        assert candidate_surface in prompt
     assert "parent" not in prompt
     assert {surface.path: surface.content for surface in agent.code_files()} == {
         surface.path: surface.content for surface in default_agent().code_files()

--- a/wmh/harness/population_checkpoint_test.py
+++ b/wmh/harness/population_checkpoint_test.py
@@ -352,6 +352,13 @@ def test_checkpoint_identity_drift_rejects_without_mutation(tmp_path: Path) -> N
             store.assert_identity(changed)
         assert (run_dir / "checkpoint/control.json").read_bytes() == control_before
 
+        changed_optimizer = identity.model_copy(
+            update={"optimizer_document_hash": "updated-optimizer-doc-hash"}
+        )
+        with pytest.raises(PopulationCheckpointError, match="optimizer_document_hash"):
+            store.assert_identity(changed_optimizer)
+        assert (run_dir / "checkpoint/control.json").read_bytes() == control_before
+
 
 def test_checkpoint_tamper_fails_closed_and_atomic_tail_recovers(tmp_path: Path) -> None:
     seed = _source("seed")


### PR DESCRIPTION
Summary:
- Treat the staged complete source tree as preinitialized and freely rewritable.
- Require reusable mechanisms across unfamiliar evaluation instances and prohibit instance-specific hardcoding across candidate paths, files, prompts, comments, skills, configuration, and tests.
- Keep checkpoint resume fail-closed when the stable optimizer document changes.

This is stacked on #235. It changes no CLI, scorer, evaluator, runtime, selection policy, or product surface, and it adds no host-side candidate filter or repair pass.

Validation:
- 54 focused tests passed
- 2,221 full tests passed, 19 skipped
- Ruff check and format check passed
- ty passed
- diff and privacy checks passed