### PR TITLE
Closed-loop agent: a JSON reply without done or tool is a message, not a finish signal

### DIFF
--- a/wmo/env/llm_agent.py
+++ b/wmo/env/llm_agent.py
@@ -66,9 +66,18 @@ class LLMAgent:
             except ValidationError:
                 reply = None
             if reply is not None:
-                if reply.done or reply.tool is None:
+                if reply.done:
                     return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
-                return Action(kind=ActionKind.TOOL_CALL, name=reply.tool, arguments=reply.arguments)
+                if reply.tool is not None:
+                    return Action(
+                        kind=ActionKind.TOOL_CALL, name=reply.tool, arguments=reply.arguments
+                    )
+                # A JSON object with neither `done` nor `tool` is NOT a finish signal: models
+                # that write prose-style calls (`get_user(...)` around a bare argument object)
+                # land here, and treating it as done ended their episodes unexecuted at step 1
+                # and scored them 0 (measured: 34% of glm-5.2 wm episodes, 0% for other pool
+                # models). Fall through to the message path so the env can answer and the
+                # episode recovers.
         # Unparseable reply: surface it as a message action; the env will answer and the episode
         # continues rather than crashing the batch.
         return Action(kind=ActionKind.MESSAGE, content=completion.text.strip()[:_MAX_HISTORY_CHARS])

--- a/wmo/env/llm_agent_test.py
+++ b/wmo/env/llm_agent_test.py
@@ -98,3 +98,22 @@ def test_tools_hint_lands_in_the_system_prompt() -> None:
     assert "run_sql(query)" in provider.system
     bare = LLMAgent(_CaptureProvider())
     assert bare is not None  # no hint -> unchanged system (covered by existing tests)
+
+
+def test_prose_tool_call_is_not_a_finish_signal() -> None:
+    # glm-5.2 sometimes writes `get_user_details({"user_id": "x"})`: extract_json_object
+    # grabs the bare ARGUMENT object, which validates with tool=None and done unset. That
+    # must fall through to a message action (the env answers, the episode recovers) - the
+    # old `tool is None -> DONE` read ended 34% of glm's episodes unexecuted at step 1.
+    agent = LLMAgent(FakeProvider('get_user_details({"user_id": "chen_silva_2201"})'))
+    action = agent.act("task", EnvState(), [])
+    assert action.kind is ActionKind.MESSAGE
+    assert action.content is not None
+    assert action.content != DONE_SIGNAL
+    assert "chen_silva_2201" in action.content
+
+
+def test_explicit_done_still_terminates() -> None:
+    agent = LLMAgent(FakeProvider('{"done": true}'))
+    action = agent.act("task", EnvState(), [])
+    assert action.content == DONE_SIGNAL


### PR DESCRIPTION
Found by the sim-to-real capture round: glm-5.2 scored 0.800 on the REAL tau-bench harness but 0.368 on the world-model matrix. Root cause (reproduced end-to-end on recorded replies): glm sometimes writes prose-style tool calls like `get_user_details({"user_id": ...})`; `extract_json_object` grabs the bare argument object, it validates as `tool=None, done=False`, and `LLMAgent.act` treated "no tool key" as "agent finished". The episode ends unexecuted at step 1-2 and the judge scores 0 with critiques like "you never actually executed any modification".

Measured blast radius: 34% of glm-5.2's wm episodes (17/50), 0% for the other eight pool models, 0% on the real harness (litellm native function-calling). With the biased episodes corrected by an unbiased estimator, glm's wm score moves 0.368 -> 0.456 and the sim-to-real Spearman +0.462 -> +0.521, so the bug explains a real part of the gap.

Fix: termination requires an explicit `done: true`; a tool-less JSON object falls through to the existing message path (the env answers, the episode recovers). Two regression tests: the exact glm reply shape must not terminate, explicit done still does.

Cohort note (recorded in the research ledger): closed-loop matrices captured before this fix understate prose-call models; the in-flight s80 capture finishes on the old code for cohort consistency, and glm-sensitive claims need a recapture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)