### PR TITLE
wmh ingest: streaming normalize, format auto-detect, Postgres source, per-step attribution

### DIFF
--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -1,9 +1,12 @@
 # Ingesting traces from anywhere
 
-The harness builds a world model from **recorded agent traces**. Ingestion is part of `wmh build`,
-not a separate step: you pick a **source** and `build` turns traces from whatever you already have -
-an observability provider, an OTLP export, or a plain chat/tool-call log - into the normalized
-`wmh.core.types.Trace` shape and runs the pipeline.
+The harness builds a world model from **recorded agent traces**. You pick a **source** and the
+harness turns traces from whatever you already have - an observability provider, an OTLP export, a
+Postgres table, or a plain chat/tool-call log - into the normalized `wmh.core.types.Trace` shape.
+
+Ingestion runs two ways: as the first stage of `wmh build`, or standalone via **`wmh ingest`**,
+which normalizes a source into an OTel-GenAI JSONL corpus (with live progress) that any later
+command reads.
 
 Everything plugs into **one interface** (`TraceAdapter`) and **one normalizer**
 (`wmh.ingest.normalize`), so adding a source is a thin adapter, never a rewrite.
@@ -11,19 +14,38 @@ Everything plugs into **one interface** (`TraceAdapter`) and **one normalizer**
 ## Quickstart
 
 ```bash
+# Standalone normalize (format auto-detected from the file; live progress):
+wmh ingest --file <export>                                   # -> <export>.otel.jsonl
+wmh ingest --file <export> --json                            # machine-readable event lines
+wmh ingest --source langfuse --pull --api-key 'pk-...:sk-...'
+wmh ingest --dsn postgresql://... --table agent_traces       # postgres rows (see below)
+
+# Or ingest as part of a build:
 wmh build --name m --source <name> --file <export>          # build from a file export
 wmh build --name m --source <name> --pull --project <p>     # build from a live vendor pull
 wmh build                                                   # or pick the source in the wizard
 ```
 
 `--source` is a registered adapter (`otel-genai`, `chat-json`, `braintrust`, `phoenix`, `langfuse`,
-`langsmith`, `posthog`, `mastra`); `--file` reads an export, `--pull` fetches live (with
-`--project`/`--api-key`) for
-sources that support it. On an interactive terminal, `wmh build` with no source launches a wizard
-that lists the sources and prompts for file-or-pull.
+`langsmith`, `posthog`, `mastra`, `postgres`); `--file` reads an export, `--pull` fetches live
+(with `--project`/`--api-key`) for sources that support it. `wmh ingest` auto-detects a file's
+format when `--source` is omitted (`wmh.ingest.detect`); an unrecognized or mixed corpus errors
+with guidance instead of guessing. On an interactive terminal, `wmh build` with no source launches
+a wizard that lists the sources and prompts for file-or-pull.
 
 Under the hood the chosen adapter normalizes to OTel-GenAI span JSONL - the same format the bundled
-`examples/*.otel.jsonl` use - so a source is interchangeable with any other corpus the harness reads.
+`examples/*.otel.jsonl` use - so a source is interchangeable with any other corpus the harness
+reads: `wmh ingest`'s output feeds `wmh build --source otel-genai --file <out>` directly.
+
+### Progress events (the streaming contract)
+
+`wmh ingest --json` (and the library generator `wmh.ingest.stream.ingest_events`) emit one JSON
+event per line: `{"type": "detected", "format", "traces"}`, then repeated
+`{"type": "progress", "normalized", "total", "note"?}`, then a terminal
+`{"type": "done", "traces", "steps", "otel_object"}` or `{"type": "error", "message", "code"?}`.
+`error.code` is one of `bad_credentials | unreachable | bad_format | empty | internal`, so a
+wrapping UI can tell a bad key from a dead endpoint. The generator never raises; failures arrive
+as the terminal event.
 
 ## Sources
 
@@ -31,12 +53,13 @@ Under the hood the chosen adapter normalizes to OTel-GenAI span JSONL - the same
 |---|---|---|---|
 | `otel-genai` | OTLP-JSON spans (OTel GenAI semconv) | ✅ | ✅ (generic OTLP query backend) |
 | `chat-json` | recorded OpenAI/LangChain-style chat + tool-call conversations | ✅ | - |
-| `phoenix` | Arize Phoenix / OpenInference spans | ✅ | provider-dependent |
-| `langfuse` | Langfuse trace + observation tree | ✅ | provider-dependent |
-| `langsmith` | LangSmith run tree | ✅ | provider-dependent |
+| `phoenix` | Arize Phoenix / OpenInference spans | ✅ | - (export to a file) |
+| `langfuse` | Langfuse trace + observation tree | ✅ | ✅ (public REST API) |
+| `langsmith` | LangSmith run tree | ✅ | ✅ (runs/query REST API) |
 | `braintrust` | Braintrust span/log rows | ✅ | ✅ (REST fetch API) |
 | `posthog` | PostHog LLM-observability `$ai_*` events | ✅ | ✅ (HogQL query API) |
 | `mastra` | Mastra AI-tracing spans (`type` = model_generation/tool_call/…) | ✅ | ✅ (server API) |
+| `postgres` | rows in your own Postgres table (steps, messages, or session blobs) | - | ✅ (`--dsn`/`--table`) |
 
 Per-provider export instructions, payload shapes, and caveats:
 [Phoenix](#ingesting-arize-phoenix-traces) · [Langfuse](#ingesting-langfuse-traces) ·
@@ -64,14 +87,35 @@ them at a file or an OTLP query backend and use `--source otel-genai`:
 If a provider isn't listed and doesn't emit OTLP, it's a ~30-line adapter (see below) - open an issue
 or add one.
 
-### Databases and other stores
+### Databases: the `postgres` source
 
-There is no bespoke database adapter - instead, **point your store at OpenTelemetry** and ingest with
-`--source otel-genai`. If your agent runs are in a SQL table, a warehouse, or a custom log, the clean
-hook-up is to emit OTel GenAI spans (most agent frameworks and the OTel GenAI instrumentations do
-this out of the box) and either export them to a file (`--file spans.otlp.json`) or serve them from
-an OTLP-compatible query backend and `--pull`. One OTel format, any store behind it - no per-database
-code to maintain.
+If your agent runs live in your own Postgres, ingest them directly - no exporter needed:
+
+```bash
+uv run wmh ingest --dsn "postgresql://user:pass@host:5432/db" --table agent_traces
+# needs the driver extra once: pip install 'world-model-harness[postgres]'
+```
+
+The table contract is three columns, all overridable: `trace_id` (groups rows into episodes; used
+when present, `--trace-id-column` to rename), `payload` (required JSON/JSONB column,
+`--payload-column`), and `created_at` (ordering, `--order-column`). The payload column's format is
+**auto-detected with the same detector files use**, so Postgres is pure transport - three row
+shapes work out of the box:
+
+1. **Row per step/span**: each payload is one span/event in any accepted shape (OTLP span,
+   Langfuse observation, PostHog event, ...); rows sharing a `trace_id` become one episode.
+2. **Row per message**: a session/thread table where each payload is one chat message
+   (`{"role": ..., ...}`); rows are assembled per `trace_id` into one conversation.
+3. **Row per trace**: each payload is a self-contained session (a `{"messages": [...]}` blob, a
+   Langfuse trace object, an OTLP envelope); no `trace_id` column needed.
+
+When the table has a `trace_id` column its value wins over any id inside the payload, so episode
+boundaries always follow your table. `--since <iso>` filters on the order column. The DSN can also
+come from `$WMH_POSTGRES_DSN`.
+
+For other stores (warehouses, custom logs), **point them at OpenTelemetry** and ingest with
+`--source otel-genai`: emit OTel GenAI spans and either export them to a file
+(`--file spans.otlp.json`) or serve them from an OTLP-compatible query backend and `--pull`.
 
 **File vs. pull.** Every adapter supports `--file` (an export you already have); `--pull` (live from
 the vendor API) is opt-in per adapter and errors with a clear "export to a file" message when a
@@ -118,6 +162,14 @@ A `Trace` is `{trace_id, steps, source, metadata}`. Each `Step` is one
 `metadata` carries provenance and anything a source wants to thread through. Open-loop replay scores
 a predicted observation for `(state_before, action)` against the recorded one, so faithful `action`
 and `observation` are what matter most.
+
+Each step also carries optional **`attribution`** (`wmh.core.types.StepAttribution`): the model
+and provider that produced the action, token counts, cost, latency, and an `error_class`
+(`controllable` = the LLM call failed, `environmental` = the tool failed). The normalizer fills it
+best-effort from the GenAI/OpenInference vocabularies (`gen_ai.response.model`, `gen_ai.usage.*`,
+span timing/status), an explicit `wmh.attribution` JSON attribute wins verbatim, and the OTel
+writer round-trips it - this is what makes an ingested corpus usable for policy training, not just
+replay.
 
 ## How the pieces fit
 
@@ -329,8 +381,10 @@ See `examples/ingest/langfuse_to_wmh.sh` for the end-to-end script.
 
 ### Caveats
 
-- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
-  first. (The Langfuse SDK would be lazy-imported in `_pull_payloads` if/when pull is added.)
+- **Live pull** uses the public REST API with plain httpx (no SDK): `--pull` with
+  `--api-key 'pk-...:sk-...'` (or `$LANGFUSE_PUBLIC_KEY`/`$LANGFUSE_SECRET_KEY`; `$LANGFUSE_HOST`
+  or `--project` for self-hosted instances). The list endpoint is paged and each trace re-fetched
+  by id for full observations.
 - The richest pairing comes from the OpenAI-style `tool_calls` on a GENERATION `output`. Custom
   output shapes that don't carry `tool_calls` fall back to a plain message step.
 - A tool observation's `input` is used as the call arguments only when the preceding GENERATION
@@ -414,9 +468,9 @@ See `examples/ingest/langsmith_to_wmh.sh` for the end-to-end script.
 
 ### Caveats
 
-- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
-  first. (The `langsmith` SDK would be lazy-imported in `_pull_payloads` if/when pull is added, so
-  the config gate stays SDK-free.)
+- **Live pull** uses `POST /api/v1/runs/query` with plain httpx (no SDK): `--pull` with
+  `--api-key` (or `$LANGCHAIN_API_KEY`/`$LANGSMITH_API_KEY`) and `--project <project-uuid>`;
+  pagination follows `cursors.next`.
 - **Tool-call paths are version-dependent.** LangChain's run-output shape varies across versions;
   the adapter digs the common locations but a custom/unusual dump that doesn't carry `tool_calls`
   falls back to a plain message step.
@@ -496,8 +550,9 @@ See `examples/ingest/braintrust_to_wmh.sh` for the end-to-end script.
 
 ### Caveats
 
-- **No live pull.** This adapter is file-only; `--pull` raises a friendly error. Export to a file
-  first. (The Braintrust SDK would be lazy-imported in `_pull_payloads` if/when pull is added.)
+- **Live pull** uses the REST fetch API with plain httpx (no SDK): `--pull` with `--api-key` (or
+  `$BRAINTRUST_API_KEY`) and `--project` (a project name or id; names are resolved via
+  `/v1/project`).
 - The richest pairing comes from OpenAI-style `tool_calls` on an llm row's `output`. Custom output
   shapes that don't carry `tool_calls` fall back to a plain message step.
 - A tool row's `input` is used as the call arguments only when the preceding llm action lacked them

--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -92,8 +92,19 @@ or add one.
 If your agent runs live in your own Postgres, ingest them directly - no exporter needed:
 
 ```bash
-uv run wmh ingest --dsn "postgresql://user:pass@host:5432/db" --table agent_traces
+uv run wmh ingest --source postgres --dsn "postgresql://user:pass@host:5432/db" --table agent_traces
+# (--source postgres is implied whenever --dsn/--table are passed)
 # needs the driver extra once: pip install 'world-model-harness[postgres]'
+```
+
+On a TTY this renders a progress bar; `--json` emits the D-INGEST event lines, e.g. against a
+session table holding two chat threads as message-per-row:
+
+```
+{"type": "detected", "format": "postgres", "traces": 2}
+{"type": "progress", "normalized": 1, "total": 2}
+{"type": "progress", "normalized": 2, "total": 2, "note": "wrote 5 spans"}
+{"type": "done", "traces": 2, "steps": 3, "otel_object": "postgres.otel.jsonl"}
 ```
 
 The table contract is three columns, all overridable: `trace_id` (groups rows into episodes; used

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,16 @@ harbor = ["harbor==0.20.0"]
 # remote-MCP OAuth/pull path. Only that path needs it, so it is an optional extra imported
 # lazily (wmh.connect.notion), same contract as the e2b extra above.
 connectors = ["mcp>=1.27"]
+# The Postgres trace source (`wmh ingest --source postgres`): the driver is imported lazily
+# inside the adapter's pull path, same contract as the vendor-SDK extras.
+postgres = ["psycopg[binary]>=3.1"]
 # dev pulls in every backend SDK so `ty check` and the full test suite resolve over the whole
 # project (the providers import anthropic/openai/boto3 lazily, but type-checking needs them present).
 dev = [
     "pytest>=8.0",
     "ruff>=0.5",
     "ty>=0.0.1a1",
-    "world-model-harness[otel,viz,e2b,connectors,harbor]",
+    "world-model-harness[otel,viz,e2b,connectors,harbor,postgres]",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1999,6 +1999,64 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3072,6 +3130,7 @@ dev = [
     { name = "mcp" },
     { name = "opentelemetry-proto" },
     { name = "pandas" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "ruff" },
     { name = "seaborn" },
@@ -3085,6 +3144,9 @@ harbor = [
 ]
 otel = [
     { name = "opentelemetry-proto" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
 ]
 viz = [
     { name = "matplotlib" },
@@ -3116,6 +3178,7 @@ requires-dist = [
     { name = "opentelemetry-proto", marker = "extra == 'otel'", specifier = ">=1.24" },
     { name = "pandas", marker = "extra == 'viz'", specifier = ">=2.0" },
     { name = "posthog", specifier = ">=7.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -3127,9 +3190,9 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.16" },
     { name = "uvicorn", specifier = ">=0.38" },
-    { name = "world-model-harness", extras = ["otel", "viz", "e2b", "connectors", "harbor"], marker = "extra == 'dev'" },
+    { name = "world-model-harness", extras = ["otel", "viz", "e2b", "connectors", "harbor", "postgres"], marker = "extra == 'dev'" },
 ]
-provides-extras = ["otel", "viz", "e2b", "harbor", "connectors", "dev"]
+provides-extras = ["otel", "viz", "e2b", "harbor", "connectors", "postgres", "dev"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -39,6 +39,7 @@ import wmh.providers as providers
 from wmh.cli.agent_session import register as register_agent_session_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app, optimize_app
+from wmh.cli.ingest_cmd import ingest as _ingest_command
 from wmh.cli.platform_cmds import register as register_platform_commands
 from wmh.cli.ui import (
     BuildParams,
@@ -144,6 +145,7 @@ app.add_typer(research_app, name="research")
 app.add_typer(scenarios_app, name="scenarios")
 app.add_typer(harness_app, name="harness")
 app.add_typer(optimize_app, name="optimize")
+app.command("ingest")(_ingest_command)
 register_platform_commands(app)
 register_agent_session_commands(app)
 _console = Console()

--- a/wmh/cli/app_test.py
+++ b/wmh/cli/app_test.py
@@ -285,6 +285,7 @@ def test_cli_exposes_the_small_command_set() -> None:
     names = {cmd.name for cmd in app.registered_commands}
     core = {
         "build",
+        "ingest",
         "list",
         "serve",
         "demo",

--- a/wmh/cli/ingest_cmd.py
+++ b/wmh/cli/ingest_cmd.py
@@ -149,7 +149,7 @@ def ingest(
         if is_pull
         else None
     )
-    stream = ingest_events(file=file, pull=vendor_pull, source=source, out=out_path)
+    stream = ingest_events(file=file, pull=vendor_pull, source=source, out=out_path, limit=limit)
 
     if json_events:
         ok = False

--- a/wmh/cli/ingest_cmd.py
+++ b/wmh/cli/ingest_cmd.py
@@ -1,0 +1,165 @@
+"""`wmh ingest`: normalize traces from any source into OTel-GenAI JSONL, with live progress.
+
+The standalone half of what `wmh build` does first: pick a source (auto-detected for files),
+normalize to the harness's OTel span JSONL, and report progress. The output feeds any downstream
+command (`wmh build --source otel-genai --file <out>`), and the same event stream drives the
+platform's SSE trace-ingest endpoint (`wmh.ingest.stream.ingest_events`), so the CLI and the
+hosted flow can't drift.
+
+Output modes: a rich progress bar on a TTY, and `--json` for one D-INGEST event object per line
+(machine-readable; what a wrapping process pipes to a wire).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.progress import BarColumn, Progress, TextColumn
+
+from wmh.ingest import VendorPull, list_adapters
+from wmh.ingest.stream import (
+    DetectedEvent,
+    DoneEvent,
+    ErrorEvent,
+    IngestEvent,
+    ProgressEvent,
+    event_json,
+    ingest_events,
+)
+
+_console = Console()
+
+
+def _default_out(file: str | None, source: str | None) -> Path:
+    if file is not None:
+        return Path(f"{Path(file).stem}.otel.jsonl")
+    return Path(f"{source or 'traces'}.otel.jsonl")
+
+
+def _render_rich(stream: Iterator[IngestEvent]) -> bool:
+    """Consume the event stream behind a progress bar; returns True on success."""
+    ok = False
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("{task.completed}/{task.total} traces"),
+        console=_console,
+    ) as progress:
+        task_id = None
+        for event in stream:
+            if isinstance(event, DetectedEvent):
+                _console.print(f"detected [bold]{event.format}[/bold] · {event.traces} traces")
+                task_id = progress.add_task("normalizing", total=event.traces)
+            elif isinstance(event, ProgressEvent) and task_id is not None:
+                progress.update(task_id, completed=event.normalized)
+                if event.note:
+                    progress.update(task_id, description=event.note)
+            elif isinstance(event, DoneEvent):
+                ok = True
+                progress.stop()
+                _console.print(
+                    f"[green]done[/green] · {event.traces} traces / {event.steps} steps "
+                    f"→ [bold]{event.otel_object}[/bold]"
+                )
+                _console.print(
+                    f"build from it: wmh build --name <name> --source otel-genai "
+                    f"--file {event.otel_object}"
+                )
+            elif isinstance(event, ErrorEvent):
+                progress.stop()
+                code = f" [{event.code}]" if event.code else ""
+                _console.print(f"[red]error{code}[/red] {event.message}")
+    return ok
+
+
+def ingest(
+    file: str = typer.Option(
+        None, "--file", help="Path to an exported traces file (format auto-detected)."
+    ),
+    source: str = typer.Option(
+        None,
+        "--source",
+        help="Trace source adapter (default: auto-detect from the file). One of: "
+        "otel-genai, chat-json, braintrust, phoenix, langfuse, langsmith, posthog, mastra, "
+        "postgres.",
+    ),
+    pull: bool = typer.Option(
+        False, "--pull", help="Pull traces live from the source's API (instead of --file)."
+    ),
+    project: str = typer.Option(None, "--project", help="Vendor project/workspace id (--pull)."),
+    api_key: str = typer.Option(None, "--api-key", help="Vendor API key (else env var)."),
+    since: str = typer.Option(None, "--since", help="Only pull traces since this ISO timestamp."),
+    limit: int = typer.Option(None, "--limit", help="Max number of traces to ingest."),
+    dsn: str = typer.Option(
+        None, "--dsn", help="Postgres connection string (implies --source postgres)."
+    ),
+    table: str = typer.Option(None, "--table", help="Postgres table holding the trace rows."),
+    trace_id_column: str = typer.Option(
+        None, "--trace-id-column", help="Postgres column grouping rows into traces."
+    ),
+    payload_column: str = typer.Option(
+        None, "--payload-column", help="Postgres JSON column holding the trace payloads."
+    ),
+    order_column: str = typer.Option(
+        None, "--order-column", help="Postgres column ordering rows (default: created_at)."
+    ),
+    out: str = typer.Option(
+        None, "--out", help="Output OTel JSONL path (default: <input>.otel.jsonl)."
+    ),
+    json_events: bool = typer.Option(
+        False, "--json", help="Emit one JSON progress event per line instead of the rich UI."
+    ),
+) -> None:
+    """Normalize traces from a file, vendor API, or Postgres table into OTel JSONL.
+
+    No model is built: the output corpus feeds `wmh build --source otel-genai --file <out>` (or
+    any other command that reads a trace file). Progress events follow the D-INGEST vocabulary:
+    detected -> progress... -> done | error.
+    """
+    if (dsn is not None or table is not None) and source is None:
+        source = "postgres"
+    is_pull = pull or dsn is not None or table is not None
+    if file is None and not is_pull:
+        raise typer.BadParameter(
+            "provide --file <export>, --pull (with --source), or --dsn/--table for postgres"
+        )
+    if file is not None and is_pull:
+        raise typer.BadParameter("pass either --file or a pull (--pull/--dsn/--table), not both")
+    if source is not None and source not in list_adapters():
+        raise typer.BadParameter(
+            f"unknown --source {source!r}; choose one of: {', '.join(list_adapters())}"
+        )
+    out_path = Path(out) if out else _default_out(file, source)
+    vendor_pull = (
+        VendorPull(
+            api_key=api_key,
+            project=project,
+            since=since,
+            limit=limit,
+            dsn=dsn,
+            table=table,
+            trace_id_column=trace_id_column,
+            payload_column=payload_column,
+            order_column=order_column,
+        )
+        if is_pull
+        else None
+    )
+    stream = ingest_events(file=file, pull=vendor_pull, source=source, out=out_path)
+
+    if json_events:
+        ok = False
+        for event in stream:
+            # soft_wrap: machine-readable lines must never be broken at terminal width.
+            _console.print(
+                json.dumps(event_json(event)), markup=False, highlight=False, soft_wrap=True
+            )
+            ok = isinstance(event, DoneEvent) or (ok and not isinstance(event, ErrorEvent))
+    else:
+        ok = _render_rich(stream)
+    if not ok:
+        raise typer.Exit(code=1)

--- a/wmh/cli/ingest_cmd_test.py
+++ b/wmh/cli/ingest_cmd_test.py
@@ -1,0 +1,98 @@
+"""Tests for the `wmh ingest` CLI command (typer runner; no network, no database)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from wmh.cli.app import app
+
+runner = CliRunner()
+
+_CONVERSATION = {
+    "messages": [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "get", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+    ]
+}
+
+
+def _corpus(tmp_path: Path) -> Path:
+    src = tmp_path / "chat.json"
+    src.write_text(json.dumps(_CONVERSATION), encoding="utf-8")
+    return src
+
+
+def test_ingest_file_json_events_end_to_end(tmp_path: Path) -> None:
+    """`wmh ingest --file x --json` streams the pinned event vocabulary and writes the corpus."""
+    src = _corpus(tmp_path)
+    out = tmp_path / "normalized.otel.jsonl"
+    result = runner.invoke(app, ["ingest", "--file", str(src), "--out", str(out), "--json"])
+    assert result.exit_code == 0, result.output
+    events = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert [e["type"] for e in events][0] == "detected"
+    assert events[0] == {"type": "detected", "format": "chat-json", "traces": 1}
+    assert events[-1]["type"] == "done"
+    assert events[-1]["otel_object"] == str(out)
+    assert all(e["type"] == "progress" for e in events[1:-1])
+    assert all("total" in e for e in events if e["type"] == "progress")
+    assert out.exists()
+
+
+def test_ingest_rich_output_and_build_hint(tmp_path: Path) -> None:
+    src = _corpus(tmp_path)
+    out = tmp_path / "n.otel.jsonl"
+    result = runner.invoke(app, ["ingest", "--file", str(src), "--out", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "detected" in result.output
+    assert "chat-json" in result.output
+    assert "wmh build" in result.output  # tells the user the next step
+
+
+def test_ingest_error_exits_nonzero(tmp_path: Path) -> None:
+    src = tmp_path / "junk.json"
+    src.write_text('{"nothing": true}', encoding="utf-8")
+    result = runner.invoke(app, ["ingest", "--file", str(src), "--json"])
+    assert result.exit_code == 1
+    events = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert events[-1]["type"] == "error"
+    assert events[-1]["code"] == "bad_format"
+
+
+def test_ingest_requires_a_transport() -> None:
+    result = runner.invoke(app, ["ingest"])
+    assert result.exit_code == 2
+    assert "--file" in result.output
+
+
+def test_ingest_rejects_file_plus_pull(tmp_path: Path) -> None:
+    src = _corpus(tmp_path)
+    result = runner.invoke(app, ["ingest", "--file", str(src), "--pull"])
+    assert result.exit_code == 2
+
+
+def test_ingest_dsn_implies_postgres_source(tmp_path: Path) -> None:
+    """`--dsn/--table` alone select the postgres adapter; unreachable db = error event, exit 1."""
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--dsn",
+            "postgresql://nobody@127.0.0.1:1/none?connect_timeout=1",
+            "--table",
+            "agent_traces",
+            "--json",
+            "--out",
+            str(tmp_path / "o.jsonl"),
+        ],
+    )
+    assert result.exit_code == 1
+    events = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert events[-1]["type"] == "error"
+    assert events[-1]["code"] in ("unreachable", "bad_credentials")

--- a/wmh/core/types.py
+++ b/wmh/core/types.py
@@ -53,6 +53,32 @@ class EnvState(BaseModel):
     scratchpad: str = ""
 
 
+class ErrorClass(StrEnum):
+    """Who owns a step's failure: the model (retrainable) or the environment (not)."""
+
+    CONTROLLABLE = "controllable"  # the LLM call itself failed (refusal, bad call, provider error)
+    ENVIRONMENTAL = "environmental"  # the tool/environment failed executing a well-formed action
+
+
+class StepAttribution(BaseModel):
+    """Per-step provenance of the LLM call behind an action.
+
+    These fields are what make an ingested corpus policy-trainable: a routing optimizer clusters
+    and prices steps by which model produced them, at what token/dollar/latency cost, and whether
+    failures were the model's fault. All fields are optional; adapters populate them best-effort
+    from whatever the source recorded, and a step with nothing known carries no attribution at all.
+    """
+
+    model: str | None = None  # the serving model id (response model preferred over request)
+    provider: str | None = None  # the model provider/system (e.g. "anthropic", "openai")
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    latency_ms: float | None = None
+    error_class: ErrorClass | None = None
+    provenance: str | None = None  # versioned capture-system marker, when the source carries one
+
+
 class Step(BaseModel):
     """One (state, action) -> observation transition. The unit of retrieval and scoring."""
 
@@ -61,6 +87,7 @@ class Step(BaseModel):
     state_before: EnvState = Field(default_factory=EnvState)
     task: str | None = None  # originating instruction (tau in DreamGym Eq. 4)
     raw_span_ids: list[str] = Field(default_factory=list)
+    attribution: StepAttribution | None = None
 
 
 class Trace(BaseModel):

--- a/wmh/core/types.py
+++ b/wmh/core/types.py
@@ -71,6 +71,9 @@ class StepAttribution(BaseModel):
 
     model: str | None = None  # the serving model id (response model preferred over request)
     provider: str | None = None  # the model provider/system (e.g. "anthropic", "openai")
+    config: JsonObject = Field(
+        default_factory=dict
+    )  # request params (temperature, max_tokens, ...)
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: float | None = None

--- a/wmh/ingest/__init__.py
+++ b/wmh/ingest/__init__.py
@@ -24,6 +24,7 @@ from wmh.ingest import mastra as mastra  # noqa: F401
 from wmh.ingest import messages as messages  # noqa: F401
 from wmh.ingest import otel_genai as otel_genai  # noqa: F401
 from wmh.ingest import phoenix as phoenix  # noqa: F401
+from wmh.ingest import postgres as postgres  # noqa: F401
 from wmh.ingest import posthog as posthog  # noqa: F401
 from wmh.ingest.adapter import (
     TraceAdapter,

--- a/wmh/ingest/adapter.py
+++ b/wmh/ingest/adapter.py
@@ -13,6 +13,16 @@ from pydantic import BaseModel
 from wmh.core.types import Trace
 
 
+class SourceCredentialError(PermissionError):
+    """A source rejected the supplied credentials (API key, DSN password).
+
+    Adapters raise this instead of bare `PermissionError` so the streaming ingest can map it
+    to the `bad_credentials` wire code without misclassifying OS-level permission failures
+    (e.g. an unreadable local file) as credential problems. Subclassing `PermissionError`
+    keeps it a stdlib type: callers never need a driver import to catch it.
+    """
+
+
 class VendorPull(BaseModel):
     """Parameters for pulling traces from an observability vendor's API or a database."""
 

--- a/wmh/ingest/adapter.py
+++ b/wmh/ingest/adapter.py
@@ -14,12 +14,19 @@ from wmh.core.types import Trace
 
 
 class VendorPull(BaseModel):
-    """Parameters for pulling traces from an observability vendor's API."""
+    """Parameters for pulling traces from an observability vendor's API or a database."""
 
     api_key: str | None = None  # falls back to the vendor's env var when None
     project: str | None = None  # vendor project / workspace to pull from
     since: str | None = None  # ISO-8601 lower bound on trace start time
     limit: int | None = None  # max traces to pull
+
+    # Database-source transport params (the `postgres` adapter); API-vendor adapters ignore them.
+    dsn: str | None = None  # connection string; falls back to $WMH_POSTGRES_DSN
+    table: str | None = None  # table holding the trace rows
+    trace_id_column: str | None = None  # override; default "trace_id" (absent -> row-per-trace)
+    payload_column: str | None = None  # override; default "payload"
+    order_column: str | None = None  # override; default "created_at" when the table has it
 
 
 @runtime_checkable

--- a/wmh/ingest/base.py
+++ b/wmh/ingest/base.py
@@ -33,6 +33,27 @@ from wmh.ingest.adapter import VendorPull
 from wmh.ingest.normalize import SpanRecord, collect_spans, spans_to_traces
 
 
+def load_payloads(text: str) -> list[JsonValue]:
+    """Parse a whole-document JSON payload, or per-line JSONL on a top-level decode failure.
+
+    Module-level (not only a `BaseTraceAdapter` method) because format auto-detection and the
+    streaming ingest need the payloads BEFORE an adapter has been chosen.
+    """
+    try:
+        return [json.loads(text)]
+    except json.JSONDecodeError:
+        payloads: list[JsonValue] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                payloads.append(json.loads(stripped))
+            except json.JSONDecodeError:
+                continue  # tolerate a truncated/corrupt line; keep the rest
+        return payloads
+
+
 class BaseTraceAdapter:
     """Default file+vendor plumbing around the shared span normalizer."""
 
@@ -50,28 +71,12 @@ class BaseTraceAdapter:
         """Fetch raw payloads from the vendor API/SDK. Override to support live pulls."""
         raise ValueError(
             f"{self.name!r} does not support live vendor pulls yet; export traces to a file and "
-            f"use `from_file` (or `wmh ingest run --source {self.name} --file <export>`)"
+            f"use `from_file` (or `wmh ingest --source {self.name} --file <export>`)"
         )
 
     # --- public API (rarely overridden) -------------------------------------------------------
 
-    def _load_payloads(self, text: str) -> list[JsonValue]:
-        """Parse a whole-document JSON payload, or per-line JSONL on a top-level decode failure."""
-        try:
-            return [json.loads(text)]
-        except json.JSONDecodeError:
-            payloads: list[JsonValue] = []
-            for line in text.splitlines():
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    payloads.append(json.loads(stripped))
-                except json.JSONDecodeError:
-                    continue  # tolerate a truncated/corrupt line; keep the rest
-            return payloads
-
-    def _collect_all(self, payloads: list[JsonValue]) -> list[SpanRecord]:
+    def collect_all(self, payloads: list[JsonValue]) -> list[SpanRecord]:
         """Map every payload to spans and re-stamp `span_id` globally unique in emission order.
 
         Adapters assign `span_id`/`start_nano` per payload, so a trace split across payloads (e.g.
@@ -89,14 +94,21 @@ class BaseTraceAdapter:
                 spans.append(span)
         return spans
 
+    def spans_from_file(self, path: str) -> list[SpanRecord]:
+        """All (uniquely re-stamped) spans in a file export — the streaming ingest's seam."""
+        return self.collect_all(load_payloads(Path(path).read_text(encoding="utf-8")))
+
+    def spans_from_pull(self, pull: VendorPull) -> list[SpanRecord]:
+        """All (uniquely re-stamped) spans from a vendor pull — the streaming ingest's seam."""
+        return self.collect_all(self._pull_payloads(pull))
+
     def from_file(self, path: str) -> list[Trace]:
-        text = Path(path).read_text(encoding="utf-8")
-        spans = self._collect_all(self._load_payloads(text))
-        return spans_to_traces(spans, source=f"{self.name}:{path}")
+        return spans_to_traces(self.spans_from_file(path), source=f"{self.name}:{path}")
 
     def from_vendor(self, pull: VendorPull) -> list[Trace]:
-        spans = self._collect_all(self._pull_payloads(pull))
-        traces = spans_to_traces(spans, source=f"{self.name}:{pull.project or 'vendor'}")
+        traces = spans_to_traces(
+            self.spans_from_pull(pull), source=f"{self.name}:{pull.project or 'vendor'}"
+        )
         if pull.limit is not None:
             traces = traces[: pull.limit]
         return traces

--- a/wmh/ingest/base.py
+++ b/wmh/ingest/base.py
@@ -95,11 +95,11 @@ class BaseTraceAdapter:
         return spans
 
     def spans_from_file(self, path: str) -> list[SpanRecord]:
-        """All (uniquely re-stamped) spans in a file export — the streaming ingest's seam."""
+        """All (uniquely re-stamped) spans in a file export: the streaming ingest's seam."""
         return self.collect_all(load_payloads(Path(path).read_text(encoding="utf-8")))
 
     def spans_from_pull(self, pull: VendorPull) -> list[SpanRecord]:
-        """All (uniquely re-stamped) spans from a vendor pull — the streaming ingest's seam."""
+        """All (uniquely re-stamped) spans from a vendor pull: the streaming ingest's seam."""
         return self.collect_all(self._pull_payloads(pull))
 
     def from_file(self, path: str) -> list[Trace]:

--- a/wmh/ingest/detect.py
+++ b/wmh/ingest/detect.py
@@ -1,0 +1,126 @@
+"""Trace-format auto-detection: which registered adapter reads this payload?
+
+The D-INGEST streaming contract (and `wmh ingest` without `--source`) starts from raw payloads
+with no declared format: a file upload names no adapter, and a Postgres payload column can hold
+any shape a file could. Each source's export carries an unambiguous structural marker (the same
+markers the adapters key their own parsing on), so detection is a cheap shape check, not a parse:
+
+  - OTLP envelope (`resourceSpans`) or bare OTLP span (`traceId` + span fields) -> `otel-genai`
+  - `{"messages": [{"role": ...}]}` or a bare message list                      -> `chat-json`
+  - a trace with an `observations` list                                          -> `langfuse`
+  - a run carrying `run_type`                                                    -> `langsmith`
+  - a span row carrying `root_span_id`                                           -> `braintrust`
+  - `$ai_*` analytics events                                                     -> `posthog`
+  - AI-tracing spans typed by `type`/`spanType`                                  -> `mastra`
+  - OpenInference span dicts with a `context` id block                           -> `phoenix`
+
+API page wrappers (`{"data"|"events"|"results"|"runs"|"spans"|"traces": [...]}`) and JSON arrays
+defer to their elements. Detection samples the first few payloads and requires agreement;
+an unknown or conflicting corpus raises with "pass --source" guidance instead of guessing.
+"""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from wmh.ingest.adapter import list_adapters
+
+# Mastra `ExportedSpan.type` values (post- and pre-2025-11-rename), per `wmh/ingest/mastra.py`.
+_MASTRA_TYPES = frozenset(
+    {
+        "model_generation",
+        "llm_generation",
+        "tool_call",
+        "mcp_tool_call",
+        "agent_run",
+        "model_chunk",
+        "model_step",
+        "generic",
+    }
+)
+_WRAPPER_KEYS = ("data", "events", "results", "runs", "spans", "traces")
+# How many payloads must agree before we trust the verdict (JSONL corpora are homogeneous, so a
+# small prefix is plenty; a conflict inside the sample is a hard error either way).
+_SAMPLE = 8
+
+
+def _is_message(value: JsonValue) -> bool:
+    return isinstance(value, dict) and isinstance(value.get("role"), str)
+
+
+def _detect_dict(payload: dict[str, JsonValue]) -> str | None:
+    if isinstance(payload.get("resourceSpans"), list):
+        return "otel-genai"
+    messages = payload.get("messages")
+    if isinstance(messages, list) and messages and all(_is_message(m) for m in messages):
+        return "chat-json"
+    if isinstance(payload.get("observations"), list):
+        return "langfuse"
+    if "run_type" in payload:
+        return "langsmith"
+    if "root_span_id" in payload:
+        return "braintrust"
+    event = payload.get("event")
+    properties = payload.get("properties")
+    if (isinstance(event, str) and event.startswith("$ai_")) or (
+        isinstance(properties, dict) and "$ai_trace_id" in properties
+    ):
+        return "posthog"
+    span_type = payload.get("type") or payload.get("spanType")
+    if isinstance(span_type, str) and (
+        span_type in _MASTRA_TYPES or span_type.startswith("workflow_")
+    ):
+        return "mastra"
+    context = payload.get("context")
+    if isinstance(context, dict) and ("span_id" in context or "trace_id" in context):
+        return "phoenix"
+    if isinstance(payload.get("traceId"), str) and (
+        "spanId" in payload or "attributes" in payload or "startTimeUnixNano" in payload
+    ):
+        return "otel-genai"
+    for key in _WRAPPER_KEYS:
+        wrapped = payload.get(key)
+        if isinstance(wrapped, list):
+            return _detect_one(wrapped)
+    return None
+
+
+def _detect_one(payload: JsonValue) -> str | None:
+    if isinstance(payload, dict):
+        return _detect_dict(payload)
+    if isinstance(payload, list):
+        if payload and all(_is_message(m) for m in payload):
+            return "chat-json"
+        for item in payload:
+            verdict = _detect_one(item)
+            if verdict is not None:
+                return verdict
+    return None
+
+
+def detect_format(payloads: list[JsonValue]) -> str:
+    """The registered adapter name for these decoded payloads.
+
+    Samples the first payloads with a recognizable shape and requires them to agree. Raises
+    `ValueError` (telling the caller to pass `--source` explicitly) when nothing is recognized
+    or when the sample is mixed — silent misdetection would normalize a corpus wrongly.
+    """
+    verdicts: list[str] = []
+    for payload in payloads:
+        verdict = _detect_one(payload)
+        if verdict is not None:
+            verdicts.append(verdict)
+        if len(verdicts) >= _SAMPLE:
+            break
+    if not verdicts:
+        raise ValueError(
+            "could not auto-detect the trace format: no payload matched a known source shape; "
+            f"pass --source explicitly (one of {list_adapters()})"
+        )
+    distinct = sorted(set(verdicts))
+    if len(distinct) > 1:
+        raise ValueError(
+            f"ambiguous trace format: payloads look like {' and '.join(distinct)}; "
+            "pass --source explicitly to pin one"
+        )
+    return distinct[0]

--- a/wmh/ingest/detect.py
+++ b/wmh/ingest/detect.py
@@ -103,7 +103,7 @@ def detect_format(payloads: list[JsonValue]) -> str:
 
     Samples the first payloads with a recognizable shape and requires them to agree. Raises
     `ValueError` (telling the caller to pass `--source` explicitly) when nothing is recognized
-    or when the sample is mixed — silent misdetection would normalize a corpus wrongly.
+    or when the sample is mixed: silent misdetection would normalize a corpus wrongly.
     """
     verdicts: list[str] = []
     for payload in payloads:

--- a/wmh/ingest/detect_test.py
+++ b/wmh/ingest/detect_test.py
@@ -1,0 +1,71 @@
+"""Tests for trace-format auto-detection (`wmh.ingest.detect`)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmh.ingest.detect import detect_format
+
+# One minimal, representative payload per source shape: exactly the markers detection keys on.
+_OTLP_ENVELOPE = {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": "t1"}]}]}]}
+_OTLP_BARE_SPAN = {
+    "traceId": "a" * 32,
+    "spanId": "b" * 16,
+    "startTimeUnixNano": 1,
+    "attributes": [{"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}}],
+}
+_CHAT = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]}
+_LANGFUSE = {"id": "lf-1", "observations": [{"id": "o1", "type": "GENERATION"}]}
+_LANGSMITH = {"id": "r1", "trace_id": "t1", "run_type": "llm", "outputs": {}}
+_BRAINTRUST = {"span_id": "s1", "root_span_id": "r1", "span_attributes": {"type": "llm"}}
+_POSTHOG = {"event": "$ai_generation", "properties": {"$ai_trace_id": "t1"}}
+_MASTRA = {"id": "s1", "traceId": "t1", "type": "model_generation", "input": [], "output": {}}
+_PHOENIX = {
+    "name": "agent_step",
+    "context": {"trace_id": "t1", "span_id": "s1"},
+    "attributes": {"openinference.span.kind": "LLM"},
+}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (_OTLP_ENVELOPE, "otel-genai"),
+        (_OTLP_BARE_SPAN, "otel-genai"),
+        (_CHAT, "chat-json"),
+        (_LANGFUSE, "langfuse"),
+        (_LANGSMITH, "langsmith"),
+        (_BRAINTRUST, "braintrust"),
+        (_POSTHOG, "posthog"),
+        (_MASTRA, "mastra"),
+        (_PHOENIX, "phoenix"),
+    ],
+)
+def test_detects_each_source_shape(payload: dict, expected: str) -> None:
+    assert detect_format([payload]) == expected
+
+
+def test_detects_inside_wrappers_and_lists() -> None:
+    # API page wrappers and JSON arrays defer to their elements' shape.
+    assert detect_format([{"data": [_LANGFUSE]}]) == "langfuse"
+    assert detect_format([{"events": [_BRAINTRUST]}]) == "braintrust"
+    assert detect_format([{"runs": [_LANGSMITH]}]) == "langsmith"
+    assert detect_format([{"results": [_POSTHOG]}]) == "posthog"
+    assert detect_format([{"spans": [_MASTRA]}]) == "mastra"
+    assert detect_format([[_PHOENIX, _PHOENIX]]) == "phoenix"
+    # A bare message list is one chat-json conversation.
+    assert detect_format([[{"role": "user", "content": "hi"}]]) == "chat-json"
+    # JSONL: one payload per line, all agreeing.
+    assert detect_format([_OTLP_BARE_SPAN, _OTLP_BARE_SPAN]) == "otel-genai"
+
+
+def test_unknown_shape_raises_with_guidance() -> None:
+    with pytest.raises(ValueError, match="--source"):
+        detect_format([{"nothing": "recognizable"}])
+    with pytest.raises(ValueError, match="--source"):
+        detect_format([])
+
+
+def test_conflicting_payloads_raise_naming_both() -> None:
+    with pytest.raises(ValueError, match="langfuse.*langsmith|langsmith.*langfuse"):
+        detect_format([_LANGFUSE, _LANGSMITH])

--- a/wmh/ingest/langfuse.py
+++ b/wmh/ingest/langfuse.py
@@ -42,7 +42,7 @@ Export the FULL trace: `GET /api/public/traces/{traceId}` (`TraceWithFullDetails
 Langfuse's native OTLP endpoint `POST /api/public/otel/v1/traces` and the `otel-genai` source, which
 is the better route for framework traces where tool calls are separate child observations).
 
-Pull: `from_vendor` fetches traces live over the public REST API with plain httpx (no SDK) — it
+Pull: `from_vendor` fetches traces live over the public REST API with plain httpx (no SDK): it
 pages the list endpoint, then re-fetches each trace by id for full observations. See
 `_pull_payloads`. File exports remain fully supported via `from_file`.
 """

--- a/wmh/ingest/langfuse.py
+++ b/wmh/ingest/langfuse.py
@@ -42,18 +42,21 @@ Export the FULL trace: `GET /api/public/traces/{traceId}` (`TraceWithFullDetails
 Langfuse's native OTLP endpoint `POST /api/public/otel/v1/traces` and the `otel-genai` source, which
 is the better route for framework traces where tool calls are separate child observations).
 
-Pull: live pull via the Langfuse SDK is not implemented; export to a file and use `from_file`. The
-`BaseTraceAdapter` default raises a friendly error pointing at `--file`.
+Pull: `from_vendor` fetches traces live over the public REST API with plain httpx (no SDK) — it
+pages the list endpoint, then re-fetches each trace by id for full observations. See
+`_pull_payloads`. File exports remain fully supported via `from_file`.
 """
 
 from __future__ import annotations
 
 import json
+import os
 
+import httpx
 from pydantic import JsonValue
 
 from wmh.core.types import JsonObject
-from wmh.ingest.adapter import register_adapter
+from wmh.ingest.adapter import VendorPull, register_adapter
 from wmh.ingest.base import BaseTraceAdapter
 from wmh.ingest.normalize import (
     SpanRecord,
@@ -92,10 +95,69 @@ def _observation_tool_name(observation: JsonObject) -> str:
     return ""
 
 
+_PUBLIC_KEY_ENV = "LANGFUSE_PUBLIC_KEY"
+_SECRET_KEY_ENV = "LANGFUSE_SECRET_KEY"
+_HOST_ENV = "LANGFUSE_HOST"
+_DEFAULT_HOST = "https://cloud.langfuse.com"
+_PAGE_SIZE = 50
+
+
 class LangfuseAdapter(BaseTraceAdapter):
     """Map a Langfuse trace export (observation tree) into normalized `Trace`s. No SDK."""
 
     name = "langfuse"
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch traces live from the Langfuse public API (plain httpx, no SDK).
+
+        Credentials are a public/secret key pair: `pull.api_key` as `"pk-...:sk-..."`, else
+        `$LANGFUSE_PUBLIC_KEY`/`$LANGFUSE_SECRET_KEY`. Host: `pull.project` (the keys already pin
+        the Langfuse project, so the field carries the host for self-hosted instances), else
+        `$LANGFUSE_HOST`, else Langfuse Cloud. The LIST endpoint returns observation-id strings
+        only, so each listed trace is re-fetched by id for its full observation objects.
+        """
+        api_key = pull.api_key
+        if not api_key:
+            public = os.environ.get(_PUBLIC_KEY_ENV)
+            secret = os.environ.get(_SECRET_KEY_ENV)
+            api_key = f"{public}:{secret}" if public and secret else None
+        if not api_key or ":" not in api_key:
+            raise ValueError(
+                "langfuse pull needs a key pair: pass --api-key 'pk-...:sk-...' or set "
+                f"${_PUBLIC_KEY_ENV} and ${_SECRET_KEY_ENV}"
+            )
+        public, secret = api_key.split(":", 1)
+        auth = (public, secret)
+        host = (pull.project or os.environ.get(_HOST_ENV) or _DEFAULT_HOST).rstrip("/")
+
+        trace_ids: list[str] = []
+        page = 1
+        while True:
+            params = {"page": str(page), "limit": str(_PAGE_SIZE)}
+            if pull.since is not None:
+                params["fromTimestamp"] = pull.since
+            resp = httpx.get(f"{host}/api/public/traces", auth=auth, params=params, timeout=60.0)
+            resp.raise_for_status()
+            body = resp.json()
+            data = body.get("data") if isinstance(body, dict) else None
+            if not isinstance(data, list) or not data:
+                break
+            for trace in data:
+                if isinstance(trace, dict) and isinstance(trace.get("id"), str):
+                    trace_ids.append(trace["id"])
+            if pull.limit is not None and len(trace_ids) >= pull.limit:
+                trace_ids = trace_ids[: pull.limit]
+                break
+            if len(data) < _PAGE_SIZE:
+                break
+            page += 1
+
+        payloads: list[JsonValue] = []
+        for trace_id in trace_ids:
+            resp = httpx.get(f"{host}/api/public/traces/{trace_id}", auth=auth, timeout=60.0)
+            resp.raise_for_status()
+            payloads.append(resp.json())
+        return payloads
 
     def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
         """Map one Langfuse trace (or a list/`{data:[...]}` page of them) to `SpanRecord`s."""

--- a/wmh/ingest/langfuse.py
+++ b/wmh/ingest/langfuse.py
@@ -100,6 +100,10 @@ _SECRET_KEY_ENV = "LANGFUSE_SECRET_KEY"
 _HOST_ENV = "LANGFUSE_HOST"
 _DEFAULT_HOST = "https://cloud.langfuse.com"
 _PAGE_SIZE = 50
+# Backstop on unbounded pulls (no --limit): every listed trace is re-fetched individually, so a
+# forever-pagination against a huge project would turn into thousands of requests. Mirrors the
+# LangSmith adapter's _MAX_RUNS backstop.
+_MAX_PAGES = 40
 
 
 class LangfuseAdapter(BaseTraceAdapter):
@@ -148,7 +152,7 @@ class LangfuseAdapter(BaseTraceAdapter):
             if pull.limit is not None and len(trace_ids) >= pull.limit:
                 trace_ids = trace_ids[: pull.limit]
                 break
-            if len(data) < _PAGE_SIZE:
+            if len(data) < _PAGE_SIZE or page >= _MAX_PAGES:
                 break
             page += 1
 

--- a/wmh/ingest/langfuse_test.py
+++ b/wmh/ingest/langfuse_test.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from wmh.core.types import ActionKind
 from wmh.ingest import get_adapter
+from wmh.ingest.adapter import VendorPull
 from wmh.ingest.langfuse import LangfuseAdapter
 
 # A realistic Langfuse `GET /api/public/traces/{id}` export: a trace with nested observations.
@@ -178,13 +181,43 @@ def test_jsonl_multiple_traces(tmp_path: Path) -> None:
     assert len(traces) == 2
 
 
-def test_vendor_pull_unsupported_is_friendly() -> None:
-    from wmh.ingest.adapter import VendorPull
-
-    try:
+def test_vendor_pull_without_keys_is_friendly(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    with pytest.raises(ValueError, match="LANGFUSE_PUBLIC_KEY"):
         LangfuseAdapter().from_vendor(VendorPull())
-    except ValueError as exc:
-        assert "does not support live vendor pulls" in str(exc)
-        assert "langfuse" in str(exc)
-    else:  # pragma: no cover
-        raise AssertionError("expected ValueError")
+
+
+def test_vendor_pull_lists_then_fetches_each_trace(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    """Live-pull path with httpx mocked: page the trace list, fetch each id in full, normalize.
+
+    The list endpoint returns observation-id STRINGS only (no steps), so the pull must re-fetch
+    each trace by id; a pull that normalized list-page traces directly would yield zero steps.
+    """
+    import wmh.ingest.langfuse as lf
+
+    calls: list[str] = []
+
+    def fake_get(url, auth=None, params=None, timeout=None):  # noqa: ANN001, ANN202 - test stub
+        class _Resp:
+            def __init__(self, payload) -> None:  # noqa: ANN001
+                self._payload = payload
+
+            def raise_for_status(self) -> None: ...
+
+            def json(self):  # noqa: ANN202
+                return self._payload
+
+        calls.append(url)
+        assert auth == ("pk-1", "sk-1")
+        if url.endswith("/api/public/traces"):
+            listed = {**_TRACE, "observations": ["o1", "o2"]}
+            return _Resp({"data": [listed], "meta": {"totalPages": 1}})
+        assert url.endswith(f"/api/public/traces/{_TRACE['id']}")
+        return _Resp(_TRACE)
+
+    monkeypatch.setattr(lf.httpx, "get", fake_get)
+    traces = LangfuseAdapter().from_vendor(VendorPull(api_key="pk-1:sk-1"))
+    assert len(traces) == 1
+    assert traces[0].steps, "full-trace fetch must yield real steps"
+    assert any(url.endswith(f"/api/public/traces/{_TRACE['id']}") for url in calls)

--- a/wmh/ingest/langfuse_test.py
+++ b/wmh/ingest/langfuse_test.py
@@ -221,3 +221,34 @@ def test_vendor_pull_lists_then_fetches_each_trace(monkeypatch) -> None:  # noqa
     assert len(traces) == 1
     assert traces[0].steps, "full-trace fetch must yield real steps"
     assert any(url.endswith(f"/api/public/traces/{_TRACE['id']}") for url in calls)
+
+
+def test_vendor_pull_unbounded_pagination_has_a_backstop(monkeypatch) -> None:  # noqa: ANN001
+    """A credential-only pull against a huge project must not page forever."""
+    import wmh.ingest.langfuse as lf
+
+    list_calls = {"count": 0}
+
+    def fake_get(url, auth=None, params=None, timeout=None):  # noqa: ANN001, ANN202 - test stub
+        class _Resp:
+            def __init__(self, payload) -> None:  # noqa: ANN001
+                self._payload = payload
+
+            def raise_for_status(self) -> None: ...
+
+            def json(self):  # noqa: ANN202
+                return self._payload
+
+        if url.endswith("/api/public/traces"):
+            assert isinstance(params, dict)
+            list_calls["count"] += 1
+            page = int(params["page"])
+            data = [
+                {"id": f"lf-{page}-{i}", "observations": ["o"]} for i in range(int(params["limit"]))
+            ]
+            return _Resp({"data": data})  # always a full page: pagination never ends naturally
+        return _Resp({**_TRACE, "id": url.rsplit("/", 1)[-1]})
+
+    monkeypatch.setattr(lf.httpx, "get", fake_get)
+    LangfuseAdapter().from_vendor(VendorPull(api_key="pk:sk"))
+    assert list_calls["count"] == lf._MAX_PAGES

--- a/wmh/ingest/langsmith.py
+++ b/wmh/ingest/langsmith.py
@@ -50,17 +50,19 @@ Accepted file shapes (`from_file`): a single run object, a JSON array of runs, a
 wrapper, or JSONL (one run per line). Grouping is by `trace_id` (falling back to `id` for a root
 run that omits it).
 
-Pull: a live pull via the `langsmith` SDK is not implemented here; export to a file and use
-`from_file`. The `BaseTraceAdapter` default raises a friendly error pointing at `--file`, so the
-config gate stays SDK-free.
+Pull: `from_vendor` fetches runs live over the REST API with plain httpx (no SDK) — see
+`_pull_payloads`. File exports remain fully supported via `from_file`.
 """
 
 from __future__ import annotations
 
+import os
+
+import httpx
 from pydantic import JsonValue
 
 from wmh.core.types import JsonObject
-from wmh.ingest.adapter import register_adapter
+from wmh.ingest.adapter import VendorPull, register_adapter
 from wmh.ingest.base import BaseTraceAdapter
 from wmh.ingest.normalize import SpanRecord, as_text, iso_to_ordinal
 
@@ -256,10 +258,71 @@ def _message_content(message: JsonObject) -> str:
     return ""
 
 
+_API_KEY_ENVS = ("LANGCHAIN_API_KEY", "LANGSMITH_API_KEY")
+_ENDPOINT_ENV = "LANGCHAIN_ENDPOINT"
+_DEFAULT_ENDPOINT = "https://api.smith.langchain.com"
+_PAGE_SIZE = 100
+# Backstop on unbounded pulls (no --limit): runs, not traces, are what the API pages by.
+_MAX_RUNS = 2000
+
+
 class LangSmithAdapter(BaseTraceAdapter):
     """Map a LangSmith run-tree export into normalized `Trace`s. No SDK; pure JSON."""
 
     name = "langsmith"
+
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch runs live from the LangSmith REST API (plain httpx, no SDK).
+
+        `pull.api_key` (else `$LANGCHAIN_API_KEY`/`$LANGSMITH_API_KEY`) auths; `pull.project` is
+        the project (session) UUID passed to `POST /api/v1/runs/query` — the list endpoint is a
+        POST with a JSON filter body. Pagination follows `cursors.next` until exhausted, `--limit`
+        traces are covered, or a run-count backstop trips.
+        """
+        api_key = pull.api_key or next(
+            (value for env in _API_KEY_ENVS if (value := os.environ.get(env))), None
+        )
+        if not api_key:
+            raise ValueError(
+                f"langsmith pull needs an API key: pass --api-key or set ${_API_KEY_ENVS[0]}"
+            )
+        endpoint = (os.environ.get(_ENDPOINT_ENV) or _DEFAULT_ENDPOINT).rstrip("/")
+        base_body: JsonObject = {"limit": _PAGE_SIZE}
+        if pull.project:
+            base_body["session"] = [pull.project]
+        if pull.since is not None:
+            base_body["start_time"] = pull.since
+
+        runs: list[JsonValue] = []
+        trace_ids: set[str] = set()
+        cursor: str | None = None
+        while True:
+            body = dict(base_body)
+            body["cursor"] = cursor
+            resp = httpx.post(
+                f"{endpoint}/api/v1/runs/query",
+                headers={"x-api-key": api_key},
+                json=body,
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            page = resp.json()
+            page_runs = page.get("runs") if isinstance(page, dict) else None
+            if not isinstance(page_runs, list) or not page_runs:
+                break
+            for run in page_runs:
+                if isinstance(run, dict):
+                    runs.append(run)
+                    trace_ids.add(self._trace_id(run))
+            if pull.limit is not None and len(trace_ids) >= pull.limit:
+                break
+            if len(runs) >= _MAX_RUNS:
+                break
+            cursors = page.get("cursors")
+            cursor = cursors.get("next") if isinstance(cursors, dict) else None
+            if not isinstance(cursor, str) or not cursor:
+                break
+        return [{"runs": runs}]
 
     def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
         """Map one payload (single run, list, `{runs:[...]}`) to ordered `SpanRecord`s by trace."""

--- a/wmh/ingest/langsmith.py
+++ b/wmh/ingest/langsmith.py
@@ -50,7 +50,7 @@ Accepted file shapes (`from_file`): a single run object, a JSON array of runs, a
 wrapper, or JSONL (one run per line). Grouping is by `trace_id` (falling back to `id` for a root
 run that omits it).
 
-Pull: `from_vendor` fetches runs live over the REST API with plain httpx (no SDK) — see
+Pull: `from_vendor` fetches runs live over the REST API with plain httpx (no SDK); see
 `_pull_payloads`. File exports remain fully supported via `from_file`.
 """
 
@@ -275,8 +275,8 @@ class LangSmithAdapter(BaseTraceAdapter):
         """Fetch runs live from the LangSmith REST API (plain httpx, no SDK).
 
         `pull.api_key` (else `$LANGCHAIN_API_KEY`/`$LANGSMITH_API_KEY`) auths; `pull.project` is
-        the project (session) UUID passed to `POST /api/v1/runs/query` — the list endpoint is a
-        POST with a JSON filter body. Pagination follows `cursors.next` until exhausted, `--limit`
+        the project (session) UUID passed to `POST /api/v1/runs/query`: the list endpoint is a
+        POST with a JSON filter body). Pagination follows `cursors.next` until exhausted, `--limit`
         traces are covered, or a run-count backstop trips.
         """
         api_key = pull.api_key or next(
@@ -298,7 +298,10 @@ class LangSmithAdapter(BaseTraceAdapter):
         cursor: str | None = None
         while True:
             body = dict(base_body)
-            body["cursor"] = cursor
+            # The cursor key is present only when following a page: cursor-based APIs
+            # commonly reject an explicit null on the first request.
+            if cursor is not None:
+                body["cursor"] = cursor
             resp = httpx.post(
                 f"{endpoint}/api/v1/runs/query",
                 headers={"x-api-key": api_key},

--- a/wmh/ingest/langsmith_test.py
+++ b/wmh/ingest/langsmith_test.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from wmh.core.types import ActionKind
 from wmh.ingest import get_adapter
+from wmh.ingest.adapter import VendorPull
 from wmh.ingest.langsmith import LangSmithAdapter
 
 # A realistic `Client.list_runs` / `GET /api/v1/runs` export: a flat list of runs in one trace.
@@ -232,18 +235,6 @@ def test_jsonl_and_chain_runs_skipped(tmp_path: Path) -> None:
     assert by_id["tr-llm"].steps[0].action.content is not None
 
 
-def test_vendor_pull_unsupported_is_friendly() -> None:
-    from wmh.ingest.adapter import VendorPull
-
-    try:
-        LangSmithAdapter().from_vendor(VendorPull())
-    except ValueError as exc:
-        assert "does not support live vendor pulls" in str(exc)
-        assert "langsmith" in str(exc)
-    else:  # pragma: no cover
-        raise AssertionError("expected ValueError")
-
-
 def test_empty_string_error_is_not_an_error(tmp_path: Path) -> None:
     """Some LangSmith dumps set error="" on a successful run; it must NOT mark the step errored."""
     run = {
@@ -260,3 +251,43 @@ def test_empty_string_error_is_not_an_error(tmp_path: Path) -> None:
 
     trace = LangSmithAdapter().from_file(str(path))[0]
     assert trace.steps[0].observation.is_error is False
+
+
+def test_vendor_pull_without_key_is_friendly(monkeypatch) -> None:  # noqa: ANN001 - fixture
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key"):
+        LangSmithAdapter().from_vendor(VendorPull())
+
+
+def test_vendor_pull_queries_runs_with_cursor_pagination(monkeypatch) -> None:  # noqa: ANN001
+    """Live-pull path with httpx mocked: POST runs/query, follow the next cursor, normalize."""
+    import wmh.ingest.langsmith as ls
+
+    bodies: list[dict] = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: ANN001, ANN202 - test stub
+        class _Resp:
+            def __init__(self, payload) -> None:  # noqa: ANN001
+                self._payload = payload
+
+            def raise_for_status(self) -> None: ...
+
+            def json(self):  # noqa: ANN202
+                return self._payload
+
+        assert url.endswith("/api/v1/runs/query")
+        assert headers == {"x-api-key": "k"}
+        assert isinstance(json, dict)
+        bodies.append(json)
+        if json.get("cursor") is None:
+            return _Resp({"runs": _RUNS[:2], "cursors": {"next": "c2"}})
+        assert json["cursor"] == "c2"
+        return _Resp({"runs": _RUNS[2:], "cursors": {"next": None}})
+
+    monkeypatch.setattr(ls.httpx, "post", fake_post)
+    traces = LangSmithAdapter().from_vendor(VendorPull(api_key="k", project="proj-uuid"))
+    assert len(bodies) == 2  # followed the pagination cursor
+    assert all(body["session"] == ["proj-uuid"] for body in bodies)
+    assert len(traces) == 1
+    assert traces[0].steps

--- a/wmh/ingest/messages.py
+++ b/wmh/ingest/messages.py
@@ -31,18 +31,13 @@ Accepted file shapes (`from_file`):
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 from pydantic import JsonValue
 
-from wmh.core.types import JsonObject, Trace
+from wmh.core.types import JsonObject
 from wmh.ingest.adapter import VendorPull, register_adapter
-from wmh.ingest.normalize import (
-    SpanRecord,
-    as_text,
-    openai_call_name_args,
-    spans_to_traces,
-)
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.normalize import SpanRecord, as_text, openai_call_name_args
 
 
 def _hash_id(*parts: str) -> str:
@@ -154,32 +149,18 @@ def _conversation_records(payload: JsonValue) -> list[tuple[str, list[JsonValue]
     return out
 
 
-class ChatMessagesAdapter:
+class ChatMessagesAdapter(BaseTraceAdapter):
     """Convert recorded chat/tool-call conversations (OpenAI-style) into `Trace`s. No SDK."""
 
     name = "chat-json"
 
-    def from_file(self, path: str) -> list[Trace]:
-        text = Path(path).read_text(encoding="utf-8")
-        payloads: list[JsonValue] = []
-        try:
-            payloads.append(json.loads(text))
-        except json.JSONDecodeError:
-            for line in text.splitlines():
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    payloads.append(json.loads(stripped))
-                except json.JSONDecodeError:
-                    continue
+    def spans_from_payload(self, payload: JsonValue) -> list[SpanRecord]:
         spans: list[SpanRecord] = []
-        for payload in payloads:
-            for trace_id, messages, metadata in _conversation_records(payload):
-                spans.extend(_spans_for_conversation(messages, trace_id, metadata))
-        return spans_to_traces(spans, source=f"chat-json:{path}")
+        for trace_id, messages, metadata in _conversation_records(payload):
+            spans.extend(_spans_for_conversation(messages, trace_id, metadata))
+        return spans
 
-    def from_vendor(self, pull: VendorPull) -> list[Trace]:
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
         raise ValueError(
             "chat-json converts local conversation files; it has no vendor API. "
             "Use `from_file` with an exported messages JSON/JSONL."

--- a/wmh/ingest/normalize.py
+++ b/wmh/ingest/normalize.py
@@ -510,9 +510,9 @@ def _opt_str(value: JsonValue) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-# `start_nano` scale sniffing for latency: adapters put three kinds of value in start/end —
+# `start_nano` scale sniffing for latency: adapters put three kinds of value in start/end:
 # real OTLP epoch NANOseconds (~2e18 today), `iso_to_ordinal` epoch MICROseconds (~2e15 today),
-# and synthetic ordinals (list indexes, the writer's i*10 stamps — tiny). Only the first two are
+# and synthetic ordinals (list indexes, the writer's i*10 stamps: tiny). Only the first two are
 # real clocks a latency can be derived from; synthetic ordinals must not masquerade as durations.
 _EPOCH_NANO_FLOOR = 10**17  # ≥ 1973 when read as ns
 _EPOCH_MICRO_FLOOR = 10**14  # ≥ 1973 when read as µs

--- a/wmh/ingest/normalize.py
+++ b/wmh/ingest/normalize.py
@@ -26,7 +26,17 @@ from datetime import UTC, datetime
 
 from pydantic import BaseModel, Field, JsonValue
 
-from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step, Trace
+from wmh.core.types import (
+    Action,
+    ActionKind,
+    EnvState,
+    ErrorClass,
+    JsonObject,
+    Observation,
+    Step,
+    StepAttribution,
+    Trace,
+)
 
 # --- attribute vocabularies (GenAI semconv first, OpenInference fallback) ---------------------
 
@@ -76,6 +86,24 @@ _LLM_PRESENCE_KEYS = (
 _STATE_STRUCTURED_KEY = "wmh.state.structured"
 _STATE_SCRATCHPAD_KEY = "wmh.state.scratchpad"
 _TRACE_METADATA_KEY = "wmh.trace.metadata"
+_ATTRIBUTION_KEY = "wmh.attribution"
+
+# Per-step attribution vocabularies (GenAI semconv first, OpenInference fallback). The response
+# model is preferred over the request model: with provider-side routing/fallback they differ, and
+# attribution wants the model that actually answered.
+_MODEL_KEYS = ("gen_ai.response.model", "gen_ai.request.model", "llm.model_name")
+_PROVIDER_KEYS = ("gen_ai.system", "gen_ai.provider.name", "llm.provider")
+_INPUT_TOKEN_KEYS = (
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.prompt_tokens",
+    "llm.token_count.prompt",
+)
+_OUTPUT_TOKEN_KEYS = (
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.completion_tokens",
+    "llm.token_count.completion",
+)
+_COST_KEYS = ("gen_ai.usage.cost", "llm.usage.total_cost")
 
 
 class SpanRecord(BaseModel):
@@ -463,16 +491,94 @@ def _trace_metadata(spans: list[SpanRecord]) -> JsonObject:
     return {}
 
 
+def _opt_int(value: JsonValue) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        coerced = to_int(value)
+        return coerced if coerced or value in (0, "0", 0.0) else None
+    return None
+
+
+def _opt_float(value: JsonValue) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _opt_str(value: JsonValue) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+# `start_nano` scale sniffing for latency: adapters put three kinds of value in start/end —
+# real OTLP epoch NANOseconds (~2e18 today), `iso_to_ordinal` epoch MICROseconds (~2e15 today),
+# and synthetic ordinals (list indexes, the writer's i*10 stamps — tiny). Only the first two are
+# real clocks a latency can be derived from; synthetic ordinals must not masquerade as durations.
+_EPOCH_NANO_FLOOR = 10**17  # ≥ 1973 when read as ns
+_EPOCH_MICRO_FLOOR = 10**14  # ≥ 1973 when read as µs
+
+
+def _span_latency_ms(start: int, end: int) -> float | None:
+    if start >= _EPOCH_NANO_FLOOR:
+        return (end - start) / 1_000_000
+    if start >= _EPOCH_MICRO_FLOOR:
+        return (end - start) / 1_000
+    return None
+
+
+def _attribution(
+    action_span: SpanRecord | None, tool_span: SpanRecord | None
+) -> StepAttribution | None:
+    """Best-effort per-step attribution from the action span's attributes.
+
+    An explicit `wmh.attribution` JSON attribute (what `otel_writer` emits, and what a capture
+    system can stamp directly) round-trips verbatim. Otherwise the fields are derived from the
+    GenAI/OpenInference vocabularies plus span timing/status. Returns None when nothing is known,
+    so sources without attribution stay clean rather than carrying an all-empty object.
+    """
+    attrs = action_span.attributes if action_span is not None else {}
+    explicit = attrs.get(_ATTRIBUTION_KEY)
+    if isinstance(explicit, str) and explicit:
+        try:
+            return StepAttribution.model_validate_json(explicit)
+        except ValueError:
+            pass
+    error_class: ErrorClass | None = None
+    if action_span is not None and action_span.status_error:
+        error_class = ErrorClass.CONTROLLABLE
+    elif tool_span is not None and tool_span.status_error:
+        error_class = ErrorClass.ENVIRONMENTAL
+    latency_ms: float | None = None
+    if action_span is not None and 0 < action_span.start_nano < action_span.end_nano:
+        latency_ms = _span_latency_ms(action_span.start_nano, action_span.end_nano)
+    attribution = StepAttribution(
+        model=_opt_str(_first(attrs, _MODEL_KEYS)),
+        provider=_opt_str(_first(attrs, _PROVIDER_KEYS)),
+        input_tokens=_opt_int(_first(attrs, _INPUT_TOKEN_KEYS)),
+        output_tokens=_opt_int(_first(attrs, _OUTPUT_TOKEN_KEYS)),
+        cost_usd=_opt_float(_first(attrs, _COST_KEYS)),
+        latency_ms=latency_ms,
+        error_class=error_class,
+    )
+    return attribution if attribution.model_dump(exclude_none=True) else None
+
+
 def _build_steps(spans: list[SpanRecord]) -> list[Step]:
     """Pair ordered Action spans with their following Observation spans into Steps."""
     task = _trace_task(spans)
     steps: list[Step] = []
     pending: Action | None = None
+    pending_span: SpanRecord | None = None
     pending_ids: list[str] = []
     pending_state = EnvState()
 
     def flush(
-        action: Action, observation: Observation, span_ids: list[str], state: EnvState
+        action: Action,
+        observation: Observation,
+        span_ids: list[str],
+        state: EnvState,
+        action_span: SpanRecord | None,
+        tool_span: SpanRecord | None,
     ) -> None:
         steps.append(
             Step(
@@ -481,6 +587,7 @@ def _build_steps(spans: list[SpanRecord]) -> list[Step]:
                 state_before=state,
                 task=task,
                 raw_span_ids=span_ids,
+                attribution=_attribution(action_span, tool_span),
             )
         )
 
@@ -489,7 +596,7 @@ def _build_steps(spans: list[SpanRecord]) -> list[Step]:
             observation = observation_from_tool_span(span)
             if pending is None:
                 action = tool_call_action_from_tool_span(span)
-                flush(action, observation, [span.span_id], _state_before(span))
+                flush(action, observation, [span.span_id], _state_before(span), None, span)
             else:
                 # The LLM span usually carries the call's name/args; backfill from the tool span
                 # only when it didn't. Derive the tool-span action once to avoid re-parsing.
@@ -501,18 +608,55 @@ def _build_steps(spans: list[SpanRecord]) -> list[Step]:
                         pending.arguments = from_tool.arguments
                     if pending.name is None:
                         pending.name = from_tool.name
-                flush(pending, observation, [*pending_ids, span.span_id], pending_state)
-            pending, pending_ids, pending_state = None, [], EnvState()
+                flush(
+                    pending,
+                    observation,
+                    [*pending_ids, span.span_id],
+                    pending_state,
+                    pending_span,
+                    span,
+                )
+            pending, pending_span, pending_ids, pending_state = None, None, [], EnvState()
         elif is_llm_span(span):
             if pending is not None:
-                flush(pending, Observation(content=""), pending_ids, pending_state)
-            pending, pending_ids = action_from_llm_span(span), [span.span_id]
+                flush(
+                    pending, Observation(content=""), pending_ids, pending_state, pending_span, None
+                )
+            pending, pending_span, pending_ids = action_from_llm_span(span), span, [span.span_id]
             pending_state = _state_before(span)
         # Non-agent spans are ignored.
 
     if pending is not None:
-        flush(pending, Observation(content=""), pending_ids, pending_state)
+        flush(pending, Observation(content=""), pending_ids, pending_state, pending_span, None)
     return steps
+
+
+def group_spans(spans: list[SpanRecord]) -> list[list[SpanRecord]]:
+    """Group spans by trace id and order: spans within a group by start time, groups likewise.
+
+    Splitting this from `trace_from_group` lets the streaming ingest count traces up front
+    (the `detected` event) and normalize group-by-group (the `progress` events).
+    """
+    by_trace: dict[str, list[SpanRecord]] = {}
+    for span in spans:
+        by_trace.setdefault(span.trace_id, []).append(span)
+    # Sorting each group by (start_nano, span_id) leaves group[0] as that trace's earliest span, so
+    # we reuse it as the inter-trace sort key rather than re-scanning.
+    groups = list(by_trace.values())
+    for group in groups:
+        group.sort(key=lambda s: (s.start_nano, s.span_id))
+    groups.sort(key=lambda group: group[0].start_nano)
+    return groups
+
+
+def trace_from_group(group: list[SpanRecord], *, source: str) -> Trace:
+    """Build one `Trace` from one already-ordered same-trace-id span group."""
+    return Trace(
+        trace_id=group[0].trace_id,
+        steps=_build_steps(group),
+        source=source,
+        metadata=_trace_metadata(group),
+    )
 
 
 def spans_to_traces(spans: list[SpanRecord], *, source: str) -> list[Trace]:
@@ -520,20 +664,4 @@ def spans_to_traces(spans: list[SpanRecord], *, source: str) -> list[Trace]:
 
     This is the shared tail every span-based adapter calls after producing `SpanRecord`s.
     """
-    by_trace: dict[str, list[SpanRecord]] = {}
-    for span in spans:
-        by_trace.setdefault(span.trace_id, []).append(span)
-    # Sorting each group by (start_nano, span_id) leaves group[0] as that trace's earliest span, so
-    # we reuse it as the inter-trace sort key rather than re-scanning.
-    ordered: list[tuple[int, Trace]] = []
-    for group in by_trace.values():
-        group.sort(key=lambda s: (s.start_nano, s.span_id))
-        trace = Trace(
-            trace_id=group[0].trace_id,
-            steps=_build_steps(group),
-            source=source,
-            metadata=_trace_metadata(group),
-        )
-        ordered.append((group[0].start_nano, trace))
-    ordered.sort(key=lambda pair: pair[0])
-    return [trace for _, trace in ordered]
+    return [trace_from_group(group, source=source) for group in group_spans(spans)]

--- a/wmh/ingest/normalize.py
+++ b/wmh/ingest/normalize.py
@@ -104,6 +104,10 @@ _OUTPUT_TOKEN_KEYS = (
     "llm.token_count.completion",
 )
 _COST_KEYS = ("gen_ai.usage.cost", "llm.usage.total_cost")
+# `gen_ai.request.*` keys that are NOT sampling/config knobs: the model has its own field, and
+# "arguments" is a legacy tool-args location (see _TOOL_ARG_KEYS), not an LLM parameter.
+_NON_CONFIG_REQUEST_KEYS = frozenset({"gen_ai.request.model", "gen_ai.request.arguments"})
+_REQUEST_PREFIX = "gen_ai.request."
 
 
 class SpanRecord(BaseModel):
@@ -551,16 +555,24 @@ def _attribution(
     latency_ms: float | None = None
     if action_span is not None and 0 < action_span.start_nano < action_span.end_nano:
         latency_ms = _span_latency_ms(action_span.start_nano, action_span.end_nano)
+    config = {
+        key[len(_REQUEST_PREFIX) :]: value
+        for key, value in attrs.items()
+        if key.startswith(_REQUEST_PREFIX) and key not in _NON_CONFIG_REQUEST_KEYS
+    }
     attribution = StepAttribution(
         model=_opt_str(_first(attrs, _MODEL_KEYS)),
         provider=_opt_str(_first(attrs, _PROVIDER_KEYS)),
+        config=config,
         input_tokens=_opt_int(_first(attrs, _INPUT_TOKEN_KEYS)),
         output_tokens=_opt_int(_first(attrs, _OUTPUT_TOKEN_KEYS)),
         cost_usd=_opt_float(_first(attrs, _COST_KEYS)),
         latency_ms=latency_ms,
         error_class=error_class,
     )
-    return attribution if attribution.model_dump(exclude_none=True) else None
+    # exclude_defaults so an empty config dict does not make an otherwise-unknown step
+    # carry an all-empty attribution object.
+    return attribution if attribution.model_dump(exclude_defaults=True) else None
 
 
 def _build_steps(spans: list[SpanRecord]) -> list[Step]:

--- a/wmh/ingest/normalize_test.py
+++ b/wmh/ingest/normalize_test.py
@@ -165,3 +165,27 @@ def test_step_attribution_latency_ignores_synthetic_ordinals_and_scales_microsec
     attribution = trace.steps[0].attribution
     assert attribution is not None
     assert attribution.latency_ms == 250.0
+
+
+def test_step_attribution_captures_request_config() -> None:
+    """`gen_ai.request.*` sampling params land in attribution.config (policy-relevant knobs)."""
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.completion": "hi",
+                "gen_ai.request.model": "m",
+                "gen_ai.request.temperature": 0.2,
+                "gen_ai.request.max_tokens": 512,
+                "gen_ai.request.top_p": 0.9,
+            },
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    attribution = trace.steps[0].attribution
+    assert attribution is not None
+    assert attribution.config == {"temperature": 0.2, "max_tokens": 512, "top_p": 0.9}
+    # The model key is attribution.model, never duplicated into config.
+    assert "model" not in attribution.config

--- a/wmh/ingest/normalize_test.py
+++ b/wmh/ingest/normalize_test.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from wmh.ingest.normalize import iso_to_ordinal, openai_call_name_args, openai_tool_calls
+from wmh.core.types import ErrorClass, StepAttribution
+from wmh.ingest.normalize import (
+    SpanRecord,
+    iso_to_ordinal,
+    openai_call_name_args,
+    openai_tool_calls,
+    spans_to_traces,
+)
 
 
 def test_iso_to_ordinal_naive_timestamp_is_utc_not_local() -> None:
@@ -46,3 +53,115 @@ def test_openai_call_name_args_nested_and_flattened() -> None:
     assert openai_call_name_args({"name": "run", "arguments": {"a": 1}}) == ("run", '{"a": 1}')
     # Missing/typeless fields degrade to empty strings, never a crash.
     assert openai_call_name_args({}) == ("", "")
+
+
+def test_step_attribution_derived_from_semconv_attributes() -> None:
+    """Model/provider/tokens/latency come off the LLM span; a tool error is environmental."""
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            start_nano=1_753_000_000_000_000_000,
+            end_nano=1_753_000_000_250_000_000,
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.tool.name": "get_user",
+                "gen_ai.tool.call.arguments": '{"id": "u1"}',
+                "gen_ai.response.model": "claude-haiku-4-5",
+                "gen_ai.system": "anthropic",
+                "gen_ai.usage.input_tokens": 120,
+                "gen_ai.usage.output_tokens": 30,
+            },
+        ),
+        SpanRecord(
+            trace_id="t1",
+            span_id="b",
+            start_nano=1_753_000_001_000_000_000,
+            status_error=True,
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.message": "boom",
+            },
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    attribution = trace.steps[0].attribution
+    assert attribution is not None
+    assert attribution.model == "claude-haiku-4-5"
+    assert attribution.provider == "anthropic"
+    assert attribution.input_tokens == 120
+    assert attribution.output_tokens == 30
+    assert attribution.latency_ms == 250.0
+    assert attribution.error_class == ErrorClass.ENVIRONMENTAL
+
+
+def test_step_attribution_errored_llm_span_is_controllable() -> None:
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            status_error=True,
+            attributes={"gen_ai.operation.name": "chat", "gen_ai.completion": "refused"},
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    attribution = trace.steps[0].attribution
+    assert attribution is not None
+    assert attribution.error_class == ErrorClass.CONTROLLABLE
+
+
+def test_step_attribution_explicit_wmh_attribute_wins() -> None:
+    """A `wmh.attribution` JSON attr round-trips verbatim, beating semconv derivation."""
+    explicit = StepAttribution(model="gpt-5.5", cost_usd=0.0123, provenance="capture-v2")
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.completion": "hi",
+                "gen_ai.response.model": "ignored-when-explicit",
+                "wmh.attribution": explicit.model_dump_json(exclude_none=True),
+            },
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    assert trace.steps[0].attribution == explicit
+
+
+def test_step_attribution_absent_when_nothing_known() -> None:
+    spans = [
+        SpanRecord(
+            trace_id="t1",
+            span_id="a",
+            attributes={"gen_ai.operation.name": "chat", "gen_ai.completion": "hi"},
+        ),
+    ]
+    (trace,) = spans_to_traces(spans, source="test")
+    assert trace.steps[0].attribution is None
+
+
+def test_step_attribution_latency_ignores_synthetic_ordinals_and_scales_microseconds() -> None:
+    """Writer/list-index ordinals must not become fake latencies; iso ordinals are µs, not ns.
+
+    Regression: re-ingesting a corpus written by `otel_writer` (timestamps i*10, i*10+1) stamped
+    every step with `latency_ms=1e-6` junk.
+    """
+    synthetic = SpanRecord(
+        trace_id="t1",
+        span_id="a",
+        start_nano=10,
+        end_nano=11,
+        attributes={"gen_ai.operation.name": "chat", "gen_ai.response.model": "m"},
+    )
+    (trace,) = spans_to_traces([synthetic], source="test")
+    attribution = trace.steps[0].attribution
+    assert attribution is not None and attribution.latency_ms is None
+
+    micros = synthetic.model_copy(
+        update={"start_nano": 1_753_000_000_000_000, "end_nano": 1_753_000_000_250_000}
+    )
+    (trace,) = spans_to_traces([micros], source="test")
+    attribution = trace.steps[0].attribution
+    assert attribution is not None
+    assert attribution.latency_ms == 250.0

--- a/wmh/ingest/otel_genai.py
+++ b/wmh/ingest/otel_genai.py
@@ -1,458 +1,44 @@
 """Official OpenTelemetry GenAI semantic-convention adapter.
 
-Maps `gen_ai.*` spans into our normalized schema:
-  - LLM / agent spans  -> Action (tool_call from `gen_ai.tool.*`, else message from `gen_ai.prompt`
-    / `gen_ai.completion`)
-  - tool / execution spans -> Observation (tool output attribute / span status)
-  - one trace_id worth of spans, ordered by start time -> one `Trace`
+This is the reference adapter and the harness's own persistence format (`wmh.ingest.otel_writer`
+emits it): OTLP-JSON spans following the `gen_ai.*` semantic conventions, mapped to normalized
+`Trace`s by the shared normalizer (`wmh.ingest.normalize`), which owns span classification,
+action/observation pairing, and the optional `wmh.*` enrichments (`wmh.state.*`,
+`wmh.trace.metadata`, `wmh.attribution`).
 
-This is the reference adapter; it also documents the generic shape other adapters target.
-
-Span classification follows the OTel GenAI semantic conventions (`gen_ai.operation.name`):
-  - LLM spans:  `chat`, `text_completion`, `invoke_agent`, `generate_content`
-  - tool spans: `execute_tool`
-When `gen_ai.operation.name` is absent we fall back to the conventional span-name prefix
-(`execute_tool ...`) and to attribute-presence heuristics.
-
-Action/Observation pairing: each LLM Action is paired with the next tool Observation in start-time
-order. An LLM message with no following tool span (e.g. the final answer) becomes a Step with an
-empty Observation; a tool span with no preceding LLM span becomes a self-contained tool_call Step
-from its own `gen_ai.tool.*` attributes.
-
-Supported file formats:
+Supported file formats (via `BaseTraceAdapter`):
   - OTLP-JSON: a single object with `resourceSpans` -> `scopeSpans` -> `spans`
   - JSON array of the above, or of bare span objects
   - JSONL: one OTLP-JSON object or one bare span object per line
 
-Optional `wmh.*` enrichments (a strict superset of the semconv — traces that omit them parse
-unchanged): an action span may carry `wmh.state.structured`/`wmh.state.scratchpad` (the env state
-BEFORE the action -> `Step.state_before`), and any span may carry `wmh.trace.metadata` (a JSON
-object -> `Trace.metadata`, e.g. the benchmark name + gold assertions a capture stamps on). These
-let a faithfully-captured benchmark trace feed open-loop replay, which scores the predicted
-observation for `(state_before, action)` against the recorded one.
+The vendor pull is a best-effort generic OTLP-JSON fetch: OTLP itself is push-only, so "pulling"
+traces is inherently vendor-specific (Grafana Tempo, Jaeger, Honeycomb, ... each expose their own
+query API and auth).
 """
 
 from __future__ import annotations
 
-import json
 import os
-from pathlib import Path
 
 import httpx
-from pydantic import BaseModel, Field, JsonValue
+from pydantic import JsonValue
 
-from wmh.core.types import Action, ActionKind, EnvState, JsonObject, Observation, Step, Trace
 from wmh.ingest.adapter import VendorPull, register_adapter
-
-# `gen_ai.operation.name` values, per the OTel GenAI semantic conventions.
-_LLM_OPS = frozenset({"chat", "text_completion", "invoke_agent", "generate_content"})
-_TOOL_OPS = frozenset({"execute_tool"})
-
-# Attribute keys carrying a tool call's serialized arguments, in priority order.
-_TOOL_ARG_KEYS = (
-    "gen_ai.tool.call.arguments",
-    "gen_ai.tool.arguments",
-    "gen_ai.tool.input",
-    "gen_ai.request.arguments",
-)
-# Attribute keys carrying a tool execution's output, in priority order.
-_TOOL_OUTPUT_KEYS = (
-    "gen_ai.tool.message",
-    "gen_ai.tool.output",
-    "gen_ai.tool.call.result",
-    "gen_ai.tool.result",
-    "gen_ai.completion",
-    "output",
-)
-
-# Optional `wmh.*` attributes that enrich a step beyond the bare OTel GenAI semconv. They are a
-# strict superset: traces that omit them (e.g. the committed `examples/*.otel.jsonl`) parse exactly
-# as before. We carry them on the LLM (action) span so a step's state is recorded with the action
-# the agent took against it, which is what open-loop replay feeds in.
-#   - `wmh.state.structured` : JSON snapshot of the env's machine-readable state BEFORE the action
-#   - `wmh.state.scratchpad` : free-text env state before the action
-# Trace-level metadata (benchmark name, gold assertions) rides on any span via `wmh.trace.metadata`
-# (a JSON object); the first span that carries it wins, so a capture can stamp it once.
-_STATE_STRUCTURED_KEY = "wmh.state.structured"
-_STATE_SCRATCHPAD_KEY = "wmh.state.scratchpad"
-_TRACE_METADATA_KEY = "wmh.trace.metadata"
+from wmh.ingest.base import BaseTraceAdapter
 
 # Env vars the (placeholder) vendor pull reads. The real query semantics are vendor-specific; see
-# the TODO in `from_vendor`.
+# the TODO in `_pull_payloads`.
 VENDOR_ENDPOINT_ENV = "WMH_OTLP_QUERY_ENDPOINT"
 VENDOR_API_KEY_ENV = "WMH_OTLP_API_KEY"
 
 
-class _ParsedSpan(BaseModel):
-    """A flattened OTLP span with its attributes already decoded to plain JSON values."""
+class OtelGenAIAdapter(BaseTraceAdapter):
+    """OTLP-JSON GenAI spans, file or generic OTLP query backend. Pure shared-normalizer."""
 
-    trace_id: str
-    span_id: str = ""
-    parent_span_id: str = ""
-    name: str = ""
-    start_nano: int = 0
-    end_nano: int = 0
-    attributes: JsonObject = Field(default_factory=dict)
-    status_error: bool = False
-
-
-# --- OTLP AnyValue / attribute decoding -------------------------------------------------------
-
-
-def _any_value(value: JsonValue) -> JsonValue:
-    """Decode an OTLP `AnyValue` (`{"stringValue": ...}` etc.) to a plain JSON value."""
-    if not isinstance(value, dict):
-        return value
-    if "stringValue" in value:
-        return value["stringValue"]
-    if "intValue" in value:
-        return _to_int(value["intValue"])
-    if "doubleValue" in value:
-        return value["doubleValue"]
-    if "boolValue" in value:
-        return value["boolValue"]
-    if "arrayValue" in value:
-        arr = value["arrayValue"]
-        values = arr.get("values") if isinstance(arr, dict) else None
-        return [_any_value(v) for v in values] if isinstance(values, list) else []
-    if "kvlistValue" in value:
-        kv = value["kvlistValue"]
-        values = kv.get("values") if isinstance(kv, dict) else None
-        return _attrs_to_dict(values) if isinstance(values, list) else {}
-    return value
-
-
-def _attrs_to_dict(attrs: JsonValue) -> JsonObject:
-    """Turn an OTLP attribute list (`[{"key": ..., "value": <AnyValue>}, ...]`) into a dict."""
-    out: JsonObject = {}
-    if not isinstance(attrs, list):
-        return out
-    for attr in attrs:
-        if isinstance(attr, dict):
-            key = attr.get("key")
-            if isinstance(key, str):
-                out[key] = _any_value(attr.get("value"))
-    return out
-
-
-def _to_int(value: JsonValue) -> int:
-    if isinstance(value, bool):  # bool is an int subclass; treat as non-numeric here.
-        return 0
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str):
-        try:
-            return int(value)
-        except ValueError:
-            return 0
-    return 0
-
-
-def _as_text(value: JsonValue) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    return json.dumps(value, ensure_ascii=False, sort_keys=True)
-
-
-def _as_str(value: JsonValue) -> str:
-    return value if isinstance(value, str) else ""
-
-
-# --- span collection --------------------------------------------------------------------------
-
-
-def _parse_span(raw: JsonValue) -> _ParsedSpan | None:
-    if not isinstance(raw, dict):
-        return None
-    trace_id = raw.get("traceId")
-    if not isinstance(trace_id, str) or not trace_id:
-        return None
-    status = raw.get("status")
-    status_error = False
-    if isinstance(status, dict):
-        code = status.get("code")
-        status_error = code in (2, "STATUS_CODE_ERROR")
-    return _ParsedSpan(
-        trace_id=trace_id,
-        span_id=_as_str(raw.get("spanId")),
-        parent_span_id=_as_str(raw.get("parentSpanId")),
-        name=_as_str(raw.get("name")),
-        start_nano=_to_int(raw.get("startTimeUnixNano")),
-        end_nano=_to_int(raw.get("endTimeUnixNano")),
-        attributes=_attrs_to_dict(raw.get("attributes")),
-        status_error=status_error,
-    )
-
-
-def _collect_spans(obj: JsonValue) -> list[_ParsedSpan]:
-    """Walk an OTLP-JSON payload, a list of payloads/spans, or a bare span into `_ParsedSpan`s."""
-    spans: list[_ParsedSpan] = []
-    if isinstance(obj, list):
-        for item in obj:
-            spans.extend(_collect_spans(item))
-        return spans
-    if not isinstance(obj, dict):
-        return spans
-    if "resourceSpans" in obj:
-        resource_spans = obj["resourceSpans"]
-        if isinstance(resource_spans, list):
-            for resource_span in resource_spans:
-                spans.extend(_spans_in_resource(resource_span))
-        return spans
-    parsed = _parse_span(obj)
-    if parsed is not None:
-        spans.append(parsed)
-    return spans
-
-
-def _spans_in_resource(resource_span: JsonValue) -> list[_ParsedSpan]:
-    spans: list[_ParsedSpan] = []
-    if not isinstance(resource_span, dict):
-        return spans
-    scope_spans = resource_span.get("scopeSpans")
-    if not isinstance(scope_spans, list):
-        return spans
-    for scope_span in scope_spans:
-        if not isinstance(scope_span, dict):
-            continue
-        raw_spans = scope_span.get("spans")
-        if not isinstance(raw_spans, list):
-            continue
-        for raw in raw_spans:
-            parsed = _parse_span(raw)
-            if parsed is not None:
-                spans.append(parsed)
-    return spans
-
-
-# --- classification + mapping -----------------------------------------------------------------
-
-
-def _operation(span: _ParsedSpan) -> str:
-    op = span.attributes.get("gen_ai.operation.name")
-    return op if isinstance(op, str) else ""
-
-
-def _is_tool_span(span: _ParsedSpan) -> bool:
-    op = _operation(span)
-    if op in _TOOL_OPS:
-        return True
-    if op in _LLM_OPS:
-        return False
-    return span.name.startswith("execute_tool")
-
-
-def _is_llm_span(span: _ParsedSpan) -> bool:
-    op = _operation(span)
-    if op in _LLM_OPS:
-        return True
-    if op in _TOOL_OPS:
-        return False
-    attrs = span.attributes
-    return any(
-        attrs.get(key) is not None
-        for key in ("gen_ai.request.model", "gen_ai.completion", "gen_ai.prompt")
-    )
-
-
-def _tool_args(attrs: JsonObject) -> JsonObject:
-    for key in _TOOL_ARG_KEYS:
-        raw = attrs.get(key)
-        if raw is None:
-            continue
-        if isinstance(raw, dict):
-            return raw
-        if isinstance(raw, str):
-            try:
-                parsed: JsonValue = json.loads(raw)
-            except json.JSONDecodeError:
-                return {"value": raw}
-            return parsed if isinstance(parsed, dict) else {"value": parsed}
-        return {"value": raw}
-    return {}
-
-
-def _action_from_llm_span(span: _ParsedSpan) -> Action:
-    attrs = span.attributes
-    tool_name = attrs.get("gen_ai.tool.name")
-    if isinstance(tool_name, str) and tool_name:
-        return Action(kind=ActionKind.TOOL_CALL, name=tool_name, arguments=_tool_args(attrs))
-    completion = attrs.get("gen_ai.completion")
-    content = attrs.get("gen_ai.prompt") if completion is None else completion
-    return Action(kind=ActionKind.MESSAGE, content=_as_text(content))
-
-
-def _tool_call_action_from_tool_span(span: _ParsedSpan) -> Action:
-    name = span.attributes.get("gen_ai.tool.name")
-    return Action(
-        kind=ActionKind.TOOL_CALL,
-        name=name if isinstance(name, str) and name else None,
-        arguments=_tool_args(span.attributes),
-    )
-
-
-def _observation_from_tool_span(span: _ParsedSpan) -> Observation:
-    content = ""
-    for key in _TOOL_OUTPUT_KEYS:
-        value = span.attributes.get(key)
-        if value is not None:
-            content = _as_text(value)
-            break
-    return Observation(content=content, is_error=span.status_error)
-
-
-def _trace_task(spans: list[_ParsedSpan]) -> str | None:
-    for span in spans:
-        prompt = span.attributes.get("gen_ai.prompt")
-        if prompt is not None:
-            return _as_text(prompt)
-    return None
-
-
-def _state_before(span: _ParsedSpan) -> EnvState:
-    """Read an optional `wmh.state.*` snapshot off an action span (empty when absent)."""
-    attrs = span.attributes
-    structured = attrs.get(_STATE_STRUCTURED_KEY)
-    if isinstance(structured, str):
-        try:
-            decoded: JsonValue = json.loads(structured)
-        except json.JSONDecodeError:
-            decoded = {}
-        structured = decoded
-    scratchpad = attrs.get(_STATE_SCRATCHPAD_KEY)
-    return EnvState(
-        structured=structured if isinstance(structured, dict) else {},
-        scratchpad=scratchpad if isinstance(scratchpad, str) else "",
-    )
-
-
-def _trace_metadata(spans: list[_ParsedSpan]) -> JsonObject:
-    """First `wmh.trace.metadata` object across a trace's spans (benchmark name, gold, ...)."""
-    for span in spans:
-        raw = span.attributes.get(_TRACE_METADATA_KEY)
-        if isinstance(raw, dict):
-            return raw
-        if isinstance(raw, str):
-            try:
-                decoded: JsonValue = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(decoded, dict):
-                return decoded
-    return {}
-
-
-def _build_steps(spans: list[_ParsedSpan]) -> list[Step]:
-    """Pair ordered Action spans with their following Observation spans into Steps.
-
-    The optional `wmh.state.*` snapshot recorded on an action span becomes that step's
-    `state_before`; absent it (the bare-semconv case) the step keeps the default empty `EnvState`.
-    """
-    task = _trace_task(spans)
-    steps: list[Step] = []
-    pending: Action | None = None
-    pending_ids: list[str] = []
-    pending_state = EnvState()
-
-    def flush(
-        action: Action, observation: Observation, span_ids: list[str], state: EnvState
-    ) -> None:
-        steps.append(
-            Step(
-                action=action,
-                observation=observation,
-                state_before=state,
-                task=task,
-                raw_span_ids=span_ids,
-            )
-        )
-
-    for span in spans:
-        if _is_tool_span(span):
-            observation = _observation_from_tool_span(span)
-            if pending is None:
-                action = _tool_call_action_from_tool_span(span)
-                flush(action, observation, [span.span_id], _state_before(span))
-            else:
-                # The LLM span usually carries the call's name/args; backfill from the tool span
-                # only when it didn't. Derive the tool-span action once to avoid re-parsing.
-                if pending.kind == ActionKind.TOOL_CALL and (
-                    not pending.arguments or pending.name is None
-                ):
-                    from_tool = _tool_call_action_from_tool_span(span)
-                    if not pending.arguments:
-                        pending.arguments = from_tool.arguments
-                    if pending.name is None:
-                        pending.name = from_tool.name
-                flush(pending, observation, [*pending_ids, span.span_id], pending_state)
-            pending, pending_ids, pending_state = None, [], EnvState()
-        elif _is_llm_span(span):
-            if pending is not None:
-                flush(pending, Observation(content=""), pending_ids, pending_state)
-            pending, pending_ids = _action_from_llm_span(span), [span.span_id]
-            pending_state = _state_before(span)
-        # Non-GenAI spans are ignored.
-
-    if pending is not None:
-        flush(pending, Observation(content=""), pending_ids, pending_state)
-    return steps
-
-
-def _spans_to_traces(spans: list[_ParsedSpan], source: str) -> list[Trace]:
-    by_trace: dict[str, list[_ParsedSpan]] = {}
-    for span in spans:
-        by_trace.setdefault(span.trace_id, []).append(span)
-    # Build each trace from its start-ordered spans, then order traces by their earliest span.
-    # Sorting each group by (start_nano, span_id) leaves group[0] as that trace's earliest span,
-    # so we reuse it as the inter-trace sort key rather than re-scanning.
-    ordered: list[tuple[int, Trace]] = []
-    for group in by_trace.values():
-        group.sort(key=lambda s: (s.start_nano, s.span_id))
-        trace = Trace(
-            trace_id=group[0].trace_id,
-            steps=_build_steps(group),
-            source=source,
-            metadata=_trace_metadata(group),
-        )
-        ordered.append((group[0].start_nano, trace))
-    ordered.sort(key=lambda pair: pair[0])
-    return [trace for _, trace in ordered]
-
-
-class OtelGenAIAdapter:
     name = "otel-genai"
 
-    def from_file(self, path: str) -> list[Trace]:
-        text = Path(path).read_text(encoding="utf-8")
-        spans: list[_ParsedSpan] = []
-        try:
-            payload: JsonValue = json.loads(text)
-        except json.JSONDecodeError:
-            # Not a single JSON document; treat as JSONL (one object/span per line). A single
-            # corrupt line (truncated by a crashed exporter, say) is skipped rather than aborting
-            # the whole ingest and losing every valid trace.
-            for line in text.splitlines():
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    spans.extend(_collect_spans(json.loads(stripped)))
-                except json.JSONDecodeError:
-                    continue
-        else:
-            spans = _collect_spans(payload)
-        return _spans_to_traces(spans, source=f"file:{path}")
-
-    def from_vendor(self, pull: VendorPull) -> list[Trace]:
-        """Pull OTLP-JSON spans from an OTLP-compatible query backend.
-
-        OTLP itself is push-only, so "pulling" traces is inherently vendor-specific (Grafana Tempo,
-        Jaeger, Honeycomb, ... each expose their own query API and auth). This implementation does a
-        best-effort generic OTLP-JSON fetch and reuses the same span->Step mapping as `from_file`.
+    def _pull_payloads(self, pull: VendorPull) -> list[JsonValue]:
+        """Fetch OTLP-JSON from an OTLP-compatible query backend.
 
         TODO: implement the vendor-specific query protocol and auth. Today we:
           - read the query URL from ``$WMH_OTLP_QUERY_ENDPOINT``;
@@ -477,13 +63,7 @@ class OtelGenAIAdapter:
             params["limit"] = str(pull.limit)
         response = httpx.get(endpoint, headers=headers, params=params, timeout=30.0)
         response.raise_for_status()
-        spans = _collect_spans(response.json())
-        traces = _spans_to_traces(spans, source=f"vendor:{pull.project or endpoint}")
-        # The `limit` query param is a placeholder a real backend may ignore; enforce it locally
-        # so the `VendorPull.limit` contract holds regardless of what the backend honors.
-        if pull.limit is not None:
-            traces = traces[: pull.limit]
-        return traces
+        return [response.json()]
 
 
 register_adapter(OtelGenAIAdapter())

--- a/wmh/ingest/otel_genai_test.py
+++ b/wmh/ingest/otel_genai_test.py
@@ -42,8 +42,12 @@ def test_from_file_parses_otlp_json_into_one_trace() -> None:
     assert call_step.observation.is_error is False
     # The originating prompt is carried onto every step's `task`.
     assert call_step.task == "What is the weather in Paris?"
-    # Both the LLM span and the tool span are recorded as provenance.
-    assert call_step.raw_span_ids == ["b7ad6b7169203331", "c8be7c8270314442"]
+    # Both the LLM span and the tool span are recorded as provenance. `BaseTraceAdapter` stamps a
+    # global emission-order prefix for cross-payload uniqueness, so match on the source-id suffix.
+    assert [sid.split("-", 1)[1] for sid in call_step.raw_span_ids] == [
+        "b7ad6b7169203331",
+        "c8be7c8270314442",
+    ]
 
     final_step = trace.steps[1]
     assert final_step.action.kind == ActionKind.MESSAGE

--- a/wmh/ingest/otel_writer.py
+++ b/wmh/ingest/otel_writer.py
@@ -41,6 +41,8 @@ def _action_attrs(
         attrs.append(_attr("wmh.state.structured", json.dumps(step.state_before.structured)))
     if step.state_before.scratchpad:
         attrs.append(_attr("wmh.state.scratchpad", step.state_before.scratchpad))
+    if step.attribution is not None:
+        attrs.append(_attr("wmh.attribution", step.attribution.model_dump_json(exclude_none=True)))
     return attrs
 
 

--- a/wmh/ingest/otel_writer_test.py
+++ b/wmh/ingest/otel_writer_test.py
@@ -93,6 +93,7 @@ def test_roundtrip_preserves_attribution(tmp_path: Path) -> None:
                 attribution=StepAttribution(
                     model="claude-haiku-4-5",
                     provider="anthropic",
+                    config={"temperature": 0.2, "max_tokens": 512},
                     input_tokens=10,
                     output_tokens=2,
                     latency_ms=99.5,

--- a/wmh/ingest/otel_writer_test.py
+++ b/wmh/ingest/otel_writer_test.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from wmh.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+from wmh.core.types import (
+    Action,
+    ActionKind,
+    EnvState,
+    ErrorClass,
+    Observation,
+    Step,
+    StepAttribution,
+    Trace,
+)
 from wmh.ingest.otel_genai import OtelGenAIAdapter
 from wmh.ingest.otel_writer import trace_to_spans, write_traces_jsonl
 
@@ -70,3 +79,31 @@ def test_roundtrip_preserves_steps_state_and_metadata(tmp_path: Path) -> None:
 def test_writer_is_deterministic() -> None:
     # No wall-clock: the same trace serializes byte-identically across calls.
     assert trace_to_spans(_trace()) == trace_to_spans(_trace())
+
+
+def test_roundtrip_preserves_attribution(tmp_path: Path) -> None:
+    """`Trace -> file -> Trace` keeps per-step attribution (the policy-training fields)."""
+    trace = Trace(
+        trace_id="c" * 32,
+        source="test",
+        steps=[
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="t", arguments={"a": 1}),
+                observation=Observation(content="ok"),
+                attribution=StepAttribution(
+                    model="claude-haiku-4-5",
+                    provider="anthropic",
+                    input_tokens=10,
+                    output_tokens=2,
+                    latency_ms=99.5,
+                    cost_usd=0.001,
+                    error_class=ErrorClass.ENVIRONMENTAL,
+                    provenance="unit-test",
+                ),
+            )
+        ],
+    )
+    path = tmp_path / "attr.otel.jsonl"
+    write_traces_jsonl([trace], path)
+    (back,) = OtelGenAIAdapter().from_file(str(path))
+    assert back.steps[0].attribution == trace.steps[0].attribution

--- a/wmh/ingest/phoenix.py
+++ b/wmh/ingest/phoenix.py
@@ -42,7 +42,7 @@ normalizer if present in a span's attributes.
 Live pull: Phoenix's query API/SDK is left as the `BaseTraceAdapter` default (a friendly
 "export to a file" error). Phoenix's recommended export path is a file (or a pandas dataframe dumped
 to JSON), and the SDK surface is version-dependent; we prefer correctness over a guessed endpoint.
-Export from Phoenix to a file and use `from_file` / `wmh ingest run --source phoenix --file ...`.
+Export from Phoenix to a file and use `from_file` / `wmh ingest --source phoenix --file <export>`.
 """
 
 from __future__ import annotations

--- a/wmh/ingest/phoenix_test.py
+++ b/wmh/ingest/phoenix_test.py
@@ -188,7 +188,7 @@ def test_dataframe_records_flat_columns_indexed_tool_calls() -> None:
     ]
 
     adapter = PhoenixAdapter()
-    traces = spans_to_traces(adapter._collect_all([records]), source="phoenix:df")
+    traces = spans_to_traces(adapter.collect_all([records]), source="phoenix:df")
 
     assert len(traces) == 1
     assert traces[0].trace_id == "d" * 32

--- a/wmh/ingest/postgres.py
+++ b/wmh/ingest/postgres.py
@@ -1,0 +1,241 @@
+"""Postgres trace source: rows in a table -> normalized `Trace`s. Transport only, no new schema.
+
+Teams that don't run an observability vendor usually have agent runs in Postgres already, in one
+of three shapes this adapter reads directly:
+
+  1. **Row per step/span** — a `trace_id` column plus a JSON `payload` column holding one span or
+     event in any shape the file adapters accept (OTLP span, Langfuse observation, PostHog event,
+     ...). Rows sharing a `trace_id` become one episode.
+  2. **Row per message** — a session/thread table where each row's payload is one chat message
+     (`{"role": ..., ...}`). Rows are assembled per `trace_id` into one conversation and read by
+     the `chat-json` converter.
+  3. **Row per trace** — each row's payload is a self-contained session (a `{"messages": [...]}`
+     blob, a Langfuse trace object, an OTLP envelope, ...). No `trace_id` column needed.
+
+The payload column's *format* is auto-detected with the same detector files use
+(`wmh.ingest.detect`), so Postgres stays pure transport and schema knowledge lives in the existing
+adapters. Default columns: `trace_id` (used when present), `payload` (required), `created_at`
+(ordering, when present) — all overridable via `VendorPull.trace_id_column` /
+`payload_column` / `order_column`. When the table has a `trace_id` column its value overrides any
+trace id inside the payload, so episode boundaries always follow the table.
+
+The driver (`psycopg`) is an optional extra (`world-model-harness[postgres]`), imported lazily
+inside the pull path like the vendor SDKs. Driver failures are re-raised as stdlib
+`PermissionError` (bad credentials) / `ConnectionError` (unreachable), so callers — the streaming
+ingest's error classifier in particular — never need psycopg imported.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+from pydantic import JsonValue
+
+from wmh.core.types import Trace
+from wmh.ingest.adapter import VendorPull, get_adapter, register_adapter
+from wmh.ingest.base import BaseTraceAdapter
+from wmh.ingest.detect import detect_format
+from wmh.ingest.normalize import SpanRecord
+
+DSN_ENV = "WMH_POSTGRES_DSN"
+
+# A table is `name` or `schema.name`; a column is one identifier. Validated (not escaped) because
+# identifiers can't be bound as query parameters and an interpolated name must not smuggle SQL.
+_IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
+_TABLE_RE = re.compile(rf"^{_IDENTIFIER}(\.{_IDENTIFIER})?$")
+_COLUMN_RE = re.compile(rf"^{_IDENTIFIER}$")
+
+_DEFAULT_TRACE_ID_COLUMN = "trace_id"
+_DEFAULT_PAYLOAD_COLUMN = "payload"
+_DEFAULT_ORDER_COLUMN = "created_at"
+
+
+def _validate_table(table: str) -> str:
+    if not table or not _TABLE_RE.match(table):
+        raise ValueError(
+            f"invalid postgres table name {table!r}: pass --table as <table> or <schema>.<table> "
+            "(letters, digits, underscores)"
+        )
+    return table
+
+
+def _validate_column(column: str, *, flag: str) -> str:
+    if not _COLUMN_RE.match(column):
+        raise ValueError(f"invalid postgres column name {column!r} for {flag}")
+    return column
+
+
+def _is_message(payload: JsonValue) -> bool:
+    return isinstance(payload, dict) and isinstance(payload.get("role"), str)
+
+
+class PostgresAdapter(BaseTraceAdapter):
+    """Read trace rows from a Postgres table; payload format shared with the file adapters."""
+
+    name = "postgres"
+
+    def from_file(self, path: str) -> list[Trace]:
+        raise ValueError(
+            "the postgres source reads a live database, not a file: pass --dsn/--table "
+            "(export the rows to JSON/JSONL and auto-detect if you prefer a file)"
+        )
+
+    def spans_from_pull(self, pull: VendorPull) -> list[SpanRecord]:
+        rows = self._fetch_rows(pull)
+        payloads = [payload for _, payload in rows]
+        if not payloads:
+            return []
+        if all(_is_message(p) for p in payloads):
+            rows = self._assemble_conversations(rows)
+            inner: BaseTraceAdapter = self._inner_adapter("chat-json")
+        else:
+            inner = self._inner_adapter(detect_format(payloads))
+        # Same global uniqueness re-stamp as `collect_all`, plus the table's trace-id override:
+        # a row's `trace_id` column value defines the episode boundary regardless of any id the
+        # payload itself carries.
+        spans: list[SpanRecord] = []
+        for trace_id, payload in rows:
+            for span in inner.spans_from_payload(payload):
+                if trace_id is not None:
+                    span.trace_id = trace_id
+                span.span_id = f"{len(spans):012d}-{span.span_id}"
+                spans.append(span)
+        return spans
+
+    @staticmethod
+    def _inner_adapter(fmt: str) -> BaseTraceAdapter:
+        adapter = get_adapter(fmt)
+        if not isinstance(adapter, BaseTraceAdapter):
+            raise ValueError(f"postgres rows detected as {fmt!r}, which cannot read row payloads")
+        return adapter
+
+    @staticmethod
+    def _assemble_conversations(
+        rows: list[tuple[str | None, JsonValue]],
+    ) -> list[tuple[str | None, JsonValue]]:
+        """Group message-per-row payloads into one `{"messages": [...]}` payload per trace id."""
+        by_trace: dict[str, list[JsonValue]] = {}
+        for trace_id, payload in rows:
+            if trace_id is None:
+                raise ValueError(
+                    "rows look like individual chat messages, which need a trace-id column to "
+                    "group them into sessions; pass --trace-id-column (or store one session per "
+                    "row as a {'messages': [...]} blob)"
+                )
+            by_trace.setdefault(trace_id, []).append(payload)
+        return [
+            (trace_id, {"trace_id": trace_id, "messages": messages})
+            for trace_id, messages in by_trace.items()
+        ]
+
+    def _fetch_rows(self, pull: VendorPull) -> list[tuple[str | None, JsonValue]]:
+        """`(trace_id, decoded payload)` per row, in `order_column` order when the table has one.
+
+        Overridable seam: tests swap it for canned rows; everything above it is driver-free.
+        """
+        if pull.table is None:
+            raise ValueError("the postgres source needs --table <table-with-trace-rows>")
+        table = _validate_table(pull.table)
+        dsn = pull.dsn or os.environ.get(DSN_ENV)
+        if not dsn:
+            raise ValueError(
+                f"the postgres source needs a connection string: pass --dsn or set ${DSN_ENV}"
+            )
+        try:
+            import psycopg
+        except ModuleNotFoundError as exc:
+            raise ValueError(
+                "the postgres source needs the psycopg driver: "
+                "pip install 'world-model-harness[postgres]'"
+            ) from exc
+        from psycopg import sql
+
+        table_ident = sql.Identifier(*table.split("."))
+        try:
+            with psycopg.connect(dsn, connect_timeout=10) as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(sql.SQL("SELECT * FROM {} LIMIT 0").format(table_ident))
+                except psycopg.errors.UndefinedTable as exc:
+                    raise ValueError(
+                        f"postgres table {table!r} does not exist; check --table "
+                        "(schema-qualify it if needed, e.g. public.agent_traces)"
+                    ) from exc
+                description = cur.description or []
+                columns = [column.name for column in description]
+                payload_column, trace_id_column, order_column = self._resolve_columns(
+                    pull, table, columns
+                )
+                selected: sql.Composable = (
+                    sql.Identifier(trace_id_column) if trace_id_column else sql.SQL("NULL")
+                )
+                query = sql.SQL("SELECT {}, {} FROM {}").format(
+                    selected, sql.Identifier(payload_column), table_ident
+                )
+                params: tuple[str, ...] = ()
+                if pull.since is not None and order_column is not None:
+                    query += sql.SQL(" WHERE {} >= %s").format(sql.Identifier(order_column))
+                    params = (pull.since,)
+                if order_column is not None:
+                    query += sql.SQL(" ORDER BY {}").format(sql.Identifier(order_column))
+                cur.execute(query, params)
+                fetched = cur.fetchall()
+                has_trace_id = trace_id_column is not None
+        except psycopg.OperationalError as exc:
+            message = str(exc).strip()
+            if "authentication" in message or "password" in message:
+                raise PermissionError(f"postgres authentication failed: {message}") from exc
+            raise ConnectionError(f"could not connect to postgres: {message}") from exc
+        rows: list[tuple[str | None, JsonValue]] = []
+        for fetched_row in fetched:
+            trace_id = str(fetched_row[0]) if has_trace_id and fetched_row[0] is not None else None
+            payload: JsonValue = fetched_row[1]
+            if isinstance(payload, (str, bytes, bytearray)):
+                try:
+                    payload = json.loads(payload)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue  # tolerate a corrupt row; keep the rest (same as corrupt JSONL lines)
+            rows.append((trace_id, payload))
+        return rows
+
+    @staticmethod
+    def _resolve_columns(
+        pull: VendorPull, table: str, columns: list[str]
+    ) -> tuple[str, str | None, str | None]:
+        """Resolve `(payload, trace_id, order)` column names against the table's real columns.
+
+        The payload column is required (explicit or the `payload` default); trace-id and order
+        columns participate only when explicitly given or present under their default names.
+        """
+        payload_column = _validate_column(
+            pull.payload_column or _DEFAULT_PAYLOAD_COLUMN, flag="--payload-column"
+        )
+        if payload_column not in columns:
+            raise ValueError(
+                f"table {table} has no {payload_column!r} column (columns: {columns}); "
+                "pass --payload-column <json-column>"
+            )
+        trace_id_column: str | None
+        if pull.trace_id_column is not None:
+            trace_id_column = _validate_column(pull.trace_id_column, flag="--trace-id-column")
+            if trace_id_column not in columns:
+                raise ValueError(
+                    f"table {table} has no {trace_id_column!r} column (columns: {columns})"
+                )
+        else:
+            present = _DEFAULT_TRACE_ID_COLUMN in columns
+            trace_id_column = _DEFAULT_TRACE_ID_COLUMN if present else None
+        order_column: str | None
+        if pull.order_column is not None:
+            order_column = _validate_column(pull.order_column, flag="--order-column")
+            if order_column not in columns:
+                raise ValueError(
+                    f"table {table} has no {order_column!r} column (columns: {columns})"
+                )
+        else:
+            order_column = _DEFAULT_ORDER_COLUMN if _DEFAULT_ORDER_COLUMN in columns else None
+        return payload_column, trace_id_column, order_column
+
+
+register_adapter(PostgresAdapter())

--- a/wmh/ingest/postgres.py
+++ b/wmh/ingest/postgres.py
@@ -34,7 +34,12 @@ import re
 from pydantic import JsonValue
 
 from wmh.core.types import Trace
-from wmh.ingest.adapter import VendorPull, get_adapter, register_adapter
+from wmh.ingest.adapter import (
+    SourceCredentialError,
+    VendorPull,
+    get_adapter,
+    register_adapter,
+)
 from wmh.ingest.base import BaseTraceAdapter
 from wmh.ingest.detect import detect_format
 from wmh.ingest.normalize import SpanRecord
@@ -185,7 +190,7 @@ class PostgresAdapter(BaseTraceAdapter):
         except psycopg.OperationalError as exc:
             message = str(exc).strip()
             if "authentication" in message or "password" in message:
-                raise PermissionError(f"postgres authentication failed: {message}") from exc
+                raise SourceCredentialError(f"postgres authentication failed: {message}") from exc
             raise ConnectionError(f"could not connect to postgres: {message}") from exc
         rows: list[tuple[str | None, JsonValue]] = []
         for fetched_row in fetched:

--- a/wmh/ingest/postgres.py
+++ b/wmh/ingest/postgres.py
@@ -3,26 +3,26 @@
 Teams that don't run an observability vendor usually have agent runs in Postgres already, in one
 of three shapes this adapter reads directly:
 
-  1. **Row per step/span** — a `trace_id` column plus a JSON `payload` column holding one span or
+  1. **Row per step/span**: a `trace_id` column plus a JSON `payload` column holding one span or
      event in any shape the file adapters accept (OTLP span, Langfuse observation, PostHog event,
      ...). Rows sharing a `trace_id` become one episode.
-  2. **Row per message** — a session/thread table where each row's payload is one chat message
+  2. **Row per message**: a session/thread table where each row's payload is one chat message
      (`{"role": ..., ...}`). Rows are assembled per `trace_id` into one conversation and read by
      the `chat-json` converter.
-  3. **Row per trace** — each row's payload is a self-contained session (a `{"messages": [...]}`
+  3. **Row per trace**: each row's payload is a self-contained session (a `{"messages": [...]}`
      blob, a Langfuse trace object, an OTLP envelope, ...). No `trace_id` column needed.
 
 The payload column's *format* is auto-detected with the same detector files use
 (`wmh.ingest.detect`), so Postgres stays pure transport and schema knowledge lives in the existing
 adapters. Default columns: `trace_id` (used when present), `payload` (required), `created_at`
-(ordering, when present) — all overridable via `VendorPull.trace_id_column` /
+(ordering, when present): all overridable via `VendorPull.trace_id_column` /
 `payload_column` / `order_column`. When the table has a `trace_id` column its value overrides any
 trace id inside the payload, so episode boundaries always follow the table.
 
 The driver (`psycopg`) is an optional extra (`world-model-harness[postgres]`), imported lazily
 inside the pull path like the vendor SDKs. Driver failures are re-raised as stdlib
-`PermissionError` (bad credentials) / `ConnectionError` (unreachable), so callers — the streaming
-ingest's error classifier in particular — never need psycopg imported.
+`PermissionError` (bad credentials) / `ConnectionError` (unreachable), so callers: the streaming
+ingest's error classifier in particular: never need psycopg imported.
 """
 
 from __future__ import annotations

--- a/wmh/ingest/postgres_test.py
+++ b/wmh/ingest/postgres_test.py
@@ -1,0 +1,151 @@
+"""Tests for the Postgres trace source (fake row source; never a live database)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import JsonValue
+
+from wmh.ingest.adapter import VendorPull, get_adapter
+from wmh.ingest.postgres import PostgresAdapter, _validate_table
+
+_OTLP_SPAN_ROWS: list[tuple[str | None, JsonValue]] = [
+    (
+        "sess-1",
+        {
+            "traceId": "ignored",
+            "spanId": "a1",
+            "startTimeUnixNano": 1,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.tool.name", "value": {"stringValue": "get_user"}},
+                {"key": "gen_ai.tool.call.arguments", "value": {"stringValue": '{"id": "u1"}'}},
+            ],
+        },
+    ),
+    (
+        "sess-1",
+        {
+            "traceId": "ignored",
+            "spanId": "a2",
+            "startTimeUnixNano": 2,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                {"key": "gen_ai.tool.message", "value": {"stringValue": "found u1"}},
+            ],
+        },
+    ),
+    (
+        "sess-2",
+        {
+            "traceId": "ignored",
+            "spanId": "b1",
+            "startTimeUnixNano": 1,
+            "attributes": [
+                {"key": "gen_ai.operation.name", "value": {"stringValue": "chat"}},
+                {"key": "gen_ai.completion", "value": {"stringValue": "all done"}},
+            ],
+        },
+    ),
+]
+
+_MESSAGE_ROWS: list[tuple[str | None, JsonValue]] = [
+    ("chat-9", {"role": "user", "content": "what's the weather?"}),
+    (
+        "chat-9",
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "wx", "arguments": "{}"}}],
+        },
+    ),
+    ("chat-9", {"role": "tool", "tool_call_id": "c1", "content": "sunny"}),
+    ("chat-9", {"role": "assistant", "content": "It's sunny."}),
+]
+
+_CONVERSATION_BLOB_ROWS: list[tuple[str | None, JsonValue]] = [
+    (
+        None,
+        {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        },
+    ),
+    (
+        None,
+        {
+            "messages": [
+                {"role": "user", "content": "bye"},
+                {"role": "assistant", "content": "later"},
+            ]
+        },
+    ),
+]
+
+
+class _FakeRows(PostgresAdapter):
+    """A PostgresAdapter with the database swapped for canned rows."""
+
+    def __init__(self, rows: list[tuple[str | None, JsonValue]]) -> None:
+        self._rows = rows
+
+    def _fetch_rows(self, pull: VendorPull) -> list[tuple[str | None, JsonValue]]:
+        return self._rows
+
+
+def test_postgres_adapter_is_registered() -> None:
+    assert isinstance(get_adapter("postgres"), PostgresAdapter)
+
+
+def test_row_per_step_groups_by_trace_id_column() -> None:
+    """Span-shaped payload rows group by the table's trace-id column, not the payload's own id."""
+    traces = _FakeRows(_OTLP_SPAN_ROWS).from_vendor(VendorPull(table="t"))
+    assert [t.trace_id for t in traces] == ["sess-1", "sess-2"]
+    step = traces[0].steps[0]
+    assert step.action.name == "get_user"
+    assert step.observation.content == "found u1"
+    assert traces[1].steps[0].action.content == "all done"
+
+
+def test_message_per_row_assembles_conversations() -> None:
+    """Rows that are individual chat messages (a session/thread table) become one episode."""
+    (trace,) = _FakeRows(_MESSAGE_ROWS).from_vendor(VendorPull(table="t"))
+    assert trace.trace_id == "chat-9"
+    assert len(trace.steps) == 2  # the tool-call step + the final assistant message
+    assert trace.steps[0].action.name == "wx"
+    assert trace.steps[0].observation.content == "sunny"
+    assert trace.steps[0].task == "what's the weather?"
+
+
+def test_row_per_trace_blobs_need_no_trace_id_column() -> None:
+    """Self-contained conversation blobs (one session per row) each become their own trace."""
+    traces = _FakeRows(_CONVERSATION_BLOB_ROWS).from_vendor(VendorPull(table="t"))
+    assert len(traces) == 2
+    assert all(len(t.steps) == 1 for t in traces)
+
+
+def test_message_rows_without_trace_id_column_error() -> None:
+    rows = [(None, payload) for _, payload in _MESSAGE_ROWS]
+    with pytest.raises(ValueError, match="trace"):
+        _FakeRows(rows).from_vendor(VendorPull(table="t"))
+
+
+def test_unrecognizable_payloads_error_with_source_guidance() -> None:
+    with pytest.raises(ValueError, match="auto-detect"):
+        _FakeRows([("t1", {"nothing": "known"})]).from_vendor(VendorPull(table="t"))
+
+
+def test_from_file_is_a_friendly_error() -> None:
+    with pytest.raises(ValueError, match="database"):
+        PostgresAdapter().from_file("whatever.json")
+
+
+def test_pull_requires_table() -> None:
+    with pytest.raises(ValueError, match="table"):
+        PostgresAdapter().from_vendor(VendorPull())
+
+
+def test_table_identifiers_are_validated() -> None:
+    assert _validate_table("public.agent_traces") == "public.agent_traces"
+    with pytest.raises(ValueError, match="table"):
+        _validate_table("traces; drop table users")

--- a/wmh/ingest/stream.py
+++ b/wmh/ingest/stream.py
@@ -1,0 +1,203 @@
+"""Streaming ingest: normalize any source to OTel JSONL while emitting progress events.
+
+This is the library seam behind `wmh ingest` and the platform's SSE trace-ingest endpoint. The
+event vocabulary is pinned by the D-INGEST contract (mirrored in the platform frontend's
+`parseTraceIngestEvent`): exactly one `detected {format, traces}`, then repeated
+`progress {normalized, total|null, note?}`, then a terminal `done {traces, steps, otel_object}` —
+or a terminal `error {message, code?}` at any point. `event_json` serializes an event to exactly
+those keys (optional fields dropped when unset, `total` kept even when null).
+
+The pipeline: load payloads (file) or pull them (vendor/database source) -> auto-detect the format
+unless pinned -> collect spans through the chosen adapter -> group into traces (the `detected`
+count) -> normalize group-by-group (the `progress` ticks) -> persist as OTel-GenAI span JSONL via
+`wmh.ingest.otel_writer` (`done.otel_object` is that path, readable by `--source otel-genai` and
+every downstream `wmh` command).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel
+
+from wmh.core.types import JsonObject, Trace
+from wmh.ingest.adapter import VendorPull, get_adapter
+from wmh.ingest.base import BaseTraceAdapter, load_payloads
+from wmh.ingest.detect import detect_format
+from wmh.ingest.normalize import SpanRecord, group_spans, trace_from_group
+from wmh.ingest.otel_writer import write_traces_jsonl
+
+
+class DetectedEvent(BaseModel):
+    """The source format has been identified and the trace count is known."""
+
+    type: Literal["detected"] = "detected"
+    format: str
+    traces: int
+
+
+class ProgressEvent(BaseModel):
+    """`normalized` of `total` traces done (`total` null for open-ended sources)."""
+
+    type: Literal["progress"] = "progress"
+    normalized: int
+    total: int | None
+    note: str | None = None
+
+
+class DoneEvent(BaseModel):
+    """Terminal success: corpus persisted at `otel_object` (a path/storage key)."""
+
+    type: Literal["done"] = "done"
+    traces: int
+    steps: int
+    otel_object: str
+
+
+class ErrorCode(StrEnum):
+    """Machine-readable failure class, so a UI can distinguish bad keys from a dead backend."""
+
+    BAD_CREDENTIALS = "bad_credentials"
+    UNREACHABLE = "unreachable"
+    BAD_FORMAT = "bad_format"
+    EMPTY = "empty"
+    INTERNAL = "internal"
+
+
+class ErrorEvent(BaseModel):
+    """Terminal failure."""
+
+    type: Literal["error"] = "error"
+    message: str
+    code: ErrorCode | None = None
+
+
+IngestEvent = DetectedEvent | ProgressEvent | DoneEvent | ErrorEvent
+
+
+def event_json(event: IngestEvent) -> JsonObject:
+    """Serialize one event to exactly the D-INGEST wire keys.
+
+    Optional fields (`note`, `code`) are dropped when unset, but `progress.total` stays present
+    as null — the pinned frontend parser requires `total` to be a number or null, not absent.
+    """
+    dump = event.model_dump(mode="json", exclude_none=True)
+    if isinstance(event, ProgressEvent) and "total" not in dump:
+        dump["total"] = None
+    return dump
+
+
+# Cap on progress events per ingest: enough for a smooth bar, no event flood on huge corpora.
+_MAX_PROGRESS_EVENTS = 100
+
+
+class _IngestFailure(Exception):
+    """Internal: a classified failure to surface as a terminal `error` event."""
+
+    def __init__(self, code: ErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _classify(exc: Exception) -> _IngestFailure:
+    if isinstance(exc, _IngestFailure):
+        return exc
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code in (401, 403):
+            return _IngestFailure(
+                ErrorCode.BAD_CREDENTIALS,
+                f"the source rejected the credentials ({exc.response.status_code}): {exc}",
+            )
+        return _IngestFailure(ErrorCode.UNREACHABLE, f"the source returned an error: {exc}")
+    if isinstance(exc, httpx.TransportError):
+        return _IngestFailure(ErrorCode.UNREACHABLE, f"could not reach the source: {exc}")
+    # The postgres adapter re-raises driver failures as stdlib exceptions so no psycopg import is
+    # needed here; order matters, both are OSError subclasses.
+    if isinstance(exc, PermissionError):
+        return _IngestFailure(ErrorCode.BAD_CREDENTIALS, str(exc))
+    if isinstance(exc, ConnectionError):
+        return _IngestFailure(ErrorCode.UNREACHABLE, str(exc))
+    if isinstance(exc, (ValueError, OSError)):
+        return _IngestFailure(ErrorCode.BAD_FORMAT, str(exc))
+    return _IngestFailure(ErrorCode.INTERNAL, f"{type(exc).__name__}: {exc}")
+
+
+def _collect_spans(
+    file: str | None, pull: VendorPull | None, source: str | None
+) -> tuple[str, list[SpanRecord]]:
+    """Resolve the adapter (detecting the format when unpinned) and collect all spans."""
+    if file is not None:
+        payloads = load_payloads(Path(file).read_text(encoding="utf-8"))
+        fmt = source or detect_format(payloads)
+        adapter = get_adapter(fmt)
+        if not isinstance(adapter, BaseTraceAdapter):
+            raise _IngestFailure(
+                ErrorCode.INTERNAL, f"adapter {fmt!r} does not support streaming ingest"
+            )
+        return fmt, adapter.collect_all(payloads)
+    if pull is not None:
+        if source is None:
+            raise _IngestFailure(
+                ErrorCode.BAD_FORMAT, "a vendor/database pull needs an explicit source name"
+            )
+        adapter = get_adapter(source)
+        if not isinstance(adapter, BaseTraceAdapter):
+            raise _IngestFailure(
+                ErrorCode.INTERNAL, f"adapter {source!r} does not support streaming ingest"
+            )
+        return source, adapter.spans_from_pull(pull)
+    raise _IngestFailure(ErrorCode.BAD_FORMAT, "ingest needs either a file path or a pull")
+
+
+def ingest_events(
+    *,
+    file: str | None = None,
+    pull: VendorPull | None = None,
+    source: str | None = None,
+    out: Path,
+) -> Iterator[IngestEvent]:
+    """Normalize one source into OTel JSONL at `out`, yielding D-INGEST progress events.
+
+    Exactly one of `file`/`pull` selects the transport. `source` pins the adapter; when omitted
+    (file transport only) the format is auto-detected. The generator never raises: every failure
+    becomes a terminal `ErrorEvent`, so a consumer can pipe events straight onto a wire.
+    """
+    try:
+        fmt, spans = _collect_spans(file, pull, source)
+        groups = group_spans(spans)
+        if pull is not None and pull.limit is not None:
+            groups = groups[: pull.limit]
+        if not groups:
+            raise _IngestFailure(
+                ErrorCode.EMPTY,
+                "the source contained no usable traces (nothing normalized); check that the "
+                "export carries agent steps, not just container/metric events",
+            )
+        yield DetectedEvent(format=fmt, traces=len(groups))
+
+        pulled_from = pull.project if pull is not None and pull.project else "vendor"
+        label = f"{fmt}:{file}" if file is not None else f"{fmt}:{pulled_from}"
+        every = max(1, len(groups) // _MAX_PROGRESS_EVENTS)
+        traces: list[Trace] = []
+        for i, group in enumerate(groups, start=1):
+            traces.append(trace_from_group(group, source=label))
+            if i % every == 0 or i == len(groups):
+                yield ProgressEvent(normalized=i, total=len(groups))
+
+        out.parent.mkdir(parents=True, exist_ok=True)
+        n_spans = write_traces_jsonl(traces, out)
+        yield ProgressEvent(
+            normalized=len(traces), total=len(groups), note=f"wrote {n_spans} spans"
+        )
+        yield DoneEvent(
+            traces=len(traces),
+            steps=sum(len(t.steps) for t in traces),
+            otel_object=str(out),
+        )
+    except Exception as exc:  # noqa: BLE001 — the wire contract IS "never raise, emit error"
+        failure = _classify(exc)
+        yield ErrorEvent(message=str(failure), code=failure.code)

--- a/wmh/ingest/stream.py
+++ b/wmh/ingest/stream.py
@@ -198,6 +198,6 @@ def ingest_events(
             steps=sum(len(t.steps) for t in traces),
             otel_object=str(out),
         )
-    except Exception as exc:  # noqa: BLE001: the wire contract IS "never raise, emit error"
+    except Exception as exc:  # noqa: BLE001 - the wire contract IS "never raise, emit error"
         failure = _classify(exc)
         yield ErrorEvent(message=str(failure), code=failure.code)

--- a/wmh/ingest/stream.py
+++ b/wmh/ingest/stream.py
@@ -25,7 +25,7 @@ import httpx
 from pydantic import BaseModel
 
 from wmh.core.types import JsonObject, Trace
-from wmh.ingest.adapter import VendorPull, get_adapter
+from wmh.ingest.adapter import SourceCredentialError, VendorPull, get_adapter
 from wmh.ingest.base import BaseTraceAdapter, load_payloads
 from wmh.ingest.detect import detect_format
 from wmh.ingest.normalize import SpanRecord, group_spans, trace_from_group
@@ -115,9 +115,11 @@ def _classify(exc: Exception) -> _IngestFailure:
         return _IngestFailure(ErrorCode.UNREACHABLE, f"the source returned an error: {exc}")
     if isinstance(exc, httpx.TransportError):
         return _IngestFailure(ErrorCode.UNREACHABLE, f"could not reach the source: {exc}")
-    # The postgres adapter re-raises driver failures as stdlib exceptions so no psycopg import is
-    # needed here; order matters, both are OSError subclasses.
-    if isinstance(exc, PermissionError):
+    # Adapters raise SourceCredentialError/ConnectionError (both stdlib subclasses, no driver
+    # import needed here) for source-side failures; order matters, both are OSError subclasses.
+    # A BARE PermissionError (an unreadable local file) is deliberately NOT a credential error:
+    # it falls through to the OSError branch as bad_format.
+    if isinstance(exc, SourceCredentialError):
         return _IngestFailure(ErrorCode.BAD_CREDENTIALS, str(exc))
     if isinstance(exc, ConnectionError):
         return _IngestFailure(ErrorCode.UNREACHABLE, str(exc))

--- a/wmh/ingest/stream.py
+++ b/wmh/ingest/stream.py
@@ -3,7 +3,7 @@
 This is the library seam behind `wmh ingest` and the platform's SSE trace-ingest endpoint. The
 event vocabulary is pinned by the D-INGEST contract (mirrored in the platform frontend's
 `parseTraceIngestEvent`): exactly one `detected {format, traces}`, then repeated
-`progress {normalized, total|null, note?}`, then a terminal `done {traces, steps, otel_object}` —
+`progress {normalized, total|null, note?}`, then a terminal `done {traces, steps, otel_object}`,
 or a terminal `error {message, code?}` at any point. `event_json` serializes an event to exactly
 those keys (optional fields dropped when unset, `total` kept even when null).
 
@@ -83,7 +83,7 @@ def event_json(event: IngestEvent) -> JsonObject:
     """Serialize one event to exactly the D-INGEST wire keys.
 
     Optional fields (`note`, `code`) are dropped when unset, but `progress.total` stays present
-    as null — the pinned frontend parser requires `total` to be a number or null, not absent.
+    as null: the pinned frontend parser requires `total` to be a number or null, not absent.
     """
     dump = event.model_dump(mode="json", exclude_none=True)
     if isinstance(event, ProgressEvent) and "total" not in dump:
@@ -198,6 +198,6 @@ def ingest_events(
             steps=sum(len(t.steps) for t in traces),
             otel_object=str(out),
         )
-    except Exception as exc:  # noqa: BLE001 — the wire contract IS "never raise, emit error"
+    except Exception as exc:  # noqa: BLE001: the wire contract IS "never raise, emit error"
         failure = _classify(exc)
         yield ErrorEvent(message=str(failure), code=failure.code)

--- a/wmh/ingest/stream.py
+++ b/wmh/ingest/stream.py
@@ -159,18 +159,22 @@ def ingest_events(
     pull: VendorPull | None = None,
     source: str | None = None,
     out: Path,
+    limit: int | None = None,
 ) -> Iterator[IngestEvent]:
     """Normalize one source into OTel JSONL at `out`, yielding D-INGEST progress events.
 
     Exactly one of `file`/`pull` selects the transport. `source` pins the adapter; when omitted
-    (file transport only) the format is auto-detected. The generator never raises: every failure
-    becomes a terminal `ErrorEvent`, so a consumer can pipe events straight onto a wire.
+    (file transport only) the format is auto-detected. `limit` caps the normalized traces for any
+    transport (a pull's own `pull.limit` additionally bounds what is fetched vendor-side). The
+    generator never raises: every failure becomes a terminal `ErrorEvent`, so a consumer can pipe
+    events straight onto a wire.
     """
     try:
         fmt, spans = _collect_spans(file, pull, source)
         groups = group_spans(spans)
-        if pull is not None and pull.limit is not None:
-            groups = groups[: pull.limit]
+        cap = limit if limit is not None else (pull.limit if pull is not None else None)
+        if cap is not None:
+            groups = groups[:cap]
         if not groups:
             raise _IngestFailure(
                 ErrorCode.EMPTY,

--- a/wmh/ingest/stream_test.py
+++ b/wmh/ingest/stream_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from wmh.ingest.adapter import SourceCredentialError
 from wmh.ingest.stream import (
     DetectedEvent,
     DoneEvent,
@@ -133,11 +134,29 @@ def test_event_json_matches_pinned_contract_shapes() -> None:
 
 
 def test_driver_failures_classify_to_credentials_and_unreachable() -> None:
-    """The postgres adapter raises stdlib PermissionError/ConnectionError; codes must map."""
-    assert _classify(PermissionError("postgres authentication failed")).code is (
+    """Adapters raise SourceCredentialError/ConnectionError; codes must map."""
+    assert _classify(SourceCredentialError("postgres authentication failed")).code is (
         ErrorCode.BAD_CREDENTIALS
     )
     assert _classify(ConnectionError("could not connect")).code is ErrorCode.UNREACHABLE
+
+
+def test_unreadable_file_is_bad_format_not_bad_credentials(tmp_path: Path) -> None:
+    """An OS PermissionError (unreadable local file) must not render "check your credentials".
+
+    Regression (Greptile P1): bare PermissionError was mapped to bad_credentials, so a
+    chmod-000 upload told the user their API key was wrong.
+    """
+    assert _classify(PermissionError("denied")).code is ErrorCode.BAD_FORMAT
+    src = tmp_path / "locked.json"
+    src.write_text('{"messages": []}', encoding="utf-8")
+    src.chmod(0)
+    try:
+        (event,) = list(ingest_events(file=str(src), out=tmp_path / "o.jsonl"))
+    finally:
+        src.chmod(0o644)
+    assert isinstance(event, ErrorEvent)
+    assert event.code is ErrorCode.BAD_FORMAT
 
 
 def test_file_ingest_honors_limit(tmp_path: Path) -> None:

--- a/wmh/ingest/stream_test.py
+++ b/wmh/ingest/stream_test.py
@@ -1,0 +1,140 @@
+"""Tests for the streaming ingest generator and its D-INGEST event vocabulary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wmh.ingest.stream import (
+    DetectedEvent,
+    DoneEvent,
+    ErrorCode,
+    ErrorEvent,
+    ProgressEvent,
+    _classify,
+    event_json,
+    ingest_events,
+)
+
+_CONVERSATIONS = [
+    {
+        "trace_id": f"{i:032x}",
+        "messages": [
+            {"role": "user", "content": f"task {i}"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c1", "function": {"name": "get", "arguments": '{"k": 1}'}}],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+            {"role": "assistant", "content": "done"},
+        ],
+    }
+    for i in range(3)
+]
+
+
+def _write_corpus(tmp_path: Path) -> Path:
+    src = tmp_path / "conversations.jsonl"
+    src.write_text("\n".join(json.dumps(c) for c in _CONVERSATIONS), encoding="utf-8")
+    return src
+
+
+def test_file_ingest_emits_detected_progress_done_in_order(tmp_path: Path) -> None:
+    src = _write_corpus(tmp_path)
+    out = tmp_path / "out.otel.jsonl"
+    events = list(ingest_events(file=str(src), out=out))
+
+    detected = events[0]
+    assert isinstance(detected, DetectedEvent)
+    assert detected.format == "chat-json"
+    assert detected.traces == 3
+
+    progress = [e for e in events[1:-1] if isinstance(e, ProgressEvent)]
+    assert progress, "expected at least one progress event"
+    assert all(e.total == 3 for e in progress)
+    assert [e.normalized for e in progress] == sorted(e.normalized for e in progress)
+    assert progress[-1].normalized == 3
+
+    done = events[-1]
+    assert isinstance(done, DoneEvent)
+    assert done.traces == 3
+    assert done.steps == 6  # 2 steps per conversation (tool call + final message)
+    assert done.otel_object == str(out)
+    # The written corpus is a real otel-genai file: re-ingesting it yields the same traces.
+    reingested = list(ingest_events(file=str(out), out=tmp_path / "again.otel.jsonl"))
+    assert isinstance(reingested[0], DetectedEvent)
+    assert reingested[0].format == "otel-genai"
+    assert isinstance(reingested[-1], DoneEvent)
+    assert reingested[-1].traces == 3
+
+
+def test_explicit_source_skips_detection(tmp_path: Path) -> None:
+    src = _write_corpus(tmp_path)
+    events = list(ingest_events(file=str(src), source="chat-json", out=tmp_path / "o.jsonl"))
+    assert isinstance(events[0], DetectedEvent)
+    assert events[0].format == "chat-json"
+
+
+def test_unknown_format_yields_bad_format_error(tmp_path: Path) -> None:
+    src = tmp_path / "junk.json"
+    src.write_text('{"nothing": "recognizable"}', encoding="utf-8")
+    (event,) = list(ingest_events(file=str(src), out=tmp_path / "o.jsonl"))
+    assert isinstance(event, ErrorEvent)
+    assert event.code == ErrorCode.BAD_FORMAT
+    assert "--source" in event.message
+
+
+def test_missing_file_yields_bad_format_error(tmp_path: Path) -> None:
+    (event,) = list(ingest_events(file=str(tmp_path / "nope.json"), out=tmp_path / "o.jsonl"))
+    assert isinstance(event, ErrorEvent)
+    assert event.code == ErrorCode.BAD_FORMAT
+
+
+def test_empty_corpus_yields_empty_error(tmp_path: Path) -> None:
+    src = tmp_path / "empty.jsonl"
+    # Valid chat-json shape but zero usable conversations after the first (detectable) one is
+    # message-free: normalization produces no steps and no traces.
+    src.write_text('{"messages": []}', encoding="utf-8")
+    events = list(ingest_events(file=str(src), source="chat-json", out=tmp_path / "o.jsonl"))
+    assert isinstance(events[-1], ErrorEvent)
+    assert events[-1].code == ErrorCode.EMPTY
+
+
+def test_event_json_matches_pinned_contract_shapes() -> None:
+    """Serialized events carry exactly the D-INGEST keys (`total` present even when null)."""
+    assert event_json(DetectedEvent(format="chat-json", traces=2)) == {
+        "type": "detected",
+        "format": "chat-json",
+        "traces": 2,
+    }
+    assert event_json(ProgressEvent(normalized=1, total=None)) == {
+        "type": "progress",
+        "normalized": 1,
+        "total": None,
+    }
+    assert event_json(ProgressEvent(normalized=1, total=9, note="n")) == {
+        "type": "progress",
+        "normalized": 1,
+        "total": 9,
+        "note": "n",
+    }
+    assert event_json(DoneEvent(traces=1, steps=2, otel_object="p.jsonl")) == {
+        "type": "done",
+        "traces": 1,
+        "steps": 2,
+        "otel_object": "p.jsonl",
+    }
+    assert event_json(ErrorEvent(message="boom")) == {"type": "error", "message": "boom"}
+    assert event_json(ErrorEvent(message="no", code=ErrorCode.BAD_CREDENTIALS)) == {
+        "type": "error",
+        "message": "no",
+        "code": "bad_credentials",
+    }
+
+
+def test_driver_failures_classify_to_credentials_and_unreachable() -> None:
+    """The postgres adapter raises stdlib PermissionError/ConnectionError; codes must map."""
+    assert _classify(PermissionError("postgres authentication failed")).code is (
+        ErrorCode.BAD_CREDENTIALS
+    )
+    assert _classify(ConnectionError("could not connect")).code is ErrorCode.UNREACHABLE

--- a/wmh/ingest/stream_test.py
+++ b/wmh/ingest/stream_test.py
@@ -138,3 +138,14 @@ def test_driver_failures_classify_to_credentials_and_unreachable() -> None:
         ErrorCode.BAD_CREDENTIALS
     )
     assert _classify(ConnectionError("could not connect")).code is ErrorCode.UNREACHABLE
+
+
+def test_file_ingest_honors_limit(tmp_path: Path) -> None:
+    """`limit` caps traces for FILE ingests too, not only vendor pulls (cost control)."""
+    src = _write_corpus(tmp_path)
+    events = list(ingest_events(file=str(src), out=tmp_path / "o.jsonl", limit=2))
+    assert isinstance(events[0], DetectedEvent)
+    assert events[0].traces == 2
+    done = events[-1]
+    assert isinstance(done, DoneEvent)
+    assert done.traces == 2


### PR DESCRIPTION
The wmh half of D-INGEST (coordination log 2026-07-23 entry): a standalone, streamable ingestion surface the platform SSE endpoint wraps, with the CLI as the first consumer. Signed off by Silen in the ingest-stream chat (row mapping, standalone command, credentials stored platform-side, all six providers, attribution).

## What this adds

- **`wmh ingest`** (new command): normalize any source into an OTel-GenAI JSONL corpus without building a model. Rich progress bar on a TTY; `--json` emits one D-INGEST event object per line. Output feeds `wmh build --source otel-genai --file <out>` directly.
- **`wmh.ingest.stream.ingest_events()`**: the library generator behind both the CLI and the platform endpoint. Event vocabulary pinned to the frontend parser (`parseTraceIngestEvent`): `detected {format, traces}` -> repeated `progress {normalized, total|null, note?}` -> `done {traces, steps, otel_object}` | `error {message, code?}` with `code` in `bad_credentials | unreachable | bad_format | empty | internal`. The generator never raises; `event_json()` serializes to exactly the wire keys (`total` kept when null).
- **Format auto-detection** (`wmh.ingest.detect`): a file upload or a Postgres payload column names no adapter, so detection keys on each source's unambiguous shape markers (verified against every adapter's own test fixtures). Unknown or mixed corpora error with guidance instead of guessing.
- **Postgres source** (`--source postgres`, implied by `--dsn`/`--table`): column contract `trace_id` / `payload` / `created_at`, all overridable. Three row shapes work: row-per-step/span, row-per-message (session tables assembled into episodes per trace id), and row-per-trace jsonb blobs (no trace id column needed). Payload format goes through the same detector as files, so Postgres stays pure transport. Driver = psycopg3 behind a `[postgres]` extra, lazy-imported like the vendor SDKs; driver failures re-raise as stdlib `PermissionError`/`ConnectionError` so the error classifier needs no psycopg import.
- **Langfuse + LangSmith live pulls** over plain httpx (no SDKs): Langfuse pages the list endpoint then re-fetches each trace by id (the list page carries observation-id strings only); LangSmith POSTs `runs/query` and follows `cursors.next`. With the existing braintrust/posthog/mastra pulls, 5 of the 6 providers pull live; phoenix stays file-export-only (version-dependent query surface).
- **`Step.attribution`** (endpoint-pivot litmus): typed optional per-step provenance (model, provider, input/output tokens, cost, latency_ms, error_class controllable-vs-environmental, provenance). Populated best-effort by the shared normalizer from GenAI/OpenInference vocabularies; an explicit `wmh.attribution` attribute wins verbatim; round-tripped by the OTel writer. Latency derives only from epoch-plausible clocks (ns or us scale), never from synthetic ordinals (caught live: re-ingesting a writer-produced corpus initially stamped junk `latency_ms=1e-6` on every step; regression-tested).

## Justification ledger

Additions, each with its consumer:
- `ingest_events` / event models / `event_json`: consumed by `wmh ingest` here and the explabs SSE endpoint (platform PR next, D-INGEST).
- `detect_format`: consumed by `ingest_events` (file uploads carry no format field in D-INGEST) and the postgres adapter.
- `PostgresAdapter` + `VendorPull` dsn/table/column fields: consumed by `wmh ingest --dsn/--table` and the platform database source. VendorPull extension chosen over a parallel pull type to keep the one `TraceAdapter` protocol.
- `Step.attribution` + `ErrorClass`: consumer is the routing optimizer's task clustering / policy pricing per the 2026-07-23 pivot ("preserve per-step attribution"); registered in DECISIONS.md before building.
- `BaseTraceAdapter.collect_all` / `spans_from_file` / `spans_from_pull`, `group_spans` / `trace_from_group`, module-level `load_payloads`: the streaming seams `ingest_events` consumes; `from_file`/`from_vendor` now compose them (one path, not two).
- `[postgres]` optional extra: same contract as the existing vendor-SDK extras.

Removals forced by the change (one way to do each thing):
- `otel_genai.py` dropped its full private copy of the normalizer (~330 lines predating `wmh/ingest/normalize.py`) and now sits on `BaseTraceAdapter`; without this it would have silently missed attribution (that is how the duplication was caught).
- `chat-json` dropped its private file-loading copy and sits on `BaseTraceAdapter` (also what makes it streamable and reusable by the postgres session mode).
- Stale docs/docstrings claiming `wmh ingest run` exists and that langfuse/langsmith/braintrust have "no live pull" corrected.

Deliberate non-removals:
- `otel-genai`'s placeholder generic OTLP-query pull (env-var driven) kept as-is: pre-existing contract, unrelated to this PR's scope.
- Two tests updated rather than deleted with stated reasons in-line: the raw-span-id assertion (ids now carry the base adapter's documented uniqueness prefix) and the CLI command-set guard (gains `ingest`).

## Verification

- Gate: `uv run ruff check .`, `uv run ruff format .`, `uv run ty check`, `uv run pytest -q` all clean (2003 passed; 30 new tests).
- Real corpus: `wmh ingest --file packages/environment-capture/tau-bench/traces.otel.jsonl` normalizes 1033 traces / 5289 steps with live progress; output re-ingests losslessly.
- Live Postgres (throwaway docker postgres:16): message-per-row table -> 2 sessions/3 steps; blob-per-row table (no trace_id column) -> 2 traces; wrong password -> `error{bad_credentials}`; missing table -> `error{bad_format}` with a fix-it message; unreachable host -> `error{unreachable}`.

## How Silen tests

```bash
cd ~/Desktop/Projects/wmh-ingest-stream

# 1. One file ingest with live progress (any corpus; tau-bench shown):
uv run wmh ingest --file ../world-model-harness/packages/environment-capture/tau-bench/traces.otel.jsonl --out /tmp/tau.otel.jsonl

# 2. The exact event stream the platform will pipe as SSE:
uv run wmh ingest --file /tmp/tau.otel.jsonl --json | head

# 3. (optional) Postgres end to end, ~30s:
docker run -d --rm --name pg-e2e -e POSTGRES_PASSWORD=t -p 5499:5432 postgres:16-alpine && sleep 5
docker exec -i pg-e2e psql -U postgres -c "CREATE TABLE t (trace_id text, payload jsonb, created_at timestamptz default now()); INSERT INTO t VALUES ('s1','{\"role\":\"user\",\"content\":\"hi\"}'),('s1','{\"role\":\"assistant\",\"content\":\"hello\"}');"
uv run wmh ingest --dsn "postgresql://postgres:t@127.0.0.1:5499/postgres" --table t --json --out /tmp/pg.otel.jsonl
docker stop pg-e2e
```

## Merge-prep (2026-07-25, per Silen): rebased over #248, five verifications

Rebased onto main including #248 (one touchpoint: the CLI's `optimize` became a sub-app; resolved as union with the new `ingest` command). Full gate green post-rebase: 2286 passed.

1. **Event vocabulary byte-exact vs the platform parser.** `test_event_json_matches_pinned_contract_shapes` asserts the exact serialized keys/types per variant (`total` present-when-null, optional fields dropped when unset), and the platform pair (#355) feeds REAL emitted payloads and a verbatim captured SSE byte stream through `parseTraceIngestEvent` + `readSseData` in its vitest suite.
2. **Episode-structure litmus, demonstrated on real data.** One normalized episode from the tau-bench corpus, no raw-source access after ingest:

One normalized episode (`efec6ac80ec3…`, 2 steps) from the real tau-bench corpus, ingested via `wmh ingest` with zero raw-source access afterward:

```
initial state / task : '{"domain": "airline", "known_info": "You are Emma Kim.\\nYour user id is emma_kim_9957.", "reason_for_call": "You want to cancel reservation EHGLP3. \\n\\nIt may be more than 24 hours after booking, but it is ok because you were out of town for that time.", "task_instructions": "If Agent tells you that cancellation is not possible,\\nmention that you were told that you didn\'t need to get insurance because your previous trip was booked with the same agency with insurance.\\n\\nYou don\'t want to cancel if you don\'t get a refund.", "unknown_info": null}'
episode metadata     : ['benchmark', 'domain', 'task_id', 'gold', 'reward'] (gold assertions ride along)
tool surface         : ['get_reservation_details', 'get_user_details']
step 0  action       : get_reservation_details({'reservation_id': 'EHGLP3'})
        observation  : '{"reservation_id": "EHGLP3", "user_id": "emma_kim_9957", "or' (is_error=False)
        attribution  : {'model': 'tau2-agent'}
step 1  action       : get_user_details({'user_id': 'emma_kim_9957'})
        observation  : '{"user_id": "emma_kim_9957", "name": {"first_name": "Emma", ' (is_error=False)
        attribution  : {'model': 'tau2-agent'}
terminal outcome     : '{"user_id": "emma_kim_9957", "name": {"first_name": "Emma", "last_name": "Kim"},'
```

   Initial state = the task (plus episode metadata carrying gold assertions and reward), tool surface = the episode's tool calls with full args/results, terminal outcome = the last step. A replayable scenario is constructible from the `Trace` object alone.
3. **Per-step attribution complete and tested**: model, provider, **config** (added this round: `gen_ai.request.*` sampling params, e.g. `{"temperature": 0.2, "max_tokens": 512}`), input/output tokens, cost, latency (epoch-plausible clocks only), error class (controllable vs environmental), and provenance (capture-system version marker, verbatim through the `wmh.attribution` round-trip). Tests: semconv derivation, explicit-attribute precedence, config capture, writer round-trip, synthetic-ordinal latency regression.
4. **Postgres row-mapping decision recorded**: coordination log, 2026-07-23 D-INGEST entry item 7 (row-per-step with `trace_id`/`payload`/`created_at` defaults; message-per-row session tables assembled per trace id; self-contained row-per-trace blobs; table's trace id always wins), exactly as agreed with Silen in-chat.
5. **CLI parity documented with examples**: docs/reference/ingest.md quickstart (`wmh ingest --file/--pull/--dsn`), the Postgres section now shows the explicit `--source postgres` form plus a worked `--json` event-stream sample, and the "Progress events" section pins the vocabulary.

**For the platform pair (#355): pin exactly `f020fd8ccd8cb3b49116f033fc562de5c3f719b1`** (this PR's post-rebase tip; #355's pin is being bumped to it).

