### PR TITLE
Prepare Harbor E2B task templates before scoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ otel = ["opentelemetry-proto>=1.24"]
 viz = ["seaborn>=0.13", "matplotlib>=3.8", "pandas>=2.0"]
 # E2B execution is opt-in and independently selectable for the pi-node harness process and Harbor
 # task environments. Local execution remains the default and imports neither E2B integration.
-e2b = ["e2b>=2.25.0", "harbor[e2b]==0.20.0"]
+e2b = ["e2b==2.31.0", "harbor[e2b]==0.20.0"]
 # Context connectors (`wmh.connect`): the MCP client SDK backs the Notion connector's
 # remote-MCP OAuth/pull path. Only that path needs it, so it is an optional extra imported
 # lazily (wmh.connect.notion), same contract as the e2b extra above.

--- a/uv.lock
+++ b/uv.lock
@@ -2992,7 +2992,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.39" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.2" },
-    { name = "e2b", marker = "extra == 'e2b'", specifier = ">=2.25.0" },
+    { name = "e2b", marker = "extra == 'e2b'", specifier = "==2.31.0" },
     { name = "environment-capture", editable = "packages/environment-capture" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "filelock", specifier = ">=3.0" },

--- a/wmh/cli/harness_optimize.py
+++ b/wmh/cli/harness_optimize.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import shutil
+from collections.abc import Callable
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,12 +29,20 @@ from wmh.agents.project import (
 )
 from wmh.cli.harbor_inputs import load_harbor_config, load_task_ids, write_json_atomic
 from wmh.cli.model_roles import resolve_required_model_config
+from wmh.cli.scorer_preparation import (
+    preparation_staging_path,
+    remove_preparation_staging,
+)
 from wmh.config import ARTIFACT_DIR
 from wmh.config.store import validate_name
 from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
 from wmh.evals.harbor.canonical import canonical_harbor_job_config
-from wmh.evals.harbor.scorer import HarborScorer
+from wmh.evals.harbor.scorer import (
+    HarborRewardMode,
+    HarborScorer,
+    normalize_harbor_reward_mode,
+)
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import (
     E2B_TEMPLATE_ENV,
@@ -108,6 +117,11 @@ def optimize_harness(
         ...,
         "--reward-key",
         help="Official Harbor verifier reward field to optimize.",
+    ),
+    reward_mode: str = typer.Option(
+        "raw",
+        "--reward-mode",
+        help="Interpret rewards as raw values or strict positive-binary successes.",
     ),
     iterations: int = typer.Option(..., min=1, help="Fixed number of singular proposal slots."),
     attempts: int = typer.Option(..., min=1, help="Attempts per exact task and candidate."),
@@ -205,6 +219,10 @@ def optimize_harness(
     if not reward_key:
         raise typer.BadParameter("--reward-key must be nonempty")
     try:
+        normalized_reward_mode = normalize_harbor_reward_mode(reward_mode)
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--reward-mode") from error
+    try:
         episode_timeout_sec = validate_episode_timeout_s(episode_timeout_sec)
     except ValueError as error:
         raise typer.BadParameter(str(error), param_hint="--episode-timeout") from error
@@ -213,6 +231,8 @@ def optimize_harness(
             "--episode-timeout requires --harness-backend e2b",
             param_hint="--episode-timeout",
         )
+    if not yes and not _console.is_terminal:
+        raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
 
     job_config = load_harbor_config(Path(harbor_config))
     task_ids = load_task_ids(Path(task_ids_file))
@@ -237,11 +257,18 @@ def optimize_harness(
         f"fixed search: 1 seed + {iterations} proposal slot(s), {len(task_ids)} task(s), "
         f"{attempts} attempt(s) -> up to {score_cells} requested score cells; "
         f"ceiling={max_score_cells}; evaluated Pi backend={harness_backend}; "
-        f"episode timeout={episode_timeout_sec:g}s; proposer project=e2b"
+        f"episode timeout={episode_timeout_sec:g}s; "
+        f"reward mode={normalized_reward_mode.replace('_', '-')}; proposer project=e2b"
     )
-    if not yes:
-        if not _console.is_terminal:
-            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+
+    def before_preparation(summary: JsonObject | None) -> None:
+        if summary is not None:
+            _console.print(
+                "task-environment preparation: "
+                + json.dumps(summary, sort_keys=True, separators=(",", ":"))
+            )
+        if yes:
+            return
         if not Confirm.ask("Proceed?", default=False):
             raise typer.Exit(0)
 
@@ -252,6 +279,7 @@ def optimize_harness(
         job_config=job_config,
         task_ids=task_ids,
         reward_key=reward_key,
+        reward_mode=normalized_reward_mode,
         iterations=iterations,
         attempts=attempts,
         max_score_cells=max_score_cells,
@@ -270,6 +298,7 @@ def optimize_harness(
         resume=resume,
         max_new_boundaries=max_new_boundaries,
         episode_timeout_sec=episode_timeout_sec,
+        before_preparation=before_preparation,
     )
     if isinstance(outcome, HarnessOptimizeProgress):
         completed = len(outcome.result.iterations) + 1
@@ -310,6 +339,8 @@ def _execute_optimization(
     resume: bool,
     max_new_boundaries: int | None = None,
     episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    reward_mode: HarborRewardMode = "raw",
+    before_preparation: Callable[[JsonObject | None], None] | None = None,
 ) -> HarnessOptimizeOutcome | HarnessOptimizeProgress:
     """Resolve one immutable scorer request, execute it, and publish evidence before winner."""
     if max_new_boundaries is not None and (
@@ -330,6 +361,11 @@ def _execute_optimization(
         ).model_dump(mode="python")
     )
     optimizer = optimizer_agent()
+    meta_provider = get_provider(meta_config)
+    if not isinstance(meta_provider, ToolCallingProvider):
+        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
+    if not resume and seed is None:
+        raise ValueError("new optimization requires a resolved seed source")
     with ExitStack() as stack:
         checkpoint: PopulationCheckpointStore | None = None
         if resume:
@@ -341,12 +377,34 @@ def _execute_optimization(
                 task_ids=task_ids,
                 provider_config=agent_config,
                 reward_key=reward_key,
+                reward_mode=reward_mode,
                 environment_command_timeout_sec=environment_command_timeout_sec,
                 episode_timeout_sec=episode_timeout_sec,
                 harness_backend=harness_backend,
                 e2b_template=e2b_template if harness_backend == "e2b" else None,
             )
         )
+        preparation_summary = scorer.preparation_summary()
+        if before_preparation is not None:
+            before_preparation(preparation_summary)
+
+        staging_path: Path | None = None
+        if checkpoint is not None:
+            seed_source = checkpoint.seed
+            if scorer.preparation_required:
+                artifact_path = checkpoint.scorer_preparation_artifact_path
+                if artifact_path is None:
+                    raise PopulationCheckpointError(
+                        "checkpoint is missing its scorer preparation artifact"
+                    )
+                scorer.load_preparation(artifact_path)
+        else:
+            assert seed is not None
+            seed_source = seed
+            if scorer.preparation_required:
+                staging_path = preparation_staging_path(run_dir)
+                asyncio.run(scorer.prepare(staging_path))
+
         request = scorer.request(attempts=attempts)
         if request.task_ids != task_ids or request.attempts != attempts:
             raise ValueError("resolved score request differs from the declared task matrix")
@@ -357,23 +415,13 @@ def _execute_optimization(
                 f"max_score_cells={max_score_cells}"
             )
 
-        meta_provider = get_provider(meta_config)
-        if not isinstance(meta_provider, ToolCallingProvider):
-            raise typer.BadParameter(
-                "settings [models.meta] provider lacks structured tool calling"
-            )
-        if checkpoint is not None:
-            seed_source = checkpoint.seed
-        else:
-            if seed is None:
-                raise ValueError("new optimization requires a resolved seed source")
-            seed_source = seed
         identity = PopulationCheckpointIdentity(
             output_name=name,
             artifact_root=str(Path(root).resolve()),
             seed_reference=seed_reference,
             seed_source_tree_hash=seed_source.tree_hash,
             score_request=request,
+            evaluator_policy=scorer.evaluator_policy(),
             iterations=iterations,
             planned_score_cells=planned_score_cells,
             max_score_cells=max_score_cells,
@@ -383,6 +431,7 @@ def _execute_optimization(
             optimizer_document_hash=optimizer.doc_hash,
             harness_backend=harness_backend,
             e2b_template=e2b_template or None,
+            scorer_preparation_artifact_hash=scorer.preparation_artifact_hash,
             project_e2b_create_rate_policy=e2b_create_rate_policy_payload(),
             environment_command_timeout_sec=environment_command_timeout_sec,
             episode_timeout_sec=episode_timeout_sec,
@@ -393,16 +442,27 @@ def _execute_optimization(
             max_history_bytes=max_history_bytes,
         )
         if checkpoint is None:
+            preparation_artifact = scorer.preparation_artifact_bytes()
             checkpoint = stack.enter_context(
                 PopulationCheckpointStore.create(
                     run_dir,
                     identity=identity,
                     seed=seed_source,
+                    scorer_preparation_artifact=preparation_artifact,
                 )
             )
+            if scorer.preparation_required:
+                checkpoint_artifact = checkpoint.scorer_preparation_artifact_path
+                if checkpoint_artifact is None or staging_path is None:
+                    raise PopulationCheckpointError(
+                        "checkpoint did not retain scorer preparation evidence"
+                    )
+                scorer.bind_preparation(checkpoint_artifact)
+                remove_preparation_staging(staging_path)
             write_json_atomic(run_dir / "inputs.json", identity.model_dump(mode="json"))
         else:
             checkpoint.assert_identity(identity)
+        asyncio.run(scorer.verify_preparation())
 
         result = checkpoint.result
         project_usage = checkpoint.control.project_sandbox_usage

--- a/wmh/cli/harness_optimize_test.py
+++ b/wmh/cli/harness_optimize_test.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import cast
+from typing import Literal, TypedDict, cast
 
 import pytest
 import typer
@@ -65,6 +65,34 @@ runner = CliRunner()
 _DIGEST = "sha256:" + "a" * 64
 
 
+class _OptimizeCommonArguments(TypedDict):
+    name: str
+    root: str
+    run_dir: Path
+    job_config: JobConfig
+    task_ids: tuple[str, ...]
+    reward_key: str
+    iterations: int
+    attempts: int
+    max_score_cells: int
+    seed_reference: str | None
+    meta_config: ProviderConfig
+    agent_config: ProviderConfig
+    harness_backend: Literal["local", "e2b"]
+    e2b_template: str | None
+    environment_command_timeout_sec: int
+    episode_timeout_sec: float
+    project_timeout_sec: float
+    max_history_candidates: int
+    max_history_bytes: int
+    max_new_boundaries: int | None
+
+
+class _OptimizeArguments(_OptimizeCommonArguments):
+    seed: HarnessSourceTree | None
+    resume: bool
+
+
 class _Reader:
     def read_bytes(self, path: str) -> bytes:
         assert path == "raw/result.json"
@@ -92,6 +120,30 @@ class _Project:
 
     def usage(self) -> SandboxUsage:
         return SandboxUsage(count=1, seconds=12.5)
+
+
+class _NoPreparationScorer:
+    """Test scorer contract for local task environments with no preparation."""
+
+    @property
+    def preparation_required(self) -> bool:
+        return False
+
+    def preparation_summary(self) -> None:
+        return None
+
+    @property
+    def preparation_artifact_hash(self) -> None:
+        return None
+
+    def preparation_artifact_bytes(self) -> None:
+        return None
+
+    async def verify_preparation(self) -> None:
+        return None
+
+    def evaluator_policy(self) -> dict[str, object]:
+        return {}
 
 
 def _source(prompt: str) -> HarnessSourceTree:
@@ -435,7 +487,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     request = _request()
     scorer_calls: list[dict[str, object]] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **kwargs: object) -> FakeScorer:
             scorer_calls.append(kwargs)
@@ -538,6 +590,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     assert scorer_call["harness_backend"] == "e2b"
     assert scorer_call["e2b_template"] == "template-x"
     assert scorer_call["episode_timeout_sec"] == 12_000
+    assert scorer_call["reward_mode"] == "raw"
     assert cast(JobConfig, scorer_call["job_config"]).jobs_dir == run_dir / "harbor"
     assert len(project_calls) == 3
     assert len({id(project) for project in projects}) == 3
@@ -568,6 +621,7 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     inputs = json.loads((run_dir / "inputs.json").read_text())
     assert inputs["iterations"] == 3
     assert inputs["episode_timeout_sec"] == 12_000
+    assert inputs["evaluator_policy"] == {}
     retry = inputs["harbor_job_template"]["retry"]
     assert retry["exclude_exceptions"] == sorted(retry["exclude_exceptions"])
     written = json.loads((run_dir / "outcome.json").read_text())
@@ -575,6 +629,386 @@ def test_execute_composes_exact_scorer_project_optimizer_archive_and_store(
     assert written["project_sandbox_usage"] == {"count": 3, "seconds": 37.5}
     assert written["known_score_cells"] == 1
     assert written["max_score_cells"] == 4
+
+
+def test_execute_checkpoints_preparation_then_resumes_inspect_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request()
+    seed = _source("seed")
+    receipt = b'{"complete":true}\n'
+    receipt_hash = "sha256:" + hashlib.sha256(receipt).hexdigest()
+    summary = {"schema_version": 1, "unique_template_count": 1}
+    run_dir = tmp_path / "run"
+    events: list[str] = []
+
+    class PreparedScorer:
+        mismatch_hash = False
+
+        def __init__(self) -> None:
+            self.artifact_path: Path | None = None
+
+        @classmethod
+        async def create(cls, **_kwargs: object) -> PreparedScorer:
+            events.append("create")
+            return cls()
+
+        @property
+        def preparation_required(self) -> bool:
+            return True
+
+        def preparation_summary(self) -> dict[str, int]:
+            events.append("summary")
+            return summary
+
+        async def prepare(self, artifact_path: Path) -> None:
+            events.append("prepare")
+            assert artifact_path == tmp_path / ".run.scorer-preparation.bin"
+            assert not run_dir.exists()
+            artifact_path.write_bytes(receipt)
+            self.artifact_path = artifact_path
+
+        def load_preparation(self, artifact_path: Path) -> None:
+            events.append("load")
+            assert artifact_path.read_bytes() == receipt
+            self.artifact_path = artifact_path
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            events.append("request")
+            assert attempts == 1
+            assert self.artifact_path is not None
+            return request
+
+        @property
+        def preparation_artifact_hash(self) -> str:
+            events.append("hash")
+            if self.mismatch_hash:
+                return "sha256:" + "b" * 64
+            return receipt_hash
+
+        def preparation_artifact_bytes(self) -> bytes:
+            events.append("bytes")
+            assert self.artifact_path is not None
+            return self.artifact_path.read_bytes()
+
+        def bind_preparation(self, artifact_path: Path) -> None:
+            events.append("bind")
+            assert artifact_path.read_bytes() == receipt
+            self.artifact_path = artifact_path
+
+        async def verify_preparation(self) -> None:
+            events.append("verify")
+            assert self.artifact_path == run_dir / "checkpoint/scorer-preparation.bin"
+
+        def evaluator_policy(self) -> dict[str, object]:
+            return {
+                "reward_key": "reward",
+                "reward_interpretation": {
+                    "mode": "positive_binary",
+                    "threshold": 0.0,
+                    "comparator": "gt",
+                },
+            }
+
+    class FakeOptimizer:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def optimize(self, **kwargs: object) -> PopulationOptimizationResult:
+            resumed = cast(PopulationOptimizationResult | None, kwargs["resume"])
+            before_step = cast(Callable[[int], None], kwargs["before_step"])
+            on_boundary = cast(
+                Callable[[PopulationOptimizationResult], None],
+                kwargs["on_boundary"],
+            )
+            if resumed is None:
+                step = 0
+                boundary = _result(seed)
+            else:
+                step = 1
+                boundary = _result_with_invalid_iterations(1, seed_source=seed)
+            events.append("boundary")
+            before_step(step)
+            on_boundary(boundary)
+            return boundary
+
+    class FakeProjectFactory:
+        @classmethod
+        def create(cls, **_kwargs: object) -> _Project:
+            events.append("project")
+            return _Project()
+
+    def confirm(observed: object) -> None:
+        events.append("confirm")
+        assert observed == summary
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", PreparedScorer)
+    monkeypatch.setattr(module, "HarnessPopulationOptimizer", FakeOptimizer)
+    monkeypatch.setattr(module, "AgentProject", FakeProjectFactory)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+    arguments: _OptimizeCommonArguments = {
+        "name": "selected",
+        "root": str(tmp_path / ".wmh"),
+        "run_dir": run_dir,
+        "job_config": _job_config(tmp_path),
+        "task_ids": ("task-a",),
+        "reward_key": "reward",
+        "iterations": 1,
+        "attempts": 1,
+        "max_score_cells": 2,
+        "seed_reference": None,
+        "meta_config": meta_config,
+        "agent_config": agent_config,
+        "harness_backend": "e2b",
+        "e2b_template": "template-x",
+        "environment_command_timeout_sec": 300,
+        "episode_timeout_sec": 12_000,
+        "project_timeout_sec": 900,
+        "max_history_candidates": 20,
+        "max_history_bytes": 1_000_000,
+        "max_new_boundaries": 1,
+    }
+
+    progress = _execute_optimization(
+        **arguments,
+        seed=seed,
+        resume=False,
+        before_preparation=confirm,
+    )
+
+    assert isinstance(progress, HarnessOptimizeProgress)
+    assert events == [
+        "create",
+        "summary",
+        "confirm",
+        "prepare",
+        "request",
+        "hash",
+        "bytes",
+        "bind",
+        "verify",
+        "boundary",
+    ]
+    artifact_path = run_dir / "checkpoint/scorer-preparation.bin"
+    assert artifact_path.read_bytes() == receipt
+    assert not (tmp_path / ".run.scorer-preparation.bin").exists()
+    identity = json.loads((run_dir / "checkpoint/identity.json").read_text())
+    assert identity["scorer_preparation_artifact_hash"] == receipt_hash
+
+    events.clear()
+    PreparedScorer.mismatch_hash = True
+    with pytest.raises(
+        PopulationCheckpointError,
+        match="scorer_preparation_artifact_hash",
+    ):
+        _execute_optimization(
+            **arguments,
+            seed=None,
+            resume=True,
+            before_preparation=confirm,
+        )
+    assert events == ["create", "summary", "confirm", "load", "request", "hash"]
+
+    events.clear()
+    PreparedScorer.mismatch_hash = False
+    outcome = _execute_optimization(
+        **arguments,
+        seed=None,
+        resume=True,
+        before_preparation=confirm,
+    )
+
+    assert isinstance(outcome, HarnessOptimizeOutcome)
+    assert events == [
+        "create",
+        "summary",
+        "confirm",
+        "load",
+        "request",
+        "hash",
+        "verify",
+        "project",
+        "boundary",
+    ]
+
+
+def test_execute_preparation_failure_leaves_only_audit_staging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    staging_path = tmp_path / ".run.scorer-preparation.bin"
+    events: list[str] = []
+
+    class BrokenPreparationScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> BrokenPreparationScorer:
+            events.append("create")
+            return cls()
+
+        @property
+        def preparation_required(self) -> bool:
+            return True
+
+        def preparation_summary(self) -> dict[str, int]:
+            events.append("summary")
+            return {"schema_version": 1}
+
+        async def prepare(self, artifact_path: Path) -> None:
+            events.append("prepare")
+            assert artifact_path == staging_path
+            artifact_path.write_bytes(b'{"complete":false}\n')
+            raise RuntimeError("provider preparation failed")
+
+    class UnreachedOptimizer:
+        def __init__(self, *_args: object) -> None:
+            raise AssertionError("preparation failure must precede the seed boundary")
+
+    class UnreachedProject:
+        @classmethod
+        def create(cls, **_kwargs: object) -> None:
+            raise AssertionError("preparation failure must precede project creation")
+
+    def confirm(_summary: object) -> None:
+        events.append("confirm")
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", BrokenPreparationScorer)
+    monkeypatch.setattr(module, "HarnessPopulationOptimizer", UnreachedOptimizer)
+    monkeypatch.setattr(module, "AgentProject", UnreachedProject)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+
+    with pytest.raises(RuntimeError, match="provider preparation failed"):
+        _execute_optimization(
+            name="selected",
+            root=str(tmp_path / ".wmh"),
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            max_score_cells=2,
+            seed=_source("seed"),
+            seed_reference=None,
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="e2b",
+            e2b_template="template-x",
+            environment_command_timeout_sec=300,
+            episode_timeout_sec=12_000,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+            resume=False,
+            before_preparation=confirm,
+        )
+
+    assert events == ["create", "summary", "confirm", "prepare"]
+    assert not run_dir.exists()
+    assert staging_path.read_bytes() == b'{"complete":false}\n'
+
+
+def test_execute_verification_failure_stops_before_seed_or_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    receipt = b'{"complete":true}\n'
+    receipt_hash = "sha256:" + hashlib.sha256(receipt).hexdigest()
+    events: list[str] = []
+
+    class UnverifiedScorer:
+        def __init__(self) -> None:
+            self.artifact_path: Path | None = None
+
+        @classmethod
+        async def create(cls, **_kwargs: object) -> UnverifiedScorer:
+            return cls()
+
+        @property
+        def preparation_required(self) -> bool:
+            return True
+
+        def preparation_summary(self) -> dict[str, int]:
+            return {"schema_version": 1}
+
+        async def prepare(self, artifact_path: Path) -> None:
+            artifact_path.write_bytes(receipt)
+            self.artifact_path = artifact_path
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return _request()
+
+        @property
+        def preparation_artifact_hash(self) -> str:
+            return receipt_hash
+
+        def preparation_artifact_bytes(self) -> bytes:
+            assert self.artifact_path is not None
+            return self.artifact_path.read_bytes()
+
+        def bind_preparation(self, artifact_path: Path) -> None:
+            self.artifact_path = artifact_path
+
+        async def verify_preparation(self) -> None:
+            events.append("verify")
+            raise RuntimeError("provider mapping changed")
+
+        def evaluator_policy(self) -> dict[str, object]:
+            return {}
+
+    class UnreachedOptimizer:
+        def __init__(self, *_args: object) -> None:
+            events.append("seed")
+            raise AssertionError("verification failure must precede the seed boundary")
+
+    class UnreachedProject:
+        @classmethod
+        def create(cls, **_kwargs: object) -> None:
+            events.append("project")
+            raise AssertionError("verification failure must precede project creation")
+
+    meta_config, agent_config = _configs()
+    monkeypatch.setattr(module, "HarborScorer", UnverifiedScorer)
+    monkeypatch.setattr(module, "HarnessPopulationOptimizer", UnreachedOptimizer)
+    monkeypatch.setattr(module, "AgentProject", UnreachedProject)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+
+    with pytest.raises(RuntimeError, match="provider mapping changed"):
+        _execute_optimization(
+            name="selected",
+            root=str(tmp_path / ".wmh"),
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            iterations=1,
+            attempts=1,
+            max_score_cells=2,
+            seed=_source("seed"),
+            seed_reference=None,
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="e2b",
+            e2b_template="template-x",
+            environment_command_timeout_sec=300,
+            episode_timeout_sec=12_000,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+            resume=False,
+        )
+
+    assert events == ["verify"]
+    assert (run_dir / "checkpoint/scorer-preparation.bin").read_bytes() == receipt
+    assert not (tmp_path / ".run.scorer-preparation.bin").exists()
+    control = json.loads((run_dir / "checkpoint/control.json").read_text())
+    assert control["committed_step"] == -1
+    assert control["state"] == "ready"
 
 
 def test_execute_stops_ready_then_resumes_without_publishing_partial_work(
@@ -587,7 +1021,7 @@ def test_execute_stops_ready_then_resumes_without_publishing_partial_work(
     optimizer_resumes: list[PopulationOptimizationResult | None] = []
     projects: list[_Project] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -639,7 +1073,7 @@ def test_execute_stops_ready_then_resumes_without_publishing_partial_work(
     monkeypatch.setattr(module, "write_population_archive", fake_archive)
     root = tmp_path / ".wmh"
     run_dir = tmp_path / "run"
-    arguments = {
+    arguments: _OptimizeCommonArguments = {
         "name": "selected",
         "root": str(root),
         "run_dir": run_dir,
@@ -697,7 +1131,7 @@ def test_execute_rejects_score_cell_plan_before_scorer_or_run_mutation(
 ) -> None:
     scorer_calls: list[dict[str, object]] = []
 
-    class UnreachedScorer:
+    class UnreachedScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **kwargs: object) -> UnreachedScorer:
             scorer_calls.append(kwargs)
@@ -782,7 +1216,7 @@ def test_execute_resumes_ready_seed_at_next_slot_without_rescoring(
 
     score_calls: list[str] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -914,7 +1348,7 @@ def test_resume_rejects_episode_timeout_drift_before_any_score_or_project_spend(
     with PopulationCheckpointStore.create(run_dir, identity=identity, seed=seed):
         pass
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -959,6 +1393,91 @@ def test_resume_rejects_episode_timeout_drift_before_any_score_or_project_spend(
             max_history_bytes=1_000_000,
             resume=True,
         )
+
+
+def test_resume_rejects_evaluator_policy_drift_before_verification_or_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    root = tmp_path / ".wmh"
+    seed = _source("seed")
+    request = _request()
+    job_config = _job_config(tmp_path)
+    meta_config, agent_config = _configs()
+    identity = _checkpoint_identity(
+        run_dir=run_dir,
+        root=root,
+        job_config=job_config,
+        seed=seed,
+        request=request,
+        iterations=1,
+        max_score_cells=2,
+        meta_config=meta_config,
+        agent_config=agent_config,
+    )
+    with PopulationCheckpointStore.create(run_dir, identity=identity, seed=seed):
+        pass
+    events: list[str] = []
+
+    class PositiveModeScorer(_NoPreparationScorer):
+        @classmethod
+        async def create(cls, **kwargs: object) -> PositiveModeScorer:
+            assert kwargs["reward_mode"] == "positive_binary"
+            return cls()
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            assert attempts == 1
+            return request
+
+        def evaluator_policy(self) -> dict[str, object]:
+            return {
+                "reward_interpretation": {
+                    "mode": "positive_binary",
+                    "threshold": 0.0,
+                    "comparator": "gt",
+                }
+            }
+
+        async def verify_preparation(self) -> None:
+            events.append("verify")
+
+    class NoProject:
+        @classmethod
+        def create(cls, **_kwargs: object) -> None:
+            events.append("project")
+            raise AssertionError("evaluator drift must fail before project creation")
+
+    monkeypatch.setattr(module, "HarborScorer", PositiveModeScorer)
+    monkeypatch.setattr(module, "AgentProject", NoProject)
+    monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
+
+    with pytest.raises(PopulationCheckpointError, match="evaluator_policy"):
+        _execute_optimization(
+            name="selected",
+            root=str(root),
+            run_dir=run_dir,
+            job_config=job_config,
+            task_ids=("task-a",),
+            reward_key="reward",
+            reward_mode="positive_binary",
+            iterations=1,
+            attempts=1,
+            max_score_cells=2,
+            seed=None,
+            seed_reference=None,
+            meta_config=meta_config,
+            agent_config=agent_config,
+            harness_backend="local",
+            e2b_template=None,
+            environment_command_timeout_sec=300,
+            project_timeout_sec=900,
+            max_history_candidates=20,
+            max_history_bytes=1_000_000,
+            resume=True,
+        )
+
+    assert events == []
 
 
 def test_execute_resumes_mixed_prefix_at_next_id_without_replaying_scores(
@@ -1039,7 +1558,7 @@ def test_execute_resumes_mixed_prefix_at_next_id_without_replaying_scores(
     proposed = _valid_proposal("candidate-0003", proposed_source)
     score_calls: list[str] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1155,7 +1674,7 @@ def test_execute_uses_fresh_project_and_restores_committed_prefix_for_each_slot(
     seed = _source("seed")
     score_calls: list[str] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1307,7 +1826,7 @@ def test_execute_finalizes_fully_committed_ready_prefix_without_project_or_score
     score_calls: list[str] = []
     project_calls: list[dict[str, object]] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1401,7 +1920,7 @@ def test_execute_resumes_exact_publication_after_alias_before_complete(
             usage=SandboxUsage(count=1, seconds=2.0),
         )
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1440,7 +1959,7 @@ def test_execute_resumes_exact_publication_after_alias_before_complete(
     monkeypatch.setattr(module, "AgentProject", UnreachedProjectFactory)
     monkeypatch.setattr(module, "get_provider", lambda config: _ToolProvider(config))
     monkeypatch.setattr(PopulationCheckpointStore, "mark_complete", fail_once)
-    arguments = {
+    arguments: _OptimizeArguments = {
         "name": "selected",
         "root": str(root),
         "run_dir": run_dir,
@@ -1509,7 +2028,7 @@ def test_project_teardown_failure_keeps_final_boundary_nonresumable(
 ) -> None:
     request = _request()
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1601,7 +2120,7 @@ def test_project_teardown_failure_keeps_final_boundary_nonresumable(
 def test_execute_closes_project_and_never_publishes_winner_after_optimizer_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1673,7 +2192,7 @@ def test_execute_closes_project_and_never_publishes_winner_after_optimizer_error
 def test_execute_does_not_claim_result_directory_when_scorer_setup_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class BrokenScorer:
+    class BrokenScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> BrokenScorer:
             raise ValueError("invalid scorer configuration")
@@ -1712,7 +2231,7 @@ def test_execute_does_not_claim_result_directory_when_scorer_setup_fails(
 def test_execute_does_not_claim_result_directory_for_non_tool_meta_provider(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **_kwargs: object) -> FakeScorer:
             return cls()
@@ -1811,6 +2330,8 @@ def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
             str(task_ids_path),
             "--reward-key",
             "reward",
+            "--reward-mode",
+            "positive-binary",
             "--iterations",
             "2",
             "--attempts",
@@ -1829,6 +2350,7 @@ def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
     assert "optimized" in invoked.output
     [call] = calls
     assert call["harness_backend"] == "local"
+    assert call["reward_mode"] == "positive_binary"
     assert call["iterations"] == 2
     assert call["task_ids"] == ("task-a",)
     assert call["e2b_template"] == "template-from-env"
@@ -1876,6 +2398,7 @@ def test_cli_uses_required_roles_complete_default_pi_seed_and_local_backend(
     assert calls[-1]["max_new_boundaries"] == 1
     assert calls[-1]["harness_backend"] == "e2b"
     assert calls[-1]["episode_timeout_sec"] == 12_000
+    assert calls[-1]["reward_mode"] == "raw"
     assert "episode timeout=12000s" in " ".join(partial.output.split())
     assert "checkpointed" in partial.output
     assert "no winner published" in partial.output
@@ -1944,4 +2467,5 @@ def test_cli_help_preserves_model_roles_seed_syntax_and_local_output_wording() -
     assert "name@ref" in invoked.output
     assert "Local run directory" in invoked.output
     assert "--episode-timeout" in invoked.output
+    assert "--reward-mode" in invoked.output
     assert "seconds" in invoked.output

--- a/wmh/cli/harness_score.py
+++ b/wmh/cli/harness_score.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
@@ -16,11 +19,20 @@ from rich.prompt import Confirm
 from wmh.agents.default import default_agent
 from wmh.cli.harbor_inputs import load_harbor_config, load_task_ids, write_json_atomic
 from wmh.cli.model_roles import resolve_required_model_config
+from wmh.cli.scorer_preparation import (
+    preparation_staging_path,
+    publish_preparation_artifact,
+    remove_preparation_staging,
+)
 from wmh.config import ARTIFACT_DIR
 from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
 from wmh.evals.harbor.canonical import canonical_harbor_job_config
-from wmh.evals.harbor.scorer import HarborScorer
+from wmh.evals.harbor.scorer import (
+    HarborRewardMode,
+    HarborScorer,
+    normalize_harbor_reward_mode,
+)
 from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
 from wmh.harness.runtime import (
     DEFAULT_EVAL_EPISODE_TIMEOUT_S,
@@ -80,6 +92,11 @@ def score_harness_command(
         "--reward-key",
         help="Official Harbor verifier reward field to score.",
     ),
+    reward_mode: str = typer.Option(
+        "raw",
+        "--reward-mode",
+        help="Interpret rewards as raw values or strict positive-binary successes.",
+    ),
     attempts: int = typer.Option(..., min=1, help="Attempts per exact task and harness."),
     harness_backend: str = typer.Option(
         "local",
@@ -128,6 +145,10 @@ def score_harness_command(
     if not reward_key:
         raise typer.BadParameter("--reward-key must be nonempty")
     try:
+        normalized_reward_mode = normalize_harbor_reward_mode(reward_mode)
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--reward-mode") from error
+    try:
         episode_timeout_sec = validate_episode_timeout_s(episode_timeout_sec)
     except ValueError as error:
         raise typer.BadParameter(str(error), param_hint="--episode-timeout") from error
@@ -143,6 +164,8 @@ def score_harness_command(
         harnesses=tuple(harnesses or ()),
     )
     validate_score_targets(targets)
+    if not yes and not _console.is_terminal:
+        raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
     job_config = load_harbor_config(Path(harbor_config))
     task_ids = load_task_ids(Path(task_ids_file))
     agent_config = resolve_required_model_config(root, "agent")
@@ -156,11 +179,18 @@ def score_harness_command(
         f"scoring {len(targets)} harness(es), {len(task_ids)} task(s), "
         f"{attempts} attempt(s) -> {score_cells} requested score cells; "
         f"evaluated harness backend={harness_backend}; "
-        f"episode timeout={episode_timeout_sec:g}s"
+        f"episode timeout={episode_timeout_sec:g}s; "
+        f"reward mode={normalized_reward_mode.replace('_', '-')}"
     )
-    if not yes:
-        if not _console.is_terminal:
-            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+
+    def before_preparation(summary: JsonObject | None) -> None:
+        if summary is not None:
+            _console.print(
+                "task-environment preparation: "
+                + json.dumps(summary, sort_keys=True, separators=(",", ":"))
+            )
+        if yes:
+            return
         if not Confirm.ask("Proceed?", default=False):
             raise typer.Exit(0)
 
@@ -169,6 +199,7 @@ def score_harness_command(
         job_config=job_config,
         task_ids=task_ids,
         reward_key=reward_key,
+        reward_mode=normalized_reward_mode,
         attempts=attempts,
         targets=targets,
         agent_config=agent_config,
@@ -176,6 +207,7 @@ def score_harness_command(
         e2b_template=(effective_e2b_template or "") if harness_backend == "e2b" else None,
         environment_command_timeout_sec=environment_command_timeout_sec,
         episode_timeout_sec=episode_timeout_sec,
+        before_preparation=before_preparation,
     )
     for entry in outcome.result.entries:
         _console.print(
@@ -199,6 +231,8 @@ def _execute_scoring(
     e2b_template: str | None,
     environment_command_timeout_sec: int,
     episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+    reward_mode: HarborRewardMode = "raw",
+    before_preparation: Callable[[JsonObject | None], None] | None = None,
 ) -> HarnessScoreOutcome:
     """Resolve one immutable scorer request, score every target, and archive evidence."""
     validate_score_targets(targets)
@@ -214,23 +248,49 @@ def _execute_scoring(
             task_ids=task_ids,
             provider_config=agent_config,
             reward_key=reward_key,
+            reward_mode=reward_mode,
             environment_command_timeout_sec=environment_command_timeout_sec,
             episode_timeout_sec=episode_timeout_sec,
             harness_backend=harness_backend,
             e2b_template=e2b_template if harness_backend == "e2b" else None,
         )
     )
+    preparation_summary = scorer.preparation_summary()
+    if before_preparation is not None:
+        before_preparation(preparation_summary)
+    staging_path: Path | None = None
+    if scorer.preparation_required:
+        staging_path = preparation_staging_path(run_dir)
+        asyncio.run(scorer.prepare(staging_path))
     request = scorer.request(attempts=attempts)
+    preparation_hash = scorer.preparation_artifact_hash
+    preparation_bytes = scorer.preparation_artifact_bytes()
+    if (preparation_hash is None) != (preparation_bytes is None):
+        raise RuntimeError("scorer preparation artifact and hash must be provided together")
+    if preparation_bytes is not None and (
+        "sha256:" + hashlib.sha256(preparation_bytes).hexdigest() != preparation_hash
+    ):
+        raise RuntimeError("scorer preparation artifact hash differs")
     run_dir.mkdir(parents=True, exist_ok=False)
+    if preparation_bytes is not None:
+        if staging_path is None:
+            raise RuntimeError("scorer preparation staging path is missing")
+        artifact_path = publish_preparation_artifact(run_dir, preparation_bytes)
+        scorer.bind_preparation(artifact_path)
+        remove_preparation_staging(staging_path)
+    asyncio.run(scorer.verify_preparation())
     inputs: JsonObject = {
-        "schema_version": 2,
+        "schema_version": 3,
         "score_request": request.model_dump(mode="json"),
+        "evaluator_policy": scorer.evaluator_policy(),
         "harbor_job_template": canonical_harbor_job_config(effective_job_config),
         "agent_provider": agent_config.model_dump(mode="json"),
         "harness_backend": harness_backend,
         "e2b_template": e2b_template or None,
         "environment_command_timeout_sec": environment_command_timeout_sec,
         "episode_timeout_sec": episode_timeout_sec,
+        "scorer_preparation_artifact_hash": preparation_hash,
+        "scorer_preparation_summary": preparation_summary,
         "targets": [
             {
                 "label": target.label,

--- a/wmh/cli/harness_score_test.py
+++ b/wmh/cli/harness_score_test.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -38,6 +40,30 @@ class _Reader:
     def read_bytes(self, path: str) -> bytes:
         assert path == "raw/result.json"
         return b"{}"
+
+
+class _NoPreparationScorer:
+    """Test scorer contract for local task environments with no preparation."""
+
+    @property
+    def preparation_required(self) -> bool:
+        return False
+
+    def preparation_summary(self) -> None:
+        return None
+
+    @property
+    def preparation_artifact_hash(self) -> None:
+        return None
+
+    def preparation_artifact_bytes(self) -> None:
+        return None
+
+    async def verify_preparation(self) -> None:
+        return None
+
+    def evaluator_policy(self) -> dict[str, object]:
+        return {}
 
 
 def _source(prompt: str) -> HarnessSourceTree:
@@ -134,7 +160,7 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
     request = _request()
     scorer_calls: list[dict[str, object]] = []
 
-    class FakeScorer:
+    class FakeScorer(_NoPreparationScorer):
         @classmethod
         async def create(cls, **kwargs: object) -> FakeScorer:
             scorer_calls.append(kwargs)
@@ -194,14 +220,16 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
     assert scorer_call["harness_backend"] == "e2b"
     assert scorer_call["e2b_template"] == "template-x"
     assert scorer_call["episode_timeout_sec"] == 12_000
+    assert scorer_call["reward_mode"] == "raw"
     [scored_call] = scored_calls
     assert scored_call[1] == (target,)
     assert scored_call[2] is request
     assert archived == [(run_dir / "scores", outcome.result)]
     assert outcome.archive_manifest == run_dir / "scores/manifest.json"
     inputs = json.loads((run_dir / "inputs.json").read_text(encoding="utf-8"))
-    assert inputs["schema_version"] == 2
+    assert inputs["schema_version"] == 3
     assert inputs["score_request"] == request.model_dump(mode="json")
+    assert inputs["evaluator_policy"] == {}
     assert inputs["episode_timeout_sec"] == 12_000
     retry = inputs["harbor_job_template"]["retry"]
     assert retry["exclude_exceptions"] == sorted(retry["exclude_exceptions"])
@@ -215,6 +243,194 @@ def test_execute_resolves_one_scorer_request_and_neutral_archive(
         }
     ]
     assert "meta_provider" not in inputs
+
+
+def test_execute_prepares_binds_and_verifies_before_scoring(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request()
+    receipt = b'{"complete":true}\n'
+    receipt_hash = "sha256:" + hashlib.sha256(receipt).hexdigest()
+    summary = {"schema_version": 1, "unique_template_count": 1}
+    events: list[str] = []
+    run_dir = tmp_path / "run"
+
+    class PreparedScorer:
+        def __init__(self) -> None:
+            self.artifact_path: Path | None = None
+
+        @classmethod
+        async def create(cls, **_kwargs: object) -> PreparedScorer:
+            events.append("create")
+            return cls()
+
+        @property
+        def preparation_required(self) -> bool:
+            return True
+
+        def preparation_summary(self) -> dict[str, int]:
+            events.append("summary")
+            return summary
+
+        async def prepare(self, artifact_path: Path) -> None:
+            events.append("prepare")
+            assert not run_dir.exists()
+            artifact_path.write_bytes(receipt)
+            self.artifact_path = artifact_path
+
+        def request(self, *, attempts: int) -> ScoreRequest:
+            events.append("request")
+            assert attempts == 1
+            assert self.artifact_path is not None
+            return request
+
+        @property
+        def preparation_artifact_hash(self) -> str:
+            events.append("hash")
+            return receipt_hash
+
+        def preparation_artifact_bytes(self) -> bytes:
+            events.append("bytes")
+            assert self.artifact_path is not None
+            return self.artifact_path.read_bytes()
+
+        def bind_preparation(self, artifact_path: Path) -> None:
+            events.append("bind")
+            assert artifact_path.read_bytes() == receipt
+            self.artifact_path = artifact_path
+
+        async def verify_preparation(self) -> None:
+            events.append("verify")
+            assert self.artifact_path == run_dir / "scorer-preparation.bin"
+
+        def evaluator_policy(self) -> dict[str, object]:
+            return {
+                "reward_key": "reward",
+                "reward_interpretation": {
+                    "mode": "positive_binary",
+                    "threshold": 0.0,
+                    "comparator": "gt",
+                },
+            }
+
+    target = HarnessScoreTarget(
+        label="candidate@v1",
+        harness=_source("p").to_doc("candidate"),
+    )
+
+    def before_preparation(observed: object) -> None:
+        events.append("confirm")
+        assert observed == summary
+
+    def fake_score_harnesses(
+        scorer: object,
+        targets: tuple[HarnessScoreTarget, ...],
+        *,
+        request: ScoreRequest,
+    ) -> HarnessScoreBatch:
+        events.append("score")
+        assert isinstance(scorer, PreparedScorer)
+        assert request == _request()
+        return _batch(targets)
+
+    monkeypatch.setattr(module, "HarborScorer", PreparedScorer)
+    monkeypatch.setattr(module, "score_harnesses", fake_score_harnesses)
+
+    _execute_scoring(
+        run_dir=run_dir,
+        job_config=_job_config(tmp_path),
+        task_ids=("task-a",),
+        reward_key="reward",
+        attempts=1,
+        targets=(target,),
+        agent_config=ProviderConfig(kind=ProviderKind.ANTHROPIC, model="agent-model"),
+        harness_backend="e2b",
+        e2b_template="template-x",
+        environment_command_timeout_sec=240,
+        episode_timeout_sec=12_000,
+        reward_mode="positive_binary",
+        before_preparation=before_preparation,
+    )
+
+    assert events == [
+        "create",
+        "summary",
+        "confirm",
+        "prepare",
+        "request",
+        "hash",
+        "bytes",
+        "bind",
+        "verify",
+        "score",
+    ]
+    assert (run_dir / "scorer-preparation.bin").read_bytes() == receipt
+    assert not (tmp_path / ".run.scorer-preparation.bin").exists()
+    inputs = json.loads((run_dir / "inputs.json").read_text(encoding="utf-8"))
+    assert inputs["scorer_preparation_artifact_hash"] == receipt_hash
+    assert inputs["scorer_preparation_summary"] == summary
+    assert inputs["evaluator_policy"]["reward_interpretation"]["mode"] == ("positive_binary")
+
+
+def test_execute_preserves_audit_staging_when_preparation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    staging_path = tmp_path / ".run.scorer-preparation.bin"
+    score_calls = 0
+
+    class BrokenPreparationScorer:
+        @classmethod
+        async def create(cls, **_kwargs: object) -> BrokenPreparationScorer:
+            return cls()
+
+        @property
+        def preparation_required(self) -> bool:
+            return True
+
+        def preparation_summary(self) -> dict[str, int]:
+            return {"schema_version": 1}
+
+        async def prepare(self, artifact_path: Path) -> None:
+            assert artifact_path == staging_path
+            artifact_path.write_bytes(b'{"complete":false}\n')
+            raise RuntimeError("provider preparation failed")
+
+    def fake_score_harnesses(*_args: object, **_kwargs: object) -> HarnessScoreBatch:
+        nonlocal score_calls
+        score_calls += 1
+        raise AssertionError("preparation failure must precede scoring")
+
+    monkeypatch.setattr(module, "HarborScorer", BrokenPreparationScorer)
+    monkeypatch.setattr(module, "score_harnesses", fake_score_harnesses)
+    target = HarnessScoreTarget(
+        label="candidate@v1",
+        harness=_source("p").to_doc("candidate"),
+    )
+
+    with pytest.raises(RuntimeError, match="provider preparation failed"):
+        _execute_scoring(
+            run_dir=run_dir,
+            job_config=_job_config(tmp_path),
+            task_ids=("task-a",),
+            reward_key="reward",
+            attempts=1,
+            targets=(target,),
+            agent_config=ProviderConfig(
+                kind=ProviderKind.ANTHROPIC,
+                model="agent-model",
+            ),
+            harness_backend="e2b",
+            e2b_template="template-x",
+            environment_command_timeout_sec=240,
+            episode_timeout_sec=12_000,
+        )
+
+    assert not run_dir.exists()
+    assert staging_path.read_bytes() == b'{"complete":false}\n'
+    assert score_calls == 0
 
 
 def test_execute_does_not_claim_result_directory_when_scorer_setup_fails(
@@ -294,6 +510,8 @@ def test_cli_resolves_default_then_immutable_stored_version_with_agent_role(
             str(task_ids_path),
             "--reward-key",
             "reward",
+            "--reward-mode",
+            "positive-binary",
             "--attempts",
             "1",
             "--result-out",
@@ -311,6 +529,7 @@ def test_cli_resolves_default_then_immutable_stored_version_with_agent_role(
     assert targets[1].harness.version == 2
     assert targets[1].harness.doc_hash == selected.doc_hash
     assert call["harness_backend"] == "local"
+    assert call["reward_mode"] == "positive_binary"
     assert call["e2b_template"] is None
     agent_config = cast(ProviderConfig, call["agent_config"])
     assert agent_config.kind is ProviderKind.ANTHROPIC
@@ -345,6 +564,7 @@ def test_cli_resolves_default_then_immutable_stored_version_with_agent_role(
     assert e2b_invoked.exit_code == 0, e2b_invoked.output
     assert calls[-1]["harness_backend"] == "e2b"
     assert calls[-1]["episode_timeout_sec"] == 12_000
+    assert calls[-1]["reward_mode"] == "raw"
     assert "episode timeout=12000s" in e2b_invoked.output
 
 
@@ -374,10 +594,21 @@ def test_cli_requires_a_target_before_model_or_scorer_resolution(tmp_path: Path)
     assert "--include-default or at least one --harness" in invoked.output
 
 
-def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Path) -> None:
+def test_cli_requires_explicit_confirmation_in_noninteractive_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     root = tmp_path / ".wmh"
     _agent_settings(root)
     config_path, task_ids_path = _write_inputs(tmp_path)
+    execute_calls = 0
+
+    def unreachable_execute(**_kwargs: object) -> HarnessScoreOutcome:
+        nonlocal execute_calls
+        execute_calls += 1
+        raise AssertionError("missing --yes must fail before scorer execution")
+
+    monkeypatch.setattr(module, "_execute_scoring", unreachable_execute)
 
     invoked = runner.invoke(
         app,
@@ -400,6 +631,63 @@ def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Pat
 
     assert invoked.exit_code == 2
     assert "pass --yes" in invoked.output
+    assert execute_calls == 0
+
+
+def test_cli_displays_preparation_summary_before_interactive_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / ".wmh"
+    _agent_settings(root)
+    config_path, task_ids_path = _write_inputs(tmp_path)
+    events: list[str] = []
+
+    class TerminalConsole:
+        is_terminal = True
+
+        def print(self, value: object) -> None:
+            text = str(value)
+            events.append("summary" if text.startswith("task-environment") else "matrix")
+
+    def confirm(*_args: object, **_kwargs: object) -> bool:
+        events.append("confirm")
+        return False
+
+    def fake_execute(**kwargs: object) -> HarnessScoreOutcome:
+        events.append("execute")
+        callback = cast(
+            Callable[[dict[str, int]], None],
+            kwargs["before_preparation"],
+        )
+        callback({"schema_version": 1, "unique_template_count": 3})
+        raise AssertionError("declined confirmation must stop scorer execution")
+
+    monkeypatch.setattr(module, "_console", TerminalConsole())
+    monkeypatch.setattr(module.Confirm, "ask", confirm)
+    monkeypatch.setattr(module, "_execute_scoring", fake_execute)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "score",
+            "--include-default",
+            "--harbor-config",
+            str(config_path),
+            "--task-ids",
+            str(task_ids_path),
+            "--reward-key",
+            "reward",
+            "--attempts",
+            "1",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert invoked.exit_code == 0, invoked.output
+    assert events == ["matrix", "execute", "summary", "confirm"]
 
 
 def test_cli_help_is_proposer_free_and_requires_only_agent_role() -> None:
@@ -411,4 +699,5 @@ def test_cli_help_is_proposer_free_and_requires_only_agent_role() -> None:
     assert "proposer" not in invoked.output.lower()
     assert "world model" not in invoked.output.lower()
     assert "--episode-timeout" in invoked.output
+    assert "--reward-mode" in invoked.output
     assert "seconds" in invoked.output

--- a/wmh/cli/scorer_preparation.py
+++ b/wmh/cli/scorer_preparation.py
@@ -1,0 +1,49 @@
+"""Durable local lifecycle helpers for scorer preparation artifacts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+SCORER_PREPARATION_FILENAME = "scorer-preparation.bin"
+
+
+def preparation_staging_path(run_dir: Path) -> Path:
+    """Return the deterministic audit-only sibling used before a run is claimed."""
+    if not run_dir.name or run_dir.name in {".", ".."}:
+        raise ValueError("run directory must have a canonical name")
+    return run_dir.parent / f".{run_dir.name}.{SCORER_PREPARATION_FILENAME}"
+
+
+def publish_preparation_artifact(run_dir: Path, content: bytes) -> Path:
+    """Durably publish exact scorer preparation bytes into a newly claimed run."""
+    if run_dir.is_symlink() or not run_dir.is_dir():
+        raise RuntimeError("scorer preparation run directory is not a regular directory")
+    destination = run_dir / SCORER_PREPARATION_FILENAME
+    if os.path.lexists(destination):
+        raise RuntimeError("scorer preparation artifact already exists")
+    temporary = run_dir / f".{SCORER_PREPARATION_FILENAME}.tmp-{uuid4().hex}"
+    with temporary.open("xb") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+    temporary.replace(destination)
+    _sync_directory(run_dir)
+    return destination
+
+
+def remove_preparation_staging(path: Path) -> None:
+    """Remove a successfully checkpointed staging artifact and sync its parent."""
+    if path.is_symlink() or not path.is_file():
+        raise RuntimeError("scorer preparation staging is not a regular file")
+    path.unlink()
+    _sync_directory(path.parent)
+
+
+def _sync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/wmh/cli/scorer_preparation_test.py
+++ b/wmh/cli/scorer_preparation_test.py
@@ -1,0 +1,45 @@
+"""Tests for durable scorer preparation artifact lifecycle helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.cli.scorer_preparation import (
+    preparation_staging_path,
+    publish_preparation_artifact,
+    remove_preparation_staging,
+)
+
+
+def test_preparation_artifact_moves_from_sibling_to_claimed_run(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    staging = preparation_staging_path(run_dir)
+    assert staging == tmp_path / ".run.scorer-preparation.bin"
+    staging.write_bytes(b"receipt\n")
+    run_dir.mkdir()
+
+    published = publish_preparation_artifact(run_dir, staging.read_bytes())
+    remove_preparation_staging(staging)
+
+    assert published == run_dir / "scorer-preparation.bin"
+    assert published.read_bytes() == b"receipt\n"
+    assert not staging.exists()
+
+
+def test_preparation_artifact_rejects_nonregular_paths(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    target = tmp_path / "target"
+    target.write_bytes(b"receipt\n")
+    staging = preparation_staging_path(run_dir)
+    staging.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        remove_preparation_staging(staging)
+
+    destination = run_dir / "scorer-preparation.bin"
+    destination.symlink_to(target)
+    with pytest.raises(RuntimeError, match="already exists"):
+        publish_preparation_artifact(run_dir, b"other\n")

--- a/wmh/evals/harbor/e2b_environment.py
+++ b/wmh/evals/harbor/e2b_environment.py
@@ -3,32 +3,268 @@
 from __future__ import annotations
 
 import asyncio
-from typing import override
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from threading import RLock
+from types import MappingProxyType
+from typing import Literal, override
 
-from e2b import AsyncSandbox
+from e2b import AsyncSandbox, AsyncTemplate, Template
+from e2b.template.main import TemplateClass
+from e2b.template.types import BuildInfo
 from harbor.environments.e2b import E2BEnvironment
-from harbor.models.task.config import NetworkMode
+from harbor.models.task.config import (
+    EnvironmentConfig,
+    NetworkMode,
+    NetworkPolicy,
+    TpuSpec,
+)
+from harbor.models.trial.config import ResourceMode, ServiceVolumeConfig
+from harbor.models.trial.paths import TrialPaths
+from tenacity import retry, stop_after_attempt, wait_exponential
 
+from wmh.evals.harbor.e2b_template_policy import (
+    E2BTemplateResources,
+    e2b_template_resource_digest,
+    qualify_harbor_e2b_template_name,
+    resolve_e2b_template_resources,
+)
 from wmh.harness.e2b_sandbox import acquire_e2b_create_slot_async
 
 _CREATE_ATTEMPTS = 2
 _CREATE_RETRY_DELAY_S = 1.0
+_PREPARATION_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class PreparedE2BTemplate:
+    """Verified provider identity and resources for one prepared template."""
+
+    template_id: str
+    build_id: str
+    cpu_count: int
+    memory_mb: int
+
+
+_PREPARED_TEMPLATES: dict[str, Mapping[str, PreparedE2BTemplate]] = {}
+_PREPARED_TEMPLATES_LOCK = RLock()
+
+
+def register_prepared_e2b_templates(
+    preparation_digest: str,
+    templates: Mapping[str, PreparedE2BTemplate],
+) -> None:
+    """Atomically register one fully verified readiness manifest for scoring."""
+    if _PREPARATION_DIGEST_PATTERN.fullmatch(preparation_digest) is None:
+        raise ValueError("preparation_digest must be a sha256 digest")
+    if not templates:
+        raise ValueError("prepared E2B template registry cannot be empty")
+    snapshot: dict[str, PreparedE2BTemplate] = {}
+    for template_name, record in templates.items():
+        if not template_name or not record.template_id or not record.build_id:
+            raise ValueError("prepared E2B template identities must be nonempty")
+        if record.cpu_count < 1 or record.memory_mb < 128:
+            raise ValueError("prepared E2B template resources are invalid")
+        snapshot[template_name] = record
+    with _PREPARED_TEMPLATES_LOCK:
+        existing = _PREPARED_TEMPLATES.get(preparation_digest)
+        if existing is not None and dict(existing) != snapshot:
+            raise ValueError("preparation digest is already registered with different templates")
+        _PREPARED_TEMPLATES[preparation_digest] = MappingProxyType(snapshot)
+
+
+def _prepared_e2b_template(
+    preparation_digest: str | None,
+    template_name: str,
+) -> PreparedE2BTemplate | None:
+    if preparation_digest is None:
+        return None
+    with _PREPARED_TEMPLATES_LOCK:
+        return _PREPARED_TEMPLATES.get(preparation_digest, {}).get(template_name)
 
 
 class WmhE2BEnvironment(E2BEnvironment):
     """Preserve Harbor's E2B behavior while pacing every provider create attempt."""
 
+    def __init__(
+        self,
+        environment_dir: Path,
+        environment_name: str,
+        session_id: str,
+        trial_paths: TrialPaths,
+        task_env_config: EnvironmentConfig,
+        logger: logging.Logger | None = None,
+        override_cpus: int | None = None,
+        override_memory_mb: int | None = None,
+        override_storage_mb: int | None = None,
+        override_gpus: int | None = None,
+        override_tpu: TpuSpec | None = None,
+        cpu_enforcement_policy: ResourceMode = ResourceMode.AUTO,
+        memory_enforcement_policy: ResourceMode = ResourceMode.AUTO,
+        persistent_env: dict[str, str] | None = None,
+        mounts: list[ServiceVolumeConfig] | None = None,
+        network_policy: NetworkPolicy | None = None,
+        phase_network_policies: Sequence[NetworkPolicy] | None = None,
+        extra_docker_compose: Sequence[Path | str] | None = None,
+        require_prebuilt: bool = False,
+        preparation_digest: str | None = None,
+        **_ignored: object,
+    ) -> None:
+        super().__init__(
+            environment_dir=environment_dir,
+            environment_name=environment_name,
+            session_id=session_id,
+            trial_paths=trial_paths,
+            task_env_config=task_env_config.model_copy(deep=True),
+            logger=logger,
+            override_cpus=override_cpus,
+            override_memory_mb=override_memory_mb,
+            override_storage_mb=override_storage_mb,
+            override_gpus=override_gpus,
+            override_tpu=override_tpu,
+            cpu_enforcement_policy=cpu_enforcement_policy,
+            memory_enforcement_policy=memory_enforcement_policy,
+            persistent_env=persistent_env,
+            mounts=mounts,
+            network_policy=network_policy,
+            phase_network_policies=phase_network_policies,
+            extra_docker_compose=extra_docker_compose,
+        )
+        if require_prebuilt and preparation_digest is None:
+            raise ValueError("require_prebuilt requires preparation_digest")
+        if not require_prebuilt and preparation_digest is not None:
+            raise ValueError("preparation_digest requires require_prebuilt")
+        if (
+            preparation_digest is not None
+            and _PREPARATION_DIGEST_PATTERN.fullmatch(preparation_digest) is None
+        ):
+            raise ValueError("preparation_digest must be a sha256 digest")
+        if self._effective_storage_mb is not None:
+            raise ValueError("Harbor E2B does not enforce requested storage")
+
+        effective_cpu = (
+            None if self._cpu_resource_mode is ResourceMode.IGNORE else self.task_env_config.cpus
+        )
+        effective_memory = (
+            None
+            if self._memory_resource_mode is ResourceMode.IGNORE
+            else self.task_env_config.memory_mb
+        )
+        resources = resolve_e2b_template_resources(
+            cpu_count=effective_cpu,
+            memory_mb=effective_memory,
+        )
+        if effective_cpu is not None and self._override_cpus is not None:
+            resources = replace(resources, cpu_source="runtime_override")
+        if effective_memory is not None and self._override_memory_mb is not None:
+            resources = replace(resources, memory_source="runtime_override")
+        self._template_resources = resources
+        self._build_source_kind: Literal["docker_image", "dockerfile"] = (
+            "docker_image" if self.task_env_config.docker_image else "dockerfile"
+        )
+        self._build_source_reference = self.task_env_config.docker_image or self.environment_id
+        self._template_name = qualify_harbor_e2b_template_name(
+            self._template_name,
+            environment_id=self.environment_id,
+            build_source_kind=self._build_source_kind,
+            build_source_reference=self._build_source_reference,
+            resources=self._template_resources,
+        )
+        self._require_prebuilt = require_prebuilt
+        self._preparation_digest = preparation_digest
+
+    @property
+    def template_name(self) -> str:
+        """Return the resource-qualified E2B template name."""
+        return self._template_name
+
+    @property
+    def template_resources(self) -> E2BTemplateResources:
+        """Return the exact numeric resources used for build and runtime checks."""
+        return self._template_resources
+
+    @property
+    def build_source_kind(self) -> Literal["docker_image", "dockerfile"]:
+        """Return the Harbor-selected E2B build source kind."""
+        return self._build_source_kind
+
+    @property
+    def build_source_reference(self) -> str:
+        """Return the canonical build source identity."""
+        return self._build_source_reference
+
+    @property
+    def template_resource_digest(self) -> str:
+        """Return the complete content, resource, and provider-policy digest."""
+        return e2b_template_resource_digest(
+            environment_id=self.environment_id,
+            build_source_kind=self.build_source_kind,
+            build_source_reference=self.build_source_reference,
+            resources=self.template_resources,
+        )
+
+    @property
+    @override
+    def _effective_cpus(self) -> int:
+        return self._template_resources.cpu_count
+
+    @property
+    @override
+    def _effective_memory_mb(self) -> int:
+        return self._template_resources.memory_mb
+
+    def _template_definition(self) -> TemplateClass:
+        if self.task_env_config.docker_image:
+            return Template().from_image(image=self.task_env_config.docker_image)
+        return Template(file_context_path=str(self.environment_dir)).from_dockerfile(
+            dockerfile_content_or_path=str(self._environment_definition_path)
+        )
+
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )
+    @override
+    async def _create_template(self) -> BuildInfo:
+        """Build with Harbor's source semantics while retaining provider identity."""
+        return await AsyncTemplate.build(
+            template=self._template_definition(),
+            name=self._template_name,
+            cpu_count=self._template_resources.cpu_count,
+            memory_mb=self._template_resources.memory_mb,
+        )
+
     @override
     async def _create_sandbox(self) -> None:
+        expected = _prepared_e2b_template(
+            self._preparation_digest,
+            self._template_name,
+        )
+        if self._require_prebuilt and expected is None:
+            raise RuntimeError("E2B template is not registered as prepared")
+        if expected is not None and (
+            expected.cpu_count != self._template_resources.cpu_count
+            or expected.memory_mb != self._template_resources.memory_mb
+        ):
+            raise RuntimeError("E2B registered resource mismatch")
         metadata = {
             "environment_name": self.environment_name,
             "session_id": self.session_id,
         }
+        template_reference = (
+            self._template_name
+            if expected is None
+            else f"{self._template_name}:{expected.build_id}"
+        )
         for attempt in range(_CREATE_ATTEMPTS):
             await acquire_e2b_create_slot_async()
             try:
                 self._sandbox = await AsyncSandbox.create(
-                    template=self._template_name,
+                    template=template_reference,
                     metadata=metadata,
                     envs=self._startup_env(),
                     timeout=86_400,
@@ -37,9 +273,41 @@ class WmhE2BEnvironment(E2BEnvironment):
                     ),
                     network=self._sandbox_create_network_options(),
                 )
-                return
+                break
             except Exception:  # noqa: BLE001 - preserve Harbor's retry-all create contract
                 self._sandbox = None
                 if attempt + 1 == _CREATE_ATTEMPTS:
                     raise
                 await asyncio.sleep(_CREATE_RETRY_DELAY_S)
+        if self._sandbox is None:
+            raise RuntimeError("E2B sandbox create returned no sandbox")
+        try:
+            info = await self._sandbox.get_info()
+            if expected is None and info.name is not None and info.name != self._template_name:
+                raise RuntimeError("E2B sandbox template name mismatch")
+            if expected is not None and info.template_id != expected.template_id:
+                raise RuntimeError("E2B sandbox template identity mismatch")
+            if (
+                info.cpu_count != self._template_resources.cpu_count
+                or info.memory_mb != self._template_resources.memory_mb
+            ):
+                raise RuntimeError("E2B sandbox resource mismatch")
+        except BaseException:
+            sandbox = self._sandbox
+            self._sandbox = None
+            await sandbox.kill()
+            raise
+
+    @override
+    async def start(self, force_build: bool) -> None:
+        """Start a task environment, failing closed when scoring requires readiness."""
+        if not self._require_prebuilt:
+            await super().start(force_build)
+            return
+        if force_build:
+            raise ValueError("force_build is incompatible with prepared Harbor E2B scoring")
+        if _prepared_e2b_template(self._preparation_digest, self._template_name) is None:
+            raise RuntimeError("Harbor E2B template is not prepared for this score request")
+        await self._create_sandbox()
+        await self.ensure_dirs(self._mount_targets(writable_only=True))
+        await self._upload_environment_dir_after_start()

--- a/wmh/evals/harbor/e2b_environment.py
+++ b/wmh/evals/harbor/e2b_environment.py
@@ -142,8 +142,12 @@ class WmhE2BEnvironment(E2BEnvironment):
             and _PREPARATION_DIGEST_PATTERN.fullmatch(preparation_digest) is None
         ):
             raise ValueError("preparation_digest must be a sha256 digest")
-        if self._effective_storage_mb is not None:
-            raise ValueError("Harbor E2B does not enforce requested storage")
+        # Harbor's E2B backend deliberately leaves task-declared storage on the
+        # provider default: E2B exposes no storage field on template build or
+        # sandbox create. Preserve that backend contract, but reject an explicit
+        # runtime override so an operator cannot mistake it for an enforced value.
+        if self._override_storage_mb is not None:
+            raise ValueError("Harbor E2B does not enforce storage overrides")
 
         effective_cpu = (
             None if self._cpu_resource_mode is ResourceMode.IGNORE else self.task_env_config.cpus

--- a/wmh/evals/harbor/e2b_environment_test.py
+++ b/wmh/evals/harbor/e2b_environment_test.py
@@ -157,6 +157,33 @@ def test_harbor_e2b_omitted_resources_become_explicit_build_values(tmp_path: Pat
     assert environment._effective_memory_mb == 1024
 
 
+def test_harbor_e2b_task_storage_is_not_sent_to_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(
+        tmp_path,
+        task_config=EnvironmentConfig(cpus=2, memory_mb=2048, storage_mb=4096),
+    )
+    calls: list[dict[str, object]] = []
+
+    async def build(**kwargs: object) -> object:
+        calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(e2b_environment_module.AsyncTemplate, "build", staticmethod(build))
+
+    asyncio.run(environment._create_template())
+
+    assert environment._effective_storage_mb == 4096
+    assert len(calls) == 1
+    assert calls[0]["name"] == environment.template_name
+    assert calls[0]["cpu_count"] == 2
+    assert calls[0]["memory_mb"] == 2048
+    assert calls[0]["template"] is not None
+    assert "storage_mb" not in calls[0]
+
+
 def test_harbor_e2b_resource_mismatch_kills_without_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/wmh/evals/harbor/e2b_environment_test.py
+++ b/wmh/evals/harbor/e2b_environment_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from harbor.models.task.config import EnvironmentConfig
@@ -14,12 +15,22 @@ pytest.importorskip("e2b")
 from e2b import AsyncSandbox  # noqa: E402
 
 import wmh.evals.harbor.e2b_environment as e2b_environment_module  # noqa: E402
-from wmh.evals.harbor.e2b_environment import WmhE2BEnvironment  # noqa: E402
+from wmh.evals.harbor.e2b_environment import (  # noqa: E402
+    PreparedE2BTemplate,
+    WmhE2BEnvironment,
+    register_prepared_e2b_templates,
+)
 
 
-def _environment(tmp_path: Path) -> WmhE2BEnvironment:
+def _environment(
+    tmp_path: Path,
+    *,
+    task_config: EnvironmentConfig | None = None,
+    require_prebuilt: bool = False,
+    preparation_digest: str | None = None,
+) -> WmhE2BEnvironment:
     environment_dir = tmp_path / "environment"
-    environment_dir.mkdir()
+    environment_dir.mkdir(parents=True)
     (environment_dir / "Dockerfile").write_text(
         "FROM alpine:3.20\nWORKDIR /workspace\n",
         encoding="utf-8",
@@ -31,8 +42,34 @@ def _environment(tmp_path: Path) -> WmhE2BEnvironment:
         environment_name="task/environment",
         session_id="trial__environment",
         trial_paths=TrialPaths(trial_dir),
-        task_env_config=EnvironmentConfig(cpus=2, memory_mb=2048),
+        task_env_config=task_config or EnvironmentConfig(cpus=2, memory_mb=2048),
+        require_prebuilt=require_prebuilt,
+        preparation_digest=preparation_digest,
     )
+
+
+class _Sandbox:
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        template_id: str = "template-id",
+        cpu_count: int = 2,
+        memory_mb: int = 2048,
+    ) -> None:
+        self.info = SimpleNamespace(
+            template_id=template_id,
+            name=name,
+            cpu_count=cpu_count,
+            memory_mb=memory_mb,
+        )
+        self.kill_calls = 0
+
+    async def get_info(self) -> SimpleNamespace:
+        return self.info
+
+    async def kill(self) -> None:
+        self.kill_calls += 1
 
 
 def test_harbor_e2b_create_reacquires_shared_gate_on_provider_retry(
@@ -42,12 +79,12 @@ def test_harbor_e2b_create_reacquires_shared_gate_on_provider_retry(
     environment = _environment(tmp_path)
     events: list[str] = []
     calls: list[dict[str, object]] = []
-    sandbox = object()
+    sandbox = _Sandbox(name=environment.template_name)
 
     async def admit() -> None:
         events.append("admit")
 
-    async def create(**kwargs: object) -> object:
+    async def create(**kwargs: object) -> _Sandbox:
         events.append("create")
         calls.append(kwargs)
         if len(calls) == 1:
@@ -83,6 +120,264 @@ def test_harbor_e2b_create_reacquires_shared_gate_on_provider_retry(
         "network": None,
     }
     assert environment._sandbox is sandbox
+
+
+def test_harbor_e2b_template_identity_includes_selected_image_with_stray_files(
+    tmp_path: Path,
+) -> None:
+    first = _environment(
+        tmp_path / "first",
+        task_config=EnvironmentConfig(
+            docker_image="ubuntu:22.04",
+            cpus=2,
+            memory_mb=2048,
+        ),
+    )
+    second = _environment(
+        tmp_path / "second",
+        task_config=EnvironmentConfig(
+            docker_image="ubuntu:24.04",
+            cpus=2,
+            memory_mb=2048,
+        ),
+    )
+
+    assert first.environment_id == second.environment_id
+    assert first.template_name != second.template_name
+    assert first.build_source_kind == "docker_image"
+    assert first.build_source_reference == "ubuntu:22.04"
+
+
+def test_harbor_e2b_omitted_resources_become_explicit_build_values(tmp_path: Path) -> None:
+    environment = _environment(tmp_path, task_config=EnvironmentConfig())
+
+    assert environment.template_resources.cpu_count == 2
+    assert environment.template_resources.memory_mb == 1024
+    assert environment._effective_cpus == 2
+    assert environment._effective_memory_mb == 1024
+
+
+def test_harbor_e2b_resource_mismatch_kills_without_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    sandbox = _Sandbox(name=environment.template_name, memory_mb=4096)
+    creates = 0
+
+    async def admit() -> None:
+        return None
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        nonlocal creates
+        creates += 1
+        return sandbox
+
+    monkeypatch.setattr(e2b_environment_module, "acquire_e2b_create_slot_async", admit)
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+
+    with pytest.raises(RuntimeError, match="resource mismatch"):
+        asyncio.run(environment._create_sandbox())
+
+    assert creates == 1
+    assert sandbox.kill_calls == 1
+    assert environment._sandbox is None
+
+
+def test_harbor_e2b_prebuilt_mode_rejects_force_build_and_missing_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation_digest = f"sha256:{'a' * 64}"
+    environment = _environment(
+        tmp_path,
+        require_prebuilt=True,
+        preparation_digest=preparation_digest,
+    )
+    build_calls = 0
+
+    async def build() -> None:
+        nonlocal build_calls
+        build_calls += 1
+
+    async def missing() -> bool:
+        return False
+
+    monkeypatch.setattr(environment, "_create_template", build)
+    monkeypatch.setattr(environment, "_does_template_exist", missing)
+
+    with pytest.raises(ValueError, match="force_build"):
+        asyncio.run(environment.start(force_build=True))
+    with pytest.raises(RuntimeError, match="not prepared"):
+        asyncio.run(environment.start(force_build=False))
+
+    assert build_calls == 0
+
+
+def test_harbor_e2b_prebuilt_mode_requires_registered_template_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation_digest = f"sha256:{'b' * 64}"
+    environment = _environment(
+        tmp_path,
+        require_prebuilt=True,
+        preparation_digest=preparation_digest,
+    )
+    register_prepared_e2b_templates(
+        preparation_digest,
+        {
+            environment.template_name: PreparedE2BTemplate(
+                template_id="expected-template",
+                build_id="expected-build",
+                cpu_count=2,
+                memory_mb=2048,
+            )
+        },
+    )
+    sandbox = _Sandbox(
+        name=environment.template_name,
+        template_id="other-template",
+    )
+
+    async def admit() -> None:
+        return None
+
+    create_calls: list[dict[str, object]] = []
+
+    async def create(**kwargs: object) -> _Sandbox:
+        create_calls.append(kwargs)
+        return sandbox
+
+    monkeypatch.setattr(e2b_environment_module, "acquire_e2b_create_slot_async", admit)
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+
+    with pytest.raises(RuntimeError, match="template identity mismatch"):
+        asyncio.run(environment._create_sandbox())
+
+    assert sandbox.kill_calls == 1
+    assert environment._sandbox is None
+    assert create_calls[0]["template"] == f"{environment.template_name}:expected-build"
+
+
+def test_harbor_e2b_prebuilt_start_never_consults_mutable_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation_digest = f"sha256:{'e' * 64}"
+    environment = _environment(
+        tmp_path,
+        require_prebuilt=True,
+        preparation_digest=preparation_digest,
+    )
+    register_prepared_e2b_templates(
+        preparation_digest,
+        {
+            environment.template_name: PreparedE2BTemplate(
+                template_id="expected-template",
+                build_id="expected-build",
+                cpu_count=2,
+                memory_mb=2048,
+            )
+        },
+    )
+    events: list[str] = []
+
+    async def mutable_alias_check() -> bool:
+        events.append("alias-check")
+        raise AssertionError("prepared scoring must not consult a mutable template alias")
+
+    async def create_sandbox() -> None:
+        events.append("create")
+
+    async def ensure_dirs(_paths: object) -> None:
+        events.append("ensure-dirs")
+
+    async def upload() -> None:
+        events.append("upload")
+
+    monkeypatch.setattr(environment, "_does_template_exist", mutable_alias_check)
+    monkeypatch.setattr(environment, "_create_sandbox", create_sandbox)
+    monkeypatch.setattr(environment, "ensure_dirs", ensure_dirs)
+    monkeypatch.setattr(environment, "_upload_environment_dir_after_start", upload)
+
+    asyncio.run(environment.start(force_build=False))
+
+    assert events == ["create", "ensure-dirs", "upload"]
+
+
+def test_harbor_e2b_prebuilt_mode_accepts_absent_diagnostic_template_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation_digest = f"sha256:{'d' * 64}"
+    environment = _environment(
+        tmp_path,
+        require_prebuilt=True,
+        preparation_digest=preparation_digest,
+    )
+    register_prepared_e2b_templates(
+        preparation_digest,
+        {
+            environment.template_name: PreparedE2BTemplate(
+                template_id="expected-template",
+                build_id="expected-build",
+                cpu_count=2,
+                memory_mb=2048,
+            )
+        },
+    )
+    sandbox = _Sandbox(name=None, template_id="expected-template")
+
+    async def admit() -> None:
+        return None
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        return sandbox
+
+    monkeypatch.setattr(e2b_environment_module, "acquire_e2b_create_slot_async", admit)
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+
+    asyncio.run(environment._create_sandbox())
+
+    assert environment._sandbox is sandbox
+    assert sandbox.kill_calls == 0
+
+
+def test_harbor_e2b_prebuilt_mode_rejects_registered_resource_drift_before_create(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    preparation_digest = f"sha256:{'c' * 64}"
+    environment = _environment(
+        tmp_path,
+        require_prebuilt=True,
+        preparation_digest=preparation_digest,
+    )
+    register_prepared_e2b_templates(
+        preparation_digest,
+        {
+            environment.template_name: PreparedE2BTemplate(
+                template_id="expected-template",
+                build_id="expected-build",
+                cpu_count=2,
+                memory_mb=4096,
+            )
+        },
+    )
+    creates = 0
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        nonlocal creates
+        creates += 1
+        return _Sandbox(name=environment.template_name)
+
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+
+    with pytest.raises(RuntimeError, match="registered resource mismatch"):
+        asyncio.run(environment._create_sandbox())
+
+    assert creates == 0
 
 
 def test_harbor_e2b_create_propagates_second_provider_failure(

--- a/wmh/evals/harbor/e2b_template_control.py
+++ b/wmh/evals/harbor/e2b_template_control.py
@@ -1,0 +1,129 @@
+"""Version-bound E2B control-plane inspection for prepared Harbor templates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import cast
+
+from e2b.api.client.api.tags import get_templates_template_id_tags
+from e2b.api.client.api.templates import (
+    get_templates_aliases_alias,
+    get_templates_template_id,
+)
+from e2b.api.client.models.template_alias_response import TemplateAliasResponse
+from e2b.api.client.models.template_build_status import TemplateBuildStatus
+from e2b.api.client.models.template_tag import TemplateTag
+from e2b.api.client.models.template_with_builds import TemplateWithBuilds
+from e2b.api.client_async import get_api_client
+from e2b.connection_config import ConnectionConfig
+
+from wmh.evals.harbor.e2b_template_policy import e2b_sdk_version
+
+E2B_CONTROL_SDK_VERSION = "2.31.0"
+
+
+class E2BTemplateNotFound(RuntimeError):
+    """A qualified E2B template name has no current control-plane target."""
+
+
+@dataclass(frozen=True)
+class E2BTemplateControlIdentity:
+    """Current provider identity and resources behind one qualified name."""
+
+    template_id: str
+    build_id: str
+    cpu_count: int
+    memory_mb: int
+
+
+async def inspect_e2b_template(
+    template_name: str,
+    *,
+    expected_cpu_count: int,
+    expected_memory_mb: int,
+) -> E2BTemplateControlIdentity:
+    """Resolve one name to its unique ready default build and exact resources."""
+    if e2b_sdk_version() != E2B_CONTROL_SDK_VERSION:
+        raise RuntimeError(
+            f"Harbor E2B template inspection requires e2b=={E2B_CONTROL_SDK_VERSION}"
+        )
+    if not template_name:
+        raise ValueError("E2B template name must be nonempty")
+    if (
+        isinstance(expected_cpu_count, bool)
+        or not isinstance(expected_cpu_count, int)
+        or isinstance(expected_memory_mb, bool)
+        or not isinstance(expected_memory_mb, int)
+        or expected_cpu_count < 1
+        or expected_memory_mb < 128
+    ):
+        raise ValueError("expected E2B template resources are invalid")
+
+    async with get_api_client(ConnectionConfig()) as api_client:
+        alias_response = await get_templates_aliases_alias.asyncio_detailed(
+            alias=template_name,
+            client=api_client,
+        )
+        if alias_response.status_code == HTTPStatus.NOT_FOUND:
+            raise E2BTemplateNotFound("qualified E2B template name was not found")
+        if (
+            alias_response.status_code != HTTPStatus.OK
+            or not isinstance(alias_response.parsed, TemplateAliasResponse)
+            or not alias_response.parsed.template_id
+        ):
+            raise RuntimeError("qualified E2B template name is unavailable")
+        template_id = alias_response.parsed.template_id
+
+        template_response = await get_templates_template_id.asyncio_detailed(
+            template_id=template_id,
+            client=api_client,
+            limit=100,
+        )
+        if template_response.status_code != HTTPStatus.OK or not isinstance(
+            template_response.parsed, TemplateWithBuilds
+        ):
+            raise RuntimeError("qualified E2B template details are unavailable")
+        details = template_response.parsed
+        if details.template_id != template_id:
+            raise RuntimeError("E2B template control-plane identity disagreement")
+
+        tag_response = await get_templates_template_id_tags.asyncio_detailed(
+            template_id=template_id,
+            client=api_client,
+        )
+        if (
+            tag_response.status_code != HTTPStatus.OK
+            or not isinstance(tag_response.parsed, list)
+            or any(not isinstance(tag, TemplateTag) for tag in tag_response.parsed)
+        ):
+            raise RuntimeError("qualified E2B template tags are unavailable")
+        tags = cast(list[TemplateTag], tag_response.parsed)
+        confirmation = await get_templates_aliases_alias.asyncio_detailed(
+            alias=template_name,
+            client=api_client,
+        )
+        if (
+            confirmation.status_code != HTTPStatus.OK
+            or not isinstance(confirmation.parsed, TemplateAliasResponse)
+            or confirmation.parsed.template_id != template_id
+        ):
+            raise RuntimeError("qualified E2B template name changed during inspection")
+    default_tags = [tag for tag in tags if tag.tag == "default"]
+    if len(default_tags) != 1 or not default_tags[0].build_id:
+        raise RuntimeError("qualified E2B template has no unique default tag")
+    build_id = str(default_tags[0].build_id)
+    builds = [build for build in details.builds if str(build.build_id) == build_id]
+    if len(builds) != 1:
+        raise RuntimeError("qualified E2B default build is absent or ambiguous")
+    build = builds[0]
+    if build.status is not TemplateBuildStatus.READY:
+        raise RuntimeError("qualified E2B default build is not ready")
+    if build.cpu_count != expected_cpu_count or build.memory_mb != expected_memory_mb:
+        raise RuntimeError("qualified E2B default build resource mismatch")
+    return E2BTemplateControlIdentity(
+        template_id=template_id,
+        build_id=build_id,
+        cpu_count=build.cpu_count,
+        memory_mb=build.memory_mb,
+    )

--- a/wmh/evals/harbor/e2b_template_control_test.py
+++ b/wmh/evals/harbor/e2b_template_control_test.py
@@ -1,0 +1,242 @@
+"""Offline tests for version-bound E2B template control-plane inspection."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from http import HTTPStatus
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from e2b.api.client.models.template_alias_response import TemplateAliasResponse
+from e2b.api.client.models.template_build import TemplateBuild
+from e2b.api.client.models.template_build_status import TemplateBuildStatus
+from e2b.api.client.models.template_tag import TemplateTag
+from e2b.api.client.models.template_with_builds import TemplateWithBuilds
+
+import wmh.evals.harbor.e2b_template_control as control
+
+_TEMPLATE_ID = "template-id"
+_BUILD_ID = UUID("00000000-0000-4000-8000-000000000001")
+_LATEST_BUILD_ID = UUID("00000000-0000-4000-8000-000000000002")
+
+
+async def _inspect() -> control.E2BTemplateControlIdentity:
+    return await control.inspect_e2b_template(
+        "wmh-hb-v1-example",
+        expected_cpu_count=4,
+        expected_memory_mb=8192,
+    )
+
+
+def _response(parsed: object, status: HTTPStatus = HTTPStatus.OK) -> SimpleNamespace:
+    return SimpleNamespace(status_code=status, parsed=parsed)
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.exited = False
+
+    async def __aenter__(self) -> _Client:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        self.exited = True
+
+
+def _details(*, status: TemplateBuildStatus = TemplateBuildStatus.READY) -> TemplateWithBuilds:
+    now = datetime.now(UTC)
+    return TemplateWithBuilds(
+        aliases=[],
+        builds=[
+            TemplateBuild(
+                build_id=_BUILD_ID,
+                cpu_count=4,
+                memory_mb=8192,
+                status=status,
+                created_at=now,
+                updated_at=now,
+            ),
+            TemplateBuild(
+                build_id=_LATEST_BUILD_ID,
+                cpu_count=8,
+                memory_mb=16384,
+                status=TemplateBuildStatus.READY,
+                created_at=now,
+                updated_at=now,
+            ),
+        ],
+        created_at=now,
+        last_spawned_at=None,
+        names=["wmh-hb-v1-example"],
+        public=False,
+        spawn_count=0,
+        template_id=_TEMPLATE_ID,
+        updated_at=now,
+    )
+
+
+def _install_control_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    details: TemplateWithBuilds | None = None,
+    tags: list[TemplateTag] | None = None,
+) -> _Client:
+    async def resolve_alias(**kwargs: object) -> SimpleNamespace:
+        assert kwargs["alias"] == "wmh-hb-v1-example"
+        return _response(TemplateAliasResponse(public=False, template_id=_TEMPLATE_ID))
+
+    async def get_template(**kwargs: object) -> SimpleNamespace:
+        assert kwargs["template_id"] == _TEMPLATE_ID
+        return _response(details or _details())
+
+    async def get_tags(**kwargs: object) -> SimpleNamespace:
+        assert kwargs["template_id"] == _TEMPLATE_ID
+        return _response(
+            tags
+            or [
+                TemplateTag(
+                    tag="default",
+                    build_id=_BUILD_ID,
+                    created_at=datetime.now(UTC),
+                ),
+                TemplateTag(
+                    tag="latest",
+                    build_id=_LATEST_BUILD_ID,
+                    created_at=datetime.now(UTC),
+                ),
+            ]
+        )
+
+    client = _Client()
+    monkeypatch.setattr(control, "get_api_client", lambda _config: client)
+    monkeypatch.setattr(control.get_templates_aliases_alias, "asyncio_detailed", resolve_alias)
+    monkeypatch.setattr(control.get_templates_template_id, "asyncio_detailed", get_template)
+    monkeypatch.setattr(control.get_templates_template_id_tags, "asyncio_detailed", get_tags)
+    return client
+
+
+def test_inspection_returns_unique_ready_default_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    client = _install_control_responses(monkeypatch)
+
+    observed = asyncio.run(_inspect())
+
+    assert observed == control.E2BTemplateControlIdentity(
+        template_id=_TEMPLATE_ID,
+        build_id=str(_BUILD_ID),
+        cpu_count=4,
+        memory_mb=8192,
+    )
+    assert client.exited
+
+
+def test_inspection_rejects_unpinned_e2b_sdk_before_api_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.32.0")
+    api_calls = 0
+
+    def get_client(_config: object) -> object:
+        nonlocal api_calls
+        api_calls += 1
+        return object()
+
+    monkeypatch.setattr(control, "get_api_client", get_client)
+
+    with pytest.raises(RuntimeError, match="requires e2b==2.31.0"):
+        asyncio.run(_inspect())
+
+    assert api_calls == 0
+
+
+def test_inspection_rejects_ambiguous_default_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    now = datetime.now(UTC)
+    _install_control_responses(
+        monkeypatch,
+        tags=[
+            TemplateTag(tag="default", build_id=_BUILD_ID, created_at=now),
+            TemplateTag(tag="default", build_id=_BUILD_ID, created_at=now),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="unique default tag"):
+        asyncio.run(_inspect())
+
+
+def test_inspection_rejects_nonready_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    _install_control_responses(
+        monkeypatch,
+        details=_details(status=TemplateBuildStatus.BUILDING),
+    )
+
+    with pytest.raises(RuntimeError, match="not ready"):
+        asyncio.run(_inspect())
+
+
+def test_inspection_rejects_resource_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    details = _details()
+    details.builds[0].memory_mb = 4096
+    _install_control_responses(monkeypatch, details=details)
+
+    with pytest.raises(RuntimeError, match="resource mismatch"):
+        asyncio.run(_inspect())
+
+
+def test_inspection_rejects_template_identity_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    details = _details()
+    details.template_id = "other-template"
+    _install_control_responses(monkeypatch, details=details)
+
+    with pytest.raises(RuntimeError, match="identity disagreement"):
+        asyncio.run(_inspect())
+
+
+def test_inspection_rejects_alias_change_during_control_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    _install_control_responses(monkeypatch)
+    alias_calls = 0
+
+    async def resolve_alias(**_kwargs: object) -> SimpleNamespace:
+        nonlocal alias_calls
+        alias_calls += 1
+        template_id = _TEMPLATE_ID if alias_calls == 1 else "other-template"
+        return _response(TemplateAliasResponse(public=False, template_id=template_id))
+
+    monkeypatch.setattr(control.get_templates_aliases_alias, "asyncio_detailed", resolve_alias)
+
+    with pytest.raises(RuntimeError, match="changed during inspection"):
+        asyncio.run(_inspect())
+
+    assert alias_calls == 2
+
+
+def test_inspection_distinguishes_exact_alias_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(control, "e2b_sdk_version", lambda: "2.31.0")
+    client = _Client()
+    monkeypatch.setattr(control, "get_api_client", lambda _config: client)
+
+    async def missing(**_kwargs: object) -> SimpleNamespace:
+        return _response(object(), status=HTTPStatus.NOT_FOUND)
+
+    monkeypatch.setattr(control.get_templates_aliases_alias, "asyncio_detailed", missing)
+
+    with pytest.raises(control.E2BTemplateNotFound, match="not found"):
+        asyncio.run(_inspect())
+
+    assert client.exited

--- a/wmh/evals/harbor/e2b_template_policy.py
+++ b/wmh/evals/harbor/e2b_template_policy.py
@@ -1,0 +1,176 @@
+"""Stable identity and policy for prepared Harbor E2B task templates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal
+
+import harbor
+from harbor.environments.definition import SNAPSHOT_HASH_LEN
+
+E2B_TEMPLATE_POLICY_VERSION = "1"
+E2B_TEMPLATE_BUILD_CONCURRENCY = 10
+E2B_TEMPLATE_BUILD_CONCURRENCY_LIMIT = 20
+E2B_DEFAULT_CPU_COUNT = 2
+E2B_DEFAULT_MEMORY_MB = 1024
+WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH = "wmh.evals.harbor.e2b_environment:WmhE2BEnvironment"
+_HARBOR_ENVIRONMENT_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+
+
+@dataclass(frozen=True)
+class E2BTemplateResources:
+    """Normalized resources passed explicitly to E2B template builds."""
+
+    cpu_count: int
+    memory_mb: int
+    cpu_source: Literal["runtime_override", "task", "provider_default"]
+    memory_source: Literal["runtime_override", "task", "provider_default"]
+
+
+def resolve_e2b_template_resources(
+    *,
+    cpu_count: int | None,
+    memory_mb: int | None,
+    override_cpu_count: int | None = None,
+    override_memory_mb: int | None = None,
+) -> E2BTemplateResources:
+    """Resolve omitted Harbor values to the pinned E2B numeric defaults."""
+    values = (cpu_count, memory_mb, override_cpu_count, override_memory_mb)
+    if any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in values
+        if value is not None
+    ):
+        raise ValueError("E2B template CPU and memory values must be integers")
+    resolved_cpu = (
+        override_cpu_count
+        if override_cpu_count is not None
+        else E2B_DEFAULT_CPU_COUNT
+        if cpu_count is None
+        else cpu_count
+    )
+    resolved_memory = (
+        override_memory_mb
+        if override_memory_mb is not None
+        else E2B_DEFAULT_MEMORY_MB
+        if memory_mb is None
+        else memory_mb
+    )
+    if resolved_cpu < 1 or resolved_memory < 128:
+        raise ValueError("E2B template CPU must be positive and memory must be at least 128 MiB")
+    return E2BTemplateResources(
+        cpu_count=resolved_cpu,
+        memory_mb=resolved_memory,
+        cpu_source=(
+            "runtime_override"
+            if override_cpu_count is not None
+            else "provider_default"
+            if cpu_count is None
+            else "task"
+        ),
+        memory_source=(
+            "runtime_override"
+            if override_memory_mb is not None
+            else "provider_default"
+            if memory_mb is None
+            else "task"
+        ),
+    )
+
+
+def e2b_sdk_version() -> str:
+    """Return the installed E2B SDK version required by the E2B runtime path."""
+    try:
+        return version("e2b")
+    except PackageNotFoundError as error:
+        raise RuntimeError("Harbor E2B readiness requires the wmh e2b extra") from error
+
+
+def harbor_version() -> str:
+    """Return the Harbor version whose build semantics define template identity."""
+    return harbor.__version__
+
+
+def e2b_template_resource_payload(
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+) -> dict[str, int | str]:
+    """Return the canonical resource-complete cache identity used by E2B."""
+    if not environment_id:
+        raise ValueError("Harbor environment_id must be nonempty")
+    if not build_source_reference:
+        raise ValueError("E2B template build source must be nonempty")
+    return {
+        "schema_version": E2B_TEMPLATE_POLICY_VERSION,
+        "harbor_environment_id": environment_id,
+        "build_source_kind": build_source_kind,
+        "build_source_reference": build_source_reference,
+        "cpu_count": resources.cpu_count,
+        "memory_mb": resources.memory_mb,
+        "harbor_version": harbor_version(),
+        "e2b_sdk_version": e2b_sdk_version(),
+    }
+
+
+def e2b_template_resource_digest(
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+) -> str:
+    """Hash one canonical Harbor-content and E2B-resource identity."""
+    payload = e2b_template_resource_payload(
+        environment_id=environment_id,
+        build_source_kind=build_source_kind,
+        build_source_reference=build_source_reference,
+        resources=resources,
+    )
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def qualify_harbor_e2b_template_name(
+    base_name: str,
+    *,
+    environment_id: str,
+    build_source_kind: Literal["docker_image", "dockerfile"],
+    build_source_reference: str,
+    resources: E2BTemplateResources,
+) -> str:
+    """Replace Harbor's content-only name with a fixed-safe complete identity."""
+    if _HARBOR_ENVIRONMENT_ID_PATTERN.fullmatch(environment_id) is None:
+        raise ValueError("Harbor environment_id must be 32 lowercase hexadecimal characters")
+    inherited_suffix = environment_id[:SNAPSHOT_HASH_LEN]
+    if not base_name.endswith(inherited_suffix):
+        raise ValueError("Harbor E2B template name does not match its environment_id")
+    digest = e2b_template_resource_digest(
+        environment_id=environment_id,
+        build_source_kind=build_source_kind,
+        build_source_reference=build_source_reference,
+        resources=resources,
+    )
+    return f"wmh-hb-v1-{digest}"
+
+
+def e2b_template_readiness_policy_payload() -> dict[str, int | str | bool]:
+    """Return the frozen readiness policy included in scorer identity."""
+    return {
+        "schema_version": E2B_TEMPLATE_POLICY_VERSION,
+        "harbor_version": harbor_version(),
+        "e2b_sdk_version": e2b_sdk_version(),
+        "default_cpu_count": E2B_DEFAULT_CPU_COUNT,
+        "default_memory_mb": E2B_DEFAULT_MEMORY_MB,
+        "build_concurrency": E2B_TEMPLATE_BUILD_CONCURRENCY,
+        "build_concurrency_limit": E2B_TEMPLATE_BUILD_CONCURRENCY_LIMIT,
+        "resource_qualified_alias": True,
+        "force_build": False,
+        "storage_policy": "reject_requested",
+    }

--- a/wmh/evals/harbor/e2b_template_policy.py
+++ b/wmh/evals/harbor/e2b_template_policy.py
@@ -172,5 +172,6 @@ def e2b_template_readiness_policy_payload() -> dict[str, int | str | bool]:
         "build_concurrency_limit": E2B_TEMPLATE_BUILD_CONCURRENCY_LIMIT,
         "resource_qualified_alias": True,
         "force_build": False,
-        "storage_policy": "reject_requested",
+        "task_storage_policy": "provider_default_unenforced",
+        "override_storage_policy": "reject",
     }

--- a/wmh/evals/harbor/e2b_template_policy_test.py
+++ b/wmh/evals/harbor/e2b_template_policy_test.py
@@ -1,0 +1,194 @@
+"""Tests for resource-complete Harbor E2B template identity."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import cast
+
+import pytest
+from harbor.environments.definition import SNAPSHOT_HASH_LEN
+
+import wmh.evals.harbor.e2b_template_policy as policy
+
+
+def test_qualified_name_replaces_harbor_name_with_fixed_safe_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.8.1")
+    environment_id = hashlib.sha256(b"environment").hexdigest()[:32]
+    base_name = f"task__{environment_id[:SNAPSHOT_HASH_LEN]}"
+    resources = policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=2048)
+
+    qualified = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=resources,
+    )
+
+    assert qualified.startswith("wmh-hb-v1-")
+    assert qualified != base_name
+    assert len(qualified) == 74
+    assert qualified.replace("-", "").isalnum()
+
+
+def test_qualified_name_changes_with_resources_and_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_id = hashlib.sha256(b"environment").hexdigest()[:32]
+    base_name = f"task__{environment_id[:SNAPSHOT_HASH_LEN]}"
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.8.1")
+    first = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+    )
+    more_memory = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=2048),
+    )
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.9.0")
+    newer_sdk = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+    )
+
+    assert len({first, more_memory, newer_sdk}) == 3
+
+
+def test_qualified_name_changes_with_harbor_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment_id = hashlib.sha256(b"environment").hexdigest()[:32]
+    base_name = f"task__{environment_id[:SNAPSHOT_HASH_LEN]}"
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.31.0")
+    monkeypatch.setattr(policy, "harbor_version", lambda: "0.20.0")
+    first = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+    )
+    monkeypatch.setattr(policy, "harbor_version", lambda: "0.21.0")
+    upgraded = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+    )
+
+    assert first != upgraded
+
+
+def test_qualified_name_rejects_unrelated_harbor_name() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        policy.qualify_harbor_e2b_template_name(
+            "task__not-the-hash",
+            environment_id="a" * 32,
+            build_source_kind="dockerfile",
+            build_source_reference="a" * 32,
+            resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+        )
+
+
+@pytest.mark.parametrize("environment_id", ["a" * 31, "a" * 33, "G" * 32])
+def test_qualified_name_rejects_noncanonical_environment_id(environment_id: str) -> None:
+    with pytest.raises(ValueError, match="32 lowercase hexadecimal"):
+        policy.qualify_harbor_e2b_template_name(
+            f"task__{environment_id[:SNAPSHOT_HASH_LEN]}",
+            environment_id=environment_id,
+            build_source_kind="dockerfile",
+            build_source_reference="a" * 32,
+            resources=policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024),
+        )
+
+
+def test_omitted_resources_resolve_to_explicit_pinned_defaults() -> None:
+    resources = policy.resolve_e2b_template_resources(cpu_count=None, memory_mb=None)
+
+    assert resources == policy.E2BTemplateResources(
+        cpu_count=2,
+        memory_mb=1024,
+        cpu_source="provider_default",
+        memory_source="provider_default",
+    )
+
+
+def test_equal_effective_resources_share_identity_regardless_of_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.31.0")
+    monkeypatch.setattr(policy, "harbor_version", lambda: "0.20.0")
+    environment_id = hashlib.sha256(b"environment").hexdigest()[:32]
+    base_name = f"task__{environment_id[:SNAPSHOT_HASH_LEN]}"
+    explicit = policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024)
+    defaults = policy.resolve_e2b_template_resources(cpu_count=None, memory_mb=None)
+
+    explicit_name = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=explicit,
+    )
+    default_name = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="dockerfile",
+        build_source_reference=environment_id,
+        resources=defaults,
+    )
+
+    assert explicit_name == default_name
+
+
+@pytest.mark.parametrize(
+    ("cpu_count", "memory_mb"),
+    [(True, 1024), (2, False), (1.5, 1024), (2, 1024.0)],
+)
+def test_resource_resolution_rejects_non_integer_values(
+    cpu_count: object,
+    memory_mb: object,
+) -> None:
+    with pytest.raises(ValueError, match="integers"):
+        policy.resolve_e2b_template_resources(
+            cpu_count=cast("int | None", cpu_count),
+            memory_mb=cast("int | None", memory_mb),
+        )
+
+
+def test_docker_image_reference_changes_identity_even_with_same_environment_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(policy, "e2b_sdk_version", lambda: "2.8.1")
+    environment_id = hashlib.sha256(b"environment").hexdigest()[:32]
+    base_name = f"task__{environment_id[:SNAPSHOT_HASH_LEN]}"
+    resources = policy.resolve_e2b_template_resources(cpu_count=2, memory_mb=1024)
+
+    first = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="docker_image",
+        build_source_reference="ubuntu:22.04",
+        resources=resources,
+    )
+    second = policy.qualify_harbor_e2b_template_name(
+        base_name,
+        environment_id=environment_id,
+        build_source_kind="docker_image",
+        build_source_reference="ubuntu:24.04",
+        resources=resources,
+    )
+
+    assert first != second

--- a/wmh/evals/harbor/e2b_template_readiness.py
+++ b/wmh/evals/harbor/e2b_template_readiness.py
@@ -1,0 +1,721 @@
+"""Crash-safe preparation and verification of Harbor E2B task templates."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from harbor.environments.factory import EnvironmentFactory
+from harbor.models.job.config import JobConfig
+from harbor.models.task.config import EnvironmentConfig as TaskEnvironmentConfig
+from harbor.models.task.paths import TaskPaths
+from harbor.models.task.verifier_mode import resolve_effective_verifier_env_config
+from harbor.models.trial.config import EnvironmentConfig as TrialEnvironmentConfig
+from harbor.models.trial.paths import TrialPaths
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from wmh.core.types import JsonObject
+from wmh.evals.harbor.e2b_environment import (
+    PreparedE2BTemplate,
+    WmhE2BEnvironment,
+    register_prepared_e2b_templates,
+)
+from wmh.evals.harbor.e2b_template_control import (
+    E2BTemplateControlIdentity,
+    E2BTemplateNotFound,
+    inspect_e2b_template,
+)
+from wmh.evals.harbor.e2b_template_policy import (
+    E2B_TEMPLATE_BUILD_CONCURRENCY,
+    e2b_template_readiness_policy_payload,
+)
+from wmh.evals.harbor.tasks import ResolvedHarborTaskSet
+
+_SCHEMA_VERSION = 1
+_DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
+
+
+class E2BTemplateReadinessEntry(BaseModel):
+    """Opaque durable evidence for one resource-qualified provider template."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    key: str = Field(pattern=_DIGEST_PATTERN)
+    resource_digest: str = Field(pattern=_DIGEST_PATTERN)
+    template_id: str = Field(min_length=1)
+    build_id: str = Field(min_length=1)
+    cpu_count: int = Field(strict=True, ge=1)
+    memory_mb: int = Field(strict=True, ge=128)
+
+
+class E2BTemplateResourceCount(BaseModel):
+    """Aggregate resource histogram without task or template names."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    cpu_count: int = Field(strict=True, ge=1)
+    memory_mb: int = Field(strict=True, ge=128)
+    count: int = Field(strict=True, ge=1)
+
+
+class E2BTemplateReadinessReceipt(BaseModel):
+    """Atomic partial or complete readiness evidence for one exact plan."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    schema_version: Literal[1] = _SCHEMA_VERSION
+    plan_digest: str = Field(pattern=_DIGEST_PATTERN)
+    expected_set_digest: str = Field(pattern=_DIGEST_PATTERN)
+    mapping_digest: str | None = Field(default=None, pattern=_DIGEST_PATTERN)
+    complete: bool
+    context_count: int = Field(strict=True, ge=1)
+    agent_context_count: int = Field(strict=True, ge=1)
+    separate_verifier_context_count: int = Field(strict=True, ge=0)
+    unique_template_count: int = Field(strict=True, ge=1)
+    ready_before_count: int = Field(strict=True, ge=0)
+    built_count: int = Field(strict=True, ge=0)
+    build_concurrency: int = Field(strict=True, ge=1)
+    context_resource_histogram: tuple[E2BTemplateResourceCount, ...]
+    template_resource_histogram: tuple[E2BTemplateResourceCount, ...]
+    policy: dict[str, int | str | bool]
+    entries: tuple[E2BTemplateReadinessEntry, ...]
+
+    @field_validator("complete", mode="before")
+    @classmethod
+    def _require_boolean_complete(cls, value: object) -> object:
+        if not isinstance(value, bool):
+            raise ValueError("readiness complete must be boolean")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_counts(self) -> E2BTemplateReadinessReceipt:
+        if len({entry.key for entry in self.entries}) != len(self.entries):
+            raise ValueError("readiness receipt contains duplicate entry keys")
+        if self.agent_context_count + self.separate_verifier_context_count != self.context_count:
+            raise ValueError("readiness receipt context counts differ")
+        if len(self.entries) > self.unique_template_count:
+            raise ValueError("readiness receipt has too many entries")
+        if self.ready_before_count + self.built_count != len(self.entries):
+            raise ValueError("readiness receipt counts differ from completed entries")
+        if self.complete and len(self.entries) != self.unique_template_count:
+            raise ValueError("complete readiness receipt requires every entry")
+        if self.complete != (self.mapping_digest is not None):
+            raise ValueError("complete readiness receipt requires exactly one mapping digest")
+        return self
+
+    @property
+    def receipt_digest(self) -> str:
+        """Return the canonical digest used by run evidence and checkpoint inputs."""
+        return _digest_json(self.model_dump(mode="json"))
+
+
+@dataclass(frozen=True)
+class _TemplateSpec:
+    environment: WmhE2BEnvironment
+    key: str
+    resource_digest: str
+    build_timeout_sec: float
+
+
+@dataclass(frozen=True)
+class _PreparedResult:
+    spec: _TemplateSpec
+    entry: E2BTemplateReadinessEntry
+    built: bool
+
+
+class E2BTemplateReadinessPlan:
+    """One exact opaque set of task and verifier templates required by a score."""
+
+    def __init__(
+        self,
+        *,
+        specs: tuple[_TemplateSpec, ...],
+        context_resource_histogram: tuple[E2BTemplateResourceCount, ...],
+        agent_context_count: int,
+        separate_verifier_context_count: int,
+        task_set: ResolvedHarborTaskSet,
+    ) -> None:
+        context_count = sum(item.count for item in context_resource_histogram)
+        if (
+            not specs
+            or context_count < len(specs)
+            or agent_context_count < 1
+            or separate_verifier_context_count < 0
+            or agent_context_count + separate_verifier_context_count != context_count
+        ):
+            raise ValueError("E2B readiness plan must contain runtime contexts")
+        self._specs = specs
+        self.context_count = context_count
+        self.agent_context_count = agent_context_count
+        self.separate_verifier_context_count = separate_verifier_context_count
+        self.unique_template_count = len(specs)
+        self._context_resource_histogram = context_resource_histogram
+        self._template_resource_histogram = _resource_histogram(
+            tuple(spec.environment for spec in specs)
+        )
+        self._task_set = task_set
+        self._expected_by_key = {spec.key: spec for spec in specs}
+        if len(self._expected_by_key) != len(specs):
+            raise ValueError("E2B readiness plan contains duplicate qualified keys")
+        self._identity_payload = self._build_identity_payload()
+        self.plan_digest = _digest_json(self._identity_payload)
+        self.expected_set_digest = _digest_json(self._template_identity_payload())
+        self._receipt: E2BTemplateReadinessReceipt | None = None
+        self._receipt_path: Path | None = None
+        self._verified = False
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        job_config: JobConfig,
+        task_set: ResolvedHarborTaskSet,
+    ) -> E2BTemplateReadinessPlan:
+        """Derive exact task and separate-verifier build contexts without provider calls."""
+        if job_config.environment.force_build:
+            raise ValueError("prepared Harbor E2B scoring does not allow force_build")
+        reserved = {"require_prebuilt", "preparation_digest"} & set(job_config.environment.kwargs)
+        if reserved:
+            raise ValueError(
+                f"prepared Harbor E2B scoring owns reserved environment kwargs: {sorted(reserved)}"
+            )
+        task_set.verify()
+        runtime_config = job_config.environment.model_copy(deep=True)
+        timeout_multiplier = (
+            job_config.environment_build_timeout_multiplier
+            if job_config.environment_build_timeout_multiplier is not None
+            else job_config.timeout_multiplier
+        )
+        contexts: list[tuple[WmhE2BEnvironment, float]] = []
+        task_inputs = task_set.task_inputs()
+        separate_verifier_context_count = 0
+        for definition, task_dir in task_inputs:
+            paths = TaskPaths(task_dir)
+            build_timeout_sec = definition.environment.build_timeout_sec * timeout_multiplier
+            contexts.append(
+                (
+                    _create_environment(
+                        runtime_config=runtime_config,
+                        job_config=job_config,
+                        environment_dir=paths.environment_dir,
+                        task_environment=definition.environment,
+                    ),
+                    build_timeout_sec,
+                )
+            )
+            steps = definition.steps or [None]
+            for step in steps:
+                verifier_environment = resolve_effective_verifier_env_config(definition, step)
+                if verifier_environment is None:
+                    continue
+                separate_verifier_context_count += 1
+                verifier_dir = paths.tests_dir
+                if step is not None and paths.step_tests_dir(step.name).exists():
+                    verifier_dir = paths.step_tests_dir(step.name)
+                verifier_runtime_config = runtime_config.model_copy(
+                    update={"extra_docker_compose": []},
+                    deep=True,
+                )
+                contexts.append(
+                    (
+                        _create_environment(
+                            runtime_config=verifier_runtime_config,
+                            job_config=job_config,
+                            environment_dir=verifier_dir,
+                            task_environment=verifier_environment,
+                        ),
+                        build_timeout_sec,
+                    )
+                )
+
+        by_name: dict[str, _TemplateSpec] = {}
+        for environment, timeout_sec in contexts:
+            key = _digest_text(environment.template_name)
+            spec = _TemplateSpec(
+                environment=environment,
+                key=key,
+                resource_digest=f"sha256:{environment.template_resource_digest}",
+                build_timeout_sec=timeout_sec,
+            )
+            existing = by_name.get(environment.template_name)
+            if existing is not None:
+                if (
+                    existing.key != spec.key
+                    or existing.resource_digest != spec.resource_digest
+                    or existing.environment.template_resources.cpu_count
+                    != spec.environment.template_resources.cpu_count
+                    or existing.environment.template_resources.memory_mb
+                    != spec.environment.template_resources.memory_mb
+                ):
+                    raise ValueError("qualified E2B template identity collision")
+                if spec.build_timeout_sec > existing.build_timeout_sec:
+                    by_name[environment.template_name] = spec
+                continue
+            by_name[environment.template_name] = spec
+        specs = tuple(sorted(by_name.values(), key=lambda spec: spec.key))
+        context_histogram = _resource_histogram(
+            tuple(environment for environment, _timeout_sec in contexts)
+        )
+        return cls(
+            specs=specs,
+            context_resource_histogram=context_histogram,
+            agent_context_count=len(task_inputs),
+            separate_verifier_context_count=separate_verifier_context_count,
+            task_set=task_set,
+        )
+
+    def identity_payload(self) -> JsonObject:
+        """Return the task-opaque semantic plan bound into scorer identity."""
+        return json.loads(json.dumps(self._identity_payload))
+
+    def aggregate_payload(self) -> JsonObject:
+        """Return outcome-blind aggregate preflight evidence without template identities."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "policy": e2b_template_readiness_policy_payload(),
+            "context_count": self.context_count,
+            "agent_context_count": self.agent_context_count,
+            "separate_verifier_context_count": self.separate_verifier_context_count,
+            "unique_template_count": self.unique_template_count,
+            "context_resource_histogram": [
+                item.model_dump(mode="json") for item in self._context_resource_histogram
+            ],
+            "template_resource_histogram": [
+                item.model_dump(mode="json") for item in self._template_resource_histogram
+            ],
+        }
+
+    @property
+    def mapping_digest(self) -> str:
+        """Return the complete actual provider mapping digest after receipt load."""
+        if self._receipt is None or self._receipt.mapping_digest is None:
+            raise RuntimeError("E2B readiness mapping is not complete")
+        return self._receipt.mapping_digest
+
+    @property
+    def receipt_digest(self) -> str:
+        """Return the complete durable receipt digest after receipt load."""
+        if self._receipt is None or not self._receipt.complete:
+            raise RuntimeError("E2B readiness receipt is not complete")
+        return self._receipt.receipt_digest
+
+    def receipt_bytes(self) -> bytes:
+        """Return the exact verified complete receipt bytes for checkpoint ownership."""
+        if self._receipt is None or not self._receipt.complete or self._receipt_path is None:
+            raise RuntimeError("E2B readiness receipt is not complete")
+        raw = _read_regular_text(self._receipt_path)
+        try:
+            on_disk = E2BTemplateReadinessReceipt.model_validate_json(raw)
+        except ValueError as error:
+            raise RuntimeError("E2B readiness receipt is invalid") from error
+        self._validate_receipt(on_disk)
+        if on_disk != self._receipt:
+            raise RuntimeError("E2B readiness receipt changed on disk")
+        return raw.encode("utf-8")
+
+    @property
+    def receipt_file_hash(self) -> str:
+        """Return the SHA-256 hash of the exact checkpoint preparation bytes."""
+        return _digest_bytes(self.receipt_bytes())
+
+    @property
+    def verified(self) -> bool:
+        """Whether the current provider mapping was inspected in this process."""
+        return self._verified
+
+    def load_complete_receipt(self, receipt_path: Path) -> E2BTemplateReadinessReceipt:
+        """Load a complete local receipt without making provider calls."""
+        self._task_set.verify()
+        receipt = self._load_receipt(receipt_path)
+        if not receipt.complete:
+            raise RuntimeError("checkpoint resume requires a complete E2B readiness receipt")
+        self._receipt = receipt
+        self._receipt_path = receipt_path
+        self._verified = False
+        return receipt
+
+    def rebind_complete_receipt(self, receipt_path: Path) -> None:
+        """Adopt an identical checkpoint-owned copy without provider access."""
+        if self._receipt is None or not self._receipt.complete:
+            raise RuntimeError("E2B readiness receipt is not complete")
+        receipt = self._load_receipt(receipt_path)
+        if not receipt.complete or receipt != self._receipt:
+            raise RuntimeError("checkpoint scorer preparation differs from readiness receipt")
+        self._receipt_path = receipt_path
+        self._verified = False
+
+    async def prepare(self, receipt_path: Path) -> E2BTemplateReadinessReceipt:
+        """Prepare a new mapping, leaving failures as audit-only partial evidence."""
+        self._task_set.verify()
+        with _exclusive_preparation(receipt_path):
+            if os.path.lexists(receipt_path):
+                raise RuntimeError(
+                    "E2B readiness receipt already exists; use a fresh run path after "
+                    "preparation failure"
+                )
+            receipt = self._new_receipt(entries=(), ready_before_count=0, built_count=0)
+            self._write_receipt(receipt_path, receipt)
+            entries: dict[str, E2BTemplateReadinessEntry] = {}
+            ready_before_count = 0
+            built_count = 0
+            update_lock = asyncio.Lock()
+            semaphore = asyncio.Semaphore(E2B_TEMPLATE_BUILD_CONCURRENCY)
+
+            async def prepare_one(spec: _TemplateSpec) -> _PreparedResult:
+                nonlocal ready_before_count, built_count
+                async with semaphore:
+                    result = await self._prepare_one(spec)
+                async with update_lock:
+                    if result.spec.key in entries:
+                        raise RuntimeError("duplicate E2B readiness result")
+                    entries[result.spec.key] = result.entry
+                    ready_before_count += int(not result.built)
+                    built_count += int(result.built)
+                    partial = self._new_receipt(
+                        entries=tuple(entries.values()),
+                        ready_before_count=ready_before_count,
+                        built_count=built_count,
+                    )
+                    self._write_receipt(receipt_path, partial)
+                return result
+
+            results = await asyncio.gather(
+                *(prepare_one(spec) for spec in self._specs),
+                return_exceptions=True,
+            )
+            failures = [result for result in results if isinstance(result, BaseException)]
+            if failures:
+                raise failures[0]
+            self._task_set.verify()
+            final = self._new_receipt(
+                entries=tuple(entries.values()),
+                ready_before_count=ready_before_count,
+                built_count=built_count,
+                complete=True,
+            )
+            self._write_receipt(receipt_path, final)
+            self._receipt = final
+            self._receipt_path = receipt_path
+            await self.verify()
+            return final
+
+    async def verify(self) -> E2BTemplateReadinessReceipt:
+        """Re-inspect and register the exact complete mapping, rejecting any drift."""
+        self._task_set.verify()
+        if self._receipt is None or not self._receipt.complete or self._receipt_path is None:
+            raise RuntimeError("E2B readiness must be complete before verification")
+        on_disk = self._load_receipt(self._receipt_path)
+        if on_disk != self._receipt:
+            raise RuntimeError("E2B readiness receipt changed on disk")
+        expected_entries = {entry.key: entry for entry in self._receipt.entries}
+        semaphore = asyncio.Semaphore(E2B_TEMPLATE_BUILD_CONCURRENCY)
+
+        async def verify_one(spec: _TemplateSpec) -> tuple[str, E2BTemplateControlIdentity]:
+            async with semaphore:
+                observed = await _inspect(spec)
+            expected = expected_entries[spec.key]
+            if _entry(spec, observed) != expected:
+                raise RuntimeError("prepared E2B template mapping changed")
+            return spec.environment.template_name, observed
+
+        observed = await asyncio.gather(*(verify_one(spec) for spec in self._specs))
+        self._task_set.verify()
+        register_prepared_e2b_templates(
+            self.mapping_digest,
+            {
+                name: PreparedE2BTemplate(
+                    template_id=identity.template_id,
+                    build_id=identity.build_id,
+                    cpu_count=identity.cpu_count,
+                    memory_mb=identity.memory_mb,
+                )
+                for name, identity in observed
+            },
+        )
+        self._verified = True
+        return self._receipt
+
+    async def _prepare_one(
+        self,
+        spec: _TemplateSpec,
+    ) -> _PreparedResult:
+        try:
+            observed = await _inspect(spec)
+        except E2BTemplateNotFound:
+            built = await asyncio.wait_for(
+                spec.environment._create_template(),
+                timeout=spec.build_timeout_sec,
+            )
+            observed = await _inspect(spec)
+            if (
+                built.template_id != observed.template_id
+                or built.build_id != observed.build_id
+                or built.name != spec.environment.template_name
+                or built.alias != spec.environment.template_name
+            ):
+                raise RuntimeError("fresh build identity differs from E2B control plane") from None
+            return _PreparedResult(spec=spec, entry=_entry(spec, observed), built=True)
+        entry = _entry(spec, observed)
+        return _PreparedResult(spec=spec, entry=entry, built=False)
+
+    def _build_identity_payload(self) -> JsonObject:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "policy": e2b_template_readiness_policy_payload(),
+            "context_count": self.context_count,
+            "agent_context_count": self.agent_context_count,
+            "separate_verifier_context_count": self.separate_verifier_context_count,
+            "unique_template_count": self.unique_template_count,
+            "context_resource_histogram": [
+                item.model_dump(mode="json") for item in self._context_resource_histogram
+            ],
+            "template_resource_histogram": [
+                item.model_dump(mode="json") for item in self._template_resource_histogram
+            ],
+            "templates": self._template_identity_payload(),
+        }
+
+    def _template_identity_payload(self) -> list[dict[str, str | int | float]]:
+        return [
+            {
+                "key": spec.key,
+                "resource_digest": spec.resource_digest,
+                "cpu_count": spec.environment.template_resources.cpu_count,
+                "memory_mb": spec.environment.template_resources.memory_mb,
+                "build_timeout_sec": spec.build_timeout_sec,
+            }
+            for spec in self._specs
+        ]
+
+    def _new_receipt(
+        self,
+        *,
+        entries: tuple[E2BTemplateReadinessEntry, ...],
+        ready_before_count: int,
+        built_count: int,
+        complete: bool = False,
+    ) -> E2BTemplateReadinessReceipt:
+        ordered = tuple(sorted(entries, key=lambda entry: entry.key))
+        mapping_digest = _digest_json([entry.model_dump(mode="json") for entry in ordered])
+        return E2BTemplateReadinessReceipt(
+            plan_digest=self.plan_digest,
+            expected_set_digest=self.expected_set_digest,
+            mapping_digest=mapping_digest if complete else None,
+            complete=complete,
+            context_count=self.context_count,
+            agent_context_count=self.agent_context_count,
+            separate_verifier_context_count=self.separate_verifier_context_count,
+            unique_template_count=self.unique_template_count,
+            ready_before_count=ready_before_count,
+            built_count=built_count,
+            build_concurrency=E2B_TEMPLATE_BUILD_CONCURRENCY,
+            context_resource_histogram=self._context_resource_histogram,
+            template_resource_histogram=self._template_resource_histogram,
+            policy=e2b_template_readiness_policy_payload(),
+            entries=ordered,
+        )
+
+    def _load_receipt(self, path: Path) -> E2BTemplateReadinessReceipt:
+        try:
+            receipt = E2BTemplateReadinessReceipt.model_validate_json(_read_regular_text(path))
+        except (OSError, ValueError) as error:
+            raise RuntimeError("E2B readiness receipt is invalid") from error
+        self._validate_receipt(receipt)
+        return receipt
+
+    def _validate_receipt(self, receipt: E2BTemplateReadinessReceipt) -> None:
+        if (
+            receipt.plan_digest != self.plan_digest
+            or receipt.expected_set_digest != self.expected_set_digest
+            or receipt.context_count != self.context_count
+            or receipt.agent_context_count != self.agent_context_count
+            or receipt.separate_verifier_context_count != self.separate_verifier_context_count
+            or receipt.unique_template_count != self.unique_template_count
+            or receipt.policy != e2b_template_readiness_policy_payload()
+            or receipt.build_concurrency != E2B_TEMPLATE_BUILD_CONCURRENCY
+            or receipt.context_resource_histogram != self._context_resource_histogram
+            or receipt.template_resource_histogram != self._template_resource_histogram
+        ):
+            raise RuntimeError("E2B readiness receipt differs from the current plan")
+        for entry in receipt.entries:
+            spec = self._expected_by_key.get(entry.key)
+            if spec is None or not _entry_matches_spec(entry, spec):
+                raise RuntimeError("E2B readiness receipt contains an unexpected template")
+        if receipt.complete:
+            expected_keys = set(self._expected_by_key)
+            if {entry.key for entry in receipt.entries} != expected_keys:
+                raise RuntimeError("complete E2B readiness receipt has the wrong entry set")
+            expected_mapping_digest = _digest_json(
+                [entry.model_dump(mode="json") for entry in receipt.entries]
+            )
+            if receipt.mapping_digest != expected_mapping_digest:
+                raise RuntimeError("E2B readiness receipt mapping digest differs")
+
+    @staticmethod
+    def _write_receipt(path: Path, receipt: E2BTemplateReadinessReceipt) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _require_regular_if_present(path)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                json.dump(receipt.model_dump(mode="json"), stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, path)
+            _fsync_directory(path.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def _create_environment(
+    *,
+    runtime_config: TrialEnvironmentConfig,
+    job_config: JobConfig,
+    environment_dir: Path,
+    task_environment: TaskEnvironmentConfig,
+) -> WmhE2BEnvironment:
+    environment = EnvironmentFactory.create_environment_from_config(
+        config=runtime_config,
+        environment_dir=environment_dir,
+        environment_name="wmh-prepare",
+        session_id="wmh-prepare",
+        trial_paths=TrialPaths(job_config.jobs_dir / ".wmh-e2b-readiness"),
+        task_env_config=task_environment,
+    )
+    if not isinstance(environment, WmhE2BEnvironment):
+        raise TypeError("Harbor E2B readiness requires WmhE2BEnvironment")
+    return environment
+
+
+async def _inspect(spec: _TemplateSpec) -> E2BTemplateControlIdentity:
+    resources = spec.environment.template_resources
+    return await inspect_e2b_template(
+        spec.environment.template_name,
+        expected_cpu_count=resources.cpu_count,
+        expected_memory_mb=resources.memory_mb,
+    )
+
+
+def _entry(
+    spec: _TemplateSpec,
+    identity: E2BTemplateControlIdentity,
+) -> E2BTemplateReadinessEntry:
+    return E2BTemplateReadinessEntry(
+        key=spec.key,
+        resource_digest=spec.resource_digest,
+        template_id=identity.template_id,
+        build_id=identity.build_id,
+        cpu_count=identity.cpu_count,
+        memory_mb=identity.memory_mb,
+    )
+
+
+def _entry_matches_spec(entry: E2BTemplateReadinessEntry, spec: _TemplateSpec) -> bool:
+    resources = spec.environment.template_resources
+    return (
+        entry.resource_digest == spec.resource_digest
+        and entry.cpu_count == resources.cpu_count
+        and entry.memory_mb == resources.memory_mb
+    )
+
+
+def _resource_histogram(
+    environments: tuple[WmhE2BEnvironment, ...],
+) -> tuple[E2BTemplateResourceCount, ...]:
+    histogram = Counter(
+        (
+            environment.template_resources.cpu_count,
+            environment.template_resources.memory_mb,
+        )
+        for environment in environments
+    )
+    return tuple(
+        E2BTemplateResourceCount(
+            cpu_count=cpu_count,
+            memory_mb=memory_mb,
+            count=count,
+        )
+        for (cpu_count, memory_mb), count in sorted(histogram.items())
+    )
+
+
+def _digest_text(value: str) -> str:
+    return _digest_bytes(value.encode())
+
+
+def _digest_json(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return _digest_bytes(encoded)
+
+
+def _digest_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+@contextmanager
+def _exclusive_preparation(receipt_path: Path) -> Iterator[None]:
+    lock_path = receipt_path.with_name(f"{receipt_path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as error:
+        raise RuntimeError("E2B readiness preparation is already active") from error
+    os.close(descriptor)
+    try:
+        yield
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+def _require_regular_if_present(path: Path) -> None:
+    if not os.path.lexists(path):
+        return
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise RuntimeError("E2B readiness receipt cannot be inspected") from error
+    if not stat.S_ISREG(mode):
+        raise RuntimeError("E2B readiness receipt must be a regular file")
+
+
+def _read_regular_text(path: Path) -> str:
+    _require_regular_if_present(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise RuntimeError("E2B readiness receipt cannot be read") from error
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RuntimeError("E2B readiness receipt must be a regular file")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as stream:
+            descriptor = -1
+            return stream.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/wmh/evals/harbor/e2b_template_readiness_test.py
+++ b/wmh/evals/harbor/e2b_template_readiness_test.py
@@ -1,0 +1,665 @@
+"""Offline tests for crash-safe Harbor E2B template readiness."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from e2b.template.types import BuildInfo
+from harbor.models.job.config import DatasetConfig, JobConfig
+from harbor.models.trial.config import AgentConfig, EnvironmentConfig, TaskConfig
+from harbor.tasks.client import TaskDownloadResult
+
+import wmh.evals.harbor.e2b_template_readiness as readiness
+from wmh.evals.harbor.e2b_environment import WmhE2BEnvironment
+from wmh.evals.harbor.e2b_template_control import (
+    E2BTemplateControlIdentity,
+    E2BTemplateNotFound,
+)
+from wmh.evals.harbor.e2b_template_policy import WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH
+from wmh.evals.harbor.tasks import (
+    ResolvedHarborTaskSet,
+    _task_identity,
+)
+
+
+def _task(root: Path, name: str, *, dockerfile: str, task_toml: str = 'version = "1.0"\n') -> Path:
+    task_dir = root / name
+    (task_dir / "environment").mkdir(parents=True, exist_ok=True)
+    (task_dir / "tests").mkdir(exist_ok=True)
+    (task_dir / "environment" / "Dockerfile").write_text(dockerfile, encoding="utf-8")
+    (task_dir / "tests" / "test.sh").write_text("exit 0\n", encoding="utf-8")
+    (task_dir / "instruction.md").write_text("Do the task.\n", encoding="utf-8")
+    (task_dir / "task.toml").write_text(task_toml, encoding="utf-8")
+    return task_dir
+
+
+def _task_set(root: Path, task_dirs: list[Path]) -> ResolvedHarborTaskSet:
+    records = []
+    for task_dir in task_dirs:
+        config = TaskConfig(path=task_dir)
+        download = TaskDownloadResult(path=task_dir, download_time_sec=0, cached=True)
+        records.append((config, download, _task_identity(config, download)))
+    dataset = DatasetConfig(path=root)
+    return ResolvedHarborTaskSet.from_tasks(
+        requested_dataset=dataset,
+        resolved_dataset=dataset,
+        tasks=records,
+    )
+
+
+def _job(tmp_path: Path, **environment_updates: object) -> JobConfig:
+    environment = EnvironmentConfig(import_path=WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH).model_copy(
+        update=environment_updates,
+        deep=True,
+    )
+    return JobConfig(
+        jobs_dir=tmp_path / "jobs",
+        agents=[AgentConfig()],
+        datasets=[DatasetConfig(path=tmp_path / "tasks")],
+        environment=environment,
+    )
+
+
+def test_plan_deduplicates_resource_complete_templates_without_public_task_metadata(
+    tmp_path: Path,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dirs = [
+        _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n"),
+        _task(tasks_root, "private-b", dockerfile="FROM alpine:3.20\n"),
+    ]
+
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, task_dirs),
+    )
+    payload = json.dumps(plan.identity_payload(), sort_keys=True)
+
+    assert plan.context_count == 2
+    assert plan.agent_context_count == 2
+    assert plan.separate_verifier_context_count == 0
+    assert plan.unique_template_count == 1
+    assert "private-a" not in payload
+    assert "private-b" not in payload
+    assert str(tasks_root) not in payload
+    assert "wmh-hb-v1-" not in payload
+
+
+def test_plan_includes_separate_verifier_build_context(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(
+        tasks_root,
+        "private-a",
+        dockerfile="FROM alpine:3.20\n",
+        task_toml=(
+            'version = "1.0"\n'
+            "[verifier]\n"
+            'environment_mode = "separate"\n'
+            "[verifier.environment]\n"
+            'docker_image = "alpine:3.20"\n'
+            "cpus = 1\n"
+            "memory_mb = 512\n"
+        ),
+    )
+
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+
+    assert plan.context_count == 2
+    assert plan.agent_context_count == 1
+    assert plan.separate_verifier_context_count == 1
+    assert plan.unique_template_count == 2
+
+
+def test_plan_deduplicates_equal_numeric_resources_from_different_sources(
+    tmp_path: Path,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dirs = [
+        _task(tasks_root, "implicit", dockerfile="FROM alpine:3.20\n"),
+        _task(
+            tasks_root,
+            "explicit",
+            dockerfile="FROM alpine:3.20\n",
+            task_toml=('version = "1.0"\n[environment]\ncpus = 2\nmemory_mb = 1024\n'),
+        ),
+    ]
+
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, task_dirs),
+    )
+    payload = plan.identity_payload()
+
+    assert plan.context_count == 2
+    assert plan.unique_template_count == 1
+    assert payload["context_resource_histogram"] == [
+        {"cpu_count": 2, "memory_mb": 1024, "count": 2}
+    ]
+    assert payload["template_resource_histogram"] == [
+        {"cpu_count": 2, "memory_mb": 1024, "count": 1}
+    ]
+
+
+def test_plan_mirrors_step_verifier_contexts_and_fallback(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(
+        tasks_root,
+        "private-a",
+        dockerfile="FROM alpine:3.20\n",
+        task_toml=(
+            'version = "1.0"\n'
+            "[environment]\n"
+            "cpus = 2\n"
+            "memory_mb = 1024\n"
+            "[[steps]]\n"
+            'name = "alpha"\n'
+            "[steps.verifier]\n"
+            'environment_mode = "separate"\n'
+            "[steps.verifier.environment]\n"
+            "cpus = 1\n"
+            "memory_mb = 512\n"
+            "[[steps]]\n"
+            'name = "beta"\n'
+            "[steps.verifier]\n"
+            'environment_mode = "separate"\n'
+        ),
+    )
+    for step_name in ("alpha", "beta"):
+        step_dir = task_dir / "steps" / step_name
+        step_dir.mkdir(parents=True)
+        (step_dir / "instruction.md").write_text("Do this step.\n", encoding="utf-8")
+    alpha_tests = task_dir / "steps" / "alpha" / "tests"
+    alpha_tests.mkdir()
+    (alpha_tests / "Dockerfile").write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    (task_dir / "tests" / "Dockerfile").write_text(
+        "FROM debian:12\n",
+        encoding="utf-8",
+    )
+
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+
+    assert plan.context_count == 3
+    assert plan.agent_context_count == 1
+    assert plan.separate_verifier_context_count == 2
+    assert plan.unique_template_count == 3
+    assert plan.identity_payload()["context_resource_histogram"] == [
+        {"cpu_count": 1, "memory_mb": 512, "count": 1},
+        {"cpu_count": 2, "memory_mb": 1024, "count": 2},
+    ]
+    aggregate = plan.aggregate_payload()
+    assert "templates" not in aggregate
+    assert aggregate["separate_verifier_context_count"] == 2
+
+
+def test_plan_rejects_storage_that_e2b_cannot_enforce(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(
+        tasks_root,
+        "private-a",
+        dockerfile="FROM alpine:3.20\n",
+        task_toml='version = "1.0"\n[environment]\nstorage_mb = 4096\n',
+    )
+
+    with pytest.raises(ValueError, match="does not enforce requested storage"):
+        readiness.E2BTemplateReadinessPlan.create(
+            job_config=_job(tmp_path),
+            task_set=_task_set(tasks_root, [task_dir]),
+        )
+
+
+@pytest.mark.parametrize(
+    ("environment_updates", "message"),
+    [
+        ({"force_build": True}, "does not allow force_build"),
+        ({"kwargs": {"require_prebuilt": True}}, "reserved environment kwargs"),
+        ({"kwargs": {"preparation_digest": "sha256:" + "0" * 64}}, "reserved"),
+        ({"override_storage_mb": 4096}, "does not enforce requested storage"),
+    ],
+)
+def test_plan_rejects_unsafe_runtime_configuration_before_provider_access(
+    tmp_path: Path,
+    environment_updates: dict[str, object],
+    message: str,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+
+    with pytest.raises(ValueError, match=message):
+        readiness.E2BTemplateReadinessPlan.create(
+            job_config=_job(tmp_path, **environment_updates),
+            task_set=_task_set(tasks_root, [task_dir]),
+        )
+
+
+def _install_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_build_number: int | None = None,
+) -> tuple[dict[str, E2BTemplateControlIdentity], list[str]]:
+    provider: dict[str, E2BTemplateControlIdentity] = {}
+    builds: list[str] = []
+
+    async def exists(environment: WmhE2BEnvironment) -> bool:
+        return environment.template_name in provider
+
+    async def build(environment: WmhE2BEnvironment) -> BuildInfo:
+        builds.append(environment.template_name)
+        if fail_build_number is not None and len(builds) == fail_build_number:
+            raise RuntimeError("build failed")
+        index = len(provider) + 1
+        identity = E2BTemplateControlIdentity(
+            template_id=f"template-{index}",
+            build_id=f"build-{index}",
+            cpu_count=environment.template_resources.cpu_count,
+            memory_mb=environment.template_resources.memory_mb,
+        )
+        provider[environment.template_name] = identity
+        return BuildInfo(
+            template_id=identity.template_id,
+            build_id=identity.build_id,
+            name=environment.template_name,
+            alias=environment.template_name,
+        )
+
+    async def inspect(
+        template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        try:
+            identity = provider[template_name]
+        except KeyError as error:
+            raise E2BTemplateNotFound(template_name) from error
+        if identity.cpu_count != expected_cpu_count or identity.memory_mb != expected_memory_mb:
+            raise RuntimeError("resource mismatch")
+        return identity
+
+    monkeypatch.setattr(WmhE2BEnvironment, "_does_template_exist", exists)
+    monkeypatch.setattr(WmhE2BEnvironment, "_create_template", build)
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    return provider, builds
+
+
+def _two_template_plan(tmp_path: Path) -> readiness.E2BTemplateReadinessPlan:
+    tasks_root = tmp_path / "tasks"
+    task_dirs = [
+        _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n"),
+        _task(tasks_root, "private-b", dockerfile="FROM ubuntu:24.04\n"),
+    ]
+    return readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, task_dirs),
+    )
+
+
+def test_prepare_builds_missing_templates_and_writes_opaque_complete_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+
+    receipt = asyncio.run(plan.prepare(receipt_path))
+    raw = receipt_path.read_text(encoding="utf-8")
+
+    assert receipt.complete
+    assert receipt.unique_template_count == 2
+    assert receipt.built_count == 2
+    assert len(builds) == 2
+    assert len(provider) == 2
+    assert "wmh-hb-v1-" not in raw
+    assert "private-a" not in raw
+    assert str(tmp_path) not in raw
+
+
+def test_prepare_reuses_existing_qualified_templates_without_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _provider, builds = _install_provider(monkeypatch)
+    first = _two_template_plan(tmp_path)
+    asyncio.run(first.prepare(tmp_path / "first" / "e2b-readiness.json"))
+    build_count = len(builds)
+
+    second = _two_template_plan(tmp_path)
+    receipt = asyncio.run(second.prepare(tmp_path / "second" / "e2b-readiness.json"))
+
+    assert len(builds) == build_count
+    assert receipt.ready_before_count == 2
+    assert receipt.built_count == 0
+
+
+def test_prepare_persists_partial_success_but_requires_a_fresh_run_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, builds = _install_provider(monkeypatch, fail_build_number=2)
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        asyncio.run(plan.prepare(receipt_path))
+    partial = json.loads(receipt_path.read_text(encoding="utf-8"))
+
+    assert partial["complete"] is False
+    assert len(partial["entries"]) == 1
+    assert len(provider) == 1
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        asyncio.run(plan.prepare(receipt_path))
+
+    previous_build_count = len(builds)
+    fresh = _two_template_plan(tmp_path)
+    receipt = asyncio.run(fresh.prepare(tmp_path / "fresh" / "e2b-readiness.json"))
+    assert receipt.complete
+    assert len(builds) - previous_build_count == 1
+
+
+def test_existing_partial_receipt_rejects_before_provider_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _provider, _builds = _install_provider(monkeypatch, fail_build_number=1)
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    with pytest.raises(RuntimeError, match="build failed"):
+        asyncio.run(plan.prepare(receipt_path))
+
+    async def unexpected_inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise AssertionError("provider must not be called")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", unexpected_inspect)
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        asyncio.run(plan.prepare(receipt_path))
+
+
+def test_exclusive_preparation_lock_rejects_before_provider_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.with_name(f"{receipt_path.name}.lock").write_text("active\n")
+
+    async def unexpected_inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise AssertionError("provider must not be called")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", unexpected_inspect)
+
+    with pytest.raises(RuntimeError, match="already active"):
+        asyncio.run(plan.prepare(receipt_path))
+
+
+def test_generic_inspection_failure_never_triggers_a_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _provider, builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+
+    async def fail_inspection(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", fail_inspection)
+
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        asyncio.run(plan.prepare(tmp_path / "receipt.json"))
+
+    assert builds == []
+
+
+def test_verify_rejects_post_prepare_build_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, _builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+    asyncio.run(plan.prepare(tmp_path / "receipt.json"))
+    first_name = next(iter(provider))
+    current = provider[first_name]
+    provider[first_name] = E2BTemplateControlIdentity(
+        template_id=current.template_id,
+        build_id="changed-build",
+        cpu_count=current.cpu_count,
+        memory_mb=current.memory_mb,
+    )
+
+    with pytest.raises(RuntimeError, match="mapping changed"):
+        asyncio.run(plan.verify())
+
+
+@pytest.mark.parametrize("tamper", ["plan", "histogram", "mapping"])
+def test_complete_receipt_tamper_rejects_before_provider_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tamper: str,
+) -> None:
+    _provider, _builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+    asyncio.run(plan.prepare(receipt_path))
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if tamper == "plan":
+        payload["plan_digest"] = "sha256:" + "0" * 64
+    elif tamper == "histogram":
+        payload["context_resource_histogram"][0]["count"] += 1
+    else:
+        payload["mapping_digest"] = "sha256:" + "0" * 64
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    async def unexpected_inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise AssertionError("provider must not be called")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", unexpected_inspect)
+    restored = _two_template_plan(tmp_path)
+
+    with pytest.raises(RuntimeError, match="differs"):
+        restored.load_complete_receipt(receipt_path)
+
+
+def test_complete_receipt_restores_stable_mapping_then_verifies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _provider, _builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+    receipt_path = tmp_path / "receipt.json"
+    receipt = asyncio.run(plan.prepare(receipt_path))
+    mapping_digest = plan.mapping_digest
+    receipt_digest = plan.receipt_digest
+
+    restored = _two_template_plan(tmp_path)
+    loaded = restored.load_complete_receipt(receipt_path)
+
+    assert loaded == receipt
+    assert restored.mapping_digest == mapping_digest
+    assert restored.receipt_digest == receipt_digest
+    assert restored.receipt_file_hash == (
+        "sha256:" + hashlib.sha256(receipt_path.read_bytes()).hexdigest()
+    )
+    assert restored.receipt_bytes() == receipt_path.read_bytes()
+    assert not restored.verified
+    asyncio.run(restored.verify())
+    assert restored.verified
+
+    checkpoint_copy = tmp_path / "checkpoint" / "scorer-preparation.bin"
+    checkpoint_copy.parent.mkdir()
+    checkpoint_copy.write_bytes(receipt_path.read_bytes())
+    restored.rebind_complete_receipt(checkpoint_copy)
+    assert not restored.verified
+    assert restored.receipt_bytes() == checkpoint_copy.read_bytes()
+
+
+def test_prepare_rejects_fresh_build_identity_disagreement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, _builds = _install_provider(monkeypatch)
+    plan = _two_template_plan(tmp_path)
+
+    original_build = WmhE2BEnvironment._create_template
+
+    async def mismatched_build(environment: WmhE2BEnvironment) -> BuildInfo:
+        built = await original_build(environment)
+        return BuildInfo(
+            template_id="different-template",
+            build_id=built.build_id,
+            name=built.name,
+            alias=built.alias,
+        )
+
+    monkeypatch.setattr(WmhE2BEnvironment, "_create_template", mismatched_build)
+
+    with pytest.raises(RuntimeError, match="fresh build identity"):
+        asyncio.run(plan.prepare(tmp_path / "receipt.json"))
+
+    assert provider
+
+
+def test_prepare_never_exceeds_fixed_build_concurrency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dirs = [
+        _task(
+            tasks_root,
+            f"private-{index}",
+            dockerfile=f"FROM alpine:3.20\nRUN echo {index}\n",
+        )
+        for index in range(12)
+    ]
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, task_dirs),
+    )
+    provider: dict[str, E2BTemplateControlIdentity] = {}
+    active = 0
+    maximum_active = 0
+
+    async def inspect(
+        template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        try:
+            return provider[template_name]
+        except KeyError as error:
+            raise E2BTemplateNotFound(template_name) from error
+
+    async def build(environment: WmhE2BEnvironment) -> BuildInfo:
+        nonlocal active, maximum_active
+        active += 1
+        maximum_active = max(maximum_active, active)
+        try:
+            await asyncio.sleep(0.01)
+            identity = E2BTemplateControlIdentity(
+                template_id=f"template-{len(provider) + 1}",
+                build_id=f"build-{len(provider) + 1}",
+                cpu_count=environment.template_resources.cpu_count,
+                memory_mb=environment.template_resources.memory_mb,
+            )
+            provider[environment.template_name] = identity
+            return BuildInfo(
+                template_id=identity.template_id,
+                build_id=identity.build_id,
+                name=environment.template_name,
+                alias=environment.template_name,
+            )
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    monkeypatch.setattr(WmhE2BEnvironment, "_create_template", build)
+
+    receipt = asyncio.run(plan.prepare(tmp_path / "run" / "e2b-readiness.json"))
+
+    assert receipt.unique_template_count == 12
+    assert maximum_active == 10
+
+
+def test_task_bytes_are_checked_before_and_after_provider_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    task_set = _task_set(tasks_root, [task_dir])
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=task_set,
+    )
+
+    async def unexpected_inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise AssertionError("provider must not be called")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", unexpected_inspect)
+    (task_dir / "instruction.md").write_text("changed before preparation\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="changed on disk"):
+        asyncio.run(plan.prepare(tmp_path / "before" / "receipt.json"))
+
+    task_dir = _task(tasks_root, "private-b", dockerfile="FROM ubuntu:24.04\n")
+    task_set = _task_set(tasks_root, [task_dir])
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=task_set,
+    )
+    provider, _builds = _install_provider(monkeypatch)
+    original_build = WmhE2BEnvironment._create_template
+
+    async def mutate_after_build(environment: WmhE2BEnvironment) -> BuildInfo:
+        built = await original_build(environment)
+        (task_dir / "instruction.md").write_text("changed during preparation\n")
+        return built
+
+    monkeypatch.setattr(WmhE2BEnvironment, "_create_template", mutate_after_build)
+
+    with pytest.raises(ValueError, match="changed on disk"):
+        asyncio.run(plan.prepare(tmp_path / "after" / "receipt.json"))
+    assert provider

--- a/wmh/evals/harbor/e2b_template_readiness_test.py
+++ b/wmh/evals/harbor/e2b_template_readiness_test.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 from e2b.template.types import BuildInfo
@@ -201,7 +202,7 @@ def test_plan_mirrors_step_verifier_contexts_and_fallback(tmp_path: Path) -> Non
     assert aggregate["separate_verifier_context_count"] == 2
 
 
-def test_plan_rejects_storage_that_e2b_cannot_enforce(tmp_path: Path) -> None:
+def test_plan_accepts_task_storage_as_unenforced_provider_default(tmp_path: Path) -> None:
     tasks_root = tmp_path / "tasks"
     task_dir = _task(
         tasks_root,
@@ -210,11 +211,19 @@ def test_plan_rejects_storage_that_e2b_cannot_enforce(tmp_path: Path) -> None:
         task_toml='version = "1.0"\n[environment]\nstorage_mb = 4096\n',
     )
 
-    with pytest.raises(ValueError, match="does not enforce requested storage"):
-        readiness.E2BTemplateReadinessPlan.create(
-            job_config=_job(tmp_path),
-            task_set=_task_set(tasks_root, [task_dir]),
-        )
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+
+    payload = plan.identity_payload()
+    policy_payload = cast("dict[str, int | str | bool]", payload["policy"])
+    assert policy_payload["task_storage_policy"] == "provider_default_unenforced"
+    assert policy_payload["override_storage_policy"] == "reject"
+    assert "storage" not in json.dumps(payload["templates"], sort_keys=True)
+    assert payload["context_resource_histogram"] == [
+        {"cpu_count": 2, "memory_mb": 1024, "count": 1}
+    ]
 
 
 @pytest.mark.parametrize(
@@ -223,7 +232,7 @@ def test_plan_rejects_storage_that_e2b_cannot_enforce(tmp_path: Path) -> None:
         ({"force_build": True}, "does not allow force_build"),
         ({"kwargs": {"require_prebuilt": True}}, "reserved environment kwargs"),
         ({"kwargs": {"preparation_digest": "sha256:" + "0" * 64}}, "reserved"),
-        ({"override_storage_mb": 4096}, "does not enforce requested storage"),
+        ({"override_storage_mb": 4096}, "does not enforce storage overrides"),
     ],
 )
 def test_plan_rejects_unsafe_runtime_configuration_before_provider_access(

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -8,11 +8,11 @@ import json
 import math
 import re
 from collections import Counter, defaultdict
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol, Self, TypeVar
+from typing import TYPE_CHECKING, Literal, Protocol, Self, TypeVar, cast
 from uuid import UUID, uuid4
 
 import harbor
@@ -26,6 +26,7 @@ from harbor.models.trial.config import TrialConfig
 from harbor.models.trial.result import TrialResult
 from pydantic import BaseModel
 
+from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import (
     MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
     WMH_HARBOR_AGENT_IMPORT_PATH,
@@ -33,6 +34,7 @@ from wmh.evals.harbor.agent import (
     WmhHarborAgent,
 )
 from wmh.evals.harbor.canonical import normalize_harbor_json
+from wmh.evals.harbor.e2b_template_policy import WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH
 from wmh.evals.harbor.tasks import (
     HarborTaskIdentity,
     ResolvedHarborTaskSet,
@@ -59,13 +61,18 @@ from wmh.harness.scoring import (
 )
 from wmh.providers.base import ProviderConfig
 
+if TYPE_CHECKING:
+    from wmh.evals.harbor.e2b_template_readiness import E2BTemplateReadinessPlan
+
 _INDEX_PATH = "raw/index.json"
 _REQUIRED_JOB_FILES = frozenset({"config.json", "lock.json", "result.json", "job.log"})
 _REQUIRED_TRIAL_FILES = frozenset({"config.json", "lock.json", "result.json", "trial.log"})
-_HARBOR_SCORER_VERSION = "4"
-WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH = "wmh.evals.harbor.e2b_environment:WmhE2BEnvironment"
+HarborRewardMode = Literal["raw", "positive_binary"]
+
+_HARBOR_SCORER_VERSION = "6"
 _CHECKSUM_PATTERN = r"^[0-9a-f]{64}$"
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
+_AsyncT = TypeVar("_AsyncT")
 
 
 @dataclass(frozen=True)
@@ -97,6 +104,20 @@ class HarborJobRunner:
             return asyncio.run(run_job())
         with ThreadPoolExecutor(max_workers=1) as executor:
             return executor.submit(lambda: asyncio.run(run_job())).result()
+
+
+def _run_async_blocking(factory: Callable[[], Awaitable[_AsyncT]]) -> _AsyncT:
+    """Run one async validation from synchronous scoring, including event-loop callers."""
+
+    async def await_result() -> _AsyncT:
+        return await factory()
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(await_result())
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(await_result())).result()
 
 
 def _validate_episode_timeout_sec(value: object) -> float:
@@ -141,6 +162,7 @@ class HarborScorer:
         task_set: ResolvedHarborTaskSet,
         provider_config: ProviderConfig,
         reward_key: str,
+        reward_mode: HarborRewardMode = "raw",
         environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         harness_backend: Literal["local", "e2b"] = "local",
@@ -185,6 +207,7 @@ class HarborScorer:
             )
         if not reward_key:
             raise ValueError("reward_key must be nonempty")
+        reward_mode = normalize_harbor_reward_mode(reward_mode)
         if (
             isinstance(environment_command_timeout_sec, bool)
             or not isinstance(environment_command_timeout_sec, int)
@@ -223,10 +246,22 @@ class HarborScorer:
             provider_config.model_dump(mode="python")
         )
         self._reward_key = reward_key
+        self._reward_mode = reward_mode
         self._environment_command_timeout_sec = environment_command_timeout_sec
         self._episode_timeout_sec = episode_timeout_sec
         self._harness_backend = harness_backend
         self._task_environment_uses_paced_e2b = task_environment_uses_paced_e2b
+        self._e2b_readiness: E2BTemplateReadinessPlan | None = None
+        self._preparation_loaded = False
+        if task_environment_uses_paced_e2b:
+            from wmh.evals.harbor.e2b_template_readiness import (
+                E2BTemplateReadinessPlan,
+            )
+
+            self._e2b_readiness = E2BTemplateReadinessPlan.create(
+                job_config=self._job_config,
+                task_set=self._task_set,
+            )
         if harness_backend == "local":
             self._local_runner_identity = {
                 "transport": "ssh",
@@ -250,6 +285,7 @@ class HarborScorer:
         task_ids: tuple[str, ...],
         provider_config: ProviderConfig,
         reward_key: str,
+        reward_mode: HarborRewardMode = "raw",
         environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
         harness_backend: Literal["local", "e2b"] = "local",
@@ -268,6 +304,7 @@ class HarborScorer:
             task_set=task_set,
             provider_config=provider_config,
             reward_key=reward_key,
+            reward_mode=reward_mode,
             environment_command_timeout_sec=environment_command_timeout_sec,
             episode_timeout_sec=episode_timeout_sec,
             harness_backend=harness_backend,
@@ -278,6 +315,80 @@ class HarborScorer:
     def context(self) -> ScoreContext:
         """Build the frozen context expected from exact resolved Harbor task identities."""
         return self._context(self._task_set.identities)
+
+    def evaluator_policy(self) -> JsonObject:
+        """Return the explicit evaluator policy persisted beside opaque score digests."""
+        return {
+            "evaluator": "harbor",
+            "harbor_version": harbor.__version__,
+            "adapter": {
+                "agent_version": WMH_HARBOR_AGENT_VERSION,
+                "scorer_version": _HARBOR_SCORER_VERSION,
+            },
+            "reward_key": self._reward_key,
+            "reward_interpretation": _reward_interpretation_payload(self._reward_mode),
+            "verifier": self._job_config.verifier.model_dump(mode="json"),
+        }
+
+    @property
+    def preparation_required(self) -> bool:
+        """Whether scoring requires a durable task-environment preparation artifact."""
+        return self._e2b_readiness is not None
+
+    async def prepare(self, artifact_path: Path) -> None:
+        """Prepare a new scorer artifact before checkpoint or scoring evidence exists."""
+        if self._e2b_readiness is None:
+            raise RuntimeError("this scorer does not require preparation")
+        if self._preparation_loaded:
+            raise RuntimeError("scorer preparation is already loaded")
+        await self._e2b_readiness.prepare(artifact_path)
+        self._preparation_loaded = True
+
+    def load_preparation(self, artifact_path: Path) -> None:
+        """Load complete local preparation evidence without provider access."""
+        if self._e2b_readiness is None:
+            raise RuntimeError("this scorer does not require preparation")
+        if self._preparation_loaded:
+            raise RuntimeError("scorer preparation is already loaded")
+        self._e2b_readiness.load_complete_receipt(artifact_path)
+        self._preparation_loaded = True
+
+    def bind_preparation(self, artifact_path: Path) -> None:
+        """Bind a prepared scorer to an identical checkpoint-owned artifact copy."""
+        if self._e2b_readiness is None or not self._preparation_loaded:
+            raise RuntimeError("scorer preparation is not loaded")
+        self._e2b_readiness.rebind_complete_receipt(artifact_path)
+
+    async def verify_preparation(self) -> None:
+        """Inspect the current provider mapping without permitting any builds."""
+        if self._e2b_readiness is None:
+            return
+        if not self._preparation_loaded:
+            raise RuntimeError("scorer preparation is not loaded")
+        await self._e2b_readiness.verify()
+
+    def preparation_artifact_bytes(self) -> bytes | None:
+        """Return exact complete preparation bytes for generic checkpoint ownership."""
+        if self._e2b_readiness is None:
+            return None
+        if not self._preparation_loaded:
+            raise RuntimeError("scorer preparation is not loaded")
+        return self._e2b_readiness.receipt_bytes()
+
+    def preparation_summary(self) -> JsonObject | None:
+        """Return task-opaque aggregate preparation evidence without provider access."""
+        if self._e2b_readiness is None:
+            return None
+        return self._e2b_readiness.aggregate_payload()
+
+    @property
+    def preparation_artifact_hash(self) -> str | None:
+        """Return the exact preparation artifact hash included in checkpoint identity."""
+        if self._e2b_readiness is None:
+            return None
+        if not self._preparation_loaded:
+            raise RuntimeError("scorer preparation is not loaded")
+        return self._e2b_readiness.receipt_file_hash
 
     def request(self, *, attempts: int) -> ScoreRequest:
         """Build the only exact score request accepted by this resolved scorer."""
@@ -305,15 +416,7 @@ class HarborScorer:
                 for task_id, identity in sorted(identities.items())
             ],
         }
-        evaluator_payload = {
-            "harbor_version": harbor.__version__,
-            "adapter": {
-                "agent_version": WMH_HARBOR_AGENT_VERSION,
-                "scorer_version": _HARBOR_SCORER_VERSION,
-            },
-            "reward_key": self._reward_key,
-            "verifier": self._job_config.verifier.model_dump(mode="python"),
-        }
+        evaluator_payload = self.evaluator_policy()
         execution_payload = {
             "job": self._job_config.model_dump(
                 mode="python",
@@ -340,12 +443,23 @@ class HarborScorer:
             "environment_command_timeout_sec": self._environment_command_timeout_sec,
             "episode_timeout_sec": self._episode_timeout_sec,
             "e2b_create_rate": self._e2b_create_rate_identity(),
+            "task_environment_preparation": self._preparation_identity(),
         }
         return ScoreContext(
             task_set_digest=_digest_json(task_payload),
             evaluator_digest=_digest_json(evaluator_payload),
             execution_config_digest=_digest_json(execution_payload),
         )
+
+    def _preparation_identity(self) -> JsonObject | None:
+        if self._e2b_readiness is None:
+            return None
+        if not self._preparation_loaded:
+            raise RuntimeError("scorer preparation is not loaded")
+        return {
+            "plan": self._e2b_readiness.identity_payload(),
+            "mapping_digest": self._e2b_readiness.mapping_digest,
+        }
 
     def _e2b_create_rate_identity(self) -> dict[str, object] | None:
         consumers = []
@@ -365,59 +479,67 @@ class HarborScorer:
         if request != self.request(attempts=request.attempts):
             raise ValueError("score request differs from the scorer's resolved task set")
         self._task_set.verify()
-        config = self._candidate_job(candidate, request=request)
-        run = self._runner.run(config)
-        grouped = self._validate_run(
-            run,
-            candidate=candidate,
-            request=request,
-            expected_config=config,
-        )
-        manifests, reader, source_paths, observed_identities = _collect_artifacts(
-            run,
-            expected_config=config,
-            grouped=grouped,
-        )
-        if self._context(observed_identities) != request.context:
-            raise ValueError("Harbor resolved task or execution context differs from the request")
-        trial_names = {trial.trial_name for trials in grouped.values() for trial in trials}
-        shared_paths = {
-            artifact_path
-            for source_path, artifact_path in source_paths.items()
-            if source_path.split("/", 1)[0] not in trial_names
-        }
-        cells: list[ScoreCell] = []
-        for task_id in request.task_ids:
-            for attempt, trial in enumerate(grouped[task_id], 1):
-                score = _official_reward(trial, reward_key=self._reward_key)
-                trial_prefix = f"{trial.trial_name}/"
-                cell_paths = {
-                    _INDEX_PATH,
-                    *shared_paths,
-                    *(
-                        artifact_path
-                        for source_path, artifact_path in source_paths.items()
-                        if source_path.startswith(trial_prefix)
-                    ),
-                }
-                cells.append(
-                    ScoreCell(
-                        task_id=task_id,
-                        attempt=attempt,
-                        score=score,
-                        passed=score == 1.0,
-                        summary=_trial_summary(trial),
-                        artifact_paths=tuple(sorted(cell_paths)),
-                    )
+        _run_async_blocking(self.verify_preparation)
+        try:
+            config = self._candidate_job(candidate, request=request)
+            run = self._runner.run(config)
+            grouped = self._validate_run(
+                run,
+                candidate=candidate,
+                request=request,
+                expected_config=config,
+            )
+            manifests, reader, source_paths, observed_identities = _collect_artifacts(
+                run,
+                expected_config=config,
+                grouped=grouped,
+            )
+            if self._context(observed_identities) != request.context:
+                raise ValueError(
+                    "Harbor resolved task or execution context differs from the request"
                 )
-        report = HarnessScoreReport(
-            source_run_id=str(run.result.id),
-            candidate_doc_hash=candidate.doc_hash,
-            request=request,
-            cells=tuple(cells),
-            artifacts=tuple(manifests),
-        )
-        return HarnessScore(report=report, artifacts=reader)
+            trial_names = {trial.trial_name for trials in grouped.values() for trial in trials}
+            shared_paths = {
+                artifact_path
+                for source_path, artifact_path in source_paths.items()
+                if source_path.split("/", 1)[0] not in trial_names
+            }
+            cells: list[ScoreCell] = []
+            for task_id in request.task_ids:
+                for attempt, trial in enumerate(grouped[task_id], 1):
+                    raw_reward = _official_reward(trial, reward_key=self._reward_key)
+                    score, passed = _interpret_reward(raw_reward, self._reward_mode)
+                    trial_prefix = f"{trial.trial_name}/"
+                    cell_paths = {
+                        _INDEX_PATH,
+                        *shared_paths,
+                        *(
+                            artifact_path
+                            for source_path, artifact_path in source_paths.items()
+                            if source_path.startswith(trial_prefix)
+                        ),
+                    }
+                    cells.append(
+                        ScoreCell(
+                            task_id=task_id,
+                            attempt=attempt,
+                            score=score,
+                            passed=passed,
+                            summary=_trial_summary(trial),
+                            artifact_paths=tuple(sorted(cell_paths)),
+                        )
+                    )
+            report = HarnessScoreReport(
+                source_run_id=str(run.result.id),
+                candidate_doc_hash=candidate.doc_hash,
+                request=request,
+                cells=tuple(cells),
+                artifacts=tuple(manifests),
+            )
+            return HarnessScore(report=report, artifacts=reader)
+        finally:
+            self._task_set.verify()
+            _run_async_blocking(self.verify_preparation)
 
     def _candidate_job(self, candidate: HarnessDoc, *, request: ScoreRequest) -> JobConfig:
         template = self._job_config.agents[0]
@@ -444,6 +566,20 @@ class HarborScorer:
             },
             deep=True,
         )
+        environment = self._job_config.environment
+        if self._e2b_readiness is not None:
+            if not self._preparation_loaded or not self._e2b_readiness.verified:
+                raise RuntimeError("scorer preparation was not verified before Harbor execution")
+            environment = environment.model_copy(
+                update={
+                    "kwargs": {
+                        **environment.kwargs,
+                        "require_prebuilt": True,
+                        "preparation_digest": self._e2b_readiness.mapping_digest,
+                    }
+                },
+                deep=True,
+            )
         return JobConfig.model_validate(
             self._job_config.model_copy(
                 update={
@@ -454,6 +590,7 @@ class HarborScorer:
                     "datasets": [],
                     "tasks": direct_tasks,
                     "agents": [agent],
+                    "environment": environment,
                 },
                 deep=True,
             ).model_dump(mode="python")
@@ -785,6 +922,27 @@ def _validate_trial_lock(lock: TrialLock, trial: TrialResult) -> None:
 def _validate_dataset_origin(requested: DatasetConfig, resolved: DatasetConfig) -> None:
     if requested.model_dump(mode="json") != resolved.model_dump(mode="json"):
         raise ValueError("resolved Harbor task set came from a different dataset selector")
+
+
+def normalize_harbor_reward_mode(value: str) -> HarborRewardMode:
+    """Normalize the CLI spelling into the scorer's canonical reward mode."""
+    normalized = value.replace("-", "_")
+    if normalized not in {"raw", "positive_binary"}:
+        raise ValueError("reward mode must be raw or positive-binary")
+    return cast("HarborRewardMode", normalized)
+
+
+def _reward_interpretation_payload(mode: HarborRewardMode) -> JsonObject:
+    if mode == "raw":
+        return {"mode": "raw", "threshold": 1.0, "comparator": "eq"}
+    return {"mode": "positive_binary", "threshold": 0.0, "comparator": "gt"}
+
+
+def _interpret_reward(value: float, mode: HarborRewardMode) -> tuple[float, bool]:
+    if mode == "raw":
+        return value, value == 1.0
+    passed = value > 0.0
+    return float(passed), passed
 
 
 def _official_reward(trial: TrialResult, *, reward_key: str) -> float:

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from collections.abc import Callable
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, cast
@@ -35,6 +37,7 @@ from harbor.models.trial.result import (
 from harbor.models.verifier.result import VerifierResult
 from harbor.tasks.client import TaskDownloadResult
 
+import wmh.evals.harbor.e2b_template_readiness as readiness_module
 import wmh.evals.harbor.scorer as scorer_module
 from wmh.evals.harbor.agent import (
     MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
@@ -53,11 +56,18 @@ from wmh.evals.harbor.scorer import (
 from wmh.evals.harbor.tasks import ResolvedHarborTaskSet, resolve_harbor_task_set
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.pi_e2b import DEFAULT_EVAL_EPISODE_TIMEOUT_S
-from wmh.harness.scoring import ScoreRequest, score_harness
+from wmh.harness.population import HarnessPopulationOptimizer
+from wmh.harness.project_proposer import CandidateProposal, EvaluatedCandidate
+from wmh.harness.runtime import TokenUsage
+from wmh.harness.scoring import HarnessScore, ScoreRequest, score_harness
+from wmh.harness.source_tree import HarnessSourceTree
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 _JOB_ID = UUID("00000000-0000-4000-8000-000000000001")
 _OPAQUE_SUFFIXES = ("a7Hm2Ks", "m4Vx8Pa", "z9Tc3Wb")
+_PREPARATION_BYTES = b'{"complete":true}\n'
+_PREPARATION_HASH = "sha256:" + hashlib.sha256(_PREPARATION_BYTES).hexdigest()
+_MAPPING_DIGEST = "sha256:" + "d" * 64
 
 
 def _sha256(value: str) -> str:
@@ -117,6 +127,56 @@ class _Runner:
         )
         (destination / "lock.json").write_text(job_lock.model_dump_json(), encoding="utf-8")
         return self.run_result
+
+
+class _FakeReadinessPlan:
+    def __init__(self) -> None:
+        self.mapping_digest = _MAPPING_DIGEST
+        self.receipt_file_hash = _PREPARATION_HASH
+        self.verified = False
+        self.verify_calls = 0
+        self.fail_verify_call: int | None = None
+
+    @classmethod
+    def create(cls, **_kwargs: object) -> _FakeReadinessPlan:
+        return cls()
+
+    async def prepare(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(_PREPARATION_BYTES)
+        self.verified = True
+
+    def load_complete_receipt(self, path: Path) -> None:
+        if path.read_bytes() != _PREPARATION_BYTES:
+            raise RuntimeError("invalid preparation")
+        self.verified = False
+
+    async def verify(self) -> None:
+        self.verify_calls += 1
+        if self.fail_verify_call == self.verify_calls:
+            raise RuntimeError("prepared mapping changed")
+        self.verified = True
+
+    def receipt_bytes(self) -> bytes:
+        return _PREPARATION_BYTES
+
+    def identity_payload(self) -> dict[str, object]:
+        return {"schema_version": 1, "policy": {"resource_qualified_alias": True}}
+
+
+def _install_fake_readiness(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        readiness_module,
+        "E2BTemplateReadinessPlan",
+        _FakeReadinessPlan,
+    )
+
+
+def _prepare_fake_scorer(scorer: HarborScorer, path: Path) -> _FakeReadinessPlan:
+    asyncio.run(scorer.prepare(path))
+    plan = scorer._e2b_readiness
+    assert isinstance(plan, _FakeReadinessPlan)
+    return plan
 
 
 def _provider(model: str = "worker-model") -> ProviderConfig:
@@ -351,6 +411,8 @@ def _scorer(
     job_config: JobConfig | None = None,
     provider: ProviderConfig | None = None,
     reward_key: str = "reward",
+    reward_mode: Literal["raw", "positive_binary"] = "raw",
+    task_ids: tuple[str, ...] = ("task-a", "task-b"),
     harness_backend: Literal["local", "e2b"] = "local",
     e2b_template: str | None = None,
     environment_command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
@@ -360,13 +422,14 @@ def _scorer(
     dataset_path = job_config.datasets[0].path
     assert dataset_path is not None
     _ensure_task_dataset(dataset_path)
-    task_set = asyncio.run(resolve_harbor_task_set(job_config.datasets[0], ("task-a", "task-b")))
+    task_set = asyncio.run(resolve_harbor_task_set(job_config.datasets[0], task_ids))
     runner = _Runner(run, task_set)
     scorer = HarborScorer(
         job_config=job_config,
         task_set=task_set,
         provider_config=provider or _provider(),
         reward_key=reward_key,
+        reward_mode=reward_mode,
         environment_command_timeout_sec=environment_command_timeout_sec,
         episode_timeout_sec=episode_timeout_sec,
         harness_backend=harness_backend,
@@ -380,9 +443,36 @@ def _request(scorer: HarborScorer, *, attempts: int = 2) -> ScoreRequest:
     return scorer.request(attempts=attempts)
 
 
+def test_local_scorer_module_import_does_not_require_e2b_sdk() -> None:
+    script = """
+import importlib.abc
+import sys
+
+class BlockE2B(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "e2b" or fullname.startswith("e2b."):
+            raise ImportError("e2b import blocked")
+        return None
+
+sys.meta_path.insert(0, BlockE2B())
+import wmh.evals.harbor.scorer
+"""
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and inline import smoke
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[3],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _install_fake_readiness(monkeypatch)
     job_dir = tmp_path / "completed-job"
     job_config = _job_config(tmp_path, backend=EnvironmentType.E2B)
     candidate = HarnessDoc.baseline("candidate")
@@ -398,6 +488,7 @@ def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
         job_config=job_config,
         harness_backend="local",
     )
+    plan = _prepare_fake_scorer(scorer, tmp_path / "preparation.json")
 
     scored = score_harness(scorer, candidate, request=_request(scorer))
 
@@ -413,6 +504,8 @@ def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
     assert config.n_attempts == 2
     assert config.environment.type is None
     assert config.environment.import_path == WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH
+    assert config.environment.kwargs["require_prebuilt"] is True
+    assert config.environment.kwargs["preparation_digest"] == _MAPPING_DIGEST
     assert config.datasets == []
     assert [task.get_task_id().get_name() for task in config.tasks] == [
         "task-a",
@@ -424,6 +517,205 @@ def test_scorer_projects_shuffled_opaque_replicates_and_injects_candidate(
     assert config.agents[0].kwargs["harness_backend"] == "local"
     assert config.agents[0].kwargs["command_timeout_sec"] == MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC
     assert "secret" not in json.dumps(config.agents[0].kwargs).lower()
+    assert plan.verify_calls == 2
+
+
+def test_positive_binary_reward_mode_uses_strict_positive_success_and_preserves_raw(
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / "completed-job"
+    trials = [
+        _trial(job_dir, "task-a", 1, score=0.0),
+        _trial(job_dir, "task-b", 1, score=0.25),
+        _trial(job_dir, "task-c", 1, score=1.0),
+    ]
+    scorer, runner = _scorer(
+        tmp_path,
+        _run(tmp_path, trials),
+        reward_mode="positive_binary",
+        task_ids=("task-a", "task-b", "task-c"),
+    )
+
+    scored = score_harness(
+        scorer,
+        HarnessDoc.baseline(),
+        request=scorer.request(attempts=1),
+    )
+
+    assert [cell.score for cell in scored.report.cells] == [0.0, 1.0, 1.0]
+    assert [cell.passed for cell in scored.report.cells] == [False, True, True]
+    assert scored.report.score == pytest.approx(2 / 3)
+    assert scored.report.pass_rate == pytest.approx(2 / 3)
+    index = json.loads(scored.artifacts.read_bytes("raw/index.json"))
+    indexed_sources = {entry["source_path"]: entry["artifact_path"] for entry in index["files"]}
+    fractional_trial = next(trial for trial in trials if trial.task_id.get_name() == "task-b")
+    reward_artifact = indexed_sources[f"{fractional_trial.trial_name}/verifier/reward.json"]
+    raw_reward = json.loads(scored.artifacts.read_bytes(reward_artifact))
+    assert raw_reward["rewards"]["reward"] == 0.25
+    assert runner.configs
+
+
+def test_reward_mode_changes_identity_and_actual_optimizer_winner(
+    tmp_path: Path,
+) -> None:
+    config = _job_config(tmp_path)
+    dataset = config.datasets[0]
+    assert dataset.path is not None
+    _ensure_task_dataset(dataset.path)
+    task_set = asyncio.run(resolve_harbor_task_set(dataset, ("task-a", "task-b")))
+    raw = HarborScorer(
+        job_config=config,
+        task_set=task_set,
+        provider_config=_provider(),
+        reward_key="reward",
+        reward_mode="raw",
+    )
+    positive = HarborScorer(
+        job_config=config,
+        task_set=task_set,
+        provider_config=_provider(),
+        reward_key="reward",
+        reward_mode="positive_binary",
+    )
+
+    assert raw.context().task_set_digest == positive.context().task_set_digest
+    assert raw.context().execution_config_digest == positive.context().execution_config_digest
+    assert raw.context().evaluator_digest != positive.context().evaluator_digest
+    evaluation_root = tmp_path / "evaluation"
+
+    def evaluate(
+        candidate_id: str,
+        rewards: tuple[float, float],
+        reward_mode: Literal["raw", "positive_binary"],
+    ) -> tuple[HarnessSourceTree, HarnessScore]:
+        source = HarnessSourceTree.from_doc(HarnessDoc.baseline(candidate_id))
+        candidate = source.to_doc(candidate_id)
+        job_config = _job_config(evaluation_root)
+        job_dir = evaluation_root / "completed-job"
+        trials = [
+            _trial(
+                job_dir,
+                task_id,
+                1,
+                score=reward,
+                candidate=candidate,
+                job_config=job_config,
+            )
+            for task_id, reward in zip(("task-a", "task-b"), rewards, strict=True)
+        ]
+        scorer, _ = _scorer(
+            evaluation_root,
+            _run(evaluation_root, trials),
+            job_config=job_config,
+            reward_mode=reward_mode,
+        )
+        return source, score_harness(
+            scorer,
+            candidate,
+            request=scorer.request(attempts=1),
+        )
+
+    _, raw_a = evaluate("candidate-0000", (1.0, 0.0), "raw")
+    _, raw_b = evaluate("candidate-0001", (0.4, 0.4), "raw")
+    source_a, positive_a = evaluate(
+        "candidate-0000",
+        (1.0, 0.0),
+        "positive_binary",
+    )
+    source_b, positive_b = evaluate(
+        "candidate-0001",
+        (0.4, 0.4),
+        "positive_binary",
+    )
+    assert raw_a.report.score > raw_b.report.score
+    assert positive_b.report.score > positive_a.report.score
+    assert positive_a.report.request == positive_b.report.request
+
+    proposal = CandidateProposal(
+        candidate_id="candidate-0001",
+        source=source_b,
+        candidate=source_b.to_doc("candidate-0001"),
+        events=(),
+        worker_usage=TokenUsage(input_tokens=0, output_tokens=0, calls=0),
+    )
+
+    class FixedProposer:
+        def propose(
+            self,
+            history: Sequence[EvaluatedCandidate],
+            *,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> CandidateProposal:
+            del should_cancel
+            assert [item.candidate_id for item in history] == ["candidate-0000"]
+            return proposal
+
+    class FixedScorer:
+        def score(self, candidate: HarnessDoc, *, request: ScoreRequest) -> HarnessScore:
+            assert request == positive_a.report.request
+            if candidate.name == "candidate-0000":
+                return positive_a
+            assert candidate.name == "candidate-0001"
+            return positive_b
+
+    result = HarnessPopulationOptimizer(FixedProposer(), FixedScorer()).optimize(
+        seed=source_a,
+        request=positive_a.report.request,
+        iterations=1,
+    )
+
+    assert result.best.candidate_id == "candidate-0001"
+    assert result.best_score == 1.0
+
+
+def test_scorer_preparation_verification_fails_before_runner_spend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_readiness(monkeypatch)
+    job_config = _job_config(tmp_path, backend=EnvironmentType.E2B)
+    scorer, runner = _scorer(
+        tmp_path,
+        _run(tmp_path, []),
+        job_config=job_config,
+    )
+    plan = _prepare_fake_scorer(scorer, tmp_path / "preparation.json")
+    plan.fail_verify_call = 1
+
+    with pytest.raises(RuntimeError, match="mapping changed"):
+        score_harness(
+            scorer,
+            HarnessDoc.baseline(),
+            request=scorer.request(attempts=1),
+        )
+
+    assert runner.configs == []
+
+
+def test_scorer_post_verification_discards_completed_harbor_score(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_readiness(monkeypatch)
+    job_config = _job_config(tmp_path, backend=EnvironmentType.E2B)
+    candidate = HarnessDoc.baseline()
+    job_dir = tmp_path / "completed-job"
+    trials = [
+        _trial(job_dir, task_id, 1, score=1, candidate=candidate, job_config=job_config)
+        for task_id in ("task-a", "task-b")
+    ]
+    scorer, runner = _scorer(
+        tmp_path,
+        _run(tmp_path, trials),
+        job_config=job_config,
+    )
+    plan = _prepare_fake_scorer(scorer, tmp_path / "preparation.json")
+    plan.fail_verify_call = 2
+
+    with pytest.raises(RuntimeError, match="mapping changed"):
+        score_harness(scorer, candidate, request=scorer.request(attempts=1))
+
+    assert len(runner.configs) == 1
 
 
 def test_scorer_rewrites_builtin_e2b_environment_without_losing_options(
@@ -431,7 +723,6 @@ def test_scorer_rewrites_builtin_e2b_environment_without_losing_options(
 ) -> None:
     environment = EnvironmentConfig(
         type=EnvironmentType.E2B,
-        force_build=True,
         override_cpus=2,
         override_memory_mb=2048,
         env={"VISIBLE": "value"},
@@ -448,6 +739,20 @@ def test_scorer_rewrites_builtin_e2b_environment_without_losing_options(
     assert rewritten.model_dump(exclude={"type", "import_path"}) == environment.model_dump(
         exclude={"type", "import_path"}
     )
+
+
+def test_scorer_rejects_task_e2b_force_build_before_preparation(tmp_path: Path) -> None:
+    config = _job_config(tmp_path, backend=EnvironmentType.E2B).model_copy(
+        update={
+            "environment": EnvironmentConfig(
+                type=EnvironmentType.E2B,
+                force_build=True,
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="does not allow force_build"):
+        _scorer(tmp_path, _run(tmp_path, []), job_config=config)
 
 
 def test_scorer_rejects_ambiguous_builtin_and_custom_e2b_environment(
@@ -470,6 +775,7 @@ def test_e2b_create_policy_is_bound_only_when_an_e2b_path_is_active(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _install_fake_readiness(monkeypatch)
     local, _ = _scorer(tmp_path / "local", _run(tmp_path / "local", []))
     task_e2b, _ = _scorer(
         tmp_path / "task-e2b",
@@ -482,6 +788,9 @@ def test_e2b_create_policy_is_bound_only_when_an_e2b_path_is_active(
         harness_backend="e2b",
         e2b_template="runner-template",
     )
+    with pytest.raises(RuntimeError, match="preparation is not loaded"):
+        task_e2b.context()
+    _prepare_fake_scorer(task_e2b, tmp_path / "task-e2b" / "preparation.json")
     local_digest = local.context().execution_config_digest
     task_digest = task_e2b.context().execution_config_digest
     worker_digest = worker_e2b.context().execution_config_digest
@@ -593,6 +902,7 @@ def test_scorer_uses_only_the_configured_official_reward_key(tmp_path: Path) -> 
         request=_request(scorer, attempts=1),
     )
     assert [cell.score for cell in scored.report.cells] == [0.25, 0.75]
+    assert [cell.passed for cell in scored.report.cells] == [False, False]
 
     wrong_path = tmp_path / "wrong"
     wrong_job_dir = wrong_path / "completed-job"
@@ -837,6 +1147,7 @@ def test_context_commits_to_tasks_evaluator_backend_model_and_harbor_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _install_fake_readiness(monkeypatch)
     run = _run(tmp_path, [])
     base, _ = _scorer(tmp_path, run)
     original = base.context()
@@ -874,6 +1185,10 @@ def test_context_commits_to_tasks_evaluator_backend_model_and_harbor_version(
         tmp_path / "task-backend",
         run,
         job_config=_job_config(tmp_path, backend=EnvironmentType.E2B),
+    )
+    _prepare_fake_scorer(
+        changed_task_backend,
+        tmp_path / "task-backend-preparation.json",
     )
     monkeypatch.setattr(harbor, "__version__", "0.20.0+changed")
     changed_version = base.context()

--- a/wmh/evals/harbor/tasks.py
+++ b/wmh/evals/harbor/tasks.py
@@ -11,6 +11,7 @@ from typing import Protocol
 
 from harbor.models.job.config import DatasetConfig
 from harbor.models.job.lock import build_trial_lock
+from harbor.models.task.config import TaskConfig as TaskDefinitionConfig
 from harbor.models.task.id import GitTaskId, PackageTaskId
 from harbor.models.task.task import Task
 from harbor.models.trial.config import TaskConfig, TrialConfig
@@ -53,6 +54,7 @@ class _ResolvedTask:
     task_id: str
     identity: HarborTaskIdentity
     config_json: str
+    definition_json: str
     download_json: str
 
     @classmethod
@@ -69,10 +71,14 @@ class _ResolvedTask:
             update={"path": download.path.resolve(strict=True)},
             deep=True,
         )
+        definition_snapshot = TaskDefinitionConfig.model_validate(
+            Task(download_snapshot.path).config.model_dump(mode="python")
+        )
         return cls(
             task_id=snapshot.get_task_id().get_name(),
             identity=HarborTaskIdentity.model_validate(identity),
             config_json=snapshot.model_dump_json(),
+            definition_json=definition_snapshot.model_dump_json(),
             download_json=download_snapshot.model_dump_json(),
         )
 
@@ -81,6 +87,9 @@ class _ResolvedTask:
 
     def download(self) -> TaskDownloadResult:
         return TaskDownloadResult.model_validate_json(self.download_json)
+
+    def definition(self) -> TaskDefinitionConfig:
+        return TaskDefinitionConfig.model_validate_json(self.definition_json)
 
 
 @dataclass(frozen=True)
@@ -138,6 +147,10 @@ class ResolvedHarborTaskSet:
 
     def task_configs(self) -> list[TaskConfig]:
         return [record.config() for record in self._tasks]
+
+    def task_inputs(self) -> tuple[tuple[TaskDefinitionConfig, Path], ...]:
+        """Return frozen task definitions paired with verified download directories."""
+        return tuple((record.definition(), record.download().path) for record in self._tasks)
 
     def verify(self) -> None:
         """Re-hash every resolved task before a candidate job can incur spend."""

--- a/wmh/evals/harbor/tasks_test.py
+++ b/wmh/evals/harbor/tasks_test.py
@@ -69,6 +69,9 @@ def test_resolver_selects_literal_task_ids_without_fnmatch_semantics(tmp_path: P
 
     assert task_set.task_ids == ("task[1]",)
     assert [task.get_task_id().get_name() for task in task_set.task_configs()] == ["task[1]"]
+    definition, definition_path = task_set.task_inputs()[0]
+    assert definition.schema_version == "1.0"
+    assert definition_path == (dataset_path / "task[1]").resolve()
     assert task_set.requested_dataset_config().path == dataset_path
     assert task_set.resolved_dataset_config().task_names is None
 

--- a/wmh/harness/population_checkpoint.py
+++ b/wmh/harness/population_checkpoint.py
@@ -42,6 +42,7 @@ _IDENTITY_FILE = "identity.json"
 _CONTROL_FILE = "control.json"
 _LOCK_FILE = "run.lock"
 _MANIFEST_FILE = "manifest.json"
+_SCORER_PREPARATION_FILE = "scorer-preparation.bin"
 
 
 class PopulationCheckpointError(RuntimeError):
@@ -67,6 +68,7 @@ class PopulationCheckpointIdentity(BaseModel):
     seed_reference: str | None = None
     seed_source_tree_hash: str = Field(min_length=1)
     score_request: ScoreRequest
+    evaluator_policy: JsonObject = Field(default_factory=dict)
     iterations: int = Field(strict=True, ge=1)
     planned_score_cells: int = Field(strict=True, ge=1)
     max_score_cells: int = Field(strict=True, ge=1)
@@ -76,6 +78,10 @@ class PopulationCheckpointIdentity(BaseModel):
     optimizer_document_hash: str = Field(min_length=1)
     harness_backend: Literal["local", "e2b"]
     e2b_template: str | None = None
+    scorer_preparation_artifact_hash: str | None = Field(
+        default=None,
+        pattern=_SHA256_PATTERN,
+    )
     project_e2b_create_rate_policy: JsonObject
     environment_command_timeout_sec: int = Field(strict=True, ge=1)
     episode_timeout_sec: float = Field(gt=0)
@@ -329,10 +335,21 @@ class PopulationCheckpointStore:
         *,
         identity: PopulationCheckpointIdentity,
         seed: HarnessSourceTree,
+        scorer_preparation_artifact: bytes | None = None,
     ) -> PopulationCheckpointStore:
         """Create and lock one new empty optimization prefix."""
         if seed.tree_hash != identity.seed_source_tree_hash:
             raise ValueError("checkpoint seed source does not match its identity")
+        expected_preparation_hash = identity.scorer_preparation_artifact_hash
+        if (expected_preparation_hash is None) != (scorer_preparation_artifact is None):
+            raise ValueError(
+                "checkpoint scorer preparation artifact and identity must be provided together"
+            )
+        if (
+            scorer_preparation_artifact is not None
+            and _sha256_bytes(scorer_preparation_artifact) != expected_preparation_hash
+        ):
+            raise ValueError("checkpoint scorer preparation artifact hash differs")
         run_dir.mkdir(parents=True, exist_ok=False)
         root = run_dir / _CHECKPOINT_DIR
         root.mkdir()
@@ -341,6 +358,11 @@ class PopulationCheckpointStore:
             identity_path = root / _IDENTITY_FILE
             _write_json_durable(identity_path, identity.model_dump(mode="json"))
             identity_hash = _hash_file(identity_path)
+            if scorer_preparation_artifact is not None:
+                _write_bytes_durable(
+                    root / _SCORER_PREPARATION_FILE,
+                    scorer_preparation_artifact,
+                )
             seed_dir = root / "seed"
             write_source_tree(seed_dir / "source", seed)
             _sync_tree(seed_dir)
@@ -359,7 +381,10 @@ class PopulationCheckpointStore:
                 known_score_cells=0,
             )
             _write_json_durable(root / _CONTROL_FILE, control.model_dump(mode="json"))
-            return cls(run_dir, lock_file, identity, control, seed, None)
+            store = cls(run_dir, lock_file, identity, control, seed, None)
+            store._validate_layout()
+            store._verify_scorer_preparation_artifact()
+            return store
         except BaseException:
             _release_lock(lock_file)
             raise
@@ -399,6 +424,7 @@ class PopulationCheckpointStore:
             seed = _read_seed(root / "seed", identity)
             store = cls(run_dir, lock_file, identity, control, seed, None)
             store._validate_layout()
+            store._verify_scorer_preparation_artifact()
             store._result = store._load_committed_result()
             if resumable_cleanup:
                 if store._result is None or control.committed_step < 0:
@@ -433,6 +459,13 @@ class PopulationCheckpointStore:
     def result(self) -> PopulationOptimizationResult | None:
         """Return the fully verified committed prefix, if the seed was scored."""
         return self._result
+
+    @property
+    def scorer_preparation_artifact_path(self) -> Path | None:
+        """Return the checkpoint-owned scorer preparation artifact path when present."""
+        if self.identity.scorer_preparation_artifact_hash is None:
+            return None
+        return self.root / _SCORER_PREPARATION_FILE
 
     @property
     def publication_id(self) -> str:
@@ -807,6 +840,8 @@ class PopulationCheckpointStore:
 
     def _validate_layout(self) -> None:
         allowed = {_IDENTITY_FILE, _CONTROL_FILE, _LOCK_FILE, "seed", "steps"}
+        if self.identity.scorer_preparation_artifact_hash is not None:
+            allowed.add(_SCORER_PREPARATION_FILE)
         actual = {path.name for path in self.root.iterdir()}
         if not actual.issubset(allowed):
             raise PopulationCheckpointError("checkpoint contains unexpected top-level paths")
@@ -817,6 +852,22 @@ class PopulationCheckpointStore:
         )
         if actual_steps != expected_steps:
             raise PopulationCheckpointError("checkpoint step directories differ from control")
+
+    def _verify_scorer_preparation_artifact(self) -> None:
+        expected = self.identity.scorer_preparation_artifact_hash
+        path = self.root / _SCORER_PREPARATION_FILE
+        if expected is None:
+            if path.exists() or path.is_symlink():
+                raise PopulationCheckpointError(
+                    "checkpoint contains an unexpected scorer preparation artifact"
+                )
+            return
+        if path.is_symlink() or not path.is_file():
+            raise PopulationCheckpointError(
+                "checkpoint scorer preparation artifact is not a regular file"
+            )
+        if _hash_file(path) != expected:
+            raise PopulationCheckpointError("checkpoint scorer preparation artifact hash differs")
 
     def _total_segment_usage(self, segment: SandboxUsage | None) -> SandboxUsage | None:
         if segment is None:
@@ -1099,11 +1150,15 @@ def _verify_file_records(
 
 
 def _write_json_durable(path: Path, value: JsonValue) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f"{path.name}.tmp-{uuid4().hex}")
     content = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode(
         "utf-8"
     )
+    _write_bytes_durable(path, content)
+
+
+def _write_bytes_durable(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{uuid4().hex}")
     with temporary.open("xb") as handle:
         handle.write(content)
         handle.flush()
@@ -1176,7 +1231,11 @@ def _is_atomic_metadata_tail(root: Path, path: Path) -> bool:
     canonical_name = match.group(1)
     relative_parent = path.parent.relative_to(root)
     if relative_parent == Path("."):
-        return canonical_name in {_IDENTITY_FILE, _CONTROL_FILE}
+        return canonical_name in {
+            _IDENTITY_FILE,
+            _CONTROL_FILE,
+            _SCORER_PREPARATION_FILE,
+        }
     if relative_parent == Path("seed"):
         return canonical_name == _MANIFEST_FILE
     parts = relative_parent.parts

--- a/wmh/harness/population_checkpoint_test.py
+++ b/wmh/harness/population_checkpoint_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -252,6 +253,88 @@ def test_checkpoint_appends_exact_boundaries_and_restores_without_replay(tmp_pat
         assert resumed.result.iterations[1].error is not None
         assert resumed.result.iterations[1].error.reason == "incomplete candidate"
         assert resumed.result.iterations[1].error.worker_usage is None
+
+
+def test_checkpoint_owns_and_verifies_exact_scorer_preparation_artifact(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    seed = _source("seed")
+    receipt = b'{"complete":true}\n'
+    receipt_hash = "sha256:" + hashlib.sha256(receipt).hexdigest()
+    identity = _identity(tmp_path / "root", seed).model_copy(
+        update={"scorer_preparation_artifact_hash": receipt_hash}
+    )
+
+    with PopulationCheckpointStore.create(
+        run_dir,
+        identity=identity,
+        seed=seed,
+        scorer_preparation_artifact=receipt,
+    ) as store:
+        assert store.scorer_preparation_artifact_path is not None
+        assert store.scorer_preparation_artifact_path.read_bytes() == receipt
+
+    with PopulationCheckpointStore.open(run_dir) as resumed:
+        assert resumed.scorer_preparation_artifact_path is not None
+        assert resumed.scorer_preparation_artifact_path.read_bytes() == receipt
+
+
+@pytest.mark.parametrize("provide_receipt", [False, True])
+def test_checkpoint_rejects_preparation_artifact_identity_mismatch_before_create(
+    tmp_path: Path,
+    provide_receipt: bool,
+) -> None:
+    seed = _source("seed")
+    receipt = b'{"complete":true}\n'
+    identity = _identity(tmp_path / "root", seed)
+    if not provide_receipt:
+        identity = identity.model_copy(update={"scorer_preparation_artifact_hash": _DIGEST_A})
+
+    with pytest.raises(ValueError, match="preparation artifact"):
+        PopulationCheckpointStore.create(
+            tmp_path / "run",
+            identity=identity,
+            seed=seed,
+            scorer_preparation_artifact=receipt if provide_receipt else None,
+        )
+
+    assert not (tmp_path / "run").exists()
+
+
+def test_checkpoint_rejects_tampered_or_linked_preparation_artifact(tmp_path: Path) -> None:
+    seed = _source("seed")
+    receipt = b'{"complete":true}\n'
+    receipt_hash = "sha256:" + hashlib.sha256(receipt).hexdigest()
+
+    def create_run(run_dir: Path) -> Path:
+        identity = _identity(tmp_path / f"root-{run_dir.name}", seed).model_copy(
+            update={"scorer_preparation_artifact_hash": receipt_hash}
+        )
+        store = PopulationCheckpointStore.create(
+            run_dir,
+            identity=identity,
+            seed=seed,
+            scorer_preparation_artifact=receipt,
+        )
+        path = store.scorer_preparation_artifact_path
+        assert path is not None
+        store.close()
+        return path
+
+    tampered_run = tmp_path / "tampered"
+    create_run(tampered_run).write_bytes(b'{"complete":false}\n')
+    with pytest.raises(PopulationCheckpointError, match="preparation artifact"):
+        PopulationCheckpointStore.open(tampered_run)
+
+    linked_run = tmp_path / "linked"
+    linked_path = create_run(linked_run)
+    linked_path.unlink()
+    target = tmp_path / "outside.json"
+    target.write_bytes(receipt)
+    linked_path.symlink_to(target)
+    with pytest.raises(PopulationCheckpointError, match="preparation artifact"):
+        PopulationCheckpointStore.open(linked_run)
 
 
 def test_checkpoint_lock_has_one_local_owner(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- derive resource-complete opaque identities for Harbor E2B task and verifier templates, prepare missing templates under a bounded policy, and bind exact template, build, and resource receipts into scorer identity
- persist generic scorer-preparation evidence across optimization checkpoints and direct score runs, with inspect-only resume plus pre-score and post-score drift checks and exact build-qualified sandbox creation
- add an evaluator-owned reward interpretation policy with backward-compatible raw mode and optional strict positive-binary mode while preserving raw Harbor artifacts
- preserve Harbor E2B storage semantics: task declarations remain an explicit provider-default, unenforced policy while runtime storage overrides fail before provider access
- keep local execution as the default and E2B optional; add no benchmark-specific command

## Product integration
This is a stacked validation PR over #237. Merged #220 remains the product UX authority. Reusable evaluator and runtime internals from this stack must migrate under the existing `wmh optimize` journey, where Harbor is an evaluator alternative and local and E2B are execution options; this PR does not establish a competing product surface.

## Validation
- `2305 passed, 19 skipped`
- `166 passed` across the modified readiness surface
- `ruff check .`
- `ruff format --check .`
- `ty check`
- `uv lock --check --offline`

Stacked on #237. Do not merge without explicit approval.