### PR TITLE
Pace shared E2B sandbox creation

### DIFF
--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -35,7 +35,12 @@ from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
 from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, SandboxUsage, resolve_e2b_template
+from wmh.harness.e2b_sandbox import (
+    E2B_TEMPLATE_ENV,
+    SandboxUsage,
+    e2b_create_rate_policy_payload,
+    resolve_e2b_template,
+)
 from wmh.harness.population import HarnessPopulationOptimizer, PopulationOptimizationResult
 from wmh.harness.population_archive import write_population_archive
 from wmh.harness.population_checkpoint import (
@@ -378,6 +383,7 @@ def _execute_optimization(
             optimizer_document_hash=optimizer.doc_hash,
             harness_backend=harness_backend,
             e2b_template=e2b_template or None,
+            project_e2b_create_rate_policy=e2b_create_rate_policy_payload(),
             environment_command_timeout_sec=environment_command_timeout_sec,
             episode_timeout_sec=episode_timeout_sec,
             project_timeout_sec=project_timeout_sec,

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -29,7 +29,7 @@ from wmh.cli.harness_optimize import (
 from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
 from wmh.evals.harbor.canonical import canonical_harbor_job_config
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.e2b_sandbox import SandboxUsage, e2b_create_rate_policy_payload
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import (
     HarnessPopulationOptimizer,
@@ -295,6 +295,7 @@ def _checkpoint_identity(
         optimizer_document_hash=module.optimizer_agent().doc_hash,
         harness_backend="local",
         e2b_template=None,
+        project_e2b_create_rate_policy=e2b_create_rate_policy_payload(),
         environment_command_timeout_sec=300,
         episode_timeout_sec=300,
         project_timeout_sec=900,
@@ -764,6 +765,7 @@ def test_execute_resumes_ready_seed_at_next_slot_without_rescoring(
         optimizer_document_hash=module.optimizer_agent().doc_hash,
         harness_backend="local",
         e2b_template=None,
+        project_e2b_create_rate_policy=e2b_create_rate_policy_payload(),
         environment_command_timeout_sec=300,
         episode_timeout_sec=300,
         project_timeout_sec=900,

--- a/wmh/evals/harbor/e2b_environment.py
+++ b/wmh/evals/harbor/e2b_environment.py
@@ -1,0 +1,45 @@
+"""Harbor E2B task environment using WMH's shared sandbox-create admission gate."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import override
+
+from e2b import AsyncSandbox
+from harbor.environments.e2b import E2BEnvironment
+from harbor.models.task.config import NetworkMode
+
+from wmh.harness.e2b_sandbox import acquire_e2b_create_slot_async
+
+_CREATE_ATTEMPTS = 2
+_CREATE_RETRY_DELAY_S = 1.0
+
+
+class WmhE2BEnvironment(E2BEnvironment):
+    """Preserve Harbor's E2B behavior while pacing every provider create attempt."""
+
+    @override
+    async def _create_sandbox(self) -> None:
+        metadata = {
+            "environment_name": self.environment_name,
+            "session_id": self.session_id,
+        }
+        for attempt in range(_CREATE_ATTEMPTS):
+            await acquire_e2b_create_slot_async()
+            try:
+                self._sandbox = await AsyncSandbox.create(
+                    template=self._template_name,
+                    metadata=metadata,
+                    envs=self._startup_env(),
+                    timeout=86_400,
+                    allow_internet_access=(
+                        self.network_policy.network_mode != NetworkMode.NO_NETWORK
+                    ),
+                    network=self._sandbox_create_network_options(),
+                )
+                return
+            except Exception:  # noqa: BLE001 - preserve Harbor's retry-all create contract
+                self._sandbox = None
+                if attempt + 1 == _CREATE_ATTEMPTS:
+                    raise
+                await asyncio.sleep(_CREATE_RETRY_DELAY_S)

--- a/wmh/evals/harbor/e2b_environment_test.py
+++ b/wmh/evals/harbor/e2b_environment_test.py
@@ -1,0 +1,121 @@
+"""Offline tests for WMH's rate-paced Harbor E2B task environment."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from harbor.models.task.config import EnvironmentConfig
+from harbor.models.trial.paths import TrialPaths
+
+pytest.importorskip("e2b")
+
+from e2b import AsyncSandbox  # noqa: E402
+
+import wmh.evals.harbor.e2b_environment as e2b_environment_module  # noqa: E402
+from wmh.evals.harbor.e2b_environment import WmhE2BEnvironment  # noqa: E402
+
+
+def _environment(tmp_path: Path) -> WmhE2BEnvironment:
+    environment_dir = tmp_path / "environment"
+    environment_dir.mkdir()
+    (environment_dir / "Dockerfile").write_text(
+        "FROM alpine:3.20\nWORKDIR /workspace\n",
+        encoding="utf-8",
+    )
+    trial_dir = tmp_path / "jobs" / "job" / "trial"
+    trial_dir.mkdir(parents=True)
+    return WmhE2BEnvironment(
+        environment_dir=environment_dir,
+        environment_name="task/environment",
+        session_id="trial__environment",
+        trial_paths=TrialPaths(trial_dir),
+        task_env_config=EnvironmentConfig(cpus=2, memory_mb=2048),
+    )
+
+
+def test_harbor_e2b_create_reacquires_shared_gate_on_provider_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    events: list[str] = []
+    calls: list[dict[str, object]] = []
+    sandbox = object()
+
+    async def admit() -> None:
+        events.append("admit")
+
+    async def create(**kwargs: object) -> object:
+        events.append("create")
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError("transient create failure")
+        return sandbox
+
+    async def sleep(seconds: float) -> None:
+        assert seconds == 1.0
+        events.append("sleep")
+
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "acquire_e2b_create_slot_async",
+        admit,
+    )
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    asyncio.run(environment._create_sandbox())
+
+    assert events == ["admit", "create", "sleep", "admit", "create"]
+    assert len(calls) == 2
+    assert calls[0] == calls[1]
+    assert calls[0] == {
+        "template": environment._template_name,
+        "metadata": {
+            "environment_name": "task/environment",
+            "session_id": "trial__environment",
+        },
+        "envs": environment._startup_env(),
+        "timeout": 86_400,
+        "allow_internet_access": True,
+        "network": None,
+    }
+    assert environment._sandbox is sandbox
+
+
+def test_harbor_e2b_create_propagates_second_provider_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    admissions = 0
+    creates = 0
+
+    async def admit() -> None:
+        nonlocal admissions
+        admissions += 1
+
+    async def create(**_kwargs: object) -> object:
+        nonlocal creates
+        creates += 1
+        raise RuntimeError("still unavailable")
+
+    async def sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "acquire_e2b_create_slot_async",
+        admit,
+    )
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="still unavailable"):
+        asyncio.run(environment._create_sandbox())
+
+    assert admissions == 2
+    assert creates == 2
+    assert environment._sandbox is None

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 import harbor
 from harbor import Job
 from harbor.models.agent.name import AgentName
+from harbor.models.environment_type import EnvironmentType
 from harbor.models.job.config import DatasetConfig, JobConfig, RetryConfig
 from harbor.models.job.lock import JobLock, TrialLock
 from harbor.models.job.result import JobResult
@@ -38,7 +39,10 @@ from wmh.evals.harbor.tasks import (
     resolve_harbor_task_set,
 )
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.e2b_sandbox import resolve_e2b_template
+from wmh.harness.e2b_sandbox import (
+    e2b_create_rate_policy_payload,
+    resolve_e2b_template,
+)
 from wmh.harness.pi_runtime import PI_RUNNER_DIR, PI_RUNNER_HOST
 from wmh.harness.runtime import (
     DEFAULT_EVAL_EPISODE_TIMEOUT_S,
@@ -58,7 +62,8 @@ from wmh.providers.base import ProviderConfig
 _INDEX_PATH = "raw/index.json"
 _REQUIRED_JOB_FILES = frozenset({"config.json", "lock.json", "result.json", "job.log"})
 _REQUIRED_TRIAL_FILES = frozenset({"config.json", "lock.json", "result.json", "trial.log"})
-_HARBOR_SCORER_VERSION = "3"
+_HARBOR_SCORER_VERSION = "4"
+WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH = "wmh.evals.harbor.e2b_environment:WmhE2BEnvironment"
 _CHECKSUM_PATTERN = r"^[0-9a-f]{64}$"
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
@@ -102,6 +107,30 @@ def _validate_episode_timeout_sec(value: object) -> float:
         raise ValueError("episode_timeout_sec must be a finite positive number") from error
 
 
+def _pace_builtin_e2b_environment(job_config: JobConfig) -> tuple[JobConfig, bool]:
+    """Route Harbor's built-in E2B backend through WMH's paced subclass."""
+    environment = job_config.environment
+    if environment.type is EnvironmentType.E2B:
+        if environment.import_path is not None:
+            raise ValueError("Harbor E2B environment cannot set both type and import_path")
+        paced_environment = environment.model_copy(
+            update={
+                "type": None,
+                "import_path": WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH,
+            },
+            deep=True,
+        )
+        paced_job = job_config.model_copy(
+            update={"environment": paced_environment},
+            deep=True,
+        )
+        return JobConfig.model_validate(paced_job.model_dump(mode="python")), True
+    return (
+        job_config,
+        environment.import_path == WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH,
+    )
+
+
 class HarborScorer:
     """Evaluate exact harness candidates through Harbor's official verifier lifecycle."""
 
@@ -118,6 +147,7 @@ class HarborScorer:
         e2b_template: str | None = None,
         runner: HarborRunner | None = None,
     ) -> None:
+        job_config, task_environment_uses_paced_e2b = _pace_builtin_e2b_environment(job_config)
         if len(job_config.datasets) != 1 or job_config.tasks:
             raise ValueError("HarborScorer requires exactly one dataset and no direct tasks")
         if len(job_config.agents) != 1:
@@ -196,6 +226,7 @@ class HarborScorer:
         self._environment_command_timeout_sec = environment_command_timeout_sec
         self._episode_timeout_sec = episode_timeout_sec
         self._harness_backend = harness_backend
+        self._task_environment_uses_paced_e2b = task_environment_uses_paced_e2b
         if harness_backend == "local":
             self._local_runner_identity = {
                 "transport": "ssh",
@@ -308,12 +339,26 @@ class HarborScorer:
             "local_runner": self._local_runner_identity,
             "environment_command_timeout_sec": self._environment_command_timeout_sec,
             "episode_timeout_sec": self._episode_timeout_sec,
+            "e2b_create_rate": self._e2b_create_rate_identity(),
         }
         return ScoreContext(
             task_set_digest=_digest_json(task_payload),
             evaluator_digest=_digest_json(evaluator_payload),
             execution_config_digest=_digest_json(execution_payload),
         )
+
+    def _e2b_create_rate_identity(self) -> dict[str, object] | None:
+        consumers = []
+        if self._task_environment_uses_paced_e2b:
+            consumers.append("task_environment")
+        if self._harness_backend == "e2b":
+            consumers.append("worker_sandbox")
+        if not consumers:
+            return None
+        return {
+            "policy": e2b_create_rate_policy_payload(),
+            "consumers": consumers,
+        }
 
     def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
         """Run and project one candidate, raising unless every requested cell is scoreable."""

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -35,6 +35,7 @@ from harbor.models.trial.result import (
 from harbor.models.verifier.result import VerifierResult
 from harbor.tasks.client import TaskDownloadResult
 
+import wmh.evals.harbor.scorer as scorer_module
 from wmh.evals.harbor.agent import (
     MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
     WMH_HARBOR_AGENT_IMPORT_PATH,
@@ -42,6 +43,7 @@ from wmh.evals.harbor.agent import (
     WmhHarborAgent,
 )
 from wmh.evals.harbor.scorer import (
+    WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH,
     HarborJobRunner,
     HarborRun,
     HarborScorer,
@@ -89,6 +91,7 @@ class _Runner:
             if task_id in task_configs:
                 trial.config.task = task_configs[task_id].model_copy(deep=True)
                 trial.task_id = trial.config.task.get_task_id()
+            trial.config.environment = config.environment.model_copy(deep=True)
             trial.task_checksum = identity.trial_checksum
             trial.config.trials_dir = destination
             trial.trial_uri = destination.joinpath(trial.trial_name).resolve().as_uri()
@@ -408,7 +411,8 @@ def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
     assert scored.report.candidate_doc_hash == candidate.doc_hash
     config = runner.configs[0]
     assert config.n_attempts == 2
-    assert config.environment.type is EnvironmentType.E2B
+    assert config.environment.type is None
+    assert config.environment.import_path == WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH
     assert config.datasets == []
     assert [task.get_task_id().get_name() for task in config.tasks] == [
         "task-a",
@@ -420,6 +424,84 @@ def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
     assert config.agents[0].kwargs["harness_backend"] == "local"
     assert config.agents[0].kwargs["command_timeout_sec"] == MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
     assert "secret" not in json.dumps(config.agents[0].kwargs).lower()
+
+
+def test_scorer_rewrites_builtin_e2b_environment_without_losing_options(
+    tmp_path: Path,
+) -> None:
+    environment = EnvironmentConfig(
+        type=EnvironmentType.E2B,
+        force_build=True,
+        override_cpus=2,
+        override_memory_mb=2048,
+        env={"VISIBLE": "value"},
+        kwargs={"option": "value"},
+    )
+    config = _job_config(tmp_path, backend=EnvironmentType.E2B).model_copy(
+        update={"environment": environment}
+    )
+    scorer, _ = _scorer(tmp_path, _run(tmp_path, []), job_config=config)
+
+    rewritten = scorer._job_config.environment
+    assert rewritten.type is None
+    assert rewritten.import_path == WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH
+    assert rewritten.model_dump(exclude={"type", "import_path"}) == environment.model_dump(
+        exclude={"type", "import_path"}
+    )
+
+
+def test_scorer_rejects_ambiguous_builtin_and_custom_e2b_environment(
+    tmp_path: Path,
+) -> None:
+    config = _job_config(tmp_path, backend=EnvironmentType.E2B).model_copy(
+        update={
+            "environment": EnvironmentConfig(
+                type=EnvironmentType.E2B,
+                import_path="package.module:CustomE2BEnvironment",
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="E2B environment.*import_path"):
+        _scorer(tmp_path, _run(tmp_path, []), job_config=config)
+
+
+def test_e2b_create_policy_is_bound_only_when_an_e2b_path_is_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    local, _ = _scorer(tmp_path / "local", _run(tmp_path / "local", []))
+    task_e2b, _ = _scorer(
+        tmp_path / "task-e2b",
+        _run(tmp_path / "task-e2b", []),
+        job_config=_job_config(tmp_path / "task-e2b", backend=EnvironmentType.E2B),
+    )
+    worker_e2b, _ = _scorer(
+        tmp_path / "worker-e2b",
+        _run(tmp_path / "worker-e2b", []),
+        harness_backend="e2b",
+        e2b_template="runner-template",
+    )
+    local_digest = local.context().execution_config_digest
+    task_digest = task_e2b.context().execution_config_digest
+    worker_digest = worker_e2b.context().execution_config_digest
+
+    monkeypatch.setattr(
+        scorer_module,
+        "e2b_create_rate_policy_payload",
+        lambda: {
+            "schema_version": 1,
+            "provider": "e2b",
+            "operation": "sandbox_create",
+            "maximum_dispatches": 3,
+            "period_milliseconds": 1000,
+            "maximum_wait_seconds": 60.0,
+        },
+    )
+
+    assert local.context().execution_config_digest == local_digest
+    assert task_e2b.context().execution_config_digest != task_digest
+    assert worker_e2b.context().execution_config_digest != worker_digest
 
 
 @pytest.mark.parametrize("case", ["missing", "extra", "duplicate", "unfinished"])

--- a/wmh/harness/e2b_sandbox.py
+++ b/wmh/harness/e2b_sandbox.py
@@ -11,12 +11,17 @@ optional extra (`uv sync --extra e2b`).
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from collections.abc import Callable, Iterator, Sequence
-from typing import Protocol, cast, runtime_checkable
+from dataclasses import dataclass
+from threading import Lock
+from typing import Literal, Protocol, cast, runtime_checkable
 
 from pydantic import BaseModel
+
+from wmh.core.types import JsonObject
 
 
 class SandboxUsage(BaseModel):
@@ -45,6 +50,108 @@ _CREATE_DELAYS = (1.0, 3.0, 9.0)
 # be proved.
 _KILL_DELAYS = (0.1, 0.5)
 _KILL_REQUEST_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class E2BCreateRatePolicy:
+    """Process-wide admission policy for calls that create E2B sandboxes."""
+
+    schema_version: Literal[1] = 1
+    provider: Literal["e2b"] = "e2b"
+    operation: Literal["sandbox_create"] = "sandbox_create"
+    maximum_dispatches: int = 4
+    period_milliseconds: int = 1_000
+    maximum_wait_seconds: float = 60.0
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.maximum_dispatches, bool)
+            or self.maximum_dispatches < 1
+            or isinstance(self.period_milliseconds, bool)
+            or self.period_milliseconds < 1
+            or isinstance(self.maximum_wait_seconds, bool)
+            or self.maximum_wait_seconds <= 0
+        ):
+            raise ValueError("E2B create-rate policy values must be positive")
+
+    @property
+    def interval_ns(self) -> int:
+        """Minimum nanoseconds between admitted sandbox-create calls."""
+        return round(self.period_milliseconds * 1_000_000 / self.maximum_dispatches)
+
+
+E2B_CREATE_RATE_POLICY = E2BCreateRatePolicy()
+
+
+def e2b_create_rate_policy_payload() -> JsonObject:
+    """Return the canonical execution-identity payload for E2B create admission."""
+    policy = E2B_CREATE_RATE_POLICY
+    return {
+        "schema_version": policy.schema_version,
+        "provider": policy.provider,
+        "operation": policy.operation,
+        "maximum_dispatches": policy.maximum_dispatches,
+        "period_milliseconds": policy.period_milliseconds,
+        "maximum_wait_seconds": policy.maximum_wait_seconds,
+    }
+
+
+class E2BCreateRateLimitError(RuntimeError):
+    """A sandbox create could not be admitted within the bounded queue wait."""
+
+
+class E2BCreateRateGate:
+    """Serialize one process's E2B creates at a fixed monotonic rate."""
+
+    def __init__(
+        self,
+        *,
+        policy: E2BCreateRatePolicy = E2B_CREATE_RATE_POLICY,
+        monotonic_ns: Callable[[], int] = time.monotonic_ns,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._policy = policy
+        self._monotonic_ns = monotonic_ns
+        self._sleep = sleep
+        self._lock = Lock()
+        self._next_admission_ns: int | None = None
+
+    def acquire(self) -> None:
+        """Wait for one create slot or fail before the policy's queue horizon."""
+        started_ns = self._monotonic_ns()
+        with self._lock:
+            now_ns = self._monotonic_ns()
+            target_ns = max(now_ns, self._next_admission_ns or now_ns)
+            total_wait_ns = target_ns - started_ns
+            maximum_wait_ns = round(self._policy.maximum_wait_seconds * 1_000_000_000)
+            if total_wait_ns > maximum_wait_ns:
+                raise E2BCreateRateLimitError(
+                    "E2B sandbox create could not be admitted within "
+                    f"{self._policy.maximum_wait_seconds:.3f} seconds"
+                )
+            while now_ns < target_ns:
+                self._sleep((target_ns - now_ns) / 1_000_000_000)
+                advanced_ns = self._monotonic_ns()
+                if advanced_ns <= now_ns:
+                    raise E2BCreateRateLimitError(
+                        "E2B sandbox create admission clock did not advance while waiting"
+                    )
+                now_ns = advanced_ns
+            admitted_ns = max(now_ns, target_ns)
+            self._next_admission_ns = admitted_ns + self._policy.interval_ns
+
+
+_E2B_CREATE_RATE_GATE = E2BCreateRateGate()
+
+
+def acquire_e2b_create_slot() -> None:
+    """Acquire one slot from the process-wide E2B sandbox-create gate."""
+    _E2B_CREATE_RATE_GATE.acquire()
+
+
+async def acquire_e2b_create_slot_async() -> None:
+    """Acquire the same process-wide slot without blocking the event loop."""
+    await asyncio.to_thread(acquire_e2b_create_slot)
 
 
 def resolve_e2b_template(template: str | None) -> str | None:
@@ -200,6 +307,7 @@ def default_sandbox_factory(
         key = api_key or os.environ.get(E2B_API_KEY_ENV)
         if not key:
             raise RuntimeError(f"set ${E2B_API_KEY_ENV} to run the harness in E2B sandboxes")
+        acquire_e2b_create_slot()
         if metadata:
             sandbox = Sandbox.create(
                 template=chosen_template,

--- a/wmh/harness/e2b_sandbox_test.py
+++ b/wmh/harness/e2b_sandbox_test.py
@@ -7,24 +7,129 @@ locally-defined `RateLimitException` stands in for e2b's, and a plain fake satis
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
 from types import ModuleType
 
 import pytest
 
+import wmh.harness.e2b_sandbox as e2b_sandbox_module
 from wmh.harness.e2b_sandbox import (
+    E2B_CREATE_RATE_POLICY,
+    E2BCreateRateGate,
+    E2BCreateRateLimitError,
+    E2BCreateRatePolicy,
     SandboxCleanupError,
     SandboxHandle,
     create_sandbox,
     default_sandbox_factory,
+    e2b_create_rate_policy_payload,
     kill_sandbox,
     resolve_e2b_template,
 )
 
+_ACQUIRE_E2B_CREATE_SLOT = e2b_sandbox_module.acquire_e2b_create_slot
+
 
 class RateLimitException(Exception):
     """Name-matches e2b's 429 exception; classification never imports the SDK."""
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self.now_ns = 0
+        self.sleeps: list[float] = []
+
+    def monotonic_ns(self) -> int:
+        with self._lock:
+            return self.now_ns
+
+    def sleep(self, seconds: float) -> None:
+        with self._lock:
+            self.sleeps.append(seconds)
+            self.now_ns += round(seconds * 1_000_000_000)
+
+
+@pytest.fixture(autouse=True)
+def _disable_process_rate_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(e2b_sandbox_module, "acquire_e2b_create_slot", lambda: None)
+
+
+def test_e2b_create_rate_policy_is_frozen_and_canonical() -> None:
+    assert E2B_CREATE_RATE_POLICY == E2BCreateRatePolicy()
+    assert e2b_create_rate_policy_payload() == {
+        "schema_version": 1,
+        "provider": "e2b",
+        "operation": "sandbox_create",
+        "maximum_dispatches": 4,
+        "period_milliseconds": 1000,
+        "maximum_wait_seconds": 60.0,
+    }
+
+
+def test_e2b_create_gate_paces_ninety_shared_concurrent_admissions() -> None:
+    clock = _FakeClock()
+    gate = E2BCreateRateGate(
+        policy=E2B_CREATE_RATE_POLICY,
+        monotonic_ns=clock.monotonic_ns,
+        sleep=clock.sleep,
+    )
+
+    with ThreadPoolExecutor(max_workers=45) as executor:
+        list(executor.map(lambda _index: gate.acquire(), range(90)))
+
+    assert clock.now_ns == 89 * 250_000_000
+    assert len(clock.sleeps) == 89
+    assert all(delay == pytest.approx(0.25) for delay in clock.sleeps)
+
+
+def test_sync_and_async_e2b_create_paths_contend_on_one_process_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _FakeClock()
+    gate = E2BCreateRateGate(
+        policy=E2B_CREATE_RATE_POLICY,
+        monotonic_ns=clock.monotonic_ns,
+        sleep=clock.sleep,
+    )
+    monkeypatch.setattr(e2b_sandbox_module, "_E2B_CREATE_RATE_GATE", gate)
+    monkeypatch.setattr(
+        e2b_sandbox_module,
+        "acquire_e2b_create_slot",
+        _ACQUIRE_E2B_CREATE_SLOT,
+    )
+
+    async def contend() -> None:
+        sync_calls = [
+            asyncio.to_thread(e2b_sandbox_module.acquire_e2b_create_slot) for _index in range(8)
+        ]
+        async_calls = [e2b_sandbox_module.acquire_e2b_create_slot_async() for _index in range(8)]
+        await asyncio.gather(*sync_calls, *async_calls)
+
+    asyncio.run(contend())
+
+    assert clock.now_ns == 15 * 250_000_000
+    assert len(clock.sleeps) == 15
+    assert all(delay == pytest.approx(0.25) for delay in clock.sleeps)
+
+
+def test_e2b_create_gate_rejects_an_admission_beyond_its_wait_bound() -> None:
+    clock = _FakeClock()
+    gate = E2BCreateRateGate(
+        policy=E2BCreateRatePolicy(maximum_wait_seconds=0.1),
+        monotonic_ns=clock.monotonic_ns,
+        sleep=clock.sleep,
+    )
+    gate.acquire()
+
+    with pytest.raises(E2BCreateRateLimitError, match="0.100 seconds"):
+        gate.acquire()
+
+    assert clock.sleeps == []
 
 
 class _Result:
@@ -281,6 +386,62 @@ def test_default_factory_passes_metadata_to_the_lazy_e2b_sdk(
             "metadata": metadata,
         }
     ]
+
+
+def test_default_factory_reacquires_rate_gate_before_every_create_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeSandbox()
+    creates: list[int] = []
+    admissions: list[int] = []
+
+    class _SandboxSdk:
+        @staticmethod
+        def create(**_kwargs: object) -> FakeSandbox:
+            creates.append(1)
+            if len(creates) < 4:
+                raise RateLimitException("slow down")
+            return fake
+
+    e2b = ModuleType("e2b")
+    e2b.__dict__["Sandbox"] = _SandboxSdk
+    monkeypatch.setitem(sys.modules, "e2b", e2b)
+    monkeypatch.setattr(
+        e2b_sandbox_module,
+        "acquire_e2b_create_slot",
+        lambda: admissions.append(1),
+    )
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    assert create_sandbox(default_sandbox_factory(api_key="key")) is fake
+    assert len(creates) == 4
+    assert len(admissions) == 4
+
+
+def test_default_factory_rate_gate_precedes_nonretryable_create_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class _SandboxSdk:
+        @staticmethod
+        def create(**_kwargs: object) -> FakeSandbox:
+            events.append("create")
+            raise ValueError("bad template")
+
+    e2b = ModuleType("e2b")
+    e2b.__dict__["Sandbox"] = _SandboxSdk
+    monkeypatch.setitem(sys.modules, "e2b", e2b)
+    monkeypatch.setattr(
+        e2b_sandbox_module,
+        "acquire_e2b_create_slot",
+        lambda: events.append("admit"),
+    )
+
+    with pytest.raises(ValueError, match="bad template"):
+        create_sandbox(default_sandbox_factory(api_key="key"))
+
+    assert events == ["admit", "create"]
 
 
 def test_default_factory_snapshots_template_environment(

--- a/wmh/harness/population_checkpoint.py
+++ b/wmh/harness/population_checkpoint.py
@@ -35,7 +35,7 @@ from wmh.harness.scoring import HarnessScore, HarnessScoreReport, ScoreRequest
 from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
 from wmh.providers.base import ProviderConfig
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
 _SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
 _CHECKPOINT_DIR = "checkpoint"
 _IDENTITY_FILE = "identity.json"
@@ -61,7 +61,7 @@ class PopulationCheckpointIdentity(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[2] = _SCHEMA_VERSION
+    schema_version: Literal[3] = _SCHEMA_VERSION
     output_name: str = Field(min_length=1, max_length=512)
     artifact_root: str = Field(min_length=1)
     seed_reference: str | None = None
@@ -76,6 +76,7 @@ class PopulationCheckpointIdentity(BaseModel):
     optimizer_document_hash: str = Field(min_length=1)
     harness_backend: Literal["local", "e2b"]
     e2b_template: str | None = None
+    project_e2b_create_rate_policy: JsonObject
     environment_command_timeout_sec: int = Field(strict=True, ge=1)
     episode_timeout_sec: float = Field(gt=0)
     project_timeout_sec: float = Field(gt=0)
@@ -161,7 +162,7 @@ class PopulationCheckpointControl(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[2] = _SCHEMA_VERSION
+    schema_version: Literal[3] = _SCHEMA_VERSION
     identity_hash: str = Field(pattern=_SHA256_PATTERN)
     state: Literal["ready", "in_progress", "complete"]
     committed_step: int = Field(strict=True, ge=-1)
@@ -230,7 +231,7 @@ class _FileRecord(BaseModel):
 class _SeedManifest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[2] = _SCHEMA_VERSION
+    schema_version: Literal[3] = _SCHEMA_VERSION
     source_tree_hash: str
     files: tuple[_FileRecord, ...]
 
@@ -238,7 +239,7 @@ class _SeedManifest(BaseModel):
 class _BoundaryManifest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    schema_version: Literal[2] = _SCHEMA_VERSION
+    schema_version: Literal[3] = _SCHEMA_VERSION
     index: int = Field(strict=True, ge=0)
     previous_manifest_hash: str | None = Field(default=None, pattern=_SHA256_PATTERN)
     outcome: Literal["seed", "scored", "invalid"]

--- a/wmh/harness/population_checkpoint_test.py
+++ b/wmh/harness/population_checkpoint_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from wmh.harness.e2b_sandbox import SandboxUsage
+from wmh.harness.e2b_sandbox import SandboxUsage, e2b_create_rate_policy_payload
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import PopulationIteration, PopulationOptimizationResult
 from wmh.harness.population_checkpoint import (
@@ -197,6 +197,7 @@ def _identity(root: Path, seed: HarnessSourceTree) -> PopulationCheckpointIdenti
         optimizer_document_hash="optimizer-doc-hash",
         harness_backend="e2b",
         e2b_template="template",
+        project_e2b_create_rate_policy=e2b_create_rate_policy_payload(),
         environment_command_timeout_sec=300,
         episode_timeout_sec=300,
         project_timeout_sec=900,
@@ -357,6 +358,21 @@ def test_checkpoint_identity_drift_rejects_without_mutation(tmp_path: Path) -> N
         )
         with pytest.raises(PopulationCheckpointError, match="optimizer_document_hash"):
             store.assert_identity(changed_optimizer)
+        assert (run_dir / "checkpoint/control.json").read_bytes() == control_before
+
+        changed_project_rate = identity.model_copy(
+            update={
+                "project_e2b_create_rate_policy": {
+                    **e2b_create_rate_policy_payload(),
+                    "maximum_dispatches": 3,
+                }
+            }
+        )
+        with pytest.raises(
+            PopulationCheckpointError,
+            match="project_e2b_create_rate_policy",
+        ):
+            store.assert_identity(changed_project_rate)
         assert (run_dir / "checkpoint/control.json").read_bytes() == control_before
 
 


### PR DESCRIPTION
## Summary

- admit process-local E2B sandbox creates through one fixed four-per-second monotonic gate
- route Harbor built-in E2B task environments through the same gate while preserving upstream create arguments and retry behavior
- bind the admission policy into score execution identity and optimizer checkpoint identity

## Design

This is backend-only plumbing with no new CLI or product vocabulary. Sync and async consumers share one in-process authority, and every actual provider retry reacquires admission. Local execution remains unchanged and importing the scorer does not require the optional E2B SDK.

This PR is stacked on #236. Before any merge approval, the reusable execution internals in this stack must be consolidated behind the authoritative #220 `wmh run` and `wmh optimize` UX; this PR does not replace that product direction.

## Verification

- 94 focused tests passed
- 2,232 full tests passed; 19 skipped
- `ruff format --check .`
- `ruff check .`
- `ty check`
- diff, optional-dependency import, direct-create, and privacy scans passed

No merge is requested.