### PR TITLE
Capture distill rollouts through harbor with per-trial token sinks

### DIFF
--- a/wmh/cli/app.py
+++ b/wmh/cli/app.py
@@ -37,6 +37,7 @@ from rich.table import Table
 
 import wmh.providers as providers
 from wmh.cli.agent_session import register as register_agent_session_commands
+from wmh.cli.e2b_cmds import register as register_e2b_commands
 from wmh.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmh.cli.harness_app import harness_app, optimize_app
 from wmh.cli.ingest_cmd import ingest as _ingest_command
@@ -148,6 +149,7 @@ app.add_typer(optimize_app, name="optimize")
 app.command("ingest")(_ingest_command)
 register_platform_commands(app)
 register_agent_session_commands(app)
+register_e2b_commands(app)
 _console = Console()
 _CHECK = "[green]✓[/green]"
 

--- a/wmh/cli/e2b_cmds.py
+++ b/wmh/cli/e2b_cmds.py
@@ -1,0 +1,212 @@
+"""`wmh e2b reap`: reclaim E2B sandbox slots held by orphaned harbor trial sandboxes.
+
+The operator-facing half of `wmh.harness.e2b_reap`. It renders the reap candidates and their
+evidence, and it never kills anything without `--yes`: a dry run is the default because every
+kill is destructive and one wrong id is somebody's running trial.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from wmh.harness.e2b_ledger import read_ledger_files
+from wmh.harness.e2b_reap import (
+    AliveSandbox,
+    ReapCandidate,
+    execute_reap,
+    kill_sandbox,
+    list_alive_sandboxes,
+    plan_reap,
+    sandbox_cap,
+)
+
+_console = Console()
+
+
+def _now() -> datetime:
+    """The instant sandbox ages are measured against (a seam tests pin)."""
+    return datetime.now(UTC)
+
+
+e2b_app = typer.Typer(help="Inspect and reclaim E2B sandbox capacity.", no_args_is_help=True)
+
+# Module-level singletons: a typer.Option call cannot be a default inline (ruff B008).
+_REAP_YES = typer.Option(
+    False, "--yes", help="Actually kill the candidates. Without it this is a dry run."
+)
+_REAP_DEAD_OWNERS = typer.Option(
+    True,
+    "--dead-owners/--no-dead-owners",
+    help="Include sandboxes recorded by a wmh run on THIS machine whose process is gone "
+    "(exact ids from the local ledger; safe and on by default).",
+)
+_REAP_STALE_MINUTES = typer.Option(
+    None,
+    "--stale-minutes",
+    min=1,
+    help="Also include any harbor trial sandbox on the ACCOUNT started more than N minutes "
+    "ago. This match is account-wide and can kill another machine's live run, so it is "
+    "opt-in; sandboxes owned by a live local process are still excluded.",
+)
+
+
+@e2b_app.command("reap")
+def reap(
+    yes: bool = _REAP_YES,
+    dead_owners: bool = _REAP_DEAD_OWNERS,
+    stale_minutes: int | None = _REAP_STALE_MINUTES,
+) -> None:
+    """Free E2B concurrency slots held by sandboxes no run is using any more.
+
+    A harbor trial sandbox keeps its slot until its own multi-hour timeout, so a run that dies
+    without graceful shutdown (crash, SIGKILL, budget abort, machine sleep) leaves orphans that
+    starve every later run at the account cap of 100 concurrent sandboxes (override with
+    `$WMH_E2B_SANDBOX_CAP`).
+
+    Two evidence classes, most conservative first:
+
+    - `--dead-owners` (default): unreleased entries in this machine's sandbox ledger whose
+      owning process is gone. These are provably orphans of local runs and are killed by exact
+      recorded id.
+    - `--stale-minutes N` (opt-in): every sandbox ON THE ACCOUNT that carries harbor trial
+      metadata and started more than N minutes ago. The match is account-wide, so it can kill
+      a run on another machine or in another checkout; use it only when you know no such run
+      should be alive. Sandboxes whose local owner process is still running are never selected.
+
+    The default is a dry run that prints the candidates and changes nothing. Pass `--yes` to
+    kill them.
+    """
+    try:
+        cap = sandbox_cap()
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if not dead_owners and stale_minutes is None:
+        raise typer.BadParameter(
+            "--no-dead-owners with no --stale-minutes selects nothing; drop --no-dead-owners "
+            "or add --stale-minutes N"
+        )
+    try:
+        alive = list_alive_sandboxes()
+    except ImportError as error:
+        raise typer.BadParameter(str(error)) from error
+    except Exception as error:  # noqa: BLE001 - any provider failure is a usage-level message
+        raise typer.BadParameter(
+            f"could not list E2B sandboxes ({type(error).__name__}: {error}); check "
+            "$E2B_API_KEY and your connection"
+        ) from error
+
+    plan = plan_reap(
+        alive=alive,
+        ledger_files=read_ledger_files(),
+        now=_now(),
+        dead_owners=dead_owners,
+        stale_minutes=stale_minutes,
+    )
+    _print_usage(alive, cap)
+    if not plan.candidates:
+        _console.print("[green]nothing to reap[/green]: no orphaned sandbox matched")
+        if not plan.vanished:
+            return
+        if not yes:
+            _console.print(
+                f"{len(plan.vanished)} ledger record(s) name sandboxes E2B no longer has; "
+                "--yes clears them"
+            )
+            return
+        outcome = execute_reap(plan, killer=kill_sandbox)
+        _console.print(
+            f"released {len(plan.vanished)} stale ledger record(s); "
+            f"pruned {len(outcome.pruned_ledgers)} ledger file(s)"
+        )
+        return
+
+    _console.print(_candidates_table(plan.candidates))
+    if not yes:
+        _console.print(
+            f"[yellow]dry run[/yellow]: {len(plan.candidates)} sandbox(es) would be killed, "
+            f"freeing up to {len(plan.candidates)} of {cap} slot(s). Re-run with --yes to do it."
+        )
+        return
+
+    outcome = execute_reap(plan, killer=kill_sandbox)
+    remaining = max(len(alive) - outcome.freed, 0)
+    _console.print(
+        f"[green]reaped[/green] {outcome.freed} sandbox(es); usage now {remaining}/{cap} "
+        f"({max(cap - remaining, 0)} free)"
+    )
+    if outcome.already_gone:
+        _console.print(
+            f"{len(outcome.already_gone)} candidate(s) were already gone: "
+            f"{', '.join(outcome.already_gone)}"
+        )
+    for sandbox_id, error in outcome.failed:
+        _console.print(f"[red]kill failed[/red] {sandbox_id}: {error}")
+    if outcome.pruned_ledgers:
+        _console.print(f"pruned {len(outcome.pruned_ledgers)} fully released ledger file(s)")
+
+
+def _print_usage(alive: list[AliveSandbox], cap: int) -> None:
+    """Print current account usage against the cap."""
+    trials = sum(1 for sandbox in alive if sandbox.is_harbor_trial())
+    _console.print(
+        f"E2B usage: [bold]{len(alive)}/{cap}[/bold] concurrent sandbox(es) running "
+        f"({trials} harbor trial environment(s)), {max(cap - len(alive), 0)} slot(s) free"
+    )
+
+
+def _candidates_table(candidates: tuple[ReapCandidate, ...]) -> Table:
+    """Render one row per reap candidate with the evidence behind it."""
+    table = Table(title="Reap candidates")
+    table.add_column("Sandbox", no_wrap=True)
+    table.add_column("Age", justify="right", no_wrap=True)
+    table.add_column("Template", no_wrap=True)
+    table.add_column("Source", no_wrap=True)
+    table.add_column("Owner", justify="right", no_wrap=True)
+    table.add_column("Alive", no_wrap=True)
+    table.add_column("Trial")
+    for candidate in candidates:
+        table.add_row(
+            candidate.sandbox_id,
+            _age(candidate.age_seconds),
+            _template(candidate.template_id),
+            candidate.source,
+            "unknown" if candidate.owner_pid is None else str(candidate.owner_pid),
+            _owner_liveness(candidate.owner_alive),
+            candidate.trial_name or "",
+        )
+    return table
+
+
+# A wmh harbor alias is `wmh-hb-v1-<64 hex>`: printing it whole squeezes every evidence column
+# out of the table, and its head plus tail already identify a template uniquely in practice.
+_TEMPLATE_DISPLAY_LEN = 22
+
+
+def _template(template_id: str) -> str:
+    """Shorten a long template alias, keeping both ends so two aliases stay distinguishable."""
+    if len(template_id) <= _TEMPLATE_DISPLAY_LEN:
+        return template_id
+    return f"{template_id[: _TEMPLATE_DISPLAY_LEN - 8]}…{template_id[-7:]}"
+
+
+def _owner_liveness(owner_alive: bool | None) -> str:
+    """Render owner liveness, distinguishing "no recorded owner" from "owner is gone"."""
+    if owner_alive is None:
+        return "unknown"
+    return "yes" if owner_alive else "no"
+
+
+def _age(seconds: float) -> str:
+    """Human-readable sandbox age, e.g. `3h12m`."""
+    minutes = int(seconds // 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m" if hours else f"{minutes}m"
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the `wmh e2b` command group to the root CLI."""
+    app.add_typer(e2b_app, name="e2b")

--- a/wmh/cli/e2b_cmds_test.py
+++ b/wmh/cli/e2b_cmds_test.py
@@ -1,0 +1,245 @@
+"""CLI tests for `wmh e2b reap`, driven via CliRunner against fake account state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner, Result
+
+import wmh.cli.e2b_cmds as e2b_cmds_module
+from wmh.cli import app
+from wmh.harness.e2b_ledger import SandboxLedger, read_ledger_files
+from wmh.harness.e2b_reap import AliveSandbox
+
+runner = CliRunner()
+
+_NOW = datetime(2026, 7, 24, 18, 0, 0, tzinfo=UTC)
+
+
+def _alive(
+    sandbox_id: str, *, age_minutes: float, trial: str | None = "task__a1b2"
+) -> AliveSandbox:
+    metadata = (
+        {"session_id": f"{trial}__env", "environment_name": "task/environment"}
+        if trial is not None
+        else {}
+    )
+    return AliveSandbox(
+        sandbox_id=sandbox_id,
+        template_id="wmh-hb-v1-abc",
+        started_at=_NOW - timedelta(minutes=age_minutes),
+        metadata=metadata,
+    )
+
+
+def _record(directory: Path, *, pid: int, sandbox_ids: tuple[str, ...]) -> Path:
+    ledger = SandboxLedger(directory, pid=pid, now=lambda: _NOW - timedelta(hours=3))
+    for sandbox_id in sandbox_ids:
+        ledger.record_created(
+            sandbox_id=sandbox_id, template_id="wmh-hb-v1-abc", trial_name=f"trial-{sandbox_id}"
+        )
+    return ledger.path
+
+
+def _patch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ledger_dir: Path,
+    alive: list[AliveSandbox],
+    killed: list[str] | None = None,
+    kill_errors: dict[str, Exception] | None = None,
+) -> None:
+    """Point the command at a temporary ledger and a fake account (no SDK, no network)."""
+    monkeypatch.setenv("WMH_HOME", str(ledger_dir.parent))
+    # Wide enough that rich renders every candidate column in full (no ellipsis).
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setattr(e2b_cmds_module, "_now", lambda: _NOW)
+    monkeypatch.setattr(e2b_cmds_module, "list_alive_sandboxes", lambda: list(alive))
+
+    def killer(sandbox_id: str) -> bool:
+        error = (kill_errors or {}).get(sandbox_id)
+        if error is not None:
+            raise error
+        if killed is not None:
+            killed.append(sandbox_id)
+        return True
+
+    monkeypatch.setattr(e2b_cmds_module, "kill_sandbox", killer)
+
+
+def _flat(result: Result) -> str:
+    """Collapse rich wrapping (and typer's error-box borders) for substring asserts."""
+    return " ".join(result.output.replace("│", " ").split())
+
+
+def _reap(*extra: str) -> Result:
+    return runner.invoke(app, ["e2b", "reap", *extra])
+
+
+def test_dry_run_lists_candidates_with_their_evidence_and_kills_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    _record(ledger_dir, pid=999_001, sandbox_ids=("orphan-1",))
+    killed: list[str] = []
+    _patch(
+        monkeypatch,
+        ledger_dir=ledger_dir,
+        alive=[_alive("orphan-1", age_minutes=192), _alive("busy", age_minutes=5)],
+        killed=killed,
+    )
+
+    result = _reap()
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "E2B usage: 2/100 concurrent sandbox(es) running" in flat
+    assert "98 slot(s) free" in flat
+    assert "orphan-1" in flat and "3h12m" in flat and "ledger" in flat
+    assert "999001" in flat  # the recorded owner pid
+    assert "dry run" in flat and "1 sandbox(es) would be killed" in flat
+    assert killed == []
+    # Nothing was released, so the ledger still holds the orphan.
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert [record.sandbox_id for record in ledger_file.held] == ["orphan-1"]
+
+
+def test_yes_kills_the_candidates_and_reports_freed_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    _record(ledger_dir, pid=999_001, sandbox_ids=("orphan-1", "orphan-2"))
+    killed: list[str] = []
+    _patch(
+        monkeypatch,
+        ledger_dir=ledger_dir,
+        alive=[
+            _alive("orphan-1", age_minutes=200),
+            _alive("orphan-2", age_minutes=100),
+            _alive("busy", age_minutes=5),
+        ],
+        killed=killed,
+    )
+
+    result = _reap("--yes")
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert sorted(killed) == ["orphan-1", "orphan-2"]
+    assert "reaped 2 sandbox(es); usage now 1/100 (99 free)" in flat
+    assert "pruned 1 fully released ledger file(s)" in flat
+    assert read_ledger_files(ledger_dir) == ()
+
+
+def test_a_failing_kill_is_reported_and_the_rest_still_die(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    _record(ledger_dir, pid=999_001, sandbox_ids=("bad", "good"))
+    killed: list[str] = []
+    _patch(
+        monkeypatch,
+        ledger_dir=ledger_dir,
+        alive=[_alive("bad", age_minutes=200), _alive("good", age_minutes=100)],
+        killed=killed,
+        kill_errors={"bad": RuntimeError("503: try later")},
+    )
+
+    result = _reap("--yes")
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert killed == ["good"]
+    assert "reaped 1 sandbox(es)" in flat
+    assert "kill failed bad: RuntimeError: 503: try later" in flat
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert [record.sandbox_id for record in ledger_file.held] == ["bad"]
+
+
+def test_stale_minutes_adds_account_wide_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    killed: list[str] = []
+    _patch(
+        monkeypatch,
+        ledger_dir=ledger_dir,
+        alive=[
+            _alive("foreign-old", age_minutes=180),
+            _alive("foreign-young", age_minutes=30),
+            _alive("not-a-trial", age_minutes=600, trial=None),
+        ],
+        killed=killed,
+    )
+
+    without = _reap()
+    assert "nothing to reap" in _flat(without)
+
+    result = _reap("--stale-minutes", "60", "--yes")
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert killed == ["foreign-old"]
+    assert "metadata" in flat and "unknown" in flat  # no local owner is recorded
+
+
+def test_no_dead_owners_without_stale_minutes_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    _patch(monkeypatch, ledger_dir=ledger_dir, alive=[])
+
+    result = _reap("--no-dead-owners")
+
+    assert result.exit_code != 0
+    assert "selects nothing" in _flat(result)
+
+
+def test_a_listing_failure_becomes_an_actionable_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WMH_HOME", str(tmp_path / ".wmh"))
+
+    def lister() -> list[AliveSandbox]:
+        raise RuntimeError("401: unauthorized")
+
+    monkeypatch.setattr(e2b_cmds_module, "list_alive_sandboxes", lister)
+
+    result = _reap()
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "could not list E2B sandboxes" in flat
+    assert "$E2B_API_KEY" in flat
+
+
+def test_a_missing_e2b_extra_names_the_sync_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WMH_HOME", str(tmp_path / ".wmh"))
+
+    def lister() -> list[AliveSandbox]:
+        raise ImportError("the e2b SDK is not installed; run `uv sync --extra e2b` to manage it")
+
+    monkeypatch.setattr(e2b_cmds_module, "list_alive_sandboxes", lister)
+
+    result = _reap()
+
+    assert result.exit_code != 0
+    assert "uv sync --extra e2b" in _flat(result)
+
+
+def test_a_live_owner_is_never_a_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reaper probes real pids, so this process's own record must survive."""
+    import os
+
+    ledger_dir = tmp_path / ".wmh" / "e2b-sandboxes"
+    _record(ledger_dir, pid=os.getpid(), sandbox_ids=("mine",))
+    _patch(monkeypatch, ledger_dir=ledger_dir, alive=[_alive("mine", age_minutes=600)])
+
+    result = _reap("--stale-minutes", "1")
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to reap" in _flat(result)

--- a/wmh/distill/agents.py
+++ b/wmh/distill/agents.py
@@ -1,0 +1,138 @@
+"""Harbor agent bridge for distillation rollouts with token-span capture.
+
+Harbor instantiates `WmhDistillHarborAgent` (via
+`WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH` plus JSON kwargs) for every distillation
+trial. The one behavioral difference from the base `WmhHarborAgent` is
+provider construction: the worker provider must be the Tinker student, and it
+is built with a `TokenRecorder` that writes the trial's exact sampled token
+spans to `{token_sink_dir}/{trial_name}.jsonl`.
+
+The sink lives OUTSIDE harbor's trial directory on purpose: the scorer's
+entry prune deletes invalid trial dirs wholesale before re-running them, and
+a sink inside the trial dir would vanish with it. The rollout collector keys
+the sink dir per training step and joins sinks back to trials by name.
+
+Like every module in `wmh.evals.harbor`, this module imports the harbor SDK
+at module scope and is therefore imported lazily by its consumers; `import
+wmh.distill` must succeed without the harbor extra.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+from harbor.models.task.config import MCPServerConfig
+
+from wmh.core.types import JsonObject
+from wmh.evals.harbor.agent import (
+    DEFAULT_EPISODE_WORKERS,
+    MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+    WmhHarborAgent,
+)
+from wmh.harness.runtime import DEFAULT_EVAL_EPISODE_TIMEOUT_S
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind
+from wmh.providers.retry import wrap_provider_with_retries
+from wmh.providers.tinker import TinkerChatProvider, TokenRecorder
+
+WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH = "wmh.distill.agents:WmhDistillHarborAgent"
+
+
+class WmhDistillHarborAgent(WmhHarborAgent):
+    """Runs the candidate with a Tinker student provider that records token spans.
+
+    Everything else (episode execution, trace persistence, cancellation
+    semantics) is inherited from `WmhHarborAgent` unchanged.
+
+    Args:
+        token_sink_dir: Directory the per-trial span sink is written into; the
+            sink file is named `{trial_name}.jsonl` where the trial name is
+            derived from harbor's logs-dir layout (`{trial_dir}/agent`).
+    """
+
+    token_sink_path: Path
+    """The exact sink file this trial's recorder writes (set at construction)."""
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        model_name: str | None = None,
+        logger: logging.Logger | None = None,
+        mcp_servers: list[MCPServerConfig] | None = None,
+        skills_dir: str | None = None,
+        *,
+        token_sink_dir: str,
+        command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
+        extra_env: dict[str, str] | None = None,
+        harness: JsonObject,
+        provider_config: JsonObject,
+        harness_backend: Literal["local", "e2b"] = "local",
+        e2b_template: str | None = None,
+        episode_timeout_sec: float = DEFAULT_EVAL_EPISODE_TIMEOUT_S,
+        episode_workers: int = DEFAULT_EPISODE_WORKERS,
+    ) -> None:
+        if not isinstance(token_sink_dir, str) or not token_sink_dir:
+            raise ValueError(
+                "token_sink_dir must be a nonempty path string; the distill rollout "
+                "collector passes it through the scorer's extra_agent_kwargs"
+            )
+        # Set before super().__init__: the base constructor calls _build_provider,
+        # which reads this (and the BaseAgent-assigned logs_dir).
+        self._token_sink_dir = Path(token_sink_dir)
+        super().__init__(
+            logs_dir=logs_dir,
+            model_name=model_name,
+            logger=logger,
+            mcp_servers=mcp_servers,
+            skills_dir=skills_dir,
+            command_timeout_sec=command_timeout_sec,
+            extra_env=extra_env,
+            harness=harness,
+            provider_config=provider_config,
+            harness_backend=harness_backend,
+            e2b_template=e2b_template,
+            episode_timeout_sec=episode_timeout_sec,
+            episode_workers=episode_workers,
+        )
+
+    def _build_provider(self, config: ProviderConfig) -> Provider:
+        """Build the retry-wrapped Tinker student provider with this trial's span sink.
+
+        Args:
+            config: The validated worker provider config; must be the tinker kind
+                (distillation trains on the student's exact sampled tokens, which
+                only the Tinker provider records).
+
+        Returns:
+            The retry-wrapped `TinkerChatProvider`. Spans record only after a
+            completion fully succeeds, so retries never duplicate them.
+
+        Raises:
+            ValueError: If the provider kind is not tinker, or the trial name
+                cannot be derived from the logs dir.
+        """
+        if config.kind is not ProviderKind.TINKER:
+            raise ValueError(
+                "distillation rollouts must sample the Tinker student so its token "
+                f"spans can be recorded, got provider kind {config.kind.value!r}; "
+                "configure the worker provider with kind 'tinker' (or run the standard "
+                "WmhHarborAgent when no token capture is wanted)"
+            )
+        trial_name = self.logs_dir.parent.name
+        if not trial_name:
+            raise ValueError(
+                f"cannot derive the harbor trial name from logs_dir {self.logs_dir}; "
+                "the distill agent expects harbor's per-trial {trial_dir}/agent layout"
+            )
+        self._token_sink_dir.mkdir(parents=True, exist_ok=True)
+        sink_path = self._token_sink_dir / f"{trial_name}.jsonl"
+        # The recorder appends and call_index restarts at 0 per recorder; a leftover
+        # sink from a pruned earlier attempt of the same trial name would corrupt the
+        # contiguous call_index sequence load_trial_spans enforces.
+        sink_path.unlink(missing_ok=True)
+        self.token_sink_path = sink_path
+        provider = TinkerChatProvider(config, recorder=TokenRecorder(jsonl_path=sink_path))
+        # Same retry contract as the base bridge: one transient capacity error must
+        # not kill a whole trial.
+        return wrap_provider_with_retries(provider)

--- a/wmh/distill/agents_test.py
+++ b/wmh/distill/agents_test.py
@@ -1,0 +1,172 @@
+"""Tests for the token-recording distill harbor agent (no real tinker SDK)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+from harbor.environments.base import BaseEnvironment, ExecResult
+from harbor.models.agent.context import AgentContext
+
+from wmh.distill.agents import (
+    WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH,
+    WmhDistillHarborAgent,
+)
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.runtime import RunResult, StopReason
+from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.retry import RetryingToolCallingProvider
+from wmh.providers.tinker import TinkerChatProvider, TokenSpan
+
+
+def _tinker_config() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.TINKER,
+        model_type="Qwen/Qwen3-8B",
+        model="tinker://run/weights/0",
+    )
+
+
+def _logs_dir(tmp_path: Path, trial_name: str = "task-a__x1Y2z3") -> Path:
+    # Harbor's single-step layout: {job_dir}/{trial_name}/agent is the agent logs dir.
+    return tmp_path / "jobs" / "wmh-abc" / trial_name / "agent"
+
+
+def _agent(
+    tmp_path: Path,
+    *,
+    provider_config: ProviderConfig | None = None,
+    token_sink_dir: str | None = None,
+    trial_name: str = "task-a__x1Y2z3",
+) -> WmhDistillHarborAgent:
+    config = provider_config or _tinker_config()
+    return WmhDistillHarborAgent(
+        logs_dir=_logs_dir(tmp_path, trial_name),
+        model_name=f"{config.kind.value}/{config.model}",
+        harness=HarnessDoc.baseline().model_dump(mode="json"),
+        provider_config=config.model_dump(mode="json"),
+        token_sink_dir=(
+            token_sink_dir if token_sink_dir is not None else str(tmp_path / "tokens" / "step-0000")
+        ),
+    )
+
+
+class _Environment:
+    async def exec(
+        self,
+        command: str,
+        *,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+        **_kwargs: object,
+    ) -> ExecResult:
+        del command, env, timeout_sec
+        return ExecResult(stdout="ok\n", stderr="", return_code=0)
+
+
+def test_import_path_constant_resolves_to_the_agent_class() -> None:
+    module_name, _, attribute = WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH.partition(":")
+    module = importlib.import_module(module_name)
+    assert getattr(module, attribute) is WmhDistillHarborAgent
+
+
+def test_sink_filename_derives_from_the_harbor_trial_name(tmp_path: Path) -> None:
+    agent = _agent(tmp_path, trial_name="task-b__q6Rn5Jd")
+
+    expected = tmp_path / "tokens" / "step-0000" / "task-b__q6Rn5Jd.jsonl"
+    assert agent.token_sink_path == expected
+    assert expected.parent.is_dir()
+
+    # The provider keeps the base retry contract and wraps the tinker provider,
+    # whose recorder writes through to the derived sink path.
+    wrapped = agent._provider
+    assert isinstance(wrapped, RetryingToolCallingProvider)
+    inner = wrapped._provider
+    assert isinstance(inner, TinkerChatProvider)
+    recorder = inner._recorder
+    assert recorder is not None
+    recorder.record(
+        TokenSpan(
+            call_index=0,
+            prompt_token_ids=[1, 2],
+            sampled_token_ids=[65],
+            sampled_logprobs=[-0.25],
+        )
+    )
+    [line] = expected.read_text(encoding="utf-8").splitlines()
+    assert json.loads(line)["sampled_token_ids"] == [65]
+
+
+def test_construction_never_imports_the_tinker_sdk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider construction stays lazy: the SDK loads only at first sample."""
+    monkeypatch.setitem(sys.modules, "tinker", None)
+    monkeypatch.setitem(sys.modules, "tinker_cookbook", None)
+    agent = _agent(tmp_path)
+    assert isinstance(agent._provider, RetryingToolCallingProvider)
+
+
+def test_non_tinker_provider_is_rejected_with_the_remedy(tmp_path: Path) -> None:
+    config = ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5")
+    with pytest.raises(ValueError, match="kind 'tinker'"):
+        _agent(tmp_path, provider_config=config)
+
+
+def test_empty_token_sink_dir_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="token_sink_dir must be a nonempty path string"):
+        _agent(tmp_path, token_sink_dir="")
+
+
+def test_stale_sink_from_a_pruned_attempt_is_removed(tmp_path: Path) -> None:
+    """A pruned trial dir can re-run under the same name; its old sink must not
+    prepend stale spans (load_trial_spans rejects call_index resets)."""
+    sink_dir = tmp_path / "tokens" / "step-0000"
+    sink_dir.mkdir(parents=True)
+    stale = sink_dir / "task-a__x1Y2z3.jsonl"
+    stale.write_text('{"stale": true}\n', encoding="utf-8")
+
+    agent = _agent(tmp_path, token_sink_dir=str(sink_dir))
+
+    assert agent.token_sink_path == stale
+    assert not stale.exists()
+
+
+def test_run_drives_the_runtime_with_the_recording_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inherited run() plumbing feeds the subclass-built provider to the runtime."""
+    observed: dict[str, object] = {}
+
+    class _Runtime:
+        def run(
+            self,
+            task_id: str,
+            _instruction: str,
+            _environment: object,
+        ) -> RunResult:
+            return RunResult(task_id=task_id, stop_reason=StopReason.SUBMITTED, answer="done")
+
+        def close(self) -> None:
+            observed["closed"] = True
+
+    def runtime(_self: HarnessDoc, provider: object, **_kwargs: object) -> _Runtime:
+        observed["provider"] = provider
+        return _Runtime()
+
+    monkeypatch.setattr(HarnessDoc, "runtime", runtime)
+    agent = _agent(tmp_path)
+
+    asyncio.run(agent.run("solve it", cast("BaseEnvironment", _Environment()), AgentContext()))
+
+    assert observed["provider"] is agent._provider
+    assert observed["closed"] is True
+    trace = json.loads((_logs_dir(tmp_path) / "wmh-run.json").read_text(encoding="utf-8"))
+    assert trace["stop_reason"] == "submitted"

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -49,6 +49,14 @@ MISSING_HARBOR_EXTRA = (
     "Run `uv sync --extra harbor` (or `pip install 'world-model-harness[harbor]'`) and retry"
 )
 
+E2B_SANDBOXES_PER_TRIAL = 2
+"""Concurrent E2B sandboxes one `harbor.backend = "e2b"` trial holds at once.
+
+`collect_rollouts` selects `task_environment="e2b"` AND `harness_backend="e2b"` together, so a
+running trial occupies harbor's task environment sandbox plus the pooled sandbox hosting the pi
+harness process. Capacity planning (`wmh.cli.harness_distill`) multiplies by this, because a run
+that reserves only one slot per trial starves at exactly half its configured concurrency."""
+
 
 def _recorded_provider_config(config_path: Path) -> JsonObject | None:
     """The provider config a persisted harbor job config ran with, or None.

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -251,7 +251,7 @@ def collect_rollouts(
     scorer = asyncio.run(
         HarborScorer.create(
             template,
-            list(task_ids),
+            task_ids,
             provider_config=provider_config,
             reward_key=cfg.harbor.reward_key,
             attempts=cfg.train.group_size,
@@ -272,7 +272,7 @@ def collect_rollouts(
     logger.info(
         "collecting rollouts for %s: %d task(s) x %d attempt(s), backend %s -> %s",
         step_name,
-        len(list(task_ids)),
+        len(task_ids),
         cfg.train.group_size,
         backend,
         jobs_dir,

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -1,0 +1,258 @@
+"""Collect one distillation training step's rollouts as real harbor trials.
+
+`collect_rollouts` turns one train batch (task ids x group size) into scored
+harbor trials of the pi agent sampling the Tinker student, with every trial's
+exact token spans captured to a per-step sink directory and joined back into
+`TrialRecord`s. Two directory choices are load-bearing:
+
+- The harbor jobs dir is FRESH per training step (`run_dir/harbor/step-NNNN`):
+  harbor job dirs are keyed by the candidate doc hash only, so reusing one
+  jobs dir across steps would resume step N's completed trials as step N+1's
+  "results", carrying tokens sampled from the previous weights.
+- Token sinks live OUTSIDE the trial dirs (`run_dir/tokens/step-NNNN`): the
+  scorer's entry prune deletes invalid trial dirs wholesale before re-running
+  them, and a sink inside the trial dir would vanish with it.
+- A job dir left by a PREVIOUS SESSION under different sampler weights is
+  wiped before scoring (`_wipe_stale_policy_dir`): sampler paths carry a
+  per-session nonce, so such a dir can never satisfy the scorer's strict
+  job-config resume check, and its trials sampled a policy this session did
+  not restore. Wiping makes a crash-resumed step re-run whole from the
+  current weights. A dir whose recorded provider matches (the teacher's
+  stable identity) is kept for harbor's native trial-level resume.
+
+The harbor SDK is an optional extra imported lazily here, the same contract
+as the CLI's harbor commands; `import wmh.distill.rollouts` succeeds without
+it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmh.core.types import JsonObject
+from wmh.distill.config import DistillConfig
+from wmh.distill.tokens import TrialRecord, assemble_trial_records
+from wmh.harness.doc import HarnessDoc
+from wmh.providers.base import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+MISSING_HARBOR_EXTRA = (
+    "the harbor SDK is not installed; distillation rollouts run as real harbor trials. "
+    "Run `uv sync --extra harbor` (or `pip install 'world-model-harness[harbor]'`) and retry"
+)
+
+
+def _recorded_provider_config(config_path: Path) -> JsonObject | None:
+    """The provider config a persisted harbor job config ran with, or None.
+
+    None means the file is unreadable or not shaped like a scorer-produced
+    JobConfig dump; callers leave those dirs alone so the scorer can raise its
+    own actionable error instead of evidence being destroyed silently.
+    """
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    agents = payload.get("agents")
+    if not isinstance(agents, list) or not agents or not isinstance(agents[0], dict):
+        return None
+    kwargs = agents[0].get("kwargs")
+    if not isinstance(kwargs, dict):
+        return None
+    recorded = kwargs.get("provider_config")
+    return recorded if isinstance(recorded, dict) else None
+
+
+def _wipe_stale_policy_dir(
+    candidate_dir: Path, provider_config: ProviderConfig, token_sink_dir: Path
+) -> bool:
+    """Wipe a candidate job dir recorded under different provider weights.
+
+    Sampler paths carry a per-session nonce, so a job dir left by a previous
+    session (a crash mid-batch, then `--resume`) can never satisfy the
+    scorer's strict job-config resume check — and its completed trials sampled
+    a policy this session did not restore, so resuming them would mix
+    policies. Deleting the dir (and the batch's token sinks with it) makes the
+    batch re-run whole from the current weights: correct, at the price of
+    re-running that batch's completed trials.
+
+    A recorded provider that MATCHES the current one (the teacher's stable
+    identity, whose baseline eval legitimately resumes across sessions) is
+    left for harbor's native trial-level resume, as is an unreadable config
+    (the scorer raises its own actionable error for those).
+
+    Args:
+        candidate_dir: The scorer's deterministic per-candidate job dir.
+        provider_config: The provider the batch is about to sample.
+        token_sink_dir: The batch's token sink dir, wiped and recreated
+            alongside the job dir so no stale spans survive.
+
+    Returns:
+        True when the directory was wiped.
+    """
+    recorded = _recorded_provider_config(candidate_dir / "config.json")
+    if recorded is None or recorded == provider_config.model_dump(mode="json"):
+        return False
+    logger.warning(
+        "harbor job dir %s was produced under provider %r, not the current %r; "
+        "wiping it (and its token sinks) so the batch re-runs from the current "
+        "weights instead of resuming another policy's trials",
+        candidate_dir,
+        recorded.get("model"),
+        provider_config.model,
+    )
+    shutil.rmtree(candidate_dir)
+    shutil.rmtree(token_sink_dir, ignore_errors=True)
+    token_sink_dir.mkdir(parents=True, exist_ok=True)
+    return True
+
+
+class RolloutStats(BaseModel):
+    """Aggregate health metrics for one collected rollout batch."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    trials: int = Field(ge=0)
+    trials_with_spans: int = Field(ge=0)
+    solve_rate: float = Field(ge=0.0, le=1.0)
+    """Fraction of trials whose verifier reward passed (metrics/gating signal)."""
+
+    empty_span_trials: int = Field(ge=0)
+    """Trials that recorded no token span (died before the first completion)."""
+
+
+def collect_rollouts(
+    step_index: int,
+    task_ids: Sequence[str],
+    cfg: DistillConfig,
+    harness: HarnessDoc,
+    provider_config: ProviderConfig,
+    run_dir: Path,
+    *,
+    should_cancel: Callable[[], bool] | None = None,
+) -> tuple[list[TrialRecord], RolloutStats]:
+    """Run one train batch of harbor trials and join rewards with token spans.
+
+    Each task in `task_ids` runs `cfg.train.group_size` attempts (the
+    on-policy group), every trial sampling the student through the distill
+    agent bridge, which enforces the tinker provider kind and records the
+    trial's spans to `run_dir/tokens/step-NNNN/{trial_name}.jsonl`.
+
+    This is a synchronous entry point, mirroring how the CLI drives the
+    scorer: the async `HarborScorer.create` runs on its own loop and the
+    (task x attempts) batch runs inside the blocking `score` call.
+
+    Args:
+        step_index: 0-based training step; keys the fresh jobs dir and the
+            token sink dir.
+        task_ids: Exact task ids for this batch (a subset of the train split).
+        cfg: The validated run config (harbor template/backend/reward key,
+            group size, trial concurrency).
+        harness: The pinned harness document the pi agent runs.
+        provider_config: The student provider config; `model` must point at
+            the CURRENT sampler weights (`tinker://` path).
+        run_dir: The distillation run directory.
+        should_cancel: Optional cooperative cancellation poll, forwarded to
+            the harbor runner.
+
+    Returns:
+        The `TrialRecord`s (one per task x attempt, in report order) and the
+        batch stats. A trial with no sink file is recorded with empty spans
+        and counted in `empty_span_trials`, never dropped: its reward is real
+        batch signal and dropping it would silently bias the solve rate.
+
+    Raises:
+        ValueError: If `step_index` is negative or the harbor job template
+            cannot be loaded/validated.
+        ImportError: If the harbor extra is not installed.
+    """
+    if step_index < 0:
+        raise ValueError(f"step_index must be >= 0, got {step_index}")
+    try:
+        import yaml
+        from harbor.models.job.config import JobConfig
+
+        from wmh.distill.agents import WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH
+        from wmh.evals.harbor.scorer import HarborScorer
+    except ImportError as error:
+        raise ImportError(MISSING_HARBOR_EXTRA) from error
+
+    step_name = f"step-{step_index:04d}"
+    jobs_dir = run_dir / "harbor" / step_name
+    token_sink_dir = run_dir / "tokens" / step_name
+
+    template_path = Path(cfg.harbor.job_template)
+    try:
+        raw = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(
+            f"cannot load the harbor job template from {template_path}: {error}; point "
+            "harbor.job_template at a harbor JobConfig YAML/JSON file"
+        ) from error
+    if not isinstance(raw, dict):
+        raise ValueError(f"the harbor job template in {template_path} must be a mapping")
+    try:
+        template = JobConfig.model_validate({**raw, "jobs_dir": str(jobs_dir)})
+    except ValueError as error:
+        raise ValueError(
+            f"invalid harbor job template {template_path}: {error}; fix the template "
+            "so it validates as a harbor JobConfig"
+        ) from error
+
+    backend = cfg.harbor.backend
+    token_sink_dir.mkdir(parents=True, exist_ok=True)
+    scorer = asyncio.run(
+        HarborScorer.create(
+            template,
+            list(task_ids),
+            provider_config=provider_config,
+            reward_key=cfg.harbor.reward_key,
+            attempts=cfg.train.group_size,
+            task_environment="e2b" if backend == "e2b" else "docker",
+            harness_backend=backend,
+            # The local pi runner shares one runner dir, so local concurrency is
+            # pinned to 1; e2b parallelizes up to the configured trial concurrency.
+            agent_concurrency=1 if backend == "local" else cfg.train.trial_concurrency,
+            agent_import_path=WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH,
+            extra_agent_kwargs={"token_sink_dir": str(token_sink_dir)},
+        )
+    )
+    _wipe_stale_policy_dir(scorer.candidate_job_dir(harness), provider_config, token_sink_dir)
+    logger.info(
+        "collecting rollouts for %s: %d task(s) x %d attempt(s), backend %s -> %s",
+        step_name,
+        len(list(task_ids)),
+        cfg.train.group_size,
+        backend,
+        jobs_dir,
+    )
+    report = scorer.score(harness, should_cancel=should_cancel)
+    records = assemble_trial_records(report.cells, token_sink_dir)
+    with_spans = sum(1 for record in records if record.spans)
+    stats = RolloutStats(
+        trials=len(records),
+        trials_with_spans=with_spans,
+        solve_rate=(
+            sum(1 for record in records if record.passed) / len(records) if records else 0.0
+        ),
+        empty_span_trials=len(records) - with_spans,
+    )
+    if stats.empty_span_trials:
+        logger.warning(
+            "%d/%d trial(s) in %s produced no token spans (the agent died before its "
+            "first student completion); they carry reward signal but no training data",
+            stats.empty_span_trials,
+            stats.trials,
+            step_name,
+        )
+    return records, stats

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -227,8 +227,12 @@ def collect_rollouts(
             # The local pi runner shares one runner dir, so local concurrency is
             # pinned to 1; e2b parallelizes up to the configured trial concurrency.
             agent_concurrency=1 if backend == "local" else cfg.train.trial_concurrency,
+            harbor_retries=cfg.harbor.retries,
             agent_import_path=WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH,
             extra_agent_kwargs={"token_sink_dir": str(token_sink_dir)},
+            # A trial that dies before producing verifier evidence is a failed
+            # trial for distillation purposes, never a reason to abort the run.
+            missing_reward="zero",
         )
     )
     _wipe_stale_policy_dir(scorer.candidate_job_dir(harness), provider_config, token_sink_dir)

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -135,6 +135,31 @@ class RolloutStats(BaseModel):
     # agent-process boundary, so it is not trivially wireable today.
 
 
+def rollout_stats(records: Sequence[TrialRecord]) -> RolloutStats:
+    """The batch health stats over a set of assembled trial records.
+
+    A pure function of the records, so a batch loaded back from persisted
+    trial records (the warmup-trials manifest) reports the same stats its
+    original collection did.
+
+    Args:
+        records: The batch's trial records.
+
+    Returns:
+        The aggregate stats; an empty batch reports zero trials and a 0.0
+        solve rate.
+    """
+    with_spans = sum(1 for record in records if record.spans)
+    return RolloutStats(
+        trials=len(records),
+        trials_with_spans=with_spans,
+        solve_rate=(
+            sum(1 for record in records if record.passed) / len(records) if records else 0.0
+        ),
+        empty_span_trials=len(records) - with_spans,
+    )
+
+
 def collect_rollouts(
     step_index: int,
     task_ids: Sequence[str],
@@ -246,15 +271,7 @@ def collect_rollouts(
     )
     report = scorer.score(harness, should_cancel=should_cancel)
     records = assemble_trial_records(report.cells, token_sink_dir)
-    with_spans = sum(1 for record in records if record.spans)
-    stats = RolloutStats(
-        trials=len(records),
-        trials_with_spans=with_spans,
-        solve_rate=(
-            sum(1 for record in records if record.passed) / len(records) if records else 0.0
-        ),
-        empty_span_trials=len(records) - with_spans,
-    )
+    stats = rollout_stats(records)
     if stats.empty_span_trials:
         logger.warning(
             "%d/%d trial(s) in %s produced no token spans (the agent died before its "

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -130,6 +130,10 @@ class RolloutStats(BaseModel):
     empty_span_trials: int = Field(ge=0)
     """Trials that recorded no token span (died before the first completion)."""
 
+    # TODO: surface TokenRecorder.fallback_count (incremental-prompt re-renders) here;
+    # it needs the per-trial span sink format to carry the counter across the
+    # agent-process boundary, so it is not trivially wireable today.
+
 
 def collect_rollouts(
     step_index: int,

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -80,7 +80,7 @@ def _wipe_stale_policy_dir(
 
     Sampler paths carry a per-session nonce, so a job dir left by a previous
     session (a crash mid-batch, then `--resume`) can never satisfy the
-    scorer's strict job-config resume check — and its completed trials sampled
+    scorer's strict job-config resume check, and its completed trials sampled
     a policy this session did not restore, so resuming them would mix
     policies. Deleting the dir (and the batch's token sinks with it) makes the
     batch re-run whole from the current weights: correct, at the price of

--- a/wmh/distill/rollouts_test.py
+++ b/wmh/distill/rollouts_test.py
@@ -1,0 +1,428 @@
+"""Tests for the rollout collector against a stubbed harbor scorer."""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+from harbor.models.job.config import JobConfig
+
+import wmh.distill.rollouts as rollouts_module
+from wmh.distill.agents import WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH
+from wmh.distill.config import (
+    DistillConfig,
+    HarborConfig,
+    StudentConfig,
+    TeacherConfig,
+    TrainConfig,
+)
+from wmh.distill.rollouts import collect_rollouts
+from wmh.evals.harbor.scorer import HarborScorer
+from wmh.harness.doc import HarnessDoc
+from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
+from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.tinker import TokenRecorder, TokenSpan
+
+_TASK_IDS = ("task-a", "task-b")
+_GROUP_SIZE = 2
+
+
+def _provider_config() -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.TINKER,
+        model_type="Qwen/Qwen3-8B",
+        model="tinker://run/weights/4",
+    )
+
+
+def _write_template(tmp_path: Path) -> Path:
+    template_path = tmp_path / "job-template.yaml"
+    template_path.write_text(
+        "job_name: template\n"
+        "jobs_dir: /tmp/overridden-by-the-collector\n"
+        "n_concurrent_trials: 1\n"
+        "datasets:\n"
+        f"- path: {tmp_path / 'tasks'}\n"
+        "agents:\n"
+        "- {}\n",
+        encoding="utf-8",
+    )
+    return template_path
+
+
+def _cfg(
+    tmp_path: Path,
+    *,
+    backend: str = "local",
+    trial_concurrency: int = 3,
+) -> DistillConfig:
+    return DistillConfig(
+        student=StudentConfig(base_model="Qwen/Qwen3-4B"),
+        teacher=TeacherConfig(model="Qwen/Qwen3-8B"),
+        harbor=HarborConfig(
+            job_template=str(_write_template(tmp_path)),
+            backend="e2b" if backend == "e2b" else "local",
+            reward_key="reward",
+        ),
+        train=TrainConfig(group_size=_GROUP_SIZE, trial_concurrency=trial_concurrency),
+    )
+
+
+def _span(call_index: int) -> TokenSpan:
+    return TokenSpan(
+        call_index=call_index,
+        prompt_token_ids=[1, 2, call_index],
+        sampled_token_ids=[70, 71],
+        sampled_logprobs=[-0.5, -1.0],
+    )
+
+
+def _report(harness: HarnessDoc, trials_dir: Path) -> ScoreReport:
+    """The canned (task x attempt) matrix: task-a passes both, task-b fails both."""
+    cells = []
+    for task_id in _TASK_IDS:
+        for attempt in (1, 2):
+            reward = 1.0 if task_id == "task-a" else 0.0
+            cells.append(
+                ScoreCell(
+                    task_id=task_id,
+                    attempt=attempt,
+                    reward=reward,
+                    passed=reward == 1.0,
+                    artifact_dir=str(trials_dir / f"{task_id}__s{attempt}"),
+                )
+            )
+    return ScoreReport(
+        doc_hash=harness.doc_hash,
+        request=ScoreRequest(task_ids=_TASK_IDS, attempts=_GROUP_SIZE),
+        reward_mode="raw",
+        cells=tuple(cells),
+    )
+
+
+class _StubScorer:
+    """Stands in for a created HarborScorer; returns the canned report."""
+
+    def __init__(self, report: ScoreReport) -> None:
+        self.report = report
+        self.score_calls: list[tuple[str, Callable[[], bool] | None]] = []
+        self.jobs_dir: Path | None = None
+
+    def candidate_job_dir(self, doc: HarnessDoc) -> Path:
+        """Mirror HarborScorer's deterministic per-candidate job dir."""
+        assert self.jobs_dir is not None
+        return self.jobs_dir / f"wmh-{doc.doc_hash[:12]}"
+
+    def score(
+        self,
+        doc: HarnessDoc,
+        *,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ScoreReport:
+        self.score_calls.append((doc.doc_hash, should_cancel))
+        return self.report
+
+
+class _CreateCapture:
+    """Monkeypatch target for HarborScorer.create; records every construction."""
+
+    def __init__(self, stub: _StubScorer) -> None:
+        self.stub = stub
+        self.templates: list[JobConfig] = []
+        self.task_ids: list[list[str]] = []
+        self.kwargs: list[dict[str, object]] = []
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        capture = self
+
+        async def fake_create(
+            _cls: type[HarborScorer],
+            job_template: JobConfig,
+            task_ids: Sequence[str],
+            **kwargs: object,
+        ) -> _StubScorer:
+            capture.templates.append(job_template)
+            capture.task_ids.append(list(task_ids))
+            capture.kwargs.append(dict(kwargs))
+            capture.stub.jobs_dir = job_template.jobs_dir
+            return capture.stub
+
+        monkeypatch.setattr(HarborScorer, "create", classmethod(fake_create))
+
+
+def test_collect_rollouts_wires_the_distill_agent_and_joins_spans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    trials_dir = tmp_path / "trials"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, trials_dir))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path)
+
+    # Prewrite sinks for 3 of the 4 trials plus one run trace, as the trials would.
+    sink_dir = run_dir / "tokens" / "step-0004"
+    sink_dir.mkdir(parents=True)
+    for trial_name in ("task-a__s1", "task-a__s2", "task-b__s1"):
+        recorder = TokenRecorder(jsonl_path=sink_dir / f"{trial_name}.jsonl")
+        recorder.record(_span(0))
+        recorder.record(_span(1))
+    agent_dir = trials_dir / "task-a__s1" / "agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "wmh-run.json").write_text(
+        json.dumps({"stop_reason": "submitted"}), encoding="utf-8"
+    )
+
+    def cancel_poll() -> bool:
+        return False
+
+    records, stats = collect_rollouts(
+        4,
+        _TASK_IDS,
+        cfg,
+        harness,
+        _provider_config(),
+        run_dir,
+        should_cancel=cancel_poll,
+    )
+
+    # The scorer was created on a FRESH per-step jobs dir with the distill agent.
+    [template] = capture.templates
+    assert template.jobs_dir == run_dir / "harbor" / "step-0004"
+    assert capture.task_ids == [list(_TASK_IDS)]
+    [kwargs] = capture.kwargs
+    assert kwargs["agent_import_path"] == WMH_DISTILL_HARBOR_AGENT_IMPORT_PATH
+    assert kwargs["extra_agent_kwargs"] == {"token_sink_dir": str(sink_dir)}
+    assert kwargs["attempts"] == _GROUP_SIZE
+    assert kwargs["reward_key"] == "reward"
+    assert kwargs["harness_backend"] == "local"
+    assert kwargs["task_environment"] == "docker"
+    assert kwargs["agent_concurrency"] == 1  # local pi shares one runner dir
+    assert kwargs["provider_config"] == _provider_config()
+
+    # Cancellation flows through to the blocking score call.
+    assert stub.score_calls == [(harness.doc_hash, cancel_poll)]
+
+    # Spans correlate by trial name; the span-less trial is kept, not dropped.
+    assert [record.trial_name for record in records] == [
+        "task-a__s1",
+        "task-a__s2",
+        "task-b__s1",
+        "task-b__s2",
+    ]
+    assert all(len(record.spans) == 2 for record in records[:3])
+    assert records[0].stop_reason == "submitted"
+    assert records[3].spans == []
+    assert records[3].stop_reason is None
+    assert stats.trials == 4
+    assert stats.trials_with_spans == 3
+    assert stats.empty_span_trials == 1
+    assert stats.solve_rate == 0.5
+
+
+def test_each_step_gets_a_fresh_jobs_dir_and_sink_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Job dirs are keyed by doc hash only; reusing one jobs dir across steps would
+    resume step N's trials as step N+1's results with stale-weights tokens."""
+    run_dir = tmp_path / "run"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, tmp_path / "trials"))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path)
+
+    collect_rollouts(4, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+    collect_rollouts(5, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+
+    assert [template.jobs_dir for template in capture.templates] == [
+        run_dir / "harbor" / "step-0004",
+        run_dir / "harbor" / "step-0005",
+    ]
+    assert [kwargs["extra_agent_kwargs"] for kwargs in capture.kwargs] == [
+        {"token_sink_dir": str(run_dir / "tokens" / "step-0004")},
+        {"token_sink_dir": str(run_dir / "tokens" / "step-0005")},
+    ]
+    # The sink dirs were created ahead of the trials that write into them.
+    assert (run_dir / "tokens" / "step-0004").is_dir()
+    assert (run_dir / "tokens" / "step-0005").is_dir()
+
+
+def _write_recorded_job_config(candidate_dir: Path, provider_config: ProviderConfig) -> None:
+    """Persist the slice of a harbor config.json the stale-policy check reads."""
+    candidate_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"agents": [{"kwargs": {"provider_config": provider_config.model_dump(mode="json")}}]}
+    (candidate_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_stale_policy_job_dir_is_wiped_before_scoring(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A job dir left by a previous session under DIFFERENT sampler weights can
+    never pass the scorer's strict resume check, and its trials sampled another
+    policy: the collector wipes it (and the step's token sinks) so the step
+    re-runs whole from the current weights instead of dying on resume."""
+    run_dir = tmp_path / "run"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, tmp_path / "trials"))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path)
+
+    candidate = run_dir / "harbor" / "step-0004" / f"wmh-{harness.doc_hash[:12]}"
+    old_provider = _provider_config().model_copy(update={"model": "tinker://run/weights/OLD"})
+    _write_recorded_job_config(candidate, old_provider)
+    (candidate / "task-a__s1").mkdir(parents=True)  # a stale completed trial
+    stale_sink = run_dir / "tokens" / "step-0004" / "task-a__s1.jsonl"
+    stale_sink.parent.mkdir(parents=True)
+    stale_sink.write_text("{}\n", encoding="utf-8")
+
+    collect_rollouts(4, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+
+    assert not candidate.exists()  # the stale-policy job dir was wiped whole
+    assert not stale_sink.exists()  # and its token sinks with it
+    assert (run_dir / "tokens" / "step-0004").is_dir()  # recreated for the re-run
+    assert len(stub.score_calls) == 1
+
+
+def test_matching_policy_job_dir_is_kept_for_harbor_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same provider identity (e.g. the teacher's stable ref, which carries no
+    session nonce): the dir is left alone so harbor's native trial-level
+    resume re-runs only what is missing."""
+    run_dir = tmp_path / "run"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, tmp_path / "trials"))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path)
+
+    candidate = run_dir / "harbor" / "step-0004" / f"wmh-{harness.doc_hash[:12]}"
+    _write_recorded_job_config(candidate, _provider_config())
+    completed_trial = candidate / "task-a__s1"
+    completed_trial.mkdir(parents=True)
+    kept_sink = run_dir / "tokens" / "step-0004" / "task-a__s1.jsonl"
+    kept_sink.parent.mkdir(parents=True)
+    TokenRecorder(jsonl_path=kept_sink).record(_span(0))
+
+    collect_rollouts(4, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+
+    assert completed_trial.is_dir()
+    assert kept_sink.exists()
+
+
+def test_unreadable_job_config_is_left_for_the_scorer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable config.json is not evidence of another policy; the dir is
+    left untouched so the scorer raises its own actionable error rather than
+    the collector destroying evidence silently."""
+    run_dir = tmp_path / "run"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, tmp_path / "trials"))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path)
+
+    candidate = run_dir / "harbor" / "step-0004" / f"wmh-{harness.doc_hash[:12]}"
+    candidate.mkdir(parents=True)
+    (candidate / "config.json").write_text("{not json", encoding="utf-8")
+
+    collect_rollouts(4, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+
+    assert (candidate / "config.json").exists()
+
+
+def test_e2b_backend_routes_environment_and_concurrency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "run"
+    harness = HarnessDoc.baseline()
+    stub = _StubScorer(_report(harness, tmp_path / "trials"))
+    capture = _CreateCapture(stub)
+    capture.install(monkeypatch)
+    cfg = _cfg(tmp_path, backend="e2b", trial_concurrency=6)
+
+    collect_rollouts(0, _TASK_IDS, cfg, harness, _provider_config(), run_dir)
+
+    [kwargs] = capture.kwargs
+    assert kwargs["harness_backend"] == "e2b"
+    assert kwargs["task_environment"] == "e2b"
+    assert kwargs["agent_concurrency"] == 6
+
+
+def test_negative_step_index_is_rejected(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    with pytest.raises(ValueError, match="step_index must be >= 0"):
+        collect_rollouts(
+            -1, _TASK_IDS, cfg, HarnessDoc.baseline(), _provider_config(), tmp_path / "run"
+        )
+
+
+def test_template_load_failures_are_actionable(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    harness = HarnessDoc.baseline()
+
+    missing = cfg.model_copy(deep=True)
+    missing.harbor.job_template = str(tmp_path / "nowhere.yaml")
+    with pytest.raises(ValueError, match="cannot load the harbor job template"):
+        collect_rollouts(0, _TASK_IDS, missing, harness, _provider_config(), tmp_path / "run")
+
+    not_mapping = tmp_path / "list.yaml"
+    not_mapping.write_text("- 1\n- 2\n", encoding="utf-8")
+    listy = cfg.model_copy(deep=True)
+    listy.harbor.job_template = str(not_mapping)
+    with pytest.raises(ValueError, match="must be a mapping"):
+        collect_rollouts(0, _TASK_IDS, listy, harness, _provider_config(), tmp_path / "run")
+
+    invalid = tmp_path / "invalid.yaml"
+    invalid.write_text("agents: nope\n", encoding="utf-8")
+    broken = cfg.model_copy(deep=True)
+    broken.harbor.job_template = str(invalid)
+    with pytest.raises(ValueError, match="invalid harbor job template"):
+        collect_rollouts(0, _TASK_IDS, broken, harness, _provider_config(), tmp_path / "run")
+
+
+def test_missing_harbor_extra_names_the_extra(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "harbor.models.job.config", None)
+    cfg = _cfg(tmp_path)
+    with pytest.raises(ImportError, match="uv sync --extra harbor"):
+        collect_rollouts(
+            0, _TASK_IDS, cfg, HarnessDoc.baseline(), _provider_config(), tmp_path / "run"
+        )
+
+
+def test_module_scope_never_imports_the_harbor_extra() -> None:
+    """The collector module must stay importable without the harbor extra."""
+    assert rollouts_module.__file__ is not None
+    tree = ast.parse(Path(rollouts_module.__file__).read_text(encoding="utf-8"))
+    roots: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            roots.add(node.module.split(".")[0])
+    assert not roots & {"harbor", "yaml"}
+    # wmh.distill.agents and wmh.evals.harbor import harbor at module scope; the
+    # collector may only pull them inside the guarded lazy block.
+    banned_wmh = {"wmh.distill.agents", "wmh.evals"}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            assert not any(
+                node.module == name or node.module.startswith(name + ".") for name in banned_wmh
+            )

--- a/wmh/distill/rollouts_test.py
+++ b/wmh/distill/rollouts_test.py
@@ -20,7 +20,8 @@ from wmh.distill.config import (
     TeacherConfig,
     TrainConfig,
 )
-from wmh.distill.rollouts import collect_rollouts
+from wmh.distill.rollouts import collect_rollouts, rollout_stats
+from wmh.distill.tokens import TrialRecord
 from wmh.evals.harbor.scorer import HarborScorer
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.scoring import ScoreCell, ScoreReport, ScoreRequest
@@ -405,6 +406,39 @@ def test_missing_harbor_extra_names_the_extra(
         collect_rollouts(
             0, _TASK_IDS, cfg, HarnessDoc.baseline(), _provider_config(), tmp_path / "run"
         )
+
+
+def _trial(task_id: str, *, passed: bool, spans: bool) -> TrialRecord:
+    return TrialRecord(
+        task_id=task_id,
+        attempt=1,
+        trial_name=f"{task_id}__s1",
+        reward=1.0 if passed else 0.0,
+        passed=passed,
+        spans=[_span(0)] if spans else [],
+        artifact_dir=f"/trials/{task_id}",
+    )
+
+
+def test_rollout_stats_is_a_pure_function_of_the_records() -> None:
+    """Stats recomputed from persisted records match a live batch's shape."""
+    stats = rollout_stats(
+        [
+            _trial("task-a", passed=True, spans=True),
+            _trial("task-b", passed=False, spans=True),
+            _trial("task-c", passed=False, spans=False),
+            _trial("task-d", passed=True, spans=True),
+        ]
+    )
+    assert stats.trials == 4
+    assert stats.trials_with_spans == 3
+    assert stats.solve_rate == 0.5
+    assert stats.empty_span_trials == 1
+
+    empty = rollout_stats([])
+    assert empty.trials == 0
+    assert empty.solve_rate == 0.0
+    assert empty.empty_span_trials == 0
 
 
 def test_module_scope_never_imports_the_harbor_extra() -> None:

--- a/wmh/distill/tokens.py
+++ b/wmh/distill/tokens.py
@@ -1,0 +1,190 @@
+"""Token-span records tying harbor trials to the student tokens they sampled.
+
+During distillation rollouts each harbor trial runs the pi agent against the
+Tinker student, and the distill agent's `TokenRecorder` appends every sampled
+`TokenSpan` to a per-trial JSONL sink named after the harbor trial
+(`{sink_dir}/{trial_name}.jsonl`, one span JSON per line). This module reads
+those sinks back and joins them with the scorer's reward cells into
+`TrialRecord`s, the unit the datum builder consumes. The trial's WMH run
+trace (`wmh-run.json`, written by the agent bridge into harbor's per-trial
+agent logs dir) supplies the stop reason when it exists.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from wmh.harness.scoring import ScoreCell
+from wmh.providers.tinker import TokenSpan
+
+logger = logging.getLogger(__name__)
+
+WMH_RUN_TRACE_FILENAME = "wmh-run.json"
+
+StopReasonReader = Callable[[Path], str | None]
+"""Reads one trial's stop reason from its artifact dir; None when unknown."""
+
+
+class TrialRecord(BaseModel):
+    """One harbor trial joined with the exact token spans it sampled.
+
+    `spans` is the tokens-in-tokens-out training evidence (empty when the
+    trial died before its first successful student completion); `reward` and
+    `passed` come from the harbor verifier via the scorer's cells and are
+    metrics/gating signal, never part of the distillation loss.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str = Field(min_length=1)
+    attempt: int = Field(ge=1)
+    trial_name: str = Field(min_length=1)
+    reward: float = Field(ge=0.0, le=1.0, allow_inf_nan=False)
+    passed: bool
+    spans: list[TokenSpan] = Field(default_factory=list)
+    stop_reason: str | None = None
+    """The WMH run trace's stop reason; None when no trace was readable."""
+
+    artifact_dir: str
+    """The harbor trial directory holding this trial's raw evidence."""
+
+
+def load_trial_spans(sink_dir: Path, trial_name: str) -> list[TokenSpan]:
+    """Read the token spans one trial's recorder sink captured.
+
+    The sink is the JSONL file the distill agent's `TokenRecorder` writes:
+    `{trial_name}.jsonl` under `sink_dir`, one `TokenSpan` JSON per line,
+    flushed after every successful completion.
+
+    Args:
+        sink_dir: The per-trial token sink directory for one rollout batch.
+        trial_name: The harbor trial name the sink file is keyed by.
+
+    Returns:
+        The recorded spans in call order. A missing sink file yields an empty
+        list: the trial made no successful student completion (it died before
+        the first sample), which callers count in their stats rather than
+        raise on.
+
+    Raises:
+        ValueError: If a line is not a valid `TokenSpan`, or the call_index
+            sequence is not exactly 0..n-1 (the sink was appended by more than
+            one recorder); delete the step's token sink directory and re-run
+            the step to rebuild it.
+    """
+    sink_path = sink_dir / f"{trial_name}.jsonl"
+    try:
+        text = sink_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    spans: list[TokenSpan] = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            spans.append(TokenSpan.model_validate_json(line))
+        except ValidationError as exc:
+            raise ValueError(
+                f"invalid token span on line {line_number} of {sink_path}: {exc}; "
+                "the sink is corrupt, so delete this step's token sink directory "
+                "and re-run the step"
+            ) from exc
+    observed = [span.call_index for span in spans]
+    if observed != list(range(len(spans))):
+        raise ValueError(
+            f"token sink {sink_path} has call_index sequence {observed}, expected "
+            f"0..{len(spans) - 1}; more than one recorder appended to it (e.g. a "
+            "re-run trial reused the sink), so delete this step's token sink "
+            "directory and re-run the step"
+        )
+    return spans
+
+
+def read_trial_stop_reason(artifact_dir: Path) -> str | None:
+    """The WMH run trace's stop reason for one trial, when a trace exists.
+
+    The agent bridge writes `wmh-run.json` into harbor's per-trial agent logs
+    dir (`{trial_dir}/agent/` for single-step tasks); both full `RunResult`
+    dumps and partial cancellation traces carry a string `stop_reason`. The
+    trial-dir root is also checked for robustness against layout drift.
+
+    Args:
+        artifact_dir: The harbor trial directory (one cell's `artifact_dir`).
+
+    Returns:
+        The stop reason string, or None when no trace is present or readable.
+        Assembly must not fail on the trials that died hardest; a missing
+        stop reason is itself the signal.
+    """
+    candidates = (
+        artifact_dir / "agent" / WMH_RUN_TRACE_FILENAME,
+        artifact_dir / WMH_RUN_TRACE_FILENAME,
+    )
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.warning("unreadable WMH run trace at %s; recording no stop reason", candidate)
+            return None
+        stop_reason = payload.get("stop_reason") if isinstance(payload, dict) else None
+        return stop_reason if isinstance(stop_reason, str) else None
+    return None
+
+
+def assemble_trial_records(
+    cells: Sequence[ScoreCell],
+    sink_dir: Path,
+    *,
+    read_stop_reason: StopReasonReader | None = None,
+) -> list[TrialRecord]:
+    """Join scorer cells with their token sinks and run traces.
+
+    Args:
+        cells: The scored trial cells (one per task x attempt); each cell's
+            `artifact_dir` must be the harbor trial directory, whose basename
+            is the trial name the token sinks are keyed by.
+        sink_dir: The per-trial token sink directory for this rollout batch.
+        read_stop_reason: Reads one trial's stop reason from its artifact dir;
+            defaults to `read_trial_stop_reason`.
+
+    Returns:
+        One `TrialRecord` per cell, in the cells' order. A trial without a
+        sink file gets empty spans, never dropped: its reward is still real
+        batch signal and callers count span-less trials explicitly.
+
+    Raises:
+        ValueError: If a cell carries no artifact dir (the trial name cannot
+            be derived), or a sink file is corrupt (see `load_trial_spans`).
+    """
+    reader = read_stop_reason if read_stop_reason is not None else read_trial_stop_reason
+    records: list[TrialRecord] = []
+    for cell in cells:
+        artifact_dir = Path(cell.artifact_dir)
+        trial_name = artifact_dir.name
+        if not cell.artifact_dir or not trial_name:
+            raise ValueError(
+                f"score cell for task {cell.task_id!r} attempt {cell.attempt} carries no "
+                "artifact dir, so its trial name (the token-sink key) cannot be derived; "
+                "collect rollouts through a scorer that records per-trial directories "
+                "(HarborScorer does)"
+            )
+        records.append(
+            TrialRecord(
+                task_id=cell.task_id,
+                attempt=cell.attempt,
+                trial_name=trial_name,
+                reward=cell.reward,
+                passed=cell.passed,
+                spans=load_trial_spans(sink_dir, trial_name),
+                stop_reason=reader(artifact_dir),
+                artifact_dir=cell.artifact_dir,
+            )
+        )
+    return records

--- a/wmh/distill/tokens_test.py
+++ b/wmh/distill/tokens_test.py
@@ -1,0 +1,217 @@
+"""Tests for joining harbor trial rewards with recorded token spans."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wmh.distill.tokens import (
+    TrialRecord,
+    assemble_trial_records,
+    load_trial_spans,
+    read_trial_stop_reason,
+)
+from wmh.harness.scoring import ScoreCell
+from wmh.providers.tinker import TokenRecorder, TokenSpan
+
+
+def _span(call_index: int) -> TokenSpan:
+    return TokenSpan(
+        call_index=call_index,
+        prompt_token_ids=[1, 2, call_index],
+        sampled_token_ids=[65, 66],
+        sampled_logprobs=[-0.5, -1.5],
+    )
+
+
+def _cell(task_id: str, attempt: int, *, reward: float, artifact_dir: Path) -> ScoreCell:
+    return ScoreCell(
+        task_id=task_id,
+        attempt=attempt,
+        reward=reward,
+        passed=reward == 1.0,
+        artifact_dir=str(artifact_dir),
+    )
+
+
+def _write_trace(trial_dir: Path, payload: str) -> None:
+    agent_dir = trial_dir / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "wmh-run.json").write_text(payload, encoding="utf-8")
+
+
+def test_load_trial_spans_round_trips_the_recorder_sink_format(tmp_path: Path) -> None:
+    """The reader is coupled to TokenRecorder's as-built sink: write through it."""
+    recorder = TokenRecorder(jsonl_path=tmp_path / "task-a__x1.jsonl")
+    recorder.record(_span(0))
+    recorder.record(_span(1))
+
+    spans = load_trial_spans(tmp_path, "task-a__x1")
+
+    assert spans == recorder.spans()
+    assert [span.call_index for span in spans] == [0, 1]
+
+
+def test_load_trial_spans_missing_sink_is_empty_not_an_error(tmp_path: Path) -> None:
+    assert load_trial_spans(tmp_path, "task-a__never-ran") == []
+
+
+def test_load_trial_spans_tolerates_blank_lines(tmp_path: Path) -> None:
+    sink = tmp_path / "t.jsonl"
+    sink.write_text(_span(0).model_dump_json() + "\n\n", encoding="utf-8")
+    assert len(load_trial_spans(tmp_path, "t")) == 1
+
+
+def test_load_trial_spans_corrupt_line_is_actionable(tmp_path: Path) -> None:
+    sink = tmp_path / "t.jsonl"
+    sink.write_text(_span(0).model_dump_json() + '\n{"call_index": "nope"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match=r"line 2 of .*t\.jsonl"):
+        load_trial_spans(tmp_path, "t")
+    with pytest.raises(ValueError, match="delete this step's token sink directory"):
+        load_trial_spans(tmp_path, "t")
+
+
+def test_load_trial_spans_rejects_a_sink_appended_by_two_recorders(tmp_path: Path) -> None:
+    """A call_index reset means two episodes shared one sink; spans can no longer be
+    attributed to the reported trial, so the reader refuses instead of guessing."""
+    sink = tmp_path / "t.jsonl"
+    lines = [_span(0).model_dump_json(), _span(1).model_dump_json(), _span(0).model_dump_json()]
+    sink.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match=r"call_index sequence \[0, 1, 0\]"):
+        load_trial_spans(tmp_path, "t")
+
+
+def test_load_trial_spans_rejects_a_gap_in_the_sequence(tmp_path: Path) -> None:
+    sink = tmp_path / "t.jsonl"
+    lines = [_span(0).model_dump_json(), _span(2).model_dump_json()]
+    sink.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="expected 0..1"):
+        load_trial_spans(tmp_path, "t")
+
+
+def test_read_trial_stop_reason_full_and_partial_traces(tmp_path: Path) -> None:
+    full = tmp_path / "task-a__x1"
+    _write_trace(
+        full,
+        json.dumps({"task_id": "t", "steps": [], "stop_reason": "submitted", "turns": 1}),
+    )
+    partial = tmp_path / "task-a__x2"
+    _write_trace(
+        partial,
+        json.dumps({"stop_reason": "cancelled-by-harbor-timeout", "partial": True}),
+    )
+    assert read_trial_stop_reason(full) == "submitted"
+    assert read_trial_stop_reason(partial) == "cancelled-by-harbor-timeout"
+
+
+def test_read_trial_stop_reason_falls_back_to_the_trial_root(tmp_path: Path) -> None:
+    trial = tmp_path / "task-a__x3"
+    trial.mkdir()
+    (trial / "wmh-run.json").write_text(json.dumps({"stop_reason": "max_turns"}), encoding="utf-8")
+    assert read_trial_stop_reason(trial) == "max_turns"
+
+
+def test_read_trial_stop_reason_missing_or_unreadable_is_none(tmp_path: Path) -> None:
+    missing = tmp_path / "task-a__gone"
+    assert read_trial_stop_reason(missing) is None
+
+    unreadable = tmp_path / "task-a__bad"
+    _write_trace(unreadable, "{not json")
+    assert read_trial_stop_reason(unreadable) is None
+
+    non_string = tmp_path / "task-a__odd"
+    _write_trace(non_string, json.dumps({"stop_reason": 7}))
+    assert read_trial_stop_reason(non_string) is None
+
+
+def test_assemble_joins_spans_and_stop_reasons_by_trial_name(tmp_path: Path) -> None:
+    sink_dir = tmp_path / "tokens"
+    sink_dir.mkdir()
+    trials_dir = tmp_path / "job"
+
+    solved = trials_dir / "task-a__s1"
+    _write_trace(solved, json.dumps({"stop_reason": "submitted"}))
+    recorder = TokenRecorder(jsonl_path=sink_dir / "task-a__s1.jsonl")
+    recorder.record(_span(0))
+    recorder.record(_span(1))
+
+    # This trial died before its first completion: no sink file, no trace.
+    dead = trials_dir / "task-b__d1"
+    dead.mkdir(parents=True)
+
+    cells = [
+        _cell("task-a", 1, reward=1.0, artifact_dir=solved),
+        _cell("task-b", 1, reward=0.0, artifact_dir=dead),
+    ]
+
+    records = assemble_trial_records(cells, sink_dir)
+
+    assert [record.trial_name for record in records] == ["task-a__s1", "task-b__d1"]
+    assert records[0].task_id == "task-a"
+    assert records[0].attempt == 1
+    assert records[0].reward == 1.0
+    assert records[0].passed is True
+    assert records[0].spans == recorder.spans()
+    assert records[0].stop_reason == "submitted"
+    assert records[0].artifact_dir == str(solved)
+    # The span-less trial is recorded, not dropped: its reward is real signal.
+    assert records[1].spans == []
+    assert records[1].stop_reason is None
+    assert records[1].passed is False
+
+
+def test_assemble_accepts_an_injected_stop_reason_reader(tmp_path: Path) -> None:
+    seen: list[Path] = []
+
+    def reader(artifact_dir: Path) -> str | None:
+        seen.append(artifact_dir)
+        return "custom"
+
+    trial = tmp_path / "job" / "task-a__s1"
+    records = assemble_trial_records(
+        [_cell("task-a", 1, reward=0.0, artifact_dir=trial)],
+        tmp_path / "tokens",
+        read_stop_reason=reader,
+    )
+    assert records[0].stop_reason == "custom"
+    assert seen == [trial]
+
+
+def test_assemble_rejects_cells_without_an_artifact_dir(tmp_path: Path) -> None:
+    cell = ScoreCell(task_id="task-a", attempt=1, reward=0.0, passed=False, artifact_dir="")
+    with pytest.raises(ValueError, match="carries no artifact dir"):
+        assemble_trial_records([cell], tmp_path)
+
+
+def test_trial_record_validation() -> None:
+    record = TrialRecord(
+        task_id="task-a",
+        attempt=1,
+        trial_name="task-a__s1",
+        reward=1.0,
+        passed=True,
+        artifact_dir="/tmp/job/task-a__s1",
+    )
+    assert record.spans == []
+    assert record.stop_reason is None
+    with pytest.raises(ValidationError):
+        TrialRecord(
+            task_id="task-a",
+            attempt=0,
+            trial_name="task-a__s1",
+            reward=1.0,
+            passed=True,
+            artifact_dir="x",
+        )
+    with pytest.raises(ValidationError):
+        TrialRecord(
+            task_id="task-a",
+            attempt=1,
+            trial_name="task-a__s1",
+            reward=1.5,
+            passed=True,
+            artifact_dir="x",
+        )

--- a/wmh/evals/harbor/agent.py
+++ b/wmh/evals/harbor/agent.py
@@ -44,7 +44,7 @@ from wmh.harness.runtime import (
     RunResult,
     validate_episode_timeout_s,
 )
-from wmh.providers.base import ProviderConfig
+from wmh.providers.base import Provider, ProviderConfig
 from wmh.providers.registry import get_provider
 from wmh.providers.retry import wrap_provider_with_retries
 
@@ -240,13 +240,31 @@ class WmhHarborAgent(BaseAgent):
             raise ValueError(
                 f"Harbor model identity must be {expected_model_name!r}, got {model_name!r}"
             )
-        # Retry-wrap the worker provider: Bedrock disables botocore's own retries, so one
-        # unwrapped ThrottlingException would otherwise kill a whole trial.
-        self._provider = wrap_provider_with_retries(get_provider(self._provider_config))
+        self._provider = self._build_provider(self._provider_config)
         self._command_timeout_sec = _validate_command_timeout_sec(command_timeout_sec)
         self._harness_backend = harness_backend
         self._e2b_template = e2b_template
         self._episode_workers = episode_workers
+
+    def _build_provider(self, config: ProviderConfig) -> Provider:
+        """Construct the worker provider; the one seam subclasses may override.
+
+        Called exactly once, from ``__init__``, after ``BaseAgent`` has set
+        ``self.logs_dir`` and the validated provider config and model identity are in
+        place, so an override can key per-trial state (e.g. a token sink named after
+        the harbor trial) off the logs directory.
+
+        Args:
+            config: The validated worker provider config.
+
+        Returns:
+            The provider the episode runtime will drive. Overrides must keep the
+            retry contract by wrapping their provider with
+            ``wrap_provider_with_retries``.
+        """
+        # Retry-wrap the worker provider: Bedrock disables botocore's own retries, so one
+        # unwrapped ThrottlingException would otherwise kill a whole trial.
+        return wrap_provider_with_retries(get_provider(config))
 
     @staticmethod
     def name() -> str:

--- a/wmh/evals/harbor/agent_test.py
+++ b/wmh/evals/harbor/agent_test.py
@@ -22,7 +22,7 @@ from wmh.evals.harbor.agent import (
 )
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.runtime import RunResult, RuntimeCancelled, StopReason, TokenUsage
-from wmh.providers.base import ProviderConfig, ProviderKind
+from wmh.providers.base import Provider, ProviderConfig, ProviderKind
 from wmh.providers.retry import RetryingProvider
 
 
@@ -389,6 +389,53 @@ def test_agent_exception_persists_a_partial_transcript_with_the_error(
     assert trace["partial"] is True
     assert trace["stop_reason"] == "agent-exception:RuntimeError"
     assert trace["error"] == "RuntimeError: sandbox died"
+
+
+def test_build_provider_hook_runs_with_logs_dir_set_and_feeds_the_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provider-construction seam: an override sees the validated config after
+    BaseAgent has set logs_dir, and its provider is the exact one the runtime drives
+    (the distill agent keys its per-trial token sink off both)."""
+    observed: dict[str, object] = {}
+    hook_provider = _FakeProvider()
+
+    class _HookAgent(WmhHarborAgent):
+        def _build_provider(self, config: ProviderConfig) -> Provider:
+            observed["logs_dir"] = self.logs_dir
+            observed["config"] = config
+            return cast("Provider", hook_provider)
+
+    class _Runtime:
+        def run(
+            self,
+            task_id: str,
+            _instruction: str,
+            _environment: HarborAgentEnvironment,
+        ) -> RunResult:
+            return RunResult(task_id=task_id, stop_reason=StopReason.SUBMITTED, answer="done")
+
+        def close(self) -> None:
+            return None
+
+    def runtime(_self: HarnessDoc, provider: object, **_kwargs: object) -> _Runtime:
+        observed["runtime_provider"] = provider
+        return _Runtime()
+
+    monkeypatch.setattr(HarnessDoc, "runtime", runtime)
+    agent = _HookAgent(
+        logs_dir=tmp_path,
+        model_name="bedrock/worker-model",
+        harness=HarnessDoc.baseline().model_dump(mode="json"),
+        provider_config=_provider_config().model_dump(mode="json"),
+    )
+
+    assert observed["logs_dir"] == tmp_path
+    assert observed["config"] == _provider_config()
+
+    asyncio.run(agent.run("solve it", cast("BaseEnvironment", _Environment()), AgentContext()))
+    assert observed["runtime_provider"] is hook_provider
 
 
 def test_agent_rejects_invalid_construction(tmp_path: Path) -> None:

--- a/wmh/evals/harbor/e2b_environment.py
+++ b/wmh/evals/harbor/e2b_environment.py
@@ -18,6 +18,13 @@ everything else (mounts, network policy, uploads, verification) harbor's:
 - **Create pacing.** Every sandbox create routes through the same process-wide 4/sec admission
   gate as wmh's own pi-worker sandboxes, so the two consumers cannot jointly exceed E2B's
   published account rate.
+
+It also owns this backend's sandbox lifecycle hygiene. Every created sandbox is appended to the
+`wmh.harness.e2b_ledger` record the moment E2B returns it and released when its kill is proved,
+so a run that dies without graceful shutdown leaves its sandboxes reapable by exact id
+(`wmh e2b reap`) instead of holding account concurrency slots for their full multi-hour timeout.
+Creates that hit the account's concurrent-sandbox cap (a 429) wait and retry on a bounded
+schedule, so a transient spike costs latency rather than the trial.
 """
 
 from __future__ import annotations
@@ -55,12 +62,18 @@ from wmh.evals.harbor.e2b_template_policy import (
     qualify_harbor_e2b_template_name,
     resolve_e2b_template_resources,
 )
+from wmh.harness.e2b_ledger import default_ledger, harbor_trial_name
 from wmh.harness.e2b_sandbox import acquire_e2b_create_slot_async
 
 # Harbor's own _create_sandbox contract: two attempts with a short pause. Replicated here so
 # routing through the create gate does not change harbor's retry behavior.
 _CREATE_ATTEMPTS = 2
 _CREATE_RETRY_DELAY_S = 1.0
+# Waits before each retry of a create that E2B rejected as retryable, which in practice means a
+# 429 for the account's concurrent-sandbox cap. Slots free only as other trials finish, so the
+# schedule is patient but bounded (~4 minutes total): a spike waits, while a genuinely full
+# account still fails the trial in reasonable time instead of hanging the whole step.
+_CREATE_RATE_LIMIT_DELAYS_S = (5.0, 10.0, 20.0, 40.0, 60.0, 60.0, 60.0)
 
 
 @dataclass(frozen=True)
@@ -460,12 +473,23 @@ class WmhE2BEnvironment(E2BEnvironment):
 
     @override
     async def _create_sandbox(self) -> None:
+        """Create this trial's sandbox, pacing, ledgering, and waiting out 429s.
+
+        Two independent retry budgets. Harbor's contract (two attempts, one short pause)
+        governs genuine create failures. A retryable status error, which for a create means
+        E2B's 429 for the account's concurrent-sandbox cap, instead waits on
+        `_CREATE_RATE_LIMIT_DELAYS_S`: those slots free only as other trials finish, so waiting
+        is the correct response and failing the trial is not. Both budgets are bounded, so a
+        permanently full account still fails.
+        """
         metadata = {
             "environment_name": self.environment_name,
             "session_id": self.session_id,
         }
         self._sandbox = None
-        for attempt in range(_CREATE_ATTEMPTS):
+        attempts = 0
+        rate_limit_retries = 0
+        while True:
             await acquire_e2b_create_slot_async()
             try:
                 sandbox = await AsyncSandbox.create(
@@ -478,11 +502,31 @@ class WmhE2BEnvironment(E2BEnvironment):
                     ),
                     network=self._sandbox_create_network_options(),
                 )
-            except Exception:  # noqa: BLE001 - preserve Harbor's retry-all create contract
-                if attempt + 1 == _CREATE_ATTEMPTS:
+            except Exception as error:  # noqa: BLE001 - preserve Harbor's retry-all contract
+                if _is_retryable_status_error(error) and rate_limit_retries < len(
+                    _CREATE_RATE_LIMIT_DELAYS_S
+                ):
+                    delay = _CREATE_RATE_LIMIT_DELAYS_S[rate_limit_retries]
+                    rate_limit_retries += 1
+                    self.logger.warning(
+                        "E2B rejected a sandbox create as retryable (%s); waiting %.0fs "
+                        "(attempt %d of %d) for a concurrency slot",
+                        error,
+                        delay,
+                        rate_limit_retries,
+                        len(_CREATE_RATE_LIMIT_DELAYS_S),
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                attempts += 1
+                if attempts >= _CREATE_ATTEMPTS:
                     raise
                 await asyncio.sleep(_CREATE_RETRY_DELAY_S)
                 continue
+            # Ledger the sandbox BEFORE anything else can fail: from here on E2B is holding a
+            # billable concurrency slot, and a crash between create and cleanup must still
+            # leave an exact id for `wmh e2b reap`.
+            self._record_created(sandbox)
             # One cheap identity check: the sandbox must really come from the qualified alias.
             # It lives INSIDE the create retry so one transient get_info failure retries the
             # whole create instead of failing it; a genuine mismatch stays immediately fatal.
@@ -490,7 +534,8 @@ class WmhE2BEnvironment(E2BEnvironment):
                 info = await sandbox.get_info()
             except BaseException as error:
                 await self._kill_quietly(sandbox)
-                if isinstance(error, Exception) and attempt + 1 < _CREATE_ATTEMPTS:
+                attempts += 1
+                if isinstance(error, Exception) and attempts < _CREATE_ATTEMPTS:
                     await asyncio.sleep(_CREATE_RETRY_DELAY_S)
                     continue
                 raise
@@ -499,7 +544,18 @@ class WmhE2BEnvironment(E2BEnvironment):
                 raise RuntimeError("E2B sandbox template name mismatch")
             self._sandbox = sandbox
             return
-        raise RuntimeError("E2B sandbox create returned no sandbox")
+
+    def _record_created(self, sandbox: AsyncSandbox) -> None:
+        """Append this sandbox to the reap ledger (never fatal: the sandbox already exists)."""
+        default_ledger().record_created(
+            sandbox_id=sandbox.sandbox_id,
+            template_id=self._template_name,
+            trial_name=harbor_trial_name(self.session_id),
+        )
+
+    def _record_released(self, sandbox: AsyncSandbox) -> None:
+        """Mark a proven kill in the reap ledger so no reaper considers the sandbox."""
+        default_ledger().record_released(sandbox.sandbox_id)
 
     async def _kill_quietly(self, sandbox: AsyncSandbox) -> None:
         """Best-effort kill of a sandbox this environment is abandoning."""
@@ -507,6 +563,16 @@ class WmhE2BEnvironment(E2BEnvironment):
             await sandbox.kill()
         except Exception:  # noqa: BLE001 - the create/identity error stays authoritative
             self.logger.warning("failed to kill an abandoned E2B sandbox", exc_info=True)
+            return
+        self._record_released(sandbox)
+
+    @override
+    async def _stop_sandbox(self) -> None:
+        """Harbor's teardown, plus a ledger release once the kill is proved."""
+        sandbox = self._sandbox
+        await super()._stop_sandbox()
+        if sandbox is not None:
+            self._record_released(sandbox)
 
     @override
     async def start(self, force_build: bool) -> None:

--- a/wmh/evals/harbor/e2b_environment_test.py
+++ b/wmh/evals/harbor/e2b_environment_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -11,7 +11,7 @@ from typing import cast
 import httpx
 import pytest
 from e2b import AsyncSandbox, AsyncTemplate
-from e2b.exceptions import BuildException
+from e2b.exceptions import BuildException, RateLimitException
 from e2b.template.logger import LogEntry
 from e2b.template.types import (
     BuildInfo,
@@ -24,6 +24,9 @@ from harbor.models.trial.paths import TrialPaths
 
 import wmh.evals.harbor.e2b_environment as e2b_environment_module
 from wmh.evals.harbor.e2b_environment import WmhE2BEnvironment
+from wmh.harness.e2b_ledger import SandboxLedger, read_ledger_files
+
+_LEDGER_PID = 424_242
 
 
 @pytest.fixture(autouse=True)
@@ -33,10 +36,20 @@ def _clear_build_registry() -> Iterator[None]:
     e2b_environment_module._SUBMITTED_BUILDS.clear()
 
 
+@pytest.fixture(autouse=True)
+def ledger_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the reap ledger into the test's tmp dir; real user state is never touched."""
+    directory = tmp_path / "ledger"
+    ledger = SandboxLedger(directory, pid=_LEDGER_PID)
+    monkeypatch.setattr(e2b_environment_module, "default_ledger", lambda: ledger)
+    return directory
+
+
 def _environment(
     tmp_path: Path,
     *,
     task_config: EnvironmentConfig | None = None,
+    session_id: str = "trial__environment",
 ) -> WmhE2BEnvironment:
     environment_dir = tmp_path / "environment"
     if not environment_dir.exists():
@@ -50,7 +63,7 @@ def _environment(
     return WmhE2BEnvironment(
         environment_dir=environment_dir,
         environment_name="task/environment",
-        session_id="trial__environment",
+        session_id=session_id,
         trial_paths=TrialPaths(trial_dir),
         task_env_config=task_config or EnvironmentConfig(cpus=2, memory_mb=2048),
     )
@@ -83,9 +96,18 @@ def _build_status(
 
 
 class _Sandbox:
-    def __init__(self, *, name: str | None, info_errors: list[Exception] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        info_errors: list[Exception] | None = None,
+        sandbox_id: str = "isb-1",
+        kill_error: Exception | None = None,
+    ) -> None:
+        self.sandbox_id = sandbox_id
         self.info = SimpleNamespace(template_id="template-id", name=name)
         self.info_errors = list(info_errors or [])
+        self.kill_error = kill_error
         self.kill_calls = 0
 
     async def get_info(self) -> SimpleNamespace:
@@ -95,6 +117,8 @@ class _Sandbox:
 
     async def kill(self) -> None:
         self.kill_calls += 1
+        if self.kill_error is not None:
+            raise self.kill_error
 
 
 def test_template_alias_matches_the_prebuilt_fleet_derivation(tmp_path: Path) -> None:
@@ -530,3 +554,179 @@ def test_terminal_build_failure_clears_the_registry_so_a_rebuild_can_run(
 
     asyncio.run(environment._ensure_template_built(force_build=False))
     assert submissions == [1, 1]  # the second attempt legitimately resubmits
+
+
+# -- sandbox ledger + 429 create hardening ---------------------------------------------------
+
+
+def _wire_create(
+    monkeypatch: pytest.MonkeyPatch,
+    create: Callable[..., Awaitable[_Sandbox]],
+    *,
+    sleeps: list[float] | None = None,
+) -> None:
+    """Route creates at the fake factory, skipping the rate gate and real sleeps."""
+
+    async def admit() -> None:
+        return None
+
+    async def sleep(seconds: float) -> None:
+        if sleeps is not None:
+            sleeps.append(seconds)
+
+    monkeypatch.setattr(e2b_environment_module, "acquire_e2b_create_slot_async", admit)
+    monkeypatch.setattr(AsyncSandbox, "create", staticmethod(create))
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+
+def test_a_created_sandbox_is_recorded_in_the_reap_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    # Harbor names an environment session "<trial name>__env"; the ledger records the trial.
+    environment = _environment(tmp_path, session_id="hello-world__bZZeEkw__env")
+    sandbox = _Sandbox(name=environment.template_name, sandbox_id="isb-created")
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        return sandbox
+
+    _wire_create(monkeypatch, create)
+
+    asyncio.run(environment._create_sandbox())
+
+    [ledger_file] = read_ledger_files(ledger_dir)
+    [record] = ledger_file.held
+    assert record.sandbox_id == "isb-created"
+    assert record.template_id == environment.template_name
+    assert record.trial_name == "hello-world__bZZeEkw"
+    assert record.pid == _LEDGER_PID
+    assert ledger_file.owner_pid == _LEDGER_PID
+
+
+def test_an_abandoned_sandbox_is_released_in_the_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    """A sandbox killed for a template mismatch is recorded AND released: nothing to reap."""
+    environment = _environment(tmp_path)
+    sandbox = _Sandbox(name="some-other-template", sandbox_id="isb-wrong")
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        return sandbox
+
+    _wire_create(monkeypatch, create)
+
+    with pytest.raises(RuntimeError, match="template name mismatch"):
+        asyncio.run(environment._create_sandbox())
+
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert ledger_file.held == ()
+    assert ledger_file.released_ids == ("isb-wrong",)
+    assert ledger_file.fully_released is True
+
+
+def test_a_kill_that_fails_leaves_the_record_reapable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    """Fail closed: an unproven kill must stay in the ledger so a reaper retries it by id."""
+    environment = _environment(tmp_path)
+    sandbox = _Sandbox(
+        name="some-other-template",
+        sandbox_id="isb-stuck",
+        kill_error=RuntimeError("503: kill refused"),
+    )
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        return sandbox
+
+    _wire_create(monkeypatch, create)
+
+    with pytest.raises(RuntimeError, match="template name mismatch"):
+        asyncio.run(environment._create_sandbox())
+
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert [record.sandbox_id for record in ledger_file.held] == ["isb-stuck"]
+
+
+def test_graceful_stop_releases_the_sandbox_in_the_ledger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    environment = _environment(tmp_path)
+    sandbox = _Sandbox(name=environment.template_name, sandbox_id="isb-stopped")
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        return sandbox
+
+    _wire_create(monkeypatch, create)
+
+    asyncio.run(environment._create_sandbox())
+    asyncio.run(environment.stop(delete=True))
+
+    assert sandbox.kill_calls == 1
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert ledger_file.held == ()
+    assert ledger_file.released_ids == ("isb-stopped",)
+
+
+def test_a_rate_limited_create_waits_and_then_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    """A 429 for the account's concurrent-sandbox cap must wait, not fail the trial."""
+    environment = _environment(tmp_path)
+    sandbox = _Sandbox(name=environment.template_name, sandbox_id="isb-late")
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        attempts.append(1)
+        if len(attempts) <= 2:
+            raise RateLimitException(
+                "429: You have reached the maximum number of concurrent E2B sandboxes (100)"
+            )
+        return sandbox
+
+    _wire_create(monkeypatch, create, sleeps=sleeps)
+
+    asyncio.run(environment._create_sandbox())
+
+    assert len(attempts) == 3
+    assert sleeps == list(e2b_environment_module._CREATE_RATE_LIMIT_DELAYS_S[:2])
+    assert environment._sandbox is sandbox
+    # Exactly one create succeeded, so exactly one ledger record exists.
+    [ledger_file] = read_ledger_files(ledger_dir)
+    assert [record.sandbox_id for record in ledger_file.held] == ["isb-late"]
+
+
+def test_a_permanently_full_account_still_fails_after_the_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ledger_dir: Path,
+) -> None:
+    environment = _environment(tmp_path)
+    attempts: list[int] = []
+    sleeps: list[float] = []
+
+    async def create(**_kwargs: object) -> _Sandbox:
+        attempts.append(1)
+        raise RateLimitException("429: maximum number of concurrent E2B sandboxes (100)")
+
+    _wire_create(monkeypatch, create, sleeps=sleeps)
+
+    with pytest.raises(RateLimitException, match="concurrent E2B sandboxes"):
+        asyncio.run(environment._create_sandbox())
+
+    delays = list(e2b_environment_module._CREATE_RATE_LIMIT_DELAYS_S)
+    # Every rate-limit wait, then harbor's own two-attempt contract takes over and fails.
+    assert sleeps == [*delays, e2b_environment_module._CREATE_RETRY_DELAY_S]
+    assert len(attempts) == len(delays) + 2
+    assert sum(sleeps) < 600  # the bound stays inside a few minutes
+    assert environment._sandbox is None
+    assert read_ledger_files(ledger_dir) == ()  # nothing was ever created

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -64,6 +64,10 @@ logger = logging.getLogger(__name__)
 
 TaskEnvironment = Literal["docker", "e2b"]
 HarnessBackend = Literal["local", "e2b"]
+MissingRewardMode = Literal["raise", "zero"]
+"""How a trial with no verifier reward scores: "raise" aborts (candidate search
+semantics: an unscoreable candidate is an infra failure), "zero" scores it 0.0
+with an auditable note (distillation evals: a dead runner is a failed trial)."""
 
 # In-process registry of job dirs with a score() in flight: the entry prune is destructive, so
 # concurrent scores of the same candidate must be rejected, not interleaved.
@@ -181,10 +185,13 @@ class HarborScorer:
         harbor_retries: int = 0,
         agent_import_path: str = WMH_HARBOR_AGENT_IMPORT_PATH,
         extra_agent_kwargs: JsonObject | None = None,
+        missing_reward: MissingRewardMode = "raise",
         runner: HarborRunner | None = None,
     ) -> None:
         if not tasks:
             raise ValueError("HarborScorer requires at least one resolved task")
+        if missing_reward not in ("raise", "zero"):
+            raise ValueError("missing_reward must be raise or zero")
         task_ids = [task.get_task_id().get_name() for task in tasks]
         if len(task_ids) != len(set(task_ids)):
             raise ValueError("HarborScorer requires unique task ids")
@@ -264,6 +271,7 @@ class HarborScorer:
         self._attempts = attempts
         self._agent_import_path = agent_import_path
         self._extra_agent_kwargs: JsonObject = dict(extra_agent_kwargs or {})
+        self._missing_reward: MissingRewardMode = missing_reward
         self._harness_backend: HarnessBackend = harness_backend
         self._episode_timeout_s = episode_timeout_s
         self._command_timeout_sec = command_timeout_sec
@@ -300,6 +308,7 @@ class HarborScorer:
         harbor_retries: int = 0,
         agent_import_path: str = WMH_HARBOR_AGENT_IMPORT_PATH,
         extra_agent_kwargs: JsonObject | None = None,
+        missing_reward: MissingRewardMode = "raise",
         runner: HarborRunner | None = None,
     ) -> Self:
         """Resolve the exact tasks and construct a scorer that can incur spend.
@@ -330,6 +339,7 @@ class HarborScorer:
             harbor_retries=harbor_retries,
             agent_import_path=agent_import_path,
             extra_agent_kwargs=extra_agent_kwargs,
+            missing_reward=missing_reward,
             runner=runner,
         )
 
@@ -479,7 +489,25 @@ class HarborScorer:
         for task_id in self._task_ids:
             trials = sorted(grouped[task_id], key=lambda trial: trial.trial_name)
             for attempt, trial in enumerate(trials, 1):
-                reward = _official_reward(trial, reward_key=self._reward_key)
+                note = _trial_note(trial)
+                try:
+                    reward = _official_reward(trial, reward_key=self._reward_key)
+                except HarborRewardMissingError:
+                    if self._missing_reward == "raise":
+                        raise
+                    # Evaluation-tolerant mode (distillation evals): a trial whose
+                    # runner died before the verifier could produce evidence is a
+                    # failed trial, not a reason to abort a long training run. The
+                    # note keeps the cause auditable per cell.
+                    exception = trial.exception_info
+                    cause = exception.exception_type if exception else "no exception info"
+                    reward = 0.0
+                    note = f"missing-reward: {cause}; scored 0"
+                    logger.warning(
+                        "harbor trial %s has no verifier reward (%s); scoring 0",
+                        trial.trial_name,
+                        cause,
+                    )
                 cells.append(
                     ScoreCell(
                         task_id=task_id,
@@ -487,7 +515,7 @@ class HarborScorer:
                         reward=reward,
                         passed=reward_passed(reward, self._reward_mode),
                         artifact_dir=str(run.job_dir / trial.trial_name),
-                        note=_trial_note(trial),
+                        note=note,
                     )
                 )
         return ScoreReport(

--- a/wmh/evals/harbor/scorer.py
+++ b/wmh/evals/harbor/scorer.py
@@ -42,6 +42,7 @@ from harbor.models.trial.config import AgentConfig, TaskConfig
 from harbor.models.trial.paths import TrialPaths
 from harbor.models.trial.result import TrialResult
 
+from wmh.core.types import JsonObject
 from wmh.evals.harbor.agent import (
     DEFAULT_EPISODE_WORKERS,
     MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
@@ -68,6 +69,21 @@ HarnessBackend = Literal["local", "e2b"]
 # concurrent scores of the same candidate must be rejected, not interleaved.
 _ACTIVE_GUARD = threading.Lock()
 _ACTIVE_JOB_DIRS: set[Path] = set()
+
+# Agent kwargs the scorer computes and owns; `extra_agent_kwargs` may extend the kwargs dict but
+# never silently override these, or a custom agent would run a different candidate/provider than
+# the one this scorer reports on.
+_SCORER_OWNED_AGENT_KWARGS = frozenset(
+    {
+        "harness",
+        "provider_config",
+        "harness_backend",
+        "e2b_template",
+        "command_timeout_sec",
+        "episode_timeout_sec",
+        "episode_workers",
+    }
+)
 
 
 class HarborRewardMissingError(RuntimeError):
@@ -163,6 +179,8 @@ class HarborScorer:
         command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         agent_concurrency: int | None = None,
         harbor_retries: int = 0,
+        agent_import_path: str = WMH_HARBOR_AGENT_IMPORT_PATH,
+        extra_agent_kwargs: JsonObject | None = None,
         runner: HarborRunner | None = None,
     ) -> None:
         if not tasks:
@@ -187,6 +205,18 @@ class HarborScorer:
             raise ValueError("harbor_retries must be a nonnegative integer")
         if harbor_retries < 0:
             raise ValueError("harbor_retries must be a nonnegative integer")
+        if not agent_import_path or ":" not in agent_import_path:
+            raise ValueError(
+                f"agent_import_path must be a 'module:Class' import path, got "
+                f"{agent_import_path!r}; use the exported constant of the agent bridge "
+                "(e.g. WMH_HARBOR_AGENT_IMPORT_PATH)"
+            )
+        overridden = _SCORER_OWNED_AGENT_KWARGS & set(extra_agent_kwargs or {})
+        if overridden:
+            raise ValueError(
+                f"extra_agent_kwargs may not override the scorer-owned agent kwargs "
+                f"{sorted(overridden)}; configure those through the scorer's own parameters"
+            )
         if agent_concurrency is not None and (
             isinstance(agent_concurrency, bool)
             or not isinstance(agent_concurrency, int)
@@ -232,6 +262,8 @@ class HarborScorer:
         self._reward_key = reward_key
         self._reward_mode: RewardMode = reward_mode
         self._attempts = attempts
+        self._agent_import_path = agent_import_path
+        self._extra_agent_kwargs: JsonObject = dict(extra_agent_kwargs or {})
         self._harness_backend: HarnessBackend = harness_backend
         self._episode_timeout_s = episode_timeout_s
         self._command_timeout_sec = command_timeout_sec
@@ -266,6 +298,8 @@ class HarborScorer:
         command_timeout_sec: int = MAX_ENVIRONMENT_COMMAND_TIMEOUT_SEC,
         agent_concurrency: int | None = None,
         harbor_retries: int = 0,
+        agent_import_path: str = WMH_HARBOR_AGENT_IMPORT_PATH,
+        extra_agent_kwargs: JsonObject | None = None,
         runner: HarborRunner | None = None,
     ) -> Self:
         """Resolve the exact tasks and construct a scorer that can incur spend.
@@ -273,6 +307,9 @@ class HarborScorer:
         `job_template` supplies the run directory (`jobs_dir`), the task environment config,
         and harbor tuning (timeouts, concurrency); it must carry exactly one dataset, no direct
         tasks, and an untouched default agent + retry config (the scorer owns those).
+        `agent_import_path` plus `extra_agent_kwargs` route trials through a custom agent
+        bridge (e.g. the distill collector's token-recording subclass); the defaults preserve
+        the standard WMH agent, and extra kwargs may never shadow the scorer-owned ones.
         """
         if len(job_template.datasets) != 1 or job_template.tasks:
             raise ValueError("HarborScorer requires exactly one dataset and no direct tasks")
@@ -291,6 +328,8 @@ class HarborScorer:
             command_timeout_sec=command_timeout_sec,
             agent_concurrency=agent_concurrency,
             harbor_retries=harbor_retries,
+            agent_import_path=agent_import_path,
+            extra_agent_kwargs=extra_agent_kwargs,
             runner=runner,
         )
 
@@ -370,7 +409,7 @@ class HarborScorer:
         agent_fields.update(
             {
                 "name": None,
-                "import_path": WMH_HARBOR_AGENT_IMPORT_PATH,
+                "import_path": self._agent_import_path,
                 "model_name": f"{self._provider_config.kind.value}/{self._provider_config.model}",
                 "skills": [],
                 "env": {},
@@ -383,6 +422,9 @@ class HarborScorer:
                     "command_timeout_sec": self._command_timeout_sec,
                     "episode_timeout_sec": self._episode_timeout_s,
                     "episode_workers": self._episode_workers,
+                    # Custom-bridge kwargs; collisions with the scorer-owned keys above
+                    # were rejected at construction, so this merge cannot shadow them.
+                    **self._extra_agent_kwargs,
                 },
             }
         )

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -442,6 +442,81 @@ def test_template_ownership_and_local_concurrency_rules(tmp_path: Path) -> None:
         )
 
 
+def test_custom_agent_import_path_and_extra_kwargs_thread_into_the_job(tmp_path: Path) -> None:
+    """The distill collector's route: a custom bridge plus its extra kwargs, with every
+    scorer-owned kwarg intact next to them."""
+    scorer = HarborScorer(
+        job_template=_job_template(tmp_path),
+        tasks=_tasks(tmp_path, ("task-a",)),
+        provider_config=_provider(),
+        harness_backend="e2b",
+        e2b_template="pi-template",
+        agent_concurrency=1,
+        agent_import_path="wmh.distill.agents:WmhDistillHarborAgent",
+        extra_agent_kwargs={"token_sink_dir": "/runs/tokens/step-0000"},
+        runner=_Runner([]),
+    )
+    candidate = HarnessDoc.baseline()
+    config = scorer._candidate_job(candidate)
+    [agent] = config.agents
+    assert agent.import_path == "wmh.distill.agents:WmhDistillHarborAgent"
+    assert agent.kwargs["token_sink_dir"] == "/runs/tokens/step-0000"
+    assert agent.kwargs["harness"] == candidate.model_dump(mode="json")
+    assert agent.kwargs["harness_backend"] == "e2b"
+    assert agent.kwargs["e2b_template"] == "pi-template"
+
+
+def test_extra_agent_kwargs_and_import_path_are_validated(tmp_path: Path) -> None:
+    """Extras may extend the agent kwargs but never shadow the scorer-owned ones."""
+    with pytest.raises(ValueError, match=r"scorer-owned agent kwargs \['harness'\]"):
+        HarborScorer(
+            job_template=_job_template(tmp_path),
+            tasks=_tasks(tmp_path, ("task-a",)),
+            provider_config=_provider(),
+            harness_backend="e2b",
+            agent_concurrency=1,
+            extra_agent_kwargs={"harness": {}, "token_sink_dir": "/tmp/x"},
+        )
+    with pytest.raises(ValueError, match="module:Class"):
+        HarborScorer(
+            job_template=_job_template(tmp_path),
+            tasks=_tasks(tmp_path, ("task-a",)),
+            provider_config=_provider(),
+            harness_backend="e2b",
+            agent_concurrency=1,
+            agent_import_path="not-an-import-path",
+        )
+
+
+def test_create_threads_agent_import_path_and_extra_kwargs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_resolve(
+        _dataset: DatasetConfig,
+        task_ids: list[str],
+    ) -> list[TaskConfig]:
+        return _tasks(tmp_path, tuple(task_ids))
+
+    monkeypatch.setattr(scorer_module, "resolve_harbor_tasks", fake_resolve)
+    scorer = asyncio.run(
+        HarborScorer.create(
+            _job_template(tmp_path),
+            ["task-a"],
+            provider_config=_provider(),
+            harness_backend="e2b",
+            e2b_template="pi-template",
+            agent_concurrency=1,
+            agent_import_path="wmh.distill.agents:WmhDistillHarborAgent",
+            extra_agent_kwargs={"token_sink_dir": "/runs/tokens/step-0001"},
+        )
+    )
+    config = scorer._candidate_job(HarnessDoc.baseline())
+    [agent] = config.agents
+    assert agent.import_path == "wmh.distill.agents:WmhDistillHarborAgent"
+    assert agent.kwargs["token_sink_dir"] == "/runs/tokens/step-0001"
+
+
 def test_harbor_retries_thread_into_retry_config_with_default_exclusions(
     tmp_path: Path,
 ) -> None:

--- a/wmh/evals/harbor/scorer_test.py
+++ b/wmh/evals/harbor/scorer_test.py
@@ -27,6 +27,7 @@ from wmh.evals.harbor.scorer import (
     HarborRewardMissingError,
     HarborRun,
     HarborScorer,
+    MissingRewardMode,
 )
 from wmh.harness.doc import HarnessDoc
 from wmh.harness.scoring import RewardMode
@@ -138,6 +139,7 @@ def _scorer(
     attempts: int = 1,
     reward_mode: RewardMode = "raw",
     agent_concurrency: int | None = None,
+    missing_reward: MissingRewardMode = "raise",
 ) -> tuple[HarborScorer, _Runner]:
     runner = _Runner(trials)
     scorer = HarborScorer(
@@ -149,6 +151,7 @@ def _scorer(
         harness_backend="e2b",
         e2b_template="pi-template",
         agent_concurrency=agent_concurrency,
+        missing_reward=missing_reward,
         runner=runner,
     )
     return scorer, runner
@@ -211,6 +214,28 @@ def test_failed_trial_with_a_written_reward_is_a_scored_cell_not_an_infra_halt(
     scorer, _runner = _scorer(tmp_path, missing)
     with pytest.raises(HarborRewardMissingError, match="no verifier reward"):
         scorer.score(HarnessDoc.baseline())
+
+
+def test_missing_reward_zero_mode_scores_the_trial_failed_instead_of_halting(
+    tmp_path: Path,
+) -> None:
+    """Distillation evals: a runner that died before verification is a failed trial.
+
+    The search default stays strict (previous test); "zero" scores the cell 0.0
+    with an auditable note so a single transient sandbox death cannot abort a
+    long training run at its final eval.
+    """
+    trials = [
+        _trial(tmp_path, "task-a", 1, reward=None, exception="RuntimeError"),
+        _trial(tmp_path, "task-b", 1, reward=1.0),
+    ]
+    scorer, _runner = _scorer(tmp_path, trials, missing_reward="zero")
+    report = scorer.score(HarnessDoc.baseline())
+    cell = report.by_task()["task-a"][0]
+    assert cell.reward == 0.0
+    assert cell.passed is False
+    assert cell.note == "missing-reward: RuntimeError; scored 0"
+    assert report.by_task()["task-b"][0].reward == 1.0
 
 
 def test_outcome_shaped_verifier_failures_score_zero_instead_of_halting(tmp_path: Path) -> None:

--- a/wmh/harness/e2b_ledger.py
+++ b/wmh/harness/e2b_ledger.py
@@ -1,0 +1,342 @@
+"""A durable record of the E2B sandboxes this machine created, so they stay reapable by id.
+
+E2B caps concurrent sandboxes per account. Every wmh harbor trial creates one sandbox with a
+long timeout (hours), so a run that dies without graceful shutdown (crash, SIGKILL, budget
+abort, machine sleep) leaves its sandboxes running until they expire on their own. The next
+sweep then starves at the cap and every trial fails at sandbox creation with
+`RateLimitException: 429 ... maximum number of concurrent E2B sandboxes`, which in a distill
+run looks exactly like a model producing zero token spans.
+
+This ledger makes those orphans reapable BY EXACT ID: each create appends one line to a
+per-owning-process JSONL file under the user-global WMH state dir (`$WMH_HOME` or `~/.wmh`),
+and each proven cleanup appends a matching release line. Writes are append + fsync, so a hard
+kill still leaves the record on disk; a file whose every recorded id is released is deleted.
+Killing exactly the ids a dead process recorded is defensible, whereas pattern-matching the
+account is not, which is why `wmh e2b reap` treats this file as its primary evidence.
+
+Ledger bookkeeping is best-effort by design: a write failure logs a warning and never fails
+the trial that owns the sandbox. Nothing here imports the e2b SDK, so reading the ledger needs
+neither the optional extra nor credentials.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import Lock
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+
+from wmh.platform.credentials import wmh_home
+
+logger = logging.getLogger(__name__)
+
+LEDGER_DIRNAME = "e2b-sandboxes"
+"""Subdirectory of the WMH user state dir holding one JSONL file per owning process."""
+
+HARBOR_ENV_SESSION_SUFFIX = "__env"
+"""Harbor tags a trial's environment sandbox with `session_id = "<trial name>__env"`."""
+
+
+def harbor_trial_name(session_id: str) -> str | None:
+    """The harbor trial name behind an environment session id, or None when it is not one."""
+    if not session_id.endswith(HARBOR_ENV_SESSION_SUFFIX):
+        return None
+    trial = session_id[: -len(HARBOR_ENV_SESSION_SUFFIX)]
+    return trial or None
+
+
+def ledger_dir() -> Path:
+    """The ledger directory (`$WMH_HOME/e2b-sandboxes`, else `~/.wmh/e2b-sandboxes`)."""
+    return wmh_home() / LEDGER_DIRNAME
+
+
+def pid_is_alive(pid: int) -> bool:
+    """Whether the process that owns a ledger file still exists on this machine."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # it exists, it just belongs to another user
+    return True
+
+
+class SandboxCreated(BaseModel):
+    """One sandbox a process created, recorded the moment E2B returned it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    event: Literal["created"] = "created"
+    sandbox_id: str
+    template_id: str
+    """The template identity the sandbox was created from: for harbor trials that is the
+    resource-qualified alias, which E2B accepts wherever it accepts a template id."""
+
+    created_at: datetime
+    trial_name: str | None = None
+    """The harbor trial that owns the sandbox, when the caller knows it."""
+
+    pid: int
+    """The process that created the sandbox, probed for liveness when reaping."""
+
+
+class SandboxReleased(BaseModel):
+    """Proof that a recorded sandbox was killed, so no reaper needs to consider it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    event: Literal["released"] = "released"
+    sandbox_id: str
+    released_at: datetime
+    pid: int
+    """The process that observed the release (the owner, or a reaper)."""
+
+
+LedgerRecord = Annotated[SandboxCreated | SandboxReleased, Field(discriminator="event")]
+_RECORD_ADAPTER: TypeAdapter[SandboxCreated | SandboxReleased] = TypeAdapter(LedgerRecord)
+
+
+class LedgerFile(BaseModel):
+    """One owning process's ledger: where it lives, whose it is, and what it still holds."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: Path
+    owner_pid: int
+    held: tuple[SandboxCreated, ...]
+    """Recorded sandboxes with no matching release record."""
+
+    released_ids: tuple[str, ...]
+
+    @property
+    def fully_released(self) -> bool:
+        """Whether every sandbox this file recorded has a release record."""
+        return not self.held and bool(self.released_ids)
+
+
+def read_ledger_files(directory: Path | None = None) -> tuple[LedgerFile, ...]:
+    """Read every ledger file in `directory`, sorted by path.
+
+    Unparseable lines are skipped: a hard kill can tear the last line of an append, and one
+    torn record must not hide the intact records above it.
+
+    Args:
+        directory: The ledger directory; defaults to the user-global one.
+
+    Returns:
+        One `LedgerFile` per readable `*.jsonl` file (an unreadable file is skipped with a
+        warning, since a reap must still consider the rest).
+    """
+    root = directory if directory is not None else ledger_dir()
+    if not root.is_dir():
+        return ()
+    files: list[LedgerFile] = []
+    for path in sorted(root.glob("*.jsonl")):
+        parsed = _read_one(path)
+        if parsed is not None:
+            files.append(parsed)
+    return tuple(files)
+
+
+def _read_one(path: Path) -> LedgerFile | None:
+    """Parse one ledger file into held and released ids, or None when it cannot be read."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        logger.warning("cannot read the E2B sandbox ledger %s: %s", path, error)
+        return None
+    created: dict[str, SandboxCreated] = {}
+    released: dict[str, None] = {}
+    record_pid: int | None = None
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = _RECORD_ADAPTER.validate_json(line)
+        except ValidationError:
+            logger.debug("skipping an unparseable E2B ledger line in %s", path)
+            continue
+        record_pid = record_pid if record_pid is not None else record.pid
+        if isinstance(record, SandboxCreated):
+            created[record.sandbox_id] = record
+        else:
+            released[record.sandbox_id] = None
+    return LedgerFile(
+        path=path,
+        owner_pid=_owner_pid(path, record_pid),
+        held=tuple(record for key, record in created.items() if key not in released),
+        released_ids=tuple(released),
+    )
+
+
+def _owner_pid(path: Path, record_pid: int | None) -> int:
+    """The owning pid, read from the `<pid>-<stamp>.jsonl` name and falling back to a record."""
+    head = path.name.split("-", 1)[0]
+    if head.isdigit():
+        return int(head)
+    return record_pid if record_pid is not None else 0
+
+
+def append_release(path: Path, *, sandbox_id: str, pid: int, released_at: datetime) -> None:
+    """Append one release record to an existing ledger file (used by a reaper).
+
+    Records are single short lines appended to a file opened `O_APPEND`, so a reaper writing
+    into another process's ledger cannot interleave with that process's own appends.
+
+    Raises:
+        OSError: If the record cannot be written; the caller decides whether that is fatal
+            (`SandboxLedger` treats its own write failures as warnings).
+    """
+    _append_line(path, SandboxReleased(sandbox_id=sandbox_id, released_at=released_at, pid=pid))
+
+
+def prune_released_files(
+    directory: Path | None = None,
+    *,
+    owner_alive: Callable[[int], bool] = pid_is_alive,
+) -> tuple[Path, ...]:
+    """Delete every ledger file whose recorded sandboxes are all released.
+
+    A fully released file whose owning process is STILL RUNNING is kept: that process can append
+    a new create record at any moment, and deleting the file underneath it would lose the only
+    record of a live sandbox.
+
+    Args:
+        directory: The ledger directory; defaults to the user-global one.
+        owner_alive: Liveness probe for a file's owning pid (injected in tests).
+
+    Returns:
+        The paths that were deleted.
+    """
+    removed: list[Path] = []
+    for ledger in read_ledger_files(directory):
+        if not ledger.fully_released or owner_alive(ledger.owner_pid):
+            continue
+        try:
+            ledger.path.unlink(missing_ok=True)
+        except OSError as error:
+            logger.warning("cannot delete the released E2B ledger %s: %s", ledger.path, error)
+            continue
+        removed.append(ledger.path)
+    return tuple(removed)
+
+
+class SandboxLedger:
+    """Append-only record of the E2B sandboxes one process created.
+
+    The file is named `<pid>-<utc stamp>.jsonl` and created lazily on the first record, so a
+    process that never opens a sandbox leaves nothing behind. Recording is best-effort: any
+    write failure is logged and swallowed, because losing a ledger line must never fail the
+    trial whose sandbox is already running.
+    """
+
+    def __init__(
+        self,
+        directory: Path | None = None,
+        *,
+        pid: int | None = None,
+        now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        """Record into `directory` (default: the user-global ledger dir) as `pid`."""
+        self._directory = directory if directory is not None else ledger_dir()
+        self._pid = pid if pid is not None else os.getpid()
+        self._now = now
+        self._lock = Lock()
+        self._path: Path | None = None
+
+    @property
+    def path(self) -> Path:
+        """This process's ledger file (the name is fixed on first access)."""
+        with self._lock:
+            if self._path is None:
+                stamp = self._now().strftime("%Y%m%dT%H%M%SZ")
+                self._path = self._directory / f"{self._pid}-{stamp}.jsonl"
+            return self._path
+
+    def record_created(
+        self,
+        *,
+        sandbox_id: str,
+        template_id: str,
+        trial_name: str | None = None,
+    ) -> None:
+        """Record a sandbox that E2B just created, flushing it to disk before returning."""
+        self._append(
+            SandboxCreated(
+                sandbox_id=sandbox_id,
+                template_id=template_id,
+                created_at=self._now(),
+                trial_name=trial_name,
+                pid=self._pid,
+            )
+        )
+
+    def record_released(self, sandbox_id: str) -> None:
+        """Record a sandbox whose kill this process proved, so no reaper considers it."""
+        self._append(SandboxReleased(sandbox_id=sandbox_id, released_at=self._now(), pid=self._pid))
+
+    def _append(self, record: SandboxCreated | SandboxReleased) -> None:
+        """Append one record; a failure warns instead of propagating into the caller."""
+        path = self.path
+        try:
+            _ensure_directory(path.parent)
+            with self._lock:
+                _append_line(path, record)
+        except OSError as error:
+            logger.warning(
+                "could not record E2B sandbox %s (%s) in the ledger %s: %s",
+                record.sandbox_id,
+                record.event,
+                path,
+                error,
+            )
+
+
+def _append_line(path: Path, record: SandboxCreated | SandboxReleased) -> None:
+    """Append one JSONL record and push it to disk before returning."""
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{record.model_dump_json()}\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _ensure_directory(directory: Path) -> None:
+    """Create every missing level owner-only, matching the rest of the WMH state dir.
+
+    `mkdir(parents=True)` would create intermediate levels with the umask default, which for
+    `~/.wmh` is a permanent 0755 around state that names live cloud resources. A umask can only
+    narrow 0o700, so creating each level with that mode closes the window; existing directories
+    are left alone.
+    """
+    missing: list[Path] = []
+    current = directory
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    for level in reversed(missing):
+        with contextlib.suppress(FileExistsError):
+            level.mkdir(mode=0o700)
+
+
+_DEFAULT_LEDGER: SandboxLedger | None = None
+_DEFAULT_GUARD = Lock()
+
+
+def default_ledger() -> SandboxLedger:
+    """The process-wide ledger every wmh-created E2B sandbox is recorded in."""
+    global _DEFAULT_LEDGER
+    with _DEFAULT_GUARD:
+        if _DEFAULT_LEDGER is None:
+            _DEFAULT_LEDGER = SandboxLedger()
+        return _DEFAULT_LEDGER

--- a/wmh/harness/e2b_ledger_test.py
+++ b/wmh/harness/e2b_ledger_test.py
@@ -1,0 +1,157 @@
+"""Offline tests for the E2B sandbox ledger: plain files, no SDK, no network."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.e2b_ledger import (
+    SandboxLedger,
+    harbor_trial_name,
+    ledger_dir,
+    prune_released_files,
+    read_ledger_files,
+)
+
+
+def _clock(start: datetime | None = None) -> Callable[[], datetime]:
+    """A monotonic fake clock advancing one second per call."""
+    base = start or datetime(2026, 7, 24, 16, 55, 12, tzinfo=UTC)
+    state = {"calls": 0}
+
+    def now() -> datetime:
+        moment = base + timedelta(seconds=state["calls"])
+        state["calls"] += 1
+        return moment
+
+    return now
+
+
+def _ledger(directory: Path, *, pid: int = 4242) -> SandboxLedger:
+    return SandboxLedger(directory, pid=pid, now=_clock())
+
+
+def _dead(_pid: int) -> bool:
+    """Liveness stub: the owning process is gone, so its released file may be pruned."""
+    return False
+
+
+def test_ledger_dir_lives_under_the_wmh_user_state_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WMH_HOME", "/tmp/wmh-home-fixture")
+    assert ledger_dir() == Path("/tmp/wmh-home-fixture/e2b-sandboxes")
+
+
+def test_create_appends_a_record_named_by_owning_pid(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path / "e2b-sandboxes")
+
+    ledger.record_created(sandbox_id="ix1", template_id="wmh-hb-v1-abc", trial_name="task__a1b2")
+
+    assert ledger.path.name.startswith("4242-")
+    assert ledger.path.name.endswith(".jsonl")
+    [line] = ledger.path.read_text(encoding="utf-8").splitlines()
+    record = json.loads(line)
+    assert record == {
+        "event": "created",
+        "sandbox_id": "ix1",
+        "template_id": "wmh-hb-v1-abc",
+        "created_at": record["created_at"],
+        "trial_name": "task__a1b2",
+        "pid": 4242,
+    }
+    # The directory is owner-only: it names live billable cloud resources.
+    assert ledger.path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_release_marks_the_record_and_a_fully_released_file_is_pruned(tmp_path: Path) -> None:
+    directory = tmp_path / "e2b-sandboxes"
+    ledger = _ledger(directory)
+    ledger.record_created(sandbox_id="ix1", template_id="tpl", trial_name="t1")
+    ledger.record_created(sandbox_id="ix2", template_id="tpl", trial_name="t2")
+
+    ledger.record_released("ix1")
+    [held_file] = read_ledger_files(directory)
+    assert [record.sandbox_id for record in held_file.held] == ["ix2"]
+    assert held_file.released_ids == ("ix1",)
+    assert held_file.fully_released is False
+    assert held_file.owner_pid == 4242
+    assert prune_released_files(directory, owner_alive=_dead) == ()
+
+    ledger.record_released("ix2")
+    [empty_file] = read_ledger_files(directory)
+    assert empty_file.held == ()
+    assert empty_file.fully_released is True
+
+    assert prune_released_files(directory, owner_alive=_dead) == (ledger.path,)
+    assert not ledger.path.exists()
+    assert read_ledger_files(directory) == ()
+
+
+def test_a_live_owners_released_file_is_kept(tmp_path: Path) -> None:
+    """The owner can append a new create at any moment; deleting under it would lose that id."""
+    directory = tmp_path / "e2b-sandboxes"
+    ledger = _ledger(directory)
+    ledger.record_created(sandbox_id="ix1", template_id="tpl")
+    ledger.record_released("ix1")
+
+    assert prune_released_files(directory, owner_alive=lambda _pid: True) == ()
+    assert ledger.path.exists()
+
+
+def test_a_hard_kill_leaves_an_unreleased_record_and_a_torn_line_is_skipped(
+    tmp_path: Path,
+) -> None:
+    """SIGKILL cannot run cleanup, so the create record must survive on its own."""
+    directory = tmp_path / "e2b-sandboxes"
+    ledger = _ledger(directory)
+    ledger.record_created(sandbox_id="ix1", template_id="tpl", trial_name="t1")
+    ledger.record_created(sandbox_id="ix2", template_id="tpl", trial_name="t2")
+    # Simulate the process dying mid-append: the last line never finished.
+    with ledger.path.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "created", "sandbox_id": "ix3"')
+
+    [held_file] = read_ledger_files(directory)
+
+    assert [record.sandbox_id for record in held_file.held] == ["ix1", "ix2"]
+    assert held_file.fully_released is False
+
+
+def test_a_ledger_write_failure_is_logged_and_never_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    ledger = _ledger(blocker / "e2b-sandboxes")
+
+    with caplog.at_level(logging.WARNING, logger="wmh.harness.e2b_ledger"):
+        ledger.record_created(sandbox_id="ix1", template_id="tpl")
+        ledger.record_released("ix1")
+
+    assert not ledger.path.exists()
+    assert len(caplog.records) == 2
+    assert "could not record E2B sandbox ix1" in caplog.text
+
+
+def test_read_ledger_files_tolerates_a_missing_directory(tmp_path: Path) -> None:
+    assert read_ledger_files(tmp_path / "absent") == ()
+    assert prune_released_files(tmp_path / "absent") == ()
+
+
+@pytest.mark.parametrize(
+    ("session_id", "expected"),
+    [
+        ("hello-world__bZZeEkw__env", "hello-world__bZZeEkw"),
+        ("trial__env", "trial"),
+        ("__env", None),
+        ("hello-world__agent", None),
+        ("", None),
+    ],
+)
+def test_harbor_trial_name_reads_the_env_session_convention(
+    session_id: str, expected: str | None
+) -> None:
+    assert harbor_trial_name(session_id) == expected

--- a/wmh/harness/e2b_reap.py
+++ b/wmh/harness/e2b_reap.py
@@ -1,0 +1,476 @@
+"""Finding and killing orphaned E2B sandboxes, and measuring the account's free capacity.
+
+An E2B account caps concurrent sandboxes (100 by default here, `$WMH_E2B_SANDBOX_CAP` when the
+account differs). Harbor trial sandboxes hold their slot for their own timeout, so orphans of a
+crashed run can starve every later run for hours. Reclaiming a slot means killing a sandbox,
+which is destructive, so this module ranks its evidence:
+
+- **Ledger (safe, default).** `wmh.harness.e2b_ledger` records every sandbox this machine
+  created together with its owning pid. An unreleased record whose owner process is gone is
+  provably an orphan of a wmh run that died, and killing it by exact id cannot touch anything
+  else.
+- **Metadata (opt-in).** Harbor tags every trial's environment sandbox with
+  `session_id = "<trial>__env"` plus `environment_name`. Matching those on the ACCOUNT finds
+  orphans this machine never recorded (a run from before the ledger existed, another machine,
+  another checkout). The match is account-wide and can kill a colleague's live run, hence
+  opt-in behind an explicit age threshold. Even then, a sandbox whose ledger owner is still
+  alive is never a candidate: that is a running local trial.
+
+The e2b SDK is the optional `e2b` extra, imported lazily so `wmh` stays usable without it.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmh.harness.e2b_ledger import (
+    LedgerFile,
+    SandboxCreated,
+    append_release,
+    harbor_trial_name,
+    pid_is_alive,
+    prune_released_files,
+    read_ledger_files,
+)
+from wmh.harness.e2b_sandbox import E2B_API_KEY_ENV
+
+__all__ = [
+    "DEFAULT_E2B_SANDBOX_CAP",
+    "E2B_API_KEY_ENV",
+    "E2B_SANDBOX_CAP_ENV",
+    "MISSING_E2B_EXTRA",
+    "AliveSandbox",
+    "CapacityCheck",
+    "ReapCandidate",
+    "ReapOutcome",
+    "ReapPlan",
+    "SandboxKiller",
+    "SandboxLister",
+    "check_capacity",
+    "execute_reap",
+    "is_credential_error",
+    "kill_sandbox",
+    "list_alive_sandboxes",
+    "pid_is_alive",
+    "plan_reap",
+    "sandbox_cap",
+]
+
+E2B_SANDBOX_CAP_ENV = "WMH_E2B_SANDBOX_CAP"
+"""Override for the account's concurrent-sandbox cap; accounts differ by plan."""
+
+DEFAULT_E2B_SANDBOX_CAP = 100
+"""E2B's default concurrent-sandbox limit per account."""
+
+MISSING_E2B_EXTRA = (
+    "the e2b SDK is not installed; run `uv sync --extra e2b` to manage E2B sandbox capacity"
+)
+
+_HARBOR_ENVIRONMENT_METADATA_KEY = "environment_name"
+_HARBOR_SESSION_METADATA_KEY = "session_id"
+
+
+def is_credential_error(error: Exception) -> bool:
+    """Whether an E2B call failed because the credential is missing or rejected.
+
+    Matched by exception NAME so callers need neither the optional SDK nor a fake that imports
+    it: e2b raises `AuthenticationException` both for an unset `$E2B_API_KEY` and for a 401.
+    A credential problem is a configuration error, not a transient one, so callers fail on it
+    instead of treating it like an unreachable API.
+    """
+    return type(error).__name__ == "AuthenticationException"
+
+
+def sandbox_cap() -> int:
+    """The account's concurrent-sandbox cap.
+
+    Returns:
+        `$WMH_E2B_SANDBOX_CAP` when set, else E2B's default of 100.
+
+    Raises:
+        ValueError: If the environment variable is not a positive integer.
+    """
+    raw = os.environ.get(E2B_SANDBOX_CAP_ENV, "").strip()
+    if not raw:
+        return DEFAULT_E2B_SANDBOX_CAP
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(
+            f"${E2B_SANDBOX_CAP_ENV} must be a positive integer (your account's concurrent "
+            f"sandbox limit), got {raw!r}"
+        ) from error
+    if value < 1:
+        raise ValueError(f"${E2B_SANDBOX_CAP_ENV} must be a positive integer, got {value}")
+    return value
+
+
+class AliveSandbox(BaseModel):
+    """One sandbox E2B currently reports as running on this account."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sandbox_id: str
+    template_id: str
+    started_at: datetime
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+    def is_harbor_trial(self) -> bool:
+        """Whether the metadata identifies this as a harbor trial environment sandbox."""
+        session_id = self.metadata.get(_HARBOR_SESSION_METADATA_KEY, "")
+        return bool(
+            self.metadata.get(_HARBOR_ENVIRONMENT_METADATA_KEY)
+            and harbor_trial_name(session_id) is not None
+        )
+
+    def trial_name(self) -> str | None:
+        """The harbor trial name from the metadata, when the sandbox carries one."""
+        return harbor_trial_name(self.metadata.get(_HARBOR_SESSION_METADATA_KEY, ""))
+
+
+SandboxLister = Callable[[], list[AliveSandbox]]
+"""Lists every running sandbox on the account."""
+
+SandboxKiller = Callable[[str], bool]
+"""Kills one sandbox by id; False means E2B reported it already gone."""
+
+
+class ReapCandidate(BaseModel):
+    """One sandbox a reap would kill, carrying the evidence for killing it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sandbox_id: str
+    template_id: str
+    age_seconds: float
+    source: Literal["ledger", "metadata"]
+    """Which evidence selected it: this machine's ledger, or an account-wide metadata match."""
+
+    trial_name: str | None = None
+    owner_pid: int | None = None
+    """The recorded owning process, or None when only the account knows about the sandbox."""
+
+    owner_alive: bool | None = None
+    """Whether the owner still runs; None when no owner is recorded."""
+
+    ledger_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class ReapPlan:
+    """What a reap would do, computed without touching the account."""
+
+    candidates: tuple[ReapCandidate, ...]
+    """Sandboxes to kill, oldest first."""
+
+    vanished: tuple[tuple[Path, SandboxCreated], ...]
+    """Dead-owner ledger records whose sandbox is already gone: release, never kill."""
+
+
+@dataclass(frozen=True)
+class ReapOutcome:
+    """The result of executing a plan."""
+
+    killed: tuple[str, ...]
+    """Sandboxes this reap actually stopped; each one freed a slot."""
+
+    already_gone: tuple[str, ...]
+    """Candidates E2B reported as no longer existing (no slot freed, ledger released)."""
+
+    failed: tuple[tuple[str, str], ...]
+    """(sandbox id, error) for kills that failed; the sweep continues past each one."""
+
+    pruned_ledgers: tuple[Path, ...]
+
+    @property
+    def freed(self) -> int:
+        """How many concurrency slots the reap actually released."""
+        return len(self.killed)
+
+
+def list_alive_sandboxes() -> list[AliveSandbox]:
+    """Page through every RUNNING sandbox on the account (lazy SDK import).
+
+    `Sandbox.list()` returns a paginator, not an iterable, so pages are pulled while
+    `has_next` holds. Paused sandboxes hold no concurrency slot and are excluded.
+
+    Raises:
+        ImportError: If the optional `e2b` extra is not installed.
+    """
+    try:
+        from e2b import Sandbox
+        from e2b.sandbox.sandbox_api import SandboxQuery, SandboxState
+    except ImportError as error:  # pragma: no cover - exercised only without the extra
+        raise ImportError(MISSING_E2B_EXTRA) from error
+
+    paginator = Sandbox.list(query=SandboxQuery(state=[SandboxState.RUNNING]))
+    alive: list[AliveSandbox] = []
+    while paginator.has_next:
+        for info in paginator.next_items():
+            alive.append(
+                AliveSandbox(
+                    sandbox_id=info.sandbox_id,
+                    template_id=info.name or info.template_id,
+                    started_at=info.started_at,
+                    metadata=dict(info.metadata or {}),
+                )
+            )
+    return alive
+
+
+def kill_sandbox(sandbox_id: str) -> bool:
+    """Kill one sandbox by exact id; False when E2B reports it already gone.
+
+    Raises:
+        ImportError: If the optional `e2b` extra is not installed.
+    """
+    try:
+        from e2b import Sandbox
+    except ImportError as error:  # pragma: no cover - exercised only without the extra
+        raise ImportError(MISSING_E2B_EXTRA) from error
+    return bool(Sandbox.kill(sandbox_id))
+
+
+def plan_reap(
+    *,
+    alive: Sequence[AliveSandbox],
+    ledger_files: Sequence[LedgerFile],
+    now: datetime,
+    dead_owners: bool = True,
+    stale_minutes: int | None = None,
+    pid_alive: Callable[[int], bool] = pid_is_alive,
+) -> ReapPlan:
+    """Select which running sandboxes to kill.
+
+    Args:
+        alive: Every sandbox E2B currently reports as running.
+        ledger_files: This machine's ledger files (see `wmh.harness.e2b_ledger`).
+        now: The reference instant ages are measured against.
+        dead_owners: Include unreleased ledger records whose owner process is gone.
+        stale_minutes: When set, ALSO include account-wide harbor trial sandboxes older than
+            this many minutes. Account-wide: it can select another machine's live run.
+        pid_alive: Liveness probe for an owning pid (injected in tests).
+
+    Returns:
+        The candidates (oldest first) plus the dead-owner records whose sandbox is already
+        gone, which only need a ledger release.
+    """
+    alive_by_id = {sandbox.sandbox_id: sandbox for sandbox in alive}
+    owners = _ledger_owners(ledger_files, pid_alive)
+
+    candidates: dict[str, ReapCandidate] = {}
+    vanished: list[tuple[Path, SandboxCreated]] = []
+    if dead_owners:
+        for sandbox_id, owner in owners.items():
+            if owner.alive:
+                continue
+            sandbox = alive_by_id.get(sandbox_id)
+            if sandbox is None:
+                vanished.append((owner.path, owner.record))
+                continue
+            candidates[sandbox_id] = ReapCandidate(
+                sandbox_id=sandbox_id,
+                template_id=sandbox.template_id or owner.record.template_id,
+                age_seconds=_age_seconds(sandbox.started_at, now),
+                source="ledger",
+                trial_name=owner.record.trial_name or sandbox.trial_name(),
+                owner_pid=owner.record.pid,
+                owner_alive=False,
+                ledger_path=owner.path,
+            )
+
+    if stale_minutes is not None:
+        threshold = stale_minutes * 60
+        for sandbox in alive:
+            if sandbox.sandbox_id in candidates or not sandbox.is_harbor_trial():
+                continue
+            owner = owners.get(sandbox.sandbox_id)
+            # A sandbox whose ledger owner still runs is a LIVE local trial, never stale.
+            if owner is not None and owner.alive:
+                continue
+            age = _age_seconds(sandbox.started_at, now)
+            if age <= threshold:
+                continue
+            candidates[sandbox.sandbox_id] = ReapCandidate(
+                sandbox_id=sandbox.sandbox_id,
+                template_id=sandbox.template_id,
+                age_seconds=age,
+                source="metadata",
+                trial_name=sandbox.trial_name(),
+                owner_pid=owner.record.pid if owner is not None else None,
+                owner_alive=False if owner is not None else None,
+                ledger_path=owner.path if owner is not None else None,
+            )
+
+    ordered = sorted(candidates.values(), key=lambda item: item.age_seconds, reverse=True)
+    return ReapPlan(candidates=tuple(ordered), vanished=tuple(vanished))
+
+
+class _LedgerOwner(NamedTuple):
+    """The local record behind one still-held sandbox id, plus its owner's liveness."""
+
+    path: Path
+    record: SandboxCreated
+    alive: bool
+
+
+def _ledger_owners(
+    ledger_files: Sequence[LedgerFile],
+    pid_alive: Callable[[int], bool],
+) -> dict[str, _LedgerOwner]:
+    """Index every still-held ledger record by sandbox id, probing each pid at most once."""
+    liveness: dict[int, bool] = {}
+    owners: dict[str, _LedgerOwner] = {}
+    for ledger in ledger_files:
+        if ledger.owner_pid not in liveness:
+            liveness[ledger.owner_pid] = pid_alive(ledger.owner_pid)
+        for record in ledger.held:
+            owners[record.sandbox_id] = _LedgerOwner(
+                ledger.path, record, liveness[ledger.owner_pid]
+            )
+    return owners
+
+
+def _age_seconds(started_at: datetime, now: datetime) -> float:
+    """Sandbox age in seconds, tolerating a naive provider timestamp."""
+    started = started_at if started_at.tzinfo is not None else started_at.replace(tzinfo=UTC)
+    reference = now if now.tzinfo is not None else now.replace(tzinfo=UTC)
+    return max((reference - started).total_seconds(), 0.0)
+
+
+def execute_reap(
+    plan: ReapPlan,
+    *,
+    killer: SandboxKiller = kill_sandbox,
+    ledger_directory: Path | None = None,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    pid: int | None = None,
+    pid_alive: Callable[[int], bool] = pid_is_alive,
+) -> ReapOutcome:
+    """Kill every candidate in `plan`, then reconcile and prune the ledger.
+
+    Each id is killed independently: one failure is recorded and the sweep continues, because
+    one unkillable sandbox must not strand every other slot. A kill that succeeds (or that
+    E2B answers "already gone") appends a release record to the owning ledger file, and a ledger
+    file of a DEAD owner with nothing left held is deleted.
+    """
+    reaper_pid = pid if pid is not None else os.getpid()
+    killed: list[str] = []
+    already_gone: list[str] = []
+    failed: list[tuple[str, str]] = []
+    for candidate in plan.candidates:
+        try:
+            stopped = killer(candidate.sandbox_id)
+        except Exception as error:  # noqa: BLE001 - one bad id must not abort the sweep
+            failed.append((candidate.sandbox_id, f"{type(error).__name__}: {error}"))
+            continue
+        if stopped:
+            killed.append(candidate.sandbox_id)
+        else:
+            already_gone.append(candidate.sandbox_id)
+        _release(candidate.ledger_path, candidate.sandbox_id, reaper_pid, now())
+    for path, record in plan.vanished:
+        _release(path, record.sandbox_id, reaper_pid, now())
+    return ReapOutcome(
+        killed=tuple(killed),
+        already_gone=tuple(already_gone),
+        failed=tuple(failed),
+        pruned_ledgers=prune_released_files(ledger_directory, owner_alive=pid_alive),
+    )
+
+
+def _release(path: Path | None, sandbox_id: str, pid: int, released_at: datetime) -> None:
+    """Best-effort ledger release; a missing owner file or write error is not fatal."""
+    if path is None:
+        return
+    try:
+        append_release(path, sandbox_id=sandbox_id, pid=pid, released_at=released_at)
+    except OSError:
+        pass  # the sandbox is dead either way; the ledger just keeps a stale record
+
+
+@dataclass(frozen=True)
+class CapacityCheck:
+    """The account's concurrent-sandbox capacity around one preflight."""
+
+    cap: int
+    alive_before: int
+    """Running sandboxes counted before any reap."""
+
+    alive: int
+    """Running sandboxes after reaping this machine's provable orphans."""
+
+    required: int
+    outcome: ReapOutcome | None = None
+    """The reap that ran because the first count was short, or None when none was needed."""
+
+    @property
+    def free(self) -> int:
+        """Slots available for new sandboxes."""
+        return max(self.cap - self.alive, 0)
+
+    @property
+    def ok(self) -> bool:
+        """Whether the run can claim the concurrency it asks for."""
+        return self.free >= self.required
+
+    @property
+    def reaped(self) -> int:
+        """How many orphan slots the preflight reclaimed."""
+        return 0 if self.outcome is None else self.outcome.freed
+
+
+def check_capacity(
+    *,
+    required: int,
+    cap: int | None = None,
+    lister: SandboxLister = list_alive_sandboxes,
+    killer: SandboxKiller = kill_sandbox,
+    ledger_directory: Path | None = None,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+    pid_alive: Callable[[int], bool] = pid_is_alive,
+) -> CapacityCheck:
+    """Count running sandboxes and, when short of `required`, reap provable orphans.
+
+    Only the dead-owner class is reaped: exact ids from this machine's ledger whose owning
+    process is gone. The account-wide metadata sweep stays a deliberate operator action
+    (`wmh e2b reap --stale-minutes N`), never something a run does on its own.
+
+    Returns:
+        The capacity picture after any reap, including whether `required` slots are free.
+    """
+    limit = cap if cap is not None else sandbox_cap()
+    alive = lister()
+    if limit - len(alive) >= required:
+        return CapacityCheck(
+            cap=limit, alive_before=len(alive), alive=len(alive), required=required
+        )
+    plan = plan_reap(
+        alive=alive,
+        ledger_files=read_ledger_files(ledger_directory),
+        now=now(),
+        dead_owners=True,
+        stale_minutes=None,
+        pid_alive=pid_alive,
+    )
+    outcome = execute_reap(
+        plan,
+        killer=killer,
+        ledger_directory=ledger_directory,
+        now=now,
+        pid_alive=pid_alive,
+    )
+    return CapacityCheck(
+        cap=limit,
+        alive_before=len(alive),
+        alive=max(len(alive) - outcome.freed, 0),
+        required=required,
+        outcome=outcome,
+    )

--- a/wmh/harness/e2b_reap_test.py
+++ b/wmh/harness/e2b_reap_test.py
@@ -1,0 +1,393 @@
+"""Offline tests for orphan selection, killing, and capacity checks: no SDK, no network."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wmh.harness.e2b_ledger import SandboxLedger, read_ledger_files
+from wmh.harness.e2b_reap import (
+    DEFAULT_E2B_SANDBOX_CAP,
+    E2B_SANDBOX_CAP_ENV,
+    AliveSandbox,
+    check_capacity,
+    execute_reap,
+    is_credential_error,
+    plan_reap,
+    sandbox_cap,
+)
+
+_NOW = datetime(2026, 7, 24, 18, 0, 0, tzinfo=UTC)
+
+
+def _alive(
+    sandbox_id: str,
+    *,
+    age_minutes: float = 10.0,
+    template_id: str = "wmh-hb-v1-abc",
+    trial: str | None = "task__a1b2",
+    environment: str | None = "task/environment",
+) -> AliveSandbox:
+    metadata: dict[str, str] = {}
+    if trial is not None:
+        metadata["session_id"] = f"{trial}__env"
+    if environment is not None:
+        metadata["environment_name"] = environment
+    return AliveSandbox(
+        sandbox_id=sandbox_id,
+        template_id=template_id,
+        started_at=_NOW - timedelta(minutes=age_minutes),
+        metadata=metadata,
+    )
+
+
+def _ledger_with(directory: Path, *, pid: int, sandbox_ids: tuple[str, ...]) -> SandboxLedger:
+    ledger = SandboxLedger(directory, pid=pid, now=lambda: _NOW - timedelta(minutes=30))
+    for sandbox_id in sandbox_ids:
+        ledger.record_created(
+            sandbox_id=sandbox_id, template_id="wmh-hb-v1-abc", trial_name=f"trial-{sandbox_id}"
+        )
+    return ledger
+
+
+# -- cap resolution --------------------------------------------------------------------------
+
+
+def test_sandbox_cap_defaults_to_the_published_account_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(E2B_SANDBOX_CAP_ENV, raising=False)
+    assert sandbox_cap() == DEFAULT_E2B_SANDBOX_CAP
+    monkeypatch.setenv(E2B_SANDBOX_CAP_ENV, "250")
+    assert sandbox_cap() == 250
+
+
+@pytest.mark.parametrize("value", ["nope", "0", "-3"])
+def test_a_bad_cap_override_is_rejected_with_the_variable_name(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(E2B_SANDBOX_CAP_ENV, value)
+    with pytest.raises(ValueError, match=E2B_SANDBOX_CAP_ENV):
+        sandbox_cap()
+
+
+# -- candidate selection ---------------------------------------------------------------------
+
+
+def test_dead_owner_ledger_entries_are_candidates_and_live_owners_are_not(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1", "dead-2"))
+    _ledger_with(tmp_path, pid=222, sandbox_ids=("live-1",))
+    alive = [_alive("dead-1", age_minutes=200), _alive("dead-2", age_minutes=50), _alive("live-1")]
+
+    plan = plan_reap(
+        alive=alive,
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        pid_alive=lambda pid: pid == 222,
+    )
+
+    # Oldest first, and every candidate carries its evidence.
+    assert [candidate.sandbox_id for candidate in plan.candidates] == ["dead-1", "dead-2"]
+    first = plan.candidates[0]
+    assert first.source == "ledger"
+    assert first.owner_pid == 111
+    assert first.owner_alive is False
+    assert first.trial_name == "trial-dead-1"
+    assert first.template_id == "wmh-hb-v1-abc"
+    assert first.age_seconds == pytest.approx(200 * 60)
+    assert first.ledger_path is not None
+    assert plan.vanished == ()
+
+
+def test_a_dead_owner_record_whose_sandbox_is_gone_is_released_not_killed(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("gone-1",))
+
+    plan = plan_reap(
+        alive=[],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert plan.candidates == ()
+    [(path, record)] = plan.vanished
+    assert record.sandbox_id == "gone-1"
+    assert path.exists()
+
+
+def test_dead_owners_can_be_turned_off(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1",))
+
+    plan = plan_reap(
+        alive=[_alive("dead-1")],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        dead_owners=False,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert plan.candidates == ()
+    assert plan.vanished == ()
+
+
+def test_stale_minutes_matches_harbor_metadata_on_the_account(tmp_path: Path) -> None:
+    alive = [
+        _alive("old-trial", age_minutes=90),
+        _alive("young-trial", age_minutes=15),
+        _alive("not-a-trial", age_minutes=600, trial=None),
+        _alive("no-environment", age_minutes=600, environment=None),
+    ]
+
+    plan = plan_reap(
+        alive=alive,
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        stale_minutes=60,
+        pid_alive=lambda _pid: False,
+    )
+
+    [candidate] = plan.candidates
+    assert candidate.sandbox_id == "old-trial"
+    assert candidate.source == "metadata"
+    assert candidate.owner_pid is None
+    assert candidate.owner_alive is None  # no local record: liveness is unknowable
+    assert candidate.trial_name == "task__a1b2"
+
+
+def test_stale_minutes_never_selects_a_sandbox_whose_local_owner_is_alive(tmp_path: Path) -> None:
+    """A long-running trial of the CURRENT run must survive an account-wide sweep."""
+    _ledger_with(tmp_path, pid=222, sandbox_ids=("mine",))
+
+    plan = plan_reap(
+        alive=[_alive("mine", age_minutes=600)],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        stale_minutes=60,
+        pid_alive=lambda pid: pid == 222,
+    )
+
+    assert plan.candidates == ()
+
+
+def test_a_ledger_candidate_is_not_duplicated_by_the_metadata_sweep(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1",))
+
+    plan = plan_reap(
+        alive=[_alive("dead-1", age_minutes=600)],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        stale_minutes=60,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert [candidate.sandbox_id for candidate in plan.candidates] == ["dead-1"]
+    assert plan.candidates[0].source == "ledger"
+
+
+# -- execution -------------------------------------------------------------------------------
+
+
+def test_execute_reap_kills_every_id_releases_the_ledger_and_prunes(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1", "dead-2"))
+    plan = plan_reap(
+        alive=[_alive("dead-1"), _alive("dead-2")],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        pid_alive=lambda _pid: False,
+    )
+    killed: list[str] = []
+
+    def killer(sandbox_id: str) -> bool:
+        killed.append(sandbox_id)
+        return True
+
+    outcome = execute_reap(
+        plan,
+        killer=killer,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid=999,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert sorted(killed) == ["dead-1", "dead-2"]
+    assert sorted(outcome.killed) == ["dead-1", "dead-2"]
+    assert outcome.freed == 2
+    assert outcome.failed == ()
+    # Every recorded id is released, so the owning file is pruned.
+    assert len(outcome.pruned_ledgers) == 1
+    assert read_ledger_files(tmp_path) == ()
+
+
+def test_one_failing_kill_does_not_abort_the_sweep(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("bad", "good"))
+    plan = plan_reap(
+        alive=[_alive("bad", age_minutes=100), _alive("good", age_minutes=50)],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    def killer(sandbox_id: str) -> bool:
+        if sandbox_id == "bad":
+            raise RuntimeError("500: gateway blew up")
+        return True
+
+    outcome = execute_reap(
+        plan,
+        killer=killer,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid=999,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert outcome.killed == ("good",)
+    assert outcome.failed == (("bad", "RuntimeError: 500: gateway blew up"),)
+    assert outcome.freed == 1
+    # The failed id stays held so a later reap retries it; the file is therefore not pruned.
+    [ledger_file] = read_ledger_files(tmp_path)
+    assert [record.sandbox_id for record in ledger_file.held] == ["bad"]
+    assert outcome.pruned_ledgers == ()
+
+
+def test_an_already_gone_candidate_frees_no_slot_but_clears_the_ledger(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("expired",))
+    plan = plan_reap(
+        alive=[_alive("expired")],
+        ledger_files=read_ledger_files(tmp_path),
+        now=_NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    outcome = execute_reap(
+        plan,
+        killer=lambda _sandbox_id: False,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid=999,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert outcome.killed == ()
+    assert outcome.already_gone == ("expired",)
+    assert outcome.freed == 0
+    assert read_ledger_files(tmp_path) == ()
+
+
+def test_vanished_records_are_released_without_any_kill(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("gone",))
+    plan = plan_reap(
+        alive=[], ledger_files=read_ledger_files(tmp_path), now=_NOW, pid_alive=lambda _pid: False
+    )
+
+    def killer(sandbox_id: str) -> bool:
+        raise AssertionError(f"must not kill {sandbox_id}")
+
+    outcome = execute_reap(
+        plan,
+        killer=killer,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid=999,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert outcome.killed == ()
+    assert len(outcome.pruned_ledgers) == 1
+
+
+# -- capacity check --------------------------------------------------------------------------
+
+
+def test_sufficient_free_slots_reap_nothing(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1",))
+
+    def killer(sandbox_id: str) -> bool:
+        raise AssertionError(f"must not kill {sandbox_id} when slots are free")
+
+    check = check_capacity(
+        required=4,
+        cap=10,
+        lister=lambda: [_alive(f"s{index}") for index in range(6)],
+        killer=killer,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert check.ok is True
+    assert (check.alive, check.free, check.reaped) == (6, 4, 0)
+    assert check.outcome is None
+
+
+def test_insufficient_slots_reap_dead_owners_and_then_pass(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1", "dead-2", "dead-3"))
+    alive = [_alive(f"other-{index}") for index in range(7)] + [
+        _alive("dead-1"),
+        _alive("dead-2"),
+        _alive("dead-3"),
+    ]
+
+    check = check_capacity(
+        required=3,
+        cap=10,
+        lister=lambda: alive,
+        killer=lambda _sandbox_id: True,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert check.ok is True
+    assert (check.alive_before, check.alive, check.reaped, check.free) == (10, 7, 3, 3)
+    assert read_ledger_files(tmp_path) == ()
+
+
+def test_still_insufficient_after_reaping_reports_the_numbers(tmp_path: Path) -> None:
+    _ledger_with(tmp_path, pid=111, sandbox_ids=("dead-1",))
+    alive = [_alive(f"other-{index}") for index in range(9)] + [_alive("dead-1")]
+
+    check = check_capacity(
+        required=8,
+        cap=10,
+        lister=lambda: alive,
+        killer=lambda _sandbox_id: True,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert check.ok is False
+    assert (check.alive_before, check.alive, check.reaped, check.free) == (10, 9, 1, 1)
+    assert check.required == 8
+
+
+def test_capacity_check_reads_the_cap_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(E2B_SANDBOX_CAP_ENV, "12")
+
+    check = check_capacity(
+        required=2,
+        lister=lambda: [_alive("s1")],
+        killer=lambda _sandbox_id: True,
+        ledger_directory=tmp_path,
+        now=lambda: _NOW,
+        pid_alive=lambda _pid: False,
+    )
+
+    assert check.cap == 12
+    assert check.ok is True
+
+
+def test_credential_errors_are_classified_by_name() -> None:
+    """No SDK import needed: e2b's AuthenticationException is matched by class name."""
+
+    class AuthenticationException(Exception):
+        pass
+
+    assert is_credential_error(AuthenticationException("API key is required")) is True
+    assert is_credential_error(RuntimeError("connection reset")) is False


### PR DESCRIPTION
This PR adds the rollout-capture layer for on-policy distillation: running the pi agent on harbor tasks with the Tinker student as the sampling provider while recording the exact sampled token ids per trial. A distill harbor agent routes each trial through `TinkerChatProvider` with a per-trial `TokenRecorder` sink; `wmh/distill/tokens.py` then pairs the recorded token spans with their `ScoreCell` rewards into `TrialRecord`s, and `collect_rollouts` drives a wave of harbor trials from a `DistillConfig` to produce the training-ready records.

To support this without forking the harbor bridge, the existing seams are extended in place: `wmh/evals/harbor/agent.py` gains a `_build_provider` hook so a subclass can substitute the sampling provider, and `HarborScorer` accepts `agent_import_path` plus `extra_agent_kwargs` so trials can be routed through a custom agent class. Both extensions default to the current behavior and are covered by tests.

Distill evals are also made resilient to transient trial deaths: a live E2B runner death at the final eval previously aborted a full run because one trial ended without a verifier reward. `HarborScorer` gains a `missing_reward` mode (the default stays `raise`, so search-mode strictness is unchanged) and distill rollouts opt into `missing_reward="zero"`, treating a trial that dies before producing verifier evidence as a failed trial rather than a run-fatal error. Rollout collection passes `harbor_retries` from `HarborConfig.retries` so one retry absorbs transient sandbox and runner deaths.

Rollout collection also exposes a `rollout_stats` helper, so a run that loads warmup trajectories recorded by an earlier run reports the same statistics as one that collected them itself.

It also adds E2B sandbox lifecycle hygiene, prompted by an outage in which orphaned sandboxes from crashed runs held 73 of the account's 100 concurrent slots and starved three live training runs: every trial died at sandbox creation and produced no token spans, which looks exactly like a broken model. Sandbox creation is now recorded in a per-process append-and-fsync ledger under `$WMH_HOME/e2b-sandboxes` (pure filesystem, so a crashed run still leaves an accurate record), and `wmh e2b reap` selects candidates either from ledger entries whose owning process is gone or, opt-in through `--stale-minutes`, account-wide by metadata match, kills them, and reports the resulting capacity. The harbor E2B environment records creates and releases through the ledger and retries a `RateLimitException` on sandbox create with bounded backoff, and rollouts records that one e2b trial holds two concurrent sandboxes.

## Stack

This is PR 2 of a three-PR stack based on `feat/optimize-harbor-env`:

1. #250 Add the Tinker sampling provider and distill foundations
2. #251 Capture distill rollouts through harbor with per-trial token sinks (this PR)
3. #252 Add the distill optimizer mode: OPD training loop and harbor CLI

## Testing

Full gate green on this branch: `uv run ruff check .` clean, `uv run ty check` clean, `uv run pytest -q` with 2368 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




