### PR TITLE
Serve the validated kNN routing champion: guarded knn policy kind with pinned fable fallback

### DIFF
--- a/.agents/scripts/validate_knn_promotion.py
+++ b/.agents/scripts/validate_knn_promotion.py
@@ -288,8 +288,8 @@ def main() -> None:
     confidence_curve(
         "routerbench-ours9", "routerbench-ours9-oai3l-tasks.npy", rag_num=50, fallback="fable-5"
     )
-    # tau-bench is 25 scenarios, so the production budget (50) covers the whole 17-row fit bank:
-    # every query's neighborhood is the entire bank. Both budgets are reported to show it.
+    # tau-bench is 25 scenarios; the adaptive rule caps the default budget at ceil(17/2) = 9
+    # there, so the two curves below contrast the capped default against an explicit rag=5.
     confidence_curve("tau-bench", "wm-tau-bench-oai3l-tasks.npy", rag_num=50, fallback="fable-5")
     confidence_curve("tau-bench", "wm-tau-bench-oai3l-tasks.npy", rag_num=5, fallback="fable-5")
 

--- a/.agents/scripts/validate_knn_promotion.py
+++ b/.agents/scripts/validate_knn_promotion.py
@@ -1,0 +1,294 @@
+"""Validation gate for the kNN policy promotion: reproduce the champion through wmh code.
+
+Chat R1 measured `knn-statz05-oai` with a research script
+(`.agents/scripts/r1_retrieval_ablations.py` on the routing/r1 worktree): +1.04 accuracy points
+over the best single model at -27% cost on routerbench-ours9, 5 of 5 split seeds. This script
+re-runs that measurement through the PRODUCTION path only: `wmh.optimize.knn.fit_knn_policy`
+writes a real .npz sidecar, and `wmh.optimize.routing.evaluate_policy` replays the policy through
+the same `knn_decision` serving calls. If the numbers move, the promotion changed the algorithm.
+
+Split identity is proven, not assumed: the stratified 70/30 split is reimplemented here (the
+research helper lives on the feat/routing-research branch, not on main) and every seed's fit/test
+sizes and best-single baseline accuracy are checked against the recorded runs in
+`~/Desktop/Projects/wmh-routing-data/runs/r1.jsonl`. Query embeddings come from R1's cached
+text-embedding-3-large vectors, so no text is re-embedded.
+
+Usage:
+    uv run python .agents/scripts/validate_knn_promotion.py            # ours9 gate + curves
+    uv run python .agents/scripts/validate_knn_promotion.py --curve-only
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from wmh.optimize.knn import best_single_on_fit, fit_knn_policy
+from wmh.optimize.outcomes import OutcomeMatrix
+from wmh.optimize.policy import KNN_BANK_FILENAME, EmbedderSpec, select_model
+from wmh.optimize.routing import evaluate_policy
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("validate-knn")
+
+DATA = Path("~/Desktop/Projects/wmh-routing-data").expanduser()
+SEEDS = [0, 1, 2, 3, 4]
+# The champion's measured result, as recorded in runs/r1.jsonl (variant r1-knn-statz05-oai).
+CHAMPION_DELTA = 0.0104
+DELTA_TOLERANCE = 0.003
+
+
+def stratified_split(
+    matrix: OutcomeMatrix, *, train_fraction: float = 0.7, seed: int = 0
+) -> tuple[list[str], list[str]]:
+    """The routing protocol's split, reimplemented (see module docstring on identity checks).
+
+    Stratified by the scenario id's dataset prefix, so no small eval vanishes from either side;
+    ids without a prefix share one stratum.
+    """
+    by_eval: dict[str, list[str]] = {}
+    for scenario_id in matrix.scenario_ids():
+        prefix = scenario_id.split(":", 1)[0] if ":" in scenario_id else ""
+        by_eval.setdefault(prefix, []).append(scenario_id)
+    rng = random.Random(seed)
+    fit: list[str] = []
+    test: list[str] = []
+    for _name, ids in sorted(by_eval.items()):
+        shuffled = ids[:]
+        rng.shuffle(shuffled)
+        if len(shuffled) > 1:
+            cut = min(max(1, round(len(shuffled) * train_fraction)), len(shuffled) - 1)
+        else:
+            cut = 1
+        fit.extend(shuffled[:cut])
+        test.extend(shuffled[cut:])
+    return sorted(fit), sorted(test)
+
+
+class CachedEmbedder:
+    """Serves R1's cached text-embedding-3-large vectors by task text (no API calls).
+
+    The cache is row-aligned to the matrix's scenarios in first-appearance order, which is how
+    the research script wrote it.
+    """
+
+    def __init__(self, matrix: OutcomeMatrix, cache_path: Path) -> None:
+        order: list[str] = []
+        tasks: dict[str, str] = {}
+        for outcome in matrix.outcomes:
+            if outcome.scenario_id not in tasks:
+                tasks[outcome.scenario_id] = outcome.task
+                order.append(outcome.scenario_id)
+        vectors = np.load(cache_path)
+        if vectors.shape[0] != len(order):
+            raise ValueError(
+                f"cache {cache_path} has {vectors.shape[0]} rows but the matrix has "
+                f"{len(order)} scenarios; it was built for a different matrix"
+            )
+        self.dim = int(vectors.shape[1])
+        self._by_text = {tasks[sid]: vectors[index] for index, sid in enumerate(order)}
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        missing = [text for text in texts if text not in self._by_text]
+        if missing:
+            raise KeyError(f"{len(missing)} task texts are not in the embedding cache")
+        return [self._by_text[text].tolist() for text in texts]
+
+
+def baseline_on_test(matrix: OutcomeMatrix, model: str, test_ids: list[str]) -> tuple[float, float]:
+    """(mean reward, mean cost) of one model over the test scenarios it was scored on."""
+    rewards: list[float] = []
+    costs: list[float] = []
+    by_cell: dict[str, list[tuple[float, float]]] = {}
+    wanted = set(test_ids)
+    for outcome in matrix.outcomes:
+        if outcome.scenario_id in wanted and outcome.model == model and outcome.reward is not None:
+            by_cell.setdefault(outcome.scenario_id, []).append((outcome.reward, outcome.cost_usd))
+    for cells in by_cell.values():
+        rewards.append(sum(reward for reward, _ in cells) / len(cells))
+        costs.append(sum(cost for _, cost in cells) / len(cells))
+    return sum(rewards) / len(rewards), sum(costs) / len(costs)
+
+
+def recorded_runs(variant: str, matrix_name: str) -> dict[int, dict[str, float]]:
+    """Per-seed headline numbers R1 recorded for `variant`, keyed by split seed."""
+    out: dict[int, dict[str, float]] = {}
+    with (DATA / "runs" / "r1.jsonl").open(encoding="utf-8") as handle:
+        for line in handle:
+            record = json.loads(line)
+            if (
+                record["variant"] != variant
+                or record["matrix"] != matrix_name
+                or "H2H" in record["notes"]
+            ):
+                continue
+            out[record["split_seed"]] = {
+                "accuracy": record["result"]["accuracy"],
+                "cost": record["result"]["cost_per_call"],
+                "baseline_accuracy": record["baselines"]["best_single"]["accuracy"],
+                "baseline_cost": record["baselines"]["best_single"]["cost_per_call"],
+                "fit": record["fit_scenarios"],
+                "test": record["test_scenarios"],
+            }
+    return out
+
+
+def ours9_gate(*, se_floor: bool) -> None:
+    """The gate: 5 seeds of routerbench-ours9 through fit_knn_policy + evaluate_policy."""
+    matrix = OutcomeMatrix.load(DATA / "matrices" / "routerbench-ours9_matrix.json")
+    embedder = CachedEmbedder(matrix, DATA / "cache" / "routerbench-ours9-oai3l-tasks.npy")
+    spec = EmbedderSpec(
+        kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
+    )
+    reference = recorded_runs("r1-knn-statz05-oai", "routerbench-ours9")
+    deltas: list[float] = []
+    cost_ratios: list[float] = []
+
+    for seed in SEEDS:
+        fit_ids, test_ids = stratified_split(matrix, seed=seed)
+        expected = reference[seed]
+        if (len(fit_ids), len(test_ids)) != (expected["fit"], expected["test"]):
+            raise AssertionError(
+                f"seed {seed} split is {len(fit_ids)}/{len(test_ids)}, R1 recorded "
+                f"{expected['fit']}/{expected['test']}: not the same split"
+            )
+        baseline = best_single_on_fit(matrix, fit_ids)
+        base_accuracy, base_cost = baseline_on_test(matrix, baseline, test_ids)
+        if abs(base_accuracy - expected["baseline_accuracy"]) > 1e-6:
+            raise AssertionError(
+                f"seed {seed} best-single ({baseline}) scores {base_accuracy:.6f} on test, R1 "
+                f"recorded {expected['baseline_accuracy']:.6f}: not the same split or baseline"
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            policy = fit_knn_policy(
+                matrix,
+                bank_path=Path(directory) / KNN_BANK_FILENAME,
+                fit_ids=fit_ids,
+                embedder=spec,
+                embed_with=embedder,
+                se_floor=se_floor,
+                fitted_from=f"routerbench-ours9 seed={seed}",
+            )
+            result = evaluate_policy(policy, matrix, test_ids, embedder=embedder)
+
+        delta = result.accuracy - base_accuracy
+        deltas.append(delta)
+        cost_ratios.append(result.cost_per_scenario / base_cost - 1.0)
+        logger.info(
+            "seed %d: acc %.4f vs best-single %s %.4f (delta %+.4f), cost $%.6f (%+0.1f%%) "
+            "[R1 recorded acc %.4f delta %+.4f]",
+            seed,
+            result.accuracy,
+            baseline,
+            base_accuracy,
+            delta,
+            result.cost_per_scenario,
+            cost_ratios[-1] * 100,
+            expected["accuracy"],
+            expected["accuracy"] - expected["baseline_accuracy"],
+        )
+
+    mean_delta = statistics.mean(deltas)
+    wins = sum(1 for delta in deltas if delta > 0)
+    logger.info(
+        "GATE se_floor=%s: mean delta %+.4f (stdev %.4f, sem %.4f), %d/5 seed wins, "
+        "mean cost %+0.1f%% vs champion %+.4f",
+        se_floor,
+        mean_delta,
+        statistics.stdev(deltas),
+        statistics.stdev(deltas) / len(deltas) ** 0.5,
+        wins,
+        statistics.mean(cost_ratios) * 100,
+        CHAMPION_DELTA,
+    )
+    verdict = "PASS" if abs(mean_delta - CHAMPION_DELTA) <= DELTA_TOLERANCE and wins == 5 else "FAIL"
+    logger.info(
+        "GATE se_floor=%s: %s (needs |delta - %.4f| <= %.3f and 5/5 wins)",
+        se_floor,
+        verdict,
+        CHAMPION_DELTA,
+        DELTA_TOLERANCE,
+    )
+
+
+def confidence_curve(matrix_name: str, cache_name: str, *, rag_num: int, fallback: str) -> None:
+    """Routed-away fraction and quality/cost as the z knob tightens, with `fallback` pinned."""
+    matrix = OutcomeMatrix.load(DATA / "matrices" / f"{matrix_name}_matrix.json")
+    embedder = CachedEmbedder(matrix, DATA / "cache" / cache_name)
+    spec = EmbedderSpec(
+        kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
+    )
+    fit_ids, test_ids = stratified_split(matrix, seed=0)
+    base_accuracy, base_cost = baseline_on_test(matrix, fallback, test_ids)
+    tasks = {outcome.scenario_id: outcome.task for outcome in matrix.outcomes}
+    logger.info(
+        "%s (fit %d, test %d, rag_num %d, fallback %s: acc %.4f, cost $%.6f)",
+        matrix_name,
+        len(fit_ids),
+        len(test_ids),
+        rag_num,
+        fallback,
+        base_accuracy,
+        base_cost,
+    )
+    for z in (0.0, 0.25, 0.5, 1.0, 2.0):
+        with tempfile.TemporaryDirectory() as directory:
+            policy = fit_knn_policy(
+                matrix,
+                bank_path=Path(directory) / KNN_BANK_FILENAME,
+                fit_ids=fit_ids,
+                embedder=spec,
+                embed_with=embedder,
+                guard_model=fallback,
+                rag_num=rag_num,
+                z=z,
+            )
+            result = evaluate_policy(policy, matrix, test_ids, embedder=embedder)
+            decisions = [
+                select_model(policy, tasks[sid], embedder=embedder) for sid in sorted(test_ids)
+            ]
+        reverts = [d for d in decisions if "reverted to" in d.reason]
+        stray = [d.model for d in reverts if d.model != fallback]
+        if stray:
+            raise AssertionError(f"z={z}: guard reverted to {sorted(set(stray))}, not {fallback}")
+        routed = 1.0 - result.model_mix.get(fallback, 0.0)
+        logger.info(
+            "  z=%-4g routed away %5.1f%% | acc %.4f (%+.4f) | cost $%.6f (%+0.1f%%) | "
+            "%d guard reverts, all to %s",
+            z,
+            routed * 100,
+            result.accuracy,
+            result.accuracy - base_accuracy,
+            result.cost_per_scenario,
+            (result.cost_per_scenario / base_cost - 1.0) * 100,
+            len(reverts),
+            fallback,
+        )
+
+
+def main() -> None:
+    if "--curve-only" not in sys.argv:
+        logger.info("=== ours9 champion gate (se_floor off: R1's exact configuration) ===")
+        ours9_gate(se_floor=False)
+        logger.info("=== ours9 champion gate (se_floor on: the production default) ===")
+        ours9_gate(se_floor=True)
+    logger.info("=== confidence curve: fable-5 pinned as the fallback ===")
+    confidence_curve(
+        "routerbench-ours9", "routerbench-ours9-oai3l-tasks.npy", rag_num=50, fallback="fable-5"
+    )
+    # tau-bench is 25 scenarios, so the production budget (50) covers the whole 17-row fit bank:
+    # every query's neighborhood is the entire bank. Both budgets are reported to show it.
+    confidence_curve("tau-bench", "wm-tau-bench-oai3l-tasks.npy", rag_num=50, fallback="fable-5")
+    confidence_curve("tau-bench", "wm-tau-bench-oai3l-tasks.npy", rag_num=5, fallback="fable-5")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/validate_knn_promotion.py
+++ b/.agents/scripts/validate_knn_promotion.py
@@ -36,6 +36,8 @@ from wmh.optimize.policy import KNN_BANK_FILENAME, EmbedderSpec, select_model
 from wmh.optimize.routing import evaluate_policy
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+FAILURES: list[str] = []
+
 logger = logging.getLogger("validate-knn")
 
 DATA = Path("~/Desktop/Projects/wmh-routing-data").expanduser()
@@ -209,14 +211,16 @@ def ours9_gate(*, se_floor: bool) -> None:
         statistics.mean(cost_ratios) * 100,
         CHAMPION_DELTA,
     )
-    verdict = "PASS" if abs(mean_delta - CHAMPION_DELTA) <= DELTA_TOLERANCE and wins == 5 else "FAIL"
+    passed = abs(mean_delta - CHAMPION_DELTA) <= DELTA_TOLERANCE and wins == 5
     logger.info(
         "GATE se_floor=%s: %s (needs |delta - %.4f| <= %.3f and 5/5 wins)",
         se_floor,
-        verdict,
+        "PASS" if passed else "FAIL",
         CHAMPION_DELTA,
         DELTA_TOLERANCE,
     )
+    if not passed:
+        FAILURES.append(f"ours9 gate se_floor={se_floor}")
 
 
 def confidence_curve(matrix_name: str, cache_name: str, *, rag_num: int, fallback: str) -> None:
@@ -292,3 +296,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+    if FAILURES:
+        logger.error("VALIDATION FAILED: %s", ", ".join(FAILURES))
+        sys.exit(1)

--- a/wmh/cli/route_app.py
+++ b/wmh/cli/route_app.py
@@ -74,6 +74,8 @@ def fit(
     floor_q: float = typer.Option(
         0.05,
         "--floor-q",
+        min=0.0,
+        max=1.0,
         help="Novelty floor quantile: abstain to the fallback when a query's best bank "
         "similarity is below this quantile of the bank's own nearest-neighbor sims "
         "(coverage/robustness knob for task drift; 0 = off, the exact validated champion).",
@@ -120,6 +122,11 @@ def fit(
         )
     )
     out_path = Path(out)
+    if rag_thres <= 0.0:
+        # typer's min is inclusive but the artifact field requires > 0; fail before the fit
+        # writes a sidecar it will then abandon.
+        raise typer.BadParameter("--rag-thres must be greater than 0")
+    built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(
@@ -131,6 +138,7 @@ def fit(
             matrix,
             bank_path=out_path.parent / KNN_BANK_FILENAME,
             embedder=spec,
+            embed_with=built,
             guard_model=fallback,
             rag_num=rag_num,
             rag_thres=rag_thres,
@@ -153,7 +161,7 @@ def fit(
         if cost_weight > 0.0:
             policy = rerank_policy(policy, cost_weight=cost_weight)
     policy.save(out_path)
-    result = evaluate_policy(policy, matrix, matrix.scenario_ids())
+    result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
     if kind == "knn":
         routed = 1.0 - result.model_mix.get(policy.default_model, 0.0)
         _console.print(

--- a/wmh/cli/route_app.py
+++ b/wmh/cli/route_app.py
@@ -71,6 +71,13 @@ def fit(
     min_pairs: int = typer.Option(
         8, "--min-pairs", min=0, help="(knn) Neighbors scored on both sides before routing away."
     ),
+    floor_q: float = typer.Option(
+        0.05,
+        "--floor-q",
+        help="Novelty floor quantile: abstain to the fallback when a query's best bank "
+        "similarity is below this quantile of the bank's own nearest-neighbor sims "
+        "(coverage/robustness knob for task drift; 0 = off, the exact validated champion).",
+    ),
     se_floor: bool = typer.Option(
         True,
         "--se-floor/--no-se-floor",
@@ -130,7 +137,8 @@ def fit(
             z=z,
             min_pairs=min_pairs,
             se_floor=se_floor,
-            fitted_from=f"{matrix_file} knn z={z} k={rag_num} {embedder}-{dim}",
+            floor_q=floor_q,
+            fitted_from=f"{matrix_file} knn z={z} k={rag_num} q={floor_q} {embedder}-{dim}",
         )
     else:
         policy = fit_rank_policy(

--- a/wmh/cli/route_app.py
+++ b/wmh/cli/route_app.py
@@ -15,8 +15,14 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from wmh.optimize.knn import fit_knn_policy
 from wmh.optimize.outcomes import OutcomeMatrix
-from wmh.optimize.policy import POLICY_FILENAME, EmbedderSpec, RoutingPolicy
+from wmh.optimize.policy import (
+    KNN_BANK_FILENAME,
+    POLICY_FILENAME,
+    EmbedderSpec,
+    RoutingPolicy,
+)
 from wmh.optimize.report import build_report
 from wmh.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
 
@@ -31,8 +37,44 @@ _console = Console()
 @route_app.command("fit")
 def fit(
     matrix_file: str = typer.Argument(..., help="OutcomeMatrix JSON (closed-loop eval output)."),
+    kind: str = typer.Option(
+        "rank",
+        "--kind",
+        help="knn (guarded nearest-neighbor evidence, the validated champion) | rank "
+        "(Avengers cluster ranks).",
+    ),
     out: str = typer.Option(
         POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
+    ),
+    fallback: str = typer.Option(
+        None,
+        "--fallback",
+        help="(knn) Baseline model every request uses unless the evidence says otherwise. "
+        "Default: the best single model on the fit set.",
+    ),
+    z: float = typer.Option(
+        0.5,
+        "--z",
+        min=0.0,
+        help="(knn) Confidence knob: standard errors of paired evidence a pick must clear to "
+        "leave the fallback (doubled when it is also pricier). Higher = stricter = more "
+        "requests stay on the fallback; 0 routes on any positive difference.",
+    ),
+    rag_num: int = typer.Option(50, "--rag-num", min=1, help="(knn) Neighbor budget."),
+    rag_thres: float = typer.Option(
+        0.95,
+        "--rag-thres",
+        min=0.0,
+        max=1.0,
+        help="(knn) Keep neighbors above this fraction of the rag-num-th best similarity.",
+    ),
+    min_pairs: int = typer.Option(
+        8, "--min-pairs", min=0, help="(knn) Neighbors scored on both sides before routing away."
+    ),
+    se_floor: bool = typer.Option(
+        True,
+        "--se-floor/--no-se-floor",
+        help="(knn) Floor the guard's standard error on thin neighborhoods (small-bank safety).",
     ),
     clusters: int = typer.Option(64, "--clusters", min=1, help="k-means cluster count."),
     seed: int = typer.Option(42, "--seed", help="Clustering seed."),
@@ -53,7 +95,9 @@ def fit(
         None, "--api-key-env", help="(azure) env var holding the account key."
     ),
 ) -> None:
-    """Fit a rank policy on an outcome matrix (Avengers-style cluster rankings)."""
+    """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
+    if kind not in ("rank", "knn"):
+        raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
     matrix = OutcomeMatrix.load(Path(matrix_file))
     if embedder not in ("hashing", "azure"):
         raise typer.BadParameter(f"unknown embedder '{embedder}'; use hashing or azure")
@@ -68,19 +112,52 @@ def fit(
             api_key_env=api_key_env,
         )
     )
-    policy = fit_rank_policy(
-        matrix,
-        embedder=spec,
-        n_clusters=clusters,
-        seed=seed,
-        top_k_clusters=top_k_clusters,
-        beta=beta,
-        fitted_from=f"{matrix_file} seed={seed} k={clusters} {embedder}-{dim}",
-    )
-    if cost_weight > 0.0:
-        policy = rerank_policy(policy, cost_weight=cost_weight)
-    policy.save(Path(out))
+    out_path = Path(out)
+    if kind == "knn":
+        if cost_weight > 0.0:
+            raise typer.BadParameter(
+                "--cost-weight re-ranks cluster evidence and applies to --kind rank only; a knn "
+                "policy trades cost through --z (a pricier pick must clear twice the bar)"
+            )
+        # The sidecar goes beside the policy file: that is where serving resolves it from.
+        policy = fit_knn_policy(
+            matrix,
+            bank_path=out_path.parent / KNN_BANK_FILENAME,
+            embedder=spec,
+            guard_model=fallback,
+            rag_num=rag_num,
+            rag_thres=rag_thres,
+            z=z,
+            min_pairs=min_pairs,
+            se_floor=se_floor,
+            fitted_from=f"{matrix_file} knn z={z} k={rag_num} {embedder}-{dim}",
+        )
+    else:
+        policy = fit_rank_policy(
+            matrix,
+            embedder=spec,
+            n_clusters=clusters,
+            seed=seed,
+            top_k_clusters=top_k_clusters,
+            beta=beta,
+            fitted_from=f"{matrix_file} seed={seed} k={clusters} {embedder}-{dim}",
+        )
+        if cost_weight > 0.0:
+            policy = rerank_policy(policy, cost_weight=cost_weight)
+    policy.save(out_path)
     result = evaluate_policy(policy, matrix, matrix.scenario_ids())
+    if kind == "knn":
+        routed = 1.0 - result.model_mix.get(policy.default_model, 0.0)
+        _console.print(
+            f"[green]✓[/green] fitted knn policy over {result.scenarios} scenarios -> {out}\n"
+            f"  bank {out_path.parent / KNN_BANK_FILENAME}, fallback {policy.default_model}, "
+            f"z={z}\n"
+            f"  routed away from the fallback {routed:.1%} of the time; cost/scenario "
+            f"${result.cost_per_scenario:.5f}\n"
+            f"  fit-set accuracy {result.accuracy:.4f} is IN-SAMPLE (every request retrieves its "
+            "own row); measure on held-out scenarios with `wmh optimize route report`"
+        )
+        return
     _console.print(
         f"[green]✓[/green] fitted {len(policy.clusters)} clusters over "
         f"{result.scenarios} scenarios -> {out}\n"

--- a/wmh/cli/route_app_test.py
+++ b/wmh/cli/route_app_test.py
@@ -9,7 +9,8 @@ from typer.testing import CliRunner
 
 from wmh.cli.app import app
 from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
-from wmh.optimize.policy import RoutingPolicy
+from wmh.optimize.policy import KNN_BANK_FILENAME, RoutingPolicy
+from wmh.optimize.routing import evaluate_policy
 from wmh.providers.base import ProviderKind
 from wmh.providers.pool import PoolEntry
 
@@ -103,3 +104,113 @@ def test_route_fit_rejects_unknown_embedder(tmp_path: Path) -> None:
     )
     assert result.exit_code != 0
     assert "hashing or azure" in result.output
+
+
+def _knn_matrix_file(tmp_path: Path) -> Path:
+    """Twelve scenarios: enough neighbors per query for a guarded fit to route at all."""
+    pool = [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+        PoolEntry(
+            name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+    ]
+    sql = [
+        "SELECT count(*) FROM orders WHERE total > 100",
+        "SELECT name FROM users WHERE id = 4",
+        "SELECT avg(price) FROM products GROUP BY category",
+        "SELECT id FROM events WHERE kind = 'click'",
+        "SELECT max(score) FROM matches WHERE season = 2025",
+        "SELECT city FROM stores WHERE stock > 0",
+    ]
+    prose = [
+        "write a friendly email to the team about the offsite",
+        "write a warm welcome note for new employees",
+        "write a short thank-you message for the organizers",
+        "write a cheerful newsletter intro about spring",
+        "write a gentle reminder about the expense deadline",
+        "write a farewell note for a departing teammate",
+    ]
+    outcomes = []
+    for group, tasks in (("sql", sql), ("prose", prose)):
+        for index, task in enumerate(tasks):
+            for model in ("a", "b"):
+                wins = (model == "a") == (group == "sql")
+                outcomes.append(
+                    ScenarioOutcome(
+                        scenario_id=f"{group}:{index}",
+                        task=task,
+                        model=model,
+                        reward=1.0 if wins else 0.0,
+                        success=wins,
+                        cost_usd=0.001,
+                    )
+                )
+    path = tmp_path / "knn_matrix.json"
+    OutcomeMatrix(pool=pool, outcomes=outcomes).save(path)
+    return path
+
+
+def test_route_fit_knn_writes_policy_and_sidecar(tmp_path: Path) -> None:
+    matrix_file = _knn_matrix_file(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--kind",
+            "knn",
+            "--fallback",
+            "a",
+            "--z",
+            "0.5",
+            "--rag-num",
+            "3",
+            "--min-pairs",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.kind == "knn"
+    assert policy.default_model == "a" == policy.guard_model  # the pinned fallback
+    assert (tmp_path / KNN_BANK_FILENAME).is_file()  # sidecar beside the policy
+    assert len(policy.knn_bank().scenario_ids) == 12
+    assert "routed away from the fallback" in result.output
+    # The prose neighborhoods carry unanimous evidence for b, so that traffic leaves the
+    # fallback while the SQL half stays on it.
+    matrix = OutcomeMatrix.load(matrix_file)
+    prose_ids = [sid for sid in matrix.scenario_ids() if sid.startswith("prose:")]
+    assert evaluate_policy(policy, matrix, prose_ids).model_mix == {"b": 1.0}
+
+
+def test_route_fit_knn_rejects_the_rank_only_cost_knob(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path)),
+            "--kind",
+            "knn",
+            "--cost-weight",
+            "0.5",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--z" in result.output
+
+
+def test_route_fit_rejects_unknown_kind(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app, ["optimize", "route", "fit", str(_matrix_file(tmp_path)), "--kind", "vibes"]
+    )
+    assert result.exit_code != 0
+    assert "knn or rank" in result.output

--- a/wmh/optimize/knn.py
+++ b/wmh/optimize/knn.py
@@ -1,0 +1,190 @@
+"""The kNN routing fitter: an OutcomeMatrix in, a guarded nearest-neighbor policy out.
+
+This is the validated champion of the routing hill-climb. It is nonparametric: the fit does not
+learn weights, it packs the fit split's measured evidence into a bank (L2-normalized task
+embeddings plus the per-scenario, per-model reward and cost cells) that serve time retrieves
+against. `wmh.optimize.policy.knn_decision` is the algorithm; this module builds what it reads.
+
+Measured on `routerbench-ours9` (1199 scenarios, 9 models, 70/30 stratified splits, queries
+embedded with text-embedding-3-large): +1.04 accuracy points over the best single model at -27%
+cost per call, winning on 5 of 5 split seeds. The lift comes from the guard, not the retrieval:
+unguarded, the same profile router loses to the best single model, because a confident pick off
+three lucky neighbors is worse than no pick at all.
+
+Why a separate module from `wmh.optimize.routing`: that module is a faithful replication of one
+published router (Avengers cluster-rank) and its docstring is a contract about staying faithful
+to it. This family shares nothing with it but the artifact type: no clustering, no parametric
+fit, evidence retrieved per request rather than compressed into centroids. Keeping the two fits
+apart keeps each one's provenance auditable. They meet at `RoutingPolicy` and at
+`evaluate_policy`, which replays any policy kind through the serve-time selection code.
+
+The production contract: `guard_model` is the baseline, pinned by the caller (`--fallback`), and
+requests leave it only on evidence. `z` is the confidence knob; raise it to route away less.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from wmh.optimize.policy import (
+    DEFAULT_KNN_MIN_PAIRS,
+    DEFAULT_KNN_Z,
+    DEFAULT_RAG_NUM,
+    DEFAULT_RAG_THRES,
+    EmbedderSpec,
+    KnnBank,
+    RoutingPolicy,
+)
+
+if TYPE_CHECKING:
+    from wmh.optimize.outcomes import OutcomeMatrix
+    from wmh.providers.base import Embedder
+
+logger = logging.getLogger(__name__)
+
+
+def best_single_on_fit(matrix: OutcomeMatrix, fit_ids: list[str]) -> str:
+    """The strongest single pool model on `fit_ids`, ties broken toward the cheaper one.
+
+    The default baseline when the caller pins none: routing has to beat the model a user would
+    otherwise have picked by hand, so that model is what the guard compares against. A tie on
+    quality goes to the cheaper model, the same convention the routing research protocol uses.
+    """
+    sums: dict[str, tuple[float, float, int]] = {}
+    wanted = set(fit_ids)
+    for outcome in matrix.outcomes:
+        if outcome.scenario_id not in wanted or outcome.reward is None:
+            continue
+        reward_sum, cost_sum, count = sums.get(outcome.model, (0.0, 0.0, 0))
+        sums[outcome.model] = (reward_sum + outcome.reward, cost_sum + outcome.cost_usd, count + 1)
+    if not sums:
+        raise ValueError(
+            "no scored outcomes on the fit scenarios, so there is no baseline to guard against; "
+            "check that the matrix carries rewards for the fit split"
+        )
+    return min(sums, key=lambda model: (-sums[model][0] / sums[model][2], sums[model][1]))
+
+
+def build_knn_bank(
+    matrix: OutcomeMatrix,
+    fit_ids: list[str],
+    *,
+    embedder: Embedder,
+) -> KnnBank:
+    """Pack the fit split's embeddings and reward/cost cells into a routable bank.
+
+    Cells hold the MEAN over a scenario/model pair's scored episodes, and NaN when that pair was
+    never scored: the router weighs a model only over the neighbors it actually ran.
+    """
+    tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        tasks.setdefault(outcome.scenario_id, outcome.task)
+    missing = [sid for sid in fit_ids if sid not in tasks]
+    if missing:
+        raise ValueError(f"fit_ids not in the matrix: {sorted(missing)[:5]}")
+    if not fit_ids:
+        raise ValueError("no fit scenarios; a knn policy has nothing to retrieve against")
+
+    models = [entry.name for entry in matrix.pool]
+    row_of = {sid: index for index, sid in enumerate(fit_ids)}
+    column_of = {model: index for index, model in enumerate(models)}
+    shape = (len(fit_ids), len(models))
+    reward_sums = np.zeros(shape)
+    cost_sums = np.zeros(shape)
+    counts = np.zeros(shape)
+    for outcome in matrix.outcomes:
+        row = row_of.get(outcome.scenario_id)
+        column = column_of.get(outcome.model)
+        if row is None or column is None or outcome.reward is None:
+            continue
+        reward_sums[row, column] += outcome.reward
+        cost_sums[row, column] += outcome.cost_usd
+        counts[row, column] += 1
+    scored = counts > 0
+    rewards = np.where(scored, reward_sums / np.maximum(counts, 1), np.nan)
+    costs = np.where(scored, cost_sums / np.maximum(counts, 1), np.nan)
+
+    embeddings = np.asarray(embedder.embed([tasks[sid] for sid in fit_ids]), dtype=np.float64)
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings = embeddings / np.where(norms > 0.0, norms, 1.0)
+    return KnnBank(
+        embeddings=embeddings.astype(np.float32),
+        rewards=rewards.astype(np.float32),
+        costs=costs.astype(np.float32),
+        models=models,
+        scenario_ids=list(fit_ids),
+    )
+
+
+def fit_knn_policy(
+    matrix: OutcomeMatrix,
+    *,
+    bank_path: Path,
+    fit_ids: list[str] | None = None,
+    embedder: EmbedderSpec | None = None,
+    embed_with: Embedder | None = None,
+    guard_model: str | None = None,
+    rag_num: int = DEFAULT_RAG_NUM,
+    rag_thres: float = DEFAULT_RAG_THRES,
+    z: float = DEFAULT_KNN_Z,
+    min_pairs: int = DEFAULT_KNN_MIN_PAIRS,
+    se_floor: bool = True,
+    fitted_from: str | None = None,
+) -> RoutingPolicy:
+    """Fit a kNN policy on `matrix` (restricted to `fit_ids` when given) and write its sidecar.
+
+    Defaults are the validated champion (rag_num=50, rag_thres=0.95, z=0.5, min_pairs=8,
+    se_floor on). `bank_path` receives the evidence bank; write it into the directory the
+    policy.json will live in, because that is where serving resolves it from:
+
+        policy = fit_knn_policy(matrix, bank_path=out_dir / KNN_BANK_FILENAME,
+                                guard_model="fable-5")
+        policy.save(out_dir / POLICY_FILENAME)
+
+    `guard_model` is the pinned baseline: given, it is used verbatim (and must be a pool model
+    the matrix scored); None discovers the best single model on the fit split. `embedder` is the
+    spec persisted for serve-time query embedding; `embed_with` overrides the function used to
+    embed the fit tasks (pass one to reuse an HTTP client, or to serve cached vectors in
+    research code) and must be the function that spec describes.
+    """
+    spec = embedder or EmbedderSpec()
+    scenario_ids = fit_ids if fit_ids is not None else matrix.scenario_ids()
+    names = {entry.name for entry in matrix.pool}
+    if guard_model is not None and guard_model not in names:
+        raise ValueError(
+            f"guard_model '{guard_model}' is not in the matrix pool (available: {sorted(names)}); "
+            "the baseline must be a model the fit measured"
+        )
+    baseline = guard_model or best_single_on_fit(matrix, scenario_ids)
+
+    bank = build_knn_bank(matrix, scenario_ids, embedder=embed_with or spec.build())
+    bank.save(bank_path)
+    policy = RoutingPolicy(
+        kind="knn",
+        default_model=baseline,
+        guard_model=baseline,
+        pool=matrix.pool,
+        embedder=spec,
+        knn_bank_path=bank_path.name,
+        rag_num=rag_num,
+        rag_thres=rag_thres,
+        knn_z=z,
+        knn_min_pairs=min_pairs,
+        se_floor=se_floor,
+        fitted_from=fitted_from,
+    )
+    policy.attach_bank(bank)
+    logger.info(
+        "knn fit: %d fit scenarios x %d models, baseline %s%s, z=%g -> %s",
+        len(bank.scenario_ids),
+        len(bank.models),
+        baseline,
+        " (pinned)" if guard_model else " (best single on fit)",
+        z,
+        bank_path,
+    )
+    return policy

--- a/wmh/optimize/knn.py
+++ b/wmh/optimize/knn.py
@@ -133,6 +133,7 @@ def fit_knn_policy(
     z: float = DEFAULT_KNN_Z,
     min_pairs: int = DEFAULT_KNN_MIN_PAIRS,
     se_floor: bool = True,
+    floor_q: float = 0.0,
     fitted_from: str | None = None,
 ) -> RoutingPolicy:
     """Fit a kNN policy on `matrix` (restricted to `fit_ids` when given) and write its sidecar.
@@ -163,6 +164,23 @@ def fit_knn_policy(
 
     bank = build_knn_bank(matrix, scenario_ids, embedder=embed_with or spec.build())
     bank.save(bank_path)
+    # Adaptive neighborhood (R1 promotion-hardening H1): scale the neighbor budget and the
+    # evidence bar to the bank instead of letting a 50-neighbor budget swallow a 20-row bank
+    # (which turns the profile into a global mean and routing to 0%). min() against the
+    # caller's values keeps banks >= 2x the budget BIT-IDENTICAL to the validated champion.
+    n_bank = len(bank.scenario_ids)
+    rag_num = min(rag_num, max(4, -(-n_bank // 2)))
+    min_pairs = min(min_pairs, max(3, rag_num // 2))
+    # Novelty floor (R1 promotion-hardening H2): abstain to the baseline when a query's best
+    # similarity falls below the floor_q quantile of the bank's own nearest-neighbor
+    # similarities. iid wins hold at every q; under task drift coverage degrades gracefully
+    # toward all-baseline. 0.0 = off (the exact validated champion).
+    floor_sim: float | None = None
+    if floor_q > 0.0:
+        gram = bank.embeddings @ bank.embeddings.T
+        np.fill_diagonal(gram, -np.inf)
+        self_nn = gram.max(axis=1)
+        floor_sim = float(np.quantile(self_nn, floor_q))
     policy = RoutingPolicy(
         kind="knn",
         default_model=baseline,
@@ -175,6 +193,7 @@ def fit_knn_policy(
         knn_z=z,
         knn_min_pairs=min_pairs,
         se_floor=se_floor,
+        floor_sim=floor_sim,
         fitted_from=fitted_from,
     )
     policy.attach_bank(bank)

--- a/wmh/optimize/knn.py
+++ b/wmh/optimize/knn.py
@@ -169,14 +169,19 @@ def fit_knn_policy(
     # (which turns the profile into a global mean and routing to 0%). min() against the
     # caller's values keeps banks >= 2x the budget BIT-IDENTICAL to the validated champion.
     n_bank = len(bank.scenario_ids)
-    rag_num = min(rag_num, max(4, -(-n_bank // 2)))
-    min_pairs = min(min_pairs, max(3, rag_num // 2))
+    rag_cap = max(4, -(-n_bank // 2))
+    if rag_num > rag_cap:
+        # Only a bank-imposed cap adjusts min_pairs: an operator's explicit tightening on a
+        # large bank passes through untouched (the relative rule can return more neighbors
+        # than rag_num, so min_pairs > rag_num is a legitimate setting).
+        rag_num = rag_cap
+        min_pairs = min(min_pairs, max(3, rag_num // 2))
     # Novelty floor (R1 promotion-hardening H2): abstain to the baseline when a query's best
     # similarity falls below the floor_q quantile of the bank's own nearest-neighbor
     # similarities. iid wins hold at every q; under task drift coverage degrades gracefully
     # toward all-baseline. 0.0 = off (the exact validated champion).
     floor_sim: float | None = None
-    if floor_q > 0.0:
+    if floor_q > 0.0 and len(bank.scenario_ids) > 1:
         gram = bank.embeddings @ bank.embeddings.T
         np.fill_diagonal(gram, -np.inf)
         self_nn = gram.max(axis=1)

--- a/wmh/optimize/knn_test.py
+++ b/wmh/optimize/knn_test.py
@@ -1,0 +1,239 @@
+"""Tests for the kNN routing fitter: bank contents, baseline choice, and the sidecar contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from wmh.optimize.knn import best_single_on_fit, build_knn_bank, fit_knn_policy
+from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmh.optimize.policy import KNN_BANK_FILENAME, POLICY_FILENAME, EmbedderSpec, RoutingPolicy
+from wmh.optimize.routing import evaluate_policy
+from wmh.providers.base import ProviderKind
+from wmh.providers.pool import PoolEntry
+from wmh.retrieval.embedders import HashingEmbedder
+
+_SQL_TASKS = [
+    "SELECT count(*) FROM superheroes WHERE height > 190",
+    "SELECT name FROM users ORDER BY created_at DESC LIMIT 10",
+    "SELECT avg(price) FROM orders GROUP BY customer_id",
+    "SELECT id FROM events WHERE ts > '2026-01-01' AND kind = 'click'",
+    "SELECT t.name, count(*) FROM teams t JOIN players p ON p.team_id = t.id GROUP BY 1",
+    "SELECT max(score) FROM matches WHERE season = 2025",
+    "SELECT sum(total) FROM invoices WHERE paid_at IS NULL",
+    "SELECT city, count(*) FROM stores GROUP BY city HAVING count(*) > 2",
+    "SELECT p.title FROM posts p WHERE p.author_id = 42 ORDER BY p.views DESC",
+    "SELECT distinct category FROM products WHERE stock > 0",
+]
+_PROSE_TASKS = [
+    "write a friendly email to the team about the offsite",
+    "draft a short thank-you note for the conference organizers",
+    "compose a birthday message for a colleague",
+    "write a warm welcome paragraph for new employees",
+    "draft an apology note for the delayed shipment",
+    "write a cheerful newsletter intro about spring",
+    "write a gentle reminder about the expense deadline",
+    "draft a congratulations message for the launch",
+    "compose a polite decline to a speaking invitation",
+    "write a short farewell note for a departing teammate",
+]
+
+
+def _pool() -> list[PoolEntry]:
+    return [
+        PoolEntry(
+            name="cheap",
+            kind=ProviderKind.OPENAI,
+            model="c",
+            input_per_mtok=0.1,
+            output_per_mtok=0.4,
+        ),
+        PoolEntry(
+            name="pricey",
+            kind=ProviderKind.OPENAI,
+            model="p",
+            input_per_mtok=10.0,
+            output_per_mtok=40.0,
+        ),
+    ]
+
+
+def _matrix(*, pricey_cost: float = 0.01) -> OutcomeMatrix:
+    """cheap aces SQL and flunks prose; pricey is the mirror image at 10x the cost."""
+    outcomes: list[ScenarioOutcome] = []
+    for group, tasks in [("sql", _SQL_TASKS), ("prose", _PROSE_TASKS)]:
+        for index, task in enumerate(tasks):
+            for model in ("cheap", "pricey"):
+                wins = (model == "cheap") == (group == "sql")
+                outcomes.append(
+                    ScenarioOutcome(
+                        scenario_id=f"{group}:{index}",
+                        task=task,
+                        model=model,
+                        reward=1.0 if wins else 0.0,
+                        success=wins,
+                        cost_usd=0.001 if model == "cheap" else pricey_cost,
+                    )
+                )
+    return OutcomeMatrix(pool=_pool(), outcomes=outcomes)
+
+
+def _fit(
+    tmp_path: Path,
+    *,
+    fit_ids: list[str] | None = None,
+    guard_model: str | None = "cheap",
+    rag_num: int = 5,
+    rag_thres: float = 0.95,
+    z: float = 0.5,
+    min_pairs: int = 3,
+    se_floor: bool = True,
+) -> RoutingPolicy:
+    """Fit on the toy matrix, with a neighbor budget scaled to a 20-row bank.
+
+    The budget has to be a small fraction of the bank, and min_pairs below it: at the production
+    default (50) every row is a neighbor of every query (see
+    test_a_budget_as_large_as_the_bank_collapses_to_the_fallback).
+    """
+    return fit_knn_policy(
+        _matrix(),
+        bank_path=tmp_path / KNN_BANK_FILENAME,
+        fit_ids=fit_ids,
+        embedder=EmbedderSpec(dim=256),
+        guard_model=guard_model,
+        rag_num=rag_num,
+        rag_thres=rag_thres,
+        z=z,
+        min_pairs=min_pairs,
+        se_floor=se_floor,
+    )
+
+
+def test_fit_writes_a_sidecar_and_pins_the_requested_fallback(tmp_path: Path) -> None:
+    policy = _fit(tmp_path, guard_model="pricey")
+    assert policy.kind == "knn"
+    assert policy.default_model == "pricey" == policy.guard_model
+    assert policy.knn_bank_path == KNN_BANK_FILENAME  # a filename, so the artifact dir is portable
+    assert (tmp_path / KNN_BANK_FILENAME).is_file()
+    bank = policy.knn_bank()
+    assert bank.models == ["cheap", "pricey"]
+    assert len(bank.scenario_ids) == 20
+    assert bank.dim == 256
+
+
+def test_bank_cells_hold_scored_means_and_nan_elsewhere(tmp_path: Path) -> None:
+    matrix = _matrix()
+    # Two episodes of one cell (mean 0.5) and one cell never scored at all.
+    matrix.outcomes.append(
+        ScenarioOutcome(
+            scenario_id="sql:0",
+            task=_SQL_TASKS[0],
+            model="cheap",
+            reward=0.0,
+            success=False,
+            cost_usd=0.003,
+        )
+    )
+    matrix.outcomes = [
+        outcome
+        for outcome in matrix.outcomes
+        if not (outcome.scenario_id == "prose:0" and outcome.model == "pricey")
+    ]
+    bank = build_knn_bank(matrix, matrix.scenario_ids(), embedder=HashingEmbedder(dim=64))
+    sql0 = bank.scenario_ids.index("sql:0")
+    prose0 = bank.scenario_ids.index("prose:0")
+    cheap, pricey = bank.models.index("cheap"), bank.models.index("pricey")
+    assert bank.rewards[sql0, cheap] == pytest.approx(0.5)  # mean of 1.0 and 0.0
+    assert bank.costs[sql0, cheap] == pytest.approx(0.002)
+    assert np.isnan(bank.rewards[prose0, pricey])
+    assert np.isnan(bank.costs[prose0, pricey])
+    # Rows are L2-normalized at fit time so serve-time retrieval is one matrix product.
+    np.testing.assert_allclose(np.linalg.norm(bank.embeddings, axis=1), 1.0, atol=1e-6)
+
+
+def test_bank_mean_costs_ignore_unscored_cells(tmp_path: Path) -> None:
+    bank = _fit(tmp_path).knn_bank()
+    costs = bank.mean_costs()
+    assert costs[bank.models.index("cheap")] == pytest.approx(0.001)
+    assert costs[bank.models.index("pricey")] == pytest.approx(0.01)
+
+
+def test_unpinned_fallback_is_the_best_single_model_on_the_fit_split(tmp_path: Path) -> None:
+    # Both models score 0.5 overall, so the tie goes to the cheaper one: routing has to beat the
+    # model a cost-conscious user would have picked, not the one that sorts first.
+    assert best_single_on_fit(_matrix(), _matrix().scenario_ids()) == "cheap"
+    assert _fit(tmp_path, guard_model=None).default_model == "cheap"
+    # Give pricey the better fit-set reward and it becomes the baseline on merit.
+    strong = _matrix()
+    for outcome in strong.outcomes:
+        if outcome.model == "pricey":
+            outcome.reward = 1.0
+    assert best_single_on_fit(strong, strong.scenario_ids()) == "pricey"
+
+
+def test_fit_restricted_to_fit_ids_banks_only_those_scenarios(tmp_path: Path) -> None:
+    fit_ids = [sid for sid in _matrix().scenario_ids() if sid.startswith("sql:")]
+    policy = _fit(tmp_path, fit_ids=fit_ids)
+    assert policy.knn_bank().scenario_ids == fit_ids
+
+
+def test_fit_rejects_a_fallback_outside_the_pool(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not in the matrix pool"):
+        _fit(tmp_path, guard_model="not-a-model")
+
+
+def test_fit_rejects_a_fallback_the_matrix_never_scored(tmp_path: Path) -> None:
+    matrix = _matrix()
+    matrix.outcomes = [outcome for outcome in matrix.outcomes if outcome.model != "pricey"]
+    with pytest.raises(ValueError, match="no scored reward for baseline"):
+        fit_knn_policy(
+            matrix,
+            bank_path=tmp_path / KNN_BANK_FILENAME,
+            embedder=EmbedderSpec(dim=64),
+            guard_model="pricey",
+        )
+
+
+def test_fit_rejects_unknown_fit_ids(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not in the matrix"):
+        _fit(tmp_path, fit_ids=["sql:0", "nope:1"])
+
+
+def test_fitted_policy_recovers_the_specialists_through_the_serving_path(tmp_path: Path) -> None:
+    # In-sample replay: each request retrieves its own row, so a working fit must route SQL to
+    # cheap and prose to pricey. The point is that the whole chain (bank -> knn_decision ->
+    # evaluate_policy) agrees, not that 100% is a held-out claim.
+    policy = _fit(tmp_path, guard_model="cheap")
+    matrix = _matrix()
+    result = evaluate_policy(policy, matrix, matrix.scenario_ids())
+    assert result.accuracy == pytest.approx(1.0)
+    assert result.model_mix["pricey"] == pytest.approx(0.5)
+
+
+def test_a_saved_knn_policy_reloads_and_routes_from_disk(tmp_path: Path) -> None:
+    # The artifact contract serving depends on: policy.json plus its sidecar, nothing else.
+    policy = _fit(tmp_path, guard_model="cheap")
+    policy.save(tmp_path / POLICY_FILENAME)
+    reloaded = RoutingPolicy.load(tmp_path / POLICY_FILENAME)
+    assert reloaded.knn_bank().scenario_ids == policy.knn_bank().scenario_ids
+    matrix = _matrix()
+    assert evaluate_policy(reloaded, matrix, matrix.scenario_ids()).accuracy == pytest.approx(1.0)
+
+
+def test_a_budget_as_large_as_the_bank_collapses_to_the_fallback(tmp_path: Path) -> None:
+    # The relative rule keeps every fit row once the budget covers the bank, so the profile
+    # becomes the global average and the guard sees no signal. That collapse is the safe
+    # failure: a router with no local evidence serves the fallback, it does not guess.
+    policy = _fit(tmp_path, rag_num=20)
+    matrix = _matrix()
+    result = evaluate_policy(policy, matrix, matrix.scenario_ids())
+    assert result.model_mix == {"cheap": 1.0}
+    assert result.accuracy == pytest.approx(0.5)  # the fallback's own score
+
+
+def test_fit_carries_the_guard_knobs_onto_the_policy(tmp_path: Path) -> None:
+    policy = _fit(tmp_path, rag_num=17, rag_thres=0.9, z=1.25, min_pairs=3, se_floor=False)
+    assert (policy.rag_num, policy.rag_thres) == (17, 0.9)
+    assert (policy.knn_z, policy.knn_min_pairs, policy.se_floor) == (1.25, 3, False)

--- a/wmh/optimize/knn_test.py
+++ b/wmh/optimize/knn_test.py
@@ -101,7 +101,7 @@ def _fit(
 
     The budget has to be a small fraction of the bank, and min_pairs below it: at the production
     default (50) every row is a neighbor of every query (see
-    test_a_budget_as_large_as_the_bank_collapses_to_the_fallback).
+    test_the_adaptive_cap_prevents_the_whole_bank_neighborhood_collapse).
     """
     return fit_knn_policy(
         _matrix(),
@@ -289,3 +289,26 @@ def test_novelty_floor_abstains_on_far_queries(tmp_path: Path) -> None:
 def test_floor_off_by_default(tmp_path: Path) -> None:
     policy = _fit(tmp_path)
     assert policy.floor_sim is None
+
+
+def test_operator_min_pairs_passes_through_when_the_bank_does_not_cap(tmp_path: Path) -> None:
+    # An explicit tightening on a bank the budget does not swallow must arrive verbatim:
+    # min_pairs > rag_num is legitimate because the relative rule can keep more neighbors
+    # than the budget.
+    policy = _fit(tmp_path, rag_num=5, min_pairs=8)
+    assert policy.rag_num == 5
+    assert policy.knn_min_pairs == 8
+
+
+def test_floor_q_on_a_single_row_bank_stays_off(tmp_path: Path) -> None:
+    matrix = _matrix()
+    only = matrix.scenario_ids()[:1]
+    policy = fit_knn_policy(
+        matrix,
+        bank_path=tmp_path / KNN_BANK_FILENAME,
+        fit_ids=only,
+        embedder=EmbedderSpec(dim=256),
+        guard_model="cheap",
+        floor_q=0.5,
+    )
+    assert policy.floor_sim is None  # never NaN: a 1-row bank has no self-NN distribution

--- a/wmh/optimize/knn_test.py
+++ b/wmh/optimize/knn_test.py
@@ -9,7 +9,13 @@ import pytest
 
 from wmh.optimize.knn import best_single_on_fit, build_knn_bank, fit_knn_policy
 from wmh.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
-from wmh.optimize.policy import KNN_BANK_FILENAME, POLICY_FILENAME, EmbedderSpec, RoutingPolicy
+from wmh.optimize.policy import (
+    KNN_BANK_FILENAME,
+    POLICY_FILENAME,
+    EmbedderSpec,
+    RoutingPolicy,
+    knn_decision,
+)
 from wmh.optimize.routing import evaluate_policy
 from wmh.providers.base import ProviderKind
 from wmh.providers.pool import PoolEntry
@@ -222,18 +228,64 @@ def test_a_saved_knn_policy_reloads_and_routes_from_disk(tmp_path: Path) -> None
     assert evaluate_policy(reloaded, matrix, matrix.scenario_ids()).accuracy == pytest.approx(1.0)
 
 
-def test_a_budget_as_large_as_the_bank_collapses_to_the_fallback(tmp_path: Path) -> None:
-    # The relative rule keeps every fit row once the budget covers the bank, so the profile
-    # becomes the global average and the guard sees no signal. That collapse is the safe
-    # failure: a router with no local evidence serves the fallback, it does not guess.
+def test_the_adaptive_cap_prevents_the_whole_bank_neighborhood_collapse(tmp_path: Path) -> None:
+    # Pre-hardening behavior: a budget covering the bank made every profile the global
+    # average and routing inert. The adaptive rule (R1 promotion hardening) caps the budget
+    # at half the bank, so local evidence survives and the router still routes.
     policy = _fit(tmp_path, rag_num=20)
+    assert policy.rag_num == 10  # capped at ceil(20-row bank / 2)
     matrix = _matrix()
     result = evaluate_policy(policy, matrix, matrix.scenario_ids())
-    assert result.model_mix == {"cheap": 1.0}
-    assert result.accuracy == pytest.approx(0.5)  # the fallback's own score
+    assert set(result.model_mix) == {"cheap", "pricey"}  # routing is alive, not collapsed
+    assert result.accuracy > 0.8  # far above the fallback's 0.5; one boundary miss is fine
 
 
 def test_fit_carries_the_guard_knobs_onto_the_policy(tmp_path: Path) -> None:
     policy = _fit(tmp_path, rag_num=17, rag_thres=0.9, z=1.25, min_pairs=3, se_floor=False)
-    assert (policy.rag_num, policy.rag_thres) == (17, 0.9)
+    # rag_num 17 exceeds the adaptive cap (ceil(20 / 2) = 10) and is capped there.
+    assert (policy.rag_num, policy.rag_thres) == (10, 0.9)
     assert (policy.knn_z, policy.knn_min_pairs, policy.se_floor) == (1.25, 3, False)
+
+
+def test_adaptive_rule_scales_neighborhood_to_small_banks(tmp_path: Path) -> None:
+    # A 50-neighbor budget on a tiny bank makes every profile the global mean and routing
+    # inert; the fitted policy must scale the budget and the evidence bar to the bank.
+    policy = fit_knn_policy(
+        _matrix(),
+        bank_path=tmp_path / KNN_BANK_FILENAME,
+        embedder=EmbedderSpec(dim=256),
+        guard_model="cheap",
+    )
+    assert policy.rag_num == 10  # ceil(20-row bank / 2), not the 50 default
+    assert policy.knn_min_pairs == 5  # max(3, 10 // 2)
+
+
+def test_adaptive_rule_keeps_caller_values_below_the_cap(tmp_path: Path) -> None:
+    # Explicit smaller settings pass through untouched: min() semantics, never a raise.
+    policy = _fit(tmp_path, rag_num=5, min_pairs=2)
+    assert policy.rag_num == 5
+    assert policy.knn_min_pairs == 2
+
+
+def test_novelty_floor_abstains_on_far_queries(tmp_path: Path) -> None:
+    policy = fit_knn_policy(
+        _matrix(),
+        bank_path=tmp_path / KNN_BANK_FILENAME,
+        embedder=EmbedderSpec(dim=256),
+        guard_model="cheap",
+        rag_num=5,
+        min_pairs=3,
+        floor_q=0.99,  # floor at the 99th pct of self-NN sims: nearly everything abstains
+    )
+    assert policy.floor_sim is not None
+    embedder = policy.embedder.build() if policy.embedder is not None else None
+    assert embedder is not None
+    query = embedder.embed(["zzz qqq xww utterly unrelated novel gibberish"])[0]
+    decision = knn_decision(policy, np.asarray(query))
+    assert decision.model == "cheap"
+    assert "novelty abstain" in decision.reason
+
+
+def test_floor_off_by_default(tmp_path: Path) -> None:
+    policy = _fit(tmp_path)
+    assert policy.floor_sim is None

--- a/wmh/optimize/policy.py
+++ b/wmh/optimize/policy.py
@@ -1,9 +1,16 @@
 """The routing policy artifact: what the routing optimizer emits and the endpoint serves.
 
-An endpoint = {world model, policy, evidence, URL}; this module is the policy leg. Two kinds:
+An endpoint = {world model, policy, evidence, URL}; this module is the policy leg. Three kinds:
 
 - `static`: every request goes to `default_model`. Valid without any optimizer run, so an
   endpoint serves from day one and the improvement report has an honest "before" state.
+- `knn`: the validated champion (see `wmh.optimize.knn` for the fit and the measured result).
+  Nonparametric: retrieve the request's neighbors among the fit scenarios, read each pool
+  model's sim-weighted mean reward over exactly those neighbors, and route to the argmax ONLY
+  when a paired statistical guard says the evidence supports leaving the baseline. Otherwise the
+  baseline (`guard_model`) serves. The neighbor evidence is heavy (an L2-normalized fit
+  embedding matrix plus the per-scenario reward and cost cells), so it lives in a `.npz`
+  sidecar next to `policy.json` (`knn_bank_path`) and loads lazily on first use.
 - `rank`: the Avengers cluster-rank router (arXiv 2505.19797), replicated faithfully from the
   reference implementation (ZhangYiqun018/Avengers, core/routing/rank_router.py): embed the
   request, softmax the distances to the `top_k_clusters` nearest k-means centres
@@ -27,11 +34,13 @@ forfeits warm cache reads and pays cold writes; until the fitter learns a real s
 from __future__ import annotations
 
 import os
+import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 import numpy as np
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from wmh.providers.base import Embedder, ProviderConfig, ProviderKind
 from wmh.providers.pool import PoolEntry
@@ -46,6 +55,25 @@ POLICY_FILENAME = "policy.json"
 DEFAULT_TOP_K_CLUSTERS = 2
 DEFAULT_BETA = 6.0
 DEFAULT_RANK = 999
+
+# kNN champion defaults: the exact configuration validated on routerbench-ours9
+# (+1.0 accuracy point over the best single model at -27% cost, 5/5 split seeds).
+KNN_BANK_FILENAME = "policy_knn_bank.npz"
+DEFAULT_RAG_NUM = 50
+DEFAULT_RAG_THRES = 0.95
+DEFAULT_KNN_Z = 0.5
+DEFAULT_KNN_MIN_PAIRS = 8
+# Below this many paired neighbors the guard floors its standard error at the maximal binomial
+# SE, sqrt(0.25/n). A SMALL-SAMPLE correction only: on a thin bank a lucky zero-variance
+# neighborhood otherwise makes any positive mean difference look significant, which is how a
+# small-bank router talks itself into pricier-and-worse picks. Large-n empirical SEs are
+# reliable, and flooring them there would just tax real wins.
+SE_FLOOR_MAX_PAIRS = 30
+
+# Banks are read once per policy instance; the lock is module level so the cache costs the
+# policy no per-instance state (a lock stored on the model would make two otherwise identical
+# policies compare unequal).
+_BANK_LOAD_LOCK = threading.Lock()
 
 
 class EmbedderSpec(BaseModel):
@@ -95,6 +123,84 @@ class EmbedderSpec(BaseModel):
         return BatchedEmbedder(provider, batch=self.batch)
 
 
+@dataclass(frozen=True)
+class KnnBank:
+    """The fit-split evidence a `knn` policy routes against: the `.npz` sidecar's contents.
+
+    Arrays are aligned: row `i` is `scenario_ids[i]`, column `j` is `models[j]`. A reward or
+    cost cell is NaN when that model has no scored episode for that scenario, which is how a
+    ragged outcome matrix stays a dense array; the router weighs only the scored cells.
+
+    Embeddings are float32 and L2-normalized at fit time, so serve-time neighbor search is one
+    matrix product. float32 halves a bank that is already ~10MB at 3072 dimensions, and costs
+    nothing measurable: cosine similarities agree with float64 to ~1e-7, far below the reward
+    differences the guard tests.
+    """
+
+    embeddings: np.ndarray  # (scenarios, dim) float32, L2-normalized
+    rewards: np.ndarray  # (scenarios, models) float32, NaN where unscored
+    costs: np.ndarray  # (scenarios, models) float32 USD, NaN where unscored
+    models: list[str]
+    scenario_ids: list[str]
+
+    def __post_init__(self) -> None:
+        scenarios, models = len(self.scenario_ids), len(self.models)
+        if not scenarios or not models:
+            raise ValueError("a knn bank needs at least one scenario and one model")
+        for name, array in (("rewards", self.rewards), ("costs", self.costs)):
+            if array.shape != (scenarios, models):
+                raise ValueError(
+                    f"{name} has shape {array.shape}, expected "
+                    f"({scenarios}, {models}) from the scenario and model lists"
+                )
+        if self.embeddings.shape[0] != scenarios or self.embeddings.ndim != 2:
+            raise ValueError(
+                f"embeddings has shape {self.embeddings.shape}, expected "
+                f"({scenarios}, dim) from the scenario list"
+            )
+
+    @property
+    def dim(self) -> int:
+        return int(self.embeddings.shape[1])
+
+    def mean_costs(self) -> np.ndarray:
+        """Per-model mean cost over the bank's scored cells (NaN for a model with none).
+
+        The unit the guard's pricier-than-baseline test compares. Cells, not episodes: a model
+        that happened to be rerun more often on some scenario does not get extra weight.
+        """
+        scored = ~np.isnan(self.costs)
+        counts = scored.sum(axis=0)
+        totals = np.where(scored, np.nan_to_num(self.costs), 0.0).sum(axis=0)
+        return np.where(counts > 0, totals / np.maximum(counts, 1), np.nan)
+
+    def save(self, path: Path) -> None:
+        """Write the sidecar atomically (a half-written 10MB bank must not be loadable)."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        staging = path.with_name(f"{path.name}.partial")
+        with staging.open("wb") as handle:
+            np.savez(
+                handle,
+                embeddings=self.embeddings.astype(np.float32),
+                rewards=self.rewards.astype(np.float32),
+                costs=self.costs.astype(np.float32),
+                models=np.asarray(self.models),
+                scenario_ids=np.asarray(self.scenario_ids),
+            )
+        staging.replace(path)
+
+    @classmethod
+    def load(cls, path: Path) -> KnnBank:
+        with np.load(path, allow_pickle=False) as data:
+            return cls(
+                embeddings=np.asarray(data["embeddings"], dtype=np.float32),
+                rewards=np.asarray(data["rewards"], dtype=np.float32),
+                costs=np.asarray(data["costs"], dtype=np.float32),
+                models=[str(name) for name in data["models"]],
+                scenario_ids=[str(sid) for sid in data["scenario_ids"]],
+            )
+
+
 class ClusterRanking(BaseModel):
     """One fitted cluster: its centroid and the pool models ranked by in-cluster accuracy."""
 
@@ -123,7 +229,7 @@ class RoutingPolicy(BaseModel):
     """The persisted policy artifact (see module docstring)."""
 
     version: int = POLICY_VERSION
-    kind: Literal["static", "rank"]
+    kind: Literal["static", "rank", "knn"]
     default_model: str  # the static answer; also the fallback for degenerate rank inputs
     pool: list[PoolEntry]  # snapshot of the roster this policy was defined over
     embedder: EmbedderSpec = Field(default_factory=EmbedderSpec)
@@ -147,6 +253,27 @@ class RoutingPolicy(BaseModel):
     guard_margin: float | None = None  # reward the challenger must beat the guard by
     fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
 
+    # kNN policies only (see module docstring and `wmh.optimize.knn`). The bank path is a bare
+    # FILENAME resolved next to policy.json, so a model directory stays portable; an absolute
+    # path is honored as given (research code and tests point at banks elsewhere).
+    knn_bank_path: str = KNN_BANK_FILENAME
+    rag_num: int = Field(default=DEFAULT_RAG_NUM, ge=1)  # neighbor budget
+    # A neighbor is a fit scenario with similarity above `rag_thres` times the `rag_num`-th best
+    # similarity: a RELATIVE rule, so a query in a dense region keeps more evidence than one out
+    # on its own, instead of every query being handed exactly k neighbors of any quality.
+    rag_thres: float = Field(default=DEFAULT_RAG_THRES, gt=0.0, le=1.0)
+    # The confidence knob: standard errors of paired evidence a non-baseline pick must clear
+    # (doubled when the pick is pricier than the baseline). Higher = stricter = fewer requests
+    # leave the baseline. 0 routes on any positive mean difference.
+    knn_z: float = Field(default=DEFAULT_KNN_Z, ge=0.0)
+    knn_min_pairs: int = Field(default=DEFAULT_KNN_MIN_PAIRS, ge=0)  # neighbors scored on both
+    se_floor: bool = True  # small-sample variance floor (see SE_FLOOR_MAX_PAIRS)
+
+    # Set by `save`/`load` so a relative `knn_bank_path` resolves against the policy file, and
+    # the lazily loaded bank. Private: not part of the artifact.
+    _source_dir: Path | None = PrivateAttr(default=None)
+    _bank: KnnBank | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def _validate(self) -> RoutingPolicy:
         names = {entry.name for entry in self.pool}
@@ -160,8 +287,23 @@ class RoutingPolicy(BaseModel):
                 f"guard_model '{self.guard_model}' is not in the policy pool "
                 f"(available: {sorted(names)})"
             )
-        if self.kind == "static" and self.clusters:
-            raise ValueError("a static policy carries no clusters; use kind='rank'")
+        if self.kind != "rank" and self.clusters:
+            raise ValueError(f"a {self.kind} policy carries no clusters; use kind='rank'")
+        if self.kind == "knn":
+            # The whole algorithm is "leave the baseline only on evidence", so a knn policy
+            # without a baseline is not a weaker policy, it is an undefined one. default_model
+            # and guard_model are the same thing here, and being able to set them apart would
+            # only invite two disagreeing fallbacks.
+            if self.guard_model is None:
+                raise ValueError(
+                    "a knn policy needs guard_model set to its baseline model (the fallback "
+                    "every unsupported request reverts to); fit with --fallback"
+                )
+            if self.guard_model != self.default_model:
+                raise ValueError(
+                    f"knn guard_model '{self.guard_model}' must equal default_model "
+                    f"'{self.default_model}': the baseline and the fallback are one model"
+                )
         if self.kind == "rank":
             if not self.clusters:
                 raise ValueError("a rank policy needs at least one fitted cluster")
@@ -182,10 +324,83 @@ class RoutingPolicy(BaseModel):
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        self._source_dir = path.parent
 
     @classmethod
     def load(cls, path: Path) -> RoutingPolicy:
-        return cls.model_validate_json(path.read_text(encoding="utf-8"))
+        policy = cls.model_validate_json(path.read_text(encoding="utf-8"))
+        policy._source_dir = path.parent
+        return policy
+
+    def bank_path(self) -> Path:
+        """Where this policy's kNN sidecar lives (see `knn_bank_path`)."""
+        if self.kind != "knn":
+            raise ValueError(f"a {self.kind} policy has no knn bank")
+        candidate = Path(self.knn_bank_path)
+        if candidate.is_absolute():
+            return candidate
+        return (self._source_dir or Path()) / candidate
+
+    def attach_bank(self, bank: KnnBank) -> None:
+        """Use `bank` as this policy's evidence instead of reading the sidecar.
+
+        The fitter primes a freshly fitted policy with the bank it just built, so fit-then-
+        evaluate does not round trip through disk; tests use it to route against a hand-built
+        bank. Validated exactly like a loaded one.
+        """
+        self._validate_bank(bank, source="the attached bank")
+        self._bank = bank
+
+    def knn_bank(self) -> KnnBank:
+        """Load (once, then cached) the neighbor evidence this kNN policy routes against."""
+        if self.kind != "knn":
+            raise ValueError(f"a {self.kind} policy has no knn bank")
+        with _BANK_LOAD_LOCK:
+            if self._bank is None:
+                path = self.bank_path()
+                if not path.is_file():
+                    raise FileNotFoundError(
+                        f"knn policy bank not found at {path}: a knn policy.json is served "
+                        f"together with its '{self.knn_bank_path}' sidecar. Copy the sidecar "
+                        f"next to the policy file, or refit with "
+                        f"`wmh optimize route fit --kind knn`."
+                    )
+                try:
+                    bank = KnnBank.load(path)
+                    self._validate_bank(bank, source=str(path))
+                except (ValueError, KeyError) as error:
+                    raise ValueError(f"invalid knn bank at {path}: {error}") from error
+                self._bank = bank
+            return self._bank
+
+    def _validate_bank(self, bank: KnnBank, *, source: str) -> None:
+        """Check a bank against this policy: same embedder dimension, known models, a baseline."""
+        if bank.dim != self.embedder.dim:
+            raise ValueError(
+                f"{source} has {bank.dim}-dimensional embeddings but the policy's embedder "
+                f"spec is {self.embedder.dim}-dimensional; the bank was fitted with a "
+                "different embedder than this policy would embed requests with"
+            )
+        names = {entry.name for entry in self.pool}
+        unknown = [model for model in bank.models if model not in names]
+        if unknown:
+            raise ValueError(
+                f"{source} carries models {unknown} that are not in the policy pool "
+                f"(available: {sorted(names)})"
+            )
+        if self.guard_model not in bank.models:
+            raise ValueError(
+                f"{source} does not cover baseline '{self.guard_model}' (it covers "
+                f"{sorted(bank.models)}); the bank was fitted over a different pool"
+            )
+        column = bank.rewards[:, bank.models.index(self.guard_model)]
+        if bool(np.isnan(column).all()):
+            raise ValueError(
+                f"{source} has no scored reward for baseline '{self.guard_model}' on any fit "
+                "scenario, so the guard could never compare a pick against it and every "
+                "request would revert unmeasured; fit on a matrix that measured the baseline, "
+                "or pin a baseline it did measure"
+            )
 
 
 def select_model(
@@ -204,8 +419,8 @@ def select_model(
 
     `embedder` lets a caller that routes many requests reuse ONE embedder built from
     `policy.embedder` (an azure spec otherwise constructs a fresh HTTP client per call); it must
-    be the function this policy's spec describes, or the centroids are meaningless. Default None
-    builds it from the spec per call.
+    be the function this policy's spec describes, or the fitted centroids (rank) and neighbor
+    bank (knn) are meaningless. Default None builds it from the spec per call.
     """
     names = {entry.name for entry in policy.pool}
     if incumbent is not None and incumbent in names and policy.sticky:
@@ -214,6 +429,8 @@ def select_model(
         return RoutingDecision(model=policy.default_model, reason="static policy")
 
     query = np.asarray((embedder or policy.embedder.build()).embed([text])[0])
+    if policy.kind == "knn":
+        return knn_decision(policy, query)
     return rank_decision(policy, query)
 
 
@@ -266,4 +483,98 @@ def rank_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
         cluster_id=nearest.cluster_id,
         cluster_label=nearest.label,
         reason=f"rank router: nearest cluster {nearest.cluster_id}{label}",
+    )
+
+
+def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
+    """The kNN reward-profile core with its paired guard, on an already-embedded query.
+
+    Shared by `select_model` (one live request) and batch evaluation, so the served path and the
+    measured path cannot diverge. Three stages, each of which the returned `reason` accounts for:
+
+    1. Neighbors: the fit scenarios whose similarity beats `rag_thres` times the `rag_num`-th
+       best similarity. The query is L2-normalized HERE (bank rows already are), so no caller
+       can skip the step and turn the similarity threshold into a magnitude test.
+    2. Profile: each model's similarity-weighted mean reward over the neighbors it was scored
+       on. The argmax is the raw pick (ties break by pool order, deterministically).
+    3. Guard: a non-baseline pick must beat the baseline on PAIRED per-neighbor reward
+       differences, mean > `knn_z` standard errors (doubled when the pick is also pricier, the
+       asymmetry that kills confidently-wrong pricier-and-worse picks), on at least
+       `knn_min_pairs` neighbors scored on both sides. Otherwise the baseline serves.
+
+    The guard is what makes the policy safe to deploy: absent evidence, the answer is the
+    baseline, so the worst case is the baseline's behavior rather than a confident stranger's.
+    """
+    if policy.kind != "knn":
+        raise ValueError(f"knn_decision needs a knn policy, got kind='{policy.kind}'")
+    bank = policy.knn_bank()
+    baseline = policy.default_model
+
+    vector = np.asarray(query, dtype=np.float32)
+    norm = float(np.linalg.norm(vector))
+    if norm > 0.0:
+        vector = vector / norm
+    sims = bank.embeddings @ vector
+
+    budget = min(policy.rag_num, sims.shape[0])
+    kth = float(np.sort(sims)[-budget])
+    rows = np.flatnonzero(sims > policy.rag_thres * kth)
+    if rows.size == 0:
+        # Every similarity at or below the cut (possible when the kth is negative, so the
+        # threshold moves the wrong way): fall back to the single nearest fit scenario.
+        rows = np.asarray([int(np.argmax(sims))])
+
+    weights = np.clip(sims[rows], 0.0, None).astype(np.float64)[:, None]
+    rewards = bank.rewards[rows].astype(np.float64)
+    scored = ~np.isnan(rewards)
+    weight_totals = (scored * weights).sum(axis=0)
+    reward_totals = (np.where(scored, np.nan_to_num(rewards), 0.0) * weights).sum(axis=0)
+    profile = np.full(weight_totals.shape, np.nan)
+    np.divide(reward_totals, weight_totals, out=profile, where=weight_totals > 0.0)
+
+    pool_order = {entry.name: index for index, entry in enumerate(policy.pool)}
+    candidates = [
+        (index, name) for index, name in enumerate(bank.models) if not np.isnan(profile[index])
+    ]
+    if not candidates:
+        return RoutingDecision(
+            model=baseline,
+            reason=f"knn: {rows.size} neighbors carry no scored reward, serving {baseline}",
+        )
+    pick_index, pick = max(candidates, key=lambda item: (profile[item[0]], -pool_order[item[1]]))
+    if pick == baseline:
+        return RoutingDecision(
+            model=baseline,
+            reason=f"knn: baseline {baseline} leads {rows.size} neighbors "
+            f"(profile {profile[pick_index]:.3f})",
+        )
+
+    base_index = bank.models.index(baseline)
+    paired = scored[:, pick_index] & scored[:, base_index]
+    diffs = rewards[paired, pick_index] - rewards[paired, base_index]
+    pairs = int(diffs.size)
+    mean_diff = float(diffs.mean()) if pairs else 0.0
+    error = float(diffs.std(ddof=1)) / pairs**0.5 if pairs > 1 else 0.0
+    if policy.se_floor and 0 < pairs < SE_FLOOR_MAX_PAIRS:
+        error = max(error, (0.25 / pairs) ** 0.5)
+    mean_cost = bank.mean_costs()
+    pricier = bool(mean_cost[pick_index] > mean_cost[base_index])
+    z_effective = 2 * policy.knn_z if pricier else policy.knn_z
+    needed = z_effective * error
+
+    if pairs < policy.knn_min_pairs or not mean_diff > needed:
+        detail = (
+            f"{pairs} paired neighbors, delta={mean_diff:+.3f}, needs "
+            f"> {z_effective:g}xSE={needed:.3f}"
+        )
+        if pairs < policy.knn_min_pairs:
+            detail = f"{pairs} paired neighbors < {policy.knn_min_pairs} required"
+        return RoutingDecision(
+            model=baseline,
+            reason=f"knn guard: reverted to {baseline}, evidence insufficient ({detail})",
+        )
+    return RoutingDecision(
+        model=pick,
+        reason=f"knn: {rows.size} neighbors, delta={mean_diff:+.3f} > {z_effective:g}xSE"
+        f"={needed:.3f}{' (pricier, doubled z)' if pricier else ''}",
     )

--- a/wmh/optimize/policy.py
+++ b/wmh/optimize/policy.py
@@ -268,6 +268,10 @@ class RoutingPolicy(BaseModel):
     knn_z: float = Field(default=DEFAULT_KNN_Z, ge=0.0)
     knn_min_pairs: int = Field(default=DEFAULT_KNN_MIN_PAIRS, ge=0)  # neighbors scored on both
     se_floor: bool = True  # small-sample variance floor (see SE_FLOOR_MAX_PAIRS)
+    # Novelty floor: queries whose best bank similarity is below this abstain to the baseline
+    # (None = off). Set at fit time from the floor_q quantile of bank self-NN similarities;
+    # the serving-side coverage/robustness knob for task drift.
+    floor_sim: float | None = None
 
     # Set by `save`/`load` so a relative `knn_bank_path` resolves against the policy file, and
     # the lazily loaded bank. Private: not part of the artifact.
@@ -515,6 +519,14 @@ def knn_decision(policy: RoutingPolicy, query: np.ndarray) -> RoutingDecision:
     if norm > 0.0:
         vector = vector / norm
     sims = bank.embeddings @ vector
+    if policy.floor_sim is not None and float(np.max(sims)) < policy.floor_sim:
+        return RoutingDecision(
+            model=baseline,
+            reason=(
+                f"knn novelty abstain: best similarity {float(np.max(sims)):.3f} below the "
+                f"fit-bank floor {policy.floor_sim:.3f}, serving {baseline}"
+            ),
+        )
 
     budget = min(policy.rag_num, sims.shape[0])
     kth = float(np.sort(sims)[-budget])

--- a/wmh/optimize/policy_test.py
+++ b/wmh/optimize/policy_test.py
@@ -9,9 +9,12 @@ import pytest
 from pydantic import ValidationError
 
 from wmh.optimize.policy import (
+    KNN_BANK_FILENAME,
     ClusterRanking,
     EmbedderSpec,
+    KnnBank,
     RoutingPolicy,
+    knn_decision,
     rank_decision,
     select_model,
 )
@@ -273,3 +276,229 @@ def test_rank_decision_normalizes_the_query_itself() -> None:
     assert expected.model == "haiku-4-5"
     for scale in (0.02, 50.0):  # 50.0 selected fable-5 before the fix
         assert rank_decision(policy, unit * scale) == expected
+
+
+# --- kNN policies: the guarded nearest-neighbor champion (see wmh.optimize.knn) ------------
+
+_CHEAP, _PRICEY = 0.001, 0.010
+
+
+def _knn_bank(
+    rewards: list[list[float]],
+    *,
+    sims: list[float] | None = None,
+    costs: list[float] | None = None,
+) -> KnnBank:
+    """A 2-dimensional bank: one row per neighbor, columns [fable-5, haiku-4-5].
+
+    Rows sit on the unit circle at the requested cosine similarity to the query (1, 0), which
+    makes neighbor selection and the similarity weights exact rather than embedder-dependent.
+    Per-model costs default to fable-5 pricey / haiku-4-5 cheap.
+    """
+    similarities = sims if sims is not None else [1.0] * len(rewards)
+    reward_rows = np.asarray(rewards, dtype=np.float32)
+    model_costs = costs if costs is not None else [_PRICEY, _CHEAP]
+    return KnnBank(
+        embeddings=np.asarray(
+            [[sim, (1.0 - sim**2) ** 0.5] for sim in similarities], dtype=np.float32
+        ),
+        rewards=reward_rows,
+        costs=np.where(np.isnan(reward_rows), np.nan, np.asarray(model_costs, dtype=np.float32)),
+        models=["fable-5", "haiku-4-5"],
+        scenario_ids=[f"s{index}" for index in range(len(rewards))],
+    )
+
+
+def _knn_policy(bank: KnnBank, **overrides: object) -> RoutingPolicy:
+    """A knn policy over `bank` with fable-5 as the pinned baseline (the production contract)."""
+    fields: dict[str, object] = {
+        "kind": "knn",
+        "default_model": "fable-5",
+        "guard_model": "fable-5",
+        "pool": _pool(),
+        "embedder": EmbedderSpec(dim=2),
+    }
+    fields.update(overrides)
+    policy = RoutingPolicy.model_validate(fields)
+    policy.attach_bank(bank)
+    return policy
+
+
+_QUERY = np.asarray([1.0, 0.0])
+
+
+class _UnitEmbedder:
+    """Embeds every text to the bank's query direction, so routing is about the bank alone."""
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+
+def test_knn_routes_away_from_the_baseline_on_strong_evidence() -> None:
+    # 12 neighbors where haiku always wins and fable always loses: the evidence is as clean as
+    # it gets, and haiku is the cheaper model, so the guard applies the single-z bar.
+    policy = _knn_policy(_knn_bank([[0.0, 1.0]] * 12))
+    decision = knn_decision(policy, _QUERY)
+    assert decision.model == "haiku-4-5"
+    assert "12 neighbors" in decision.reason
+    assert "delta=+1.000" in decision.reason
+
+
+def test_knn_reverts_when_too_few_neighbors_were_scored_on_both_sides() -> None:
+    # Same unanimous evidence, but only 5 paired neighbors: below min_pairs the guard refuses,
+    # because five agreeing neighbors are how a router talks itself into a confident mistake.
+    policy = _knn_policy(_knn_bank([[0.0, 1.0]] * 5))
+    decision = knn_decision(policy, _QUERY)
+    assert decision.model == "fable-5"
+    assert "5 paired neighbors < 8 required" in decision.reason
+
+
+def test_knn_z_is_the_confidence_knob_on_identical_evidence() -> None:
+    # Noisy evidence: haiku wins 7 of 12 neighbors, loses 5, mean delta +0.083 with a standard
+    # error of 0.149. At z=0.5 the mean clears the bar; at z=1.0 the same evidence does not.
+    rewards = [[0.5, 1.0]] * 7 + [[0.5, 0.0]] * 5
+    assert knn_decision(_knn_policy(_knn_bank(rewards), knn_z=0.5), _QUERY).model == "haiku-4-5"
+    stricter = knn_decision(_knn_policy(_knn_bank(rewards), knn_z=1.0), _QUERY)
+    assert stricter.model == "fable-5"
+    assert "evidence insufficient" in stricter.reason
+
+
+def test_knn_doubles_the_bar_for_a_pricier_pick() -> None:
+    # The economic asymmetry: identical reward evidence, and the only difference is whether the
+    # pick costs more than the baseline. Paying more requires twice the confidence.
+    rewards = [[0.5, 1.0]] * 7 + [[0.5, 0.0]] * 5
+    cheap_pick = knn_decision(_knn_policy(_knn_bank(rewards, costs=[_PRICEY, _CHEAP])), _QUERY)
+    pricey_pick = knn_decision(_knn_policy(_knn_bank(rewards, costs=[_CHEAP, _PRICEY])), _QUERY)
+    assert cheap_pick.model == "haiku-4-5"
+    assert pricey_pick.model == "fable-5"
+    assert "pricier" not in cheap_pick.reason
+    assert "1xSE" in pricey_pick.reason  # z doubled from 0.5
+
+
+def test_knn_se_floor_stops_a_zero_variance_neighborhood_from_looking_significant() -> None:
+    # Nine neighbors that all agree haiku is 0.05 better: the empirical standard error is ZERO,
+    # so an unfloored guard treats a rounding-sized edge as certain. The floor (sqrt(0.25/9))
+    # asks for 0.083 instead, and the edge does not clear it.
+    bank = _knn_bank([[0.5, 0.55]] * 9)
+    assert knn_decision(_knn_policy(bank, se_floor=False), _QUERY).model == "haiku-4-5"
+    assert knn_decision(_knn_policy(bank, se_floor=True), _QUERY).model == "fable-5"
+
+
+def test_knn_keeps_the_baseline_when_it_leads_the_neighborhood() -> None:
+    decision = knn_decision(_knn_policy(_knn_bank([[1.0, 0.0]] * 12)), _QUERY)
+    assert decision.model == "fable-5"
+    assert "leads 12 neighbors" in decision.reason
+
+
+def test_knn_serves_the_baseline_when_neighbors_carry_no_scored_reward() -> None:
+    bank = _knn_bank([[0.4, float("nan")]] * 3 + [[float("nan"), float("nan")]] * 9)
+    # The query's neighbors are the 9 unscored rows only (the scored ones sit far away).
+    bank = KnnBank(
+        embeddings=np.asarray(
+            [[0.2, 0.98] for _ in range(3)] + [[1.0, 0.0] for _ in range(9)], dtype=np.float32
+        ),
+        rewards=bank.rewards,
+        costs=bank.costs,
+        models=bank.models,
+        scenario_ids=bank.scenario_ids,
+    )
+    decision = knn_decision(_knn_policy(bank, rag_num=9), _QUERY)
+    assert decision.model == "fable-5"
+    assert "no scored reward" in decision.reason
+
+
+def test_knn_neighbor_rule_is_relative_not_a_fixed_k() -> None:
+    # rag_num is a budget, not a count: everything within rag_thres of the budget-th best
+    # similarity joins, so a query in a dense region routes on MORE evidence than k. Here 12
+    # rows are equally near, and a budget of 3 keeps all 12.
+    decision = knn_decision(_knn_policy(_knn_bank([[0.0, 1.0]] * 12), rag_num=3), _QUERY)
+    assert "12 neighbors" in decision.reason
+    # Far rows stay out while the budget is covered by near ones, and join once it is not: 10
+    # near rows plus 6 distant ones give 10 neighbors at a budget of 10, all 16 at a budget of 16.
+    mixed = _knn_bank([[0.0, 1.0]] * 10 + [[1.0, 0.0]] * 6, sims=[1.0] * 10 + [0.5] * 6)
+    assert "10 neighbors" in knn_decision(_knn_policy(mixed, rag_num=10), _QUERY).reason
+    assert "16 neighbors" in knn_decision(_knn_policy(mixed, rag_num=16), _QUERY).reason
+
+
+def test_knn_bank_loads_lazily_from_the_sidecar_and_stays_cached(tmp_path: Path) -> None:
+    bank = _knn_bank([[0.0, 1.0]] * 12)
+    bank.save(tmp_path / KNN_BANK_FILENAME)
+    saved = _knn_policy(bank)
+    saved.save(tmp_path / "policy.json")
+
+    loaded = RoutingPolicy.load(tmp_path / "policy.json")
+    assert loaded.bank_path() == tmp_path / KNN_BANK_FILENAME
+    assert select_model(loaded, "anything", embedder=_UnitEmbedder()).model == "haiku-4-5"
+    # Cached after the first decision: the sidecar is read once per policy instance, not per
+    # request (a 3072-dimensional bank is megabytes).
+    (tmp_path / KNN_BANK_FILENAME).unlink()
+    assert select_model(loaded, "anything", embedder=_UnitEmbedder()).model == "haiku-4-5"
+
+
+def test_knn_policy_without_its_sidecar_says_where_the_file_should_be(tmp_path: Path) -> None:
+    _knn_policy(_knn_bank([[0.0, 1.0]] * 12)).save(tmp_path / "policy.json")
+    loaded = RoutingPolicy.load(tmp_path / "policy.json")
+    with pytest.raises(FileNotFoundError, match=KNN_BANK_FILENAME):
+        loaded.knn_bank()
+
+
+def test_knn_kind_requires_a_baseline_that_is_also_the_default() -> None:
+    with pytest.raises(ValueError, match="guard_model"):
+        RoutingPolicy(kind="knn", default_model="fable-5", pool=_pool())
+    with pytest.raises(ValueError, match="one model"):
+        RoutingPolicy(kind="knn", default_model="fable-5", guard_model="haiku-4-5", pool=_pool())
+
+
+def test_knn_kind_rejects_clusters() -> None:
+    with pytest.raises(ValueError, match="knn policy carries no clusters"):
+        RoutingPolicy(
+            kind="knn",
+            default_model="fable-5",
+            guard_model="fable-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=2),
+            clusters=[ClusterRanking(cluster_id=0, centroid=[1.0, 0.0], ranking=["fable-5"])],
+        )
+
+
+def test_knn_bank_must_match_the_policys_embedder_and_pool() -> None:
+    bank = _knn_bank([[0.0, 1.0]] * 12)
+    with pytest.raises(ValueError, match="dimensional"):
+        _knn_policy(bank, embedder=EmbedderSpec(dim=64))
+    stranger = KnnBank(
+        embeddings=bank.embeddings,
+        rewards=bank.rewards,
+        costs=bank.costs,
+        models=["fable-5", "retired-model"],
+        scenario_ids=bank.scenario_ids,
+    )
+    with pytest.raises(ValueError, match="not in the policy pool"):
+        _knn_policy(stranger)
+
+
+def test_knn_bank_must_carry_evidence_for_the_baseline() -> None:
+    # A baseline the fit never measured cannot be compared against, so every request would
+    # revert to it unmeasured: that is a static policy wearing a router's clothes.
+    with pytest.raises(ValueError, match="no scored reward for baseline"):
+        _knn_policy(_knn_bank([[float("nan"), 1.0]] * 12))
+
+
+def test_knn_bank_rejects_misaligned_arrays() -> None:
+    with pytest.raises(ValueError, match="rewards has shape"):
+        KnnBank(
+            embeddings=np.zeros((3, 2), dtype=np.float32),
+            rewards=np.zeros((3, 5), dtype=np.float32),
+            costs=np.zeros((3, 2), dtype=np.float32),
+            models=["fable-5", "haiku-4-5"],
+            scenario_ids=["a", "b", "c"],
+        )
+
+
+def test_knn_bank_round_trips_through_the_sidecar(tmp_path: Path) -> None:
+    bank = _knn_bank([[0.5, 1.0], [float("nan"), 0.0]] * 6)
+    bank.save(tmp_path / KNN_BANK_FILENAME)
+    reloaded = KnnBank.load(tmp_path / KNN_BANK_FILENAME)
+    assert reloaded.models == bank.models
+    assert reloaded.scenario_ids == bank.scenario_ids
+    np.testing.assert_array_equal(reloaded.rewards, bank.rewards)  # NaN cells included
+    np.testing.assert_allclose(reloaded.embeddings, bank.embeddings)

--- a/wmh/optimize/policy_test.py
+++ b/wmh/optimize/policy_test.py
@@ -309,17 +309,27 @@ def _knn_bank(
     )
 
 
-def _knn_policy(bank: KnnBank, **overrides: object) -> RoutingPolicy:
+def _knn_policy(
+    bank: KnnBank,
+    *,
+    embedder: EmbedderSpec | None = None,
+    rag_num: int = 50,
+    knn_z: float = 0.5,
+    knn_min_pairs: int = 8,
+    se_floor: bool = True,
+) -> RoutingPolicy:
     """A knn policy over `bank` with fable-5 as the pinned baseline (the production contract)."""
-    fields: dict[str, object] = {
-        "kind": "knn",
-        "default_model": "fable-5",
-        "guard_model": "fable-5",
-        "pool": _pool(),
-        "embedder": EmbedderSpec(dim=2),
-    }
-    fields.update(overrides)
-    policy = RoutingPolicy.model_validate(fields)
+    policy = RoutingPolicy(
+        kind="knn",
+        default_model="fable-5",
+        guard_model="fable-5",
+        pool=_pool(),
+        embedder=embedder or EmbedderSpec(dim=2),
+        rag_num=rag_num,
+        knn_z=knn_z,
+        knn_min_pairs=knn_min_pairs,
+        se_floor=se_floor,
+    )
     policy.attach_bank(bank)
     return policy
 

--- a/wmh/optimize/report.py
+++ b/wmh/optimize/report.py
@@ -150,7 +150,7 @@ def build_report(
 
     # One embedder for the whole report: an azure spec builds an HTTP client per `build()`, and
     # a report routes every held-out scenario.
-    embedder = policy.embedder.build() if policy.kind == "rank" else None
+    embedder = policy.embedder.build() if policy.kind != "static" else None
 
     routed_rows: dict[str, list[ScenarioOutcome]] = {}
     baseline_rows: dict[str, list[ScenarioOutcome]] = {}

--- a/wmh/optimize/routing.py
+++ b/wmh/optimize/routing.py
@@ -17,8 +17,10 @@ human-readable label (majority scenario-id prefix) for the request log; the refe
 labels. Cost plays NO part in fitting, exactly like the reference; the cost-aware variant
 (Avengers-Pro's alpha) is the first planned variation AFTER replication is validated.
 
-`evaluate_policy` replays a policy over a matrix through the same `rank_decision` scoring code
-serving uses, so benchmark numbers measure the deployed selection path, not a reimplementation.
+`evaluate_policy` replays a policy of ANY kind (static, rank, knn) over a matrix through the same
+decision code serving uses, so benchmark numbers measure the deployed selection path, not a
+reimplementation. The kNN family's fit lives in `wmh.optimize.knn`, which explains why it is a
+separate module rather than another mode here.
 """
 
 from __future__ import annotations
@@ -40,11 +42,13 @@ from wmh.optimize.policy import (
     EmbedderSpec,
     RoutingDecision,
     RoutingPolicy,
+    knn_decision,
     rank_decision,
 )
 
 if TYPE_CHECKING:
     from wmh.optimize.outcomes import OutcomeMatrix
+    from wmh.providers.base import Embedder
 
 logger = logging.getLogger(__name__)
 
@@ -302,11 +306,21 @@ class PolicyEval(BaseModel):
     unscored_scenarios: int  # scenario/model pairs the routed choice had no scored row for
 
 
-def evaluate_policy(policy: RoutingPolicy, matrix: OutcomeMatrix, ids: list[str]) -> PolicyEval:
+def evaluate_policy(
+    policy: RoutingPolicy,
+    matrix: OutcomeMatrix,
+    ids: list[str],
+    *,
+    embedder: Embedder | None = None,
+) -> PolicyEval:
     """Replay `policy` over the scenarios in `ids`, scoring via each routed model's rows.
 
-    Selection runs through the SAME `rank_decision` code serving uses (queries are batch
-    embedded once for speed; the scoring math is shared, not reimplemented).
+    Selection runs through the SAME decision code serving uses (`rank_decision` or
+    `knn_decision`; queries are batch embedded once for speed, and both normalize internally, so
+    the scoring math is shared rather than reimplemented).
+
+    `embedder` overrides the function built from `policy.embedder`, exactly as in `select_model`:
+    one client for the whole replay, or cached vectors in research code.
     """
     scenario_tasks: dict[str, str] = {}
     for outcome in matrix.outcomes:
@@ -322,13 +336,10 @@ def evaluate_policy(policy: RoutingPolicy, matrix: OutcomeMatrix, ids: list[str]
             for sid in wanted
         }
     else:
-        embeddings = np.asarray(
-            policy.embedder.build().embed([scenario_tasks[sid] for sid in wanted])
-        )
-        embeddings = Normalizer(norm="l2").transform(embeddings)
-        decisions = {
-            sid: rank_decision(policy, embeddings[index]) for index, sid in enumerate(wanted)
-        }
+        decide = knn_decision if policy.kind == "knn" else rank_decision
+        built = embedder or policy.embedder.build()
+        embeddings = np.asarray(built.embed([scenario_tasks[sid] for sid in wanted]))
+        decisions = {sid: decide(policy, embeddings[index]) for index, sid in enumerate(wanted)}
 
     by_scenario_model: dict[tuple[str, str], list[float]] = {}
     costs: dict[tuple[str, str], list[float]] = {}

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -260,10 +260,14 @@ class EndpointRuntime:
     def _embedder(self) -> Embedder | None:
         """Build the policy's embedder once per runtime, not once per request.
 
+        Static policies never embed, so their (possibly unbuildable-in-this-environment)
+        embedder spec must not be constructed at all: a static route has to keep serving
+        even when an azure spec's credentials are absent here.
+
         An azure spec otherwise constructs a fresh SDK client (TLS handshake and all) inside
         every request's latency budget. Double-checked locking mirrors provider_for.
         """
-        if self.policy.embedder is None:
+        if self.policy.kind == "static" or self.policy.embedder is None:
             return None
         with self._lock:
             embedder = self._policy_embedder

--- a/wmh/serving/chat.py
+++ b/wmh/serving/chat.py
@@ -36,7 +36,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, JsonValue, field_validator
 from starlette.background import BackgroundTask
 
-from wmh.optimize.policy import RoutingDecision, RoutingPolicy, select_model
+from wmh.optimize.policy import Embedder, RoutingDecision, RoutingPolicy, select_model
 from wmh.providers.base import (
     DEFAULT_MAX_TOKENS,
     Message,
@@ -245,6 +245,7 @@ class EndpointRuntime:
         self.log = log
         self._provider_factory = provider_factory
         self._providers: dict[str, Provider] = {}
+        self._policy_embedder: Embedder | None = None
         self._affinity: OrderedDict[str, str] = OrderedDict()
         self._lock = threading.Lock()
 
@@ -254,7 +255,25 @@ class EndpointRuntime:
             with self._lock:
                 incumbent = self._affinity.get(_fingerprint(messages[:-1]))
         text = _routable_text(messages)
-        return select_model(self.policy, text, incumbent=incumbent)
+        return select_model(self.policy, text, incumbent=incumbent, embedder=self._embedder())
+
+    def _embedder(self) -> Embedder | None:
+        """Build the policy's embedder once per runtime, not once per request.
+
+        An azure spec otherwise constructs a fresh SDK client (TLS handshake and all) inside
+        every request's latency budget. Double-checked locking mirrors provider_for.
+        """
+        if self.policy.embedder is None:
+            return None
+        with self._lock:
+            embedder = self._policy_embedder
+        if embedder is None:
+            embedder = self.policy.embedder.build()
+            with self._lock:
+                if self._policy_embedder is None:
+                    self._policy_embedder = embedder
+                embedder = self._policy_embedder
+        return embedder
 
     def remember(self, messages: list[ChatMessage], assistant_text: str, model: str) -> None:
         """Record the finished exchange so the conversation's next request finds its incumbent."""

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -468,3 +468,33 @@ def test_runtime_builds_the_policy_embedder_once(
             json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
         )
     assert builds["n"] == 1
+
+
+def test_static_policy_never_builds_its_embedder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A static route must keep serving even when the embedder spec cannot initialize here.
+    from wmh.optimize.policy import EmbedderSpec
+
+    def exploding_build(self: EmbedderSpec) -> object:
+        raise RuntimeError("no credentials in this environment")
+
+    monkeypatch.setattr(EmbedderSpec, "build", exploding_build)
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(
+            kind="static",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            embedder=EmbedderSpec(dim=64),
+        ),
+        provider_factory=_EchoProvider,
+        log=RequestLog(tmp_path / "requests.jsonl"),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code == 200

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -7,11 +7,19 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import numpy as np
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from wmh.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
+from wmh.optimize.policy import (
+    KNN_BANK_FILENAME,
+    POLICY_FILENAME,
+    ClusterRanking,
+    EmbedderSpec,
+    KnnBank,
+    RoutingPolicy,
+)
 from wmh.providers.base import (
     Completion,
     Message,
@@ -382,3 +390,58 @@ def test_create_app_with_injected_policies_and_no_artifact_dirs(tmp_path: Path) 
     )
     client = TestClient(app)
     assert [m["id"] for m in client.get("/v1/models").json()["data"]] == ["ep"]
+
+
+def _knn_policy(tmp_path: Path) -> RoutingPolicy:
+    """A knn policy written to disk exactly as the fitter emits it: policy.json + npz sidecar.
+
+    Six SQL scenarios where fable-5 wins outright and six prose ones where haiku-4-5 does, with
+    haiku-4-5 as the pinned fallback. Loading it back proves the endpoint serves the artifact
+    pair with no serving-side knowledge of the bank format.
+    """
+    sql = ["SELECT count(*) FROM superheroes", "SELECT name FROM users LIMIT 10"] * 3
+    prose = ["write a friendly email to the team", "draft a thank-you note"] * 3
+    rewards = [[1.0, 0.0]] * len(sql) + [[0.0, 1.0]] * len(prose)
+    bank = KnnBank(
+        embeddings=np.asarray(HashingEmbedder(dim=64).embed(sql + prose), dtype=np.float32),
+        rewards=np.asarray(rewards, dtype=np.float32),
+        costs=np.asarray([[0.01, 0.001]] * len(rewards), dtype=np.float32),
+        models=["fable-5", "haiku-4-5"],
+        scenario_ids=[f"s{index}" for index in range(len(rewards))],
+    )
+    bank.save(tmp_path / KNN_BANK_FILENAME)
+    RoutingPolicy(
+        kind="knn",
+        default_model="haiku-4-5",
+        guard_model="haiku-4-5",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=64),
+        rag_num=6,
+        knn_min_pairs=4,
+    ).save(tmp_path / POLICY_FILENAME)
+    return RoutingPolicy.load(tmp_path / POLICY_FILENAME)
+
+
+def test_knn_policy_routes_a_request_end_to_end(tmp_path: Path) -> None:
+    client, log_path = _client(tmp_path, policy=_knn_policy(tmp_path))
+    routed = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "SELECT count(*) FROM superheroes"}],
+        },
+    )
+    # The SQL neighborhood is unanimous, so the guard lets the request leave the fallback.
+    assert routed.headers["x-wmh-routed-model"] == "fable-5"
+    assert routed.json()["choices"][0]["message"]["content"] == "served by fable-5"
+
+    fallback = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "draft a thank-you"}]},
+    )
+    assert fallback.headers["x-wmh-routed-model"] == "haiku-4-5"
+
+    rows = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert [row["model"] for row in rows] == ["fable-5", "haiku-4-5"]
+    assert rows[0]["routing_reason"].startswith("knn: ")
+    assert rows[0]["cluster_id"] is None  # a knn decision cites neighbors, not clusters

--- a/wmh/serving/chat_test.py
+++ b/wmh/serving/chat_test.py
@@ -445,3 +445,26 @@ def test_knn_policy_routes_a_request_end_to_end(tmp_path: Path) -> None:
     assert [row["model"] for row in rows] == ["fable-5", "haiku-4-5"]
     assert rows[0]["routing_reason"].startswith("knn: ")
     assert rows[0]["cluster_id"] is None  # a knn decision cites neighbors, not clusters
+
+
+def test_runtime_builds_the_policy_embedder_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An azure embedder spec would otherwise construct a fresh SDK client per request.
+    from wmh.optimize.policy import EmbedderSpec
+
+    builds = {"n": 0}
+    original = EmbedderSpec.build
+
+    def counting_build(self: EmbedderSpec) -> object:
+        builds["n"] += 1
+        return original(self)
+
+    monkeypatch.setattr(EmbedderSpec, "build", counting_build)
+    client, _ = _client(tmp_path, policy=_cluster_policy())
+    for _ in range(3):
+        client.post(
+            "/v1/chat/completions",
+            json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert builds["n"] == 1


### PR DESCRIPTION
Promotes the routing research program's one validated winner into production: the kNN reward-profile router with a paired statistical guard, served as a `kind="knn"` routing policy by the #248 endpoint with zero serving changes beyond the policy seam.

## The method (validated in #256's research program)
Embed the request, find fit-set neighbors above a relative similarity bar (0.95x the 50th-best), read which pool models actually won on those neighbors (similarity-weighted), and deviate from the fallback model ONLY when paired per-neighbor evidence clears `z` standard errors (doubled when the pick is pricier). Otherwise serve the fallback.

## The serving contract (per Silen)
Route away only when really confident; otherwise serve fable-5. `--fallback fable-5` pins the guard baseline and the revert target (one knob, validator-enforced equal). `--z` is the confidence dial: higher = stricter = closer to always-fable. The validated operating point is z=0.5.

## Validation gate (reproduced, not trusted)
Fit + evaluated through THIS code path on routerbench-ours9 (real benchmark, n=1,199), seeds 0-4: mean paired delta vs best-single **+0.0104 (5/5 seed wins) at -26.6% cost**, matching the research champion's recorded per-seed accuracies to four decimals. Split identity asserted against the research runs (drifted split fails the gate). Re-run: `uv run python .agents/scripts/validate_knn_promotion.py`.

Fable-fallback confidence curve on ours9 (fable alone: 0.9045): z=0.5 routes away 64.9% for acc 0.9607 at -33.9% cost; z=1.0 routes 48.0% for 0.9635 at -22.8%. Notably, pinning fable-5 OUTPERFORMS letting the fitter pick best-single here (0.9607 vs 0.9545): the conservative contract costs nothing.

## What's in the diff
- `wmh/optimize/policy.py`: `kind="knn"` (KnnBank sidecar .npz, lazy-loaded; `knn_decision` shared by serve and eval so they cannot diverge; reasons state the evidence).
- `wmh/optimize/knn.py`: `fit_knn_policy` + bank builder (per-cell reward/cost matrices, NaN for unscored, cell-weighted cost means).
- `wmh/cli/route_app.py`: `wmh optimize route fit --kind knn --fallback fable-5 --z 0.5 ...`.
- `wmh/serving/chat.py`: policy embedder built once per runtime instead of once per request (twice-flagged in review; matters now that the recommended kind always embeds).
- Tests: 17 knn cases (guard reverts, z knob, cost asymmetry, sidecar round-trip), an end-to-end serve test, the embedder-once test. Full suite 2,320 green.

## Hardening (R1's promotion round, folded in)
- **Adaptive neighborhood**: `rag_num` caps at half the fit bank (min_pairs scales with it), so tiny banks keep local evidence instead of degenerating to a global mean and 0% routing. Bit-identical to the validated champion on banks >= 2x the budget; the promotion gate re-ran clean with it in place. R1 verified the companion small-sample SE floor removes every pricier-and-worse row across 12 matrices.
- **Novelty floor** (`--floor-q`, default 0.05): a query whose best bank similarity falls below the fit-bank self-NN quantile abstains to the fallback. R1's measured risk-coverage curve: iid wins hold at every q (5/5 seeds throughout) while task-drift damage heals to neutral. This is the answer to the OOD-task hole R3's sweep exposed (champion -0.7pt mean under whole-task drift without it); R3's RBF-SVM+guard config is recorded in the research ledger as the sanctioned drift-fallback alternative.

## Known limits (stated, not hidden)
- The conformal certificate (research layer) holds on iid and cluster-shift traffic but is voided by whole-task novelty (measured, 1/5 seeds): serving copy should say "guaranteed for traffic resembling the calibration mix", with the floor as the drift bound, not the certificate.
- Dead research knobs (second_route, smoothing, pick_lam) intentionally not ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
