### PR TITLE
Group root CLI help by feature

### DIFF
--- a/wmh/cli/agent_session.py
+++ b/wmh/cli/agent_session.py
@@ -849,10 +849,10 @@ _SESSION_OPT = typer.Option(
 )
 
 
-def register(app: typer.Typer) -> None:
+def register(app: typer.Typer, *, rich_help_panel: str | None = None) -> None:
     """Register the unified ``wmh run`` command on the root app."""
 
-    @app.command("run")
+    @app.command("run", rich_help_panel=rich_help_panel)
     def run(
         target: Annotated[str | None, _TARGET_ARG] = None,
         directory: Annotated[str | None, _DIR_OPT] = None,

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -124,6 +124,12 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+_PROJECT_SETUP_PANEL = "Project Setup"
+_AGENTS_PANEL = "Agents"
+_WORLD_MODELS_PANEL = "World Models"
+_PLATFORM_PANEL = "Platform"
+_RESEARCH_PANEL = "Research"
+
 
 providers_app = typer.Typer(help="Manage and verify LLM providers.", no_args_is_help=True)
 examples_app = typer.Typer(
@@ -137,15 +143,12 @@ scenarios_app = typer.Typer(
     help="Construct and verify representative eval scenario sets from traces.",
     no_args_is_help=True,
 )
-app.add_typer(providers_app, name="providers")
-app.add_typer(examples_app, name="examples")
-app.add_typer(config_app, name="config")
-app.add_typer(research_app, name="research")
-app.add_typer(scenarios_app, name="scenarios")
-app.add_typer(harness_app, name="harness")
-app.command("optimize")(optimize)
-register_platform_commands(app)
-register_agent_session_commands(app)
+app.add_typer(providers_app, name="providers", rich_help_panel=_PROJECT_SETUP_PANEL)
+app.add_typer(config_app, name="config", rich_help_panel=_PROJECT_SETUP_PANEL)
+app.add_typer(examples_app, name="examples", rich_help_panel=_PROJECT_SETUP_PANEL)
+register_agent_session_commands(app, rich_help_panel=_AGENTS_PANEL)
+app.command("optimize", rich_help_panel=_AGENTS_PANEL)(optimize)
+app.add_typer(harness_app, name="harness", rich_help_panel=_AGENTS_PANEL)
 _console = Console()
 _CHECK = "[green]✓[/green]"
 
@@ -388,7 +391,7 @@ def examples_run(
     raise typer.Exit(result.returncode)
 
 
-@app.command("build")
+@app.command("build", rich_help_panel=_WORLD_MODELS_PANEL)
 def build(
     name: str = typer.Option(None, "--name", help="Name for this world model."),
     source: str = typer.Option(
@@ -752,7 +755,7 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
         raise typer.Exit(1)
 
 
-@app.command("list")
+@app.command("list", rich_help_panel=_WORLD_MODELS_PANEL)
 def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list.")) -> None:
     """List every world model built under the project dir."""
     infos = WorldModelStore(root).list_info()
@@ -762,7 +765,7 @@ def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list
     _console.print(models_table(infos))
 
 
-@app.command("download")
+@app.command("download", rich_help_panel=_WORLD_MODELS_PANEL)
 def download(
     benchmarks: list[str] = _DOWNLOAD_BENCHMARKS,
     force: bool = typer.Option(False, "--force", help="Overwrite existing local files."),
@@ -849,7 +852,7 @@ def _fetch_with_progress(name: str, *, force: bool) -> Path:
         return fetch_corpus(name, force=force, on_progress=on_progress)
 
 
-@app.command("serve")
+@app.command("serve", rich_help_panel=_WORLD_MODELS_PANEL)
 def serve(
     name: list[str] = typer.Option(  # noqa: B008 - typer reads option defaults at definition time
         None, "--name", help="World model(s) to serve. Repeatable; default: all built ones."
@@ -883,7 +886,7 @@ def serve(
     uvicorn.run(server_app, host="127.0.0.1", port=port)
 
 
-@app.command("eval")
+@app.command("eval", rich_help_panel=_WORLD_MODELS_PANEL)
 def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin isn't used here
     tokens: list[str] | None = _EVAL_TOKENS,
     mode: str = typer.Option(
@@ -1562,7 +1565,10 @@ def _eval_report_payload(report: EvalReport) -> JsonObject:
     }
 
 
-@app.command("knowledge")
+app.add_typer(scenarios_app, name="scenarios", rich_help_panel=_WORLD_MODELS_PANEL)
+
+
+@app.command("knowledge", rich_help_panel=_WORLD_MODELS_PANEL)
 def knowledge_(
     name: str = typer.Option(None, "--name", help="World model (default: the only one)."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
@@ -1820,7 +1826,7 @@ def _resolve_scenario_embedder(
     )
 
 
-@app.command("demo")
+@app.command("demo", rich_help_panel=_WORLD_MODELS_PANEL)
 def demo(
     name: str = typer.Option(None, "--name", help="World model to demo (default: pick one)."),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir (example models are found too)."),
@@ -1953,7 +1959,7 @@ def _first_prompt(wm: WorldModel, trace) -> str:  # noqa: ANN001 - core Trace
         wm.end_session(probe.id)
 
 
-@app.command("play")
+@app.command("play", rich_help_panel=_WORLD_MODELS_PANEL)
 def play(
     name: str = typer.Option(None, "--name", help="World model to play (default: pick one)."),
     task: str = typer.Option(None, "--task", help="Task to seed the session with."),
@@ -1968,6 +1974,10 @@ def play(
     )
     suggestions = _action_suggestions(wm)
     run_play_repl(_console, wm, resolved_name, task, suggestions=suggestions)
+
+
+register_platform_commands(app, rich_help_panel=_PLATFORM_PANEL)
+app.add_typer(research_app, name="research", rich_help_panel=_RESEARCH_PANEL)
 
 
 def _traces_for_root(model_root: Path) -> Path | None:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -337,6 +337,27 @@ def test_bare_invocation_shows_help(args: list[str]) -> None:
     assert result.exit_code == 2
 
 
+def test_root_help_groups_commands_by_feature() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, result.output
+
+    headings = ["Project Setup", "Agents", "World Models", "Platform", "Research"]
+    positions = [result.output.index(heading) for heading in headings]
+    assert positions == sorted(positions)
+
+    expected_commands = {
+        "Project Setup": ("providers", "config", "examples"),
+        "Agents": ("run", "optimize", "harness"),
+        "World Models": ("build", "list", "download", "serve", "eval", "scenarios"),
+        "Platform": ("login", "logout", "status", "push", "pull"),
+        "Research": ("research",),
+    }
+    for heading, commands in expected_commands.items():
+        heading_index = result.output.index(heading)
+        for command in commands:
+            assert result.output.index(command) > heading_index
+
+
 def test_build_rejects_invalid_name_flag_with_friendly_error(tmp_path) -> None:  # noqa: ANN001
     result = runner.invoke(
         app,

--- a/wmh/cli/platform_cmds.py
+++ b/wmh/cli/platform_cmds.py
@@ -361,10 +361,10 @@ def _print_orgs(identity: WhoAmI, default_org: str | None) -> None:
     _console.print(table)
 
 
-def register(app: typer.Typer) -> None:
+def register(app: typer.Typer, *, rich_help_panel: str | None = None) -> None:
     """Attach the platform commands to the root CLI."""
-    app.command("login")(login)
-    app.command("logout")(logout)
-    app.command("status")(status)
-    app.command("push")(push)
-    app.command("pull")(pull)
+    app.command("login", rich_help_panel=rich_help_panel)(login)
+    app.command("logout", rich_help_panel=rich_help_panel)(logout)
+    app.command("status", rich_help_panel=rich_help_panel)(status)
+    app.command("push", rich_help_panel=rich_help_panel)(push)
+    app.command("pull", rich_help_panel=rich_help_panel)(pull)


### PR DESCRIPTION
## Summary

#243 

Groups root `wmh` / `wmh --help` commands by feature using Typer/Rich help panels.

<img width="1130" height="595" alt="image" src="https://github.com/user-attachments/assets/abec5d3b-b3d1-4dd6-9114-3d743a88300c" />


## Notes

Command names and descriptions are unchanged.

Feel free to suggest category changes.