### PR TITLE
wmh optimize <agent> harbor: complete-source harness optimization on real tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,10 @@ uv run pytest -q
 
 - `wmh optimize <agent> <world-model> --tasks <tasks.jsonl>` is the primary public
   harness-creation workflow. Keep CLI wiring in `wmh/cli/harness_app.py` and search behavior in
-  `wmh/harness/create.py`; another public workflow needs a distinct user case and equivalent
-  validation, audit, and versioning guarantees.
+  `wmh/harness/create.py` (world-model delta search) or `wmh/harness/population.py` plus
+  `wmh/harness/project_proposer.py` (the `harbor` environment's complete-source population
+  search); another public workflow needs a distinct user case and equivalent validation, audit,
+  and versioning guarantees.
 - A harness is a validated `HarnessDoc`, not an editable directory. Its typed surfaces cover
   prompts, skills, tool policy, loop parameters, and executable code; rendered files are exports.
 - Change harnesses only through `HarnessDelta`. Preserve parent and child hashes, per-surface

--- a/README.md
+++ b/README.md
@@ -117,6 +117,28 @@ The optimizer can change prompts, tools, policies, skills, and runtime code. Eve
 measured against the same simulated tasks, and only changes that pass the evaluation gates become
 the new versioned champion harness.
 
+### Optimize on real benchmark tasks (harbor)
+
+Passing the literal environment `harbor` scores complete-source harness candidates on real
+[harbor](https://pypi.org/project/harbor/) benchmark tasks instead of a world model
+(`pip install "world-model-harness[harbor]"`). Each iteration, a proposer model rewrites the
+whole harness source tree from the fixed seed, reading every prior candidate's source, scores,
+and raw trial transcripts; harbor's own verifiers then score the candidate on real tasks.
+
+```bash
+wmh optimize pi harbor \
+  --harbor-config job.yaml --task-ids tasks.json \
+  --backend e2b --iterations 10 --run-dir runs/harbor-01
+```
+
+`--backend` controls the task environment and worker placement (`local` = docker task containers
+with a local pi worker; `e2b` = E2B task environments with a sandboxed pi worker). The PROPOSER
+project always runs in E2B in this version, so `E2B_API_KEY` is required on either backend. All
+durable state lives in `--run-dir`: an interrupted run continues with `--resume` (flags that
+conflict with the recorded `run-config.json` are rejected), and `--max-iterations-this-run 1`
+advances one boundary at a time. The winner is saved as the seed agent's next version and becomes
+its champion.
+
 ## Development
 
 Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -134,10 +134,14 @@ wmh optimize pi harbor \
 `--backend` controls the task environment and worker placement (`local` = docker task containers
 with a local pi worker; `e2b` = E2B task environments with a sandboxed pi worker). The PROPOSER
 project always runs in E2B in this version, so `E2B_API_KEY` is required on either backend. All
-durable state lives in `--run-dir`: an interrupted run continues with `--resume` (flags that
-conflict with the recorded `run-config.json` are rejected), and `--max-iterations-this-run 1`
-advances one boundary at a time. The winner is saved as the seed agent's next version and becomes
-its champion.
+durable state lives in `--run-dir`: an interrupted run continues with `--resume` (flags, model
+roles, and dataset pins that conflict with the recorded `run-config.json` are rejected), and
+`--max-iterations-this-run 1` advances one boundary at a time. The winner is saved as the seed
+agent's next version and becomes its champion, exactly once per run dir.
+
+The bare seed literal `pi` ALWAYS means the built-in default agent (the fixed-seed protocol),
+even after a stored `pi` champion exists; to compound on an earlier result, seed explicitly from
+the store with `pi@champion` or `pi@vN`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -117,32 +117,6 @@ The optimizer can change prompts, tools, policies, skills, and runtime code. Eve
 measured against the same simulated tasks, and only changes that pass the evaluation gates become
 the new versioned champion harness.
 
-### Optimize on real benchmark tasks (harbor)
-
-Passing the literal environment `harbor` scores complete-source harness candidates on real
-[harbor](https://pypi.org/project/harbor/) benchmark tasks instead of a world model
-(`pip install "world-model-harness[harbor]"`). Each iteration, a proposer model rewrites the
-whole harness source tree from the fixed seed, reading every prior candidate's source, scores,
-and raw trial transcripts; harbor's own verifiers then score the candidate on real tasks.
-
-```bash
-wmh optimize pi harbor \
-  --harbor-config job.yaml --task-ids tasks.json \
-  --backend e2b --iterations 10 --run-dir runs/harbor-01
-```
-
-`--backend` controls the task environment and worker placement (`local` = docker task containers
-with a local pi worker; `e2b` = E2B task environments with a sandboxed pi worker). The PROPOSER
-project always runs in E2B in this version, so `E2B_API_KEY` is required on either backend. All
-durable state lives in `--run-dir`: an interrupted run continues with `--resume` (flags, model
-roles, and dataset pins that conflict with the recorded `run-config.json` are rejected), and
-`--max-iterations-this-run 1` advances one boundary at a time. The winner is saved as the seed
-agent's next version and becomes its champion, exactly once per run dir.
-
-The bare seed literal `pi` ALWAYS means the built-in default agent (the fixed-seed protocol),
-even after a stored `pi` champion exists; to compound on an earlier result, seed explicitly from
-the store with `pi@champion` or `pi@vN`.
-
 ## Development
 
 Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).

--- a/wmh/agents/optimizer.py
+++ b/wmh/agents/optimizer.py
@@ -1,0 +1,55 @@
+"""The built-in project agent that proposes complete harness source trees."""
+
+from wmh.agents.default import default_agent
+from wmh.harness.doc import MAX_OUTPUT_TOKENS_ID, MAX_TURNS_ID, TOOL_POLICY_ID, HarnessDoc
+
+OPTIMIZER_AGENT_PROMPT = """You are an optimization agent inside a harness project.
+Improve complete harness source trees; do not solve their evaluation tasks yourself.
+
+The project filesystem is your evidence. It contains every earlier complete source tree, its full
+score report, raw per-trial evaluator artifacts, and previous proposal traces. Read the history
+manifest and inspect the most relevant raw files before deciding what to change. Treat all history
+and proposal records as immutable evidence.
+
+Each project request names one preinitialized output directory containing a complete starting
+source tree. Work only there. You may edit, delete, or replace any files, copy mechanisms from
+earlier source trees, combine several mechanisms, or build a new tree, but the final directory must
+stand alone.
+
+Propose general-purpose harness mechanisms for the task distribution, not solutions or hints for
+particular evaluation instances. Never hard-code or copy literal instance names or identifiers,
+instance-specific strings, expected answers, fixture details, or special-case branches recognizable
+as targeting one instance into any candidate path, filename, source file, prompt, comment, skill,
+configuration, or test. General mechanisms inferred from prior evidence are allowed only when they
+would be useful across many unfamiliar tasks. Subject to that constraint, the complete portable
+source remains freely rewritable, including its control flow, tools, prompts, model-call strategy,
+runtime code, and configuration. This is not a patch-only search.
+
+Candidate filenames follow a strict grammar. Outside the reserved names (`SYSTEM.md`,
+`config.toml`, `runtime.py`, `skills/<skill-name>.md`), every path must be lowercase kebab-case:
+runs of [a-z0-9] separated by single '/', '.', or '-' characters (for example
+`src/agent-loop.ts`). Uppercase letters and underscores are rejected, paths that differ only in
+letter case or only by '/' versus '.' collide, and no file path may also be a directory prefix of
+another. One bad filename invalidates the whole candidate.
+
+Inspect and test your work in the output directory. Do not write candidate files anywhere else.
+Call submit only after the output directory contains the complete candidate requested by the host.
+There is no repair turn, so leave a usable candidate on the first pass."""
+
+
+def optimizer_agent(name: str = "optimizer") -> HarnessDoc:
+    """Return a pi-derived coding agent constrained to one project candidate stage."""
+    base = default_agent(name)
+    surfaces = []
+    for surface in base.surfaces:
+        if surface.id == "prompt:core":
+            surfaces.append(surface.model_copy(update={"content": OPTIMIZER_AGENT_PROMPT}))
+        elif surface.id == TOOL_POLICY_ID:
+            surfaces.append(surface.model_copy(update={"content": "bash\nread_file\nsubmit"}))
+        elif surface.id == MAX_TURNS_ID:
+            surfaces.append(surface.model_copy(update={"content": "60"}))
+        elif surface.id == MAX_OUTPUT_TOKENS_ID:
+            surfaces.append(surface.model_copy(update={"content": "16384"}))
+        else:
+            surfaces.append(surface)
+    return HarnessDoc(name=name, surfaces=surfaces)

--- a/wmh/agents/optimizer_test.py
+++ b/wmh/agents/optimizer_test.py
@@ -1,0 +1,14 @@
+"""Tests for the complete-source optimizer persona."""
+
+from wmh.agents.optimizer import optimizer_agent
+
+
+def test_optimizer_agent_locks_tools_budgets_and_the_contract() -> None:
+    doc = optimizer_agent()
+    assert doc.tools() == ["bash", "read_file", "submit"]
+    assert doc.max_turns() == 60
+    assert doc.max_output_tokens() == 16384
+    prompt = doc.system_prompt()
+    # Two load-bearing phrases: the anti-overfitting contract and the filename grammar.
+    assert "Never hard-code" in prompt
+    assert "kebab-case" in prompt

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import shlex
 import time
@@ -9,6 +10,8 @@ from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Protocol
+
+from pydantic import BaseModel
 
 from wmh.core.types import JsonObject
 from wmh.harness.doc import HarnessDoc
@@ -30,13 +33,19 @@ from wmh.harness.live_session import (
 from wmh.harness.pi_e2b import start_live_runner
 from wmh.harness.runner_link import Channel, TokenUsage
 from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.source_tree import MAX_SOURCE_PATH_BYTES, HarnessSourceFile, HarnessSourceTree
 from wmh.harness.tools import resolve_tools
 from wmh.providers.base import ToolCallingProvider
 
 PROJECT_WORKSPACE = "/home/user/project"
 DEFAULT_PROJECT_TIMEOUT_S = 21_600
+DEFAULT_SOURCE_TREE_MAX_FILES = 1_024
+DEFAULT_SOURCE_TREE_MAX_BYTES = 8 * 1024 * 1024
 _OUTPUT_CAP = 16_000
-_PROJECT_TOOLS = frozenset({"read_file", "write_file", "submit"})
+# Combined stdout+stderr budget for one bash command (head+tail truncated per stream).
+_BASH_OUTPUT_CAP = 32 * 1024
+_BASH_TIMEOUT_S = 60.0
+_PROJECT_TOOLS = frozenset({"bash", "read_file", "write_file", "submit"})
 _RECOVERABLE_SESSION_MARKERS = (
     "server disconnected",
     "connection reset",
@@ -53,6 +62,80 @@ _RECOVERABLE_SESSION_MARKERS = (
     "live session runner did not become ready",
     "channel send failed",
 )
+
+# One trusted in-sandbox walk turning a project directory into bounded {path: base64} JSON.
+# Regular files only (symlinks, sockets, and pipes are skipped); path and byte bounds are
+# enforced in-sandbox so the host never downloads more than the declared budget.
+_SNAPSHOT_SOURCE_TREE_SCRIPT = r"""
+import base64
+import json
+import os
+import stat
+import sys
+
+
+def fail(message):
+    sys.stderr.write(message + "\n")
+    raise SystemExit(2)
+
+
+root = sys.argv[1]
+max_files = int(sys.argv[2])
+max_bytes = int(sys.argv[3])
+max_path_bytes = int(sys.argv[4])
+if not os.path.isdir(root):
+    fail("source directory does not exist: " + root)
+
+files = []
+total_bytes = 0
+for current, directories, names in os.walk(root, topdown=True, followlinks=False):
+    directories.sort()
+    names.sort()
+    for name in names:
+        path = os.path.join(current, name)
+        if not stat.S_ISREG(os.lstat(path).st_mode):
+            continue
+        relative = os.path.relpath(path, root).replace(os.sep, "/")
+        if len(relative.encode("utf-8")) > max_path_bytes:
+            fail("file path exceeds " + str(max_path_bytes) + " bytes: " + relative)
+        if len(files) >= max_files:
+            fail("directory exceeds the " + str(max_files) + " file bound")
+        with open(path, "rb") as source:
+            content = source.read(max_bytes - total_bytes + 1)
+        total_bytes += len(content)
+        if total_bytes > max_bytes:
+            fail("directory exceeds the " + str(max_bytes) + " byte bound")
+        files.append(
+            {
+                "path": relative,
+                "content_base64": base64.b64encode(content).decode("ascii"),
+            }
+        )
+
+json.dump({"files": files}, sys.stdout, separators=(",", ":"))
+"""
+
+
+@dataclass(frozen=True)
+class ProjectBashResult:
+    """One finished project bash command: bounded streams plus its exit code."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+class _EncodedSourceFile(BaseModel):
+    """One regular snapshot file encoded for bounded JSON transport."""
+
+    path: str
+    content_base64: str
+
+
+class _EncodedSourceSnapshot(BaseModel):
+    """The trusted sandbox script's wire representation."""
+
+    files: tuple[_EncodedSourceFile, ...]
 
 
 class ChannelFactory(Protocol):
@@ -190,6 +273,93 @@ class AgentProject:
         self._file_contents[relative] = content
         return content
 
+    def run_bash(self, command: str, *, timeout_s: float = _BASH_TIMEOUT_S) -> ProjectBashResult:
+        """Run one bounded shell command in the workspace as the default sandbox user.
+
+        The command runs under ``timeout --kill-after`` inside a profile-free bash with the
+        project workspace as its working directory. A nonzero exit is a RESULT, not an
+        exception: E2B raises on nonzero exits with the streams attached to the exception, so
+        that shape is unwrapped here. Only a transport failure (no exit code) propagates.
+        Streams are head+tail truncated to a fixed combined budget.
+        """
+        if self._closing:
+            raise RuntimeError("cannot run bash in a closed project")
+        budget_s = max(1, int(timeout_s))
+        script = (
+            f"cd {shlex.quote(self.workspace)} && "
+            f"timeout --kill-after=10s {budget_s}s "
+            f"bash --noprofile --norc -c {shlex.quote(command)}"
+        )
+        result: object
+        try:
+            result = self._sandbox.commands.run(script, timeout=budget_s + 30)
+        except Exception as error:  # noqa: BLE001 - E2B raises finished nonzero exits
+            exit_code = getattr(error, "exit_code", None)
+            if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+                raise  # a transport failure, not a finished command
+            result = error
+        return ProjectBashResult(
+            stdout=_head_tail(str(getattr(result, "stdout", "") or ""), _BASH_OUTPUT_CAP // 2),
+            stderr=_head_tail(str(getattr(result, "stderr", "") or ""), _BASH_OUTPUT_CAP // 2),
+            exit_code=int(getattr(result, "exit_code", 0) or 0),
+        )
+
+    def stage_source_tree(
+        self,
+        tree: HarnessSourceTree,
+        dest: str,
+        *,
+        max_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+    ) -> None:
+        """Write one bounded, validated source tree under a project-relative directory."""
+        tree.validate_bounds(max_files=max_files, max_bytes=max_bytes)
+        self._absolute_path(dest)  # containment: reject absolute or traversing destinations
+        for item in tree.files:
+            self.write_text(f"{dest}/{item.path}", item.content)
+
+    def snapshot_source_tree(
+        self,
+        directory: str,
+        *,
+        max_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+    ) -> HarnessSourceTree:
+        """Capture one project directory as a bounded, validated host-side source tree.
+
+        A single in-sandbox python walk emits every regular file as base64 JSON on stdout;
+        the host decodes and validates it into a :class:`HarnessSourceTree`. Bound breaches,
+        non-UTF-8 content, and invalid paths raise with the offending path in the message.
+        """
+        if self._closing:
+            raise RuntimeError("cannot snapshot a source tree in a closed project")
+        if isinstance(max_files, bool) or not isinstance(max_files, int) or max_files < 1:
+            raise ValueError("max_files must be a positive integer")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+        absolute = self._absolute_path(directory)
+        command = (
+            f"python3 -c {shlex.quote(_SNAPSHOT_SOURCE_TREE_SCRIPT)} {shlex.quote(absolute)} "
+            f"{max_files} {max_bytes} {MAX_SOURCE_PATH_BYTES}"
+        )
+        try:
+            result = self._sandbox.commands.run(command, timeout=120)
+        except Exception as error:  # noqa: BLE001 - E2B raises command failures
+            detail = str(getattr(error, "stderr", "") or error)
+            raise RuntimeError(
+                f"project source snapshot failed: {_head_tail(detail, 4_096)}"
+            ) from error
+        exit_code = int(getattr(result, "exit_code", 0) or 0)
+        if exit_code != 0:
+            stderr = str(getattr(result, "stderr", "") or "snapshot command failed")
+            raise RuntimeError(f"project source snapshot failed: {_head_tail(stderr, 4_096)}")
+        try:
+            tree = _decode_source_tree_snapshot(str(getattr(result, "stdout", "")))
+        except ValueError as error:
+            raise RuntimeError(f"project source snapshot is invalid: {error}") from error
+        tree.validate_bounds(max_files=max_files, max_bytes=max_bytes)
+        return tree
+
     def run(
         self,
         agent: HarnessDoc,
@@ -200,6 +370,7 @@ class AgentProject:
         on_event: Callable[[SessionEvent], None] | None = None,
         should_cancel: Callable[[], bool] | None = None,
         writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
     ) -> AgentProjectRun:
         """Run one turn of an ordinary agent against this persistent project.
 
@@ -210,7 +381,9 @@ class AgentProject:
         agent's ``write_file`` tool access to exact project-relative files for
         this logical run. Omitting it preserves unrestricted project writes;
         an empty collection denies every agent write. Host ``write_text`` calls
-        are not constrained by an agent turn's grant.
+        are not constrained by an agent turn's grant. ``retry_recoverable=False``
+        makes the run exactly one agent attempt: a transport failure closes the
+        session and propagates instead of transparently replaying paid work.
         """
         if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
@@ -224,8 +397,9 @@ class AgentProject:
         write_grant = self._normalize_writable_files(writable_files)
         usage_before = self._total_worker_usage()
         self._active_writable_files = write_grant
+        max_attempts = 2 if retry_recoverable else 1
         try:
-            for attempt in range(2):
+            for attempt in range(max_attempts):
                 try:
                     result = self._run_turn(
                         agent,
@@ -244,7 +418,12 @@ class AgentProject:
                 except HarnessSearchCancelled:
                     raise
                 except Exception as error:
-                    if attempt > 0 or not _is_recoverable_session_error(error):
+                    if not _is_recoverable_session_error(error):
+                        raise
+                    if attempt + 1 >= max_attempts:
+                        # A transport-poisoned session is never reused by a later logical run,
+                        # even when the caller deliberately owns recovery at a higher level.
+                        self._close_agent_session()
                         raise
                     if self._sandbox_factory is None:
                         self._close_agent_session()
@@ -573,8 +752,21 @@ class AgentProject:
         arguments: JsonObject,
         emit: Callable[[str, str], None],
     ) -> ToolOutcome:
-        del emit  # Project file tools return one bounded observation; they do not stream output.
+        del emit  # Project tools return one bounded observation; they do not stream output.
         try:
+            if name == "bash":
+                # Agent bash writes bypass the host-side file mirror, so a sandbox replacement
+                # would silently lose them. That is sound only because bash-driven proposal
+                # turns run with retry_recoverable=False: a dead transport ends the turn
+                # instead of replaying it onto a replacement sandbox.
+                result = self.run_bash(str(arguments.get("command", "")))
+                body = result.stdout
+                if result.stderr:
+                    body = f"{body}\n[stderr]\n{result.stderr}" if body else result.stderr
+                if result.exit_code != 0:
+                    marker = f"[exit {result.exit_code}]"
+                    body = f"{body}\n{marker}" if body else marker
+                return ToolOutcome(content=body, is_error=result.exit_code != 0)
             if name == "read_file":
                 path = self._tool_path(str(arguments.get("path", "")))
                 relative = self._relative_path(path)
@@ -683,3 +875,25 @@ def _capped(content: str, *, is_error: bool = False) -> ToolOutcome:
         is_error=is_error,
         truncated=True,
     )
+
+
+def _head_tail(content: str, cap: int) -> str:
+    """Keep both ends of one stream within `cap` characters, with an omission marker."""
+    if len(content) <= cap:
+        return content
+    half = cap // 2
+    omitted = len(content) - cap
+    return f"{content[:half]}\n... {omitted} characters truncated ...\n{content[-half:]}"
+
+
+def _decode_source_tree_snapshot(payload: str) -> HarnessSourceTree:
+    """Decode bounded base64 JSON from the trusted snapshot script."""
+    encoded = _EncodedSourceSnapshot.model_validate_json(payload)
+    files: list[HarnessSourceFile] = []
+    for item in encoded.files:
+        try:
+            content = base64.b64decode(item.content_base64, validate=True).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as error:
+            raise ValueError(f"file {item.path!r} is not valid UTF-8 text") from error
+        files.append(HarnessSourceFile(path=item.path, content=content))
+    return HarnessSourceTree(files=tuple(files))

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -64,8 +64,10 @@ _RECOVERABLE_SESSION_MARKERS = (
 )
 
 # One trusted in-sandbox walk turning a project directory into bounded {path: base64} JSON.
-# Regular files only (symlinks, sockets, and pipes are skipped); path and byte bounds are
-# enforced in-sandbox so the host never downloads more than the declared budget.
+# Only regular files are captured; every non-regular entry (symlink, socket, pipe) is COUNTED
+# in the payload's `skipped` list so the host can reject a candidate that would otherwise be
+# silently thinner than what the agent built. Path and byte bounds are enforced in-sandbox so
+# the host never downloads more than the declared budget.
 _SNAPSHOT_SOURCE_TREE_SCRIPT = r"""
 import base64
 import json
@@ -87,15 +89,21 @@ if not os.path.isdir(root):
     fail("source directory does not exist: " + root)
 
 files = []
+skipped = []
 total_bytes = 0
 for current, directories, names in os.walk(root, topdown=True, followlinks=False):
     directories.sort()
     names.sort()
+    for name in directories:
+        path = os.path.join(current, name)
+        if not stat.S_ISDIR(os.lstat(path).st_mode):
+            skipped.append(os.path.relpath(path, root).replace(os.sep, "/"))
     for name in names:
         path = os.path.join(current, name)
-        if not stat.S_ISREG(os.lstat(path).st_mode):
-            continue
         relative = os.path.relpath(path, root).replace(os.sep, "/")
+        if not stat.S_ISREG(os.lstat(path).st_mode):
+            skipped.append(relative)
+            continue
         if len(relative.encode("utf-8")) > max_path_bytes:
             fail("file path exceeds " + str(max_path_bytes) + " bytes: " + relative)
         if len(files) >= max_files:
@@ -112,7 +120,7 @@ for current, directories, names in os.walk(root, topdown=True, followlinks=False
             }
         )
 
-json.dump({"files": files}, sys.stdout, separators=(",", ":"))
+json.dump({"files": files, "skipped": sorted(skipped)}, sys.stdout, separators=(",", ":"))
 """
 
 
@@ -136,6 +144,9 @@ class _EncodedSourceSnapshot(BaseModel):
     """The trusted sandbox script's wire representation."""
 
     files: tuple[_EncodedSourceFile, ...]
+    # Non-regular entries (symlinks, sockets, pipes) the walk refused to capture. A candidate
+    # containing them is invalid, not silently thinner, so the host raises on a nonzero count.
+    skipped: tuple[str, ...] = ()
 
 
 class ChannelFactory(Protocol):
@@ -329,7 +340,9 @@ class AgentProject:
 
         A single in-sandbox python walk emits every regular file as base64 JSON on stdout;
         the host decodes and validates it into a :class:`HarnessSourceTree`. Bound breaches,
-        non-UTF-8 content, and invalid paths raise with the offending path in the message.
+        non-UTF-8 content, invalid paths, and non-regular entries (symlinks, sockets, pipes)
+        all raise with the offending path in the message: a candidate is captured exactly or
+        rejected, never silently thinner.
         """
         if self._closing:
             raise RuntimeError("cannot snapshot a source tree in a closed project")
@@ -889,6 +902,12 @@ def _head_tail(content: str, cap: int) -> str:
 def _decode_source_tree_snapshot(payload: str) -> HarnessSourceTree:
     """Decode bounded base64 JSON from the trusted snapshot script."""
     encoded = _EncodedSourceSnapshot.model_validate_json(payload)
+    if encoded.skipped:
+        names = ", ".join(encoded.skipped)
+        raise ValueError(
+            f"directory contains {len(encoded.skipped)} non-regular entr(y/ies) that cannot "
+            f"be part of a portable source tree: {names}; replace them with regular files"
+        )
     files: list[HarnessSourceFile] = []
     for item in encoded.files:
         try:

--- a/wmh/agents/project.py
+++ b/wmh/agents/project.py
@@ -397,6 +397,10 @@ class AgentProject:
         are not constrained by an agent turn's grant. ``retry_recoverable=False``
         makes the run exactly one agent attempt: a transport failure closes the
         session and propagates instead of transparently replaying paid work.
+        A bash-capable agent REQUIRES it: shell writes bypass the replayable
+        host mirror, so a replayed turn would land on a replacement sandbox
+        missing those edits, and that mismatch is rejected here, not silently
+        downgraded.
         """
         if self._closing:
             raise RuntimeError("cannot run an agent in a closed project")
@@ -407,6 +411,12 @@ class AgentProject:
         if unsupported:
             names = ", ".join(sorted(unsupported))
             raise ValueError(f"project agents cannot use uncontained tools: {names}")
+        if retry_recoverable and "bash" in agent.tools():
+            raise ValueError(
+                "bash-capable project agents must run with retry_recoverable=False: shell "
+                "writes bypass the replayable host file mirror, so a transparently retried "
+                "turn could replay onto a replacement sandbox missing those edits"
+            )
         write_grant = self._normalize_writable_files(writable_files)
         usage_before = self._total_worker_usage()
         self._active_writable_files = write_grant
@@ -769,9 +779,9 @@ class AgentProject:
         try:
             if name == "bash":
                 # Agent bash writes bypass the host-side file mirror, so a sandbox replacement
-                # would silently lose them. That is sound only because bash-driven proposal
-                # turns run with retry_recoverable=False: a dead transport ends the turn
-                # instead of replaying it onto a replacement sandbox.
+                # would silently lose them. That is sound only because run() ENFORCES that a
+                # bash-capable agent runs with retry_recoverable=False: a dead transport ends
+                # the turn instead of replaying it onto a replacement sandbox.
                 result = self.run_bash(str(arguments.get("command", "")))
                 body = result.stdout
                 if result.stderr:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -1383,12 +1383,15 @@ def test_snapshot_source_tree_surfaces_in_sandbox_failures() -> None:
         project.snapshot_source_tree("candidate", max_files=10, max_bytes=1_000)
 
 
-def test_snapshot_script_walks_regular_files_within_bounds(tmp_path: Path) -> None:
-    """The trusted in-sandbox walk itself: sorted regular files, symlinks skipped, bounds."""
+def test_snapshot_script_walks_regular_files_and_counts_skipped_entries(
+    tmp_path: Path,
+) -> None:
+    """The trusted in-sandbox walk: sorted regular files, symlinks REPORTED, bounds."""
     (tmp_path / "src").mkdir()
     (tmp_path / "SYSTEM.md").write_text("hi", encoding="utf-8")
     (tmp_path / "src" / "loop.ts").write_text("x", encoding="utf-8")
     (tmp_path / "link.md").symlink_to(tmp_path / "SYSTEM.md")
+    (tmp_path / "link-dir").symlink_to(tmp_path / "src")
     script = project_module._SNAPSHOT_SOURCE_TREE_SCRIPT
 
     done = subprocess.run(
@@ -1399,6 +1402,8 @@ def test_snapshot_script_walks_regular_files_within_bounds(tmp_path: Path) -> No
     )
     data = json.loads(done.stdout)
     assert [item["path"] for item in data["files"]] == ["SYSTEM.md", "src/loop.ts"]
+    # Non-regular entries are counted, never silently dropped from the candidate.
+    assert data["skipped"] == ["link-dir", "link.md"]
 
     over = subprocess.run(
         [sys.executable, "-c", script, str(tmp_path), "10", "1", "1024"],
@@ -1407,6 +1412,14 @@ def test_snapshot_script_walks_regular_files_within_bounds(tmp_path: Path) -> No
     )
     assert over.returncode == 2
     assert "byte bound" in over.stderr
+
+
+def test_snapshot_source_tree_rejects_candidates_with_non_regular_entries() -> None:
+    payload = json.dumps({"files": [], "skipped": ["candidate/link.md"]})
+    project, _commands = _scripted_project([_Output(stdout=payload)])
+
+    with pytest.raises(RuntimeError, match="candidate/link.md"):
+        project.snapshot_source_tree("candidate", max_files=10, max_bytes=1_000)
 
 
 def test_run_retry_recoverable_false_is_single_attempt_and_closes_the_session() -> None:

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -13,6 +13,7 @@ from llm_waterfall import ChatResponse
 
 from wmh.agents import project as project_module
 from wmh.agents.meta import meta_agent
+from wmh.agents.optimizer import optimizer_agent
 from wmh.agents.project import AgentProject
 from wmh.core.types import JsonObject
 from wmh.harness import e2b_sandbox as e2b_sandbox_module
@@ -1450,3 +1451,18 @@ def test_run_retry_recoverable_false_is_single_attempt_and_closes_the_session() 
 
     assert replacement.killed is False
     assert project._session is None  # the poisoned session is never reused by a later run
+
+
+def test_bash_capable_agents_must_run_single_attempt() -> None:
+    """Shell writes bypass the replayable host mirror, so a transparently retried turn could
+    replay onto a replacement sandbox missing them; run() rejects that combination outright
+    instead of silently downgrading the retry."""
+    project = AgentProject(_Sandbox(), channel_factory=lambda sandbox, workspace: _Channel())
+
+    with pytest.raises(ValueError, match="retry_recoverable=False"):
+        project.run(optimizer_agent(), _Provider(), "propose", timeout=1)
+
+    result = project.run(
+        optimizer_agent(), _Provider(), "propose", timeout=1, retry_recoverable=False
+    )
+    assert result.answer == "finished"

--- a/wmh/agents/project_test.py
+++ b/wmh/agents/project_test.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from llm_waterfall import ChatResponse
 
@@ -14,6 +20,7 @@ from wmh.harness.doc import TOOL_POLICY_ID, HarnessDoc
 from wmh.harness.e2b_sandbox import SandboxCleanupError, SandboxUsage
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
 from wmh.providers.base import ProviderConfig, ProviderKind
 
 
@@ -1235,9 +1242,13 @@ def test_agent_file_tools_reject_paths_outside_the_project() -> None:
         assert "escapes project workspace" in outcome.content
 
 
-@pytest.mark.parametrize("tool", ["bash", "read_skill"])
+@pytest.mark.parametrize("tool", ["read_skill"])
 def test_project_rejects_agents_with_uncontained_tools(tool: str) -> None:
-    """The project still rejects capabilities outside its isolated tool allowlist."""
+    """The project still rejects capabilities outside its isolated tool allowlist.
+
+    `bash` moved INTO the allowlist for the harbor optimizer's proposer turns (it executes in
+    the project sandbox as the default user), so only genuinely unrouted tools remain rejected.
+    """
     base = meta_agent()
     uncontained = HarnessDoc(
         name="uncontained",
@@ -1252,3 +1263,177 @@ def test_project_rejects_agents_with_uncontained_tools(tool: str) -> None:
 
     with pytest.raises(ValueError, match=f"uncontained tools: {tool}"):
         project.run(uncontained, _Provider(), "escape", timeout=1)
+
+
+# -- bash, stage/snapshot, and single-attempt runs (the harbor proposer surface) --------------
+
+
+class _ScriptedCommands(_Commands):
+    """Commands fake with scripted responses for bash and snapshot commands."""
+
+    def __init__(self, files: _Files | None = None) -> None:
+        super().__init__(files)
+        self.responses: list[object] = []
+
+    def run(self, cmd: str, background: bool | None = None, **kwargs: object) -> _Output:
+        if self.responses and (cmd.startswith(("cd ", "python3 -c"))):
+            self.runs.append(cmd)
+            item = self.responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            assert isinstance(item, _Output)
+            return item
+        return super().run(cmd, background, **kwargs)
+
+
+class _ExitError(RuntimeError):
+    """E2B's CommandExitException shape: a raised failure carrying the finished streams."""
+
+    def __init__(self, *, stdout: str = "", stderr: str = "", exit_code: int = 1) -> None:
+        super().__init__(f"exit {exit_code}")
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+def _scripted_project(responses: list[object]) -> tuple[AgentProject, _ScriptedCommands]:
+    sandbox = _Sandbox()
+    commands = _ScriptedCommands(sandbox.files)
+    sandbox.commands = commands
+    project = AgentProject(
+        sandbox, channel_factory=lambda sandbox, workspace: _Channel(), owns_sandbox=False
+    )
+    commands.responses = responses
+    return project, commands
+
+
+def test_bash_tool_reports_nonzero_exit_as_output_not_a_crash() -> None:
+    project, commands = _scripted_project(
+        [_ExitError(stdout="partial", stderr="boom", exit_code=2)]
+    )
+
+    outcome = project._execute_tool("bash", {"command": "false"}, lambda stream, data: None)
+
+    assert outcome.is_error is True
+    assert "partial" in outcome.content
+    assert "boom" in outcome.content
+    assert "[exit 2]" in outcome.content
+    command = commands.runs[-1]
+    assert command.startswith("cd /home/user/project && timeout --kill-after=10s 60s ")
+    assert "bash --noprofile --norc -c false" in command
+
+
+def test_run_bash_truncates_streams_head_and_tail() -> None:
+    big = "a" * 20_000 + "MIDDLE" + "b" * 20_000
+    project, _commands = _scripted_project([_Output(stdout=big)])
+
+    result = project.run_bash("cat big")
+
+    assert result.exit_code == 0
+    assert "characters truncated" in result.stdout
+    assert result.stdout.startswith("aaa")
+    assert result.stdout.endswith("bbb")
+    assert "MIDDLE" not in result.stdout
+
+
+def test_run_bash_propagates_transport_failures() -> None:
+    project, _commands = _scripted_project([RuntimeError("connection reset by peer")])
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        project.run_bash("ls")
+
+
+def test_stage_and_snapshot_source_tree_roundtrip() -> None:
+    tree = HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content="hello"),
+            HarnessSourceFile(path="src/agent-loop.ts", content="export {};"),
+        )
+    )
+    payload = json.dumps(
+        {
+            "files": [
+                {
+                    "path": item.path,
+                    "content_base64": base64.b64encode(item.content.encode()).decode(),
+                }
+                for item in tree.files
+            ]
+        }
+    )
+    project, commands = _scripted_project([_Output(stdout=payload)])
+
+    project.stage_source_tree(tree, "candidate")
+    assert commands.files is not None
+    assert commands.files.values["/home/user/project/candidate/SYSTEM.md"] == "hello"
+
+    snapshot = project.snapshot_source_tree("candidate", max_files=10, max_bytes=1_000)
+    assert snapshot == tree
+    command = commands.runs[-1]
+    assert command.startswith("python3 -c")
+    assert command.endswith("/home/user/project/candidate 10 1000 1024")
+
+
+def test_snapshot_source_tree_surfaces_in_sandbox_failures() -> None:
+    project, _commands = _scripted_project(
+        [_Output(stderr="directory exceeds the 10 file bound", exit_code=2)]
+    )
+
+    with pytest.raises(RuntimeError, match="10 file bound"):
+        project.snapshot_source_tree("candidate", max_files=10, max_bytes=1_000)
+
+
+def test_snapshot_script_walks_regular_files_within_bounds(tmp_path: Path) -> None:
+    """The trusted in-sandbox walk itself: sorted regular files, symlinks skipped, bounds."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "SYSTEM.md").write_text("hi", encoding="utf-8")
+    (tmp_path / "src" / "loop.ts").write_text("x", encoding="utf-8")
+    (tmp_path / "link.md").symlink_to(tmp_path / "SYSTEM.md")
+    script = project_module._SNAPSHOT_SOURCE_TREE_SCRIPT
+
+    done = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path), "10", "1000", "1024"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(done.stdout)
+    assert [item["path"] for item in data["files"]] == ["SYSTEM.md", "src/loop.ts"]
+
+    over = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path), "10", "1", "1024"],
+        capture_output=True,
+        text=True,
+    )
+    assert over.returncode == 2
+    assert "byte bound" in over.stderr
+
+
+def test_run_retry_recoverable_false_is_single_attempt_and_closes_the_session() -> None:
+    """A recoverable transport death must not replay a paid proposal turn."""
+
+    class _DisconnectChannel(_Channel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.inbound = [
+                {"type": "state", "status": "idle"},
+                {"type": "state", "status": "running"},
+            ]
+
+        def recv(self, timeout: float | None = None) -> JsonObject | None:
+            if self.inbound:
+                return super().recv(timeout)
+            raise RuntimeError("server disconnected")
+
+    replacement = _Sandbox()
+    project = AgentProject(
+        _Sandbox(),
+        channel_factory=lambda sandbox, workspace: _DisconnectChannel(),
+        sandbox_factory=lambda: pytest.fail("retry_recoverable=False must not replace"),
+    )
+
+    with pytest.raises(RuntimeError, match="server disconnected"):
+        project.run(meta_agent(), _Provider(), "propose", timeout=1, retry_recoverable=False)
+
+    assert replacement.killed is False
+    assert project._session is None  # the poisoned session is never reused by a later run

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -536,6 +536,11 @@ def build(
         validate_name(params.name)
     except ValueError as err:
         raise typer.BadParameter(str(err)) from None
+    if params.name == "harbor":
+        raise typer.BadParameter(
+            "world model name 'harbor' is reserved: `wmh optimize <agent> harbor` selects "
+            "the harbor benchmark environment; choose another name"
+        )
     try:
         tier = FidelityTier(params.fidelity)
     except ValueError:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -346,6 +346,16 @@ def test_build_rejects_invalid_name_flag_with_friendly_error(tmp_path) -> None: 
     assert "invalid world model name" in result.output
 
 
+def test_build_rejects_the_reserved_harbor_name(tmp_path) -> None:  # noqa: ANN001
+    """`harbor` is the optimize environment literal, so no world model may claim it."""
+    result = runner.invoke(
+        app,
+        ["build", "--name", "harbor", "--file", _traces_file(tmp_path), "--no-interactive"],
+    )
+    assert result.exit_code == 2
+    assert "reserved" in result.output
+
+
 def test_examples_run_rejects_invalid_name_with_friendly_error() -> None:
     result = runner.invoke(app, ["examples", "run", "tau bench"])
     assert result.exit_code == 2  # usage error, not a ValueError traceback

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -173,7 +173,12 @@ def optimize(
         "--seed",
         help="Harness to start from, as a name or name@version (default: built-in baseline).",
     ),
-    iterations: int = typer.Option(None, min=1, help="Propose-and-gate steps (the search budget)."),
+    iterations: int = typer.Option(
+        None,
+        min=0,
+        help="Propose-and-gate steps (the search budget). 0 scores the seed only (harbor env), "
+        "the way a baseline or a frozen champion is scored on a task set.",
+    ),
     proposal_batch_size: int = typer.Option(
         1,
         "--proposal-batch-size",
@@ -311,6 +316,11 @@ def optimize(
         raise typer.BadParameter(
             f"{', '.join(harbor_only)} apply only to the harbor environment; "
             "use `wmh optimize <agent> harbor ...`"
+        )
+    if iterations == 0:
+        raise typer.BadParameter(
+            "--iterations 0 (score-only) applies only to the harbor environment; "
+            "world-model optimization needs at least one search iteration"
         )
     interactive = _console.is_terminal
     if name is None:

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -11,28 +11,60 @@ steers what the agent's scaffold should be. Run one closed-loop with
 
 from __future__ import annotations
 
+import asyncio
+import json
 import shlex
 from pathlib import Path
+from typing import Literal
 
 import typer
+from pydantic import BaseModel, ConfigDict, ValidationError
 from rich.console import Console
 from rich.markup import escape
 from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 
-from wmh.cli.model_roles import resolve_opt_in_model_provider
+from wmh.agents.default import default_agent
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import AgentProject
+from wmh.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
 from wmh.config import ARTIFACT_DIR, WorldModelStore
 from wmh.config.store import validate_name
+from wmh.core.types import JsonObject
 from wmh.engine import load_world_model
 from wmh.engine.world_model import WorldModel
 from wmh.evals.gold import GoldJudge
 from wmh.evals.tasks import TaskSpec, load_tasks
 from wmh.harness.create import ProposalRecord, create_harness
 from wmh.harness.doc import HarnessDoc
-from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
+from wmh.harness.population import (
+    CandidateProposer,
+    PopulationResult,
+    SlotOutcome,
+    write_json_atomic,
+)
+from wmh.harness.population import (
+    optimize as optimize_population,
+)
+from wmh.harness.project_proposer import CandidateProject, ProjectCandidateProposer
 from wmh.harness.proposer import ProviderDeltaProposer
+from wmh.harness.runtime import DEFAULT_EVAL_EPISODE_TIMEOUT_S
+from wmh.harness.scoring import RewardMode, Scorer, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceTree
 from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
-from wmh.providers.base import Provider
+from wmh.providers.base import Provider, ProviderConfig, ToolCallingProvider
+from wmh.providers.registry import get_provider
+
+# The default agent seed's literal CLI name: `wmh optimize pi harbor ...` starts from the
+# built-in pi agent and publishes new versions under the store name "pi".
+DEFAULT_SEED_AGENT = "pi"
+_DEFAULT_HARBOR_ITERATIONS = 10
+_HARBOR_ENVIRONMENT = "harbor"
+_HARBOR_EXTRA_HINT = (
+    "the harbor environment needs the harbor extra; run `uv sync --extra harbor` "
+    "(or `pip install 'world-model-harness[harbor]'`)"
+)
 
 harness_app = typer.Typer(
     help="Inspect and initialize named, versioned agent harnesses.",
@@ -96,10 +128,12 @@ def show_harness(
 
 
 def optimize(
+    ctx: typer.Context,
     name: str = typer.Argument(None, help="Agent name for the optimized harness."),
     model: str = typer.Argument(
         None,
-        help="World model to optimize against (default: the only built one).",
+        help="World model to optimize against (default: the only built one), or the literal "
+        "'harbor' to optimize on real harbor benchmark tasks.",
     ),
     tasks_file: str = typer.Option(None, "--tasks", help="JSONL task file to optimize against."),
     holdout_file: str = typer.Option(
@@ -145,15 +179,114 @@ def optimize(
         None, "--archive", help="Also write the full delta archive JSON here."
     ),
     yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation prompt."),
+    harbor_config: str = typer.Option(
+        None,
+        "--harbor-config",
+        help="(harbor) Harbor JobConfig template, YAML or JSON: the task-environment config "
+        "and harbor tuning, with exactly one dataset and no direct tasks.",
+    ),
+    task_ids_file: str = typer.Option(
+        None,
+        "--task-ids",
+        help="(harbor) JSON file containing the exact task-id string list to optimize on.",
+    ),
+    attempts: int = typer.Option(
+        None, "--attempts", min=1, help="(harbor) Attempts per task per candidate (default 1)."
+    ),
+    reward_key: str = typer.Option(
+        None,
+        "--reward-key",
+        help="(harbor) Verifier reward key to optimize (default 'reward').",
+    ),
+    reward_mode: str = typer.Option(
+        None,
+        "--reward-mode",
+        help="(harbor) raw | positive-binary (default positive-binary: reward > 0 passes).",
+    ),
+    harbor_retries: int = typer.Option(
+        None,
+        "--harbor-retries",
+        min=0,
+        help="(harbor) Harbor-level retries per failed trial (default 0).",
+    ),
+    episode_timeout: float = typer.Option(
+        None,
+        "--episode-timeout",
+        min=0.001,
+        help="(harbor) Wall seconds per evaluated episode (default 300; needs --backend e2b).",
+    ),
+    run_dir: str = typer.Option(
+        None,
+        "--run-dir",
+        help="(harbor) Directory holding ALL durable run state (required for harbor).",
+    ),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="(harbor) Continue the interrupted run recorded in --run-dir.",
+    ),
+    max_iterations_this_run: int = typer.Option(
+        None,
+        "--max-iterations-this-run",
+        min=1,
+        help="(harbor) Stop after this many new boundaries this invocation; continue later "
+        "with --resume.",
+    ),
 ) -> None:
-    """Optimize an agent harness by searching against a world model.
+    """Optimize an agent harness by searching against a world model or on harbor tasks.
 
-    The optimizer proposes harness changes, scores them against the simulated environment, and
-    saves the best gated result as the new champion. Configure distinct agent and optimizer models
-    with `models.agent` and `models.meta` in `.wmh/settings.toml`.
+    The optimizer proposes harness changes, scores them against the environment, and saves the
+    best result as the new champion. Configure distinct agent and optimizer models with
+    `models.agent` and `models.meta` in `.wmh/settings.toml`.
 
-    The backend controls where the worker process runs. The environment remains the world model.
+    With a world-model ENVIRONMENT, the backend controls where the worker process runs and the
+    environment remains the world model. With the literal `harbor` ENVIRONMENT, complete-source
+    candidates are scored on real benchmark tasks: --backend controls the task environment and
+    worker placement (local = docker tasks + local pi; e2b = E2B tasks + sandboxed pi), while
+    the PROPOSER project always runs in E2B in this version.
     """
+    if model == _HARBOR_ENVIRONMENT:
+        _optimize_harbor(
+            ctx,
+            name=name,
+            backend=backend,
+            e2b_template=e2b_template,
+            iterations=iterations,
+            harbor_config=harbor_config,
+            task_ids_file=task_ids_file,
+            attempts=attempts,
+            reward_key=reward_key,
+            reward_mode=reward_mode,
+            harbor_retries=harbor_retries,
+            episode_timeout=episode_timeout,
+            run_dir_option=run_dir,
+            resume=resume,
+            max_iterations_this_run=max_iterations_this_run,
+            root=root,
+            yes=yes,
+        )
+        return
+    harbor_only = [
+        flag
+        for flag, provided in (
+            ("--harbor-config", harbor_config is not None),
+            ("--task-ids", task_ids_file is not None),
+            ("--attempts", attempts is not None),
+            ("--reward-key", reward_key is not None),
+            ("--reward-mode", reward_mode is not None),
+            ("--harbor-retries", harbor_retries is not None),
+            ("--episode-timeout", episode_timeout is not None),
+            ("--run-dir", run_dir is not None),
+            ("--resume", resume),
+            ("--max-iterations-this-run", max_iterations_this_run is not None),
+        )
+        if provided
+    ]
+    if harbor_only:
+        raise typer.BadParameter(
+            f"{', '.join(harbor_only)} apply only to the harbor environment; "
+            "use `wmh optimize <agent> harbor ...`"
+        )
     interactive = _console.is_terminal
     if name is None:
         if not interactive:
@@ -327,6 +460,373 @@ def _load_world_model(name: str | None, root: str) -> tuple[WorldModel, Provider
         raise typer.BadParameter(str(exc)) from exc
     world_model, provider = load_world_model(model_dir)
     return world_model, provider, model_dir.name
+
+
+# -- the harbor environment: complete-source population optimization on real tasks ------------
+
+
+class _HarborRunConfig(BaseModel):
+    """The resolved harbor optimize configuration persisted as `run-config.json`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    agent: str
+    attempts: int
+    backend: Literal["local", "e2b"]
+    e2b_template: str | None
+    episode_timeout_s: float
+    harbor_job_template: JsonObject
+    harbor_retries: int
+    iterations: int
+    reward_key: str
+    reward_mode: RewardMode
+    task_ids: tuple[str, ...]
+
+
+def _optimize_harbor(
+    ctx: typer.Context,
+    *,
+    name: str | None,
+    backend: str,
+    e2b_template: str | None,
+    iterations: int | None,
+    harbor_config: str | None,
+    task_ids_file: str | None,
+    attempts: int | None,
+    reward_key: str | None,
+    reward_mode: str | None,
+    harbor_retries: int | None,
+    episode_timeout: float | None,
+    run_dir_option: str | None,
+    resume: bool,
+    max_iterations_this_run: int | None,
+    root: str,
+    yes: bool,
+) -> None:
+    """Run the harbor population optimizer: fixed seed, sequential complete-source proposals."""
+    if name is None:
+        raise typer.BadParameter(
+            "provide the seed agent NAME (the literal 'pi' is the built-in default agent): "
+            "`wmh optimize pi harbor --harbor-config ... --task-ids ... --run-dir ...`"
+        )
+    if backend not in ("local", "e2b"):
+        raise typer.BadParameter(f"unknown --backend {backend!r}; choose local or e2b")
+    if reward_mode is not None and reward_mode not in ("raw", "positive-binary"):
+        raise typer.BadParameter(
+            f"unknown --reward-mode {reward_mode!r}; choose raw or positive-binary"
+        )
+    if run_dir_option is None:
+        raise typer.BadParameter(
+            "--run-dir is required for the harbor environment: it holds all durable run state"
+        )
+    if WorldModelStore(root).exists(_HARBOR_ENVIRONMENT):
+        raise typer.BadParameter(
+            "a stored world model is literally named 'harbor', which now selects the harbor "
+            "benchmark environment; rename that model directory under <root>/models/ and retry"
+        )
+    if backend == "local" and episode_timeout is not None:
+        raise typer.BadParameter("--episode-timeout requires --backend e2b")
+
+    run_dir = Path(run_dir_option)
+    config_path = run_dir / "run-config.json"
+    if resume:
+        config = _resumed_harbor_config(
+            ctx,
+            config_path,
+            name=name,
+            backend=backend,
+            e2b_template=e2b_template,
+            iterations=iterations,
+            harbor_config=harbor_config,
+            task_ids_file=task_ids_file,
+            attempts=attempts,
+            reward_key=reward_key,
+            reward_mode=reward_mode,
+            harbor_retries=harbor_retries,
+            episode_timeout=episode_timeout,
+        )
+    else:
+        if config_path.exists():
+            raise typer.BadParameter(
+                f"{run_dir} already holds a run; pass --resume to continue it or choose a "
+                "fresh --run-dir"
+            )
+        if harbor_config is None or task_ids_file is None:
+            raise typer.BadParameter(
+                "--harbor-config and --task-ids are required to start a harbor optimization"
+            )
+        config = _HarborRunConfig(
+            agent=name,
+            attempts=attempts if attempts is not None else 1,
+            backend="e2b" if backend == "e2b" else "local",
+            e2b_template=resolve_e2b_template(e2b_template),
+            episode_timeout_s=(
+                episode_timeout if episode_timeout is not None else DEFAULT_EVAL_EPISODE_TIMEOUT_S
+            ),
+            harbor_job_template=_load_harbor_job_template(Path(harbor_config)),
+            harbor_retries=harbor_retries if harbor_retries is not None else 0,
+            iterations=iterations if iterations is not None else _DEFAULT_HARBOR_ITERATIONS,
+            reward_key=reward_key if reward_key is not None else "reward",
+            reward_mode="raw" if reward_mode == "raw" else "positive-binary",
+            task_ids=_load_harbor_task_ids(Path(task_ids_file)),
+        )
+
+    seed_name, seed_tree = _resolve_harbor_seed(root, config.agent)
+    meta_config = resolve_required_model_config(root, "meta")
+    agent_config = resolve_required_model_config(root, "agent")
+    if not resume:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(config_path, config.model_dump(mode="json"))
+    scorer = _build_harbor_scorer(config, run_dir=run_dir, provider_config=agent_config)
+    proposer = _build_harbor_proposer(
+        run_dir=run_dir, meta_config=meta_config, e2b_template=config.e2b_template
+    )
+
+    _console.print(
+        f"harbor population search from [bold]{config.agent}[/bold]: 1 seed + "
+        f"{config.iterations} proposal slot(s), {len(config.task_ids)} task(s), "
+        f"{config.attempts} attempt(s), reward mode {config.reward_mode}, "
+        f"worker backend {config.backend} (proposer project: E2B) -> {run_dir}"
+    )
+    if _console.is_terminal and not yes and not Confirm.ask("Proceed?", default=True):
+        raise typer.Exit(0)
+
+    def _on_boundary(outcome: SlotOutcome) -> None:
+        if outcome.evaluated is None:
+            _console.print(
+                f"  [slot {outcome.slot}] {outcome.candidate_id}: "
+                f"[yellow]invalid[/yellow] ({escape(outcome.reason)})"
+            )
+        else:
+            tag = "seed" if outcome.slot == 0 else f"slot {outcome.slot}"
+            _console.print(f"  [{tag}] {outcome.candidate_id}: score={outcome.evaluated.score:.3f}")
+
+    result = optimize_population(
+        seed_tree,
+        scorer,
+        proposer,
+        config.iterations,
+        run_dir=run_dir,
+        max_new_boundaries=max_iterations_this_run,
+        on_boundary=_on_boundary,
+    )
+    if not result.completed:
+        _console.print(
+            f"[yellow]checkpointed[/yellow] {len(result.outcomes)}/{config.iterations + 1} "
+            f"boundaries; continue with: [bold]wmh optimize {config.agent} harbor --resume "
+            f"--run-dir {run_dir}[/bold]"
+        )
+        return
+    _publish_harbor_winner(result, root=root, seed_name=seed_name, run_dir=run_dir)
+
+
+def _publish_harbor_winner(
+    result: PopulationResult, *, root: str, seed_name: str, run_dir: Path
+) -> None:
+    """Save the score winner as the seed agent's next version and move champion."""
+    store = HarnessStore(root)
+    winner = result.best.source.to_doc(seed_name)
+    saved = store.save_version(winner, alias=CHAMPION_ALIAS)
+    scored = sum(1 for outcome in result.outcomes if outcome.evaluated is not None)
+    _console.print(
+        f"[green]optimized[/green] [bold]{seed_name}[/bold] v{saved.version} (champion) "
+        f"score={result.best_score:.3f} from {result.best.candidate_id} "
+        f"({scored} scored, {len(result.outcomes) - scored} invalid slot(s)) "
+        f"-> {store.dir_for(seed_name)}; evidence -> {run_dir}"
+    )
+
+
+def _resumed_harbor_config(
+    ctx: typer.Context,
+    config_path: Path,
+    *,
+    name: str,
+    backend: str,
+    e2b_template: str | None,
+    iterations: int | None,
+    harbor_config: str | None,
+    task_ids_file: str | None,
+    attempts: int | None,
+    reward_key: str | None,
+    reward_mode: str | None,
+    harbor_retries: int | None,
+    episode_timeout: float | None,
+) -> _HarborRunConfig:
+    """Load the recorded run config, rejecting explicit CLI flags that conflict with it."""
+    if not config_path.is_file():
+        raise typer.BadParameter(
+            f"--resume found no run-config.json under {config_path.parent}; "
+            "start the run once without --resume"
+        )
+    try:
+        stored = _HarborRunConfig.model_validate_json(config_path.read_text(encoding="utf-8"))
+    except ValidationError as error:
+        raise typer.BadParameter(f"cannot load {config_path}: {error}") from error
+
+    def explicit(param: str) -> bool:
+        # Compared by name: typer vendors click, so its ParameterSource enum is not
+        # click.core's class and an identity check would silently never match.
+        source = ctx.get_parameter_source(param)
+        return source is not None and source.name == "COMMANDLINE"
+
+    conflicts: list[str] = []
+    if name != stored.agent:
+        conflicts.append(f"NAME {name!r} != recorded {stored.agent!r}")
+    checks: list[tuple[str, str, object, object]] = [
+        ("backend", "--backend", backend, stored.backend),
+        ("iterations", "--iterations", iterations, stored.iterations),
+        ("attempts", "--attempts", attempts, stored.attempts),
+        ("reward_key", "--reward-key", reward_key, stored.reward_key),
+        ("reward_mode", "--reward-mode", reward_mode, stored.reward_mode),
+        ("harbor_retries", "--harbor-retries", harbor_retries, stored.harbor_retries),
+        ("episode_timeout", "--episode-timeout", episode_timeout, stored.episode_timeout_s),
+        (
+            "e2b_template",
+            "--e2b-template",
+            resolve_e2b_template(e2b_template),
+            stored.e2b_template,
+        ),
+    ]
+    conflicts.extend(
+        f"{flag} {value!r} != recorded {recorded!r}"
+        for param, flag, value, recorded in checks
+        if explicit(param) and value != recorded
+    )
+    if explicit("harbor_config") and harbor_config is not None:
+        template = _load_harbor_job_template(Path(harbor_config))
+        if template != stored.harbor_job_template:
+            conflicts.append("--harbor-config differs from the recorded job template")
+    if explicit("task_ids_file") and task_ids_file is not None:
+        task_ids = _load_harbor_task_ids(Path(task_ids_file))
+        if task_ids != stored.task_ids:
+            conflicts.append("--task-ids differs from the recorded task list")
+    if conflicts:
+        raise typer.BadParameter(
+            "--resume uses the recorded run-config.json; conflicting flag(s): "
+            + "; ".join(conflicts)
+            + ". Drop them to continue this run, or start a fresh --run-dir"
+        )
+    return stored
+
+
+def _resolve_harbor_seed(root: str, agent_ref: str) -> tuple[str, HarnessSourceTree]:
+    """Resolve the seed AGENT positional: literal 'pi' is built-in, otherwise store name@ref."""
+    base, _, ref = agent_ref.partition("@")
+    try:
+        validate_name(base)
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if base == DEFAULT_SEED_AGENT and not ref:
+        return base, HarnessSourceTree.from_doc(default_agent(base))
+    try:
+        doc = HarnessStore(root).load(base, ref or None)
+    except (FileNotFoundError, ValueError) as error:
+        raise typer.BadParameter(
+            f"{error}; the built-in default agent seed is the literal {DEFAULT_SEED_AGENT!r}"
+        ) from error
+    return base, HarnessSourceTree.from_doc(doc)
+
+
+def _load_harbor_job_template(path: Path) -> JsonObject:
+    """Load one harbor JobConfig template (YAML or JSON) as canonical JSON.
+
+    The harbor SDK is an optional extra imported lazily, exactly like the e2b extra: only the
+    harbor environment needs it, and `import wmh` must succeed without it.
+    """
+    try:
+        import yaml
+        from harbor.models.job.config import JobConfig
+    except ImportError as error:
+        raise typer.BadParameter(_HARBOR_EXTRA_HINT) from error
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        template = JobConfig.model_validate(raw)
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as error:
+        raise typer.BadParameter(f"cannot load the harbor config from {path}: {error}") from error
+    return template.model_dump(mode="json")
+
+
+def _load_harbor_task_ids(path: Path) -> tuple[str, ...]:
+    """Load the exact ordered task-id list, validated by the canonical score request rules."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise typer.BadParameter(f"cannot load task ids from {path}: {error}") from error
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise typer.BadParameter(f"{path} must contain one JSON array of task-id strings")
+    try:
+        request = ScoreRequest(task_ids=tuple(raw), attempts=1)
+    except ValidationError as error:
+        raise typer.BadParameter(f"invalid task ids in {path}: {error}") from error
+    return request.task_ids
+
+
+def _build_harbor_scorer(
+    config: _HarborRunConfig, *, run_dir: Path, provider_config: ProviderConfig
+) -> Scorer:
+    """Construct the harbor evaluator for the resolved run config (lazy harbor import)."""
+    try:
+        from harbor.models.job.config import JobConfig
+
+        from wmh.evals.harbor.scorer import HarborScorer
+    except ImportError as error:
+        raise typer.BadParameter(_HARBOR_EXTRA_HINT) from error
+    template = JobConfig.model_validate(
+        {**config.harbor_job_template, "jobs_dir": str(run_dir / "harbor")}
+    )
+    try:
+        return asyncio.run(
+            HarborScorer.create(
+                template,
+                list(config.task_ids),
+                provider_config=provider_config,
+                reward_key=config.reward_key,
+                reward_mode=config.reward_mode,
+                attempts=config.attempts,
+                task_environment="e2b" if config.backend == "e2b" else "docker",
+                harness_backend=config.backend,
+                # "" pins template absence so the scorer cannot re-read a changed environment.
+                e2b_template=(config.e2b_template or "") if config.backend == "e2b" else None,
+                episode_timeout_s=(
+                    config.episode_timeout_s
+                    if config.backend == "e2b"
+                    else DEFAULT_EVAL_EPISODE_TIMEOUT_S
+                ),
+                harbor_retries=config.harbor_retries,
+            )
+        )
+    except ValueError as error:
+        raise typer.BadParameter(f"cannot build the harbor scorer: {error}") from error
+
+
+def _build_harbor_proposer(
+    *, run_dir: Path, meta_config: ProviderConfig, e2b_template: str | None
+) -> CandidateProposer:
+    """Wire the proposer: a fresh E2B project per slot driving the optimizer persona.
+
+    The proposer project requires E2B even under `--backend local` in this version: the
+    optimizer persona needs a contained filesystem plus node for interface validation, and the
+    pi worker template already ships both.
+    """
+    provider = get_provider(meta_config)
+    if not isinstance(provider, ToolCallingProvider):
+        raise typer.BadParameter(
+            "settings [models.meta] provider lacks structured tool calling, which the "
+            "harbor proposer requires"
+        )
+
+    def project_factory() -> CandidateProject:
+        return AgentProject.create(
+            template=e2b_template,
+            metadata={"wmh_component": "optimize-harbor-proposer"},
+        )
+
+    return ProjectCandidateProposer(
+        optimizer_agent(),
+        provider,
+        project_factory=project_factory,
+        run_dir=run_dir,
+    )
 
 
 @harness_app.command("init")

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -41,6 +41,7 @@ from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
 from wmh.harness.population import (
     CandidateProposer,
     PopulationResult,
+    PopulationRunState,
     SlotOutcome,
     write_json_atomic,
 )
@@ -129,7 +130,13 @@ def show_harness(
 
 def optimize(
     ctx: typer.Context,
-    name: str = typer.Argument(None, help="Agent name for the optimized harness."),
+    name: str = typer.Argument(
+        None,
+        help="Agent name for the optimized harness. For the harbor environment this is the "
+        "seed and the publication target: the bare literal 'pi' is ALWAYS the built-in "
+        "default agent (fixed-seed protocol), even after a stored 'pi' champion exists; "
+        "seed from a stored version explicitly with 'pi@champion' or 'pi@vN'.",
+    ),
     model: str = typer.Argument(
         None,
         help="World model to optimize against (default: the only built one), or the literal "
@@ -246,6 +253,24 @@ def optimize(
     the PROPOSER project always runs in E2B in this version.
     """
     if model == _HARBOR_ENVIRONMENT:
+        world_model_only = [
+            flag
+            for param, flag in (
+                ("tasks_file", "--tasks"),
+                ("holdout_file", "--holdout"),
+                ("seed", "--seed"),
+                ("k", "--k"),
+                ("eval_concurrency", "--eval-concurrency"),
+                ("proposal_batch_size", "--proposal-batch-size"),
+                ("archive_out", "--archive"),
+            )
+            if _explicit(ctx, param)
+        ]
+        if world_model_only:
+            raise typer.BadParameter(
+                f"{', '.join(world_model_only)} apply only to a world-model environment; "
+                "drop them for `wmh optimize <agent> harbor ...`"
+            )
         _optimize_harbor(
             ctx,
             name=name,
@@ -475,12 +500,48 @@ class _HarborRunConfig(BaseModel):
     backend: Literal["local", "e2b"]
     e2b_template: str | None
     episode_timeout_s: float
+    # The PARSED RAW job template mapping, never a harbor model_dump (which would redact
+    # sensitive-named env values that differ from this process's environment).
     harbor_job_template: JsonObject
     harbor_retries: int
     iterations: int
+    # The worker and proposer model identities resolved at run start; a resume re-resolves the
+    # roles and rejects a mismatch so a mid-run settings.toml edit cannot silently change what
+    # is being scored or who is proposing.
+    proposer_model: JsonObject
+    worker_model: JsonObject
     reward_key: str
     reward_mode: RewardMode
+    # The stored-seed version this run started from; None means the built-in default agent.
+    # Resumes load the seed from the run dir itself, so champion movement (including this
+    # run's own publication) can never re-resolve the seed to a different tree.
+    seed_version: int | None
     task_ids: tuple[str, ...]
+    # Per-task provenance pins (git commit / package ref / local path) resolved on the first
+    # run; None until the dataset has resolved once. A resume that resolves differently is
+    # rejected instead of silently scoring different task bytes.
+    task_pins: JsonObject | None = None
+
+
+def _model_identity(config: ProviderConfig) -> JsonObject:
+    """The provider identity fields a run pins (and a resume must re-resolve identically)."""
+    return {
+        "provider": config.kind.value,
+        "model": config.model,
+        "deployment": config.deployment,
+        "region": config.region,
+        "reasoning_effort": config.reasoning_effort,
+    }
+
+
+def _explicit(ctx: typer.Context, param: str) -> bool:
+    """Whether `param` was explicitly passed on the command line.
+
+    Compared by enum NAME: typer vendors click, so its ParameterSource enum is not
+    click.core's class and an identity check would silently never match.
+    """
+    source = ctx.get_parameter_source(param)
+    return source is not None and source.name == "COMMANDLINE"
 
 
 def _optimize_harbor(
@@ -524,11 +585,11 @@ def _optimize_harbor(
             "a stored world model is literally named 'harbor', which now selects the harbor "
             "benchmark environment; rename that model directory under <root>/models/ and retry"
         )
-    if backend == "local" and episode_timeout is not None:
-        raise typer.BadParameter("--episode-timeout requires --backend e2b")
 
     run_dir = Path(run_dir_option)
     config_path = run_dir / "run-config.json"
+    meta_config = resolve_required_model_config(root, "meta")
+    agent_config = resolve_required_model_config(root, "agent")
     if resume:
         config = _resumed_harbor_config(
             ctx,
@@ -544,7 +605,10 @@ def _optimize_harbor(
             reward_mode=reward_mode,
             harbor_retries=harbor_retries,
             episode_timeout=episode_timeout,
+            meta_config=meta_config,
+            agent_config=agent_config,
         )
+        seed_name, seed_tree = _resumed_harbor_seed(run_dir, root, config)
     else:
         if config_path.exists():
             raise typer.BadParameter(
@@ -555,6 +619,7 @@ def _optimize_harbor(
             raise typer.BadParameter(
                 "--harbor-config and --task-ids are required to start a harbor optimization"
             )
+        seed_name, seed_tree, seed_version = _resolve_harbor_seed(root, name)
         config = _HarborRunConfig(
             agent=name,
             attempts=attempts if attempts is not None else 1,
@@ -566,21 +631,17 @@ def _optimize_harbor(
             harbor_job_template=_load_harbor_job_template(Path(harbor_config)),
             harbor_retries=harbor_retries if harbor_retries is not None else 0,
             iterations=iterations if iterations is not None else _DEFAULT_HARBOR_ITERATIONS,
+            proposer_model=_model_identity(meta_config),
+            worker_model=_model_identity(agent_config),
             reward_key=reward_key if reward_key is not None else "reward",
             reward_mode="raw" if reward_mode == "raw" else "positive-binary",
+            seed_version=seed_version,
             task_ids=_load_harbor_task_ids(Path(task_ids_file)),
         )
-
-    seed_name, seed_tree = _resolve_harbor_seed(root, config.agent)
-    meta_config = resolve_required_model_config(root, "meta")
-    agent_config = resolve_required_model_config(root, "agent")
-    if not resume:
-        run_dir.mkdir(parents=True, exist_ok=True)
-        write_json_atomic(config_path, config.model_dump(mode="json"))
-    scorer = _build_harbor_scorer(config, run_dir=run_dir, provider_config=agent_config)
-    proposer = _build_harbor_proposer(
-        run_dir=run_dir, meta_config=meta_config, e2b_template=config.e2b_template
-    )
+    # Validated on the EFFECTIVE (stored-or-CLI) config: a consistent resume of an e2b run may
+    # restate --episode-timeout even though this invocation's --backend default is local.
+    if config.backend == "local" and config.episode_timeout_s != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
+        raise typer.BadParameter("--episode-timeout requires --backend e2b")
 
     _console.print(
         f"harbor population search from [bold]{config.agent}[/bold]: 1 seed + "
@@ -590,6 +651,24 @@ def _optimize_harbor(
     )
     if _console.is_terminal and not yes and not Confirm.ask("Proceed?", default=True):
         raise typer.Exit(0)
+
+    scorer, task_pins = _build_harbor_scorer(config, run_dir=run_dir, provider_config=agent_config)
+    if resume:
+        if config.task_pins is not None and task_pins != config.task_pins:
+            raise typer.BadParameter(
+                "the dataset resolved differently than this run recorded: "
+                f"recorded pins {config.task_pins}, resolved pins {task_pins}; restore the "
+                "recorded dataset revision or start a fresh --run-dir"
+            )
+    else:
+        # Recorded only now: the template validated, the user confirmed, and the dataset pins
+        # are known, so a declined or failed start never poisons the run dir.
+        config = config.model_copy(update={"task_pins": task_pins})
+        run_dir.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(config_path, config.model_dump(mode="json"))
+    proposer = _build_harbor_proposer(
+        run_dir=run_dir, meta_config=meta_config, e2b_template=config.e2b_template
+    )
 
     def _on_boundary(outcome: SlotOutcome) -> None:
         if outcome.evaluated is None:
@@ -623,10 +702,34 @@ def _optimize_harbor(
 def _publish_harbor_winner(
     result: PopulationResult, *, root: str, seed_name: str, run_dir: Path
 ) -> None:
-    """Save the score winner as the seed agent's next version and move champion."""
+    """Save the score winner as the seed agent's next version, exactly once per run.
+
+    `published.json` is the run's publication record and is written LAST: a completed run
+    resumed again re-prints that record instead of appending a duplicate store version and
+    moving the champion alias a second time.
+    """
+    published_path = run_dir / "published.json"
+    if published_path.exists():
+        record = json.loads(published_path.read_text(encoding="utf-8"))
+        _console.print(
+            f"[green]already published[/green] [bold]{record.get('name')}[/bold] "
+            f"v{record.get('version')} (doc_hash={str(record.get('doc_hash'))[:12]}) "
+            f"from {record.get('best_candidate_id')}; evidence -> {run_dir}"
+        )
+        return
     store = HarnessStore(root)
     winner = result.best.source.to_doc(seed_name)
     saved = store.save_version(winner, alias=CHAMPION_ALIAS)
+    write_json_atomic(
+        published_path,
+        {
+            "name": saved.name,
+            "version": saved.version,
+            "doc_hash": saved.doc_hash,
+            "best_candidate_id": result.best.candidate_id,
+            "best_score": result.best_score,
+        },
+    )
     scored = sum(1 for outcome in result.outcomes if outcome.evaluated is not None)
     _console.print(
         f"[green]optimized[/green] [bold]{seed_name}[/bold] v{saved.version} (champion) "
@@ -634,6 +737,33 @@ def _publish_harbor_winner(
         f"({scored} scored, {len(result.outcomes) - scored} invalid slot(s)) "
         f"-> {store.dir_for(seed_name)}; evidence -> {run_dir}"
     )
+
+
+def _resumed_harbor_seed(
+    run_dir: Path, root: str, config: _HarborRunConfig
+) -> tuple[str, HarnessSourceTree]:
+    """The seed for a resumed run: the run dir's own record, never a live movable ref.
+
+    `candidates/candidate-0000/source` is authoritative once the seed boundary committed;
+    re-resolving the NAME live would let champion movement (including this run's own
+    publication) resolve a different tree and brick a legitimate resume. Before the first
+    boundary the seed is re-resolved from the PINNED version recorded at start.
+    """
+    seed_name = config.agent.partition("@")[0]
+    # load() only returns COMMITTED boundaries (state.json) and re-verifies each candidate's
+    # doc hash, so a crash that left a partial candidate-0000/source dir cannot leak in.
+    outcomes = PopulationRunState(run_dir).load()
+    if outcomes and outcomes[0].evaluated is not None:
+        return seed_name, outcomes[0].evaluated.source
+    if config.seed_version is None:
+        return seed_name, HarnessSourceTree.from_doc(default_agent(seed_name))
+    try:
+        doc = HarnessStore(root).load(seed_name, str(config.seed_version))
+    except (FileNotFoundError, ValueError) as error:
+        raise typer.BadParameter(
+            f"cannot reload the recorded seed {seed_name}@v{config.seed_version}: {error}"
+        ) from error
+    return seed_name, HarnessSourceTree.from_doc(doc)
 
 
 def _resumed_harbor_config(
@@ -651,6 +781,8 @@ def _resumed_harbor_config(
     reward_mode: str | None,
     harbor_retries: int | None,
     episode_timeout: float | None,
+    meta_config: ProviderConfig,
+    agent_config: ProviderConfig,
 ) -> _HarborRunConfig:
     """Load the recorded run config, rejecting explicit CLI flags that conflict with it."""
     if not config_path.is_file():
@@ -662,12 +794,6 @@ def _resumed_harbor_config(
         stored = _HarborRunConfig.model_validate_json(config_path.read_text(encoding="utf-8"))
     except ValidationError as error:
         raise typer.BadParameter(f"cannot load {config_path}: {error}") from error
-
-    def explicit(param: str) -> bool:
-        # Compared by name: typer vendors click, so its ParameterSource enum is not
-        # click.core's class and an identity check would silently never match.
-        source = ctx.get_parameter_source(param)
-        return source is not None and source.name == "COMMANDLINE"
 
     conflicts: list[str] = []
     if name != stored.agent:
@@ -690,13 +816,13 @@ def _resumed_harbor_config(
     conflicts.extend(
         f"{flag} {value!r} != recorded {recorded!r}"
         for param, flag, value, recorded in checks
-        if explicit(param) and value != recorded
+        if _explicit(ctx, param) and value != recorded
     )
-    if explicit("harbor_config") and harbor_config is not None:
+    if _explicit(ctx, "harbor_config") and harbor_config is not None:
         template = _load_harbor_job_template(Path(harbor_config))
         if template != stored.harbor_job_template:
             conflicts.append("--harbor-config differs from the recorded job template")
-    if explicit("task_ids_file") and task_ids_file is not None:
+    if _explicit(ctx, "task_ids_file") and task_ids_file is not None:
         task_ids = _load_harbor_task_ids(Path(task_ids_file))
         if task_ids != stored.task_ids:
             conflicts.append("--task-ids differs from the recorded task list")
@@ -706,32 +832,58 @@ def _resumed_harbor_config(
             + "; ".join(conflicts)
             + ". Drop them to continue this run, or start a fresh --run-dir"
         )
+    # Provider roles come from settings.toml, not flags, so they are ALWAYS re-checked: a
+    # mid-run settings edit that changes the worker or proposer identity would silently break
+    # cross-slot score comparability.
+    role_changes = [
+        f"settings [models.{role}] resolved to {resolved} but this run recorded {recorded}"
+        for role, resolved, recorded in (
+            ("agent", _model_identity(agent_config), stored.worker_model),
+            ("meta", _model_identity(meta_config), stored.proposer_model),
+        )
+        if resolved != recorded
+    ]
+    if role_changes:
+        raise typer.BadParameter(
+            "; ".join(role_changes) + "; restore the recorded models or start a fresh --run-dir"
+        )
     return stored
 
 
-def _resolve_harbor_seed(root: str, agent_ref: str) -> tuple[str, HarnessSourceTree]:
-    """Resolve the seed AGENT positional: literal 'pi' is built-in, otherwise store name@ref."""
+def _resolve_harbor_seed(root: str, agent_ref: str) -> tuple[str, HarnessSourceTree, int | None]:
+    """Resolve the seed AGENT positional: literal 'pi' is built-in, otherwise store name@ref.
+
+    The bare literal 'pi' ALWAYS means the built-in default agent (the fixed-seed protocol),
+    even after this command publishes a stored 'pi' champion; compounding runs seed from a
+    stored version explicitly via 'pi@champion' or 'pi@vN'. Returns the publication base name,
+    the seed tree, and the resolved store version (None for the built-in seed) so a resume can
+    pin exactly what this run started from.
+    """
     base, _, ref = agent_ref.partition("@")
     try:
         validate_name(base)
     except ValueError as error:
         raise typer.BadParameter(str(error)) from error
     if base == DEFAULT_SEED_AGENT and not ref:
-        return base, HarnessSourceTree.from_doc(default_agent(base))
+        return base, HarnessSourceTree.from_doc(default_agent(base)), None
     try:
         doc = HarnessStore(root).load(base, ref or None)
     except (FileNotFoundError, ValueError) as error:
         raise typer.BadParameter(
             f"{error}; the built-in default agent seed is the literal {DEFAULT_SEED_AGENT!r}"
         ) from error
-    return base, HarnessSourceTree.from_doc(doc)
+    return base, HarnessSourceTree.from_doc(doc), doc.version
 
 
 def _load_harbor_job_template(path: Path) -> JsonObject:
-    """Load one harbor JobConfig template (YAML or JSON) as canonical JSON.
+    """Load one harbor JobConfig template (YAML or JSON) as the PARSED RAW mapping.
 
-    The harbor SDK is an optional extra imported lazily, exactly like the e2b extra: only the
-    harbor environment needs it, and `import wmh` must succeed without it.
+    The raw mapping is validated against `JobConfig` for checking only and returned untouched:
+    serializing harbor models redacts sensitive-named env values that differ from this
+    process's environment, so a `model_dump` here would corrupt the recorded run config and
+    every trial's environment. The harbor SDK is an optional extra imported lazily, exactly
+    like the e2b extra: only the harbor environment needs it, and `import wmh` must succeed
+    without it.
     """
     try:
         import yaml
@@ -740,10 +892,18 @@ def _load_harbor_job_template(path: Path) -> JsonObject:
         raise typer.BadParameter(_HARBOR_EXTRA_HINT) from error
     try:
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        template = JobConfig.model_validate(raw)
+        JobConfig.model_validate(raw)
     except (OSError, yaml.YAMLError, ValueError, TypeError) as error:
         raise typer.BadParameter(f"cannot load the harbor config from {path}: {error}") from error
-    return template.model_dump(mode="json")
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(f"the harbor config in {path} must be a mapping")
+    try:
+        normalized = json.loads(json.dumps(raw))
+    except (TypeError, ValueError) as error:
+        raise typer.BadParameter(
+            f"the harbor config in {path} contains values that cannot be recorded as JSON: {error}"
+        ) from error
+    return normalized
 
 
 def _load_harbor_task_ids(path: Path) -> tuple[str, ...]:
@@ -763,8 +923,13 @@ def _load_harbor_task_ids(path: Path) -> tuple[str, ...]:
 
 def _build_harbor_scorer(
     config: _HarborRunConfig, *, run_dir: Path, provider_config: ProviderConfig
-) -> Scorer:
-    """Construct the harbor evaluator for the resolved run config (lazy harbor import)."""
+) -> tuple[Scorer, JsonObject]:
+    """Construct the harbor evaluator and its resolved per-task provenance pins.
+
+    The harbor import is lazy (optional extra). The pins (git commit / package ref / local
+    path per task id) are recorded in the run config on the first run and re-checked on
+    resume, so a dataset that re-resolves differently is rejected instead of silently scored.
+    """
     try:
         from harbor.models.job.config import JobConfig
 
@@ -775,7 +940,7 @@ def _build_harbor_scorer(
         {**config.harbor_job_template, "jobs_dir": str(run_dir / "harbor")}
     )
     try:
-        return asyncio.run(
+        scorer = asyncio.run(
             HarborScorer.create(
                 template,
                 list(config.task_ids),
@@ -797,6 +962,7 @@ def _build_harbor_scorer(
         )
     except ValueError as error:
         raise typer.BadParameter(f"cannot build the harbor scorer: {error}") from error
+    return scorer, dict(scorer.task_pins)
 
 
 def _build_harbor_proposer(

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -456,11 +456,13 @@ def _harbor_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str
 
     def fake_scorer(
         config: _HarborRunConfig, *, run_dir: Path, provider_config: ProviderConfig
-    ) -> _FakeHarborScorer:
+    ) -> tuple[_FakeHarborScorer, dict[str, str]]:
         del run_dir
         captured["config"] = config
         captured["provider_config"] = provider_config
-        return _FakeHarborScorer(config.task_ids, config.attempts)
+        salt = str(captured.get("pin_salt", ""))
+        pins = {task_id: f"path:/tasks/{task_id}{salt}" for task_id in config.task_ids}
+        return _FakeHarborScorer(config.task_ids, config.attempts), pins
 
     def fake_proposer(
         *, run_dir: Path, meta_config: ProviderConfig, e2b_template: str | None
@@ -514,6 +516,10 @@ def test_harbor_dispatch_runs_the_population_and_publishes_the_winner(
     run_config = json.loads((tmp_path / "run" / "run-config.json").read_text(encoding="utf-8"))
     assert run_config["agent"] == "pi"
     assert run_config["iterations"] == 1
+    assert run_config["seed_version"] is None  # the built-in seed carries no store version
+    assert run_config["task_pins"] == {"t1": "path:/tasks/t1"}
+    assert run_config["worker_model"]["model"] == "gpt-5.5"
+    assert run_config["proposer_model"]["provider"] == "azure"
     state = json.loads((tmp_path / "run" / "state.json").read_text(encoding="utf-8"))
     assert [entry["candidate_id"] for entry in state["outcomes"]] == [
         "candidate-0000",
@@ -602,3 +608,185 @@ def test_world_model_path_rejects_harbor_only_flags(tmp_path: Path) -> None:
     )
     assert result.exit_code == 2
     assert "apply only to the harbor environment" in result.output
+
+
+def test_harbor_run_config_preserves_sensitive_env_values_verbatim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The recorded job template is the PARSED RAW mapping, never a harbor model_dump.
+
+    Harbor's env serializers redact sensitive-named values that differ from this process's
+    environment; a round-trip through model_dump would corrupt the recorded run config and
+    every trial. MY_API_KEY is sensitive-named and deliberately absent from os.environ.
+    """
+    captured = _harbor_project(tmp_path, monkeypatch)
+    monkeypatch.delenv("MY_API_KEY", raising=False)
+    (tmp_path / "job.yaml").write_text(
+        _HARBOR_JOB_YAML + "verifier:\n  env:\n    MY_API_KEY: run-specific-secret\n",
+        encoding="utf-8",
+    )
+
+    result = _invoke_harbor(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    run_config = json.loads((tmp_path / "run" / "run-config.json").read_text(encoding="utf-8"))
+    assert run_config["harbor_job_template"]["verifier"]["env"]["MY_API_KEY"] == (
+        "run-specific-secret"
+    )
+    config = captured["config"]
+    assert isinstance(config, _HarborRunConfig)
+    verifier = config.harbor_job_template["verifier"]
+    assert isinstance(verifier, dict)
+    assert verifier["env"] == {"MY_API_KEY": "run-specific-secret"}
+
+
+def test_harbor_publication_is_idempotent_across_resumes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harbor_project(tmp_path, monkeypatch)
+    first = _invoke_harbor(tmp_path)
+    assert first.exit_code == 0, first.output
+    store = HarnessStore(str(tmp_path / ".wmh"))
+    assert store.versions("pi") == [1]
+
+    again = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi",
+            "harbor",
+            "--resume",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+
+    assert again.exit_code == 0, again.output
+    assert "already published" in again.output
+    assert store.versions("pi") == [1]  # no duplicate version, champion did not move again
+    assert store.aliases("pi")["champion"] == 1
+
+
+def test_harbor_rejects_world_model_only_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harbor_project(tmp_path, monkeypatch)
+    result = _invoke_harbor(tmp_path, "--tasks", "tasks.jsonl", "--k", "3")
+    assert result.exit_code == 2
+    flat = " ".join(result.output.split())
+    assert "--tasks" in flat
+    assert "world-model environment" in flat
+
+
+def test_harbor_seed_ref_resolves_through_the_store_and_resume_pins_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """'pi@champion' seeds from the store, and a resume uses the RECORDED seed even after
+    this run's own publication (or anything else) moves the champion alias."""
+    _harbor_project(tmp_path, monkeypatch)
+    store = HarnessStore(str(tmp_path / ".wmh"))
+    stored_seed = HarnessDoc.baseline("pi").model_copy(update={"name": "pi"})
+    store.save_version(stored_seed, alias="champion")  # v1, champion
+
+    first = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi@champion",
+            "harbor",
+            "--harbor-config",
+            str(tmp_path / "job.yaml"),
+            "--task-ids",
+            str(tmp_path / "tasks.json"),
+            "--iterations",
+            "1",
+            "--max-iterations-this-run",
+            "1",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+    assert first.exit_code == 0, first.output
+    assert "checkpointed" in first.output
+    run_config = json.loads((tmp_path / "run" / "run-config.json").read_text(encoding="utf-8"))
+    assert run_config["seed_version"] == 1
+    recorded = tmp_path / "run" / "candidates" / "candidate-0000" / "source" / "SYSTEM.md"
+    assert recorded.read_text(encoding="utf-8") == stored_seed.system_prompt()
+
+    # Champion moves before the resume; the run must keep its recorded seed regardless.
+    store.save_version(stored_seed.model_copy(update={"version": 0}), alias="champion")  # v2
+    resumed = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi@champion",
+            "harbor",
+            "--resume",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    assert "optimized" in resumed.output
+    assert recorded.read_text(encoding="utf-8") == stored_seed.system_prompt()
+    assert store.versions("pi") == [1, 2, 3]  # the winner published as the next version
+
+
+def test_harbor_resume_rejects_changed_model_roles_and_dataset_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _harbor_project(tmp_path, monkeypatch)
+    first = _invoke_harbor(tmp_path, "--max-iterations-this-run", "1")
+    assert first.exit_code == 0, first.output
+
+    # A mid-run settings.toml edit silently changing the worker model is rejected.
+    root = tmp_path / ".wmh"
+    changed = ModelRole(provider="azure", model="gpt-6", endpoint="https://x.example")
+    kept = ModelRole(provider="azure", model="gpt-5.5", endpoint="https://x.example")
+    save_settings(ProjectSettings(models=ModelsSettings(meta=kept, agent=changed)), root)
+    role_conflict = _invoke_harbor(tmp_path, "--resume")
+    assert role_conflict.exit_code == 2
+    assert "models.agent" in " ".join(role_conflict.output.split())
+
+    # A dataset that re-resolves to different task pins is rejected too.
+    save_settings(ProjectSettings(models=ModelsSettings(meta=kept, agent=kept)), root)
+    captured["pin_salt"] = "@drifted"
+    pin_conflict = _invoke_harbor(tmp_path, "--resume")
+    assert pin_conflict.exit_code == 2
+    assert "resolved differently" in " ".join(pin_conflict.output.split())
+
+
+def test_harbor_resume_accepts_a_restated_episode_timeout_for_an_e2b_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Flag consistency is judged on the EFFECTIVE config: restating --episode-timeout on a
+    resumed e2b run must not trip the local-backend guard via this invocation's defaults."""
+    _harbor_project(tmp_path, monkeypatch)
+    first = _invoke_harbor(
+        tmp_path, "--backend", "e2b", "--episode-timeout", "120", "--max-iterations-this-run", "1"
+    )
+    assert first.exit_code == 0, first.output
+
+    resumed = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi",
+            "harbor",
+            "--resume",
+            "--episode-timeout",
+            "120",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    assert "optimized" in resumed.output

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -9,18 +9,25 @@ advertises. Flag validation, task loading, and the harness store are real.
 from __future__ import annotations
 
 import importlib
+import json
 import shlex
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner, Result
 
 from wmh.cli import app
+from wmh.cli.harness_app import _HarborRunConfig
 from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
 from wmh.evals.tasks import TaskSpec
 from wmh.harness.create import CreateResult, DeltaArchive
 from wmh.harness.doc import HarnessDoc
+from wmh.harness.population import CandidateProposal, EvaluatedCandidate, candidate_slot_id
 from wmh.harness.proposer import ProviderDeltaProposer
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.harness.store import HarnessStore
 from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
 
 # The Typer object `harness_app` shadows the submodule name on plain attribute access; go
@@ -363,3 +370,235 @@ def test_optimize_rejects_unknown_backend(tmp_path: Path) -> None:
     result = _invoke(tmp_path, "--backend", "banana")
     assert result.exit_code == 2  # usage error, not a traceback
     assert "choose local or e2b" in result.output
+
+
+# -- the harbor environment: dispatch, durable state, resume, and publication ------------------
+
+
+_HARBOR_JOB_YAML = """\
+job_name: template
+jobs_dir: jobs
+environment:
+  type: docker
+agents:
+  - {}
+datasets:
+  - path: tasks
+"""
+
+
+class _FakeHarborScorer:
+    """Passes every cell; the report matrix comes from the recorded run config."""
+
+    def __init__(self, task_ids: tuple[str, ...], attempts: int) -> None:
+        self._request = ScoreRequest(task_ids=task_ids, attempts=attempts)
+
+    @property
+    def request(self) -> ScoreRequest:
+        return self._request
+
+    def score(
+        self,
+        doc: HarnessDoc,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ScoreReport:
+        del should_cancel
+        cells = tuple(
+            ScoreCell(task_id=task_id, attempt=attempt, reward=1.0, passed=True)
+            for task_id in self._request.task_ids
+            for attempt in range(1, self._request.attempts + 1)
+        )
+        return ScoreReport(
+            doc_hash=doc.doc_hash,
+            request=self._request,
+            reward_mode="positive-binary",
+            cells=cells,
+        )
+
+
+class _FakeHarborProposer:
+    """Returns the seed tree with a rewritten SYSTEM.md, one candidate per slot."""
+
+    def propose(
+        self,
+        population: Sequence[EvaluatedCandidate],
+        *,
+        slot: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        del should_cancel
+        files = {
+            item.path: item.content
+            for item in population[0].source.files
+            if item.path != "SYSTEM.md"
+        }
+        files["SYSTEM.md"] = f"improved by slot {slot}"
+        tree = HarnessSourceTree(
+            files=tuple(
+                HarnessSourceFile(path=path, content=content) for path, content in files.items()
+            )
+        )
+        candidate_id = candidate_slot_id(slot)
+        return CandidateProposal(
+            candidate_id=candidate_id, source=tree, candidate=tree.to_doc(candidate_id)
+        )
+
+
+def _harbor_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Write harbor inputs + role settings and fake the scorer/proposer builder seams."""
+    (tmp_path / "job.yaml").write_text(_HARBOR_JOB_YAML, encoding="utf-8")
+    (tmp_path / "tasks.json").write_text('["t1"]', encoding="utf-8")
+    root = tmp_path / ".wmh"
+    role = ModelRole(provider="azure", model="gpt-5.5", endpoint="https://x.example")
+    save_settings(ProjectSettings(models=ModelsSettings(meta=role, agent=role)), root)
+    captured: dict[str, object] = {}
+
+    def fake_scorer(
+        config: _HarborRunConfig, *, run_dir: Path, provider_config: ProviderConfig
+    ) -> _FakeHarborScorer:
+        del run_dir
+        captured["config"] = config
+        captured["provider_config"] = provider_config
+        return _FakeHarborScorer(config.task_ids, config.attempts)
+
+    def fake_proposer(
+        *, run_dir: Path, meta_config: ProviderConfig, e2b_template: str | None
+    ) -> _FakeHarborProposer:
+        del run_dir
+        captured["meta_config"] = meta_config
+        captured["proposer_e2b_template"] = e2b_template
+        return _FakeHarborProposer()
+
+    monkeypatch.setattr(harness_app_module, "_build_harbor_scorer", fake_scorer)
+    monkeypatch.setattr(harness_app_module, "_build_harbor_proposer", fake_proposer)
+    return captured
+
+
+def _invoke_harbor(tmp_path: Path, *extra: str) -> Result:
+    return runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi",
+            "harbor",
+            "--harbor-config",
+            str(tmp_path / "job.yaml"),
+            "--task-ids",
+            str(tmp_path / "tasks.json"),
+            "--iterations",
+            "1",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+            *extra,
+        ],
+    )
+
+
+def test_harbor_dispatch_runs_the_population_and_publishes_the_winner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _harbor_project(tmp_path, monkeypatch)
+
+    result = _invoke_harbor(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    config = captured["config"]
+    assert isinstance(config, _HarborRunConfig)
+    assert config.task_ids == ("t1",)
+    assert config.attempts == 1
+    assert config.reward_mode == "positive-binary"  # the harbor default, not scoring "raw"
+    assert config.backend == "local"
+    run_config = json.loads((tmp_path / "run" / "run-config.json").read_text(encoding="utf-8"))
+    assert run_config["agent"] == "pi"
+    assert run_config["iterations"] == 1
+    state = json.loads((tmp_path / "run" / "state.json").read_text(encoding="utf-8"))
+    assert [entry["candidate_id"] for entry in state["outcomes"]] == [
+        "candidate-0000",
+        "candidate-0001",
+    ]
+    # Winner publication: a lineage-less doc lands as pi v1 with the champion alias.
+    store = HarnessStore(str(tmp_path / ".wmh"))
+    saved = store.load("pi")
+    assert saved.version == 1
+    assert store.aliases("pi")["champion"] == 1
+    assert "optimized" in result.output
+
+
+def test_harbor_checkpoint_then_resume_completes_and_rejects_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harbor_project(tmp_path, monkeypatch)
+
+    first = _invoke_harbor(tmp_path, "--max-iterations-this-run", "1")
+    assert first.exit_code == 0, first.output
+    assert "checkpointed" in first.output
+    assert not HarnessStore(str(tmp_path / ".wmh")).exists("pi")
+
+    conflict = _invoke_harbor(tmp_path, "--resume", "--reward-mode", "raw")
+    assert conflict.exit_code == 2
+    flat = " ".join(conflict.output.split())  # rich wraps (and boxes) the error line
+    assert "conflicting" in flat
+    assert "--reward-mode" in flat
+
+    resumed = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi",
+            "harbor",
+            "--resume",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+    assert resumed.exit_code == 0, resumed.output
+    assert "optimized" in resumed.output
+    assert HarnessStore(str(tmp_path / ".wmh")).load("pi").version == 1
+
+
+def test_harbor_errors_when_a_world_model_is_named_harbor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harbor_project(tmp_path, monkeypatch)
+    model_dir = tmp_path / ".wmh" / "models" / "harbor"
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.toml").write_text("", encoding="utf-8")
+
+    result = _invoke_harbor(tmp_path)
+
+    assert result.exit_code == 2
+    assert "rename" in result.output
+
+
+def test_harbor_requires_a_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _harbor_project(tmp_path, monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "pi",
+            "harbor",
+            "--harbor-config",
+            str(tmp_path / "job.yaml"),
+            "--task-ids",
+            str(tmp_path / "tasks.json"),
+            "--root",
+            str(tmp_path / ".wmh"),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "--run-dir is required" in result.output
+
+
+def test_world_model_path_rejects_harbor_only_flags(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["optimize", "made", "--run-dir", str(tmp_path / "run"), "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 2
+    assert "apply only to the harbor environment" in result.output

--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import typer
 
-from wmh.config.settings import load_settings
+from wmh.config.settings import ModelRole, load_settings
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.providers.registry import get_provider
 
@@ -38,6 +38,27 @@ def resolve_opt_in_model_provider(
     configured = load_settings(root).models.resolve(role)
     if configured is None:
         return fallback, None
+    config = _model_config(configured, role=role)
+    return get_provider(config), configured.model
+
+
+def resolve_required_model_config(root: str, role: OptInModelRole) -> ProviderConfig:
+    """Resolve one opt-in role a workflow requires (no fallback provider exists for it).
+
+    The harbor optimize flow has no world model whose provider could stand in, so its
+    ``agent`` (worker) and ``meta`` (proposer) roles must be configured explicitly.
+    """
+    configured = load_settings(root).models.resolve(role)
+    if configured is None:
+        raise typer.BadParameter(
+            f"settings [models.{role}] must be configured in <root>/settings.toml for this "
+            f"workflow; add a [models.{role}] table with provider and model"
+        )
+    return _model_config(configured, role=role)
+
+
+def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderConfig:
+    """Turn one configured role into provider-neutral config with the Azure default."""
     try:
         kind = ProviderKind(configured.provider)
     except ValueError:
@@ -49,7 +70,7 @@ def resolve_opt_in_model_provider(
     api_version = configured.api_version
     if api_version is None and kind is ProviderKind.AZURE_OPENAI:
         api_version = _DEFAULT_AZURE_API_VERSION
-    config = ProviderConfig(
+    return ProviderConfig(
         kind=kind,
         model=configured.model,
         region=configured.region,
@@ -58,4 +79,3 @@ def resolve_opt_in_model_provider(
         api_version=api_version,
         reasoning_effort=configured.reasoning_effort,
     )
-    return get_provider(config), configured.model

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -304,6 +304,26 @@ class HarborScorer:
         """The frozen reward interpretation this scorer applies."""
         return self._reward_mode
 
+    @property
+    def task_pins(self) -> dict[str, str]:
+        """One stable provenance pin per resolved task, keyed by task id.
+
+        Git tasks pin their resolved commit and package tasks their name@ref, so a caller can
+        record the exact task identity a run was scored against and detect a dataset that
+        re-resolves differently on resume. Local-path tasks pin only their resolved path (the
+        weaker identity is deliberate: hashing arbitrary task dirs is not this scorer's job).
+        """
+        pins: dict[str, str] = {}
+        for task in self._tasks:
+            task_id = task.get_task_id().get_name()
+            if task.is_package_task():
+                pins[task_id] = f"package:{task.name}@{task.ref or 'latest'}"
+            elif task.is_git_task():
+                pins[task_id] = f"git:{task.git_url}@{task.git_commit_id}"
+            else:
+                pins[task_id] = f"path:{task.path}"
+        return pins
+
     def candidate_job_dir(self, doc: HarnessDoc) -> Path:
         """The deterministic job directory one candidate's trials live in (resume key)."""
         return self._job_template.jobs_dir / f"wmh-{doc.doc_hash[:12]}"

--- a/wmh/harness/population.py
+++ b/wmh/harness/population.py
@@ -1,0 +1,413 @@
+"""Sequential population optimization of complete harness source trees.
+
+`optimize` is the paper's outer loop: score the fixed seed once, then consume a fixed number of
+sequential proposal slots. Each slot asks the proposer for one complete candidate source tree.
+An invalid proposal (`CandidateProposalError`) consumes its slot as recorded evidence and the
+loop continues; scorer and infrastructure exceptions PROPAGATE, because a missing evaluation can
+never be reinterpreted as a reward. Selection is the maximum mean per-task score with the
+earliest candidate winning ties.
+
+Durable state is the run directory. After every boundary (the scored seed, one scored proposal,
+or one consumed invalid slot) the outcome's evidence lands under `candidates/candidate-NNNN/`
+(`source/`, `report.json`, and `proposal.json` or `error.json`) and the ordered index is
+committed by an atomic tmp+rename of `state.json`. Resuming reloads that state and continues at
+the first missing slot, so an interrupted run re-pays at most one boundary (and the harbor
+scorer's own trial-level resume usually far less).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import JsonValue
+
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.scoring import Scorer, ScoreReport
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = "state.json"
+_CANDIDATES_DIR = "candidates"
+
+
+def candidate_slot_id(slot: int) -> str:
+    """The fixed candidate identity for one slot (`candidate-0000` is the seed)."""
+    if isinstance(slot, bool) or not isinstance(slot, int) or slot < 0:
+        raise ValueError("slot must be a nonnegative integer")
+    return f"candidate-{slot:04d}"
+
+
+@dataclass(frozen=True)
+class EvaluatedCandidate:
+    """One complete source candidate paired with its immutable score report."""
+
+    candidate_id: str
+    source: HarnessSourceTree
+    report: ScoreReport
+
+    def __post_init__(self) -> None:
+        if self.source.to_doc(self.candidate_id).doc_hash != self.report.doc_hash:
+            raise ValueError(
+                f"score report for {self.candidate_id!r} does not match its source tree"
+            )
+
+    @property
+    def candidate(self) -> HarnessDoc:
+        """Reparse the complete source into its validated harness document."""
+        return self.source.to_doc(self.candidate_id)
+
+    @property
+    def score(self) -> float:
+        """The selection objective: mean of per-task pass rates."""
+        return self.report.score
+
+
+@dataclass(frozen=True)
+class CandidateProposal:
+    """One complete, host-captured and reparsed candidate proposal."""
+
+    candidate_id: str
+    source: HarnessSourceTree
+    candidate: HarnessDoc
+
+    def __post_init__(self) -> None:
+        if self.candidate.name != self.candidate_id:
+            raise ValueError("proposal document name does not match its candidate_id")
+        if self.source.to_doc(self.candidate_id).doc_hash != self.candidate.doc_hash:
+            raise ValueError("proposal source does not match its candidate document")
+
+
+class CandidateProposalError(RuntimeError):
+    """One proposal turn that did not publish a valid complete candidate.
+
+    This is a CANDIDATE outcome: the loop records it and the slot is consumed. Raw evidence
+    (the request, events, raw snapshot, and error) lives under ``evidence_dir`` when set.
+    """
+
+    def __init__(self, candidate_id: str, reason: str, *, evidence_dir: str = "") -> None:
+        super().__init__(f"{candidate_id}: {reason}")
+        self.candidate_id = candidate_id
+        self.reason = reason
+        self.evidence_dir = evidence_dir
+
+
+class CandidateProposer(Protocol):
+    """Produce exactly one complete candidate for one slot from the evaluated population."""
+
+    def propose(
+        self,
+        population: Sequence[EvaluatedCandidate],
+        *,
+        slot: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal: ...
+
+
+@dataclass(frozen=True)
+class SlotOutcome:
+    """One consumed slot: either a scored candidate or a recorded invalid proposal."""
+
+    slot: int
+    candidate_id: str
+    evaluated: EvaluatedCandidate | None = None
+    reason: str = ""
+    evidence_dir: str = ""
+
+    def __post_init__(self) -> None:
+        if self.candidate_id != candidate_slot_id(self.slot):
+            raise ValueError("slot outcome candidate_id does not match its slot")
+        if (self.evaluated is None) == (not self.reason):
+            raise ValueError("a slot outcome is either evaluated or carries an invalid reason")
+
+
+@dataclass(frozen=True)
+class PopulationResult:
+    """Every consumed slot, the evaluated population, and the current score winner."""
+
+    outcomes: tuple[SlotOutcome, ...]
+    population: tuple[EvaluatedCandidate, ...]
+    best: EvaluatedCandidate
+    completed: bool
+
+    @property
+    def best_score(self) -> float:
+        return self.best.score
+
+
+def write_json_atomic(path: Path, value: JsonValue) -> None:
+    """Write deterministic JSON through a same-directory tmp+rename."""
+    temporary = path.with_name(f"{path.name}.tmp")
+    temporary.parent.mkdir(parents=True, exist_ok=True)
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+class PopulationRunState:
+    """Durable per-boundary population state under one run directory."""
+
+    def __init__(self, run_dir: str | Path) -> None:
+        self.run_dir = Path(run_dir)
+
+    def candidate_dir(self, candidate_id: str) -> Path:
+        return self.run_dir / _CANDIDATES_DIR / candidate_id
+
+    def load(self) -> tuple[SlotOutcome, ...]:
+        """Reload every committed slot outcome, re-verifying candidate evidence integrity."""
+        path = self.run_dir / _STATE_FILE
+        if not path.exists():
+            return ()
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        entries = raw.get("outcomes")
+        if not isinstance(entries, list):
+            raise ValueError(f"{path} does not contain an outcomes list")
+        outcomes: list[SlotOutcome] = []
+        for index, entry in enumerate(entries):
+            candidate_id = candidate_slot_id(index)
+            if not isinstance(entry, dict):
+                raise ValueError(f"{path} outcome at slot {index} is not an object")
+            if entry.get("slot") != index or entry.get("candidate_id") != candidate_id:
+                raise ValueError(f"{path} outcomes are not contiguous at slot {index}")
+            if entry.get("kind") == "invalid":
+                outcomes.append(
+                    SlotOutcome(
+                        slot=index,
+                        candidate_id=candidate_id,
+                        reason=str(entry.get("reason") or "invalid proposal"),
+                        evidence_dir=str(entry.get("evidence_dir") or ""),
+                    )
+                )
+                continue
+            directory = self.candidate_dir(candidate_id)
+            report_path = directory / "report.json"
+            try:
+                report = ScoreReport.model_validate_json(report_path.read_text(encoding="utf-8"))
+                source = _read_source_tree(directory / "source")
+            except (OSError, ValueError) as error:
+                raise ValueError(
+                    f"run dir {self.run_dir} is missing evidence for {candidate_id}: {error}"
+                ) from error
+            outcomes.append(
+                SlotOutcome(
+                    slot=index,
+                    candidate_id=candidate_id,
+                    evaluated=EvaluatedCandidate(candidate_id, source, report),
+                    evidence_dir=str(entry.get("evidence_dir") or ""),
+                )
+            )
+        return tuple(outcomes)
+
+    def commit(self, outcomes: Sequence[SlotOutcome]) -> None:
+        """Persist the newest outcome's evidence, then atomically commit the ordered index."""
+        latest = outcomes[-1]
+        directory = self.candidate_dir(latest.candidate_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        if latest.evaluated is None:
+            write_json_atomic(
+                directory / "error.json",
+                {
+                    "candidate_id": latest.candidate_id,
+                    "reason": latest.reason,
+                    "evidence_dir": latest.evidence_dir,
+                },
+            )
+        else:
+            for item in latest.evaluated.source.files:
+                target = directory / "source" / item.path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(item.content, encoding="utf-8")
+            write_json_atomic(
+                directory / "report.json", latest.evaluated.report.model_dump(mode="json")
+            )
+            if latest.slot > 0:
+                write_json_atomic(
+                    directory / "proposal.json",
+                    {
+                        "candidate_id": latest.candidate_id,
+                        "doc_hash": latest.evaluated.report.doc_hash,
+                        "tree_hash": latest.evaluated.source.tree_hash,
+                        "evidence_dir": latest.evidence_dir,
+                    },
+                )
+        write_json_atomic(
+            self.run_dir / _STATE_FILE,
+            {"outcomes": [_state_entry(outcome) for outcome in outcomes]},
+        )
+
+
+def optimize(
+    seed: HarnessSourceTree,
+    scorer: Scorer,
+    proposer: CandidateProposer,
+    iterations: int,
+    *,
+    run_dir: str | Path,
+    should_cancel: Callable[[], bool] | None = None,
+    max_new_boundaries: int | None = None,
+    on_boundary: Callable[[SlotOutcome], None] | None = None,
+) -> PopulationResult:
+    """Score the seed and `iterations` sequential proposal slots with durable resume.
+
+    `max_new_boundaries` stops this invocation after that many NEW boundaries (already
+    committed slots do not count), leaving the fixed total plan resumable. The result's
+    `completed` flag says whether every slot has been consumed.
+    """
+    if isinstance(iterations, bool) or not isinstance(iterations, int) or iterations < 1:
+        raise ValueError("iterations must be a positive integer")
+    if max_new_boundaries is not None and (
+        isinstance(max_new_boundaries, bool)
+        or not isinstance(max_new_boundaries, int)
+        or max_new_boundaries < 1
+    ):
+        raise ValueError("max_new_boundaries must be a positive integer")
+    state = PopulationRunState(run_dir)
+    outcomes = list(state.load())
+    if len(outcomes) > iterations + 1:
+        raise ValueError(
+            f"run dir {state.run_dir} already holds {len(outcomes)} slot outcomes, more than "
+            f"the requested {iterations} iterations allow; rerun with the recorded iterations"
+        )
+    _validate_resumed(outcomes, seed=seed, scorer=scorer)
+    new_boundaries = 0
+
+    def record(outcome: SlotOutcome) -> None:
+        nonlocal new_boundaries
+        outcomes.append(outcome)
+        state.commit(outcomes)
+        new_boundaries += 1
+        if on_boundary is not None:
+            on_boundary(outcome)
+
+    _check_cancelled(should_cancel)
+    if not outcomes:
+        seed_id = candidate_slot_id(0)
+        report = scorer.score(seed.to_doc(seed_id), should_cancel=should_cancel)
+        record(
+            SlotOutcome(
+                slot=0,
+                candidate_id=seed_id,
+                evaluated=EvaluatedCandidate(seed_id, seed, report),
+            )
+        )
+
+    while len(outcomes) <= iterations:
+        if max_new_boundaries is not None and new_boundaries >= max_new_boundaries:
+            break
+        _check_cancelled(should_cancel)
+        slot = len(outcomes)
+        candidate_id = candidate_slot_id(slot)
+        population = tuple(
+            outcome.evaluated for outcome in outcomes if outcome.evaluated is not None
+        )
+        try:
+            proposal = proposer.propose(population, slot=slot, should_cancel=should_cancel)
+        except CandidateProposalError as error:
+            logger.info("slot %d consumed by an invalid proposal: %s", slot, error.reason)
+            record(
+                SlotOutcome(
+                    slot=slot,
+                    candidate_id=candidate_id,
+                    reason=error.reason,
+                    evidence_dir=error.evidence_dir,
+                )
+            )
+            continue
+        if proposal.candidate_id != candidate_id:
+            raise ValueError(
+                f"proposer returned {proposal.candidate_id!r} for slot {slot}; "
+                f"expected {candidate_id!r}"
+            )
+        _check_cancelled(should_cancel)
+        report = scorer.score(proposal.candidate, should_cancel=should_cancel)
+        record(
+            SlotOutcome(
+                slot=slot,
+                candidate_id=candidate_id,
+                evaluated=EvaluatedCandidate(candidate_id, proposal.source, report),
+            )
+        )
+
+    population = tuple(outcome.evaluated for outcome in outcomes if outcome.evaluated is not None)
+    return PopulationResult(
+        outcomes=tuple(outcomes),
+        population=population,
+        best=_earliest_best(population),
+        completed=len(outcomes) == iterations + 1,
+    )
+
+
+def _earliest_best(population: Sequence[EvaluatedCandidate]) -> EvaluatedCandidate:
+    """The maximum-score candidate; the EARLIEST one wins ties (seed beats equal successors)."""
+    best = population[0]
+    for candidate in population[1:]:
+        if candidate.score > best.score:
+            best = candidate
+    return best
+
+
+def _validate_resumed(
+    outcomes: Sequence[SlotOutcome],
+    *,
+    seed: HarnessSourceTree,
+    scorer: Scorer,
+) -> None:
+    if not outcomes:
+        return
+    recorded_seed = outcomes[0].evaluated
+    if recorded_seed is None:
+        raise ValueError("run dir state is corrupt: the seed slot is recorded as invalid")
+    if recorded_seed.source.tree_hash != seed.tree_hash:
+        raise ValueError(
+            "run dir belongs to a different seed source tree; start a fresh run dir for a new seed"
+        )
+    for outcome in outcomes:
+        if outcome.evaluated is not None and outcome.evaluated.report.request != scorer.request:
+            raise ValueError(
+                "run dir was scored under a different task-by-attempt request; "
+                "rerun with the recorded tasks and attempts or start a fresh run dir"
+            )
+
+
+def _state_entry(outcome: SlotOutcome) -> dict[str, JsonValue]:
+    if outcome.evaluated is None:
+        return {
+            "slot": outcome.slot,
+            "candidate_id": outcome.candidate_id,
+            "kind": "invalid",
+            "reason": outcome.reason,
+            "evidence_dir": outcome.evidence_dir,
+        }
+    return {
+        "slot": outcome.slot,
+        "candidate_id": outcome.candidate_id,
+        "kind": "scored",
+        "score": outcome.evaluated.score,
+        "doc_hash": outcome.evaluated.report.doc_hash,
+        "evidence_dir": outcome.evidence_dir,
+    }
+
+
+def _read_source_tree(directory: Path) -> HarnessSourceTree:
+    files = [
+        HarnessSourceFile(
+            path=path.relative_to(directory).as_posix(),
+            content=path.read_text(encoding="utf-8"),
+        )
+        for path in sorted(directory.rglob("*"))
+        if path.is_file()
+    ]
+    return HarnessSourceTree(files=tuple(files))
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness search cancelled")

--- a/wmh/harness/population.py
+++ b/wmh/harness/population.py
@@ -10,15 +10,20 @@ earliest candidate winning ties.
 Durable state is the run directory. After every boundary (the scored seed, one scored proposal,
 or one consumed invalid slot) the outcome's evidence lands under `candidates/candidate-NNNN/`
 (`source/`, `report.json`, and `proposal.json` or `error.json`) and the ordered index is
-committed by an atomic tmp+rename of `state.json`. Resuming reloads that state and continues at
-the first missing slot, so an interrupted run re-pays at most one boundary (and the harbor
-scorer's own trial-level resume usually far less).
+committed by an atomic tmp+rename of `state.json`. An ACCEPTED proposal is additionally
+checkpointed (`source/` + `proposal.json` + `pending.json`) BEFORE its evaluation starts, so a
+crash mid-score resumes by rescoring the exact same candidate instead of paying a fresh proposer
+turn whose different doc hash would also orphan the part-paid evaluator job. Resuming reloads
+state and continues at the first missing slot, so an interrupted run re-pays at most one
+boundary (and the harbor scorer's own trial-level resume usually far less).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -35,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 _STATE_FILE = "state.json"
 _CANDIDATES_DIR = "candidates"
+_PENDING_FILE = "pending.json"
 
 
 def candidate_slot_id(slot: int) -> str:
@@ -142,14 +148,25 @@ class PopulationResult:
 
 
 def write_json_atomic(path: Path, value: JsonValue) -> None:
-    """Write deterministic JSON through a same-directory tmp+rename."""
+    """Write deterministic JSON through a same-directory fsynced tmp+rename.
+
+    The temp file is fsynced before the rename and the directory after it: without both, a
+    power loss can persist the rename while the data blocks are lost, leaving a truncated or
+    empty state file behind an apparently successful commit.
+    """
     temporary = path.with_name(f"{path.name}.tmp")
     temporary.parent.mkdir(parents=True, exist_ok=True)
-    temporary.write_text(
-        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    payload = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    with temporary.open("w", encoding="utf-8") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
     temporary.replace(path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
 
 
 class PopulationRunState:
@@ -192,19 +209,70 @@ class PopulationRunState:
             try:
                 report = ScoreReport.model_validate_json(report_path.read_text(encoding="utf-8"))
                 source = _read_source_tree(directory / "source")
+                evaluated = EvaluatedCandidate(candidate_id, source, report)
             except (OSError, ValueError) as error:
                 raise ValueError(
-                    f"run dir {self.run_dir} is missing evidence for {candidate_id}: {error}"
+                    f"run dir {self.run_dir} holds corrupt or missing evidence for "
+                    f"{candidate_id}: {error}"
                 ) from error
             outcomes.append(
                 SlotOutcome(
                     slot=index,
                     candidate_id=candidate_id,
-                    evaluated=EvaluatedCandidate(candidate_id, source, report),
+                    evaluated=evaluated,
                     evidence_dir=str(entry.get("evidence_dir") or ""),
                 )
             )
         return tuple(outcomes)
+
+    def record_pending(self, proposal: CandidateProposal, *, evidence_dir: str = "") -> None:
+        """Durably checkpoint one ACCEPTED proposal before its paid evaluation starts.
+
+        The source tree and proposal record land first; the atomic `pending.json` marker is
+        written last, so a marker's presence implies complete candidate bytes. A crash between
+        this checkpoint and the boundary commit resumes by rescoring this exact candidate.
+        """
+        directory = self.candidate_dir(proposal.candidate_id)
+        _write_candidate_source(directory / "source", proposal.source)
+        write_json_atomic(
+            directory / "proposal.json",
+            {
+                "candidate_id": proposal.candidate_id,
+                "doc_hash": proposal.candidate.doc_hash,
+                "tree_hash": proposal.source.tree_hash,
+                "evidence_dir": evidence_dir,
+            },
+        )
+        write_json_atomic(
+            directory / _PENDING_FILE,
+            {
+                "candidate_id": proposal.candidate_id,
+                "doc_hash": proposal.candidate.doc_hash,
+                "tree_hash": proposal.source.tree_hash,
+            },
+        )
+
+    def load_pending(self, slot: int) -> HarnessSourceTree | None:
+        """The checkpointed-but-unscored candidate for `slot`, or None when there is none."""
+        candidate_id = candidate_slot_id(slot)
+        directory = self.candidate_dir(candidate_id)
+        marker_path = directory / _PENDING_FILE
+        if not marker_path.is_file():
+            return None
+        try:
+            marker = json.loads(marker_path.read_text(encoding="utf-8"))
+            source = _read_source_tree(directory / "source")
+        except (OSError, ValueError) as error:
+            raise ValueError(
+                f"run dir {self.run_dir} holds a corrupt pending candidate {candidate_id}: "
+                f"{error}; delete {directory} to redo the proposal"
+            ) from error
+        if not isinstance(marker, dict) or marker.get("tree_hash") != source.tree_hash:
+            raise ValueError(
+                f"pending candidate {candidate_id} in {self.run_dir} does not match its "
+                f"recorded tree hash; delete {directory} to redo the proposal"
+            )
+        return source
 
     def commit(self, outcomes: Sequence[SlotOutcome]) -> None:
         """Persist the newest outcome's evidence, then atomically commit the ordered index."""
@@ -221,10 +289,7 @@ class PopulationRunState:
                 },
             )
         else:
-            for item in latest.evaluated.source.files:
-                target = directory / "source" / item.path
-                target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text(item.content, encoding="utf-8")
+            _write_candidate_source(directory / "source", latest.evaluated.source)
             write_json_atomic(
                 directory / "report.json", latest.evaluated.report.model_dump(mode="json")
             )
@@ -242,6 +307,9 @@ class PopulationRunState:
             self.run_dir / _STATE_FILE,
             {"outcomes": [_state_entry(outcome) for outcome in outcomes]},
         )
+        # Cleared only AFTER the state commit: a crash in between leaves a stale marker for an
+        # already-committed slot, which load_pending never consults again.
+        (directory / _PENDING_FILE).unlink(missing_ok=True)
 
 
 def optimize(
@@ -305,34 +373,43 @@ def optimize(
         _check_cancelled(should_cancel)
         slot = len(outcomes)
         candidate_id = candidate_slot_id(slot)
-        population = tuple(
-            outcome.evaluated for outcome in outcomes if outcome.evaluated is not None
-        )
-        try:
-            proposal = proposer.propose(population, slot=slot, should_cancel=should_cancel)
-        except CandidateProposalError as error:
-            logger.info("slot %d consumed by an invalid proposal: %s", slot, error.reason)
-            record(
-                SlotOutcome(
-                    slot=slot,
-                    candidate_id=candidate_id,
-                    reason=error.reason,
-                    evidence_dir=error.evidence_dir,
+        # A pending checkpoint means this slot's proposal was already accepted and paid for;
+        # skip straight to (re)scoring it instead of buying a fresh proposer turn whose new
+        # doc hash would also orphan the part-paid evaluator job.
+        source = state.load_pending(slot)
+        if source is None:
+            population = tuple(
+                outcome.evaluated for outcome in outcomes if outcome.evaluated is not None
+            )
+            try:
+                proposal = proposer.propose(population, slot=slot, should_cancel=should_cancel)
+            except CandidateProposalError as error:
+                logger.info("slot %d consumed by an invalid proposal: %s", slot, error.reason)
+                record(
+                    SlotOutcome(
+                        slot=slot,
+                        candidate_id=candidate_id,
+                        reason=error.reason,
+                        evidence_dir=error.evidence_dir,
+                    )
                 )
-            )
-            continue
-        if proposal.candidate_id != candidate_id:
-            raise ValueError(
-                f"proposer returned {proposal.candidate_id!r} for slot {slot}; "
-                f"expected {candidate_id!r}"
-            )
+                continue
+            if proposal.candidate_id != candidate_id:
+                raise ValueError(
+                    f"proposer returned {proposal.candidate_id!r} for slot {slot}; "
+                    f"expected {candidate_id!r}"
+                )
+            state.record_pending(proposal)
+            source = proposal.source
+        else:
+            logger.info("slot %d resumes its checkpointed pending candidate", slot)
         _check_cancelled(should_cancel)
-        report = scorer.score(proposal.candidate, should_cancel=should_cancel)
+        report = scorer.score(source.to_doc(candidate_id), should_cancel=should_cancel)
         record(
             SlotOutcome(
                 slot=slot,
                 candidate_id=candidate_id,
-                evaluated=EvaluatedCandidate(candidate_id, proposal.source, report),
+                evaluated=EvaluatedCandidate(candidate_id, source, report),
             )
         )
 
@@ -396,11 +473,28 @@ def _state_entry(outcome: SlotOutcome) -> dict[str, JsonValue]:
     }
 
 
+def _write_candidate_source(directory: Path, source: HarnessSourceTree) -> None:
+    """Replace one candidate's source dir with exact bytes (no leftovers, no newline drift).
+
+    Clearing first matters: a crashed prior attempt's leftover files would otherwise merge into
+    a redone slot's tree and fail doc-hash re-verification on every later load. Bytes are
+    written and read without newline translation so content hashes round-trip exactly.
+    """
+    if directory.exists():
+        shutil.rmtree(directory)
+    for item in source.files:
+        target = directory / item.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(item.content.encode("utf-8"))
+
+
 def _read_source_tree(directory: Path) -> HarnessSourceTree:
+    # read_bytes + exact decode: Path.read_text's universal newlines would fold \r into \n and
+    # silently change content hashes on every resume.
     files = [
         HarnessSourceFile(
             path=path.relative_to(directory).as_posix(),
-            content=path.read_text(encoding="utf-8"),
+            content=path.read_bytes().decode("utf-8"),
         )
         for path in sorted(directory.rglob("*"))
         if path.is_file()

--- a/wmh/harness/population.py
+++ b/wmh/harness/population.py
@@ -325,12 +325,14 @@ def optimize(
 ) -> PopulationResult:
     """Score the seed and `iterations` sequential proposal slots with durable resume.
 
+    `iterations == 0` is score-only: the seed is scored and committed and no proposal runs,
+    which is how a fixed harness (a baseline or a frozen champion) is scored on a task set.
     `max_new_boundaries` stops this invocation after that many NEW boundaries (already
     committed slots do not count), leaving the fixed total plan resumable. The result's
     `completed` flag says whether every slot has been consumed.
     """
-    if isinstance(iterations, bool) or not isinstance(iterations, int) or iterations < 1:
-        raise ValueError("iterations must be a positive integer")
+    if isinstance(iterations, bool) or not isinstance(iterations, int) or iterations < 0:
+        raise ValueError("iterations must be a non-negative integer")
     if max_new_boundaries is not None and (
         isinstance(max_new_boundaries, bool)
         or not isinstance(max_new_boundaries, int)

--- a/wmh/harness/population_test.py
+++ b/wmh/harness/population_test.py
@@ -196,3 +196,69 @@ def test_proposer_returning_the_wrong_slot_identity_is_a_bug(tmp_path: Path) -> 
     scorer = _FakeScorer({"seed": (1.0, 0.0), "v2": (1.0, 1.0)})
     with pytest.raises(ValueError, match="expected 'candidate-0001'"):
         optimize(_tree("seed"), scorer, _WrongIdProposer(), 1, run_dir=tmp_path)
+
+
+class _FlakyScorer:
+    """Delegates to a real fake scorer but dies once on a chosen candidate (infra crash)."""
+
+    def __init__(self, inner: _FakeScorer, *, fail_on: str) -> None:
+        self._inner = inner
+        self._fail_on = fail_on
+        self._failed = False
+
+    @property
+    def request(self) -> ScoreRequest:
+        return self._inner.request
+
+    def score(
+        self,
+        doc: HarnessDoc,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ScoreReport:
+        if doc.system_prompt() == self._fail_on and not self._failed:
+            self._failed = True
+            raise RuntimeError("score infra died")
+        return self._inner.score(doc, should_cancel=should_cancel)
+
+
+def test_accepted_proposal_is_checkpointed_before_scoring_and_resumed_as_pending(
+    tmp_path: Path,
+) -> None:
+    """A crash mid-score must rescore the SAME candidate, never repay a proposer turn."""
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "v2": (1.0, 1.0)})
+    with pytest.raises(RuntimeError, match="score infra died"):
+        optimize(
+            _tree("seed"),
+            _FlakyScorer(scorer, fail_on="v2"),
+            _ScriptedProposer([_tree("v2")]),
+            1,
+            run_dir=tmp_path,
+        )
+
+    # Resume: the pending checkpoint short-circuits the proposer entirely.
+    untouched = _ScriptedProposer([])
+    resumed = optimize(_tree("seed"), scorer, untouched, 1, run_dir=tmp_path)
+
+    assert untouched.slots == []
+    assert resumed.completed is True
+    evaluated = resumed.outcomes[1].evaluated
+    assert evaluated is not None
+    assert evaluated.source == _tree("v2")  # the exact checkpointed candidate was rescored
+    assert not (tmp_path / "candidates" / "candidate-0001" / "pending.json").exists()
+
+
+def test_commit_clears_stale_source_leftovers_from_a_crashed_attempt(tmp_path: Path) -> None:
+    """Leftover files from an earlier attempt must never merge into a redone slot's tree."""
+    junk = tmp_path / "candidates" / "candidate-0001" / "source" / "junk.md"
+    junk.parent.mkdir(parents=True)
+    junk.write_text("leftover", encoding="utf-8")
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "v2": (1.0, 1.0)})
+
+    optimize(_tree("seed"), scorer, _ScriptedProposer([_tree("v2")]), 1, run_dir=tmp_path)
+
+    reloaded = PopulationRunState(tmp_path).load()  # doc-hash re-verification must hold
+    evaluated = reloaded[1].evaluated
+    assert evaluated is not None
+    assert evaluated.source == _tree("v2")
+    assert not junk.exists()

--- a/wmh/harness/population_test.py
+++ b/wmh/harness/population_test.py
@@ -1,0 +1,198 @@
+"""Tests for the durable population loop: slot semantics, resume, and selection."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.population import (
+    CandidateProposal,
+    CandidateProposalError,
+    EvaluatedCandidate,
+    PopulationRunState,
+    candidate_slot_id,
+    optimize,
+)
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+_REQUEST = ScoreRequest(task_ids=("t1", "t2"), attempts=1)
+
+
+def _tree(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(files=(HarnessSourceFile(path="SYSTEM.md", content=prompt),))
+
+
+class _FakeScorer:
+    """Scores a doc by its system prompt via a fixed per-task reward table."""
+
+    def __init__(
+        self,
+        rewards: dict[str, tuple[float, ...]],
+        request: ScoreRequest = _REQUEST,
+    ) -> None:
+        self.rewards = rewards
+        self._request = request
+        self.scored: list[str] = []
+
+    @property
+    def request(self) -> ScoreRequest:
+        return self._request
+
+    def score(
+        self,
+        doc: HarnessDoc,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ScoreReport:
+        del should_cancel
+        self.scored.append(doc.system_prompt())
+        cells = tuple(
+            ScoreCell(task_id=task_id, attempt=1, reward=reward, passed=reward > 0)
+            for task_id, reward in zip(
+                self._request.task_ids, self.rewards[doc.system_prompt()], strict=True
+            )
+        )
+        return ScoreReport(
+            doc_hash=doc.doc_hash,
+            request=self._request,
+            reward_mode="positive-binary",
+            cells=cells,
+        )
+
+
+class _ScriptedProposer:
+    """Pops one scripted item per slot: a source tree, "invalid", or an exception to raise."""
+
+    def __init__(self, script: list[object]) -> None:
+        self.script = script
+        self.slots: list[int] = []
+
+    def propose(
+        self,
+        population: Sequence[EvaluatedCandidate],
+        *,
+        slot: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        del population, should_cancel
+        self.slots.append(slot)
+        item = self.script.pop(0)
+        candidate_id = candidate_slot_id(slot)
+        if item == "invalid":
+            raise CandidateProposalError(candidate_id, "scripted invalid", evidence_dir="x")
+        if isinstance(item, Exception):
+            raise item
+        assert isinstance(item, HarnessSourceTree)
+        return CandidateProposal(
+            candidate_id=candidate_id, source=item, candidate=item.to_doc(candidate_id)
+        )
+
+
+def test_seed_and_proposals_scored_with_earliest_tie_selection(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "better": (1.0, 1.0), "tie": (1.0, 1.0)})
+    proposer = _ScriptedProposer([_tree("better"), _tree("tie")])
+
+    result = optimize(_tree("seed"), scorer, proposer, 2, run_dir=tmp_path)
+
+    assert result.completed is True
+    assert [o.candidate_id for o in result.outcomes] == [
+        "candidate-0000",
+        "candidate-0001",
+        "candidate-0002",
+    ]
+    assert proposer.slots == [1, 2]
+    # candidate-0001 and candidate-0002 both score 1.0: the EARLIEST wins the tie.
+    assert result.best.candidate_id == "candidate-0001"
+    assert result.best_score == 1.0
+
+
+def test_invalid_proposal_consumes_slot_and_records_evidence(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "fix": (0.0, 1.0)})
+    proposer = _ScriptedProposer(["invalid", _tree("fix")])
+
+    result = optimize(_tree("seed"), scorer, proposer, 2, run_dir=tmp_path)
+
+    assert result.completed is True
+    assert result.outcomes[1].evaluated is None
+    assert result.outcomes[1].reason == "scripted invalid"
+    assert len(result.population) == 2  # the invalid slot never joins the population
+    error = json.loads((tmp_path / "candidates" / "candidate-0001" / "error.json").read_text())
+    assert error["reason"] == "scripted invalid"
+    assert error["evidence_dir"] == "x"
+    # seed (0.5) ties candidate-0002 (0.5): earliest wins, so the seed stays champion.
+    assert result.best.candidate_id == "candidate-0000"
+
+
+def test_infrastructure_errors_propagate_and_leave_committed_boundaries(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 1.0)})
+    proposer = _ScriptedProposer([RuntimeError("sandbox exploded")])
+
+    with pytest.raises(RuntimeError, match="sandbox exploded"):
+        optimize(_tree("seed"), scorer, proposer, 1, run_dir=tmp_path)
+
+    committed = PopulationRunState(tmp_path).load()
+    assert [o.candidate_id for o in committed] == ["candidate-0000"]
+
+
+def test_resume_continues_at_first_missing_slot_without_rescoring(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "v2": (1.0, 1.0)})
+    first = optimize(
+        _tree("seed"), scorer, _ScriptedProposer([]), 1, run_dir=tmp_path, max_new_boundaries=1
+    )
+    assert first.completed is False
+    assert len(first.outcomes) == 1
+
+    proposer = _ScriptedProposer([_tree("v2")])
+    second = optimize(_tree("seed"), scorer, proposer, 1, run_dir=tmp_path)
+
+    assert second.completed is True
+    assert proposer.slots == [1]
+    assert scorer.scored == ["seed", "v2"]  # the committed seed boundary was never re-paid
+    assert second.best.candidate_id == "candidate-0001"
+
+
+def test_resume_rejects_a_different_seed_or_request(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 0.0)})
+    optimize(
+        _tree("seed"), scorer, _ScriptedProposer([]), 1, run_dir=tmp_path, max_new_boundaries=1
+    )
+
+    with pytest.raises(ValueError, match="different seed"):
+        optimize(_tree("other"), scorer, _ScriptedProposer([]), 1, run_dir=tmp_path)
+    changed = _FakeScorer({"seed": (1.0,)}, request=ScoreRequest(task_ids=("t1",), attempts=1))
+    with pytest.raises(ValueError, match="different task-by-attempt request"):
+        optimize(_tree("seed"), changed, _ScriptedProposer([]), 1, run_dir=tmp_path)
+
+
+def test_resume_rejects_more_recorded_slots_than_requested_iterations(tmp_path: Path) -> None:
+    scorer = _FakeScorer({"seed": (1.0, 0.0)})
+    proposer = _ScriptedProposer(["invalid", "invalid"])
+    optimize(_tree("seed"), scorer, proposer, 2, run_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="rerun with the recorded iterations"):
+        optimize(_tree("seed"), scorer, _ScriptedProposer([]), 1, run_dir=tmp_path)
+
+
+def test_proposer_returning_the_wrong_slot_identity_is_a_bug(tmp_path: Path) -> None:
+    class _WrongIdProposer:
+        def propose(
+            self,
+            population: Sequence[EvaluatedCandidate],
+            *,
+            slot: int,
+            should_cancel: Callable[[], bool] | None = None,
+        ) -> CandidateProposal:
+            del population, slot, should_cancel
+            tree = _tree("v2")
+            return CandidateProposal(
+                candidate_id="candidate-0009", source=tree, candidate=tree.to_doc("candidate-0009")
+            )
+
+    scorer = _FakeScorer({"seed": (1.0, 0.0), "v2": (1.0, 1.0)})
+    with pytest.raises(ValueError, match="expected 'candidate-0001'"):
+        optimize(_tree("seed"), scorer, _WrongIdProposer(), 1, run_dir=tmp_path)

--- a/wmh/harness/population_test.py
+++ b/wmh/harness/population_test.py
@@ -111,6 +111,21 @@ def test_seed_and_proposals_scored_with_earliest_tie_selection(tmp_path: Path) -
     assert result.best_score == 1.0
 
 
+def test_zero_iterations_scores_only_the_seed(tmp_path: Path) -> None:
+    # Score-only mode: a fixed harness (baseline or frozen champion) is scored on a task set
+    # with no proposal. This is how heldout scoring runs.
+    scorer = _FakeScorer({"seed": (1.0, 0.0)})
+    proposer = _ScriptedProposer([])
+
+    result = optimize(_tree("seed"), scorer, proposer, 0, run_dir=tmp_path)
+
+    assert result.completed is True
+    assert [o.candidate_id for o in result.outcomes] == ["candidate-0000"]
+    assert proposer.slots == []  # the proposer is never consulted
+    assert scorer.scored == ["seed"]
+    assert result.best.candidate_id == "candidate-0000"
+
+
 def test_invalid_proposal_consumes_slot_and_records_evidence(tmp_path: Path) -> None:
     scorer = _FakeScorer({"seed": (1.0, 0.0), "fix": (0.0, 1.0)})
     proposer = _ScriptedProposer(["invalid", _tree("fix")])

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -1,0 +1,495 @@
+"""One-turn agentic proposal of complete harness source trees from a scored population.
+
+`ProjectCandidateProposer` implements the population loop's `CandidateProposer` seam with the
+paper's protocol: a FRESH agent project (E2B sandbox) per proposal slot, a navigable filesystem
+history of every evaluated candidate (complete source, score report, and the raw per-trial
+`wmh-run.json` transcripts plus verifier outputs), a fixed-seed stage in `candidate/`, exactly
+one agent turn with `retry_recoverable=False`, then a bounded snapshot, parse, and `node`
+interface validation. Every failure path (agent error, missing submit, snapshot failure,
+invalid tree, syntax error, or transport death) consumes the slot as a
+:class:`CandidateProposalError` with raw evidence persisted under `proposals/slot-NNNN/` in the
+run directory, so later slots learn from it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+from collections.abc import Callable, Collection, Sequence
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import JsonValue
+
+from wmh.agents.project import (
+    DEFAULT_SOURCE_TREE_MAX_BYTES,
+    DEFAULT_SOURCE_TREE_MAX_FILES,
+    AgentProjectRun,
+    ProjectBashResult,
+)
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.population import (
+    CandidateProposal,
+    CandidateProposalError,
+    EvaluatedCandidate,
+    candidate_slot_id,
+)
+from wmh.harness.runtime import HarnessSearchCancelled
+from wmh.harness.scoring import ScoreCell
+from wmh.harness.source_tree import HarnessSourceTree
+from wmh.providers.base import ToolCallingProvider
+
+logger = logging.getLogger(__name__)
+
+CANDIDATE_STAGE_DIR = "candidate"
+PROPOSALS_DIR = "proposals"
+# Per-candidate budget for materialized raw trial evidence; breaches truncate, never halt.
+DEFAULT_CANDIDATE_HISTORY_BYTES = 256 * 1024 * 1024
+# Per-file cap before head/tail truncation (transcripts keep both ends plus a marker).
+DEFAULT_HISTORY_FILE_BYTES = 2 * 1024 * 1024
+_WMH_RUN_FILENAME = "wmh-run.json"
+_TRIAL_AGENT_DIR = "agent"
+_TRIAL_VERIFIER_DIR = "verifier"
+
+
+class CandidateProject(Protocol):
+    """The project-side operations one proposal slot needs (a fresh instance per slot)."""
+
+    workspace: str
+
+    def write_text(self, path: str, content: str) -> None: ...
+
+    def run_bash(self, command: str) -> ProjectBashResult: ...
+
+    def stage_source_tree(self, tree: HarnessSourceTree, dest: str) -> None: ...
+
+    def snapshot_source_tree(
+        self,
+        directory: str,
+        *,
+        max_files: int,
+        max_bytes: int,
+    ) -> HarnessSourceTree: ...
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        on_event: Callable[[SessionEvent], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
+    ) -> AgentProjectRun: ...
+
+    def close(self) -> None: ...
+
+
+class ProjectCandidateProposer:
+    """Run one contained coding turn per slot against the complete scored population."""
+
+    def __init__(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        *,
+        project_factory: Callable[[], CandidateProject],
+        run_dir: str | Path,
+        max_source_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
+        max_source_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
+        max_candidate_history_bytes: int = DEFAULT_CANDIDATE_HISTORY_BYTES,
+        max_history_file_bytes: int = DEFAULT_HISTORY_FILE_BYTES,
+    ) -> None:
+        for field, value in (
+            ("max_source_files", max_source_files),
+            ("max_source_bytes", max_source_bytes),
+            ("max_candidate_history_bytes", max_candidate_history_bytes),
+            ("max_history_file_bytes", max_history_file_bytes),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{field} must be a positive integer")
+        self._agent = agent
+        self._provider = provider
+        self._project_factory = project_factory
+        self._run_dir = Path(run_dir)
+        self._max_source_files = max_source_files
+        self._max_source_bytes = max_source_bytes
+        self._max_candidate_history_bytes = max_candidate_history_bytes
+        self._max_history_file_bytes = max_history_file_bytes
+
+    def propose(
+        self,
+        population: Sequence[EvaluatedCandidate],
+        *,
+        slot: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        """Produce one new candidate from the fixed seed stage, never a selected parent."""
+        if not population:
+            raise ValueError("candidate proposal requires an evaluated seed in the population")
+        if isinstance(slot, bool) or not isinstance(slot, int) or slot < 1:
+            raise ValueError("slot must be a positive integer")
+        _check_cancelled(should_cancel)
+        candidate_id = candidate_slot_id(slot)
+        slot_dir = self._run_dir / PROPOSALS_DIR / f"slot-{slot:04d}"
+        # An uncommitted leftover from a crashed attempt at this same slot is stale evidence;
+        # committed earlier slots are never touched.
+        if slot_dir.exists():
+            shutil.rmtree(slot_dir)
+        slot_dir.mkdir(parents=True)
+        try:
+            return self._propose(
+                tuple(population),
+                candidate_id=candidate_id,
+                slot=slot,
+                slot_dir=slot_dir,
+                should_cancel=should_cancel,
+            )
+        except (HarnessSearchCancelled, CandidateProposalError):
+            raise
+        except Exception as error:
+            # Transport and materialization failures consume the paid slot (never a silent
+            # replay of a proposal turn); the population loop records the evidence path.
+            reason = f"proposal infrastructure failed: {error}"
+            _write_json(slot_dir / "error.json", {"candidate_id": candidate_id, "reason": reason})
+            raise CandidateProposalError(
+                candidate_id, reason, evidence_dir=str(slot_dir)
+            ) from error
+
+    def _propose(
+        self,
+        population: tuple[EvaluatedCandidate, ...],
+        *,
+        candidate_id: str,
+        slot: int,
+        slot_dir: Path,
+        should_cancel: Callable[[], bool] | None,
+    ) -> CandidateProposal:
+        project = self._project_factory()
+        try:
+            self._materialize_history(project, population)
+            self._materialize_prior_proposals(project, slot)
+            project.stage_source_tree(population[0].source, CANDIDATE_STAGE_DIR)
+            request = _proposal_request(
+                candidate_id=candidate_id,
+                stage_dir=f"{project.workspace}/{CANDIDATE_STAGE_DIR}",
+                slot=slot,
+                population_count=len(population),
+            )
+            (slot_dir / "REQUEST.md").write_text(request, encoding="utf-8")
+            project.write_text(f"{PROPOSALS_DIR}/slot-{slot:04d}/REQUEST.md", request)
+            _check_cancelled(should_cancel)
+
+            events: list[SessionEvent] = []
+            run_error: str | None = None
+            try:
+                project.run(
+                    self._agent,
+                    self._provider,
+                    request,
+                    on_event=events.append,
+                    should_cancel=should_cancel,
+                    writable_files=(),
+                    retry_recoverable=False,
+                )
+            except HarnessSearchCancelled:
+                self._write_events(slot_dir, events)
+                raise
+            except Exception as error:  # noqa: BLE001 - the failed turn is slot evidence
+                run_error = str(error)
+            self._write_events(slot_dir, events)
+            _check_cancelled(should_cancel)
+
+            source: HarnessSourceTree | None = None
+            snapshot_error: str | None = None
+            try:
+                source = project.snapshot_source_tree(
+                    CANDIDATE_STAGE_DIR,
+                    max_files=self._max_source_files,
+                    max_bytes=self._max_source_bytes,
+                )
+            except Exception as error:  # noqa: BLE001 - a bad snapshot is slot evidence
+                snapshot_error = str(error)
+            if source is not None:
+                for item in source.files:
+                    target = slot_dir / "source" / item.path
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(item.content, encoding="utf-8")
+
+            failures: list[str] = []
+            if run_error is not None:
+                failures.append(f"agent turn failed: {run_error}")
+            if not any(event.kind == "submit" for event in events):
+                failures.append("agent turn did not submit a completed candidate")
+            if snapshot_error is not None:
+                failures.append(f"candidate snapshot failed: {snapshot_error}")
+            candidate: HarnessDoc | None = None
+            if source is not None:
+                try:
+                    candidate = source.to_doc(candidate_id)
+                except (TypeError, ValueError) as error:
+                    failures.append(f"candidate source is not a valid harness: {error}")
+            if source is not None and candidate is not None and not failures:
+                failures.extend(_interface_errors(project, source))
+
+            _write_json(
+                slot_dir / "status.json",
+                {
+                    "candidate_id": candidate_id,
+                    "valid": candidate is not None and not failures,
+                    "candidate_doc_hash": None if candidate is None else candidate.doc_hash,
+                    "source_tree_hash": None if source is None else source.tree_hash,
+                    "errors": failures,
+                },
+            )
+            if failures or source is None or candidate is None:
+                reason = "; ".join(failures) or "candidate source was not captured"
+                raise CandidateProposalError(candidate_id, reason, evidence_dir=str(slot_dir))
+            return CandidateProposal(candidate_id=candidate_id, source=source, candidate=candidate)
+        finally:
+            try:
+                project.close()
+            except Exception:  # noqa: BLE001 - closing must not mask the slot outcome
+                logger.warning(
+                    "proposer project close failed; the sandbox may stay billable until its "
+                    "lifetime timeout",
+                    exc_info=True,
+                )
+
+    def _materialize_history(
+        self,
+        project: CandidateProject,
+        population: tuple[EvaluatedCandidate, ...],
+    ) -> None:
+        """Write every evaluated candidate's source, report, and raw trial evidence."""
+        manifest: list[dict[str, JsonValue]] = []
+        for evaluated in population:
+            directory = f"history/{evaluated.candidate_id}"
+            for item in evaluated.source.files:
+                project.write_text(f"{directory}/source/{item.path}", item.content)
+            report = evaluated.report
+            cells: list[dict[str, JsonValue]] = []
+            budget = self._max_candidate_history_bytes
+            truncated = False
+            for cell in report.cells:
+                trial_dir = f"{directory}/trials/{cell.task_id}/attempt-{cell.attempt}"
+                cells.append(
+                    {
+                        "task_id": cell.task_id,
+                        "attempt": cell.attempt,
+                        "reward": cell.reward,
+                        "passed": cell.passed,
+                        "note": cell.note,
+                        "trial_dir": trial_dir,
+                    }
+                )
+                if truncated:
+                    continue
+                budget = self._copy_trial_evidence(project, trial_dir, cell, budget)
+                if budget <= 0:
+                    truncated = True
+                    project.write_text(
+                        f"{directory}/trials/TRUNCATED.md",
+                        "Raw trial evidence for this candidate reached the byte budget; "
+                        "later trials were omitted.",
+                    )
+            project.write_text(
+                f"{directory}/report.json",
+                _json(
+                    {
+                        "candidate_id": evaluated.candidate_id,
+                        "score": report.score,
+                        "pass_rate": report.pass_rate,
+                        "reward_mode": report.reward_mode,
+                        "attempts": report.request.attempts,
+                        "cells": cells,
+                    }
+                ),
+            )
+            manifest.append(
+                {
+                    "candidate_id": evaluated.candidate_id,
+                    "score": report.score,
+                    "pass_rate": report.pass_rate,
+                    "by_task": {
+                        task_id: sum(1 for cell in cells_ if cell.passed) / len(cells_)
+                        for task_id, cells_ in report.by_task().items()
+                    },
+                    "source_dir": f"{directory}/source",
+                    "report": f"{directory}/report.json",
+                    "trials_dir": f"{directory}/trials",
+                }
+            )
+        project.write_text(
+            "history/manifest.json",
+            _json(
+                {
+                    "candidate_count": len(manifest),
+                    "candidates": manifest,
+                    "proposals_dir": PROPOSALS_DIR,
+                }
+            ),
+        )
+
+    def _copy_trial_evidence(
+        self,
+        project: CandidateProject,
+        trial_dir: str,
+        cell: ScoreCell,
+        budget: int,
+    ) -> int:
+        """Copy one trial's transcript and verifier output (never harbor's ceremony files)."""
+        if not cell.artifact_dir:
+            return budget
+        artifact_dir = Path(cell.artifact_dir)
+        sources: list[tuple[Path, str]] = []
+        transcript = artifact_dir / _TRIAL_AGENT_DIR / _WMH_RUN_FILENAME
+        if transcript.is_file():
+            sources.append((transcript, f"{trial_dir}/{_WMH_RUN_FILENAME}"))
+        verifier_dir = artifact_dir / _TRIAL_VERIFIER_DIR
+        if verifier_dir.is_dir():
+            sources.extend(
+                (path, f"{trial_dir}/{_TRIAL_VERIFIER_DIR}/{path.relative_to(verifier_dir)}")
+                for path in sorted(verifier_dir.rglob("*"))
+                if path.is_file()
+            )
+        for host_path, target in sources:
+            if budget <= 0:
+                break
+            try:
+                content = _read_evidence(host_path, self._max_history_file_bytes)
+            except OSError as error:
+                content = f"[unreadable evidence file: {error}]"
+            project.write_text(target, content)
+            budget -= len(content.encode("utf-8"))
+        return budget
+
+    def _materialize_prior_proposals(self, project: CandidateProject, slot: int) -> None:
+        """Upload every earlier slot's proposal trace so failures teach later turns."""
+        proposals_root = self._run_dir / PROPOSALS_DIR
+        if not proposals_root.is_dir():
+            return
+        budget = self._max_candidate_history_bytes
+        for slot_dir in sorted(proposals_root.iterdir()):
+            if not slot_dir.is_dir() or slot_dir.name == f"slot-{slot:04d}":
+                continue
+            for path in sorted(slot_dir.rglob("*")):
+                if not path.is_file() or budget <= 0:
+                    continue
+                try:
+                    content = _read_evidence(path, self._max_history_file_bytes)
+                except OSError as error:
+                    content = f"[unreadable evidence file: {error}]"
+                relative = path.relative_to(proposals_root).as_posix()
+                project.write_text(f"{PROPOSALS_DIR}/{relative}", content)
+                budget -= len(content.encode("utf-8"))
+
+    def _write_events(self, slot_dir: Path, events: Sequence[SessionEvent]) -> None:
+        _write_json(
+            slot_dir / "events.json",
+            [{"kind": event.kind, "payload": event.payload} for event in events],
+        )
+
+
+def _interface_errors(project: CandidateProject, source: HarnessSourceTree) -> list[str]:
+    """The paper's interface-validation gate: node syntax-checks every candidate code file.
+
+    A candidate that cannot parse must never burn a paid evaluation, so each `.ts`/`.js` file
+    is checked with `node --experimental-strip-types --check` inside the project sandbox (the
+    pi template ships node). Failures preserve node's stderr as slot evidence.
+    """
+    errors: list[str] = []
+    for item in source.files:
+        if not item.path.endswith((".ts", ".js")):
+            continue
+        staged = f"{CANDIDATE_STAGE_DIR}/{item.path}"
+        result = project.run_bash(f"node --experimental-strip-types --check {shlex.quote(staged)}")
+        if result.exit_code != 0:
+            detail = result.stderr or result.stdout or f"exit {result.exit_code}"
+            errors.append(f"interface validation failed for {item.path}: {detail}")
+    return errors
+
+
+def _read_evidence(path: Path, max_bytes: int) -> str:
+    """Read one evidence file, head/tail-truncating oversized content with a marker."""
+    size = path.stat().st_size
+    if size <= max_bytes:
+        return path.read_bytes().decode("utf-8", errors="replace")
+    half = max_bytes // 2
+    with path.open("rb") as handle:
+        head = handle.read(half)
+        handle.seek(size - half)
+        tail = handle.read(half)
+    return (
+        head.decode("utf-8", errors="replace")
+        + f"\n... {size - max_bytes} bytes truncated ...\n"
+        + tail.decode("utf-8", errors="replace")
+    )
+
+
+def _proposal_request(
+    *,
+    candidate_id: str,
+    stage_dir: str,
+    slot: int,
+    population_count: int,
+) -> str:
+    previous_trace = (
+        f"The most recent proposal-turn trace is `{PROPOSALS_DIR}/slot-{slot - 1:04d}/`; "
+        "failed turns keep their captured source and errors in the same layout."
+        if slot > 1
+        else "There is no earlier proposal turn in this project."
+    )
+    return f"""Produce exactly one complete harness candidate: {candidate_id}.
+
+Read `history/manifest.json`. It indexes all {population_count} evaluated candidates: complete
+source directories, full score reports, and raw per-trial evidence under
+`history/<candidate>/trials/<task>/attempt-N/` (`{_WMH_RUN_FILENAME}` is the complete agent
+transcript for that trial; `verifier/` holds the verifier's own output). Earlier proposal-turn
+traces, including failed ones, remain under `{PROPOSALS_DIR}/`. {previous_trace} Use the full
+population as evidence.
+
+Your only candidate output is this directory:
+`{stage_dir}`
+
+The host initialized it with a complete, freely editable copy of the fixed first evaluated seed at
+`history/candidate-0000/source`. Every proposal slot receives that same fixed scaffold regardless
+of later candidates or scores. Use bash to inspect the immutable project evidence and to create,
+edit, delete, replace, and test files inside the candidate directory. Leave one complete
+standalone harness source tree there; it must not import from or otherwise depend on `history/`,
+`{PROPOSALS_DIR}/`, or any other project path. The final portable source tree must contain a
+UTF-8 `SYSTEM.md`; optional `config.toml`, `runtime.py`, `skills/*.md`, and code files must
+remain valid in the portable source format and parse together as one complete harness.
+
+Filename grammar (strict): outside the reserved names above, every file path must be lowercase
+kebab-case, meaning runs of [a-z0-9] separated by single '/', '.', or '-' characters (for example
+`src/agent-loop.ts`). Uppercase letters and underscores are rejected (`src/a_b.ts` is invalid).
+Because '/' and '.' both canonicalize to '-', paths like `a-b.ts` and `a/b.ts` collide; paths
+differing only by letter case collide too, and no file path may also be a directory prefix of
+another (`a` next to `a/b.ts`). One bad filename invalidates the whole candidate, so name files
+carefully instead of spending this slot on cosmetics.
+
+Do not modify immutable project paths. When the candidate is complete, call submit. The host
+snapshots the directory once after this turn, syntax-checks every `.ts`/`.js` file with
+`node --experimental-strip-types --check`, and will not ask for a repair.
+
+This turn's immutable request and trace are stored under `{PROPOSALS_DIR}/slot-{slot:04d}/`.
+"""
+
+
+def _json(value: JsonValue) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _write_json(path: Path, value: JsonValue) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json(value) + "\n", encoding="utf-8")
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness search cancelled")

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import json
 import logging
 import shlex
-import shutil
 from collections.abc import Callable, Collection, Sequence
 from pathlib import Path
 from typing import Protocol
@@ -136,11 +135,11 @@ class ProjectCandidateProposer:
         _check_cancelled(should_cancel)
         candidate_id = candidate_slot_id(slot)
         slot_dir = self._run_dir / PROPOSALS_DIR / f"slot-{slot:04d}"
-        # An uncommitted leftover from a crashed attempt at this same slot is stale evidence;
-        # committed earlier slots are never touched.
-        if slot_dir.exists():
-            shutil.rmtree(slot_dir)
-        slot_dir.mkdir(parents=True)
+        # A crashed earlier attempt at this same slot is still evidence: move it aside into
+        # attempt-K/ (never delete it) so the redone turn starts clean but later slots and
+        # humans can still read what happened.
+        _set_aside_prior_attempt(slot_dir)
+        slot_dir.mkdir(parents=True, exist_ok=True)
         try:
             return self._propose(
                 tuple(population),
@@ -218,7 +217,8 @@ class ProjectCandidateProposer:
                 for item in source.files:
                     target = slot_dir / "source" / item.path
                     target.parent.mkdir(parents=True, exist_ok=True)
-                    target.write_text(item.content, encoding="utf-8")
+                    # Exact bytes: newline translation would silently change content hashes.
+                    target.write_bytes(item.content.encode("utf-8"))
 
             failures: list[str] = []
             if run_error is not None:
@@ -274,7 +274,6 @@ class ProjectCandidateProposer:
             report = evaluated.report
             cells: list[dict[str, JsonValue]] = []
             budget = self._max_candidate_history_bytes
-            truncated = False
             for cell in report.cells:
                 trial_dir = f"{directory}/trials/{cell.task_id}/attempt-{cell.attempt}"
                 cells.append(
@@ -287,16 +286,7 @@ class ProjectCandidateProposer:
                         "trial_dir": trial_dir,
                     }
                 )
-                if truncated:
-                    continue
                 budget = self._copy_trial_evidence(project, trial_dir, cell, budget)
-                if budget <= 0:
-                    truncated = True
-                    project.write_text(
-                        f"{directory}/trials/TRUNCATED.md",
-                        "Raw trial evidence for this candidate reached the byte budget; "
-                        "later trials were omitted.",
-                    )
             project.write_text(
                 f"{directory}/report.json",
                 _json(
@@ -342,8 +332,17 @@ class ProjectCandidateProposer:
         cell: ScoreCell,
         budget: int,
     ) -> int:
-        """Copy one trial's transcript and verifier output (never harbor's ceremony files)."""
+        """Copy one trial's transcript and verifier output (never harbor's ceremony files).
+
+        Every gap is marked where the proposer will look: a trial with no recorded artifact
+        directory gets `NO-EVIDENCE.md`, and a trial whose files were truncated or omitted by
+        the byte budget gets `EVIDENCE-TRUNCATED.md` naming exactly what is incomplete.
+        """
         if not cell.artifact_dir:
+            project.write_text(
+                f"{trial_dir}/NO-EVIDENCE.md",
+                "This trial recorded no artifact directory; no raw evidence was captured.",
+            )
             return budget
         artifact_dir = Path(cell.artifact_dir)
         sources: list[tuple[Path, str]] = []
@@ -357,15 +356,24 @@ class ProjectCandidateProposer:
                 for path in sorted(verifier_dir.rglob("*"))
                 if path.is_file()
             )
+        incomplete: list[str] = []
         for host_path, target in sources:
             if budget <= 0:
-                break
+                incomplete.append(f"omitted (byte budget reached): {target}")
+                continue
             try:
-                content = _read_evidence(host_path, self._max_history_file_bytes)
+                content, was_truncated = _read_evidence(host_path, self._max_history_file_bytes)
             except OSError as error:
-                content = f"[unreadable evidence file: {error}]"
+                content, was_truncated = f"[unreadable evidence file: {error}]", False
             project.write_text(target, content)
             budget -= len(content.encode("utf-8"))
+            if was_truncated:
+                incomplete.append(f"head/tail truncated: {target}")
+        if incomplete:
+            project.write_text(
+                f"{trial_dir}/EVIDENCE-TRUNCATED.md",
+                "This trial's raw evidence is incomplete:\n" + "\n".join(incomplete),
+            )
         return budget
 
     def _materialize_prior_proposals(self, project: CandidateProject, slot: int) -> None:
@@ -374,19 +382,29 @@ class ProjectCandidateProposer:
         if not proposals_root.is_dir():
             return
         budget = self._max_candidate_history_bytes
+        omitted: list[str] = []
         for slot_dir in sorted(proposals_root.iterdir()):
             if not slot_dir.is_dir() or slot_dir.name == f"slot-{slot:04d}":
                 continue
             for path in sorted(slot_dir.rglob("*")):
-                if not path.is_file() or budget <= 0:
+                if not path.is_file():
+                    continue
+                relative = path.relative_to(proposals_root).as_posix()
+                if budget <= 0:
+                    omitted.append(relative)
                     continue
                 try:
-                    content = _read_evidence(path, self._max_history_file_bytes)
+                    content, _was_truncated = _read_evidence(path, self._max_history_file_bytes)
                 except OSError as error:
                     content = f"[unreadable evidence file: {error}]"
-                relative = path.relative_to(proposals_root).as_posix()
                 project.write_text(f"{PROPOSALS_DIR}/{relative}", content)
                 budget -= len(content.encode("utf-8"))
+        if omitted:
+            project.write_text(
+                f"{PROPOSALS_DIR}/TRUNCATED.md",
+                "Prior proposal evidence beyond the byte budget was omitted:\n"
+                + "\n".join(omitted),
+            )
 
     def _write_events(self, slot_dir: Path, events: Sequence[SessionEvent]) -> None:
         _write_json(
@@ -395,30 +413,85 @@ class ProjectCandidateProposer:
         )
 
 
+# In-sandbox syntax validation for candidate .ts/.js files. `node --check` cannot be used for
+# TypeScript: it does NOT strip types under --check (verified on node 22.23), so it falsely
+# rejects valid TS including the seed's own vendored files. `stripTypeScriptTypes` (node >=
+# 22.13) fully parses TS module grammar and throws on syntax errors, and plain JS is a subset
+# of that grammar, so one code path validates both. When the sandbox's node predates it, the
+# script reports the skip marker and validation is SKIPPED rather than false-rejecting every
+# candidate.
+_TS_VALIDATION_SKIP_MARKER = "typescript-validation-skipped"
+_TS_CHECK_SCRIPT = f"""\
+const {{ readFileSync }} = require('node:fs');
+let strip;
+try {{
+  ({{ stripTypeScriptTypes: strip }} = require('node:module'));
+}} catch {{}}
+if (typeof strip !== 'function') {{
+  console.log('{_TS_VALIDATION_SKIP_MARKER}: node:module.stripTypeScriptTypes unavailable');
+  process.exit(0);
+}}
+let failed = false;
+for (const path of process.argv.slice(1)) {{
+  try {{
+    strip(readFileSync(path, 'utf8'));
+  }} catch (error) {{
+    failed = true;
+    console.error(path + ': ' + (error && error.message ? error.message : String(error)));
+  }}
+}}
+process.exit(failed ? 1 : 0);
+"""
+
+
 def _interface_errors(project: CandidateProject, source: HarnessSourceTree) -> list[str]:
-    """The paper's interface-validation gate: node syntax-checks every candidate code file.
+    """The paper's interface-validation gate: parse-check every candidate code file.
 
-    A candidate that cannot parse must never burn a paid evaluation, so each `.ts`/`.js` file
-    is checked with `node --experimental-strip-types --check` inside the project sandbox (the
-    pi template ships node). Failures preserve node's stderr as slot evidence.
+    A candidate that cannot parse must never burn a paid evaluation. One in-sandbox node
+    invocation strips/parses every `.ts`/`.js` file via `node:module.stripTypeScriptTypes`
+    (which throws on bad syntax); failures preserve node's per-file error as slot evidence.
     """
-    errors: list[str] = []
-    for item in source.files:
-        if not item.path.endswith((".ts", ".js")):
-            continue
-        staged = f"{CANDIDATE_STAGE_DIR}/{item.path}"
-        result = project.run_bash(f"node --experimental-strip-types --check {shlex.quote(staged)}")
-        if result.exit_code != 0:
-            detail = result.stderr or result.stdout or f"exit {result.exit_code}"
-            errors.append(f"interface validation failed for {item.path}: {detail}")
-    return errors
+    staged = [
+        f"{CANDIDATE_STAGE_DIR}/{item.path}"
+        for item in source.files
+        if item.path.endswith((".ts", ".js"))
+    ]
+    if not staged:
+        return []
+    quoted_paths = " ".join(shlex.quote(path) for path in staged)
+    result = project.run_bash(f"node -e {shlex.quote(_TS_CHECK_SCRIPT)} {quoted_paths}")
+    if result.exit_code == 0:
+        if _TS_VALIDATION_SKIP_MARKER in result.stdout:
+            logger.warning("candidate interface validation skipped: %s", result.stdout.strip())
+        return []
+    detail = result.stderr or result.stdout or f"exit {result.exit_code}"
+    return [f"interface validation failed: {detail}"]
 
 
-def _read_evidence(path: Path, max_bytes: int) -> str:
-    """Read one evidence file, head/tail-truncating oversized content with a marker."""
+def _set_aside_prior_attempt(slot_dir: Path) -> None:
+    """Move a crashed prior attempt's evidence into `attempt-K/` instead of deleting it."""
+    if not slot_dir.is_dir():
+        return
+    prior = [path for path in slot_dir.iterdir() if not path.name.startswith("attempt-")]
+    if not prior:
+        return
+    attempt_count = sum(
+        1 for path in slot_dir.iterdir() if path.is_dir() and path.name.startswith("attempt-")
+    )
+    attempt_dir = slot_dir / f"attempt-{attempt_count + 1}"
+    attempt_dir.mkdir()
+    for path in prior:
+        path.rename(attempt_dir / path.name)
+
+
+def _read_evidence(path: Path, max_bytes: int) -> tuple[str, bool]:
+    """Read one evidence file, head/tail-truncating oversized content with a marker.
+
+    Returns the content and whether it was truncated.
+    """
     size = path.stat().st_size
     if size <= max_bytes:
-        return path.read_bytes().decode("utf-8", errors="replace")
+        return path.read_bytes().decode("utf-8", errors="replace"), False
     half = max_bytes // 2
     with path.open("rb") as handle:
         head = handle.read(half)
@@ -428,7 +501,7 @@ def _read_evidence(path: Path, max_bytes: int) -> str:
         head.decode("utf-8", errors="replace")
         + f"\n... {size - max_bytes} bytes truncated ...\n"
         + tail.decode("utf-8", errors="replace")
-    )
+    ), True
 
 
 def _proposal_request(
@@ -474,8 +547,9 @@ another (`a` next to `a/b.ts`). One bad filename invalidates the whole candidate
 carefully instead of spending this slot on cosmetics.
 
 Do not modify immutable project paths. When the candidate is complete, call submit. The host
-snapshots the directory once after this turn, syntax-checks every `.ts`/`.js` file with
-`node --experimental-strip-types --check`, and will not ask for a repair.
+snapshots the directory once after this turn, parse-checks every `.ts`/`.js` file with node's
+TypeScript syntax stripper (a syntax error anywhere invalidates the candidate), and will not ask
+for a repair.
 
 This turn's immutable request and trace are stored under `{PROPOSALS_DIR}/slot-{slot:04d}/`.
 """

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,8 +12,10 @@ from pathlib import Path
 import pytest
 from llm_waterfall import ChatResponse
 
+from wmh.agents.default import default_agent
 from wmh.agents.optimizer import optimizer_agent
 from wmh.agents.project import AgentProjectRun, ProjectBashResult
+from wmh.harness import project_proposer
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import CandidateProposalError, EvaluatedCandidate
@@ -164,10 +168,11 @@ def test_proposer_materializes_history_stages_seed_and_returns_one_candidate(
     assert report["score"] == 1.0
     manifest = json.loads(project.files["history/manifest.json"])
     assert manifest["candidates"][0]["by_task"] == {"t1": 1.0}
-    # The interface gate checked the candidate's one code file inside the project.
-    assert project.bash_commands == [
-        "node --experimental-strip-types --check candidate/src/agent-loop.ts"
-    ]
+    # The interface gate parse-checked the candidate's one code file in ONE node call.
+    [check_command] = project.bash_commands
+    assert check_command.startswith("node -e ")
+    assert "stripTypeScriptTypes" in check_command
+    assert check_command.endswith(" candidate/src/agent-loop.ts")
     assert project.closed == 1
     slot_dir = run_dir / "proposals" / "slot-0001"
     assert (slot_dir / "REQUEST.md").is_file()
@@ -201,7 +206,8 @@ def test_interface_validation_failure_preserves_node_stderr(tmp_path: Path) -> N
     with pytest.raises(CandidateProposalError, match="SyntaxError") as excinfo:
         _proposer([project], tmp_path / "run").propose((seed,), slot=1)
 
-    assert "interface validation failed for src/agent-loop.ts" in excinfo.value.reason
+    assert "interface validation failed" in excinfo.value.reason
+    assert "SyntaxError: unexpected end of input" in excinfo.value.reason
 
 
 def test_agent_transport_failure_consumes_the_slot_instead_of_propagating(
@@ -259,3 +265,116 @@ def test_each_slot_gets_a_fresh_project_carrying_prior_proposal_evidence(
     assert "proposals/slot-0001/status.json" in second.files
     assert "proposals/slot-0001/REQUEST.md" in second.files
     assert not any(path.startswith("proposals/slot-0002") for path in first.files)
+
+
+_NODE = shutil.which("node")
+
+
+def _run_ts_check(paths: list[str]) -> subprocess.CompletedProcess[str]:
+    assert _NODE is not None
+    return subprocess.run(
+        [_NODE, "-e", project_proposer._TS_CHECK_SCRIPT, *paths],  # noqa: SLF001
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(_NODE is None, reason="node is not installed")
+def test_interface_validation_script_accepts_every_vendored_pi_source(tmp_path: Path) -> None:
+    """Empirical gate check: the seed's own vendored TS/JS must pass, or every slot burns.
+
+    (`node --check` is NOT usable here: it does not strip types under --check on node 22 and
+    falsely rejects valid TS such as the vendored pi sources.)
+    """
+    tree = HarnessSourceTree.from_doc(default_agent())
+    code_paths: list[str] = []
+    for item in tree.files:
+        if not item.path.endswith((".ts", ".js")):
+            continue
+        target = tmp_path / item.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(item.content, encoding="utf-8")
+        code_paths.append(str(target))
+    assert len(code_paths) >= 20  # the whole vendored agent, not a sample
+
+    done = _run_ts_check(code_paths)
+
+    if project_proposer._TS_VALIDATION_SKIP_MARKER in done.stdout:  # noqa: SLF001
+        pytest.skip("local node lacks node:module.stripTypeScriptTypes")
+    assert done.returncode == 0, done.stderr
+
+
+@pytest.mark.skipif(_NODE is None, reason="node is not installed")
+def test_interface_validation_script_rejects_broken_typescript_with_the_node_error(
+    tmp_path: Path,
+) -> None:
+    good = tmp_path / "good.ts"
+    good.write_text("export function fine(value: string): string { return value; }\n")
+    bad = tmp_path / "bad.ts"
+    bad.write_text("export function broken(: string {\n")
+
+    done = _run_ts_check([str(good), str(bad)])
+
+    if project_proposer._TS_VALIDATION_SKIP_MARKER in done.stdout:  # noqa: SLF001
+        pytest.skip("local node lacks node:module.stripTypeScriptTypes")
+    assert done.returncode == 1
+    assert "bad.ts" in done.stderr  # per-file attribution with node's own error preserved
+    assert "good.ts" not in done.stderr
+    assert "Expected" in done.stderr or "Unexpected" in done.stderr
+
+
+def test_evidence_gaps_are_marked_per_trial_and_for_prior_proposals(tmp_path: Path) -> None:
+    """Truncation honesty: missing, truncated, and omitted evidence is marked where it lives."""
+    seed = _seed_with_trial(tmp_path)
+    no_evidence_cell = ScoreCell(task_id="t2", attempt=1, reward=0.0, passed=False)
+    tree = seed.source
+    doc = tree.to_doc("candidate-0000")
+    report = ScoreReport(
+        doc_hash=doc.doc_hash,
+        request=ScoreRequest(task_ids=("t1", "t2"), attempts=1),
+        reward_mode="positive-binary",
+        cells=(seed.report.cells[0], no_evidence_cell),
+    )
+    seed = EvaluatedCandidate("candidate-0000", tree, report)
+    transcript = Path(seed.report.cells[0].artifact_dir) / "agent" / "wmh-run.json"
+    transcript.write_text("H" * 200 + "T" * 200, encoding="utf-8")
+    run_dir = tmp_path / "run"
+    first = _FakeProject([_tree("improved")])
+    first.emit_submit = False
+    proposer = _proposer([first], run_dir, max_history_file_bytes=64)
+    with pytest.raises(CandidateProposalError):
+        proposer.propose((seed,), slot=1)
+
+    truncated_marker = first.files[
+        "history/candidate-0000/trials/t1/attempt-1/EVIDENCE-TRUNCATED.md"
+    ]
+    assert "head/tail truncated" in truncated_marker
+    assert "wmh-run.json" in truncated_marker
+    assert (
+        "no raw evidence"
+        in (first.files["history/candidate-0000/trials/t2/attempt-1/NO-EVIDENCE.md"])
+    )
+
+    # A second slot with an exhausted prior-proposal budget marks the omissions too.
+    second = _FakeProject([_tree("improved")])
+    tight = _proposer([second], run_dir, max_candidate_history_bytes=1)
+    tight.propose((seed,), slot=2)
+    assert "slot-0001" in second.files["proposals/TRUNCATED.md"]
+
+
+def test_crashed_slot_evidence_is_set_aside_not_deleted(tmp_path: Path) -> None:
+    """A redone slot keeps the crashed attempt's raw evidence under attempt-K/."""
+    seed = _seed_with_trial(tmp_path)
+    run_dir = tmp_path / "run"
+    slot_dir = run_dir / "proposals" / "slot-0001"
+    slot_dir.mkdir(parents=True)
+    (slot_dir / "REQUEST.md").write_text("crashed attempt request", encoding="utf-8")
+    project = _FakeProject([_tree("improved")])
+
+    proposal = _proposer([project], run_dir).propose((seed,), slot=1)
+
+    assert proposal.candidate_id == "candidate-0001"
+    aside = slot_dir / "attempt-1" / "REQUEST.md"
+    assert aside.read_text(encoding="utf-8") == "crashed attempt request"
+    assert (slot_dir / "REQUEST.md").read_text(encoding="utf-8") != "crashed attempt request"

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -1,0 +1,261 @@
+"""Tests for the fresh-project-per-slot proposer (in-memory fake project, no E2B)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Collection
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from llm_waterfall import ChatResponse
+
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import AgentProjectRun, ProjectBashResult
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.live_session import SessionEvent
+from wmh.harness.population import CandidateProposalError, EvaluatedCandidate
+from wmh.harness.project_proposer import ProjectCandidateProposer
+from wmh.harness.runtime import TokenUsage
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
+
+
+@dataclass(frozen=True)
+class _RunCall:
+    instruction: str
+    retry_recoverable: bool
+
+
+class _FakeProject:
+    workspace = "/home/user/project"
+
+    def __init__(self, snapshots: list[HarnessSourceTree | Exception]) -> None:
+        self.files: dict[str, str] = {}
+        self.snapshots = snapshots
+        self.staged: list[tuple[HarnessSourceTree, str]] = []
+        self.bash_commands: list[str] = []
+        self.bash_results: dict[str, ProjectBashResult] = {}
+        self.run_calls: list[_RunCall] = []
+        self.emit_submit = True
+        self.run_raises: Exception | None = None
+        self.closed = 0
+
+    def write_text(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    def run_bash(self, command: str) -> ProjectBashResult:
+        self.bash_commands.append(command)
+        for marker, result in self.bash_results.items():
+            if marker in command:
+                return result
+        return ProjectBashResult(stdout="", stderr="", exit_code=0)
+
+    def stage_source_tree(self, tree: HarnessSourceTree, dest: str) -> None:
+        self.staged.append((tree, dest))
+
+    def snapshot_source_tree(
+        self, directory: str, *, max_files: int, max_bytes: int
+    ) -> HarnessSourceTree:
+        del directory, max_files, max_bytes
+        item = self.snapshots.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def run(
+        self,
+        agent: HarnessDoc,
+        provider: ToolCallingProvider,
+        instruction: str,
+        *,
+        on_event: Callable[[SessionEvent], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+        writable_files: Collection[str] | None = None,
+        retry_recoverable: bool = True,
+    ) -> AgentProjectRun:
+        del agent, provider, should_cancel, writable_files
+        self.run_calls.append(_RunCall(instruction, retry_recoverable))
+        if self.run_raises is not None:
+            raise self.run_raises
+        if self.emit_submit and on_event is not None:
+            on_event(SessionEvent(kind="submit", payload={"answer": "done"}))
+        return AgentProjectRun(answer="done", events=(), worker_usage=TokenUsage())
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+class _Provider:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="meta")
+
+    def complete_chat(self, request: object) -> ChatResponse:
+        del request
+        raise AssertionError("the fake project never calls the provider")
+
+
+def _tree(prompt: str, *extra: tuple[str, str]) -> HarnessSourceTree:
+    files = [HarnessSourceFile(path="SYSTEM.md", content=prompt)]
+    files.extend(HarnessSourceFile(path=path, content=content) for path, content in extra)
+    return HarnessSourceTree(files=tuple(files))
+
+
+def _seed_with_trial(tmp_path: Path) -> EvaluatedCandidate:
+    trial = tmp_path / "harbor" / "wmh-abc" / "t1__trial"
+    (trial / "agent").mkdir(parents=True)
+    (trial / "agent" / "wmh-run.json").write_text('{"steps": ["s1"]}', encoding="utf-8")
+    (trial / "verifier").mkdir()
+    (trial / "verifier" / "output.txt").write_text("PASS", encoding="utf-8")
+    (trial / "config.json").write_text("{}", encoding="utf-8")  # ceremony: never copied
+    tree = _tree("seed")
+    doc = tree.to_doc("candidate-0000")
+    report = ScoreReport(
+        doc_hash=doc.doc_hash,
+        request=ScoreRequest(task_ids=("t1",), attempts=1),
+        reward_mode="positive-binary",
+        cells=(
+            ScoreCell(task_id="t1", attempt=1, reward=1.0, passed=True, artifact_dir=str(trial)),
+        ),
+    )
+    return EvaluatedCandidate("candidate-0000", tree, report)
+
+
+def _proposer(
+    projects: list[_FakeProject], run_dir: Path, **kwargs: int
+) -> ProjectCandidateProposer:
+    return ProjectCandidateProposer(
+        optimizer_agent(),
+        _Provider(),
+        project_factory=lambda: projects.pop(0),
+        run_dir=run_dir,
+        **kwargs,
+    )
+
+
+def test_proposer_materializes_history_stages_seed_and_returns_one_candidate(
+    tmp_path: Path,
+) -> None:
+    candidate = _tree("improved", ("src/agent-loop.ts", "export {};"))
+    project = _FakeProject([candidate])
+    seed = _seed_with_trial(tmp_path)
+    run_dir = tmp_path / "run"
+
+    proposal = _proposer([project], run_dir).propose((seed,), slot=1)
+
+    assert proposal.candidate_id == "candidate-0001"
+    assert proposal.source == candidate
+    assert project.staged == [(seed.source, "candidate")]
+    assert project.run_calls[0].retry_recoverable is False
+    request = project.run_calls[0].instruction
+    assert "/home/user/project/candidate" in request
+    assert "kebab-case" in request  # the filename grammar is load-bearing prompt content
+    assert "history/candidate-0000/source" in request
+    # Complete history: source, report, transcript, and verifier output; NOT harbor ceremony.
+    assert project.files["history/candidate-0000/source/SYSTEM.md"] == "seed"
+    assert project.files["history/candidate-0000/trials/t1/attempt-1/wmh-run.json"] == (
+        '{"steps": ["s1"]}'
+    )
+    assert project.files["history/candidate-0000/trials/t1/attempt-1/verifier/output.txt"] == (
+        "PASS"
+    )
+    assert not any("config.json" in path for path in project.files)
+    report = json.loads(project.files["history/candidate-0000/report.json"])
+    assert report["score"] == 1.0
+    manifest = json.loads(project.files["history/manifest.json"])
+    assert manifest["candidates"][0]["by_task"] == {"t1": 1.0}
+    # The interface gate checked the candidate's one code file inside the project.
+    assert project.bash_commands == [
+        "node --experimental-strip-types --check candidate/src/agent-loop.ts"
+    ]
+    assert project.closed == 1
+    slot_dir = run_dir / "proposals" / "slot-0001"
+    assert (slot_dir / "REQUEST.md").is_file()
+    assert (slot_dir / "source" / "SYSTEM.md").read_text(encoding="utf-8") == "improved"
+    assert json.loads((slot_dir / "status.json").read_text(encoding="utf-8"))["valid"] is True
+
+
+def test_missing_submit_consumes_the_slot_with_persisted_evidence(tmp_path: Path) -> None:
+    project = _FakeProject([_tree("improved")])
+    project.emit_submit = False
+    seed = _seed_with_trial(tmp_path)
+    run_dir = tmp_path / "run"
+
+    with pytest.raises(CandidateProposalError, match="did not submit") as excinfo:
+        _proposer([project], run_dir).propose((seed,), slot=1)
+
+    slot_dir = run_dir / "proposals" / "slot-0001"
+    assert excinfo.value.evidence_dir == str(slot_dir)
+    status = json.loads((slot_dir / "status.json").read_text(encoding="utf-8"))
+    assert status["valid"] is False
+    assert (slot_dir / "events.json").is_file()
+
+
+def test_interface_validation_failure_preserves_node_stderr(tmp_path: Path) -> None:
+    project = _FakeProject([_tree("improved", ("src/agent-loop.ts", "export {"))])
+    project.bash_results["node "] = ProjectBashResult(
+        stdout="", stderr="SyntaxError: unexpected end of input", exit_code=1
+    )
+    seed = _seed_with_trial(tmp_path)
+
+    with pytest.raises(CandidateProposalError, match="SyntaxError") as excinfo:
+        _proposer([project], tmp_path / "run").propose((seed,), slot=1)
+
+    assert "interface validation failed for src/agent-loop.ts" in excinfo.value.reason
+
+
+def test_agent_transport_failure_consumes_the_slot_instead_of_propagating(
+    tmp_path: Path,
+) -> None:
+    project = _FakeProject([_tree("leftover")])
+    project.run_raises = RuntimeError("server disconnected mid-turn")
+    seed = _seed_with_trial(tmp_path)
+
+    with pytest.raises(CandidateProposalError, match="server disconnected"):
+        _proposer([project], tmp_path / "run").propose((seed,), slot=1)
+    assert project.closed == 1
+
+
+def test_invalid_snapshot_tree_is_slot_evidence(tmp_path: Path) -> None:
+    project = _FakeProject([ValueError("paths differ only by letter case")])
+    seed = _seed_with_trial(tmp_path)
+
+    with pytest.raises(CandidateProposalError, match="letter case"):
+        _proposer([project], tmp_path / "run").propose((seed,), slot=1)
+
+
+def test_oversized_evidence_is_head_tail_truncated_never_fatal(tmp_path: Path) -> None:
+    seed = _seed_with_trial(tmp_path)
+    transcript = Path(seed.report.cells[0].artifact_dir) / "agent" / "wmh-run.json"
+    transcript.write_text("H" * 200 + "MIDDLE" + "T" * 200, encoding="utf-8")
+    project = _FakeProject([_tree("improved")])
+
+    _proposer([project], tmp_path / "run", max_history_file_bytes=64).propose((seed,), slot=1)
+
+    copied = project.files["history/candidate-0000/trials/t1/attempt-1/wmh-run.json"]
+    assert "bytes truncated" in copied
+    assert copied.startswith("HHH")
+    assert copied.endswith("TTT")
+    assert "MIDDLE" not in copied
+
+
+def test_each_slot_gets_a_fresh_project_carrying_prior_proposal_evidence(
+    tmp_path: Path,
+) -> None:
+    seed = _seed_with_trial(tmp_path)
+    run_dir = tmp_path / "run"
+    first = _FakeProject([_tree("improved")])
+    first.emit_submit = False  # slot 1 fails and leaves evidence in the run dir
+    second = _FakeProject([_tree("improved")])
+    proposer = _proposer([first, second], run_dir)
+
+    with pytest.raises(CandidateProposalError):
+        proposer.propose((seed,), slot=1)
+    proposal = proposer.propose((seed,), slot=2)
+
+    assert proposal.candidate_id == "candidate-0002"
+    assert first.closed == 1 and second.closed == 1
+    # The failed turn's trace teaches the next fresh project.
+    assert "proposals/slot-0001/status.json" in second.files
+    assert "proposals/slot-0001/REQUEST.md" in second.files
+    assert not any(path.startswith("proposals/slot-0002") for path in first.files)

--- a/wmh/serving/builds.py
+++ b/wmh/serving/builds.py
@@ -282,6 +282,12 @@ class BuildManager:
 
     def start(self, request: BuildRouteRequest) -> str:
         """Validate and launch a build, returning its id. Raises before spending anything."""
+        if request.name == "harbor":
+            # Mirrors the `wmh build` CLI guard: the literal is the optimize environment.
+            raise ValueError(
+                "world model name 'harbor' is reserved: `wmh optimize <agent> harbor` selects "
+                "the harbor benchmark environment; choose another name"
+            )
         config = HarnessConfig.for_build(
             serve_provider=ProviderKind(request.provider),
             serve_model=request.model,

--- a/wmh/serving/builds_test.py
+++ b/wmh/serving/builds_test.py
@@ -182,6 +182,14 @@ def test_start_rejects_upload_symlink_escape(tmp_path: Path) -> None:
         manager.start(request)
 
 
+def test_start_rejects_the_reserved_harbor_name(tmp_path: Path) -> None:
+    # Same reservation as the `wmh build` CLI: 'harbor' is the optimize environment literal.
+    manager, _ = _manager(tmp_path)
+    request = _request(tmp_path)
+    with pytest.raises(ValueError, match="reserved"):
+        manager.start(request.model_copy(update={"name": "harbor"}))
+
+
 def test_start_rejects_existing_model_name(tmp_path: Path) -> None:
     model_dir = tmp_path / ".wmh" / "models" / "fresh"
     model_dir.mkdir(parents=True)


### PR DESCRIPTION
Third and final PR of the meta-harness replication stack (on #240 → #241). The existing top-level `wmh optimize NAME ENVIRONMENT` gains the `harbor` environment: the meta-harness optimizer from arXiv 2603.28052, where a proposer LLM rewrites the complete harness source each iteration and every candidate is scored on real Terminal-Bench-2 tasks through #241's `HarborScorer`. The world-model path of `wmh optimize` is untouched (its tests pass unchanged); `--backend local|e2b` keeps its meaning on both environments.

```bash
wmh optimize pi harbor --harbor-config job.yaml --task-ids tasks.json \
  --backend e2b --iterations 10 --reward-mode positive-binary --run-dir runs/train-01
```

## The optimizer (paper semantics)
- **Population loop** (`wmh/harness/population.py`): the seed (`pi` = the built-in default harness, always; `pi@champion`/`name@vN` for compounding) is scored as candidate-0000, then N sequential proposal slots. Invalid proposals consume their slot and become evidence; scorer/infra exceptions propagate (a broken evaluation is never scored as 0). Selection: highest equal-task-weight mean, earliest candidate on ties.
- **Proposer** (`wmh/harness/project_proposer.py`): each slot runs one turn of a proposer agent (the `meta` role, e.g. GPT-5.5 at high reasoning) in a **fresh E2B project** whose filesystem holds the full evaluated population — complete sources, per-task score reports, and the **raw trial evidence** (`wmh-run.json` full transcripts + verifier output) the paper's ablation identifies as the load-bearing feedback channel. The candidate directory is preinitialized with the fixed seed every slot; the agent edits it with bash and submits. The host snapshots the tree, parses it as a harness, and syntax-gates every `.ts`/`.js` via `node:module.stripTypeScriptTypes` in-sandbox before any paid evaluation. Failed turns keep their captured source, events, and errors as evidence for later slots. Truncation of oversized evidence is explicit (per-trial markers), never silent.
- **Project plumbing** (`wmh/agents/project.py`): project agents gain a plain `bash` tool (default sandbox user, bounded output, timeout wrapper), source-tree staging/snapshot (one bounded base64 roundtrip; non-regular files are counted and rejected, not dropped), and `retry_recoverable=False` single-attempt turns — a paid proposal turn is never transparently replayed.

## Built to survive the multi-hour paid run
The run dir is the state: every boundary commits via fsynced atomic JSON. Accepted proposals are checkpointed **before** scoring, so a crash mid-score resumes into scoring the *same* candidate (preserving #241's trial-level job resume) instead of re-paying a proposer turn. `--resume` re-verifies everything that could silently drift and rejects mismatches with actionable errors: explicit CLI flag conflicts, worker/proposer model identity, dataset pins (git commits), and the seed (pinned + recovered from the run dir's committed record, immune to champion movement). Winner publication is idempotent (`published.json`); re-invoking a completed run re-prints the result. `--max-iterations-this-run` supports one-boundary-at-a-time operation.

Sensitive-env safety: the CLI persists the raw parsed job template (validated against harbor's `JobConfig` for checking only) — harbor's env-redacting serializers never touch what lands in `run-config.json` or the trials.

## Also
- `harbor` is a reserved world-model name (CLI build + serving build API).
- README + AGENTS.md updated; command help documents the fixed-seed semantics of bare `pi`.

## Verification
`ruff check` / `format --check` / `ty check` clean; **2122 passed, 18 skipped** (base #241: 2081). Fake-seam tests pin the load-bearing semantics: slot consumption, pre-score checkpointing and crash-resume identity, stale-source clearing, exact-byte round-trips (CR-safe), resume conflict/pin rejection matrices, idempotent publication, TS-gate empirics (all 25 vendored pi files pass; a broken file fails with node's error), snapshot symlink rejection, and CLI dispatch for both environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)