### PR TITLE
Add the Tinker sampling provider and distill foundations

### DIFF
--- a/packages/llm-waterfall/llm_waterfall/classify.py
+++ b/packages/llm-waterfall/llm_waterfall/classify.py
@@ -56,8 +56,9 @@ _SDK_CAPACITY_TYPE_NAMES = frozenset(
 )
 
 # Top-level modules whose exceptions we trust for name/status-code classification. An exception
-# named `RateLimitError` from arbitrary application code proves nothing.
-_TRUSTED_SDK_MODULES = frozenset({"openai", "anthropic", "httpx", "httpcore"})
+# named `RateLimitError` from arbitrary application code proves nothing. tinker's exceptions
+# mirror openai's shape (same capacity type names; `status_code` on its APIStatusError family).
+_TRUSTED_SDK_MODULES = frozenset({"openai", "anthropic", "httpx", "httpcore", "tinker"})
 
 # HTTP statuses on a trusted SDK error that mean capacity/transient failure. 529 is Anthropic's
 # "overloaded". Everything else (400/401/403/404/422/...) is a client error.

--- a/packages/llm-waterfall/llm_waterfall/classify.py
+++ b/packages/llm-waterfall/llm_waterfall/classify.py
@@ -105,6 +105,22 @@ def _is_botocore_transport_error(exc: Exception) -> bool:
     return False
 
 
+# tinker's sidecar family (the SDK's local transport subprocess dying, failing to start, or
+# losing IPC mid-request), matched anywhere in the MRO by (module, name) like the botocore
+# transport bases above: these carry no status_code, no openai-shaped capacity name, and no
+# reliable message phrasing, but a fresh attempt (which respawns the sidecar) can succeed.
+_TINKER_TRANSPORT_BASES = frozenset({"SidecarError"})
+
+
+def _is_tinker_transport_error(exc: Exception) -> bool:
+    """Whether `exc` is any member of tinker's SidecarError family."""
+    for klass in type(exc).__mro__:
+        module = getattr(klass, "__module__", "") or ""
+        if module.split(".")[0] == "tinker" and klass.__name__ in _TINKER_TRANSPORT_BASES:
+            return True
+    return False
+
+
 def outcome_for(exc: Exception) -> Outcome:
     """Classify an exception raised by a backend attempt.
 
@@ -115,10 +131,13 @@ def outcome_for(exc: Exception) -> Outcome:
          message substring can never overrule it.
       3. Botocore's ConnectionError/HTTPClientError family, matched by MRO (module, name) —
          transport failures whose subclasses carry no code and keep inventing new phrasings.
-      4. SDK exception type name, gated on the defining module.
-      5. HTTP status, from a `status_code` attribute on the exception or on its `.response`
+      4. Tinker's non-HTTP failure families, same MRO matching: the SidecarError family is
+         transport-shaped (retry can respawn the sidecar), and RequestFailedError classifies
+         by its `category` field (a "user" request is wrong; "server"/"unknown" are transient).
+      5. SDK exception type name, gated on the defining module.
+      6. HTTP status, from a `status_code` attribute on the exception or on its `.response`
          (httpx.HTTPStatusError carries it there), same module gate.
-      6. Conservative transport-phrase substrings for structureless errors.
+      7. Conservative transport-phrase substrings for structureless errors.
     """
     if isinstance(exc, WaterfallExhausted):
         return "capacity_error"
@@ -135,9 +154,18 @@ def outcome_for(exc: Exception) -> Outcome:
     if _is_botocore_transport_error(exc):
         return "capacity_error"
 
+    if _is_tinker_transport_error(exc):
+        return "capacity_error"
+
     if _from_trusted_sdk(exc):
         if type(exc).__name__ in _SDK_CAPACITY_TYPE_NAMES:
             return "capacity_error"
+        if type(exc).__name__ == "RequestFailedError":
+            # tinker's async-request failure carries a StrEnum `category` instead of a
+            # status code: "user" means this request is wrong (propagate); "server" and
+            # "unknown" mean the service failed it and a fresh attempt can succeed.
+            category = str(getattr(exc, "category", "")).lower()
+            return "client_error" if category == "user" else "capacity_error"
         status = getattr(exc, "status_code", None)
         if not isinstance(status, int):
             # httpx.HTTPStatusError keeps the status on the response object instead.

--- a/packages/llm-waterfall/llm_waterfall/classify_test.py
+++ b/packages/llm-waterfall/llm_waterfall/classify_test.py
@@ -81,6 +81,20 @@ def test_sdk_capacity_types_are_capacity(name: str, module: str) -> None:
     assert is_capacity_error(_sdk_exception(name, module))
 
 
+@pytest.mark.parametrize("name", ["RateLimitError", "APITimeoutError", "APIConnectionError"])
+def test_tinker_capacity_types_are_capacity(name: str) -> None:
+    # The tinker SDK defines openai-shaped exceptions in the `tinker` module; without the
+    # module gate trusting it, a transient tinker 429/timeout would classify as client_error
+    # and kill a whole trial instead of being retried.
+    assert is_capacity_error(_sdk_exception(name, "tinker._exceptions"))
+
+
+def test_tinker_status_and_bad_request_classify_like_openai() -> None:
+    assert is_capacity_error(_sdk_exception("APIStatusError", "tinker", status_code=503))
+    exc = _sdk_exception("BadRequestError", "tinker", status_code=400)
+    assert outcome_for(exc) == "client_error"
+
+
 def test_sdk_type_name_from_foreign_module_is_client_error() -> None:
     # Same class name, wrong module: the gate must reject lookalikes from arbitrary code.
     assert outcome_for(_sdk_exception("RateLimitError", "myapp.errors")) == "client_error"

--- a/packages/llm-waterfall/llm_waterfall/classify_test.py
+++ b/packages/llm-waterfall/llm_waterfall/classify_test.py
@@ -16,15 +16,21 @@ class _BotocoreShaped(Exception):
 
 
 def _sdk_exception(
-    name: str, module: str, message: str = "", status_code: int | None = None
+    name: str,
+    module: str,
+    message: str = "",
+    status_code: int | None = None,
+    category: str | None = None,
 ) -> Exception:
-    """Build a fake SDK exception with a chosen class name, module, and optional status_code."""
+    """Build a fake SDK exception with a chosen class name, module, and optional attributes."""
     attrs: dict[str, int] = {}
     cls = type(name, (Exception,), attrs)
     cls.__module__ = module
     exc = cls(message)
     if status_code is not None:
         exc.status_code = status_code
+    if category is not None:
+        exc.category = category
     return exc
 
 
@@ -93,6 +99,39 @@ def test_tinker_status_and_bad_request_classify_like_openai() -> None:
     assert is_capacity_error(_sdk_exception("APIStatusError", "tinker", status_code=503))
     exc = _sdk_exception("BadRequestError", "tinker", status_code=400)
     assert outcome_for(exc) == "client_error"
+
+
+def _tinker_sidecar_exception(name: str, module: str = "tinker._exceptions") -> Exception:
+    """Build a fake subclass of tinker's SidecarError base, mirroring the real hierarchy."""
+    base = type("SidecarError", (Exception,), {})
+    base.__module__ = module
+    cls = type(name, (base,), {})
+    cls.__module__ = module
+    return cls("sidecar failed")
+
+
+@pytest.mark.parametrize("name", ["SidecarDiedError", "SidecarStartupError", "SidecarIPCError"])
+def test_tinker_sidecar_family_is_capacity(name: str) -> None:
+    # The sidecar subprocess dying carries no status_code, no openai-shaped name, and no
+    # transport phrasing; without the MRO family match it would classify as client_error
+    # and kill a whole trial instead of retrying against a respawned sidecar.
+    assert is_capacity_error(_tinker_sidecar_exception(name))
+
+
+def test_sidecar_lookalike_from_foreign_module_is_client_error() -> None:
+    exc = _tinker_sidecar_exception("SidecarDiedError", module="myapp.errors")
+    assert outcome_for(exc) == "client_error"
+
+
+def test_tinker_request_failed_classifies_by_category() -> None:
+    # tinker.RequestFailedError (an async request completing in a failed state) carries a
+    # StrEnum category instead of a status code: "user" is a bad request, everything else
+    # is the service failing transiently.
+    for category in ("server", "unknown"):
+        exc = _sdk_exception("RequestFailedError", "tinker", category=category)
+        assert outcome_for(exc) == "capacity_error"
+    user = _sdk_exception("RequestFailedError", "tinker", category="user")
+    assert outcome_for(user) == "client_error"
 
 
 def test_sdk_type_name_from_foreign_module_is_client_error() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,20 @@ connectors = ["mcp>=1.27"]
 # The Postgres trace source (`wmh ingest --source postgres`): the driver is imported lazily
 # inside the adapter's pull path, same contract as the vendor-SDK extras.
 postgres = ["psycopg[binary]>=3.1"]
+# On-policy distillation (`wmh.distill` + the tinker provider): trains a LoRA student on
+# Tinker from harbor rollouts. Imported lazily, same contract as the e2b extra. The cookbook
+# pin tracks the 0.4.x renderer surface this integration was verified against; Tinker's model
+# lineup churns, so base-model names live in run configs, never in code. The tinker pin tracks
+# the 0.23.x exception surface llm-waterfall's classification trusts by name (classify.py).
+# wandb is optional run tracking (lazy import, activated only via [wandb] enabled in the run config).
+distill = ["tinker>=0.23,<0.24", "tinker-cookbook>=0.4.3,<0.5", "wandb>=0.17"]
 # dev pulls in every backend SDK so `ty check` and the full test suite resolve over the whole
 # project (the providers import anthropic/openai/boto3 lazily, but type-checking needs them present).
 dev = [
     "pytest>=8.0",
     "ruff>=0.5",
     "ty>=0.0.1a1",
-    "world-model-harness[otel,viz,e2b,connectors,harbor,postgres]",
+    "world-model-harness[otel,viz,e2b,connectors,harbor,postgres,distill]",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,21 @@ wheels = [
 ]
 
 [[package]]
+name = "blobfile"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "lxml" },
+    { name = "pycryptodomex" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/3e/9f613b3bf2f70a96a03ee102f8ad0d570d5637674f0e1814e7c301c68134/blobfile-3.2.0.tar.gz", hash = "sha256:78514a9265b9aa7d4607042dc77c5e6461ab27036450ad8e1f6ef9a7f29bf958", size = 78442, upload-time = "2026-02-07T03:10:54.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/ab/e0a104d874f18e2552d981e6e978c64d3c8fa2fad4fbc46e9daa42b31db3/blobfile-3.2.0-py3-none-any.whl", hash = "sha256:e5e4095477da9f09e2077f41320c006001b2102a61f07d41ceaaecdf5d9741d8", size = 76958, upload-time = "2026-02-07T03:10:52.86Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.40"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +425,18 @@ wheels = [
 ]
 
 [[package]]
+name = "chz"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/6c/09c8ca50c40e18be211f25ad6dcdb81f8110ba2d611cd0375f5fb65fb762/chz-0.4.0.tar.gz", hash = "sha256:5380039e6970a1056c2140288aafa41a33f26d5e4c685117be80f7e260c8d679", size = 82473, upload-time = "2025-11-24T00:55:10.634Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/eb/77789ad6f1807328a61c205881580546af597f60334f1f96fd4f3bb6e929/chz-0.4.0-py3-none-any.whl", hash = "sha256:5db5ffe42f6be38f1c37e1b18f0d5559572ee8a8dc941116e67f1bd5396e2a9b", size = 56277, upload-time = "2025-11-24T00:55:09.381Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -419,6 +446,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -547,12 +583,112 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "datasets"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
 ]
 
 [[package]]
@@ -565,6 +701,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -846,11 +991,16 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.6.0"
+version = "2026.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -1348,6 +1498,86 @@ requires-dist = [
 provides-extras = ["openai", "anthropic", "bedrock", "azure", "all", "dev"]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1511,6 +1741,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1610,12 +1849,38 @@ wheels = [
 ]
 
 [[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1670,6 +1935,158 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1689,6 +2106,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1698,6 +2127,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
 ]
 
 [[package]]
@@ -2057,12 +2539,78 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
+    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]
@@ -2199,6 +2747,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/8576f0eeb44d3fe14c70e2bafa77ae6930c5e6f42b93c568719ea4456715/pyqwest-0.7.0.tar.gz", hash = "sha256:ac65f2243f3e814e7f4aad3f2fcfe78f89aad2de2a825eaaabf4c102f1937843", size = 457991, upload-time = "2026-07-19T05:20:06.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/49/7f26a2c2a3e8bbab4862bcbf4f54b706d9524fa9705cc0127553b81ed161/pyqwest-0.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7b2339f3b55ae179e0cb55bbd5792ae1c954d31f80de7b4dde0e95b03576b6be", size = 5159904, upload-time = "2026-07-19T05:18:57.757Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/4aba1976566936ca873e1a726a0d9bdf8195a0dc4e4f78122f6050328566/pyqwest-0.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2159c7e2eaf2563cdadfda17314e2b1747c30603979bf73db8daef311247db82", size = 5044476, upload-time = "2026-07-19T05:18:59.473Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/06/45908e5cda7fa28ba60df5ed2091056893c394c3217a796bc6577c4bd294/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a826f1b492a7497f469c8467bd51faf582733654bb2bc9fcdd4fa502f3e6ca1", size = 5560021, upload-time = "2026-07-19T05:19:01.097Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/3d/603f5c9446e8c13a4970b816246d7928e895408a7ed1778d98de3e25ea43/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da43c7e86bee9e74ff474d4829cd398fb9220ff0d84d633094ea6797fdfe03a1", size = 5506130, upload-time = "2026-07-19T05:19:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/2984aa02f4d0296dddb5df159e1af6c6e0ddc0b507d592f13d6ccd0b3162/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d1c71327c323a19dc90a0dafb1d68fb13f4f775a2498a26bf95f17165e64da9f", size = 5719961, upload-time = "2026-07-19T05:19:04.213Z" },
+    { url = "https://files.pythonhosted.org/packages/19/06/e30c0d31eea17cabf99ef90c7c02e14cc94ca7d59793d397de9359148693/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c002e0fc31a96f1c47986299710f49ed4551e4a912a7cdb69aba6fd94db6d544", size = 5908279, upload-time = "2026-07-19T05:19:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/db/a1368faae1cbd094a0d179b76de69b8d1908bd45898d3bcd29ac98622072/pyqwest-0.7.0-cp310-abi3-win_amd64.whl", hash = "sha256:847e4468b5379a219b91a13dd3c92dd3b7b3d9f59af23e4c6776e663594cb241", size = 4755104, upload-time = "2026-07-19T05:19:07.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/c493e85ebd17d3a5c56eb53fbea36a1a6f396b999b38173ffde513576eb1/pyqwest-0.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4988fa1c368072886dce48f52fcbabe9f25784c6e189a9a6f2b42f6e9f383973", size = 5172962, upload-time = "2026-07-19T05:19:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/68/1b340fdc7735b5682d308cabc2d65ea76c03a6cc2c30072a0c14c24f716c/pyqwest-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dfb61138c802c7317d840a274fa24f9d878301f693268e9186a9896452017a71", size = 5032604, upload-time = "2026-07-19T05:19:10.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/52/eecd858568ef6586cbdc3c419a9a0b1e8f891e2968f0f6b2a9fa9bdaac19/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6fdc0601590bdc547007828627082f0dc0e445e92d900dccb227e51898d7243", size = 5558302, upload-time = "2026-07-19T05:19:12.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8f/b67d0056b18a9f99a1c9253cb983d5c4361e3e102d729df6623b71d6d939/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f82c971810695f5fd7962859a2469616c83b7aca6664d8f147287ee5ff430cd", size = 5501483, upload-time = "2026-07-19T05:19:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a6/69b87c4c80ced01645a143679458895dcb5c0e5ca0b3d4a43d979939cce6/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9dc2f405803b94525ab030c01cdac7093bcc1a5da6802de3345a868a0f51b3da", size = 5717334, upload-time = "2026-07-19T05:19:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/5891b72b9193b692b50ecdc4e26e7e3687f9763f5f263646bc8f997f5b62/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:537f71f97a533fa355d02c15ed9f0cc05fb8915996cb921caa87fe7310b457ee", size = 5902447, upload-time = "2026-07-19T05:19:17.273Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/1b280618af3f9d36081449d153efc5620f0eea93ac169574fc69208d2b91/pyqwest-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:196aa73fb7eee4b6c052d6f4172a4321904a7208331f4322ccee3ee7d0adbc78", size = 4750469, upload-time = "2026-07-19T05:19:18.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/9c/64c8df83a152804ac3074fb879c1229c3aca55a12dc33dc73c72e93405e6/pyqwest-0.7.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:72d001892ed570df1dcc489ef8b0a03bc7abd4fbdca10625c358a87e66b226ad", size = 5171308, upload-time = "2026-07-19T05:19:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d1/46e629541a3f7231dd978fa9939e6ddcd075238880395bcfb16544769165/pyqwest-0.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:03da0797bac5c2eb1a40f02afccd4b5aad5ad0d375bb993df2f5e0c692fc0c6c", size = 5032449, upload-time = "2026-07-19T05:19:21.967Z" },
+    { url = "https://files.pythonhosted.org/packages/44/3c/132194c747696e41ad5745c51587bd20057d800b6a64fb901ce2ac990149/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:837e18aef4490eed25b4194d49f16732ccf1abf2cdd0845e75d75d2a4428b98c", size = 5556847, upload-time = "2026-07-19T05:19:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5d/6726a70e89c60bf3cd30d5d918eff68dc1d1ceb9c911331d7fb57977bfc3/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:418e8c3a67ca6226bfb6147b8668203c74d9c872657117086f4c264a674d7980", size = 5500333, upload-time = "2026-07-19T05:19:25.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3f/329df64d3e8778bc311a22e432280cd317619c3f9b7e414f375127bb90b0/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31176abbbcbe6d03740967b5c0241deaa60b328792644cb2e317a34d6b076433", size = 5717248, upload-time = "2026-07-19T05:19:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/93/6670afb97c6ce7b5ba27981e023d9edc7413e509bbe18afebb729834d9e6/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e21102f9c13234a0066d42bb5429dc5c311d7fd99401878837d9675a7f6e03b9", size = 5902814, upload-time = "2026-07-19T05:19:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d3/bf9440a03c97f408743313215d8c7e9875b0b2b0d2ef97f5fbb5066cd57d/pyqwest-0.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:ca19e96b5e902a6d35e18cee7f5e90612fca6ab169378d42242cdcb638578cee", size = 4750510, upload-time = "2026-07-19T05:19:30.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/25/8b0919bf504309982857e564e3035ffd799d7aaa23457eb351485573e5ee/pyqwest-0.7.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4e4e79187c3e4ebd07d663d8dc7a7cba865c72020332e41807426a7e3526fda0", size = 5177972, upload-time = "2026-07-19T05:19:32.051Z" },
+    { url = "https://files.pythonhosted.org/packages/52/12/d652213fe336c52b75fb4df710f5cff08f8a1dcc9e385c9120f18476f5c9/pyqwest-0.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1bc2c569481ade1bc0b89b07daf1b49b20a1337a53207ffe0ef325260f509404", size = 5032608, upload-time = "2026-07-19T05:19:33.772Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b0/406c91563140b87ade5c5935410997b26449b8eb2f91511bc52741ae38fb/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ef1bfbdca9ec9c8a7b223268f5ef8d45694da7226929454b0cb40f2e3d1ddd5", size = 5558937, upload-time = "2026-07-19T05:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/17/a0a09936b5dd5d9d7517289aee3683bbf6554b0853bce5280ead9da27336/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c2f6a6830becfa1c5bb94aa169ad854da5749a95a440aee759932d5965c213", size = 5500603, upload-time = "2026-07-19T05:19:37.023Z" },
+    { url = "https://files.pythonhosted.org/packages/00/34/ccec52ca9f14fbe11292fadbe89c771353e0f46d58aa88d8e93d6e018117/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0d11128ccc382f64fcdf92d3bce6be7191489c1b3a9a3f0dbdf89e55451638de", size = 5719784, upload-time = "2026-07-19T05:19:38.649Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/58dca466c236e497cbb2e75b97a2489225d21f5063d932ab7d1723294112/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5832373c7bcccfbc3bb79c44b592e0871631139a2ef5aef771b8fe2b7bd4301d", size = 5901396, upload-time = "2026-07-19T05:19:40.402Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a0/983ea3b859828bef8372896e9c407f62bf426b84526d0b0cf9fd9abce411/pyqwest-0.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7330070c4497e564007985716ac347cb9a7500eba5c9610500653a2ce4cfe86e", size = 4751036, upload-time = "2026-07-19T05:19:42.159Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1d/e2fe3dfe6d87989017412f394abc45435a3af2526e998c83cf836937b23c/pyqwest-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:02fd606a35be7803a770071f642a375e55df4c2025e49b10b859430f424c4492", size = 5165801, upload-time = "2026-07-19T05:19:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/fe/90126ac71fe09c729f36c166cb71b5148dd8a80e47f6f232bf71494604a2/pyqwest-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a807835c6a0777f0cc57c321c78c7bf162f6354698844d78db6e03ba9edd83dc", size = 5025128, upload-time = "2026-07-19T05:19:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/15/ee84ce834705d613c0b113fb4cf9d274011cfcc6c6ededb52d92a38a2367/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86d84871cb0a572700dece3a6c45c294721f655f3d0b85477333209b487ecef1", size = 5551017, upload-time = "2026-07-19T05:19:47.046Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/18b4540fb276f9b540018efe024aca0801acfe4209417d4faed85bccdb04/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:005ddd2a777d30ca7ce4de12df1336760e14d46394ab56299a9e81626d78b991", size = 5493032, upload-time = "2026-07-19T05:19:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/91/f25477eb80c375378a876cf2bac80c55ec9ea36b94bd7d4b2b2931860c85/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ca02089249c292ab9c148fa86c06927701897090226a13e392a6ec53312380ea", size = 5712503, upload-time = "2026-07-19T05:19:50.542Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/63/c5be988c55c69c87de950e3dabab322f82a78dc7c2ebdf89af32626bd473/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:da3bc117c1380e9577994da15b8236f7c3bb400111d6be4b57a9b2e4f30c9a79", size = 5893782, upload-time = "2026-07-19T05:19:52.286Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a7/96144e6db9a49eb5e42734562ac5d387c2b78fe1142674d3a284ce188ef7/pyqwest-0.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a599ddac7ded32ed62d15ca90bc9c77652ba34b225cf17a404821cec92a189fa", size = 4744187, upload-time = "2026-07-19T05:19:53.921Z" },
 ]
 
 [[package]]
@@ -2590,6 +3184,30 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
 name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2704,6 +3322,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -2839,12 +3479,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]
@@ -2904,30 +3565,83 @@ wheels = [
 ]
 
 [[package]]
+name = "tinker"
+version = "0.23.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "distro" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "orjson" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyqwest" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/31/73f5231dc8956919533ea9ce0a7a0c2b6b858e61186e133ec78ecc159e0e/tinker-0.23.4.tar.gz", hash = "sha256:1829f5efb8d663d384c7f5bf53de9345850a80b2c9258d7c4ac7203bf4e93495", size = 255873, upload-time = "2026-07-25T01:39:52.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/65/4edc24cdec88c7c50d5daa7a87ed4558cffe2f6a1780a89773385b2c55aa/tinker-0.23.4-py3-none-any.whl", hash = "sha256:35ce7221f8cc827eef1b6083d880b3ed2babc2e2c865abb11247046e4bfa6837", size = 245304, upload-time = "2026-07-25T01:39:50.661Z" },
+]
+
+[[package]]
+name = "tinker-cookbook"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "blobfile" },
+    { name = "chz" },
+    { name = "cloudpickle" },
+    { name = "datasets" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "safetensors" },
+    { name = "termcolor" },
+    { name = "tiktoken" },
+    { name = "tinker" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/66/e29025eb28c968b7d72624fa2766470a0b6d81617ef336796b5ead3979af/tinker_cookbook-0.4.3.tar.gz", hash = "sha256:15927af65c0e85f42161c4b4a03038ab5307981be16839b19003e075cb1826f5", size = 4595925, upload-time = "2026-06-24T16:35:47.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/b7/2c1bfee684aa66c1c486a23ffae782432c9ee472f6e5cdf0f83c0984f81a/tinker_cookbook-0.4.3-py3-none-any.whl", hash = "sha256:4a794a015a41462ff18a8085ea5a282139cca54325cbd38b4736b6916b5a40ce", size = 934603, upload-time = "2026-06-24T16:35:45.485Z" },
+]
+
+[[package]]
 name = "tokenizers"
-version = "0.23.1"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
-    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
-    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -2949,6 +3663,45 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2958,6 +3711,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]
@@ -3053,6 +3841,34 @@ wheels = [
 ]
 
 [[package]]
+name = "wandb"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/fb/8d3f96a8b143060d6fa145462d0785981373e04694e4152555ccb5d23939/wandb-0.28.1.tar.gz", hash = "sha256:870ccb1a01238b0ac07c6fd96a0810a1f79090aba04ea29f4ee012ac8327705d", size = 40578119, upload-time = "2026-07-16T18:47:05.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/21/8df50164d07623cfcefec19bbf9327d9be84b637a827cea1f0c06db005fd/wandb-0.28.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:da909a76e65c64c0d93acc485d2a19f66e336f1e3f725f1c98a070883e084943", size = 24277925, upload-time = "2026-07-16T18:46:42.383Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/18/6c3da7e6cb215ad363324db8dc4d83b93626f5e339822b05b1c38a6097fd/wandb-0.28.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:3da3db219c54bfd1082c00e9061c8ea894ba43e42733b5af00bb10c09d7158fe", size = 25480852, upload-time = "2026-07-16T18:46:45.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1a/d15bcfb4417fa69edcaa33db8ea012db733da1057e193b047e3f69fdd671/wandb-0.28.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ae9ae6fb29e2e2b1d097ed8b75c0c0240c778c2a8cad1d996dee870a1e401c2c", size = 24832138, upload-time = "2026-07-16T18:46:47.433Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/da/49924c7df2952dfd82c86c3779c339c0c3d6f6439387c03d97d0470c3658/wandb-0.28.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8cfb898b6a6c884d9c9294b02764e88bce65049f027a124d6bee53fe722469b6", size = 26486533, upload-time = "2026-07-16T18:46:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/06b23518e29690784f1b3081e39c7679ca076cb0af094cb9b4bb309150f5/wandb-0.28.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cf2b1533945395e4fdbe6182b272bb0ca8a02c10b3086a395e2d57686ae3ed0d", size = 25022635, upload-time = "2026-07-16T18:46:52.376Z" },
+    { url = "https://files.pythonhosted.org/packages/23/30/6de2f7995a8a6eecbd03d24c79a139a734c0168f5520cf4c7ccb43c1dbbc/wandb-0.28.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7233061080507a4b4098bed1ccb381ce6f890c60397cd4153d060285bcb267bd", size = 27008895, upload-time = "2026-07-16T18:46:55.025Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/49deab9447687625371435ca21b6da82f223f1c7d014d77386b9cb91833c/wandb-0.28.1-py3-none-win32.whl", hash = "sha256:4bc461cda3ce23a19d8df5e42981a664d95fa3231efb10fd1e85d9d4824c7d29", size = 24418398, upload-time = "2026-07-16T18:46:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/6f/ed6616b11ea15b8ceabedcaa567286c1c9ec65fa50563230a90bfb627cc5/wandb-0.28.1-py3-none-win_amd64.whl", hash = "sha256:d98a10370162b1e970850237114c56e9c4c58f3cb701e4b8cb38f36f6749fd52", size = 24418404, upload-time = "2026-07-16T18:47:00.427Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/75b6827a6665337a715c5347c5edbd84eca660f7a0f48d8d6d24d1f66bee/wandb-0.28.1-py3-none-win_arm64.whl", hash = "sha256:4aa07f13dd3bcac2c0524c8d0f49f76e83ab5c1054fd09f3b1a436cfcde146a6", size = 22299006, upload-time = "2026-07-16T18:47:02.71Z" },
+]
+
+[[package]]
 name = "wcmatch"
 version = "10.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3134,7 +3950,15 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "seaborn" },
+    { name = "tinker" },
+    { name = "tinker-cookbook" },
     { name = "ty" },
+    { name = "wandb" },
+]
+distill = [
+    { name = "tinker" },
+    { name = "tinker-cookbook" },
+    { name = "wandb" },
 ]
 e2b = [
     { name = "e2b" },
@@ -3186,18 +4010,134 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "seaborn", marker = "extra == 'viz'", specifier = ">=0.13" },
+    { name = "tinker", marker = "extra == 'distill'", specifier = ">=0.23,<0.24" },
+    { name = "tinker-cookbook", marker = "extra == 'distill'", specifier = ">=0.4.3,<0.5" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.16" },
     { name = "uvicorn", specifier = ">=0.38" },
-    { name = "world-model-harness", extras = ["otel", "viz", "e2b", "connectors", "harbor", "postgres"], marker = "extra == 'dev'" },
+    { name = "wandb", marker = "extra == 'distill'", specifier = ">=0.17" },
+    { name = "world-model-harness", extras = ["otel", "viz", "e2b", "connectors", "harbor", "postgres", "distill"], marker = "extra == 'dev'" },
 ]
-provides-extras = ["otel", "viz", "e2b", "harbor", "connectors", "postgres", "dev"]
+provides-extras = ["otel", "viz", "e2b", "harbor", "connectors", "postgres", "distill", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "environment-capture", extras = ["bedrock", "fetch"], editable = "packages/environment-capture" },
     { name = "llm-waterfall", extras = ["all"], editable = "packages/llm-waterfall" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/91/f65c34a7aa7b4e7cf4854f8e6ef3f7ee32ceac41d4f008da0780db0612f6/xxhash-3.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e6e49370822c1f4d8d90e678b06dbcb08b51a026a7c4b55479e7d467f2e813bc", size = 34680, upload-time = "2026-07-06T10:44:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/57/04/b10a245a4c09a9cfa88f8e9ae755029413ad1ac17047f9a61906e5ae0799/xxhash-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:220d68130f83f7cc86d6edfdeab176adc73d7200bf3a8ec10c629e8cf605c215", size = 32397, upload-time = "2026-07-06T10:44:42.196Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/75/45ab795b5945b6388583bd75202106af505537935566c15a1577797a0e08/xxhash-3.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d365ee1892c1fa803536f8c6ce21d24b29c9718ec75eb856095c07830f8c478", size = 220549, upload-time = "2026-07-06T10:44:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/13/44/5ba2bd0a14ddf4193fc7d8ec29625f659f22c06d60b28f04bf46305d8330/xxhash-3.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:852bfe059720632e2f16a6a4745e41d20937b2bf2a42a401e2412046bb6971cc", size = 241186, upload-time = "2026-07-06T10:44:45.534Z" },
+    { url = "https://files.pythonhosted.org/packages/23/32/c4147def4d1e4538b906f82731e0ba23424377fc50a7cddd03cd284c8f63/xxhash-3.8.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f8c25a7061d952de589bd0ea0eaadee32378ff83dd6a677b267f9cd86f401f8", size = 264852, upload-time = "2026-07-06T10:44:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/bd/71ed14f4f0318bb7fd7b2ec51999413487fa8da8d41208e84d50d1ef0f98/xxhash-3.8.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:868a8dcaff1a84ba78038e1cef14fc88ccf84d9b4d12ea604696e0693296aa56", size = 242663, upload-time = "2026-07-06T10:44:48.846Z" },
+    { url = "https://files.pythonhosted.org/packages/91/09/70af22c565a8473b3f2ae73f88e7721af281bc4a575236dbd1970c9f76f6/xxhash-3.8.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6536d8677d2fff7e64cd0b98b976df9de7aee0e69590044c2af5f51b76b7a170", size = 473510, upload-time = "2026-07-06T10:44:50.695Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/34db781c8f0cf99c544ca1f2bc2e5bf55426e1eb4ca6de8ea5da56a9f352/xxhash-3.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82c0cedd280eab2e8291270e6c04894dbc096f8159a39dcf1807429f026ca3cc", size = 220469, upload-time = "2026-07-06T10:44:52.422Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/9a184f615fa5a4dce30c01534f62946ce5a11ce40f73785cbd356ccabaa9/xxhash-3.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daa86e4b68221d38e669bb236ba112d0335353829fb627c82e5909e4bbe8694c", size = 310290, upload-time = "2026-07-06T10:44:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dc/9b9a9789011ee153723a5eb9e7dd7fcbae2ba9b3fe7a729249ca7c252056/xxhash-3.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2bc7113e6f2b6b3922dd61796ca9f36af09da3773898e7003038dc992fc83b8d", size = 238173, upload-time = "2026-07-06T10:44:55.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/71c6005ada9dcb608a4e1902e8475ecadb5f3fbfa04e1e244d276a2d0c43/xxhash-3.8.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5eed32dad81d6ba8e62dc7b9ffa0500199385d7810a8dd9d4eafaceb8c6e20bb", size = 269026, upload-time = "2026-07-06T10:44:57.424Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/87/d6c036ba25dfbd9c8633be5aa86fc9474bbb9e2c68212a841d090abe7344/xxhash-3.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:83697b0ea1f10e7f5d8b26a4906fa851393c61546c63839643a2b7fe2d868061", size = 224970, upload-time = "2026-07-06T10:44:59.085Z" },
+    { url = "https://files.pythonhosted.org/packages/48/62/4c1f035a41c5752aa05e195b6c904c07b94fe9061a16de61e72a6e6b135f/xxhash-3.8.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:36fc69160465ae75c6ec4ac9f781bb2aa16ae7ff869e73c26fee85fbb11b9887", size = 240820, upload-time = "2026-07-06T10:45:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/da/14/d39d565069b87e86d21a2af2a31d04db79249d25aa8d5b62959056a89857/xxhash-3.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:445e0f5a31f2f3546ae0895d4811e159518cdc9d824c11419898d40cfadb677e", size = 300619, upload-time = "2026-07-06T10:45:02.716Z" },
+    { url = "https://files.pythonhosted.org/packages/13/22/75467acc887edc8cf71c97ab1708feb3df7a88bda589b9f399765c6387d2/xxhash-3.8.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:dfe0580fbfd5e4af87d0cc52d2044f155d55ebd8c8a93568758a2ea7d8e15975", size = 443267, upload-time = "2026-07-06T10:45:04.653Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b6/1da3baa5fa6ef705e3425fddd382be7dfc4dfba2686df90a20f16e9c7b1b/xxhash-3.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:095e1323fa108be1292c54c86da3ef3c7a7dc015b105a52133973bc07a6ad11a", size = 217338, upload-time = "2026-07-06T10:45:06.304Z" },
+    { url = "https://files.pythonhosted.org/packages/78/dd/b5295a9f97484e7a1c2b283a742ca45e3104991c55a1ef670dde161829ba/xxhash-3.8.1-cp312-cp312-win32.whl", hash = "sha256:bf28f55e427e0483acb1f666bd0d869b6d5e5a716680c216ad7befe3d4cfba2e", size = 31970, upload-time = "2026-07-06T10:45:07.823Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/31/3fa0b807d7e21515cd975e7fe5c039d52ac3e9401a96d6ad68dae6305215/xxhash-3.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:2256e80e4960ee282f63428adb349cb7f8bd8efe4db770d88eb815f4b9860724", size = 32741, upload-time = "2026-07-06T10:45:09.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/05/86feada74e239600e6875aa507afb40482a89b92700aa74a92da83bdcb77/xxhash-3.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:9df56e6df96a60590935e22373041cccc91fd55858763dcffb55bf63b3a2b396", size = 29234, upload-time = "2026-07-06T10:45:10.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/446bb782cd0d27007a917b5569a08dd73219c3e8d6e459014db104b27bdb/xxhash-3.8.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:3c682fcd96eb4bf64be32a4d95f96107e1588005831bd8a741b324fdda01b913", size = 38562, upload-time = "2026-07-06T10:45:12.425Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ec/c0c45627eaa6be7a5d6117423adf8f7a15b17ee74b4b17072cca5959a225/xxhash-3.8.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:036a024d8b9c01f70782e09ed98d532e76fd23f950ae7154bd950fe94e90ebec", size = 36656, upload-time = "2026-07-06T10:45:13.932Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/94/8324c04cc7597154caaeba6c094e01fbd2e7601d01e7a13eea9f5420e77b/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d6a5c0bce213b23b0166fe0d35bcbbe23ce4b968f257cc7eb6fd57cb8e1e6297", size = 31169, upload-time = "2026-07-06T10:45:15.687Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a4/beb6bb26e1184e126dbe7a5682330214ef54dcfbf882078aa9f4b5428d42/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:5177aa44eddaa97c6ef0cc00c6d540edb64d51781d2f8fb941612ec61a92c9ed", size = 32177, upload-time = "2026-07-06T10:45:17.035Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0f/fc4c92a5a528f839b34b6419b2e53c8597f2a629d5a1f5d721f65bfa1fd6/xxhash-3.8.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7801b7223db017b9c0c9ccf37e44524edb35a1544a1c032add22c061c6af0276", size = 34642, upload-time = "2026-07-06T10:45:18.39Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/58/edbfb141d4000767ac6a9694f8ac0763e2c2e983e65c9e31620ba56e2667/xxhash-3.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e80238259655bf69d7bcd08226a970d7f42605f3157786bfa76dd13472d7fa0", size = 34684, upload-time = "2026-07-06T10:45:20.033Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3f/5072f1f0f5714186f0ac2a0b5a4929ce30d4b845e94886b6c01b6ebda0be/xxhash-3.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bcab50a389cc04d87f90092af78a6adba2ab3deca63175a3344ca83514045315", size = 32401, upload-time = "2026-07-06T10:45:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c7/802ea2f9c2ed59219934d6d65c470d502b1788043eae277a52af8658bda6/xxhash-3.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2489d3a776fa380cb8e71f54c7fda268a9baf3de9b1395093fd280f95735907", size = 220617, upload-time = "2026-07-06T10:45:23.234Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a8/e10488efd31fcb13fcd6acbc6e788f10c6f8e3a0cc4ae3eb89dc19c55a12/xxhash-3.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32ab1e5432690276e71192be7401b55f96db2d0eedea5d44eb1f164505669cc0", size = 241295, upload-time = "2026-07-06T10:45:25.364Z" },
+    { url = "https://files.pythonhosted.org/packages/18/cc/14180b17d44892a631f8ae7323c30bfbb1328efc8209e528a480293528ac/xxhash-3.8.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b30e01a0b97a4bc3f519a4d7a82da3dc53251fb0de5eeea8660dcd4ff094c0c2", size = 264688, upload-time = "2026-07-06T10:45:27.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/a14019d0c5f6c41ee407a503036ae32787c91325ca218a96a9b5627be651/xxhash-3.8.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f44275ddb0978b67a58a951501903f04d49335a91f7681c9ce122ecb8ccb329", size = 242740, upload-time = "2026-07-06T10:45:28.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/08/92550e556c6fcfcb96c6a336945eb53a431ed43120ed749636debb16c5cf/xxhash-3.8.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3b87cbd974512c0c5fc7b469c36b2cdc9ee6d76e4ec78bccb2c7184611c49b0", size = 473599, upload-time = "2026-07-06T10:45:30.524Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/e361d3c1acd1b21e1d489616de6fa4aaf843365d8179f612e3743eac20a9/xxhash-3.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98ee81b4b7f3023c9cb04a78cc67610baffcb5812d92f2096cb5a5efc6f19437", size = 220559, upload-time = "2026-07-06T10:45:32.979Z" },
+    { url = "https://files.pythonhosted.org/packages/05/01/006a4243c2c2a6831827f9999f6d1c23feeef100eb023c1f886022a00bf3/xxhash-3.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2666f059a1588a99267e33605365ed89cea92f424b3522806a9f4bd8ad2e3d62", size = 310383, upload-time = "2026-07-06T10:45:35.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/20/af388e8bf9f9a0f89eeef7d2a1935d176ee1c20bc6adeda05035879379cf/xxhash-3.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0093cf7eeb91b84776e8742113afa4bdf47533d36cf719179aaaf1f56f6f8bf", size = 238228, upload-time = "2026-07-06T10:45:38.02Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6b/4666579a87eebd1744663c404297355fa0658617b015cedfa58810ee7036/xxhash-3.8.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3a800912a2e5e975d4128969d645c4a2a80aa886ccd6c9b1c6f44529e327e8cf", size = 269137, upload-time = "2026-07-06T10:45:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d3/e963a8a46f900a137d91b02144d8ea07a8f812971b138204a3b2f8b8e55c/xxhash-3.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0fe37f72a207223d22a4eddc3149d4298993385aa9daef25c039246ca5a309f3", size = 225068, upload-time = "2026-07-06T10:45:41.718Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/80/9d181dbcde4b0fe48375f48833a5832d4b8cd2b349b15110c92ee472d874/xxhash-3.8.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5db43f249b4be9f99ef4b967863f37094fb40e67effafb78ba4f0356b6396104", size = 240874, upload-time = "2026-07-06T10:45:43.414Z" },
+    { url = "https://files.pythonhosted.org/packages/39/15/ce3ab5a1cd27ead25a5196e55a7284220f6ad6e316da494ffd900b2b600f/xxhash-3.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c4ed42965c2cd9081f011be22f69d0e65d3b6165fe7734072fd0c232840bbd4e", size = 300702, upload-time = "2026-07-06T10:45:45.135Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c0/2281a8ab5f2a62dbf57a23c58a01ccc1d98abf40f71193c8a81f59e759b5/xxhash-3.8.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3557bec8fcb11738a8920eeb68974bc76b75262f6947998d3147954ce0a4b893", size = 443351, upload-time = "2026-07-06T10:45:47.188Z" },
+    { url = "https://files.pythonhosted.org/packages/81/2e/071a58c1a53a52d4f7a3aa0987be0c396dffd40da8204805fe1b130a81f4/xxhash-3.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00de40f3b42240db23a82a5c682b55d7263d84a26a953240c1aee463409660e3", size = 217396, upload-time = "2026-07-06T10:45:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/44/36ab58134badd9d3433fc7b53c4ca8d113d8e807782885628640f8297a4d/xxhash-3.8.1-cp313-cp313-win32.whl", hash = "sha256:b5196cc2574cfec572a5f3fb7cfa5ade27305ae3d06516a082132441aff4c83a", size = 31974, upload-time = "2026-07-06T10:45:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/2a0b84798448e766f7b89ceed073cb0cb5a43fc9ebbacbdea74a38de18e3/xxhash-3.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:538f5f865df6cd8c32dd63158a0e5b4f5dd08d732a7da8b7228a5a0776c8ce55", size = 32739, upload-time = "2026-07-06T10:45:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/bb51dbf7c363ff88a7cbd50b7959718219577ef44d7cf255929ffc4a2194/xxhash-3.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6617f30641ba0d8baa1635fbefb1dffc5165ec36d26921bd5cee13497cd937a", size = 29239, upload-time = "2026-07-06T10:45:53.714Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d3/827ca123c2ee5443a6aaed3c5dd199237dc2f010e2bebd7ec09ef36f3a5f/xxhash-3.8.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:bfcd82852c62a60e314670a9602de354c4460f8adad916e2e42a20860c7870bc", size = 34964, upload-time = "2026-07-06T10:45:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/05/67/67ae2a3ccdeb8b8ef025d35aee9edd1d26c3abe5051d47da9286232afbf8/xxhash-3.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:08ea2081f5e88615fec8622a9f87fbe21b8ea58d88cfc02163ca11026ee62a92", size = 32697, upload-time = "2026-07-06T10:45:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/38/5a/3d3994346e1f45493679cb5c1ffc2bf454e410e9d1e8a662d253becee91e/xxhash-3.8.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2e32855b6f9e5b18f449e59d45e3d5778bdeb660632ef2693cca267a11246c75", size = 225954, upload-time = "2026-07-06T10:45:58.897Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2c/53169270309b7cd8e05504e07fe123bac053b89d00ac63617faacf0a2ec0/xxhash-3.8.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6e088bd7870775624256a0d84c2a6714afd223b2eeb56b0ca58398e52a32fda", size = 249776, upload-time = "2026-07-06T10:46:00.977Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/5c551d8d592f944506f7c5185e210255c15e672a3c6008c156a1bd9b775e/xxhash-3.8.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:72eb5ae575cc7ae2b23f6f8064a8b10f638c7149819ae9cc6d20ebd4d37a1629", size = 274776, upload-time = "2026-07-06T10:46:02.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/d3a762270cee2d7bcd0e25e28c623e5f3f5c0dc637b66e3e47dd5b0bb3f0/xxhash-3.8.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d0b48cdf690a64cedf7258c3dc9506cc41fc86edd7739c40e3098952265dc068", size = 252056, upload-time = "2026-07-06T10:46:04.688Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/b78e4373b2cb6d1c42af60ea2d7e9146ad0710b239ac7f706d5d31d5bb98/xxhash-3.8.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb9e256a357dfcede7818c6d34e70db2d6b664394803d1de4b6984d2de76c0f1", size = 482108, upload-time = "2026-07-06T10:46:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/642d923336ea61a15f8ce64fc7e078729e6e06c3a026e517fa79b2c23b7a/xxhash-3.8.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51f71a6e2ad071e70c937e41fcb6c19f82c3f9f49831eba850ed4a106ffbb647", size = 226739, upload-time = "2026-07-06T10:46:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0a/a37d6da6427d45a8d23e3ee3a0ca9c9d4a90364849c6637fe2963a755f9b/xxhash-3.8.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4a6443968c4e8dc69967e12776776a5952c119cc1bd94168ad1c5ad667c2be1", size = 319658, upload-time = "2026-07-06T10:46:10.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/51/ebbd40da8a3f1bc53b4b7a9a87f8e28bd95c5f21bc14b8a57860cf367d1b/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:714503083a1f2065c9ad15340dd49ac8a8e948a505a705ffa1750cb951519113", size = 246059, upload-time = "2026-07-06T10:46:12.634Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4c/d9014030147e1f0bb26e7da47aa240dd9ec61c763c573e558111d869f8e1/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:77f74e45a1e5574bbbf80181c8027b3a4c65c2248fffbd557bd596fff13102f9", size = 275535, upload-time = "2026-07-06T10:46:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/caee2db41fadcd5a25aa4323213f9afec5a8586d4e419241e3d659362bd7/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4e0e1b0fb0259c1b75d1251ac0bb4d7ab675d36f7a6bf4ba6aa630dae94f9ffa", size = 231292, upload-time = "2026-07-06T10:46:16.452Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/60/f52f08bcdc904c4514ea5c25caa19e9f3214144434a6ff96dc82dc1cbddd/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:10e4393ec33633c2f05ad01869e546ad080b1a18f2650503731f153774608b31", size = 250490, upload-time = "2026-07-06T10:46:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a0/94dc7ae310838f250669c6ad7168e6d6fca17d49dac1053f06dc232c4a56/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b3ba794c3d885803db6c3116686923f1ec13bc86e621e169a375282b63ea1cc6", size = 309861, upload-time = "2026-07-06T10:46:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f9/adeead7d0eb28cdfc2832544ea639ffbc6749ccde47a8e228d667459182e/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:57189a69c0891e4818853feaa521c972d22c880a001453addea015f48e3c3398", size = 448739, upload-time = "2026-07-06T10:46:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/22ec0e07db57d901c9298ae98aa3cf2be45bafded6f07c13131e85b89032/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d59e71153fe9ff85648d00e18649b07e9b22c797291abb7e27274fa06df8b838", size = 223657, upload-time = "2026-07-06T10:46:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/94/32/8a9531f37b59e5a013003db7cb7414baf4ce7e0e1268e0d5947cd3d6a2df/xxhash-3.8.1-cp313-cp313t-win32.whl", hash = "sha256:5b96f0024e9840f449bd91b2d005c921a4b666055a0d1b6492463799f32aae22", size = 32377, upload-time = "2026-07-06T10:46:26.86Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/2ca45fd7f671de5f81fc297ef1c95080b40c86ec6be0cc6034b8f7707ac8/xxhash-3.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:37d5a56c36dcc0b9a87b814cd992598d33863ff683749de6c86081f278d5e629", size = 33274, upload-time = "2026-07-06T10:46:28.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/54/20d7163463ddb6438b73a427d1655a77a502cf9b9b0c3ada3599629d9c0a/xxhash-3.8.1-cp313-cp313t-win_arm64.whl", hash = "sha256:6696c8752aded28ff3b16f33ef28ce28fb5d209b80c206746f943199fcf5fd65", size = 29375, upload-time = "2026-07-06T10:46:29.962Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/df2ba04f22a6cd6b39f96a6577329a8471a55c90ef8d8e2f7c102363613f/xxhash-3.8.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:9db455cb649dcfe4504d6d68a6d83a7315a99a3ca59871dc3ff840671f99adba", size = 38430, upload-time = "2026-07-06T10:46:31.496Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4f/6a059e8ad3ca8deedc91dfe335b211204900895152212c03ebbe721de68b/xxhash-3.8.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:affb37f152e55b5e4494bb9d0107f7bb08515c6704fbed82d9f61214d74adc17", size = 36558, upload-time = "2026-07-06T10:46:33.078Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/95/40be178205acce092ae418feb20ac737b32a02c7b864926ed0717354c9f8/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:460261045936975193bfd20549a0de1cd52a33b405cbb972f0d80940c42266cd", size = 31181, upload-time = "2026-07-06T10:46:34.793Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/89/2da4dbf051bafa156c0e3f12012db2b0ac3b84ff37ca1f021f6bfffcdfbb/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:38c887aedb696ef8bca19983206d270848558cfae4a91afa6a2fb05dde58ffc5", size = 32192, upload-time = "2026-07-06T10:46:36.393Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4e/e000bbae3566bc8e0be771a8a0f294aa99075e3f0bc4ef43922ebffdebc8/xxhash-3.8.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:594131ce1aad18db3689781f806db1b065cdaa04f4df36b4c038d2013aefd0bf", size = 34691, upload-time = "2026-07-06T10:46:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4a/ea954aacc7d1c8711880ac2b55da94429a9b4296b151c4fc0966549ca1ee/xxhash-3.8.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:78c794b643d214f1522e7a288bcf5a2de120d26cd170516749a4009dc92722c9", size = 34807, upload-time = "2026-07-06T10:46:39.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/29/df598e738ff37558ac627264deb2e560902d9bf7f46d3bd5175c9eee593e/xxhash-3.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af0c9fedc4a2c24e8664953882fe8185f3790b8338c9c700f76f5ad660817711", size = 32410, upload-time = "2026-07-06T10:46:41.359Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/81ab40e7d33ada0b3df5d1bc884894d15dbf4f805cd645b685e4606bb8e0/xxhash-3.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:115772daeb71b2f3b9381177017f53e6cf3f3439c840737fdabd21aba6e54920", size = 220564, upload-time = "2026-07-06T10:46:43.463Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/62ae6f5c8606320a0e2a41c2dc8c6d91cc5d63d0f84dd9582e9543779dd8/xxhash-3.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:000435984a0469b0f822fe76f35bddea0f96a4d6521b3339a60a6428cdee1edc", size = 241462, upload-time = "2026-07-06T10:46:45.509Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/9c3a0ec6cb524396f551eddd102a76690a795494eb9784fc67542b0daa37/xxhash-3.8.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f1c68394818e0595569c2ff3cbc1e6d5a36a434e796f5c526b987b80c8a8c62", size = 264491, upload-time = "2026-07-06T10:46:47.655Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/700a4674e4308eb59d2fdb973977e82eae231bea5044753fee5c9eec0e0c/xxhash-3.8.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:46b39976d008e2a845758650f0ff7136bca004f40da0c8798bd37ac37860154f", size = 242905, upload-time = "2026-07-06T10:46:49.857Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8a/72d9874375c8d4cbc64a8cd1d659d5695a8765c3db82efa82dc5bd9f14d0/xxhash-3.8.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d5006c65ec507a333479e76e00e2c368781f16c24ededa764763956b32a0e93e", size = 473873, upload-time = "2026-07-06T10:46:51.953Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f0/6db07590ed7e0a77f186ef0bcea8d52553bf1ba57833e09467a2411f0f2d/xxhash-3.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31a2649bcf1fe97cf11c79848d761df33ac46b3896942d31b640557b486ff6b", size = 220765, upload-time = "2026-07-06T10:46:55.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/10/00d12d8b8beabbf49a8bbc626fb9f40445145a8887eb41a6acfb69149ac4/xxhash-3.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8f759eed402448c2bdbb492e4fba1f20668ffe29688605ea61f0f67f9e4e386d", size = 310478, upload-time = "2026-07-06T10:46:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f9/12a82394eefb0f185d15a7f7b9f627c61c475a72dd83718436a5b84b42ac/xxhash-3.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5f97ecfede10d5b2870383620e2d25c8561e217c7bf9081073802b54248d2b", size = 238393, upload-time = "2026-07-06T10:46:59.87Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f3/53f963e320b9ce678337aa7273f39ce692ded8b99e3d22a866ec722159ab/xxhash-3.8.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1da930bbcac3e8fbe2191850e2abb57977a99348c12c4b385e1058ac1b0a9ecc", size = 268704, upload-time = "2026-07-06T10:47:01.806Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/50/5b5badbd87c82d9f9b5f58ac74a3f29ef08f6fc387b324b8fd482450b862/xxhash-3.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:747476436f6891b9773374ce8d48edcc8b12cb5b61b67c6fb6289633747d088f", size = 225015, upload-time = "2026-07-06T10:47:03.784Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/3ca68265afe7b4e69435e08a7b6a1d9d0f2a071e889da1f8041ed00fe878/xxhash-3.8.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4ef09bbc2519a93cd0f95f2ceb5f7b85919dffea643278e02362bf40e3c4bed1", size = 240951, upload-time = "2026-07-06T10:47:05.816Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/27e19670c40f46b5e76e11f2f4713d21054804568425d870670e757172ad/xxhash-3.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a5eed9d41995a83f3332b4e3396abb7f433cac584222bd7e305b606d8353861e", size = 300751, upload-time = "2026-07-06T10:47:07.95Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fb/b33e27689959fe7ed2ae0b830af41560d65213943983afa9db3a8d481bce/xxhash-3.8.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:53f3ed9118397074ff63a79b66b7fec1c84c782eecde35c5bc94e420a971c231", size = 443480, upload-time = "2026-07-06T10:47:10Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/0e0d973be5fe280753ef02fbc89349492ad6e903bf1dcb870b668f94b662/xxhash-3.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d247b34bf433c92b41689318fd25d246313cab2275a6a47e2efac178b80d6efe", size = 217657, upload-time = "2026-07-06T10:47:12.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/68/c9e3ecef4a9a417d464cb5bd200aa12f73192dee677901b9e08e0ad0d1bb/xxhash-3.8.1-cp314-cp314-win32.whl", hash = "sha256:d58ce8b6cfa9c4d2f230557f69caf7c06369e318015d0b19485095bc2c5963ab", size = 32690, upload-time = "2026-07-06T10:47:14.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/99/e9e44588c0b62837bbec5ba7927816de0afa03406b1a0b6c7a7e1d1a30a0/xxhash-3.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:6cee733fe4ccb1737e0997135283c82341e5cfa9cf214b165f9087fb663aaf4f", size = 33460, upload-time = "2026-07-06T10:47:16.021Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/64f36d86380b3657ad9031967ab814f3ef31307174650853f69c18932ebc/xxhash-3.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:58346024d47e84f7d8b3e7f5d6faa1d58acbbe49a8771497872059f58c1d8ea5", size = 30092, upload-time = "2026-07-06T10:47:17.81Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cb/18b64bff88c58a0ca209dc533e63cf02d7ae5aa6b1b9a9fd14e81b5dbd60/xxhash-3.8.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:01cab782f8a0a05ecad2c63d7ef10f7ab475f660e0d6419d069418c14d88de7c", size = 35024, upload-time = "2026-07-06T10:47:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/72d8a70520e5dcddb472ea0486d299da3240745a10658290cd7b5690ede2/xxhash-3.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:717b12fdc51819833704e85e6926d76981ffa3f780ef92e33ebb8b26d46bb230", size = 32697, upload-time = "2026-07-06T10:47:21.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b8/e041f555903c56db3d0a731b3d72a6575d75e0ed868b1bd2e5176111ca44/xxhash-3.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ec55d80e9b8a519d742669e0b49e8ce9e6747be42bf3c138158b6543a9c8e489", size = 226044, upload-time = "2026-07-06T10:47:23.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7e/5cdcf06bf6ec4b5d2ac073feb23432ec1d603fd438864cbd2c09c7cb45e1/xxhash-3.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98d8ac1129b4dd39098cffed94d1284aceb61c3aa396757ccc736ac392e4cee5", size = 249899, upload-time = "2026-07-06T10:47:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c0/eb7e059cb5e1dba11fd30d2fdf882f56e5a417a3eaa43669d43623767f45/xxhash-3.8.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3bc0fa90830df1e1277f33cc6e55de9990b83c0319fd8c7412866cfde38b025e", size = 274892, upload-time = "2026-07-06T10:47:27.931Z" },
+    { url = "https://files.pythonhosted.org/packages/66/74/a600aaf7cd39957fd1510adeedb1749c1e7eb82bd632a1153d9c664c3135/xxhash-3.8.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c73b6f652f0745425aa6378319c331293b5341756262e9408ed3d45f183375e6", size = 252243, upload-time = "2026-07-06T10:47:30.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/78d88fa75a6763e5d09bf1b947a392a27988903381b219006f92f3c68fc8/xxhash-3.8.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6114692261eff4266386cdec0f7d87eee24e317ab397c218b7ae6a76b4c6339", size = 482191, upload-time = "2026-07-06T10:47:32.45Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/06/07a8aea1108d682de8791ce608cdf367d75ff4e7e57cd3c154bdc6f47b23/xxhash-3.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df57c0b161ec1b3ed0526a67b0db0914b557e86ee8aae51887aec941b261542", size = 226877, upload-time = "2026-07-06T10:47:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b5/86bade5618a524d2c06c4041aa2fe8e5749ce16e88afba60d67c1684a21f/xxhash-3.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9043877a917be88ccf230aa5667c1bd059bce80f4c2727e4defa1b29b7f48b08", size = 319794, upload-time = "2026-07-06T10:47:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/23/69/9b1a2b89b1621bb740fbcb7beb512f60f99480c1bdc680c0c90e1f56ff75/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:559e3cabe522231909f9de98ef06929edbd53782046bd21aae0c72db6f2a0775", size = 246202, upload-time = "2026-07-06T10:47:39.676Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ea/662ed6cb49f1d34078b6a3a3e0f3d29ff93fd7b5a03c0bc9ecfd9b2159c3/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:264710bd335016f303763ce1275c6486df30bb57c2245c91b224c983d7ac39b8", size = 275628, upload-time = "2026-07-06T10:47:41.99Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/49fc9e4c6728a5a3bd8fe639199d2fa67609b3a84f938aff6e8568dd3e4f/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e14800b9b10bb39d7a60ad4a310e403164d7b8988a27ae933d4e40618a44088e", size = 231390, upload-time = "2026-07-06T10:47:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9d/3acaf8f599c0e0b30e910a3a11ba32929da53c86dc73c7c55fe6a010b4e9/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:ea6a3e734b0fd41b82784a400be946821900daebe610c050a5e0760838a34f99", size = 250600, upload-time = "2026-07-06T10:47:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/23/64/8acab4c5ec60dbe664b5b9858fd44c2413b07e535b09556a0a5022e78aa6/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cf399fac542a1c7a4734a435b93df2c55e858c7d31abf6c1bdf46f9ae67fbfd0", size = 310032, upload-time = "2026-07-06T10:47:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/a0288d7329b1fe63e2734a32d19d444a96ae2b4810f545bc61e561224917/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:44c89d915a75c11d2547eaee9098fcd80398987c4bff2974a0497a925bf92c07", size = 448882, upload-time = "2026-07-06T10:47:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e7/3071dfd3beb5c38204ce1cf56bf7749fce08de900fa92714b81d1d8ca1f2/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:358650d5bda9c635da699c53adf4e8134af492ecc79c960f917eebf088bb6799", size = 223728, upload-time = "2026-07-06T10:47:55.093Z" },
+    { url = "https://files.pythonhosted.org/packages/12/11/b99949f0ba2b07e9f9ffe83b9c86faa685f9080725dc21a916a607313be5/xxhash-3.8.1-cp314-cp314t-win32.whl", hash = "sha256:c240939e963653054fc7e4a17c382829cda4aa88a7daf0af841715dbded1b497", size = 33150, upload-time = "2026-07-06T10:47:57.274Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1c/09703eb341f8416e74e58d6c6732d4b5c46de59c942363203cb237cc95b0/xxhash-3.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:7258ee276e8772599bc19e14b36f6260306e21b637190cd7cb489a2449d48684", size = 34005, upload-time = "2026-07-06T10:47:59.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f9/6ed7251bb6a8af10ac73b1821c60583d2826e5b2064e45a979c935287c98/xxhash-3.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:8f454166c2ffed45636c8d501741e649851ba2f346c4eb73a64c07ac00428f20", size = 30239, upload-time = "2026-07-06T10:48:01.874Z" },
 ]
 
 [[package]]
@@ -3289,4 +4229,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]

--- a/wmh/cli/model_roles.py
+++ b/wmh/cli/model_roles.py
@@ -73,6 +73,7 @@ def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderCon
     return ProviderConfig(
         kind=kind,
         model=configured.model,
+        model_type=configured.model_type,
         region=configured.region,
         endpoint=configured.endpoint,
         deployment=configured.deployment,

--- a/wmh/cli/model_roles_test.py
+++ b/wmh/cli/model_roles_test.py
@@ -109,6 +109,40 @@ def test_configured_role_forwards_fields_and_defaults_the_azure_api_version(
     assert config.reasoning_effort == "high"
 
 
+def test_tinker_role_forwards_model_type_for_weights_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A distilled student is a tinker:// weights path plus the base model identity in
+    # model_type; without the pass-through, the tinker provider cannot resolve its
+    # renderer and tokenizer from settings-configured roles.
+    root = tmp_path / ".wmh"
+    save_settings(
+        _settings_for_role(
+            "agent",
+            ModelRole(
+                provider="tinker",
+                model="tinker://run/weights/42",
+                model_type="Qwen/Qwen3-8B",
+            ),
+        ),
+        root,
+    )
+    configs: list[ProviderConfig] = []
+
+    def fake_get_provider(config: ProviderConfig) -> _Provider:
+        configs.append(config)
+        return _Provider()
+
+    monkeypatch.setattr(model_roles_module, "get_provider", fake_get_provider)
+
+    resolve_opt_in_model_provider(str(root), "agent", _Provider())
+
+    [config] = configs
+    assert config.kind is ProviderKind.TINKER
+    assert config.model == "tinker://run/weights/42"
+    assert config.model_type == "Qwen/Qwen3-8B"
+
+
 def test_explicit_api_version_overrides_the_azure_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmh/config/config.py
+++ b/wmh/config/config.py
@@ -131,7 +131,14 @@ PROVIDER_ENV_VARS: dict[ProviderKind, list[str]] = {
     ProviderKind.AZURE_OPENAI: ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
     ProviderKind.OPENAI: ["OPENAI_API_KEY"],
     ProviderKind.OPENAI_RESPONSES: ["OPENAI_API_KEY"],
+    # Kept as a literal like every other entry (importing the provider module here would
+    # invert the config -> providers dependency); `wmh.providers.tinker.TINKER_API_KEY_ENV`
+    # is the name the provider actually reads, and a test pins the two together.
+    ProviderKind.TINKER: ["TINKER_API_KEY"],
 }
+"""Every `ProviderKind` must appear here: the CLI's credential prompts, the picker's
+"creds set" annotation, and the `providers verify` failure hint all read this dict, and a
+missing kind silently degrades all three to "no credentials known"."""
 
 
 class HarnessConfig(BaseModel):

--- a/wmh/config/config_test.py
+++ b/wmh/config/config_test.py
@@ -7,13 +7,27 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from wmh.config.config import ArtifactPaths, HarnessConfig, load_config, save_config
+from wmh.config.config import (
+    PROVIDER_ENV_VARS,
+    ArtifactPaths,
+    HarnessConfig,
+    load_config,
+    save_config,
+)
 from wmh.providers.base import EmbedderKind, ProviderConfig, ProviderKind
 
 
 def test_gepa_budget_default_is_modest() -> None:
     # 10 iterations ~= 700 metric calls with the capped valset; 50 was ~3.4k calls (hours).
     assert HarnessConfig().gepa_budget == 10
+
+
+@pytest.mark.parametrize("kind", list(ProviderKind))
+def test_every_provider_kind_declares_its_credential_env_vars(kind: ProviderKind) -> None:
+    # A missing kind is silent: the CLI's credential prompt, the picker's "creds set"
+    # annotation, and the `providers verify` failure hint all degrade to "no credentials
+    # known" rather than erroring, so only this exhaustiveness check catches the gap.
+    assert PROVIDER_ENV_VARS.get(kind), f"{kind.value} has no PROVIDER_ENV_VARS entry"
 
 
 def test_save_then_load_round_trips(tmp_path: Path) -> None:

--- a/wmh/config/settings.py
+++ b/wmh/config/settings.py
@@ -26,6 +26,9 @@ class ModelRole(BaseModel):
 
     provider: str  # a ProviderKind value ("bedrock", "azure", "openai", ...)
     model: str
+    # Canonical model identity when `model` is a runtime id that does not carry it, e.g. a
+    # tinker:// weights path whose base model determines the renderer and tokenizer.
+    model_type: str | None = None
     region: str | None = None  # AWS Bedrock region
     endpoint: str | None = None  # Azure OpenAI / custom base URL
     deployment: str | None = None  # Azure OpenAI deployment name

--- a/wmh/distill/__init__.py
+++ b/wmh/distill/__init__.py
@@ -1,0 +1,12 @@
+"""On-policy distillation optimizer mode.
+
+Trains a Tinker LoRA student from rollouts the pi agent produces on harbor
+tasks (TerminalBench-2). The teacher scores the student's sampled tokens via
+compute_logprobs, and reverse-KL advantages feed the importance_sampling loss.
+The public surface is deliberately minimal for now: the per-run TOML config
+model and its loader.
+"""
+
+from wmh.distill.config import DistillConfig, load_distill_config
+
+__all__ = ["DistillConfig", "load_distill_config"]

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -134,18 +134,29 @@ class SamplingConfig(BaseModel):
 
 
 class WarmupConfig(BaseModel):
-    """Reserved supervised warmup phase (only 0 steps supported in v1)."""
+    """Supervised warmup on the teacher's own pi trajectories before OPD steps.
+
+    The remedy for a student that samples only failing trajectories (on-policy
+    distillation then matches the teacher on failures): before the OPD step
+    loop, the teacher runs the pi harness on the TRAIN tasks, its kept trials
+    become cross_entropy SFT datums via the same prefix merge, and the student
+    trains `steps` full-batch passes over them. 0 steps (the default) disables
+    the phase entirely.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     steps: int = Field(default=0, ge=0)
+    """Full-batch SFT passes over the kept teacher trajectories; 0 disables."""
 
-    @field_validator("steps")
-    @classmethod
-    def _reject_warmup(cls, value: int) -> int:
-        if value > 0:
-            raise ValueError("warmup is reserved; not implemented yet (set warmup.steps = 0)")
-        return value
+    rollouts_per_task: int = Field(default=1, ge=1)
+    """Teacher attempts per train task when collecting warmup trajectories."""
+
+    keep: Literal["passed", "all"] = "passed"
+    """Which teacher trials feed the SFT set: reward-passing only, or all."""
+
+    learning_rate: Annotated[float, Field(gt=0)] | None = None
+    """Warmup optimizer LR; None uses `train.learning_rate`."""
 
 
 class EvalConfig(BaseModel):

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -1,0 +1,286 @@
+"""Per-run TOML configuration for an on-policy distillation run.
+
+A distillation run is described by one TOML file with sections mirroring the
+sub-models below (student, teacher, harbor, rollout, train, sampling, warmup,
+eval, gate, pricing, budget, wandb). `load_distill_config` reads and validates
+the file; `snapshot_toml` renders a validated config back to TOML so a run dir
+can carry an exact snapshot of the configuration it ran with.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Annotated, Literal
+
+import tomli_w
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+
+class StudentConfig(BaseModel):
+    """The Tinker LoRA student under training."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    base_model: str
+    lora_rank: int = 32
+
+
+class TeacherConfig(BaseModel):
+    """The teacher that scores student tokens via compute_logprobs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    backend: Literal["tinker"] = "tinker"
+    model: str
+    checkpoint: str | None = None
+    """Optional tinker:// checkpoint path to serve the teacher from."""
+
+
+class HarborConfig(BaseModel):
+    """How rollouts are produced: the pi agent on harbor tasks.
+
+    Attempts per task are NOT configured here: training rollouts use
+    `train.group_size` (the on-policy group) and evals use `eval.k` / `gate.k`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_template: str
+    """Path to a Harbor JobConfig YAML/JSON used as the task template."""
+
+    backend: Literal["local", "e2b"] = "local"
+    reward_key: str = "reward"
+
+
+class RolloutConfig(BaseModel):
+    """Per-episode rollout limits."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_turns: int = Field(default=20, ge=1)
+    """Episode turn cap; pinned into the harness doc's `param:max-turns`."""
+
+    context_budget_tokens: int = Field(default=65536, ge=1024)
+    """Context cap: episodes where any call's prompt plus sampled tokens exceed
+    it are dropped whole from training (`build_datums`), and the cost estimate
+    caps per-episode tokens here."""
+
+    compaction: bool = False
+
+    @field_validator("compaction")
+    @classmethod
+    def _reject_compaction(cls, value: bool) -> bool:
+        """Reject compaction: it breaks the prefix property the cost model relies on.
+
+        Every turn's prompt must extend the previous turn's tokens verbatim so
+        prefill work amortizes across turns and sampled spans stay aligned for
+        teacher scoring. Compacting mid-rollout rewrites the prefix, so each
+        later turn would be a full re-prefill and issued spans would no longer
+        appear verbatim in the episode tokens.
+        """
+        if value:
+            raise ValueError(
+                "rollout.compaction = true is not supported: compaction rewrites the "
+                "token prefix mid-episode, breaking the prefix property that keeps "
+                "prefill costs amortized across turns and sampled spans verbatim in "
+                "the episode; set compaction = false (episodes that outgrow "
+                "context_budget_tokens are dropped whole from training instead)"
+            )
+        return value
+
+
+class TrainConfig(BaseModel):
+    """Optimizer-loop schedule and batch shape."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    steps: int = Field(default=40, ge=1)
+    tasks_per_batch: int = Field(default=8, ge=1)
+    group_size: int = Field(default=4, ge=1)
+    learning_rate: float = Field(default=1e-4, gt=0)
+    advantage_clip: float = Field(default=4.0, gt=0)
+    center_advantages: bool = True
+    max_datum_tokens: int = 65536
+    sampler_refresh_every: int = Field(default=1, ge=1)
+    save_state_every: int = Field(default=8, ge=1)
+    trial_concurrency: int = Field(default=8, ge=1)
+
+
+class SamplingConfig(BaseModel):
+    """Student sampling parameters used during rollouts.
+
+    Both values are pinned into the harness document's param surfaces
+    (`param:temperature`, `param:max-output-tokens`), which is how the pi
+    runtimes stamp them onto every worker request.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    temperature: float = Field(default=1.0, ge=0, le=2)
+    """Rollout sampling temperature. 1.0 (the default) keeps the sampler's
+    issued logprobs directly comparable to the teacher's untempered
+    compute_logprobs values; any other value biases the reverse-KL advantages
+    and is warned about at run start."""
+
+    max_tokens: int = Field(default=8192, ge=1)
+    """Per-completion output cap for every rollout request."""
+
+
+class WarmupConfig(BaseModel):
+    """Reserved supervised warmup phase (only 0 steps supported in v1)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    steps: int = Field(default=0, ge=0)
+
+    @field_validator("steps")
+    @classmethod
+    def _reject_warmup(cls, value: int) -> int:
+        if value > 0:
+            raise ValueError("warmup is reserved; not implemented yet (set warmup.steps = 0)")
+        return value
+
+
+class EvalConfig(BaseModel):
+    """Periodic held-out evaluation schedule."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    every: int = Field(default=10, ge=0)
+    """Evaluate every N train steps; 0 means final eval only."""
+
+    tasks: int = Field(default=12, ge=1)
+    k: int = Field(default=1, ge=1)
+
+
+class GateConfig(BaseModel):
+    """Promotion gate for the distilled student."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    k: int = Field(default=3, ge=1)
+    min_teacher_fraction: float = Field(default=0.7, gt=0, le=1)
+    require_no_regression: bool = True
+
+
+class PricingConfig(BaseModel):
+    """Per-model per-meter prices, USD per million tokens (all optional)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    student_prefill: Annotated[float, Field(ge=0)] | None = None
+    student_sample: Annotated[float, Field(ge=0)] | None = None
+    student_train: Annotated[float, Field(ge=0)] | None = None
+    teacher_prefill: Annotated[float, Field(ge=0)] | None = None
+
+    def is_complete(self) -> bool:
+        """Whether every meter has a price, so run cost can be fully accounted."""
+        return (
+            self.student_prefill is not None
+            and self.student_sample is not None
+            and self.student_train is not None
+            and self.teacher_prefill is not None
+        )
+
+
+class BudgetConfig(BaseModel):
+    """Optional hard USD budget for the whole run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_usd: Annotated[float, Field(gt=0)] | None = None
+
+
+class WandbConfig(BaseModel):
+    """Optional Weights & Biases run tracking (off by default).
+
+    Enabling it requires the wandb SDK (`uv sync --extra distill`) and
+    credentials (WANDB_API_KEY or a prior `wandb login`); both are checked
+    before the run spends anything (see `wmh.distill.tracking`).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    project: str = "wmh-distill"
+    entity: str | None = None
+    run_name: str | None = None
+    """The wandb run name; None derives one from the agent name and run dir."""
+
+    tags: list[str] = Field(default_factory=list)
+
+
+class DistillConfig(BaseModel):
+    """Top-level configuration for one distillation run.
+
+    The student, teacher, and harbor sections are required (each carries a
+    required field); every other section has complete defaults and may be
+    omitted from the TOML file.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    student: StudentConfig
+    teacher: TeacherConfig
+    harbor: HarborConfig
+    rollout: RolloutConfig = Field(default_factory=RolloutConfig)
+    train: TrainConfig = Field(default_factory=TrainConfig)
+    sampling: SamplingConfig = Field(default_factory=SamplingConfig)
+    warmup: WarmupConfig = Field(default_factory=WarmupConfig)
+    eval: EvalConfig = Field(default_factory=EvalConfig)
+    gate: GateConfig = Field(default_factory=GateConfig)
+    pricing: PricingConfig = Field(default_factory=PricingConfig)
+    budget: BudgetConfig = Field(default_factory=BudgetConfig)
+    wandb: WandbConfig = Field(default_factory=WandbConfig)
+
+
+def load_distill_config(path: Path) -> DistillConfig:
+    """Load and validate a distillation run config from a TOML file.
+
+    Args:
+        path: Path to the per-run TOML file.
+
+    Returns:
+        The validated DistillConfig.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file is not valid TOML or fails validation; the
+            message names the file and each failing field.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"distill config not found: {path}") from exc
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"invalid distill config {path}: not valid TOML ({exc})") from exc
+    try:
+        return DistillConfig.model_validate(data)
+    except ValidationError as exc:
+        details = "; ".join(
+            "{field}: {msg}".format(
+                field=".".join(str(part) for part in err["loc"]) or "(top level)",
+                msg=err["msg"],
+            )
+            for err in exc.errors()
+        )
+        raise ValueError(f"invalid distill config {path}: {details}") from exc
+
+
+def snapshot_toml(cfg: DistillConfig) -> str:
+    """Render a validated config back to TOML for run-dir snapshotting.
+
+    Unset optional fields (None) are omitted; parsing the result back yields
+    an identical DistillConfig.
+
+    Args:
+        cfg: The config to snapshot.
+
+    Returns:
+        A valid TOML document string.
+    """
+    data = cfg.model_dump(mode="json", exclude_none=True)
+    return tomli_w.dumps(data)

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -107,7 +107,7 @@ class TrainConfig(BaseModel):
     learning_rate: float = Field(default=1e-4, gt=0)
     advantage_clip: float = Field(default=4.0, gt=0)
     center_advantages: bool = True
-    max_datum_tokens: int = 65536
+    max_datum_tokens: int = Field(default=65536, ge=1)
     sampler_refresh_every: int = Field(default=1, ge=1)
     save_state_every: int = Field(default=8, ge=1)
     trial_concurrency: int = Field(default=8, ge=1)
@@ -190,6 +190,15 @@ USD/Mtok). An explicit `*_cached_prefill` field overrides this derivation.
 """
 
 
+def _effective_cached(explicit: float | None, full_prefill: float | None) -> float | None:
+    """The cached-prefill rate charged: the explicit override, else 20% of the full rate."""
+    if explicit is not None:
+        return explicit
+    if full_prefill is not None:
+        return full_prefill * CACHED_PREFILL_FRACTION
+    return None
+
+
 class PricingConfig(BaseModel):
     """Per-model per-meter prices, USD per million tokens (all optional).
 
@@ -222,35 +231,26 @@ class PricingConfig(BaseModel):
     @property
     def effective_student_cached_prefill(self) -> float | None:
         """The student cached-prefill price actually charged (see class docstring)."""
-        if self.student_cached_prefill is not None:
-            return self.student_cached_prefill
-        if self.student_prefill is not None:
-            return self.student_prefill * CACHED_PREFILL_FRACTION
-        return None
+        return _effective_cached(self.student_cached_prefill, self.student_prefill)
 
     @property
     def effective_teacher_cached_prefill(self) -> float | None:
         """The teacher cached-prefill price actually charged (see class docstring)."""
-        if self.teacher_cached_prefill is not None:
-            return self.teacher_cached_prefill
-        if self.teacher_prefill is not None:
-            return self.teacher_prefill * CACHED_PREFILL_FRACTION
-        return None
+        return _effective_cached(self.teacher_cached_prefill, self.teacher_prefill)
 
     def is_complete(self) -> bool:
         """Whether every meter has a price, so run cost can be fully accounted.
 
         The cached-prefill meters count as priced through their derived 20%
-        defaults, so completeness needs exactly the four full prices plus
-        `teacher_sample`.
+        defaults whenever the corresponding full prefill price is set (which
+        this requires), so completeness needs exactly the four full prices
+        plus `teacher_sample`.
         """
         return (
             self.student_prefill is not None
-            and self.effective_student_cached_prefill is not None
             and self.student_sample is not None
             and self.student_train is not None
             and self.teacher_prefill is not None
-            and self.effective_teacher_cached_prefill is not None
             and self.teacher_sample is not None
         )
 

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -105,12 +105,32 @@ class TrainConfig(BaseModel):
     tasks_per_batch: int = Field(default=8, ge=1)
     group_size: int = Field(default=4, ge=1)
     learning_rate: float = Field(default=1e-4, gt=0)
+    loss: Literal["importance_sampling", "topk_ce"] = "importance_sampling"
+    """The distillation loss. `importance_sampling` (the default) trains on
+    per-token reverse-KL advantages over the student's realized tokens;
+    `topk_ce` trains a weighted cross-entropy over the teacher's top-k
+    candidate tokens at every loss position (renormalized teacher probs as
+    weights), which carries dense supervision from tokens the student did
+    NOT sample at roughly k times the training-token volume."""
+
+    topk: int = Field(default=8, ge=1, le=64)
+    """How many teacher candidates per position under `loss = "topk_ce"`
+    (ignored by `importance_sampling`). Training volume scales linearly
+    with it (k replicated cross_entropy datums per source datum)."""
+
     advantage_clip: float = Field(default=4.0, gt=0)
     center_advantages: bool = True
     max_datum_tokens: int = Field(default=65536, ge=1)
     sampler_refresh_every: int = Field(default=1, ge=1)
     save_state_every: int = Field(default=8, ge=1)
     trial_concurrency: int = Field(default=8, ge=1)
+
+    log_sample_rollouts: int = Field(default=2, ge=0)
+    """How many sample episodes each batch renders to human-readable text:
+    after every training step, the warmup collection, and each eval batch,
+    the first N span-bearing trials are decoded WITH the chat template's
+    special tokens and written to the run dir's `samples/` files plus the
+    tracker's samples table (see `wmh.distill.samples`). 0 disables."""
 
 
 class SamplingConfig(BaseModel):
@@ -158,17 +178,41 @@ class WarmupConfig(BaseModel):
     learning_rate: Annotated[float, Field(gt=0)] | None = None
     """Warmup optimizer LR; None uses `train.learning_rate`."""
 
+    trajectories_from: str | None = None
+    """Path to another run dir whose warmup COLLECTION completed: the warmup
+    phase loads that run's `warmup-trials.json` manifest instead of collecting
+    teacher rollouts here. The manifest's teacher must match this run's
+    teacher, the `keep` filter applies at load time (so it may differ from the
+    source run's), and loading charges no meter (the source run paid for the
+    collection); the CE training passes still run per this run's config."""
+
 
 class EvalConfig(BaseModel):
-    """Periodic held-out evaluation schedule."""
+    """Held-out evaluation schedule plus cross-run baseline reuse."""
 
     model_config = ConfigDict(extra="forbid")
 
-    every: int = Field(default=10, ge=0)
-    """Evaluate every N train steps; 0 means final eval only."""
+    every: int = Field(default=0, ge=0)
+    """Evaluate every N train steps; 0 (the default) means final eval only."""
 
     tasks: int = Field(default=12, ge=1)
     k: int = Field(default=1, ge=1)
+
+    teacher_baseline_from: str | None = None
+    """Path to a prior run's `evals/baseline-teacher.json` to reuse instead of
+    re-running the teacher-in-harness holdout baseline (the teacher's solve
+    rate is a property of the teacher, not of the training run). The report
+    must cover exactly this run's holdout task ids, carry at least `gate.k`
+    attempts, and name the same teacher model; it is copied into this run's
+    `evals/` with a provenance `source` note."""
+
+    student_baseline_from: str | None = None
+    """Path to a prior run's `evals/baseline-student-before.json` to reuse
+    instead of re-running the pre-training student baseline (parallel runs
+    from the same base model share it). Validated like
+    `teacher_baseline_from`, except the model check is on the report's
+    recorded `base_model` field: the student's provider model is a per-run
+    sampler path and never matches across runs."""
 
 
 class GateConfig(BaseModel):

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -181,23 +181,77 @@ class GateConfig(BaseModel):
     require_no_regression: bool = True
 
 
+CACHED_PREFILL_FRACTION = 0.2
+"""Default cached-prefill price as a fraction of the full prefill price.
+
+Tinker bills a request's verbatim repeated prompt prefix at 20% of the full
+prefill price (the ratio its console lists, e.g. Ultra 0.498 vs 2.49
+USD/Mtok). An explicit `*_cached_prefill` field overrides this derivation.
+"""
+
+
 class PricingConfig(BaseModel):
-    """Per-model per-meter prices, USD per million tokens (all optional)."""
+    """Per-model per-meter prices, USD per million tokens (all optional).
+
+    Tinker bills prefill PER REQUEST over each call's full prompt: every
+    agent turn re-bills its whole context, with the verbatim repeated prefix
+    billed at a discounted cached rate. The `*_cached_prefill` fields carry
+    that cached rate; when left unset they default to
+    `CACHED_PREFILL_FRACTION` (20%) of the corresponding full prefill price
+    whenever that price is set, and stay unpriced otherwise. `teacher_sample`
+    prices the tokens teacher-in-harness episodes (warmup collection and the
+    gate's teacher baseline) SAMPLE, which bill at the sampling rate
+    (~2.5x prefill on the live price list), not the prefill rate.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     student_prefill: Annotated[float, Field(ge=0)] | None = None
+    student_cached_prefill: Annotated[float, Field(ge=0)] | None = None
+    """Student cached-prefill rate; None means 20% of student_prefill when set."""
+
     student_sample: Annotated[float, Field(ge=0)] | None = None
     student_train: Annotated[float, Field(ge=0)] | None = None
     teacher_prefill: Annotated[float, Field(ge=0)] | None = None
+    teacher_cached_prefill: Annotated[float, Field(ge=0)] | None = None
+    """Teacher cached-prefill rate; None means 20% of teacher_prefill when set."""
+
+    teacher_sample: Annotated[float, Field(ge=0)] | None = None
+    """Sampling rate for teacher-in-harness episodes (warmup, gate baseline)."""
+
+    @property
+    def effective_student_cached_prefill(self) -> float | None:
+        """The student cached-prefill price actually charged (see class docstring)."""
+        if self.student_cached_prefill is not None:
+            return self.student_cached_prefill
+        if self.student_prefill is not None:
+            return self.student_prefill * CACHED_PREFILL_FRACTION
+        return None
+
+    @property
+    def effective_teacher_cached_prefill(self) -> float | None:
+        """The teacher cached-prefill price actually charged (see class docstring)."""
+        if self.teacher_cached_prefill is not None:
+            return self.teacher_cached_prefill
+        if self.teacher_prefill is not None:
+            return self.teacher_prefill * CACHED_PREFILL_FRACTION
+        return None
 
     def is_complete(self) -> bool:
-        """Whether every meter has a price, so run cost can be fully accounted."""
+        """Whether every meter has a price, so run cost can be fully accounted.
+
+        The cached-prefill meters count as priced through their derived 20%
+        defaults, so completeness needs exactly the four full prices plus
+        `teacher_sample`.
+        """
         return (
             self.student_prefill is not None
+            and self.effective_student_cached_prefill is not None
             and self.student_sample is not None
             and self.student_train is not None
             and self.teacher_prefill is not None
+            and self.effective_teacher_cached_prefill is not None
+            and self.teacher_sample is not None
         )
 
 

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -52,6 +52,12 @@ class HarborConfig(BaseModel):
     backend: Literal["local", "e2b"] = "local"
     reward_key: str = "reward"
 
+    retries: int = Field(default=1, ge=0)
+    """Harbor-level retries per failed trial. Distill batches see transient
+    sandbox/runner deaths (e.g. an E2B transport drop killing the pi runner
+    mid-episode); one retry absorbs them, and any trial that still ends
+    without a verifier reward scores 0.0 instead of aborting the run."""
+
 
 class RolloutConfig(BaseModel):
     """Per-episode rollout limits."""

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -12,6 +12,7 @@ from wmh.distill.config import (
     PricingConfig,
     StudentConfig,
     TeacherConfig,
+    TrainConfig,
     WandbConfig,
     WarmupConfig,
     load_distill_config,
@@ -409,6 +410,14 @@ def test_snapshot_round_trips_the_pricing_section(tmp_path: Path) -> None:
 def test_direct_model_validation_rejects_extra() -> None:
     with pytest.raises(ValidationError):
         StudentConfig.model_validate({"base_model": "m", "surprise": 1})
+
+
+@pytest.mark.parametrize("value", [0, -65536])
+def test_train_max_datum_tokens_must_be_positive(value: int) -> None:
+    # A zero or negative cap (a dropped minus sign survives TOML) would silently
+    # reject every episode from training after the rollout budget was already spent.
+    with pytest.raises(ValidationError):
+        TrainConfig.model_validate({"max_datum_tokens": value})
 
 
 def test_checked_in_run_configs_resolve_cookbook_renderers() -> None:

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -13,6 +13,7 @@ from wmh.distill.config import (
     StudentConfig,
     TeacherConfig,
     WandbConfig,
+    WarmupConfig,
     load_distill_config,
     snapshot_toml,
 )
@@ -68,6 +69,9 @@ def test_load_minimal_applies_defaults(tmp_path: Path) -> None:
     assert cfg.sampling.temperature == pytest.approx(1.0)
     assert cfg.sampling.max_tokens == 8192
     assert cfg.warmup.steps == 0
+    assert cfg.warmup.rollouts_per_task == 1
+    assert cfg.warmup.keep == "passed"
+    assert cfg.warmup.learning_rate is None
     assert cfg.eval.every == 10
     assert cfg.eval.tasks == 12
     assert cfg.eval.k == 1
@@ -119,6 +123,12 @@ trial_concurrency = 4
 temperature = 0.0
 max_tokens = 128
 
+[warmup]
+steps = 2
+rollouts_per_task = 3
+keep = "all"
+learning_rate = 2e-5
+
 [eval]
 every = 0
 tasks = 2
@@ -153,6 +163,10 @@ tags = ["smoke", "tb2"]
     assert cfg.rollout.max_turns == 5
     assert cfg.train.center_advantages is False
     assert cfg.sampling.temperature == 0.0
+    assert cfg.warmup.steps == 2
+    assert cfg.warmup.rollouts_per_task == 3
+    assert cfg.warmup.keep == "all"
+    assert cfg.warmup.learning_rate == pytest.approx(2e-5)
     assert cfg.eval.every == 0
     assert cfg.gate.min_teacher_fraction == 1.0
     assert cfg.pricing.is_complete()
@@ -170,9 +184,17 @@ def test_compaction_true_rejected(tmp_path: Path) -> None:
         load_distill_config(_write(tmp_path, text))
 
 
-def test_warmup_steps_rejected(tmp_path: Path) -> None:
-    text = MINIMAL_TOML + "\n[warmup]\nsteps = 5\n"
-    with pytest.raises(ValueError, match="warmup is reserved; not implemented yet"):
+@pytest.mark.parametrize("steps", [0, 1, 5])
+def test_warmup_steps_accepted(tmp_path: Path, steps: int) -> None:
+    # Warmup was config-reserved in v1 (steps > 0 rejected); it is implemented now.
+    text = MINIMAL_TOML + f"\n[warmup]\nsteps = {steps}\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.warmup.steps == steps
+
+
+def test_warmup_keep_rejects_unknown_value(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[warmup]\nkeep = 'best'\n"
+    with pytest.raises(ValueError, match="warmup.keep"):
         load_distill_config(_write(tmp_path, text))
 
 
@@ -189,6 +211,9 @@ def test_warmup_steps_rejected(tmp_path: Path) -> None:
         "[sampling]\ntemperature = 2.5",
         "[sampling]\nmax_tokens = 0",
         "[warmup]\nsteps = -1",
+        "[warmup]\nrollouts_per_task = 0",
+        "[warmup]\nlearning_rate = 0.0",
+        "[warmup]\nlearning_rate = -1e-5",
         "[eval]\nevery = -1",
         "[eval]\ntasks = 0",
         "[gate]\nk = 0",
@@ -288,6 +313,20 @@ def test_snapshot_round_trips_the_wandb_section(tmp_path: Path) -> None:
         ),
     ):
         cfg = _minimal_config().model_copy(update={"wandb": wandb}, deep=True)
+        snap_path = tmp_path / "snapshot.toml"
+        snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
+        assert load_distill_config(snap_path) == cfg
+
+
+def test_snapshot_round_trips_the_warmup_section(tmp_path: Path) -> None:
+    # Both shapes must survive snapshot -> parse: the all-defaults section
+    # (learning_rate is None, so exclude_none omits it) and a fully populated
+    # one.
+    for warmup in (
+        WarmupConfig(),
+        WarmupConfig(steps=2, rollouts_per_task=2, keep="all", learning_rate=5e-5),
+    ):
+        cfg = _minimal_config().model_copy(update={"warmup": warmup}, deep=True)
         snap_path = tmp_path / "snapshot.toml"
         snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
         assert load_distill_config(snap_path) == cfg

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from wmh.distill.config import (
     DistillConfig,
+    EvalConfig,
     HarborConfig,
     PricingConfig,
     StudentConfig,
@@ -73,9 +74,12 @@ def test_load_minimal_applies_defaults(tmp_path: Path) -> None:
     assert cfg.warmup.rollouts_per_task == 1
     assert cfg.warmup.keep == "passed"
     assert cfg.warmup.learning_rate is None
-    assert cfg.eval.every == 10
+    # Interim evals default OFF: the holdout gate is the run's measurement.
+    assert cfg.eval.every == 0
     assert cfg.eval.tasks == 12
     assert cfg.eval.k == 1
+    assert cfg.eval.teacher_baseline_from is None
+    assert cfg.eval.student_baseline_from is None
     assert cfg.gate.k == 3
     assert cfg.gate.min_teacher_fraction == pytest.approx(0.7)
     assert cfg.gate.require_no_regression is True
@@ -131,9 +135,11 @@ keep = "all"
 learning_rate = 2e-5
 
 [eval]
-every = 0
+every = 5
 tasks = 2
 k = 2
+teacher_baseline_from = "runs/prior/evals/baseline-teacher.json"
+student_baseline_from = "runs/prior/evals/baseline-student-before.json"
 
 [gate]
 k = 1
@@ -171,7 +177,9 @@ tags = ["smoke", "tb2"]
     assert cfg.warmup.rollouts_per_task == 3
     assert cfg.warmup.keep == "all"
     assert cfg.warmup.learning_rate == pytest.approx(2e-5)
-    assert cfg.eval.every == 0
+    assert cfg.eval.every == 5
+    assert cfg.eval.teacher_baseline_from == "runs/prior/evals/baseline-teacher.json"
+    assert cfg.eval.student_baseline_from == "runs/prior/evals/baseline-student-before.json"
     assert cfg.gate.min_teacher_fraction == 1.0
     assert cfg.pricing.is_complete()
     # Explicit cached rates win over the 20%-of-prefill derivation.
@@ -206,6 +214,50 @@ def test_warmup_keep_rejects_unknown_value(tmp_path: Path) -> None:
         load_distill_config(_write(tmp_path, text))
 
 
+def test_log_sample_rollouts_defaults_to_two_and_zero_disables(tmp_path: Path) -> None:
+    cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))
+    assert cfg.train.log_sample_rollouts == 2
+    disabled = load_distill_config(
+        _write(tmp_path, MINIMAL_TOML + "\n[train]\nlog_sample_rollouts = 0\n")
+    )
+    assert disabled.train.log_sample_rollouts == 0
+
+
+def test_train_loss_defaults_to_importance_sampling(tmp_path: Path) -> None:
+    cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))
+    assert cfg.train.loss == "importance_sampling"
+    assert cfg.train.topk == 8
+
+
+@pytest.mark.parametrize("loss", ["importance_sampling", "topk_ce"])
+def test_train_loss_accepts_both_modes(tmp_path: Path, loss: str) -> None:
+    text = MINIMAL_TOML + f"\n[train]\nloss = '{loss}'\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.train.loss == loss
+
+
+def test_train_loss_rejects_unknown_value(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[train]\nloss = 'forward_kl'\n"
+    with pytest.raises(ValueError, match="train.loss"):
+        load_distill_config(_write(tmp_path, text))
+
+
+@pytest.mark.parametrize("topk", [1, 8, 64])
+def test_train_topk_bounds_accepted(tmp_path: Path, topk: int) -> None:
+    text = MINIMAL_TOML + f"\n[train]\nloss = 'topk_ce'\ntopk = {topk}\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.train.topk == topk
+
+
+def test_snapshot_round_trips_the_topk_ce_loss(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[train]\nloss = 'topk_ce'\ntopk = 16\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    restored = load_distill_config(_write(tmp_path, snapshot_toml(cfg)))
+    assert restored == cfg
+    assert restored.train.loss == "topk_ce"
+    assert restored.train.topk == 16
+
+
 @pytest.mark.parametrize(
     "snippet",
     [
@@ -215,6 +267,9 @@ def test_warmup_keep_rejects_unknown_value(tmp_path: Path) -> None:
         "[train]\nlearning_rate = 0.0",
         "[train]\nadvantage_clip = 0.0",
         "[train]\ngroup_size = 0",
+        "[train]\ntopk = 0",
+        "[train]\ntopk = 65",
+        "[train]\nlog_sample_rollouts = -1",
         "[sampling]\ntemperature = -0.1",
         "[sampling]\ntemperature = 2.5",
         "[sampling]\nmax_tokens = 0",
@@ -335,9 +390,35 @@ def test_snapshot_round_trips_the_warmup_section(tmp_path: Path) -> None:
     # one.
     for warmup in (
         WarmupConfig(),
-        WarmupConfig(steps=2, rollouts_per_task=2, keep="all", learning_rate=5e-5),
+        WarmupConfig(
+            steps=2,
+            rollouts_per_task=2,
+            keep="all",
+            learning_rate=5e-5,
+            trajectories_from=".wmh/distill/runs/source-run",
+        ),
     ):
         cfg = _minimal_config().model_copy(update={"warmup": warmup}, deep=True)
+        snap_path = tmp_path / "snapshot.toml"
+        snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
+        assert load_distill_config(snap_path) == cfg
+
+
+def test_snapshot_round_trips_the_eval_section(tmp_path: Path) -> None:
+    # Both shapes must survive snapshot -> parse: the all-defaults section
+    # (both baseline reuse paths are None, so exclude_none omits them) and a
+    # fully populated one.
+    for eval_cfg in (
+        EvalConfig(),
+        EvalConfig(
+            every=5,
+            tasks=4,
+            k=2,
+            teacher_baseline_from="runs/prior/evals/baseline-teacher.json",
+            student_baseline_from="runs/prior/evals/baseline-student-before.json",
+        ),
+    ):
+        cfg = _minimal_config().model_copy(update={"eval": eval_cfg}, deep=True)
         snap_path = tmp_path / "snapshot.toml"
         snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
         assert load_distill_config(snap_path) == cfg

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -1,0 +1,332 @@
+"""Tests for the distillation run config: loading, validators, snapshotting."""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.distill.config import (
+    DistillConfig,
+    HarborConfig,
+    PricingConfig,
+    StudentConfig,
+    TeacherConfig,
+    WandbConfig,
+    load_distill_config,
+    snapshot_toml,
+)
+
+MINIMAL_TOML = """
+[student]
+base_model = "Qwen/Qwen3-8B"
+
+[teacher]
+model = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+
+[harbor]
+job_template = "jobs/tb2.yaml"
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "distill.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _minimal_config() -> DistillConfig:
+    return DistillConfig(
+        student=StudentConfig(base_model="Qwen/Qwen3-8B"),
+        teacher=TeacherConfig(model="Qwen/Qwen3-235B-A22B-Instruct-2507"),
+        harbor=HarborConfig(job_template="jobs/tb2.yaml"),
+    )
+
+
+def test_load_minimal_applies_defaults(tmp_path: Path) -> None:
+    cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))
+    assert cfg.student.base_model == "Qwen/Qwen3-8B"
+    assert cfg.student.lora_rank == 32
+    assert cfg.teacher.backend == "tinker"
+    assert cfg.teacher.checkpoint is None
+    assert cfg.harbor.backend == "local"
+    assert cfg.harbor.reward_key == "reward"
+    assert cfg.rollout.max_turns == 20
+    assert cfg.rollout.context_budget_tokens == 65536
+    assert cfg.rollout.compaction is False
+    assert cfg.train.steps == 40
+    assert cfg.train.tasks_per_batch == 8
+    assert cfg.train.group_size == 4
+    assert cfg.train.learning_rate == pytest.approx(1e-4)
+    assert cfg.train.advantage_clip == pytest.approx(4.0)
+    assert cfg.train.center_advantages is True
+    assert cfg.train.max_datum_tokens == 65536
+    assert cfg.train.sampler_refresh_every == 1
+    assert cfg.train.save_state_every == 8
+    assert cfg.train.trial_concurrency == 8
+    # 1.0 keeps issued sampler logprobs comparable to untempered teacher logprobs.
+    assert cfg.sampling.temperature == pytest.approx(1.0)
+    assert cfg.sampling.max_tokens == 8192
+    assert cfg.warmup.steps == 0
+    assert cfg.eval.every == 10
+    assert cfg.eval.tasks == 12
+    assert cfg.eval.k == 1
+    assert cfg.gate.k == 3
+    assert cfg.gate.min_teacher_fraction == pytest.approx(0.7)
+    assert cfg.gate.require_no_regression is True
+    assert cfg.pricing.student_prefill is None
+    assert cfg.budget.max_usd is None
+    assert cfg.wandb.enabled is False
+    assert cfg.wandb.project == "wmh-distill"
+    assert cfg.wandb.entity is None
+    assert cfg.wandb.run_name is None
+    assert cfg.wandb.tags == []
+
+
+def test_load_full_overrides(tmp_path: Path) -> None:
+    text = """
+[student]
+base_model = "Qwen/Qwen3-4B"
+lora_rank = 8
+
+[teacher]
+backend = "tinker"
+model = "big-teacher"
+checkpoint = "tinker://run/weights/ck-7"
+
+[harbor]
+job_template = "jobs/tb2.json"
+backend = "e2b"
+reward_key = "score"
+
+[rollout]
+max_turns = 5
+context_budget_tokens = 2048
+
+[train]
+steps = 2
+tasks_per_batch = 1
+group_size = 2
+learning_rate = 5e-5
+advantage_clip = 2.0
+center_advantages = false
+max_datum_tokens = 4096
+sampler_refresh_every = 2
+save_state_every = 1
+trial_concurrency = 4
+
+[sampling]
+temperature = 0.0
+max_tokens = 128
+
+[eval]
+every = 0
+tasks = 2
+k = 2
+
+[gate]
+k = 1
+min_teacher_fraction = 1.0
+require_no_regression = false
+
+[pricing]
+student_prefill = 0.1
+student_sample = 0.4
+student_train = 0.6
+teacher_prefill = 1.2
+
+[budget]
+max_usd = 50.0
+
+[wandb]
+enabled = true
+project = "my-distill"
+entity = "my-team"
+run_name = "smoke-01"
+tags = ["smoke", "tb2"]
+"""
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.student.lora_rank == 8
+    assert cfg.teacher.checkpoint == "tinker://run/weights/ck-7"
+    assert cfg.harbor.backend == "e2b"
+    assert cfg.harbor.reward_key == "score"
+    assert cfg.rollout.max_turns == 5
+    assert cfg.train.center_advantages is False
+    assert cfg.sampling.temperature == 0.0
+    assert cfg.eval.every == 0
+    assert cfg.gate.min_teacher_fraction == 1.0
+    assert cfg.pricing.is_complete()
+    assert cfg.budget.max_usd == pytest.approx(50.0)
+    assert cfg.wandb.enabled is True
+    assert cfg.wandb.project == "my-distill"
+    assert cfg.wandb.entity == "my-team"
+    assert cfg.wandb.run_name == "smoke-01"
+    assert cfg.wandb.tags == ["smoke", "tb2"]
+
+
+def test_compaction_true_rejected(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[rollout]\ncompaction = true\n"
+    with pytest.raises(ValueError, match="prefix property"):
+        load_distill_config(_write(tmp_path, text))
+
+
+def test_warmup_steps_rejected(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[warmup]\nsteps = 5\n"
+    with pytest.raises(ValueError, match="warmup is reserved; not implemented yet"):
+        load_distill_config(_write(tmp_path, text))
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "[rollout]\nmax_turns = 0",
+        "[rollout]\ncontext_budget_tokens = 512",
+        "[train]\nsteps = 0",
+        "[train]\nlearning_rate = 0.0",
+        "[train]\nadvantage_clip = 0.0",
+        "[train]\ngroup_size = 0",
+        "[sampling]\ntemperature = -0.1",
+        "[sampling]\ntemperature = 2.5",
+        "[sampling]\nmax_tokens = 0",
+        "[warmup]\nsteps = -1",
+        "[eval]\nevery = -1",
+        "[eval]\ntasks = 0",
+        "[gate]\nk = 0",
+        "[gate]\nmin_teacher_fraction = 0.0",
+        "[gate]\nmin_teacher_fraction = 1.5",
+        "[pricing]\nstudent_prefill = -0.1",
+        "[budget]\nmax_usd = 0.0",
+    ],
+)
+def test_bad_ranges_rejected(tmp_path: Path, snippet: str) -> None:
+    base = MINIMAL_TOML if "[harbor]" not in snippet else MINIMAL_TOML.split("[harbor]")[0]
+    with pytest.raises(ValueError, match="invalid distill config"):
+        load_distill_config(_write(tmp_path, base + "\n" + snippet + "\n"))
+
+
+def test_unknown_key_rejected(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[train]\nnot_a_field = 1\n"
+    with pytest.raises(ValueError, match="train.not_a_field"):
+        load_distill_config(_write(tmp_path, text))
+
+
+def test_unknown_section_rejected(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[mystery]\nx = 1\n"
+    with pytest.raises(ValueError, match="mystery"):
+        load_distill_config(_write(tmp_path, text))
+
+
+def test_load_error_names_file_and_field(tmp_path: Path) -> None:
+    path = _write(tmp_path, MINIMAL_TOML + "\n[train]\nsteps = 0\n")
+    with pytest.raises(ValueError) as excinfo:
+        load_distill_config(path)
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "train.steps" in message
+
+
+def test_missing_required_field_named(tmp_path: Path) -> None:
+    text = "[student]\nbase_model = 'm'\n[teacher]\nmodel = 't'\n"
+    path = _write(tmp_path, text)
+    with pytest.raises(ValueError) as excinfo:
+        load_distill_config(path)
+    assert "harbor" in str(excinfo.value)
+    assert str(path) in str(excinfo.value)
+
+
+def test_missing_file_error_names_path(tmp_path: Path) -> None:
+    path = tmp_path / "nope.toml"
+    with pytest.raises(FileNotFoundError, match="nope.toml"):
+        load_distill_config(path)
+
+
+def test_invalid_toml_error_names_file(tmp_path: Path) -> None:
+    path = _write(tmp_path, "[student\n")
+    with pytest.raises(ValueError, match="not valid TOML"):
+        load_distill_config(path)
+
+
+def test_snapshot_round_trip_minimal(tmp_path: Path) -> None:
+    cfg = _minimal_config()
+    rendered = snapshot_toml(cfg)
+    parsed = DistillConfig.model_validate(tomllib.loads(rendered))
+    assert parsed == cfg
+
+
+def test_snapshot_round_trip_via_file(tmp_path: Path) -> None:
+    cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))
+    cfg = cfg.model_copy(deep=True)
+    snap_path = tmp_path / "snapshot.toml"
+    snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
+    assert load_distill_config(snap_path) == cfg
+
+
+def test_snapshot_preserves_overrides(tmp_path: Path) -> None:
+    cfg = _minimal_config().model_copy(deep=True)
+    cfg.train.learning_rate = 5e-5
+    cfg.pricing.student_prefill = 0.25
+    cfg.budget.max_usd = 10.0
+    parsed = DistillConfig.model_validate(tomllib.loads(snapshot_toml(cfg)))
+    assert parsed.train.learning_rate == pytest.approx(5e-5)
+    assert parsed.pricing.student_prefill == pytest.approx(0.25)
+    assert parsed.budget.max_usd == pytest.approx(10.0)
+    assert parsed == cfg
+
+
+def test_snapshot_round_trips_the_wandb_section(tmp_path: Path) -> None:
+    # Both shapes must survive snapshot -> parse: the all-defaults section
+    # (entity and run_name are None, so exclude_none omits them) and a fully
+    # populated one.
+    for wandb in (
+        WandbConfig(),
+        WandbConfig(
+            enabled=True,
+            project="my-distill",
+            entity="my-team",
+            run_name="smoke-01",
+            tags=["smoke", "tb2"],
+        ),
+    ):
+        cfg = _minimal_config().model_copy(update={"wandb": wandb}, deep=True)
+        snap_path = tmp_path / "snapshot.toml"
+        snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
+        assert load_distill_config(snap_path) == cfg
+
+
+def test_wandb_unknown_key_rejected(tmp_path: Path) -> None:
+    text = MINIMAL_TOML + "\n[wandb]\nteam = 'nope'\n"
+    with pytest.raises(ValueError, match="wandb.team"):
+        load_distill_config(_write(tmp_path, text))
+
+
+def test_pricing_is_complete() -> None:
+    assert not PricingConfig().is_complete()
+    partial = PricingConfig(student_prefill=0.1, student_sample=0.2)
+    assert not partial.is_complete()
+    full = PricingConfig(
+        student_prefill=0.1, student_sample=0.2, student_train=0.3, teacher_prefill=0.4
+    )
+    assert full.is_complete()
+
+
+def test_direct_model_validation_rejects_extra() -> None:
+    with pytest.raises(ValidationError):
+        StudentConfig.model_validate({"base_model": "m", "surprise": 1})
+
+
+def test_checked_in_run_configs_resolve_cookbook_renderers() -> None:
+    # The smoke configs pin real Tinker lineup names; the cookbook must know a renderer
+    # for each or the very first rollout completion of that run fails in build_renderer
+    # (regression: the Nemotron smoke config once carried lineup names absent from the
+    # cookbook 0.4.x catalog).
+    pytest.importorskip("tinker_cookbook")
+    from tinker_cookbook.model_info import get_recommended_renderer_name
+
+    config_dir = Path(__file__).resolve().parents[2] / ".agents" / "distill"
+    paths = sorted(config_dir.glob("*.toml"))
+    if not paths:
+        pytest.skip("no checked-in distill run configs in this tree")
+    for path in paths:
+        cfg = load_distill_config(path)
+        for model in (cfg.student.base_model, cfg.teacher.model):
+            assert get_recommended_renderer_name(model), f"{path.name}: {model}"

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -141,9 +141,12 @@ require_no_regression = false
 
 [pricing]
 student_prefill = 0.1
+student_cached_prefill = 0.03
 student_sample = 0.4
 student_train = 0.6
 teacher_prefill = 1.2
+teacher_cached_prefill = 0.3
+teacher_sample = 3.0
 
 [budget]
 max_usd = 50.0
@@ -170,6 +173,10 @@ tags = ["smoke", "tb2"]
     assert cfg.eval.every == 0
     assert cfg.gate.min_teacher_fraction == 1.0
     assert cfg.pricing.is_complete()
+    # Explicit cached rates win over the 20%-of-prefill derivation.
+    assert cfg.pricing.effective_student_cached_prefill == pytest.approx(0.03)
+    assert cfg.pricing.effective_teacher_cached_prefill == pytest.approx(0.3)
+    assert cfg.pricing.teacher_sample == pytest.approx(3.0)
     assert cfg.budget.max_usd == pytest.approx(50.0)
     assert cfg.wandb.enabled is True
     assert cfg.wandb.project == "my-distill"
@@ -220,6 +227,9 @@ def test_warmup_keep_rejects_unknown_value(tmp_path: Path) -> None:
         "[gate]\nmin_teacher_fraction = 0.0",
         "[gate]\nmin_teacher_fraction = 1.5",
         "[pricing]\nstudent_prefill = -0.1",
+        "[pricing]\nstudent_cached_prefill = -0.1",
+        "[pricing]\nteacher_cached_prefill = -0.1",
+        "[pricing]\nteacher_sample = -0.1",
         "[budget]\nmax_usd = 0.0",
     ],
 )
@@ -342,10 +352,58 @@ def test_pricing_is_complete() -> None:
     assert not PricingConfig().is_complete()
     partial = PricingConfig(student_prefill=0.1, student_sample=0.2)
     assert not partial.is_complete()
-    full = PricingConfig(
+    # The four full prices alone are not complete: teacher-in-harness episodes
+    # bill teacher_sample, so it must be priced too.
+    no_teacher_sample = PricingConfig(
         student_prefill=0.1, student_sample=0.2, student_train=0.3, teacher_prefill=0.4
     )
+    assert not no_teacher_sample.is_complete()
+    # The cached rates never block completeness: their 20% defaults derive
+    # from the full prefill prices.
+    full = PricingConfig(
+        student_prefill=0.1,
+        student_sample=0.2,
+        student_train=0.3,
+        teacher_prefill=0.4,
+        teacher_sample=1.0,
+    )
     assert full.is_complete()
+
+
+def test_pricing_cached_defaults_derive_20_percent_of_prefill() -> None:
+    derived = PricingConfig(student_prefill=1.0, teacher_prefill=10.0)
+    assert derived.effective_student_cached_prefill == pytest.approx(0.2)
+    assert derived.effective_teacher_cached_prefill == pytest.approx(2.0)
+    # No full prefill price means no derivation: the cached meter is unpriced.
+    assert PricingConfig().effective_student_cached_prefill is None
+    assert PricingConfig().effective_teacher_cached_prefill is None
+    # An explicit cached price stands alone, even without the full price.
+    explicit = PricingConfig(student_cached_prefill=0.07, teacher_cached_prefill=0.9)
+    assert explicit.effective_student_cached_prefill == pytest.approx(0.07)
+    assert explicit.effective_teacher_cached_prefill == pytest.approx(0.9)
+
+
+def test_snapshot_round_trips_the_pricing_section(tmp_path: Path) -> None:
+    cfg = _minimal_config().model_copy(
+        update={
+            "pricing": PricingConfig(
+                student_prefill=0.3,
+                student_sample=0.7,
+                student_train=0.6,
+                teacher_prefill=2.49,
+                teacher_cached_prefill=0.498,
+                teacher_sample=6.225,
+            )
+        },
+        deep=True,
+    )
+    snap_path = tmp_path / "snapshot.toml"
+    snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
+    parsed = load_distill_config(snap_path)
+    assert parsed == cfg
+    # The unset student cached rate stays unset (derived at charge time).
+    assert parsed.pricing.student_cached_prefill is None
+    assert parsed.pricing.effective_student_cached_prefill == pytest.approx(0.06)
 
 
 def test_direct_model_validation_rejects_extra() -> None:

--- a/wmh/distill/deadlines.py
+++ b/wmh/distill/deadlines.py
@@ -1,0 +1,223 @@
+"""Hard wall-clock deadlines around Tinker SDK calls.
+
+A wedged Tinker session can block forever inside the SDK's internal
+JWT-refresh/heartbeat retry loop: the call neither returns nor raises, so
+provider retry wrappers and trial/episode timeouts never engage (one live run
+hung 33 minutes this way while a fresh connection worked at the same moment).
+The `Sdk*` adapters therefore bound every SDK call with a per-call-kind
+deadline. Expiry raises `TinkerDeadlineError`, whose message deliberately
+reads as a timeout so llm-waterfall classifies it as a capacity (transient)
+error: callers retry with a fresh session instead of hanging.
+
+Defaults carry generous headroom over measured live latencies (sample mean
+2.8s / p95 7.7s / max 10.2s; compute_logprobs max 1.5s; forward_backward
+~1.5s; optim_step ~0.5s; save_state ~2.4s; save_weights_for_sampler mean
+4.4s / max 18s with one observed 80s outlier). Each default is overridable
+via one env var per kind, `WMH_TINKER_DEADLINE_<KIND>` in seconds:
+
+- sample: 120s (WMH_TINKER_DEADLINE_SAMPLE)
+- compute_logprobs: 60s (WMH_TINKER_DEADLINE_COMPUTE_LOGPROBS)
+- forward_backward: 120s (WMH_TINKER_DEADLINE_FORWARD_BACKWARD)
+- optim_step: 120s (WMH_TINKER_DEADLINE_OPTIM_STEP)
+- save_state: 120s (WMH_TINKER_DEADLINE_SAVE_STATE)
+- load_state: 120s (WMH_TINKER_DEADLINE_LOAD_STATE)
+- save_weights_for_sampler: 600s (WMH_TINKER_DEADLINE_SAVE_WEIGHTS_FOR_SAMPLER)
+- connect: 60s (WMH_TINKER_DEADLINE_CONNECT)
+
+"connect" covers every synchronous call with no future to wait on: service
+client construction, sampling/training client creation, and tokenizer
+fetches. Overrides must be a positive finite number of seconds; anything
+unparsable or non-positive raises immediately (a silently ignored override
+would defeat the whole point), and sub-millisecond values clamp up to 1ms.
+
+Two waiting strategies, chosen per call site:
+
+- `wait_with_deadline` uses the SDK future's own `result(timeout=...)`. The
+  abandoned request keeps polling on the SDK's background loop, but the
+  caller proceeds immediately.
+- `call_with_deadline` runs a fully blocking call (no timeout parameter in
+  the SDK) on a dedicated daemon thread and waits at most the deadline. On
+  expiry the thread is abandoned and may linger inside the SDK; a daemon
+  thread never blocks interpreter exit, and the run proceeds with a typed,
+  retryable error.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import threading
+import time
+from collections.abc import Callable
+from typing import Literal, Protocol
+
+logger = logging.getLogger(__name__)
+
+TinkerCallKind = Literal[
+    "sample",
+    "compute_logprobs",
+    "forward_backward",
+    "optim_step",
+    "save_state",
+    "load_state",
+    "save_weights_for_sampler",
+    "connect",
+]
+
+DEADLINE_ENV_PREFIX = "WMH_TINKER_DEADLINE_"
+
+DEFAULT_DEADLINES_S: dict[TinkerCallKind, float] = {
+    "sample": 120.0,
+    "compute_logprobs": 60.0,
+    "forward_backward": 120.0,
+    "optim_step": 120.0,
+    "save_state": 120.0,
+    "load_state": 120.0,
+    "save_weights_for_sampler": 600.0,
+    "connect": 60.0,
+}
+"""Per-kind default deadlines; see the module docstring for their derivation."""
+
+_MIN_DEADLINE_S = 0.001
+"""Floor for overrides: a sub-millisecond deadline clamps up to this."""
+
+
+class DeadlineFuture[T](Protocol):
+    """The slice of a tinker `APIFuture` the deadline wait consumes."""
+
+    def result(self, timeout: float | None = None) -> T:
+        """Block for the result, raising `TimeoutError` after `timeout` seconds."""
+        ...
+
+
+class TinkerDeadlineError(TimeoutError):
+    """A Tinker SDK call blew its wall-clock deadline; the session is likely wedged.
+
+    The call was abandoned, so the caller can proceed; the remedy is a retry
+    through a fresh session (the wmh adapters drop and rebuild their cached
+    clients where they own them). Subclasses `TimeoutError` and keeps the
+    phrase "timed out" in its message on purpose: that is what makes
+    llm-waterfall's `is_capacity_error` classify it as transient, so the
+    provider retry wrapper re-attempts instead of propagating.
+
+    Attributes:
+        kind: Which call kind expired.
+        elapsed_s: Wall-clock seconds actually waited.
+        deadline_s: The deadline that was in force.
+    """
+
+    def __init__(self, kind: TinkerCallKind, *, elapsed_s: float, deadline_s: float) -> None:
+        self.kind = kind
+        self.elapsed_s = elapsed_s
+        self.deadline_s = deadline_s
+        super().__init__(
+            f"tinker {kind} timed out after {elapsed_s:.1f}s (deadline {deadline_s:.1f}s, "
+            f"override via {env_var_for(kind)}); the session is likely wedged inside the "
+            "SDK's internal retry loop. The call was abandoned; retry with a fresh "
+            "session (the wmh adapters rebuild their own clients on the next attempt)"
+        )
+
+
+def env_var_for(kind: TinkerCallKind) -> str:
+    """The env var that overrides one call kind's deadline."""
+    return DEADLINE_ENV_PREFIX + kind.upper()
+
+
+def deadline_for(kind: TinkerCallKind) -> float:
+    """The effective deadline for one call kind, in seconds.
+
+    Reads the kind's env var on every call so an override set mid-process
+    (e.g. by a test) takes effect immediately.
+
+    Raises:
+        ValueError: If the override is unparsable, non-finite, or not
+            positive; the message names the env var and the fix.
+    """
+    env_var = env_var_for(kind)
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return DEFAULT_DEADLINES_S[kind]
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid {env_var}={raw!r}: set a positive number of seconds "
+            f"(e.g. {env_var}={DEFAULT_DEADLINES_S[kind]:g}), or unset it for the default"
+        ) from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(
+            f"invalid {env_var}={raw!r}: the deadline must be a positive finite number "
+            f"of seconds (default {DEFAULT_DEADLINES_S[kind]:g}); unset it for the default"
+        )
+    return max(value, _MIN_DEADLINE_S)
+
+
+def wait_with_deadline[T](kind: TinkerCallKind, future: DeadlineFuture[T]) -> T:
+    """Wait for an SDK future under the kind's deadline.
+
+    Uses the future's own `result(timeout=...)`, so no extra thread is
+    needed; on expiry the abandoned request keeps polling on the SDK's
+    background loop while this caller proceeds.
+
+    Args:
+        kind: The call kind, for the deadline lookup and the error message.
+        future: The SDK future to wait on.
+
+    Returns:
+        The future's result.
+
+    Raises:
+        TinkerDeadlineError: If the deadline expires before the result lands.
+    """
+    deadline = deadline_for(kind)
+    started = time.monotonic()
+    try:
+        return future.result(timeout=deadline)
+    except TinkerDeadlineError:
+        raise
+    except TimeoutError as exc:
+        raise TinkerDeadlineError(
+            kind, elapsed_s=time.monotonic() - started, deadline_s=deadline
+        ) from exc
+
+
+def call_with_deadline[T](kind: TinkerCallKind, call: Callable[[], T]) -> T:
+    """Run a fully blocking SDK call under the kind's deadline.
+
+    For SDK calls with no timeout parameter and no future (client and
+    tokenizer construction): the call runs on a dedicated daemon thread and
+    the caller waits at most the deadline. On expiry the thread is abandoned;
+    it may linger blocked inside the SDK, but daemon threads never block
+    interpreter exit and the run proceeds.
+
+    Args:
+        kind: The call kind, for the deadline lookup and the error message.
+        call: The zero-argument blocking call.
+
+    Returns:
+        Whatever `call` returns.
+
+    Raises:
+        TinkerDeadlineError: If the deadline expires before the call returns.
+        Exception: Anything `call` itself raises, re-raised on this thread.
+    """
+    deadline = deadline_for(kind)
+    outcome: list[T] = []
+    failure: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            outcome.append(call())
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller thread below
+            failure.append(exc)
+
+    thread = threading.Thread(target=_run, name=f"wmh-tinker-{kind}", daemon=True)
+    started = time.monotonic()
+    thread.start()
+    thread.join(deadline)
+    if thread.is_alive():
+        raise TinkerDeadlineError(kind, elapsed_s=time.monotonic() - started, deadline_s=deadline)
+    if failure:
+        raise failure[0]
+    return outcome[0]

--- a/wmh/distill/deadlines.py
+++ b/wmh/distill/deadlines.py
@@ -12,15 +12,20 @@ error: callers retry with a fresh session instead of hanging.
 Defaults carry generous headroom over measured live latencies (sample mean
 2.8s / p95 7.7s / max 10.2s; compute_logprobs max 1.5s; forward_backward
 ~1.5s; optim_step ~0.5s; save_state ~2.4s; save_weights_for_sampler mean
-4.4s / max 18s with one observed 80s outlier). Each default is overridable
-via one env var per kind, `WMH_TINKER_DEADLINE_<KIND>` in seconds:
+4.4s / max 18s with one observed 80s outlier). `load_state` gets the same
+600s as save_weights_for_sampler for a different reason: restoring a large
+student's weights plus optimizer state exceeded 120s on a live 120B resume,
+and the call cannot be retried on the same client (tinker refuses LoadWeights
+once anything initialized the model, see `SdkTrainingClient`), so its deadline
+is the whole budget rather than the first of two attempts. Each default is
+overridable via one env var per kind, `WMH_TINKER_DEADLINE_<KIND>` in seconds:
 
 - sample: 120s (WMH_TINKER_DEADLINE_SAMPLE)
 - compute_logprobs: 60s (WMH_TINKER_DEADLINE_COMPUTE_LOGPROBS)
 - forward_backward: 120s (WMH_TINKER_DEADLINE_FORWARD_BACKWARD)
 - optim_step: 120s (WMH_TINKER_DEADLINE_OPTIM_STEP)
 - save_state: 120s (WMH_TINKER_DEADLINE_SAVE_STATE)
-- load_state: 120s (WMH_TINKER_DEADLINE_LOAD_STATE)
+- load_state: 600s (WMH_TINKER_DEADLINE_LOAD_STATE)
 - save_weights_for_sampler: 600s (WMH_TINKER_DEADLINE_SAVE_WEIGHTS_FOR_SAMPLER)
 - connect: 60s (WMH_TINKER_DEADLINE_CONNECT)
 
@@ -73,7 +78,7 @@ DEFAULT_DEADLINES_S: dict[TinkerCallKind, float] = {
     "forward_backward": 120.0,
     "optim_step": 120.0,
     "save_state": 120.0,
-    "load_state": 120.0,
+    "load_state": 600.0,
     "save_weights_for_sampler": 600.0,
     "connect": 60.0,
 }

--- a/wmh/distill/deadlines_test.py
+++ b/wmh/distill/deadlines_test.py
@@ -1,0 +1,168 @@
+"""Tests for the Tinker deadline utilities: expiry, overrides, classification."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import NoReturn
+
+import pytest
+from llm_waterfall import is_capacity_error
+
+from wmh.distill.deadlines import (
+    DEFAULT_DEADLINES_S,
+    DeadlineFuture,
+    TinkerCallKind,
+    TinkerDeadlineError,
+    call_with_deadline,
+    deadline_for,
+    env_var_for,
+    wait_with_deadline,
+)
+
+_SHORT_DEADLINE = "0.05"
+_GENEROUS_WAIT_S = 5.0
+"""An expiry must land well before this (the deadline is 0.05s)."""
+
+
+class _BlockingFuture:
+    """A fake SDK future that never completes; result(timeout) honors the timeout.
+
+    Mirrors the real `APIFuture.result(timeout)` contract: block on an event
+    that is never set, then raise the builtin `TimeoutError`.
+    """
+
+    def __init__(self) -> None:
+        self._never = threading.Event()
+
+    def result(self, timeout: float | None = None) -> NoReturn:
+        self._never.wait(timeout)
+        raise TimeoutError(f"fake future gave up after {timeout}s")
+
+
+class _ReadyFuture:
+    """A fake SDK future whose result is immediately available."""
+
+    def result(self, timeout: float | None = None) -> str:
+        del timeout
+        return "ready"
+
+
+class _BrokenFuture:
+    """A fake SDK future that fails with a non-timeout error."""
+
+    def result(self, timeout: float | None = None) -> NoReturn:
+        del timeout
+        raise RuntimeError("terminal SDK failure")
+
+
+def test_defaults_match_the_documented_values() -> None:
+    assert DEFAULT_DEADLINES_S == {
+        "sample": 120.0,
+        "compute_logprobs": 60.0,
+        "forward_backward": 120.0,
+        "optim_step": 120.0,
+        "save_state": 120.0,
+        "load_state": 120.0,
+        "save_weights_for_sampler": 600.0,
+        "connect": 60.0,
+    }
+
+
+def test_wait_with_deadline_returns_the_result() -> None:
+    future: DeadlineFuture[str] = _ReadyFuture()
+    assert wait_with_deadline("sample", future) == "ready"
+
+
+@pytest.mark.parametrize("kind", sorted(DEFAULT_DEADLINES_S))
+def test_blocking_future_expires_within_the_shortened_deadline(
+    kind: TinkerCallKind, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var_for(kind), _SHORT_DEADLINE)
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError) as info:
+        wait_with_deadline(kind, _BlockingFuture())
+    assert time.monotonic() - started < _GENEROUS_WAIT_S
+    assert info.value.kind == kind
+    assert info.value.deadline_s == pytest.approx(0.05)
+    message = str(info.value)
+    assert "timed out" in message
+    assert "wedged" in message
+    assert env_var_for(kind) in message
+    assert f"{info.value.elapsed_s:.1f}s" in message
+
+
+def test_blocking_call_expires_within_the_shortened_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A fully blocking call (no timeout parameter anywhere): the bounded wait
+    # abandons the daemon thread, which stays parked on the never-set event.
+    monkeypatch.setenv(env_var_for("connect"), _SHORT_DEADLINE)
+    never = threading.Event()
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError, match="tinker connect timed out"):
+        call_with_deadline("connect", never.wait)
+    assert time.monotonic() - started < _GENEROUS_WAIT_S
+
+
+def test_call_with_deadline_returns_the_result() -> None:
+    assert call_with_deadline("connect", lambda: 41 + 1) == 42
+
+
+def test_call_with_deadline_reraises_the_calls_own_error() -> None:
+    def explode() -> NoReturn:
+        raise ValueError("bad model name")
+
+    with pytest.raises(ValueError, match="bad model name"):
+        call_with_deadline("connect", explode)
+
+
+def test_wait_with_deadline_propagates_non_timeout_errors_unchanged() -> None:
+    with pytest.raises(RuntimeError, match="terminal SDK failure"):
+        wait_with_deadline("sample", _BrokenFuture())
+
+
+def test_nested_deadline_error_is_not_rewrapped() -> None:
+    inner = TinkerDeadlineError("compute_logprobs", elapsed_s=0.1, deadline_s=0.1)
+
+    class _NestedFuture:
+        def result(self, timeout: float | None = None) -> NoReturn:
+            del timeout
+            raise inner
+
+    with pytest.raises(TinkerDeadlineError) as info:
+        wait_with_deadline("sample", _NestedFuture())
+    assert info.value is inner
+
+
+def test_env_override_parses_as_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(env_var_for("sample"), "0.25")
+    assert deadline_for("sample") == 0.25
+
+
+def test_unset_env_falls_back_to_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(env_var_for("sample"), raising=False)
+    assert deadline_for("sample") == 120.0
+
+
+def test_sub_millisecond_override_clamps_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(env_var_for("sample"), "0.0000001")
+    assert deadline_for("sample") == 0.001
+
+
+@pytest.mark.parametrize("raw", ["fast", "", "0", "-5", "inf", "nan"])
+def test_invalid_override_raises_naming_the_env_var(
+    raw: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(env_var_for("optim_step"), raw)
+    with pytest.raises(ValueError, match="WMH_TINKER_DEADLINE_OPTIM_STEP"):
+        deadline_for("optim_step")
+
+
+def test_deadline_error_is_a_capacity_error_for_the_retry_stack() -> None:
+    # Load-bearing pin: the provider retry wrapper (and the waterfall) only
+    # retries what llm_waterfall classifies as capacity. The error subclasses
+    # TimeoutError and says "timed out" precisely so this holds.
+    error = TinkerDeadlineError("sample", elapsed_s=120.4, deadline_s=120.0)
+    assert isinstance(error, TimeoutError)
+    assert is_capacity_error(error) is True

--- a/wmh/distill/deadlines_test.py
+++ b/wmh/distill/deadlines_test.py
@@ -63,7 +63,7 @@ def test_defaults_match_the_documented_values() -> None:
         "forward_backward": 120.0,
         "optim_step": 120.0,
         "save_state": 120.0,
-        "load_state": 120.0,
+        "load_state": 600.0,
         "save_weights_for_sampler": 600.0,
         "connect": 60.0,
     }

--- a/wmh/distill/fake_tinker.py
+++ b/wmh/distill/fake_tinker.py
@@ -83,6 +83,37 @@ class FakeSampledSequence:
 
 
 @dataclass(frozen=True)
+class FakeForwardBackwardOutput:
+    """One forward/backward result, mirroring tinker.types.ForwardBackwardOutput.
+
+    The real output carries per-datum `loss_fn_outputs` tensors (the cookbook
+    reads a per-datum "logprobs" TensorData) plus a server-populated
+    `metrics: dict[str, float]` whose keys carry a ":reduction" suffix for
+    the SDK's chunk combiner. The fake keeps the per-datum shape (one empty
+    dict per datum) and reports a deterministic batch loss under
+    "total_loss:sum" (the cookbook's "total_loss" name plus the combiner
+    suffix), so adapters exercise the same suffix-tolerant metric extraction
+    they run against the real SDK.
+    """
+
+    loss_fn_output_type: str
+    loss_fn_outputs: list[dict[str, list[float]]]
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class FakeOptimStepResponse:
+    """One optimizer-step result, mirroring tinker.types.OptimStepResponse.
+
+    The real response carries only an untyped optional metrics mapping; the
+    fake reports a deterministic "grad_norm:mean" so adapters can prove their
+    extraction plumbing on a stable value.
+    """
+
+    metrics: dict[str, float] | None
+
+
+@dataclass(frozen=True)
 class IssuedSample:
     """A record of one span a sampling client issued: the TITO ground truth."""
 
@@ -304,7 +335,7 @@ class FakeTrainingClient:
         """The deterministic char-level tokenizer for this fake model."""
         return FakeTokenizer()
 
-    def forward_backward(self, datums: list[FakeDatum], loss_fn: str) -> None:
+    def forward_backward(self, datums: list[FakeDatum], loss_fn: str) -> FakeForwardBackwardOutput:
         """Record a training batch after asserting the TITO invariant.
 
         Every sampled span in every datum (maximal nonzero-weight run of
@@ -319,6 +350,11 @@ class FakeTrainingClient:
             loss_fn: Loss function name (e.g. "importance_sampling" or
                 "cross_entropy"); recorded but not interpreted.
 
+        Returns:
+            A deterministic SDK-shaped output: the metrics dict carries a
+            "total_loss:sum" value derived purely from (loss_fn, batch
+            target tokens), so the same batch always reports the same loss.
+
         Raises:
             AssertionError: If a sampled span was never issued by an eligible
                 issuer; the message names the datum, the span, and the first
@@ -332,6 +368,14 @@ class FakeTrainingClient:
                     continue
                 raise AssertionError(self._tito_message(datum_index, span, records))
         self.forward_backward_calls.append((list(datums), loss_fn))
+        loss = -_derived_logprob(
+            "batch-loss", loss_fn, *(_ids_key(datum.target_tokens) for datum in datums)
+        )
+        return FakeForwardBackwardOutput(
+            loss_fn_output_type="FakeLossReturn",
+            loss_fn_outputs=[{} for _ in datums],
+            metrics={"total_loss:sum": loss},
+        )
 
     def _issuer_records(self) -> list[IssuedSample]:
         """Every span an eligible issuer recorded: linked ledger + service clients."""
@@ -372,10 +416,17 @@ class FakeTrainingClient:
             )
         return f"TITO violation in datum {datum_index}: {detail}"
 
-    def optim_step(self, learning_rate: float) -> None:
-        """Apply one optimizer step: increments the step counter."""
+    def optim_step(self, learning_rate: float) -> FakeOptimStepResponse:
+        """Apply one optimizer step: increments the step counter.
+
+        Returns:
+            A deterministic SDK-shaped response whose metrics carry a
+            "grad_norm:mean" derived purely from (step count, learning rate).
+        """
         self.optim_step_lrs.append(learning_rate)
         self.step_count += 1
+        grad_norm = -_derived_logprob("grad-norm", str(self.step_count), str(learning_rate))
+        return FakeOptimStepResponse(metrics={"grad_norm:mean": grad_norm})
 
     def save_state(self) -> str:
         """Save training state, returning a fake tinker:// state path."""

--- a/wmh/distill/fake_tinker.py
+++ b/wmh/distill/fake_tinker.py
@@ -13,6 +13,15 @@ Everything is deterministic: sampled tokens and logprobs are derived from
 SHA-256 hashes of (seed, prompt ids, position), never from time or global
 randomness, so a run replayed with the same inputs produces identical outputs.
 
+The fakes also mirror the live service's model-initialization ordering rule:
+tinker accepts LoadWeights only on an uninitialized model, so
+`FakeTrainingClient.load_state` raises once any weight-affecting call has run
+on that client (see `MODEL_INITIALIZING_CALLS`), and every client keeps an
+ordered `calls` log so tests can assert what ran before what. Saved states
+therefore live on the `FakeServiceClient`, not the client that wrote them,
+exactly as real tinker:// state paths outlive their session: a later session's
+freshly created training client can restore them.
+
 The fakes also enforce the tokens-in-tokens-out (TITO) invariant that on-policy
 distillation depends on: every sampled span trained on must be byte-identical
 to a span some sampling client actually issued. The issuer set is the training
@@ -37,6 +46,19 @@ from typing import Literal
 _SAMPLED_TOKEN_BASE = 32
 _SAMPLED_TOKEN_RANGE = 95
 """Sampled token ids stay in the printable ASCII range so decode() is total."""
+
+MODEL_INITIALIZING_CALLS = frozenset(
+    {"load_state", "save_state", "save_weights_for_sampler", "forward_backward", "optim_step"}
+)
+"""Training-client calls after which the live service refuses LoadWeights.
+
+Tinker's error is "LoadWeights can only be called on uninitialized models
+(before any weights have been loaded or training has started)", so
+`FakeTrainingClient.load_state` refuses once any of these ran on the same
+client. `get_tokenizer` is deliberately absent: the SDK serves it from a
+metadata-only GetInfo request that never touches weights, so it is safe
+before a restore.
+"""
 
 
 def _digest(*parts: str) -> bytes:
@@ -422,6 +444,10 @@ class FakeTrainingClient:
     vs the real client: results return directly (no APIFuture), datums are
     FakeDatum (plain lists rather than tensors), and optim_step takes a bare
     learning rate rather than AdamParams.
+
+    Like the real client this one is UNINITIALIZED until a weight-affecting
+    call runs on it, and `load_state` is legal only while it stays that way
+    (see `MODEL_INITIALIZING_CALLS` and `load_state`).
     """
 
     def __init__(self, service: FakeServiceClient, base_model: str, rank: int) -> None:
@@ -430,14 +456,21 @@ class FakeTrainingClient:
         self.step_count = 0
         self.forward_backward_calls: list[tuple[list[FakeDatum], str]] = []
         self.optim_step_lrs: list[float] = []
+        self.calls: list[str] = []
+        """Ordered log of every method called on this client, oldest first."""
+
         self._service = service
         self._ledger = _SpanLedger()
-        self._saved_states: dict[str, int] = {}
-        self._state_counter = 0
         self._sampler_counter = 0
 
     def get_tokenizer(self) -> FakeTokenizer:
-        """The deterministic char-level tokenizer for this fake model."""
+        """The deterministic char-level tokenizer for this fake model.
+
+        Logged like every other call, but absent from
+        `MODEL_INITIALIZING_CALLS`: the real SDK answers it from a
+        metadata-only GetInfo request, so it never blocks a later restore.
+        """
+        self.calls.append("get_tokenizer")
         return FakeTokenizer()
 
     def forward_backward(self, datums: list[FakeDatum], loss_fn: str) -> FakeForwardBackwardOutput:
@@ -504,6 +537,7 @@ class FakeTrainingClient:
                 if span in issued:
                     continue
                 raise AssertionError(self._tito_message(datum_index, span, records))
+        self.calls.append("forward_backward")
         self.forward_backward_calls.append((list(datums), loss_fn))
         loss = -_derived_logprob(
             "batch-loss", loss_fn, *(_ids_key(datum.target_tokens) for datum in datums)
@@ -560,33 +594,52 @@ class FakeTrainingClient:
             A deterministic SDK-shaped response whose metrics carry a
             "grad_norm:mean" derived purely from (step count, learning rate).
         """
+        self.calls.append("optim_step")
         self.optim_step_lrs.append(learning_rate)
         self.step_count += 1
         grad_norm = -_derived_logprob("grad-norm", str(self.step_count), str(learning_rate))
         return FakeOptimStepResponse(metrics={"grad_norm:mean": grad_norm})
 
     def save_state(self) -> str:
-        """Save training state, returning a fake tinker:// state path."""
-        path = f"tinker://fake/state/{self._state_counter}"
-        self._state_counter += 1
-        self._saved_states[path] = self.step_count
-        return path
+        """Save training state, returning a fake tinker:// state path.
+
+        The state lands in the owning FakeServiceClient's artifact store, not
+        on this client: real tinker:// state paths outlive the session that
+        wrote them, which is what lets a later session restore them on a
+        freshly created training client.
+        """
+        self.calls.append("save_state")
+        return self._service._register_state(self.step_count)
 
     def load_state(self, path: str) -> None:
-        """Restore a previously saved state.
+        """Restore a previously saved state; must be this client's FIRST call.
+
+        Mirrors the live service's rule that LoadWeights is accepted only on
+        an uninitialized model: once any call in `MODEL_INITIALIZING_CALLS`
+        has run here, restoring is refused. That is the exact failure a
+        resumed distillation run hits when anything (a sampler-weights save,
+        a forward pass, or an earlier abandoned restore) touches the training
+        client before the checkpoint is loaded.
 
         Args:
-            path: A path returned by save_state on this client.
+            path: A path returned by save_state on any training client of the
+                owning service.
 
         Raises:
-            ValueError: If the path was never saved by this client.
+            RuntimeError: If a weight-affecting call already ran on this
+                client; the message names them in order.
+            ValueError: If the path was never returned by save_state.
         """
-        if path not in self._saved_states:
-            raise ValueError(
-                f"unknown state path {path!r}: it was never returned by save_state "
-                "on this training client"
+        initialized = [call for call in self.calls if call in MODEL_INITIALIZING_CALLS]
+        if initialized:
+            raise RuntimeError(
+                "LoadWeights can only be called on uninitialized models: load_state "
+                f"came after {initialized} on this training client. Restore the "
+                "checkpoint as the first call on a freshly created training client"
             )
-        self.step_count = self._saved_states[path]
+        step_count = self._service._saved_state_step(path)
+        self.calls.append("load_state")
+        self.step_count = step_count
 
     def save_weights_for_sampler(self, name: str) -> str:
         """Save current weights for sampling, returning a fake sampler path.
@@ -594,6 +647,7 @@ class FakeTrainingClient:
         The path can be exchanged for a linked FakeSamplingClient via
         FakeServiceClient.create_sampling_client.
         """
+        self.calls.append("save_weights_for_sampler")
         path = f"tinker://fake/sampler/{name}/{self._sampler_counter}"
         self._sampler_counter += 1
         self._service._register_sampler_path(path, self)
@@ -618,14 +672,21 @@ class FakeServiceClient:
     student through the same account, so tokens the teacher client genuinely
     sampled are legitimate training targets for the warmup phase, while ids no
     client ever issued remain violations.
+
+    The service also owns the saved-state artifact store, so a state one
+    training client wrote can be restored by another (what a resumed run
+    does): every `create_lora_training_client` call yields a fresh,
+    uninitialized client, just like the real service.
     """
 
     def __init__(self) -> None:
         self._sampler_paths: dict[str, FakeTrainingClient] = {}
         self._sampling_clients: list[FakeSamplingClient] = []
+        self._states: dict[str, int] = {}
+        self._state_counter = 0
 
     def create_lora_training_client(self, base_model: str, rank: int = 32) -> FakeTrainingClient:
-        """Create a fake LoRA training client for the given base model."""
+        """Create a fresh, uninitialized fake LoRA training client."""
         return FakeTrainingClient(service=self, base_model=base_model, rank=rank)
 
     def create_sampling_client(self, model_path: str) -> FakeSamplingClient:
@@ -651,3 +712,23 @@ class FakeServiceClient:
 
     def _register_sampler_path(self, path: str, training: FakeTrainingClient) -> None:
         self._sampler_paths[path] = training
+
+    def _register_state(self, step_count: int) -> str:
+        """Store one saved state, returning its fresh service-wide path."""
+        path = f"tinker://fake/state/{self._state_counter}"
+        self._state_counter += 1
+        self._states[path] = step_count
+        return path
+
+    def _saved_state_step(self, path: str) -> int:
+        """The step count a saved state carries.
+
+        Raises:
+            ValueError: If no training client of this service saved `path`.
+        """
+        if path not in self._states:
+            raise ValueError(
+                f"unknown state path {path!r}: it was never returned by save_state "
+                "on a training client of this service"
+            )
+        return self._states[path]

--- a/wmh/distill/fake_tinker.py
+++ b/wmh/distill/fake_tinker.py
@@ -15,8 +15,13 @@ randomness, so a run replayed with the same inputs produces identical outputs.
 
 The fakes also enforce the tokens-in-tokens-out (TITO) invariant that on-policy
 distillation depends on: every sampled span trained on must be byte-identical
-to a span some linked sampling client actually issued. FakeTrainingClient
-raises AssertionError from forward_backward when a datum violates it.
+to a span some sampling client actually issued. The issuer set is the training
+client's own linked samplers (its refreshed student weights) plus every
+sampling client its owning FakeServiceClient created (the teacher client the
+warmup phase trains on is created through the service, not linked to the
+student); fabricated or corrupted token ids were issued by nobody and still
+fail. FakeTrainingClient raises AssertionError from forward_backward when a
+datum violates it.
 """
 
 from __future__ import annotations
@@ -303,32 +308,44 @@ class FakeTrainingClient:
         """Record a training batch after asserting the TITO invariant.
 
         Every sampled span in every datum (maximal nonzero-weight run of
-        target tokens) must exactly equal the sampled ids of some span a
-        linked sampling client previously issued.
+        target tokens) must exactly equal the sampled ids of some span an
+        eligible issuer previously issued: a linked sampling client (this
+        training client's refreshed student weights) or any sampling client
+        the owning FakeServiceClient created (the teacher client the warmup
+        phase trains on). Fabricated ids fail either way.
 
         Args:
             datums: The batch to train on.
-            loss_fn: Loss function name (e.g. "importance_sampling"); recorded
-                but not interpreted.
+            loss_fn: Loss function name (e.g. "importance_sampling" or
+                "cross_entropy"); recorded but not interpreted.
 
         Raises:
-            AssertionError: If a sampled span was never issued by a linked
-                sampler; the message names the datum, the span, and the first
+            AssertionError: If a sampled span was never issued by an eligible
+                issuer; the message names the datum, the span, and the first
                 mismatching token position against the closest issued span.
         """
-        issued = {record.sampled_ids for record in self._ledger.records}
+        records = self._issuer_records()
+        issued = {record.sampled_ids for record in records}
         for datum_index, datum in enumerate(datums):
             for span in datum.sampled_spans():
                 if span in issued:
                     continue
-                raise AssertionError(self._tito_message(datum_index, span))
+                raise AssertionError(self._tito_message(datum_index, span, records))
         self.forward_backward_calls.append((list(datums), loss_fn))
 
-    def _tito_message(self, datum_index: int, span: tuple[int, ...]) -> str:
+    def _issuer_records(self) -> list[IssuedSample]:
+        """Every span an eligible issuer recorded: linked ledger + service clients."""
+        records = list(self._ledger.records)
+        records.extend(self._service.issued_records())
+        return records
+
+    def _tito_message(
+        self, datum_index: int, span: tuple[int, ...], records: list[IssuedSample]
+    ) -> str:
         """Build the TITO failure message naming the first mismatch position."""
         best: IssuedSample | None = None
         best_prefix = -1
-        for record in self._ledger.records:
+        for record in records:
             prefix = 0
             for a, b in zip(span, record.sampled_ids, strict=False):
                 if a != b:
@@ -340,7 +357,7 @@ class FakeTrainingClient:
         if best is None:
             return (
                 f"TITO violation in datum {datum_index}: sampled span of length "
-                f"{len(span)} trained on, but no linked sampler issued any span"
+                f"{len(span)} trained on, but no eligible sampler issued any span"
             )
         mismatch = best_prefix
         if mismatch < len(span) and mismatch < len(best.sampled_ids):
@@ -406,27 +423,43 @@ class FakeTrainingClient:
 
 
 class FakeServiceClient:
-    """Deterministic stand-in for tinker.ServiceClient."""
+    """Deterministic stand-in for tinker.ServiceClient.
+
+    Every sampling client it creates is remembered as a potential TITO issuer
+    (see `issued_records`): the real service serves the teacher and the
+    student through the same account, so tokens the teacher client genuinely
+    sampled are legitimate training targets for the warmup phase, while ids no
+    client ever issued remain violations.
+    """
 
     def __init__(self) -> None:
         self._sampler_paths: dict[str, FakeTrainingClient] = {}
+        self._sampling_clients: list[FakeSamplingClient] = []
 
     def create_lora_training_client(self, base_model: str, rank: int = 32) -> FakeTrainingClient:
         """Create a fake LoRA training client for the given base model."""
         return FakeTrainingClient(service=self, base_model=base_model, rank=rank)
 
     def create_sampling_client(self, model_path: str) -> FakeSamplingClient:
-        """Create a sampling client for a saved sampler path.
+        """Create (and track as a TITO issuer) a sampling client for a path.
 
         Paths produced by a linked training client's save_weights_for_sampler
         yield clients that share that training client's span ledger; any other
         path (e.g. a base model name for a standalone teacher) yields an
-        unlinked client seeded with the path.
+        unlinked client seeded with the path. Either way the client is tracked
+        so its issued spans satisfy the training clients' TITO checks.
         """
         training = self._sampler_paths.get(model_path)
         if training is not None:
-            return FakeSamplingClient(seed=model_path, ledger=training._ledger)
-        return FakeSamplingClient(seed=model_path)
+            client = FakeSamplingClient(seed=model_path, ledger=training._ledger)
+        else:
+            client = FakeSamplingClient(seed=model_path)
+        self._sampling_clients.append(client)
+        return client
+
+    def issued_records(self) -> list[IssuedSample]:
+        """Every span any sampling client created by this service issued."""
+        return [record for client in self._sampling_clients for record in client.issued]
 
     def _register_sampler_path(self, path: str, training: FakeTrainingClient) -> None:
         self._sampler_paths[path] = training

--- a/wmh/distill/fake_tinker.py
+++ b/wmh/distill/fake_tinker.py
@@ -1,0 +1,432 @@
+"""Deterministic in-memory fakes of the Tinker SDK surface the distill loop uses.
+
+These fakes mirror the shapes of the real SDK (tinker.ServiceClient,
+tinker.TrainingClient, tinker.SamplingClient, tinker.types.Datum and
+tinker.types.SampledSequence) structurally, without importing tinker at all,
+so the test suite runs without the `distill` extra installed. Method names and
+call shapes match the real clients closely enough that the distill loop can be
+exercised end to end against them; the notable simplifications are documented
+on each method (token ids are plain `list[int]` rather than ModelInput chunks,
+results are returned directly rather than through futures).
+
+Everything is deterministic: sampled tokens and logprobs are derived from
+SHA-256 hashes of (seed, prompt ids, position), never from time or global
+randomness, so a run replayed with the same inputs produces identical outputs.
+
+The fakes also enforce the tokens-in-tokens-out (TITO) invariant that on-policy
+distillation depends on: every sampled span trained on must be byte-identical
+to a span some linked sampling client actually issued. FakeTrainingClient
+raises AssertionError from forward_backward when a datum violates it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Literal
+
+_SAMPLED_TOKEN_BASE = 32
+_SAMPLED_TOKEN_RANGE = 95
+"""Sampled token ids stay in the printable ASCII range so decode() is total."""
+
+
+def _digest(*parts: str) -> bytes:
+    """A 32-byte SHA-256 digest of the given parts joined unambiguously."""
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).digest()
+
+
+def _ids_key(token_ids: list[int]) -> str:
+    return ",".join(str(t) for t in token_ids)
+
+
+def _derived_token(seed: str, prompt_ids: list[int], sample_index: int, position: int) -> int:
+    digest = _digest("token", seed, _ids_key(prompt_ids), str(sample_index), str(position))
+    value = int.from_bytes(digest[:4], "big")
+    return _SAMPLED_TOKEN_BASE + (value % _SAMPLED_TOKEN_RANGE)
+
+
+def _derived_logprob(*parts: str) -> float:
+    """A deterministic pseudo-logprob in [-4.05, -0.05), from the given parts."""
+    digest = _digest("logprob", *parts)
+    value = int.from_bytes(digest[:4], "big")
+    return -0.05 - (value % 4000) / 1000.0
+
+
+class FakeTokenizer:
+    """A tiny deterministic char-level tokenizer: token id = code point."""
+
+    def encode(self, text: str) -> list[int]:
+        """Encode text to token ids (one token per character)."""
+        return [ord(ch) for ch in text]
+
+    def decode(self, token_ids: list[int]) -> str:
+        """Decode token ids back to text."""
+        return "".join(chr(t) for t in token_ids)
+
+
+@dataclass(frozen=True)
+class FakeSampledSequence:
+    """One sampled sequence, mirroring tinker.types.SampledSequence.
+
+    `tokens` are the generated token ids and `logprobs[j]` is the logprob the
+    sampler assigned to `tokens[j]`, aligned one to one.
+    """
+
+    tokens: list[int]
+    logprobs: list[float]
+    stop_reason: Literal["length", "stop"]
+
+
+@dataclass(frozen=True)
+class IssuedSample:
+    """A record of one span a sampling client issued: the TITO ground truth."""
+
+    prompt_ids: tuple[int, ...]
+    sampled_ids: tuple[int, ...]
+    logprobs: tuple[float, ...]
+
+
+@dataclass
+class _SpanLedger:
+    """Issued-span records shared by a training client and its samplers."""
+
+    records: list[IssuedSample] = field(default_factory=list)
+
+
+class FakeDatum:
+    """A training datum, mirroring tinker.types.Datum structurally.
+
+    The real Datum carries a ModelInput plus tensor-valued loss_fn_inputs;
+    here everything is plain lists. `model_input_tokens` is the full input
+    sequence and the loss inputs are aligned with `target_tokens`.
+
+    Args:
+        model_input_tokens: The full input token sequence (all but the final
+            target position, in the usual shifted-by-one layout; the fakes do
+            not enforce that layout).
+        target_tokens: Tokens the loss is computed over.
+        weights: Per-target-token loss weights; positions with weight 0 are
+            prompt/tool tokens outside the sampled spans. Defaults to all 1.0.
+        advantages: Optional per-target-token advantages (importance_sampling).
+        logprobs: Optional per-target-token behavior-policy logprobs.
+    """
+
+    def __init__(
+        self,
+        model_input_tokens: list[int],
+        target_tokens: list[int],
+        weights: list[float] | None = None,
+        advantages: list[float] | None = None,
+        logprobs: list[float] | None = None,
+    ) -> None:
+        self.model_input_tokens = list(model_input_tokens)
+        self.target_tokens = list(target_tokens)
+        self.weights = list(weights) if weights is not None else [1.0] * len(target_tokens)
+        self.advantages = list(advantages) if advantages is not None else []
+        self.logprobs = list(logprobs) if logprobs is not None else []
+        if len(self.weights) != len(self.target_tokens):
+            raise ValueError(
+                f"weights length {len(self.weights)} does not match "
+                f"target_tokens length {len(self.target_tokens)}"
+            )
+
+    def sampled_spans(self) -> list[tuple[int, ...]]:
+        """Maximal contiguous runs of target tokens with nonzero weight."""
+        spans: list[tuple[int, ...]] = []
+        current: list[int] = []
+        for token, weight in zip(self.target_tokens, self.weights, strict=True):
+            if weight != 0.0:
+                current.append(token)
+            elif current:
+                spans.append(tuple(current))
+                current = []
+        if current:
+            spans.append(tuple(current))
+        return spans
+
+
+class FakeSamplingClient:
+    """Deterministic stand-in for tinker.SamplingClient.
+
+    Simplifications vs the real client: prompts are `list[int]` (the real
+    client takes ModelInput), results are returned directly (no futures), and
+    one call returns one sequence.
+
+    Args:
+        seed: Seed string, by convention the fake sampler weights path; all
+            sampled tokens and logprobs derive from it.
+        ledger: Shared issued-span ledger; samplers refreshed from the same
+            training client share one ledger so TITO checks see all of them.
+    """
+
+    def __init__(self, seed: str, ledger: _SpanLedger | None = None) -> None:
+        self.seed = seed
+        self._ledger = ledger if ledger is not None else _SpanLedger()
+        self.issued: list[IssuedSample] = []
+
+    def sample(
+        self,
+        prompt_token_ids: list[int],
+        max_tokens: int,
+        temperature: float,
+        stop: list[int] | list[str] | None = None,
+        sample_index: int = 0,
+    ) -> FakeSampledSequence:
+        """Sample a deterministic sequence for the prompt and record it.
+
+        Tokens and logprobs derive purely from a hash of (seed, prompt ids,
+        sample_index, position): calling again with identical arguments
+        returns an identical sequence. Pass distinct `sample_index` values to
+        get distinct group members deterministically (the real SDK's
+        num_samples analogue). `temperature` is accepted for signature parity
+        and does not affect the fake's output.
+
+        Args:
+            prompt_token_ids: Prompt tokens the sample conditions on.
+            max_tokens: Maximum number of tokens to generate.
+            temperature: Accepted for parity; unused by the fake.
+            stop: Optional stop token ids or stop strings (the real
+                SamplingParams accepts both). A generated stop token is
+                included in the output and ends generation with stop_reason
+                "stop"; a stop string fires when the generation so far, decoded
+                with the char-level FakeTokenizer convention, ends with it.
+            sample_index: Deterministic nonce distinguishing group members.
+
+        Returns:
+            The sampled sequence with aligned per-token logprobs.
+        """
+        del temperature
+        int_stops = {item for item in (stop or ()) if isinstance(item, int)}
+        str_stops = [item for item in (stop or ()) if isinstance(item, str)]
+        tokens: list[int] = []
+        logprobs: list[float] = []
+        stop_reason: Literal["length", "stop"] = "length"
+        for position in range(max_tokens):
+            token = _derived_token(self.seed, prompt_token_ids, sample_index, position)
+            logprob = _derived_logprob(
+                "issued", self.seed, _ids_key(prompt_token_ids), str(sample_index), str(position)
+            )
+            tokens.append(token)
+            logprobs.append(logprob)
+            if token in int_stops:
+                stop_reason = "stop"
+                break
+            if str_stops:
+                text = "".join(chr(t) for t in tokens)
+                if any(text.endswith(item) for item in str_stops):
+                    stop_reason = "stop"
+                    break
+        record = IssuedSample(
+            prompt_ids=tuple(prompt_token_ids),
+            sampled_ids=tuple(tokens),
+            logprobs=tuple(logprobs),
+        )
+        self.issued.append(record)
+        self._ledger.records.append(record)
+        return FakeSampledSequence(tokens=tokens, logprobs=logprobs, stop_reason=stop_reason)
+
+    def compute_logprobs(self, token_ids: list[int]) -> list[float | None]:
+        """Per-position logprobs for a full token sequence.
+
+        Indexing convention (mirroring the real SDK's prompt_logprobs): index
+        i holds the logprob of token i given tokens < i, and index 0 is None
+        because the first token has no context (the real SDK likewise returns
+        None where a logprob cannot be computed; we chose None over a
+        placeholder to match it exactly).
+
+        Positions covered by a previously issued sampled span, meaning the
+        span's sampled ids appear in `token_ids` immediately after that span's
+        exact prompt ids, echo the exact logprobs issued at sampling time
+        (first matching record wins for overlaps). Every other position gets
+        a deterministic hash-derived value from (seed, tokens <= i).
+
+        Args:
+            token_ids: The full sequence to score.
+
+        Returns:
+            One entry per input position; entry 0 is None.
+        """
+        n = len(token_ids)
+        result: list[float | None] = [None] * n
+        filled = [False] * n
+        if n > 0:
+            filled[0] = True  # position 0 stays None by convention
+        for record in self._ledger.records:
+            span_len = len(record.sampled_ids)
+            prompt_len = len(record.prompt_ids)
+            if span_len == 0:
+                continue
+            for start in range(prompt_len, n - span_len + 1):
+                if tuple(token_ids[start : start + span_len]) != record.sampled_ids:
+                    continue
+                if tuple(token_ids[start - prompt_len : start]) != record.prompt_ids:
+                    continue
+                for offset in range(span_len):
+                    position = start + offset
+                    if not filled[position]:
+                        result[position] = record.logprobs[offset]
+                        filled[position] = True
+        for position in range(1, n):
+            if not filled[position]:
+                result[position] = _derived_logprob(
+                    "context", self.seed, _ids_key(token_ids[: position + 1])
+                )
+        return result
+
+
+class FakeTrainingClient:
+    """Deterministic stand-in for tinker.TrainingClient.
+
+    Create via FakeServiceClient.create_lora_training_client. Simplifications
+    vs the real client: results return directly (no APIFuture), datums are
+    FakeDatum (plain lists rather than tensors), and optim_step takes a bare
+    learning rate rather than AdamParams.
+    """
+
+    def __init__(self, service: FakeServiceClient, base_model: str, rank: int) -> None:
+        self.base_model = base_model
+        self.rank = rank
+        self.step_count = 0
+        self.forward_backward_calls: list[tuple[list[FakeDatum], str]] = []
+        self.optim_step_lrs: list[float] = []
+        self._service = service
+        self._ledger = _SpanLedger()
+        self._saved_states: dict[str, int] = {}
+        self._state_counter = 0
+        self._sampler_counter = 0
+
+    def get_tokenizer(self) -> FakeTokenizer:
+        """The deterministic char-level tokenizer for this fake model."""
+        return FakeTokenizer()
+
+    def forward_backward(self, datums: list[FakeDatum], loss_fn: str) -> None:
+        """Record a training batch after asserting the TITO invariant.
+
+        Every sampled span in every datum (maximal nonzero-weight run of
+        target tokens) must exactly equal the sampled ids of some span a
+        linked sampling client previously issued.
+
+        Args:
+            datums: The batch to train on.
+            loss_fn: Loss function name (e.g. "importance_sampling"); recorded
+                but not interpreted.
+
+        Raises:
+            AssertionError: If a sampled span was never issued by a linked
+                sampler; the message names the datum, the span, and the first
+                mismatching token position against the closest issued span.
+        """
+        issued = {record.sampled_ids for record in self._ledger.records}
+        for datum_index, datum in enumerate(datums):
+            for span in datum.sampled_spans():
+                if span in issued:
+                    continue
+                raise AssertionError(self._tito_message(datum_index, span))
+        self.forward_backward_calls.append((list(datums), loss_fn))
+
+    def _tito_message(self, datum_index: int, span: tuple[int, ...]) -> str:
+        """Build the TITO failure message naming the first mismatch position."""
+        best: IssuedSample | None = None
+        best_prefix = -1
+        for record in self._ledger.records:
+            prefix = 0
+            for a, b in zip(span, record.sampled_ids, strict=False):
+                if a != b:
+                    break
+                prefix += 1
+            if prefix > best_prefix:
+                best_prefix = prefix
+                best = record
+        if best is None:
+            return (
+                f"TITO violation in datum {datum_index}: sampled span of length "
+                f"{len(span)} trained on, but no linked sampler issued any span"
+            )
+        mismatch = best_prefix
+        if mismatch < len(span) and mismatch < len(best.sampled_ids):
+            detail = (
+                f"first mismatch at position {mismatch}: datum has {span[mismatch]}, "
+                f"closest issued span has {best.sampled_ids[mismatch]}"
+            )
+        else:
+            detail = (
+                f"first mismatch at position {mismatch}: datum span length {len(span)} "
+                f"vs closest issued span length {len(best.sampled_ids)}"
+            )
+        return f"TITO violation in datum {datum_index}: {detail}"
+
+    def optim_step(self, learning_rate: float) -> None:
+        """Apply one optimizer step: increments the step counter."""
+        self.optim_step_lrs.append(learning_rate)
+        self.step_count += 1
+
+    def save_state(self) -> str:
+        """Save training state, returning a fake tinker:// state path."""
+        path = f"tinker://fake/state/{self._state_counter}"
+        self._state_counter += 1
+        self._saved_states[path] = self.step_count
+        return path
+
+    def load_state(self, path: str) -> None:
+        """Restore a previously saved state.
+
+        Args:
+            path: A path returned by save_state on this client.
+
+        Raises:
+            ValueError: If the path was never saved by this client.
+        """
+        if path not in self._saved_states:
+            raise ValueError(
+                f"unknown state path {path!r}: it was never returned by save_state "
+                "on this training client"
+            )
+        self.step_count = self._saved_states[path]
+
+    def save_weights_for_sampler(self, name: str) -> str:
+        """Save current weights for sampling, returning a fake sampler path.
+
+        The path can be exchanged for a linked FakeSamplingClient via
+        FakeServiceClient.create_sampling_client.
+        """
+        path = f"tinker://fake/sampler/{name}/{self._sampler_counter}"
+        self._sampler_counter += 1
+        self._service._register_sampler_path(path, self)
+        return path
+
+    def save_weights_and_get_sampling_client(self, name: str) -> FakeSamplingClient:
+        """Save current weights and return a fresh linked sampling client.
+
+        Each call yields a distinct sampler path (so a refreshed sampler
+        samples different tokens) whose client shares this training client's
+        span ledger (so TITO checks see every sampler's issued spans).
+        """
+        path = self.save_weights_for_sampler(name)
+        return FakeSamplingClient(seed=path, ledger=self._ledger)
+
+
+class FakeServiceClient:
+    """Deterministic stand-in for tinker.ServiceClient."""
+
+    def __init__(self) -> None:
+        self._sampler_paths: dict[str, FakeTrainingClient] = {}
+
+    def create_lora_training_client(self, base_model: str, rank: int = 32) -> FakeTrainingClient:
+        """Create a fake LoRA training client for the given base model."""
+        return FakeTrainingClient(service=self, base_model=base_model, rank=rank)
+
+    def create_sampling_client(self, model_path: str) -> FakeSamplingClient:
+        """Create a sampling client for a saved sampler path.
+
+        Paths produced by a linked training client's save_weights_for_sampler
+        yield clients that share that training client's span ledger; any other
+        path (e.g. a base model name for a standalone teacher) yields an
+        unlinked client seeded with the path.
+        """
+        training = self._sampler_paths.get(model_path)
+        if training is not None:
+            return FakeSamplingClient(seed=model_path, ledger=training._ledger)
+        return FakeSamplingClient(seed=model_path)
+
+    def _register_sampler_path(self, path: str, training: FakeTrainingClient) -> None:
+        self._sampler_paths[path] = training

--- a/wmh/distill/fake_tinker.py
+++ b/wmh/distill/fake_tinker.py
@@ -21,7 +21,11 @@ sampling client its owning FakeServiceClient created (the teacher client the
 warmup phase trains on is created through the service, not linked to the
 student); fabricated or corrupted token ids were issued by nobody and still
 fail. FakeTrainingClient raises AssertionError from forward_backward when a
-datum violates it.
+datum violates it. Datums flagged `topk=True` (topk-CE replicas) get the
+input-side variant of the check: their TARGETS are intentionally
+teacher-proposed candidate tokens no sampler issued, so the invariant binds
+the model INPUT under the loss-weighted positions instead, which must still
+be the student's exact sampled tokens (see FakeTrainingClient.forward_backward).
 """
 
 from __future__ import annotations
@@ -42,6 +46,16 @@ def _digest(*parts: str) -> bytes:
 
 def _ids_key(token_ids: list[int]) -> str:
     return ",".join(str(t) for t in token_ids)
+
+
+def _contains_run(haystack: tuple[int, ...], needle: tuple[int, ...]) -> bool:
+    """Whether `needle` appears as a contiguous run inside `haystack`."""
+    if not needle:
+        return True
+    span = len(needle)
+    return any(
+        haystack[start : start + span] == needle for start in range(len(haystack) - span + 1)
+    )
 
 
 def _derived_token(seed: str, prompt_ids: list[int], sample_index: int, position: int) -> int:
@@ -145,6 +159,9 @@ class FakeDatum:
             prompt/tool tokens outside the sampled spans. Defaults to all 1.0.
         advantages: Optional per-target-token advantages (importance_sampling).
         logprobs: Optional per-target-token behavior-policy logprobs.
+        topk: Marks a topk-CE replica: its targets are teacher-proposed
+            candidates (fractional weights), so the TITO check binds the
+            model INPUT under the weighted positions instead of the targets.
     """
 
     def __init__(
@@ -154,12 +171,14 @@ class FakeDatum:
         weights: list[float] | None = None,
         advantages: list[float] | None = None,
         logprobs: list[float] | None = None,
+        topk: bool = False,
     ) -> None:
         self.model_input_tokens = list(model_input_tokens)
         self.target_tokens = list(target_tokens)
         self.weights = list(weights) if weights is not None else [1.0] * len(target_tokens)
         self.advantages = list(advantages) if advantages is not None else []
         self.logprobs = list(logprobs) if logprobs is not None else []
+        self.topk = topk
         if len(self.weights) != len(self.target_tokens):
             raise ValueError(
                 f"weights length {len(self.weights)} does not match "
@@ -174,6 +193,31 @@ class FakeDatum:
             if weight != 0.0:
                 current.append(token)
             elif current:
+                spans.append(tuple(current))
+                current = []
+        if current:
+            spans.append(tuple(current))
+        return spans
+
+    def input_loss_spans(self) -> list[tuple[int, ...]]:
+        """Model-INPUT token runs under the nonzero-weight target positions.
+
+        Target index j scores unshifted position j + 1, whose token sits at
+        model_input index j + 1 when that index exists (the final target's
+        token was shifted out of the input, so a loss run reaching the
+        sequence end contributes one token fewer here). This is what the
+        TITO check inspects for topk-CE replicas: the targets are candidate
+        tokens by design, but the input context at the loss positions must
+        still be tokens a sampler actually issued.
+        """
+        spans: list[tuple[int, ...]] = []
+        current: list[int] = []
+        for index, weight in enumerate(self.weights):
+            in_input = index + 1 < len(self.model_input_tokens)
+            if weight != 0.0 and in_input:
+                current.append(self.model_input_tokens[index + 1])
+                continue
+            if current:
                 spans.append(tuple(current))
                 current = []
         if current:
@@ -309,6 +353,67 @@ class FakeSamplingClient:
                 )
         return result
 
+    def topk_prompt_logprobs(
+        self, token_ids: list[int], k: int
+    ) -> tuple[list[float | None], list[list[tuple[int, float]] | None]]:
+        """Deterministic echo of the SDK's prefill-only top-k prompt logprobs.
+
+        Mirrors `sample(prompt=token_ids, max_tokens=1,
+        include_prompt_logprobs=True, topk_prompt_logprobs=k)` on the real
+        client: the first return value is the realized per-position logprobs
+        (exactly `compute_logprobs(token_ids)`, so issued spans echo their
+        sampling-time logprobs), and the second is one top-k candidate list
+        per position (None at position 0, which has no context). At each
+        scoreable position the top-1 candidate is the sequence's own token
+        with its realized logprob; the remaining k - 1 candidates carry
+        hash-derived token ids and strictly decreasing hash-derived logprobs
+        below it, so ranks are unambiguous and the whole result is a pure
+        function of (seed, ledger echoes, token_ids, k): replaying the same
+        call always returns the identical value.
+
+        Args:
+            token_ids: The full sequence to score, prompt-style.
+            k: Candidates per position (>= 1).
+
+        Returns:
+            The (realized logprobs, top-k rows) pair, both with one entry
+            per input position.
+
+        Raises:
+            ValueError: If `k` is not positive.
+        """
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        if k > _SAMPLED_TOKEN_RANGE:
+            raise ValueError(
+                f"the fake vocabulary has only {_SAMPLED_TOKEN_RANGE} derivable "
+                f"candidate ids per position, got k = {k} (the config caps "
+                "train.topk at 64, well inside it)"
+            )
+        realized = self.compute_logprobs(token_ids)
+        rows: list[list[tuple[int, float]] | None] = [None] * len(token_ids)
+        for position in range(1, len(token_ids)):
+            top_logprob = realized[position]
+            assert top_logprob is not None  # compute_logprobs fills every p >= 1
+            entries: list[tuple[int, float]] = [(token_ids[position], top_logprob)]
+            seen = {token_ids[position]}
+            logprob = top_logprob
+            rank = 1
+            while len(entries) < k:
+                token = _derived_token(f"topk:{self.seed}", token_ids[:position], rank, position)
+                while token in seen:
+                    token = _SAMPLED_TOKEN_BASE + (
+                        (token - _SAMPLED_TOKEN_BASE + 1) % _SAMPLED_TOKEN_RANGE
+                    )
+                seen.add(token)
+                logprob += _derived_logprob(
+                    "topk-gap", self.seed, _ids_key(token_ids[: position + 1]), str(rank)
+                )
+                entries.append((token, logprob))
+                rank += 1
+            rows[position] = entries
+        return realized, rows
+
 
 class FakeTrainingClient:
     """Deterministic stand-in for tinker.TrainingClient.
@@ -345,10 +450,22 @@ class FakeTrainingClient:
         the owning FakeServiceClient created (the teacher client the warmup
         phase trains on). Fabricated ids fail either way.
 
+        Datums flagged `topk=True` (topk-CE replicas) are checked on the
+        model INPUT instead of the targets: their targets are intentionally
+        teacher-proposed candidate tokens that no sampler ever issued (that
+        is the whole point of the loss), while the input context must remain
+        the student's exact sampled tokens. Each input-side loss span
+        (`FakeDatum.input_loss_spans`) must appear as a contiguous run inside
+        some issued span (a contiguous run rather than the whole span, since
+        the next-token shift truncates a sequence-final span by one token and
+        rank padding can split a run). Topk replicas are additionally pinned
+        to the cross_entropy loss.
+
         Args:
             datums: The batch to train on.
             loss_fn: Loss function name (e.g. "importance_sampling" or
-                "cross_entropy"); recorded but not interpreted.
+                "cross_entropy"); recorded but not interpreted beyond the
+                topk-replica pin above.
 
         Returns:
             A deterministic SDK-shaped output: the metrics dict carries a
@@ -357,12 +474,32 @@ class FakeTrainingClient:
 
         Raises:
             AssertionError: If a sampled span was never issued by an eligible
-                issuer; the message names the datum, the span, and the first
-                mismatching token position against the closest issued span.
+                issuer (the message names the datum, the span, and the first
+                mismatching token position against the closest issued span),
+                if a topk replica's input-side loss span appears in no issued
+                span, or if a topk replica arrives under a loss other than
+                cross_entropy.
         """
         records = self._issuer_records()
         issued = {record.sampled_ids for record in records}
         for datum_index, datum in enumerate(datums):
+            if datum.topk:
+                if loss_fn != "cross_entropy":
+                    raise AssertionError(
+                        f"topk-CE replica datum {datum_index} was trained under "
+                        f"loss_fn {loss_fn!r}; candidate targets are only valid "
+                        "under cross_entropy"
+                    )
+                for span in datum.input_loss_spans():
+                    if any(_contains_run(record.sampled_ids, span) for record in records):
+                        continue
+                    raise AssertionError(
+                        f"TITO violation in topk datum {datum_index}: the model input "
+                        f"under a loss-weighted span (length {len(span)}) matches no "
+                        "issued span; topk-CE may propose candidate TARGETS, but the "
+                        "input context must stay the student's exact sampled tokens"
+                    )
+                continue
             for span in datum.sampled_spans():
                 if span in issued:
                     continue

--- a/wmh/distill/fake_tinker_test.py
+++ b/wmh/distill/fake_tinker_test.py
@@ -212,6 +212,41 @@ def test_optim_step_counts_and_records_lr() -> None:
     assert training.optim_step_lrs == [1e-4, 5e-5]
 
 
+def test_forward_backward_reports_a_deterministic_batch_loss() -> None:
+    """The SDK-shaped output carries a stable "total_loss:sum" per batch."""
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    seq = sampler.sample([1, 2, 3], max_tokens=4, temperature=0.7)
+    datum = FakeDatum(
+        model_input_tokens=[1, 2, 3] + seq.tokens[:-1],
+        target_tokens=[2, 3] + seq.tokens,
+        weights=[0.0, 0.0] + [1.0] * len(seq.tokens),
+    )
+    first = training.forward_backward([datum], "importance_sampling")
+    second = training.forward_backward([datum], "importance_sampling")
+    assert first.loss_fn_output_type == "FakeLossReturn"
+    assert len(first.loss_fn_outputs) == 1  # one entry per datum, like the SDK
+    loss = first.metrics["total_loss:sum"]
+    assert loss > 0.0
+    assert second.metrics == first.metrics  # pure function of (loss_fn, batch)
+    # A different loss_fn or batch reports a different (still deterministic) loss.
+    other_loss = training.forward_backward([datum], "cross_entropy")
+    assert other_loss.metrics["total_loss:sum"] != loss
+
+
+def test_optim_step_reports_a_deterministic_grad_norm() -> None:
+    """The SDK-shaped response carries a stable "grad_norm:mean" per step."""
+    a = _make_training()
+    b = _make_training()
+    first_a = a.optim_step(1e-4)
+    first_b = b.optim_step(1e-4)
+    assert first_a.metrics is not None and first_b.metrics is not None
+    assert first_a.metrics["grad_norm:mean"] > 0.0
+    assert first_a.metrics == first_b.metrics  # pure function of (step count, lr)
+    second_a = a.optim_step(1e-4)
+    assert second_a.metrics != first_a.metrics  # the step count advanced
+
+
 def test_save_and_load_state() -> None:
     training = _make_training()
     training.optim_step(1e-4)

--- a/wmh/distill/fake_tinker_test.py
+++ b/wmh/distill/fake_tinker_test.py
@@ -182,7 +182,7 @@ def test_tito_fires_on_corrupted_datum() -> None:
 def test_tito_fires_when_nothing_issued() -> None:
     training = _make_training()
     datum = FakeDatum(model_input_tokens=[1, 2], target_tokens=[3, 4])
-    with pytest.raises(AssertionError, match="no linked sampler issued any span"):
+    with pytest.raises(AssertionError, match="no eligible sampler issued any span"):
         training.forward_backward([datum], "importance_sampling")
 
 
@@ -266,12 +266,58 @@ def test_create_sampling_client_from_saved_path_is_linked() -> None:
     assert echoed[2:] == seq.logprobs
 
 
-def test_create_sampling_client_unknown_path_is_standalone() -> None:
+def test_create_sampling_client_unknown_path_is_unlinked_but_tracked() -> None:
+    """An unknown-path sampler (the teacher) is unlinked yet a TITO issuer.
+
+    This replaces the pre-warmup expectation that teacher spans fail TITO:
+    the warmup phase deliberately trains on TEACHER-sampled tokens, and the
+    real service serves teacher and student through the same account, so a
+    span a service-created client genuinely issued is legitimate training
+    data. Unlinked still means its spans never echo through the student's
+    shared ledger.
+    """
     service = FakeServiceClient()
     teacher = service.create_sampling_client("teacher-base-model")
     seq = teacher.sample([1], max_tokens=2, temperature=0.0)
     assert len(seq.tokens) == 2
-    # Standalone samplers do not feed any training client's ledger.
+    # Unlinked: the student's samplers cannot echo the teacher's issued logprobs.
+    training = service.create_lora_training_client("base")
+    student = training.save_weights_and_get_sampling_client("s0")
+    echoed = student.compute_logprobs([1] + seq.tokens)
+    assert echoed[1:] != seq.logprobs
+    # Tracked issuer: teacher-sampled spans satisfy the TITO check (warmup SFT).
+    datum = FakeDatum(
+        model_input_tokens=[1] + seq.tokens,
+        target_tokens=list(seq.tokens),
+        weights=[1.0] * len(seq.tokens),
+    )
+    training.forward_backward([datum], "cross_entropy")
+    assert training.forward_backward_calls[-1][1] == "cross_entropy"
+
+
+def test_corrupted_teacher_span_still_fails_tito() -> None:
+    """The issuer extension does not weaken the assertion: fabricated ids die."""
+    service = FakeServiceClient()
+    teacher = service.create_sampling_client("teacher-base-model")
+    seq = teacher.sample([1, 2], max_tokens=4, temperature=0.0)
+    corrupted = list(seq.tokens)
+    corrupted[1] = corrupted[1] + 1
+    training = service.create_lora_training_client("base")
+    datum = FakeDatum(
+        model_input_tokens=[1, 2] + corrupted,
+        target_tokens=corrupted,
+        weights=[1.0] * len(corrupted),
+    )
+    with pytest.raises(AssertionError, match=r"TITO violation in datum 0.*position 1"):
+        training.forward_backward([datum], "cross_entropy")
+    assert training.forward_backward_calls == []
+
+
+def test_directly_constructed_sampler_is_not_an_issuer() -> None:
+    """Only service-created clients count; a bare FakeSamplingClient does not."""
+    service = FakeServiceClient()
+    rogue = FakeSamplingClient(seed="rogue-sampler")
+    seq = rogue.sample([1], max_tokens=3, temperature=0.0)
     training = service.create_lora_training_client("base")
     datum = FakeDatum(
         model_input_tokens=[1] + seq.tokens,

--- a/wmh/distill/fake_tinker_test.py
+++ b/wmh/distill/fake_tinker_test.py
@@ -247,19 +247,89 @@ def test_optim_step_reports_a_deterministic_grad_norm() -> None:
     assert second_a.metrics != first_a.metrics  # the step count advanced
 
 
-def test_save_and_load_state() -> None:
-    training = _make_training()
-    training.optim_step(1e-4)
-    path = training.save_state()
+def test_save_and_load_state_across_training_clients() -> None:
+    """States live on the service, so a later client restores them.
+
+    This is the resume shape: the session that saved the checkpoint is gone
+    and a freshly created (uninitialized) training client loads it, which is
+    the only ordering the live service accepts.
+    """
+    service = FakeServiceClient()
+    first = service.create_lora_training_client("base-model", rank=16)
+    first.optim_step(1e-4)
+    path = first.save_state()
     assert path == "tinker://fake/state/0"
-    training.optim_step(1e-4)
-    assert training.step_count == 2
-    training.load_state(path)
-    assert training.step_count == 1
-    second = training.save_state()
-    assert second == "tinker://fake/state/1"
+    first.optim_step(1e-4)
+    assert first.step_count == 2
+
+    second = service.create_lora_training_client("base-model", rank=16)
+    second.load_state(path)
+    assert second.step_count == 1
+    assert second.save_state() == "tinker://fake/state/1"  # the service-wide counter
+
+    third = service.create_lora_training_client("base-model", rank=16)
     with pytest.raises(ValueError, match="never returned by save_state"):
-        training.load_state("tinker://fake/state/999")
+        third.load_state("tinker://fake/state/999")
+    assert third.calls == []  # a rejected restore left the client uninitialized
+
+
+def test_load_state_after_a_weights_call_is_refused() -> None:
+    """The live service's rule, mirrored: LoadWeights needs an uninitialized model.
+
+    A resumed distill run that let anything touch the training client before
+    restoring the checkpoint died on this exact error, so the fake fails the
+    same way instead of silently accepting the restore.
+    """
+    service = FakeServiceClient()
+    training = service.create_lora_training_client("base-model", rank=16)
+    path = training.save_state()
+    training.save_weights_for_sampler("s0")
+
+    with pytest.raises(RuntimeError, match="LoadWeights can only be called on uninitialized"):
+        training.load_state(path)
+
+    # A second restore is refused for the same reason (the live failure was
+    # precisely a retried load_state on one client).
+    fresh = service.create_lora_training_client("base-model", rank=16)
+    fresh.load_state(path)
+    with pytest.raises(RuntimeError, match=r"after \['load_state'\]"):
+        fresh.load_state(path)
+
+
+def test_the_call_log_records_order_and_excludes_get_tokenizer() -> None:
+    """`calls` is the ordered log tests assert against.
+
+    get_tokenizer is logged but is NOT model-initializing (the SDK answers it
+    from a metadata-only GetInfo), so it may precede a restore.
+    """
+    service = FakeServiceClient()
+    training = service.create_lora_training_client("base-model", rank=16)
+    path = training.save_state()
+
+    restored = service.create_lora_training_client("base-model", rank=16)
+    restored.get_tokenizer()
+    restored.load_state(path)
+    sampler = restored.save_weights_and_get_sampling_client("s0")
+    seq = sampler.sample([1, 2], max_tokens=3, temperature=0.7)
+    restored.forward_backward(
+        [
+            FakeDatum(
+                model_input_tokens=[1, 2] + seq.tokens,
+                target_tokens=list(seq.tokens),
+                weights=[1.0] * len(seq.tokens),
+            )
+        ],
+        "importance_sampling",
+    )
+    restored.optim_step(1e-4)
+
+    assert restored.calls == [
+        "get_tokenizer",
+        "load_state",
+        "save_weights_for_sampler",
+        "forward_backward",
+        "optim_step",
+    ]
 
 
 def test_sampler_refresh_distinct_but_linked() -> None:

--- a/wmh/distill/fake_tinker_test.py
+++ b/wmh/distill/fake_tinker_test.py
@@ -361,3 +361,117 @@ def test_directly_constructed_sampler_is_not_an_issuer() -> None:
     )
     with pytest.raises(AssertionError, match="TITO violation"):
         training.forward_backward([datum], "importance_sampling")
+
+
+# --- prefill top-k echo -------------------------------------------------------
+
+
+def test_topk_prompt_logprobs_echo_and_determinism() -> None:
+    """Top-1 is the sequence's own token with its realized logprob, ranks are
+    strictly decreasing hash-derived values, and the whole result is a pure
+    function of (seed, token_ids, k)."""
+    client = FakeSamplingClient(seed="tinker://fake/sampler/teacher/0")
+    prompt = [10, 11, 12]
+    seq = client.sample(prompt, max_tokens=4, temperature=1.0)
+    tokens = prompt + seq.tokens
+
+    realized, rows = client.topk_prompt_logprobs(tokens, 4)
+    realized_again, rows_again = client.topk_prompt_logprobs(tokens, 4)
+
+    assert (realized, rows) == (realized_again, rows_again)
+    # The realized logprobs ARE compute_logprobs: issued spans echo exactly.
+    assert realized == client.compute_logprobs(tokens)
+    assert realized[len(prompt) :] == list(seq.logprobs)
+    assert rows[0] is None
+    for position in range(1, len(tokens)):
+        row = rows[position]
+        assert row is not None
+        assert len(row) == 4
+        assert row[0] == (tokens[position], realized[position])
+        logprobs = [lp for _, lp in row]
+        assert logprobs == sorted(logprobs, reverse=True)
+        assert len(set(logprobs)) == 4  # strictly decreasing, no ties
+        assert len({token for token, _ in row}) == 4  # distinct candidate ids
+
+
+def test_topk_prompt_logprobs_k1_is_the_pure_echo() -> None:
+    client = FakeSamplingClient(seed="s")
+    tokens = [1, 2, 3, 4]
+    realized, rows = client.topk_prompt_logprobs(tokens, 1)
+    assert rows[0] is None
+    for position in range(1, len(tokens)):
+        assert rows[position] == [(tokens[position], realized[position])]
+
+
+def test_topk_prompt_logprobs_rejects_bad_k() -> None:
+    client = FakeSamplingClient(seed="s")
+    with pytest.raises(ValueError, match=">= 1"):
+        client.topk_prompt_logprobs([1, 2], 0)
+    with pytest.raises(ValueError, match="fake vocabulary"):
+        client.topk_prompt_logprobs([1, 2], 96)
+
+
+# --- topk-CE replicas: the input-side TITO variant ----------------------------
+
+
+def _topk_replica_datum(
+    prompt: list[int], sampled: list[int], candidate_targets: list[int]
+) -> FakeDatum:
+    """A shifted topk replica: candidate targets, fractional weights, flagged."""
+    tokens = prompt + sampled
+    # Candidate targets replace the sampled positions in target space; the
+    # target index scoring the first sampled token is len(prompt) - 1.
+    span_start = len(prompt) - 1
+    next_tokens = tokens[1:]
+    targets = next_tokens[:span_start] + candidate_targets[: len(next_tokens) - span_start]
+    weights = [0.0] * span_start + [0.25] * (len(next_tokens) - span_start)
+    return FakeDatum(
+        model_input_tokens=tokens[:-1],
+        target_tokens=targets,
+        weights=weights,
+        topk=True,
+    )
+
+
+def test_topk_datum_with_candidate_targets_passes_input_side_tito() -> None:
+    """Teacher-proposed targets are fine; the INPUT is genuine sampled tokens.
+
+    In topk-CE the targets are intentionally candidates no sampler issued
+    (that is the loss), so the fake checks the model input under the
+    loss-weighted positions against the ledger instead of the targets.
+    """
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    prompt = [1, 2, 3]
+    seq = sampler.sample(prompt, max_tokens=5, temperature=0.7)
+    fabricated_candidates = [201, 202, 203, 204, 205]  # issued by nobody
+    datum = _topk_replica_datum(prompt, list(seq.tokens), fabricated_candidates)
+
+    training.forward_backward([datum], "cross_entropy")
+
+    assert len(training.forward_backward_calls) == 1
+
+
+def test_topk_datum_with_corrupted_input_fails_tito() -> None:
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    prompt = [1, 2, 3]
+    seq = sampler.sample(prompt, max_tokens=5, temperature=0.7)
+    corrupted = list(seq.tokens)
+    corrupted[1] = corrupted[1] + 1  # the INPUT context is corrupted
+    datum = _topk_replica_datum(prompt, corrupted, [201, 202, 203, 204, 205])
+
+    with pytest.raises(AssertionError, match="TITO violation in topk datum 0"):
+        training.forward_backward([datum], "cross_entropy")
+    assert training.forward_backward_calls == []
+
+
+def test_topk_datum_under_non_ce_loss_is_rejected() -> None:
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    prompt = [1, 2, 3]
+    seq = sampler.sample(prompt, max_tokens=4, temperature=0.7)
+    datum = _topk_replica_datum(prompt, list(seq.tokens), [201, 202, 203, 204])
+
+    with pytest.raises(AssertionError, match="cross_entropy"):
+        training.forward_backward([datum], "importance_sampling")

--- a/wmh/distill/fake_tinker_test.py
+++ b/wmh/distill/fake_tinker_test.py
@@ -1,0 +1,282 @@
+"""Tests for the deterministic fake Tinker clients: determinism, TITO, echoes."""
+
+import pytest
+
+from wmh.distill.fake_tinker import (
+    FakeDatum,
+    FakeSamplingClient,
+    FakeServiceClient,
+    FakeTokenizer,
+    FakeTrainingClient,
+)
+
+
+def _make_training() -> FakeTrainingClient:
+    return FakeServiceClient().create_lora_training_client("base-model", rank=16)
+
+
+def test_tokenizer_round_trip() -> None:
+    tok = FakeTokenizer()
+    text = "ls -la /tmp && echo done"
+    ids = tok.encode(text)
+    assert all(isinstance(t, int) for t in ids)
+    assert tok.decode(ids) == text
+    assert tok.encode(text) == ids
+
+
+def test_sample_is_deterministic_across_clients() -> None:
+    a = FakeSamplingClient(seed="tinker://fake/sampler/s/0")
+    b = FakeSamplingClient(seed="tinker://fake/sampler/s/0")
+    prompt = [1, 2, 3]
+    seq_a = a.sample(prompt, max_tokens=16, temperature=0.7)
+    seq_b = b.sample(prompt, max_tokens=16, temperature=0.7)
+    assert seq_a.tokens == seq_b.tokens
+    assert seq_a.logprobs == seq_b.logprobs
+    assert seq_a.stop_reason == "length"
+    assert len(seq_a.tokens) == 16
+    assert len(seq_a.logprobs) == 16
+    assert all(lp < 0 for lp in seq_a.logprobs)
+
+
+def test_sample_repeated_call_identical() -> None:
+    client = FakeSamplingClient(seed="s")
+    first = client.sample([5, 6], max_tokens=8, temperature=0.0)
+    second = client.sample([5, 6], max_tokens=8, temperature=0.0)
+    assert first == second
+
+
+def test_sample_varies_with_seed_prompt_and_index() -> None:
+    prompt = [1, 2, 3]
+    base = FakeSamplingClient(seed="s").sample(prompt, max_tokens=12, temperature=0.7)
+    other_seed = FakeSamplingClient(seed="s2").sample(prompt, max_tokens=12, temperature=0.7)
+    other_prompt = FakeSamplingClient(seed="s").sample([9, 9], max_tokens=12, temperature=0.7)
+    other_index = FakeSamplingClient(seed="s").sample(
+        prompt, max_tokens=12, temperature=0.7, sample_index=1
+    )
+    assert base.tokens != other_seed.tokens
+    assert base.tokens != other_prompt.tokens
+    assert base.tokens != other_index.tokens
+
+
+def test_sample_prefix_property_and_stop() -> None:
+    client = FakeSamplingClient(seed="s")
+    long = client.sample([1], max_tokens=20, temperature=0.7)
+    short = client.sample([1], max_tokens=5, temperature=0.7)
+    assert long.tokens[:5] == short.tokens
+    stop_token = long.tokens[3]
+    first_hit = long.tokens.index(stop_token)
+    stopped = client.sample([1], max_tokens=20, temperature=0.7, stop=[stop_token])
+    assert stopped.stop_reason == "stop"
+    assert stopped.tokens == long.tokens[: first_hit + 1]
+    assert stopped.tokens[-1] == stop_token
+
+
+def test_sample_string_stop_matches_decoded_suffix() -> None:
+    # String stops mirror the real SamplingParams contract: generation ends
+    # when the decoded output so far ends with the stop string.
+    reference = FakeSamplingClient(seed="s").sample([1, 2], max_tokens=12, temperature=0.7)
+    decoded = FakeTokenizer().decode(reference.tokens)
+    stop = decoded[3:5]
+    end = decoded.index(stop) + len(stop)
+    stopped = FakeSamplingClient(seed="s").sample(
+        [1, 2], max_tokens=12, temperature=0.7, stop=[stop]
+    )
+    assert stopped.stop_reason == "stop"
+    assert stopped.tokens == reference.tokens[:end]
+
+
+def test_sample_records_issued_spans() -> None:
+    client = FakeSamplingClient(seed="s")
+    seq = client.sample([7, 8], max_tokens=4, temperature=0.7)
+    assert len(client.issued) == 1
+    record = client.issued[0]
+    assert record.prompt_ids == (7, 8)
+    assert record.sampled_ids == tuple(seq.tokens)
+    assert record.logprobs == tuple(seq.logprobs)
+
+
+def test_compute_logprobs_echoes_issued_spans() -> None:
+    client = FakeSamplingClient(seed="s")
+    prompt = [10, 11, 12]
+    seq = client.sample(prompt, max_tokens=6, temperature=0.7)
+    full = prompt + seq.tokens
+    logprobs = client.compute_logprobs(full)
+    assert len(logprobs) == len(full)
+    assert logprobs[0] is None
+    assert logprobs[len(prompt) :] == seq.logprobs
+
+
+def test_compute_logprobs_multi_turn_episode() -> None:
+    client = FakeSamplingClient(seed="s")
+    prompt1 = [1, 2, 3]
+    seq1 = client.sample(prompt1, max_tokens=4, temperature=0.7)
+    tool_tokens = [50, 51]
+    prompt2 = prompt1 + seq1.tokens + tool_tokens
+    seq2 = client.sample(prompt2, max_tokens=3, temperature=0.7)
+    episode = prompt2 + seq2.tokens
+    logprobs = client.compute_logprobs(episode)
+    start1 = len(prompt1)
+    assert logprobs[start1 : start1 + 4] == seq1.logprobs
+    start2 = len(prompt2)
+    assert logprobs[start2 : start2 + 3] == seq2.logprobs
+    for position in range(start1 + 4, start2):
+        assert logprobs[position] is not None
+
+
+def test_compute_logprobs_unissued_positions_deterministic() -> None:
+    a = FakeSamplingClient(seed="s")
+    b = FakeSamplingClient(seed="s")
+    ids = [1, 2, 3, 4]
+    assert a.compute_logprobs(ids) == b.compute_logprobs(ids)
+    assert a.compute_logprobs(ids)[0] is None
+    assert all(lp is not None and lp < 0 for lp in a.compute_logprobs(ids)[1:])
+    other_seed = FakeSamplingClient(seed="s2").compute_logprobs(ids)
+    assert other_seed != a.compute_logprobs(ids)
+
+
+def test_compute_logprobs_requires_prompt_context() -> None:
+    # The issued span embedded WITHOUT its prompt directly before it is not
+    # recognized: those positions get hash-derived values, not the echo.
+    client = FakeSamplingClient(seed="s")
+    seq = client.sample([1, 2, 3], max_tokens=4, temperature=0.7)
+    detached = [99, 98] + seq.tokens
+    logprobs = client.compute_logprobs(detached)
+    assert logprobs[2:] != seq.logprobs
+
+
+def test_tito_passes_on_faithful_datums() -> None:
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    prompt = [1, 2, 3]
+    seq = sampler.sample(prompt, max_tokens=5, temperature=0.7)
+    datum = FakeDatum(
+        model_input_tokens=prompt + seq.tokens,
+        target_tokens=prompt[1:] + seq.tokens,
+        weights=[0.0] * (len(prompt) - 1) + [1.0] * len(seq.tokens),
+        advantages=[0.0] * (len(prompt) - 1) + [0.5] * len(seq.tokens),
+        logprobs=[0.0] * (len(prompt) - 1) + list(seq.logprobs),
+    )
+    training.forward_backward([datum], "importance_sampling")
+    assert len(training.forward_backward_calls) == 1
+    recorded_datums, recorded_loss = training.forward_backward_calls[0]
+    assert recorded_loss == "importance_sampling"
+    assert recorded_datums[0] is datum
+
+
+def test_tito_fires_on_corrupted_datum() -> None:
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    seq = sampler.sample([1, 2], max_tokens=5, temperature=0.7)
+    corrupted = list(seq.tokens)
+    corrupted[2] = corrupted[2] + 1
+    datum = FakeDatum(
+        model_input_tokens=[1, 2] + corrupted,
+        target_tokens=corrupted,
+        weights=[1.0] * len(corrupted),
+    )
+    with pytest.raises(AssertionError, match=r"TITO violation in datum 0.*position 2"):
+        training.forward_backward([datum], "importance_sampling")
+    assert training.forward_backward_calls == []
+
+
+def test_tito_fires_when_nothing_issued() -> None:
+    training = _make_training()
+    datum = FakeDatum(model_input_tokens=[1, 2], target_tokens=[3, 4])
+    with pytest.raises(AssertionError, match="no linked sampler issued any span"):
+        training.forward_backward([datum], "importance_sampling")
+
+
+def test_tito_ignores_zero_weight_positions() -> None:
+    training = _make_training()
+    sampler = training.save_weights_and_get_sampling_client("s0")
+    seq = sampler.sample([9], max_tokens=3, temperature=0.7)
+    # Prompt/tool tokens carry weight 0 and never need to have been issued.
+    datum = FakeDatum(
+        model_input_tokens=[9, 8, 7] + seq.tokens,
+        target_tokens=[8, 7] + seq.tokens,
+        weights=[0.0, 0.0] + [1.0] * len(seq.tokens),
+    )
+    training.forward_backward([datum], "importance_sampling")
+
+
+def test_datum_rejects_misaligned_weights() -> None:
+    with pytest.raises(ValueError, match="weights length"):
+        FakeDatum(model_input_tokens=[1], target_tokens=[1, 2], weights=[1.0])
+
+
+def test_optim_step_counts_and_records_lr() -> None:
+    training = _make_training()
+    training.optim_step(1e-4)
+    training.optim_step(5e-5)
+    assert training.step_count == 2
+    assert training.optim_step_lrs == [1e-4, 5e-5]
+
+
+def test_save_and_load_state() -> None:
+    training = _make_training()
+    training.optim_step(1e-4)
+    path = training.save_state()
+    assert path == "tinker://fake/state/0"
+    training.optim_step(1e-4)
+    assert training.step_count == 2
+    training.load_state(path)
+    assert training.step_count == 1
+    second = training.save_state()
+    assert second == "tinker://fake/state/1"
+    with pytest.raises(ValueError, match="never returned by save_state"):
+        training.load_state("tinker://fake/state/999")
+
+
+def test_sampler_refresh_distinct_but_linked() -> None:
+    training = _make_training()
+    first = training.save_weights_and_get_sampling_client("ck")
+    second = training.save_weights_and_get_sampling_client("ck")
+    assert first.seed != second.seed
+    prompt = [1, 2]
+    seq_first = first.sample(prompt, max_tokens=4, temperature=0.7)
+    seq_second = second.sample(prompt, max_tokens=4, temperature=0.7)
+    assert seq_first.tokens != seq_second.tokens
+    # Spans issued by BOTH samplers satisfy TITO on the shared training client.
+    for seq in (seq_first, seq_second):
+        datum = FakeDatum(
+            model_input_tokens=prompt + seq.tokens,
+            target_tokens=list(seq.tokens),
+            weights=[1.0] * len(seq.tokens),
+        )
+        training.forward_backward([datum], "importance_sampling")
+    assert len(training.forward_backward_calls) == 2
+
+
+def test_create_sampling_client_from_saved_path_is_linked() -> None:
+    service = FakeServiceClient()
+    training = service.create_lora_training_client("base", rank=8)
+    path = training.save_weights_for_sampler("ck")
+    assert path.startswith("tinker://fake/sampler/ck/")
+    sampler = service.create_sampling_client(path)
+    seq = sampler.sample([4, 5], max_tokens=3, temperature=0.7)
+    datum = FakeDatum(
+        model_input_tokens=[4, 5] + seq.tokens,
+        target_tokens=list(seq.tokens),
+        weights=[1.0] * len(seq.tokens),
+    )
+    training.forward_backward([datum], "importance_sampling")
+    # A linked sampler sees peers' issued spans through the shared ledger.
+    peer = service.create_sampling_client(path)
+    echoed = peer.compute_logprobs([4, 5] + seq.tokens)
+    assert echoed[2:] == seq.logprobs
+
+
+def test_create_sampling_client_unknown_path_is_standalone() -> None:
+    service = FakeServiceClient()
+    teacher = service.create_sampling_client("teacher-base-model")
+    seq = teacher.sample([1], max_tokens=2, temperature=0.0)
+    assert len(seq.tokens) == 2
+    # Standalone samplers do not feed any training client's ledger.
+    training = service.create_lora_training_client("base")
+    datum = FakeDatum(
+        model_input_tokens=[1] + seq.tokens,
+        target_tokens=list(seq.tokens),
+        weights=[1.0] * len(seq.tokens),
+    )
+    with pytest.raises(AssertionError, match="TITO violation"):
+        training.forward_backward([datum], "importance_sampling")

--- a/wmh/distill/rendering.py
+++ b/wmh/distill/rendering.py
@@ -1,0 +1,290 @@
+"""A thin wmh-owned seam over tinker-cookbook chat renderers.
+
+The Tinker provider needs exactly four things from a renderer: turn a
+structured chat request into prompt token ids, expose the model's stop
+sequences, decode token ids for plain-text callers, and parse sampled token
+ids back into an assistant message (text plus tool calls). `ChatRendering`
+captures that contract; `CookbookChatRendering` implements it on top of a
+tinker-cookbook `Renderer` so cookbook churn stays contained in this module.
+
+`build_renderer` resolves the cookbook renderer for a base model the same way
+the cookbook's own LiteLLM provider does (`get_recommended_renderer_name`).
+tinker-cookbook is an optional extra and is imported lazily
+(`uv sync --extra distill`), mirroring the e2b extra's contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol, cast
+
+from llm_waterfall.types import ChatFunctionCall, ChatMessage, ChatTool, ChatToolCall
+from pydantic import BaseModel, Field, JsonValue
+
+if TYPE_CHECKING:
+    from tinker_cookbook.renderers import Renderer
+    from tinker_cookbook.renderers.base import Message as RendererMessage
+    from tinker_cookbook.renderers.base import ToolSpec
+    from tinker_cookbook.tokenizer_utils import Tokenizer
+
+logger = logging.getLogger(__name__)
+
+MISSING_DISTILL_EXTRA = (
+    "the tinker-cookbook SDK is not installed; run `uv sync --extra distill` "
+    "to use the Tinker distillation provider"
+)
+
+
+class RendererTokenizer(Protocol):
+    """The tokenizer slice cookbook renderers rely on.
+
+    HuggingFace `PreTrainedTokenizer` (what `tinker.SamplingClient.get_tokenizer`
+    returns) satisfies this structurally; tests supply small deterministic fakes.
+    """
+
+    def encode(self, text: str, add_special_tokens: bool = ...) -> list[int]:
+        """Encode text to token ids."""
+        ...
+
+    def decode(self, token_ids: list[int]) -> str:
+        """Decode token ids back to text."""
+        ...
+
+
+class ParsedAssistantMessage(BaseModel):
+    """One sampled assistant turn parsed out of student token ids."""
+
+    text: str = ""
+    """Assistant text, with any thinking rendered inline as <think>...</think>."""
+
+    tool_calls: list[ChatToolCall] = Field(default_factory=list)
+    """Parsed tool calls in OpenAI chat format."""
+
+    stopped: bool
+    """True when generation terminated cleanly (stop sequence or EOS), False on truncation."""
+
+
+class ChatRendering(Protocol):
+    """What the Tinker provider needs from a chat renderer."""
+
+    @property
+    def stop_sequences(self) -> list[str] | list[int]:
+        """Stop strings or stop token ids that end one assistant turn."""
+        ...
+
+    def build_generation_prompt(
+        self, messages: list[ChatMessage], tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render chat messages (and optional tool schemas) into prompt token ids."""
+        ...
+
+    def decode(self, token_ids: list[int]) -> str:
+        """Decode token ids back to text."""
+        ...
+
+    def parse_response(self, sampled_ids: list[int]) -> ParsedAssistantMessage:
+        """Parse sampled token ids into an assistant message (text plus tool calls)."""
+        ...
+
+
+def _text_content(content: JsonValue) -> str:
+    """Flatten llm_waterfall message content (None, string, or part list) to text.
+
+    OpenAI-format content parts (`{"type": "text", "text": ...}`) are joined in
+    order; non-text parts are rejected loudly rather than dropped silently.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        fragments: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                raise ValueError(f"unsupported message content part: {part!r}")
+            text = part.get("text")
+            if not isinstance(text, str):
+                raise ValueError(
+                    "the tinker provider is text-only; message content parts must be "
+                    f"text parts, got {part.get('type')!r}"
+                )
+            fragments.append(text)
+        return "".join(fragments)
+    raise ValueError(f"unsupported message content: {content!r}")
+
+
+def renderer_messages_from_chat(messages: list[ChatMessage]) -> list[RendererMessage]:
+    """Convert llm_waterfall chat messages into cookbook renderer messages.
+
+    Mirrors the cookbook's `openai_messages_to_tinker`: roles pass through,
+    content flattens to text, and tool-result linkage (`tool_call_id`, `name`)
+    plus assistant `tool_calls` are preserved.
+
+    Raises:
+        ImportError: If tinker-cookbook is not installed (distill extra).
+        ValueError: If a message carries non-text content parts.
+    """
+    try:
+        from tinker_cookbook.renderers.base import ToolCall
+    except ImportError as exc:  # pragma: no cover - exercised via sys.modules patching
+        raise ImportError(MISSING_DISTILL_EXTRA) from exc
+
+    out: list[RendererMessage] = []
+    for msg in messages:
+        renderer_msg: RendererMessage = {
+            "role": msg.role,
+            "content": _text_content(msg.content),
+        }
+        if msg.tool_call_id is not None:
+            renderer_msg["tool_call_id"] = msg.tool_call_id
+        name = (msg.model_extra or {}).get("name")
+        if isinstance(name, str):
+            renderer_msg["name"] = name
+        if msg.tool_calls:
+            renderer_msg["tool_calls"] = [
+                ToolCall(
+                    id=tc.id,
+                    function=ToolCall.FunctionBody(
+                        name=tc.function.name, arguments=tc.function.arguments
+                    ),
+                )
+                for tc in msg.tool_calls
+            ]
+        out.append(renderer_msg)
+    return out
+
+
+def tool_specs_from_chat(tools: list[ChatTool]) -> list[ToolSpec]:
+    """Convert llm_waterfall tool definitions into cookbook ToolSpec dicts."""
+    return [
+        {
+            "name": tool.function.name,
+            "description": tool.function.description,
+            "parameters": dict(tool.function.parameters),
+        }
+        for tool in tools
+    ]
+
+
+class CookbookChatRendering:
+    """`ChatRendering` backed by a tinker-cookbook `Renderer`.
+
+    Construct via `build_renderer`. Tool schemas are injected through the
+    renderer's `create_conversation_prefix_with_tools`, folding any leading
+    system message into the tool prefix the way the cookbook's LiteLLM
+    provider does.
+    """
+
+    def __init__(self, renderer: Renderer) -> None:
+        self._renderer = renderer
+
+    @property
+    def stop_sequences(self) -> list[str] | list[int]:
+        """The renderer's stop strings or stop token ids."""
+        return self._renderer.get_stop_sequences()
+
+    def build_generation_prompt(
+        self, messages: list[ChatMessage], tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render chat messages (and optional tool schemas) into prompt token ids."""
+        renderer_messages = renderer_messages_from_chat(messages)
+        if tools:
+            system_prompt = ""
+            if renderer_messages and renderer_messages[0]["role"] == "system":
+                first_content = renderer_messages[0]["content"]
+                system_prompt = first_content if isinstance(first_content, str) else ""
+                renderer_messages = renderer_messages[1:]
+            prefix = self._renderer.create_conversation_prefix_with_tools(
+                tool_specs_from_chat(tools), system_prompt
+            )
+            renderer_messages = list(prefix) + renderer_messages
+        return self._renderer.build_generation_prompt(renderer_messages).to_ints()
+
+    def decode(self, token_ids: list[int]) -> str:
+        """Decode token ids back to text with the renderer's tokenizer."""
+        return str(self._renderer.tokenizer.decode(token_ids))
+
+    def parse_response(self, sampled_ids: list[int]) -> ParsedAssistantMessage:
+        """Parse sampled token ids into text plus OpenAI-format tool calls.
+
+        Thinking parts are rendered back inline as `<think>...</think>` so the
+        parsed text round-trips the decoded sample exactly (the cookbook's
+        `parse_content_blocks` preserves whitespace). Tool calls the renderer
+        could not parse are dropped with a warning, matching the cookbook's
+        LiteLLM provider.
+        """
+        message, termination = self._renderer.parse_response(sampled_ids)
+        content = message["content"]
+        if isinstance(content, str):
+            text = content
+        else:
+            fragments: list[str] = []
+            for part in content:
+                if part["type"] == "thinking":
+                    fragments.append("<think>" + part["thinking"] + "</think>")
+                elif part["type"] == "text":
+                    fragments.append(part["text"])
+                else:
+                    raise ValueError(
+                        "sampled response contained a non-text content part "
+                        f"({part['type']!r}); the tinker provider is text-only"
+                    )
+            text = "".join(fragments)
+        tool_calls = [
+            ChatToolCall(
+                id=tc.id or f"call_{index}",
+                function=ChatFunctionCall(name=tc.function.name, arguments=tc.function.arguments),
+            )
+            for index, tc in enumerate(message.get("tool_calls") or [])
+        ]
+        unparsed = message.get("unparsed_tool_calls") or []
+        if unparsed:
+            logger.warning(
+                "dropping %d tool call(s) the renderer could not parse: %s",
+                len(unparsed),
+                "; ".join(item.error for item in unparsed),
+            )
+        # is_clean, not is_stop_sequence: some renderers (e.g. role_colon) report a
+        # clean end-of-turn via the model's EOS token, which must not read as truncation.
+        return ParsedAssistantMessage(
+            text=text, tool_calls=tool_calls, stopped=termination.is_clean
+        )
+
+
+def build_renderer(base_model: str, tokenizer: RendererTokenizer) -> CookbookChatRendering:
+    """Build the cookbook-backed rendering for a base model.
+
+    The renderer name comes from the cookbook's own model catalog
+    (`get_recommended_renderer_name`), exactly how its LiteLLM provider picks
+    renderers, so wmh never maintains a parallel model-to-renderer table.
+
+    Args:
+        base_model: Base model name in `org/model` form (e.g. `Qwen/Qwen3-8B`).
+        tokenizer: Tokenizer for that base model, typically from
+            `tinker.SamplingClient.get_tokenizer()`.
+
+    Returns:
+        The cookbook-backed `ChatRendering` implementation.
+
+    Raises:
+        ImportError: If tinker-cookbook is not installed (distill extra).
+        ValueError: If the cookbook has no renderer mapping for `base_model`.
+    """
+    try:
+        from tinker_cookbook.exceptions import ConfigurationError
+        from tinker_cookbook.model_info import get_recommended_renderer_name
+        from tinker_cookbook.renderers import get_renderer
+    except ImportError as exc:  # pragma: no cover - exercised via sys.modules patching
+        raise ImportError(MISSING_DISTILL_EXTRA) from exc
+
+    try:
+        renderer_name = get_recommended_renderer_name(base_model)
+    except (ConfigurationError, KeyError, ValueError) as exc:
+        raise ValueError(
+            f"no cookbook renderer is known for base model {base_model!r} ({exc}); "
+            "use a model family listed in tinker_cookbook.model_info"
+        ) from exc
+    # The cookbook types its tokenizer as HF PreTrainedTokenizer but treats it as
+    # Any at runtime; RendererTokenizer is the slice it actually calls.
+    renderer = get_renderer(renderer_name, cast("Tokenizer", tokenizer), model_name=base_model)
+    return CookbookChatRendering(renderer)

--- a/wmh/distill/rendering_test.py
+++ b/wmh/distill/rendering_test.py
@@ -1,0 +1,223 @@
+"""Tests for the wmh rendering seam over tinker-cookbook renderers.
+
+Conversion-only logic is tested without the cookbook; everything that touches
+a real renderer is gated on the cookbook being importable (it is part of the
+distill extra), so the suite still passes in an environment without it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+import pytest
+from llm_waterfall.types import (
+    ChatFunctionCall,
+    ChatFunctionDefinition,
+    ChatMessage,
+    ChatTool,
+    ChatToolCall,
+)
+
+from wmh.distill.rendering import (
+    build_renderer,
+    renderer_messages_from_chat,
+    tool_specs_from_chat,
+)
+
+
+class _CharTokenizer:
+    """Char-level tokenizer whose listed special strings map to single ids."""
+
+    _SPECIALS = {"<|im_start|>": 300000, "<|im_end|>": 300001}
+
+    bos_token: str | None = None
+    eos_token_id: int | None = None
+    name_or_path = "fake/char"
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        """Encode text; each special string becomes one id, other chars one id each."""
+        del add_special_tokens
+        pattern = "(" + "|".join(re.escape(special) for special in self._SPECIALS) + ")"
+        ids: list[int] = []
+        for piece in re.split(pattern, text):
+            special = self._SPECIALS.get(piece)
+            if special is not None:
+                ids.append(special)
+            else:
+                ids.extend(ord(ch) for ch in piece)
+        return ids
+
+    def decode(self, token_ids: list[int]) -> str:
+        """Decode ids back to text, restoring special strings."""
+        reverse = {v: k for k, v in self._SPECIALS.items()}
+        return "".join(reverse.get(t) or chr(t) for t in token_ids)
+
+
+def _tool(name: str) -> ChatTool:
+    return ChatTool(
+        function=ChatFunctionDefinition(
+            name=name,
+            description=f"run {name}",
+            parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+        )
+    )
+
+
+def test_tool_specs_from_chat_converts_openai_tools() -> None:
+    specs = tool_specs_from_chat([_tool("ls")])
+    assert specs == [
+        {
+            "name": "ls",
+            "description": "run ls",
+            "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+        }
+    ]
+
+
+def test_renderer_messages_from_chat_converts_roles_content_and_tools() -> None:
+    pytest.importorskip("tinker_cookbook")
+    from tinker_cookbook.renderers.base import ToolCall
+
+    messages = [
+        ChatMessage(role="system", content="be terse"),
+        ChatMessage(
+            role="user",
+            content=[{"type": "text", "text": "hello "}, {"type": "text", "text": "world"}],
+        ),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                ChatToolCall(
+                    id="call_7",
+                    function=ChatFunctionCall(name="ls", arguments='{"path": "/tmp"}'),
+                )
+            ],
+        ),
+        ChatMessage.model_validate(
+            {"role": "tool", "content": "ok", "tool_call_id": "call_7", "name": "ls"}
+        ),
+    ]
+    converted = renderer_messages_from_chat(messages)
+    assert [msg["role"] for msg in converted] == ["system", "user", "assistant", "tool"]
+    assert converted[1]["content"] == "hello world"
+    assert converted[2]["content"] == ""
+    tool_calls = converted[2]["tool_calls"]
+    assert isinstance(tool_calls[0], ToolCall)
+    assert tool_calls[0].id == "call_7"
+    assert tool_calls[0].function.name == "ls"
+    assert tool_calls[0].function.arguments == '{"path": "/tmp"}'
+    assert converted[3]["tool_call_id"] == "call_7"
+    assert converted[3]["name"] == "ls"
+
+
+def test_renderer_messages_from_chat_rejects_non_text_parts() -> None:
+    pytest.importorskip("tinker_cookbook")
+    messages = [
+        ChatMessage(
+            role="user",
+            content=[{"type": "image_url", "image_url": {"url": "http://x/y.png"}}],
+        )
+    ]
+    with pytest.raises(ValueError, match="text-only"):
+        renderer_messages_from_chat(messages)
+
+
+def test_build_renderer_role_colon_round_trip() -> None:
+    # meta-llama/Llama-3.2-1B is a base model, so the cookbook maps it to the
+    # role_colon renderer; the generation prompt must carry the user content.
+    pytest.importorskip("tinker_cookbook")
+    tokenizer = _CharTokenizer()
+    rendering = build_renderer("meta-llama/Llama-3.2-1B", tokenizer)
+
+    prompt_ids = rendering.build_generation_prompt(
+        [ChatMessage(role="user", content="hello world")]
+    )
+    prompt_text = rendering.decode(prompt_ids)
+    assert "User: hello world" in prompt_text
+    assert prompt_text.endswith("Assistant:")
+    assert rendering.stop_sequences == ["\n\nUser:"]
+
+    stopped = rendering.parse_response(tokenizer.encode("hi there\n\nUser:"))
+    assert stopped.text == "hi there"
+    assert stopped.tool_calls == []
+    assert stopped.stopped is True
+
+    truncated = rendering.parse_response(tokenizer.encode("cut off mid"))
+    assert truncated.stopped is False
+
+
+def test_role_colon_eos_termination_is_a_clean_stop() -> None:
+    # role_colon reports a bare EOS token as a clean end of turn (ParseTermination.EOS);
+    # it must parse as stopped, not truncation, or a finished answer would reach the
+    # agent as finish_reason "length".
+    pytest.importorskip("tinker_cookbook")
+
+    class _EosCharTokenizer(_CharTokenizer):
+        eos_token_id = 300002
+
+    tokenizer = _EosCharTokenizer()
+    rendering = build_renderer("meta-llama/Llama-3.2-1B", tokenizer)
+    ended = rendering.parse_response([*tokenizer.encode("all done"), 300002])
+    assert ended.text == "all done"
+    assert ended.stopped is True
+
+
+def test_build_renderer_qwen3_tools_prompt_and_tool_call_parse() -> None:
+    pytest.importorskip("tinker_cookbook")
+    tokenizer = _CharTokenizer()
+    rendering = build_renderer("Qwen/Qwen3-8B", tokenizer)
+
+    prompt_ids = rendering.build_generation_prompt(
+        [
+            ChatMessage(role="system", content="be brief"),
+            ChatMessage(role="user", content="list files"),
+        ],
+        tools=[_tool("ls")],
+    )
+    prompt_text = rendering.decode(prompt_ids)
+    assert "<tools>" in prompt_text
+    assert '"ls"' in prompt_text
+    assert "be brief" in prompt_text
+    assert "list files" in prompt_text
+    assert prompt_text.endswith("<|im_start|>assistant\n")
+    assert rendering.stop_sequences == [_CharTokenizer._SPECIALS["<|im_end|>"]]
+
+    sampled = tokenizer.encode(
+        "<think>plan</think>listing now\n"
+        '<tool_call>\n{"name": "ls", "arguments": {"path": "/tmp"}}\n</tool_call>'
+        "<|im_end|>"
+    )
+    parsed = rendering.parse_response(sampled)
+    assert parsed.stopped is True
+    assert "<think>plan</think>" in parsed.text
+    assert "listing now" in parsed.text
+    assert len(parsed.tool_calls) == 1
+    call = parsed.tool_calls[0]
+    assert call.id == "call_0"
+    assert call.function.name == "ls"
+    assert json.loads(call.function.arguments) == {"path": "/tmp"}
+
+    truncated = rendering.parse_response(tokenizer.encode("ran out of bud"))
+    assert truncated.stopped is False
+
+
+def test_build_renderer_unknown_model_is_actionable() -> None:
+    pytest.importorskip("tinker_cookbook")
+    with pytest.raises(ValueError, match="unknown-org/mystery"):
+        build_renderer("unknown-org/mystery", _CharTokenizer())
+
+
+def test_build_renderer_missing_extra_names_the_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Simulate the distill extra being absent: None entries make every import
+    # of the package (and its already-imported submodules) raise ImportError.
+    for name in list(sys.modules):
+        if name == "tinker_cookbook" or name.startswith("tinker_cookbook."):
+            monkeypatch.setitem(sys.modules, name, None)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook", None)
+    with pytest.raises(ImportError, match="uv sync --extra distill"):
+        build_renderer("Qwen/Qwen3-8B", _CharTokenizer())

--- a/wmh/harness/runner_link.py
+++ b/wmh/harness/runner_link.py
@@ -20,6 +20,7 @@ brokers frames plus environment tool calls.
 from __future__ import annotations
 
 import json
+import logging
 import struct
 import time
 import uuid
@@ -43,8 +44,21 @@ from wmh.harness.skills import SkillLibrary
 from wmh.harness.tools import READ_SKILL, ToolSpec
 from wmh.providers.base import ToolCallingProvider
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_MAX_ENV_ACTIONS = 40
 DEFAULT_CANCEL_POLL_INTERVAL_S = 0.5
+
+_WORKER_ERROR_LOG_CHARS = 500
+"""Warning-level cap on a worker exception message (full detail at debug)."""
+
+
+def _bounded_error_text(exc: Exception) -> str:
+    """One warning-sized line for a worker failure, truncated past the cap."""
+    text = " ".join(str(exc).split())
+    if len(text) > _WORKER_ERROR_LOG_CHARS:
+        return text[:_WORKER_ERROR_LOG_CHARS] + "... (truncated)"
+    return text
 
 
 # --------------------------------------------------------------------------------------------------
@@ -460,6 +474,18 @@ class RunnerLink:
                 "completion": completion.wire_payload(),
             }
         except Exception as exc:  # noqa: BLE001 - report to the runner, never crash the host
+            # Never silent: a provider that fails every call otherwise ends the
+            # episode as a clean-looking zero-turn "submitted" (the runner owns
+            # what it does with the error frame), which buried a live outage.
+            logger.warning(
+                "worker completion failed for episode %s (req %s): %s: %s; "
+                "returning the error frame to the runner",
+                episode_id,
+                req_id,
+                type(exc).__name__,
+                _bounded_error_text(exc),
+            )
+            logger.debug("worker completion failure detail", exc_info=exc)
             response = {
                 "type": "llm_response",
                 "episode_id": episode_id,

--- a/wmh/harness/runner_link_test.py
+++ b/wmh/harness/runner_link_test.py
@@ -7,6 +7,7 @@ for the world model; `worker_fn` is injected so the worker-LLM callback needs no
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, cast
 
@@ -324,6 +325,43 @@ def test_worker_fn_error_is_reported_not_crashed() -> None:
     assert len(responses) == 1
     resp = responses[0]
     assert "provider down" in resp["error"]  # surfaced to the runner, host survives
+    assert result.stop_reason is StopReason.SUBMITTED
+
+
+def test_worker_fn_error_is_logged_at_warning_with_type_and_bounded_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The live outage: a provider that failed every call was surfaced only to
+    # the runner, so the host logs showed clean zero-turn episodes. The host
+    # must warn (bounded, no traceback) before returning the error frame.
+    long_detail = "session capacity exceeded " + "x" * 2000
+
+    def boom(request: ChatRequest) -> ChatResponse:
+        del request
+        raise RuntimeError(long_detail)
+
+    script = [
+        {"type": "llm_request", "req_id": 1, "openai_body": {}},
+        {"type": "done", "answer": "ok"},
+    ]
+    ch = _FakeChannel(script)
+    with caplog.at_level(logging.WARNING, logger="wmh.harness.runner_link"):
+        result = RunnerLink(ch, worker_fn=boom).run("t1", "x", _Env(), tools=_tools())
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "worker completion failed" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "RuntimeError" in warnings[0]
+    assert "session capacity exceeded" in warnings[0]
+    assert "(truncated)" in warnings[0]
+    assert len(warnings[0]) < 700  # bounded at warning level
+    # The error frame still flows to the runner and the episode still ends.
+    responses = _sent(ch, "llm_response")
+    assert len(responses) == 1
+    assert "session capacity exceeded" in responses[0]["error"]
     assert result.stop_reason is StopReason.SUBMITTED
 
 

--- a/wmh/providers/base.py
+++ b/wmh/providers/base.py
@@ -16,6 +16,7 @@ class ProviderKind(StrEnum):
     AZURE_OPENAI = "azure"  # GPT 5.5 via the Azure OpenAI service
     OPENAI = "openai"  # GPT 5.5 direct
     OPENAI_RESPONSES = "openai_responses"  # GPT 5.x direct via the Responses API
+    TINKER = "tinker"  # Tinker LoRA sampling for distillation rollouts (lazy distill extra)
 
 
 class EmbedderKind(StrEnum):

--- a/wmh/providers/registry.py
+++ b/wmh/providers/registry.py
@@ -12,6 +12,7 @@ from wmh.providers.base import Provider, ProviderConfig, ProviderKind, VerifyRes
 from wmh.providers.bedrock import BedrockProvider
 from wmh.providers.openai import OpenAIProvider
 from wmh.providers.openai_responses import OpenAIResponsesProvider
+from wmh.providers.tinker import TinkerChatProvider
 
 _BACKENDS = {
     ProviderKind.ANTHROPIC: AnthropicProvider,
@@ -19,6 +20,7 @@ _BACKENDS = {
     ProviderKind.AZURE_OPENAI: AzureOpenAIProvider,
     ProviderKind.OPENAI: OpenAIProvider,
     ProviderKind.OPENAI_RESPONSES: OpenAIResponsesProvider,
+    ProviderKind.TINKER: TinkerChatProvider,
 }
 
 

--- a/wmh/providers/tests/registry_test.py
+++ b/wmh/providers/tests/registry_test.py
@@ -6,12 +6,21 @@ import pytest
 
 from wmh.providers import ProviderConfig, ProviderKind, get_provider, verify_embedder
 from wmh.providers.base import Provider
+from wmh.providers.tinker import TinkerChatProvider
 
 
-def test_all_four_providers_construct_and_satisfy_protocol() -> None:
+def test_all_provider_kinds_construct_and_satisfy_protocol() -> None:
     for kind in ProviderKind:
         provider = get_provider(ProviderConfig(kind=kind, model="m"))
         assert isinstance(provider, Provider)
+
+
+def test_tinker_kind_constructs_tinker_provider() -> None:
+    # Construction is SDK-free: the tinker extra is imported lazily on first use.
+    config = ProviderConfig(
+        kind=ProviderKind.TINKER, model_type="Qwen/Qwen3-8B", model="tinker://run/weights/0"
+    )
+    assert isinstance(get_provider(config), TinkerChatProvider)
 
 
 def test_verify_never_raises_and_reports_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmh/providers/tinker.py
+++ b/wmh/providers/tinker.py
@@ -237,6 +237,15 @@ class TinkerChatProvider:
             from the base model name and the sampling client's tokenizer.
         recorder: Optional per-episode span recorder; when present, every
             successful completion records exactly one `TokenSpan`.
+        api_key: Accepted for `get_provider`'s explicit-credential channel and
+            REJECTED when set. The Tinker SDK reads `TINKER_API_KEY` from the
+            process environment when it builds a `ServiceClient`; it takes no
+            per-client credential, so a pool entry's key cannot be honored
+            here. Failing loudly beats silently sampling on a different
+            account than the pool entry named.
+
+    Raises:
+        ValueError: If `api_key` is set.
     """
 
     def __init__(
@@ -246,7 +255,18 @@ class TinkerChatProvider:
         sampling_client: TinkerSampler | None = None,
         renderer: ChatRendering | None = None,
         recorder: TokenRecorder | None = None,
+        api_key: str | None = None,
     ) -> None:
+        # get_provider promises the backend authenticates with exactly this key
+        # (wmh/providers/registry.py). Tinker structurally cannot, so refuse
+        # rather than break that contract quietly.
+        if api_key is not None:
+            raise ValueError(
+                "the tinker provider does not accept an explicit api_key: the SDK reads "
+                f"{TINKER_API_KEY_ENV} from the process environment, so a per-entry key "
+                f"cannot be honored; drop api_key_env from the pool entry and export "
+                f"{TINKER_API_KEY_ENV} instead"
+            )
         self.config = config
         self._sampler = sampling_client
         # Only a client the provider built itself may be dropped and rebuilt

--- a/wmh/providers/tinker.py
+++ b/wmh/providers/tinker.py
@@ -237,6 +237,12 @@ class TinkerChatProvider:
     def _base_model_name(self) -> str:
         base = self.config.model_type or self.config.model
         if base.startswith("tinker://"):
+            if self.config.model_type:
+                raise ValueError(
+                    "config.model_type is a tinker:// weights path; set model_type to "
+                    "the base model name (e.g. 'Qwen/Qwen3-8B') so the renderer and "
+                    "tokenizer can be resolved (weights paths belong in config.model)"
+                )
             raise ValueError(
                 "config.model is a tinker:// weights path and config.model_type is "
                 "unset; set model_type to the base model name (e.g. 'Qwen/Qwen3-8B') "

--- a/wmh/providers/tinker.py
+++ b/wmh/providers/tinker.py
@@ -14,6 +14,14 @@ never re-encoded, and a sample without per-token logprobs fails loudly.
 identity); `config.model` carries either a `tinker://` sampler-weights path or
 a base model name for an untrained student. The tinker SDK is an optional
 extra imported lazily (`uv sync --extra distill`), same contract as e2b.
+
+Every SDK call is deadline-bounded (`wmh.distill.deadlines`): a wedged Tinker
+session blocks forever inside the SDK's own retry loop, so client construction
+and tokenizer fetches run under the `connect` deadline and the sample future
+under the `sample` deadline. An expiry raises the retryable
+`TinkerDeadlineError` and drops the provider-owned sampling client, so the
+retry wrapper's next attempt builds a fresh session instead of inheriting the
+wedge.
 """
 
 from __future__ import annotations
@@ -26,6 +34,7 @@ from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 from llm_waterfall.types import ChatChoice, ChatMessage, ChatTool, ChatUsage
 from pydantic import BaseModel, model_validator
 
+from wmh.distill.deadlines import TinkerDeadlineError, call_with_deadline, wait_with_deadline
 from wmh.distill.rendering import (
     ChatRendering,
     ParsedAssistantMessage,
@@ -177,23 +186,32 @@ class SdkSampler:
         temperature: float,
         stop: list[str] | list[int] | None = None,
     ) -> SampledSequenceLike:
-        """Run one synchronous sample and return the single sampled sequence."""
+        """Run one deadline-bounded sample and return the single sampled sequence.
+
+        Raises:
+            TinkerDeadlineError: If the `sample` deadline expires (the session
+                is likely wedged; the caller should retry with a fresh one).
+        """
         import tinker
 
-        response = self._client.sample(
+        future = self._client.sample(
             prompt=tinker.ModelInput.from_ints(prompt_token_ids),
             num_samples=1,
             sampling_params=tinker.SamplingParams(
                 max_tokens=max_tokens, temperature=temperature, stop=stop
             ),
-        ).result()
-        return response.sequences[0]
+        )
+        return wait_with_deadline("sample", future).sequences[0]
 
     def get_tokenizer(self) -> RendererTokenizer:
-        """The HF tokenizer for the client's base model."""
+        """The HF tokenizer for the client's base model (deadline-bounded fetch).
+
+        Raises:
+            TinkerDeadlineError: If the `connect` deadline expires.
+        """
         # HF stubs type decode as `str | list[str]` depending on the input
         # shape; for the list[int] calls renderers make it is always str.
-        return cast("RendererTokenizer", self._client.get_tokenizer())
+        return cast("RendererTokenizer", call_with_deadline("connect", self._client.get_tokenizer))
 
 
 class _SampledTurn(BaseModel):
@@ -231,6 +249,9 @@ class TinkerChatProvider:
     ) -> None:
         self.config = config
         self._sampler = sampling_client
+        # Only a client the provider built itself may be dropped and rebuilt
+        # after a deadline expiry; an injected one cannot be reconstructed.
+        self._owns_sampler = sampling_client is None
         self._rendering = renderer
         self._recorder = recorder
 
@@ -251,6 +272,15 @@ class TinkerChatProvider:
         return base
 
     def _get_sampler(self) -> TinkerSampler:
+        """The sampling client, built on first use and rebuilt after a wedge.
+
+        Raises:
+            ImportError: If the tinker SDK is not installed (the distill extra).
+            RuntimeError: If TINKER_API_KEY is missing from the environment.
+            TinkerDeadlineError: If service-client construction or sampling-client
+                creation exceeds the `connect` deadline. Neither is cached in that
+                case, so the next attempt starts from a fresh session.
+        """
         # Lazy: don't import the SDK or read the key env var until first use.
         if self._sampler is None:
             try:
@@ -262,13 +292,35 @@ class TinkerChatProvider:
                     f"{TINKER_API_KEY_ENV} is not set in the environment; set it to "
                     "your Tinker API key to use the tinker provider"
                 )
-            service = tinker.ServiceClient()
-            if self.config.model.startswith("tinker://"):
-                client = service.create_sampling_client(model_path=self.config.model)
-            else:
-                client = service.create_sampling_client(base_model=self.config.model)
-            self._sampler = SdkSampler(client)
+            # Both SDK calls are fully blocking with no timeout parameter, so they run
+            # under the "connect" deadline on a daemon thread rather than forever.
+            service = call_with_deadline("connect", tinker.ServiceClient)
+            model = self.config.model
+
+            def build() -> tinker.SamplingClient:
+                if model.startswith("tinker://"):
+                    return service.create_sampling_client(model_path=model)
+                return service.create_sampling_client(base_model=model)
+
+            self._sampler = SdkSampler(call_with_deadline("connect", build))
         return self._sampler
+
+    def _drop_wedged_sampler(self) -> None:
+        """Forget a sampling client that blew its deadline, so the next attempt rebuilds.
+
+        A wedged session keeps timing out while a freshly built one succeeds, so
+        holding the cached client would turn one expiry into an endless run of
+        them. Dropping it makes the next `_get_sampler` construct a new
+        `ServiceClient` and a new `SamplingClient` (each construction is itself
+        `connect`-bounded). An injected client is never dropped: the provider
+        cannot rebuild what it did not build.
+        """
+        if self._owns_sampler and self._sampler is not None:
+            logger.warning(
+                "dropping the tinker sampling client after a deadline expiry; "
+                "the next attempt builds a fresh session"
+            )
+            self._sampler = None
 
     def _get_rendering(self) -> ChatRendering:
         if self._rendering is None:
@@ -292,14 +344,21 @@ class TinkerChatProvider:
         max_tokens: int,
     ) -> _SampledTurn:
         """Render, sample, parse, and (on success) record exactly one span."""
-        rendering = self._get_rendering()
-        prompt_ids = rendering.build_generation_prompt(messages, tools)
-        sequence = self._get_sampler().sample(
-            prompt_ids,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            stop=rendering.stop_sequences,
-        )
+        try:
+            rendering = self._get_rendering()
+            prompt_ids = rendering.build_generation_prompt(messages, tools)
+            sequence = self._get_sampler().sample(
+                prompt_ids,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                stop=rendering.stop_sequences,
+            )
+        except TinkerDeadlineError:
+            # The session is likely wedged; drop it so the retry wrapper's next
+            # attempt rebuilds fresh. No span was recorded (recording happens
+            # only after the whole completion succeeds, below).
+            self._drop_wedged_sampler()
+            raise
         sampled_ids = list(sequence.tokens)
         logprobs = sequence.logprobs
         if logprobs is None or len(logprobs) != len(sampled_ids):
@@ -412,8 +471,14 @@ class TinkerChatProvider:
         return verify_via_ping(self, ping=self._ping)
 
     def _ping(self) -> None:
-        rendering = self._get_rendering()
-        prompt_ids = rendering.build_generation_prompt([ChatMessage(role="user", content="ping")])
-        self._get_sampler().sample(
-            prompt_ids, max_tokens=1, temperature=0.0, stop=rendering.stop_sequences
-        )
+        try:
+            rendering = self._get_rendering()
+            prompt_ids = rendering.build_generation_prompt(
+                [ChatMessage(role="user", content="ping")]
+            )
+            self._get_sampler().sample(
+                prompt_ids, max_tokens=1, temperature=0.0, stop=rendering.stop_sequences
+            )
+        except TinkerDeadlineError:
+            self._drop_wedged_sampler()
+            raise

--- a/wmh/providers/tinker.py
+++ b/wmh/providers/tinker.py
@@ -1,0 +1,413 @@
+"""Tinker sampling provider: serves the pi agent from a Tinker LoRA student.
+
+During distillation rollouts the student model lives on Tinker. This provider
+renders each structured chat request to token ids with the base model's
+cookbook renderer, samples from a Tinker sampling client, and parses the
+sampled tokens back into an OpenAI-style chat response for the pi bridge.
+
+Every successful completion records a `TokenSpan` (exact prompt ids, sampled
+ids, and per-token logprobs) into an optional `TokenRecorder`. Downstream
+training consumes ONLY these recorded ids (tokens-in tokens-out); text is
+never re-encoded, and a sample without per-token logprobs fails loudly.
+
+`config.model_type` carries the base model name (renderer and tokenizer
+identity); `config.model` carries either a `tinker://` sampler-weights path or
+a base model name for an untrained student. The tinker SDK is an optional
+extra imported lazily (`uv sync --extra distill`), same contract as e2b.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+from llm_waterfall.types import ChatChoice, ChatMessage, ChatTool, ChatUsage
+from pydantic import BaseModel, model_validator
+
+from wmh.distill.rendering import (
+    ChatRendering,
+    ParsedAssistantMessage,
+    RendererTokenizer,
+    build_renderer,
+)
+from wmh.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    ChatRequest,
+    ChatResponse,
+    Completion,
+    Message,
+    ProviderConfig,
+    TokenUsage,
+    VerifyResult,
+    verify_via_ping,
+)
+
+if TYPE_CHECKING:
+    import tinker
+
+logger = logging.getLogger(__name__)
+
+TINKER_API_KEY_ENV = "TINKER_API_KEY"
+
+_MISSING_TINKER_EXTRA = (
+    "the tinker SDK is not installed; run `uv sync --extra distill` to use the tinker provider"
+)
+
+# The tinker SamplingParams default; used when a structured request carries no
+# temperature (pi normally stamps one on every request).
+_DEFAULT_CHAT_TEMPERATURE = 1.0
+
+
+class TokenSpan(BaseModel):
+    """The exact tokens one sampling call consumed and produced.
+
+    This is the tokens-in-tokens-out ground truth for one completion: training
+    data is assembled from these ids verbatim, never from re-encoded text.
+    """
+
+    call_index: int
+    """0-based index of the successful completion within one episode."""
+
+    prompt_token_ids: list[int]
+    sampled_token_ids: list[int]
+    sampled_logprobs: list[float]
+    """Sampler-assigned logprob for each sampled token, aligned one to one."""
+
+    @model_validator(mode="after")
+    def _check_alignment(self) -> TokenSpan:
+        if len(self.sampled_logprobs) != len(self.sampled_token_ids):
+            raise ValueError(
+                f"sampled_logprobs length {len(self.sampled_logprobs)} does not match "
+                f"sampled_token_ids length {len(self.sampled_token_ids)}"
+            )
+        return self
+
+
+class TokenRecorder:
+    """Collects the `TokenSpan`s of ONE episode/trial.
+
+    Ownership contract: one recorder per episode, driven by a single thread
+    (the pi agent issues its completions sequentially). Create a fresh
+    recorder (and a fresh sink file) per episode so `call_index` starts at 0.
+
+    Args:
+        jsonl_path: Optional sink; every recorded span is appended and flushed
+            immediately, so a killed trial still leaves its captured spans on
+            disk.
+    """
+
+    def __init__(self, jsonl_path: Path | None = None) -> None:
+        self._spans: list[TokenSpan] = []
+        self._jsonl_path = jsonl_path
+
+    def __len__(self) -> int:
+        return len(self._spans)
+
+    def record(self, span: TokenSpan) -> None:
+        """Append one span, writing through to the jsonl sink when configured."""
+        self._spans.append(span)
+        if self._jsonl_path is not None:
+            with self._jsonl_path.open("a", encoding="utf-8") as sink:
+                sink.write(span.model_dump_json() + "\n")
+                sink.flush()
+
+    def spans(self) -> list[TokenSpan]:
+        """A snapshot copy of the spans recorded so far."""
+        return list(self._spans)
+
+
+class SampledSequenceLike(Protocol):
+    """The slice of a sampled sequence the provider consumes."""
+
+    @property
+    def tokens(self) -> list[int]:
+        """Sampled token ids."""
+        ...
+
+    @property
+    def logprobs(self) -> list[float] | None:
+        """Per-token logprobs aligned with `tokens`, or None if unavailable."""
+        ...
+
+
+class TinkerSampler(Protocol):
+    """The sampling call the provider makes, in token-id terms.
+
+    `wmh.distill.fake_tinker.FakeSamplingClient` satisfies this directly;
+    real `tinker.SamplingClient`s are adapted via `SdkSampler`.
+    """
+
+    def sample(
+        self,
+        prompt_token_ids: list[int],
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | list[int] | None = None,
+    ) -> SampledSequenceLike:
+        """Sample one sequence conditioned on the prompt token ids."""
+        ...
+
+
+@runtime_checkable
+class _TokenizerSource(Protocol):
+    """A sampling client that can supply the base model's tokenizer."""
+
+    def get_tokenizer(self) -> RendererTokenizer: ...
+
+
+class SdkSampler:
+    """Adapts a real `tinker.SamplingClient` to the `TinkerSampler` seam.
+
+    The provider's lazy path builds this itself; callers that already hold a
+    sampling client (e.g. the distill loop refreshing student weights via
+    `save_weights_and_get_sampling_client`) wrap it in this before injecting.
+    """
+
+    def __init__(self, client: tinker.SamplingClient) -> None:
+        self._client = client
+
+    def sample(
+        self,
+        prompt_token_ids: list[int],
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | list[int] | None = None,
+    ) -> SampledSequenceLike:
+        """Run one synchronous sample and return the single sampled sequence."""
+        import tinker
+
+        response = self._client.sample(
+            prompt=tinker.ModelInput.from_ints(prompt_token_ids),
+            num_samples=1,
+            sampling_params=tinker.SamplingParams(
+                max_tokens=max_tokens, temperature=temperature, stop=stop
+            ),
+        ).result()
+        return response.sequences[0]
+
+    def get_tokenizer(self) -> RendererTokenizer:
+        """The HF tokenizer for the client's base model."""
+        # HF stubs type decode as `str | list[str]` depending on the input
+        # shape; for the list[int] calls renderers make it is always str.
+        return cast("RendererTokenizer", self._client.get_tokenizer())
+
+
+class _SampledTurn(BaseModel):
+    """One successful render-sample-parse round trip (internal)."""
+
+    prompt_token_ids: list[int]
+    sampled_token_ids: list[int]
+    parsed: ParsedAssistantMessage
+
+
+class TinkerChatProvider:
+    """Serves completions from a Tinker-hosted LoRA student during distillation.
+
+    Args:
+        config: Provider config; `model_type` is the base model name and
+            `model` is the `tinker://` sampler-weights path (or a base model
+            name for an untrained student).
+        sampling_client: Optional injected sampler (tests use the fakes in
+            `wmh.distill.fake_tinker`; wrap a real `tinker.SamplingClient` in
+            `SdkSampler`). When None, a real client is built lazily from
+            `config.model` on first use.
+        renderer: Optional injected rendering. When None, it is built lazily
+            from the base model name and the sampling client's tokenizer.
+        recorder: Optional per-episode span recorder; when present, every
+            successful completion records exactly one `TokenSpan`.
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        sampling_client: TinkerSampler | None = None,
+        renderer: ChatRendering | None = None,
+        recorder: TokenRecorder | None = None,
+    ) -> None:
+        self.config = config
+        self._sampler = sampling_client
+        self._rendering = renderer
+        self._recorder = recorder
+
+    def _base_model_name(self) -> str:
+        base = self.config.model_type or self.config.model
+        if base.startswith("tinker://"):
+            raise ValueError(
+                "config.model is a tinker:// weights path and config.model_type is "
+                "unset; set model_type to the base model name (e.g. 'Qwen/Qwen3-8B') "
+                "so the renderer and tokenizer can be resolved"
+            )
+        return base
+
+    def _get_sampler(self) -> TinkerSampler:
+        # Lazy: don't import the SDK or read the key env var until first use.
+        if self._sampler is None:
+            try:
+                import tinker
+            except ImportError as exc:
+                raise ImportError(_MISSING_TINKER_EXTRA) from exc
+            if not os.environ.get(TINKER_API_KEY_ENV):
+                raise RuntimeError(
+                    f"{TINKER_API_KEY_ENV} is not set in the environment; set it to "
+                    "your Tinker API key to use the tinker provider"
+                )
+            service = tinker.ServiceClient()
+            if self.config.model.startswith("tinker://"):
+                client = service.create_sampling_client(model_path=self.config.model)
+            else:
+                client = service.create_sampling_client(base_model=self.config.model)
+            self._sampler = SdkSampler(client)
+        return self._sampler
+
+    def _get_rendering(self) -> ChatRendering:
+        if self._rendering is None:
+            base_model = self._base_model_name()
+            sampler = self._get_sampler()
+            if not isinstance(sampler, _TokenizerSource):
+                raise RuntimeError(
+                    "the injected sampling client exposes no get_tokenizer(); pass "
+                    "renderer= explicitly when constructing TinkerChatProvider with "
+                    "a custom sampling client"
+                )
+            self._rendering = build_renderer(base_model, sampler.get_tokenizer())
+        return self._rendering
+
+    def _sample_turn(
+        self,
+        messages: list[ChatMessage],
+        tools: list[ChatTool] | None,
+        *,
+        temperature: float,
+        max_tokens: int,
+    ) -> _SampledTurn:
+        """Render, sample, parse, and (on success) record exactly one span."""
+        rendering = self._get_rendering()
+        prompt_ids = rendering.build_generation_prompt(messages, tools)
+        sequence = self._get_sampler().sample(
+            prompt_ids,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=rendering.stop_sequences,
+        )
+        sampled_ids = list(sequence.tokens)
+        logprobs = sequence.logprobs
+        if logprobs is None or len(logprobs) != len(sampled_ids):
+            got = (
+                "no logprobs"
+                if logprobs is None
+                else f"{len(logprobs)} logprobs for {len(sampled_ids)} tokens"
+            )
+            raise RuntimeError(
+                f"tinker sampling returned {got}; per-token logprobs are required "
+                "for tokens-in-tokens-out training and are never fabricated"
+            )
+        parsed = rendering.parse_response(sampled_ids)
+        # Record only after the whole completion succeeded, so a failure that an
+        # outer retry wrapper re-invokes never leaves a span behind.
+        if self._recorder is not None:
+            self._recorder.record(
+                TokenSpan(
+                    call_index=len(self._recorder),
+                    prompt_token_ids=prompt_ids,
+                    sampled_token_ids=sampled_ids,
+                    sampled_logprobs=list(logprobs),
+                )
+            )
+        return _SampledTurn(
+            prompt_token_ids=prompt_ids, sampled_token_ids=sampled_ids, parsed=parsed
+        )
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        """Serve one structured agent request from the student sampler."""
+        temperature = (
+            request.temperature if request.temperature is not None else _DEFAULT_CHAT_TEMPERATURE
+        )
+        max_tokens = request.max_completion_tokens or request.max_tokens or DEFAULT_MAX_TOKENS
+        if (request.model_extra or {}).get("stop") is not None:
+            logger.debug(
+                "ignoring request-supplied stop sequences; the renderer's stop "
+                "sequences are authoritative for token-exact sampling"
+            )
+        # tool_choice is honored where token sampling can express it ("none" renders
+        # without tool schemas) and rejected loudly where it cannot ("required" or a
+        # named function would need constrained decoding the sampler does not offer).
+        tools = request.tools
+        choice = request.tool_choice
+        if choice == "none":
+            tools = None
+        elif choice is not None and choice != "auto":
+            raise ValueError(
+                f"unsupported tool_choice {choice!r}: the tinker provider samples raw "
+                "tokens and cannot force the student to call a tool; use 'auto', "
+                "'none', or omit tool_choice"
+            )
+        turn = self._sample_turn(
+            request.messages, tools, temperature=temperature, max_tokens=max_tokens
+        )
+        parsed = turn.parsed
+        if parsed.tool_calls:
+            finish_reason = "tool_calls"
+        elif parsed.stopped:
+            finish_reason = "stop"
+        else:
+            finish_reason = "length"
+        message = ChatMessage(
+            role="assistant",
+            content=parsed.text or None,
+            tool_calls=parsed.tool_calls or None,
+        )
+        return ChatResponse(
+            choices=[ChatChoice(index=0, message=message, finish_reason=finish_reason)],
+            usage=ChatUsage(
+                prompt_tokens=len(turn.prompt_token_ids),
+                completion_tokens=len(turn.sampled_token_ids),
+            ),
+            model=self.config.model,
+        )
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        """Plain-text completion through the same render-sample-parse machinery."""
+        chat_messages: list[ChatMessage] = []
+        if system:
+            chat_messages.append(ChatMessage(role="system", content=system))
+        chat_messages.extend(ChatMessage(role=m.role, content=m.content) for m in messages)
+        turn = self._sample_turn(
+            chat_messages, None, temperature=temperature, max_tokens=max_tokens
+        )
+        return Completion(
+            text=turn.parsed.text,
+            usage=TokenUsage(
+                input_tokens=len(turn.prompt_token_ids),
+                output_tokens=len(turn.sampled_token_ids),
+            ),
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Tinker has no embeddings API; configure a dedicated embedder instead."""
+        raise ValueError(
+            "the tinker provider has no embeddings API; configure a dedicated "
+            "embedder (hashing, openai, azure, or bedrock) for retrieval instead"
+        )
+
+    def verify(self) -> VerifyResult:
+        """One-token sample through the real render+sample path (never recorded)."""
+        return verify_via_ping(self, ping=self._ping)
+
+    def _ping(self) -> None:
+        rendering = self._get_rendering()
+        prompt_ids = rendering.build_generation_prompt([ChatMessage(role="user", content="ping")])
+        self._get_sampler().sample(
+            prompt_ids, max_tokens=1, temperature=0.0, stop=rendering.stop_sequences
+        )

--- a/wmh/providers/tinker_test.py
+++ b/wmh/providers/tinker_test.py
@@ -369,7 +369,20 @@ def test_missing_api_key_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_tinker_path_without_model_type_is_actionable() -> None:
     config = ProviderConfig(kind=ProviderKind.TINKER, model="tinker://run/weights/0")
     provider = TinkerChatProvider(config, sampling_client=FakeSamplingClient(seed="s"))
-    with pytest.raises(ValueError, match="model_type"):
+    with pytest.raises(ValueError, match="model_type is unset"):
+        provider.complete_chat(_request())
+
+
+def test_tinker_path_in_model_type_names_the_swapped_field() -> None:
+    # The swapped-fields mistake (weights path in model_type) must not claim that
+    # model_type is unset; the message points at the field that actually holds the path.
+    config = ProviderConfig(
+        kind=ProviderKind.TINKER,
+        model="Qwen/Qwen3-8B",
+        model_type="tinker://run/weights/0",
+    )
+    provider = TinkerChatProvider(config, sampling_client=FakeSamplingClient(seed="s"))
+    with pytest.raises(ValueError, match="weights paths belong in config.model"):
         provider.complete_chat(_request())
 
 

--- a/wmh/providers/tinker_test.py
+++ b/wmh/providers/tinker_test.py
@@ -1,0 +1,400 @@
+"""Tests for the Tinker provider: span recording, response shape, lazy imports.
+
+Everything runs against the deterministic fakes in `wmh.distill.fake_tinker`
+plus a minimal char-level `ChatRendering`; the real tinker SDK is never
+touched (several tests pin that by poisoning `sys.modules`).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from llm_waterfall.types import (
+    ChatFunctionCall,
+    ChatFunctionDefinition,
+    ChatMessage,
+    ChatRequest,
+    ChatTool,
+    ChatToolCall,
+)
+from pydantic import JsonValue, ValidationError
+
+import wmh.distill.rendering as rendering_module
+import wmh.providers.tinker as tinker_module
+from wmh.distill.fake_tinker import FakeSampledSequence, FakeSamplingClient, FakeTokenizer
+from wmh.distill.rendering import ParsedAssistantMessage
+from wmh.providers.base import (
+    Message,
+    Provider,
+    ProviderConfig,
+    ProviderKind,
+    ToolCallingProvider,
+)
+from wmh.providers.registry import get_provider
+from wmh.providers.tinker import TinkerChatProvider, TokenRecorder, TokenSpan
+
+
+class _MiniRendering:
+    """Minimal char-level ChatRendering that drives the provider without the cookbook."""
+
+    def __init__(self) -> None:
+        self._tok = FakeTokenizer()
+
+    @property
+    def stop_sequences(self) -> list[str] | list[int]:
+        # Newline: outside the fake sampler's printable-ASCII token range, so
+        # deterministic samples always run to max_tokens.
+        return [ord("\n")]
+
+    def build_generation_prompt(
+        self, messages: list[ChatMessage], tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        lines: list[str] = []
+        if tools:
+            lines.append("tools: " + ",".join(tool.function.name for tool in tools))
+        for message in messages:
+            content = message.content if isinstance(message.content, str) else ""
+            lines.append(f"{message.role}: {content}")
+        lines.append("assistant:")
+        return self._tok.encode("\n".join(lines))
+
+    def decode(self, token_ids: list[int]) -> str:
+        return self._tok.decode(token_ids)
+
+    def parse_response(self, sampled_ids: list[int]) -> ParsedAssistantMessage:
+        return ParsedAssistantMessage(
+            text=self._tok.decode(sampled_ids), tool_calls=[], stopped=False
+        )
+
+
+class _ToolCallRendering(_MiniRendering):
+    """Parses every sample into one fixed tool call (tool-call shape tests)."""
+
+    def parse_response(self, sampled_ids: list[int]) -> ParsedAssistantMessage:
+        del sampled_ids
+        call = ChatToolCall(
+            id="call_0", function=ChatFunctionCall(name="bash", arguments='{"cmd": "ls"}')
+        )
+        return ParsedAssistantMessage(text="", tool_calls=[call], stopped=True)
+
+
+class _FlakySampler:
+    """Raises on the first sample() calls, then delegates to a fake sampler."""
+
+    def __init__(self, inner: FakeSamplingClient, failures: int = 1) -> None:
+        self._inner = inner
+        self._failures = failures
+
+    def sample(
+        self,
+        prompt_token_ids: list[int],
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | list[int] | None = None,
+    ) -> FakeSampledSequence:
+        if self._failures > 0:
+            self._failures -= 1
+            raise RuntimeError("simulated sampler outage")
+        return self._inner.sample(
+            prompt_token_ids, max_tokens=max_tokens, temperature=temperature, stop=stop
+        )
+
+
+def _config() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.TINKER,
+        model_type="Qwen/Qwen3-8B",
+        model="tinker://run/weights/0",
+    )
+
+
+def _request(max_tokens: int = 16) -> ChatRequest:
+    return ChatRequest(
+        messages=[
+            ChatMessage(role="system", content="be terse"),
+            ChatMessage(role="user", content="hi"),
+        ],
+        temperature=0.7,
+        max_tokens=max_tokens,
+    )
+
+
+def _as_dict(value: JsonValue) -> dict[str, JsonValue]:
+    assert isinstance(value, dict)
+    return value
+
+
+def _as_list(value: JsonValue) -> list[JsonValue]:
+    assert isinstance(value, list)
+    return value
+
+
+def _span(call_index: int = 0) -> TokenSpan:
+    return TokenSpan(
+        call_index=call_index,
+        prompt_token_ids=[1, 2],
+        sampled_token_ids=[65, 66],
+        sampled_logprobs=[-0.5, -1.5],
+    )
+
+
+def test_token_span_requires_aligned_logprobs() -> None:
+    with pytest.raises(ValidationError, match="does not match"):
+        TokenSpan(
+            call_index=0,
+            prompt_token_ids=[1],
+            sampled_token_ids=[2, 3],
+            sampled_logprobs=[-0.1],
+        )
+
+
+def test_recorder_snapshot_is_a_copy() -> None:
+    recorder = TokenRecorder()
+    recorder.record(_span())
+    snapshot = recorder.spans()
+    snapshot.clear()
+    assert len(recorder) == 1
+    assert recorder.spans()[0].call_index == 0
+
+
+def test_recorder_jsonl_sink_written_incrementally(tmp_path: Path) -> None:
+    sink = tmp_path / "spans.jsonl"
+    recorder = TokenRecorder(jsonl_path=sink)
+    recorder.record(_span(0))
+    assert len(sink.read_text(encoding="utf-8").splitlines()) == 1
+    recorder.record(_span(1))
+    lines = sink.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    parsed = [json.loads(line) for line in lines]
+    assert [item["call_index"] for item in parsed] == [0, 1]
+    assert parsed[0]["sampled_token_ids"] == [65, 66]
+    assert parsed[0]["sampled_logprobs"] == [-0.5, -1.5]
+
+
+def test_complete_chat_shape_and_span_matches_issued_sample() -> None:
+    fake = FakeSamplingClient(seed="student-v0")
+    recorder = TokenRecorder()
+    provider = TinkerChatProvider(
+        _config(), sampling_client=fake, renderer=_MiniRendering(), recorder=recorder
+    )
+
+    response = provider.complete_chat(_request(max_tokens=16))
+
+    choice = response.choices[0]
+    assert choice.message.role == "assistant"
+    assert isinstance(choice.message.content, str)
+    assert choice.message.content
+    assert choice.message.tool_calls is None
+    # _MiniRendering never reports a stop signal, so truncation reads as length.
+    assert choice.finish_reason == "length"
+    expected_prompt = _MiniRendering().build_generation_prompt(_request().messages)
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == len(expected_prompt)
+    assert response.usage.completion_tokens == 16
+    assert response.model == "tinker://run/weights/0"
+
+    # TITO: the recorded span is byte-identical to what the sampler issued.
+    assert len(recorder) == 1
+    span = recorder.spans()[0]
+    issued = fake.issued[0]
+    assert span.call_index == 0
+    assert span.prompt_token_ids == list(issued.prompt_ids) == expected_prompt
+    assert span.sampled_token_ids == list(issued.sampled_ids)
+    assert span.sampled_logprobs == list(issued.logprobs)
+
+    wire = response.wire_payload()
+    wire_message = _as_dict(_as_dict(_as_list(wire["choices"])[0])["message"])
+    assert wire_message["role"] == "assistant"
+    assert _as_dict(wire["usage"])["completion_tokens"] == 16
+
+
+def test_complete_chat_tool_calls_in_openai_format() -> None:
+    provider = TinkerChatProvider(
+        _config(), sampling_client=FakeSamplingClient(seed="s"), renderer=_ToolCallRendering()
+    )
+    response = provider.complete_chat(_request())
+    choice = response.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.tool_calls is not None
+    assert choice.message.tool_calls[0].function.name == "bash"
+
+    wire = response.wire_payload()
+    wire_message = _as_dict(_as_dict(_as_list(wire["choices"])[0])["message"])
+    wire_call = _as_list(wire_message["tool_calls"])[0]
+    assert wire_call == {
+        "id": "call_0",
+        "type": "function",
+        "function": {"name": "bash", "arguments": '{"cmd": "ls"}'},
+    }
+    # Empty text serializes as an absent content key, like OpenAI's null content.
+    assert "content" not in wire_message
+
+
+def test_tool_choice_none_renders_without_tool_schemas() -> None:
+    recorder = TokenRecorder()
+    rendering = _MiniRendering()
+    provider = TinkerChatProvider(
+        _config(),
+        sampling_client=FakeSamplingClient(seed="s"),
+        renderer=rendering,
+        recorder=recorder,
+    )
+    request = _request()
+    request.tools = [
+        ChatTool(
+            function=ChatFunctionDefinition(
+                name="bash", description="run bash", parameters={"type": "object"}
+            )
+        )
+    ]
+    request.tool_choice = "none"
+    provider.complete_chat(request)
+    prompt_text = rendering.decode(recorder.spans()[0].prompt_token_ids)
+    assert "tools:" not in prompt_text
+
+
+@pytest.mark.parametrize("choice", ["required", {"type": "function", "function": {"name": "bash"}}])
+def test_unsupported_tool_choice_raises_actionable_error(choice: JsonValue) -> None:
+    provider = TinkerChatProvider(
+        _config(), sampling_client=FakeSamplingClient(seed="s"), renderer=_MiniRendering()
+    )
+    request = _request()
+    request.tool_choice = choice
+    with pytest.raises(ValueError, match="tool_choice"):
+        provider.complete_chat(request)
+
+
+def test_span_recorded_once_per_success_and_not_on_failure() -> None:
+    recorder = TokenRecorder()
+    provider = TinkerChatProvider(
+        _config(),
+        sampling_client=_FlakySampler(FakeSamplingClient(seed="s"), failures=1),
+        renderer=_MiniRendering(),
+        recorder=recorder,
+    )
+    # First attempt fails mid-sampling: an outer retry wrapper would re-invoke
+    # complete_chat, and the failed attempt must not leave a span behind.
+    with pytest.raises(RuntimeError, match="outage"):
+        provider.complete_chat(_request())
+    assert len(recorder) == 0
+
+    provider.complete_chat(_request())
+    assert [span.call_index for span in recorder.spans()] == [0]
+
+    provider.complete_chat(_request())
+    assert [span.call_index for span in recorder.spans()] == [0, 1]
+
+
+def test_complete_plain_text_uses_same_machinery() -> None:
+    recorder = TokenRecorder()
+    rendering = _MiniRendering()
+    provider = TinkerChatProvider(
+        _config(),
+        sampling_client=FakeSamplingClient(seed="s"),
+        renderer=rendering,
+        recorder=recorder,
+    )
+    completion = provider.complete(
+        "sys prompt", [Message(role="user", content="do it")], temperature=0.5, max_tokens=8
+    )
+    span = recorder.spans()[0]
+    assert completion.text == rendering.decode(span.sampled_token_ids)
+    assert completion.usage.input_tokens == len(span.prompt_token_ids)
+    assert completion.usage.output_tokens == 8
+    # The system prompt travels as a leading system message.
+    assert "system: sys prompt" in rendering.decode(span.prompt_token_ids)
+
+
+def test_embed_raises_actionable_error() -> None:
+    provider = TinkerChatProvider(_config(), sampling_client=FakeSamplingClient(seed="s"))
+    with pytest.raises(ValueError, match="embedder"):
+        provider.embed(["text"])
+
+
+def test_verify_ok_via_fakes_and_never_records() -> None:
+    recorder = TokenRecorder()
+    provider = TinkerChatProvider(
+        _config(),
+        sampling_client=FakeSamplingClient(seed="s"),
+        renderer=_MiniRendering(),
+        recorder=recorder,
+    )
+    result = provider.verify()
+    assert result.ok is True
+    assert result.kind is ProviderKind.TINKER
+    assert result.model == "tinker://run/weights/0"
+    assert len(recorder) == 0
+
+
+def test_registry_constructs_provider_without_touching_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Poison the SDK modules: construction and fake-backed completions must
+    # never import tinker or tinker_cookbook.
+    monkeypatch.setitem(sys.modules, "tinker", None)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook", None)
+    provider = get_provider(_config())
+    assert isinstance(provider, TinkerChatProvider)
+    assert isinstance(provider, Provider)
+    assert isinstance(provider, ToolCallingProvider)
+
+    injected = TinkerChatProvider(
+        _config(), sampling_client=FakeSamplingClient(seed="s"), renderer=_MiniRendering()
+    )
+    response = injected.complete_chat(_request())
+    assert response.choices[0].message.role == "assistant"
+
+
+def test_missing_extra_names_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "tinker", None)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    with pytest.raises(ImportError, match="uv sync --extra distill"):
+        provider.complete_chat(_request())
+
+
+def test_missing_api_key_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("tinker")
+    monkeypatch.delenv("TINKER_API_KEY", raising=False)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    # The message must state the problem (not set) and the remedy (set it).
+    with pytest.raises(RuntimeError, match="TINKER_API_KEY is not set"):
+        provider.complete_chat(_request())
+
+
+def test_tinker_path_without_model_type_is_actionable() -> None:
+    config = ProviderConfig(kind=ProviderKind.TINKER, model="tinker://run/weights/0")
+    provider = TinkerChatProvider(config, sampling_client=FakeSamplingClient(seed="s"))
+    with pytest.raises(ValueError, match="model_type"):
+        provider.complete_chat(_request())
+
+
+def test_injected_sampler_without_tokenizer_requires_renderer() -> None:
+    provider = TinkerChatProvider(_config(), sampling_client=FakeSamplingClient(seed="s"))
+    with pytest.raises(RuntimeError, match="renderer="):
+        provider.complete_chat(_request())
+
+
+def _module_scope_import_roots(path: Path) -> set[str]:
+    """Top-level import roots of a module (TYPE_CHECKING blocks excluded)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    roots: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_module_scope_never_imports_the_distill_extra() -> None:
+    # The tinker/tinker-cookbook SDKs are optional; module import must stay
+    # lazy so the provider modules load without the distill extra installed.
+    for module in (tinker_module, rendering_module):
+        assert module.__file__ is not None
+        roots = _module_scope_import_roots(Path(module.__file__))
+        assert not roots & {"tinker", "tinker_cookbook"}, module.__name__

--- a/wmh/providers/tinker_test.py
+++ b/wmh/providers/tinker_test.py
@@ -569,6 +569,22 @@ def test_provider_env_vars_names_the_key_the_provider_actually_reads() -> None:
     assert PROVIDER_ENV_VARS[ProviderKind.TINKER] == [TINKER_API_KEY_ENV]
 
 
+def test_get_provider_can_construct_tinker_without_an_explicit_key() -> None:
+    # Registering ProviderKind.TINKER puts this provider on get_provider's trusted-credential
+    # path, which calls backend(config, api_key=api_key) for EVERY kind. Before __init__ grew
+    # the parameter this was an unconditional TypeError the type checker caught and no test did.
+    assert isinstance(get_provider(_config()), TinkerChatProvider)
+
+
+def test_an_explicit_api_key_is_refused_rather_than_silently_ignored() -> None:
+    # The SDK reads TINKER_API_KEY from the process environment, so a pool entry's own key
+    # cannot be honored. get_provider promises the backend authenticates with exactly the key
+    # it was handed; sampling on a different account than the entry named would break that
+    # quietly, and the operator would only find out on the invoice.
+    with pytest.raises(ValueError, match=TINKER_API_KEY_ENV):
+        get_provider(_config(), api_key="sk-some-other-account")
+
+
 def test_sample_is_bounded_by_the_sample_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     # The live failure: a wedged session's future never resolves, and an unbounded
     # `.result()` hung one run for 33 minutes.

--- a/wmh/providers/tinker_test.py
+++ b/wmh/providers/tinker_test.py
@@ -1,8 +1,10 @@
-"""Tests for the Tinker provider: span recording, response shape, lazy imports.
+"""Tests for the Tinker provider: span recording, response shape, lazy imports, deadlines.
 
 Everything runs against the deterministic fakes in `wmh.distill.fake_tinker`
 plus a minimal char-level `ChatRendering`; the real tinker SDK is never
-touched (several tests pin that by poisoning `sys.modules`).
+touched (several tests pin that by poisoning `sys.modules`). The deadline
+tests substitute a stub `tinker` module whose calls never come back, which is
+the wedged-session failure mode the deadlines exist for.
 """
 
 from __future__ import annotations
@@ -10,7 +12,12 @@ from __future__ import annotations
 import ast
 import json
 import sys
+import threading
+import time
+from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, NoReturn, cast
 
 import pytest
 from llm_waterfall.types import (
@@ -25,6 +32,8 @@ from pydantic import JsonValue, ValidationError
 
 import wmh.distill.rendering as rendering_module
 import wmh.providers.tinker as tinker_module
+from wmh.config import PROVIDER_ENV_VARS
+from wmh.distill.deadlines import TinkerDeadlineError, env_var_for
 from wmh.distill.fake_tinker import FakeSampledSequence, FakeSamplingClient, FakeTokenizer
 from wmh.distill.rendering import ParsedAssistantMessage
 from wmh.providers.base import (
@@ -35,7 +44,16 @@ from wmh.providers.base import (
     ToolCallingProvider,
 )
 from wmh.providers.registry import get_provider
-from wmh.providers.tinker import TinkerChatProvider, TokenRecorder, TokenSpan
+from wmh.providers.tinker import (
+    TINKER_API_KEY_ENV,
+    SdkSampler,
+    TinkerChatProvider,
+    TokenRecorder,
+    TokenSpan,
+)
+
+if TYPE_CHECKING:
+    import tinker
 
 
 class _MiniRendering:
@@ -103,6 +121,158 @@ class _FlakySampler:
         return self._inner.sample(
             prompt_token_ids, max_tokens=max_tokens, temperature=temperature, stop=stop
         )
+
+
+class _DeadlineSampler:
+    """A sampler whose every sample expires, as a wedged session's would."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def sample(
+        self,
+        prompt_token_ids: list[int],
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | list[int] | None = None,
+    ) -> NoReturn:
+        del prompt_token_ids, max_tokens, temperature, stop
+        self.calls += 1
+        raise TinkerDeadlineError("sample", elapsed_s=0.05, deadline_s=0.05)
+
+
+class _StubModelInput:
+    """Stands in for `tinker.ModelInput`; the provider only builds one from ids."""
+
+    def __init__(self, token_ids: list[int]) -> None:
+        self.token_ids = token_ids
+
+    @classmethod
+    def from_ints(cls, tokens: list[int]) -> _StubModelInput:
+        return cls(list(tokens))
+
+
+class _StubSamplingParams:
+    """Stands in for `tinker.SamplingParams`."""
+
+    def __init__(
+        self,
+        *,
+        max_tokens: int,
+        temperature: float,
+        stop: list[str] | list[int] | None = None,
+    ) -> None:
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.stop = stop
+
+
+class _NeverFuture:
+    """A sample future that never resolves; `result(timeout)` honors the timeout.
+
+    Mirrors the real `APIFuture.result(timeout)` contract, which is what makes
+    the difference between a bounded wait and the original 33-minute hang.
+    """
+
+    def result(self, timeout: float | None = None) -> NoReturn:
+        threading.Event().wait(timeout)
+        raise TimeoutError(f"stub future gave up after {timeout}s")
+
+
+class _ReadyFuture:
+    """A sample future that resolves at once, recording the timeout it was handed."""
+
+    def __init__(self, sequence: FakeSampledSequence) -> None:
+        self._sequence = sequence
+        self.timeouts: list[float | None] = []
+
+    def result(self, timeout: float | None = None) -> SimpleNamespace:
+        self.timeouts.append(timeout)
+        return SimpleNamespace(sequences=[self._sequence])
+
+
+class _StubSdkClient:
+    """The `tinker.SamplingClient` surface `SdkSampler` wraps (sample + get_tokenizer).
+
+    Args:
+        future: The future `sample()` hands back; defaults to one that never
+            resolves, which is how a wedged session actually presents (the SDK
+            returns the future promptly and the wait is what hangs).
+        wedged_tokenizer: When True, `get_tokenizer()` blocks forever.
+    """
+
+    def __init__(
+        self,
+        *,
+        future: _NeverFuture | _ReadyFuture | None = None,
+        wedged_tokenizer: bool = False,
+    ) -> None:
+        self._future: _NeverFuture | _ReadyFuture = future or _NeverFuture()
+        self._wedged_tokenizer = wedged_tokenizer
+        self.samples = 0
+
+    def sample(
+        self,
+        *,
+        prompt: _StubModelInput,
+        num_samples: int,
+        sampling_params: _StubSamplingParams,
+    ) -> _NeverFuture | _ReadyFuture:
+        del prompt, num_samples, sampling_params
+        self.samples += 1
+        return self._future
+
+    def get_tokenizer(self) -> FakeTokenizer:
+        if self._wedged_tokenizer:
+            _block_forever()
+        return FakeTokenizer()
+
+
+class _StubService:
+    """The `tinker.ServiceClient` surface the lazy build path touches."""
+
+    def __init__(self, *, wedged_create: bool = False) -> None:
+        self.created: list[str] = []
+        self.clients: list[_StubSdkClient] = []
+        self._wedged_create = wedged_create
+
+    def create_sampling_client(
+        self, *, model_path: str | None = None, base_model: str | None = None
+    ) -> _StubSdkClient:
+        self.created.append(model_path or base_model or "")
+        if self._wedged_create:
+            _block_forever()
+        client = _StubSdkClient()  # every sample() on it wedges
+        self.clients.append(client)
+        return client
+
+
+def _sdk_sampler(client: _StubSdkClient) -> SdkSampler:
+    """Wrap a stub client in `SdkSampler`, whose seam is typed to the real SDK class."""
+    return SdkSampler(cast("tinker.SamplingClient", client))
+
+
+def _block_forever() -> NoReturn:
+    """Park on an event nobody sets: the SDK call that neither returns nor raises."""
+    threading.Event().wait()
+    raise AssertionError("unreachable: the deadline abandons this daemon thread")
+
+
+def _install_stub_tinker(
+    monkeypatch: pytest.MonkeyPatch, service_factory: Callable[[], _StubService]
+) -> None:
+    """Put a stub `tinker` module in `sys.modules` and set the API key."""
+    monkeypatch.setenv(TINKER_API_KEY_ENV, "test-key")
+    monkeypatch.setitem(
+        sys.modules,
+        "tinker",
+        SimpleNamespace(
+            ModelInput=_StubModelInput,
+            SamplingParams=_StubSamplingParams,
+            ServiceClient=service_factory,
+        ),
+    )
 
 
 def _config() -> ProviderConfig:
@@ -390,6 +560,142 @@ def test_injected_sampler_without_tokenizer_requires_renderer() -> None:
     provider = TinkerChatProvider(_config(), sampling_client=FakeSamplingClient(seed="s"))
     with pytest.raises(RuntimeError, match="renderer="):
         provider.complete_chat(_request())
+
+
+def test_provider_env_vars_names_the_key_the_provider_actually_reads() -> None:
+    # Without the entry the `providers verify` hint drops the "(TINKER_API_KEY)" clue and
+    # the CLI never prompts for the key; the equality pins the literal in config.py to the
+    # name the provider reads, so the two cannot drift.
+    assert PROVIDER_ENV_VARS[ProviderKind.TINKER] == [TINKER_API_KEY_ENV]
+
+
+def test_sample_is_bounded_by_the_sample_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The live failure: a wedged session's future never resolves, and an unbounded
+    # `.result()` hung one run for 33 minutes.
+    monkeypatch.setenv(env_var_for("sample"), "0.05")
+    monkeypatch.setitem(
+        sys.modules,
+        "tinker",
+        SimpleNamespace(ModelInput=_StubModelInput, SamplingParams=_StubSamplingParams),
+    )
+    sampler = _sdk_sampler(_StubSdkClient(future=_NeverFuture()))
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError) as info:
+        sampler.sample([1, 2, 3], max_tokens=4, temperature=0.0)
+    assert time.monotonic() - started < 5.0
+    assert info.value.kind == "sample"
+
+
+def test_sample_hands_the_future_its_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The happy path must go through the deadline too: a `result()` called with no
+    # timeout is exactly the unbounded wait this fix removes.
+    monkeypatch.setenv(env_var_for("sample"), "7.5")
+    monkeypatch.setitem(
+        sys.modules,
+        "tinker",
+        SimpleNamespace(ModelInput=_StubModelInput, SamplingParams=_StubSamplingParams),
+    )
+    expected = FakeSampledSequence(tokens=[65, 66], logprobs=[-0.1, -0.2], stop_reason="length")
+    future = _ReadyFuture(expected)
+    sampler = _sdk_sampler(_StubSdkClient(future=future))
+    assert sampler.sample([1, 2], max_tokens=2, temperature=0.0) is expected
+    assert future.timeouts == [7.5]
+
+
+def test_get_tokenizer_is_bounded_by_the_connect_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_var_for("connect"), "0.05")
+    sampler = _sdk_sampler(_StubSdkClient(wedged_tokenizer=True))
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError) as info:
+        sampler.get_tokenizer()
+    assert time.monotonic() - started < 5.0
+    assert info.value.kind == "connect"
+
+
+def test_service_client_construction_is_bounded_by_the_connect_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_var_for("connect"), "0.05")
+    _install_stub_tinker(monkeypatch, _block_forever)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError, match="tinker connect timed out"):
+        provider.complete_chat(_request())
+    assert time.monotonic() - started < 5.0
+
+
+def test_sampling_client_creation_is_bounded_by_the_connect_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_var_for("connect"), "0.05")
+    service = _StubService(wedged_create=True)
+    _install_stub_tinker(monkeypatch, lambda: service)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    started = time.monotonic()
+    with pytest.raises(TinkerDeadlineError, match="tinker connect timed out"):
+        provider.complete_chat(_request())
+    assert time.monotonic() - started < 5.0
+    assert service.created == ["tinker://run/weights/0"]
+
+
+def test_expired_sample_drops_the_owned_client_so_the_next_attempt_rebuilds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A wedged client keeps expiring; caching it would turn one expiry into an endless
+    # run of them, so the retry wrapper's next attempt must get a fresh session.
+    monkeypatch.setenv(env_var_for("sample"), "0.05")
+    services: list[_StubService] = []
+
+    def factory() -> _StubService:
+        service = _StubService()
+        services.append(service)
+        return service
+
+    _install_stub_tinker(monkeypatch, factory)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    for _ in range(2):
+        with pytest.raises(TinkerDeadlineError, match="tinker sample timed out"):
+            provider.complete_chat(_request())
+    assert [service.created for service in services] == [
+        ["tinker://run/weights/0"],
+        ["tinker://run/weights/0"],
+    ]
+    # Each wedged client was used exactly once and then dropped, never reused.
+    assert [client.samples for service in services for client in service.clients] == [1, 1]
+
+
+def test_expired_ping_drops_the_owned_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `verify()` runs the same render+sample path, so it must heal the same way.
+    monkeypatch.setenv(env_var_for("sample"), "0.05")
+    services: list[_StubService] = []
+
+    def factory() -> _StubService:
+        service = _StubService()
+        services.append(service)
+        return service
+
+    _install_stub_tinker(monkeypatch, factory)
+    provider = TinkerChatProvider(_config(), renderer=_MiniRendering())
+    for _ in range(2):
+        result = provider.verify()
+        assert result.ok is False
+        assert "timed out" in (result.detail or "")
+    assert len(services) == 2
+
+
+def test_injected_client_is_never_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The provider cannot rebuild a client it did not build, so an expiry must leave the
+    # injected sampler in place. Poisoning the SDK proves no rebuild is attempted: a drop
+    # would surface as ImportError on the second call instead of another expiry.
+    monkeypatch.setitem(sys.modules, "tinker", None)
+    sampler = _DeadlineSampler()
+    provider = TinkerChatProvider(_config(), sampling_client=sampler, renderer=_MiniRendering())
+    for _ in range(2):
+        with pytest.raises(TinkerDeadlineError):
+            provider.complete_chat(_request())
+    assert sampler.calls == 2
 
 
 def _module_scope_import_roots(path: Path) -> set[str]:


### PR DESCRIPTION
This PR lays the foundations for the on-policy distillation (OPD) work: a new `tinker` ProviderKind with a `TinkerChatProvider` that samples completions from Tinker LoRA weights through the standard provider seam, so a distilled student can serve as the worker model anywhere a provider is accepted. The provider is backed by a new `wmh/distill` package containing the chat rendering layer (prompt rendering and assistant-message parsing against the tinker-cookbook renderer surface) and a `fake_tinker` test double, so the whole provider path is unit-tested without the tinker SDK or network access.

Packaging and config plumbing come along: a `distill` optional extra (`tinker`, `tinker-cookbook` pinned to the verified 0.4.x renderer surface, and `wandb` for optional run tracking), folded into the `dev` extra so the full gate resolves over it. `ModelRole` gains a `model_type` field so a `tinker://` weights path can carry its base-model identity (which determines renderer and tokenizer) through model roles, and `llm-waterfall` adds `tinker` to its trusted SDK modules since its exceptions mirror openai's shape for capacity classification. The per-run distill TOML config model and loader land here as the package's initial public surface.

The stack also bounds every Tinker SDK call with a wall-clock deadline via the stdlib-only `wmh/distill/deadlines.py` seam: per-call-kind default deadlines derived from measured latencies, `WMH_TINKER_DEADLINE_*` environment overrides, and a `TinkerDeadlineError` classified as a capacity error so the retry layer rebuilds a fresh session instead of hanging on a wedged one. `HarborConfig` gains a `retries` field, `WarmupConfig` gains the supervised-warmup fields plus `trajectories_from` for reusing another run's warmup rollouts, `PricingConfig` gains cached-prefill and teacher_sample pricing, `TrainConfig` gains `loss`/`topk` (selecting the top-k weighted cross-entropy objective) and `log_sample_rollouts`, and `EvalConfig` gains an `every` schedule with `teacher_baseline_from`/`student_baseline_from`. The fake Tinker double carries an issuer ledger for teacher-sampled spans, structured forward-backward and optim outputs for RL metrics, and an input-side assertion for top-k TITO requests. All consumers land further up the stack.

The harness runner link also stops swallowing worker failures: a provider that fails every call previously ended the episode as a clean-looking zero-turn "submitted" with nothing logged host-side, which hid a live production outage for 16 training steps. The link now emits a bounded warning line (full detail at debug) before returning the error frame to the runner; runner-facing behavior is unchanged.

The deadline layer also encodes what a live 120B resume proved about restoring training state: tinker accepts LoadWeights only on an uninitialized model, so a restore cannot follow a weights call on the same client or be retried there, and `load_state` gets the full 600s budget rather than the first of two attempts. The fake training client enforces that ordering and keeps an ordered call log, so the rule is testable without the SDK.

## Stack

This is PR 1 of a three-PR stack based on `feat/optimize-harbor-env`:

1. #250 Add the Tinker sampling provider and distill foundations (this PR)
2. #251 Capture distill rollouts through harbor with per-trial token sinks
3. #252 Add the distill optimizer mode: OPD training loop and harbor CLI

## Testing

Full gate green on this branch: `uv run ruff check .` clean, `uv run ty check` clean, `uv run pytest -q` with 2287 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




