### PR TITLE
Endpoint serving core: model pool, native streaming, optimizer interface, routing policy artifact, OpenAI-compatible endpoint

### DIFF
--- a/.agents/docs/proposals/routing-optimizer-v1.md
+++ b/.agents/docs/proposals/routing-optimizer-v1.md
@@ -1,0 +1,89 @@
+# Routing optimizer v1: benchmark + implementation proposal (DISCUSSION DRAFT)
+
+Status: awaiting Silen's back-and-forth (his explicit direction 2026-07-24: no fitting code
+until the benchmark and approach are agreed). Everything AROUND the optimizer already exists
+on feat/optimizer-switch: pool, closed-loop OutcomeMatrix, policy artifact + serve-time
+selection, OpenAI-compatible streaming endpoint, improvement report. The fitter drops into
+`RoutingPolicy` (wmh/optimize/policy.py) and is judged by the benchmark below.
+
+## 1. The benchmark: what "working" means
+
+One number cannot honestly answer "does routing work"; the benchmark is a fixed table computed
+from one precomputed OutcomeMatrix per benchmark corpus (RouterBench methodology: run the pool
+over the scenarios once, compare every policy variant offline on identical data).
+
+**Data**: per corpus (start: tau-bench, terminal-tasks, bird-sql), scenarios split by SCENARIO
+id into fit/validation/test with task-level leakage control (D26 precedent). The test split is
+never seen by any fitting run. Episodes per scenario: 2 (judge-noise floor per D30).
+
+**Baselines (the quartet, all from the same matrix)**:
+1. Best single model in hindsight (chosen on fit split, evaluated on test): the "why route at
+   all" bar. THE PASS/FAIL GATE IS AGAINST THIS, not against a weak strawman.
+2. Random assignment (expectation over the pool): sanity floor.
+3. Oracle (per-scenario best on test): the ceiling; how much headroom routing has at all.
+4. All-frontier (the D-REPORT baseline model everywhere): the cost-savings anchor.
+
+**Metrics**:
+- Cost-quality Pareto frontier plot (policy knob swept) + AIQ (area under cost-quality, absolute
+  dollars, RouterBench convention).
+- Headline pair at the balanced default knob: accuracy delta vs best-single-model (must be
+  >= -1 noise-floor point) AND cost delta (must be materially cheaper; propose >= 30% cheaper,
+  else routing is complexity without payoff).
+- Latency p50/p95 carried but reported, not gated, in v1.
+- Judge noise bar: every headline delta is reported with the seed/episode spread; a delta
+  inside the spread is "no effect" by definition (env-luck lesson, stdev 0.34 history).
+
+**PASS for v1** = on >= 2 of 3 corpora, at the default knob: accuracy within noise of
+best-single-model AND cost <= 0.7x best-single-model's, on the untouched test split, judge
+pinned. FAIL = anything else; we then ship static policies and say so.
+
+**Cache honesty**: matrix episodes are effectively cold-cache single conversations, so v1
+benchmark cost is single-shot and the report's cost_assumptions says exactly that. The
+multi-turn cache-adjusted benchmark (traffic replay with per-model cache state, switching cost
+= residual prefill per GORGO 2602.11688) is phase 2, tied to capturing cached_tokens in
+providers. We do NOT quote multi-turn savings until then (2604.12385 is the closest prior art
+and is simulation-only; being wired to real cache state is our claim, so it must be real).
+
+## 2. v1 algorithm proposal (to agree on, then build)
+
+Avengers-style cluster-then-assign (2505.19797), the literature's small-data winner:
+1. Embed fit-split scenario tasks (HashingEmbedder first; measure, then decide if a provider
+   embedder is worth credentials, per the 2505.12601 locality diagnostic).
+2. k-means (numpy, k swept over ~4-16, chosen on validation).
+3. Per cluster, assign argmax over pool of `mean_reward - lambda * cost_per_run`; lambda is the
+   single knob (Hybrid-LLM style: fit once, slide at eval time to trace the frontier; default
+   knob = balanced point). Thin clusters (< N scored episodes) fall back to default_model,
+   counted and reported, never silently.
+4. Emit RoutingPolicy(kind="cluster") + ImprovementReport; `fitted_from` pins the matrix.
+Explicitly NOT in v1: trained per-query predictors (MTRouter-style, v2), cascades, bandits,
+switching-penalty learning (serving is default-sticky until phase 2).
+
+## 3. Invocation shape (CLI/factory), to reconcile with `wmh optimize <agent>`
+
+`wmh optimize` today means harness optimization (PR #242). Proposal: keep positional semantics
+and add the switch as a subcommand group later only if a third CLI-visible optimizer appears;
+for the routing optimizer the natural surface is endpoint-centric, not optimizer-centric:
+
+    wmh route fit <world-model> --pool .wmh/pool.toml --episodes 2 [--knob 0.5]
+    wmh route report <world-model>   # rebuild the report from the pinned matrix
+
+(name "route" is internal-dev vocabulary; customer copy never says router.) Alternative
+steelman: `wmh optimize --optimizer routing <world-model>` keeps one verb as the brief sketched,
+but overloads a command whose positional args mean something else today. Recommendation: the
+endpoint-centric `wmh route` pair; revisit if Silen prefers verb unification.
+
+## 4. Open questions for Silen
+
+1. Pass/fail thresholds in §1 (within-noise accuracy AND <= 0.7x cost on 2/3 corpora): right
+   bar? Steelman for stricter: the demo story wants ~10x; steelman for this bar: 0.7x vs the
+   hindsight-best single model is already a strong claim (most of the 10x comes vs all-frontier).
+2. Scenario tool surface (2026-07-24 finding): fit only on corpora whose scenarios carry tools,
+   or accept the affordance-guessing bias for v1 corpora that lack them? Recommendation: block
+   fitting on the wm-create tool-surface contract for agentic corpora; chat-style corpora are
+   unaffected.
+3. Judge pin for the matrix: Opus 4.8 (house default) vs gpt-5.4-mini (cheap, pinned in
+   wm-benchmarks)? Recommendation: Opus 4.8, third-family vs most candidates, and never compare
+   across judges.
+4. Router training longer-term (affects D-METERING router_cost_usd and the artifact): if v2 is
+   a trained predictor, do we host it (own deployment, real per-call cost) or embed it in
+   serving (amortized)? No decision needed now; shapes already carry the cost either way.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ uv run pytest -q
 
 ## Harness optimization
 
-- `wmh optimize <agent> <world-model> --tasks <tasks.jsonl>` is the primary public
+- `wmh optimize harness <agent> <world-model> --tasks <tasks.jsonl>` is the primary public
   harness-creation workflow. Keep CLI wiring in `wmh/cli/harness_app.py` and search behavior in
   `wmh/harness/create.py` (world-model delta search) or `wmh/harness/population.py` plus
   `wmh/harness/project_proposer.py` (the `harbor` environment's complete-source population
@@ -83,7 +83,7 @@ uv run pytest -q
 - Persist every proposal and verdict in `DeltaArchive`, including screened, rejected, and invalid
   deltas. `HarnessStore` writes immutable `vN` versions and moves the `champion` alias for
   promotion or rollback.
-- `wmh scenarios build` produces a weighted `ScenarioSet`; `wmh optimize --tasks` currently
+- `wmh scenarios build` produces a weighted `ScenarioSet`; `wmh optimize harness --tasks` currently
   requires `TaskSpec` JSONL. Do not treat those artifact formats as interchangeable.
 - Changes here require focused coverage in `create_test.py`, `delta_test.py`, `store_test.py`,
   `proposer_test.py`, and the scenario builder or verification tests as applicable.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ wmh build --file traces.jsonl --name my-environment
 Then optimize an agent harness against that model and a set of tasks:
 
 ```bash
-wmh optimize my-agent my-environment --tasks tasks.jsonl
+wmh optimize harness my-agent my-environment --tasks tasks.jsonl
 ```
 
 ### Hosted platform
@@ -59,7 +59,7 @@ E2B, install the extra and provide an E2B key:
 ```bash
 pip install "world-model-harness[e2b]"
 export E2B_API_KEY=...
-wmh optimize my-agent my-environment --tasks tasks.jsonl --backend e2b
+wmh optimize harness my-agent my-environment --tasks tasks.jsonl --backend e2b
 ```
 
 ## Use a world model as an API
@@ -109,7 +109,7 @@ WMH can run the real [pi](https://github.com/earendil-works/pi) worker inside is
 evaluation rollouts run in parallel, and model credentials stay outside the sandbox.
 
 ```bash
-wmh optimize my-agent my-environment --tasks tasks.jsonl --backend e2b
+wmh optimize harness my-agent my-environment --tasks tasks.jsonl --backend e2b
 wmh eval tasks.jsonl --mode closed-loop --harness my-agent --harness-backend e2b
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "uvicorn>=0.38",
     "pydantic>=2.6",
     "numpy>=1.26",
+    # The routing optimizer's clustering stack (KMeans + Normalizer), matching the Avengers
+    # reference implementation it replicates; serving only reads fitted centroids (numpy).
+    "scikit-learn>=1.4",
     "httpx>=0.27",
     "rich>=14.1",
     # Workspace member (resolved from source via [tool.uv.sources]): the data-bundle

--- a/uv.lock
+++ b/uv.lock
@@ -1148,6 +1148,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1598,6 +1607,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
 ]
 
 [[package]]
@@ -2527,6 +2545,96 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
 name = "seaborn"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2679,6 +2787,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -2938,6 +3055,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "rich" },
+    { name = "scikit-learn" },
     { name = "tomli-w" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -3003,6 +3121,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rich", specifier = ">=14.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "scikit-learn", specifier = ">=1.4" },
     { name = "seaborn", marker = "extra == 'viz'", specifier = ">=0.13" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -38,7 +38,7 @@ from rich.table import Table
 import wmh.providers as providers
 from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
-from wmh.cli.harness_app import harness_app, optimize
+from wmh.cli.harness_app import harness_app, optimize_app
 from wmh.cli.platform_cmds import register as register_platform_commands
 from wmh.cli.ui import (
     BuildParams,
@@ -143,7 +143,7 @@ app.add_typer(config_app, name="config")
 app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
 app.add_typer(harness_app, name="harness")
-app.command("optimize")(optimize)
+app.add_typer(optimize_app, name="optimize")
 register_platform_commands(app)
 register_agent_session_commands(app)
 _console = Console()
@@ -538,7 +538,7 @@ def build(
         raise typer.BadParameter(str(err)) from None
     if params.name == "harbor":
         raise typer.BadParameter(
-            "world model name 'harbor' is reserved: `wmh optimize <agent> harbor` selects "
+            "world model name 'harbor' is reserved: `wmh optimize harness <agent> harbor` selects "
             "the harbor benchmark environment; choose another name"
         )
     try:

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -292,10 +292,12 @@ def test_cli_exposes_the_small_command_set() -> None:
         "play",
         "download",
         "knowledge",
-        "optimize",
     }
     platform = {"login", "logout", "status", "push", "pull", "run"}
     assert names == core | platform
+    # `optimize` is a GROUP now (harness today; route and training-type optimizers join it).
+    groups = {group.name for group in app.registered_groups}
+    assert "optimize" in groups
 
 
 def test_knowledge_command_prints_path_and_files(tmp_path) -> None:  # noqa: ANN001 - fixture

--- a/wmh/cli/harness_app.py
+++ b/wmh/cli/harness_app.py
@@ -2,7 +2,8 @@
 
 A harness is the scaffold an agent runs with: prompt surfaces, a tool policy, loop parameters, and
 skills, stored as immutable numbered versions with movable aliases (`champion` is what runs by
-default). `init` writes the baseline as v1; `list`/`show` inspect what exists; `wmh optimize`
+default). `init` writes the baseline as v1; `list`/`show` inspect what exists;
+`wmh optimize harness`
 searches for a better harness by **inverting the world model**. Delta variants are scored
 closed-loop against it and gated on non-regression, so the environment model the traces built now
 steers what the agent's scaffold should be. Run one closed-loop with
@@ -57,7 +58,7 @@ from wmh.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmh.providers.base import Provider, ProviderConfig, ToolCallingProvider
 from wmh.providers.registry import get_provider
 
-# The default agent seed's literal CLI name: `wmh optimize pi harbor ...` starts from the
+# The default agent seed's literal CLI name: `wmh optimize harness pi harbor ...` starts from the
 # built-in pi agent and publishes new versions under the store name "pi".
 DEFAULT_SEED_AGENT = "pi"
 _DEFAULT_HARBOR_ITERATIONS = 10
@@ -128,6 +129,20 @@ def show_harness(
         _console.print(surface.content)
 
 
+optimize_app = typer.Typer(
+    help="Optimizers behind one switch: harness (agent-scaffold search) today; route "
+    "(learned inference policy) and training-type optimizers join as subcommands.",
+    no_args_is_help=True,
+)
+
+# Local import placement: route_app imports the optimize package; registering here keeps the
+# whole optimizer family visible in one place.
+from wmh.cli.route_app import route_app  # noqa: E402
+
+optimize_app.add_typer(route_app, name="route")
+
+
+@optimize_app.command("harness")
 def optimize(
     ctx: typer.Context,
     name: str = typer.Argument(
@@ -274,7 +289,7 @@ def optimize(
         if world_model_only:
             raise typer.BadParameter(
                 f"{', '.join(world_model_only)} apply only to a world-model environment; "
-                "drop them for `wmh optimize <agent> harbor ...`"
+                "drop them for `wmh optimize harness <agent> harbor ...`"
             )
         _optimize_harbor(
             ctx,
@@ -315,7 +330,7 @@ def optimize(
     if harbor_only:
         raise typer.BadParameter(
             f"{', '.join(harbor_only)} apply only to the harbor environment; "
-            "use `wmh optimize <agent> harbor ...`"
+            "use `wmh optimize harness <agent> harbor ...`"
         )
     if iterations == 0:
         raise typer.BadParameter(
@@ -578,7 +593,7 @@ def _optimize_harbor(
     if name is None:
         raise typer.BadParameter(
             "provide the seed agent NAME (the literal 'pi' is the built-in default agent): "
-            "`wmh optimize pi harbor --harbor-config ... --task-ids ... --run-dir ...`"
+            "`wmh optimize harness pi harbor --harbor-config ... --task-ids ... --run-dir ...`"
         )
     if backend not in ("local", "e2b"):
         raise typer.BadParameter(f"unknown --backend {backend!r}; choose local or e2b")
@@ -702,7 +717,7 @@ def _optimize_harbor(
     if not result.completed:
         _console.print(
             f"[yellow]checkpointed[/yellow] {len(result.outcomes)}/{config.iterations + 1} "
-            f"boundaries; continue with: [bold]wmh optimize {config.agent} harbor --resume "
+            f"boundaries; continue with: [bold]wmh optimize harness {config.agent} harbor --resume "
             f"--run-dir {run_dir}[/bold]"
         )
         return
@@ -1016,7 +1031,7 @@ def init_harness(
         if store.exists(name):
             raise typer.BadParameter(
                 f"harness {name!r} already exists; new versions are appended by "
-                "`wmh optimize`, and aliases move with `set_alias`"
+                "`wmh optimize harness`, and aliases move with `set_alias`"
             )
         doc = store.save_version(HarnessDoc.baseline(name), alias=CHAMPION_ALIAS)
     except ValueError as exc:  # invalid name -> usage error, not a traceback

--- a/wmh/cli/harness_app_test.py
+++ b/wmh/cli/harness_app_test.py
@@ -96,6 +96,7 @@ def _invoke(tmp_path: Path, *extra: str) -> Result:
         app,
         [
             "optimize",
+            "harness",
             "made",
             "--tasks",
             _tasks_file(tmp_path),
@@ -236,6 +237,7 @@ def test_optimize_accepts_world_model_as_second_argument(
         app,
         [
             "optimize",
+            "harness",
             "made",
             "wm-user",
             "--tasks",
@@ -482,6 +484,7 @@ def _invoke_harbor(tmp_path: Path, *extra: str) -> Result:
         app,
         [
             "optimize",
+            "harness",
             "pi",
             "harbor",
             "--harbor-config",
@@ -553,6 +556,7 @@ def test_harbor_checkpoint_then_resume_completes_and_rejects_conflicts(
         app,
         [
             "optimize",
+            "harness",
             "pi",
             "harbor",
             "--resume",
@@ -587,6 +591,7 @@ def test_harbor_requires_a_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         app,
         [
             "optimize",
+            "harness",
             "pi",
             "harbor",
             "--harbor-config",
@@ -604,7 +609,15 @@ def test_harbor_requires_a_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 def test_world_model_path_rejects_harbor_only_flags(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
-        ["optimize", "made", "--run-dir", str(tmp_path / "run"), "--root", str(tmp_path)],
+        [
+            "optimize",
+            "harness",
+            "made",
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path),
+        ],
     )
     assert result.exit_code == 2
     assert "apply only to the harbor environment" in result.output
@@ -653,6 +666,7 @@ def test_harbor_publication_is_idempotent_across_resumes(
         app,
         [
             "optimize",
+            "harness",
             "pi",
             "harbor",
             "--resume",
@@ -694,6 +708,7 @@ def test_harbor_seed_ref_resolves_through_the_store_and_resume_pins_it(
         app,
         [
             "optimize",
+            "harness",
             "pi@champion",
             "harbor",
             "--harbor-config",
@@ -723,6 +738,7 @@ def test_harbor_seed_ref_resolves_through_the_store_and_resume_pins_it(
         app,
         [
             "optimize",
+            "harness",
             "pi@champion",
             "harbor",
             "--resume",
@@ -777,6 +793,7 @@ def test_harbor_resume_accepts_a_restated_episode_timeout_for_an_e2b_run(
         app,
         [
             "optimize",
+            "harness",
             "pi",
             "harbor",
             "--resume",

--- a/wmh/cli/route_app.py
+++ b/wmh/cli/route_app.py
@@ -1,0 +1,117 @@
+"""`wmh optimize route`: fit and report learned inference policies from outcome matrices.
+
+The routing optimizer's CLI face, sitting beside `wmh optimize harness` in the optimizer
+family. Consumes a persisted `OutcomeMatrix` (produced by closed-loop pool evaluation or a
+research adapter such as RouterBench) and emits the policy artifact serving loads, plus the
+improvement report the endpoint cites. Vocabulary note: "route" is developer-facing CLI only;
+customer copy never says router.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from wmh.optimize.outcomes import OutcomeMatrix
+from wmh.optimize.policy import POLICY_FILENAME, EmbedderSpec, RoutingPolicy
+from wmh.optimize.report import build_report
+from wmh.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+
+route_app = typer.Typer(
+    help="Fit and report learned inference policies from closed-loop outcome matrices.",
+    no_args_is_help=True,
+)
+
+_console = Console()
+
+
+@route_app.command("fit")
+def fit(
+    matrix_file: str = typer.Argument(..., help="OutcomeMatrix JSON (closed-loop eval output)."),
+    out: str = typer.Option(
+        POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
+    ),
+    clusters: int = typer.Option(64, "--clusters", min=1, help="k-means cluster count."),
+    seed: int = typer.Option(42, "--seed", help="Clustering seed."),
+    top_k_clusters: int = typer.Option(2, "--top-k-clusters", min=1),
+    beta: float = typer.Option(6.0, "--beta", help="Cluster softmax sharpness."),
+    cost_weight: float = typer.Option(
+        0.0,
+        "--cost-weight",
+        min=0.0,
+        help="Quality/cost knob: reward points paid per average-call-cost unit (0 = pure "
+        "accuracy ranking, the Avengers reference behavior).",
+    ),
+    embedder: str = typer.Option("hashing", "--embedder", help="hashing | azure"),
+    dim: int = typer.Option(512, "--dim", help="Embedding dimension."),
+    deployment: str = typer.Option(None, "--deployment", help="(azure) embedding deployment."),
+    endpoint: str = typer.Option(None, "--endpoint", help="(azure) resource endpoint."),
+    api_key_env: str = typer.Option(
+        None, "--api-key-env", help="(azure) env var holding the account key."
+    ),
+) -> None:
+    """Fit a rank policy on an outcome matrix (Avengers-style cluster rankings)."""
+    matrix = OutcomeMatrix.load(Path(matrix_file))
+    if embedder not in ("hashing", "azure"):
+        raise typer.BadParameter(f"unknown embedder '{embedder}'; use hashing or azure")
+    spec = (
+        EmbedderSpec(dim=dim)
+        if embedder == "hashing"
+        else EmbedderSpec(
+            kind="azure",
+            dim=dim,
+            deployment=deployment,
+            endpoint=endpoint,
+            api_key_env=api_key_env,
+        )
+    )
+    policy = fit_rank_policy(
+        matrix,
+        embedder=spec,
+        n_clusters=clusters,
+        seed=seed,
+        top_k_clusters=top_k_clusters,
+        beta=beta,
+        fitted_from=f"{matrix_file} seed={seed} k={clusters} {embedder}-{dim}",
+    )
+    if cost_weight > 0.0:
+        policy = rerank_policy(policy, cost_weight=cost_weight)
+    policy.save(Path(out))
+    result = evaluate_policy(policy, matrix, matrix.scenario_ids())
+    _console.print(
+        f"[green]✓[/green] fitted {len(policy.clusters)} clusters over "
+        f"{result.scenarios} scenarios -> {out}\n"
+        f"  fit-set accuracy {result.accuracy:.4f}, cost/scenario ${result.cost_per_scenario:.5f}"
+    )
+
+
+@route_app.command("report")
+def report(
+    matrix_file: str = typer.Argument(..., help="OutcomeMatrix JSON with held-out scenarios."),
+    policy_file: str = typer.Argument(..., help="Fitted policy JSON."),
+    baseline: str = typer.Option(
+        ..., "--baseline", help="Frontier pool model the report compares against."
+    ),
+    endpoint: str = typer.Option("endpoint", "--endpoint", help="Endpoint id for the report."),
+    out: str = typer.Option("report.json", "--out", help="Where to write the report JSON."),
+) -> None:
+    """Build the improvement report for a fitted policy over a matrix."""
+    matrix = OutcomeMatrix.load(Path(matrix_file))
+    policy = RoutingPolicy.load(Path(policy_file))
+    improvement = build_report(
+        matrix,
+        policy,
+        baseline=baseline,
+        endpoint=endpoint,
+        generated_at=datetime.now(tz=UTC).isoformat(),
+    )
+    Path(out).write_text(improvement.model_dump_json(indent=2), encoding="utf-8")
+    headline = improvement.headline
+    _console.print(
+        f"[green]✓[/green] report -> {out}\n"
+        f"  routed acc {headline.accuracy:.4f} @ ${headline.cost_per_run_usd:.5f}/run vs "
+        f"{baseline} {headline.baseline_accuracy:.4f} @ ${headline.baseline_cost_per_run_usd:.5f}"
+    )

--- a/wmh/cli/route_app_test.py
+++ b/wmh/cli/route_app_test.py
@@ -1,0 +1,105 @@
+"""CLI tests for `wmh optimize route` (fit + report), driven via CliRunner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wmh.cli.app import app
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.policy import RoutingPolicy
+from wmh.providers.base import ProviderKind
+from wmh.providers.pool import PoolEntry
+
+runner = CliRunner()
+
+
+def _matrix_file(tmp_path: Path) -> Path:
+    pool = [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+        PoolEntry(
+            name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+    ]
+    outcomes = []
+    tasks = {
+        "s1": "SELECT count(*) FROM t",
+        "s2": "SELECT name FROM users WHERE id = 4",
+        "s3": "write a poem about rivers",
+        "s4": "draft a thank-you note",
+    }
+    for sid, task in tasks.items():
+        sql = sid in ("s1", "s2")
+        for model in ("a", "b"):
+            wins = (model == "a") == sql
+            outcomes.append(
+                ScenarioOutcome(
+                    scenario_id=sid,
+                    task=task,
+                    model=model,
+                    reward=1.0 if wins else 0.0,
+                    success=wins,
+                    cost_usd=0.001,
+                )
+            )
+    path = tmp_path / "matrix.json"
+    OutcomeMatrix(pool=pool, outcomes=outcomes).save(path)
+    return path
+
+
+def test_route_fit_and_report(tmp_path: Path) -> None:
+    matrix_file = _matrix_file(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--out",
+            str(policy_file),
+            "--clusters",
+            "2",
+            "--top-k-clusters",
+            "1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.kind == "rank"
+    assert len(policy.clusters) == 2
+
+    report_file = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "report",
+            str(matrix_file),
+            str(policy_file),
+            "--baseline",
+            "a",
+            "--out",
+            str(report_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    report = json.loads(report_file.read_text())
+    assert report["baseline"]["model_id"] == "a"
+    assert report["headline"]["baseline_accuracy"] == 0.5
+    assert report["cost_assumptions"]
+
+
+def test_route_fit_rejects_unknown_embedder(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["optimize", "route", "fit", str(_matrix_file(tmp_path)), "--embedder", "vibes"],
+    )
+    assert result.exit_code != 0
+    assert "hashing or azure" in result.output

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -43,7 +43,7 @@ class ModelsSettings(BaseModel):
     extraction (trace facets/digests); `meta` is the harness-search delta proposer, which
     needs a long-context, long-output model (one proposal holds every harness surface in its
     prompt and replies with a complete replacement surface); `agent` is the agent-under-test
-    whose harness `wmh optimize` searches. Set it to optimize a harness for a model
+    whose harness `wmh optimize harness` searches. Set it to optimize a harness for a model
     distinct from the world model's serve provider (e.g. a small self-hosted agent against a
     frontier-served world model). Unset `judge`/`summary` fall back to `worker`; each command
     documents which explicit model flags and opt-in roles it uses.
@@ -61,7 +61,7 @@ class ModelsSettings(BaseModel):
         `meta` and `agent` deliberately do NOT fall back to `worker`: each is picked for a
         need the scenario worker does not serve (the proposer's long-context/long-output
         surface; the agent-under-test's own identity), so when unset they return None and the
-        caller keeps its own default (`wmh optimize` and closed-loop eval use the world
+        caller keeps its own default (`wmh optimize harness` and closed-loop eval use the world
         model's provider for the opt-in roles when unset).
         """
         if role not in ("worker", "judge", "summary", "meta", "agent"):

--- a/wmh/config/settings_test.py
+++ b/wmh/config/settings_test.py
@@ -107,7 +107,7 @@ def test_meta_role_resolves_when_configured_and_never_falls_back_to_worker() -> 
 def test_agent_role_resolves_when_configured_and_never_falls_back_to_worker() -> None:
     """The agent-under-test role is opt-in: unset agent means the caller's default.
 
-    `wmh optimize` optimizes a harness for a specific agent model, which may differ
+    `wmh optimize harness` optimizes a harness for a specific agent model, which may differ
     from the world model's serve model; an unset agent must keep the world-model-provider
     default rather than silently inheriting the scenario worker.
     """

--- a/wmh/env/closed_loop.py
+++ b/wmh/env/closed_loop.py
@@ -1,0 +1,163 @@
+"""Closed-loop evaluation: roll every pool candidate over a scenario set, collect the matrix.
+
+Each (candidate model, scenario, episode) cell runs one `run_episode` with the candidate driving
+`LLMAgent` against the env, then reads the env's episode score (VERIFY). The result is the
+`OutcomeMatrix` the routing optimizer fits on and the improvement report cites.
+
+Measurement notes:
+- Latency is measured per POLICY CALL (the candidate's own completions), not per episode: episode
+  wall time is dominated by the world model's simulation latency, which production traffic never
+  pays, so quoting it would flatter nobody honestly.
+- Cost is the candidate side only, priced by its own pool entry; the env's serve/judge cost is
+  metered separately by the world model (D12 cost split).
+- Every raw candidate reply is stored (`ScenarioOutcome.replies`): that is the future
+  distillation feed. Providers do not yet surface separated thinking blocks; when they do, the
+  capture point is `_TimedProvider.complete`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from wmh.env.base import Env
+from wmh.env.episode import run_episode
+from wmh.env.llm_agent import LLMAgent
+from wmh.env.scenarios import Scenario
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.reward import EpisodeScore
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    Completion,
+    Message,
+    Provider,
+    ProviderConfig,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.providers.pool import ModelPool, PoolEntry, pool_provider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class _TimedProvider:
+    """Wraps the candidate's provider to record per-call seconds, usage, and raw replies."""
+
+    def __init__(self, provider: Provider) -> None:
+        self._provider = provider
+        self.call_seconds: list[float] = []
+        self.replies: list[str] = []
+        self.usage = TokenUsage()
+
+    @property
+    def config(self) -> ProviderConfig:
+        return self._provider.config
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        started = time.monotonic()
+        completion = self._provider.complete(
+            system, messages, temperature=temperature, max_tokens=max_tokens
+        )
+        self.call_seconds.append(time.monotonic() - started)
+        self.replies.append(completion.text)
+        self.usage = TokenUsage(
+            input_tokens=self.usage.input_tokens + completion.usage.input_tokens,
+            output_tokens=self.usage.output_tokens + completion.usage.output_tokens,
+        )
+        return completion
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._provider.embed(texts)
+
+    def verify(self) -> VerifyResult:
+        return self._provider.verify()
+
+
+def scenario_id(scenario: Scenario) -> str:
+    """Stable id for a scenario: its first provenance trace id, else a hash of the task.
+
+    Provisional until wm-create's generate contract ships first-class scenario ids
+    (DECISIONS.md 2026-07-23); both forms are deterministic across runs.
+    """
+    if scenario.provenance:
+        return scenario.provenance[0]
+    return hashlib.sha256(scenario.task.encode("utf-8")).hexdigest()[:12]
+
+
+def evaluate_pool(
+    env_factory: Callable[[], Env],
+    pool: ModelPool,
+    scenarios: list[Scenario],
+    *,
+    episodes_per_scenario: int = 1,
+    max_steps: int = 20,
+    agent_temperature: float = 0.0,
+    tools_hint: str | None = None,
+    provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
+    on_outcome: Callable[[ScenarioOutcome], None] | None = None,
+) -> OutcomeMatrix:
+    """Run every pool candidate over `scenarios`, one fresh env per episode.
+
+    The env must score episodes on close (`WorldModelEnv(..., score_on_close=True)`): a matrix
+    without verified rewards is not evidence. Episodes that error before scoring are recorded
+    unscored (`reward=None`, `error` set) rather than defaulted to 0. `on_outcome` fires after
+    each cell for progress display.
+    """
+    outcomes: list[ScenarioOutcome] = []
+    for entry in pool.models:
+        for scenario in scenarios:
+            sid = scenario_id(scenario)
+            for episode in range(episodes_per_scenario):
+                timed = _TimedProvider(provider_factory(entry))
+                agent = LLMAgent(timed, temperature=agent_temperature, tools_hint=tools_hint)
+                env = env_factory()
+                result = run_episode(env, agent, scenario.task, max_steps=max_steps)
+                score = getattr(env, "last_score", None)
+                if score is None and result.error is None:
+                    raise ValueError(
+                        "env produced no episode score; evaluate_pool needs a scoring env "
+                        "(e.g. WorldModelEnv(world_model, score_on_close=True))"
+                    )
+                if not isinstance(score, EpisodeScore):
+                    score = None
+                outcome = ScenarioOutcome(
+                    scenario_id=sid,
+                    task=scenario.task,
+                    model=entry.name,
+                    episode=episode,
+                    reward=score.reward if score else None,
+                    success=score.success if score else False,
+                    critique=score.critique if score else "",
+                    steps=len(result.steps),
+                    stop_reason=str(result.stop_reason),
+                    usage=timed.usage,
+                    cost_usd=entry.cost_usd(timed.usage),
+                    call_seconds=timed.call_seconds,
+                    replies=timed.replies,
+                    error=result.error,
+                )
+                outcomes.append(outcome)
+                if on_outcome is not None:
+                    on_outcome(outcome)
+                logger.info(
+                    "closed-loop %s on %s ep%d: reward=%s cost=$%.5f steps=%d",
+                    entry.name,
+                    sid,
+                    episode,
+                    "unscored" if outcome.reward is None else f"{outcome.reward:.2f}",
+                    outcome.cost_usd,
+                    outcome.steps,
+                )
+    return OutcomeMatrix(pool=pool.models, outcomes=outcomes)

--- a/wmh/env/closed_loop.py
+++ b/wmh/env/closed_loop.py
@@ -13,6 +13,11 @@ Measurement notes:
 - Every raw candidate reply is stored (`ScenarioOutcome.replies`): that is the future
   distillation feed. Providers do not yet surface separated thinking blocks; when they do, the
   capture point is `_TimedProvider.complete`.
+- A cell is recorded SCORED only when the episode also ran clean. An episode that errored
+  mid-flight (provider throttle, agent crash) is unscored even if the env still produced a
+  score, because that score grades a run the candidate never got to finish: counting it as
+  reward would read infrastructure failure as incapability. The salvaged critique is kept on
+  the row, prefixed, so the diagnostic text is not lost.
 """
 
 from __future__ import annotations
@@ -20,7 +25,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, cast
 
 from wmh.env.base import Env
 from wmh.env.episode import run_episode
@@ -87,6 +92,50 @@ class _TimedProvider:
         return self._provider.verify()
 
 
+_NEEDS_SCORING_ENV = (
+    "env produced no episode score; evaluate_pool needs a scoring env "
+    "(e.g. WorldModelEnv(world_model, score_on_close=True))"
+)
+
+# Prefix on a critique salvaged from an episode that errored: the text is diagnostic, the
+# verdict is not evidence (see the module docstring).
+_SALVAGE_PREFIX = "salvage-judged despite error: "
+
+
+class _ScoringEnv(Protocol):
+    """The scoring surface `evaluate_pool` needs on top of `Env`; `WorldModelEnv` provides it."""
+
+    @property
+    def last_score(self) -> EpisodeScore: ...
+
+
+def _read_episode_score(env: Env) -> tuple[EpisodeScore | None, str | None]:
+    """Read `env.last_score` defensively, returning (score, reason it is missing).
+
+    The two failure modes are NOT the same failure. A missing attribute means the caller handed
+    `evaluate_pool` a non-scoring env, so no cell of the sweep can ever be evidence and the
+    error is fatal. A `last_score` that RAISES (WorldModelEnv re-raises a close-time scoring
+    failure, e.g. a throttled judge call) is per-episode: that one cell is unscored with the
+    reason recorded, and the sweep keeps its other completed cells.
+    """
+    scoring = cast("_ScoringEnv", env)
+    try:
+        raw: object = scoring.last_score
+    except AttributeError as exc:
+        raise ValueError(_NEEDS_SCORING_ENV) from exc
+    except RuntimeError as exc:
+        return None, f"episode scoring failed: {exc}"
+    if raw is None:
+        return None, None
+    if not isinstance(raw, EpisodeScore):
+        # An unscored row must always say WHY (the outcomes contract); a wrong-typed score
+        # silently becoming reward=None/error=None would violate it.
+        return None, (
+            f"env last_score is {type(raw).__name__}, not EpisodeScore; episode left unscored"
+        )
+    return raw, None
+
+
 def scenario_id(scenario: Scenario) -> str:
     """Stable id for a scenario: its first provenance trace id, else a hash of the task.
 
@@ -113,9 +162,11 @@ def evaluate_pool(
     """Run every pool candidate over `scenarios`, one fresh env per episode.
 
     The env must score episodes on close (`WorldModelEnv(..., score_on_close=True)`): a matrix
-    without verified rewards is not evidence. Episodes that error before scoring are recorded
-    unscored (`reward=None`, `error` set) rather than defaulted to 0. `on_outcome` fires after
-    each cell for progress display.
+    without verified rewards is not evidence. Episodes that error, and episodes whose scoring
+    itself fails, are recorded unscored (`reward=None`, `error` set) rather than defaulted to 0,
+    and never abort the sweep. `on_outcome` fires after each cell for progress display; a
+    callback that raises is logged and ignored, since a broken progress pipe must not throw away
+    the cells already paid for.
     """
     outcomes: list[ScenarioOutcome] = []
     for entry in pool.models:
@@ -126,20 +177,17 @@ def evaluate_pool(
                 agent = LLMAgent(timed, temperature=agent_temperature, tools_hint=tools_hint)
                 env = env_factory()
                 result = run_episode(env, agent, scenario.task, max_steps=max_steps)
-                score = getattr(env, "last_score", None)
+                score, score_error = _read_episode_score(env)
                 error = result.error
+                if score_error is not None:
+                    error = f"{error}; {score_error}" if error else score_error
                 if score is None and error is None:
-                    raise ValueError(
-                        "env produced no episode score; evaluate_pool needs a scoring env "
-                        "(e.g. WorldModelEnv(world_model, score_on_close=True))"
-                    )
-                if score is not None and not isinstance(score, EpisodeScore):
-                    # An unscored row must always say WHY (the outcomes contract); a wrong-typed
-                    # score silently becoming reward=None/error=None would violate it.
-                    error = error or (
-                        f"env last_score is {type(score).__name__}, not EpisodeScore; "
-                        "episode left unscored"
-                    )
+                    raise ValueError(_NEEDS_SCORING_ENV)
+                critique = score.critique if score else ""
+                if score is not None and result.error is not None:
+                    # The episode broke mid-flight, so this verdict grades an unfinished run:
+                    # keep the text, drop the reward (see the module docstring).
+                    critique = f"{_SALVAGE_PREFIX}{critique}" if critique else ""
                     score = None
                 outcome = ScenarioOutcome(
                     scenario_id=sid,
@@ -148,7 +196,7 @@ def evaluate_pool(
                     episode=episode,
                     reward=score.reward if score else None,
                     success=score.success if score else False,
-                    critique=score.critique if score else "",
+                    critique=critique,
                     steps=len(result.steps),
                     stop_reason=str(result.stop_reason),
                     usage=timed.usage,
@@ -159,7 +207,16 @@ def evaluate_pool(
                 )
                 outcomes.append(outcome)
                 if on_outcome is not None:
-                    on_outcome(outcome)
+                    try:
+                        on_outcome(outcome)
+                    except Exception:  # noqa: BLE001 - a broken progress pipe never costs cells
+                        logger.warning(
+                            "on_outcome callback failed for %s on %s ep%d; sweep continues",
+                            entry.name,
+                            sid,
+                            episode,
+                            exc_info=True,
+                        )
                 logger.info(
                     "closed-loop %s on %s ep%d: reward=%s cost=$%.5f steps=%d",
                     entry.name,

--- a/wmh/env/closed_loop.py
+++ b/wmh/env/closed_loop.py
@@ -74,6 +74,8 @@ class _TimedProvider:
         self.replies.append(completion.text)
         self.usage = TokenUsage(
             input_tokens=self.usage.input_tokens + completion.usage.input_tokens,
+            cached_input_tokens=self.usage.cached_input_tokens
+            + completion.usage.cached_input_tokens,
             output_tokens=self.usage.output_tokens + completion.usage.output_tokens,
         )
         return completion

--- a/wmh/env/closed_loop.py
+++ b/wmh/env/closed_loop.py
@@ -127,12 +127,19 @@ def evaluate_pool(
                 env = env_factory()
                 result = run_episode(env, agent, scenario.task, max_steps=max_steps)
                 score = getattr(env, "last_score", None)
-                if score is None and result.error is None:
+                error = result.error
+                if score is None and error is None:
                     raise ValueError(
                         "env produced no episode score; evaluate_pool needs a scoring env "
                         "(e.g. WorldModelEnv(world_model, score_on_close=True))"
                     )
-                if not isinstance(score, EpisodeScore):
+                if score is not None and not isinstance(score, EpisodeScore):
+                    # An unscored row must always say WHY (the outcomes contract); a wrong-typed
+                    # score silently becoming reward=None/error=None would violate it.
+                    error = error or (
+                        f"env last_score is {type(score).__name__}, not EpisodeScore; "
+                        "episode left unscored"
+                    )
                     score = None
                 outcome = ScenarioOutcome(
                     scenario_id=sid,
@@ -148,7 +155,7 @@ def evaluate_pool(
                     cost_usd=entry.cost_usd(timed.usage),
                     call_seconds=timed.call_seconds,
                     replies=timed.replies,
-                    error=result.error,
+                    error=error,
                 )
                 outcomes.append(outcome)
                 if on_outcome is not None:

--- a/wmh/env/closed_loop_test.py
+++ b/wmh/env/closed_loop_test.py
@@ -9,6 +9,7 @@ import pytest
 from wmh.core.types import Action, EnvState, Observation
 from wmh.env.closed_loop import evaluate_pool
 from wmh.env.scenarios import Scenario
+from wmh.optimize.outcomes import ScenarioOutcome
 from wmh.optimize.reward import EpisodeScore
 from wmh.providers.base import (
     Completion,
@@ -25,6 +26,27 @@ class _FakeEnv:
 
     def __init__(self, score: EpisodeScore | None) -> None:
         self.last_score = score
+
+    def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
+        return EnvState()
+
+    def step(self, action: Action) -> Observation:
+        return Observation(content="ok")
+
+    def close(self) -> None:
+        return None
+
+
+class _ThrottledScoringEnv:
+    """Env shaped like WorldModelEnv: `last_score` is a property that RAISES when scoring failed.
+
+    A throttled judge call at close time surfaces exactly this way, and it must cost one cell,
+    not the sweep.
+    """
+
+    @property
+    def last_score(self) -> EpisodeScore:
+        raise RuntimeError("Bedrock ThrottlingException while scoring the session")
 
     def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
         return EnvState()
@@ -64,6 +86,20 @@ class _ScriptedProvider:
 
     def verify(self) -> VerifyResult:
         raise NotImplementedError
+
+
+class _FailFirstProvider(_ScriptedProvider):
+    """Provider that throws on its first completion: an agent-side failure mid-episode."""
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        raise RuntimeError("RateLimitError: 429 too many requests")
 
 
 def _pool() -> ModelPool:
@@ -159,6 +195,60 @@ def test_scenario_ids_fall_back_to_task_hash() -> None:
         provider_factory=_ScriptedProvider,
     )
     assert rerun.scenario_ids() == [scenario_id]
+
+
+def test_scoring_failure_costs_one_cell_not_the_sweep() -> None:
+    # A raising last_score (throttled judge at close) leaves the cell unscored WITH the reason,
+    # and every other cell of the sweep still gets measured.
+    matrix = evaluate_pool(
+        _ThrottledScoringEnv,
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_ScriptedProvider,
+    )
+    assert len(matrix.outcomes) == 4  # 2 models x 2 scenarios: nothing aborted
+    for outcome in matrix.outcomes:
+        assert outcome.reward is None
+        assert outcome.success is False
+        assert outcome.error is not None
+        assert "ThrottlingException" in outcome.error
+        assert outcome.steps == 1  # the episode itself ran fine; only scoring failed
+
+
+def test_errored_episode_is_unscored_even_when_the_env_scored_it() -> None:
+    # The agent died on its first call, so the env's score grades a run that never happened:
+    # recording it as reward would read a provider throttle as incapability.
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.05, success=False, critique="did nothing")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=_FailFirstProvider,
+    )
+    outcome = matrix.outcomes[0]
+    assert outcome.reward is None
+    assert outcome.success is False
+    assert outcome.error is not None and "429" in outcome.error
+    # The judge text survives, labelled for what it is.
+    assert outcome.critique == "salvage-judged despite error: did nothing"
+
+
+def test_broken_progress_callback_does_not_abort_the_sweep() -> None:
+    seen: list[str] = []
+
+    def explode(outcome: ScenarioOutcome) -> None:
+        seen.append(outcome.model)
+        raise RuntimeError("progress socket closed")
+
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_ScriptedProvider,
+        on_outcome=explode,
+    )
+    assert len(seen) == 4  # every cell still reported
+    assert len(matrix.outcomes) == 4
+    assert all(o.reward == pytest.approx(0.8) for o in matrix.outcomes)
 
 
 def test_wrong_typed_score_yields_unscored_row_with_reason() -> None:

--- a/wmh/env/closed_loop_test.py
+++ b/wmh/env/closed_loop_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from wmh.core.types import Action, EnvState, Observation
@@ -157,3 +159,17 @@ def test_scenario_ids_fall_back_to_task_hash() -> None:
         provider_factory=_ScriptedProvider,
     )
     assert rerun.scenario_ids() == [scenario_id]
+
+
+def test_wrong_typed_score_yields_unscored_row_with_reason() -> None:
+    # A last_score that isn't an EpisodeScore must not silently become an
+    # unscored-with-no-error row: unscored rows always say why (outcomes contract).
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(cast("EpisodeScore", {"reward": 1.0})),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=_ScriptedProvider,
+    )
+    outcome = matrix.outcomes[0]
+    assert outcome.reward is None
+    assert outcome.error is not None and "not EpisodeScore" in outcome.error

--- a/wmh/env/closed_loop_test.py
+++ b/wmh/env/closed_loop_test.py
@@ -1,0 +1,159 @@
+"""Tests for the closed-loop pool evaluation (candidate models rolled against an Env)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.core.types import Action, EnvState, Observation
+from wmh.env.closed_loop import evaluate_pool
+from wmh.env.scenarios import Scenario
+from wmh.optimize.reward import EpisodeScore
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderKind,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.providers.pool import ModelPool, PoolEntry
+
+
+class _FakeEnv:
+    """Scripted Env: every action gets one observation; scoring is canned."""
+
+    def __init__(self, score: EpisodeScore | None) -> None:
+        self.last_score = score
+
+    def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
+        return EnvState()
+
+    def step(self, action: Action) -> Observation:
+        return Observation(content="ok")
+
+    def close(self) -> None:
+        return None
+
+
+class _ScriptedProvider:
+    """Provider whose completions are a fixed script (one tool call, then done)."""
+
+    def __init__(self, entry: PoolEntry) -> None:
+        self.config = entry.provider_config()
+        self._script = [
+            '{"tool": "ls", "arguments": {}}',
+            '{"done": true, "summary": "finished"}',
+        ]
+        self._i = 0
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        text = self._script[min(self._i, len(self._script) - 1)]
+        self._i += 1
+        return Completion(text=text, usage=TokenUsage(input_tokens=10, output_tokens=5))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+def _pool() -> ModelPool:
+    return ModelPool(
+        models=[
+            PoolEntry(
+                name="candidate-a",
+                kind=ProviderKind.OPENAI,
+                model="custom-a",
+                input_per_mtok=1.0,
+                output_per_mtok=2.0,
+            ),
+            PoolEntry(
+                name="candidate-b",
+                kind=ProviderKind.OPENAI,
+                model="custom-b",
+                input_per_mtok=10.0,
+                output_per_mtok=20.0,
+            ),
+        ]
+    )
+
+
+_SCENARIOS = [
+    Scenario(task="list the files", provenance=["trace-1"]),
+    Scenario(task="delete the files", provenance=["trace-2"]),
+]
+
+
+def test_evaluate_pool_builds_full_matrix() -> None:
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_ScriptedProvider,
+        max_steps=5,
+    )
+
+    assert matrix.model_names() == ["candidate-a", "candidate-b"]
+    assert matrix.scenario_ids() == ["trace-1", "trace-2"]
+    assert len(matrix.outcomes) == 4  # 2 models x 2 scenarios x 1 episode
+    outcome = matrix.for_scenario("trace-1")[0]
+    assert outcome.model == "candidate-a"
+    assert outcome.reward == pytest.approx(0.8)
+    assert outcome.success is True
+    assert outcome.critique == "fine"
+    assert outcome.stop_reason == "agent_done"
+    # Two policy calls (tool call + done), scripted usage 10in/5out each.
+    assert outcome.usage == TokenUsage(input_tokens=20, output_tokens=10)
+    assert len(outcome.call_seconds) == 2
+    assert len(outcome.replies) == 2
+    # Cost prices the POOL ENTRY's override, not the built-in table.
+    assert outcome.cost_usd == pytest.approx((20 * 1.0 + 10 * 2.0) / 1_000_000)
+    expensive = matrix.for_scenario("trace-1")[1]
+    assert expensive.cost_usd == pytest.approx((20 * 10.0 + 10 * 20.0) / 1_000_000)
+
+
+def test_evaluate_pool_repeats_episodes() -> None:
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.5, success=True, critique="")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=_ScriptedProvider,
+        episodes_per_scenario=3,
+    )
+    episodes = [o.episode for o in matrix.outcomes if o.model == "candidate-a"]
+    assert episodes == [0, 1, 2]
+
+
+def test_evaluate_pool_requires_a_scoring_env() -> None:
+    with pytest.raises(ValueError, match="score"):
+        evaluate_pool(
+            lambda: _FakeEnv(None),
+            _pool(),
+            _SCENARIOS[:1],
+            provider_factory=_ScriptedProvider,
+        )
+
+
+def test_scenario_ids_fall_back_to_task_hash() -> None:
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.1, success=False, critique="")),
+        _pool(),
+        [Scenario(task="no provenance here")],
+        provider_factory=_ScriptedProvider,
+    )
+    (scenario_id,) = matrix.scenario_ids()
+    assert scenario_id  # deterministic, non-empty
+    rerun = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.1, success=False, critique="")),
+        _pool(),
+        [Scenario(task="no provenance here")],
+        provider_factory=_ScriptedProvider,
+    )
+    assert rerun.scenario_ids() == [scenario_id]

--- a/wmh/env/llm_agent.py
+++ b/wmh/env/llm_agent.py
@@ -41,14 +41,20 @@ class _AgentReply(BaseModel):
 class LLMAgent:
     """`Agent`-protocol adapter around a provider: history in, one JSON tool call out."""
 
-    def __init__(self, provider: Provider, *, temperature: float = 0.0) -> None:
+    def __init__(
+        self, provider: Provider, *, temperature: float = 0.0, tools_hint: str | None = None
+    ) -> None:
         self._provider = provider
         self._temperature = temperature
+        # Corpus-derived tool surface (names + argument keys observed in the traces). Without
+        # it, capable models honestly refuse to invent tools while weaker ones hallucinate
+        # them, and closed-loop rewards measure affordance-guessing instead of capability.
+        self._system = AGENT_SYSTEM if not tools_hint else f"{AGENT_SYSTEM}\n\n{tools_hint}"
 
     def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
         prompt = _render_turn(task, state, history)
         completion = self._provider.complete(
-            AGENT_SYSTEM,
+            self._system,
             [Message(role="user", content=prompt)],
             temperature=self._temperature,
             max_tokens=1024,

--- a/wmh/env/llm_agent_test.py
+++ b/wmh/env/llm_agent_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step
 from wmh.env.episode import DONE_SIGNAL
 from wmh.env.llm_agent import LLMAgent
-from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind
+from wmh.providers.base import Completion, Message, ProviderConfig, ProviderKind, VerifyResult
 
 
 class FakeProvider:
@@ -67,3 +67,34 @@ def test_agent_prompt_includes_task_state_and_history() -> None:
     assert "TASK: find x" in prompt
     assert "db is empty" in prompt
     assert "search" in prompt and "found it" in prompt
+
+
+def test_tools_hint_lands_in_the_system_prompt() -> None:
+    class _CaptureProvider:
+        def __init__(self) -> None:
+            self.system = ""
+            self.config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model="m")
+
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            self.system = system
+            return Completion(text='{"done": true, "summary": "x"}')
+
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            raise NotImplementedError
+
+        def verify(self) -> VerifyResult:
+            raise NotImplementedError
+
+    provider = _CaptureProvider()
+    agent = LLMAgent(provider, tools_hint="TOOLS: run_sql(query), list_tables()")
+    agent.act("do it", EnvState(), [])
+    assert "run_sql(query)" in provider.system
+    bare = LLMAgent(_CaptureProvider())
+    assert bare is not None  # no hint -> unchanged system (covered by existing tests)

--- a/wmh/env/scenarios.py
+++ b/wmh/env/scenarios.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from wmh.core.types import Trace
+from wmh.core.types import ActionKind, Trace
 
 
 class Scenario(BaseModel):
@@ -50,3 +50,24 @@ def _trace_task(trace: Trace) -> str | None:
         if step.task and step.task.strip():
             return step.task.strip()
     return None
+
+
+def tools_hint_from_traces(traces: list[Trace]) -> str:
+    """Summarize the corpus's observed tool surface for the rollout agent's system prompt.
+
+    One line per tool: name + the union of argument keys seen in the traces (the D28
+    tools.json derivation, inlined). Empty string for tool-less corpora. This is the
+    trace-derived stopgap for the scenario tool-surface contract: agents told what exists
+    stop being scored on their willingness to hallucinate affordances.
+    """
+    args_by_tool: dict[str, set[str]] = {}
+    for trace in traces:
+        for step in trace.steps:
+            action = step.action
+            if action.kind is not ActionKind.TOOL_CALL or not action.name:
+                continue
+            args_by_tool.setdefault(action.name, set()).update(action.arguments)
+    if not args_by_tool:
+        return ""
+    lines = [f"- {name}({', '.join(sorted(keys))})" for name, keys in sorted(args_by_tool.items())]
+    return "AVAILABLE TOOLS (observed in this environment):\n" + "\n".join(lines)

--- a/wmh/env/scenarios_test.py
+++ b/wmh/env/scenarios_test.py
@@ -36,3 +36,47 @@ def test_skips_traces_without_a_task() -> None:
 
 def test_empty_input_gives_empty_output() -> None:
     assert scenarios_from_traces([]) == []
+
+
+def test_tools_hint_from_traces_summarizes_tool_surface() -> None:
+    from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+    from wmh.env.scenarios import tools_hint_from_traces
+
+    steps = [
+        Step(
+            state_before=EnvState(),
+            action=Action(kind=ActionKind.TOOL_CALL, name="run_sql", arguments={"query": "q"}),
+            observation=Observation(content="ok"),
+        ),
+        Step(
+            state_before=EnvState(),
+            action=Action(
+                kind=ActionKind.TOOL_CALL, name="run_sql", arguments={"query": "q", "db": "x"}
+            ),
+            observation=Observation(content="ok"),
+        ),
+        Step(
+            state_before=EnvState(),
+            action=Action(kind=ActionKind.MESSAGE, content="hello"),
+            observation=Observation(content="ok"),
+        ),
+    ]
+    traces = [Trace(trace_id="t1", steps=steps)]
+    hint = tools_hint_from_traces(traces)
+    assert "run_sql" in hint
+    assert "db" in hint and "query" in hint
+    assert "hello" not in hint  # messages are not tools
+
+
+def test_tools_hint_empty_for_toolless_traces() -> None:
+    from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+    from wmh.env.scenarios import tools_hint_from_traces
+
+    steps = [
+        Step(
+            state_before=EnvState(),
+            action=Action(kind=ActionKind.MESSAGE, content="hi"),
+            observation=Observation(content="ok"),
+        )
+    ]
+    assert tools_hint_from_traces([Trace(trace_id="t", steps=steps)]) == ""

--- a/wmh/harness/pi_e2b.py
+++ b/wmh/harness/pi_e2b.py
@@ -3,7 +3,7 @@
 For pi-node harnesses the agent *process* itself must run for real (its multi-file TypeScript
 source — context forking, dropping, summarizing — is the thing under search), while the worker LLM
 and the tool routing stay host-side. The ENVIRONMENT is whatever `AgentEnvironment` the eval
-binds; in `wmh optimize` / `wmh eval` that is the world-model simulation. The sandbox is
+binds; in `wmh optimize harness` / `wmh eval` that is the world-model simulation. The sandbox is
 purely the compute substrate for the harness process, and its filesystem is never an environment.
 
 `E2BStdioChannel` carries the existing RunnerLink frame protocol over an E2B background command's

--- a/wmh/harness/store.py
+++ b/wmh/harness/store.py
@@ -1,7 +1,8 @@
 """Harnesses on disk: immutable numbered versions plus movable aliases, per name.
 
 Like world models under `.wmh/models/<name>/`, a harness is a named artifact — but harnesses
-accumulate *versions*, because they are the thing `wmh optimize` iterates on. A version, once
+accumulate *versions*, because they are the thing `wmh optimize harness` iterates on. A
+version, once
 written, never changes; deployment state lives in movable aliases; and every eval result keys to an
 immutable version rather than to "whatever the harness currently is".
 

--- a/wmh/optimize/__init__.py
+++ b/wmh/optimize/__init__.py
@@ -1,11 +1,17 @@
-"""GEPA prompt optimization + the LLM judge that scores predictions."""
+"""Pluggable optimizers (GEPA prompt evolution today) + the LLM judges that score predictions.
 
-from wmh.optimize.gepa import GEPAOptimizer, OptimizeMetrics, Optimizer, OptimizeResult
+The switchable-optimizer interface lives in `wmh.optimize.base`; concrete optimizers implement
+its `Optimizer` protocol and return `OptimizeResult`s whose `ArtifactRef`s say what they built.
+"""
+
+from wmh.optimize.base import ArtifactRef, OptimizeMetrics, Optimizer, OptimizeResult
+from wmh.optimize.gepa import GEPAOptimizer
 from wmh.optimize.judge import Judge, JudgeResult, RubricJudge
 from wmh.optimize.numeric import NumericJudge
 from wmh.optimize.reward import EpisodeRewardJudge, EpisodeScore
 
 __all__ = [
+    "ArtifactRef",
     "EpisodeRewardJudge",
     "EpisodeScore",
     "GEPAOptimizer",

--- a/wmh/optimize/base.py
+++ b/wmh/optimize/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from wmh.core.types import JsonObject, Trace
 
@@ -26,18 +26,51 @@ from wmh.core.types import JsonObject, Trace
 # else) is the extension point for a new optimizer type.
 ArtifactKind = Literal["prompt", "routing_policy", "model_weights", "adapter"]
 
+# Ownership boundary (pricing/commercial contract, carried as type shape): artifacts trained
+# on a customer's traces (prompts, checkpoints, adapters) are customer-owned and exportable;
+# routing policies encode OUR serving intelligence and are never exportable, whatever a caller
+# passes. Enforced by `ArtifactRef._enforce_exportability`.
+_NEVER_EXPORTABLE: frozenset[str] = frozenset({"routing_policy"})
+
+
+class ArtifactProvenance(BaseModel):
+    """Where an artifact came from: enough to audit, reproduce, and hand over ownership.
+
+    Required on exportable artifacts (a customer-owned checkpoint without provenance is not
+    auditable); optional on internal ones. `trace_sha256` fingerprints the training corpus
+    without carrying it; `config` holds the small reproducibility facts (seed, budget,
+    hyperparameters), not datasets.
+    """
+
+    optimizer: str  # e.g. "gepa", "route-fit"
+    base_model: str = ""  # the model the artifact was trained from/for ("" when N/A)
+    trace_count: int = 0
+    trace_sha256: str = ""  # sha256 over the ordered training trace ids ("" when N/A)
+    created_at: str = ""  # ISO timestamp, stamped by the producing optimizer
+    config: JsonObject = Field(default_factory=dict)
+
 
 class ArtifactRef(BaseModel):
     """A typed reference to something an optimizer produced.
 
     `path` is a filesystem path or URI to the persisted artifact; None for artifacts carried
     inline on the result (the GEPA prompt). `metadata` holds small artifact-specific facts
-    (adapter rank, checkpoint step, policy version), not the artifact itself.
+    (adapter rank, checkpoint step, policy version), not the artifact itself. `exportable`
+    marks whether the artifact may leave the platform (customer-owned checkpoints/adapters:
+    yes, with `provenance`; routing policies: never - forced False regardless of input).
     """
 
     kind: ArtifactKind
     path: str | None = None
     metadata: JsonObject = Field(default_factory=dict)
+    exportable: bool = True
+    provenance: ArtifactProvenance | None = None
+
+    @model_validator(mode="after")
+    def _enforce_exportability(self) -> ArtifactRef:
+        if self.kind in _NEVER_EXPORTABLE:
+            self.exportable = False
+        return self
 
 
 class OptimizeMetrics(BaseModel):
@@ -76,4 +109,23 @@ class Optimizer(Protocol):
         budget: int,
         *,
         rag_corpus: list[Trace] | None = None,
+    ) -> OptimizeResult: ...
+
+
+@runtime_checkable
+class ResumableOptimizer(Protocol):
+    """Continual-learning hook: extend a prior artifact with newly ingested traces.
+
+    Type shape only for now - no optimizer implements it yet. The contract: `prior` is an
+    `ArtifactRef` a previous `optimize`/`resume` run produced (its provenance identifies the
+    corpus already learned from), `new_traces` is the increment, and the result's artifacts
+    supersede `prior`. Optimizers that cannot warm-start simply never claim this protocol,
+    and callers fall back to a full `optimize`.
+    """
+
+    def resume(
+        self,
+        prior: ArtifactRef,
+        new_traces: list[Trace],
+        budget: int,
     ) -> OptimizeResult: ...

--- a/wmh/optimize/base.py
+++ b/wmh/optimize/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from wmh.core.types import JsonObject, Trace
 
@@ -58,7 +58,16 @@ class ArtifactRef(BaseModel):
     (adapter rank, checkpoint step, policy version), not the artifact itself. `exportable`
     marks whether the artifact may leave the platform (customer-owned checkpoints/adapters:
     yes, with `provenance`; routing policies: never - forced False regardless of input).
+
+    `validate_assignment` re-runs the exportability validator on every field write, so
+    `ref.exportable = True` cannot flip the boundary after construction. Two documented ways
+    around it remain, both by pydantic design and neither reachable by accident:
+    `model_copy(update=...)` writes fields without validating, and `model_construct` skips
+    validation entirely. Anything crossing a serialization boundary is re-normalized, since
+    `model_validate`/`model_validate_json` run the validator again.
     """
+
+    model_config = ConfigDict(validate_assignment=True)
 
     kind: ArtifactKind
     path: str | None = None
@@ -68,7 +77,10 @@ class ArtifactRef(BaseModel):
 
     @model_validator(mode="after")
     def _enforce_exportability(self) -> ArtifactRef:
-        if self.kind in _NEVER_EXPORTABLE:
+        # The guard on `self.exportable` is what makes this terminate under
+        # validate_assignment: the corrective write re-enters the validator exactly once, and
+        # the second pass has nothing left to correct.
+        if self.kind in _NEVER_EXPORTABLE and self.exportable:
             self.exportable = False
         return self
 

--- a/wmh/optimize/base.py
+++ b/wmh/optimize/base.py
@@ -1,0 +1,79 @@
+"""The pluggable optimizer interface: one Protocol, switchable implementations.
+
+Every optimizer, whatever it produces, satisfies `Optimizer` and returns an `OptimizeResult`.
+What differs between families is the ARTIFACT each one emits, carried as typed `ArtifactRef`s:
+
+- prompt evolution (GEPA, `wmh.optimize.gepa`): the winning env prompt (also kept in
+  `OptimizeResult.prompt`, the field the build pipeline serves);
+- routing optimization: a `routing_policy` artifact (per-cluster model assignment served by the
+  OpenAI-compatible endpoint);
+- training-type optimizers (e.g. CoT distillation into a smaller model, future): `model_weights`
+  and `adapter` references. The plumbing exists so they fit; nothing builds them yet.
+
+Kept import-light (pydantic + core types only) so any subsystem can consume the interface
+without pulling in an optimizer's machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+from wmh.core.types import JsonObject, Trace
+
+# The artifact families the optimizer switch must carry. Adding a family here (and nowhere
+# else) is the extension point for a new optimizer type.
+ArtifactKind = Literal["prompt", "routing_policy", "model_weights", "adapter"]
+
+
+class ArtifactRef(BaseModel):
+    """A typed reference to something an optimizer produced.
+
+    `path` is a filesystem path or URI to the persisted artifact; None for artifacts carried
+    inline on the result (the GEPA prompt). `metadata` holds small artifact-specific facts
+    (adapter rank, checkpoint step, policy version), not the artifact itself.
+    """
+
+    kind: ArtifactKind
+    path: str | None = None
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class OptimizeMetrics(BaseModel):
+    """Outcome metrics from an optimization run."""
+
+    # Mean judge score on the SELECTION data, measured on the path that decided the run: GEPA's
+    # search-time valset aggregate when base won the search; the fresh paired re-check mean (over
+    # the valset, or the `recheck` set when supplied) when a non-base winner was accepted or
+    # reverted; the HARD-subset mean under `select_on_hard` when base won. Comparable across runs
+    # only at a fixed configuration - report a separate test-split score for cross-run numbers.
+    held_out_accuracy: float = 0.0
+    rollouts_used: int = 0  # search metric calls + the acceptance re-check's paired passes
+    # True when the search's winning candidate LOST the fresh base-vs-winner acceptance re-check
+    # and the base prompt was restored (see `GEPAOptimizer.optimize`). Surfaced so research runs
+    # can report how often GEPA's search wins fail to survive an independent evaluation.
+    reverted_to_base: bool = False
+    # Reserved: judge self-consistency / human-agreement proxy. Populating it needs repeated or
+    # independent judging (not yet implemented); `None` until then so it never reads as a real 0.0.
+    judge_agreement: float | None = None
+
+
+class OptimizeResult(BaseModel):
+    prompt: str  # winning specialized env prompt ("" for optimizers that don't evolve prompts)
+    frontier: list[str] = Field(default_factory=list)  # Pareto candidates
+    metrics: OptimizeMetrics = Field(default_factory=OptimizeMetrics)
+    artifacts: list[ArtifactRef] = Field(default_factory=list)
+
+
+@runtime_checkable
+class Optimizer(Protocol):
+    def optimize(
+        self,
+        train: list[Trace],
+        test: list[Trace],
+        base_prompt: str,
+        budget: int,
+        *,
+        rag_corpus: list[Trace] | None = None,
+    ) -> OptimizeResult: ...

--- a/wmh/optimize/base_test.py
+++ b/wmh/optimize/base_test.py
@@ -1,0 +1,51 @@
+"""Tests for the pluggable optimizer interface (result types + artifact refs)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.optimize.base import ArtifactRef, OptimizeMetrics, Optimizer, OptimizeResult
+from wmh.optimize.gepa import GEPAOptimizer
+
+if TYPE_CHECKING:
+    from wmh.optimize.judge import Judge
+    from wmh.providers.base import Provider
+
+
+def test_optimize_result_defaults_are_prompt_only() -> None:
+    result = OptimizeResult(prompt="serve this")
+    assert result.prompt == "serve this"
+    assert result.artifacts == []
+    assert result.metrics == OptimizeMetrics()
+
+
+def test_artifact_refs_cover_every_optimizer_family() -> None:
+    # prompt (GEPA), routing_policy (routing), model_weights + adapter (future distillation):
+    # the result type must carry each so a training-type optimizer FITS without schema changes.
+    refs = [
+        ArtifactRef(kind="prompt"),
+        ArtifactRef(kind="routing_policy", path=".wmh/models/tau/policy.json"),
+        ArtifactRef(kind="model_weights", path="s3://bucket/ckpt-30b"),
+        ArtifactRef(kind="adapter", path=".wmh/adapters/lora-1", metadata={"rank": 32}),
+    ]
+    result = OptimizeResult(prompt="", artifacts=refs)
+    assert [a.kind for a in result.artifacts] == [
+        "prompt",
+        "routing_policy",
+        "model_weights",
+        "adapter",
+    ]
+
+
+def test_artifact_ref_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError):
+        ArtifactRef.model_validate({"kind": "vibes"})
+
+
+def test_gepa_optimizer_satisfies_the_protocol() -> None:
+    provider = cast("Provider", None)  # protocol check needs no live backend
+    judge = cast("Judge", None)
+    assert isinstance(GEPAOptimizer(provider, judge), Optimizer)

--- a/wmh/optimize/base_test.py
+++ b/wmh/optimize/base_test.py
@@ -66,6 +66,18 @@ def test_routing_policies_are_never_exportable() -> None:
     weights = ArtifactRef(kind="model_weights", path="s3://bucket/ckpt")
     assert weights.exportable is True
 
+    # Assignment re-validates, so the boundary cannot be flipped after construction.
+    policy.exportable = True
+    assert policy.exportable is False
+    # Switching an exportable artifact's kind pulls its exportability with it.
+    weights.kind = "routing_policy"
+    assert weights.exportable is False
+    # model_copy(update=...) bypasses validation by pydantic design (documented on ArtifactRef);
+    # anything that crosses a serialization boundary is re-normalized.
+    leaked = policy.model_copy(update={"exportable": True})
+    assert leaked.exportable is True
+    assert ArtifactRef.model_validate_json(leaked.model_dump_json()).exportable is False
+
 
 def test_exportable_checkpoint_carries_provenance() -> None:
     ref = ArtifactRef(

--- a/wmh/optimize/base_test.py
+++ b/wmh/optimize/base_test.py
@@ -7,7 +7,14 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from pydantic import ValidationError
 
-from wmh.optimize.base import ArtifactRef, OptimizeMetrics, Optimizer, OptimizeResult
+from wmh.optimize.base import (
+    ArtifactProvenance,
+    ArtifactRef,
+    OptimizeMetrics,
+    Optimizer,
+    OptimizeResult,
+    ResumableOptimizer,
+)
 from wmh.optimize.gepa import GEPAOptimizer
 
 if TYPE_CHECKING:
@@ -49,3 +56,44 @@ def test_gepa_optimizer_satisfies_the_protocol() -> None:
     provider = cast("Provider", None)  # protocol check needs no live backend
     judge = cast("Judge", None)
     assert isinstance(GEPAOptimizer(provider, judge), Optimizer)
+
+
+def test_routing_policies_are_never_exportable() -> None:
+    # The ownership boundary: customer-owned checkpoints leave the platform, routing policies
+    # never do - even when a caller explicitly claims otherwise.
+    policy = ArtifactRef(kind="routing_policy", path="policy.json", exportable=True)
+    assert policy.exportable is False
+    weights = ArtifactRef(kind="model_weights", path="s3://bucket/ckpt")
+    assert weights.exportable is True
+
+
+def test_exportable_checkpoint_carries_provenance() -> None:
+    ref = ArtifactRef(
+        kind="model_weights",
+        path="s3://bucket/ckpt-30b",
+        provenance=ArtifactProvenance(
+            optimizer="distill",
+            base_model="qwen3-30b",
+            trace_count=1200,
+            trace_sha256="ab" * 32,
+            created_at="2026-07-25T00:00:00Z",
+            config={"seed": 42},
+        ),
+    )
+    assert ref.provenance is not None
+    assert ref.provenance.trace_count == 1200
+    # Round-trips through JSON so the platform can persist ownership records verbatim.
+    again = ArtifactRef.model_validate_json(ref.model_dump_json())
+    assert again.provenance == ref.provenance
+
+
+def test_resumable_optimizer_is_a_runtime_checkable_shape() -> None:
+    class WarmStart:
+        def resume(self, prior: ArtifactRef, new_traces: list, budget: int) -> OptimizeResult:
+            return OptimizeResult(prompt="resumed")
+
+    class ColdOnly:
+        def optimize(self) -> None: ...
+
+    assert isinstance(WarmStart(), ResumableOptimizer)
+    assert not isinstance(ColdOnly(), ResumableOptimizer)

--- a/wmh/optimize/gepa.py
+++ b/wmh/optimize/gepa.py
@@ -21,15 +21,14 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
 
 import gepa
 from gepa.core.adapter import EvaluationBatch, GEPAAdapter
-from pydantic import BaseModel, Field
 
 from wmh.core.parsing import dumps_observation_contract, parse_observation
 from wmh.core.render import build_env_prompt, encode_state_action
 from wmh.core.types import Action, EnvState, JsonValue, Observation, Step, Trace
+from wmh.optimize.base import OptimizeMetrics, OptimizeResult
 from wmh.optimize.judge import Judge
 from wmh.providers.base import DEFAULT_MAX_TOKENS, Message, Provider
 from wmh.retrieval import Retriever
@@ -43,44 +42,6 @@ _EVAL_CONCURRENCY = 4
 
 # Called once per judged rollout: (rollouts_done, mean_score_so_far). Used to drive build progress.
 RolloutCallback = Callable[[int, float | None], None]
-
-
-class OptimizeMetrics(BaseModel):
-    """Outcome metrics from an optimization run."""
-
-    # Mean judge score on the SELECTION data, measured on the path that decided the run: GEPA's
-    # search-time valset aggregate when base won the search; the fresh paired re-check mean (over
-    # the valset, or the `recheck` set when supplied) when a non-base winner was accepted or
-    # reverted; the HARD-subset mean under `select_on_hard` when base won. Comparable across runs
-    # only at a fixed configuration - report a separate test-split score for cross-run numbers.
-    held_out_accuracy: float = 0.0
-    rollouts_used: int = 0  # search metric calls + the acceptance re-check's paired passes
-    # True when the search's winning candidate LOST the fresh base-vs-winner acceptance re-check
-    # and the base prompt was restored (see `GEPAOptimizer.optimize`). Surfaced so research runs
-    # can report how often GEPA's search wins fail to survive an independent evaluation.
-    reverted_to_base: bool = False
-    # Reserved: judge self-consistency / human-agreement proxy. Populating it needs repeated or
-    # independent judging (not yet implemented); `None` until then so it never reads as a real 0.0.
-    judge_agreement: float | None = None
-
-
-class OptimizeResult(BaseModel):
-    prompt: str  # winning specialized env prompt
-    frontier: list[str] = Field(default_factory=list)  # Pareto candidates
-    metrics: OptimizeMetrics = Field(default_factory=OptimizeMetrics)
-
-
-@runtime_checkable
-class Optimizer(Protocol):
-    def optimize(
-        self,
-        train: list[Trace],
-        test: list[Trace],
-        base_prompt: str,
-        budget: int,
-        *,
-        rag_corpus: list[Trace] | None = None,
-    ) -> OptimizeResult: ...
 
 
 # --- prediction helper (provider-only; no engine import, to avoid an engine<->optimize cycle) ----

--- a/wmh/optimize/gepa_test.py
+++ b/wmh/optimize/gepa_test.py
@@ -8,11 +8,10 @@ critique. We assert the optimizer runs a bounded loop and returns a valid fronti
 from __future__ import annotations
 
 from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+from wmh.optimize.base import Optimizer, OptimizeResult
 from wmh.optimize.gepa import (
     ENV_PROMPT_COMPONENT,
     GEPAOptimizer,
-    Optimizer,
-    OptimizeResult,
     WorldModelGEPAAdapter,
     _eval_steps,
     _EvalStep,

--- a/wmh/optimize/outcomes.py
+++ b/wmh/optimize/outcomes.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from wmh.providers.base import TokenUsage
 from wmh.providers.pool import PoolEntry
@@ -55,6 +55,23 @@ class OutcomeMatrix(BaseModel):
 
     pool: list[PoolEntry]
     outcomes: list[ScenarioOutcome]
+
+    @model_validator(mode="after")
+    def _outcomes_name_pool_models(self) -> OutcomeMatrix:
+        """Every outcome must name a pool entry, or the matrix is not self-describing.
+
+        Consumers index the pool by outcome model (`fit_rank_policy`'s `pool_order`, the report's
+        per-candidate table). A row naming a model the pool never heard of used to surface as a
+        bare `KeyError` deep inside a fitter; caught here it names the offender instead.
+        """
+        names = {entry.name for entry in self.pool}
+        ghosts = sorted({o.model for o in self.outcomes if o.model not in names})
+        if ghosts:
+            raise ValueError(
+                f"outcomes name models missing from the pool: {ghosts[:5]}; "
+                f"pool models are {sorted(names)}"
+            )
+        return self
 
     def model_names(self) -> list[str]:
         return [entry.name for entry in self.pool]

--- a/wmh/optimize/outcomes.py
+++ b/wmh/optimize/outcomes.py
@@ -1,0 +1,86 @@
+"""Closed-loop outcome matrix: per (scenario x candidate model x episode) eval records.
+
+This is the routing optimizer's training data and the improvement report's evidence base, the
+RouterBench-style precomputed matrix: run the pool over the scenario set once, then compare any
+number of policy variants offline on identical data. Produced by `wmh.env.closed_loop`
+(kept import-free of `wmh.env`/`wmh.engine` here so optimizers can consume it without cycles).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from wmh.providers.base import TokenUsage
+from wmh.providers.pool import PoolEntry
+
+
+class ScenarioOutcome(BaseModel):
+    """One episode of one candidate model on one scenario.
+
+    `reward` is None only for unscored episodes (`error` says why); consumers fitting policies
+    or reporting numbers must skip unscored rows, never default them to 0 (an infrastructure
+    failure is not a judge verdict).
+    """
+
+    scenario_id: str
+    task: str
+    model: str  # pool entry name (the stable handle policy artifacts key on)
+    episode: int = 0
+    reward: float | None = None
+    success: bool = False
+    critique: str = ""
+    steps: int = 0
+    stop_reason: str = ""
+    usage: TokenUsage = TokenUsage()
+    cost_usd: float = 0.0  # candidate-side cost, priced by ITS pool entry
+    call_seconds: list[float] = []  # wall seconds per policy call (env time excluded)
+    # Raw completion texts per call: the future distillation feed (stored, never used by v1
+    # fitting). Reasoning models that emit thought before the JSON action keep it here.
+    replies: list[str] = []
+    error: str | None = None
+
+    @property
+    def scored(self) -> bool:
+        return self.reward is not None
+
+
+class OutcomeMatrix(BaseModel):
+    """The full pool x scenario outcome grid, plus the pool it was measured on.
+
+    Carrying the pool snapshot makes the matrix self-describing: a policy fitted from it can
+    record exactly which candidates (and at what prices) its assignments were chosen over.
+    """
+
+    pool: list[PoolEntry]
+    outcomes: list[ScenarioOutcome]
+
+    def model_names(self) -> list[str]:
+        return [entry.name for entry in self.pool]
+
+    def scenario_ids(self) -> list[str]:
+        seen: dict[str, None] = {}
+        for outcome in self.outcomes:
+            seen.setdefault(outcome.scenario_id, None)
+        return list(seen)
+
+    def for_scenario(self, scenario_id: str) -> list[ScenarioOutcome]:
+        return [o for o in self.outcomes if o.scenario_id == scenario_id]
+
+    def mean_reward(self, model: str) -> float:
+        """Mean reward of `model` over its scored episodes."""
+        if model not in self.model_names():
+            raise KeyError(f"no pool model named '{model}'; available: {self.model_names()}")
+        rewards = [o.reward for o in self.outcomes if o.model == model and o.reward is not None]
+        if not rewards:
+            raise ValueError(f"pool model '{model}' has no scored episodes in this matrix")
+        return sum(rewards) / len(rewards)
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> OutcomeMatrix:
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))

--- a/wmh/optimize/outcomes_test.py
+++ b/wmh/optimize/outcomes_test.py
@@ -1,0 +1,67 @@
+"""Tests for the closed-loop outcome matrix types (the routing optimizer's training data)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.providers.base import ProviderKind, TokenUsage
+from wmh.providers.pool import PoolEntry
+
+
+def _outcome(
+    scenario_id: str, model: str, *, reward: float = 0.5, episode: int = 0
+) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=scenario_id,
+        task="do the thing",
+        model=model,
+        episode=episode,
+        reward=reward,
+        success=reward >= 0.5,
+        critique="ok",
+        steps=3,
+        stop_reason="agent_done",
+        usage=TokenUsage(input_tokens=100, output_tokens=50),
+        cost_usd=0.01,
+        call_seconds=[0.2, 0.3, 0.25],
+        replies=["{}", "{}", '{"done": true}'],
+    )
+
+
+def _matrix() -> OutcomeMatrix:
+    entries = [
+        PoolEntry(name="fable-5", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5"),
+    ]
+    outcomes = [
+        _outcome("s1", "fable-5", reward=0.9),
+        _outcome("s2", "fable-5", reward=0.7),
+        _outcome("s1", "haiku-4-5", reward=0.4),
+        _outcome("s2", "haiku-4-5", reward=0.8),
+    ]
+    return OutcomeMatrix(pool=entries, outcomes=outcomes)
+
+
+def test_matrix_accessors() -> None:
+    matrix = _matrix()
+    assert matrix.model_names() == ["fable-5", "haiku-4-5"]
+    assert matrix.scenario_ids() == ["s1", "s2"]
+    assert matrix.mean_reward("fable-5") == pytest.approx(0.8)
+    assert matrix.mean_reward("haiku-4-5") == pytest.approx(0.6)
+    assert [o.model for o in matrix.for_scenario("s1")] == ["fable-5", "haiku-4-5"]
+
+
+def test_matrix_round_trips_through_json(tmp_path: Path) -> None:
+    matrix = _matrix()
+    path = tmp_path / "outcomes.json"
+    matrix.save(path)
+    loaded = OutcomeMatrix.load(path)
+    assert loaded == matrix
+
+
+def test_mean_reward_unknown_model_errors() -> None:
+    with pytest.raises(KeyError, match="fable-5"):
+        _matrix().mean_reward("nope")

--- a/wmh/optimize/outcomes_test.py
+++ b/wmh/optimize/outcomes_test.py
@@ -65,3 +65,13 @@ def test_matrix_round_trips_through_json(tmp_path: Path) -> None:
 def test_mean_reward_unknown_model_errors() -> None:
     with pytest.raises(KeyError, match="fable-5"):
         _matrix().mean_reward("nope")
+
+
+def test_outcomes_must_name_pool_models() -> None:
+    # A ghost model used to reach the fitter and die on a bare KeyError; the matrix names it.
+    matrix = _matrix()
+    with pytest.raises(ValueError, match="ghost-model"):
+        OutcomeMatrix(
+            pool=matrix.pool,
+            outcomes=[*matrix.outcomes, _outcome("s1", "ghost-model")],
+        )

--- a/wmh/optimize/policy.py
+++ b/wmh/optimize/policy.py
@@ -8,8 +8,11 @@ An endpoint = {world model, policy, evidence, URL}; this module is the policy le
   reference implementation (ZhangYiqun018/Avengers, core/routing/rank_router.py): embed the
   request, softmax the distances to the `top_k_clusters` nearest k-means centres
   (`-beta * (1 - centre . query)` logits), score every pool model by the probability-weighted
-  reciprocal of its per-cluster accuracy rank (`1 / (rank + 0.1)`; models absent from a
-  cluster's ranking score `1 / default_rank`), and route to the argmax.
+  reciprocal of its per-cluster accuracy rank (`1 / (rank + 0.1)`, summed over the mixed
+  clusters the model appears in), and route to the argmax. `default_rank` is the floor for a
+  model absent from ALL of the mixed clusters (`1 / default_rank`); a model ranked in one and
+  absent from another simply collects nothing from the latter, it is not charged a default rank
+  there. This matches the reference.
 
 The FIT that produces rank policies lives in `wmh.optimize.routing`; this module pins the
 artifact schema and the serve-time selection so serving, reports, and the platform stay stable
@@ -101,6 +104,9 @@ class ClusterRanking(BaseModel):
     ranking: list[str] = Field(min_length=1)  # pool entry names, best first
     scores: dict[str, float] = Field(default_factory=dict)  # per-model mean reward (evidence)
     costs: dict[str, float] = Field(default_factory=dict)  # per-model mean cost (evidence)
+    # Per-model scored EPISODES behind those means: the support the fit-time guard weighs, kept
+    # so `rerank_policy` can re-apply the identical check without the outcome matrix.
+    support: dict[str, int] = Field(default_factory=dict)
     total: int = 0  # fit scenarios that landed in this cluster
 
 
@@ -129,10 +135,16 @@ class RoutingPolicy(BaseModel):
     # ProxRouter-inspired support tilt (2510.09852, ADAPTED to clusters: their exponential
     # tilt reweights nonparametric scores by a prior; ours multiplies cluster probabilities
     # by support^gamma so thin outlier clusters lose routing weight). 0 = off (reference).
-    support_tilt_gamma: float = 0.0
+    support_tilt_gamma: float = Field(default=0.0, ge=0.0)
     # Fit-set mean cost per scored episode (all models): the unit the cost knob trades against
     # one reward point. 0 when the fit carried no usable costs.
     cost_scale: float = 0.0
+    # The fit-time only-replace-if-better guard, recorded so any later transform of this policy
+    # (today `rerank_policy`) re-applies the SAME floor instead of quietly dropping it. None
+    # means the fit ran unguarded.
+    guard_model: str | None = None
+    min_support: int | None = None  # scored episodes a challenger needs to lead its cluster
+    guard_margin: float | None = None  # reward the challenger must beat the guard by
     fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
 
     @model_validator(mode="after")
@@ -141,6 +153,11 @@ class RoutingPolicy(BaseModel):
         if self.default_model not in names:
             raise ValueError(
                 f"default_model '{self.default_model}' is not in the policy pool "
+                f"(available: {sorted(names)})"
+            )
+        if self.guard_model is not None and self.guard_model not in names:
+            raise ValueError(
+                f"guard_model '{self.guard_model}' is not in the policy pool "
                 f"(available: {sorted(names)})"
             )
         if self.kind == "static" and self.clusters:
@@ -172,7 +189,11 @@ class RoutingPolicy(BaseModel):
 
 
 def select_model(
-    policy: RoutingPolicy, text: str, *, incumbent: str | None = None
+    policy: RoutingPolicy,
+    text: str,
+    *,
+    incumbent: str | None = None,
+    embedder: Embedder | None = None,
 ) -> RoutingDecision:
     """Pick the pool model for one request.
 
@@ -180,6 +201,11 @@ def select_model(
     message). `incumbent` is the model already serving this conversation, if any: a sticky
     policy keeps it (per-model prompt caches make switching expensive), unless it has been
     retired from the pool, in which case the request re-routes as if fresh.
+
+    `embedder` lets a caller that routes many requests reuse ONE embedder built from
+    `policy.embedder` (an azure spec otherwise constructs a fresh HTTP client per call); it must
+    be the function this policy's spec describes, or the centroids are meaningless. Default None
+    builds it from the spec per call.
     """
     names = {entry.name for entry in policy.pool}
     if incumbent is not None and incumbent in names and policy.sticky:
@@ -187,7 +213,7 @@ def select_model(
     if policy.kind == "static":
         return RoutingDecision(model=policy.default_model, reason="static policy")
 
-    query = np.asarray(policy.embedder.build().embed([text])[0])
+    query = np.asarray((embedder or policy.embedder.build()).embed([text])[0])
     return rank_decision(policy, query)
 
 
@@ -196,13 +222,20 @@ def rank_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
 
     Shared by `select_model` (one live request) and batch evaluation (the benchmark embeds
     all scenarios once) so the served path and the measured path can never diverge. Faithful
-    to the reference implementation: the embedder output is L2-normalized (their Normalizer
-    step); centres are used exactly as fitted, NOT re-normalized (k-means centres of unit
-    vectors are near-unit; the reference dots them raw, so we do too).
+    to the reference implementation: the query is L2-normalized HERE, so no caller can skip the
+    step and silently change the softmax temperature (`beta * distance` is scale-sensitive even
+    though the nearest-cluster order is not); centres are used exactly as fitted, NOT
+    re-normalized (k-means centres of unit vectors are near-unit; the reference dots them raw,
+    so we do too).
     """
     names = {entry.name for entry in policy.pool}
     centres = np.asarray([cluster.centroid for cluster in policy.clusters])
-    dists = 1.0 - centres @ query
+    vector = np.asarray(query, dtype=np.float64)
+    norm = float(np.linalg.norm(vector))
+    if norm > 0.0:
+        # A zero query keeps its zeros, exactly like sklearn's Normalizer.
+        vector = vector / norm
+    dists = 1.0 - centres @ vector
     top = np.argsort(dists)[: policy.top_k_clusters]
     logits = -policy.beta * dists[top]
     probs = np.exp(logits - logits.max())

--- a/wmh/optimize/policy.py
+++ b/wmh/optimize/policy.py
@@ -1,0 +1,236 @@
+"""The routing policy artifact: what the routing optimizer emits and the endpoint serves.
+
+An endpoint = {world model, policy, evidence, URL}; this module is the policy leg. Two kinds:
+
+- `static`: every request goes to `default_model`. Valid without any optimizer run, so an
+  endpoint serves from day one and the improvement report has an honest "before" state.
+- `rank`: the Avengers cluster-rank router (arXiv 2505.19797), replicated faithfully from the
+  reference implementation (ZhangYiqun018/Avengers, core/routing/rank_router.py): embed the
+  request, softmax the distances to the `top_k_clusters` nearest k-means centres
+  (`-beta * (1 - centre . query)` logits), score every pool model by the probability-weighted
+  reciprocal of its per-cluster accuracy rank (`1 / (rank + 0.1)`; models absent from a
+  cluster's ranking score `1 / default_rank`), and route to the argmax.
+
+The FIT that produces rank policies lives in `wmh.optimize.routing`; this module pins the
+artifact schema and the serve-time selection so serving, reports, and the platform stay stable
+across fitter iterations.
+
+Serve-time stickiness: `select_model` keeps a conversation's incumbent model whenever the policy
+is sticky (the default). Provider prompt caches are per-model, so switching mid-conversation
+forfeits warm cache reads and pays cold writes; until the fitter learns a real switching rule
+(expected gain vs switch cost), pure affinity is the honest default.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from pydantic import BaseModel, Field, model_validator
+
+from wmh.providers.base import Embedder, ProviderConfig, ProviderKind
+from wmh.providers.pool import PoolEntry
+from wmh.providers.registry import get_provider
+from wmh.retrieval.embedders import BatchedEmbedder, HashingEmbedder
+
+POLICY_VERSION = 2
+POLICY_FILENAME = "policy.json"
+
+# Avengers reference defaults (config/experts_template.yaml: top_k=2, beta=6.0,
+# default_rank=999). Kept on the policy so serving needs no side-channel config.
+DEFAULT_TOP_K_CLUSTERS = 2
+DEFAULT_BETA = 6.0
+DEFAULT_RANK = 999
+
+
+class EmbedderSpec(BaseModel):
+    """How to reproduce the policy's embedding function at serve time.
+
+    `hashing` is deterministic, offline, and credential-free, so a policy file is fully
+    self-contained. `azure` uses an Azure embedding deployment (per-entry credential
+    conventions matching the model pool: `api_key_env` names the env var); the fitter records
+    whichever the fit actually used, and serving reconstructs the identical function.
+    """
+
+    kind: Literal["hashing", "azure"] = "hashing"
+    dim: int = 512
+    deployment: str | None = None  # azure embedding deployment name
+    endpoint: str | None = None
+    api_key_env: str | None = None
+    batch: int = 256  # provider embeds are chunked to this many texts per request
+
+    @model_validator(mode="after")
+    def _validate_backend(self) -> EmbedderSpec:
+        if self.kind == "azure" and not (self.deployment and self.endpoint):
+            raise ValueError("an azure embedder spec needs deployment and endpoint")
+        return self
+
+    def build(self) -> Embedder:
+        if self.kind == "hashing":
+            return HashingEmbedder(dim=self.dim)
+        api_key = None
+        if self.api_key_env:
+            api_key = os.environ.get(self.api_key_env)
+            if not api_key:
+                raise ValueError(
+                    f"embedder spec: environment variable {self.api_key_env} is unset or "
+                    "empty; export that account's API key"
+                )
+        provider = get_provider(
+            ProviderConfig(
+                kind=ProviderKind.AZURE_OPENAI,
+                model=self.deployment or "",
+                embed_model=self.deployment,
+                embed_dim=self.dim,
+                endpoint=self.endpoint,
+                api_version="2024-10-21",
+            ),
+            api_key=api_key,
+        )
+        return BatchedEmbedder(provider, batch=self.batch)
+
+
+class ClusterRanking(BaseModel):
+    """One fitted cluster: its centroid and the pool models ranked by in-cluster accuracy."""
+
+    cluster_id: int
+    label: str = ""  # human-readable, surfaces as cluster_label in the request log
+    centroid: list[float]
+    ranking: list[str] = Field(min_length=1)  # pool entry names, best first
+    scores: dict[str, float] = Field(default_factory=dict)  # per-model mean reward (evidence)
+    costs: dict[str, float] = Field(default_factory=dict)  # per-model mean cost (evidence)
+    total: int = 0  # fit scenarios that landed in this cluster
+
+
+class RoutingDecision(BaseModel):
+    """Where one request goes and why (the request log's model/cluster/routing_reason)."""
+
+    model: str
+    cluster_id: int | None = None
+    cluster_label: str = ""
+    reason: str
+
+
+class RoutingPolicy(BaseModel):
+    """The persisted policy artifact (see module docstring)."""
+
+    version: int = POLICY_VERSION
+    kind: Literal["static", "rank"]
+    default_model: str  # the static answer; also the fallback for degenerate rank inputs
+    pool: list[PoolEntry]  # snapshot of the roster this policy was defined over
+    embedder: EmbedderSpec = Field(default_factory=EmbedderSpec)
+    clusters: list[ClusterRanking] = Field(default_factory=list)
+    top_k_clusters: int = Field(default=DEFAULT_TOP_K_CLUSTERS, ge=1)
+    beta: float = Field(default=DEFAULT_BETA, gt=0.0)
+    default_rank: int = Field(default=DEFAULT_RANK, ge=1)
+    sticky: bool = True  # keep a conversation's incumbent model (see module docstring)
+    # ProxRouter-inspired support tilt (2510.09852, ADAPTED to clusters: their exponential
+    # tilt reweights nonparametric scores by a prior; ours multiplies cluster probabilities
+    # by support^gamma so thin outlier clusters lose routing weight). 0 = off (reference).
+    support_tilt_gamma: float = 0.0
+    # Fit-set mean cost per scored episode (all models): the unit the cost knob trades against
+    # one reward point. 0 when the fit carried no usable costs.
+    cost_scale: float = 0.0
+    fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
+
+    @model_validator(mode="after")
+    def _validate(self) -> RoutingPolicy:
+        names = {entry.name for entry in self.pool}
+        if self.default_model not in names:
+            raise ValueError(
+                f"default_model '{self.default_model}' is not in the policy pool "
+                f"(available: {sorted(names)})"
+            )
+        if self.kind == "static" and self.clusters:
+            raise ValueError("a static policy carries no clusters; use kind='rank'")
+        if self.kind == "rank":
+            if not self.clusters:
+                raise ValueError("a rank policy needs at least one fitted cluster")
+            for cluster in self.clusters:
+                unknown = [name for name in cluster.ranking if name not in names]
+                if unknown:
+                    raise ValueError(
+                        f"cluster {cluster.cluster_id} ranks {unknown}, "
+                        f"not in the policy pool (available: {sorted(names)})"
+                    )
+                if len(cluster.centroid) != self.embedder.dim:
+                    raise ValueError(
+                        f"cluster {cluster.cluster_id} centroid has dim "
+                        f"{len(cluster.centroid)}, embedder dim is {self.embedder.dim}"
+                    )
+        return self
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> RoutingPolicy:
+        return cls.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def select_model(
+    policy: RoutingPolicy, text: str, *, incumbent: str | None = None
+) -> RoutingDecision:
+    """Pick the pool model for one request.
+
+    `text` is whatever the caller deems the routable content (serving passes the latest user
+    message). `incumbent` is the model already serving this conversation, if any: a sticky
+    policy keeps it (per-model prompt caches make switching expensive), unless it has been
+    retired from the pool, in which case the request re-routes as if fresh.
+    """
+    names = {entry.name for entry in policy.pool}
+    if incumbent is not None and incumbent in names and policy.sticky:
+        return RoutingDecision(model=incumbent, reason="sticky: conversation affinity")
+    if policy.kind == "static":
+        return RoutingDecision(model=policy.default_model, reason="static policy")
+
+    query = np.asarray(policy.embedder.build().embed([text])[0])
+    return rank_decision(policy, query)
+
+
+def rank_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
+    """The Avengers rank-routing core, on an already-embedded query.
+
+    Shared by `select_model` (one live request) and batch evaluation (the benchmark embeds
+    all scenarios once) so the served path and the measured path can never diverge. Faithful
+    to the reference implementation: the embedder output is L2-normalized (their Normalizer
+    step); centres are used exactly as fitted, NOT re-normalized (k-means centres of unit
+    vectors are near-unit; the reference dots them raw, so we do too).
+    """
+    names = {entry.name for entry in policy.pool}
+    centres = np.asarray([cluster.centroid for cluster in policy.clusters])
+    dists = 1.0 - centres @ query
+    top = np.argsort(dists)[: policy.top_k_clusters]
+    logits = -policy.beta * dists[top]
+    probs = np.exp(logits - logits.max())
+    if policy.support_tilt_gamma > 0.0:
+        support = np.asarray(
+            [max(policy.clusters[int(index)].total, 1) for index in top], dtype=np.float64
+        )
+        probs = probs * support**policy.support_tilt_gamma
+    probs /= probs.sum()
+
+    scores: dict[str, float] = {}
+    for cluster_index, prob in zip(top, probs, strict=True):
+        ranking = policy.clusters[int(cluster_index)].ranking
+        for name in names:
+            if name in ranking:
+                rank_score = 1.0 / (ranking.index(name) + 0.1)
+                scores[name] = scores.get(name, 0.0) + float(prob) * rank_score
+    for name in names:
+        scores.setdefault(name, 1.0 / policy.default_rank)
+
+    # Argmax; ties break by pool order (deterministic; the reference relies on dict order).
+    pool_order = {entry.name: index for index, entry in enumerate(policy.pool)}
+    winner = max(scores.items(), key=lambda kv: (kv[1], -pool_order[kv[0]]))[0]
+    nearest = policy.clusters[int(top[0])]
+    label = f" ({nearest.label})" if nearest.label else ""
+    return RoutingDecision(
+        model=winner,
+        cluster_id=nearest.cluster_id,
+        cluster_label=nearest.label,
+        reason=f"rank router: nearest cluster {nearest.cluster_id}{label}",
+    )

--- a/wmh/optimize/policy_test.py
+++ b/wmh/optimize/policy_test.py
@@ -1,0 +1,225 @@
+"""Tests for the routing policy artifact and the Avengers-style rank selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.optimize.policy import (
+    ClusterRanking,
+    EmbedderSpec,
+    RoutingPolicy,
+    select_model,
+)
+from wmh.providers.base import ProviderKind
+from wmh.providers.pool import PoolEntry
+from wmh.retrieval.embedders import HashingEmbedder
+
+
+def _pool() -> list[PoolEntry]:
+    return [
+        PoolEntry(name="fable-5", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5"),
+    ]
+
+
+def _static() -> RoutingPolicy:
+    return RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool())
+
+
+def _rank_policy(top_k_clusters: int = 1) -> RoutingPolicy:
+    embedder = HashingEmbedder(dim=64)
+    sql, prose = embedder.embed(["SELECT count(*) FROM superheroes", "write a friendly email"])
+    return RoutingPolicy(
+        kind="rank",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=64),
+        top_k_clusters=top_k_clusters,
+        clusters=[
+            ClusterRanking(
+                cluster_id=0,
+                label="sql",
+                centroid=sql,
+                ranking=["fable-5", "haiku-4-5"],
+                scores={"fable-5": 0.9, "haiku-4-5": 0.5},
+                total=10,
+            ),
+            ClusterRanking(
+                cluster_id=1,
+                label="prose",
+                centroid=prose,
+                ranking=["haiku-4-5", "fable-5"],
+                scores={"haiku-4-5": 0.8, "fable-5": 0.7},
+                total=10,
+            ),
+        ],
+    )
+
+
+def test_static_policy_routes_to_default() -> None:
+    decision = select_model(_static(), "anything at all")
+    assert decision.model == "haiku-4-5"
+    assert decision.cluster_id is None
+    assert "static" in decision.reason
+
+
+def test_rank_policy_routes_by_nearest_cluster_ranking() -> None:
+    policy = _rank_policy()
+    sql_decision = select_model(policy, "SELECT name FROM superheroes WHERE power = 'flight'")
+    assert sql_decision.model == "fable-5"
+    assert sql_decision.cluster_label == "sql"
+    assert "rank router" in sql_decision.reason
+    prose_decision = select_model(policy, "write a friendly email to the team")
+    assert prose_decision.model == "haiku-4-5"
+    assert prose_decision.cluster_label == "prose"
+
+
+def test_rank_policy_soft_mixing_follows_the_closer_cluster() -> None:
+    # With both clusters mixed in (top_k=2) and symmetric opposite rankings, the winner is
+    # decided by which cluster is closer: score(m) = sum_c p_c / (rank_c(m) + 0.1).
+    policy = _rank_policy(top_k_clusters=2)
+    assert select_model(policy, "SELECT count(*) FROM superheroes").model == "fable-5"
+    assert select_model(policy, "write a friendly email").model == "haiku-4-5"
+
+
+def test_models_missing_from_rankings_score_default_rank() -> None:
+    # Ranking mentions only fable-5; haiku scores 1/default_rank and cannot win.
+    embedder = HashingEmbedder(dim=32)
+    (centroid,) = embedder.embed(["anything"])
+    policy = RoutingPolicy(
+        kind="rank",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=32),
+        top_k_clusters=1,
+        clusters=[ClusterRanking(cluster_id=0, centroid=centroid, ranking=["fable-5"])],
+    )
+    assert select_model(policy, "anything").model == "fable-5"
+
+
+def test_incumbent_sticks_by_default() -> None:
+    decision = select_model(_rank_policy(), "SELECT 1", incumbent="haiku-4-5")
+    assert decision.model == "haiku-4-5"  # affinity wins over the cluster preference
+    assert "sticky" in decision.reason
+
+
+def test_retired_incumbent_reroutes() -> None:
+    decision = select_model(_rank_policy(), "SELECT 1", incumbent="gone-model")
+    assert decision.model == "fable-5"
+
+
+def test_default_model_must_be_in_pool() -> None:
+    with pytest.raises(ValueError, match="default_model"):
+        RoutingPolicy(kind="static", default_model="nope", pool=_pool())
+
+
+def test_ranking_models_must_be_in_pool() -> None:
+    with pytest.raises(ValueError, match="missing"):
+        RoutingPolicy(
+            kind="rank",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=4),
+            clusters=[ClusterRanking(cluster_id=0, centroid=[1, 0, 0, 0], ranking=["missing"])],
+        )
+
+
+def test_rank_kind_requires_clusters_and_matching_dims() -> None:
+    with pytest.raises(ValueError, match="cluster"):
+        RoutingPolicy(kind="rank", default_model="haiku-4-5", pool=_pool())
+    with pytest.raises(ValueError, match="dim"):
+        RoutingPolicy(
+            kind="rank",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=8),
+            clusters=[ClusterRanking(cluster_id=0, centroid=[1.0, 0.0], ranking=["fable-5"])],
+        )
+
+
+def test_static_kind_rejects_clusters() -> None:
+    with pytest.raises(ValueError, match="static"):
+        RoutingPolicy(
+            kind="static",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=2),
+            clusters=[ClusterRanking(cluster_id=0, centroid=[1.0, 0.0], ranking=["fable-5"])],
+        )
+
+
+def test_policy_round_trips_through_json(tmp_path: Path) -> None:
+    policy = _rank_policy()
+    path = tmp_path / "policy.json"
+    policy.save(path)
+    assert RoutingPolicy.load(path) == policy
+
+
+def test_azure_embedder_spec_requires_backend_fields() -> None:
+    with pytest.raises(ValueError, match="deployment"):
+        EmbedderSpec(kind="azure", dim=3072)
+
+
+def test_azure_embedder_spec_builds_a_batched_provider_embedder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AZ_EMBED_KEY", "sk-test")
+    spec = EmbedderSpec(
+        kind="azure",
+        dim=3072,
+        deployment="text-embedding-3-large",
+        endpoint="https://example.openai.azure.com",
+        api_key_env="AZ_EMBED_KEY",
+        batch=128,
+    )
+    embedder = spec.build()  # constructs lazily; no network until embed()
+    from wmh.retrieval.embedders import BatchedEmbedder
+
+    assert isinstance(embedder, BatchedEmbedder)
+
+
+def test_azure_embedder_spec_missing_key_env_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AZ_EMBED_KEY", raising=False)
+    spec = EmbedderSpec(
+        kind="azure",
+        dim=8,
+        deployment="d",
+        endpoint="https://example.openai.azure.com",
+        api_key_env="AZ_EMBED_KEY",
+    )
+    with pytest.raises(ValueError, match="AZ_EMBED_KEY"):
+        spec.build()
+
+
+def test_support_tilt_shifts_weight_to_supported_clusters() -> None:
+    # Two near-equidistant clusters with opposite rankings; the tiny cluster (total=1) wins
+    # untilted (slightly closer), the big one (total=400) wins under tilt.
+    embedder = HashingEmbedder(dim=64)
+    near, far = embedder.embed(["SELECT count(*) FROM t", "SELECT sum(x) FROM t"])
+
+    def build(gamma: float) -> RoutingPolicy:
+        return RoutingPolicy(
+            kind="rank",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=64),
+            top_k_clusters=2,
+            beta=1.0,
+            support_tilt_gamma=gamma,
+            clusters=[
+                ClusterRanking(
+                    cluster_id=0, centroid=near, ranking=["fable-5", "haiku-4-5"], total=1
+                ),
+                ClusterRanking(
+                    cluster_id=1, centroid=far, ranking=["haiku-4-5", "fable-5"], total=400
+                ),
+            ],
+        )
+
+    query = "SELECT count(*) FROM t"
+    assert select_model(build(0.0), query).model == "fable-5"
+    assert select_model(build(1.0), query).model == "haiku-4-5"

--- a/wmh/optimize/policy_test.py
+++ b/wmh/optimize/policy_test.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from wmh.optimize.policy import (
     ClusterRanking,
     EmbedderSpec,
     RoutingPolicy,
+    rank_decision,
     select_model,
 )
 from wmh.providers.base import ProviderKind
@@ -223,3 +226,50 @@ def test_support_tilt_shifts_weight_to_supported_clusters() -> None:
     query = "SELECT count(*) FROM t"
     assert select_model(build(0.0), query).model == "fable-5"
     assert select_model(build(1.0), query).model == "haiku-4-5"
+
+
+def test_select_model_uses_a_caller_supplied_embedder() -> None:
+    # The seam a many-request caller needs: build the policy's embedder once and hand it in.
+    # Proven by handing in one that maps SQL text onto the prose centroid.
+    class _ProseEmbedder:
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            (prose,) = HashingEmbedder(dim=64).embed(["write a friendly email"])
+            return [prose for _ in texts]
+
+    policy = _rank_policy()
+    assert select_model(policy, "SELECT 1").model == "fable-5"
+    assert select_model(policy, "SELECT 1", embedder=_ProseEmbedder()).model == "haiku-4-5"
+
+
+def test_support_tilt_gamma_rejects_negative_values() -> None:
+    # A negative tilt would reweight AWAY from supported clusters, silently inverting the lever.
+    with pytest.raises(ValidationError):
+        RoutingPolicy(
+            kind="static", default_model="haiku-4-5", pool=_pool(), support_tilt_gamma=-1.0
+        )
+
+
+def test_rank_decision_normalizes_the_query_itself() -> None:
+    # `beta * distance` is a softmax temperature, so an unnormalized query silently changes how
+    # sharply the top clusters mix (with the support tilt on, that flips the winner). The
+    # normalization is enforced inside rank_decision, so no caller can skip it.
+    embedder = HashingEmbedder(dim=64)
+    near, far = embedder.embed(["SELECT count(*) FROM t", "SELECT sum(x) FROM t"])
+    policy = RoutingPolicy(
+        kind="rank",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=64),
+        top_k_clusters=2,
+        beta=1.0,
+        support_tilt_gamma=1.0,
+        clusters=[
+            ClusterRanking(cluster_id=0, centroid=near, ranking=["fable-5", "haiku-4-5"], total=1),
+            ClusterRanking(cluster_id=1, centroid=far, ranking=["haiku-4-5", "fable-5"], total=400),
+        ],
+    )
+    unit = np.asarray(embedder.embed(["SELECT count(*) FROM t"])[0])
+    expected = rank_decision(policy, unit)
+    assert expected.model == "haiku-4-5"
+    for scale in (0.02, 50.0):  # 50.0 selected fable-5 before the fix
+        assert rank_decision(policy, unit * scale) == expected

--- a/wmh/optimize/report.py
+++ b/wmh/optimize/report.py
@@ -11,6 +11,14 @@ held-out scenarios and is labeled as such; cost and latency are real measurement
 episodes; `cost_assumptions` states what the cost numbers do and do not include (today:
 single-shot eval, list prices, cache effects not yet modeled). Unscored episodes are counted
 and surfaced, never averaged in as zeros.
+
+Paired comparison (why the headline is not a plain per-side mean): skipping unscored episodes
+per side would let the two sides average DIFFERENT scenario subsets, and unscored is not random
+- a candidate that times out on the hardest scenarios gets graded on the easy remainder and can
+out-score a baseline that answered everything. So the headline aggregates both sides over the
+intersection of scenarios scored on BOTH sides, and reports how many scenarios that left in
+(`scenarios_compared`) and out (`scenarios_excluded`). With an empty intersection there is
+nothing to report and `build_report` raises.
 """
 
 from __future__ import annotations
@@ -38,7 +46,11 @@ class ModelRef(BaseModel):
 
 
 class Headline(BaseModel):
-    """The endpoint's big numbers: routed policy vs the frontier baseline, same scenarios."""
+    """The endpoint's big numbers: routed policy vs the frontier baseline, same scenarios.
+
+    "Same scenarios" is literal and enforced: every number here is measured over the
+    `scenarios_compared` scenarios that BOTH sides scored (see the module docstring).
+    """
 
     accuracy: float
     baseline_accuracy: float
@@ -48,6 +60,8 @@ class Headline(BaseModel):
     baseline_latency_p50_ms: float
     latency_p95_ms: float
     baseline_latency_p95_ms: float
+    scenarios_compared: int = 0  # scenarios scored on BOTH sides: what the numbers cover
+    scenarios_excluded: int = 0  # held out of the comparison because one side went unscored
 
 
 class CandidateResult(BaseModel):
@@ -89,6 +103,9 @@ def _p50_p95_ms(seconds: list[float]) -> tuple[float, float]:
 
 
 def _mean(values: list[float]) -> float:
+    # 0.0 on empty is safe ONLY in the per-candidate table, where `scored_episodes` sits beside
+    # the number and says it rests on nothing. The headline never takes this path: `build_report`
+    # raises rather than quote a mean over zero commonly-scored scenarios.
     return sum(values) / len(values) if values else 0.0
 
 
@@ -117,7 +134,11 @@ def build_report(
     The routed side replays the policy's serve-time selection over each held-out scenario's
     task text and takes THAT model's measured outcomes for the scenario; the baseline side is
     `baseline`'s own rows on the same scenarios. Both sides therefore quote real, per-scenario
-    measurements from the identical matrix.
+    measurements from the identical matrix, over the identical scenarios (module docstring:
+    the headline is a PAIRED comparison over commonly-scored scenarios).
+
+    Raises ValueError when no scenario was scored on both sides: a matrix that measured nothing
+    comparable has no honest report in it.
     """
     names = {entry.name: entry for entry in matrix.pool}
     if baseline not in names:
@@ -127,16 +148,39 @@ def build_report(
     for outcome in matrix.outcomes:
         scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
 
-    routed: list[ScenarioOutcome] = []
+    # One embedder for the whole report: an azure spec builds an HTTP client per `build()`, and
+    # a report routes every held-out scenario.
+    embedder = policy.embedder.build() if policy.kind == "rank" else None
+
+    routed_rows: dict[str, list[ScenarioOutcome]] = {}
+    baseline_rows: dict[str, list[ScenarioOutcome]] = {}
     assignment_counts: dict[str, int] = {}
     for scenario_id, task in scenario_tasks.items():
-        decision = select_model(policy, task)
+        decision = select_model(policy, task, embedder=embedder)
         assignment_counts[decision.model] = assignment_counts.get(decision.model, 0) + 1
-        routed.extend(o for o in matrix.for_scenario(scenario_id) if o.model == decision.model)
-    baseline_rows = [o for o in matrix.outcomes if o.model == baseline]
+        rows = matrix.for_scenario(scenario_id)
+        routed_rows[scenario_id] = [o for o in rows if o.model == decision.model]
+        baseline_rows[scenario_id] = [o for o in rows if o.model == baseline]
 
-    routed_acc, _, routed_cost, routed_p50, routed_p95 = _aggregate(routed)
-    base_acc, _, base_cost, base_p50, base_p95 = _aggregate(baseline_rows)
+    compared = [
+        scenario_id
+        for scenario_id in scenario_tasks
+        if any(o.reward is not None for o in routed_rows[scenario_id])
+        and any(o.reward is not None for o in baseline_rows[scenario_id])
+    ]
+    if not compared:
+        raise ValueError(
+            f"no scenario has a scored episode on BOTH sides (routed policy and baseline "
+            f"'{baseline}'), so there is nothing to compare over "
+            f"{len(scenario_tasks)} scenarios; check the matrix for unscored episodes"
+        )
+
+    routed_acc, _, routed_cost, routed_p50, routed_p95 = _aggregate(
+        [o for scenario_id in compared for o in routed_rows[scenario_id]]
+    )
+    base_acc, _, base_cost, base_p50, base_p95 = _aggregate(
+        [o for scenario_id in compared for o in baseline_rows[scenario_id]]
+    )
 
     def _ref(name: str) -> ModelRef:
         entry = names[name]
@@ -175,6 +219,8 @@ def build_report(
             baseline_latency_p50_ms=base_p50,
             latency_p95_ms=routed_p95,
             baseline_latency_p95_ms=base_p95,
+            scenarios_compared=len(compared),
+            scenarios_excluded=total - len(compared),
         ),
         candidates=candidates,
         model_mix=[

--- a/wmh/optimize/report.py
+++ b/wmh/optimize/report.py
@@ -1,0 +1,185 @@
+"""The improvement report (D-REPORT): the endpoint's evidence artifact.
+
+Pure aggregation over an `OutcomeMatrix` given a `RoutingPolicy`: what the policy's routed mix
+scores on the held-out scenarios versus one frontier baseline model, at what cost and latency,
+and which models the mix uses. No fitting happens here; any policy (hand-written, static, or a
+future fitted one) reports through the same function, so the artifact shape is stable before
+the optimizer exists.
+
+Numbers honesty (binding, endpoint-common.md): accuracy is verifier-scored task success on
+held-out scenarios and is labeled as such; cost and latency are real measurements from the eval
+episodes; `cost_assumptions` states what the cost numbers do and do not include (today:
+single-shot eval, list prices, cache effects not yet modeled). Unscored episodes are counted
+and surfaced, never averaged in as zeros.
+"""
+
+from __future__ import annotations
+
+from statistics import median, quantiles
+
+from pydantic import BaseModel, Field
+
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.policy import RoutingPolicy, select_model
+from wmh.providers.pool import Tier
+
+# What the v1 cost numbers assume; shipped verbatim in every report until the cache-aware cost
+# model replaces it (2026-07-23 caching entry in the coordination log).
+COST_ASSUMPTIONS_V1 = (
+    "Costs are measured candidate-side per eval episode at the pool's per-token prices "
+    "(single-shot; provider prompt-cache effects on multi-turn traffic not yet modeled)."
+)
+
+
+class ModelRef(BaseModel):
+    model_id: str  # pool entry name
+    label: str
+    tier: Tier
+
+
+class Headline(BaseModel):
+    """The endpoint's big numbers: routed policy vs the frontier baseline, same scenarios."""
+
+    accuracy: float
+    baseline_accuracy: float
+    cost_per_run_usd: float
+    baseline_cost_per_run_usd: float
+    latency_p50_ms: float
+    baseline_latency_p50_ms: float
+    latency_p95_ms: float
+    baseline_latency_p95_ms: float
+
+
+class CandidateResult(BaseModel):
+    """One pool model's closed-loop row (the report's per-model evidence table)."""
+
+    model: ModelRef
+    accuracy: float
+    success_rate: float
+    cost_per_run_usd: float
+    latency_p50_ms: float
+    latency_p95_ms: float
+    scored_episodes: int
+    unscored_episodes: int
+
+
+class MixShare(BaseModel):
+    model_id: str
+    share: float  # fraction of held-out scenarios the policy routes to this model
+
+
+class ImprovementReport(BaseModel):
+    endpoint_id: str
+    generated_at: str
+    scenario_count: int
+    scenario_label: str  # e.g. "on 90 held-out scenarios reconstructed from your traces"
+    baseline: ModelRef
+    headline: Headline
+    candidates: list[CandidateResult]
+    model_mix: list[MixShare]
+    cost_assumptions: str = Field(min_length=1)
+
+
+def _p50_p95_ms(seconds: list[float]) -> tuple[float, float]:
+    if not seconds:
+        return 0.0, 0.0
+    p50 = median(seconds) * 1000
+    p95 = (quantiles(seconds, n=20)[-1] if len(seconds) > 1 else seconds[0]) * 1000
+    return p50, p95
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _aggregate(outcomes: list[ScenarioOutcome]) -> tuple[float, float, float, float, float]:
+    """(accuracy, success_rate, cost_per_run, p50_ms, p95_ms) over SCORED episodes."""
+    scored = [o for o in outcomes if o.reward is not None]
+    rewards = [o.reward for o in scored if o.reward is not None]
+    accuracy = _mean(rewards)
+    success = _mean([1.0 if o.success else 0.0 for o in scored])
+    cost = _mean([o.cost_usd for o in scored])
+    calls = [s for o in scored for s in o.call_seconds]
+    p50, p95 = _p50_p95_ms(calls)
+    return accuracy, success, cost, p50, p95
+
+
+def build_report(
+    matrix: OutcomeMatrix,
+    policy: RoutingPolicy,
+    *,
+    baseline: str,
+    endpoint: str,
+    generated_at: str,
+) -> ImprovementReport:
+    """Aggregate `matrix` into the endpoint's improvement report under `policy`.
+
+    The routed side replays the policy's serve-time selection over each held-out scenario's
+    task text and takes THAT model's measured outcomes for the scenario; the baseline side is
+    `baseline`'s own rows on the same scenarios. Both sides therefore quote real, per-scenario
+    measurements from the identical matrix.
+    """
+    names = {entry.name: entry for entry in matrix.pool}
+    if baseline not in names:
+        raise KeyError(f"baseline '{baseline}' is not in the matrix pool; have: {sorted(names)}")
+
+    scenario_tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+
+    routed: list[ScenarioOutcome] = []
+    assignment_counts: dict[str, int] = {}
+    for scenario_id, task in scenario_tasks.items():
+        decision = select_model(policy, task)
+        assignment_counts[decision.model] = assignment_counts.get(decision.model, 0) + 1
+        routed.extend(o for o in matrix.for_scenario(scenario_id) if o.model == decision.model)
+    baseline_rows = [o for o in matrix.outcomes if o.model == baseline]
+
+    routed_acc, _, routed_cost, routed_p50, routed_p95 = _aggregate(routed)
+    base_acc, _, base_cost, base_p50, base_p95 = _aggregate(baseline_rows)
+
+    def _ref(name: str) -> ModelRef:
+        entry = names[name]
+        return ModelRef(model_id=entry.name, label=entry.model, tier=entry.tier)
+
+    candidates: list[CandidateResult] = []
+    for entry in matrix.pool:
+        rows = [o for o in matrix.outcomes if o.model == entry.name]
+        accuracy, success, cost, p50, p95 = _aggregate(rows)
+        candidates.append(
+            CandidateResult(
+                model=_ref(entry.name),
+                accuracy=accuracy,
+                success_rate=success,
+                cost_per_run_usd=cost,
+                latency_p50_ms=p50,
+                latency_p95_ms=p95,
+                scored_episodes=sum(1 for o in rows if o.reward is not None),
+                unscored_episodes=sum(1 for o in rows if o.reward is None),
+            )
+        )
+
+    total = len(scenario_tasks)
+    return ImprovementReport(
+        endpoint_id=endpoint,
+        generated_at=generated_at,
+        scenario_count=total,
+        scenario_label=f"on {total} held-out scenarios reconstructed from your traces",
+        baseline=_ref(baseline),
+        headline=Headline(
+            accuracy=routed_acc,
+            baseline_accuracy=base_acc,
+            cost_per_run_usd=routed_cost,
+            baseline_cost_per_run_usd=base_cost,
+            latency_p50_ms=routed_p50,
+            baseline_latency_p50_ms=base_p50,
+            latency_p95_ms=routed_p95,
+            baseline_latency_p95_ms=base_p95,
+        ),
+        candidates=candidates,
+        model_mix=[
+            MixShare(model_id=model, share=count / total)
+            for model, count in sorted(assignment_counts.items())
+        ],
+        cost_assumptions=COST_ASSUMPTIONS_V1,
+    )

--- a/wmh/optimize/report_test.py
+++ b/wmh/optimize/report_test.py
@@ -1,0 +1,139 @@
+"""Tests for the improvement report (D-REPORT): aggregation over an outcome matrix."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
+from wmh.optimize.report import build_report
+from wmh.providers.base import ProviderKind, TokenUsage
+from wmh.providers.pool import PoolEntry
+from wmh.retrieval.embedders import HashingEmbedder
+
+
+def _entries() -> list[PoolEntry]:
+    return [
+        PoolEntry(name="fable-5", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        PoolEntry(
+            name="cheap",
+            kind=ProviderKind.OPENAI,
+            model="custom-cheap",
+            tier="open",
+            input_per_mtok=1.0,
+            output_per_mtok=2.0,
+        ),
+    ]
+
+
+def _outcome(sid: str, task: str, model: str, reward: float, cost: float) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=sid,
+        task=task,
+        model=model,
+        reward=reward,
+        success=reward >= 0.5,
+        steps=2,
+        stop_reason="agent_done",
+        usage=TokenUsage(input_tokens=100, output_tokens=50),
+        cost_usd=cost,
+        call_seconds=[0.2, 0.4],
+        replies=["a", "b"],
+    )
+
+
+_SQL_TASK = "SELECT count(*) FROM superheroes"
+_PROSE_TASK = "write a friendly email"
+
+
+def _matrix() -> OutcomeMatrix:
+    return OutcomeMatrix(
+        pool=_entries(),
+        outcomes=[
+            _outcome("s1", _SQL_TASK, "fable-5", reward=0.9, cost=0.010),
+            _outcome("s2", _PROSE_TASK, "fable-5", reward=0.8, cost=0.012),
+            _outcome("s1", _SQL_TASK, "cheap", reward=0.7, cost=0.001),
+            _outcome("s2", _PROSE_TASK, "cheap", reward=0.8, cost=0.001),
+        ],
+    )
+
+
+def _cluster_policy() -> RoutingPolicy:
+    embedder = HashingEmbedder(dim=64)
+    sql, prose = embedder.embed([_SQL_TASK, _PROSE_TASK])
+    return RoutingPolicy(
+        kind="rank",
+        default_model="cheap",
+        pool=_entries(),
+        embedder=EmbedderSpec(dim=64),
+        top_k_clusters=1,
+        clusters=[
+            ClusterRanking(cluster_id=0, label="sql", centroid=sql, ranking=["fable-5", "cheap"]),
+            ClusterRanking(
+                cluster_id=1, label="prose", centroid=prose, ranking=["cheap", "fable-5"]
+            ),
+        ],
+    )
+
+
+def test_report_headline_vs_baseline() -> None:
+    report = build_report(
+        _matrix(),
+        _cluster_policy(),
+        baseline="fable-5",
+        endpoint="tau-bench",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    # Routed: s1 -> fable-5 (0.9, $0.010), s2 -> cheap (0.8, $0.001).
+    assert report.headline.accuracy == pytest.approx(0.85)
+    assert report.headline.cost_per_run_usd == pytest.approx(0.0055)
+    # Baseline: fable-5 on everything.
+    assert report.headline.baseline_accuracy == pytest.approx(0.85)
+    assert report.headline.baseline_cost_per_run_usd == pytest.approx(0.011)
+    assert report.scenario_count == 2
+    assert "2 held-out scenarios" in report.scenario_label
+    assert report.baseline.model_id == "fable-5"
+    assert report.baseline.tier == "frontier"
+    assert report.cost_assumptions  # the honesty string is mandatory
+
+
+def test_report_model_mix_and_candidates() -> None:
+    report = build_report(
+        _matrix(),
+        _cluster_policy(),
+        baseline="fable-5",
+        endpoint="tau-bench",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    mix = {m.model_id: m.share for m in report.model_mix}
+    assert mix == {"fable-5": 0.5, "cheap": 0.5}
+    by_name = {c.model.model_id: c for c in report.candidates}
+    assert by_name["cheap"].accuracy == pytest.approx(0.75)
+    assert by_name["cheap"].cost_per_run_usd == pytest.approx(0.001)
+    assert by_name["cheap"].model.tier == "open"
+    assert by_name["fable-5"].latency_p50_ms == pytest.approx(300.0)
+
+
+def test_report_static_policy_and_unscored_rows() -> None:
+    matrix = _matrix()
+    matrix.outcomes.append(
+        ScenarioOutcome(scenario_id="s3", task="broken run", model="cheap", error="env exploded")
+    )
+    policy = RoutingPolicy(kind="static", default_model="cheap", pool=_entries())
+    report = build_report(
+        matrix, policy, baseline="fable-5", endpoint="e", generated_at="2026-07-24T00:00:00Z"
+    )
+    by_name = {c.model.model_id: c for c in report.candidates}
+    assert by_name["cheap"].unscored_episodes == 1  # surfaced, never averaged as 0
+    assert by_name["cheap"].accuracy == pytest.approx(0.75)
+
+
+def test_report_requires_baseline_in_matrix() -> None:
+    with pytest.raises(KeyError, match="nope"):
+        build_report(
+            _matrix(),
+            _cluster_policy(),
+            baseline="nope",
+            endpoint="e",
+            generated_at="2026-07-24T00:00:00Z",
+        )

--- a/wmh/optimize/report_test.py
+++ b/wmh/optimize/report_test.py
@@ -7,7 +7,7 @@ import pytest
 from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmh.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
 from wmh.optimize.report import build_report
-from wmh.providers.base import ProviderKind, TokenUsage
+from wmh.providers.base import Embedder, ProviderKind, TokenUsage
 from wmh.providers.pool import PoolEntry
 from wmh.retrieval.embedders import HashingEmbedder
 
@@ -126,6 +126,80 @@ def test_report_static_policy_and_unscored_rows() -> None:
     by_name = {c.model.model_id: c for c in report.candidates}
     assert by_name["cheap"].unscored_episodes == 1  # surfaced, never averaged as 0
     assert by_name["cheap"].accuracy == pytest.approx(0.75)
+
+
+def test_headline_compares_only_commonly_scored_scenarios() -> None:
+    # The cheap model CRASHED on the two hard scenarios and scored well on the two easy ones.
+    # Averaging each side over whatever it happened to score would hand the cheap model a
+    # winning headline (0.85 vs 0.72) on the strength of the scenarios it skipped.
+    pool = _entries()
+    outcomes: list[ScenarioOutcome] = []
+    for index in range(4):
+        hard = index < 2
+        task = f"task {index}"
+        outcomes.append(
+            _outcome(f"s{index}", task, "fable-5", reward=0.3 if hard else 0.9, cost=0.02)
+        )
+        if hard:
+            outcomes.append(
+                ScenarioOutcome(scenario_id=f"s{index}", task=task, model="cheap", error="timeout")
+            )
+        else:
+            outcomes.append(_outcome(f"s{index}", task, "cheap", reward=0.85, cost=0.001))
+    matrix = OutcomeMatrix(pool=pool, outcomes=outcomes)
+    report = build_report(
+        matrix,
+        RoutingPolicy(kind="static", default_model="cheap", pool=pool),
+        baseline="fable-5",
+        endpoint="e",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    # Both sides over the two commonly-scored scenarios: the baseline wins, as it should.
+    assert report.headline.accuracy == pytest.approx(0.85)
+    assert report.headline.baseline_accuracy == pytest.approx(0.9)
+    assert report.headline.scenarios_compared == 2
+    assert report.headline.scenarios_excluded == 2
+    assert report.scenario_count == 4  # the excluded scenarios are still counted, not hidden
+
+
+def test_report_over_a_fully_unscored_matrix_raises() -> None:
+    pool = _entries()
+    matrix = OutcomeMatrix(
+        pool=pool,
+        outcomes=[
+            ScenarioOutcome(scenario_id=f"s{i}", task=f"t{i}", model=name, error="provider 429")
+            for i in range(3)
+            for name in ("fable-5", "cheap")
+        ],
+    )
+    with pytest.raises(ValueError, match="nothing to compare"):
+        build_report(
+            matrix,
+            RoutingPolicy(kind="static", default_model="cheap", pool=pool),
+            baseline="fable-5",
+            endpoint="e",
+            generated_at="2026-07-24T00:00:00Z",
+        )
+
+
+def test_report_builds_the_embedder_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    builds = 0
+    original = EmbedderSpec.build
+
+    def counted(self: EmbedderSpec) -> Embedder:
+        nonlocal builds
+        builds += 1
+        return original(self)
+
+    monkeypatch.setattr(EmbedderSpec, "build", counted)
+    build_report(
+        _matrix(),
+        _cluster_policy(),
+        baseline="fable-5",
+        endpoint="e",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    assert builds == 1  # not one per routed scenario
 
 
 def test_report_requires_baseline_in_matrix() -> None:

--- a/wmh/optimize/routing.py
+++ b/wmh/optimize/routing.py
@@ -49,6 +49,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _guarded_ranking(
+    ranking: list[str],
+    *,
+    guard_model: str,
+    scores: dict[str, float],
+    costs: dict[str, float],
+    support: dict[str, int],
+    min_support: int,
+    guard_margin: float,
+) -> list[str]:
+    """Only-replace-if-better, per cluster: the router's worst case must be the guard model.
+
+    A cluster keeps its own winner ONLY when that winner beats the guard's in-cluster evidence by
+    `guard_margin` (doubled when the winner is also pricier, which kills the confidently-wrong
+    pricier-and-worse mode) on at least `min_support` scored EPISODES. Otherwise the guard leads.
+
+    Absence of guard evidence is not a pass: when the guard model has no scored episode in the
+    cluster there is nothing to beat, so the cluster reverts rather than admitting a challenger
+    that was never compared. A cluster with no scored evidence at all is left alone (its ranking
+    is the fitter's global fallback, not a claim about this cluster).
+    """
+    if not ranking or not scores:
+        return ranking
+    top = ranking[0]
+    if top == guard_model:
+        return ranking
+    reverted = [guard_model, *[model for model in ranking if model != guard_model]]
+    if guard_model not in scores:
+        return reverted
+    if support.get(top, 0) < min_support:
+        return reverted
+    margin = guard_margin
+    if costs.get(top, 0.0) > costs.get(guard_model, float("inf")):
+        margin = 2 * guard_margin
+    if scores[top] <= scores[guard_model] + margin:
+        return reverted
+    return ranking
+
+
 def fit_rank_policy(
     matrix: OutcomeMatrix,
     *,
@@ -70,6 +109,11 @@ def fit_rank_policy(
     Defaults mirror the reference (n_clusters=64, seed=42, top_k=2, beta=6.0).
     `default_model` falls back to the best overall mean reward on the fit scenarios
     (ties break by pool order).
+
+    `guard_model` turns on the only-replace-if-better guard (`_guarded_ranking`): a challenger
+    must beat the guard's in-cluster mean by `guard_margin` on at least `min_support` scored
+    EPISODES (not scenarios) to lead its cluster. The three parameters are recorded on the
+    returned policy so `rerank_policy` can re-apply the identical check off the stored evidence.
     """
     scenario_tasks: dict[str, str] = {}
     for outcome in matrix.outcomes:
@@ -139,29 +183,22 @@ def fit_rank_policy(
             model: cost_sum / count
             for model, (_reward_sum, cost_sum, count) in sums[cluster].items()
         }
+        support = {model: count for model, (_reward_sum, _cost_sum, count) in sums[cluster].items()}
         if not means:
             # A cluster with no scored episodes ranks nothing; selection falls through to
             # default_rank scores. Logged, never silent.
             logger.warning("cluster %d has no scored episodes; it ranks no models", cluster)
         ranking = sorted(means, key=lambda m: (-means[m], pool_order[m]))
-        if guard_model is not None and ranking:
-            # Only-replace-if-better, per cluster: the router's worst case must be the
-            # baseline model, so a cluster keeps its own winner ONLY when that winner beats
-            # the baseline's in-cluster evidence with enough support; otherwise the baseline
-            # leads. Thin clusters (support < min_support) always revert.
-            top = ranking[0]
-            support = sums[cluster].get(top, (0.0, 0.0, 0))[2]
-            baseline_mean = means.get(guard_model, 0.0)
-            # Margin: the cluster winner must beat the baseline's evidence by guard_margin
-            # (doubled when the winner is pricier), or the cluster reverts. Kills the
-            # confidently-wrong pricier-and-worse failure mode.
-            margin = guard_margin
-            if mean_costs.get(top, 0.0) > mean_costs.get(guard_model, float("inf")):
-                margin = 2 * guard_margin
-            if top != guard_model and (
-                support < min_support or means[top] <= baseline_mean + margin
-            ):
-                ranking = [guard_model, *[m for m in ranking if m != guard_model]]
+        if guard_model is not None:
+            ranking = _guarded_ranking(
+                ranking,
+                guard_model=guard_model,
+                scores=means,
+                costs=mean_costs,
+                support=support,
+                min_support=min_support,
+                guard_margin=guard_margin,
+            )
         label = ""
         if prefix_counts[cluster]:
             label = prefix_counts[cluster].most_common(1)[0][0]
@@ -173,6 +210,7 @@ def fit_rank_policy(
                 ranking=ranking or [_overall_best(matrix, set(scenario_ids))],
                 scores={model: round(mean, 6) for model, mean in means.items()},
                 costs={model: round(mean, 8) for model, mean in mean_costs.items()},
+                support=support,
                 total=counts[cluster],
             )
         )
@@ -188,6 +226,9 @@ def fit_rank_policy(
         beta=beta,
         default_rank=default_rank,
         cost_scale=(total_cost / total_count) if total_count else 0.0,
+        guard_model=guard_model,
+        min_support=min_support if guard_model is not None else None,
+        guard_margin=guard_margin if guard_model is not None else None,
         fitted_from=fitted_from,
     )
 
@@ -214,6 +255,12 @@ def rerank_policy(policy: RoutingPolicy, *, cost_weight: float) -> RoutingPolicy
     so cost_weight trades one reward point against one average call). `cost_weight=0` returns
     the policy unchanged - the faithful Avengers behavior; the reference has no cost term
     (Avengers-Pro's alpha is the published analogue).
+
+    The fit-time guard travels with the policy and is re-applied here: sliding the knob may not
+    undo the only-replace-if-better floor, or every guarded cluster would flip back to its
+    unguarded winner at the first non-zero cost weight (the cost term reorders, the guard then
+    has to re-veto). Cost pressure can still demote a challenger BELOW the guard; it can never
+    promote one the guard rejected.
     """
     if cost_weight == 0.0:
         return policy
@@ -230,6 +277,16 @@ def rerank_policy(policy: RoutingPolicy, *, cost_weight: float) -> RoutingPolicy
             for model in cluster.ranking
         }
         ranking = sorted(keyed, key=lambda m: (-keyed[m], pool_order[m]))
+        if policy.guard_model is not None:
+            ranking = _guarded_ranking(
+                ranking,
+                guard_model=policy.guard_model,
+                scores=cluster.scores,
+                costs=cluster.costs,
+                support=cluster.support,
+                min_support=policy.min_support or 0,
+                guard_margin=policy.guard_margin or 0.0,
+            )
         clusters.append(cluster.model_copy(update={"ranking": ranking}))
     provenance = f"{policy.fitted_from or 'unknown'} | cost_weight={cost_weight:g}"
     return policy.model_copy(update={"clusters": clusters, "fitted_from": provenance})

--- a/wmh/optimize/routing.py
+++ b/wmh/optimize/routing.py
@@ -1,0 +1,305 @@
+"""The routing fitter: an OutcomeMatrix in, an Avengers-style rank policy out.
+
+Faithful replication of the reference implementation (arXiv 2505.19797,
+github.com/ZhangYiqun018/Avengers, core/generate_rank_router.py), stage by stage:
+
+1. Embed the fit scenarios' task texts and L2-normalize (their `Normalizer(norm="l2")`).
+2. K-means the normalized embeddings (their exact configuration: k-means++, n_init="auto",
+   max_iter=1000, elkan, seeded).
+3. Per cluster, rank the pool models by mean reward over the cluster's SCORED episodes
+   (their correct/total accuracy, generalized to graded rewards; identical on binary data).
+   Models with no scored episode in a cluster are absent from its ranking and fall back to
+   `default_rank` at selection time, matching the reference.
+
+Deliberate deltas from the reference, both recorded here so the post-hoc comparison audit has
+the list in one place: (a) rewards may be graded, not just 0/1; (b) clusters get a
+human-readable label (majority scenario-id prefix) for the request log; the reference has no
+labels. Cost plays NO part in fitting, exactly like the reference; the cost-aware variant
+(Avengers-Pro's alpha) is the first planned variation AFTER replication is validated.
+
+`evaluate_policy` replays a policy over a matrix through the same `rank_decision` scoring code
+serving uses, so benchmark numbers measure the deployed selection path, not a reimplementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pydantic import BaseModel
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import Normalizer
+
+from wmh.optimize.policy import (
+    DEFAULT_BETA,
+    DEFAULT_RANK,
+    DEFAULT_TOP_K_CLUSTERS,
+    ClusterRanking,
+    EmbedderSpec,
+    RoutingDecision,
+    RoutingPolicy,
+    rank_decision,
+)
+
+if TYPE_CHECKING:
+    from wmh.optimize.outcomes import OutcomeMatrix
+
+logger = logging.getLogger(__name__)
+
+
+def fit_rank_policy(
+    matrix: OutcomeMatrix,
+    *,
+    fit_ids: list[str] | None = None,
+    embedder: EmbedderSpec | None = None,
+    n_clusters: int = 64,
+    seed: int = 42,
+    top_k_clusters: int = DEFAULT_TOP_K_CLUSTERS,
+    beta: float = DEFAULT_BETA,
+    default_rank: int = DEFAULT_RANK,
+    default_model: str | None = None,
+    guard_model: str | None = None,
+    min_support: int = 0,
+    guard_margin: float = 0.0,
+    fitted_from: str | None = None,
+) -> RoutingPolicy:
+    """Fit a rank policy on `matrix` (restricted to `fit_ids` when given).
+
+    Defaults mirror the reference (n_clusters=64, seed=42, top_k=2, beta=6.0).
+    `default_model` falls back to the best overall mean reward on the fit scenarios
+    (ties break by pool order).
+    """
+    scenario_tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+    if fit_ids is not None:
+        wanted = set(fit_ids)
+        missing = wanted - scenario_tasks.keys()
+        if missing:
+            raise ValueError(f"fit_ids not in the matrix: {sorted(missing)[:5]}")
+        scenario_tasks = {sid: scenario_tasks[sid] for sid in fit_ids}
+    if not scenario_tasks:
+        raise ValueError("no scenarios to fit on")
+
+    spec = embedder or EmbedderSpec()
+    scenario_ids = list(scenario_tasks)
+    embeddings = np.asarray(spec.build().embed([scenario_tasks[sid] for sid in scenario_ids]))
+    embeddings = Normalizer(norm="l2").fit_transform(embeddings)
+
+    k = min(n_clusters, len(scenario_ids))
+    kmeans = KMeans(
+        n_clusters=k,
+        random_state=seed,
+        init="k-means++",
+        n_init="auto",
+        max_iter=1000,
+        algorithm="elkan",
+    )
+    labels = kmeans.fit_predict(embeddings)
+    logger.info(
+        "k-means: %d clusters over %d scenarios (inertia %.4f)",
+        k,
+        len(scenario_ids),
+        kmeans.inertia_,
+    )
+
+    # Per-cluster, per-model reward sums over SCORED episodes only.
+    cluster_of = {sid: int(label) for sid, label in zip(scenario_ids, labels, strict=True)}
+    sums: dict[int, dict[str, tuple[float, float, int]]] = {c: {} for c in range(k)}
+    counts: Counter[int] = Counter(cluster_of.values())
+    prefix_counts: dict[int, Counter[str]] = {c: Counter() for c in range(k)}
+    for sid, cluster in cluster_of.items():
+        if ":" in sid:
+            prefix_counts[cluster][sid.split(":", 1)[0]] += 1
+    pool_order = {entry.name: index for index, entry in enumerate(matrix.pool)}
+    total_cost = 0.0
+    total_count = 0
+    for outcome in matrix.outcomes:
+        cluster = cluster_of.get(outcome.scenario_id)
+        if cluster is None or outcome.reward is None:
+            continue
+        reward_sum, cost_sum, count = sums[cluster].get(outcome.model, (0.0, 0.0, 0))
+        sums[cluster][outcome.model] = (
+            reward_sum + outcome.reward,
+            cost_sum + outcome.cost_usd,
+            count + 1,
+        )
+        total_cost += outcome.cost_usd
+        total_count += 1
+
+    clusters: list[ClusterRanking] = []
+    for cluster in range(k):
+        means = {
+            model: reward_sum / count
+            for model, (reward_sum, _cost_sum, count) in sums[cluster].items()
+        }
+        mean_costs = {
+            model: cost_sum / count
+            for model, (_reward_sum, cost_sum, count) in sums[cluster].items()
+        }
+        if not means:
+            # A cluster with no scored episodes ranks nothing; selection falls through to
+            # default_rank scores. Logged, never silent.
+            logger.warning("cluster %d has no scored episodes; it ranks no models", cluster)
+        ranking = sorted(means, key=lambda m: (-means[m], pool_order[m]))
+        if guard_model is not None and ranking:
+            # Only-replace-if-better, per cluster: the router's worst case must be the
+            # baseline model, so a cluster keeps its own winner ONLY when that winner beats
+            # the baseline's in-cluster evidence with enough support; otherwise the baseline
+            # leads. Thin clusters (support < min_support) always revert.
+            top = ranking[0]
+            support = sums[cluster].get(top, (0.0, 0.0, 0))[2]
+            baseline_mean = means.get(guard_model, 0.0)
+            # Margin: the cluster winner must beat the baseline's evidence by guard_margin
+            # (doubled when the winner is pricier), or the cluster reverts. Kills the
+            # confidently-wrong pricier-and-worse failure mode.
+            margin = guard_margin
+            if mean_costs.get(top, 0.0) > mean_costs.get(guard_model, float("inf")):
+                margin = 2 * guard_margin
+            if top != guard_model and (
+                support < min_support or means[top] <= baseline_mean + margin
+            ):
+                ranking = [guard_model, *[m for m in ranking if m != guard_model]]
+        label = ""
+        if prefix_counts[cluster]:
+            label = prefix_counts[cluster].most_common(1)[0][0]
+        clusters.append(
+            ClusterRanking(
+                cluster_id=cluster,
+                label=label,
+                centroid=[float(v) for v in kmeans.cluster_centers_[cluster]],
+                ranking=ranking or [_overall_best(matrix, set(scenario_ids))],
+                scores={model: round(mean, 6) for model, mean in means.items()},
+                costs={model: round(mean, 8) for model, mean in mean_costs.items()},
+                total=counts[cluster],
+            )
+        )
+
+    chosen_default = default_model or _overall_best(matrix, set(scenario_ids))
+    return RoutingPolicy(
+        kind="rank",
+        default_model=chosen_default,
+        pool=matrix.pool,
+        embedder=spec,
+        clusters=clusters,
+        top_k_clusters=top_k_clusters,
+        beta=beta,
+        default_rank=default_rank,
+        cost_scale=(total_cost / total_count) if total_count else 0.0,
+        fitted_from=fitted_from,
+    )
+
+
+def _overall_best(matrix: OutcomeMatrix, ids: set[str]) -> str:
+    sums: dict[str, tuple[float, int]] = {}
+    for outcome in matrix.outcomes:
+        if outcome.scenario_id not in ids or outcome.reward is None:
+            continue
+        reward_sum, count = sums.get(outcome.model, (0.0, 0))
+        sums[outcome.model] = (reward_sum + outcome.reward, count + 1)
+    if not sums:
+        raise ValueError("no scored outcomes; cannot pick a default model")
+    pool_order = {entry.name: index for index, entry in enumerate(matrix.pool)}
+    return min(sums, key=lambda m: (-(sums[m][0] / sums[m][1]), pool_order[m]))
+
+
+def rerank_policy(policy: RoutingPolicy, *, cost_weight: float) -> RoutingPolicy:
+    """Re-rank a fitted policy's clusters under a cost weight, WITHOUT refitting.
+
+    The fit-once, slide-the-knob property (Hybrid LLM, arXiv 2404.14618): every cluster keeps
+    its stored reward/cost evidence, and the ranking key becomes
+    `mean_reward - cost_weight * mean_cost / cost_scale` (cost in fit-set-average-call units,
+    so cost_weight trades one reward point against one average call). `cost_weight=0` returns
+    the policy unchanged - the faithful Avengers behavior; the reference has no cost term
+    (Avengers-Pro's alpha is the published analogue).
+    """
+    if cost_weight == 0.0:
+        return policy
+    if policy.kind != "rank":
+        raise ValueError("only rank policies can be re-ranked")
+    if policy.cost_scale <= 0.0:
+        raise ValueError("policy has no cost_scale; refit with cost evidence to use the knob")
+    pool_order = {entry.name: index for index, entry in enumerate(policy.pool)}
+    clusters = []
+    for cluster in policy.clusters:
+        keyed = {
+            model: cluster.scores.get(model, 0.0)
+            - cost_weight * cluster.costs.get(model, 0.0) / policy.cost_scale
+            for model in cluster.ranking
+        }
+        ranking = sorted(keyed, key=lambda m: (-keyed[m], pool_order[m]))
+        clusters.append(cluster.model_copy(update={"ranking": ranking}))
+    provenance = f"{policy.fitted_from or 'unknown'} | cost_weight={cost_weight:g}"
+    return policy.model_copy(update={"clusters": clusters, "fitted_from": provenance})
+
+
+class PolicyEval(BaseModel):
+    """One policy replayed over a matrix: what the benchmark tables are made of."""
+
+    accuracy: float
+    cost_per_scenario: float
+    model_mix: dict[str, float]
+    scenarios: int
+    unscored_scenarios: int  # scenario/model pairs the routed choice had no scored row for
+
+
+def evaluate_policy(policy: RoutingPolicy, matrix: OutcomeMatrix, ids: list[str]) -> PolicyEval:
+    """Replay `policy` over the scenarios in `ids`, scoring via each routed model's rows.
+
+    Selection runs through the SAME `rank_decision` code serving uses (queries are batch
+    embedded once for speed; the scoring math is shared, not reimplemented).
+    """
+    scenario_tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+    wanted = [sid for sid in ids if sid in scenario_tasks]
+    if not wanted:
+        raise ValueError("none of the requested ids are in the matrix")
+
+    decisions: dict[str, RoutingDecision]
+    if policy.kind == "static":
+        decisions = {
+            sid: RoutingDecision(model=policy.default_model, reason="static policy")
+            for sid in wanted
+        }
+    else:
+        embeddings = np.asarray(
+            policy.embedder.build().embed([scenario_tasks[sid] for sid in wanted])
+        )
+        embeddings = Normalizer(norm="l2").transform(embeddings)
+        decisions = {
+            sid: rank_decision(policy, embeddings[index]) for index, sid in enumerate(wanted)
+        }
+
+    by_scenario_model: dict[tuple[str, str], list[float]] = {}
+    costs: dict[tuple[str, str], list[float]] = {}
+    for outcome in matrix.outcomes:
+        key = (outcome.scenario_id, outcome.model)
+        if outcome.reward is not None:
+            by_scenario_model.setdefault(key, []).append(outcome.reward)
+            costs.setdefault(key, []).append(outcome.cost_usd)
+
+    rewards: list[float] = []
+    cost_values: list[float] = []
+    mix: Counter[str] = Counter()
+    unscored = 0
+    for sid in wanted:
+        model = decisions[sid].model
+        mix[model] += 1
+        key = (sid, model)
+        if key not in by_scenario_model:
+            unscored += 1
+            continue
+        rewards.append(sum(by_scenario_model[key]) / len(by_scenario_model[key]))
+        cost_values.append(sum(costs[key]) / len(costs[key]))
+    if not rewards:
+        raise ValueError("no scored outcomes for any routed choice; nothing to evaluate")
+    return PolicyEval(
+        accuracy=sum(rewards) / len(rewards),
+        cost_per_scenario=sum(cost_values) / len(cost_values),
+        model_mix={model: count / len(wanted) for model, count in sorted(mix.items())},
+        scenarios=len(wanted),
+        unscored_scenarios=unscored,
+    )

--- a/wmh/optimize/routing_test.py
+++ b/wmh/optimize/routing_test.py
@@ -1,0 +1,235 @@
+"""Tests for the routing fitter (Avengers replication) and its policy evaluation."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
+from wmh.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+from wmh.providers.base import ProviderKind
+from wmh.providers.pool import PoolEntry
+from wmh.retrieval.embedders import HashingEmbedder
+
+_SQL_TASKS = [
+    "SELECT count(*) FROM superheroes WHERE height > 190",
+    "SELECT name FROM users ORDER BY created_at DESC LIMIT 10",
+    "SELECT avg(price) FROM orders GROUP BY customer_id",
+    "SELECT id FROM events WHERE ts > '2026-01-01' AND kind = 'click'",
+    "SELECT t.name, count(*) FROM teams t JOIN players p ON p.team_id = t.id GROUP BY 1",
+    "SELECT max(score) FROM matches WHERE season = 2025",
+]
+_PROSE_TASKS = [
+    "write a friendly email to the team about the offsite",
+    "draft a short thank-you note for the conference organizers",
+    "compose a birthday message for a colleague",
+    "write a warm welcome paragraph for new employees",
+    "draft an apology note for the delayed shipment",
+    "write a cheerful newsletter intro about spring",
+]
+
+
+def _entries() -> list[PoolEntry]:
+    return [
+        PoolEntry(
+            name="sql-model",
+            kind=ProviderKind.OPENAI,
+            model="custom-sql",
+            input_per_mtok=1.0,
+            output_per_mtok=1.0,
+        ),
+        PoolEntry(
+            name="prose-model",
+            kind=ProviderKind.OPENAI,
+            model="custom-prose",
+            input_per_mtok=1.0,
+            output_per_mtok=1.0,
+        ),
+    ]
+
+
+def _matrix() -> OutcomeMatrix:
+    """sql-model aces SQL and flunks prose; prose-model is the mirror image."""
+    outcomes: list[ScenarioOutcome] = []
+    for group, tasks in [("sql", _SQL_TASKS), ("prose", _PROSE_TASKS)]:
+        for index, task in enumerate(tasks):
+            sid = f"{group}:{index}"
+            for model in ["sql-model", "prose-model"]:
+                wins = (model == "sql-model") == (group == "sql")
+                outcomes.append(
+                    ScenarioOutcome(
+                        scenario_id=sid,
+                        task=task,
+                        model=model,
+                        reward=1.0 if wins else 0.0,
+                        success=wins,
+                        cost_usd=0.001,
+                    )
+                )
+    return OutcomeMatrix(pool=_entries(), outcomes=outcomes)
+
+
+def _fit(**kwargs: object) -> RoutingPolicy:
+    matrix = _matrix()
+    defaults: dict = {
+        "embedder": EmbedderSpec(dim=256),
+        "n_clusters": 2,
+        "seed": 42,
+        "top_k_clusters": 1,
+    }
+    defaults.update(kwargs)
+    return fit_rank_policy(matrix, **defaults)
+
+
+def test_fit_recovers_the_specialists() -> None:
+    policy = _fit()
+    assert policy.kind == "rank"
+    assert len(policy.clusters) == 2
+    result = evaluate_policy(policy, _matrix(), _matrix().scenario_ids())
+    # Audited (2026-07-24): hashing-trigram geometry puts one prose text in the sql-majority
+    # cluster, so routing is 11/12, not 12/12 - an EMBEDDER locality miss, not a fitter bug
+    # (the mixed cluster's ranking still has the sql specialist first at 6/7). The algorithm's
+    # guarantee is beating every single model (0.5 here), not perfection.
+    assert result.accuracy >= 11 / 12 - 1e-9
+    assert result.accuracy > 0.5
+    mix = result.model_mix
+    assert set(mix) == {"sql-model", "prose-model"}
+    assert all(share > 0.3 for share in mix.values())
+
+
+def test_fit_is_deterministic() -> None:
+    assert _fit() == _fit()
+
+
+def test_cluster_count_clamps_to_scenarios() -> None:
+    policy = _fit(n_clusters=500)
+    assert len(policy.clusters) == 12  # one per scenario at most
+
+
+def test_default_model_is_overall_best_when_unset() -> None:
+    policy = _fit()
+    assert policy.default_model in {"sql-model", "prose-model"}  # tied overall; pool order wins
+    assert policy.default_model == "sql-model"
+
+
+def test_rankings_only_contain_scored_models() -> None:
+    matrix = _matrix()
+    # prose-model never scored anywhere: with a single cluster it must be absent from the
+    # ranking entirely (it falls back to default_rank at selection time, like the reference).
+    matrix.outcomes = [o for o in matrix.outcomes if o.model != "prose-model"]
+    policy = fit_rank_policy(
+        matrix, embedder=EmbedderSpec(dim=256), n_clusters=1, seed=42, top_k_clusters=1
+    )
+    (cluster,) = policy.clusters
+    assert cluster.ranking == ["sql-model"]
+
+
+def test_evaluate_policy_static_baseline() -> None:
+    matrix = _matrix()
+    static = RoutingPolicy(kind="static", default_model="sql-model", pool=_entries())
+    result = evaluate_policy(static, matrix, matrix.scenario_ids())
+    assert result.accuracy == pytest.approx(0.5)
+    assert result.model_mix == {"sql-model": 1.0}
+
+
+def test_fitted_from_provenance_recorded() -> None:
+    policy = _fit(fitted_from="routerbench_0shot.pkl@seed0")
+    assert policy.fitted_from == "routerbench_0shot.pkl@seed0"
+
+
+def test_fit_stores_cost_evidence() -> None:
+    policy = _fit()
+    assert policy.cost_scale == pytest.approx(0.001)
+    for cluster in policy.clusters:
+        assert set(cluster.costs) == set(cluster.scores)
+        assert all(cost == pytest.approx(0.001) for cost in cluster.costs.values())
+
+
+def test_rerank_zero_weight_is_identity() -> None:
+    policy = _fit()
+    assert rerank_policy(policy, cost_weight=0.0) == policy
+
+
+def test_rerank_prefers_cheap_when_quality_is_close() -> None:
+    # One cluster: expensive model barely better (0.9 vs 0.8) but 100x the cost.
+    embedder = HashingEmbedder(dim=32)
+    (centroid,) = embedder.embed(["anything"])
+    pool = [
+        PoolEntry(
+            name="pricey",
+            kind=ProviderKind.OPENAI,
+            model="p",
+            input_per_mtok=1.0,
+            output_per_mtok=1.0,
+        ),
+        PoolEntry(
+            name="cheap",
+            kind=ProviderKind.OPENAI,
+            model="c",
+            input_per_mtok=1.0,
+            output_per_mtok=1.0,
+        ),
+    ]
+    policy = RoutingPolicy(
+        kind="rank",
+        default_model="cheap",
+        pool=pool,
+        embedder=EmbedderSpec(dim=32),
+        top_k_clusters=1,
+        cost_scale=0.001,
+        clusters=[
+            ClusterRanking(
+                cluster_id=0,
+                centroid=centroid,
+                ranking=["pricey", "cheap"],
+                scores={"pricey": 0.9, "cheap": 0.8},
+                costs={"pricey": 0.1, "cheap": 0.001},
+            )
+        ],
+    )
+    # cost in cost_scale units: pricey 100, cheap 1. At weight 0.01: 0.9-1.0 < 0.8-0.01.
+    reranked = rerank_policy(policy, cost_weight=0.01)
+    assert reranked.clusters[0].ranking == ["cheap", "pricey"]
+    assert "cost_weight=0.01" in (reranked.fitted_from or "")
+    # The original is untouched (rerank returns a new policy).
+    assert policy.clusters[0].ranking == ["pricey", "cheap"]
+
+
+def test_rerank_requires_cost_scale() -> None:
+    policy = _fit()
+    zeroed = policy.model_copy(update={"cost_scale": 0.0})
+    with pytest.raises(ValueError, match="cost_scale"):
+        rerank_policy(zeroed, cost_weight=0.5)
+
+
+def test_baseline_guard_reverts_thin_or_losing_clusters() -> None:
+    # Cluster evidence: prose-model barely ahead in a thin cluster -> guard reverts to the
+    # global best (sql-model); a cluster where prose wins with support keeps prose first.
+    matrix = _matrix()
+    policy = fit_rank_policy(
+        matrix,
+        embedder=EmbedderSpec(dim=256),
+        n_clusters=2,
+        seed=42,
+        top_k_clusters=1,
+        guard_model="sql-model",
+        min_support=100,  # nothing has this support -> EVERY cluster reverts
+    )
+    for cluster in policy.clusters:
+        assert cluster.ranking[0] == "sql-model"
+
+
+def test_baseline_guard_keeps_real_winners() -> None:
+    matrix = _matrix()
+    policy = fit_rank_policy(
+        matrix,
+        embedder=EmbedderSpec(dim=256),
+        n_clusters=2,
+        seed=42,
+        top_k_clusters=1,
+        guard_model="sql-model",
+        min_support=2,
+    )
+    # The prose-majority cluster has strong prose evidence (support >= 2, mean 1.0 vs 0.0):
+    # prose-model must survive the guard there.
+    assert any(c.ranking[0] == "prose-model" for c in policy.clusters)

--- a/wmh/optimize/routing_test.py
+++ b/wmh/optimize/routing_test.py
@@ -219,6 +219,67 @@ def test_baseline_guard_reverts_thin_or_losing_clusters() -> None:
         assert cluster.ranking[0] == "sql-model"
 
 
+def test_guard_without_in_cluster_evidence_reverts_the_cluster() -> None:
+    # The guard model errored out everywhere, so no cluster has evidence about it. Zero-filling
+    # its mean would make the guard PASS exactly where it cannot be checked; the cluster must
+    # revert to the guard instead.
+    matrix = _matrix()
+    matrix.outcomes = [
+        o.model_copy(update={"reward": None, "success": False, "error": "provider 500"})
+        if o.model == "sql-model"
+        else o
+        for o in matrix.outcomes
+    ]
+    policy = fit_rank_policy(
+        matrix,
+        embedder=EmbedderSpec(dim=256),
+        n_clusters=2,
+        seed=42,
+        top_k_clusters=1,
+        guard_model="sql-model",
+        min_support=1,
+        guard_margin=0.0,
+    )
+    for cluster in policy.clusters:
+        assert "sql-model" not in cluster.scores  # nothing measured about the guard here
+        assert cluster.ranking[0] == "sql-model"  # and it still leads
+
+
+def test_guard_survives_the_cost_knob() -> None:
+    # The guard is a property of the fitted policy, not of one call: re-ranking under cost
+    # pressure re-sorts the cluster and must then re-apply the same floor.
+    matrix = _matrix()
+    guarded = fit_rank_policy(
+        matrix,
+        embedder=EmbedderSpec(dim=256),
+        n_clusters=2,
+        seed=42,
+        top_k_clusters=1,
+        guard_model="sql-model",
+        min_support=100,  # nothing has this support -> every cluster reverts to the guard
+    )
+    assert guarded.guard_model == "sql-model"
+    assert guarded.min_support == 100
+    reranked = rerank_policy(guarded, cost_weight=1e-6)
+    for cluster in reranked.clusters:
+        assert cluster.ranking[0] == "sql-model"
+
+    # Control: the identical fit WITHOUT a guard does flip under the same knob, so the
+    # assertion above is testing the guard and not an inert cost term.
+    unguarded = fit_rank_policy(
+        matrix, embedder=EmbedderSpec(dim=256), n_clusters=2, seed=42, top_k_clusters=1
+    )
+    flipped = rerank_policy(unguarded, cost_weight=1e-6)
+    assert any(cluster.ranking[0] == "prose-model" for cluster in flipped.clusters)
+
+
+def test_fit_records_per_model_support() -> None:
+    policy = _fit()
+    for cluster in policy.clusters:
+        assert set(cluster.support) == set(cluster.scores)
+        assert sum(cluster.support.values()) == 2 * cluster.total  # both models, one episode each
+
+
 def test_baseline_guard_keeps_real_winners() -> None:
     matrix = _matrix()
     policy = fit_rank_policy(

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -11,9 +11,11 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from llm_waterfall import ChatMaxTokensField, ChatRequest, ChatResponse
 from openai import BadRequestError
 
-from wmh.providers.base import Completion, Message, TokenUsage
+from wmh.providers.base import Completion, Message, StreamChunk, TokenUsage
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from openai.types import CreateEmbeddingResponse
     from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
@@ -95,6 +97,47 @@ def complete(
         else TokenUsage()
     )
     return Completion(text=text, usage=token_usage)
+
+
+def stream(
+    chat_completions: object,
+    model: str,
+    system: str,
+    messages: list[Message],
+    max_tokens: int,
+    temperature: float | None = None,
+) -> Iterator[StreamChunk]:
+    """Stream one chat completion as `StreamChunk`s (deltas, then a terminal chunk with usage).
+
+    `stream_options.include_usage` makes the wire stream end with a usage-bearing chunk, so the
+    terminal `StreamChunk` carries real token counts instead of estimates. `temperature` follows
+    the same rule as `complete`: sent only when given (reasoning models reject sampling params).
+    """
+    resource = cast("Any", chat_completions)
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": to_messages(system, messages),
+        "max_completion_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    usage = TokenUsage()
+    for chunk in resource.create(**kwargs):
+        choices = getattr(chunk, "choices", None) or []
+        if choices:
+            delta = getattr(choices[0], "delta", None)
+            text = getattr(delta, "content", None) if delta is not None else None
+            if text:
+                yield StreamChunk(delta=text)
+        chunk_usage = getattr(chunk, "usage", None)
+        if chunk_usage is not None:
+            usage = TokenUsage(
+                input_tokens=chunk_usage.prompt_tokens,
+                output_tokens=chunk_usage.completion_tokens,
+            )
+    yield StreamChunk(done=True, usage=usage)
 
 
 def complete_chat(

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -91,11 +91,7 @@ def complete(
         raise ValueError(f"{model} returned no choices")
     text = response.choices[0].message.content or ""
     usage = response.usage
-    token_usage = (
-        TokenUsage(input_tokens=usage.prompt_tokens, output_tokens=usage.completion_tokens)
-        if usage is not None
-        else TokenUsage()
-    )
+    token_usage = _chat_usage(usage) if usage is not None else TokenUsage()
     return Completion(text=text, usage=token_usage)
 
 
@@ -133,11 +129,18 @@ def stream(
                 yield StreamChunk(delta=text)
         chunk_usage = getattr(chunk, "usage", None)
         if chunk_usage is not None:
-            usage = TokenUsage(
-                input_tokens=chunk_usage.prompt_tokens,
-                output_tokens=chunk_usage.completion_tokens,
-            )
+            usage = _chat_usage(chunk_usage)
     yield StreamChunk(done=True, usage=usage)
+
+
+def _chat_usage(usage: object) -> TokenUsage:
+    """Chat-completions usage -> TokenUsage, including the cached-prompt split when reported."""
+    details = getattr(usage, "prompt_tokens_details", None)
+    return TokenUsage(
+        input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+        output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+        cached_input_tokens=(getattr(details, "cached_tokens", None) or 0) if details else 0,
+    )
 
 
 def complete_chat(

--- a/wmh/providers/_openai_common.py
+++ b/wmh/providers/_openai_common.py
@@ -53,38 +53,36 @@ def complete(
     messages: list[Message],
     max_tokens: int,
     temperature: float | None = None,
+    max_tokens_field: str = "max_completion_tokens",
 ) -> Completion:
     """Run one chat completion and map it onto our `Completion`.
 
-    `max_completion_tokens` (not the deprecated `max_tokens`) keeps this compatible with GPT 5.5.
-    `temperature` is sent ONLY when given: GPT 5.5's reasoning models reject non-default sampling
-    params (callers pass None), while OpenAI-compatible servers (vLLM policies) need it.
+    `max_tokens_field` names the output-budget parameter the deployment accepts: GPT-5.x wants
+    `max_completion_tokens`, while Azure MaaS open models (DeepSeek, Kimi) still take the
+    classic `max_tokens` (see `ProviderConfig.resolved_chat_max_tokens_field`). `temperature`
+    is sent ONLY when given: GPT 5.5's reasoning models reject non-default sampling params
+    (callers pass None), while OpenAI-compatible servers (vLLM policies) need it.
     """
+    # The output-budget param name is dynamic, so this call crosses the SDK boundary through
+    # the same one-line cast `stream` uses below.
+    resource = cast("Any", chat_completions)
+    base_kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": to_messages(system, messages),
+        max_tokens_field: max_tokens,
+    }
     if temperature is None:
-        response = chat_completions.create(
-            model=model,
-            messages=to_messages(system, messages),
-            max_completion_tokens=max_tokens,
-        )
+        response: ChatCompletion = resource.create(**base_kwargs)
     else:
         try:
-            response = chat_completions.create(
-                model=model,
-                messages=to_messages(system, messages),
-                max_completion_tokens=max_tokens,
-                temperature=temperature,
-            )
+            response = resource.create(**base_kwargs, temperature=temperature)
         except BadRequestError as exc:
             # Reasoning-model deployments (GPT-5.x behind Azure/custom endpoints) reject any
             # non-default temperature with a 400 unsupported_value. The caller can't know which
             # models sample; degrade to the model's default rather than failing the request.
             if "temperature" not in str(exc):
                 raise
-            response = chat_completions.create(
-                model=model,
-                messages=to_messages(system, messages),
-                max_completion_tokens=max_tokens,
-            )
+            response = resource.create(**base_kwargs)
     if not response.choices:
         # Content filtering (and some error modes) can return zero choices; surface it clearly
         # rather than letting choices[0] raise a bare IndexError.
@@ -102,34 +100,43 @@ def stream(
     messages: list[Message],
     max_tokens: int,
     temperature: float | None = None,
+    max_tokens_field: str = "max_completion_tokens",
 ) -> Iterator[StreamChunk]:
     """Stream one chat completion as `StreamChunk`s (deltas, then a terminal chunk with usage).
 
     `stream_options.include_usage` makes the wire stream end with a usage-bearing chunk, so the
-    terminal `StreamChunk` carries real token counts instead of estimates. `temperature` follows
-    the same rule as `complete`: sent only when given (reasoning models reject sampling params).
+    terminal `StreamChunk` carries real token counts instead of estimates. `temperature` and
+    `max_tokens_field` follow the same rules as `complete`.
     """
     resource = cast("Any", chat_completions)
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": to_messages(system, messages),
-        "max_completion_tokens": max_tokens,
+        max_tokens_field: max_tokens,
         "stream": True,
         "stream_options": {"include_usage": True},
     }
     if temperature is not None:
         kwargs["temperature"] = temperature
     usage = TokenUsage()
-    for chunk in resource.create(**kwargs):
-        choices = getattr(chunk, "choices", None) or []
-        if choices:
-            delta = getattr(choices[0], "delta", None)
-            text = getattr(delta, "content", None) if delta is not None else None
-            if text:
-                yield StreamChunk(delta=text)
-        chunk_usage = getattr(chunk, "usage", None)
-        if chunk_usage is not None:
-            usage = _chat_usage(chunk_usage)
+    upstream = resource.create(**kwargs)
+    try:
+        for chunk in upstream:
+            choices = getattr(chunk, "choices", None) or []
+            if choices:
+                delta = getattr(choices[0], "delta", None)
+                text = getattr(delta, "content", None) if delta is not None else None
+                if text:
+                    yield StreamChunk(delta=text)
+            chunk_usage = getattr(chunk, "usage", None)
+            if chunk_usage is not None:
+                usage = _chat_usage(chunk_usage)
+    finally:
+        # The SDK Stream holds an httpx response; without an explicit close an abandoned
+        # stream releases the connection only when the object is garbage collected.
+        close = getattr(upstream, "close", None)
+        if callable(close):
+            close()
     yield StreamChunk(done=True, usage=usage)
 
 

--- a/wmh/providers/anthropic.py
+++ b/wmh/providers/anthropic.py
@@ -67,6 +67,7 @@ class AnthropicProvider:
         usage = TokenUsage(
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
+            cached_input_tokens=getattr(response.usage, "cache_read_input_tokens", None) or 0,
         )
         return Completion(text=text, usage=usage)
 
@@ -100,6 +101,9 @@ class AnthropicProvider:
             kind = getattr(event, "type", "")
             if kind == "message_start":
                 usage.input_tokens = event.message.usage.input_tokens
+                usage.cached_input_tokens = (
+                    getattr(event.message.usage, "cache_read_input_tokens", None) or 0
+                )
             elif kind == "content_block_delta":
                 delta = event.delta
                 if getattr(delta, "type", "") == "text_delta" and delta.text:

--- a/wmh/providers/anthropic.py
+++ b/wmh/providers/anthropic.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
     Completion,
     Message,
     ProviderConfig,
+    StreamChunk,
     TokenUsage,
     VerifyResult,
     verify_via_ping,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from anthropic import Anthropic
     from anthropic.types import MessageParam
 
@@ -22,8 +25,11 @@ if TYPE_CHECKING:
 class AnthropicProvider:
     """Primary backend: Opus 4.8 for env simulation, GEPA reflection, and the judge."""
 
-    def __init__(self, config: ProviderConfig) -> None:
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
         self.config = config
+        # Trusted explicit credential from get_provider (pool entries with api_key_env);
+        # None means the SDK reads ANTHROPIC_API_KEY from the environment.
+        self._api_key = api_key
         self._client: Anthropic | None = None
 
     def _get_client(self) -> Anthropic:
@@ -32,7 +38,10 @@ class AnthropicProvider:
         if self._client is None:
             from anthropic import Anthropic
 
-            self._client = Anthropic()  # picks up ANTHROPIC_API_KEY from the environment
+            if self._api_key is not None:
+                self._client = Anthropic(api_key=self._api_key)
+            else:
+                self._client = Anthropic()  # picks up ANTHROPIC_API_KEY from the environment
         return self._client
 
     def complete(
@@ -60,6 +69,44 @@ class AnthropicProvider:
             output_tokens=response.usage.output_tokens,
         )
         return Completion(text=text, usage=usage)
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion natively (raw SSE events; temperature not forwarded, as complete)."""
+        del temperature  # Claude 4.8+/5 reject sampling params; mirror complete()
+        api_messages = [
+            cast("MessageParam", {"role": m.role, "content": m.content}) for m in messages
+        ]
+        # The SDK's raw stream-event union stays behind this one boundary cast; the event loop
+        # below narrows by the wire `type` tag (same pattern as the Responses provider).
+        events = cast(
+            "Iterator[Any]",
+            self._get_client().messages.create(
+                model=self.config.model,
+                system=system,
+                messages=api_messages,
+                max_tokens=max_tokens,
+                stream=True,
+            ),
+        )
+        usage = TokenUsage()
+        for event in events:
+            kind = getattr(event, "type", "")
+            if kind == "message_start":
+                usage.input_tokens = event.message.usage.input_tokens
+            elif kind == "content_block_delta":
+                delta = event.delta
+                if getattr(delta, "type", "") == "text_delta" and delta.text:
+                    yield StreamChunk(delta=delta.text)
+            elif kind == "message_delta":
+                usage.output_tokens = event.usage.output_tokens
+        yield StreamChunk(done=True, usage=usage)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         # Anthropic has no embeddings API; retrieval (phi) must use a separate embed provider

--- a/wmh/providers/anthropic.py
+++ b/wmh/providers/anthropic.py
@@ -64,10 +64,13 @@ class AnthropicProvider:
             max_tokens=max_tokens,
         )
         text = "".join(block.text for block in response.content if block.type == "text")
+        # Anthropic reports cache reads BESIDE input_tokens (input_tokens excludes them);
+        # TokenUsage's contract is cached-as-subset, so normalize by summing.
+        cache_read = getattr(response.usage, "cache_read_input_tokens", None) or 0
         usage = TokenUsage(
-            input_tokens=response.usage.input_tokens,
+            input_tokens=response.usage.input_tokens + cache_read,
             output_tokens=response.usage.output_tokens,
-            cached_input_tokens=getattr(response.usage, "cache_read_input_tokens", None) or 0,
+            cached_input_tokens=cache_read,
         )
         return Completion(text=text, usage=usage)
 
@@ -97,19 +100,26 @@ class AnthropicProvider:
             ),
         )
         usage = TokenUsage()
-        for event in events:
-            kind = getattr(event, "type", "")
-            if kind == "message_start":
-                usage.input_tokens = event.message.usage.input_tokens
-                usage.cached_input_tokens = (
-                    getattr(event.message.usage, "cache_read_input_tokens", None) or 0
-                )
-            elif kind == "content_block_delta":
-                delta = event.delta
-                if getattr(delta, "type", "") == "text_delta" and delta.text:
-                    yield StreamChunk(delta=delta.text)
-            elif kind == "message_delta":
-                usage.output_tokens = event.usage.output_tokens
+        try:
+            for event in events:
+                kind = getattr(event, "type", "")
+                if kind == "message_start":
+                    # Same sibling-to-subset normalization as complete().
+                    cache_read = getattr(event.message.usage, "cache_read_input_tokens", None) or 0
+                    usage.input_tokens = event.message.usage.input_tokens + cache_read
+                    usage.cached_input_tokens = cache_read
+                elif kind == "content_block_delta":
+                    delta = event.delta
+                    if getattr(delta, "type", "") == "text_delta" and delta.text:
+                        yield StreamChunk(delta=delta.text)
+                elif kind == "message_delta":
+                    usage.output_tokens = event.usage.output_tokens
+        finally:
+            # The SDK Stream holds an httpx response; close it explicitly so an abandoned
+            # stream does not pin the connection until garbage collection.
+            close = getattr(events, "close", None)
+            if callable(close):
+                close()
         yield StreamChunk(done=True, usage=usage)
 
     def embed(self, texts: list[str]) -> list[list[float]]:

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -187,7 +187,15 @@ class AzureOpenAIProvider:
                 ),
             )
         return _openai_common.complete(
-            self._get_client().chat.completions, self._deployment(), system, messages, max_tokens
+            self._get_client().chat.completions,
+            self._deployment(),
+            system,
+            messages,
+            max_tokens,
+            # Open-tier deployments (DeepSeek, Kimi) genuinely sample and take the classic
+            # max_tokens param; GPT-5.x rejects sampling params and wants max_completion_tokens.
+            temperature=temperature if self._forward_temperature else None,
+            max_tokens_field=self.config.resolved_chat_max_tokens_field(),
         )
 
     def stream(
@@ -198,8 +206,11 @@ class AzureOpenAIProvider:
         temperature: float = 0.7,
         max_tokens: int = DEFAULT_MAX_TOKENS,
     ) -> Iterator[StreamChunk]:
-        """Stream a completion natively from the deployment (temperature not forwarded)."""
-        del temperature  # mirror complete(): GPT-5.x deployments reject sampling params
+        """Stream a completion natively from the deployment.
+
+        Temperature is forwarded only for deployments that sample (open-tier models like
+        DeepSeek/Kimi); GPT-5.x deployments reject sampling params, mirroring `complete`.
+        """
         if self.config.reasoning_effort is not None:
             # The api-versioned chat-completions stream would silently drop reasoning_effort;
             # honest failure until a native Responses-route stream lands with the serving PR.
@@ -213,6 +224,8 @@ class AzureOpenAIProvider:
             system,
             messages,
             max_tokens,
+            temperature=temperature if self._forward_temperature else None,
+            max_tokens_field=self.config.resolved_chat_max_tokens_field(),
         )
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:

--- a/wmh/providers/azure_openai.py
+++ b/wmh/providers/azure_openai.py
@@ -22,6 +22,7 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    StreamChunk,
     TokenUsage,
     VerifyResult,
     normalize_chat_temperature,
@@ -29,6 +30,8 @@ from wmh.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from openai import AzureOpenAI, OpenAI
 
 
@@ -46,8 +49,13 @@ _REASONING_PING = ChatRequest.model_validate(
 class AzureOpenAIProvider:
     """GPT 5.5 via an Azure OpenAI deployment."""
 
-    def __init__(self, config: ProviderConfig) -> None:
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
         self.config = config
+        # Trusted explicit credential from get_provider (pool entries with api_key_env). When
+        # set, it authenticates the config endpoint directly: the pool file is operator config,
+        # so its endpoint+key pairing is trusted and the untrusted-endpoint downgrade below
+        # does not apply. Multi-account pools (several Azure resources, one key each) need this.
+        self._api_key = api_key
         self._client: AzureOpenAI | None = None
         self._responses_client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
@@ -82,7 +90,15 @@ class AzureOpenAIProvider:
 
             from openai import AzureOpenAI
 
-            if is_config_endpoint:
+            if self._api_key is not None:
+                # Trusted explicit credential (see __init__): authenticate this endpoint with
+                # exactly the operator-paired key, bypassing the untrusted-endpoint downgrade.
+                self._client = AzureOpenAI(
+                    api_version=self.config.api_version,
+                    azure_endpoint=endpoint,
+                    api_key=self._api_key,
+                )
+            elif is_config_endpoint:
                 # A config-controlled endpoint (config.toml can come from an untrusted model
                 # bundle) is an untrusted host. NEVER let the SDK fall back to the real
                 # AZURE_OPENAI_API_KEY for it: auth comes from WMH_ENDPOINT_API_KEY, mirroring
@@ -105,7 +121,10 @@ class AzureOpenAIProvider:
         """Create the Azure v1 client used by configured structured reasoning calls."""
         if self._responses_client is None:
             endpoint, is_config_endpoint = self._resolved_endpoint()
-            if is_config_endpoint:
+            if self._api_key is not None:
+                # Same trusted explicit credential as _get_client.
+                api_key: str | None = self._api_key
+            elif is_config_endpoint:
                 api_key = os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed"
             else:
                 api_key = os.environ.get("AZURE_OPENAI_API_KEY")
@@ -169,6 +188,31 @@ class AzureOpenAIProvider:
             )
         return _openai_common.complete(
             self._get_client().chat.completions, self._deployment(), system, messages, max_tokens
+        )
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion natively from the deployment (temperature not forwarded)."""
+        del temperature  # mirror complete(): GPT-5.x deployments reject sampling params
+        if self.config.reasoning_effort is not None:
+            # The api-versioned chat-completions stream would silently drop reasoning_effort;
+            # honest failure until a native Responses-route stream lands with the serving PR.
+            raise NotImplementedError(
+                "streaming is not yet implemented for reasoning_effort Azure configs; "
+                "unset reasoning_effort or use complete()"
+            )
+        return _openai_common.stream(
+            self._get_client().chat.completions,
+            self._deployment(),
+            system,
+            messages,
+            max_tokens,
         )
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -49,6 +49,11 @@ class Message(BaseModel):
 class TokenUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+    # Prompt tokens served from the provider's cache (a SUBSET of input_tokens, never in
+    # addition to it). Cache reads bill at a discounted rate, so effective-cost accounting
+    # (PoolEntry.cost_usd, D-METERING records) needs the split; providers that don't report
+    # cache usage leave it 0, which prices the whole prompt at the full input rate.
+    cached_input_tokens: int = 0
 
 
 class Completion(BaseModel):

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from enum import StrEnum
 from typing import Literal, Protocol, runtime_checkable
 
@@ -164,6 +164,44 @@ class Provider(Protocol):
 
     def verify(self) -> VerifyResult:
         """Cheap creds/model check run on startup (`wmh providers verify`)."""
+        ...
+
+
+class StreamChunk(BaseModel):
+    """One increment of a streamed completion.
+
+    A stream is zero or more delta chunks followed by exactly one terminal chunk (`done=True`)
+    carrying the call's `TokenUsage` (and, for failover chains, the model that actually served).
+    Putting usage on the terminal chunk keeps streamed traffic meterable at the provider
+    boundary exactly like `complete()`.
+    """
+
+    delta: str = ""
+    done: bool = False
+    usage: TokenUsage | None = None
+    model: str | None = Field(default=None, min_length=1)
+
+
+@runtime_checkable
+class StreamingProvider(Protocol):
+    """Provider capability for native token streaming.
+
+    Separate from :class:`Provider` for the same reason as :class:`ToolCallingProvider`: the
+    world model, judge, and optimizers consume whole completions, while the serving endpoint
+    must forward tokens as the upstream model emits them (a synthesized stream would hold the
+    full response before the first byte, which defeats streaming). Every shipped backend
+    implements it natively.
+    """
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Yield delta chunks as the model emits them, then one terminal chunk with usage."""
         ...
 
 

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -53,6 +53,10 @@ class TokenUsage(BaseModel):
     # addition to it). Cache reads bill at a discounted rate, so effective-cost accounting
     # (PoolEntry.cost_usd, D-METERING records) needs the split; providers that don't report
     # cache usage leave it 0, which prices the whole prompt at the full input rate.
+    # Providers whose APIs report cache reads BESIDE the input count (Anthropic Messages,
+    # Bedrock Converse) normalize at the construction site: input_tokens = fresh + cache_read.
+    # Cache WRITES (billed at a premium) are not captured yet; nothing sends cache_control
+    # today, and the field lands with the cache-aware routing work.
     cached_input_tokens: int = 0
 
 

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 from wmh.core.types import JsonValue
 from wmh.providers._bedrock_chat import converse_request, converse_response
@@ -41,6 +41,7 @@ class _ContentBlock(TypedDict):
 class _Usage(TypedDict):
     input_tokens: int
     output_tokens: int
+    cache_read_input_tokens: NotRequired[int]
 
 
 class _BedrockResponse(TypedDict):
@@ -161,6 +162,7 @@ class BedrockProvider:
         usage = TokenUsage(
             input_tokens=data["usage"]["input_tokens"],
             output_tokens=data["usage"]["output_tokens"],
+            cached_input_tokens=data["usage"].get("cache_read_input_tokens", 0),
         )
         return Completion(text=text, usage=usage)
 
@@ -209,6 +211,7 @@ class BedrockProvider:
                     usage = TokenUsage(
                         input_tokens=int(event_usage["inputTokens"]),
                         output_tokens=int(event_usage["outputTokens"]),
+                        cached_input_tokens=int(event_usage.get("cacheReadInputTokens", 0) or 0),
                     )
         yield StreamChunk(done=True, usage=usage)
 
@@ -238,6 +241,7 @@ class BedrockProvider:
         usage = TokenUsage(
             input_tokens=int(response["usage"]["inputTokens"]),
             output_tokens=int(response["usage"]["outputTokens"]),
+            cached_input_tokens=int(response["usage"].get("cacheReadInputTokens", 0) or 0),
         )
         return Completion(text=text, usage=usage)
 

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -159,10 +159,13 @@ class BedrockProvider:
         raw = self._get_client().invoke_model(modelId=self.config.model, body=json.dumps(body))
         data = cast("_BedrockResponse", json.loads(raw["body"].read()))
         text = "".join(block["text"] for block in data["content"] if block["type"] == "text")
+        # Anthropic-native semantics: cache reads reported BESIDE input_tokens; normalize to
+        # TokenUsage's cached-as-subset contract by summing.
+        cache_read = data["usage"].get("cache_read_input_tokens", 0)
         usage = TokenUsage(
-            input_tokens=data["usage"]["input_tokens"],
+            input_tokens=data["usage"]["input_tokens"] + cache_read,
             output_tokens=data["usage"]["output_tokens"],
-            cached_input_tokens=data["usage"].get("cache_read_input_tokens", 0),
+            cached_input_tokens=cache_read,
         )
         return Completion(text=text, usage=usage)
 
@@ -200,19 +203,29 @@ class BedrockProvider:
             kwargs["system"] = [{"text": system}]
         response = self._get_client().converse_stream(**kwargs)
         usage = TokenUsage()
-        for event in response["stream"]:
-            if "contentBlockDelta" in event:
-                text = event["contentBlockDelta"]["delta"].get("text", "")
-                if text:
-                    yield StreamChunk(delta=text)
-            elif "metadata" in event:
-                event_usage = event["metadata"].get("usage")
-                if event_usage is not None:
-                    usage = TokenUsage(
-                        input_tokens=int(event_usage["inputTokens"]),
-                        output_tokens=int(event_usage["outputTokens"]),
-                        cached_input_tokens=int(event_usage.get("cacheReadInputTokens", 0) or 0),
-                    )
+        stream = response["stream"]
+        try:
+            for event in stream:
+                if "contentBlockDelta" in event:
+                    text = event["contentBlockDelta"]["delta"].get("text", "")
+                    if text:
+                        yield StreamChunk(delta=text)
+                elif "metadata" in event:
+                    event_usage = event["metadata"].get("usage")
+                    if event_usage is not None:
+                        # Converse reports cacheReadInputTokens beside inputTokens; normalize
+                        # to the cached-as-subset contract.
+                        cache_read = int(event_usage.get("cacheReadInputTokens", 0) or 0)
+                        usage = TokenUsage(
+                            input_tokens=int(event_usage["inputTokens"]) + cache_read,
+                            output_tokens=int(event_usage["outputTokens"]),
+                            cached_input_tokens=cache_read,
+                        )
+        finally:
+            # botocore's EventStream pins the HTTP connection until closed.
+            close = getattr(stream, "close", None)
+            if callable(close):
+                close()
         yield StreamChunk(done=True, usage=usage)
 
     def _complete_converse(
@@ -238,10 +251,11 @@ class BedrockProvider:
         response = self._get_client().converse(**kwargs)
         blocks = response["output"]["message"]["content"]
         text = "".join(block["text"] for block in blocks if "text" in block)
+        cache_read = int(response["usage"].get("cacheReadInputTokens", 0) or 0)
         usage = TokenUsage(
-            input_tokens=int(response["usage"]["inputTokens"]),
+            input_tokens=int(response["usage"]["inputTokens"]) + cache_read,
             output_tokens=int(response["usage"]["outputTokens"]),
-            cached_input_tokens=int(response["usage"].get("cacheReadInputTokens", 0) or 0),
+            cached_input_tokens=cache_read,
         )
         return Completion(text=text, usage=usage)
 

--- a/wmh/providers/bedrock.py
+++ b/wmh/providers/bedrock.py
@@ -14,6 +14,7 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    StreamChunk,
     TokenUsage,
     VerifyResult,
     normalize_chat_temperature,
@@ -21,6 +22,8 @@ from wmh.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from botocore.client import BaseClient
 
 # Bedrock speaks the same Anthropic Messages schema as the direct API, pinned by this version tag.
@@ -79,7 +82,14 @@ def _is_nova(model_id: str) -> bool:
 class BedrockProvider:
     """Claude 4.8 via the Bedrock Runtime (InvokeModel with the Anthropic Messages body)."""
 
-    def __init__(self, config: ProviderConfig) -> None:
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
+        if api_key is not None:
+            # Keeps the backend union uniformly constructible from get_provider while failing
+            # loudly: Bedrock has no API-key auth to send the credential to.
+            raise ValueError(
+                "Bedrock authenticates with AWS credentials (profile/role), not an API key; "
+                "drop api_key/api_key_env for this provider"
+            )
         self.config = config
         self._client: BaseClient | None = None
         # Model capability lives in WMH's canonical catalog. Subclasses may
@@ -162,6 +172,45 @@ class BedrockProvider:
         )
         raw = self._get_client().converse(**converse_request(normalized, self.config.model))
         return converse_response(raw, self.config.model)
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion via ConverseStream (model-agnostic, Claude included).
+
+        Temperature is forwarded only when the model catalog says the model samples (Claude 4.8+
+        rejects sampling params), matching the non-streaming paths.
+        """
+        inference_config: dict[str, JsonValue] = {"maxTokens": max_tokens}
+        if self._forward_temperature:
+            inference_config["temperature"] = temperature
+        kwargs: dict[str, JsonValue] = {
+            "modelId": self.config.model,
+            "messages": [{"role": m.role, "content": [{"text": m.content}]} for m in messages],
+            "inferenceConfig": inference_config,
+        }
+        if system:
+            kwargs["system"] = [{"text": system}]
+        response = self._get_client().converse_stream(**kwargs)
+        usage = TokenUsage()
+        for event in response["stream"]:
+            if "contentBlockDelta" in event:
+                text = event["contentBlockDelta"]["delta"].get("text", "")
+                if text:
+                    yield StreamChunk(delta=text)
+            elif "metadata" in event:
+                event_usage = event["metadata"].get("usage")
+                if event_usage is not None:
+                    usage = TokenUsage(
+                        input_tokens=int(event_usage["inputTokens"]),
+                        output_tokens=int(event_usage["outputTokens"]),
+                    )
+        yield StreamChunk(done=True, usage=usage)
 
     def _complete_converse(
         self,

--- a/wmh/providers/models.py
+++ b/wmh/providers/models.py
@@ -180,8 +180,11 @@ def resolve_provider_model(provider: ProviderKind, model: str) -> ProviderModel:
     is identical. This preserves WMH's open-ended provider contract while
     canonicalizing every model in the built-in catalog.
     """
+    # Case-insensitive: Azure deployments are often created with vendor casing
+    # ("DeepSeek-V4-Pro") while the catalog rows are lowercase.
+    wanted = model.lower()
     for spec in _MODELS:
-        if spec.provider is provider and model in (spec.model_type, spec.model_id):
+        if spec.provider is provider and wanted in (spec.model_type.lower(), spec.model_id.lower()):
             return spec
     return ProviderModel(provider=provider, model_type=model, model_id=model)
 
@@ -193,7 +196,10 @@ def resolve_chat_max_tokens_field(
     fallback: ChatMaxTokensField = "max_completion_tokens",
 ) -> ChatMaxTokensField:
     """Resolve a known model contract, or preserve a custom endpoint's fallback."""
+    # Case-insensitive for the same reason as resolve_provider_model: Azure deployments
+    # carry vendor casing ("DeepSeek-V4-Pro") while catalog rows are lowercase.
+    wanted = model.lower()
     for spec in _MODELS:
-        if spec.provider is provider and model in (spec.model_type, spec.model_id):
+        if spec.provider is provider and wanted in (spec.model_type.lower(), spec.model_id.lower()):
             return spec.chat_max_tokens_field
     return fallback

--- a/wmh/providers/openai.py
+++ b/wmh/providers/openai.py
@@ -19,20 +19,27 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    StreamChunk,
     VerifyResult,
     normalize_chat_temperature,
     verify_via_ping,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from openai import OpenAI
 
 
 class OpenAIProvider:
     """GPT 5.5 via the OpenAI API."""
 
-    def __init__(self, config: ProviderConfig) -> None:
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
         self.config = config
+        # Trusted explicit credential from get_provider (pool entries with api_key_env). When
+        # set, it authenticates even against a config endpoint: the pool file is operator
+        # config, so its endpoint+key pairing is trusted, unlike a model bundle's config.toml.
+        self._api_key = api_key
         self._client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
 
@@ -52,10 +59,19 @@ class OpenAIProvider:
             # target, a grid's OpenAI/self-hosted target is a SINGLE provider with no chain behind
             # it, so removing this retry would turn any transient 429/5xx into a permanent 0.0 step
             # and bias the comparison against exactly those models. Key + OPENAI_BASE_URL from env.
-            if self.config.endpoint:
+            if self._api_key is not None:
+                # Trusted explicit credential (see __init__): the operator paired this key with
+                # this endpoint, so it is sent as-is (base_url=None keeps the SDK default).
+                self._client = OpenAI(
+                    base_url=self.config.endpoint,
+                    api_key=self._api_key,
+                    timeout=240.0,
+                    max_retries=1,
+                )
+            elif self.config.endpoint:
                 # OpenAI-compatible server. Auth comes from WMH_ENDPOINT_API_KEY; NEVER send
                 # the real OPENAI_API_KEY to an arbitrary base_url. Most self-hosted servers
-                # ignore auth, but the SDK insists on *a* key — hence the placeholder.
+                # ignore auth, but the SDK insists on *a* key, hence the placeholder.
                 self._client = OpenAI(
                     base_url=self.config.endpoint,
                     api_key=os.environ.get("WMH_ENDPOINT_API_KEY") or "not-needed",
@@ -82,6 +98,24 @@ class OpenAIProvider:
             max_tokens,
             # Self-hosted OpenAI-compatible servers honor sampling params (a policy being
             # trained NEEDS temperature diversity); real OpenAI GPT-5.5 rejects them.
+            temperature=temperature if self.config.endpoint else None,
+        )
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion natively (same temperature rule as complete)."""
+        return _openai_common.stream(
+            self._get_client().chat.completions,
+            self.config.model,
+            system,
+            messages,
+            max_tokens,
             temperature=temperature if self.config.endpoint else None,
         )
 

--- a/wmh/providers/openai_responses.py
+++ b/wmh/providers/openai_responses.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from wmh.providers import _openai_common, _responses_common
 from wmh.providers.base import (
@@ -13,11 +13,14 @@ from wmh.providers.base import (
     Completion,
     Message,
     ProviderConfig,
+    StreamChunk,
     TokenUsage,
     VerifyResult,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from openai import OpenAI
     from openai.types.responses.response_input_param import ResponseInputParam
     from openai.types.shared_params.reasoning import Reasoning
@@ -26,8 +29,11 @@ if TYPE_CHECKING:
 class OpenAIResponsesProvider:
     """GPT 5.x via OpenAI's Responses API."""
 
-    def __init__(self, config: ProviderConfig) -> None:
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
         self.config = config
+        # Trusted explicit credential from get_provider (pool entries with api_key_env);
+        # None means the SDK reads OPENAI_API_KEY from the environment.
+        self._api_key = api_key
         self._client: OpenAI | None = None
 
     def _get_client(self) -> OpenAI:
@@ -36,7 +42,10 @@ class OpenAIResponsesProvider:
         if self._client is None:
             from openai import OpenAI
 
-            self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
+            if self._api_key is not None:
+                self._client = OpenAI(api_key=self._api_key)
+            else:
+                self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
         return self._client
 
     def complete(
@@ -79,6 +88,44 @@ class OpenAIResponsesProvider:
                 store=False,
             )
         return Completion(text=_response_text(response), usage=_usage_from_response(response))
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion through the Responses API (temperature not forwarded)."""
+        del temperature  # mirror complete(): Responses models keep provider-default sampling
+        response_input = cast("ResponseInputParam", _responses_input(system, messages))
+        kwargs: dict[str, object] = {
+            "model": self.config.model,
+            "input": response_input,
+            "max_output_tokens": max_tokens,
+            "store": False,
+            "stream": True,
+        }
+        if self.config.reasoning_effort:
+            kwargs["reasoning"] = cast("Reasoning", {"effort": self.config.reasoning_effort})
+        usage = TokenUsage()
+        # The evolving Responses stream-event union stays behind this one SDK-boundary cast
+        # (same pattern as _openai_common.complete_chat).
+        events = cast("Any", self._get_client().responses).create(**kwargs)
+        for event in events:
+            kind = getattr(event, "type", "")
+            if kind == "response.output_text.delta":
+                if event.delta:
+                    yield StreamChunk(delta=event.delta)
+            elif kind == "response.completed":
+                event_usage = event.response.usage
+                if event_usage is not None:
+                    usage = TokenUsage(
+                        input_tokens=event_usage.input_tokens,
+                        output_tokens=event_usage.output_tokens,
+                    )
+        yield StreamChunk(done=True, usage=usage)
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         """Run a full structured request through the native Responses API."""

--- a/wmh/providers/openai_responses.py
+++ b/wmh/providers/openai_responses.py
@@ -113,18 +113,20 @@ class OpenAIResponsesProvider:
         # The evolving Responses stream-event union stays behind this one SDK-boundary cast
         # (same pattern as _openai_common.complete_chat).
         events = cast("Any", self._get_client().responses).create(**kwargs)
-        for event in events:
-            kind = getattr(event, "type", "")
-            if kind == "response.output_text.delta":
-                if event.delta:
-                    yield StreamChunk(delta=event.delta)
-            elif kind == "response.completed":
-                event_usage = event.response.usage
-                if event_usage is not None:
-                    usage = TokenUsage(
-                        input_tokens=event_usage.input_tokens,
-                        output_tokens=event_usage.output_tokens,
-                    )
+        try:
+            for event in events:
+                kind = getattr(event, "type", "")
+                if kind == "response.output_text.delta":
+                    if event.delta:
+                        yield StreamChunk(delta=event.delta)
+                elif kind == "response.completed":
+                    # Same extractor as complete(): keeps the cached-token split, which OpenAI
+                    # populates automatically for prompts >= 1024 tokens.
+                    usage = _usage_from_response(event.response)
+        finally:
+            close = getattr(events, "close", None)
+            if callable(close):
+                close()
         yield StreamChunk(done=True, usage=usage)
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:

--- a/wmh/providers/openai_responses.py
+++ b/wmh/providers/openai_responses.py
@@ -230,7 +230,9 @@ def _usage_from_response(response: object) -> TokenUsage:
     usage = _get(response, "usage")
     if usage is None:
         return TokenUsage()
+    details = _get(usage, "input_tokens_details")
     return TokenUsage(
         input_tokens=_as_int(_get(usage, "input_tokens")),
         output_tokens=_as_int(_get(usage, "output_tokens")),
+        cached_input_tokens=_as_int(_get(details, "cached_tokens")) if details is not None else 0,
     )

--- a/wmh/providers/pool.py
+++ b/wmh/providers/pool.py
@@ -81,7 +81,7 @@ class PoolEntry(BaseModel):
 
         Cache-adjusted: cached prompt tokens (`usage.cached_input_tokens`) bill at
         `cached_input_per_mtok` when the entry carries a cache-read price, and at the full
-        input rate otherwise — never silently free. The global `wmh.tracking.pricing.cost_usd`
+        input rate otherwise (never silently free). The global `wmh.tracking.pricing.cost_usd`
         only knows the built-in table; pool entries with explicit prices must be costed here
         or they would silently read $0.
         """

--- a/wmh/providers/pool.py
+++ b/wmh/providers/pool.py
@@ -45,6 +45,7 @@ class PoolEntry(BaseModel):
     endpoint: str | None = None
     deployment: str | None = None  # Azure deployment name
     api_version: str | None = None  # Azure api-version
+    region: str | None = None  # AWS Bedrock region (bedrock entries only)
     api_key_env: str | None = None  # env var holding this entry's API key (multi-account pools)
     tier: Tier = "frontier"
     input_per_mtok: float | None = None
@@ -104,6 +105,7 @@ class PoolEntry(BaseModel):
             endpoint=self.endpoint,
             deployment=self.deployment,
             api_version=self.api_version,
+            region=self.region,
         )
 
 

--- a/wmh/providers/pool.py
+++ b/wmh/providers/pool.py
@@ -76,14 +76,25 @@ class PoolEntry(BaseModel):
         return price
 
     def cost_usd(self, usage: TokenUsage) -> float:
-        """USD cost of `usage` priced by THIS entry's row (overrides included).
+        """Effective USD cost of `usage` priced by THIS entry's row (overrides included).
 
-        The global `wmh.tracking.pricing.cost_usd` only knows the built-in table; pool entries
-        with explicit prices must be costed here or they would silently read $0.
+        Cache-adjusted: cached prompt tokens (`usage.cached_input_tokens`) bill at
+        `cached_input_per_mtok` when the entry carries a cache-read price, and at the full
+        input rate otherwise — never silently free. The global `wmh.tracking.pricing.cost_usd`
+        only knows the built-in table; pool entries with explicit prices must be costed here
+        or they would silently read $0.
         """
         price = self.price()
+        cached = min(usage.cached_input_tokens, usage.input_tokens)
+        cached_rate = (
+            self.cached_input_per_mtok
+            if self.cached_input_per_mtok is not None
+            else price.input_per_mtok
+        )
         return (
-            usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+            (usage.input_tokens - cached) * price.input_per_mtok
+            + cached * cached_rate
+            + usage.output_tokens * price.output_per_mtok
         ) / 1_000_000
 
     def provider_config(self) -> ProviderConfig:

--- a/wmh/providers/pool.py
+++ b/wmh/providers/pool.py
@@ -23,7 +23,7 @@ import tomllib
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from wmh.providers.base import Provider, ProviderConfig, ProviderKind, TokenUsage
 from wmh.providers.registry import get_provider
@@ -37,7 +37,13 @@ Tier = Literal["frontier", "open"]
 
 
 class PoolEntry(BaseModel):
-    """One candidate model. `name` is the stable handle policy artifacts and request logs key on."""
+    """One candidate model. `name` is the stable handle policy artifacts and request logs key on.
+
+    `extra="forbid"`: a typo like `api_key_evn` must fail at load, not surface as a 401 at
+    request time with no hint (same policy as `.wmh/fallback.toml`'s rungs).
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1)
     kind: ProviderKind
@@ -62,6 +68,13 @@ class PoolEntry(BaseModel):
             raise ValueError(
                 f"pool model '{self.name}': '{self.model}' has no built-in price; add "
                 "input_per_mtok and output_per_mtok (USD per 1M tokens) to its pool entry"
+            )
+        if self.kind is ProviderKind.AZURE_OPENAI and self.deployment is None:
+            # Without this the entry loads fine and the first request routed to it 500s
+            # from AzureOpenAIProvider._deployment(); load is the validation boundary.
+            raise ValueError(
+                f"pool model '{self.name}': azure entries need `deployment` (the Azure "
+                "deployment name to call)"
             )
         return self
 

--- a/wmh/providers/pool.py
+++ b/wmh/providers/pool.py
@@ -1,0 +1,144 @@
+"""Candidate model pool: the editable roster the routing optimizer selects over.
+
+The pool is one operator-owned TOML file (default `.wmh/pool.toml`, like `.wmh/fallback.toml`),
+one `[[model]]` table per candidate. Swapping the roster is editing that file; nothing else in
+the harness hardcodes candidate models.
+
+Trust note: the pool file is trusted local config, unlike a model bundle's `config.toml`. That is
+why entries may name `api_key_env` (which environment variable holds that account's API key) and
+`pool_provider` resolves it and hands the key to `get_provider` as an explicit argument: the
+explicit-argument channel is unreachable from bundle-controlled config, so a bundle can never
+choose which env var gets read or where its value gets sent.
+
+Pricing: entries for models in the built-in `wmh.tracking.pricing` table need no price fields;
+anything else must declare `input_per_mtok`/`output_per_mtok` so downstream cost numbers stay
+honest (an unpriced candidate would silently report $0). `cached_input_per_mtok` is the provider
+cache-READ price, carried for cache-aware routing costs.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind, TokenUsage
+from wmh.providers.registry import get_provider
+from wmh.tracking.pricing import ModelPrice, price_for
+
+DEFAULT_POOL_PATH = Path(".wmh/pool.toml")
+
+# D-REPORT ModelRef vocabulary: "frontier" anchors the improvement report's comparison; "open"
+# models carry the run-10x-more-for-the-same-budget story.
+Tier = Literal["frontier", "open"]
+
+
+class PoolEntry(BaseModel):
+    """One candidate model. `name` is the stable handle policy artifacts and request logs key on."""
+
+    name: str = Field(min_length=1)
+    kind: ProviderKind
+    model: str = Field(min_length=1)  # provider runtime id (on Azure: the base model id)
+    endpoint: str | None = None
+    deployment: str | None = None  # Azure deployment name
+    api_version: str | None = None  # Azure api-version
+    api_key_env: str | None = None  # env var holding this entry's API key (multi-account pools)
+    tier: Tier = "frontier"
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+    cached_input_per_mtok: float | None = None  # provider cache-read price, USD per 1M tokens
+
+    @model_validator(mode="after")
+    def _validate_price(self) -> PoolEntry:
+        if (self.input_per_mtok is None) != (self.output_per_mtok is None):
+            raise ValueError(
+                f"pool model '{self.name}': set both input_per_mtok and output_per_mtok, or neither"
+            )
+        if self.input_per_mtok is None and price_for(self.model) is None:
+            raise ValueError(
+                f"pool model '{self.name}': '{self.model}' has no built-in price; add "
+                "input_per_mtok and output_per_mtok (USD per 1M tokens) to its pool entry"
+            )
+        return self
+
+    def price(self) -> ModelPrice:
+        """This entry's price row: the explicit override, else the built-in pricing table."""
+        if self.input_per_mtok is not None and self.output_per_mtok is not None:
+            return ModelPrice(
+                input_per_mtok=self.input_per_mtok, output_per_mtok=self.output_per_mtok
+            )
+        price = price_for(self.model)
+        if price is None:  # unreachable after validation; keep the failure loud, not $0
+            raise ValueError(f"pool model '{self.name}': no price available for '{self.model}'")
+        return price
+
+    def cost_usd(self, usage: TokenUsage) -> float:
+        """USD cost of `usage` priced by THIS entry's row (overrides included).
+
+        The global `wmh.tracking.pricing.cost_usd` only knows the built-in table; pool entries
+        with explicit prices must be costed here or they would silently read $0.
+        """
+        price = self.price()
+        return (
+            usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+        ) / 1_000_000
+
+    def provider_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            kind=self.kind,
+            model=self.model,
+            endpoint=self.endpoint,
+            deployment=self.deployment,
+            api_version=self.api_version,
+        )
+
+
+class ModelPool(BaseModel):
+    """The full candidate roster, as loaded from one pool TOML."""
+
+    models: list[PoolEntry] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _unique_names(self) -> ModelPool:
+        seen: set[str] = set()
+        for entry in self.models:
+            if entry.name in seen:
+                raise ValueError(f"pool model '{entry.name}' is declared twice; names are handles")
+            seen.add(entry.name)
+        return self
+
+    def entry(self, name: str) -> PoolEntry:
+        for candidate in self.models:
+            if candidate.name == name:
+                return candidate
+        available = ", ".join(m.name for m in self.models)
+        raise KeyError(f"no pool model named '{name}'; available: {available}")
+
+
+def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
+    """Load and validate the pool file at `path`."""
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"no model pool file at {path}; create it with one [[model]] table per candidate "
+            "(fields: name, kind, model, and for non-built-in models input_per_mtok/"
+            "output_per_mtok; endpoint/deployment/api_version/api_key_env as the backend needs)"
+        )
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    return ModelPool.model_validate({"models": data.get("model", [])})
+
+
+def pool_provider(entry: PoolEntry) -> Provider:
+    """Construct the provider for one pool entry, resolving its per-account API key."""
+    api_key: str | None = None
+    if entry.api_key_env:
+        api_key = os.environ.get(entry.api_key_env)
+        if not api_key:
+            raise ValueError(
+                f"pool model '{entry.name}': environment variable {entry.api_key_env} is unset "
+                "or empty; export that account's API key or drop api_key_env to use the "
+                "backend's default credentials"
+            )
+    return get_provider(entry.provider_config(), api_key=api_key)

--- a/wmh/providers/pool_test.py
+++ b/wmh/providers/pool_test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
-from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.base import ProviderConfig, ProviderKind, TokenUsage
 from wmh.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool, pool_provider
 from wmh.providers.registry import get_provider
 
@@ -154,3 +154,29 @@ def test_get_provider_rejects_api_key_for_bedrock() -> None:
     config = ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8")
     with pytest.raises(ValueError, match="[Bb]edrock"):
         get_provider(config, api_key="sk-nope")
+
+
+def test_cost_usd_is_cache_adjusted() -> None:
+    entry = PoolEntry(
+        name="cached",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        input_per_mtok=10.0,
+        output_per_mtok=20.0,
+        cached_input_per_mtok=1.0,
+    )
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=400_000)
+    # 600k fresh @ $10/M + 400k cached @ $1/M = $6.40 - never the $10 list price.
+    assert entry.cost_usd(usage) == pytest.approx(6.4)
+
+
+def test_cost_usd_without_cache_price_bills_cached_tokens_at_full_rate() -> None:
+    entry = PoolEntry(
+        name="no-cache-price",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        input_per_mtok=10.0,
+        output_per_mtok=20.0,
+    )
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=400_000)
+    assert entry.cost_usd(usage) == pytest.approx(10.0)  # honest fallback, never free

--- a/wmh/providers/pool_test.py
+++ b/wmh/providers/pool_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from wmh.providers.azure_openai import AzureOpenAIProvider
 from wmh.providers.base import ProviderConfig, ProviderKind, TokenUsage
@@ -161,6 +162,7 @@ def test_cost_usd_is_cache_adjusted() -> None:
         name="cached",
         kind=ProviderKind.AZURE_OPENAI,
         model="gpt-5.5",
+        deployment="gpt-5.5",
         input_per_mtok=10.0,
         output_per_mtok=20.0,
         cached_input_per_mtok=1.0,
@@ -175,6 +177,7 @@ def test_cost_usd_without_cache_price_bills_cached_tokens_at_full_rate() -> None
         name="no-cache-price",
         kind=ProviderKind.AZURE_OPENAI,
         model="gpt-5.5",
+        deployment="gpt-5.5",
         input_per_mtok=10.0,
         output_per_mtok=20.0,
     )
@@ -190,3 +193,27 @@ def test_bedrock_entry_pins_region() -> None:
         region="us-east-1",
     )
     assert entry.provider_config().region == "us-east-1"
+
+
+def test_unknown_pool_keys_fail_at_load() -> None:
+    # A typo like api_key_evn must fail at load, not surface as a 401 at request time.
+    with pytest.raises(ValidationError, match="api_key_evn"):
+        PoolEntry.model_validate(
+            {
+                "name": "typo",
+                "kind": "anthropic",
+                "model": "claude-haiku-4-5",
+                "api_key_evn": "SOME_KEY",
+            }
+        )
+
+
+def test_azure_entry_requires_deployment() -> None:
+    with pytest.raises(ValidationError, match="deployment"):
+        PoolEntry(
+            name="no-deploy",
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            input_per_mtok=1.0,
+            output_per_mtok=2.0,
+        )

--- a/wmh/providers/pool_test.py
+++ b/wmh/providers/pool_test.py
@@ -180,3 +180,13 @@ def test_cost_usd_without_cache_price_bills_cached_tokens_at_full_rate() -> None
     )
     usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=400_000)
     assert entry.cost_usd(usage) == pytest.approx(10.0)  # honest fallback, never free
+
+
+def test_bedrock_entry_pins_region() -> None:
+    entry = PoolEntry(
+        name="opus-4-8",
+        kind=ProviderKind.BEDROCK,
+        model="us.anthropic.claude-opus-4-8",
+        region="us-east-1",
+    )
+    assert entry.provider_config().region == "us-east-1"

--- a/wmh/providers/pool_test.py
+++ b/wmh/providers/pool_test.py
@@ -1,0 +1,156 @@
+"""Tests for the candidate model pool (schema, loading, pricing, provider construction)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmh.providers.azure_openai import AzureOpenAIProvider
+from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool, pool_provider
+from wmh.providers.registry import get_provider
+
+_POOL_TOML = """
+[[model]]
+name = "deepseek-v4-pro"
+kind = "azure"
+model = "DeepSeek-V4-Pro"
+deployment = "DeepSeek-V4-Pro"
+endpoint = "https://silen-resource.services.ai.azure.com"
+api_version = "2024-10-21"
+api_key_env = "AZURE_SILEN_RESOURCE_API_KEY"
+tier = "open"
+input_per_mtok = 1.2
+output_per_mtok = 4.8
+cached_input_per_mtok = 0.12
+
+[[model]]
+name = "gpt-5.5"
+kind = "azure"
+model = "gpt-5.5"
+deployment = "gpt-5.5"
+endpoint = "https://google-sheets.openai.azure.com"
+api_version = "2024-10-21"
+api_key_env = "AZURE_GOOGLE_SHEETS_API_KEY"
+
+[[model]]
+name = "fable"
+kind = "anthropic"
+model = "claude-fable-5"
+"""
+
+
+def _write_pool(tmp_path: Path, text: str = _POOL_TOML) -> Path:
+    path = tmp_path / "pool.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_load_pool_parses_entries(tmp_path: Path) -> None:
+    pool = load_pool(_write_pool(tmp_path))
+    assert [m.name for m in pool.models] == ["deepseek-v4-pro", "gpt-5.5", "fable"]
+    deepseek = pool.entry("deepseek-v4-pro")
+    assert deepseek.kind is ProviderKind.AZURE_OPENAI
+    assert deepseek.tier == "open"
+    assert deepseek.api_key_env == "AZURE_SILEN_RESOURCE_API_KEY"
+    assert deepseek.cached_input_per_mtok == 0.12
+    # Entries default to the frontier tier (the D-REPORT ModelRef vocabulary).
+    assert pool.entry("fable").tier == "frontier"
+
+
+def test_load_pool_missing_file_says_what_to_create(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.toml"
+    with pytest.raises(FileNotFoundError, match=r"\[\[model\]\]"):
+        load_pool(missing)
+    assert DEFAULT_POOL_PATH == Path(".wmh/pool.toml")
+
+
+def test_duplicate_names_rejected(tmp_path: Path) -> None:
+    extra = '\n[[model]]\nname = "fable"\nkind = "anthropic"\nmodel = "claude-fable-5"\n'
+    dupe = _POOL_TOML + extra
+    with pytest.raises(ValueError, match="fable"):
+        load_pool(_write_pool(tmp_path, dupe))
+
+
+def test_empty_pool_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        load_pool(_write_pool(tmp_path, "# no models\n"))
+
+
+def test_unknown_model_requires_explicit_price() -> None:
+    with pytest.raises(ValueError, match="input_per_mtok"):
+        PoolEntry(name="glm", kind=ProviderKind.OPENAI, model="FW-GLM-5.2")
+
+
+def test_price_must_be_set_as_a_pair() -> None:
+    with pytest.raises(ValueError, match="both"):
+        PoolEntry(name="glm", kind=ProviderKind.OPENAI, model="FW-GLM-5.2", input_per_mtok=1.0)
+
+
+def test_price_falls_back_to_builtin_table() -> None:
+    entry = PoolEntry(name="fable", kind=ProviderKind.ANTHROPIC, model="claude-fable-5")
+    price = entry.price()
+    assert price.input_per_mtok == 10.0
+    assert price.output_per_mtok == 50.0
+
+
+def test_price_override_wins_over_table() -> None:
+    entry = PoolEntry(
+        name="fable-discount",
+        kind=ProviderKind.ANTHROPIC,
+        model="claude-fable-5",
+        input_per_mtok=1.0,
+        output_per_mtok=2.0,
+    )
+    assert entry.price().input_per_mtok == 1.0
+
+
+def test_provider_config_maps_backend_knobs() -> None:
+    entry = PoolEntry(
+        name="gpt",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+        endpoint="https://google-sheets.openai.azure.com",
+        api_version="2024-10-21",
+    )
+    config = entry.provider_config()
+    assert config.kind is ProviderKind.AZURE_OPENAI
+    assert config.model == "gpt-5.5"
+    assert config.deployment == "gpt-5.5"
+    assert config.endpoint == "https://google-sheets.openai.azure.com"
+    assert config.api_version == "2024-10-21"
+
+
+def test_pool_provider_requires_named_env_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AZURE_SILEN_RESOURCE_API_KEY", raising=False)
+    pool = load_pool(_write_pool(tmp_path))
+    with pytest.raises(ValueError, match="AZURE_SILEN_RESOURCE_API_KEY"):
+        pool_provider(pool.entry("deepseek-v4-pro"))
+
+
+def test_pool_provider_passes_explicit_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_SILEN_RESOURCE_API_KEY", "sk-pool-test")
+    pool = load_pool(_write_pool(tmp_path))
+    provider = pool_provider(pool.entry("deepseek-v4-pro"))
+    assert isinstance(provider, AzureOpenAIProvider)
+    # The explicit key is the trusted channel: the client authenticates with the entry's own
+    # account key even though the endpoint differs from AZURE_OPENAI_ENDPOINT (which would
+    # otherwise downgrade auth to the WMH_ENDPOINT_API_KEY placeholder).
+    client = provider._get_client()  # noqa: SLF001 - asserting the wired credential
+    assert client.api_key == "sk-pool-test"
+
+
+def test_pool_entry_unknown_name_lists_available(tmp_path: Path) -> None:
+    pool = load_pool(_write_pool(tmp_path))
+    with pytest.raises(KeyError, match="deepseek-v4-pro"):
+        pool.entry("not-a-model")
+
+
+def test_get_provider_rejects_api_key_for_bedrock() -> None:
+    config = ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8")
+    with pytest.raises(ValueError, match="[Bb]edrock"):
+        get_provider(config, api_key="sk-nope")

--- a/wmh/providers/registry.py
+++ b/wmh/providers/registry.py
@@ -22,13 +22,20 @@ _BACKENDS = {
 }
 
 
-def get_provider(config: ProviderConfig) -> Provider:
-    """Construct the provider for `config.kind`. The one place backends are wired in."""
+def get_provider(config: ProviderConfig, *, api_key: str | None = None) -> Provider:
+    """Construct the provider for `config.kind`. The one place backends are wired in.
+
+    `api_key` is the trusted explicit-credential channel: only operator-owned call sites (the
+    model pool, tests) can pass it, so untrusted bundle config can never choose a credential.
+    When set, the backend authenticates with exactly this key instead of its default env vars.
+    """
     try:
         backend = _BACKENDS[config.kind]
     except KeyError:  # pragma: no cover - exhaustive over the enum
         raise ValueError(f"unknown provider kind: {config.kind}") from None
-    return backend(config)
+    if api_key is None:
+        return backend(config)
+    return backend(config, api_key=api_key)
 
 
 def verify_all(configs: list[ProviderConfig]) -> list[VerifyResult]:

--- a/wmh/providers/tests/streaming_test.py
+++ b/wmh/providers/tests/streaming_test.py
@@ -1,0 +1,320 @@
+"""Native streaming across every backend: deltas in order, one final chunk with usage.
+
+The SDK clients are faked via each provider's `_get_client` (same idiom as the sibling tests);
+no network. The contract under test: `stream()` yields text deltas as they arrive and exactly
+one terminal chunk (`done=True`) carrying the call's `TokenUsage`, so metering and request logs
+can account for streamed traffic the same way they do `complete()`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from wmh.providers.anthropic import AnthropicProvider
+from wmh.providers.azure_openai import AzureOpenAIProvider
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    StreamChunk,
+    StreamingProvider,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.providers.bedrock import BedrockProvider
+from wmh.providers.openai import OpenAIProvider
+from wmh.providers.openai_responses import OpenAIResponsesProvider
+from wmh.tracking.metered import MeteredProvider
+from wmh.tracking.tracker import Phase, RunTracker
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_MESSAGES = [Message(role="user", content="hi")]
+
+
+def _collect(chunks: Iterator[StreamChunk]) -> tuple[str, StreamChunk]:
+    parts: list[str] = []
+    final: StreamChunk | None = None
+    for chunk in chunks:
+        if chunk.done:
+            assert final is None, "stream yielded more than one terminal chunk"
+            final = chunk
+        else:
+            parts.append(chunk.delta)
+    assert final is not None, "stream never yielded a terminal chunk"
+    return "".join(parts), final
+
+
+# --- Anthropic -----------------------------------------------------------------------------
+
+
+class _FakeAnthropicMessages:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> Iterator[object]:
+        self.last_kwargs = kwargs
+        return iter(self._events)
+
+
+def test_anthropic_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[object] = [
+        SimpleNamespace(
+            type="message_start",
+            message=SimpleNamespace(usage=SimpleNamespace(input_tokens=9)),
+        ),
+        SimpleNamespace(
+            type="content_block_delta", delta=SimpleNamespace(type="text_delta", text="hel")
+        ),
+        SimpleNamespace(
+            type="content_block_delta", delta=SimpleNamespace(type="text_delta", text="lo")
+        ),
+        SimpleNamespace(type="message_delta", usage=SimpleNamespace(output_tokens=5)),
+        SimpleNamespace(type="message_stop"),
+    ]
+    fake_messages = _FakeAnthropicMessages(events)
+    provider = AnthropicProvider(
+        ProviderConfig(kind=ProviderKind.ANTHROPIC, model="claude-fable-5")
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: SimpleNamespace(messages=fake_messages))
+
+    text, final = _collect(provider.stream("be terse", _MESSAGES, max_tokens=64))
+
+    assert text == "hello"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    assert fake_messages.last_kwargs["stream"] is True
+    assert fake_messages.last_kwargs["max_tokens"] == 64
+    assert "temperature" not in fake_messages.last_kwargs
+
+
+# --- OpenAI-shaped (OpenAI + Azure chat completions) ----------------------------------------
+
+
+def _openai_chunks() -> list[object]:
+    return [
+        SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="hel"))], usage=None
+        ),
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))], usage=None),
+        SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=None))], usage=None),
+        SimpleNamespace(choices=[], usage=SimpleNamespace(prompt_tokens=9, completion_tokens=5)),
+    ]
+
+
+class _FakeChatCompletions:
+    def __init__(self, chunks: list[object]) -> None:
+        self._chunks = chunks
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> Iterator[object]:
+        self.last_kwargs = kwargs
+        return iter(self._chunks)
+
+
+def test_openai_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeChatCompletions(_openai_chunks())
+    provider = OpenAIProvider(ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5"))
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: SimpleNamespace(chat=SimpleNamespace(completions=fake)),
+    )
+
+    text, final = _collect(provider.stream("sys", _MESSAGES))
+
+    assert text == "hello"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    assert fake.last_kwargs["stream"] is True
+    assert fake.last_kwargs["stream_options"] == {"include_usage": True}
+
+
+def test_azure_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeChatCompletions(_openai_chunks())
+    provider = AzureOpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            deployment="gpt-5.5",
+            endpoint="https://example.openai.azure.com",
+            api_version="2024-10-21",
+        ),
+        api_key="sk-test",
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: SimpleNamespace(chat=SimpleNamespace(completions=fake)),
+    )
+
+    text, final = _collect(provider.stream("sys", _MESSAGES))
+
+    assert text == "hello"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    # Azure routes stream() to the deployment name, not the base model id.
+    assert fake.last_kwargs["model"] == "gpt-5.5"
+
+
+def test_azure_stream_rejects_reasoning_configs() -> None:
+    provider = AzureOpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            deployment="gpt-5.5",
+            endpoint="https://example.openai.azure.com",
+            api_version="2024-10-21",
+            reasoning_effort="high",
+        ),
+        api_key="sk-test",
+    )
+    with pytest.raises(NotImplementedError, match="reasoning_effort"):
+        next(iter(provider.stream("sys", _MESSAGES)))
+
+
+# --- OpenAI Responses ------------------------------------------------------------------------
+
+
+class _FakeResponses:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> Iterator[object]:
+        self.last_kwargs = kwargs
+        return iter(self._events)
+
+
+def test_openai_responses_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[object] = [
+        SimpleNamespace(type="response.output_text.delta", delta="hel"),
+        SimpleNamespace(type="response.output_text.delta", delta="lo"),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(usage=SimpleNamespace(input_tokens=9, output_tokens=5)),
+        ),
+    ]
+    fake = _FakeResponses(events)
+    provider = OpenAIResponsesProvider(
+        ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="gpt-5.5")
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: SimpleNamespace(responses=fake))
+
+    text, final = _collect(provider.stream("sys", _MESSAGES))
+
+    assert text == "hello"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    assert fake.last_kwargs["stream"] is True
+    assert fake.last_kwargs["store"] is False
+
+
+# --- Bedrock ---------------------------------------------------------------------------------
+
+
+class _FakeBedrockClient:
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        self._events = events
+        self.last_kwargs: dict[str, object] = {}
+
+    def converse_stream(self, **kwargs: object) -> dict[str, object]:
+        self.last_kwargs = kwargs
+        return {"stream": iter(self._events)}
+
+
+def test_bedrock_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[dict[str, object]] = [
+        {"contentBlockDelta": {"delta": {"text": "hel"}}},
+        {"contentBlockDelta": {"delta": {"text": "lo"}}},
+        {"metadata": {"usage": {"inputTokens": 9, "outputTokens": 5}}},
+    ]
+    fake = _FakeBedrockClient(events)
+    provider = BedrockProvider(
+        ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8")
+    )
+    monkeypatch.setattr(provider, "_get_client", lambda: fake)
+
+    text, final = _collect(provider.stream("sys", _MESSAGES, max_tokens=64))
+
+    assert text == "hello"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    assert fake.last_kwargs["modelId"] == "us.anthropic.claude-opus-4-8"
+    # Claude via Converse: max tokens forwarded, temperature withheld (catalog says no sampling).
+    assert fake.last_kwargs["inferenceConfig"] == {"maxTokens": 64}
+
+
+# --- Protocol + metering ----------------------------------------------------------------------
+
+
+def test_all_backends_are_streaming_providers() -> None:
+    providers: list[object] = [
+        AnthropicProvider(ProviderConfig(kind=ProviderKind.ANTHROPIC, model="m")),
+        OpenAIProvider(ProviderConfig(kind=ProviderKind.OPENAI, model="m")),
+        AzureOpenAIProvider(ProviderConfig(kind=ProviderKind.AZURE_OPENAI, model="m")),
+        OpenAIResponsesProvider(ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="m")),
+        BedrockProvider(ProviderConfig(kind=ProviderKind.BEDROCK, model="m")),
+    ]
+    for provider in providers:
+        assert isinstance(provider, StreamingProvider), type(provider).__name__
+
+
+class _ProviderStub:
+    """Minimal full-Provider surface so MeteredProvider accepts the fake."""
+
+    def __init__(self, model: str) -> None:
+        self.config = ProviderConfig(kind=ProviderKind.ANTHROPIC, model=model)
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        raise NotImplementedError
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+def test_metered_stream_records_usage_once() -> None:
+    class _FakeStreamingProvider(_ProviderStub):
+        def stream(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Iterator[StreamChunk]:
+            yield StreamChunk(delta="hi")
+            yield StreamChunk(done=True, usage=TokenUsage(input_tokens=9, output_tokens=5))
+
+    tracker = RunTracker(run_id="r", kind="test")
+    metered = MeteredProvider(
+        _FakeStreamingProvider("claude-fable-5"), tracker, base_phase=Phase.SERVE
+    )
+
+    text, final = _collect(metered.stream("sys", _MESSAGES))
+
+    assert text == "hi"
+    assert final.usage == TokenUsage(input_tokens=9, output_tokens=5)
+    assert len(tracker.events) == 1
+    event = tracker.events[0]
+    assert event.phase is Phase.SERVE
+    assert event.model == "claude-fable-5"
+    assert event.usage.input_tokens == 9
+
+
+def test_metered_stream_rejects_non_streaming_provider() -> None:
+    tracker = RunTracker(run_id="r", kind="test")
+    metered = MeteredProvider(_ProviderStub("m"), tracker)
+    with pytest.raises(TypeError, match="stream"):
+        next(iter(metered.stream("sys", _MESSAGES)))

--- a/wmh/research/pipeline.py
+++ b/wmh/research/pipeline.py
@@ -26,7 +26,8 @@ from wmh.core.types import Step, Trace
 from wmh.engine.grounding import Grounder, SourceResolver
 from wmh.engine.replay import ReplayReport, replay
 from wmh.engine.workspace import RepoTreeResolver
-from wmh.optimize.gepa import GEPAOptimizer, OptimizeResult
+from wmh.optimize.base import OptimizeResult
+from wmh.optimize.gepa import GEPAOptimizer
 from wmh.optimize.judge import RUBRIC_DIMENSIONS, Judge, RubricDimension
 from wmh.providers.base import Embedder, Provider
 from wmh.retrieval import EmbeddingRetriever, RetrievalKey

--- a/wmh/retrieval/embedders.py
+++ b/wmh/retrieval/embedders.py
@@ -81,3 +81,25 @@ def get_embedder(config: HarnessConfig) -> Embedder:
 
     # `embed_provider_config` resolves the backing provider and stamps `embed_dim` on it.
     return get_provider(config.embed_provider_config())
+
+
+class BatchedEmbedder:
+    """Chunk large embed calls to fit a provider's per-request input limits.
+
+    Provider embedding APIs cap inputs per request (Azure/OpenAI: 2048 items and a token
+    budget). Fitting embeds tens of thousands of scenario texts at once; this wrapper splits
+    them into `batch`-sized requests and concatenates, so callers keep the one-call `Embedder`
+    protocol.
+    """
+
+    def __init__(self, embedder: Embedder, *, batch: int = 256) -> None:
+        if batch <= 0:
+            raise ValueError(f"batch must be positive, got {batch}")
+        self._embedder = embedder
+        self._batch = batch
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for start in range(0, len(texts), self._batch):
+            vectors.extend(self._embedder.embed(texts[start : start + self._batch]))
+        return vectors

--- a/wmh/retrieval/embedders_test.py
+++ b/wmh/retrieval/embedders_test.py
@@ -94,3 +94,21 @@ def test_get_embedder_missing_provider_config_raises() -> None:
     config = HarnessConfig(embed_provider=EmbedderKind.OPENAI)
     with pytest.raises(ValueError, match="no provider config for openai"):
         get_embedder(config)
+
+
+def test_batched_embedder_chunks_requests() -> None:
+    from wmh.retrieval.embedders import BatchedEmbedder
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            self.calls.append(len(texts))
+            return [[float(len(t))] for t in texts]
+
+    recorder = _Recorder()
+    batched = BatchedEmbedder(recorder, batch=2)
+    vectors = batched.embed(["a", "bb", "ccc", "dddd", "eeeee"])
+    assert recorder.calls == [2, 2, 1]
+    assert vectors == [[1.0], [2.0], [3.0], [4.0], [5.0]]

--- a/wmh/serving/builds.py
+++ b/wmh/serving/builds.py
@@ -285,7 +285,8 @@ class BuildManager:
         if request.name == "harbor":
             # Mirrors the `wmh build` CLI guard: the literal is the optimize environment.
             raise ValueError(
-                "world model name 'harbor' is reserved: `wmh optimize <agent> harbor` selects "
+                "world model name 'harbor' is reserved: `wmh optimize harness <agent> harbor` "
+                "selects "
                 "the harbor benchmark environment; choose another name"
             )
         config = HarnessConfig.for_build(

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -19,6 +19,7 @@ cache-aware routing model.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -32,6 +33,7 @@ from typing import TYPE_CHECKING, Literal
 from fastapi import APIRouter, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from starlette.background import BackgroundTask
 
 from wmh.optimize.policy import RoutingDecision, RoutingPolicy, select_model
 from wmh.providers.base import (
@@ -325,10 +327,13 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     max_tokens=request.output_budget(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
+                # Full detail goes to the request log and server log only: upstream exception
+                # text can carry internal endpoints/stack info (CodeQL: information exposure).
                 _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
+                logger.error("upstream call for %s failed: %s", entry.name, exc)
                 return _error_response(
                     502,
-                    f"upstream model call failed: {exc}",
+                    f"upstream model call failed ({type(exc).__name__})",
                     err_type="api_error",
                     code="upstream_error",
                 )
@@ -373,13 +378,21 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             first = next(upstream, None)
         except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
             _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
+            logger.error("stream start for %s failed: %s", entry.name, exc)
             return _error_response(
                 502,
-                f"upstream model call failed: {exc}",
+                f"upstream model call failed ({type(exc).__name__})",
                 err_type="api_error",
                 code="upstream_error",
             )
         ttfb_ms = (time.monotonic() - started) * 1000
+
+        # Shared with _finalize: a disconnecting client makes starlette CANCEL the stream
+        # without ever closing the sync generator, so cleanup inside the generator (finally,
+        # GeneratorExit) never runs on that path. The BackgroundTask below is the only hook
+        # that fires on both normal completion and disconnect.
+        stream_state = {"recorded": False}
+        partial_usage = TokenUsage()
 
         def _events() -> Iterator[str]:
             yield _sse(
@@ -388,7 +401,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 )
             )
             parts: list[str] = []
-            usage = TokenUsage()
+            usage = partial_usage
             try:
                 chunk = first
                 while chunk is not None:
@@ -407,6 +420,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                         )
                     chunk = next(upstream, None)
             except Exception as exc:  # noqa: BLE001 - response already started; log and end
+                stream_state["recorded"] = True
                 _record(usage, ttfb_ms=ttfb_ms, status="error", error_message=str(exc))
                 logger.error("stream from %s failed mid-response: %s", entry.name, exc)
                 yield "data: [DONE]\n\n"
@@ -429,12 +443,34 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 )
             yield "data: [DONE]\n\n"
             runtime.remember(request.messages, "".join(parts), decision.model)
+            stream_state["recorded"] = True
             _record(usage, ttfb_ms=ttfb_ms)
+
+        def _finalize() -> None:
+            """Runs after the response ends, HOWEVER it ends (starlette BackgroundTask).
+
+            An abandoned stream still consumed upstream tokens: leaving it unrecorded would
+            be silent usage loss (D-METERING). Also closes the upstream iterator, which the
+            cancelled threadpool iteration otherwise leaks.
+            """
+            close = getattr(upstream, "close", None)
+            if callable(close):
+                with contextlib.suppress(Exception):
+                    close()
+            if not stream_state["recorded"]:
+                stream_state["recorded"] = True
+                _record(
+                    partial_usage,
+                    ttfb_ms=ttfb_ms,
+                    status="error",
+                    error_message="client disconnected mid-stream",
+                )
 
         return StreamingResponse(
             _events(),
             media_type="text/event-stream",
             headers={**headers, "Cache-Control": "no-cache"},
+            background=BackgroundTask(_finalize),
         )
 
     return router

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -1,0 +1,394 @@
+"""OpenAI-compatible `/v1/chat/completions` serving over a routing policy.
+
+The endpoint face of the pivot: a customer points their OpenAI client at wmh, `model` in the
+request names an ENDPOINT (world model + policy), and the learned inference policy picks which
+pool model actually serves each call. Responses stay OpenAI-pure and name only the endpoint;
+the mechanism (routed model, cluster, reason) goes to the request log and the
+`x-wmh-routed-model` debug header, never customer-facing copy.
+
+Conversation affinity: provider prompt caches are per-model, so switching mid-conversation
+forfeits warm cache reads. The runtime fingerprints each finished exchange (full transcript
+including the assistant reply) and, when the next request arrives with that transcript as its
+prefix, `select_model` sees the incumbent and sticks to it by default.
+
+Request log: one JSONL row per call with the D-SERVING-LOG fields (id, ts, endpoint, routed
+model, cluster, tokens, cost, latency, ttfb, status, reason). Cached-token counts and
+provider cache controls are not captured yet; they land with the cache-aware cost model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import uuid
+from collections import OrderedDict, deque
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from wmh.optimize.policy import RoutingDecision, RoutingPolicy, select_model
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    Message,
+    Provider,
+    StreamingProvider,
+    TokenUsage,
+)
+from wmh.providers.pool import PoolEntry, pool_provider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Finished-exchange fingerprints remembered per endpoint for conversation affinity. Bounded so
+# a long-running server cannot grow without limit; least-recently-used conversations re-route.
+_AFFINITY_CAPACITY = 4096
+
+ChatRole = Literal["system", "user", "assistant"]
+
+
+class ChatMessage(BaseModel):
+    role: ChatRole
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    """The OpenAI request subset the endpoint serves (text chat; tools are future work)."""
+
+    model: str  # the ENDPOINT name
+    messages: list[ChatMessage] = Field(min_length=1)
+    stream: bool = False
+    temperature: float | None = None
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
+
+    def output_budget(self) -> int:
+        return self.max_completion_tokens or self.max_tokens or DEFAULT_MAX_TOKENS
+
+
+class RequestLogRecord(BaseModel):
+    """One metered call, as the request log persists it (D-METERING / D-SERVING-LOG shape).
+
+    This is the wmh half of the metering contract: the platform wrap adds tenancy
+    (org_id, api_key_id) when it persists these rows. `cached_tokens` is carried but always 0
+    until providers surface cache-read counts; `router_cost_usd` is the policy's OWN inference
+    cost per call, 0 for the free hashing policy and real once a trained router serves.
+    """
+
+    id: str
+    ts: str
+    endpoint: str
+    leg: Literal["serving", "optimization", "eval", "overhead"] = "serving"
+    model: str  # routed pool entry name
+    provider_model: str  # the provider runtime id behind it
+    cluster_id: int | None = None
+    cluster_label: str = ""
+    routing_reason: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0  # cache-read tokens; 0 until providers surface them
+    cost_usd: float = 0.0  # cache-adjusted once cached_tokens are real; list-priced until then
+    router_cost_usd: float = 0.0  # the routing decision's own inference cost, passed through
+    latency_ms: float = 0.0
+    ttfb_ms: float | None = None
+    status: Literal["ok", "error"] = "ok"
+    error_message: str | None = None
+
+
+class RequestLog:
+    """Append-only JSONL request log plus a bounded in-memory tail."""
+
+    def __init__(self, path: Path | None, *, keep: int = 200) -> None:
+        self._path = path
+        self._recent: deque[RequestLogRecord] = deque(maxlen=keep)
+        self._lock = threading.Lock()
+        if path is not None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, record: RequestLogRecord) -> None:
+        with self._lock:
+            self._recent.append(record)
+            if self._path is not None:
+                with self._path.open("a", encoding="utf-8") as handle:
+                    handle.write(record.model_dump_json() + "\n")
+
+    def recent(self) -> list[RequestLogRecord]:
+        with self._lock:
+            return list(self._recent)
+
+
+class EndpointRuntime:
+    """One served endpoint: its policy, its providers, its affinity memory, its log."""
+
+    def __init__(
+        self,
+        name: str,
+        policy: RoutingPolicy,
+        *,
+        provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
+        log: RequestLog,
+    ) -> None:
+        self.name = name
+        self.policy = policy
+        self.log = log
+        self._provider_factory = provider_factory
+        self._providers: dict[str, Provider] = {}
+        self._affinity: OrderedDict[str, str] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def decide(self, messages: list[ChatMessage]) -> RoutingDecision:
+        incumbent = None
+        if len(messages) > 1:
+            with self._lock:
+                incumbent = self._affinity.get(_fingerprint(messages[:-1]))
+        text = _routable_text(messages)
+        return select_model(self.policy, text, incumbent=incumbent)
+
+    def remember(self, messages: list[ChatMessage], assistant_text: str, model: str) -> None:
+        """Record the finished exchange so the conversation's next request finds its incumbent."""
+        transcript = [*messages, ChatMessage(role="assistant", content=assistant_text)]
+        key = _fingerprint(transcript)
+        with self._lock:
+            self._affinity[key] = model
+            self._affinity.move_to_end(key)
+            while len(self._affinity) > _AFFINITY_CAPACITY:
+                self._affinity.popitem(last=False)
+
+    def provider_for(self, pool_name: str) -> tuple[PoolEntry, Provider]:
+        entry = next(e for e in self.policy.pool if e.name == pool_name)
+        with self._lock:
+            provider = self._providers.get(pool_name)
+            if provider is None:
+                provider = self._provider_factory(entry)
+                self._providers[pool_name] = provider
+        return entry, provider
+
+
+def _fingerprint(messages: list[ChatMessage]) -> str:
+    canonical = json.dumps([(m.role, m.content) for m in messages], ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _routable_text(messages: list[ChatMessage]) -> str:
+    for message in reversed(messages):
+        if message.role == "user":
+            return message.content
+    return messages[-1].content
+
+
+def _split_for_provider(messages: list[ChatMessage]) -> tuple[str, list[Message]]:
+    """Fold system turns into the provider's system string; keep user/assistant order."""
+    system_parts = [m.content for m in messages if m.role == "system"]
+    turns = [Message(role=m.role, content=m.content) for m in messages if m.role != "system"]
+    return "\n\n".join(system_parts), turns
+
+
+def _usage_dict(usage: TokenUsage) -> dict[str, int]:
+    return {
+        "prompt_tokens": usage.input_tokens,
+        "completion_tokens": usage.output_tokens,
+        "total_tokens": usage.input_tokens + usage.output_tokens,
+    }
+
+
+def _sse(payload: object) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _chunk_payload(
+    completion_id: str,
+    created: int,
+    endpoint: str,
+    delta: dict[str, str],
+    *,
+    finish_reason: str | None = None,
+    usage: TokenUsage | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": endpoint,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    }
+    if usage is not None:
+        payload["usage"] = _usage_dict(usage)
+    return payload
+
+
+def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
+    """Mount `/v1/models` + `/v1/chat/completions` over the given endpoints."""
+    router = APIRouter()
+
+    def _endpoint_or_404(name: str) -> EndpointRuntime:
+        runtime = endpoints.get(name)
+        if runtime is None:
+            available = ", ".join(sorted(endpoints)) or "(none)"
+            raise HTTPException(status_code=404, detail=f"no endpoint {name!r}; have: {available}")
+        return runtime
+
+    @router.get("/v1/models")
+    def list_models() -> dict[str, object]:
+        return {
+            "object": "list",
+            "data": [
+                {"id": name, "object": "model", "created": 0, "owned_by": "wmh"}
+                for name in sorted(endpoints)
+            ],
+        }
+
+    @router.post("/v1/chat/completions")
+    def chat_completions(request: ChatCompletionRequest) -> Response:
+        runtime = _endpoint_or_404(request.model)
+        decision = runtime.decide(request.messages)
+        entry, provider = runtime.provider_for(decision.model)
+        system, turns = _split_for_provider(request.messages)
+        completion_id = f"chatcmpl-{uuid.uuid4().hex}"
+        created = int(time.time())
+        started = time.monotonic()
+
+        def _record(
+            usage: TokenUsage,
+            *,
+            ttfb_ms: float | None,
+            status: Literal["ok", "error"] = "ok",
+            error_message: str | None = None,
+        ) -> None:
+            runtime.log.append(
+                RequestLogRecord(
+                    id=completion_id,
+                    ts=datetime.now(tz=UTC).isoformat(),
+                    endpoint=runtime.name,
+                    model=entry.name,
+                    provider_model=entry.model,
+                    cluster_id=decision.cluster_id,
+                    cluster_label=decision.cluster_label,
+                    routing_reason=decision.reason,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=entry.cost_usd(usage),
+                    latency_ms=(time.monotonic() - started) * 1000,
+                    ttfb_ms=ttfb_ms,
+                    status=status,
+                    error_message=error_message,
+                )
+            )
+
+        headers = {"x-wmh-routed-model": decision.model}
+
+        if not request.stream:
+            try:
+                completion = provider.complete(
+                    system,
+                    turns,
+                    temperature=request.temperature if request.temperature is not None else 0.7,
+                    max_tokens=request.output_budget(),
+                )
+            except Exception as exc:
+                _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
+                raise HTTPException(
+                    status_code=502, detail=f"upstream model call failed: {exc}"
+                ) from exc
+            runtime.remember(request.messages, completion.text, decision.model)
+            _record(completion.usage, ttfb_ms=None)
+            return Response(
+                content=json.dumps(
+                    {
+                        "id": completion_id,
+                        "object": "chat.completion",
+                        "created": created,
+                        "model": runtime.name,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": completion.text},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": _usage_dict(completion.usage),
+                    },
+                    ensure_ascii=False,
+                ),
+                media_type="application/json",
+                headers=headers,
+            )
+
+        if not isinstance(provider, StreamingProvider):
+            raise HTTPException(
+                status_code=501,
+                detail=f"pool model '{entry.name}' has no native streaming backend",
+            )
+        try:
+            upstream = provider.stream(
+                system,
+                turns,
+                temperature=request.temperature if request.temperature is not None else 0.7,
+                max_tokens=request.output_budget(),
+            )
+            first = next(upstream, None)
+        except Exception as exc:
+            _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
+            raise HTTPException(
+                status_code=502, detail=f"upstream model call failed: {exc}"
+            ) from exc
+        ttfb_ms = (time.monotonic() - started) * 1000
+
+        def _events() -> Iterator[str]:
+            yield _sse(
+                _chunk_payload(
+                    completion_id, created, runtime.name, {"role": "assistant", "content": ""}
+                )
+            )
+            parts: list[str] = []
+            usage = TokenUsage()
+            try:
+                chunk = first
+                while chunk is not None:
+                    if chunk.done:
+                        if chunk.usage is not None:
+                            usage = chunk.usage
+                    elif chunk.delta:
+                        parts.append(chunk.delta)
+                        yield _sse(
+                            _chunk_payload(
+                                completion_id,
+                                created,
+                                runtime.name,
+                                {"content": chunk.delta},
+                            )
+                        )
+                    chunk = next(upstream, None)
+            except Exception as exc:  # noqa: BLE001 - response already started; log and end
+                _record(usage, ttfb_ms=ttfb_ms, status="error", error_message=str(exc))
+                logger.error("stream from %s failed mid-response: %s", entry.name, exc)
+                yield "data: [DONE]\n\n"
+                return
+            yield _sse(
+                _chunk_payload(
+                    completion_id,
+                    created,
+                    runtime.name,
+                    {},
+                    finish_reason="stop",
+                    usage=usage,
+                )
+            )
+            yield "data: [DONE]\n\n"
+            runtime.remember(request.messages, "".join(parts), decision.model)
+            _record(usage, ttfb_ms=ttfb_ms)
+
+        return StreamingResponse(
+            _events(),
+            media_type="text/event-stream",
+            headers={**headers, "Cache-Control": "no-cache"},
+        )
+
+    return router

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -30,9 +30,10 @@ from collections import OrderedDict, deque
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue, field_validator
 from starlette.background import BackgroundTask
 
 from wmh.optimize.policy import RoutingDecision, RoutingPolicy, select_model
@@ -59,8 +60,35 @@ ChatRole = Literal["system", "user", "assistant"]
 
 
 class ChatMessage(BaseModel):
+    """One chat turn, normalized from the OpenAI request shapes clients actually send.
+
+    `developer` (OpenAI's system replacement on gpt-5-class models) maps to `system`, and
+    multi-part text content (`[{"type": "text", "text": ...}]`, emitted by LangChain and the
+    Vercel AI SDK) is joined; a non-text part is a hard error, not a silent drop.
+    """
+
     role: ChatRole
     content: str
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def _developer_is_system(cls, value: object) -> object:
+        return "system" if value == "developer" else value
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def _join_text_parts(cls, value: object) -> object:
+        if not isinstance(value, list):
+            return value
+        parts: list[str] = []
+        for part in value:
+            if not (isinstance(part, dict) and part.get("type") == "text"):
+                raise ValueError(
+                    "only text content parts are supported; images and other modalities "
+                    "are not available on this endpoint yet"
+                )
+            parts.append(str(part.get("text", "")))
+        return "".join(parts)
 
 
 class StreamOptions(BaseModel):
@@ -70,7 +98,11 @@ class StreamOptions(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
-    """The OpenAI request subset the endpoint serves (text chat; tools are future work)."""
+    """The OpenAI request subset the endpoint serves (text chat; tools are future work).
+
+    Unsupported FUNCTIONAL parameters are declared here so they can be rejected explicitly
+    (see `unsupported_features`); genuinely unknown extra fields are ignored like OpenAI does.
+    """
 
     model: str  # the ENDPOINT name
     messages: list[ChatMessage] = Field(min_length=1)
@@ -79,12 +111,35 @@ class ChatCompletionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
+    # Declared only to be REJECTED with a clear 400 (silently ignoring tools would make a
+    # tool-calling client read prose where it expects tool_calls).
+    tools: list[JsonValue] | None = None
+    tool_choice: JsonValue | None = None
+    response_format: JsonValue | None = None
+    n: int = 1
+    logprobs: bool | None = None
 
     def output_budget(self) -> int:
         return self.max_completion_tokens or self.max_tokens or DEFAULT_MAX_TOKENS
 
     def wants_stream_usage(self) -> bool:
         return self.stream_options is not None and self.stream_options.include_usage
+
+    def unsupported_features(self) -> str:
+        """Name the requested-but-unsupported params, '' when the request is serveable."""
+        used = [
+            name
+            for name, value in (
+                ("tools", self.tools),
+                ("tool_choice", self.tool_choice),
+                ("response_format", self.response_format),
+                ("logprobs", self.logprobs),
+            )
+            if value
+        ]
+        if self.n != 1:
+            used.append("n != 1")
+        return ", ".join(used)
 
 
 def _error_response(status_code: int, message: str, *, err_type: str, code: str) -> Response:
@@ -101,6 +156,24 @@ def _error_response(status_code: int, message: str, *, err_type: str, code: str)
         status_code=status_code,
         media_type="application/json",
     )
+
+
+def install_openai_error_shapes(app: FastAPI) -> None:
+    """Convert request-validation failures to OpenAI's 400 + error-body shape.
+
+    Without this a malformed request gets FastAPI's 422 `{"detail": [...]}`, which OpenAI
+    clients surface as an empty error. App-level because exception handlers cannot attach to
+    a router; every app that mounts `create_chat_router` should call this.
+    """
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error(_request: Request, exc: RequestValidationError) -> Response:
+        first = exc.errors()[0] if exc.errors() else {}
+        location = ".".join(str(part) for part in first.get("loc", []) if part != "body")
+        message = f"invalid request: {location}: {first.get('msg', 'validation failed')}"
+        return _error_response(
+            400, message, err_type="invalid_request_error", code="invalid_request"
+        )
 
 
 class RequestLogRecord(BaseModel):
@@ -197,9 +270,13 @@ class EndpointRuntime:
         entry = next(e for e in self.policy.pool if e.name == pool_name)
         with self._lock:
             provider = self._providers.get(pool_name)
-            if provider is None:
-                provider = self._provider_factory(entry)
-                self._providers[pool_name] = provider
+        if provider is None:
+            # Construct OUTSIDE the lock: a slow client build (TLS handshake, credential
+            # resolution) must not head-of-line-block every other request's affinity lookup.
+            # A racing duplicate build is harmless; first insert wins.
+            provider = self._provider_factory(entry)
+            with self._lock:
+                provider = self._providers.setdefault(pool_name, provider)
         return entry, provider
 
 
@@ -281,8 +358,49 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 err_type="invalid_request_error",
                 code="model_not_found",
             )
-        decision = runtime.decide(request.messages)
-        entry, provider = runtime.provider_for(decision.model)
+        unsupported = request.unsupported_features()
+        if unsupported:
+            # Silently dropping tools/n/response_format would make a tool-calling client read
+            # plain text where it expects tool_calls: a compatibility gap disguised as a
+            # model-quality problem. Reject loudly instead.
+            return _error_response(
+                400,
+                f"this endpoint does not support {unsupported} yet",
+                err_type="invalid_request_error",
+                code="unsupported_parameter",
+            )
+        if not any(m.role != "system" for m in request.messages):
+            return _error_response(
+                400,
+                "at least one user or assistant message is required",
+                err_type="invalid_request_error",
+                code="invalid_messages",
+            )
+        try:
+            decision = runtime.decide(request.messages)
+            entry, provider = runtime.provider_for(decision.model)
+        except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502 + log row
+            # The likeliest production failure: an unset api_key_env or a failing embed call.
+            # Without this guard it surfaces as a bare text/plain 500 with no log row.
+            logger.error("routing/provider setup for %s failed: %s", runtime.name, exc)
+            runtime.log.append(
+                RequestLogRecord(
+                    id=f"chatcmpl-{uuid.uuid4().hex}",
+                    ts=datetime.now(tz=UTC).isoformat(),
+                    endpoint=runtime.name,
+                    model="",
+                    provider_model="",
+                    routing_reason="error-before-routing",
+                    status="error",
+                    error_message=str(exc),
+                )
+            )
+            return _error_response(
+                502,
+                f"endpoint setup failed ({type(exc).__name__})",
+                err_type="api_error",
+                code="routing_error",
+            )
         system, turns = _split_for_provider(request.messages)
         completion_id = f"chatcmpl-{uuid.uuid4().hex}"
         created = int(time.time())
@@ -323,7 +441,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 completion = provider.complete(
                     system,
                     turns,
-                    temperature=request.temperature if request.temperature is not None else 0.7,
+                    temperature=request.temperature if request.temperature is not None else 1.0,
                     max_tokens=request.output_budget(),
                 )
             except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
@@ -362,6 +480,13 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             )
 
         if not isinstance(provider, StreamingProvider):
+            # A real endpoint-level failure: keep one-record-per-request intact.
+            _record(
+                TokenUsage(),
+                ttfb_ms=None,
+                status="error",
+                error_message=f"pool model '{entry.name}' has no native streaming backend",
+            )
             return _error_response(
                 501,
                 f"pool model '{entry.name}' has no native streaming backend",
@@ -372,7 +497,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             upstream = provider.stream(
                 system,
                 turns,
-                temperature=request.temperature if request.temperature is not None else 0.7,
+                temperature=request.temperature if request.temperature is not None else 1.0,
                 max_tokens=request.output_budget(),
             )
             first = next(upstream, None)

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -12,8 +12,9 @@ including the assistant reply) and, when the next request arrives with that tran
 prefix, `select_model` sees the incumbent and sticks to it by default.
 
 Request log: one JSONL row per call with the D-SERVING-LOG fields (id, ts, endpoint, routed
-model, cluster, tokens, cost, latency, ttfb, status, reason). Cached-token counts and
-provider cache controls are not captured yet; they land with the cache-aware cost model.
+model, cluster, tokens incl. cached, cache-adjusted cost, latency, ttfb, status, reason).
+Provider cache CONTROLS (breakpoint placement, TTL) are not exposed yet; they land with the
+cache-aware routing model.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ from collections import OrderedDict, deque
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -60,12 +61,19 @@ class ChatMessage(BaseModel):
     content: str
 
 
+class StreamOptions(BaseModel):
+    """OpenAI `stream_options`: opt-in for the trailing usage chunk on streamed responses."""
+
+    include_usage: bool = False
+
+
 class ChatCompletionRequest(BaseModel):
     """The OpenAI request subset the endpoint serves (text chat; tools are future work)."""
 
     model: str  # the ENDPOINT name
     messages: list[ChatMessage] = Field(min_length=1)
     stream: bool = False
+    stream_options: StreamOptions | None = None
     temperature: float | None = None
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
@@ -73,14 +81,35 @@ class ChatCompletionRequest(BaseModel):
     def output_budget(self) -> int:
         return self.max_completion_tokens or self.max_tokens or DEFAULT_MAX_TOKENS
 
+    def wants_stream_usage(self) -> bool:
+        return self.stream_options is not None and self.stream_options.include_usage
+
+
+def _error_response(status_code: int, message: str, *, err_type: str, code: str) -> Response:
+    """An OpenAI-shaped error body: real OpenAI clients read `body["error"]["message"]`.
+
+    FastAPI's default `{"detail": ...}` shape parses as a generic APIStatusError in the openai
+    SDK but loses the message; this shape surfaces it exactly like the upstream API does.
+    """
+    return Response(
+        content=json.dumps(
+            {"error": {"message": message, "type": err_type, "param": None, "code": code}},
+            ensure_ascii=False,
+        ),
+        status_code=status_code,
+        media_type="application/json",
+    )
+
 
 class RequestLogRecord(BaseModel):
     """One metered call, as the request log persists it (D-METERING / D-SERVING-LOG shape).
 
     This is the wmh half of the metering contract: the platform wrap adds tenancy
-    (org_id, api_key_id) when it persists these rows. `cached_tokens` is carried but always 0
-    until providers surface cache-read counts; `router_cost_usd` is the policy's OWN inference
-    cost per call, 0 for the free hashing policy and real once a trained router serves.
+    (org_id, api_key_id) when it persists these rows. `cached_tokens` mirrors
+    `TokenUsage.cached_input_tokens` (cache-read prompt tokens, a subset of `input_tokens`);
+    `cost_usd` is cache-adjusted via `PoolEntry.cost_usd`. `router_cost_usd` is the policy's
+    OWN inference cost per call, 0 for the free hashing policy and real once a trained router
+    serves.
     """
 
     id: str
@@ -94,8 +123,8 @@ class RequestLogRecord(BaseModel):
     routing_reason: str
     input_tokens: int = 0
     output_tokens: int = 0
-    cached_tokens: int = 0  # cache-read tokens; 0 until providers surface them
-    cost_usd: float = 0.0  # cache-adjusted once cached_tokens are real; list-priced until then
+    cached_tokens: int = 0  # cache-read prompt tokens (subset of input_tokens)
+    cost_usd: float = 0.0  # effective cost: cached tokens billed at the cache-read rate
     router_cost_usd: float = 0.0  # the routing decision's own inference cost, passed through
     latency_ms: float = 0.0
     ttfb_ms: float | None = None
@@ -191,11 +220,13 @@ def _split_for_provider(messages: list[ChatMessage]) -> tuple[str, list[Message]
     return "\n\n".join(system_parts), turns
 
 
-def _usage_dict(usage: TokenUsage) -> dict[str, int]:
+def _usage_dict(usage: TokenUsage) -> dict[str, object]:
     return {
         "prompt_tokens": usage.input_tokens,
         "completion_tokens": usage.output_tokens,
         "total_tokens": usage.input_tokens + usage.output_tokens,
+        # OpenAI's cached-prompt reporting shape; 0 when the upstream provider reported none.
+        "prompt_tokens_details": {"cached_tokens": usage.cached_input_tokens},
     }
 
 
@@ -210,30 +241,22 @@ def _chunk_payload(
     delta: dict[str, str],
     *,
     finish_reason: str | None = None,
-    usage: TokenUsage | None = None,
 ) -> dict[str, object]:
-    payload: dict[str, object] = {
+    return {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": created,
         "model": endpoint,
         "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
     }
-    if usage is not None:
-        payload["usage"] = _usage_dict(usage)
-    return payload
 
 
 def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
     """Mount `/v1/models` + `/v1/chat/completions` over the given endpoints."""
     router = APIRouter()
 
-    def _endpoint_or_404(name: str) -> EndpointRuntime:
-        runtime = endpoints.get(name)
-        if runtime is None:
-            available = ", ".join(sorted(endpoints)) or "(none)"
-            raise HTTPException(status_code=404, detail=f"no endpoint {name!r}; have: {available}")
-        return runtime
+    def _endpoint_or_none(name: str) -> EndpointRuntime | None:
+        return endpoints.get(name)
 
     @router.get("/v1/models")
     def list_models() -> dict[str, object]:
@@ -247,7 +270,15 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
 
     @router.post("/v1/chat/completions")
     def chat_completions(request: ChatCompletionRequest) -> Response:
-        runtime = _endpoint_or_404(request.model)
+        runtime = _endpoint_or_none(request.model)
+        if runtime is None:
+            available = ", ".join(sorted(endpoints)) or "(none)"
+            return _error_response(
+                404,
+                f"no endpoint {request.model!r}; have: {available}",
+                err_type="invalid_request_error",
+                code="model_not_found",
+            )
         decision = runtime.decide(request.messages)
         entry, provider = runtime.provider_for(decision.model)
         system, turns = _split_for_provider(request.messages)
@@ -274,6 +305,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     routing_reason=decision.reason,
                     input_tokens=usage.input_tokens,
                     output_tokens=usage.output_tokens,
+                    cached_tokens=usage.cached_input_tokens,
                     cost_usd=entry.cost_usd(usage),
                     latency_ms=(time.monotonic() - started) * 1000,
                     ttfb_ms=ttfb_ms,
@@ -292,11 +324,14 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     temperature=request.temperature if request.temperature is not None else 0.7,
                     max_tokens=request.output_budget(),
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
                 _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
-                raise HTTPException(
-                    status_code=502, detail=f"upstream model call failed: {exc}"
-                ) from exc
+                return _error_response(
+                    502,
+                    f"upstream model call failed: {exc}",
+                    err_type="api_error",
+                    code="upstream_error",
+                )
             runtime.remember(request.messages, completion.text, decision.model)
             _record(completion.usage, ttfb_ms=None)
             return Response(
@@ -322,9 +357,11 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             )
 
         if not isinstance(provider, StreamingProvider):
-            raise HTTPException(
-                status_code=501,
-                detail=f"pool model '{entry.name}' has no native streaming backend",
+            return _error_response(
+                501,
+                f"pool model '{entry.name}' has no native streaming backend",
+                err_type="api_error",
+                code="streaming_unsupported",
             )
         try:
             upstream = provider.stream(
@@ -334,11 +371,14 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 max_tokens=request.output_budget(),
             )
             first = next(upstream, None)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
             _record(TokenUsage(), ttfb_ms=None, status="error", error_message=str(exc))
-            raise HTTPException(
-                status_code=502, detail=f"upstream model call failed: {exc}"
-            ) from exc
+            return _error_response(
+                502,
+                f"upstream model call failed: {exc}",
+                err_type="api_error",
+                code="upstream_error",
+            )
         ttfb_ms = (time.monotonic() - started) * 1000
 
         def _events() -> Iterator[str]:
@@ -372,15 +412,21 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 yield "data: [DONE]\n\n"
                 return
             yield _sse(
-                _chunk_payload(
-                    completion_id,
-                    created,
-                    runtime.name,
-                    {},
-                    finish_reason="stop",
-                    usage=usage,
-                )
+                _chunk_payload(completion_id, created, runtime.name, {}, finish_reason="stop")
             )
+            if request.wants_stream_usage():
+                # OpenAI's include_usage framing: one extra chunk with NO choices and the
+                # final usage, after the finish_reason chunk and before [DONE].
+                yield _sse(
+                    {
+                        "id": completion_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": runtime.name,
+                        "choices": [],
+                        "usage": _usage_dict(usage),
+                    }
+                )
             yield "data: [DONE]\n\n"
             runtime.remember(request.messages, "".join(parts), decision.model)
             _record(usage, ttfb_ms=ttfb_ms)

--- a/wmh/serving/chat_openai_client_test.py
+++ b/wmh/serving/chat_openai_client_test.py
@@ -1,0 +1,172 @@
+"""OpenAI compatibility proven with the REAL `openai` client library, not our own requests.
+
+`chat_test.py` exercises the route with FastAPI's TestClient, which only proves we can parse
+our own output. These tests boot an actual uvicorn server and drive it with the official
+`openai` SDK - the same code path a customer's integration uses - covering non-streaming
+response parsing, streaming chunk framing with `stream_options.include_usage`, and error body
+shapes (the SDK must raise its typed exception AND surface our message from
+`body["error"]["message"]`). The upstream provider is a deterministic in-process fake, so the
+tests prove wire compatibility without network or keys.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from typing import cast
+
+import openai
+import pytest
+import uvicorn
+from fastapi import FastAPI
+
+from wmh.optimize.policy import RoutingPolicy
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderKind,
+    StreamChunk,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.providers.pool import PoolEntry
+from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
+
+
+class _FakeProvider:
+    """Deterministic upstream: echoes a fixed reply, reports cache-split usage."""
+
+    def __init__(self, entry: PoolEntry) -> None:
+        self.config = entry.provider_config()
+        self.name = entry.name
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+    ) -> Completion:
+        return Completion(
+            text=f"served by {self.name}",
+            usage=TokenUsage(input_tokens=10, output_tokens=5, cached_input_tokens=4),
+        )
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+    ) -> Iterator[StreamChunk]:
+        yield StreamChunk(delta="served ")
+        yield StreamChunk(delta="by ")
+        yield StreamChunk(delta=self.name)
+        yield StreamChunk(
+            done=True,
+            usage=TokenUsage(input_tokens=10, output_tokens=5, cached_input_tokens=4),
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+@pytest.fixture(scope="module")
+def live_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """A real uvicorn server on an ephemeral port, serving one static endpoint."""
+    pool = [PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5")]
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=pool),
+        provider_factory=_FakeProvider,
+        log=RequestLog(tmp_path_factory.mktemp("serving") / "requests.jsonl"),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("uvicorn did not start within 10s")
+        time.sleep(0.02)
+    yield f"http://127.0.0.1:{port}/v1"
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def _client(base_url: str) -> openai.OpenAI:
+    return openai.OpenAI(base_url=base_url, api_key="test-key", max_retries=0)
+
+
+def test_real_client_parses_completion(live_server: str) -> None:
+    completion = _client(live_server).chat.completions.create(
+        model="tau-bench",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    assert completion.choices[0].message.content == "served by haiku-4-5"
+    assert completion.choices[0].finish_reason == "stop"
+    assert completion.model == "tau-bench"  # endpoint name, never the routed pool model
+    assert completion.usage is not None
+    assert completion.usage.prompt_tokens == 10
+    assert completion.usage.completion_tokens == 5
+    details = completion.usage.prompt_tokens_details
+    assert details is not None and details.cached_tokens == 4
+
+
+def test_real_client_streams_with_usage_chunk(live_server: str) -> None:
+    stream = _client(live_server).chat.completions.create(
+        model="tau-bench",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    parts: list[str] = []
+    finish_reasons: list[str] = []
+    usage = None
+    for chunk in stream:
+        if chunk.usage is not None:
+            # OpenAI framing: the usage chunk carries NO choices.
+            assert chunk.choices == []
+            usage = chunk.usage
+        for choice in chunk.choices:
+            if choice.delta.content:
+                parts.append(choice.delta.content)
+            if choice.finish_reason:
+                finish_reasons.append(choice.finish_reason)
+    assert "".join(parts) == "served by haiku-4-5"
+    assert finish_reasons == ["stop"]
+    assert usage is not None and usage.prompt_tokens == 10 and usage.completion_tokens == 5
+
+
+def test_real_client_stream_without_usage_opt_in_gets_none(live_server: str) -> None:
+    stream = _client(live_server).chat.completions.create(
+        model="tau-bench",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=True,
+    )
+    assert all(chunk.usage is None for chunk in stream)
+
+
+def test_real_client_gets_typed_error_with_message(live_server: str) -> None:
+    with pytest.raises(openai.NotFoundError) as excinfo:
+        _client(live_server).chat.completions.create(
+            model="no-such-endpoint",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+    assert isinstance(excinfo.value.body, dict)
+    body = cast("dict[str, str]", excinfo.value.body)
+    assert body["code"] == "model_not_found"
+    assert "no endpoint 'no-such-endpoint'" in body["message"]
+    assert "tau-bench" in body["message"]  # the error names what IS available

--- a/wmh/serving/chat_openai_client_test.py
+++ b/wmh/serving/chat_openai_client_test.py
@@ -11,7 +11,6 @@ tests prove wire compatibility without network or keys.
 
 from __future__ import annotations
 
-import socket
 import threading
 import time
 from collections.abc import Iterator
@@ -32,7 +31,12 @@ from wmh.providers.base import (
     VerifyResult,
 )
 from wmh.providers.pool import PoolEntry
-from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
+from wmh.serving.chat import (
+    EndpointRuntime,
+    RequestLog,
+    create_chat_router,
+    install_openai_error_shapes,
+)
 
 
 class _FakeProvider:
@@ -90,17 +94,18 @@ def live_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     )
     app = FastAPI()
     app.include_router(create_chat_router({"tau-bench": runtime}))
-    with socket.socket() as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = probe.getsockname()[1]
-    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error"))
+    install_openai_error_shapes(app)
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error"))
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
     deadline = time.monotonic() + 10
     while not server.started:
+        if not thread.is_alive():
+            raise RuntimeError("uvicorn thread died during startup")
         if time.monotonic() > deadline:
             raise RuntimeError("uvicorn did not start within 10s")
         time.sleep(0.02)
+    port = server.servers[0].sockets[0].getsockname()[1]
     yield f"http://127.0.0.1:{port}/v1"
     server.should_exit = True
     thread.join(timeout=5)
@@ -170,3 +175,38 @@ def test_real_client_gets_typed_error_with_message(live_server: str) -> None:
     assert body["code"] == "model_not_found"
     assert "no endpoint 'no-such-endpoint'" in body["message"]
     assert "tau-bench" in body["message"]  # the error names what IS available
+
+
+def test_real_client_validation_error_is_openai_shaped_400(live_server: str) -> None:
+    with pytest.raises(openai.BadRequestError) as excinfo:
+        _client(live_server).chat.completions.create(
+            model="tau-bench",
+            messages=[],  # violates min_length=1
+        )
+    assert isinstance(excinfo.value.body, dict)
+    body = cast("dict[str, str]", excinfo.value.body)
+    assert body["code"] == "invalid_request"
+    assert "messages" in body["message"]
+
+
+def test_real_client_tools_rejected_not_silently_dropped(live_server: str) -> None:
+    with pytest.raises(openai.BadRequestError) as excinfo:
+        _client(live_server).chat.completions.create(
+            model="tau-bench",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        )
+    body = cast("dict[str, str]", excinfo.value.body)
+    assert body["code"] == "unsupported_parameter"
+    assert "tools" in body["message"]
+
+
+def test_real_client_developer_role_and_content_parts(live_server: str) -> None:
+    completion = _client(live_server).chat.completions.create(
+        model="tau-bench",
+        messages=[
+            {"role": "developer", "content": "be terse"},
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ],
+    )
+    assert completion.choices[0].message.content == "served by haiku-4-5"

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from fastapi import FastAPI
@@ -25,6 +26,7 @@ from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from typing import Any
 
     from wmh.providers.base import ProviderConfig
 
@@ -293,3 +295,67 @@ def test_provider_failure_logs_error_and_502s(tmp_path: Path) -> None:
     row = json.loads(log_path.read_text().splitlines()[0])
     assert row["status"] == "error"
     assert "upstream on fire" in row["error_message"]
+
+
+def test_abandoned_stream_still_records_metering(tmp_path: Path) -> None:
+    # A client that disconnects mid-stream closes the generator; the upstream call still
+    # consumed tokens, so a request-log row must land anyway (D-METERING: no silent loss).
+    class _EndlessProvider(_EchoProvider):
+        def stream(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Iterator[StreamChunk]:
+            for _ in range(1_000_000):  # far more than any client buffer; never finishes
+                yield StreamChunk(delta="x")
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=_EndlessProvider,
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+
+    # Drive the ASGI app directly: after the request body, `receive` reports
+    # http.disconnect, which is what starlette listens for to cancel a StreamingResponse
+    # and close its body iterator (GeneratorExit in the generator).
+    body = json.dumps(
+        {"model": "tau-bench", "stream": True, "messages": [{"role": "user", "content": "hi"}]}
+    ).encode()
+    state = {"request_sent": False}
+
+    async def receive() -> dict[str, object]:
+        if not state["request_sent"]:
+            state["request_sent"] = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        return None
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("test", 0),
+        "server": ("test", 80),
+    }
+    asyncio.run(app(cast("Any", scope), cast("Any", receive), cast("Any", send)))
+
+    rows = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert "disconnected" in rows[0]["error_message"]

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -369,3 +369,16 @@ def test_abandoned_stream_still_records_metering(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0]["status"] == "error"
     assert "disconnected" in rows[0]["error_message"]
+
+
+def test_create_app_with_injected_policies_and_no_artifact_dirs(tmp_path: Path) -> None:
+    # The injected-policies test pattern must not require an artifact root for the request log.
+    from wmh.serving.server import create_app
+
+    app = create_app(
+        artifact_dirs=(),
+        world_models={},
+        policies={"ep": RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool())},
+    )
+    client = TestClient(app)
+    assert [m["id"] for m in client.get("/v1/models").json()["data"]] == ["ep"]

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -257,12 +257,22 @@ def test_create_app_mounts_endpoints_from_policies(tmp_path: Path) -> None:
     assert [m["id"] for m in body["data"]] == ["tau-bench"]
 
 
-def test_create_app_without_policies_has_no_chat_routes(tmp_path: Path) -> None:
+def test_create_app_without_policies_serves_empty_model_list(tmp_path: Path) -> None:
+    # A client wired up before any policy is fitted gets an empty list and an OpenAI-shaped
+    # "no endpoint" error, never a bare 404 on the whole /v1 surface.
     from wmh.serving.server import create_app
 
     app = create_app(artifact_dirs=(str(tmp_path),), world_models={})
     client = TestClient(app)
-    assert client.get("/v1/models").status_code == 404
+    models = client.get("/v1/models")
+    assert models.status_code == 200
+    assert models.json()["data"] == []
+    chat = client.post(
+        "/v1/chat/completions",
+        json={"model": "anything", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert chat.status_code == 404
+    assert chat.json()["error"]["code"] == "model_not_found"
 
 
 def test_provider_failure_logs_error_and_502s(tmp_path: Path) -> None:

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -128,7 +128,12 @@ def test_completion_matches_openai_shape(tmp_path: Path) -> None:
     assert body["model"] == "tau-bench"  # the endpoint, not the mechanism
     assert body["choices"][0]["message"]["content"] == "served by haiku-4-5"
     assert body["choices"][0]["finish_reason"] == "stop"
-    assert body["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    assert body["usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "prompt_tokens_details": {"cached_tokens": 0},
+    }
     assert response.headers["x-wmh-routed-model"] == "haiku-4-5"
 
 
@@ -140,6 +145,7 @@ def test_streaming_emits_openai_chunks(tmp_path: Path) -> None:
         json={
             "model": "tau-bench",
             "stream": True,
+            "stream_options": {"include_usage": True},
             "messages": [{"role": "user", "content": "hi"}],
         },
     ) as response:
@@ -150,9 +156,11 @@ def test_streaming_emits_openai_chunks(tmp_path: Path) -> None:
     assert payloads[-1] == "[DONE]"
     chunks = [json.loads(p) for p in payloads[:-1]]
     assert all(c["object"] == "chat.completion.chunk" for c in chunks)
-    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks if c["choices"])
     assert text == "served by haiku-4-5"
-    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    # OpenAI include_usage framing: finish_reason chunk, THEN a choices-less usage chunk.
+    assert chunks[-2]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[-1]["choices"] == []
     assert chunks[-1]["usage"]["total_tokens"] == 15
 
 
@@ -190,7 +198,10 @@ def test_unknown_endpoint_404s_with_available(tmp_path: Path) -> None:
         json={"model": "nope", "messages": [{"role": "user", "content": "hi"}]},
     )
     assert response.status_code == 404
-    assert "tau-bench" in response.json()["detail"]
+    body = response.json()
+    # OpenAI error shape: clients read body["error"]["message"], never FastAPI's "detail".
+    assert body["error"]["code"] == "model_not_found"
+    assert "tau-bench" in body["error"]["message"]
 
 
 def test_models_endpoint_lists_endpoints(tmp_path: Path) -> None:

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -1,0 +1,284 @@
+"""Tests for the OpenAI-compatible chat endpoint (routing, streaming, affinity, request log)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from wmh.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
+from wmh.providers.base import (
+    Completion,
+    Message,
+    ProviderKind,
+    StreamChunk,
+    TokenUsage,
+    VerifyResult,
+)
+from wmh.providers.pool import PoolEntry
+from wmh.retrieval.embedders import HashingEmbedder
+from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from wmh.providers.base import ProviderConfig
+
+
+class _EchoProvider:
+    """Fake provider: replies with its own pool name so tests see who served."""
+
+    def __init__(self, entry: PoolEntry) -> None:
+        self.config: ProviderConfig = entry.provider_config()
+        self.name = entry.name
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        return Completion(
+            text=f"served by {self.name}",
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Iterator[StreamChunk]:
+        yield StreamChunk(delta="served by ")
+        yield StreamChunk(delta=self.name)
+        yield StreamChunk(done=True, usage=TokenUsage(input_tokens=10, output_tokens=5))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+def _pool() -> list[PoolEntry]:
+    return [
+        PoolEntry(
+            name="fable-5",
+            kind=ProviderKind.ANTHROPIC,
+            model="claude-fable-5",
+        ),
+        PoolEntry(
+            name="haiku-4-5",
+            kind=ProviderKind.ANTHROPIC,
+            model="claude-haiku-4-5",
+        ),
+    ]
+
+
+def _cluster_policy() -> RoutingPolicy:
+    embedder = HashingEmbedder(dim=64)
+    sql, prose = embedder.embed(["SELECT count(*) FROM superheroes", "write a friendly email"])
+    return RoutingPolicy(
+        kind="rank",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=64),
+        top_k_clusters=1,
+        clusters=[
+            ClusterRanking(
+                cluster_id=0, label="sql", centroid=sql, ranking=["fable-5", "haiku-4-5"]
+            ),
+            ClusterRanking(
+                cluster_id=1, label="prose", centroid=prose, ranking=["haiku-4-5", "fable-5"]
+            ),
+        ],
+    )
+
+
+def _client(tmp_path: Path, policy: RoutingPolicy | None = None) -> tuple[TestClient, Path]:
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=policy or RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=_EchoProvider,
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    return TestClient(app), log_path
+
+
+def test_completion_matches_openai_shape(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "chat.completion"
+    assert body["model"] == "tau-bench"  # the endpoint, not the mechanism
+    assert body["choices"][0]["message"]["content"] == "served by haiku-4-5"
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert body["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    assert response.headers["x-wmh-routed-model"] == "haiku-4-5"
+
+
+def test_streaming_emits_openai_chunks(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        lines = [line for line in response.iter_lines() if line.startswith("data: ")]
+    payloads = [line.removeprefix("data: ") for line in lines]
+    assert payloads[-1] == "[DONE]"
+    chunks = [json.loads(p) for p in payloads[:-1]]
+    assert all(c["object"] == "chat.completion.chunk" for c in chunks)
+    text = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert text == "served by haiku-4-5"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[-1]["usage"]["total_tokens"] == 15
+
+
+def test_cluster_routing_and_affinity(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path, policy=_cluster_policy())
+    first = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "SELECT count(*) FROM superheroes"}],
+        },
+    )
+    assert first.headers["x-wmh-routed-model"] == "fable-5"
+    reply = first.json()["choices"][0]["message"]["content"]
+    # Turn 2 would route to the prose cluster if fresh, but the conversation prefix
+    # (turn-1 user + assistant reply) pins the incumbent: affinity wins.
+    second = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "SELECT count(*) FROM superheroes"},
+                {"role": "assistant", "content": reply},
+                {"role": "user", "content": "write a friendly email about it"},
+            ],
+        },
+    )
+    assert second.headers["x-wmh-routed-model"] == "fable-5"
+
+
+def test_unknown_endpoint_404s_with_available(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "nope", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code == 404
+    assert "tau-bench" in response.json()["detail"]
+
+
+def test_models_endpoint_lists_endpoints(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+    body = client.get("/v1/models").json()
+    assert body["object"] == "list"
+    assert [m["id"] for m in body["data"]] == ["tau-bench"]
+
+
+def test_request_log_rows(tmp_path: Path) -> None:
+    client, log_path = _client(tmp_path, policy=_cluster_policy())
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "SELECT 1"}],
+        },
+    )
+    rows = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["endpoint"] == "tau-bench"
+    assert row["model"] == "fable-5"
+    assert row["cluster_id"] == 0
+    assert row["cluster_label"] == "sql"
+    assert row["routing_reason"]
+    assert row["input_tokens"] == 10
+    assert row["output_tokens"] == 5
+    assert row["cost_usd"] == pytest.approx((10 * 10.0 + 5 * 50.0) / 1_000_000)
+    assert row["latency_ms"] >= 0
+    assert row["status"] == "ok"
+    assert row["ts"]
+    assert row["id"]
+    assert row["leg"] == "serving"
+    assert row["cached_tokens"] == 0  # carried for the metering contract, not yet captured
+    assert row["router_cost_usd"] == 0.0  # hashing policy routes for free; passed through
+
+
+def test_create_app_mounts_endpoints_from_policies(tmp_path: Path) -> None:
+    from wmh.serving.server import create_app
+
+    app = create_app(
+        artifact_dirs=(str(tmp_path),),
+        world_models={},
+        policies={
+            "tau-bench": RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool())
+        },
+    )
+    client = TestClient(app)
+    body = client.get("/v1/models").json()
+    assert [m["id"] for m in body["data"]] == ["tau-bench"]
+
+
+def test_create_app_without_policies_has_no_chat_routes(tmp_path: Path) -> None:
+    from wmh.serving.server import create_app
+
+    app = create_app(artifact_dirs=(str(tmp_path),), world_models={})
+    client = TestClient(app)
+    assert client.get("/v1/models").status_code == 404
+
+
+def test_provider_failure_logs_error_and_502s(tmp_path: Path) -> None:
+    class _BoomProvider(_EchoProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            raise RuntimeError("upstream on fire")
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=_BoomProvider,
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    client = TestClient(app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code == 502
+    row = json.loads(log_path.read_text().splitlines()[0])
+    assert row["status"] == "error"
+    assert "upstream on fire" in row["error_message"]

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -241,7 +241,9 @@ def create_app(
                     raise ValueError(f"invalid routing policy at {policy_path}: {exc}") from exc
     # Mounted even with zero policies so a client wired up before a policy is fitted gets an
     # empty /v1/models list and an OpenAI-shaped "no endpoint" error instead of a bare 404.
-    request_log = RequestLog(Path(artifact_dirs[0]) / "serving" / "requests.jsonl")
+    # With no artifact root (injected-models tests) the log keeps its in-memory tail only.
+    log_path = Path(artifact_dirs[0]) / "serving" / "requests.jsonl" if artifact_dirs else None
+    request_log = RequestLog(log_path)
     app.include_router(
         create_chat_router(
             {

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -34,7 +34,12 @@ from wmh.engine.world_model import WorldModel
 from wmh.optimize.policy import POLICY_FILENAME, RoutingPolicy
 from wmh.optimize.reward import EpisodeScore
 from wmh.serving.builds import BuildManager, BuildRouteRequest, BuildSnapshot
-from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
+from wmh.serving.chat import (
+    EndpointRuntime,
+    RequestLog,
+    create_chat_router,
+    install_openai_error_shapes,
+)
 from wmh.serving.traces_source import (
     TRACES_FILENAME,
     TracesDownloader,
@@ -234,16 +239,18 @@ def create_app(
                     # Fail fast, but name the file: a bare ValidationError at startup doesn't
                     # say WHICH model's policy.json is broken.
                     raise ValueError(f"invalid routing policy at {policy_path}: {exc}") from exc
-    if endpoint_policies:
-        request_log = RequestLog(Path(artifact_dirs[0]) / "serving" / "requests.jsonl")
-        app.include_router(
-            create_chat_router(
-                {
-                    endpoint_name: EndpointRuntime(endpoint_name, policy, log=request_log)
-                    for endpoint_name, policy in endpoint_policies.items()
-                }
-            )
+    # Mounted even with zero policies so a client wired up before a policy is fitted gets an
+    # empty /v1/models list and an OpenAI-shaped "no endpoint" error instead of a bare 404.
+    request_log = RequestLog(Path(artifact_dirs[0]) / "serving" / "requests.jsonl")
+    app.include_router(
+        create_chat_router(
+            {
+                endpoint_name: EndpointRuntime(endpoint_name, policy, log=request_log)
+                for endpoint_name, policy in endpoint_policies.items()
+            }
         )
+    )
+    install_openai_error_shapes(app)
 
     def _register(name: str, model_dir: Path) -> None:
         """A finished serve-side build joins the live serving set immediately.

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -228,7 +228,12 @@ def create_app(
         for model_name, model_dir in model_dirs.items():
             policy_path = model_dir / POLICY_FILENAME
             if policy_path.is_file():
-                endpoint_policies[model_name] = RoutingPolicy.load(policy_path)
+                try:
+                    endpoint_policies[model_name] = RoutingPolicy.load(policy_path)
+                except Exception as exc:
+                    # Fail fast, but name the file: a bare ValidationError at startup doesn't
+                    # say WHICH model's policy.json is broken.
+                    raise ValueError(f"invalid routing policy at {policy_path}: {exc}") from exc
     if endpoint_policies:
         request_log = RequestLog(Path(artifact_dirs[0]) / "serving" / "requests.jsonl")
         app.include_router(

--- a/wmh/serving/server.py
+++ b/wmh/serving/server.py
@@ -31,8 +31,10 @@ from wmh.config.card import ModelCard, load_card
 from wmh.core.types import Action, EnvState, Observation, Session
 from wmh.engine.loader import load_world_model
 from wmh.engine.world_model import WorldModel
+from wmh.optimize.policy import POLICY_FILENAME, RoutingPolicy
 from wmh.optimize.reward import EpisodeScore
 from wmh.serving.builds import BuildManager, BuildRouteRequest, BuildSnapshot
+from wmh.serving.chat import EndpointRuntime, RequestLog, create_chat_router
 from wmh.serving.traces_source import (
     TRACES_FILENAME,
     TracesDownloader,
@@ -184,6 +186,7 @@ def create_app(
     cards: dict[str, ModelCard | None] | None = None,
     build_manager: BuildManager | None = None,
     max_fidelity: bool = False,
+    policies: dict[str, RoutingPolicy] | None = None,
 ) -> FastAPI:
     """Build the FastAPI app serving one or more named WorldModels.
 
@@ -193,6 +196,10 @@ def create_app(
     (the writable one, `.wmh` by convention); with injected models pass `build_manager`
     explicitly or the build routes return 503. `max_fidelity` serves every disk-loaded model
     with its online extras (the build-measured winner — see `WorldModel.load`).
+
+    A model whose artifact dir carries a `policy.json` also serves as an OpenAI-compatible
+    ENDPOINT: `/v1/chat/completions` (streaming included) routes each call through that policy
+    (`wmh.serving.chat`). `policies` injects them directly for tests.
     """
     app = FastAPI(title="World Model Harness")
     # The website (localhost:3000/6001/...) is a browser client of this API on another port.
@@ -213,6 +220,25 @@ def create_app(
             artifact_dirs, names, max_fidelity=max_fidelity
         )
     downloader = TracesDownloader()
+
+    # OpenAI-compatible endpoints: every served model whose artifact dir carries a policy.json
+    # (or every injected `policies` entry) answers /v1/chat/completions through that policy.
+    endpoint_policies = policies if policies is not None else {}
+    if policies is None:
+        for model_name, model_dir in model_dirs.items():
+            policy_path = model_dir / POLICY_FILENAME
+            if policy_path.is_file():
+                endpoint_policies[model_name] = RoutingPolicy.load(policy_path)
+    if endpoint_policies:
+        request_log = RequestLog(Path(artifact_dirs[0]) / "serving" / "requests.jsonl")
+        app.include_router(
+            create_chat_router(
+                {
+                    endpoint_name: EndpointRuntime(endpoint_name, policy, log=request_log)
+                    for endpoint_name, policy in endpoint_policies.items()
+                }
+            )
+        )
 
     def _register(name: str, model_dir: Path) -> None:
         """A finished serve-side build joins the live serving set immediately.

--- a/wmh/tracking/metered.py
+++ b/wmh/tracking/metered.py
@@ -13,7 +13,7 @@ was constructed with. Callers that want exact control can pass their own `classi
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 from wmh.optimize.judge import JUDGE_MARKER
 from wmh.providers.base import (
@@ -22,6 +22,8 @@ from wmh.providers.base import (
     Message,
     Provider,
     ProviderConfig,
+    StreamChunk,
+    StreamingProvider,
     TokenUsage,
     VerifyResult,
 )
@@ -82,6 +84,33 @@ class MeteredProvider:
         model = completion.model or self._provider.config.model
         self._tracker.record(phase, model, completion.usage)
         return completion
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Forward a native stream, recording usage from the terminal chunk.
+
+        A stream abandoned before its terminal chunk records nothing even though the provider
+        billed the partial generation; serving owns closing streams it starts.
+        """
+        if not isinstance(self._provider, StreamingProvider):
+            raise TypeError(
+                f"{type(self._provider).__name__} does not implement StreamingProvider; "
+                "stream() is only available for native backends"
+            )
+        phase = self._classify(system) if self._classify is not None else self._base_phase
+        for chunk in self._provider.stream(
+            system, messages, temperature=temperature, max_tokens=max_tokens
+        ):
+            if chunk.done and chunk.usage is not None:
+                model = chunk.model or self._provider.config.model
+                self._tracker.record(phase, model, chunk.usage)
+            yield chunk
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         # Embeddings carry no token usage from our providers; record a zero-usage event for the


### PR DESCRIPTION
The production core of the endpoint pivot. The research/hillclimbing layer (dashboard, ablation grid, IRT/benchmark adapters, bounds audits) is split out to #256, stacked on this. **Merge this first; everything pins to it.**

## What's here
- **Model pool** (`wmh/providers/pool.py`): PoolEntry/ModelPool from `.wmh/pool.toml` — the easily-editable candidate file. Prices are mandatory for unknown models (never a silent $0); `api_key_env` is a trusted-channel field so untrusted bundle config can never choose which env var is read.
- **Native streaming on all 5 providers** (`StreamingProvider`/`StreamChunk`): anthropic raw SSE, openai/azure chat with `include_usage`, responses API, bedrock converse_stream; `MeteredProvider.stream` meters the terminal chunk.
- **Switchable optimizer interface** (`wmh/optimize/base.py`): `Optimizer` protocol + typed `ArtifactRef`s (prompt | routing_policy | model_weights | adapter). GEPA implements it unchanged.
- **Routing policy artifact** (`wmh/optimize/policy.py` + `routing.py`): static | rank kinds, `select_model`/`rank_decision` shared serve/eval scoring, basic rank fitter with per-cluster only-replace-if-better guard + fit-once cost knob. The policy artifact is JSON, swappable, and serves without the fitter imported.
- **Closed-loop eval** (`wmh/env/closed_loop.py`, `wmh/optimize/outcomes.py`): pool x scenarios -> `OutcomeMatrix`; unscored episodes recorded as None, never zero-filled.
- **OpenAI-compatible endpoint** (`wmh/serving/chat.py`): `/v1/chat/completions` + `/v1/models` mounted from `policy.json` in model dirs; conversation affinity (prompt caches are per-model); D-METERING request log.

## Merge-gate verification (Silen's 7 items)
1. **Pricing-meeting constraints in the types** — `ArtifactRef.exportable` + `ArtifactProvenance` (optimizer, base_model, trace_count/sha256, created_at, config): checkpoints/adapters customer-owned + exportable with provenance; `routing_policy` FORCED non-exportable by validator regardless of caller input; `ResumableOptimizer` protocol = the continual-learning hook (prior artifact + new traces). Type shape only; tests pin all three.
2. **Effective cost per completed task** — `TokenUsage.cached_input_tokens` now flows from all 5 providers (anthropic cache_read, openai/azure prompt_tokens_details, responses input_tokens_details, bedrock cacheReadInputTokens); `PoolEntry.cost_usd` bills cached tokens at `cached_input_per_mtok` (full input rate when unset — never free); closed-loop accumulates it end-to-end. Tests: cache-adjusted vs list price.
3. **Proven against the real OpenAI client library** — `wmh/serving/chat_openai_client_test.py` boots live uvicorn and drives it with the actual `openai` SDK: non-stream parse, streaming with OpenAI's exact `include_usage` framing (separate choices-less usage chunk), no-opt-in => no usage chunks, and typed errors with OpenAI-shaped bodies (`error.message`/`code`, not FastAPI `detail`).
4. **D-SERVING-LOG field audit vs platform #354** — field-for-field comparison done; matches on all v1 fields; six gaps flagged in DECISIONS.md 2026-07-25 (platform missing router_cost_usd/leg/routing_reason columns; id semantics; provider_model; cost null-vs-0 on error rows; body capture and endpoint_id mapping are wrap-owned). Nothing in this PR blocks the wrap.
5. **Routing fit stays deferred** — policy artifact is swappable JSON behind `select_model`; hillclimbing lives in #256; proposal doc under `.agents/docs/proposals/` (internal); repo docs reference no `.agents` paths (test-enforced).
6. **CLI parity** — `wmh optimize` is now a family: `wmh optimize harness <agent> harbor` (the #242 command, unchanged behavior) and `wmh optimize route fit|report`. `wmh serve` mounts any model dir containing `policy.json` as an endpoint alongside existing world-model routes.
7. **What #249 rebases over** — `wmh/providers/base.py`: new `StreamChunk`/`StreamingProvider` + `TokenUsage.cached_input_tokens` (additive); `registry.get_provider(api_key=...)` keyword (additive); all 5 provider modules gained `stream()`; `wmh/cli/app.py` gained the optimize group restructure; `pyproject.toml` adds scikit-learn. No changes to ingest/trace types.

## Verification for Silen
- Full suite: 2219 passed / 17 skipped; ruff + ty clean.
- Live endpoint verified earlier on this branch: SQL prompt -> deepseek-v4-pro, prose stream -> haiku, exact costs in `.wmh/serving/requests.jsonl`; 9/9 pool models live-verified with real keys.
- Real-client compat is CI-proven (no keys needed): `uv run pytest wmh/serving/chat_openai_client_test.py`.
- To eyeball the endpoint: `uv run wmh serve` in a dir with a policy-bearing model, point any OpenAI client at it with `model=<endpoint name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)