### PR TITLE
Harness source trees, unified path grammar, and Azure Responses reasoning

### DIFF
--- a/wmh/cli/eval_closed_loop_test.py
+++ b/wmh/cli/eval_closed_loop_test.py
@@ -66,7 +66,9 @@ def _pi_doc() -> HarnessDoc:
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
-            Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
+            Surface(
+                id="code:src-agent-ts", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"
+            ),
         ],
     )
 

--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -56,5 +56,6 @@ def resolve_opt_in_model_provider(
         endpoint=configured.endpoint,
         deployment=configured.deployment,
         api_version=api_version,
+        reasoning_effort=configured.reasoning_effort,
     )
     return get_provider(config), configured.model

--- a/wmh/cli/model_roles_test.py
+++ b/wmh/cli/model_roles_test.py
@@ -80,6 +80,7 @@ def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
                     region="us-east-2",
                     endpoint="https://x.example",
                     deployment="gpt-5-5",
+                    reasoning_effort="high",
                 )
             )
         ),
@@ -105,6 +106,7 @@ def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
     assert config.endpoint == "https://x.example"
     assert config.deployment == "gpt-5-5"
     assert config.api_version == "2024-05-01-preview"
+    assert config.reasoning_effort == "high"
 
 
 def test_explicit_api_version_overrides_the_azure_default(

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -335,7 +335,9 @@ def _pull_harness(
         version = harness.latest_version
     payload = client.get_harness_version(org_id, name, version)
     doc = HarnessDoc.model_validate(payload.doc)
-    if doc.doc_hash != payload.doc_hash:
+    # Versions the platform recorded before doc_hash covered materialized paths carry the legacy
+    # hash; accept either so pre-change pathful (pi-node) records stay pullable.
+    if payload.doc_hash not in (doc.doc_hash, doc.legacy_doc_hash):
         _console.print("[red]Pulled doc failed its integrity check; not saving.[/red]")
         raise typer.Exit(code=1)
     saved = HarnessStore(root).save_version(

--- a/wmh/cli/platform_cmds_test.py
+++ b/wmh/cli/platform_cmds_test.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import typer
 from typer.testing import CliRunner
 
 from wmh.cli.app import app
-from wmh.cli.platform_cmds import _resolve_kind
-from wmh.platform.client import PlatformError, WhoAmI
+from wmh.cli.platform_cmds import _pull_harness, _resolve_kind
+from wmh.harness.doc import HarnessDoc, Surface, SurfaceKind
+from wmh.harness.store import HarnessStore
+from wmh.platform.client import HarnessVersionDoc, PlatformError, WhoAmI
 from wmh.platform.credentials import ENV_HOME, PlatformCredentials, save_credentials
+
+if TYPE_CHECKING:
+    from wmh.platform.client import PlatformClient
 
 runner = CliRunner()
 
@@ -98,6 +104,62 @@ def test_pull_rejects_unknown_kind() -> None:
     result = runner.invoke(app, ["pull", "anything", "--kind", "typo"])
     assert result.exit_code != 0
     assert "must be 'model' or 'harness'" in result.output
+
+
+def _pathful_doc() -> HarnessDoc:
+    return HarnessDoc(
+        name="pi",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
+            Surface(
+                id="code:src-agent-ts",
+                kind=SurfaceKind.CODE,
+                path="src/agent.ts",
+                content="// a",
+            ),
+        ],
+    )
+
+
+class _HarnessVersionClient(_StubClient):
+    """Serves one canned harness version payload with a configurable hash."""
+
+    payload_doc_hash = ""
+
+    def get_harness_version(self, org_id: str, name: str, version: int) -> HarnessVersionDoc:
+        del org_id, name
+        return HarnessVersionDoc(
+            version=version,
+            doc=_pathful_doc().model_dump(mode="json"),
+            doc_hash=type(self).payload_doc_hash,
+        )
+
+
+def test_pull_harness_accepts_the_legacy_doc_hash(tmp_path: Path) -> None:
+    """Pathful versions the platform recorded pre-path-hash must stay pullable."""
+    doc = _pathful_doc()
+    root = str(tmp_path / ".wmh")
+
+    class _LegacyClient(_HarnessVersionClient):
+        payload_doc_hash = doc.legacy_doc_hash
+
+    _pull_harness(cast("PlatformClient", _LegacyClient()), "org-1", "pi", root, version=3)
+
+    assert HarnessStore(root).load("pi").doc_hash == doc.doc_hash
+
+
+def test_pull_harness_still_rejects_a_corrupt_doc_hash(tmp_path: Path) -> None:
+    class _CorruptClient(_HarnessVersionClient):
+        payload_doc_hash = "0" * 32
+
+    with pytest.raises(typer.Exit):
+        _pull_harness(
+            cast("PlatformClient", _CorruptClient()),
+            "org-1",
+            "pi",
+            str(tmp_path / ".wmh"),
+            version=3,
+        )
 
 
 def test_login_with_token_drops_stale_default_org(

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -30,6 +30,7 @@ class ModelRole(BaseModel):
     endpoint: str | None = None  # Azure OpenAI / custom base URL
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version (azure roles get a default)
+    reasoning_effort: str | None = None  # structured reasoning effort, when supported
 
 
 class ModelsSettings(BaseModel):

--- a/wmh/harness/create_test.py
+++ b/wmh/harness/create_test.py
@@ -1037,7 +1037,9 @@ def _pi_seed() -> HarnessDoc:
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
             Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
-            Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
+            Surface(
+                id="code:src-agent-ts", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"
+            ),
         ],
     )
 

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -107,7 +107,7 @@ class Surface(BaseModel):
     def _validate(self) -> Surface:
         validate_durable_text(self.content, field=f"surface {self.id!r} content")
         prefix, sep, slug = self.id.partition(":")
-        if not sep or prefix != self.kind.value or not _SLUG_RE.match(slug):
+        if not sep or prefix != self.kind.value or not _SLUG_RE.fullmatch(slug):
             raise ValueError(
                 f"surface id {self.id!r} must be '{self.kind.value}:<kebab-slug>' matching its kind"
             )
@@ -116,7 +116,7 @@ class Surface(BaseModel):
                 raise ValueError(f"surface {self.id!r}: only code surfaces may carry a path")
             candidate = PurePosixPath(self.path)
             if (
-                not _SAFE_PATH_RE.match(self.path)
+                not _SAFE_PATH_RE.fullmatch(self.path)
                 or not candidate.parts
                 or candidate.as_posix() != self.path
                 or ".." in candidate.parts
@@ -138,7 +138,7 @@ class Surface(BaseModel):
                     f"carry a path (got {self.path!r}); rename the file so it maps to its own id"
                 )
             expected_id = code_surface_id(self.path)
-            if not _SLUG_RE.match(expected_id.partition(":")[2]):
+            if not _SLUG_RE.fullmatch(expected_id.partition(":")[2]):
                 raise ValueError(
                     f"code surface path {self.path!r} maps to surface id {expected_id!r}, which "
                     "is not a valid 'code:<kebab-slug>' id; use lowercase [a-z0-9] runs separated "

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -28,6 +28,7 @@ import os
 import re
 from collections.abc import Callable
 from enum import StrEnum
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -67,7 +68,17 @@ CODE_RUNTIME_ID = "code:runtime"
 
 _SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
 
+# Store metadata filenames a pathful code surface may never materialize to: on render they
+# would shadow the harness store's own authority files.
+_STORE_METADATA_FILES = frozenset({"doc.json", "aliases.toml"})
+MAX_SURFACE_PATH_BYTES = 1_024
+
 DEFAULT_TEMPERATURE = 0.7
+
+
+def code_surface_id(relpath: str) -> str:
+    """A stable surface id from a path (`src/agent-loop.ts` -> `code:src-agent-loop-ts`)."""
+    return "code:" + relpath.replace("/", "-").replace(".", "-")
 
 
 class SurfaceKind(StrEnum):
@@ -103,8 +114,41 @@ class Surface(BaseModel):
         if self.path is not None:
             if self.kind is not SurfaceKind.CODE:
                 raise ValueError(f"surface {self.id!r}: only code surfaces may carry a path")
-            if not _SAFE_PATH_RE.match(self.path) or ".." in self.path.split("/"):
-                raise ValueError(f"surface {self.id!r}: unsafe path {self.path!r}")
+            candidate = PurePosixPath(self.path)
+            if (
+                not _SAFE_PATH_RE.match(self.path)
+                or not candidate.parts
+                or candidate.as_posix() != self.path
+                or ".." in candidate.parts
+                or len(self.path.encode("utf-8")) > MAX_SURFACE_PATH_BYTES
+            ):
+                raise ValueError(
+                    f"surface {self.id!r}: unsafe path {self.path!r}; a code surface path must "
+                    f"be a canonical relative POSIX path of at most {MAX_SURFACE_PATH_BYTES} "
+                    "UTF-8 bytes with no '.' or '..' segments"
+                )
+            if self.path in _STORE_METADATA_FILES:
+                raise ValueError(
+                    f"surface {self.id!r}: path {self.path!r} would shadow a harness store "
+                    "metadata file; rename the file"
+                )
+            if self.id == CODE_RUNTIME_ID:
+                raise ValueError(
+                    f"surface {CODE_RUNTIME_ID!r} is the in-process runtime module and must not "
+                    f"carry a path (got {self.path!r}); rename the file so it maps to its own id"
+                )
+            expected_id = code_surface_id(self.path)
+            if not _SLUG_RE.match(expected_id.partition(":")[2]):
+                raise ValueError(
+                    f"code surface path {self.path!r} maps to surface id {expected_id!r}, which "
+                    "is not a valid 'code:<kebab-slug>' id; use lowercase [a-z0-9] runs separated "
+                    "by single '/', '.', or '-' characters (for example src/agent-loop.ts)"
+                )
+            if self.id != expected_id:
+                raise ValueError(
+                    f"surface {self.id!r} does not match its path {self.path!r}: a pathful code "
+                    f"surface must use id {expected_id!r} (code_surface_id of its path)"
+                )
         if self.budget is not None and len(self.content) > self.budget:
             raise ValueError(
                 f"surface {self.id!r} content is {len(self.content)} chars, "
@@ -192,6 +236,17 @@ class HarnessDoc(BaseModel):
             + (f"\x00path={surface.path}" if surface.path is not None else "")
             for surface in self.surfaces
         )
+        return _digest(joined)
+
+    @property
+    def legacy_doc_hash(self) -> str:
+        """The pre-path-inclusion document identity (surface id + content hash only).
+
+        Exists ONLY so `wmh pull` can integrity-check harness versions the platform recorded
+        before `doc_hash` covered materialized paths. Never use it anywhere else: not for new
+        records, dedupe, or caching.
+        """
+        joined = "\n".join(f"{s.id}\x00{s.content_hash}" for s in self.surfaces)
         return _digest(joined)
 
     # -- derived, validated views ------------------------------------------------------------

--- a/wmh/harness/doc.py
+++ b/wmh/harness/doc.py
@@ -182,8 +182,16 @@ class HarnessDoc(BaseModel):
 
     @property
     def doc_hash(self) -> str:
-        """Content identity of the whole document (order-independent via canonical sort)."""
-        joined = "\n".join(f"{s.id}\x00{s.content_hash}" for s in self.surfaces)
+        """Identity of every surface field that can change materialized execution.
+
+        Display metadata and validation-only budgets do not affect execution. A code surface's
+        destination path does, even when its id and content stay unchanged.
+        """
+        joined = "\n".join(
+            f"{surface.id}\x00{surface.content_hash}"
+            + (f"\x00path={surface.path}" if surface.path is not None else "")
+            for surface in self.surfaces
+        )
         return _digest(joined)
 
     # -- derived, validated views ------------------------------------------------------------

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -42,6 +42,20 @@ def test_surface_id_must_match_kind() -> None:
         Surface(id="prompt:Not Kebab", kind=SurfaceKind.PROMPT, content="x")
 
 
+def test_trailing_newline_never_slips_past_id_or_path_validation() -> None:
+    # `$` in re.match also matches before a final newline; the validators must use fullmatch
+    # or a newline-carrying surface passes here and fails only at render/reparse time.
+    with pytest.raises(ValidationError, match="matching its kind"):
+        Surface(id="prompt:core\n", kind=SurfaceKind.PROMPT, content="x")
+    with pytest.raises(ValidationError, match="unsafe path"):
+        Surface(
+            id=code_surface_id("src/agent.ts"),
+            kind=SurfaceKind.CODE,
+            content="x",
+            path="src/agent.ts\n",
+        )
+
+
 def test_budget_is_enforced_at_construction() -> None:
     Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="ok", budget=10)
     with pytest.raises(ValidationError, match="over its budget"):

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -65,6 +65,38 @@ def test_doc_hash_is_content_and_order_independent() -> None:
     assert doc3.doc_hash != doc1.doc_hash
 
 
+def test_doc_hash_includes_materialized_paths_and_ignores_display_metadata() -> None:
+    first = HarnessDoc(
+        name="first",
+        version=1,
+        surfaces=[
+            Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
+            Surface(
+                id="code:worker",
+                kind=SurfaceKind.CODE,
+                content="export const value = 1;",
+                path="src/worker.ts",
+            ),
+        ],
+    )
+    renamed = first.model_copy(update={"name": "renamed", "version": 99})
+    moved = HarnessDoc(
+        name="moved",
+        surfaces=[
+            Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
+            Surface(
+                id="code:worker",
+                kind=SurfaceKind.CODE,
+                content="export const value = 1;",
+                path="src/moved.ts",
+            ),
+        ],
+    )
+
+    assert renamed.doc_hash == first.doc_hash
+    assert moved.doc_hash != first.doc_hash
+
+
 def test_duplicate_surface_ids_rejected() -> None:
     a = Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="A")
     with pytest.raises(ValidationError, match="duplicate surface id"):

--- a/wmh/harness/doc_test.py
+++ b/wmh/harness/doc_test.py
@@ -13,6 +13,7 @@ from wmh.harness.doc import (
     HarnessDoc,
     Surface,
     SurfaceKind,
+    code_surface_id,
 )
 from wmh.harness.skills import Skill
 
@@ -66,13 +67,15 @@ def test_doc_hash_is_content_and_order_independent() -> None:
 
 
 def test_doc_hash_includes_materialized_paths_and_ignores_display_metadata() -> None:
+    # "src/worker.ts" and "src.worker.ts" both map (lossily) to id "code:src-worker-ts", so the
+    # id and content alone cannot tell these two materializations apart; the hash must.
     first = HarnessDoc(
         name="first",
         version=1,
         surfaces=[
             Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
             Surface(
-                id="code:worker",
+                id="code:src-worker-ts",
                 kind=SurfaceKind.CODE,
                 content="export const value = 1;",
                 path="src/worker.ts",
@@ -85,16 +88,56 @@ def test_doc_hash_includes_materialized_paths_and_ignores_display_metadata() -> 
         surfaces=[
             Surface(id="prompt:main", kind=SurfaceKind.PROMPT, content="prompt"),
             Surface(
-                id="code:worker",
+                id="code:src-worker-ts",
                 kind=SurfaceKind.CODE,
                 content="export const value = 1;",
-                path="src/moved.ts",
+                path="src.worker.ts",
             ),
         ],
     )
 
     assert renamed.doc_hash == first.doc_hash
     assert moved.doc_hash != first.doc_hash
+    # The legacy identity (pull compatibility only) predates path coverage: it cannot tell the
+    # moved document apart, which is exactly why doc_hash now includes paths.
+    assert first.legacy_doc_hash == moved.legacy_doc_hash
+    assert first.legacy_doc_hash != first.doc_hash
+
+
+def test_pathless_doc_hash_matches_its_legacy_hash() -> None:
+    doc = HarnessDoc.baseline("base")
+    assert doc.doc_hash == doc.legacy_doc_hash
+
+
+def test_code_surface_path_must_derive_its_id() -> None:
+    Surface(id="code:src-agent-ts", kind=SurfaceKind.CODE, path="src/agent.ts", content="// ok")
+    with pytest.raises(ValidationError, match="must use id 'code:src-agent-ts'"):
+        Surface(id="code:other", kind=SurfaceKind.CODE, path="src/agent.ts", content="// no")
+
+
+@pytest.mark.parametrize("path", ["src/agent_utils.ts", "Upper.ts", "src/a..b.ts"])
+def test_code_surface_rejects_paths_outside_the_id_grammar(path: str) -> None:
+    with pytest.raises(ValidationError, match="kebab-slug"):
+        Surface(id="code:whatever", kind=SurfaceKind.CODE, path=path, content="x")
+
+
+@pytest.mark.parametrize("path", ["./x.ts", "src/./x.ts", "src//x.ts", "/abs.ts", "a/../b.ts"])
+def test_code_surface_rejects_noncanonical_paths(path: str) -> None:
+    with pytest.raises(ValidationError, match="canonical relative POSIX path"):
+        Surface(id="code:x-ts", kind=SurfaceKind.CODE, path=path, content="x")
+
+
+@pytest.mark.parametrize("path", ["doc.json", "aliases.toml"])
+def test_code_surface_rejects_store_metadata_paths(path: str) -> None:
+    with pytest.raises(ValidationError, match="store metadata"):
+        Surface(id=code_surface_id(path), kind=SurfaceKind.CODE, path=path, content="x")
+
+
+def test_code_runtime_surface_must_be_pathless() -> None:
+    # A file named exactly `runtime` would mint a pathful code:runtime that hijacks the
+    # in-process runtime module and collides with the rendered runtime.py on reparse.
+    with pytest.raises(ValidationError, match="must not carry a path"):
+        Surface(id="code:runtime", kind=SurfaceKind.CODE, path="runtime", content="x")
 
 
 def test_duplicate_surface_ids_rejected() -> None:
@@ -213,7 +256,9 @@ def _pi_doc() -> HarnessDoc:
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
-            Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
+            Surface(
+                id="code:src-agent-ts", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"
+            ),
         ],
     )
 

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -140,11 +140,13 @@ _params_schema = params_schema
 class _ShimServer(ThreadingHTTPServer):
     """A threading HTTP server that carries the current episode for its handlers."""
 
-    # Environment calls mutate evaluator-owned state. server_close() must join an active /tool
-    # handler so no environment write can land after the episode is declared finished: against
-    # a real execution environment (unlike the world-model simulation) a late write would mutate
-    # state the evaluator is already verifying. Handlers stay bounded because each tool command
-    # runs with a finite budget, which bounds the join.
+    # Environment calls mutate evaluator-owned state, so server_close() must join every active
+    # handler: no environment write may land after the episode is declared finished (against a
+    # real execution environment a late write would mutate state the evaluator is already
+    # verifying; with the world model it was merely cosmetic). The join is bounded by whatever
+    # the slowest handler is blocked on, worst case a completion handler waiting out the provider
+    # SDK's timeout and retries (minutes during an outage), not just a tool command's budget. A
+    # slow close is the accepted price of a trustworthy verdict.
     daemon_threads = False
     episode: _Episode
 

--- a/wmh/harness/pi_runtime.py
+++ b/wmh/harness/pi_runtime.py
@@ -140,6 +140,12 @@ _params_schema = params_schema
 class _ShimServer(ThreadingHTTPServer):
     """A threading HTTP server that carries the current episode for its handlers."""
 
+    # Environment calls mutate evaluator-owned state. server_close() must join an active /tool
+    # handler so no environment write can land after the episode is declared finished: against
+    # a real execution environment (unlike the world-model simulation) a late write would mutate
+    # state the evaluator is already verifying. Handlers stay bounded because each tool command
+    # runs with a finite budget, which bounds the join.
+    daemon_threads = False
     episode: _Episode
 
 

--- a/wmh/harness/pi_runtime_test.py
+++ b/wmh/harness/pi_runtime_test.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import threading
+import time
+from socket import socket
+from typing import cast
+
+import pytest
 from llm_waterfall import ChatRequest, ChatResponse
 
 from wmh.core.types import Action, Observation
@@ -15,7 +21,13 @@ from wmh.harness.doc import (
     Surface,
     SurfaceKind,
 )
-from wmh.harness.pi_runtime import PiRuntime, _Episode, _params_schema
+from wmh.harness.pi_runtime import (
+    PiRuntime,
+    _Episode,
+    _params_schema,
+    _ShimHandler,
+    _ShimServer,
+)
 from wmh.harness.skills import Skill, SkillLibrary
 from wmh.harness.tools import SUBMIT, TOOL_REGISTRY
 
@@ -118,6 +130,41 @@ def test_read_skill_is_runtime_local_and_does_not_consume_environment_budget() -
     assert found == {"content": "wc -w <path>", "is_error": False}
     assert missing == {"content": "no skill named 'ghost'", "is_error": True}
     assert env.actions == []
+
+
+def test_local_shim_close_waits_for_active_environment_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    close_finished = threading.Event()
+    server = _ShimServer(("127.0.0.1", 0), _ShimHandler, bind_and_activate=False)
+
+    def blocking_request(_request: object, _client_address: object) -> None:
+        handler_started.set()
+        assert release_handler.wait(timeout=2)
+
+    monkeypatch.setattr(server, "process_request_thread", blocking_request)
+    server.process_request(cast("socket", object()), ("127.0.0.1", 1))
+    assert handler_started.wait(timeout=1)
+
+    def close_server() -> None:
+        server.server_close()
+        close_finished.set()
+
+    close_thread = threading.Thread(target=close_server)
+    close_thread.start()
+    try:
+        time.sleep(0.05)
+        assert _ShimServer.daemon_threads is False
+        assert close_finished.is_set() is False
+        assert close_thread.is_alive()
+    finally:
+        release_handler.set()
+        close_thread.join(timeout=2)
+
+    assert close_thread.is_alive() is False
+    assert close_finished.is_set()
 
 
 def test_doc_dispatches_pi_runtime_for_pi_node_kind() -> None:

--- a/wmh/harness/pi_vendor.py
+++ b/wmh/harness/pi_vendor.py
@@ -19,17 +19,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from wmh.harness.doc import Surface, SurfaceKind
+# code_surface_id lives with the Surface grammar in doc.py; imported (and re-exported) here for
+# the existing pi-vendor call sites.
+from wmh.harness.doc import Surface, SurfaceKind, code_surface_id
 
 # The committed, byte-exact vendored copy (see VENDOR.md for the upstream pin).
 PI_AGENT_ROOT = Path(__file__).parent / "vendor" / "pi-agent"
 # pi's runnable TypeScript source — the harness the meta-agent searches over.
 _SOURCE_GLOB = "src/**/*.ts"
-
-
-def code_surface_id(relpath: str) -> str:
-    """A stable surface id from a path (`src/agent-loop.ts` -> `code:src-agent-loop-ts`)."""
-    return "code:" + relpath.replace("/", "-").replace(".", "-")
 
 
 def pi_agent_source_paths() -> list[Path]:

--- a/wmh/harness/proposer_test.py
+++ b/wmh/harness/proposer_test.py
@@ -418,7 +418,7 @@ def test_project_parent_manifest_splits_large_surfaces_below_read_cap() -> None:
                 content="submit",
             ),
             Surface(
-                id="code:large",
+                id="code:src-large-ts",
                 kind=SurfaceKind.CODE,
                 content=content,
                 path="src/large.ts",
@@ -433,7 +433,7 @@ def test_project_parent_manifest_splits_large_surfaces_below_read_cap() -> None:
 
     manifest_text = project.files["context/iteration-0001/parent.json"]
     surfaces = _parent_surface_manifests(project, "context/iteration-0001/parent.json")
-    code_surface = next(surface for surface in surfaces if surface["id"] == "code:large")
+    code_surface = next(surface for surface in surfaces if surface["id"] == "code:src-large-ts")
     relative_files = [
         path.removeprefix(f"{project.workspace}/")
         for path in cast("list[str]", code_surface["content_files"])

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -557,7 +557,9 @@ def test_doc_runtime_dispatches_runner_link_under_pi_transport_link() -> None:
             Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
             Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content="7"),
             Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="16384"),
-            Surface(id="code:a", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"),
+            Surface(
+                id="code:src-agent-ts", kind=SurfaceKind.CODE, path="src/agent.ts", content="// a"
+            ),
         ],
     )
     provider = cast(Provider, _P())

--- a/wmh/harness/source_tree.py
+++ b/wmh/harness/source_tree.py
@@ -310,7 +310,7 @@ class HarnessSourceTree(BaseModel):
 def _code_surface_id(path: str) -> str:
     """Derive a code file's surface id, failing with the path and the allowed grammar."""
     surface_id = code_surface_id(path)
-    if not _SLUG_RE.match(surface_id.partition(":")[2]):
+    if not _SLUG_RE.fullmatch(surface_id.partition(":")[2]):
         raise ValueError(
             f"code file path {path!r} maps to surface id {surface_id!r}, which is not a valid "
             "'code:<kebab-slug>' id; use lowercase [a-z0-9] runs separated by single '/', '.', "

--- a/wmh/harness/source_tree.py
+++ b/wmh/harness/source_tree.py
@@ -1,0 +1,291 @@
+"""Portable source trees for editing and reconstructing complete harnesses."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import tomllib
+from pathlib import PurePosixPath
+
+import tomli_w
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from wmh.core.text import validate_durable_text
+
+# _SLUG_RE is doc's surface-id grammar; reusing it keeps `to_doc`'s path checks and Surface
+# validation from ever drifting apart.
+from wmh.harness.doc import (
+    _SLUG_RE,
+    CODE_RUNTIME_ID,
+    MAX_OUTPUT_TOKENS_ID,
+    MAX_TURNS_ID,
+    RUNTIME_KIND_ID,
+    TEMPERATURE_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.pi_vendor import code_surface_id
+from wmh.harness.skills import Skill
+
+SYSTEM_FILE = "SYSTEM.md"
+CONFIG_FILE = "config.toml"
+RUNTIME_FILE = "runtime.py"
+SKILLS_DIR = "skills"
+
+_STORE_METADATA_FILES = frozenset({"doc.json", "aliases.toml"})
+_RESERVED_RENDER_FILES = frozenset({SYSTEM_FILE, CONFIG_FILE, RUNTIME_FILE})
+_SOURCE_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
+_TREE_HASH_BYTES = 16
+MAX_SOURCE_PATH_BYTES = 1_024
+
+
+class HarnessSourceFile(BaseModel):
+    """One UTF-8 text file at a canonical path inside a harness source tree."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    content: str
+
+    @model_validator(mode="after")
+    def _validate_file(self) -> HarnessSourceFile:
+        candidate = PurePosixPath(self.path)
+        if (
+            candidate.is_absolute()
+            or not candidate.parts
+            or candidate.as_posix() != self.path
+            or ".." in candidate.parts
+            or not _SOURCE_PATH_RE.fullmatch(self.path)
+            or len(self.path.encode("utf-8")) > MAX_SOURCE_PATH_BYTES
+        ):
+            raise ValueError(f"source path {self.path!r} must be a canonical relative POSIX path")
+        validate_durable_text(self.content, field=f"source file {self.path!r}")
+        return self
+
+
+class HarnessSourceTree(BaseModel):
+    """A complete editable file representation that can be parsed into a HarnessDoc.
+
+    Round-tripping through `from_doc`/`to_doc` is lossless only on the canonical subset: a
+    multi-prompt document renders as one SYSTEM.md and reparses as a single `prompt:core`
+    surface, and validation-only `Surface.budget` values are dropped.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    files: tuple[HarnessSourceFile, ...]
+
+    @field_validator("files")
+    @classmethod
+    def _canonical_files(
+        cls, files: tuple[HarnessSourceFile, ...]
+    ) -> tuple[HarnessSourceFile, ...]:
+        paths = [item.path for item in files]
+        duplicates = sorted({path for path in paths if paths.count(path) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate source path(s): {duplicates}")
+        metadata = sorted(path for path in paths if path in _STORE_METADATA_FILES)
+        if metadata:
+            raise ValueError(f"source tree cannot contain store metadata file(s): {metadata}")
+        return tuple(sorted(files, key=lambda item: item.path))
+
+    @classmethod
+    def from_doc(cls, doc: HarnessDoc) -> HarnessSourceTree:
+        """Render a harness into the exact source files an external editor should see."""
+        files: dict[str, str] = {
+            SYSTEM_FILE: doc.system_prompt(),
+            CONFIG_FILE: tomli_w.dumps(
+                {
+                    "harness": {
+                        "tools": doc.tools(),
+                        "max_turns": doc.max_turns(),
+                        "max_output_tokens": doc.max_output_tokens(),
+                        "temperature": doc.temperature(),
+                        "runtime_kind": doc.runtime_kind(),
+                    }
+                }
+            ),
+        }
+        for skill in doc.skills():
+            files[f"{SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
+        runtime = doc.surface(CODE_RUNTIME_ID)
+        if runtime is not None:
+            files[RUNTIME_FILE] = runtime.content
+        for surface in doc.code_files():
+            assert surface.path is not None
+            if surface.path in _RESERVED_RENDER_FILES or surface.path.startswith(f"{SKILLS_DIR}/"):
+                raise ValueError(
+                    f"code surface path {surface.path!r} collides with a reserved file"
+                )
+            files[surface.path] = surface.content
+        return cls(
+            files=tuple(
+                HarnessSourceFile(path=path, content=content) for path, content in files.items()
+            )
+        )
+
+    def to_doc(self, name: str) -> HarnessDoc:
+        """Parse the complete source tree into one validated harness document."""
+        files = self.file_map()
+        if SYSTEM_FILE not in files:
+            raise ValueError(f"harness source tree is missing required {SYSTEM_FILE}")
+        surfaces = [
+            Surface(
+                id="prompt:core",
+                kind=SurfaceKind.PROMPT,
+                content=files[SYSTEM_FILE],
+            )
+        ]
+        config_text = files.get(CONFIG_FILE)
+        if config_text is not None:
+            parsed_config = tomllib.loads(config_text)
+            unknown_tables = sorted(set(parsed_config) - {"harness"})
+            if unknown_tables:
+                raise ValueError(
+                    f"{CONFIG_FILE} contains unknown top-level table(s): {unknown_tables}"
+                )
+            config = parsed_config.get("harness", {})
+            if not isinstance(config, dict):
+                raise ValueError(f"{CONFIG_FILE} [harness] must be a table")
+            allowed_fields = {
+                "tools",
+                "max_turns",
+                "max_output_tokens",
+                "temperature",
+                "runtime_kind",
+            }
+            unknown_fields = sorted(set(config) - allowed_fields)
+            if unknown_fields:
+                raise ValueError(
+                    f"{CONFIG_FILE} [harness] contains unknown field(s): {unknown_fields}"
+                )
+            tools = config.get("tools")
+            if tools is not None:
+                if not isinstance(tools, list) or not all(isinstance(item, str) for item in tools):
+                    raise ValueError(f"{CONFIG_FILE} harness.tools must be an array of strings")
+                surfaces.append(
+                    Surface(
+                        id=TOOL_POLICY_ID,
+                        kind=SurfaceKind.TOOL_POLICY,
+                        content="\n".join(tools),
+                    )
+                )
+            scalar_fields = (
+                ("max_turns", MAX_TURNS_ID),
+                ("max_output_tokens", MAX_OUTPUT_TOKENS_ID),
+                ("temperature", TEMPERATURE_ID),
+            )
+            for field, surface_id in scalar_fields:
+                if field in config:
+                    surfaces.append(
+                        Surface(
+                            id=surface_id,
+                            kind=SurfaceKind.PARAM,
+                            content=str(config[field]),
+                        )
+                    )
+            runtime_kind = config.get("runtime_kind")
+            if runtime_kind is not None and not isinstance(runtime_kind, str):
+                raise ValueError(f"{CONFIG_FILE} harness.runtime_kind must be a string")
+            if runtime_kind and runtime_kind != "kit-python":
+                surfaces.append(
+                    Surface(
+                        id=RUNTIME_KIND_ID,
+                        kind=SurfaceKind.PARAM,
+                        content=str(runtime_kind),
+                    )
+                )
+        runtime = files.get(RUNTIME_FILE)
+        if runtime is not None:
+            surfaces.append(Surface(id=CODE_RUNTIME_ID, kind=SurfaceKind.CODE, content=runtime))
+        for item in self.files:
+            path = PurePosixPath(item.path)
+            if path.parts[0] != SKILLS_DIR:
+                continue
+            if len(path.parts) != 2 or path.suffix != ".md":
+                raise ValueError(f"skill source path {item.path!r} must be skills/<skill-name>.md")
+            skill = Skill.from_markdown(item.content)
+            if path.stem != skill.name:
+                raise ValueError(
+                    f"skill source path {item.path!r} does not match declared name {skill.name!r}"
+                )
+            surfaces.append(
+                Surface(
+                    id=f"skill:{skill.name}",
+                    kind=SurfaceKind.SKILL,
+                    content=skill.to_markdown(),
+                )
+            )
+        code_paths_by_id: dict[str, str] = {}
+        for item in self.files:
+            if item.path in _RESERVED_RENDER_FILES or item.path.startswith(f"{SKILLS_DIR}/"):
+                continue
+            surface_id = _code_surface_id(item.path)
+            claimed = code_paths_by_id.get(surface_id)
+            if claimed is not None:
+                raise ValueError(
+                    f"code file paths {claimed!r} and {item.path!r} both map to surface id "
+                    f"{surface_id!r} ('/' and '.' both become '-'); rename one so every "
+                    "path keeps a distinct id"
+                )
+            code_paths_by_id[surface_id] = item.path
+            surfaces.append(
+                Surface(
+                    id=surface_id,
+                    kind=SurfaceKind.CODE,
+                    path=item.path,
+                    content=item.content,
+                )
+            )
+        return HarnessDoc(name=name, surfaces=surfaces)
+
+    def file_map(self) -> dict[str, str]:
+        """Return a new path-to-content mapping in canonical path order."""
+        return {item.path: item.content for item in self.files}
+
+    @property
+    def total_bytes(self) -> int:
+        """Return the UTF-8 payload size across all source files."""
+        return sum(len(item.content.encode("utf-8")) for item in self.files)
+
+    @property
+    def tree_hash(self) -> str:
+        """Return a content address covering every source path and byte."""
+        digest = hashlib.blake2b(digest_size=_TREE_HASH_BYTES)
+        for item in self.files:
+            path = item.path.encode("utf-8")
+            content = item.content.encode("utf-8")
+            digest.update(len(path).to_bytes(4, "big"))
+            digest.update(path)
+            digest.update(len(content).to_bytes(8, "big"))
+            digest.update(content)
+        return digest.hexdigest()
+
+    def validate_bounds(self, *, max_files: int, max_bytes: int) -> None:
+        """Reject a tree that exceeds explicit file-count or UTF-8 byte bounds."""
+        if isinstance(max_files, bool) or not isinstance(max_files, int) or max_files < 1:
+            raise ValueError("max_files must be a positive integer")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+        if len(self.files) > max_files:
+            raise ValueError(
+                f"source tree has {len(self.files)} files, more than {max_files} files allowed"
+            )
+        if self.total_bytes > max_bytes:
+            raise ValueError(
+                f"source tree has {self.total_bytes} bytes, more than {max_bytes} bytes allowed"
+            )
+
+
+def _code_surface_id(path: str) -> str:
+    """Derive a code file's surface id, failing with the path and the allowed grammar."""
+    surface_id = code_surface_id(path)
+    if not _SLUG_RE.match(surface_id.partition(":")[2]):
+        raise ValueError(
+            f"code file path {path!r} maps to surface id {surface_id!r}, which is not a valid "
+            "'code:<kebab-slug>' id; use lowercase [a-z0-9] runs separated by single '/', '.', "
+            "or '-' characters (for example src/agent-loop.ts)"
+        )
+    return surface_id

--- a/wmh/harness/source_tree.py
+++ b/wmh/harness/source_tree.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import re
 import tomllib
 from pathlib import PurePosixPath
 
@@ -12,12 +11,15 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from wmh.core.text import validate_durable_text
 
-# _SLUG_RE is doc's surface-id grammar; reusing it keeps `to_doc`'s path checks and Surface
-# validation from ever drifting apart.
+# _SAFE_PATH_RE and _SLUG_RE are doc's path and surface-id grammars; sharing them keeps this
+# module's file checks and Surface validation from ever drifting apart.
 from wmh.harness.doc import (
+    _SAFE_PATH_RE,
     _SLUG_RE,
+    _STORE_METADATA_FILES,
     CODE_RUNTIME_ID,
     MAX_OUTPUT_TOKENS_ID,
+    MAX_SURFACE_PATH_BYTES,
     MAX_TURNS_ID,
     RUNTIME_KIND_ID,
     TEMPERATURE_ID,
@@ -25,8 +27,8 @@ from wmh.harness.doc import (
     HarnessDoc,
     Surface,
     SurfaceKind,
+    code_surface_id,
 )
-from wmh.harness.pi_vendor import code_surface_id
 from wmh.harness.skills import Skill
 
 SYSTEM_FILE = "SYSTEM.md"
@@ -34,11 +36,9 @@ CONFIG_FILE = "config.toml"
 RUNTIME_FILE = "runtime.py"
 SKILLS_DIR = "skills"
 
-_STORE_METADATA_FILES = frozenset({"doc.json", "aliases.toml"})
 _RESERVED_RENDER_FILES = frozenset({SYSTEM_FILE, CONFIG_FILE, RUNTIME_FILE})
-_SOURCE_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
 _TREE_HASH_BYTES = 16
-MAX_SOURCE_PATH_BYTES = 1_024
+MAX_SOURCE_PATH_BYTES = MAX_SURFACE_PATH_BYTES
 
 
 class HarnessSourceFile(BaseModel):
@@ -57,7 +57,7 @@ class HarnessSourceFile(BaseModel):
             or not candidate.parts
             or candidate.as_posix() != self.path
             or ".." in candidate.parts
-            or not _SOURCE_PATH_RE.fullmatch(self.path)
+            or not _SAFE_PATH_RE.fullmatch(self.path)
             or len(self.path.encode("utf-8")) > MAX_SOURCE_PATH_BYTES
         ):
             raise ValueError(f"source path {self.path!r} must be a canonical relative POSIX path")
@@ -89,6 +89,28 @@ class HarnessSourceTree(BaseModel):
         metadata = sorted(path for path in paths if path in _STORE_METADATA_FILES)
         if metadata:
             raise ValueError(f"source tree cannot contain store metadata file(s): {metadata}")
+        # Renders land on real filesystems, so structural conflicts must fail here, at
+        # validation time, not later inside a store write.
+        by_fold: dict[str, str] = {}
+        for path in sorted(paths):
+            claimed = by_fold.setdefault(path.casefold(), path)
+            if claimed != path:
+                raise ValueError(
+                    f"source paths {claimed!r} and {path!r} differ only by letter case and "
+                    "would collide on a case-insensitive filesystem; rename one"
+                )
+        directory_prefixes: dict[str, str] = {}
+        for path in paths:
+            parts = path.split("/")
+            for index in range(1, len(parts)):
+                directory_prefixes.setdefault("/".join(parts[:index]), path)
+        for path in sorted(paths):
+            child = directory_prefixes.get(path)
+            if child is not None:
+                raise ValueError(
+                    f"source path {path!r} is a file but is also the directory holding "
+                    f"{child!r}; rename one so no file path is a directory prefix of another"
+                )
         return tuple(sorted(files, key=lambda item: item.path))
 
     @classmethod
@@ -223,6 +245,12 @@ class HarnessSourceTree(BaseModel):
             if item.path in _RESERVED_RENDER_FILES or item.path.startswith(f"{SKILLS_DIR}/"):
                 continue
             surface_id = _code_surface_id(item.path)
+            if surface_id == CODE_RUNTIME_ID:
+                raise ValueError(
+                    f"code file path {item.path!r} would alias the reserved in-process runtime "
+                    f"surface {CODE_RUNTIME_ID!r} (which renders as {RUNTIME_FILE}); rename "
+                    "the file"
+                )
             claimed = code_paths_by_id.get(surface_id)
             if claimed is not None:
                 raise ValueError(

--- a/wmh/harness/source_tree_test.py
+++ b/wmh/harness/source_tree_test.py
@@ -101,6 +101,46 @@ def test_source_tree_rejects_duplicate_paths() -> None:
         )
 
 
+def test_source_tree_rejects_case_insensitive_path_collisions() -> None:
+    """{SYSTEM.md, system.md} silently corrupts renders on case-insensitive filesystems."""
+    with pytest.raises(
+        ValueError, match=r"'SYSTEM\.md' and 'system\.md' differ only by letter case"
+    ):
+        HarnessSourceTree(
+            files=(
+                HarnessSourceFile(path="SYSTEM.md", content="one"),
+                HarnessSourceFile(path="system.md", content="two"),
+            )
+        )
+
+
+def test_source_tree_rejects_file_and_directory_prefix_conflicts() -> None:
+    """{src, src/a.ts} would crash a store write halfway instead of failing validation."""
+    with pytest.raises(
+        ValueError, match=r"'src' is a file but is also the directory holding 'src/a\.ts'"
+    ):
+        HarnessSourceTree(
+            files=(
+                HarnessSourceFile(path="SYSTEM.md", content="p"),
+                HarnessSourceFile(path="src", content="conflict"),
+                HarnessSourceFile(path="src/a.ts", content="x"),
+            )
+        )
+
+
+def test_source_tree_rejects_a_file_that_aliases_the_runtime_surface() -> None:
+    """A file named exactly `runtime` must not hijack the in-process code:runtime surface."""
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="runtime", content="x"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="would alias the reserved in-process runtime"):
+        tree.to_doc("invalid")
+
+
 def test_source_tree_rejects_unparsed_skill_namespace_files() -> None:
     tree = HarnessSourceTree(
         files=(

--- a/wmh/harness/source_tree_test.py
+++ b/wmh/harness/source_tree_test.py
@@ -1,0 +1,180 @@
+"""Tests for the portable, editable harness source-tree representation."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.harness.doc import (
+    MAX_OUTPUT_TOKENS_ID,
+    RUNTIME_KIND_ID,
+    TOOL_POLICY_ID,
+    HarnessDoc,
+    Surface,
+    SurfaceKind,
+)
+from wmh.harness.pi_vendor import pi_agent_code_surfaces
+from wmh.harness.skills import Skill
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+
+def _pi_document() -> HarnessDoc:
+    skill = Skill(name="inspect-code", description="Inspect code", body="Use rg before editing.")
+    return HarnessDoc(
+        name="pi",
+        surfaces=[
+            Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="Work carefully."),
+            Surface(id=TOOL_POLICY_ID, kind=SurfaceKind.TOOL_POLICY, content="bash\nsubmit"),
+            Surface(id=RUNTIME_KIND_ID, kind=SurfaceKind.PARAM, content="pi-node"),
+            Surface(id=MAX_OUTPUT_TOKENS_ID, kind=SurfaceKind.PARAM, content="8192"),
+            Surface(
+                id="skill:inspect-code",
+                kind=SurfaceKind.SKILL,
+                content=skill.to_markdown(),
+            ),
+            *pi_agent_code_surfaces(),
+        ],
+    )
+
+
+def test_source_tree_round_trips_a_complete_pathful_harness() -> None:
+    """The public call site carries every executable file without store metadata."""
+    original = _pi_document()
+
+    tree = HarnessSourceTree.from_doc(original)
+    restored = tree.to_doc("restored")
+
+    paths = set(tree.file_map())
+    assert "SYSTEM.md" in paths
+    assert "config.toml" in paths
+    assert "skills/inspect-code.md" in paths
+    assert "doc.json" not in paths
+    assert restored.system_prompt() == original.system_prompt()
+    assert restored.tools() == original.tools()
+    assert restored.runtime_kind() == original.runtime_kind()
+    assert restored.max_output_tokens() == original.max_output_tokens()
+    assert [skill.name for skill in restored.skills()] == ["inspect-code"]
+    assert {(item.path, item.content) for item in restored.code_files()} == {
+        (item.path, item.content) for item in original.code_files()
+    }
+
+
+def test_source_tree_reparse_preserves_deletions_and_rewrites() -> None:
+    original = HarnessSourceTree.from_doc(_pi_document())
+    deleted_path = next(item.path for item in original.files if item.path.startswith("src/"))
+    rewritten = HarnessSourceTree(
+        files=tuple(
+            item.model_copy(update={"content": "Changed prompt."})
+            if item.path == "SYSTEM.md"
+            else item
+            for item in original.files
+            if item.path != deleted_path
+        )
+    )
+
+    candidate = rewritten.to_doc("candidate")
+
+    assert candidate.system_prompt() == "Changed prompt."
+    assert deleted_path not in {item.path for item in candidate.code_files()}
+    assert len(candidate.code_files()) == len(_pi_document().code_files()) - 1
+    assert rewritten.tree_hash != original.tree_hash
+
+
+@pytest.mark.parametrize("path", ["doc.json", "aliases.toml"])
+def test_source_tree_rejects_store_authority_files(path: str) -> None:
+    with pytest.raises(ValueError, match="store metadata"):
+        HarnessSourceTree(files=(HarnessSourceFile(path=path, content="{}"),))
+
+
+@pytest.mark.parametrize("path", ["/absolute.ts", "../escape.ts", "src/../escape.ts", "src\\x.ts"])
+def test_source_tree_rejects_noncanonical_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="canonical relative POSIX path"):
+        HarnessSourceTree(files=(HarnessSourceFile(path=path, content="x"),))
+
+
+def test_source_tree_rejects_duplicate_paths() -> None:
+    with pytest.raises(ValueError, match="duplicate source path"):
+        HarnessSourceTree(
+            files=(
+                HarnessSourceFile(path="SYSTEM.md", content="one"),
+                HarnessSourceFile(path="SYSTEM.md", content="two"),
+            )
+        )
+
+
+def test_source_tree_rejects_unparsed_skill_namespace_files() -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="skills/nested/ignored.md", content="ignored"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="skill source path"):
+        tree.to_doc("invalid")
+
+
+@pytest.mark.parametrize("path", ["src/agent_utils.ts", "Upper.ts", "src/a..b.ts"])
+def test_source_tree_names_the_file_behind_an_invalid_code_surface_id(path: str) -> None:
+    """A path outside the surface-id grammar fails naming the file, not just the bad slug."""
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path=path, content="x"),
+        )
+    )
+
+    with pytest.raises(ValueError, match=rf"code file path '{path}'.*kebab-slug"):
+        tree.to_doc("invalid")
+
+
+def test_source_tree_names_both_files_behind_a_surface_id_collision() -> None:
+    """`/` and `.` both map to `-`, so distinct paths can collide on one surface id."""
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="src/a-b.ts", content="one"),
+            HarnessSourceFile(path="src/a/b.ts", content="two"),
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"'src/a-b\.ts' and 'src/a/b\.ts' both map"):
+        tree.to_doc("invalid")
+
+
+@pytest.mark.parametrize(
+    "config, error",
+    [
+        ("[provider]\nmodel = 'mutable'\n", "unknown top-level"),
+        ("[harness]\ntools = ['submit']\nmodel = 'mutable'\n", "unknown field"),
+        ("[harness]\nruntime_kind = false\n", "runtime_kind must be a string"),
+    ],
+)
+def test_source_tree_rejects_config_that_would_not_affect_the_parsed_harness(
+    config: str,
+    error: str,
+) -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="config.toml", content=config),
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        tree.to_doc("invalid")
+
+
+def test_bounds_validation_reports_files_and_bytes() -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="p"),
+            HarnessSourceFile(path="src/a.ts", content="abcdef"),
+        )
+    )
+
+    tree.validate_bounds(max_files=2, max_bytes=7)
+    assert tree.total_bytes == 7
+    with pytest.raises(ValueError, match="more than 1 files"):
+        tree.validate_bounds(max_files=1, max_bytes=7)
+    with pytest.raises(ValueError, match="more than 6 bytes"):
+        tree.validate_bounds(max_files=2, max_bytes=6)

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -26,32 +26,14 @@ from pathlib import Path
 import tomli_w
 
 from wmh.config.store import validate_name
-from wmh.harness.doc import (
-    CODE_RUNTIME_ID,
-    MAX_OUTPUT_TOKENS_ID,
-    MAX_TURNS_ID,
-    RUNTIME_KIND_ID,
-    TEMPERATURE_ID,
-    TOOL_POLICY_ID,
-    HarnessDoc,
-    Surface,
-    SurfaceKind,
-)
-from wmh.harness.pi_vendor import code_surface_id
-from wmh.harness.skills import Skill
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.source_tree import SYSTEM_FILE, HarnessSourceFile, HarnessSourceTree
 
 HARNESSES_DIR = "harnesses"
 CHAMPION_ALIAS = "champion"
 
 _DOC_FILE = "doc.json"
-_SYSTEM_FILE = "SYSTEM.md"
-_CONFIG_FILE = "config.toml"
-_RUNTIME_FILE = "runtime.py"
-_SKILLS_DIR = "skills"
 _ALIASES_FILE = "aliases.toml"
-
-# Top-level render filenames a pathful code surface must not shadow (skills/ is guarded by prefix).
-_RESERVED_FILES = frozenset({_DOC_FILE, _SYSTEM_FILE, _CONFIG_FILE, _RUNTIME_FILE})
 
 
 class HarnessStore:
@@ -162,34 +144,7 @@ class HarnessStore:
 
 def _render(doc: HarnessDoc) -> dict[str, str]:
     """Render the document to its file export (relative path -> content)."""
-    files = {
-        _SYSTEM_FILE: doc.system_prompt(),
-        _CONFIG_FILE: tomli_w.dumps(
-            {
-                "harness": {
-                    "tools": doc.tools(),
-                    "max_turns": doc.max_turns(),
-                    "max_output_tokens": doc.max_output_tokens(),
-                    "temperature": doc.temperature(),
-                    "runtime_kind": doc.runtime_kind(),
-                }
-            }
-        ),
-    }
-    for skill in doc.skills():
-        files[f"{_SKILLS_DIR}/{skill.name}.md"] = skill.to_markdown()
-    code = doc.surface(CODE_RUNTIME_ID)
-    if code is not None:
-        files[_RUNTIME_FILE] = code.content
-    # Pathful code surfaces (a pi-node harness's vendored source) render to their own paths, so
-    # the export is the harness's real directory tree — what the agent view browses and what an
-    # execution sandbox downloads. Their `code_surface_id` is recovered from the path on reparse.
-    for surface in doc.code_files():
-        assert surface.path is not None  # code_files() only returns pathful surfaces
-        if surface.path in _RESERVED_FILES or surface.path.startswith(f"{_SKILLS_DIR}/"):
-            raise ValueError(f"code surface path {surface.path!r} collides with a reserved file")
-        files[surface.path] = surface.content
-    return files
+    return HarnessSourceTree.from_doc(doc).file_map()
 
 
 def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
@@ -198,87 +153,14 @@ def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
     The whole `SYSTEM.md` becomes one `prompt:core` surface — section boundaries are not
     recoverable from a rendered prompt, which is exactly why `doc.json` is the authoritative form.
     """
-    system_path = directory / _SYSTEM_FILE
-    if not system_path.exists():
-        raise ValueError(f"harness dir {directory} has neither {_DOC_FILE} nor {_SYSTEM_FILE}")
-    surfaces = [
-        Surface(
-            id="prompt:core",
-            kind=SurfaceKind.PROMPT,
-            content=system_path.read_text(encoding="utf-8"),
-        )
-    ]
-    config_path = directory / _CONFIG_FILE
-    if config_path.exists():
-        config = tomllib.loads(config_path.read_text(encoding="utf-8")).get("harness", {})
-        if "tools" in config:
-            surfaces.append(
-                Surface(
-                    id=TOOL_POLICY_ID,
-                    kind=SurfaceKind.TOOL_POLICY,
-                    content="\n".join(str(t) for t in config["tools"]),
-                )
-            )
-        if "max_turns" in config:
-            surfaces.append(
-                Surface(id=MAX_TURNS_ID, kind=SurfaceKind.PARAM, content=str(config["max_turns"]))
-            )
-        if "max_output_tokens" in config:
-            surfaces.append(
-                Surface(
-                    id=MAX_OUTPUT_TOKENS_ID,
-                    kind=SurfaceKind.PARAM,
-                    content=str(config["max_output_tokens"]),
-                )
-            )
-        if "temperature" in config:
-            surfaces.append(
-                Surface(
-                    id=TEMPERATURE_ID, kind=SurfaceKind.PARAM, content=str(config["temperature"])
-                )
-            )
-        # runtime_kind classifies the harness (pi-node vs in-process); a default "kit-python" is
-        # implicit, so only a non-default value needs its own surface on reconstruction.
-        if config.get("runtime_kind") and config["runtime_kind"] != "kit-python":
-            surfaces.append(
-                Surface(
-                    id=RUNTIME_KIND_ID,
-                    kind=SurfaceKind.PARAM,
-                    content=str(config["runtime_kind"]),
-                )
-            )
-    runtime_path = directory / _RUNTIME_FILE
-    if runtime_path.exists():
-        surfaces.append(
-            Surface(
-                id=CODE_RUNTIME_ID,
-                kind=SurfaceKind.CODE,
-                content=runtime_path.read_text(encoding="utf-8"),
-            )
-        )
-    skills_dir = directory / _SKILLS_DIR
-    if skills_dir.exists():
-        for path in sorted(skills_dir.glob("*.md")):
-            skill = Skill.from_markdown(path.read_text(encoding="utf-8"))
-            surfaces.append(
-                Surface(
-                    id=f"skill:{skill.name}", kind=SurfaceKind.SKILL, content=skill.to_markdown()
-                )
-            )
-    # Everything else under the dir is a pathful code surface (a pi-node harness's source tree):
-    # the inverse of `_render`'s per-path write, keyed back to its `code_surface_id`.
+    files: list[HarnessSourceFile] = []
     for path in sorted(directory.rglob("*")):
         if not path.is_file():
             continue
         rel = path.relative_to(directory).as_posix()
-        if rel in _RESERVED_FILES or rel == _ALIASES_FILE or rel.startswith(f"{_SKILLS_DIR}/"):
+        if rel in {_DOC_FILE, _ALIASES_FILE}:
             continue
-        surfaces.append(
-            Surface(
-                id=code_surface_id(rel),
-                kind=SurfaceKind.CODE,
-                path=rel,
-                content=path.read_text(encoding="utf-8"),
-            )
-        )
-    return HarnessDoc(name=name, surfaces=surfaces)
+        files.append(HarnessSourceFile(path=rel, content=path.read_text(encoding="utf-8")))
+    if not files:
+        raise ValueError(f"harness dir {directory} has neither {_DOC_FILE} nor {SYSTEM_FILE}")
+    return HarnessSourceTree(files=tuple(files)).to_doc(name)

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -16,6 +16,9 @@ immutable version rather than to "whatever the harness currently is".
 
 `doc.json` is authoritative; the rendered files are an export. A directory with rendered files but
 no `doc.json` (a hand-authored harness) still loads: the files parse into a single-prompt document.
+Rendered-only loads are strict: unknown config.toml tables or fields, non-.md files under skills/,
+and a skill filename that does not match its frontmatter name are errors with actionable messages,
+not silently ignored. Dotfiles (.DS_Store and friends) are skipped.
 """
 
 from __future__ import annotations
@@ -157,7 +160,13 @@ def _parse_rendered(name: str, directory: Path) -> HarnessDoc:
     for path in sorted(directory.rglob("*")):
         if not path.is_file():
             continue
-        rel = path.relative_to(directory).as_posix()
+        rel_path = path.relative_to(directory)
+        if any(part.startswith(".") for part in rel_path.parts):
+            # Finder and editors drop metadata like .DS_Store (often with NUL bytes) into
+            # hand-authored dirs. A dotfile can never be a harness surface (its code_surface_id
+            # is not a valid slug), so skip it instead of failing the load on its content.
+            continue
+        rel = rel_path.as_posix()
         if rel in {_DOC_FILE, _ALIASES_FILE}:
             continue
         files.append(HarnessSourceFile(path=rel, content=path.read_text(encoding="utf-8")))

--- a/wmh/harness/store_test.py
+++ b/wmh/harness/store_test.py
@@ -199,9 +199,27 @@ def test_code_surface_path_colliding_with_a_reserved_file_is_rejected(tmp_path: 
         name="x",
         surfaces=[
             Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p"),
-            Surface(id="code:sys", kind=SurfaceKind.CODE, path="SYSTEM.md", content="// nope"),
+            Surface(
+                id="code:config-toml", kind=SurfaceKind.CODE, path="config.toml", content="# nope"
+            ),
         ],
     )
     store = HarnessStore(tmp_path)
     with pytest.raises(ValueError, match="reserved file"):
         store.save_version(doc)
+
+
+def test_hand_authored_dir_load_skips_dotfiles(tmp_path: Path) -> None:
+    """Finder metadata (.DS_Store, binary) must not break a rendered-only load."""
+    store = HarnessStore(tmp_path)
+    directory = store.dir_for("hand") / "v1"
+    directory.mkdir(parents=True)
+    (directory / "SYSTEM.md").write_text("You are careful.", encoding="utf-8")
+    (directory / ".DS_Store").write_bytes(b"\x00\x01Bud1\x00")
+    (directory / ".hidden").mkdir()
+    (directory / ".hidden" / "note.txt").write_text("ignored", encoding="utf-8")
+
+    doc = store.load("hand")
+
+    assert doc.system_prompt() == "You are careful."
+    assert doc.code_files() == []

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -22,6 +22,7 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    TokenUsage,
     VerifyResult,
     normalize_chat_temperature,
     verify_via_ping,
@@ -139,6 +140,33 @@ class AzureOpenAIProvider:
         temperature: float = 0.7,
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Completion:
+        if self.config.reasoning_effort is not None:
+            # Text completion consumers (proposer, judges, the baseline loop) must use the same
+            # verified v1 Responses route as complete_chat; the api-versioned chat client would
+            # silently drop reasoning_effort. Reasoning models reject non-default sampling, so
+            # `temperature` is not forwarded (matching OpenAIResponsesProvider.complete).
+            response = self.complete_chat(
+                ChatRequest.model_validate(
+                    {
+                        "messages": [
+                            *([{"role": "system", "content": system}] if system else []),
+                            *[{"role": m.role, "content": m.content} for m in messages],
+                        ],
+                        "max_completion_tokens": max_tokens,
+                    }
+                )
+            )
+            message = response.choices[0].message if response.choices else None
+            text = (
+                message.content if message is not None and isinstance(message.content, str) else ""
+            )
+            usage = response.token_usage()
+            return Completion(
+                text=text,
+                usage=TokenUsage(
+                    input_tokens=usage.input_tokens, output_tokens=usage.output_tokens
+                ),
+            )
         return _openai_common.complete(
             self._get_client().chat.completions, self._deployment(), system, messages, max_tokens
         )

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
-from wmh.providers import _openai_common
+from wmh.providers import _openai_common, _responses_common
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
+    PING_MAX_TOKENS,
     ChatRequest,
     ChatResponse,
     Completion,
@@ -27,7 +28,18 @@ from wmh.providers.base import (
 )
 
 if TYPE_CHECKING:
-    from openai import AzureOpenAI
+    from openai import AzureOpenAI, OpenAI
+
+
+# One read-only verify probe for reasoning configs, sent through the same structured Responses
+# route real calls use. PING_MAX_TOKENS leaves room for a reasoning prelude; base's
+# reachable-error forgiveness covers models that still exhaust it.
+_REASONING_PING = ChatRequest.model_validate(
+    {
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_completion_tokens": PING_MAX_TOKENS,
+    }
+)
 
 
 class AzureOpenAIProvider:
@@ -36,7 +48,25 @@ class AzureOpenAIProvider:
     def __init__(self, config: ProviderConfig) -> None:
         self.config = config
         self._client: AzureOpenAI | None = None
+        self._responses_client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
+
+    def _resolved_endpoint(self) -> tuple[str, bool]:
+        """Return the endpoint and whether it came from untrusted model configuration."""
+        env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+        endpoint = self.config.endpoint or env_endpoint
+        if not endpoint:
+            raise ValueError(
+                "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
+                "AZURE_OPENAI_ENDPOINT."
+            )
+        # Compare canonically so a trailing slash or host-casing difference between the config
+        # value and the trusted env endpoint doesn't misclassify the same Azure resource as an
+        # untrusted host (which would strip the real key and break the call).
+        is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
+            self.config.endpoint, env_endpoint
+        )
+        return endpoint, is_config_endpoint
 
     def _get_client(self) -> AzureOpenAI:
         # Lazy: construct on first use. api_version must be supplied by config; the endpoint and
@@ -47,22 +77,10 @@ class AzureOpenAIProvider:
             if self.config.api_version is None:
                 raise ValueError("AzureOpenAIProvider requires config.api_version to be set.")
 
-            env_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
-            endpoint = self.config.endpoint or env_endpoint
-            if not endpoint:
-                raise ValueError(
-                    "AzureOpenAIProvider needs an endpoint: set config.endpoint or "
-                    "AZURE_OPENAI_ENDPOINT."
-                )
+            endpoint, is_config_endpoint = self._resolved_endpoint()
 
             from openai import AzureOpenAI
 
-            # Compare canonically so a trailing slash or host-casing difference between the config
-            # value and the trusted env endpoint doesn't misclassify the same Azure resource as an
-            # untrusted host (which would strip the real key and break the call).
-            is_config_endpoint = self.config.endpoint is not None and not _same_endpoint(
-                self.config.endpoint, env_endpoint
-            )
             if is_config_endpoint:
                 # A config-controlled endpoint (config.toml can come from an untrusted model
                 # bundle) is an untrusted host. NEVER let the SDK fall back to the real
@@ -81,6 +99,31 @@ class AzureOpenAIProvider:
                     azure_endpoint=endpoint,
                 )
         return self._client
+
+    def _get_responses_client(self) -> OpenAI:
+        """Create the Azure v1 client used by configured structured reasoning calls."""
+        if self._responses_client is None:
+            endpoint, is_config_endpoint = self._resolved_endpoint()
+            if is_config_endpoint:
+                api_key = os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed"
+            else:
+                api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "AzureOpenAIProvider needs AZURE_OPENAI_API_KEY for the v1 Responses API."
+                    )
+
+            from openai import OpenAI
+
+            self._responses_client = OpenAI(
+                api_key=api_key,
+                base_url=_responses_base_url(endpoint),
+                timeout=240.0,
+                # A lost SDK response may already be billed. Keep one WMH proposer turn equal to
+                # one provider dispatch so usage and the operator's hard budget stay observable.
+                max_retries=0,
+            )
+        return self._responses_client
 
     def _deployment(self) -> str:
         # On Azure, the `model` arg to the API is the deployment name, not the base model id.
@@ -106,6 +149,16 @@ class AzureOpenAIProvider:
             request,
             forward_temperature=self._forward_temperature,
         )
+        if self.config.reasoning_effort is not None:
+            # Structured reasoning needs Azure's native v1 Responses route: encrypted-reasoning
+            # replay and reasoning.effort are not part of the api-versioned chat-completions API.
+            return _responses_common.complete_chat(
+                self._get_responses_client().responses,
+                self._deployment(),
+                request,
+                reasoning_effort=self.config.reasoning_effort,
+                allow_sampling=False,
+            )
         return _openai_common.complete_chat(
             self._get_client().chat.completions,
             self._deployment(),
@@ -123,6 +176,10 @@ class AzureOpenAIProvider:
         )
 
     def verify(self) -> VerifyResult:
+        if self.config.reasoning_effort is not None:
+            # A reasoning config dispatches through the Azure v1 Responses route; a plain
+            # chat-completions ping would prove the wrong endpoint and api surface.
+            return verify_via_ping(self, ping=lambda: self.complete_chat(_REASONING_PING))
         return verify_via_ping(self)
 
 
@@ -143,3 +200,12 @@ def _same_endpoint(a: str, b: str | None) -> bool:
         pb.path.rstrip("/"),
         pb.query,
     )
+
+
+def _responses_base_url(endpoint: str) -> str:
+    """Normalize an Azure resource endpoint onto its native v1 route."""
+    parsed = urlsplit(endpoint)
+    path = parsed.path.rstrip("/")
+    if not path.lower().endswith("/openai/v1"):
+        path = f"{path}/openai/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, f"{path}/", parsed.query, ""))

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 from typing import Literal, Protocol, runtime_checkable
 
@@ -200,15 +201,20 @@ _REACHABLE_ERROR_MARKERS = (
 )
 
 
-def verify_via_ping(provider: Provider) -> VerifyResult:
+def verify_via_ping(provider: Provider, ping: Callable[[], object] | None = None) -> VerifyResult:
     """Shared `verify()`: one cheap short completion, reporting failure as ok=False.
 
     Every backend's verify() is identical apart from its kind/model (both on the config), so they
-    all delegate here. Never raises — `verify_all` relies on that to not crash startup.
+    all delegate here. `ping` substitutes the probe call when the config dispatches through a
+    route plain `complete` would not exercise (e.g. a structured Responses branch). Never
+    raises; `verify_all` relies on that to not crash startup.
     """
     cfg = provider.config
     try:
-        provider.complete("", _PING_MESSAGES, max_tokens=PING_MAX_TOKENS)
+        if ping is None:
+            provider.complete("", _PING_MESSAGES, max_tokens=PING_MAX_TOKENS)
+        else:
+            ping()
     except Exception as exc:  # noqa: BLE001 - verify reports failure, never raises
         # A max-tokens/output-limit error confirms reachability: the request reached the model
         # (auth + model id are valid) and only failed because a reasoning model consumed the 1-token

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -362,6 +362,37 @@ def test_reasoning_verify_pings_the_responses_route(monkeypatch: pytest.MonkeyPa
     assert responses.calls[0]["max_output_tokens"] == 2048
 
 
+def test_reasoning_complete_routes_through_the_responses_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text completion consumers must use the same verified route as complete_chat."""
+    responses = _FakeResponses()
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning complete must not use chat")),
+    )
+
+    completion = provider.complete("sys", [Message(role="user", content="hi")], max_tokens=32)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0]["input"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+    assert responses.calls[0]["max_output_tokens"] == 32
+    assert responses.calls[0]["reasoning"] == {"effort": "high"}
+    assert "temperature" not in responses.calls[0]
+    assert completion.usage.input_tokens == 11
+    assert completion.usage.output_tokens == 7
+
+
 def test_reasoning_verify_treats_an_exhausted_ping_budget_as_reachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/wmh/providers/tests/azure_openai_test.py
+++ b/wmh/providers/tests/azure_openai_test.py
@@ -61,6 +61,48 @@ class _FakeChat:
         self.completions = completions
 
 
+class _FakeResponsesResponse:
+    def __init__(self, tool_name: str = "bash") -> None:
+        self.tool_name = tool_name
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "model": "gpt-5.5-2026-06-01",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "reasoning-1",
+                    "summary": [],
+                    "encrypted_content": "ciphertext-1",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": self.tool_name,
+                    "arguments": '{"command":"pwd"}',
+                    "status": "completed",
+                },
+            ],
+            "usage": {"input_tokens": 11, "output_tokens": 7},
+        }
+
+
+class _FakeResponses:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs: object) -> _FakeResponsesResponse:
+        self.calls.append(kwargs)
+        return _FakeResponsesResponse()
+
+
+class _FakeResponsesClient:
+    def __init__(self, responses: _FakeResponses) -> None:
+        self.responses = responses
+
+
 class _FakeEmbeddingItem:
     def __init__(self, embedding: list[float]) -> None:
         self.embedding = embedding
@@ -97,6 +139,10 @@ def _config() -> ProviderConfig:
         deployment="gpt55-deploy",
         api_version="2024-10-21",
     )
+
+
+def _reasoning_config() -> ProviderConfig:
+    return _config().model_copy(update={"reasoning_effort": "high"})
 
 
 def test_complete_sends_deployment_as_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -139,6 +185,198 @@ def test_structured_chat_applies_model_temperature_capability(
     )
 
     assert ("temperature" in chat.last_kwargs) is expects_temperature
+
+
+def test_structured_reasoning_uses_azure_v1_and_replays_tool_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = _FakeResponses()
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning tools must not use chat")),
+    )
+
+    first = provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "inspect"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "description": "run a command",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "temperature": 0.3,
+                "top_p": 0.7,
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+
+    assert responses.calls[0] == {
+        "model": "gpt55-deploy",
+        "input": [{"role": "user", "content": "inspect"}],
+        "stream": False,
+        "store": False,
+        "include": ["reasoning.encrypted_content"],
+        "max_output_tokens": 4096,
+        "tools": [
+            {
+                "type": "function",
+                "name": "bash",
+                "description": "run a command",
+                "parameters": {"type": "object"},
+            }
+        ],
+        "reasoning": {"effort": "high"},
+    }
+    assert first.choices[0].finish_reason == "tool_calls"
+    assert first.choices[0].message.tool_calls is not None
+    assert first.choices[0].message.tool_calls[0].function.name == "bash"
+    assert first.token_usage().input_tokens == 11
+    assert first.token_usage().output_tokens == 7
+
+    assistant = first.choices[0].message.model_dump(mode="json", exclude_none=True)
+    provider.complete_chat(
+        ChatRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "user", "content": "inspect"},
+                    assistant,
+                    {"role": "tool", "tool_call_id": "call-1", "content": "/workspace"},
+                ],
+                "max_completion_tokens": 4096,
+            }
+        )
+    )
+
+    assert len(responses.calls) == 2
+    assert responses.calls[1]["input"] == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": ""},
+        {
+            "type": "reasoning",
+            "id": "reasoning-1",
+            "summary": [],
+            "encrypted_content": "ciphertext-1",
+        },
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "bash",
+            "arguments": '{"command":"pwd"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": "/workspace",
+        },
+    ]
+    assert responses.calls[1]["reasoning"] == {"effort": "high"}
+
+
+def test_responses_client_uses_trusted_key_and_normalized_v1_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://Trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _reasoning_config().model_copy(update={"endpoint": "https://trusted.openai.azure.com/"})
+    )
+
+    first = provider._get_responses_client()
+    second = provider._get_responses_client()
+
+    assert first is second
+    assert constructed == [
+        {
+            "api_key": "az-real-secret",
+            "base_url": "https://trusted.openai.azure.com/openai/v1/",
+            "timeout": 240.0,
+            "max_retries": 0,
+        }
+    ]
+
+
+def test_untrusted_responses_endpoint_never_receives_real_azure_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[dict[str, object]] = []
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            constructed.append(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "az-real-secret")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://trusted.openai.azure.com")
+    monkeypatch.setenv("WMH_ENDPOINT_API_KEY", "endpoint-token")
+    provider = AzureOpenAIProvider(
+        _reasoning_config().model_copy(update={"endpoint": "https://untrusted.example"})
+    )
+
+    provider._get_responses_client()
+
+    assert constructed[0]["api_key"] == "endpoint-token"
+    assert constructed[0]["base_url"] == "https://untrusted.example/openai/v1/"
+
+
+def test_reasoning_verify_pings_the_responses_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = _FakeResponses()
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(
+        provider,
+        "_get_responses_client",
+        lambda: _FakeResponsesClient(responses),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("reasoning verify must not use chat")),
+    )
+
+    result = provider.verify()
+
+    assert result.ok is True
+    assert len(responses.calls) == 1
+    assert responses.calls[0]["reasoning"] == {"effort": "high"}
+    assert responses.calls[0]["max_output_tokens"] == 2048
+
+
+def test_reasoning_verify_treats_an_exhausted_ping_budget_as_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incomplete max_output_tokens response proves auth and route; verify must pass."""
+
+    class _ExhaustedClient:
+        class responses:  # noqa: N801 - mimic the SDK attribute path
+            @staticmethod
+            def create(**kwargs: object) -> object:
+                raise ValueError("Responses API returned incomplete response: max_output_tokens")
+
+    provider = AzureOpenAIProvider(_reasoning_config())
+    monkeypatch.setattr(provider, "_get_responses_client", lambda: _ExhaustedClient())
+
+    assert provider.verify().ok is True
 
 
 def test_missing_deployment_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
First of three PRs replacing the closed #217–#239 experiment stack with a minimal path to the meta-harness replication (arXiv 2603.28052): optimize complete harness source on real Terminal-Bench-2 tasks through Harbor. This PR is the foundation layer — everything here has standalone value on main and no Harbor dependency. PR 2 adds the Harbor evaluator (environment side), PR 3 extends `wmh optimize` with the `harbor` environment and the complete-source population optimizer.

## What's here

**`HarnessSourceTree` (new) + store delegation.** A complete harness as a validated set of UTF-8 files with lossless `from_doc`/`to_doc` round-tripping to `HarnessDoc` (canonical subset: multi-prompt docs merge to one `prompt:core`, `Surface.budget` is validation-only). `HarnessStore` render/reparse now delegates to it (−130 duplicated lines). This is the candidate representation the PR-3 optimizer feeds LLM-written trees through, so structural conflicts fail at validation time with actionable messages: case-folded duplicates (`SYSTEM.md` vs `system.md` silently corrupted renders on APFS), file-vs-directory prefix conflicts (crashed mid-write), store-metadata filenames, and a file named `runtime` (aliased the reserved in-process `code:runtime` surface).

**One canonical code-surface path grammar.** `Surface` now enforces at construction what the render layer required at write time: canonical relative POSIX paths (no `.`/`..`), ≤1024 UTF-8 bytes, and `code_surface_id(path) == id` for pathful code surfaces (`code:runtime` must stay path-less). Previously a proposal could carry `path="src/agent_utils.ts"` through delta validation and a full paid evaluation, then explode at champion-save time; now it fails at proposal validation with the allowed grammar in the message. `code_surface_id` moved to `doc.py` (re-exported from `pi_vendor`) so the grammar cannot drift again.

**`doc_hash` includes materialized paths.** Moving/renaming a vendored code file previously produced an identical `doc_hash` (path-only `replace` ops were invisible to identity), silently merging behaviorally distinct harnesses in lineage archives, session caches, and push/pull integrity. The preimage is unchanged for path-less docs. ⚠️ **Compat:** pathful (pi-node) harnesses hash differently now. Pulls of pre-change server records still work via a clearly-scoped `legacy_doc_hash` fallback in the pull integrity check; **the platform repo needs a rehash migration when it bumps its wmh pin** — until then, pathful pushes from post-change clients will 422 on the server's declared-hash check.

**Local pi shim shutdown.** `_ShimServer` now joins in-flight `/tool` handlers on close (`daemon_threads = False`): no environment write may land after an episode is declared finished. Against the world model this was cosmetic; against a real execution environment (PR 2) a late write would mutate state the verifier is already checking. Worst-case join bound is the provider SDK timeout, documented in the comment.

**Azure Responses-v1 reasoning.** With `reasoning_effort` set, `complete_chat()` *and* `complete()` route through Azure's v1 Responses API (`<endpoint>/openai/v1/`) via the shared `_responses_common` layer (tools, encrypted-reasoning replay, usage), instead of silently dropping the setting on the api-versioned chat route; `verify()` pings the route actually used. `ModelRole` gains `reasoning_effort`, threaded through `resolve_opt_in_model_provider`. This is what lets `[models.meta]` run GPT-5.5 at high reasoning effort as the PR-3 proposer.

**Rendered-only store loads are strict now** (documented in the module docstring): unknown config tables/fields, non-`.md` files under `skills/`, and stem≠frontmatter-name error with actionable messages instead of being silently ignored; dotfiles (`.DS_Store`) are skipped rather than crashing the load.

## Verification
`ruff check` / `ruff format --check` / `ty check` clean; full suite **2014 passed, 18 skipped** (main baseline: 1839 passed). New tests cover round-trip identity, every new validation error message, the doc_hash/legacy-hash matrix, shim close-joins-handler, and the Azure v1 wire contract (input items, encrypted reasoning replay, tool flattening, no temperature forwarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)