### PR TITLE
Add wmh harness improve: feedback-directed, world-model-gated one-step self-edit

### DIFF
--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -27,6 +27,7 @@ from rich.table import Table
 from wmh.agents.default import default_agent
 from wmh.agents.optimizer import optimizer_agent
 from wmh.agents.project import AgentProject
+from wmh.cli.harness_improve import improve_harness_command
 from wmh.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
 from wmh.config import ARTIFACT_DIR, WorldModelStore
 from wmh.config.store import validate_name
@@ -72,6 +73,10 @@ harness_app = typer.Typer(
     no_args_is_help=True,
 )
 _console = Console()
+
+# Feedback-directed one-step improvement lives in its own module; mount it as `wmh harness
+# improve` here so the harness app stays the single mount point for harness subcommands.
+harness_app.command("improve")(improve_harness_command)
 
 
 @harness_app.command("list")

--- a/wmh/cli/harness_improve.py
+++ b/wmh/cli/harness_improve.py
@@ -1,0 +1,397 @@
+"""Local CLI composition for feedback-directed one-step harness improvement.
+
+The `improve` subcommand mounts under `wmh harness`: `harness_app.py` registers
+`improve_harness_command` via `harness_app.command("improve")(...)`. One piece of user feedback
+becomes the proposer directive and is synthesized (through settings ``models.meta``) into
+must-pass verification tasks; tasks the seed already passes are dropped before any optimization
+spend. Candidates are scored closed-loop against the world model by
+:class:`wmh.evals.world_model_scorer.WorldModelScorer`, and promotion is decided by
+:func:`wmh.harness.improve.improve_harness`'s explicit gate. The evaluated harness runs locally
+in this version; the proposer project is always an E2B `AgentProject`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+from rich.prompt import Confirm
+
+from wmh.agents.default import default_agent
+from wmh.agents.optimizer import optimizer_agent
+from wmh.agents.project import AgentProject
+from wmh.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
+from wmh.config import ARTIFACT_DIR, ArtifactPaths, WorldModelStore
+from wmh.config.store import validate_name
+from wmh.core.types import JsonObject
+from wmh.engine import load_world_model
+from wmh.engine.knowledge import KnowledgeBase
+from wmh.evals.gold import GoldJudge
+from wmh.evals.tasks import TaskSpec, load_tasks
+from wmh.evals.world_model_scorer import WorldModelScorer
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.e2b_sandbox import E2B_TEMPLATE_ENV, resolve_e2b_template
+from wmh.harness.improve import (
+    DEFAULT_SUITE_MARGIN,
+    ImproveGate,
+    ImproveOutcome,
+    improve_harness,
+    verification_results,
+)
+from wmh.harness.population import SlotOutcome, write_json_atomic
+from wmh.harness.project_proposer import CandidateProject, ProjectCandidateProposer
+from wmh.harness.source_tree import HarnessSourceTree
+from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
+from wmh.providers.base import Provider, ProviderConfig, ToolCallingProvider
+from wmh.providers.registry import get_provider
+from wmh.scenarios.feedback import synthesize_verification_tasks
+
+_console = Console()
+
+
+@dataclass(frozen=True)
+class ImproveAlreadySatisfied:
+    """QA outcome: the seed already passes every synthesized verification task."""
+
+    dropped: tuple[str, ...]
+    run_dir: Path
+
+
+@dataclass(frozen=True)
+class HarnessImproveOutcome:
+    """Completed local improve-run artifacts and the optional published version."""
+
+    outcome: ImproveOutcome
+    saved: HarnessDoc | None
+    run_dir: Path
+    dropped: tuple[str, ...]
+
+
+def improve_harness_command(
+    name: str = typer.Argument(..., help="Harness name to improve; accepted winners save here."),
+    feedback: str | None = typer.Option(
+        None,
+        "--feedback",
+        help="One piece of user feedback naming the capability the harness should gain.",
+    ),
+    feedback_file: str | None = typer.Option(
+        None,
+        "--feedback-file",
+        help="Read the feedback text from this file instead of --feedback.",
+    ),
+    tasks_file: str = typer.Option(
+        ...,
+        "--tasks",
+        help="JSONL standard suite the improved harness must not regress on.",
+    ),
+    model: str = typer.Option(
+        ...,
+        "--model",
+        help="World model that simulates the environment for every evaluation.",
+    ),
+    verification_count: int = typer.Option(
+        3,
+        "--verification-count",
+        min=1,
+        help="Maximum number of must-pass verification tasks synthesized from the feedback.",
+    ),
+    margin: float = typer.Option(
+        DEFAULT_SUITE_MARGIN,
+        "--margin",
+        help="Allowed relative suite regression, a fraction in [0, 1).",
+    ),
+    iterations: int = typer.Option(1, min=1, help="Fixed number of singular proposal slots."),
+    attempts: int = typer.Option(3, min=1, help="Attempts per exact task and candidate."),
+    e2b_template: str | None = typer.Option(
+        None,
+        "--e2b-template",
+        envvar=E2B_TEMPLATE_ENV,
+        help="Optional template for the E2B proposer project.",
+    ),
+    seed: str | None = typer.Option(
+        None,
+        "--seed",
+        help="Stored harness name@ref to improve; default is NAME's champion when it exists, "
+        "else the complete built-in default agent.",
+    ),
+    seed_knowledge: bool = typer.Option(
+        True,
+        "--seed-knowledge/--no-seed-knowledge",
+        help="Write the synthesized environment knowledge into the world model's knowledge dir.",
+    ),
+    run_dir_option: str = typer.Option(
+        ...,
+        "--run-dir",
+        help="Directory holding ALL durable run state (required).",
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, help="Project artifact root and harness store."),
+    yes: bool = typer.Option(False, "--yes", help="Acknowledge the displayed execution matrix."),
+) -> None:
+    """Improve a harness from one piece of feedback, gated on the suite plus verification.
+
+    The feedback becomes the proposer directive and is synthesized (via settings
+    ``models.meta``, which also drives the proposer) into must-pass verification tasks; tasks
+    the seed already passes are dropped before any optimization spend. Candidates are scored
+    closed-loop against the world model (the agent under test resolves from settings
+    ``models.agent`` when set, else the world model's provider). A candidate is promoted only
+    when its standard suite score stays within ``--margin`` of the seed AND every surviving
+    verification task passes a strict majority of attempts.
+    """
+    try:
+        validate_name(name)
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if (feedback is None) == (feedback_file is None):
+        raise typer.BadParameter("provide exactly one of --feedback or --feedback-file")
+    if feedback_file is not None:
+        try:
+            feedback = Path(feedback_file).read_text(encoding="utf-8")
+        except OSError as error:
+            raise typer.BadParameter(
+                f"cannot read --feedback-file {feedback_file!r}: {error}"
+            ) from error
+    assert feedback is not None
+    if not feedback.strip():
+        raise typer.BadParameter("the feedback text is empty")
+    try:
+        gate = ImproveGate(suite_margin=margin)
+    except ValidationError as error:
+        raise typer.BadParameter(
+            f"--margin must be a fraction in [0, 1): {error}", param_hint="--margin"
+        ) from error
+    try:
+        suite_tasks = load_tasks(tasks_file)
+    except (OSError, ValueError) as error:
+        raise typer.BadParameter(f"cannot load tasks from {tasks_file!r}: {error}") from error
+    meta_config = resolve_required_model_config(root, "meta")
+    run_dir = Path(run_dir_option)
+    if (run_dir / "state.json").exists() or (run_dir / "run-config.json").exists():
+        raise typer.BadParameter(
+            f"{run_dir} already holds durable run state; choose a fresh --run-dir"
+        )
+
+    planned_cells = (iterations + 1) * (len(suite_tasks) + verification_count) * attempts
+    qa_cells = verification_count * attempts
+    _console.print(
+        f"feedback improvement: 1 seed + {iterations} proposal slot(s), {len(suite_tasks)} "
+        f"suite task(s) + up to {verification_count} verification task(s), {attempts} "
+        f"attempt(s) -> up to {planned_cells} score cells (+ up to {qa_cells} seed QA cells); "
+        f"gate: suite within {gate.suite_margin:.0%} of seed, every verification task passes; "
+        f"evaluated harness backend=local; proposer project=e2b -> {run_dir}"
+    )
+    if not yes:
+        if not _console.is_terminal:
+            raise typer.BadParameter("pass --yes to acknowledge the execution matrix")
+        if not Confirm.ask("Proceed?", default=False):
+            raise typer.Exit(0)
+
+    result = _execute_improvement(
+        name=name,
+        root=root,
+        run_dir=run_dir,
+        feedback=feedback,
+        suite_tasks=suite_tasks,
+        model=model,
+        verification_count=verification_count,
+        gate=gate,
+        iterations=iterations,
+        attempts=attempts,
+        e2b_template=resolve_e2b_template(e2b_template),
+        seed_reference=seed,
+        seed_knowledge=seed_knowledge,
+        meta_config=meta_config,
+    )
+    if isinstance(result, ImproveAlreadySatisfied):
+        dropped = ", ".join(result.dropped)
+        _console.print(
+            f"[yellow]feedback appears already satisfied[/yellow]: the seed harness already "
+            f"passes all {len(result.dropped)} synthesized verification task(s) ({dropped}); "
+            "no optimization was run"
+        )
+        raise typer.Exit(1)
+    outcome = result.outcome
+    if outcome.accepted:
+        assert result.saved is not None
+        assert outcome.candidate_suite_score is not None
+        passed = sum(1 for item in outcome.verification if item.passed)
+        _console.print(
+            f"[green]improved[/green] [bold]{name}[/bold] v{result.saved.version} (champion) "
+            f"suite={outcome.candidate_suite_score:.6f} (seed {outcome.seed_suite_score:.6f}); "
+            f"verification {passed}/{len(outcome.verification)} passed; "
+            f"evidence -> {result.run_dir}"
+        )
+        return
+    _console.print(
+        f"[yellow]rejected[/yellow] [bold]{name}[/bold]: {outcome.reason}; "
+        f"evidence -> {result.run_dir}"
+    )
+
+
+def _execute_improvement(
+    *,
+    name: str,
+    root: str,
+    run_dir: Path,
+    feedback: str,
+    suite_tasks: list[TaskSpec],
+    model: str,
+    verification_count: int,
+    gate: ImproveGate,
+    iterations: int,
+    attempts: int,
+    e2b_template: str | None,
+    seed_reference: str | None,
+    seed_knowledge: bool,
+    meta_config: ProviderConfig,
+) -> HarnessImproveOutcome | ImproveAlreadySatisfied:
+    """Synthesize the gate, QA it against the seed, run one improvement, and publish evidence."""
+    meta_provider = get_provider(meta_config)
+    if not isinstance(meta_provider, ToolCallingProvider):
+        raise typer.BadParameter("settings [models.meta] provider lacks structured tool calling")
+    if not isinstance(meta_provider, Provider):
+        raise typer.BadParameter("settings [models.meta] provider lacks plain completions")
+    world_store = WorldModelStore(root)
+    try:
+        model_dir = world_store.resolve(model)
+    except (FileNotFoundError, ValueError) as error:
+        raise typer.BadParameter(str(error)) from error
+    world_model, wm_provider = load_world_model(model_dir)
+    agent_provider, _agent_model = resolve_opt_in_model_provider(root, "agent", wm_provider)
+    judge = GoldJudge(wm_provider)
+    seed_source = _resolve_seed_source(root, name=name, seed=seed_reference)
+    seed_doc = seed_source.to_doc("candidate-0000")
+
+    synthesis = synthesize_verification_tasks(
+        feedback,
+        provider=meta_provider,
+        count=verification_count,
+    )
+    suite_ids = {task.task_id for task in suite_tasks}
+    collisions = sorted({task.task_id for task in synthesis.tasks} & suite_ids)
+    if collisions:
+        raise ValueError(
+            f"synthesized verification task id(s) collide with the suite: {collisions}"
+        )
+
+    def build_scorer(tasks: list[TaskSpec]) -> WorldModelScorer:
+        return WorldModelScorer(
+            world_model=world_model,
+            tasks=tasks,
+            agent_provider=agent_provider,
+            judge=judge,
+            attempts=attempts,
+            eval_concurrency=1,
+        )
+
+    # QA: a verification task the seed already passes verifies nothing new; drop it before it
+    # can make the gate pass vacuously.
+    qa_scorer = build_scorer(list(synthesis.tasks))
+    qa_report = qa_scorer.score(seed_doc)
+    qa_outcomes = verification_results(qa_report, [task.task_id for task in synthesis.tasks])
+    dropped = tuple(item.task_id for item in qa_outcomes if item.passed)
+    surviving = [task for task in synthesis.tasks if task.task_id not in set(dropped)]
+    if not surviving:
+        return ImproveAlreadySatisfied(dropped=dropped, run_dir=run_dir)
+
+    knowledge_file: str | None = None
+    if seed_knowledge and synthesis.knowledge_notes:
+        knowledge_file = _write_feedback_knowledge(
+            model_dir, feedback=feedback, notes=synthesis.knowledge_notes
+        )
+        _console.print(f"wrote environment knowledge -> {model_dir / 'knowledge'}/{knowledge_file}")
+
+    full_scorer = build_scorer([*suite_tasks, *surviving])
+
+    def project_factory() -> CandidateProject:
+        return AgentProject.create(
+            template=e2b_template,
+            metadata={"wmh_component": "harness_improve"},
+        )
+
+    proposer = ProjectCandidateProposer(
+        optimizer_agent(),
+        meta_provider,
+        project_factory=project_factory,
+        run_dir=run_dir,
+        directive=feedback,
+        on_event=None,
+    )
+
+    def _on_boundary(outcome: SlotOutcome) -> None:
+        if outcome.evaluated is None:
+            _console.print(
+                f"  [slot {outcome.slot}] {outcome.candidate_id}: invalid ({outcome.reason})"
+            )
+        else:
+            tag = "seed" if outcome.slot == 0 else f"slot {outcome.slot}"
+            _console.print(f"  [{tag}] {outcome.candidate_id}: score={outcome.evaluated.score:.3f}")
+
+    outcome = improve_harness(
+        seed=seed_source,
+        feedback=feedback,
+        suite_task_ids=[task.task_id for task in suite_tasks],
+        verification_task_ids=[task.task_id for task in surviving],
+        scorer=full_scorer,
+        proposer=proposer,
+        run_dir=run_dir,
+        iterations=iterations,
+        gate=gate,
+        on_boundary=_on_boundary,
+    )
+
+    payload: JsonObject = {
+        "schema_version": 1,
+        "accepted": outcome.accepted,
+        "reason": outcome.reason,
+        "feedback": feedback,
+        "seed_suite_score": outcome.seed_suite_score,
+        "candidate_suite_score": outcome.candidate_suite_score,
+        "selected_candidate_id": (
+            outcome.selected.candidate_id if outcome.selected is not None else None
+        ),
+        "verification": [item.model_dump(mode="json") for item in outcome.verification],
+        "suite_task_ids": [task.task_id for task in suite_tasks],
+        "verification_task_ids": [task.task_id for task in surviving],
+        "dropped_verification_task_ids": list(dropped),
+        "suite_margin": gate.suite_margin,
+        "knowledge_file": knowledge_file,
+    }
+    write_json_atomic(run_dir / "improve-outcome.json", payload)
+
+    saved: HarnessDoc | None = None
+    if outcome.accepted:
+        assert outcome.selected is not None
+        selected_doc = outcome.selected.candidate.model_copy(update={"name": name, "version": 0})
+        saved = HarnessStore(root).save_version(selected_doc, alias=CHAMPION_ALIAS)
+    return HarnessImproveOutcome(
+        outcome=outcome,
+        saved=saved,
+        run_dir=run_dir,
+        dropped=dropped,
+    )
+
+
+def _write_feedback_knowledge(model_dir: Path, *, feedback: str, notes: str) -> str:
+    """Write the synthesized environment facts as one new feedback-keyed knowledge file."""
+    digest = hashlib.sha256(feedback.encode("utf-8")).hexdigest()[:12]
+    file_name = f"feedback-{digest}.md"
+    KnowledgeBase(ArtifactPaths(model_dir).knowledge).write_file(file_name, notes.rstrip() + "\n")
+    return file_name
+
+
+def _resolve_seed_source(root: str, *, name: str, seed: str | None) -> HarnessSourceTree:
+    """Resolve the seed: an explicit ref, NAME's champion when it exists, else the baseline."""
+    store = HarnessStore(root)
+    if seed is not None:
+        base, _, ref = seed.partition("@")
+        try:
+            return HarnessSourceTree.from_doc(store.load(base, ref or None))
+        except (FileNotFoundError, ValueError) as error:
+            raise typer.BadParameter(str(error)) from error
+    if store.exists(name):
+        return HarnessSourceTree.from_doc(store.load(name))
+    return HarnessSourceTree.from_doc(default_agent())

--- a/wmh/cli/harness_improve_test.py
+++ b/wmh/cli/harness_improve_test.py
@@ -1,0 +1,336 @@
+"""CLI tests for feedback-directed harness improvement (execution seam monkeypatched)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import cast
+
+import pytest
+from typer.testing import CliRunner
+
+from wmh.cli import app
+from wmh.cli.harness_improve import HarnessImproveOutcome, ImproveAlreadySatisfied
+from wmh.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
+from wmh.harness.improve import ImproveGate, ImproveOutcome, VerificationResult
+from wmh.harness.population import EvaluatedCandidate, PopulationResult, SlotOutcome
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+from wmh.providers.base import ProviderConfig
+
+module = importlib.import_module("wmh.cli.harness_improve")
+runner = CliRunner()
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n',
+            ),
+        )
+    )
+
+
+def _evaluated(candidate_id: str, source: HarnessSourceTree) -> EvaluatedCandidate:
+    doc = source.to_doc(candidate_id)
+    request = ScoreRequest(task_ids=("suite-a", "feedback-verify-01"), attempts=1)
+    report = ScoreReport(
+        doc_hash=doc.doc_hash,
+        request=request,
+        reward_mode="positive-binary",
+        cells=(
+            ScoreCell(task_id="suite-a", attempt=1, reward=0.8, passed=True, note="suite"),
+            ScoreCell(
+                task_id="feedback-verify-01", attempt=1, reward=1.0, passed=True, note="verify"
+            ),
+        ),
+    )
+    return EvaluatedCandidate(candidate_id=candidate_id, source=source, report=report)
+
+
+def _accepted_outcome() -> ImproveOutcome:
+    evaluated = _evaluated("candidate-0000", _source("seed"))
+    result = PopulationResult(
+        outcomes=(SlotOutcome(slot=0, candidate_id="candidate-0000", evaluated=evaluated),),
+        population=(evaluated,),
+        best=evaluated,
+        completed=True,
+    )
+    return ImproveOutcome(
+        accepted=True,
+        reason="candidate-0000 passed the gate",
+        seed_suite_score=0.7,
+        candidate_suite_score=0.8,
+        verification=(
+            VerificationResult(task_id="feedback-verify-01", passed=True, pass_count=1, attempts=1),
+        ),
+        selected=evaluated,
+        result=result,
+    )
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / ".wmh"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                meta=ModelRole(provider="openai_responses", model="meta-model"),
+            )
+        ),
+        root,
+    )
+    tasks_path = tmp_path / "suite.jsonl"
+    tasks_path.write_text(
+        '{"task_id": "suite-a", "instruction": "do a", "gold": ["done"]}\n',
+        encoding="utf-8",
+    )
+    return root, tasks_path
+
+
+def test_cli_requires_exactly_one_feedback_source(tmp_path: Path) -> None:
+    _root, tasks_path = _write_inputs(tmp_path)
+    run_dir = tmp_path / "run"
+
+    neither = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+    assert neither.exit_code == 2
+    assert "exactly one of --feedback or --feedback-file" in neither.output
+
+    feedback_file = tmp_path / "feedback.txt"
+    feedback_file.write_text("give me GitHub access\n", encoding="utf-8")
+    both = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--run-dir",
+            str(run_dir),
+            "--feedback",
+            "text",
+            "--feedback-file",
+            str(feedback_file),
+        ],
+    )
+    assert both.exit_code == 2
+    assert "exactly one of --feedback or --feedback-file" in both.output
+
+
+def test_cli_requires_explicit_confirmation_in_noninteractive_mode(tmp_path: Path) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--feedback",
+            "give me GitHub access",
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert invoked.exit_code == 2
+    assert "pass --yes" in invoked.output
+
+
+def test_cli_composes_inputs_and_prints_the_accepted_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    feedback_file = tmp_path / "feedback.txt"
+    feedback_file.write_text("give me GitHub access\n", encoding="utf-8")
+    run_dir = tmp_path / "improve-run"
+    calls: list[dict[str, object]] = []
+    outcome = _accepted_outcome()
+
+    def fake_execute(**kwargs: object) -> HarnessImproveOutcome:
+        calls.append(kwargs)
+        assert outcome.selected is not None
+        saved = outcome.selected.candidate.model_copy(update={"name": "helper", "version": 4})
+        return HarnessImproveOutcome(
+            outcome=outcome,
+            saved=saved,
+            run_dir=cast("Path", kwargs["run_dir"]),
+            dropped=("feedback-verify-02",),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_execute)
+
+    invoked = runner.invoke(
+        app,
+        [
+            "harness",
+            "improve",
+            "helper",
+            "--feedback-file",
+            str(feedback_file),
+            "--tasks",
+            str(tasks_path),
+            "--model",
+            "wm",
+            "--verification-count",
+            "2",
+            "--margin",
+            "0.2",
+            "--iterations",
+            "3",
+            "--attempts",
+            "5",
+            "--seed",
+            "other@2",
+            "--no-seed-knowledge",
+            "--run-dir",
+            str(run_dir),
+            "--root",
+            str(root),
+            "--yes",
+        ],
+    )
+
+    assert invoked.exit_code == 0, invoked.output
+    normalized = " ".join(invoked.output.split())
+    assert "improved" in normalized
+    assert "v4" in normalized
+    assert "verification 1/1 passed" in normalized
+    [call] = calls
+    assert call["name"] == "helper"
+    assert call["feedback"] == "give me GitHub access\n"
+    assert call["model"] == "wm"
+    assert call["verification_count"] == 2
+    assert call["gate"] == ImproveGate(suite_margin=0.2)
+    assert call["iterations"] == 3
+    assert call["attempts"] == 5
+    assert call["seed_reference"] == "other@2"
+    assert call["seed_knowledge"] is False
+    assert call["run_dir"] == run_dir
+    assert cast("ProviderConfig", call["meta_config"]).model == "meta-model"
+
+
+def test_cli_reports_rejection_and_already_satisfied_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    rejected = ImproveOutcome(
+        accepted=False,
+        reason="suite regression beyond margin: best candidate candidate-0001 scored 0.5",
+        seed_suite_score=0.8,
+        candidate_suite_score=None,
+        verification=(),
+        selected=None,
+        result=_accepted_outcome().result,
+    )
+
+    def fake_rejected(**kwargs: object) -> HarnessImproveOutcome:
+        return HarnessImproveOutcome(
+            outcome=rejected,
+            saved=None,
+            run_dir=cast("Path", kwargs["run_dir"]),
+            dropped=(),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_rejected)
+    argv = [
+        "harness",
+        "improve",
+        "helper",
+        "--feedback",
+        "give me GitHub access",
+        "--tasks",
+        str(tasks_path),
+        "--model",
+        "wm",
+        "--run-dir",
+        str(tmp_path / "run"),
+        "--root",
+        str(root),
+        "--yes",
+    ]
+
+    invoked = runner.invoke(app, argv)
+    assert invoked.exit_code == 0, invoked.output
+    assert "rejected" in invoked.output
+    assert "suite regression beyond margin" in invoked.output
+
+    def fake_satisfied(**kwargs: object) -> ImproveAlreadySatisfied:
+        return ImproveAlreadySatisfied(
+            dropped=("feedback-verify-01",),
+            run_dir=cast("Path", kwargs["run_dir"]),
+        )
+
+    monkeypatch.setattr(module, "_execute_improvement", fake_satisfied)
+    satisfied = runner.invoke(app, argv)
+    assert satisfied.exit_code == 1
+    assert "already satisfied" in satisfied.output
+    assert "feedback-verify-01" in satisfied.output
+
+
+def test_cli_rejects_invalid_margin_and_existing_run_dir(tmp_path: Path) -> None:
+    root, tasks_path = _write_inputs(tmp_path)
+    base = [
+        "harness",
+        "improve",
+        "helper",
+        "--feedback",
+        "give me GitHub access",
+        "--tasks",
+        str(tasks_path),
+        "--model",
+        "wm",
+        "--root",
+        str(root),
+        "--yes",
+    ]
+
+    bad_margin = runner.invoke(app, [*base, "--run-dir", str(tmp_path / "m"), "--margin", "1.0"])
+    assert bad_margin.exit_code == 2
+    assert "--margin" in bad_margin.output
+
+    taken = tmp_path / "taken"
+    taken.mkdir()
+    (taken / "state.json").write_text("{}", encoding="utf-8")
+    existing = runner.invoke(app, [*base, "--run-dir", str(taken)])
+    assert existing.exit_code == 2
+    # The panel wraps and inserts box borders, so assert on a short unbroken tail of the message.
+    assert "run-dir" in existing.output
+
+
+def test_cli_help_names_the_gate_and_feedback_inputs() -> None:
+    invoked = runner.invoke(app, ["harness", "improve", "--help"])
+
+    assert invoked.exit_code == 0, invoked.output
+    # The 80-column help panel truncates long option names, so assert stable prefixes.
+    assert "--feedback" in invoked.output
+    assert "--verification" in invoked.output
+    assert "--margin" in invoked.output
+    assert "--seed-knowled" in invoked.output
+    assert "--run-dir" in invoked.output
+    assert "models.meta" in invoked.output
+    assert "name@ref" in invoked.output

--- a/wmh/engine/loader.py
+++ b/wmh/engine/loader.py
@@ -20,17 +20,23 @@ def load_world_model(
     *,
     telemetry_root: str | Path | None = None,
     max_fidelity: bool = False,
+    knowledge_dir: str | Path | None = None,
 ) -> tuple[WorldModel, Provider]:
     """Load the world model under `model_dir`, returning it with the serve provider it was built on.
 
     The provider is returned alongside so callers that also need it (e.g. `wmh demo`, which runs an
     LLM agent against the same provider) don't re-read the config or reconstruct it.
     `max_fidelity` turns on the online extras (the build-measured winner when the artifact has
-    one); a plain load runs pure RAG.
+    one); a plain load runs pure RAG. `knowledge_dir` overrides where the knowledge base reads and
+    writes, leaving the (often read-only, shared) bundle untouched; None keeps the artifact path.
     """
     config = load_config(str(model_dir))
     provider = provider_or_chain(config.serve_provider_config())
     wm = WorldModel.load(
-        str(model_dir), provider, telemetry_root=telemetry_root, max_fidelity=max_fidelity
+        str(model_dir),
+        provider,
+        telemetry_root=telemetry_root,
+        max_fidelity=max_fidelity,
+        knowledge_dir=knowledge_dir,
     )
     return wm, provider

--- a/wmh/engine/loader_test.py
+++ b/wmh/engine/loader_test.py
@@ -1,0 +1,75 @@
+"""Tests for `load_world_model`: it forwards the load knobs and returns the serve provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import wmh.engine.loader as loader_module
+from wmh.config import HarnessConfig, save_config
+from wmh.engine.loader import load_world_model
+from wmh.providers.base import ProviderConfig, ProviderKind
+
+
+def _bedrock_config() -> HarnessConfig:
+    """A minimal config whose serve provider resolves (loader builds it before loading)."""
+    return HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="m")],
+        serve_provider=ProviderKind.BEDROCK,
+    )
+
+
+def _record_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, Any], object]:
+    """Patch out the provider factory and `WorldModel.load`; return the captured kwargs + provider.
+
+    Keeps the test hermetic: `load_config` still runs on a real saved config, but no live provider
+    is constructed and no artifact is loaded. The returned dict records exactly what the loader
+    forwarded into `WorldModel.load`.
+    """
+    sentinel_provider = object()
+    sentinel_wm = object()
+    captured: dict[str, Any] = {}
+
+    def fake_provider_or_chain(config: object) -> object:
+        return sentinel_provider
+
+    def fake_load(model_dir: str, provider: object, **kwargs: object) -> object:
+        captured["model_dir"] = model_dir
+        captured["provider"] = provider
+        captured["kwargs"] = kwargs
+        return sentinel_wm
+
+    monkeypatch.setattr(loader_module, "provider_or_chain", fake_provider_or_chain)
+    monkeypatch.setattr(loader_module.WorldModel, "load", staticmethod(fake_load))
+    return captured, sentinel_provider
+
+
+def test_forwards_knowledge_dir_and_returns_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmh"
+    save_config(_bedrock_config(), root=root)
+    captured, sentinel_provider = _record_load(monkeypatch)
+    override = tmp_path / "run-knowledge"
+
+    wm, provider = load_world_model(root, knowledge_dir=override, max_fidelity=True)
+
+    assert provider is sentinel_provider
+    assert wm is not None
+    assert captured["kwargs"]["knowledge_dir"] == override
+    assert captured["kwargs"]["max_fidelity"] is True
+
+
+def test_defaults_knowledge_dir_to_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / ".wmh"
+    save_config(_bedrock_config(), root=root)
+    captured, _ = _record_load(monkeypatch)
+
+    load_world_model(root)
+
+    assert captured["kwargs"]["knowledge_dir"] is None
+    assert captured["kwargs"]["max_fidelity"] is False

--- a/wmh/engine/world_model.py
+++ b/wmh/engine/world_model.py
@@ -101,6 +101,7 @@ class WorldModel:
         telemetry_root: str | Path | None = None,
         reward_provider: Provider | None = None,
         max_fidelity: bool = False,
+        knowledge_dir: str | Path | None = None,
     ) -> WorldModel:
         """Construct from a built `.wmh/` artifact (optimized prompt + indexed replay buffer).
 
@@ -114,6 +115,14 @@ class WorldModel:
         (config.toml's `reasoning`/`knowledge`/`verify`/`grounder`). `max_fidelity=True` turns on
         the online extras: the build-measured winner from `auto_fidelity.json` when the artifact
         has one (high/max-tier builds), otherwise every extra the artifact can support.
+
+        `knowledge_dir` overrides where the knowledge base reads and writes: when set (and
+        knowledge is enabled), the KB is built from `knowledge_dir` instead of the artifact's own
+        `knowledge/`, leaving the (often read-only, shared) bundle untouched. Callers seed a
+        per-run temp dir and point at it; None keeps the default artifact path. It only takes
+        effect when the artifact enables knowledge (config's `knowledge` flag, or `max_fidelity`):
+        a plain RAG load stays pure RAG, so a seeded file in `knowledge_dir` is not rendered unless
+        the model was built with knowledge on.
         """
         config = load_config(artifact_dir)
         paths = ArtifactPaths(artifact_dir)
@@ -150,8 +159,9 @@ class WorldModel:
             else:
                 # No measured winner (low/medium builds): all the extras the artifact supports.
                 reasoning, verify = True, True
-                knowledge_on = paths.knowledge.is_dir()
+                knowledge_on = _knowledge_dir(paths, knowledge_dir).is_dir()
                 grounder_kind = "fetch" if grounder_kind == "none" else grounder_kind
+        effective_knowledge_dir = _knowledge_dir(paths, knowledge_dir)
         return cls(
             provider,
             retriever,
@@ -160,8 +170,8 @@ class WorldModel:
             telemetry_root=telemetry_root or _default_telemetry_root(artifact_dir),
             reward_provider=reward_provider,
             knowledge=(
-                KnowledgeBase(paths.knowledge)
-                if knowledge_on and paths.knowledge.is_dir()
+                KnowledgeBase(effective_knowledge_dir)
+                if knowledge_on and effective_knowledge_dir.is_dir()
                 else None
             ),
             reasoning=reasoning,
@@ -559,6 +569,11 @@ class WorldModel:
 
 def _user_message(text: str) -> Message:
     return Message(role="user", content=text)
+
+
+def _knowledge_dir(paths: ArtifactPaths, override: str | Path | None) -> Path:
+    """The effective knowledge directory: the caller's override when given, else the artifact's."""
+    return Path(override) if override is not None else paths.knowledge
 
 
 def _default_telemetry_root(artifact_dir: str | Path) -> Path:

--- a/wmh/engine/world_model_test.py
+++ b/wmh/engine/world_model_test.py
@@ -387,6 +387,46 @@ def test_load_picks_up_knowledge_dir_and_flags(tmp_path: Path) -> None:
     assert '"reasoning"' in user
 
 
+def test_load_knowledge_dir_override_renders_from_the_temp_dir(tmp_path: Path) -> None:
+    # The bundle's own knowledge/ is empty; a per-run override dir seeds a fact the caller
+    # controls, and that fact (not the bundle) is what renders into the env prompt.
+    root = tmp_path / ".wmh"
+    save_config(
+        HarnessConfig(serve_provider=ProviderKind.BEDROCK, reasoning=True, knowledge=True),
+        root=root,
+    )
+    override = tmp_path / "run-knowledge"
+    KnowledgeBase(override).write_file("foo.md", "- override fact: seeded per run")
+    provider = FakeProvider('{"reasoning": "r", "output": "ok", "is_error": false}')
+
+    wm = WorldModel.load(str(root), provider, knowledge_dir=override)
+
+    assert wm.knowledge is not None
+    assert "foo.md" in wm.knowledge.files()
+    session = wm.new_session(task="t")
+    wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="f", arguments={}))
+    assert "override fact: seeded per run" in (provider.last_user or "")
+
+
+def test_load_knowledge_dir_none_uses_the_artifacts_own_dir(tmp_path: Path) -> None:
+    # None override: the artifact's own knowledge/ is used unchanged.
+    root = tmp_path / ".wmh"
+    save_config(
+        HarnessConfig(serve_provider=ProviderKind.BEDROCK, reasoning=True, knowledge=True),
+        root=root,
+    )
+    KnowledgeBase(ArtifactPaths(root).knowledge).write_file("rules.md", "- gate: auth first")
+    provider = FakeProvider('{"reasoning": "r", "output": "ok", "is_error": false}')
+
+    wm = WorldModel.load(str(root), provider, knowledge_dir=None)
+
+    assert wm.knowledge is not None
+    assert wm.knowledge.directory == ArtifactPaths(root).knowledge
+    session = wm.new_session(task="t")
+    wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="f", arguments={}))
+    assert "gate: auth first" in (provider.last_user or "")
+
+
 def test_plain_load_stays_pure_rag_even_with_a_knowledge_dir(tmp_path: Path) -> None:
     # "You either just run it, or you run it with --max-fidelity": a knowledge/ dir alone must
     # not change plain-run behavior — only explicit config flags or max_fidelity activate it.

--- a/wmh/evals/world_model_scorer.py
+++ b/wmh/evals/world_model_scorer.py
@@ -1,0 +1,218 @@
+"""Closed-loop world-model projection into evaluator-neutral harness score reports.
+
+The world-model sibling of :class:`wmh.evals.harbor.scorer.HarborScorer`: both implement the
+`wmh.harness.scoring.Scorer` protocol, but this one runs the fixed agent against a SIMULATED
+environment. Every environment response comes from the world model, a :class:`GoldJudge` grades
+each rollout transcript against the task's gold assertions, and each (task, attempt) verdict
+becomes one :class:`ScoreCell`. Rollouts reuse the merged closed-loop machinery
+(`wmh.evals.closed_loop.evaluate_closed_loop`) rather than reimplementing them.
+
+Unlike the harbor scorer there is no per-trial artifact directory on the host filesystem: the
+world model produces evidence in memory, not a job directory the proposer can re-read, so every
+cell carries an empty `artifact_dir` and a short diagnostic `note`. The proposer marks those
+gaps with `NO-EVIDENCE.md`; that is the accepted local-backend behavior. `reward_mode` is
+carried on the report for record only: the closed-loop judge already decided pass/fail per its
+gold semantics, so `passed` comes from the judge and is never re-thresholded here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Protocol
+
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import (
+    ClosedLoopReport,
+    RolloutEvidence,
+    evaluate_closed_loop,
+)
+from wmh.evals.gold import GoldJudge, GoldVerdict
+from wmh.evals.tasks import TaskSpec
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.runtime import HarnessSearchCancelled, Runtime, RuntimeCancelled
+from wmh.harness.scoring import (
+    MAX_CELL_NOTE_CHARS,
+    RewardMode,
+    ScoreCell,
+    ScoreReport,
+    ScoreRequest,
+)
+from wmh.providers.base import Provider
+
+# The rollout evidence rationale is folded into a bounded cell note; keep it well under the
+# frozen MAX_CELL_NOTE_CHARS so the leading diagnostic prefix always survives.
+_NOTE_RATIONALE_CHARS = 1_500
+
+
+class ClosedLoopEvaluate(Protocol):
+    """The exact rollout seam `evaluate_closed_loop` satisfies.
+
+    The scorer owns request minting and cell projection; the seam owns rollouts and judging.
+    Tests inject a fake here so no provider, world model, or sandbox is exercised.
+    """
+
+    def __call__(
+        self,
+        tasks: list[TaskSpec],
+        world_model: WorldModel,
+        agent_provider: Provider,
+        judge: GoldJudge,
+        *,
+        label: str,
+        k: int,
+        concurrency: int,
+        runtime: Runtime | None,
+        on_progress: Callable[[str, int, GoldVerdict], None] | None,
+        should_cancel: Callable[[], bool] | None,
+    ) -> ClosedLoopReport: ...
+
+
+class WorldModelScorer:
+    """Evaluate exact harness candidates closed-loop against a simulated environment.
+
+    Each `score` call runs `request.attempts` passes per configured task with the world model
+    answering every environment action, judges each rollout with the configured `GoldJudge`,
+    and projects the per-task verdicts onto the exact requested cell matrix. The backend is
+    local only: `evaluate_closed_loop` runs the fixed `agent_provider` through an
+    `AgentRuntime` in-process, so there is no e2b harness backend, no sandbox pool, and no
+    execution digest.
+    """
+
+    def __init__(
+        self,
+        *,
+        world_model: WorldModel,
+        tasks: Sequence[TaskSpec],
+        agent_provider: Provider,
+        judge: GoldJudge,
+        attempts: int,
+        reward_mode: RewardMode = "positive-binary",
+        eval_concurrency: int = 1,
+        should_cancel: Callable[[], bool] | None = None,
+        evaluate: ClosedLoopEvaluate | None = None,
+    ) -> None:
+        task_list = [TaskSpec.model_validate(task.model_dump(mode="python")) for task in tasks]
+        if not task_list:
+            raise ValueError("tasks must be nonempty")
+        ids = [task.task_id for task in task_list]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate task_id(s): {duplicates}")
+        if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 1:
+            raise ValueError("attempts must be a positive integer")
+        if (
+            isinstance(eval_concurrency, bool)
+            or not isinstance(eval_concurrency, int)
+            or eval_concurrency < 0
+        ):
+            raise ValueError("eval_concurrency must be an integer >= 0 (0 runs every cell at once)")
+        if reward_mode not in ("raw", "positive-binary"):
+            raise ValueError("reward_mode must be raw or positive-binary")
+        self._world_model = world_model
+        self._tasks = tuple(task_list)
+        self._tasks_by_id = {task.task_id: task for task in task_list}
+        self._task_ids = tuple(task.task_id for task in task_list)
+        self._agent_provider = agent_provider
+        self._judge = judge
+        self._attempts = attempts
+        self._reward_mode: RewardMode = reward_mode
+        self._eval_concurrency = eval_concurrency
+        self._should_cancel = should_cancel
+        self._evaluate: ClosedLoopEvaluate = (
+            evaluate if evaluate is not None else evaluate_closed_loop
+        )
+
+    @property
+    def request(self) -> ScoreRequest:
+        """The exact task-by-attempt matrix every `score` call evaluates (configured order)."""
+        return ScoreRequest(task_ids=self._task_ids, attempts=self._attempts)
+
+    @property
+    def reward_mode(self) -> RewardMode:
+        """The frozen reward interpretation carried on every report (record only)."""
+        return self._reward_mode
+
+    def score(
+        self,
+        doc: HarnessDoc,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ScoreReport:
+        """Run one candidate closed-loop and project its judged verdicts into cells.
+
+        The scorer always evaluates its full configured suite: main's `ScoreRequest` carries no
+        subset, and `optimize` always calls `score(doc)` with the scorer's own request.
+        """
+        cancel = should_cancel if should_cancel is not None else self._should_cancel
+        _check_cancelled(cancel)
+        try:
+            report = self._evaluate(
+                list(self._tasks),
+                self._world_model,
+                self._agent_provider,
+                self._judge,
+                label=doc.name,
+                k=self._attempts,
+                concurrency=self._eval_concurrency,
+                runtime=None,
+                on_progress=None,
+                should_cancel=cancel,
+            )
+        except RuntimeCancelled as error:
+            # Cancelled cells are not scoreable outcomes: convert at the scorer boundary so
+            # population.optimize propagates it as a search cancellation, never a partial report.
+            raise HarnessSearchCancelled(
+                "harness score cancelled", worker_usage=error.worker_usage
+            ) from error
+        return self._project(doc, report)
+
+    def _project(self, doc: HarnessDoc, report: ClosedLoopReport) -> ScoreReport:
+        """Map the closed-loop report onto the exact requested cell matrix, fail-closed."""
+        cells: list[ScoreCell] = []
+        for task_id in self._task_ids:
+            outcome = report.per_task.get(task_id)
+            if outcome is None:
+                raise ValueError(f"closed-loop report is missing task {task_id!r}")
+            if len(outcome.verdicts) != self._attempts or len(outcome.attempts) != self._attempts:
+                raise ValueError(
+                    f"closed-loop report for task {task_id!r} does not carry exactly "
+                    f"{self._attempts} judged attempt(s)"
+                )
+            for attempt in range(1, self._attempts + 1):
+                verdict = outcome.verdicts[attempt - 1]
+                evidence = outcome.attempts[attempt - 1]
+                cells.append(
+                    ScoreCell(
+                        task_id=task_id,
+                        attempt=attempt,
+                        # verdict.fraction is already in [0, 1]; passed comes straight from the
+                        # judge's gold decision and is never re-thresholded by reward_mode.
+                        reward=verdict.fraction,
+                        passed=verdict.passed,
+                        artifact_dir="",
+                        note=_cell_note(verdict, evidence),
+                    )
+                )
+        return ScoreReport(
+            doc_hash=doc.doc_hash,
+            request=self.request,
+            reward_mode=self._reward_mode,
+            cells=tuple(cells),
+        )
+
+
+def _cell_note(verdict: GoldVerdict, evidence: RolloutEvidence) -> str:
+    """One short diagnostic per cell, bounded to the frozen cell-note length."""
+    rationale = verdict.rationale
+    if len(rationale) > _NOTE_RATIONALE_CHARS:
+        rationale = rationale[:_NOTE_RATIONALE_CHARS] + " ..."
+    note = (
+        f"passed={verdict.passed} fraction={verdict.fraction:.3f} "
+        f"stop={evidence.stop_reason.value} turns={evidence.turns}: {rationale}"
+    )
+    return note[:MAX_CELL_NOTE_CHARS]
+
+
+def _check_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel is not None and should_cancel():
+        raise HarnessSearchCancelled("harness score cancelled")

--- a/wmh/evals/world_model_scorer_test.py
+++ b/wmh/evals/world_model_scorer_test.py
@@ -1,0 +1,356 @@
+"""Hermetic WorldModelScorer tests: a role-playing provider and a stubbed rollout seam.
+
+Two layers: the round-trip test drives the REAL `evaluate_closed_loop` machinery with one
+`RoleProvider` playing agent, world model, and judge (the `closed_loop_test` pattern), while the
+projection tests inject a `FakeEvaluate` seam so cell mapping and report shape are pinned without
+any rollout, provider, world model, or sandbox.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+
+from wmh.engine.world_model import WorldModel
+from wmh.evals.closed_loop import ClosedLoopReport, RolloutEvidence, TaskOutcome
+from wmh.evals.gold import AssertionResult, GoldJudge, GoldVerdict
+from wmh.evals.tasks import TaskSpec
+from wmh.evals.world_model_scorer import ClosedLoopEvaluate, WorldModelScorer
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.runtime import HarnessSearchCancelled, Runtime, RuntimeCancelled, StopReason
+from wmh.harness.scoring import RewardMode
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.retrieval import EmbeddingRetriever, HashingEmbedder
+
+
+class RoleProvider:
+    """Plays agent, world model, and gold judge, keyed off the system prompt."""
+
+    def __init__(self, *, judge_passes: bool = True, model: str = "m") -> None:
+        self.config = ProviderConfig(kind=ProviderKind.BEDROCK, model=model)
+        self._judge_passes = judge_passes
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 2048,
+    ) -> Completion:
+        del messages, temperature, max_tokens
+        if "grade whether an agent completed a task" in system:
+            passed = "true" if self._judge_passes else "false"
+            return Completion(
+                text='{"assertions": [{"assertion": "did it", "passed": '
+                + passed
+                + ', "why": "x"}], "passed": '
+                + passed
+                + "}"
+            )
+        if system.startswith("You are a capable command-line agent"):
+            return Completion(
+                text='{"tool": "submit", "arguments": {"answer": "the answer is 42"}}'
+            )
+        return Completion(text='{"output": "ok", "is_error": false}')
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201 - test fake never calls it
+        raise NotImplementedError
+
+
+def _wm(provider: RoleProvider) -> WorldModel:
+    return WorldModel(provider, EmbeddingRetriever(HashingEmbedder(dim=16)))
+
+
+def _tasks() -> list[TaskSpec]:
+    return [
+        TaskSpec(task_id="q1", instruction="answer it", gold=["did it"]),
+        TaskSpec(task_id="q2", instruction="answer it again", gold=["did it"]),
+    ]
+
+
+def _seam_tasks() -> list[TaskSpec]:
+    return [
+        TaskSpec(task_id="a", instruction="do a", gold=["g"]),
+        TaskSpec(task_id="b", instruction="do b", gold=["g"]),
+        TaskSpec(task_id="c", instruction="do c", gold=["g"]),
+    ]
+
+
+def _make_scorer(
+    *,
+    provider: RoleProvider | None = None,
+    tasks: list[TaskSpec] | None = None,
+    attempts: int = 2,
+    reward_mode: RewardMode = "positive-binary",
+    eval_concurrency: int = 1,
+    should_cancel: Callable[[], bool] | None = None,
+    evaluate: ClosedLoopEvaluate | None = None,
+) -> WorldModelScorer:
+    resolved = provider if provider is not None else RoleProvider()
+    return WorldModelScorer(
+        world_model=_wm(resolved),
+        tasks=tasks if tasks is not None else _tasks(),
+        agent_provider=resolved,
+        judge=GoldJudge(resolved),
+        attempts=attempts,
+        reward_mode=reward_mode,
+        eval_concurrency=eval_concurrency,
+        should_cancel=should_cancel,
+        evaluate=evaluate,
+    )
+
+
+class FakeEvaluate:
+    """Rollout seam stub: records every call and fabricates a `ClosedLoopReport` per plan."""
+
+    def __init__(
+        self,
+        *,
+        fractions: dict[str, list[float]] | None = None,
+        drop_last_verdict: bool = False,
+        extra_task_id: str | None = None,
+        raises: BaseException | None = None,
+    ) -> None:
+        self.fractions = fractions
+        self.drop_last_verdict = drop_last_verdict
+        self.extra_task_id = extra_task_id
+        self.raises = raises
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(
+        self,
+        tasks: list[TaskSpec],
+        world_model: WorldModel,
+        agent_provider: object,
+        judge: GoldJudge,
+        *,
+        label: str,
+        k: int,
+        concurrency: int,
+        runtime: Runtime | None,
+        on_progress: object,
+        should_cancel: Callable[[], bool] | None,
+    ) -> ClosedLoopReport:
+        del world_model, agent_provider, judge, on_progress, should_cancel
+        self.calls.append(
+            {
+                "task_ids": [task.task_id for task in tasks],
+                "label": label,
+                "k": k,
+                "concurrency": concurrency,
+                "runtime": runtime,
+            }
+        )
+        if self.raises is not None:
+            raise self.raises
+        per_task = {task.task_id: self._outcome(task, k) for task in tasks}
+        if self.extra_task_id is not None:
+            extra = TaskSpec(task_id=self.extra_task_id, instruction="extra", gold=["g"])
+            per_task[extra.task_id] = self._outcome(extra, k)
+        return ClosedLoopReport(label=label, k=k, per_task=per_task)
+
+    def _outcome(self, task: TaskSpec, k: int) -> TaskOutcome:
+        fracs = (self.fractions or {}).get(task.task_id, [1.0] * k)
+        verdicts = [
+            GoldVerdict(
+                passed=fraction == 1.0,
+                fraction=fraction,
+                assertions=[AssertionResult(assertion="g", passed=fraction == 1.0, why="w")],
+                rationale=f"{task.task_id} attempt {attempt} rationale",
+            )
+            for attempt, fraction in enumerate(fracs, 1)
+        ]
+        if self.drop_last_verdict:
+            verdicts = verdicts[:-1]
+        attempts = [
+            RolloutEvidence(
+                answer=f"answer-{task.task_id}-{attempt}",
+                transcript=f"[1] tool_call: bash cmd-{task.task_id}-{attempt}\n    -> ok",
+                stop_reason=StopReason.SUBMITTED,
+                turns=attempt,
+            )
+            for attempt in range(1, len(fracs) + 1)
+        ]
+        return TaskOutcome(
+            task_id=task.task_id,
+            success_rate=sum(1.0 for verdict in verdicts if verdict.passed) / max(len(fracs), 1),
+            mean_fraction=sum(verdict.fraction for verdict in verdicts) / max(len(fracs), 1),
+            passes=k,
+            verdicts=verdicts,
+            attempts=attempts,
+        )
+
+
+# -- request property ---------------------------------------------------------------------------
+
+
+def test_request_is_the_full_suite_in_configured_order() -> None:
+    scorer = _make_scorer(attempts=2)
+    request = scorer.request
+    assert request.task_ids == ("q1", "q2")
+    assert request.attempts == 2
+    # request is a property, stable across reads, and preserves configured order.
+    reversed_scorer = _make_scorer(tasks=list(reversed(_tasks())), attempts=1)
+    assert reversed_scorer.request.task_ids == ("q2", "q1")
+
+
+# -- end to end through the real closed-loop machinery -----------------------------------------
+
+
+def test_score_round_trips_through_real_rollouts() -> None:
+    scorer = _make_scorer(attempts=2)
+    candidate = HarnessDoc.baseline("candidate")
+
+    report = scorer.score(candidate)
+
+    assert report.doc_hash == candidate.doc_hash
+    assert report.request == scorer.request
+    assert report.reward_mode == "positive-binary"
+    assert [(cell.task_id, cell.attempt, cell.reward, cell.passed) for cell in report.cells] == [
+        ("q1", 1, 1.0, True),
+        ("q1", 2, 1.0, True),
+        ("q2", 1, 1.0, True),
+        ("q2", 2, 1.0, True),
+    ]
+    assert report.score == 1.0
+    assert report.pass_rate == 1.0
+    assert all(cell.artifact_dir == "" for cell in report.cells)
+    assert all(cell.note.startswith("passed=True fraction=1.000") for cell in report.cells)
+
+
+def test_failed_judgement_maps_to_zero_reward_cells() -> None:
+    scorer = _make_scorer(provider=RoleProvider(judge_passes=False), attempts=1)
+    report = scorer.score(HarnessDoc.baseline())
+    assert report.score == 0.0
+    assert all(not cell.passed for cell in report.cells)
+    assert all(cell.reward == 0.0 for cell in report.cells)
+
+
+# -- cell mapping through the stubbed seam ------------------------------------------------------
+
+
+def test_cells_map_fraction_passed_and_one_indexed_attempts() -> None:
+    fake = FakeEvaluate(fractions={"a": [1.0, 0.5], "b": [0.0, 1.0], "c": [1.0, 1.0]})
+    scorer = _make_scorer(tasks=_seam_tasks(), attempts=2, evaluate=fake)
+    candidate = HarnessDoc.baseline("candidate")
+
+    report = scorer.score(candidate)
+
+    assert [(cell.task_id, cell.attempt, cell.reward, cell.passed) for cell in report.cells] == [
+        ("a", 1, 1.0, True),
+        ("a", 2, 0.5, False),
+        ("b", 1, 0.0, False),
+        ("b", 2, 1.0, True),
+        ("c", 1, 1.0, True),
+        ("c", 2, 1.0, True),
+    ]
+    # report.score is the mean of per-task pass RATES: a=0.5, b=0.5, c=1.0 -> 2/3.
+    assert report.score == pytest.approx(2.0 / 3.0)
+    by_task = report.by_task()
+    assert set(by_task) == {"a", "b", "c"}
+    half_credit = next(cell for cell in report.cells if (cell.task_id, cell.attempt) == ("a", 2))
+    assert "fraction=0.500" in half_credit.note
+    assert "a attempt 2 rationale" in half_credit.note
+    assert len(half_credit.note) <= 2_000
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["k"] == 2
+    assert fake.calls[0]["concurrency"] == 1
+    assert fake.calls[0]["label"] == "candidate"
+    assert fake.calls[0]["task_ids"] == ["a", "b", "c"]
+    assert fake.calls[0]["runtime"] is None
+
+
+def test_passed_is_the_judge_decision_never_re_thresholded() -> None:
+    # A partial fraction that "passes" positive-binary thresholding must still be marked failed:
+    # passed comes straight from the judge, not from reward_passed(fraction, reward_mode).
+    fake = FakeEvaluate(fractions={"a": [0.5]})
+    scorer = _make_scorer(
+        tasks=_seam_tasks()[:1], attempts=1, reward_mode="positive-binary", evaluate=fake
+    )
+    report = scorer.score(HarnessDoc.baseline())
+    [cell] = report.cells
+    assert cell.reward == 0.5
+    assert cell.passed is False
+
+
+# -- report validation --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("defect", ["drop_last_verdict", "missing_task"])
+def test_malformed_closed_loop_reports_are_rejected(defect: str) -> None:
+    fake = FakeEvaluate(
+        drop_last_verdict=defect == "drop_last_verdict",
+        fractions={"a": [1.0, 1.0], "b": [], "c": [1.0, 1.0]} if defect == "missing_task" else None,
+    )
+    scorer = _make_scorer(tasks=_seam_tasks(), attempts=2, evaluate=fake)
+    with pytest.raises(ValueError):
+        scorer.score(HarnessDoc.baseline())
+
+
+def test_extra_report_task_is_ignored_only_requested_cells_are_projected() -> None:
+    fake = FakeEvaluate(extra_task_id="zz")
+    scorer = _make_scorer(tasks=_seam_tasks(), attempts=1, evaluate=fake)
+    report = scorer.score(HarnessDoc.baseline())
+    assert {cell.task_id for cell in report.cells} == {"a", "b", "c"}
+
+
+# -- cancellation ------------------------------------------------------------------------------
+
+
+def test_cancellation_before_rollout_raises_without_evaluating() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(tasks=_seam_tasks(), attempts=1, evaluate=fake)
+    with pytest.raises(HarnessSearchCancelled):
+        scorer.score(HarnessDoc.baseline(), should_cancel=lambda: True)
+    assert fake.calls == []
+
+
+def test_runtime_cancelled_is_converted_at_the_scorer_boundary() -> None:
+    fake = FakeEvaluate(raises=RuntimeCancelled("cell cancelled mid-wave"))
+    scorer = _make_scorer(tasks=_seam_tasks(), attempts=1, evaluate=fake)
+    with pytest.raises(HarnessSearchCancelled):
+        scorer.score(HarnessDoc.baseline())
+
+
+def test_constructor_should_cancel_is_the_default_seam() -> None:
+    fake = FakeEvaluate()
+    scorer = _make_scorer(
+        tasks=_seam_tasks(), attempts=1, evaluate=fake, should_cancel=lambda: True
+    )
+    with pytest.raises(HarnessSearchCancelled):
+        scorer.score(HarnessDoc.baseline())
+    assert fake.calls == []
+
+
+# -- constructor validation ---------------------------------------------------------------------
+
+
+def test_constructor_rejects_bad_configuration() -> None:
+    with pytest.raises(ValueError, match="tasks must be nonempty"):
+        _make_scorer(tasks=[])
+    with pytest.raises(ValueError, match="duplicate task_id"):
+        _make_scorer(tasks=[_tasks()[0], _tasks()[0]])
+    with pytest.raises(ValueError, match="attempts must be a positive integer"):
+        _make_scorer(attempts=0)
+    with pytest.raises(ValueError, match="attempts must be a positive integer"):
+        _make_scorer(attempts=cast("int", True))
+    with pytest.raises(ValueError, match="eval_concurrency"):
+        _make_scorer(eval_concurrency=-1)
+    with pytest.raises(ValueError, match="eval_concurrency"):
+        _make_scorer(eval_concurrency=cast("int", True))
+    with pytest.raises(ValueError, match="reward_mode"):
+        _make_scorer(reward_mode=cast("RewardMode", "binary"))
+
+
+def test_scorer_snapshots_tasks_against_caller_mutation() -> None:
+    tasks = _tasks()
+    scorer = _make_scorer(tasks=tasks, attempts=1)
+    before = scorer.request
+    tasks[0].instruction = "mutated after construction"
+    assert scorer.request == before

--- a/wmh/harness/improve.py
+++ b/wmh/harness/improve.py
@@ -1,0 +1,284 @@
+"""Feedback-directed one-step harness improvement behind an explicit promotion gate.
+
+One piece of user feedback ("you should have access to my GitHub") drives one
+:func:`wmh.harness.population.optimize` run: the feedback text is baked into the proposer
+directive, and the must-pass verification tasks synthesized from it join the standard suite in
+one exact score request. Promotion is decided HERE, never by the optimizer's blended
+``result.best`` (which averages suite and verification cells together): a candidate is promotable
+only when its standard-suite mean stays within :class:`ImproveGate.suite_margin` of the seed AND
+a strict majority of attempts passes on every verification task. Among gate-passing candidates
+the highest suite score wins, with the earliest candidate breaking ties.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmh.harness.population import (
+    CandidateProposer,
+    EvaluatedCandidate,
+    PopulationResult,
+    SlotOutcome,
+    optimize,
+)
+from wmh.harness.scoring import Scorer, ScoreReport
+from wmh.harness.source_tree import HarnessSourceTree
+
+DEFAULT_SUITE_MARGIN = 0.10
+
+
+class ImproveGate(BaseModel):
+    """Relative regression budget on the standard suite (verification tasks get none).
+
+    A candidate's suite mean must be at least ``(1 - suite_margin) * seed_suite_mean``. The
+    margin is a fraction in ``[0, 1)``: 0 demands no regression at all, and values at or above
+    1 would accept a zero-scoring candidate, so they are rejected.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    suite_margin: float = Field(default=DEFAULT_SUITE_MARGIN, ge=0.0, lt=1.0)
+
+
+_DEFAULT_GATE = ImproveGate()
+
+
+class VerificationResult(BaseModel):
+    """Majority-rule outcome for one verification task across all its attempts."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str
+    passed: bool
+    pass_count: int
+    attempts: int
+
+
+@dataclass(frozen=True)
+class ImproveOutcome:
+    """The gate's promotion decision plus the complete evaluated population evidence.
+
+    ``candidate_suite_score`` and ``verification`` describe the selected candidate; they are
+    ``None`` and empty when no candidate passed the gate (the rejection reason still carries the
+    best candidate's numbers).
+    """
+
+    accepted: bool
+    reason: str
+    seed_suite_score: float
+    candidate_suite_score: float | None
+    verification: tuple[VerificationResult, ...]
+    selected: EvaluatedCandidate | None
+    result: PopulationResult
+
+
+def suite_score(report: ScoreReport, suite_task_ids: Collection[str]) -> float:
+    """Return the mean cell reward restricted to the standard-suite tasks.
+
+    Args:
+        report: One complete candidate scorecard.
+        suite_task_ids: The task ids that constitute the standard suite.
+
+    Returns:
+        The mean of ``cell.reward`` over every cell whose task id is in ``suite_task_ids``.
+
+    Raises:
+        ValueError: When no cell in the report matches ``suite_task_ids``.
+    """
+    wanted = set(suite_task_ids)
+    rewards = [cell.reward for cell in report.cells if cell.task_id in wanted]
+    if not rewards:
+        raise ValueError("score report contains no cells for the given suite task ids")
+    return fmean(rewards)
+
+
+def verification_results(
+    report: ScoreReport,
+    verification_task_ids: Sequence[str],
+) -> tuple[VerificationResult, ...]:
+    """Apply the strict-majority pass rule to each verification task, in the given order.
+
+    A task passes only when strictly more than half of its attempts have ``cell.passed`` True:
+    2 of 3 passes, while exactly half (for example 1 of 2) does not.
+
+    Args:
+        report: One complete candidate scorecard containing the verification cells.
+        verification_task_ids: The verification task ids, in reporting order.
+
+    Returns:
+        One :class:`VerificationResult` per requested task id.
+
+    Raises:
+        ValueError: When a named task has no cells in the report.
+    """
+    results: list[VerificationResult] = []
+    for task_id in verification_task_ids:
+        cells = [cell for cell in report.cells if cell.task_id == task_id]
+        if not cells:
+            raise ValueError(f"score report contains no cells for verification task {task_id!r}")
+        pass_count = sum(1 for cell in cells if cell.passed)
+        results.append(
+            VerificationResult(
+                task_id=task_id,
+                passed=pass_count * 2 > len(cells),
+                pass_count=pass_count,
+                attempts=len(cells),
+            )
+        )
+    return tuple(results)
+
+
+def improve_harness(
+    *,
+    seed: HarnessSourceTree,
+    feedback: str,
+    suite_task_ids: Sequence[str],
+    verification_task_ids: Sequence[str],
+    scorer: Scorer,
+    proposer: CandidateProposer,
+    run_dir: str | Path,
+    iterations: int = 1,
+    gate: ImproveGate = _DEFAULT_GATE,
+    should_cancel: Callable[[], bool] | None = None,
+    on_boundary: Callable[[SlotOutcome], None] | None = None,
+) -> ImproveOutcome:
+    """Run one feedback-directed population step and gate promotion explicitly.
+
+    The scorer must already be configured with the suite tasks followed by the verification
+    tasks, in that exact order; its request is asserted against that contract before any spend.
+    The proposer must already be built with the feedback baked into its directive.
+
+    Args:
+        seed: The champion source tree every proposal slot starts from.
+        feedback: The user's feedback; must be nonblank (the proposer carries it as a directive).
+        suite_task_ids: The standard-suite task ids, gated on the relative margin.
+        verification_task_ids: The synthesized must-pass task ids, gated on strict majority.
+        scorer: Scorer whose request is ``suite_task_ids`` then ``verification_task_ids``.
+        proposer: The candidate proposer for the population loop.
+        run_dir: Directory holding the optimizer's durable per-slot state.
+        iterations: Fixed number of proposal slots.
+        gate: The suite regression budget.
+        should_cancel: Optional cooperative cancellation callback.
+        on_boundary: Optional per-slot callback forwarded to the optimizer.
+
+    Returns:
+        The promotion decision with the full population evidence. ``result.best`` (the
+        optimizer's blended winner) is deliberately ignored for promotion.
+
+    Raises:
+        ValueError: On blank feedback, an empty task set, non-disjoint or duplicate task ids
+            across the two sets, or a scorer request that does not match the declared task
+            order.
+    """
+    if not feedback.strip():
+        raise ValueError("feedback must be a nonempty description of the desired improvement")
+    suite_ids = tuple(suite_task_ids)
+    verification_ids = tuple(verification_task_ids)
+    if not suite_ids:
+        raise ValueError("suite_task_ids must be nonempty")
+    if not verification_ids:
+        raise ValueError("verification_task_ids must be nonempty")
+    combined = suite_ids + verification_ids
+    if len(set(combined)) != len(combined):
+        raise ValueError("suite and verification task ids must be unique and disjoint")
+
+    request = scorer.request
+    if request.task_ids != combined:
+        raise ValueError(
+            "scorer request task ids must be exactly the suite tasks followed by the "
+            "verification tasks, in order"
+        )
+
+    result = optimize(
+        seed,
+        scorer,
+        proposer,
+        iterations,
+        run_dir=run_dir,
+        should_cancel=should_cancel,
+        on_boundary=on_boundary,
+    )
+    # population[0] is the scored seed; population[1:] the scored proposal candidates.
+    seed_suite = suite_score(result.population[0].report, suite_ids)
+    floor = (1.0 - gate.suite_margin) * seed_suite
+    candidates = result.population[1:]
+    if not candidates:
+        return ImproveOutcome(
+            accepted=False,
+            reason=(
+                "no valid proposals: every proposal slot failed to produce a scoreable candidate"
+            ),
+            seed_suite_score=seed_suite,
+            candidate_suite_score=None,
+            verification=(),
+            selected=None,
+            result=result,
+        )
+
+    graded = [
+        (
+            candidate,
+            suite_score(candidate.report, suite_ids),
+            verification_results(candidate.report, verification_ids),
+        )
+        for candidate in candidates
+    ]
+    # The population is ordered by ascending candidate_id, so replacing only on a strictly
+    # higher suite score keeps the earliest candidate on ties.
+    selected: tuple[EvaluatedCandidate, float, tuple[VerificationResult, ...]] | None = None
+    for candidate, candidate_suite, verification in graded:
+        if candidate_suite < floor or not all(item.passed for item in verification):
+            continue
+        if selected is None or candidate_suite > selected[1]:
+            selected = (candidate, candidate_suite, verification)
+    if selected is not None:
+        candidate, candidate_suite, verification = selected
+        return ImproveOutcome(
+            accepted=True,
+            reason=(
+                f"candidate {candidate.candidate_id} passed the gate: suite "
+                f"{candidate_suite:.6f} vs seed {seed_suite:.6f} (floor {floor:.6f} at margin "
+                f"{gate.suite_margin:.0%}); all {len(verification)} verification task(s) passed"
+            ),
+            seed_suite_score=seed_suite,
+            candidate_suite_score=candidate_suite,
+            verification=verification,
+            selected=candidate,
+            result=result,
+        )
+
+    # No candidate passed. Diagnose using the best candidate by suite score (ties keep the
+    # earliest, because max returns the first maximal element).
+    best_candidate, best_suite, best_verification = max(graded, key=lambda entry: entry[1])
+    if best_suite < floor:
+        reason = (
+            f"suite regression beyond margin: best candidate {best_candidate.candidate_id} "
+            f"scored {best_suite:.6f} on the suite, below the floor {floor:.6f} "
+            f"({1.0 - gate.suite_margin:.2f} x seed {seed_suite:.6f}, margin "
+            f"{gate.suite_margin:.0%})"
+        )
+    else:
+        failing = ", ".join(
+            f"{item.task_id} ({item.pass_count}/{item.attempts} passed)"
+            for item in best_verification
+            if not item.passed
+        )
+        reason = (
+            f"verification tasks failed: candidate {best_candidate.candidate_id} (suite "
+            f"{best_suite:.6f} vs seed {seed_suite:.6f}) did not reach a strict majority on "
+            f"{failing}"
+        )
+    return ImproveOutcome(
+        accepted=False,
+        reason=reason,
+        seed_suite_score=seed_suite,
+        candidate_suite_score=None,
+        verification=(),
+        selected=None,
+        result=result,
+    )

--- a/wmh/harness/improve_test.py
+++ b/wmh/harness/improve_test.py
@@ -1,0 +1,396 @@
+"""Behavioral tests for the feedback-directed one-step improvement gate.
+
+The tests drive the REAL `wmh.harness.population.optimize` loop through a tmp run dir with a
+fake main `Scorer` (request property + `score(doc)`) and a fake main `CandidateProposer`
+(`propose(population, *, slot, should_cancel)`), so the gate decisions are asserted on real
+`ScoreReport` cells (`reward`/`passed`) and `result.population`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.improve import (
+    ImproveGate,
+    ImproveOutcome,
+    improve_harness,
+    suite_score,
+    verification_results,
+)
+from wmh.harness.population import (
+    CandidateProposal,
+    CandidateProposalError,
+    EvaluatedCandidate,
+)
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
+
+# One preplanned score call: task_id -> one (reward, passed) pair per attempt.
+_CellPlan = Mapping[str, Sequence[tuple[float, bool]]]
+
+
+class _Scorer:
+    """Yields one preplanned per-task cell matrix per score call (keyed by doc hash).
+
+    The population loop scores the seed first, then each candidate in slot order, so the plans
+    are consumed in that same order. Each report's doc_hash is taken from the scored doc so
+    `EvaluatedCandidate` accepts it.
+    """
+
+    def __init__(
+        self,
+        task_ids: Sequence[str],
+        attempts: int,
+        outcomes: Sequence[_CellPlan],
+    ) -> None:
+        self._task_ids = tuple(task_ids)
+        self._attempts = attempts
+        self._outcomes = list(outcomes)
+        self.calls: list[str] = []
+
+    @property
+    def request(self) -> ScoreRequest:
+        return ScoreRequest(task_ids=self._task_ids, attempts=self._attempts)
+
+    def score(
+        self, doc: HarnessDoc, *, should_cancel: Callable[[], bool] | None = None
+    ) -> ScoreReport:
+        del should_cancel
+        self.calls.append(doc.doc_hash)
+        per_task = self._outcomes.pop(0)
+        cells: list[ScoreCell] = []
+        for task_id in self._task_ids:
+            attempt_outcomes = per_task[task_id]
+            assert len(attempt_outcomes) == self._attempts
+            for attempt, (reward, passed) in enumerate(attempt_outcomes, start=1):
+                cells.append(
+                    ScoreCell(
+                        task_id=task_id,
+                        attempt=attempt,
+                        reward=reward,
+                        passed=passed,
+                        note="planned cell",
+                    )
+                )
+        return ScoreReport(
+            doc_hash=doc.doc_hash,
+            request=self.request,
+            reward_mode="positive-binary",
+            cells=tuple(cells),
+        )
+
+
+class _Proposer:
+    """Returns one preplanned source tree (or raises an error) per slot."""
+
+    def __init__(self, outcomes: Sequence[HarnessSourceTree | CandidateProposalError]) -> None:
+        self._outcomes = list(outcomes)
+        self.slots: list[int] = []
+
+    def propose(
+        self,
+        population: Sequence[EvaluatedCandidate],
+        *,
+        slot: int,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> CandidateProposal:
+        del population, should_cancel
+        self.slots.append(slot)
+        outcome = self._outcomes.pop(0)
+        candidate_id = f"candidate-{slot:04d}"
+        if isinstance(outcome, CandidateProposalError):
+            raise outcome
+        return CandidateProposal(
+            candidate_id=candidate_id,
+            source=outcome,
+            candidate=outcome.to_doc(candidate_id),
+        )
+
+
+def _source(prompt: str) -> HarnessSourceTree:
+    return HarnessSourceTree(
+        files=(
+            HarnessSourceFile(path="SYSTEM.md", content=prompt),
+            HarnessSourceFile(
+                path="config.toml",
+                content='[harness]\ntools = ["bash", "submit"]\nruntime_kind = "pi-node"\n',
+            ),
+        )
+    )
+
+
+def _uniform(task_outcomes: Mapping[str, tuple[float, bool]], attempts: int) -> _CellPlan:
+    return {task_id: [outcome] * attempts for task_id, outcome in task_outcomes.items()}
+
+
+_SUITE = ("suite-a", "suite-b")
+_VERIFY = ("verify-1",)
+_ALL_IDS = ("suite-a", "suite-b", "verify-1")
+
+
+def _improve(
+    *,
+    scorer: _Scorer,
+    proposer: _Proposer,
+    run_dir: Path,
+    iterations: int,
+    suite: Sequence[str] = _SUITE,
+    verification: Sequence[str] = _VERIFY,
+    feedback: str = "the agent should have access to my GitHub",
+    gate: ImproveGate | None = None,
+) -> ImproveOutcome:
+    return improve_harness(
+        seed=_source("seed"),
+        feedback=feedback,
+        suite_task_ids=suite,
+        verification_task_ids=verification,
+        scorer=scorer,
+        proposer=proposer,
+        run_dir=run_dir,
+        iterations=iterations,
+        gate=gate if gate is not None else ImproveGate(),
+    )
+
+
+def test_gate_accepts_candidate_within_margin_with_all_verification_passing(
+    tmp_path: Path,
+) -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            {
+                "suite-a": [(0.75, True)] * 3,
+                "suite-b": [(0.75, True)] * 3,
+                "verify-1": [(1.0, True), (1.0, True), (0.0, False)],  # 2 of 3: strict majority
+            },
+        ],
+    )
+    proposer = _Proposer([_source("improved")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=1)
+
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+    assert outcome.seed_suite_score == pytest.approx(0.8)
+    assert outcome.candidate_suite_score == pytest.approx(0.75)
+    [verification] = outcome.verification
+    assert verification.task_id == "verify-1"
+    assert verification.passed is True
+    assert verification.pass_count == 2
+    assert verification.attempts == 3
+    assert "candidate-0001" in outcome.reason
+
+
+def test_gate_rejects_suite_regression_beyond_margin(tmp_path: Path) -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            # Suite mean 0.6 is below the floor 0.72 = 0.9 * 0.8 even though verification passes.
+            _uniform({"suite-a": (0.6, True), "suite-b": (0.6, True), "verify-1": (1.0, True)}, 3),
+        ],
+    )
+    proposer = _Proposer([_source("regressed")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=1)
+
+    assert outcome.accepted is False
+    assert outcome.selected is None
+    assert outcome.candidate_suite_score is None
+    assert outcome.verification == ()
+    assert "suite regression beyond margin" in outcome.reason
+    assert "0.600000" in outcome.reason
+    assert "0.720000" in outcome.reason
+
+
+def test_gate_rejects_when_a_verification_task_fails_majority(tmp_path: Path) -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+            {
+                "suite-a": [(0.9, True)] * 3,
+                "suite-b": [(0.9, True)] * 3,
+                "verify-1": [(1.0, True), (0.0, False), (0.0, False)],  # 1 of 3: no majority
+            },
+        ],
+    )
+    proposer = _Proposer([_source("half done")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=1)
+
+    assert outcome.accepted is False
+    assert outcome.selected is None
+    assert "verification tasks failed" in outcome.reason
+    assert "verify-1" in outcome.reason
+    assert "1/3" in outcome.reason
+
+
+def test_selection_prefers_highest_suite_score_over_optimizer_blended_best(
+    tmp_path: Path,
+) -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.5, True), "suite-b": (0.5, True), "verify-1": (0.0, False)}, 3),
+            # Higher suite (0.9) but a partial verify (2 of 3) -> blended per-task pass rate 0.889.
+            {
+                "suite-a": [(0.9, True)] * 3,
+                "suite-b": [(0.9, True)] * 3,
+                "verify-1": [(1.0, True), (1.0, True), (0.0, False)],
+            },
+            # Lower suite (0.7) but all verify passes -> blended pass rate 1.0 (optimizer's best).
+            _uniform({"suite-a": (0.7, True), "suite-b": (0.7, True), "verify-1": (1.0, True)}, 3),
+        ],
+    )
+    proposer = _Proposer([_source("high suite"), _source("high verification")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=2)
+
+    # The optimizer's blended best is candidate-0002 (mean per-task pass rate 1.0 > 0.889); our
+    # gate picks the higher-suite candidate-0001 (0.9 > 0.7) instead.
+    assert outcome.result.best.candidate_id == "candidate-0002"
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+    assert outcome.candidate_suite_score == pytest.approx(0.9)
+
+
+def test_selection_tie_on_suite_score_keeps_the_earliest_candidate(tmp_path: Path) -> None:
+    plan = _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (1.0, True)}, 1)
+    scorer = _Scorer(
+        _ALL_IDS,
+        1,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 1),
+            plan,
+            plan,
+        ],
+    )
+    proposer = _Proposer([_source("first tie"), _source("second tie")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=2)
+
+    assert outcome.accepted is True
+    assert outcome.selected is not None
+    assert outcome.selected.candidate_id == "candidate-0001"
+
+
+def test_seed_only_population_reports_no_valid_proposals(tmp_path: Path) -> None:
+    scorer = _Scorer(
+        _ALL_IDS,
+        3,
+        [
+            _uniform({"suite-a": (0.8, True), "suite-b": (0.8, True), "verify-1": (0.0, False)}, 3),
+        ],
+    )
+    proposer = _Proposer([CandidateProposalError("candidate-0001", "agent turn did not submit")])
+
+    outcome = _improve(scorer=scorer, proposer=proposer, run_dir=tmp_path / "run", iterations=1)
+
+    assert outcome.accepted is False
+    assert "no valid proposals" in outcome.reason
+    assert outcome.selected is None
+    assert outcome.candidate_suite_score is None
+    assert outcome.verification == ()
+    assert [item.candidate_id for item in outcome.result.population] == ["candidate-0000"]
+    assert outcome.seed_suite_score == pytest.approx(0.8)
+
+
+def _report(task_ids: Sequence[str], attempts: int, plan: _CellPlan) -> ScoreReport:
+    scorer = _Scorer(task_ids, attempts, [plan])
+    doc = _source("unit").to_doc("candidate-0000")
+    return scorer.score(doc)
+
+
+def test_suite_score_means_only_matching_cells_and_rejects_empty_selection() -> None:
+    report = _report(
+        ("suite-a", "suite-b", "verify-1"),
+        2,
+        {
+            "suite-a": [(1.0, True), (0.0, False)],
+            "suite-b": [(0.5, True), (0.5, True)],
+            "verify-1": [(0.0, False), (0.0, False)],
+        },
+    )
+
+    assert suite_score(report, ("suite-a", "suite-b")) == pytest.approx(0.5)
+    assert suite_score(report, ("suite-a",)) == pytest.approx(0.5)
+    with pytest.raises(ValueError, match="no cells"):
+        suite_score(report, ("absent-task",))
+    with pytest.raises(ValueError, match="no cells"):
+        suite_score(report, ())
+
+
+def test_verification_results_apply_the_strict_majority_rule() -> None:
+    half = _report(("verify-1",), 2, {"verify-1": [(1.0, True), (0.0, False)]})
+    [result] = verification_results(half, ("verify-1",))
+    assert result.passed is False  # exactly half (1 of 2) is not a strict majority
+    assert result.pass_count == 1
+    assert result.attempts == 2
+
+    majority = _report(("verify-1",), 3, {"verify-1": [(1.0, True), (1.0, True), (0.0, False)]})
+    [result] = verification_results(majority, ("verify-1",))
+    assert result.passed is True
+    assert result.pass_count == 2
+    assert result.attempts == 3
+
+    with pytest.raises(ValueError, match="absent-task"):
+        verification_results(majority, ("absent-task",))
+
+
+def test_improve_validates_task_sets_and_request_before_any_proposal(tmp_path: Path) -> None:
+    proposer = _Proposer([])
+    valid_scorer = _Scorer(_ALL_IDS, 1, [])
+
+    with pytest.raises(ValueError, match="disjoint"):
+        _improve(
+            scorer=valid_scorer,
+            proposer=proposer,
+            run_dir=tmp_path / "a",
+            iterations=1,
+            verification=("suite-a",),
+        )
+    with pytest.raises(ValueError, match="suite_task_ids must be nonempty"):
+        _improve(
+            scorer=valid_scorer, proposer=proposer, run_dir=tmp_path / "b", iterations=1, suite=()
+        )
+    with pytest.raises(ValueError, match="verification_task_ids must be nonempty"):
+        _improve(
+            scorer=valid_scorer,
+            proposer=proposer,
+            run_dir=tmp_path / "c",
+            iterations=1,
+            verification=(),
+        )
+    with pytest.raises(ValueError, match="feedback"):
+        _improve(
+            scorer=valid_scorer,
+            proposer=proposer,
+            run_dir=tmp_path / "d",
+            iterations=1,
+            feedback="   ",
+        )
+
+    reordered_scorer = _Scorer(("verify-1", "suite-a", "suite-b"), 1, [])
+    with pytest.raises(ValueError, match="suite tasks followed by the verification tasks"):
+        _improve(scorer=reordered_scorer, proposer=proposer, run_dir=tmp_path / "e", iterations=1)
+    assert proposer.slots == []
+
+
+def test_margin_gate_validates_its_fraction() -> None:
+    assert ImproveGate().suite_margin == pytest.approx(0.10)
+    assert ImproveGate(suite_margin=0.0).suite_margin == 0.0
+    for invalid in (-0.1, 1.0, 1.5):
+        with pytest.raises(ValueError):
+            ImproveGate(suite_margin=invalid)

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -28,6 +28,7 @@ from wmh.agents.project import (
     AgentProjectRun,
     ProjectBashResult,
 )
+from wmh.core.text import validate_durable_text
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import (
@@ -45,6 +46,8 @@ logger = logging.getLogger(__name__)
 
 CANDIDATE_STAGE_DIR = "candidate"
 PROPOSALS_DIR = "proposals"
+# Upper bound on a feedback directive threaded into every proposal request.
+MAX_DIRECTIVE_CHARS = 20_000
 # Per-candidate budget for materialized raw trial evidence; breaches truncate, never halt.
 DEFAULT_CANDIDATE_HISTORY_BYTES = 256 * 1024 * 1024
 # Per-file cap before head/tail truncation (transcripts keep both ends plus a marker).
@@ -98,6 +101,8 @@ class ProjectCandidateProposer:
         *,
         project_factory: Callable[[], CandidateProject],
         run_dir: str | Path,
+        directive: str = "",
+        on_event: Callable[[SessionEvent], None] | None = None,
         max_source_files: int = DEFAULT_SOURCE_TREE_MAX_FILES,
         max_source_bytes: int = DEFAULT_SOURCE_TREE_MAX_BYTES,
         max_candidate_history_bytes: int = DEFAULT_CANDIDATE_HISTORY_BYTES,
@@ -111,10 +116,16 @@ class ProjectCandidateProposer:
         ):
             if isinstance(value, bool) or not isinstance(value, int) or value < 1:
                 raise ValueError(f"{field} must be a positive integer")
+        if directive:
+            validate_durable_text(directive, field="proposal directive")
+            if len(directive) > MAX_DIRECTIVE_CHARS:
+                raise ValueError(f"proposal directive exceeds {MAX_DIRECTIVE_CHARS} characters")
         self._agent = agent
         self._provider = provider
         self._project_factory = project_factory
         self._run_dir = Path(run_dir)
+        self._directive = directive
+        self._on_event = on_event
         self._max_source_files = max_source_files
         self._max_source_bytes = max_source_bytes
         self._max_candidate_history_bytes = max_candidate_history_bytes
@@ -178,19 +189,29 @@ class ProjectCandidateProposer:
                 stage_dir=f"{project.workspace}/{CANDIDATE_STAGE_DIR}",
                 slot=slot,
                 population_count=len(population),
+                directive=self._directive,
             )
             (slot_dir / "REQUEST.md").write_text(request, encoding="utf-8")
             project.write_text(f"{PROPOSALS_DIR}/slot-{slot:04d}/REQUEST.md", request)
             _check_cancelled(should_cancel)
 
             events: list[SessionEvent] = []
+
+            def sink(event: SessionEvent) -> None:
+                events.append(event)
+                if self._on_event is not None:
+                    try:
+                        self._on_event(event)
+                    except Exception:  # noqa: BLE001 - a sink error must never abort the proposal
+                        logger.warning("proposer on_event sink raised", exc_info=True)
+
             run_error: str | None = None
             try:
                 project.run(
                     self._agent,
                     self._provider,
                     request,
-                    on_event=events.append,
+                    on_event=sink,
                     should_cancel=should_cancel,
                     writable_files=(),
                     retry_recoverable=False,
@@ -510,12 +531,19 @@ def _proposal_request(
     stage_dir: str,
     slot: int,
     population_count: int,
+    directive: str = "",
 ) -> str:
     previous_trace = (
         f"The most recent proposal-turn trace is `{PROPOSALS_DIR}/slot-{slot - 1:04d}/`; "
         "failed turns keep their captured source and errors in the same layout."
         if slot > 1
         else "There is no earlier proposal turn in this project."
+    )
+    directive_block = (
+        "The user directing this optimization gave the following feedback. Treat it as the "
+        f"primary objective of this candidate:\n\n{directive}\n\n"
+        if directive
+        else ""
     )
     return f"""Produce exactly one complete harness candidate: {candidate_id}.
 
@@ -526,7 +554,7 @@ transcript for that trial; `verifier/` holds the verifier's own output). Earlier
 traces, including failed ones, remain under `{PROPOSALS_DIR}/`. {previous_trace} Use the full
 population as evidence.
 
-Your only candidate output is this directory:
+{directive_block}Your only candidate output is this directory:
 `{stage_dir}`
 
 The host initialized it with a complete, freely editable copy of the fixed first evaluated seed at

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -19,7 +19,11 @@ from wmh.harness import project_proposer
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.live_session import SessionEvent
 from wmh.harness.population import CandidateProposalError, EvaluatedCandidate
-from wmh.harness.project_proposer import ProjectCandidateProposer
+from wmh.harness.project_proposer import (
+    DEFAULT_CANDIDATE_HISTORY_BYTES,
+    DEFAULT_HISTORY_FILE_BYTES,
+    ProjectCandidateProposer,
+)
 from wmh.harness.runtime import TokenUsage
 from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
 from wmh.harness.source_tree import HarnessSourceFile, HarnessSourceTree
@@ -126,14 +130,19 @@ def _seed_with_trial(tmp_path: Path) -> EvaluatedCandidate:
 
 
 def _proposer(
-    projects: list[_FakeProject], run_dir: Path, **kwargs: int
+    projects: list[_FakeProject],
+    run_dir: Path,
+    *,
+    max_candidate_history_bytes: int = DEFAULT_CANDIDATE_HISTORY_BYTES,
+    max_history_file_bytes: int = DEFAULT_HISTORY_FILE_BYTES,
 ) -> ProjectCandidateProposer:
     return ProjectCandidateProposer(
         optimizer_agent(),
         _Provider(),
         project_factory=lambda: projects.pop(0),
         run_dir=run_dir,
-        **kwargs,
+        max_candidate_history_bytes=max_candidate_history_bytes,
+        max_history_file_bytes=max_history_file_bytes,
     )
 
 
@@ -178,6 +187,70 @@ def test_proposer_materializes_history_stages_seed_and_returns_one_candidate(
     assert (slot_dir / "REQUEST.md").is_file()
     assert (slot_dir / "source" / "SYSTEM.md").read_text(encoding="utf-8") == "improved"
     assert json.loads((slot_dir / "status.json").read_text(encoding="utf-8"))["valid"] is True
+
+
+def test_directive_appears_in_the_request_and_on_event_forwards(tmp_path: Path) -> None:
+    candidate = _tree("improved")
+    project = _FakeProject([candidate])
+    seed = _seed_with_trial(tmp_path)
+    run_dir = tmp_path / "run"
+    forwarded: list[SessionEvent] = []
+    proposer = ProjectCandidateProposer(
+        optimizer_agent(),
+        _Provider(),
+        project_factory=lambda: project,
+        run_dir=run_dir,
+        directive="the agent should have access to my GitHub",
+        on_event=forwarded.append,
+    )
+
+    proposer.propose((seed,), slot=1)
+
+    request = project.run_calls[0].instruction
+    assert "The user directing this optimization gave the following feedback" in request
+    assert "the agent should have access to my GitHub" in request
+    # The wrapped sink forwards the same events the project emitted to the CLI callback.
+    assert [event.kind for event in forwarded] == ["submit"]
+
+
+def test_on_event_sink_error_never_aborts_the_proposal(tmp_path: Path) -> None:
+    project = _FakeProject([_tree("improved")])
+    seed = _seed_with_trial(tmp_path)
+
+    def boom(_event: SessionEvent) -> None:
+        raise RuntimeError("sink is broken")
+
+    proposer = ProjectCandidateProposer(
+        optimizer_agent(),
+        _Provider(),
+        project_factory=lambda: project,
+        run_dir=tmp_path / "run",
+        on_event=boom,
+    )
+
+    proposal = proposer.propose((seed,), slot=1)
+    assert proposal.candidate_id == "candidate-0001"
+
+
+def test_directive_validation_rejects_oversized_and_non_durable_text(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="exceeds"):
+        ProjectCandidateProposer(
+            optimizer_agent(),
+            _Provider(),
+            project_factory=lambda: _FakeProject([]),
+            run_dir=tmp_path / "run",
+            directive="x" * 20_001,
+        )
+
+
+def test_no_directive_leaves_the_request_free_of_the_feedback_block(tmp_path: Path) -> None:
+    project = _FakeProject([_tree("improved")])
+    seed = _seed_with_trial(tmp_path)
+
+    _proposer([project], tmp_path / "run").propose((seed,), slot=1)
+
+    request = project.run_calls[0].instruction
+    assert "The user directing this optimization" not in request
 
 
 def test_missing_submit_consumes_the_slot_with_persisted_evidence(tmp_path: Path) -> None:

--- a/wmh/scenarios/feedback.py
+++ b/wmh/scenarios/feedback.py
@@ -1,0 +1,177 @@
+"""Feedback-directed verification tasks: turn one piece of user feedback into a must-pass gate.
+
+One piece of natural-language feedback about an agent ("you should have access to my GitHub")
+names a capability the current harness lacks. An LLM converts that feedback into a small set of
+verification `TaskSpec`s that exercise the NEW capability directly, plus the knowledge notes the
+world-model environment needs to simulate it plausibly. The tasks are the acceptance gate for a
+feedback-directed one-step harness improvement: they run closed-loop against the world model and
+are judged by their gold assertions, so an improvement only counts when the new capability
+demonstrably works.
+
+Unlike the trace-driven `ScenarioSynthesizer` (which degrades gracefully because a corpus has
+thousands of traces), a gate synthesized from one sentence of feedback has no fallback that is
+still meaningful: an unusable reply is retried once with the validation error, then raised.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from wmh.core.parsing import extract_json_object
+from wmh.evals.tasks import TaskSpec
+from wmh.providers.base import Message, Provider
+
+FEEDBACK_SYNTHESIS_SYSTEM = """You design verification tasks for an AI agent. A user gave one
+piece of feedback naming a capability the agent should have but currently lacks. Write tasks
+that PROVE the new capability works once the agent's harness is improved.
+
+Respond with ONLY a JSON object, no prose around it:
+{{"tasks": [{{"task_id": "feedback-verify-01", "instruction": "<self-contained task a user would
+give the agent>", "gold": ["<concrete assertion>", "..."]}}, ...],
+ "knowledge_notes": "<markdown facts the environment simulator needs>"}}
+
+Rules:
+- Produce between 1 and {count} tasks.
+- Each instruction is a self-contained task a real user would give the agent, and it must
+  exercise the NEW capability the feedback asks for. Never write a meta-task about editing the
+  agent's configuration, prompt, or tools: the task is what a user asks AFTER the capability
+  exists.
+- Each gold list holds 2 to 5 concrete, outcome-focused assertions that a judge can check from
+  the run transcript alone: the agent invoked the new capability, it surfaced the correct data,
+  and it did not fabricate results it never retrieved.
+- Tasks must differ from each other. When the task budget allows more than one, cover the happy
+  path plus at least one edge or error path (for example: authentication missing, or the
+  requested entity does not exist).
+- knowledge_notes gives the world-model environment simulator the facts it needs to answer the
+  new tool calls consistently: tool or API names, request/response shapes, and realistic sample
+  entities with concrete names, ids, and values that the gold assertions can reference. Use an
+  empty string only when the environment truly needs nothing new.
+- task_id values must be unique, contain only characters safe in kebab-case or snake_case, and
+  start with "feedback-verify-"."""
+
+
+class FeedbackSynthesis(BaseModel):
+    """Verification tasks plus the environment knowledge needed to simulate the new capability.
+
+    `knowledge_notes` is markdown destined for the world-model environment's knowledge base: the
+    tool names, request/response shapes, and sample entities the simulator needs to answer the
+    new capability's tool calls consistently. Empty when nothing is needed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tasks: tuple[TaskSpec, ...]
+    knowledge_notes: str = ""
+
+
+class _RawTask(BaseModel):
+    task_id: str
+    instruction: str
+    gold: list[str] = Field(default_factory=list)
+
+
+class _RawFeedbackSynthesis(BaseModel):
+    tasks: list[_RawTask] = Field(default_factory=list)
+    knowledge_notes: str = ""
+
+
+def synthesize_verification_tasks(
+    feedback: str,
+    *,
+    provider: Provider,
+    count: int = 3,
+    environment_context: str = "",
+) -> FeedbackSynthesis:
+    """Synthesize the must-pass verification tasks for one piece of user feedback.
+
+    Args:
+        feedback: One piece of natural-language user feedback about the agent, naming the
+            capability it should gain (e.g. "you should have access to my GitHub").
+        provider: LLM provider used to write the tasks.
+        count: Maximum number of tasks to synthesize (the model returns 1 to `count`).
+        environment_context: Optional caller-supplied prose about the environment (e.g. a
+            knowledge-base excerpt) that grounds the tasks in existing entities.
+
+    Returns:
+        The validated tasks plus the knowledge notes the environment simulator needs.
+
+    Raises:
+        ValueError: When `feedback` is blank, `count` is not positive, or the model failed to
+            produce a valid reply after one retry. There is no silent fallback: these tasks gate
+            a harness change, so a degraded task set must fail loudly, not pass vacuously.
+    """
+    if not feedback.strip():
+        raise ValueError("feedback must be a nonempty description of the desired capability")
+    if count < 1:
+        raise ValueError(f"count must be at least 1, got {count}")
+    system = FEEDBACK_SYNTHESIS_SYSTEM.format(count=count)
+    request = _render_request(feedback, environment_context)
+    completion = provider.complete(
+        system,
+        [Message(role="user", content=request)],
+        temperature=0.0,
+        max_tokens=4096,
+    )
+    try:
+        return _parse_synthesis(completion.text, count=count)
+    except ValueError as first_error:
+        retry_request = (
+            f"{request}\n\nYour previous reply was rejected: {first_error}\n"
+            "Reply again with ONLY the corrected JSON object."
+        )
+        completion = provider.complete(
+            system,
+            [Message(role="user", content=retry_request)],
+            temperature=0.0,
+            max_tokens=4096,
+        )
+        try:
+            return _parse_synthesis(completion.text, count=count)
+        except ValueError as second_error:
+            raise ValueError(
+                "could not synthesize verification tasks from the feedback after one retry: "
+                f"{second_error}"
+            ) from second_error
+
+
+def _render_request(feedback: str, environment_context: str) -> str:
+    """Render the user message: the feedback, grounded by any caller-supplied context."""
+    sections = [f"User feedback about the agent:\n{feedback.strip()}"]
+    if environment_context.strip():
+        sections.append(f"Known environment context:\n{environment_context.strip()}")
+    return "\n\n".join(sections)
+
+
+def _parse_synthesis(text: str, *, count: int) -> FeedbackSynthesis:
+    """Parse and validate one model reply; raise ValueError describing the first defect found."""
+    raw = extract_json_object(text)
+    if raw is None:
+        raise ValueError("reply contains no JSON object")
+    try:
+        parsed = _RawFeedbackSynthesis.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ValueError(f"reply JSON does not match the contract: {exc}") from exc
+    if not 1 <= len(parsed.tasks) <= count:
+        raise ValueError(f"expected between 1 and {count} tasks, got {len(parsed.tasks)}")
+    tasks: list[TaskSpec] = []
+    seen_ids: set[str] = set()
+    for index, raw_task in enumerate(parsed.tasks, start=1):
+        try:
+            spec = TaskSpec(
+                task_id=raw_task.task_id.strip(),
+                instruction=raw_task.instruction.strip(),
+                gold=[assertion.strip() for assertion in raw_task.gold if assertion.strip()],
+            )
+        except ValidationError as exc:
+            raise ValueError(f"task {index} is not a valid TaskSpec: {exc}") from exc
+        if not spec.task_id:
+            raise ValueError(f"task {index} has an empty task_id")
+        if not spec.instruction:
+            raise ValueError(f"task {spec.task_id!r} has an empty instruction")
+        if not spec.gold:
+            raise ValueError(f"task {spec.task_id!r} has no gold assertions")
+        if spec.task_id in seen_ids:
+            raise ValueError(f"duplicate task_id {spec.task_id!r}")
+        seen_ids.add(spec.task_id)
+        tasks.append(spec)
+    return FeedbackSynthesis(tasks=tuple(tasks), knowledge_notes=parsed.knowledge_notes.strip())

--- a/wmh/scenarios/feedback_test.py
+++ b/wmh/scenarios/feedback_test.py
@@ -1,0 +1,169 @@
+"""Tests for feedback-directed verification tasks (strict parse, retry once, no fallback)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.core.types import JsonValue
+from wmh.evals.tasks import TaskSpec
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.scenarios.feedback import FeedbackSynthesis, synthesize_verification_tasks
+
+
+class FakeProvider:
+    """Returns queued completion texts in order; records every prompt for assertions."""
+
+    def __init__(self, replies: list[str]) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model="m")
+        self._replies = list(replies)
+        self.systems: list[str] = []
+        self.requests: list[str] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.systems.append(system)
+        self.requests.append(messages[0].content)
+        if not self._replies:
+            raise AssertionError("provider called more times than replies were queued")
+        return Completion(text=self._replies.pop(0))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    def verify(self):  # noqa: ANN201
+        raise NotImplementedError
+
+
+def _task(task_id: str, instruction: str = "List my open GitHub PRs.") -> dict[str, JsonValue]:
+    return {
+        "task_id": task_id,
+        "instruction": instruction,
+        "gold": [
+            "The agent called the GitHub API to list pull requests",
+            "The agent reported PR #42 'Fix login bug' from acme/webapp",
+        ],
+    }
+
+
+def _reply(tasks: list[dict[str, JsonValue]], **extra: JsonValue) -> str:
+    payload: dict[str, JsonValue] = {"tasks": tasks, "knowledge_notes": "GitHub notes"}
+    payload.update(extra)
+    return json.dumps(payload)
+
+
+def test_happy_path_parses_into_feedback_synthesis() -> None:
+    reply = _reply(
+        [
+            _task("feedback-verify-01"),
+            _task("feedback-verify-02", "Look up nonexistent repo acme/ghost."),
+        ],
+        knowledge_notes="## GitHub\n- repo acme/webapp has PR #42 'Fix login bug'",
+    )
+    provider = FakeProvider(["Here you go:\n```json\n" + reply + "\n```"])
+    result = synthesize_verification_tasks(
+        "you should have access to my GitHub",
+        provider=provider,
+        count=3,
+        environment_context="The user works in the acme org.",
+    )
+    assert isinstance(result, FeedbackSynthesis)
+    assert isinstance(result.tasks, tuple)
+    assert [t.task_id for t in result.tasks] == ["feedback-verify-01", "feedback-verify-02"]
+    assert all(isinstance(t, TaskSpec) for t in result.tasks)
+    assert result.tasks[0].instruction == "List my open GitHub PRs."
+    assert len(result.tasks[0].gold) == 2
+    assert result.knowledge_notes == "## GitHub\n- repo acme/webapp has PR #42 'Fix login bug'"
+    # One clean call: the feedback, the caller's context, and the count all reached the model.
+    assert len(provider.requests) == 1
+    assert "you should have access to my GitHub" in provider.requests[0]
+    assert "The user works in the acme org." in provider.requests[0]
+    assert "between 1 and 3 tasks" in provider.systems[0]
+
+
+def test_unparseable_reply_retries_once_then_raises() -> None:
+    provider = FakeProvider(["not json at all", "still not json"])
+    with pytest.raises(ValueError, match="after one retry.*no JSON object"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    # The retry carries the first validation error back to the model.
+    assert "rejected" in provider.requests[1]
+    assert "no JSON object" in provider.requests[1]
+
+
+def test_duplicate_task_ids_trigger_retry_then_succeed() -> None:
+    bad = _reply([_task("feedback-verify-01"), _task("feedback-verify-01")])
+    good = _reply([_task("feedback-verify-01")])
+    provider = FakeProvider([bad, good])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    assert "duplicate task_id 'feedback-verify-01'" in provider.requests[1]
+    assert [t.task_id for t in result.tasks] == ["feedback-verify-01"]
+
+
+def test_empty_gold_triggers_retry_then_raises_when_still_invalid() -> None:
+    empty = _task("feedback-verify-01")
+    empty["gold"] = []
+    whitespace = _task("feedback-verify-01")
+    whitespace["gold"] = ["   ", ""]
+    provider = FakeProvider([_reply([empty]), _reply([whitespace])])
+    with pytest.raises(ValueError, match="no gold assertions"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+
+
+def test_empty_instruction_triggers_retry() -> None:
+    bad = _reply([_task("feedback-verify-01", instruction="   ")])
+    good = _reply([_task("feedback-verify-01")])
+    provider = FakeProvider([bad, good])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert len(provider.requests) == 2
+    assert "empty instruction" in provider.requests[1]
+    assert result.tasks[0].instruction == "List my open GitHub PRs."
+
+
+def test_count_is_enforced_and_named_in_the_prompt() -> None:
+    three = _reply([_task(f"feedback-verify-0{i}") for i in (1, 2, 3)])
+    two = _reply([_task("feedback-verify-01"), _task("feedback-verify-02")])
+    provider = FakeProvider([three, two])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider, count=2)
+    assert len(result.tasks) == 2
+    assert "between 1 and 2 tasks" in provider.systems[0]
+    assert "expected between 1 and 2 tasks, got 3" in provider.requests[1]
+
+
+def test_zero_tasks_is_invalid() -> None:
+    provider = FakeProvider([_reply([]), _reply([])])
+    with pytest.raises(ValueError, match="between 1 and 3 tasks, got 0"):
+        synthesize_verification_tasks("add GitHub access", provider=provider)
+
+
+def test_knowledge_notes_defaults_to_empty_when_omitted() -> None:
+    reply = json.dumps({"tasks": [_task("feedback-verify-01")]})
+    provider = FakeProvider([reply])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    assert result.knowledge_notes == ""
+
+
+def test_blank_feedback_and_bad_count_raise_without_calling_provider() -> None:
+    provider = FakeProvider([])
+    with pytest.raises(ValueError, match="nonempty"):
+        synthesize_verification_tasks("   ", provider=provider)
+    with pytest.raises(ValueError, match="count must be at least 1"):
+        synthesize_verification_tasks("add GitHub access", provider=provider, count=0)
+    assert provider.requests == []
+
+
+def test_result_model_is_frozen() -> None:
+    provider = FakeProvider([_reply([_task("feedback-verify-01")])])
+    result = synthesize_verification_tasks("add GitHub access", provider=provider)
+    with pytest.raises(ValidationError):
+        result.knowledge_notes = "mutated"  # type: ignore[misc]


### PR DESCRIPTION
## What

`wmh harness improve` — a one-step, world-model-gated harness self-edit driven by natural-language feedback. Re-homed onto main's re-landed optimize stack (#240 source trees, #241 Harbor `Scorer`, #242 `wmh optimize` harbor / slot-based `population.optimize`). Supersedes the closed #233, which was built on the abandoned #217–#231 stack.

## Flow

1. `wmh/scenarios/feedback.py` synthesizes must-pass **verification** `TaskSpec`s (plus knowledge notes) from the feedback; seed QA drops any the champion already passes.
2. `wmh/evals/world_model_scorer.py` — `WorldModelScorer` implements main's `Scorer` protocol (`request` property + `score(doc) -> ScoreReport`), reusing `evaluate_closed_loop`; each (task, attempt) maps to a `ScoreCell` with `reward = verdict.fraction`, `passed = verdict.passed`.
3. `wmh/harness/improve.py` — `improve_harness` runs one `population.optimize` slot with the feedback as the proposer directive, then applies an **explicit gate** (standard suite within a relative margin, default 10%, of the seed **and** every verification task passing a strict majority of attempts), ignoring the optimizer's blended `best`.
4. `wmh/cli/harness_improve.py` — `wmh harness improve NAME --feedback ... --tasks suite.jsonl --model WM`.

## Additive changes to main

- `ProjectCandidateProposer` gains optional `directive` and `on_event` (main already stages the seed into `candidate/` and edits it in place; its `run_bash` runs as the default sandbox user in the workspace, so no contained-shell workarounds are needed).
- `WorldModel.load` / `load_world_model` gain an optional `knowledge_dir` override.

## Validation

Full gate green on main's tip: `ruff format` / `ruff check` / `ty check` clean; `pytest -q`: **2176 passed, 18 skipped**. All new tests hermetic (no network, no E2B, no providers).

The companion platform PR (#347) drives this from a live-session composer; it will re-point its wmh pin to this branch and adapt its improve worker to these APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)