### PR TITLE
fix(e2b): poll template builds without replaying submission

### DIFF
--- a/wmh/evals/harbor/e2b_environment.py
+++ b/wmh/evals/harbor/e2b_environment.py
@@ -12,9 +12,11 @@ from threading import RLock
 from types import MappingProxyType
 from typing import Literal, override
 
+import httpx
 from e2b import AsyncSandbox, AsyncTemplate, Template
+from e2b.exceptions import BuildException, RateLimitException
 from e2b.template.main import TemplateClass
-from e2b.template.types import BuildInfo
+from e2b.template.types import BuildInfo, TemplateBuildStatus, TemplateBuildStatusResponse
 from harbor.environments.e2b import E2BEnvironment
 from harbor.models.task.config import (
     EnvironmentConfig,
@@ -24,9 +26,10 @@ from harbor.models.task.config import (
 )
 from harbor.models.trial.config import ResourceMode, ServiceVolumeConfig
 from harbor.models.trial.paths import TrialPaths
-from tenacity import retry, stop_after_attempt, wait_exponential
 
 from wmh.evals.harbor.e2b_template_policy import (
+    E2B_TEMPLATE_BUILD_STATUS_POLL_INTERVAL_MS,
+    E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS,
     E2BTemplateResources,
     e2b_template_resource_digest,
     qualify_harbor_e2b_template_name,
@@ -37,6 +40,46 @@ from wmh.harness.e2b_sandbox import acquire_e2b_create_slot_async
 _CREATE_ATTEMPTS = 2
 _CREATE_RETRY_DELAY_S = 1.0
 _PREPARATION_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+async def _get_template_build_status(
+    build_info: BuildInfo,
+    *,
+    logs_offset: int,
+) -> TemplateBuildStatusResponse:
+    """Retry only the idempotent GET for one already-submitted exact build."""
+    for attempt in range(len(E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS) + 1):
+        try:
+            return await AsyncTemplate.get_build_status(build_info, logs_offset=logs_offset)
+        except (httpx.TransportError, RateLimitException):
+            if attempt == len(E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS):
+                raise
+            await asyncio.sleep(E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS[attempt] / 1_000)
+    raise AssertionError("unreachable template build status retry state")
+
+
+async def _wait_for_template_build(build_info: BuildInfo) -> None:
+    """Wait for one submitted build without ever replaying its submission."""
+    logs_offset = 0
+    while True:
+        response = await _get_template_build_status(build_info, logs_offset=logs_offset)
+        if (
+            response.template_id != build_info.template_id
+            or response.build_id != build_info.build_id
+        ):
+            raise RuntimeError("E2B template build status identity disagreement")
+        logs_offset += len(response.log_entries)
+        if response.status is TemplateBuildStatus.READY:
+            return
+        if response.status is TemplateBuildStatus.ERROR:
+            message = response.reason.message if response.reason else "E2B template build failed"
+            raise BuildException(message)
+        if response.status not in (
+            TemplateBuildStatus.BUILDING,
+            TemplateBuildStatus.WAITING,
+        ):
+            raise BuildException("E2B template build returned an unknown status")
+        await asyncio.sleep(E2B_TEMPLATE_BUILD_STATUS_POLL_INTERVAL_MS / 1_000)
 
 
 @dataclass(frozen=True)
@@ -227,20 +270,23 @@ class WmhE2BEnvironment(E2BEnvironment):
             dockerfile_content_or_path=str(self._environment_definition_path)
         )
 
-    @retry(
-        stop=stop_after_attempt(2),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
     @override
     async def _create_template(self) -> BuildInfo:
-        """Build with Harbor's source semantics while retaining provider identity."""
-        return await AsyncTemplate.build(
+        """Submit once and poll the exact build without replaying submission.
+
+        A submission transport failure has an unknown outcome and propagates. Once E2B
+        returns ``BuildInfo``, only idempotent status GETs for that identity are retried.
+        A fresh run after an ambiguous submission is safe only after separate provider
+        reconciliation proves there are no active builds; an alias 404 is insufficient.
+        """
+        build_info = await AsyncTemplate.build_in_background(
             template=self._template_definition(),
             name=self._template_name,
             cpu_count=self._template_resources.cpu_count,
             memory_mb=self._template_resources.memory_mb,
         )
+        await _wait_for_template_build(build_info)
+        return build_info
 
     @override
     async def _create_sandbox(self) -> None:

--- a/wmh/evals/harbor/e2b_environment_test.py
+++ b/wmh/evals/harbor/e2b_environment_test.py
@@ -6,6 +6,7 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from harbor.models.task.config import EnvironmentConfig
 from harbor.models.trial.paths import TrialPaths
@@ -13,6 +14,13 @@ from harbor.models.trial.paths import TrialPaths
 pytest.importorskip("e2b")
 
 from e2b import AsyncSandbox  # noqa: E402
+from e2b.exceptions import BuildException, RateLimitException  # noqa: E402
+from e2b.template.types import (  # noqa: E402
+    BuildInfo,
+    BuildStatusReason,
+    TemplateBuildStatus,
+    TemplateBuildStatusResponse,
+)
 
 import wmh.evals.harbor.e2b_environment as e2b_environment_module  # noqa: E402
 from wmh.evals.harbor.e2b_environment import (  # noqa: E402
@@ -45,6 +53,32 @@ def _environment(
         task_env_config=task_config or EnvironmentConfig(cpus=2, memory_mb=2048),
         require_prebuilt=require_prebuilt,
         preparation_digest=preparation_digest,
+    )
+
+
+def _build_info(environment: WmhE2BEnvironment) -> BuildInfo:
+    return BuildInfo(
+        template_id="template-id",
+        build_id="build-id",
+        name=environment.template_name,
+        alias=environment.template_name,
+        tags=[],
+    )
+
+
+def _build_status(
+    build_info: BuildInfo,
+    status: TemplateBuildStatus,
+    *,
+    reason: BuildStatusReason | None = None,
+) -> TemplateBuildStatusResponse:
+    return TemplateBuildStatusResponse(
+        template_id=build_info.template_id,
+        build_id=build_info.build_id,
+        status=status,
+        log_entries=[],
+        logs=[],
+        reason=reason,
     )
 
 
@@ -166,12 +200,21 @@ def test_harbor_e2b_task_storage_is_not_sent_to_provider(
         task_config=EnvironmentConfig(cpus=2, memory_mb=2048, storage_mb=4096),
     )
     calls: list[dict[str, object]] = []
+    build_info = _build_info(environment)
 
-    async def build(**kwargs: object) -> object:
+    async def build(**kwargs: object) -> BuildInfo:
         calls.append(kwargs)
-        return object()
+        return build_info
 
-    monkeypatch.setattr(e2b_environment_module.AsyncTemplate, "build", staticmethod(build))
+    async def wait(observed: BuildInfo) -> None:
+        assert observed is build_info
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(e2b_environment_module, "_wait_for_template_build", wait)
 
     asyncio.run(environment._create_template())
 
@@ -182,6 +225,270 @@ def test_harbor_e2b_task_storage_is_not_sent_to_provider(
     assert calls[0]["memory_mb"] == 2048
     assert calls[0]["template"] is not None
     assert "storage_mb" not in calls[0]
+
+
+@pytest.mark.parametrize(
+    "first_failure",
+    [
+        httpx.ReadError(
+            "template status connection closed",
+            request=httpx.Request("GET", "https://provider.invalid/build-status"),
+        ),
+        RateLimitException("template status rate limited"),
+    ],
+    ids=["read-error", "rate-limit"],
+)
+def test_harbor_e2b_template_status_retry_never_replays_submission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    first_failure: Exception,
+) -> None:
+    environment = _environment(tmp_path)
+    build_info = _build_info(environment)
+    submissions = 0
+    status_calls = 0
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        return build_info
+
+    async def get_status(observed: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert observed is build_info
+        assert logs_offset == 0
+        status_calls += 1
+        if status_calls == 1:
+            raise first_failure
+        return _build_status(build_info, TemplateBuildStatus.READY)
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS",
+        (0,),
+    )
+
+    assert asyncio.run(environment._create_template()) is build_info
+    assert submissions == 1
+    assert status_calls == 2
+
+
+def test_harbor_e2b_building_status_advances_log_offset_for_exact_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    build_info = _build_info(environment)
+    submissions = 0
+    observed_offsets: list[int] = []
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        return build_info
+
+    async def get_status(observed: BuildInfo, logs_offset: int = 0) -> object:
+        assert observed is build_info
+        observed_offsets.append(logs_offset)
+        if len(observed_offsets) == 1:
+            return SimpleNamespace(
+                template_id=build_info.template_id,
+                build_id=build_info.build_id,
+                status=TemplateBuildStatus.BUILDING,
+                log_entries=[object(), object()],
+            )
+        return _build_status(build_info, TemplateBuildStatus.READY)
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "E2B_TEMPLATE_BUILD_STATUS_POLL_INTERVAL_MS",
+        0,
+    )
+
+    assert asyncio.run(environment._create_template()) is build_info
+    assert submissions == 1
+    assert observed_offsets == [0, 2]
+
+
+def test_harbor_e2b_ambiguous_template_submission_never_polls_or_replays(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    submissions = 0
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        raise httpx.ReadError(
+            "template submission response lost",
+            request=httpx.Request("POST", "https://provider.invalid/build"),
+        )
+
+    async def unexpected_status(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("ambiguous submission must not be polled")
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(unexpected_status),
+    )
+
+    with pytest.raises(httpx.ReadError, match="submission response lost"):
+        asyncio.run(environment._create_template())
+
+    assert submissions == 1
+
+
+def test_harbor_e2b_terminal_template_error_is_not_retried(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    build_info = _build_info(environment)
+    submissions = 0
+    status_calls = 0
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        return build_info
+
+    async def get_status(observed: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert observed is build_info
+        assert logs_offset == 0
+        status_calls += 1
+        return _build_status(
+            build_info,
+            TemplateBuildStatus.ERROR,
+            reason=BuildStatusReason(
+                message="provider build failed",
+                step=None,
+                log_entries=[],
+            ),
+        )
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+
+    with pytest.raises(BuildException, match="provider build failed"):
+        asyncio.run(environment._create_template())
+
+    assert submissions == 1
+    assert status_calls == 1
+
+
+def test_harbor_e2b_unknown_template_status_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    build_info = _build_info(environment)
+    submissions = 0
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        return build_info
+
+    async def get_status(observed: BuildInfo, logs_offset: int = 0) -> object:
+        assert observed is build_info
+        assert logs_offset == 0
+        return SimpleNamespace(
+            template_id=build_info.template_id,
+            build_id=build_info.build_id,
+            status="future-provider-status",
+            log_entries=[],
+        )
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+
+    with pytest.raises(BuildException, match="unknown status"):
+        asyncio.run(environment._create_template())
+
+    assert submissions == 1
+
+
+def test_harbor_e2b_template_status_identity_mismatch_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    environment = _environment(tmp_path)
+    build_info = _build_info(environment)
+    submissions = 0
+
+    async def build(**_kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        return build_info
+
+    async def get_status(_observed: BuildInfo, logs_offset: int = 0) -> object:
+        assert logs_offset == 0
+        return SimpleNamespace(
+            template_id=build_info.template_id,
+            build_id="different-build-id",
+            status=TemplateBuildStatus.READY,
+            log_entries=[],
+        )
+
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+
+    with pytest.raises(RuntimeError, match="identity disagreement"):
+        asyncio.run(environment._create_template())
+
+    assert submissions == 1
 
 
 def test_harbor_e2b_resource_mismatch_kills_without_retry(

--- a/wmh/evals/harbor/e2b_template_policy.py
+++ b/wmh/evals/harbor/e2b_template_policy.py
@@ -15,6 +15,10 @@ from harbor.environments.definition import SNAPSHOT_HASH_LEN
 E2B_TEMPLATE_POLICY_VERSION = "1"
 E2B_TEMPLATE_BUILD_CONCURRENCY = 10
 E2B_TEMPLATE_BUILD_CONCURRENCY_LIMIT = 20
+E2B_TEMPLATE_BUILD_STATUS_POLL_INTERVAL_MS = 1_000
+E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS = (250, 500, 1_000, 2_000, 4_000)
+E2B_TEMPLATE_BUILD_STRATEGY = "single-submit-exact-build-status-v1"
+E2B_TEMPLATE_BUILD_STATUS_RETRY_ERRORS = "httpx.TransportError,e2b.exceptions.RateLimitException"
 E2B_DEFAULT_CPU_COUNT = 2
 E2B_DEFAULT_MEMORY_MB = 1024
 WMH_HARBOR_E2B_ENVIRONMENT_IMPORT_PATH = "wmh.evals.harbor.e2b_environment:WmhE2BEnvironment"
@@ -160,7 +164,10 @@ def qualify_harbor_e2b_template_name(
     return f"wmh-hb-v1-{digest}"
 
 
-def e2b_template_readiness_policy_payload() -> dict[str, int | str | bool]:
+def e2b_template_readiness_policy_payload() -> dict[
+    str,
+    int | str | bool | tuple[int, ...],
+]:
     """Return the frozen readiness policy included in scorer identity."""
     return {
         "schema_version": E2B_TEMPLATE_POLICY_VERSION,
@@ -170,6 +177,11 @@ def e2b_template_readiness_policy_payload() -> dict[str, int | str | bool]:
         "default_memory_mb": E2B_DEFAULT_MEMORY_MB,
         "build_concurrency": E2B_TEMPLATE_BUILD_CONCURRENCY,
         "build_concurrency_limit": E2B_TEMPLATE_BUILD_CONCURRENCY_LIMIT,
+        "build_strategy": E2B_TEMPLATE_BUILD_STRATEGY,
+        "build_submit_once": True,
+        "build_status_poll_interval_ms": E2B_TEMPLATE_BUILD_STATUS_POLL_INTERVAL_MS,
+        "build_status_retry_delays_ms": E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS,
+        "build_status_retry_errors": E2B_TEMPLATE_BUILD_STATUS_RETRY_ERRORS,
         "resource_qualified_alias": True,
         "force_build": False,
         "task_storage_policy": "provider_default_unenforced",

--- a/wmh/evals/harbor/e2b_template_readiness.py
+++ b/wmh/evals/harbor/e2b_template_readiness.py
@@ -87,7 +87,7 @@ class E2BTemplateReadinessReceipt(BaseModel):
     build_concurrency: int = Field(strict=True, ge=1)
     context_resource_histogram: tuple[E2BTemplateResourceCount, ...]
     template_resource_histogram: tuple[E2BTemplateResourceCount, ...]
-    policy: dict[str, int | str | bool]
+    policy: dict[str, int | str | bool | tuple[int, ...]]
     entries: tuple[E2BTemplateReadinessEntry, ...]
 
     @field_validator("complete", mode="before")

--- a/wmh/evals/harbor/e2b_template_readiness_test.py
+++ b/wmh/evals/harbor/e2b_template_readiness_test.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
+import httpx
 import pytest
-from e2b.template.types import BuildInfo
+from e2b.exceptions import BuildException, RateLimitException
+from e2b.template.types import BuildInfo, TemplateBuildStatus
 from harbor.models.job.config import DatasetConfig, JobConfig
 from harbor.models.trial.config import AgentConfig, EnvironmentConfig, TaskConfig
 from harbor.tasks.client import TaskDownloadResult
 
+import wmh.evals.harbor.e2b_environment as e2b_environment_module
+import wmh.evals.harbor.e2b_template_policy as template_policy
 import wmh.evals.harbor.e2b_template_readiness as readiness
 from wmh.evals.harbor.e2b_environment import WmhE2BEnvironment
 from wmh.evals.harbor.e2b_template_control import (
@@ -217,13 +223,44 @@ def test_plan_accepts_task_storage_as_unenforced_provider_default(tmp_path: Path
     )
 
     payload = plan.identity_payload()
-    policy_payload = cast("dict[str, int | str | bool]", payload["policy"])
+    policy_payload = cast(
+        "dict[str, int | str | bool | list[int]]",
+        payload["policy"],
+    )
     assert policy_payload["task_storage_policy"] == "provider_default_unenforced"
     assert policy_payload["override_storage_policy"] == "reject"
+    assert policy_payload["build_submit_once"] is True
+    assert policy_payload["build_strategy"] == "single-submit-exact-build-status-v1"
+    assert policy_payload["build_status_retry_delays_ms"] == [
+        250,
+        500,
+        1_000,
+        2_000,
+        4_000,
+    ]
+    assert policy_payload["build_status_retry_errors"] == (
+        "httpx.TransportError,e2b.exceptions.RateLimitException"
+    )
     assert "storage" not in json.dumps(payload["templates"], sort_keys=True)
     assert payload["context_resource_histogram"] == [
         {"cpu_count": 2, "memory_mb": 1024, "count": 1}
     ]
+
+
+def test_status_retry_schedule_changes_readiness_plan_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = _two_template_plan(tmp_path)
+    monkeypatch.setattr(
+        template_policy,
+        "E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS",
+        (1, 2, 3),
+    )
+    changed = _two_template_plan(tmp_path)
+
+    assert changed.plan_digest != original.plan_digest
+    assert changed.identity_payload()["policy"] != original.identity_payload()["policy"]
 
 
 @pytest.mark.parametrize(
@@ -374,6 +411,418 @@ def test_prepare_persists_partial_success_but_requires_a_fresh_run_path(
     receipt = asyncio.run(fresh.prepare(tmp_path / "fresh" / "e2b-readiness.json"))
     assert receipt.complete
     assert len(builds) - previous_build_count == 1
+
+
+def test_prepare_poll_read_failure_keeps_receipt_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    submissions = 0
+    status_calls = 0
+
+    async def inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise E2BTemplateNotFound("qualified alias absent")
+
+    async def build(**kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        name = cast("str", kwargs["name"])
+        return BuildInfo(
+            template_id="template-id",
+            build_id="build-id",
+            name=name,
+            alias=name,
+            tags=[],
+        )
+
+    async def get_status(_build_info: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert logs_offset == 0
+        status_calls += 1
+        raise httpx.ReadError(
+            "template status connection closed",
+            request=httpx.Request("GET", "https://provider.invalid/build-status"),
+        )
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS",
+        (0, 0),
+    )
+
+    with pytest.raises(httpx.ReadError, match="status connection closed"):
+        asyncio.run(plan.prepare(receipt_path))
+
+    partial = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert submissions == 1
+    assert status_calls == 3
+    assert partial["complete"] is False
+    assert partial["entries"] == []
+
+
+@pytest.mark.parametrize(
+    "first_failure",
+    [
+        httpx.ReadError(
+            "template status connection closed",
+            request=httpx.Request("GET", "https://provider.invalid/build-status"),
+        ),
+        RateLimitException("template status rate limited"),
+    ],
+    ids=["read-error", "rate-limit"],
+)
+def test_prepare_recovers_status_get_and_commits_exact_complete_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    first_failure: Exception,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    submissions = 0
+    status_calls = 0
+    inspections = 0
+    built: BuildInfo | None = None
+
+    async def inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        nonlocal inspections
+        inspections += 1
+        if inspections == 1:
+            raise E2BTemplateNotFound("qualified alias absent")
+        assert built is not None
+        return E2BTemplateControlIdentity(
+            template_id=built.template_id,
+            build_id=built.build_id,
+            cpu_count=expected_cpu_count,
+            memory_mb=expected_memory_mb,
+        )
+
+    async def build(**kwargs: object) -> BuildInfo:
+        nonlocal submissions, built
+        submissions += 1
+        name = cast("str", kwargs["name"])
+        built = BuildInfo(
+            template_id="template-id",
+            build_id="build-id",
+            name=name,
+            alias=name,
+            tags=[],
+        )
+        return built
+
+    async def get_status(build_info: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert build_info is built
+        assert logs_offset == 0
+        status_calls += 1
+        if status_calls == 1:
+            raise first_failure
+        return SimpleNamespace(
+            template_id=build_info.template_id,
+            build_id=build_info.build_id,
+            status=TemplateBuildStatus.READY,
+            log_entries=[],
+            reason=None,
+        )
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module,
+        "E2B_TEMPLATE_BUILD_STATUS_RETRY_DELAYS_MS",
+        (0,),
+    )
+
+    receipt = asyncio.run(plan.prepare(receipt_path))
+
+    assert receipt.complete
+    assert receipt.built_count == 1
+    assert receipt.ready_before_count == 0
+    assert len(receipt.entries) == 1
+    assert submissions == 1
+    assert status_calls == 2
+    assert inspections == 3
+
+
+@pytest.mark.parametrize(
+    ("failure_mode", "expected_error", "expected_status_calls"),
+    [
+        ("ambiguous-submit", httpx.ReadError, 0),
+        ("terminal-error", BuildException, 1),
+        ("unknown-status", BuildException, 1),
+        ("mapping-mismatch", RuntimeError, 1),
+    ],
+)
+def test_prepare_build_failure_modes_never_fabricate_complete_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+    expected_error: type[Exception],
+    expected_status_calls: int,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    submissions = 0
+    status_calls = 0
+    inspections = 0
+
+    async def inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        nonlocal inspections
+        inspections += 1
+        if failure_mode == "mapping-mismatch" and inspections == 2:
+            return E2BTemplateControlIdentity(
+                template_id="different-template-id",
+                build_id="build-id",
+                cpu_count=expected_cpu_count,
+                memory_mb=expected_memory_mb,
+            )
+        raise E2BTemplateNotFound("qualified alias absent")
+
+    async def build(**kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        if failure_mode == "ambiguous-submit":
+            raise httpx.ReadError(
+                "template submission response lost",
+                request=httpx.Request("POST", "https://provider.invalid/build"),
+            )
+        name = cast("str", kwargs["name"])
+        return BuildInfo(
+            template_id="template-id",
+            build_id="build-id",
+            name=name,
+            alias=name,
+            tags=[],
+        )
+
+    async def get_status(build_info: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert logs_offset == 0
+        status_calls += 1
+        status: object = TemplateBuildStatus.READY
+        if failure_mode == "terminal-error":
+            status = TemplateBuildStatus.ERROR
+        elif failure_mode == "unknown-status":
+            status = "future-provider-status"
+        return SimpleNamespace(
+            template_id=build_info.template_id,
+            build_id=build_info.build_id,
+            status=status,
+            log_entries=[],
+            reason=None,
+        )
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+
+    with pytest.raises(expected_error):
+        asyncio.run(plan.prepare(receipt_path))
+
+    partial = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert submissions == 1
+    assert status_calls == expected_status_calls
+    assert partial["complete"] is False
+    assert partial["entries"] == []
+
+
+def test_prepare_outer_build_timeout_cancels_exact_poll_without_resubmission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+    plan._specs = (replace(plan._specs[0], build_timeout_sec=0.01),)
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    submissions = 0
+    status_calls = 0
+
+    async def inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise E2BTemplateNotFound("qualified alias absent")
+
+    async def build(**kwargs: object) -> BuildInfo:
+        nonlocal submissions
+        submissions += 1
+        name = cast("str", kwargs["name"])
+        return BuildInfo(
+            template_id="template-id",
+            build_id="build-id",
+            name=name,
+            alias=name,
+            tags=[],
+        )
+
+    async def get_status(_build_info: BuildInfo, logs_offset: int = 0) -> object:
+        nonlocal status_calls
+        assert logs_offset == 0
+        status_calls += 1
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "build_in_background",
+        staticmethod(build),
+    )
+    monkeypatch.setattr(
+        e2b_environment_module.AsyncTemplate,
+        "get_build_status",
+        staticmethod(get_status),
+    )
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(plan.prepare(receipt_path))
+
+    partial = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert submissions == 1
+    assert status_calls == 1
+    assert partial["complete"] is False
+    assert partial["entries"] == []
+
+
+def test_prepare_cancellation_keeps_receipt_incomplete_without_resubmission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _task(tasks_root, "private-a", dockerfile="FROM alpine:3.20\n")
+    plan = readiness.E2BTemplateReadinessPlan.create(
+        job_config=_job(tmp_path),
+        task_set=_task_set(tasks_root, [task_dir]),
+    )
+    receipt_path = tmp_path / "run" / "e2b-readiness.json"
+    submissions = 0
+    status_calls = 0
+
+    async def inspect(
+        _template_name: str,
+        *,
+        expected_cpu_count: int,
+        expected_memory_mb: int,
+    ) -> E2BTemplateControlIdentity:
+        del expected_cpu_count, expected_memory_mb
+        raise E2BTemplateNotFound("qualified alias absent")
+
+    monkeypatch.setattr(readiness, "inspect_e2b_template", inspect)
+
+    async def scenario() -> None:
+        nonlocal submissions, status_calls
+        status_started = asyncio.Event()
+
+        async def build(**kwargs: object) -> BuildInfo:
+            nonlocal submissions
+            submissions += 1
+            name = cast("str", kwargs["name"])
+            return BuildInfo(
+                template_id="template-id",
+                build_id="build-id",
+                name=name,
+                alias=name,
+                tags=[],
+            )
+
+        async def get_status(_build_info: BuildInfo, logs_offset: int = 0) -> object:
+            nonlocal status_calls
+            assert logs_offset == 0
+            status_calls += 1
+            status_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(
+            e2b_environment_module.AsyncTemplate,
+            "build_in_background",
+            staticmethod(build),
+        )
+        monkeypatch.setattr(
+            e2b_environment_module.AsyncTemplate,
+            "get_build_status",
+            staticmethod(get_status),
+        )
+        task = asyncio.create_task(plan.prepare(receipt_path))
+        await status_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+
+    partial = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert submissions == 1
+    assert status_calls == 1
+    assert partial["complete"] is False
+    assert partial["entries"] == []
 
 
 def test_existing_partial_receipt_rejects_before_provider_calls(


### PR DESCRIPTION
## Summary

- submit each E2B template build exactly once and retain the returned build identity
- retry only idempotent status reads for that exact build on transport or rate-limit failures
- bind the deterministic polling policy into readiness identity and keep receipts incomplete on ambiguous or terminal failures
- cover success, failure, cancellation, timeout, identity, and receipt boundaries

Stacked on #238.

## Verification

- focused E2B readiness suite: 73 passed
- full suite: 2,322 passed, 19 skipped (localhost-binding cases rerun outside the restricted sandbox)
- Ruff check and format: passed
- Ty: passed
- git diff --check: passed

No merge is requested.