### PR TITLE
Surface per-episode token telemetry to the harness proposer

### DIFF
--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -22,6 +22,7 @@ Two operational behaviors matter most here:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import math
 import shutil
@@ -31,7 +32,7 @@ from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol, Self
+from typing import Literal, Protocol, Self, TypedDict
 
 from harbor import Job
 from harbor.models.agent.name import AgentName
@@ -51,6 +52,7 @@ from wmh.evals.harbor.e2b_template_policy import WMH_HARBOR_E2B_ENVIRONMENT_IMPO
 from wmh.evals.harbor.tasks import resolve_harbor_tasks
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.e2b_sandbox import resolve_e2b_template
+from wmh.harness.project_proposer import TRIAL_AGENT_DIR, WMH_RUN_FILENAME
 from wmh.harness.runtime import (
     DEFAULT_EVAL_EPISODE_TIMEOUT_S,
     HarnessSearchCancelled,
@@ -433,19 +435,23 @@ class HarborScorer:
         if wrong_counts:
             raise ValueError(f"harbor task matrix is incomplete: counts={wrong_counts}")
 
+        max_turns = doc.max_turns()
         cells: list[ScoreCell] = []
         for task_id in self._task_ids:
             trials = sorted(grouped[task_id], key=lambda trial: trial.trial_name)
             for attempt, trial in enumerate(trials, 1):
                 reward = _official_reward(trial, reward_key=self._reward_key)
+                trial_dir = run.job_dir / trial.trial_name
+                telemetry = _trial_telemetry(trial, trial_dir, max_turns=max_turns)
                 cells.append(
                     ScoreCell(
                         task_id=task_id,
                         attempt=attempt,
                         reward=reward,
                         passed=reward_passed(reward, self._reward_mode),
-                        artifact_dir=str(run.job_dir / trial.trial_name),
+                        artifact_dir=str(trial_dir),
                         note=_trial_note(trial),
+                        **telemetry,
                     )
                 )
         return ScoreReport(
@@ -655,3 +661,86 @@ def _official_reward(trial: TrialResult, *, reward_key: str) -> float:
 def _trial_note(trial: TrialResult) -> str:
     exception = trial.exception_info
     return "completed" if exception is None else f"completed with {exception.exception_type}"
+
+
+# Stop-reason markers a WMH transcript writes when the episode was cut short by a timeout: the
+# harbor agent-timeout cancellation marker and the max-turns sentinel are both interesting to the
+# proposer. See wmh/evals/harbor/agent.py (_CANCELLED_STOP_REASON) and StopReason.
+_TIMEOUT_STOP_REASON_SUBSTRINGS = ("timeout", "cancelled")
+# Exception types that mean the WMH episode itself timed out (harbor's agent timeout), distinct
+# from the verifier-outcome exceptions scored 0 above.
+_TIMEOUT_EXCEPTIONS = frozenset({"AgentTimeoutError", "TimeoutError"})
+
+
+class _TrialTelemetry(TypedDict):
+    """The optional per-episode telemetry fields projected onto one ScoreCell."""
+
+    turns: int | None
+    calls: int | None
+    input_tokens: int | None
+    output_tokens: int | None
+    stop_reason: str
+    hit_turn_cap: bool
+    hit_timeout: bool
+
+
+def _trial_telemetry(trial: TrialResult, trial_dir: Path, *, max_turns: int) -> _TrialTelemetry:
+    """Best-effort per-episode token telemetry from the trial's WMH transcript.
+
+    Non-fatal by contract: a missing, absent, or unparseable wmh-run.json (or one without
+    worker_usage) leaves every field defaulted and never raises, so a broken transcript cannot
+    break scoring. Reading it is the only new I/O in the projection, and it is cheap relative to
+    the harbor job that produced it.
+    """
+    telemetry: _TrialTelemetry = {
+        "turns": None,
+        "calls": None,
+        "input_tokens": None,
+        "output_tokens": None,
+        "stop_reason": "",
+        "hit_turn_cap": False,
+        "hit_timeout": False,
+    }
+    transcript_path = trial_dir / TRIAL_AGENT_DIR / WMH_RUN_FILENAME
+    try:
+        raw = json.loads(transcript_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # No transcript, or unreadable/invalid JSON: leave defaults and mark a timeout from the
+        # trial exception alone, so a cancelled episode with a lost transcript still reports it.
+        telemetry["hit_timeout"] = _exception_is_timeout(trial)
+        return telemetry
+    if not isinstance(raw, dict):
+        telemetry["hit_timeout"] = _exception_is_timeout(trial)
+        return telemetry
+
+    turns = _as_optional_int(raw.get("turns"))
+    telemetry["turns"] = turns
+    stop_reason = raw.get("stop_reason")
+    telemetry["stop_reason"] = stop_reason if isinstance(stop_reason, str) else ""
+    usage = raw.get("worker_usage")
+    if isinstance(usage, dict):
+        telemetry["calls"] = _as_optional_int(usage.get("calls"))
+        telemetry["input_tokens"] = _as_optional_int(usage.get("input_tokens"))
+        telemetry["output_tokens"] = _as_optional_int(usage.get("output_tokens"))
+    telemetry["hit_turn_cap"] = turns is not None and turns >= max_turns
+    telemetry["hit_timeout"] = _stop_reason_is_timeout(telemetry["stop_reason"]) or (
+        _exception_is_timeout(trial)
+    )
+    return telemetry
+
+
+def _as_optional_int(value: object) -> int | None:
+    """Coerce a transcript field to a nonnegative int, or None when it is not one."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _stop_reason_is_timeout(stop_reason: str) -> bool:
+    lowered = stop_reason.lower()
+    return any(marker in lowered for marker in _TIMEOUT_STOP_REASON_SUBSTRINGS)
+
+
+def _exception_is_timeout(trial: TrialResult) -> bool:
+    exception = trial.exception_info
+    return exception is not None and exception.exception_type in _TIMEOUT_EXCEPTIONS

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import subprocess
 import sys
 import threading
@@ -99,10 +100,17 @@ def _trial(
 
 
 class _Runner:
-    """Materializes trial dirs under the candidate's deterministic job dir, like harbor."""
+    """Materializes trial dirs under the candidate's deterministic job dir, like harbor.
 
-    def __init__(self, trials: list[TrialResult]) -> None:
+    `transcripts` maps a trial name to the exact `agent/wmh-run.json` bytes harbor would have
+    written for that episode; unlisted trials get no transcript (the common no-telemetry case).
+    """
+
+    def __init__(
+        self, trials: list[TrialResult], *, transcripts: dict[str, str] | None = None
+    ) -> None:
         self.trials = trials
+        self.transcripts = transcripts or {}
         self.configs: list[JobConfig] = []
 
     def run(
@@ -118,6 +126,11 @@ class _Runner:
             trial_dir = job_dir / trial.trial_name
             trial_dir.mkdir(parents=True, exist_ok=True)
             (trial_dir / "result.json").write_text(trial.model_dump_json(), encoding="utf-8")
+            transcript = self.transcripts.get(trial.trial_name)
+            if transcript is not None:
+                agent_dir = trial_dir / "agent"
+                agent_dir.mkdir(parents=True, exist_ok=True)
+                (agent_dir / "wmh-run.json").write_text(transcript, encoding="utf-8")
         now = datetime.now(UTC)
         result = JobResult(
             id=_JOB_ID,
@@ -138,8 +151,9 @@ def _scorer(
     attempts: int = 1,
     reward_mode: RewardMode = "raw",
     agent_concurrency: int | None = None,
+    transcripts: dict[str, str] | None = None,
 ) -> tuple[HarborScorer, _Runner]:
-    runner = _Runner(trials)
+    runner = _Runner(trials, transcripts=transcripts)
     scorer = HarborScorer(
         job_template=_job_template(tmp_path),
         tasks=_tasks(tmp_path, task_ids),
@@ -253,6 +267,110 @@ def test_positive_binary_mode_passes_on_any_positive_reward_and_keeps_raw_values
     assert cell.reward == 0.25  # raw reward untouched
     assert cell.passed is True
     assert report.score == 0.5
+
+
+def _trial_name(task_id: str, attempt: int) -> str:
+    return f"{task_id}__{_SUFFIXES[attempt - 1]}"
+
+
+def test_scorer_populates_telemetry_from_the_wmh_transcript(tmp_path: Path) -> None:
+    """Turns/calls/tokens/stop_reason lift from agent/wmh-run.json; hit_turn_cap fires when the
+    episode reached the scored doc's cap and hit_timeout on a harbor-timeout stop_reason."""
+    candidate = HarnessDoc.baseline("candidate")  # baseline max_turns == 20
+    trials = [
+        _trial(tmp_path, "task-a", 1, reward=1.0),
+        _trial(tmp_path, "task-b", 1, reward=0.0, exception="AgentTimeoutError"),
+    ]
+    transcripts = {
+        # A clean submitted episode well under the turn cap.
+        _trial_name("task-a", 1): json.dumps(
+            {
+                "task_id": "task-a",
+                "stop_reason": "submitted",
+                "turns": 7,
+                "worker_usage": {"input_tokens": 1200, "output_tokens": 340, "calls": 7},
+            }
+        ),
+        # A timed-out partial episode that reached the turn cap.
+        _trial_name("task-b", 1): json.dumps(
+            {
+                "task_id": "task-b",
+                "stop_reason": "cancelled-by-harbor-timeout",
+                "turns": 20,
+                "partial": True,
+                "worker_usage": {"input_tokens": 9000, "output_tokens": 512, "calls": 20},
+            }
+        ),
+    }
+    scorer, _runner = _scorer(tmp_path, trials, transcripts=transcripts)
+
+    report = scorer.score(candidate)
+
+    clean = report.by_task()["task-a"][0]
+    assert clean.turns == 7
+    assert clean.calls == 7
+    assert clean.input_tokens == 1200
+    assert clean.output_tokens == 340
+    assert clean.stop_reason == "submitted"
+    assert clean.hit_turn_cap is False
+    assert clean.hit_timeout is False
+
+    timed_out = report.by_task()["task-b"][0]
+    assert timed_out.turns == 20
+    assert timed_out.hit_turn_cap is True  # turns >= baseline max_turns (20)
+    assert timed_out.hit_timeout is True  # cancelled-by-harbor-timeout stop_reason
+    assert timed_out.input_tokens == 9000
+
+    # The candidate-level aggregate is now computable straight off the report.
+    summary = report.telemetry_summary()
+    assert summary["n_with_telemetry"] == 2
+    assert summary["turn_cap_hit_rate"] == pytest.approx(0.5)
+    assert summary["timeout_rate"] == pytest.approx(0.5)
+
+
+def test_missing_or_unparseable_transcript_is_non_fatal_and_defaults_telemetry(
+    tmp_path: Path,
+) -> None:
+    """A missing/unparseable wmh-run.json must never break scoring: the cell scores normally with
+    every telemetry field defaulted (turns None, flags False), and the aggregate is empty."""
+    candidate = HarnessDoc.baseline("candidate")
+    trials = [
+        _trial(tmp_path, "task-a", 1, reward=1.0),  # no transcript at all
+        _trial(tmp_path, "task-b", 1, reward=0.0),  # unparseable transcript
+    ]
+    transcripts = {_trial_name("task-b", 1): "{not valid json"}
+    scorer, _runner = _scorer(tmp_path, trials, transcripts=transcripts)
+
+    report = scorer.score(candidate)  # must not raise
+
+    assert report.score == pytest.approx(0.5)  # scoring unaffected
+    for cell in report.cells:
+        assert cell.turns is None
+        assert cell.calls is None
+        assert cell.input_tokens is None
+        assert cell.output_tokens is None
+        assert cell.stop_reason == ""
+        assert cell.hit_turn_cap is False
+        assert cell.hit_timeout is False
+    assert report.telemetry_summary() == {"n_with_telemetry": 0}
+
+
+def test_timeout_exception_marks_hit_timeout_even_without_a_transcript(tmp_path: Path) -> None:
+    """A cancelled episode whose transcript was lost still reports hit_timeout from the trial
+    exception alone, so timeout pressure is not silently dropped."""
+    candidate = HarnessDoc.baseline("candidate")
+    trials = [
+        _trial(tmp_path, "task-a", 1, reward=0.0, exception="AgentTimeoutError"),
+        _trial(tmp_path, "task-b", 1, reward=1.0),
+    ]
+    scorer, _runner = _scorer(tmp_path, trials)  # no transcripts written
+
+    report = scorer.score(candidate)
+
+    timed_out = report.by_task()["task-a"][0]
+    assert timed_out.turns is None  # no transcript, so no turn/token telemetry
+    assert timed_out.hit_timeout is True  # inferred from the AgentTimeoutError exception
+    assert report.by_task()["task-b"][0].hit_timeout is False
 
 
 def test_entry_prunes_only_unscoreable_trial_dirs(tmp_path: Path) -> None:

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -289,9 +289,17 @@ class ProjectCandidateProposer:
                         "passed": cell.passed,
                         "note": cell.note,
                         "trial_dir": trial_dir,
+                        "turns": cell.turns,
+                        "calls": cell.calls,
+                        "input_tokens": cell.input_tokens,
+                        "output_tokens": cell.output_tokens,
+                        "stop_reason": cell.stop_reason,
+                        "hit_turn_cap": cell.hit_turn_cap,
+                        "hit_timeout": cell.hit_timeout,
                     }
                 )
                 budget = self._copy_trial_evidence(project, trial_dir, cell, budget)
+            telemetry = _candidate_telemetry(evaluated)
             project.write_text(
                 f"{directory}/report.json",
                 _json(
@@ -301,6 +309,7 @@ class ProjectCandidateProposer:
                         "pass_rate": report.pass_rate,
                         "reward_mode": report.reward_mode,
                         "attempts": report.request.attempts,
+                        "telemetry": telemetry,
                         "cells": cells,
                     }
                 ),
@@ -314,6 +323,7 @@ class ProjectCandidateProposer:
                         task_id: sum(1 for cell in cells_ if cell.passed) / len(cells_)
                         for task_id, cells_ in report.by_task().items()
                     },
+                    "telemetry": telemetry,
                     "source_dir": f"{directory}/source",
                     "report": f"{directory}/report.json",
                     "trials_dir": f"{directory}/trials",
@@ -531,6 +541,17 @@ transcript for that trial; `verifier/` holds the verifier's own output). Earlier
 traces, including failed ones, remain under `{PROPOSALS_DIR}/`. {previous_trace} Use the full
 population as evidence.
 
+Each candidate's `manifest.json` entry and its `history/<candidate>/report.json` carry per-task
+token telemetry (turns, calls, input/output tokens, stop_reason, hit_turn_cap, hit_timeout) and a
+candidate-level `telemetry` aggregate (`turn_cap_hit_rate`, `timeout_rate`, token medians,
+`output_tokens_p90`) beside the harness's own `max_turns` and `max_output_tokens` caps. Use it to
+decide which settings actually change behavior: a high `turn_cap_hit_rate` means episodes are
+running out of turns, so raising `max_turns` can help; an `output_tokens_p90` far below
+`max_output_tokens` means that cap is not the bottleneck, so leave it alone; a high
+`input_tokens_median` with a rising `timeout_rate` means context is bloating, so trim or manage
+context rather than only adding turns. Telemetry is absent (`n_with_telemetry` is 0 or a field is
+null) for trials whose transcript was missing or unparseable; treat those as no signal.
+
 Your only candidate output is this directory:
 `{stage_dir}`
 
@@ -558,6 +579,31 @@ for a repair.
 
 This turn's immutable request and trace are stored under `{PROPOSALS_DIR}/slot-{slot:04d}/`.
 """
+
+
+def _candidate_telemetry(evaluated: EvaluatedCandidate) -> dict[str, JsonValue]:
+    """The candidate's token-telemetry aggregate paired with the caps it should be compared to.
+
+    Pairing `output_tokens_p90`/`turn_cap_hit_rate` with the harness's own `max_output_tokens`
+    and `max_turns` lets the proposer read straight off one block whether a cap is binding: an
+    output p90 far below max_output_tokens means that cap is not the bottleneck, while a high
+    turn-cap-hit-rate means raising max_turns can move behavior. Deriving the caps reparses the
+    candidate source; a malformed doc is not this feedback's job to surface, so fall back to the
+    summary alone (the caps also live in each candidate's materialized config.toml).
+    """
+    summary = dict(evaluated.report.telemetry_summary())
+    try:
+        doc = evaluated.candidate
+        summary["max_turns"] = doc.max_turns()
+        summary["max_output_tokens"] = doc.max_output_tokens()
+    except (TypeError, ValueError):
+        logger.warning(
+            "could not derive caps for candidate %s telemetry; the summary omits them "
+            "(caps still live in the candidate's config.toml)",
+            evaluated.candidate_id,
+            exc_info=True,
+        )
+    return summary
 
 
 def _json(value: JsonValue) -> str:

--- a/wmh/harness/project_proposer.py
+++ b/wmh/harness/project_proposer.py
@@ -49,8 +49,13 @@ PROPOSALS_DIR = "proposals"
 DEFAULT_CANDIDATE_HISTORY_BYTES = 256 * 1024 * 1024
 # Per-file cap before head/tail truncation (transcripts keep both ends plus a marker).
 DEFAULT_HISTORY_FILE_BYTES = 2 * 1024 * 1024
-_WMH_RUN_FILENAME = "wmh-run.json"
-_TRIAL_AGENT_DIR = "agent"
+# The harbor trial layout the proposer and the scorer both read: the WMH transcript lives at
+# `<trial>/<TRIAL_AGENT_DIR>/<WMH_RUN_FILENAME>`. Shared (not duplicated) so telemetry extraction
+# in the scorer and evidence materialization here can never drift onto divergent literals.
+TRIAL_AGENT_DIR = "agent"
+WMH_RUN_FILENAME = "wmh-run.json"
+_WMH_RUN_FILENAME = WMH_RUN_FILENAME
+_TRIAL_AGENT_DIR = TRIAL_AGENT_DIR
 _TRIAL_VERIFIER_DIR = "verifier"
 
 

--- a/wmh/harness/project_proposer_test.py
+++ b/wmh/harness/project_proposer_test.py
@@ -180,6 +180,66 @@ def test_proposer_materializes_history_stages_seed_and_returns_one_candidate(
     assert json.loads((slot_dir / "status.json").read_text(encoding="utf-8"))["valid"] is True
 
 
+def test_materialized_history_carries_telemetry_into_report_manifest_and_request(
+    tmp_path: Path,
+) -> None:
+    """Per-task telemetry lands in report.json cells, the candidate aggregate lands in both
+    report.json and the manifest beside the harness caps, and REQUEST.md tells the proposer to
+    use it."""
+    trial = tmp_path / "harbor" / "wmh-tele" / "t1__trial"
+    (trial / "agent").mkdir(parents=True)
+    (trial / "agent" / "wmh-run.json").write_text('{"steps": []}', encoding="utf-8")
+    tree = _tree("seed")
+    doc = tree.to_doc("candidate-0000")
+    report = ScoreReport(
+        doc_hash=doc.doc_hash,
+        request=ScoreRequest(task_ids=("t1",), attempts=1),
+        reward_mode="positive-binary",
+        cells=(
+            ScoreCell(
+                task_id="t1",
+                attempt=1,
+                reward=1.0,
+                passed=True,
+                artifact_dir=str(trial),
+                turns=20,
+                calls=20,
+                input_tokens=8000,
+                output_tokens=300,
+                stop_reason="max_turns",
+                hit_turn_cap=True,
+                hit_timeout=False,
+            ),
+        ),
+    )
+    seed = EvaluatedCandidate("candidate-0000", tree, report)
+    project = _FakeProject([_tree("improved")])
+
+    _proposer([project], tmp_path / "run").propose((seed,), slot=1)
+
+    report_json = json.loads(project.files["history/candidate-0000/report.json"])
+    [cell] = report_json["cells"]
+    assert cell["turns"] == 20
+    assert cell["output_tokens"] == 300
+    assert cell["stop_reason"] == "max_turns"
+    assert cell["hit_turn_cap"] is True
+    # The candidate-level aggregate sits beside the harness's own caps for direct comparison.
+    telemetry = report_json["telemetry"]
+    assert telemetry["n_with_telemetry"] == 1
+    assert telemetry["turn_cap_hit_rate"] == 1.0
+    assert telemetry["output_tokens_p90"] == 300
+    assert telemetry["max_turns"] == doc.max_turns()
+    assert telemetry["max_output_tokens"] == doc.max_output_tokens()
+    manifest = json.loads(project.files["history/manifest.json"])
+    assert manifest["candidates"][0]["telemetry"] == telemetry
+    # The prompt tells the proposer these fields exist and how to read them.
+    request = project.run_calls[0].instruction
+    assert "telemetry" in request
+    assert "turn_cap_hit_rate" in request
+    assert "output_tokens_p90" in request
+    assert "max_output_tokens" in request
+
+
 def test_missing_submit_consumes_the_slot_with_persisted_evidence(tmp_path: Path) -> None:
     project = _FakeProject([_tree("improved")])
     project.emit_submit = False

--- a/wmh/harness/scoring.py
+++ b/wmh/harness/scoring.py
@@ -14,10 +14,10 @@ passed iff its raw reward is strictly positive; `raw` counts it passed iff the r
 from __future__ import annotations
 
 from collections.abc import Callable
-from statistics import fmean
+from statistics import fmean, median
 from typing import Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
 from wmh.core.text import validate_durable_text
 from wmh.harness.doc import HarnessDoc
@@ -33,6 +33,14 @@ def reward_passed(reward: float, mode: RewardMode) -> bool:
     if mode == "raw":
         return reward == 1.0
     return reward > 0.0
+
+
+def _p90(values: list[int]) -> int:
+    """The 90th-percentile value by nearest-rank (deterministic, no interpolation)."""
+    ordered = sorted(values)
+    # Nearest-rank: rank ceil(0.9 * n), 1-indexed, clamped into the sample.
+    rank = -(-9 * len(ordered) // 10)  # ceil(0.9 * n) via ceil-division
+    return ordered[min(max(rank, 1), len(ordered)) - 1]
 
 
 class ScoreRequest(BaseModel):
@@ -80,6 +88,20 @@ class ScoreCell(BaseModel):
     # A short diagnostic, e.g. "completed with AgentTimeoutError". A trial that failed but still
     # produced a verifier reward is a candidate outcome, and the note says why it looks that way.
     note: str = Field(default="", max_length=MAX_CELL_NOTE_CHARS)
+    # Optional per-episode token telemetry lifted from the trial's WMH transcript. All fields are
+    # best-effort and default when no transcript exists or it cannot be parsed, so every existing
+    # construction and the `.score`/`.pass_rate` contract stay unchanged. The proposer reads these
+    # to tell which harness settings (turn cap, output cap, context size) actually change behavior.
+    turns: int | None = None
+    calls: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    # The episode's stop reason (e.g. "submitted", "max_turns", "cancelled-by-harbor-timeout").
+    stop_reason: str = Field(default="", max_length=MAX_CELL_NOTE_CHARS)
+    # True when the episode reached the scored doc's turn cap (a lever raising max_turns can move).
+    hit_turn_cap: bool = False
+    # True when the episode was cancelled by a harbor agent timeout or carried a timeout exception.
+    hit_timeout: bool = False
 
     @field_validator("attempt", mode="before")
     @classmethod
@@ -146,6 +168,32 @@ class ScoreReport(BaseModel):
         return {
             task_id: tuple(cell for cell in self.cells if cell.task_id == task_id)
             for task_id in self.request.task_ids
+        }
+
+    def telemetry_summary(self) -> dict[str, JsonValue]:
+        """Candidate-level token telemetry aggregated over cells that carry it.
+
+        Deterministic and pure: it only reads the cells' populated telemetry fields (a cell with
+        `turns is None` contributed no transcript and is skipped). Returns
+        `{"n_with_telemetry": 0}` when no cell has telemetry, so a caller can always distinguish
+        "no signal" from a real aggregate rather than guessing from an empty dict. This is the
+        "impossible to miss" signal the proposer reads to decide which harness caps are binding:
+        a high `turn_cap_hit_rate` means raising max_turns will help, while an `output_tokens_p90`
+        far below the harness's max_output_tokens means that cap is not the bottleneck.
+        """
+        cells = [cell for cell in self.cells if cell.turns is not None]
+        n = len(cells)
+        if n == 0:
+            return {"n_with_telemetry": 0}
+        input_tokens = [cell.input_tokens for cell in cells if cell.input_tokens is not None]
+        output_tokens = [cell.output_tokens for cell in cells if cell.output_tokens is not None]
+        return {
+            "n_with_telemetry": n,
+            "turn_cap_hit_rate": fmean(1.0 if cell.hit_turn_cap else 0.0 for cell in cells),
+            "timeout_rate": fmean(1.0 if cell.hit_timeout else 0.0 for cell in cells),
+            "input_tokens_median": median(input_tokens) if input_tokens else None,
+            "output_tokens_median": median(output_tokens) if output_tokens else None,
+            "output_tokens_p90": _p90(output_tokens) if output_tokens else None,
         }
 
 

--- a/wmh/harness/scoring_test.py
+++ b/wmh/harness/scoring_test.py
@@ -92,3 +92,98 @@ def test_request_rejects_empty_duplicate_and_boolean_inputs() -> None:
         ScoreRequest(task_ids=("a", "a"), attempts=1)
     with pytest.raises(ValidationError, match="not boolean"):
         ScoreRequest(task_ids=("a",), attempts=True)  # type: ignore[arg-type]
+
+
+def test_telemetry_fields_default_and_keep_the_score_contract_unchanged() -> None:
+    # A cell built the old way carries no telemetry; the score/pass_rate contract is untouched.
+    report = _report(
+        (_cell("a", 1, 1.0), _cell("b", 1, 0.0)),
+        tasks=("a", "b"),
+        attempts=1,
+    )
+    for cell in report.cells:
+        assert cell.turns is None
+        assert cell.calls is None
+        assert cell.input_tokens is None
+        assert cell.output_tokens is None
+        assert cell.stop_reason == ""
+        assert cell.hit_turn_cap is False
+        assert cell.hit_timeout is False
+    assert report.score == pytest.approx(0.5)
+    assert report.pass_rate == pytest.approx(0.5)
+    # No cell has telemetry, so the aggregate is the explicit empty marker (not a bare {}).
+    assert report.telemetry_summary() == {"n_with_telemetry": 0}
+
+
+def _telemetry_cell(
+    task_id: str,
+    attempt: int,
+    *,
+    turns: int,
+    input_tokens: int,
+    output_tokens: int,
+    hit_turn_cap: bool = False,
+    hit_timeout: bool = False,
+) -> ScoreCell:
+    return ScoreCell(
+        task_id=task_id,
+        attempt=attempt,
+        reward=1.0,
+        passed=True,
+        turns=turns,
+        calls=turns,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        stop_reason="submitted",
+        hit_turn_cap=hit_turn_cap,
+        hit_timeout=hit_timeout,
+    )
+
+
+def test_telemetry_summary_aggregates_only_cells_that_carry_telemetry() -> None:
+    report = _report(
+        (
+            _telemetry_cell("a", 1, turns=5, input_tokens=100, output_tokens=10, hit_turn_cap=True),
+            _telemetry_cell("a", 2, turns=8, input_tokens=200, output_tokens=20, hit_timeout=True),
+            _telemetry_cell("b", 1, turns=3, input_tokens=300, output_tokens=90),
+            # No-telemetry cell: skipped by the aggregate (turns is None).
+            _cell("b", 2, 1.0),
+        ),
+        tasks=("a", "b"),
+        attempts=2,
+    )
+    summary = report.telemetry_summary()
+    assert summary["n_with_telemetry"] == 3  # the fourth cell has no telemetry
+    assert summary["turn_cap_hit_rate"] == pytest.approx(1 / 3)
+    assert summary["timeout_rate"] == pytest.approx(1 / 3)
+    assert summary["input_tokens_median"] == 200  # median of [100, 200, 300]
+    assert summary["output_tokens_median"] == 20  # median of [10, 20, 90]
+    # p90 by nearest rank over [10, 20, 90]: ceil(0.9*3)=3 -> the largest value.
+    assert summary["output_tokens_p90"] == 90
+
+
+def test_telemetry_summary_tolerates_turns_present_but_token_fields_absent() -> None:
+    # A timed-out episode can record turns/stop_reason with no worker_usage: medians stay None,
+    # but the rates and count still reflect the cell (turns is not None).
+    report = _report(
+        (
+            ScoreCell(
+                task_id="a",
+                attempt=1,
+                reward=0.0,
+                passed=False,
+                turns=4,
+                stop_reason="cancelled-by-harbor-timeout",
+                hit_timeout=True,
+            ),
+        ),
+        tasks=("a",),
+        attempts=1,
+    )
+    summary = report.telemetry_summary()
+    assert summary["n_with_telemetry"] == 1
+    assert summary["timeout_rate"] == pytest.approx(1.0)
+    assert summary["turn_cap_hit_rate"] == pytest.approx(0.0)
+    assert summary["input_tokens_median"] is None
+    assert summary["output_tokens_median"] is None
+    assert summary["output_tokens_p90"] is None


### PR DESCRIPTION
## Why
A token-level meta-analysis of a completed meta-harness run (Haiku 4.5 worker, TB2) found the optimizer improved the harness by **bundling changes it could not individually attribute**. The winning candidate raised `max_turns` (load-bearing: ~49% of *passing* episodes used >20 turns, which the old cap would have truncated-and-killed), `max_output_tokens` (**provably inert** — episodes never reached even 0.9x the *old* cap; per-call output median ~250-300 tokens), and temperature. Because the proposer only ever saw a scalar score plus raw transcripts it rarely opened (it read ~0.1-0.2% of the materialized traces), it could not tell which mutation mattered and re-proposed the whole inert bundle repeatedly.

The per-episode token telemetry needed to isolate the effective lever **already exists** in every trial's `wmh-run.json` (`turns`, `stop_reason`, `worker_usage.{input_tokens, output_tokens, calls}`). This PR surfaces it in the aggregate feedback the proposer actually reads. Output tokens are ~3% of run cost, so richer structured feedback is nearly free. (Grounds GEPA's finding that structured "why it failed" diagnostics beat scalar reward at far fewer rollouts.)

This is the first of the meta-analysis's recommendations; the others (context-management as a scored dimension, an accuracy-per-token fitness term, curated failure-trace bundles, variance-aware selection) are intentionally **not** in this PR.

## What
- **`ScoreCell`** gains seven optional, all-defaulted fields: `turns`, `calls`, `input_tokens`, `output_tokens` (`int | None`), `stop_reason`, `hit_turn_cap`, `hit_timeout`. Frozen/`extra="forbid"` preserved; `.score`/`.pass_rate`/validators unchanged.
- **`ScoreReport.telemetry_summary()`** aggregates over telemetry-bearing cells (`turn_cap_hit_rate`, `timeout_rate`, `input_tokens_median`, `output_tokens_median`, `output_tokens_p90`, `n_with_telemetry`), returning the explicit `{"n_with_telemetry": 0}` marker when none carry telemetry.
- **`HarborScorer`** populates each cell's telemetry from the trial transcript, **best-effort and non-fatal**: a missing/unparseable `wmh-run.json` leaves fields defaulted and never breaks scoring. `hit_turn_cap = turns >= doc.max_turns()`; `hit_timeout` from the transcript stop reason or a timeout trial exception.
- **Proposer history** now writes the telemetry into every `report.json` cell and adds a candidate-level `telemetry` block (the summary plus the harness's own `max_turns`/`max_output_tokens` for direct comparison) to `report.json` and each `manifest` entry. The proposal prompt gains a short factual how-to-use-it note: a high `turn_cap_hit_rate` means raising `max_turns` helps; `output_tokens_p90` far below `max_output_tokens` means that cap is not the bottleneck; high `input_tokens_median` with a rising `timeout_rate` means context is bloating.

Fully additive and backward-compatible.

## Verification
`ruff check` / `format --check` / `ty check` clean; full suite **2136 passed, 18 skipped** (base main: 2129; +7 new tests, none changed). New tests cover: non-fatal missing/unparseable transcript, `hit_turn_cap` at the cap, `hit_timeout` from stop reason and from a transcript-less timeout exception, aggregate correctness + empty marker, and telemetry landing in report.json/manifest/REQUEST.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)