### PR TITLE
D-COMPRESS serving seam: pricing cache tiers, segment-aware compressor, compress stage, eval threading

### DIFF
--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -28,6 +28,7 @@ from rich.table import Table
 from wmo.cli.route_app import (
     BIAS_ACCEPTED_NOTE,
     NO_EVIDENCE_WARNING,
+    _compressor_note,
     cell_progress,
     print_coverage,
     print_deferred_risks,
@@ -39,6 +40,7 @@ from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.closed_loop import scenario_id
+from wmo.optimize.compression import compression_signature
 from wmo.optimize.knn import (
     COST_QUALITY_BALANCED,
     DEFAULT_KNN_MIN_PAIRS,
@@ -478,6 +480,12 @@ def _live_inputs(
                     "scenarios": _scenario_identity(plan),
                     "episodes": str(plan.episodes),
                     "max_steps": str(plan.max_steps),
+                    # A matrix's rewards belong to ONE D-COMPRESS arm, so a changed compressor
+                    # means different evidence and the cells have to be bought again. The
+                    # orchestrator exposes no compression flag yet, so this reads "raw text"
+                    # today; recording it now means the reserved COMPACT stage cannot arrive
+                    # and silently reuse a matrix measured under a different arm.
+                    "compression": compression_signature(plan.compression),
                 },
                 artifact=paths.matrix,
                 artifact_identity=file_sha256(paths.matrix),
@@ -682,7 +690,7 @@ def _print_plan(
         f"input + {ASSUMED_OUTPUT_TOKENS:,} assumed output token(s) per call, times the real cell "
         f"and call counts, at each candidate's own pool price)"
     )
-    console.print(_world_model_forecast(projection))
+    console.print(_world_model_forecast(projection, compressed=plan.compression is not None))
 
 
 def _print_budget_stop(name: str, exc: BudgetExceeded) -> None:
@@ -699,7 +707,7 @@ def _will_sweep(decisions: list[StageDecision]) -> bool:
     return any(decision.stage is Stage.SWEEP and decision.will_run for decision in decisions)
 
 
-def _world_model_forecast(projection: SweepSpendProjection) -> str:
+def _world_model_forecast(projection: SweepSpendProjection, *, compressed: bool) -> str:
     """What to say about the OTHER side of the bill before the operator authorizes the run.
 
     Two honest answers, never a zero. With a prior sweep of this model there is a measured ratio
@@ -708,11 +716,20 @@ def _world_model_forecast(projection: SweepSpendProjection) -> str:
     be, or "not in this figure" reads as "not much" and the operator plans against the wrong
     number.
     """
+    # A compressed arm makes the candidate projection wrong in BOTH directions at once, so say
+    # so rather than let the reader assume the usual over-estimate is the whole story.
+    arm = (
+        "\n  on a compressed arm that candidate figure is an OVER-estimate (it assumes "
+        "uncompressed tokens) while the compressor's OWN per-call cost is not in it at all, "
+        "because nothing predicts that in advance. Both are measured when the sweep finishes."
+        if compressed
+        else ""
+    )
     if projection.projected:
         return (
             f"  plus a projected ~${projection.world_model_usd:.2f} world-model side "
             f"({projection.basis}), so ~${projection.total_usd:.2f} total is what --max-usd is "
-            "checked against. That half is a forecast from one prior sweep, not arithmetic."
+            "checked against. That half is a forecast from one prior sweep, not arithmetic." + arm
         )
     return (
         "  the world model's own serve and judge calls are NOT in that figure and are not "
@@ -720,7 +737,7 @@ def _world_model_forecast(projection: SweepSpendProjection) -> str:
         "judge's token use per episode in advance. It is not a rounding error either, measuring "
         "7.0x the candidate side on one real tau corpus, so treat the number above as a lower "
         "bound. Both sides are measured and reported when the sweep finishes, and the next run "
-        "forecasts this line from them."
+        "forecasts this line from them." + arm
     )
 
 
@@ -866,8 +883,8 @@ def _stage_sweep(plan: SweepPlan, *, model_dir: Path, pool_file: Path) -> StageR
     _console.print(
         f"  [green]✓[/green] {len(matrix.outcomes)} cell(s), {scored} scored -> "
         f"{escape(str(plan.out_path))}\n"
-        f"  measured candidate spend ${run.candidate_usd:.4f} (the world model's own serve/judge "
-        "cost is metered separately)",
+        f"  measured candidate spend ${run.candidate_usd:.4f}{_compressor_note(run)} (the world "
+        "model's own serve/judge cost is metered separately)",
         soft_wrap=True,
     )
     print_world_model_spend(_console, run)
@@ -878,11 +895,13 @@ def _stage_sweep(plan: SweepPlan, *, model_dir: Path, pool_file: Path) -> StageR
             "scenarios": _scenario_identity(plan),
             "episodes": str(plan.episodes),
             "max_steps": str(plan.max_steps),
+            "compression": compression_signature(plan.compression),
         },
         artifact_path=str(plan.out_path),
         artifact_identity=file_sha256(plan.out_path),
         completed_at=_now(),
         spend_usd=run.candidate_usd,
+        compressor_spend_usd=run.compressor_usd,
         world_model_spend_usd=run.world_model_usd,
     )
     return record

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -885,7 +885,9 @@ def test_a_second_sweep_forecasts_the_world_model_side_from_the_first(
     forced = _run(tmp_path, root, "--yes", "--force-from", "sweep")
     assert forced.exit_code == 0, forced.output
     assert _says(forced.output, "plus a projected ~$30.00 world-model side")
-    assert _says(forced.output, "measured $0.1200 world-model against $0.0013 candidate")
+    assert _says(
+        forced.output, "measured $0.1200 world-model against $0.0013 projectable candidate"
+    )
     assert _says(forced.output, "90.9x")
     assert _says(forced.output, "a forecast from one prior sweep, not arithmetic")
 

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -40,7 +40,11 @@ from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_en
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
-from wmo.optimize.compression import CompressionConfig, get_compressor
+from wmo.optimize.compression import (
+    CompressingEmbedder,
+    CompressionConfig,
+    servable_compressor,
+)
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     DialResult,
@@ -836,8 +840,11 @@ def fit(
         raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
     compression = None
     if compressor is not None:
+        compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
         try:
-            get_compressor(compressor)  # model_copy below skips validators; check here
+            # Fail before the fit spends anything: model_copy below skips validators, and an
+            # unservable compressor would otherwise only surface when serving mounts the result.
+            servable_compressor(compression)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
         compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
@@ -865,6 +872,11 @@ def fit(
         print_knn_fit(_console, fitted, out=out, z=z)
         return
     built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
+    if compression is not None:
+        # Representation consistency: the cluster centroids have to live in the geometry of the
+        # text serving will embed, which is the COMPRESSED text (see `fit_knn_artifact`, which
+        # applies the same rule to the bank on the knn path).
+        built = CompressingEmbedder(built, compression)
     policy = fit_rank_policy(
         matrix,
         embedder=spec,
@@ -880,9 +892,13 @@ def fit(
     if cost_weight > 0.0:
         policy = rerank_policy(policy, cost_weight=cost_weight)
     if compression is not None:
-        # Validated above (unknown ids fail before anything is written). The knn path stamps
-        # inside `fit_knn_artifact`, which saves its own artifact and returns before this line.
-        policy = policy.model_copy(update={"compression": compression})
+        # Stamped as BOTH halves of the contract: what this endpoint serves, and what its
+        # evidence was fitted under. They are the same config here by construction (the fit just
+        # embedded through it), which is exactly what the mount gate re-checks. The knn path
+        # stamps inside `fit_knn_artifact`, which saves and returns before this line.
+        policy = policy.model_copy(
+            update={"compression": compression, "fit_compression": compression}
+        )
     policy.save(out_path)
     result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
     _console.print(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -807,8 +807,9 @@ def fit(
         "--aggressiveness",
         min=0.0,
         max=1.0,
-        help="Fraction of compressible content the compressor may remove, in [0, 1]. "
-        "Only meaningful with --compressor.",
+        help="Compressor-defined dial in [0, 1]: 0.0 is a no-op and higher never removes "
+        "less, but it is not an exact removal fraction (the achieved ratio is reported per "
+        "call). Only meaningful with --compressor.",
     ),
 ) -> None:
     """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -40,6 +40,7 @@ from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_en
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
+from wmo.optimize.compression import CompressionConfig, get_compressor
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     DialResult,
@@ -791,6 +792,20 @@ def fit(
     api_key_env: str = typer.Option(
         None, "--api-key-env", help="(azure) env var holding the account key."
     ),
+    compressor: str = typer.Option(
+        None,
+        "--compressor",
+        help="D-COMPRESS: compressor id the endpoint applies before routing (identity | "
+        "truncate). Default: compression off.",
+    ),
+    aggressiveness: float = typer.Option(
+        0.0,
+        "--aggressiveness",
+        min=0.0,
+        max=1.0,
+        help="Fraction of compressible content the compressor may remove, in [0, 1]. "
+        "Only meaningful with --compressor.",
+    ),
 ) -> None:
     """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
     if kind not in ("rank", "knn"):
@@ -817,6 +832,15 @@ def fit(
         probe_embedder(spec)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    if compressor is None and aggressiveness > 0.0:
+        raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
+    compression = None
+    if compressor is not None:
+        try:
+            get_compressor(compressor)  # model_copy below skips validators; check here
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(
@@ -836,6 +860,7 @@ def fit(
             min_pairs=min_pairs,
             se_floor=se_floor,
             floor_q=floor_q,
+            compression=compression,
         )
         print_knn_fit(_console, fitted, out=out, z=z)
         return
@@ -854,6 +879,10 @@ def fit(
     )
     if cost_weight > 0.0:
         policy = rerank_policy(policy, cost_weight=cost_weight)
+    if compression is not None:
+        # Validated above (unknown ids fail before anything is written). The knn path stamps
+        # inside `fit_knn_artifact`, which saves its own artifact and returns before this line.
+        policy = policy.model_copy(update={"compression": compression})
     policy.save(out_path)
     result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
     _console.print(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -43,6 +43,8 @@ from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compression import (
     CompressingEmbedder,
     CompressionConfig,
+    compression_signature,
+    same_compression,
     servable_compressor,
 )
 from wmo.optimize.knn import (
@@ -166,6 +168,22 @@ def sweep(
         "scenarios. The fit is then biased (both fitters skip unscored rows and weigh the rest per "
         "episode); the coverage table prints either way.",
     ),
+    compressor: str = typer.Option(
+        None,
+        "--compressor",
+        help="D-COMPRESS: measure every candidate call through this compressor (identity | "
+        "truncate), so the matrix is the compressed ARM of the grid. Default: uncompressed. "
+        "`fit` requires the matrix arm to match the policy it stamps.",
+    ),
+    aggressiveness: float = typer.Option(
+        0.0,
+        "--aggressiveness",
+        min=0.0,
+        max=1.0,
+        help="Compressor-defined dial in [0, 1] for --compressor: 0.0 is a no-op and higher "
+        "never removes less, but it is not an exact removal fraction (the achieved ratio is "
+        "recorded per episode).",
+    ),
 ) -> None:
     """Measure every pool candidate closed-loop and write the outcome matrix `fit` consumes.
 
@@ -226,6 +244,19 @@ def sweep(
     it, and the matrix is written either way.
     """
     out_path = Path(out)
+    if compressor is None and aggressiveness > 0.0:
+        raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
+    sweep_compression = None
+    if compressor is not None:
+        sweep_compression = CompressionConfig(
+            compressor_id=compressor, aggressiveness=aggressiveness
+        )
+        try:
+            # Checked before a single episode is paid for, and against the SERVING rule: there
+            # is no point measuring an arm whose compressor could never be mounted.
+            servable_compressor(sweep_compression)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
     store = WorldModelStore(root)
     try:
         model_dir = store.resolve(model)
@@ -849,6 +880,21 @@ def fit(
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
         compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
+    # The rewards in this matrix were produced under SOME compression config, and a joint fit is
+    # only joint if that config is the one being fitted. `--compressor` moves the fit-side
+    # representation (embeddings), but it cannot retroactively change what the episodes ran
+    # under: fitting a compressed policy over uncompressed rewards would stamp an arm that was
+    # never measured. Checked both directions, since compressed rewards under a raw fit is the
+    # same mistake mirrored.
+    measured = matrix.measured_compression()
+    if not same_compression(measured, compression):
+        raise typer.BadParameter(
+            f"this matrix's rewards were measured with {compression_signature(measured)}, but "
+            f"the fit would stamp {compression_signature(compression)}. Rewards cannot be "
+            "recompressed after the fact, so measure the arm you intend to serve: "
+            "`wmo optimize route sweep <model> --compressor <id> --aggressiveness <a>` writes a "
+            "matrix whose episodes actually ran that way (one matrix per arm)."
+        )
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -310,6 +310,7 @@ def sweep(
             assume_input_tokens=assume_input_tokens,
             assume_output_tokens=assume_output_tokens,
             history_chars=history_chars,
+            compression=sweep_compression,
         )
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -335,8 +336,8 @@ def sweep(
     # the line would print a path that does not exist (and this one is meant to be copied).
     _console.print(
         f"[green]✓[/green] {len(matrix.outcomes)} cell(s), {scored} scored -> {escape(out)}\n"
-        f"  measured candidate spend ${run.candidate_usd:.4f} (the world model's own serve/judge "
-        "cost is metered separately)",
+        f"  measured candidate spend ${run.candidate_usd:.4f}{_compressor_note(run)} (the world "
+        "model's own serve/judge cost is metered separately)",
         soft_wrap=True,  # a path a user copies must not be wrapped
     )
     print_world_model_spend(_console, run)
@@ -403,6 +404,19 @@ def print_tiny_corpus_note(console: Console, plan: SweepPlan) -> None:
         "these scenarios come from the FULL corpus: they are not leak-free, and a policy "
         "fitted on them is a smoke test, not evidence"
     )
+
+
+def _compressor_note(run: SweepRun) -> str:
+    """Name the compressor's share of candidate spend, but only when one actually billed.
+
+    The D-COMPRESS rule folds the compressor's inference cost into the candidate figure, so on a
+    compressed arm that number is not just the models. Saying so on an UNCOMPRESSED sweep would
+    be noise about a stage that did not run, which is why this is conditional on a nonzero bill
+    rather than on the flag.
+    """
+    if run.compressor_usd <= 0.0:
+        return ""
+    return f" (incl. ${run.compressor_usd:.4f} compressor)"
 
 
 def print_world_model_spend(console: Console, run: SweepRun) -> None:
@@ -896,7 +910,6 @@ def fit(
             compression = _compression_for(compressor, aggressiveness)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
-        compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
     # The rewards in this matrix were produced under SOME compression config, and a joint fit is
     # only joint if that config is the one being fitted. `--compressor` moves the fit-side
     # representation (embeddings), but it cannot retroactively change what the episodes ran

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -44,6 +44,7 @@ from wmo.optimize.compression import (
     CompressingEmbedder,
     CompressionConfig,
     compression_signature,
+    get_compressor,
     same_compression,
     servable_compressor,
 )
@@ -101,6 +102,26 @@ _console = Console()
 
 DEFAULT_MATRIX_FILENAME = "matrix.json"
 """Default `sweep --out`: the outcome matrix `fit` takes as its argument."""
+
+
+def _compression_for(compressor: str, aggressiveness: float) -> CompressionConfig:
+    """The compression config `--compressor` names, stamped with the version that will RUN.
+
+    The version is read off the resolved implementation rather than defaulted, because that is
+    what the field means: the version this config was fitted against. Defaulting it to "1" made
+    every fit against a version-bumped compressor stamp a lie, which the mount gate would then
+    correctly refuse with a remedy the CLI has no flag to carry out.
+
+    Raises (naming the compressor) when the id is unknown or the implementation is not servable.
+    """
+    resolved = get_compressor(compressor)
+    config = CompressionConfig(
+        compressor_id=compressor,
+        compressor_version=resolved.version,
+        aggressiveness=aggressiveness,
+    )
+    servable_compressor(config)
+    return config
 
 
 @route_app.command("sweep")
@@ -248,13 +269,10 @@ def sweep(
         raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
     sweep_compression = None
     if compressor is not None:
-        sweep_compression = CompressionConfig(
-            compressor_id=compressor, aggressiveness=aggressiveness
-        )
         try:
             # Checked before a single episode is paid for, and against the SERVING rule: there
             # is no point measuring an arm whose compressor could never be mounted.
-            servable_compressor(sweep_compression)
+            sweep_compression = _compression_for(compressor, aggressiveness)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     store = WorldModelStore(root)
@@ -872,11 +890,10 @@ def fit(
         raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
     compression = None
     if compressor is not None:
-        compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)
         try:
             # Fail before the fit spends anything: model_copy below skips validators, and an
             # unservable compressor would otherwise only surface when serving mounts the result.
-            servable_compressor(compression)
+            compression = _compression_for(compressor, aggressiveness)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
         compression = CompressionConfig(compressor_id=compressor, aggressiveness=aggressiveness)

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -22,7 +22,12 @@ from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, S
 from wmo.distill.store import DistillModelCard
 from wmo.engine.world_model import WorldModel
 from wmo.ingest.otel_writer import write_traces_jsonl
-from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.compression import (
+    CompressionConfig,
+    Compressor,
+    TruncateCompressor,
+    register_compressor,
+)
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
 from wmo.optimize.reward import EpisodeScore
@@ -2447,3 +2452,42 @@ def test_route_sweep_rejects_orphan_aggressiveness(tmp_path: Path) -> None:
     )
     assert result.exit_code != 0
     assert "--compressor" in result.output
+
+
+def test_route_fit_stamps_the_running_compressor_version(tmp_path: Path) -> None:
+    # Regression: the config was built without a version, so it defaulted to "1" and any fit
+    # against a version-bumped compressor stamped a lie. The mount gate then hard-stopped the
+    # result with a remedy the CLI has no flag to carry out. Latent while everything is v1,
+    # which is exactly why it needs a test.
+    class _V3(TruncateCompressor):
+        id = "cli-v3-for-tests"
+        version = "3"
+
+    register_compressor(cast("Compressor", _V3()))
+    config = CompressionConfig(
+        compressor_id="cli-v3-for-tests", compressor_version="3", aggressiveness=0.5
+    )
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path, compression=config)),
+            "--out",
+            str(policy_file),
+            "--dim",
+            "64",
+            "--compressor",
+            "cli-v3-for-tests",
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)  # loads, so the version gate is satisfied
+    assert policy.compression is not None
+    assert policy.compression.compressor_version == "3"
+    assert policy.fit_compression == policy.compression
+    assert policy.serving_compressor() is not None  # and it mounts

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -2302,3 +2302,33 @@ def test_route_fit_rejects_orphan_aggressiveness(tmp_path: Path) -> None:
     )
     assert result.exit_code != 0
     assert "--compressor" in result.output
+
+
+def test_route_fit_stamps_what_the_evidence_was_fitted_under(tmp_path: Path) -> None:
+    # D-COMPRESS requirement A: --compressor does not just switch serving on, it moves the FIT
+    # onto the compressed representation and records that on the artifact, which is what makes
+    # the resulting policy mountable at all.
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_knn_matrix_file(tmp_path)),
+            "--kind",
+            "knn",
+            "--out",
+            str(policy_file),
+            "--dim",
+            "64",
+            "--compressor",
+            "truncate",
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)  # loads, so the mount gate is satisfied
+    assert policy.fit_compression is not None
+    assert policy.fit_compression == policy.compression

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -2233,3 +2233,72 @@ def test_route_sweep_persists_the_world_models_own_spend_as_a_run_record(
     assert _says(result.output, "measured candidate spend")
     assert _says(result.output, "measured world-model spend $0.1200 over 4 session(s)")
     assert _says(result.output, "eval infrastructure, not serving cost")
+
+
+def test_route_fit_writes_compression_config(tmp_path: Path) -> None:
+    matrix_file = _matrix_file(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--kind",
+            "rank",
+            "--out",
+            str(policy_file),
+            "--clusters",
+            "2",
+            "--dim",
+            "64",
+            "--compressor",
+            "truncate",
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.compression is not None
+    assert policy.compression.compressor_id == "truncate"
+    assert policy.compression.aggressiveness == 0.5
+
+
+def test_route_fit_rejects_unknown_compressor(tmp_path: Path) -> None:
+    matrix_file = _matrix_file(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--out",
+            str(tmp_path / "policy.json"),
+            "--compressor",
+            "llmzip",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown compressor" in result.output
+
+
+def test_route_fit_rejects_orphan_aggressiveness(tmp_path: Path) -> None:
+    matrix_file = _matrix_file(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--out",
+            str(tmp_path / "policy.json"),
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--compressor" in result.output

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -27,6 +27,7 @@ from wmo.optimize.compression import (
     Compressor,
     TruncateCompressor,
     register_compressor,
+    same_compression,
 )
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
@@ -2491,3 +2492,55 @@ def test_route_fit_stamps_the_running_compressor_version(tmp_path: Path) -> None
     assert policy.compression.compressor_version == "3"
     assert policy.fit_compression == policy.compression
     assert policy.serving_compressor() is not None  # and it mounts
+
+
+def test_route_fit_knn_stamps_the_compression_it_was_fitted_under(tmp_path: Path) -> None:
+    """The knn path must carry the stamp, not just the rank path.
+
+    `--kind knn` returns from `fit_knn_artifact` before the rank path's stamping line, so a fit
+    that attached compression only after the branch would write a knn policy with no
+    `fit_compression` at all. That is the representation-consistency failure in a new costume:
+    the endpoint would serve compressed while its bank claimed to be raw, and the mount gate
+    would have nothing to compare.
+    """
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    matrix_file = _knn_matrix_file(tmp_path, compression=config)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(matrix_file),
+            "--kind",
+            "knn",
+            "--out",
+            str(policy_file),
+            "--fallback",
+            "a",
+            "--min-pairs",
+            "0",
+            "--compressor",
+            "truncate",
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.kind == "knn"
+    assert policy.compression is not None
+    assert policy.compression.compressor_id == "truncate"
+    # Both halves, so the mount gate has an identity to check rather than a null.
+    assert policy.fit_compression is not None
+    assert same_compression(policy.compression, policy.fit_compression)
+
+
+def test_route_fit_knn_leaves_the_stamp_null_without_the_flag(tmp_path: Path) -> None:
+    """The negative control: an uncompressed knn fit is byte-identical to before this seam."""
+    policy_file = tmp_path / "policy.json"
+    result = _fit_knn(_knn_matrix_file(tmp_path), policy_file)
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.compression is None and policy.fit_compression is None

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -22,6 +22,7 @@ from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, S
 from wmo.distill.store import DistillModelCard
 from wmo.engine.world_model import WorldModel
 from wmo.ingest.otel_writer import write_traces_jsonl
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
 from wmo.optimize.reward import EpisodeScore
@@ -45,7 +46,24 @@ from wmo.tracking import Phase, RunRecord, UsageTotals, load_runs
 runner = CliRunner()
 
 
-def _matrix_file(tmp_path: Path) -> Path:
+def _arm(compression: CompressionConfig | None) -> tuple[str, str, float]:
+    """The D-COMPRESS fields an episode measured under `compression` would carry.
+
+    A matrix records the arm its rewards were produced under, and `fit` refuses to stamp a
+    policy whose compression config disagrees, so a fixture fitting `--compressor` has to look
+    like episodes that actually ran that way.
+    """
+    if compression is None:
+        return "", "", 0.0
+    return (
+        compression.compressor_id,
+        compression.compressor_version,
+        compression.aggressiveness,
+    )
+
+
+def _matrix_file(tmp_path: Path, *, compression: CompressionConfig | None = None) -> Path:
+    """The uncompressed arm by default; `compression` stamps the rows as that arm instead."""
     pool = [
         PoolEntry(
             name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
@@ -54,6 +72,7 @@ def _matrix_file(tmp_path: Path) -> Path:
             name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
         ),
     ]
+    arm_id, arm_version, arm_aggressiveness = _arm(compression)
     outcomes = []
     tasks = {
         "s1": "SELECT count(*) FROM t",
@@ -73,6 +92,9 @@ def _matrix_file(tmp_path: Path) -> Path:
                     reward=1.0 if wins else 0.0,
                     success=wins,
                     cost_usd=0.001,
+                    compressor_id=arm_id,
+                    compressor_version=arm_version,
+                    aggressiveness=arm_aggressiveness,
                 )
             )
     path = tmp_path / "matrix.json"
@@ -134,7 +156,13 @@ def test_route_fit_rejects_unknown_embedder(tmp_path: Path) -> None:
     assert "hashing or azure" in result.output
 
 
-def _knn_matrix_file(tmp_path: Path, *, flip: bool = False, name: str = "knn_matrix.json") -> Path:
+def _knn_matrix_file(
+    tmp_path: Path,
+    *,
+    flip: bool = False,
+    name: str = "knn_matrix.json",
+    compression: CompressionConfig | None = None,
+) -> Path:
     """Twelve scenarios: enough neighbors per query for a guarded fit to route at all.
 
     `flip` swaps which model wins each half, so two matrices built here disagree on every cell.
@@ -165,6 +193,7 @@ def _knn_matrix_file(tmp_path: Path, *, flip: bool = False, name: str = "knn_mat
         "write a gentle reminder about the expense deadline",
         "write a farewell note for a departing teammate",
     ]
+    arm_id, arm_version, arm_aggressiveness = _arm(compression)
     outcomes = []
     for group, tasks in (("sql", sql), ("prose", prose)):
         for index, task in enumerate(tasks):
@@ -178,6 +207,9 @@ def _knn_matrix_file(tmp_path: Path, *, flip: bool = False, name: str = "knn_mat
                         reward=1.0 if wins else 0.0,
                         success=wins,
                         cost_usd=0.001,
+                        compressor_id=arm_id,
+                        compressor_version=arm_version,
+                        aggressiveness=arm_aggressiveness,
                     )
                 )
     path = tmp_path / name
@@ -2236,7 +2268,8 @@ def test_route_sweep_persists_the_world_models_own_spend_as_a_run_record(
 
 
 def test_route_fit_writes_compression_config(tmp_path: Path) -> None:
-    matrix_file = _matrix_file(tmp_path)
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    matrix_file = _matrix_file(tmp_path, compression=config)
     policy_file = tmp_path / "policy.json"
     result = runner.invoke(
         app,
@@ -2309,13 +2342,14 @@ def test_route_fit_stamps_what_the_evidence_was_fitted_under(tmp_path: Path) -> 
     # onto the compressed representation and records that on the artifact, which is what makes
     # the resulting policy mountable at all.
     policy_file = tmp_path / "policy.json"
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
     result = runner.invoke(
         app,
         [
             "optimize",
             "route",
             "fit",
-            str(_knn_matrix_file(tmp_path)),
+            str(_knn_matrix_file(tmp_path, compression=config)),
             "--kind",
             "knn",
             "--out",
@@ -2332,3 +2366,84 @@ def test_route_fit_stamps_what_the_evidence_was_fitted_under(tmp_path: Path) -> 
     policy = RoutingPolicy.load(policy_file)  # loads, so the mount gate is satisfied
     assert policy.fit_compression is not None
     assert policy.fit_compression == policy.compression
+
+
+def test_route_fit_refuses_to_stamp_an_arm_the_matrix_never_measured(tmp_path: Path) -> None:
+    # The contract gap: --compressor moved the fit-side embeddings but could not retroactively
+    # change what the EPISODES ran under, so a compressed policy could be stamped over rewards
+    # measured uncompressed. That is a joint fit over an arm nobody ran.
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path)),  # uncompressed rewards
+            "--out",
+            str(tmp_path / "policy.json"),
+            "--compressor",
+            "truncate",
+            "--aggressiveness",
+            "0.5",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "measured with raw text" in result.output
+    assert "one matrix per arm" in result.output
+
+
+def test_route_fit_refuses_compressed_rewards_under_a_raw_fit(tmp_path: Path) -> None:
+    # The mirror image, and the same error: rewards produced under compression do not describe
+    # an endpoint that serves raw text.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path, compression=config)),
+            "--out",
+            str(tmp_path / "policy.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "would stamp raw text" in result.output
+
+
+def test_route_sweep_rejects_an_unservable_compressor_before_spending(tmp_path: Path) -> None:
+    # The arm has to be one that could actually be served, and the check lands before any
+    # episode is paid for.
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--compressor",
+            "llmzip",
+            "--root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown compressor" in result.output
+
+
+def test_route_sweep_rejects_orphan_aggressiveness(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--aggressiveness",
+            "0.5",
+            "--root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--compressor" in result.output

--- a/wmo/env/closed_loop.py
+++ b/wmo/env/closed_loop.py
@@ -31,6 +31,7 @@ from wmo.env.base import Env
 from wmo.env.episode import run_episode
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS, LLMAgent
 from wmo.env.scenarios import Scenario
+from wmo.optimize.compression import CompressionConfig, estimate_tokens, get_compressor
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.reward import EpisodeScore
 from wmo.providers.base import (
@@ -81,9 +82,66 @@ class _TimedProvider:
             input_tokens=self.usage.input_tokens + completion.usage.input_tokens,
             cached_input_tokens=self.usage.cached_input_tokens
             + completion.usage.cached_input_tokens,
+            cache_write_input_tokens=self.usage.cache_write_input_tokens
+            + completion.usage.cache_write_input_tokens,
             output_tokens=self.usage.output_tokens + completion.usage.output_tokens,
         )
         return completion
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._provider.embed(texts)
+
+    def verify(self) -> VerifyResult:
+        return self._provider.verify()
+
+
+class _CompressingProvider:
+    """Applies the D-COMPRESS stage to the candidate's calls, so eval measures through it.
+
+    Sits ABOVE `_TimedProvider` (agent -> compressing -> timed -> real): the timed layer then
+    records the latency and provider-reported usage of the ACTUAL, compressed call. Mirrors
+    the serving rule exactly: only user-role message content is compressed; the system prompt
+    and the model's own prior replies pass through verbatim. Determinism keeps the growing
+    transcript append-stable across the episode's calls, exactly as serving's affinity-miss
+    path reproduces bytes. Accumulates the compressor's own accounting per episode.
+    """
+
+    def __init__(self, provider: Provider, config: CompressionConfig) -> None:
+        self._provider = provider
+        self._config = config
+        self.compressor = get_compressor(config.compressor_id)
+        self.tokens_in_raw = 0
+        self.tokens_in_compressed = 0
+        self.latency_s = 0.0
+        self.cost_usd = 0.0
+
+    @property
+    def config(self) -> ProviderConfig:
+        return self._provider.config
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        started = time.monotonic()
+        user_segments = [m.content for m in messages if m.role == "user"]
+        result = self.compressor.compress(user_segments, self._config)
+        replacements = iter(result.segments)
+        compressed = [
+            Message(role="user", content=next(replacements)) if m.role == "user" else m
+            for m in messages
+        ]
+        self.tokens_in_raw += sum(estimate_tokens(m.content) for m in messages)
+        self.tokens_in_compressed += sum(estimate_tokens(m.content) for m in compressed)
+        self.cost_usd += result.cost_usd
+        self.latency_s += time.monotonic() - started
+        return self._provider.complete(
+            system, compressed, temperature=temperature, max_tokens=max_tokens
+        )
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         return self._provider.embed(texts)
@@ -159,6 +217,7 @@ def evaluate_pool(
     history_chars: int = DEFAULT_HISTORY_CHARS,
     provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
     on_outcome: Callable[[ScenarioOutcome], None] | None = None,
+    compression: CompressionConfig | None = None,
 ) -> OutcomeMatrix:
     """Run every pool candidate over `scenarios`, one fresh env per episode.
 
@@ -174,6 +233,10 @@ def evaluate_pool(
     default was raised to 2000 after 500 truncated tau-bench payloads into verbatim re-fetch
     loops, and a corpus with larger observations needs more still. It changes what the candidates
     are measured on, so it is part of a matrix's capture cohort.
+
+    `compression` applies the D-COMPRESS stage to every candidate call, measured through the
+    same wrapper stack production serves through; each outcome then carries the compressor's
+    per-episode accounting fields. None (the default) = uncompressed, today's rows exactly.
     """
     outcomes: list[ScenarioOutcome] = []
     for entry in pool.models:
@@ -181,8 +244,11 @@ def evaluate_pool(
             sid = scenario_id(scenario)
             for episode in range(episodes_per_scenario):
                 timed = _TimedProvider(provider_factory(entry))
+                compressing = (
+                    _CompressingProvider(timed, compression) if compression is not None else None
+                )
                 agent = LLMAgent(
-                    timed,
+                    compressing if compressing is not None else timed,
                     temperature=agent_temperature,
                     tools_hint=tools_hint,
                     history_chars=history_chars,
@@ -216,6 +282,13 @@ def evaluate_pool(
                     call_seconds=timed.call_seconds,
                     replies=timed.replies,
                     error=error,
+                    tokens_in_raw=compressing.tokens_in_raw if compressing else 0,
+                    tokens_in_compressed=compressing.tokens_in_compressed if compressing else 0,
+                    compressor_id=compressing.compressor.id if compressing else "",
+                    compressor_version=compressing.compressor.version if compressing else "",
+                    aggressiveness=compression.aggressiveness if compression else 0.0,
+                    compressor_latency_s=compressing.latency_s if compressing else 0.0,
+                    compressor_cost_usd=compressing.cost_usd if compressing else 0.0,
                 )
                 outcomes.append(outcome)
                 if on_outcome is not None:

--- a/wmo/env/closed_loop_test.py
+++ b/wmo/env/closed_loop_test.py
@@ -9,6 +9,7 @@ import pytest
 from wmo.core.types import Action, EnvState, Observation
 from wmo.env.closed_loop import evaluate_pool
 from wmo.env.scenarios import Scenario
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import ScenarioOutcome
 from wmo.optimize.reward import EpisodeScore
 from wmo.providers.base import (
@@ -336,3 +337,100 @@ def test_history_chars_reaches_the_agent_from_evaluate_pool() -> None:
     assert later_turns, seen
     assert "z" * 77 in later_turns[0]
     assert "z" * 78 not in later_turns[0]
+
+
+class _RecordingProvider(_ScriptedProvider):
+    """Scripted provider that also records the messages each completion was asked with."""
+
+    def __init__(self, entry: PoolEntry) -> None:
+        super().__init__(entry)
+        self.seen: list[list[Message]] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.seen.append(list(messages))
+        return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
+
+
+def test_evaluate_pool_threads_compression_through_the_measured_path() -> None:
+    providers: list[_RecordingProvider] = []
+
+    def factory(entry: PoolEntry) -> _RecordingProvider:
+        provider = _RecordingProvider(entry)
+        providers.append(provider)
+        return provider
+
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=factory,
+        max_steps=5,
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+    )
+
+    outcome = matrix.outcomes[0]
+    # The compressor's per-episode accounting landed on the row...
+    assert outcome.compressor_id == "truncate"
+    assert outcome.compressor_version == "1"
+    assert outcome.aggressiveness == 0.5
+    assert outcome.tokens_in_compressed < outcome.tokens_in_raw
+    assert outcome.compressor_latency_s >= 0.0
+    assert outcome.compressor_cost_usd == 0.0  # truncate has no inference cost
+    # ...and the provider genuinely received compressed input (measured path, not
+    # bookkeeping): the user content the model saw is strictly shorter than what an
+    # uncompressed control run sends, and non-user content is untouched.
+    control: list[_RecordingProvider] = []
+
+    def control_factory(entry: PoolEntry) -> _RecordingProvider:
+        provider = _RecordingProvider(entry)
+        control.append(provider)
+        return provider
+
+    evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=control_factory,
+        max_steps=5,
+    )
+    compressed_users = [m.content for m in providers[0].seen[0] if m.role == "user"]
+    raw_users = [m.content for m in control[0].seen[0] if m.role == "user"]
+    assert len(compressed_users) == len(raw_users)
+    assert all(len(c) < len(r) for c, r in zip(compressed_users, raw_users, strict=True))
+
+
+def test_uncompressed_rows_keep_default_compression_fields() -> None:
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS[:1],
+        provider_factory=_ScriptedProvider,
+        max_steps=5,
+    )
+    outcome = matrix.outcomes[0]
+    assert outcome.compressor_id == ""
+    assert outcome.tokens_in_raw == 0
+    assert outcome.tokens_in_compressed == 0
+    assert outcome.aggressiveness == 0.0
+
+
+def test_pre_compression_outcome_json_loads_with_defaults() -> None:
+    # Additive-fields guarantee for the matrix: rows serialized before the D-COMPRESS fields
+    # existed must load with them defaulted.
+    row = ScenarioOutcome(scenario_id="s", task="t", model="candidate-a")
+    dumped = {
+        key: value
+        for key, value in row.model_dump(mode="json").items()
+        if not key.startswith(("tokens_in_", "compressor_")) and key != "aggressiveness"
+    }
+    loaded = ScenarioOutcome.model_validate(dumped)
+    assert loaded.compressor_id == ""
+    assert loaded.tokens_in_raw == 0
+    assert loaded.compressor_cost_usd == 0.0

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -27,6 +27,8 @@ from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
+from wmo.providers.base import Embedder
+
 # The proxy tokenizer: ~4 chars per token, the industry rule of thumb. Deterministic and
 # provider-agnostic; used only for the compressor's own raw-vs-compressed accounting.
 _CHARS_PER_TOKEN = 4
@@ -86,10 +88,21 @@ class CompressionStats(BaseModel):
 
 @runtime_checkable
 class Compressor(Protocol):
-    """The pluggable compressor seam. Implementations must be deterministic and 0.0-safe."""
+    """The pluggable compressor seam. Implementations must be deterministic and 0.0-safe.
+
+    `append_stable` is the implementation's ATTESTATION that appending a segment never rewrites
+    the bytes of the segments already emitted (C1's audit calls this append-only; the selection
+    rule decides it, not the scorer). It is a serving admission ticket, not a hint: C2's cache
+    simulation measured churny full recompression at up to 2.65x the input cost of no
+    compression at all on cached providers, because every turn forfeits the whole prompt-cache
+    prefix to save a fraction of the tokens. v1 serves append-stable compressors only; a churny
+    method needs turn-local-commit support that does not exist yet, so it is refused at mount
+    rather than silently allowed to lose money.
+    """
 
     id: str
     version: str
+    append_stable: bool
 
     def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
         """Compress the mutable segments; never sees the cached prefix by construction."""
@@ -101,6 +114,7 @@ class IdentityCompressor:
 
     id = "identity"
     version = "1"
+    append_stable = True  # it changes nothing, so it cannot churn anything
 
     def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
         del config
@@ -121,10 +135,17 @@ class TruncateCompressor:
     segment. Deterministic per segment, so an unchanged segment always compresses to the same
     bytes (append-stability). This is a CONTROL, not a method: a learned compressor that does
     not beat it at equal ratio has learned nothing (the track's mandatory baseline).
+
+    Append-stable by C1's round-0 semantics: head-keep truncation is head-absolute per segment,
+    the kept prefix of a segment depends on nothing outside that segment, and a segment already
+    emitted is never revisited. (C1's correction to the lit review applies here: the "ratio
+    budgets are never append-only" rule is a fact about percentile SELECTION, not about
+    head-keep truncation, whose kept prefix only ever extends.)
     """
 
     id = "truncate"
     version = "1"
+    append_stable = True
 
     def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
         start = time.monotonic()
@@ -147,6 +168,104 @@ _COMPRESSORS: dict[str, Compressor] = {
 }
 
 
+def register_compressor(compressor: Compressor) -> None:
+    """Register a compressor implementation under its `id` (research-track entry point).
+
+    The module docstring's contract: real compressors are chosen by the research track and
+    register here. Registration is idempotent for the same object and refuses to silently
+    replace a DIFFERENT implementation under an existing id, because a policy artifact
+    referencing that id must always resolve to the bytes it was fitted against.
+
+    The `append_stable` attestation is required at registration rather than at mount, so an
+    implementation that forgot to state it fails in the researcher's own process instead of on
+    the first served request.
+    """
+    if not isinstance(getattr(compressor, "append_stable", None), bool):
+        raise ValueError(
+            f"compressor '{compressor.id}' does not declare `append_stable`; a compressor must "
+            "attest whether appending a segment rewrites already-emitted bytes (see the "
+            "Compressor protocol). Measure it with the append-stability audit, then set the "
+            "attribute."
+        )
+    existing = _COMPRESSORS.get(compressor.id)
+    if existing is not None and existing is not compressor:
+        raise ValueError(
+            f"compressor id '{compressor.id}' is already registered by "
+            f"{type(existing).__name__}; ids are stable policy references and cannot be "
+            "silently rebound"
+        )
+    _COMPRESSORS[compressor.id] = compressor
+
+
+class CompressingEmbedder:
+    """Embeds the COMPRESSED form of each text, so a fit sees what serving will see.
+
+    The fit-side half of representation consistency (C2's Q2 result). A routing bank and its
+    novelty floor are geometry: fit them on raw task text and then query them with compressed
+    text and the queries land farther from every bank row, the floor trips 10-13x more often,
+    and the router abstains to the expensive fallback on 20-30% more requests. Wrapping the fit's
+    embedder is all it takes to move the bank and the floor onto the served representation.
+
+    Serving does NOT wrap its embedder: the compression stage has already rewritten the request
+    by the time the router embeds it, so wrapping there would compress twice.
+    """
+
+    def __init__(self, inner: Embedder, config: CompressionConfig) -> None:
+        self._inner = inner
+        self._config = config
+        self._compressor = get_compressor(config.compressor_id)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._inner.embed(self._compressor.compress(list(texts), self._config).segments)
+
+
+def compression_signature(config: CompressionConfig | None) -> str:
+    """How a compression config reads in an error message; None is spelled out as raw text."""
+    if config is None:
+        return "raw text (no compression)"
+    return (
+        f"compressor '{config.compressor_id}' version {config.compressor_version} "
+        f"at aggressiveness {config.aggressiveness:g}"
+    )
+
+
+def same_compression(left: CompressionConfig | None, right: CompressionConfig | None) -> bool:
+    """Whether two configs produce the same representation: same compressor, version, and level.
+
+    None (raw) equals only None. Anything else is compared on the whole triple, because a
+    version bump changes the emitted bytes exactly as a different id would.
+    """
+    if left is None or right is None:
+        return left is None and right is None
+    return (
+        left.compressor_id == right.compressor_id
+        and left.compressor_version == right.compressor_version
+        and left.aggressiveness == right.aggressiveness
+    )
+
+
+def servable_compressor(config: CompressionConfig | None) -> Compressor | None:
+    """The compressor `config` names, checked against the v1 serving rule (None: compress off).
+
+    Raises when the id is unknown, or when the implementation does not attest append stability:
+    a churny compressor recompresses the cached prefix on every turn, which C2 measured as a net
+    LOSS of up to 2.65x on cached providers. Serving it would quietly cost more than compressing
+    nothing, so the mount is refused instead.
+    """
+    if config is None:
+        return None
+    compressor = get_compressor(config.compressor_id)
+    if not compressor.append_stable:
+        raise ValueError(
+            f"compressor '{config.compressor_id}' is not attested append-stable, so it cannot be "
+            "served in v1: it rewrites the already-compressed prefix on every turn, which "
+            "forfeits the provider prompt cache and measured as a net cost INCREASE (up to 2.65x) "
+            "against no compression at all. Serve an append-stable compressor (identity, "
+            "truncate), or wait for turn-local-commit support."
+        )
+    return compressor
+
+
 def get_compressor(compressor_id: str) -> Compressor:
     """Resolve a compressor by id, or raise naming the known ids (fail at mount, not mid-call)."""
     compressor = _COMPRESSORS.get(compressor_id)
@@ -154,7 +273,7 @@ def get_compressor(compressor_id: str) -> Compressor:
         known = ", ".join(sorted(_COMPRESSORS))
         raise ValueError(
             f"unknown compressor '{compressor_id}'; known compressors: {known}. "
-            "Register new compressors in wmo.optimize.compression before referencing them "
-            "in a policy's compression config."
+            "Register new compressors with wmo.optimize.compression.register_compressor "
+            "before referencing them in a policy's compression config."
         )
     return compressor

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -283,6 +283,19 @@ def servable_compressor(config: CompressionConfig | None) -> Compressor | None:
     if config is None:
         return None
     compressor = get_compressor(config.compressor_id)
+    if compressor.version != config.compressor_version:
+        # The id alone does not identify the bytes. A stamped version that this build cannot
+        # produce means the artifact was fitted against a DIFFERENT implementation of the same
+        # id, so its bank sits in that implementation's geometry: the same failure as serving a
+        # different compressor entirely, and invisible without this check.
+        raise ValueError(
+            f"compressor '{config.compressor_id}' is version {compressor.version} in this "
+            f"build, but the policy was fitted against version {config.compressor_version}. "
+            "The bytes a compressor emits are versioned, so its routing evidence does not "
+            "transfer across versions: refit under the running version "
+            "(`wmo optimize route fit --compressor <id> --aggressiveness <a>`), or deploy the "
+            "build whose compressor matches the artifact."
+        )
     if not compressor.append_stable:
         raise ValueError(
             f"compressor '{config.compressor_id}' is not attested append-stable, so it cannot be "

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import math
 import time
+from collections.abc import Callable
 from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
@@ -106,10 +107,19 @@ class Compressor(Protocol):
     no-op, and the dial is monotone; see `CompressionConfig`), and it attests `append_stable`
     truthfully.
 
-    One `compress` call takes ALL of a request's mutable segments at once, so an implementation
-    backed by a network endpoint pays one round trip per request rather than one per message,
-    and can batch internally. Per-segment determinism still holds: a segment's output may not
-    depend on which other segments accompanied it.
+    Callers hand over as many segments per call as the implementation's cap allows, chunked
+    deterministically (`compress_segments`), so a network-backed implementation pays as few
+    round trips as it can rather than one per message. Per-segment determinism still holds and
+    is what makes chunking safe: a segment's output may not depend on which other segments
+    accompanied it, so where the chunk boundaries fall cannot change the bytes.
+
+    `max_segments_per_call` is the OPTIONAL cap (absent or None = unlimited): the most segments
+    one call may carry, which for a served implementation is whatever its server enforces.
+    Declaring it is how a compressor gets chunked instead of 413'd.
+
+    A `compress` call must return EXACTLY as many segments as it was given, in order. A
+    compressor rewrites segments; it never merges, splits, drops, or reorders them, because the
+    caller owns the conversation structure and maps the result back onto it positionally.
 
     `append_stable` is the implementation's ATTESTATION that appending a segment never rewrites
     the bytes of the segments already emitted (C1's audit calls this append-only; the selection
@@ -128,6 +138,10 @@ class Compressor(Protocol):
     def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
         """Compress the mutable segments; never sees the cached prefix by construction."""
         ...
+
+
+type CompressorFactory = Callable[[], Compressor]
+"""Builds a compressor on first use (see `register_compressor_factory`)."""
 
 
 class IdentityCompressor:
@@ -191,6 +205,10 @@ _COMPRESSORS: dict[str, Compressor] = {
     TruncateCompressor.id: TruncateCompressor(),
 }
 
+# Compressors that are too expensive to build at import (see `register_compressor_factory`).
+# Constructed on first resolution, then they live in `_COMPRESSORS` like any other.
+_COMPRESSOR_FACTORIES: dict[str, CompressorFactory] = {}
+
 
 def register_compressor(compressor: Compressor) -> None:
     """Register a compressor implementation under its `id` (research-track entry point).
@@ -211,6 +229,7 @@ def register_compressor(compressor: Compressor) -> None:
             "Compressor protocol). Measure it with the append-stability audit, then set the "
             "attribute."
         )
+    segment_batch_limit(compressor)  # a malformed cap fails here, not on the first big batch
     existing = _COMPRESSORS.get(compressor.id)
     if existing is not None and existing is not compressor:
         raise ValueError(
@@ -219,6 +238,73 @@ def register_compressor(compressor: Compressor) -> None:
             "silently rebound"
         )
     _COMPRESSORS[compressor.id] = compressor
+
+
+def segment_batch_limit(compressor: Compressor) -> int | None:
+    """The most segments `compressor` accepts in one call, or None for unlimited.
+
+    Optional by design: a local compressor has no reason to declare a cap, and every
+    implementation written before the attribute existed keeps working as unlimited. A served
+    one declares whatever its server enforces, which is how it gets chunked instead of refused.
+    """
+    limit = getattr(compressor, "max_segments_per_call", None)
+    if limit is None:
+        return None
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise ValueError(
+            f"compressor '{compressor.id}' declares max_segments_per_call={limit!r}; it must be "
+            "a positive integer, or None for no limit"
+        )
+    return limit
+
+
+def compress_segments(
+    compressor: Compressor, segments: list[str], config: CompressionConfig
+) -> CompressionResult:
+    """Run `segments` through `compressor` in as few calls as its cap allows, and check the shape.
+
+    CHUNKING. A served compressor caps how many segments one request may carry (the endpoint
+    rejects oversized batches outright), and both callers can exceed any such cap easily: a bank
+    fit compresses every scenario in the matrix. Chunking is safe precisely because the protocol
+    requires per-segment determinism: a segment's output cannot depend on which other segments
+    travelled with it, so where the boundaries fall cannot change the bytes. For the compressors
+    this matters for, that property is measured rather than assumed (fixed-threshold selection
+    is per token, and fp32 output was verified batch-invariant at batch 1/4/16, which is why
+    serving pins fp32).
+
+    SHAPE. The protocol says a call returns exactly as many segments as it was given, in order,
+    and nothing enforced it: one short and the caller's zip ran out mid-transcript, surfacing as
+    an anonymous 502; one long and the extra was silently discarded, which serves a transcript
+    nobody checked. Both are now a named error against the compressor that did it.
+    """
+    limit = segment_batch_limit(compressor)
+    size = len(segments) if limit is None else limit
+    out: list[str] = []
+    tokens_in_raw = 0
+    tokens_in_compressed = 0
+    latency_s = 0.0
+    cost_usd = 0.0
+    for start in range(0, len(segments), max(size, 1)):
+        chunk = segments[start : start + max(size, 1)]
+        result = compressor.compress(chunk, config)
+        if len(result.segments) != len(chunk):
+            raise ValueError(
+                f"compressor '{compressor.id}' returned {len(result.segments)} segments for "
+                f"{len(chunk)}; a compressor rewrites segments in place and must return exactly "
+                "as many as it was given, in order (the caller maps them back positionally)"
+            )
+        out.extend(result.segments)
+        tokens_in_raw += result.tokens_in_raw
+        tokens_in_compressed += result.tokens_in_compressed
+        latency_s += result.latency_s
+        cost_usd += result.cost_usd
+    return CompressionResult(
+        segments=out,
+        tokens_in_raw=tokens_in_raw,
+        tokens_in_compressed=tokens_in_compressed,
+        latency_s=latency_s,
+        cost_usd=cost_usd,
+    )
 
 
 class CompressingEmbedder:
@@ -233,9 +319,10 @@ class CompressingEmbedder:
     Serving does NOT wrap its embedder: the compression stage has already rewritten the request
     by the time the router embeds it, so wrapping there would compress twice.
 
-    One `compress` call per `embed` batch, not one per text: fitting a bank means compressing
-    every fit scenario, which would otherwise be a round trip each against an endpoint-backed
-    compressor.
+    As few compressor calls per `embed` batch as the compressor's cap allows, not one per text:
+    fitting a bank means compressing every fit scenario, which would otherwise be a round trip
+    each against an endpoint-backed compressor. A matrix routinely has more scenarios than a
+    served compressor accepts per call, so this goes through `compress_segments` to be chunked.
     """
 
     def __init__(self, inner: Embedder, config: CompressionConfig) -> None:
@@ -244,7 +331,8 @@ class CompressingEmbedder:
         self._compressor = get_compressor(config.compressor_id)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        return self._inner.embed(self._compressor.compress(list(texts), self._config).segments)
+        compressed = compress_segments(self._compressor, list(texts), self._config)
+        return self._inner.embed(compressed.segments)
 
 
 def compression_signature(config: CompressionConfig | None) -> str:
@@ -307,14 +395,58 @@ def servable_compressor(config: CompressionConfig | None) -> Compressor | None:
     return compressor
 
 
+def register_compressor_factory(compressor_id: str, factory: CompressorFactory) -> None:
+    """Register a compressor to be CONSTRUCTED on first use, not at import.
+
+    The entry point for a compressor that cannot be built for free. A served one has to reach
+    its server to know what it is (the endpoint client verifies the server's selection rule
+    before it will attest `append_stable`, since attesting on faith is how a churny compressor
+    gets served), and doing that at import time would put a network call, a credential lookup,
+    and a failure mode into every `import wmo`. Importing stays side-effect-free; the cost and
+    the risk move to the first policy that actually names the compressor.
+
+    `factory` runs at most once, on first resolution, and its result is registered normally
+    (attestation checked, id rebinding refused). A factory that raises propagates with the id
+    named, and stays registered, so a transient failure can be retried by resolving again.
+    """
+    if compressor_id in _COMPRESSORS:
+        raise ValueError(
+            f"compressor id '{compressor_id}' is already registered by "
+            f"{type(_COMPRESSORS[compressor_id]).__name__}; ids are stable policy references "
+            "and cannot be silently rebound"
+        )
+    _COMPRESSOR_FACTORIES[compressor_id] = factory
+
+
 def get_compressor(compressor_id: str) -> Compressor:
     """Resolve a compressor by id, or raise naming the known ids (fail at mount, not mid-call)."""
     compressor = _COMPRESSORS.get(compressor_id)
-    if compressor is None:
-        known = ", ".join(sorted(_COMPRESSORS))
-        raise ValueError(
-            f"unknown compressor '{compressor_id}'; known compressors: {known}. "
-            "Register new compressors with wmo.optimize.compression.register_compressor "
-            "before referencing them in a policy's compression config."
-        )
-    return compressor
+    if compressor is not None:
+        return compressor
+    factory = _COMPRESSOR_FACTORIES.get(compressor_id)
+    if factory is not None:
+        try:
+            built = factory()
+        except Exception as exc:
+            # Name the compressor: the bare failure from a factory that reached out to a server
+            # and could not verify it says nothing about which policy field caused it.
+            raise ValueError(
+                f"compressor '{compressor_id}' could not be constructed: {exc}"
+            ) from exc
+        if built.id != compressor_id:
+            # Otherwise the factory's compressor lands in the registry under ITS id while this
+            # lookup hands it back for a different one, so a policy naming the registered id
+            # gets an implementation that does not answer to it.
+            raise ValueError(
+                f"the factory registered for compressor '{compressor_id}' built one with id "
+                f"'{built.id}'; a factory must build the compressor it was registered under"
+            )
+        register_compressor(built)
+        return built
+    known = ", ".join(sorted({*_COMPRESSORS, *_COMPRESSOR_FACTORIES}))
+    raise ValueError(
+        f"unknown compressor '{compressor_id}'; known compressors: {known}. "
+        "Register new compressors with wmo.optimize.compression.register_compressor "
+        "(or register_compressor_factory, for one that must be constructed on first use) "
+        "before referencing them in a policy's compression config."
+    )

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -405,15 +405,28 @@ def register_compressor_factory(compressor_id: str, factory: CompressorFactory) 
     and a failure mode into every `import wmo`. Importing stays side-effect-free; the cost and
     the risk move to the first policy that actually names the compressor.
 
-    `factory` runs at most once, on first resolution, and its result is registered normally
-    (attestation checked, id rebinding refused). A factory that raises propagates with the id
-    named, and stays registered, so a transient failure can be retried by resolving again.
+    `factory` runs at most once, on SUCCESS, and its result is registered normally (attestation
+    checked, id rebinding refused). Failures are never cached: a factory that raises propagates
+    with the id named and stays registered, so an endpoint that was down or an env var that was
+    unset at first resolution can be fixed and retried rather than poisoning the id for the life
+    of the process.
+
+    Rebinding is refused the same way `register_compressor` refuses it, and against BOTH
+    registries: an id that already resolves to a live instance cannot be shadowed by a factory
+    (a test that registered a fake must not be silently replaced by the real thing), and a
+    second factory cannot displace a first.
     """
     if compressor_id in _COMPRESSORS:
         raise ValueError(
             f"compressor id '{compressor_id}' is already registered by "
             f"{type(_COMPRESSORS[compressor_id]).__name__}; ids are stable policy references "
             "and cannot be silently rebound"
+        )
+    existing = _COMPRESSOR_FACTORIES.get(compressor_id)
+    if existing is not None and existing is not factory:
+        raise ValueError(
+            f"compressor id '{compressor_id}' already has a registered factory; ids are stable "
+            "policy references and cannot be silently rebound"
         )
     _COMPRESSOR_FACTORIES[compressor_id] = factory
 

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -42,10 +42,21 @@ def estimate_tokens(text: str) -> int:
 class CompressionConfig(BaseModel):
     """Per-cluster compression choice carried on the policy artifact (D-COMPRESS shape).
 
-    `aggressiveness` is the fraction of content the compressor may remove, in [0, 1];
-    risk-tiered per cluster and learned within bounds by the research track. 0.0 must be a
-    no-op for every compressor. `compressor_version` records the version the config was
-    fitted against (provenance); serving logs the version that actually ran.
+    `aggressiveness` is a compressor-DEFINED dial in [0, 1], deliberately not a removal
+    fraction. Two invariants bind every implementation: 0.0 is a strict bit-for-bit no-op, and
+    the dial is monotone (a higher value never removes less than a lower one). Requiring an
+    exact removal fraction instead would force per-input percentile selection, which is the
+    cache-hostile selection rule this track rejected (it rewrites the already-emitted prefix
+    every turn, see `Compressor.append_stable`); the cache-safe learned compressors are
+    fixed-threshold ones, whose removal varies with the input by construction.
+
+    The ACHIEVED removal ratio is therefore an outcome, not a setting: read it per call off
+    `CompressionResult` (tokens_in_compressed / tokens_in_raw), and match ratio-matched controls
+    on that achieved ratio rather than on the nominal dial.
+
+    Aggressiveness is risk-tiered per cluster and learned within bounds by the research track.
+    `compressor_version` records the version the config was fitted against (provenance);
+    serving logs the version that actually ran.
     """
 
     compressor_id: str = Field(min_length=1)
@@ -88,7 +99,17 @@ class CompressionStats(BaseModel):
 
 @runtime_checkable
 class Compressor(Protocol):
-    """The pluggable compressor seam. Implementations must be deterministic and 0.0-safe.
+    """The pluggable compressor seam.
+
+    Three contracts bind an implementation: it is deterministic (same segments and config, same
+    bytes out), it honors the `aggressiveness` dial's invariants (0.0 is a strict bit-for-bit
+    no-op, and the dial is monotone; see `CompressionConfig`), and it attests `append_stable`
+    truthfully.
+
+    One `compress` call takes ALL of a request's mutable segments at once, so an implementation
+    backed by a network endpoint pays one round trip per request rather than one per message,
+    and can batch internally. Per-segment determinism still holds: a segment's output may not
+    depend on which other segments accompanied it.
 
     `append_stable` is the implementation's ATTESTATION that appending a segment never rewrites
     the bytes of the segments already emitted (C1's audit calls this append-only; the selection
@@ -129,12 +150,15 @@ class IdentityCompressor:
 
 
 class TruncateCompressor:
-    """The trivial ratio-matched control: drop the trailing `aggressiveness` fraction.
+    """The trivial ratio-matched control: drop the trailing words of every segment.
 
     Keeps the leading ceil((1 - aggressiveness) * n) whitespace-delimited tokens of each
-    segment. Deterministic per segment, so an unchanged segment always compresses to the same
-    bytes (append-stability). This is a CONTROL, not a method: a learned compressor that does
-    not beat it at equal ratio has learned nothing (the track's mandatory baseline).
+    segment, which is this compressor's own reading of the dial. Being structural, it can hit a
+    removal fraction exactly; a learned compressor generally cannot (see `CompressionConfig`),
+    which is why controls are matched on ACHIEVED ratio. Deterministic per segment, so an
+    unchanged segment always compresses to the same bytes (append-stability). This is a CONTROL,
+    not a method: a learned compressor that does not beat it at equal achieved ratio has learned
+    nothing (the track's mandatory baseline).
 
     Append-stable by C1's round-0 semantics: head-keep truncation is head-absolute per segment,
     the kept prefix of a segment depends on nothing outside that segment, and a segment already
@@ -208,6 +232,10 @@ class CompressingEmbedder:
 
     Serving does NOT wrap its embedder: the compression stage has already rewritten the request
     by the time the router embeds it, so wrapping there would compress twice.
+
+    One `compress` call per `embed` batch, not one per text: fitting a bank means compressing
+    every fit scenario, which would otherwise be a round trip each against an endpoint-backed
+    compressor.
     """
 
     def __init__(self, inner: Embedder, config: CompressionConfig) -> None:

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -1,0 +1,143 @@
+"""Segment-aware context compression behind the optimizer interface (D-COMPRESS seam).
+
+A compressor removes low-information tokens from the model's input before the provider call.
+The seam is SEGMENT-aware, not string-aware: the caller splits the conversation into
+(cached-prefix, turn-local) segments and hands the compressor ONLY the segments it is allowed
+to change. The provider prompt cache is prefix-matched, so recompressing an incumbent
+conversation's cached prefix would forfeit ~0.9x discounts to save ~0.1x of tokens; keeping
+that prefix out of the compressor's hands makes cache safety a property of the construction,
+not a convention each compressor must remember.
+
+This module ships the protocol plus the two reference implementations the seam is proven
+with: `identity` (today's behavior, bit-for-bit) and `truncate` (the trivial ratio-matched
+control every learned compressor must beat). Real compressors are chosen by the research
+track and register here; nothing else in the harness hardcodes one.
+
+Every compressor must be deterministic: the same segments and config always produce the same
+output (append-stability of the serving path depends on it, and so does replaying a request
+log). Token counts reported here are a deterministic chars/4 PROXY for accounting the
+compressor's own effect; billable truth stays with the provider-reported `TokenUsage`.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+# The proxy tokenizer: ~4 chars per token, the industry rule of thumb. Deterministic and
+# provider-agnostic; used only for the compressor's own raw-vs-compressed accounting.
+_CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Deterministic proxy token count of `text` (ceil of chars/4; 0 only for empty text)."""
+    return math.ceil(len(text) / _CHARS_PER_TOKEN)
+
+
+class CompressionConfig(BaseModel):
+    """Per-cluster compression choice carried on the policy artifact (D-COMPRESS shape).
+
+    `aggressiveness` is the fraction of content the compressor may remove, in [0, 1];
+    risk-tiered per cluster and learned within bounds by the research track. 0.0 must be a
+    no-op for every compressor. `compressor_version` records the version the config was
+    fitted against (provenance); serving logs the version that actually ran.
+    """
+
+    compressor_id: str = Field(min_length=1)
+    compressor_version: str = "1"
+    aggressiveness: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class CompressionResult(BaseModel):
+    """What one compress() call did: the output segments plus its own accounting.
+
+    `segments` has the same length and order as the input (a compressor rewrites segments,
+    it never merges, splits, or reorders them; the caller owns the conversation structure).
+    Token counts use `estimate_tokens`; `cost_usd` and `latency_s` are the compressor's OWN
+    inference cost and wall-clock, which sit inside effective cost per the track's rules.
+    """
+
+    segments: list[str]
+    tokens_in_raw: int
+    tokens_in_compressed: int
+    latency_s: float
+    cost_usd: float = 0.0
+
+
+@runtime_checkable
+class Compressor(Protocol):
+    """The pluggable compressor seam. Implementations must be deterministic and 0.0-safe."""
+
+    id: str
+    version: str
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        """Compress the mutable segments; never sees the cached prefix by construction."""
+        ...
+
+
+class IdentityCompressor:
+    """Compression off: returns every segment bit-for-bit. The seam's do-no-harm proof."""
+
+    id = "identity"
+    version = "1"
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        start = time.monotonic()
+        raw = sum(estimate_tokens(segment) for segment in segments)
+        return CompressionResult(
+            segments=list(segments),
+            tokens_in_raw=raw,
+            tokens_in_compressed=raw,
+            latency_s=time.monotonic() - start,
+        )
+
+
+class TruncateCompressor:
+    """The trivial ratio-matched control: drop the trailing `aggressiveness` fraction.
+
+    Keeps the leading ceil((1 - aggressiveness) * n) whitespace-delimited tokens of each
+    segment. Deterministic per segment, so an unchanged segment always compresses to the same
+    bytes (append-stability). This is a CONTROL, not a method: a learned compressor that does
+    not beat it at equal ratio has learned nothing (the track's mandatory baseline).
+    """
+
+    id = "truncate"
+    version = "1"
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        start = time.monotonic()
+        out: list[str] = []
+        for segment in segments:
+            words = segment.split()
+            keep = math.ceil(len(words) * (1.0 - config.aggressiveness))
+            out.append(segment if keep >= len(words) else " ".join(words[:keep]))
+        return CompressionResult(
+            segments=out,
+            tokens_in_raw=sum(estimate_tokens(segment) for segment in segments),
+            tokens_in_compressed=sum(estimate_tokens(segment) for segment in out),
+            latency_s=time.monotonic() - start,
+        )
+
+
+_COMPRESSORS: dict[str, Compressor] = {
+    IdentityCompressor.id: IdentityCompressor(),
+    TruncateCompressor.id: TruncateCompressor(),
+}
+
+
+def get_compressor(compressor_id: str) -> Compressor:
+    """Resolve a compressor by id, or raise naming the known ids (fail at mount, not mid-call)."""
+    compressor = _COMPRESSORS.get(compressor_id)
+    if compressor is None:
+        known = ", ".join(sorted(_COMPRESSORS))
+        raise ValueError(
+            f"unknown compressor '{compressor_id}'; known compressors: {known}. "
+            "Register new compressors in wmo.optimize.compression before referencing them "
+            "in a policy's compression config."
+        )
+    return compressor

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -67,6 +67,23 @@ class CompressionResult(BaseModel):
     cost_usd: float = 0.0
 
 
+class CompressionStats(BaseModel):
+    """Request-level accounting of one applied compression stage (D-SERVING-LOG / eval shape).
+
+    `compressor_version` is the version that actually RAN (the config's copy is fit-time
+    provenance). Token counts are whole-request `estimate_tokens` totals: what the input would
+    have measured raw vs what was sent, so on-vs-off savings read straight off the record.
+    """
+
+    compressor_id: str
+    compressor_version: str
+    aggressiveness: float
+    tokens_in_raw: int
+    tokens_in_compressed: int
+    latency_s: float
+    cost_usd: float = 0.0
+
+
 @runtime_checkable
 class Compressor(Protocol):
     """The pluggable compressor seam. Implementations must be deterministic and 0.0-safe."""

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -13,9 +13,11 @@ from wmo.optimize.compression import (
     Compressor,
     IdentityCompressor,
     TruncateCompressor,
+    compress_segments,
     estimate_tokens,
     get_compressor,
     register_compressor,
+    register_compressor_factory,
     same_compression,
     servable_compressor,
 )
@@ -237,3 +239,190 @@ def test_a_version_bumped_implementation_refuses_the_old_stamp() -> None:
     )
     with pytest.raises(ValueError, match="version 2 in this build.*fitted against version 1"):
         servable_compressor(CompressionConfig(compressor_id=_V2.id, compressor_version="1"))
+
+
+class _CappedCompressor:
+    """A compressor whose server refuses batches over its cap, like the real endpoint's 413."""
+
+    id = "capped-for-tests"
+    version = "1"
+    append_stable = True
+    max_segments_per_call = 3
+
+    def __init__(self) -> None:
+        self.batches: list[int] = []
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        if len(segments) > self.max_segments_per_call:
+            raise RuntimeError(
+                f"413: {len(segments)} segments over cap {self.max_segments_per_call}"
+            )
+        self.batches.append(len(segments))
+        out = [segment.split(" ")[0] for segment in segments]
+        return CompressionResult(
+            segments=out,
+            tokens_in_raw=sum(estimate_tokens(s) for s in segments),
+            tokens_in_compressed=sum(estimate_tokens(s) for s in out),
+            latency_s=0.5,
+            cost_usd=0.001,
+        )
+
+
+def test_a_capped_compressor_is_chunked_instead_of_overflowed() -> None:
+    # The fit path hands over every scenario in the matrix at once, which is far past any served
+    # compressor's per-call cap. Chunking is what makes those two facts compatible.
+    capped = _CappedCompressor()
+    segments = [f"segment {index} tail" for index in range(7)]
+    result = compress_segments(capped, segments, CompressionConfig(compressor_id=capped.id))
+    assert capped.batches == [3, 3, 1]  # chunked to the cap, nothing dropped
+    assert result.segments == ["segment" for _ in range(7)]
+    assert len(result.segments) == len(segments)
+    # Per-chunk accounting is summed, not taken from the last chunk.
+    assert result.latency_s == pytest.approx(1.5)
+    assert result.cost_usd == pytest.approx(0.003)
+
+
+def test_chunking_does_not_change_the_bytes() -> None:
+    # Safe only because the protocol requires per-segment determinism; this pins that the seam
+    # relies on nothing else. Same segments, two different chunk sizes, identical output.
+    segments = [f"one two three {index}" for index in range(10)]
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    whole = compress_segments(get_compressor("truncate"), segments, config)
+
+    class _Capped2(TruncateCompressor):
+        max_segments_per_call = 2
+
+    chunked = compress_segments(cast("Compressor", _Capped2()), segments, config)
+    assert chunked.segments == whole.segments
+
+
+def test_an_uncapped_compressor_still_gets_one_call() -> None:
+    calls: list[int] = []
+
+    class _Counting(TruncateCompressor):
+        def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+            calls.append(len(segments))
+            return super().compress(segments, config)
+
+    compress_segments(
+        cast("Compressor", _Counting()),
+        ["a b", "c d", "e f"],
+        CompressionConfig(compressor_id="truncate"),
+    )
+    assert calls == [3]
+
+
+def test_a_malformed_cap_is_refused_at_registration() -> None:
+    class _BadCap:
+        id = "bad-cap-for-tests"
+        version = "1"
+        append_stable = True
+        max_segments_per_call = 0
+
+        def compress(
+            self, segments: list[str], config: CompressionConfig
+        ) -> CompressionResult:  # pragma: no cover - never reached
+            raise NotImplementedError
+
+    with pytest.raises(ValueError, match="max_segments_per_call"):
+        register_compressor(cast("Compressor", _BadCap()))
+
+
+class _WrongLength:
+    """Returns the wrong number of segments, the contract violation nothing used to catch."""
+
+    id = "wrong-length-for-tests"
+    version = "1"
+    append_stable = True
+
+    def __init__(self, delta: int) -> None:
+        self.delta = delta
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        out = list(segments)
+        if self.delta < 0:
+            out = out[:-1]
+        else:
+            out = [*out, "extra"]
+        return CompressionResult(
+            segments=out, tokens_in_raw=1, tokens_in_compressed=1, latency_s=0.0
+        )
+
+
+def test_a_short_return_is_a_named_error_not_a_stopiteration() -> None:
+    # It used to surface as StopIteration from the caller's zip, i.e. an anonymous 502 that
+    # blamed nothing in particular.
+    with pytest.raises(ValueError, match="wrong-length-for-tests.*returned 1 segments for 2"):
+        compress_segments(
+            cast("Compressor", _WrongLength(-1)),
+            ["a", "b"],
+            CompressionConfig(compressor_id="x"),
+        )
+
+
+def test_a_long_return_is_refused_instead_of_silently_truncated() -> None:
+    # The worse direction: the extra segment used to be discarded and the request served, so a
+    # compressor that split a segment corrupted the transcript with nobody the wiser.
+    with pytest.raises(ValueError, match="returned 3 segments for 2"):
+        compress_segments(
+            cast("Compressor", _WrongLength(1)),
+            ["a", "b"],
+            CompressionConfig(compressor_id="x"),
+        )
+
+
+def test_a_factory_compressor_is_built_on_first_resolution_not_at_import() -> None:
+    # The endpoint client has to reach its server to verify the selection rule before it can
+    # attest append_stable, and doing that at import would put a network call in `import wmo`.
+    built: list[int] = []
+
+    class _Lazy(TruncateCompressor):
+        id = "lazy-for-tests"
+
+    def factory() -> Compressor:
+        built.append(1)
+        return cast("Compressor", _Lazy())
+
+    register_compressor_factory("lazy-for-tests", factory)
+    assert built == []  # registering builds nothing
+
+    first = get_compressor("lazy-for-tests")
+    assert built == [1]
+    assert get_compressor("lazy-for-tests") is first  # built once, then cached
+    assert built == [1]
+
+
+def test_a_failing_factory_names_the_compressor_and_can_be_retried() -> None:
+    attempts: list[int] = []
+
+    class _Flaky(TruncateCompressor):
+        id = "flaky-for-tests"
+
+    def factory() -> Compressor:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("endpoint unreachable")
+        return cast("Compressor", _Flaky())
+
+    register_compressor_factory("flaky-for-tests", factory)
+    with pytest.raises(ValueError, match="'flaky-for-tests' could not be constructed"):
+        get_compressor("flaky-for-tests")
+    # Still registered, so a transient failure is retried rather than poisoning the id.
+    assert get_compressor("flaky-for-tests") is not None
+
+
+def test_a_factory_cannot_shadow_a_registered_compressor() -> None:
+    with pytest.raises(ValueError, match="already registered"):
+        register_compressor_factory("truncate", lambda: cast("Compressor", TruncateCompressor()))
+
+
+def test_a_factory_that_builds_the_wrong_compressor_is_caught() -> None:
+    # Otherwise it lands in the registry under ITS id while this lookup hands it back for a
+    # different one, so a policy naming the registered id gets an implementation that does not
+    # answer to it.
+    register_compressor_factory(
+        "mislabelled-for-tests", lambda: cast("Compressor", TruncateCompressor())
+    )
+    with pytest.raises(ValueError, match="built one with id 'truncate'"):
+        get_compressor("mislabelled-for-tests")

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -19,6 +19,7 @@ from wmo.optimize.compression import (
     register_compressor,
     register_compressor_factory,
     same_compression,
+    segment_batch_limit,
     servable_compressor,
 )
 
@@ -426,3 +427,76 @@ def test_a_factory_that_builds_the_wrong_compressor_is_caught() -> None:
     )
     with pytest.raises(ValueError, match="built one with id 'truncate'"):
         get_compressor("mislabelled-for-tests")
+
+
+def test_a_factory_failure_keeps_the_original_message_and_cause() -> None:
+    # A served compressor's construction error is the actionable part (which env var, which
+    # host), so the wrapper must not swallow it. The TYPE is normalized to ValueError on
+    # purpose: this resolves inside a pydantic validator, which converts ValueError into a
+    # ValidationError and lets anything else escape raw, and the CLI catches ValueError to turn
+    # it into a usage error. The original exception stays reachable as __cause__.
+    class _EndpointDown(RuntimeError):
+        pass
+
+    detail = "set WMO_COMPRESSOR_URL and WMO_COMPRESSOR_API_KEY, then retry"
+
+    def factory() -> Compressor:
+        raise _EndpointDown(detail)
+
+    register_compressor_factory("actionable-for-tests", factory)
+    with pytest.raises(ValueError) as caught:
+        get_compressor("actionable-for-tests")
+    assert detail in str(caught.value)  # the operator keeps the fix
+    assert "actionable-for-tests" in str(caught.value)  # and learns which compressor
+    assert isinstance(caught.value.__cause__, _EndpointDown)
+
+
+def test_a_second_factory_cannot_displace_the_first() -> None:
+    def first() -> Compressor:  # pragma: no cover - never resolved
+        raise NotImplementedError
+
+    def second() -> Compressor:  # pragma: no cover - never resolved
+        raise NotImplementedError
+
+    register_compressor_factory("one-factory-for-tests", first)
+    register_compressor_factory("one-factory-for-tests", first)  # idempotent for the same object
+    with pytest.raises(ValueError, match="already has a registered factory"):
+        register_compressor_factory("one-factory-for-tests", second)
+
+
+def test_a_factory_cannot_shadow_a_live_instance() -> None:
+    # A test that registered a fake under an id must not be silently replaced by the real one.
+    register_compressor(_CHURNY)
+    with pytest.raises(ValueError, match="already registered"):
+        register_compressor_factory(_CHURNY.id, lambda: _CHURNY)
+
+
+def test_unknown_compressor_lists_registered_factories_too() -> None:
+    # A factory-registered compressor IS available; leaving it out of the known list would tell
+    # an operator to register something that is already there.
+    def factory() -> Compressor:  # pragma: no cover - never resolved
+        raise NotImplementedError
+
+    register_compressor_factory("listed-for-tests", factory)
+    with pytest.raises(ValueError, match="listed-for-tests"):
+        get_compressor("definitely-not-registered")
+
+
+def test_the_cap_is_read_off_the_constructed_instance() -> None:
+    # A served compressor learns its cap from the server, so the value only exists after
+    # construction. Nothing may require it as a class-level constant inspected beforehand.
+    class _LearnsItsCap(TruncateCompressor):
+        id = "learned-cap-for-tests"
+
+        def __init__(self) -> None:
+            self.max_segments_per_call = 2  # as if read from /healthz
+
+    register_compressor_factory(
+        "learned-cap-for-tests", lambda: cast("Compressor", _LearnsItsCap())
+    )
+    resolved = get_compressor("learned-cap-for-tests")
+    assert segment_batch_limit(resolved) == 2
+    result = compress_segments(
+        resolved, ["a b", "c d", "e f"], CompressionConfig(compressor_id="learned-cap-for-tests")
+    )
+    assert len(result.segments) == 3

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -197,3 +197,43 @@ def test_one_call_carries_every_segment() -> None:
     config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
     result = get_compressor("truncate").compress(["one two", "three four", "five six"], config)
     assert len(result.segments) == 3
+
+
+class _V2Compressor:
+    """Stands in for a compressor whose implementation was version-bumped under a stable id."""
+
+    id = "versioned-compression-test"
+    version = "2"
+    append_stable = True
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        out = [segment.upper() for segment in segments]
+        return CompressionResult(
+            segments=out,
+            tokens_in_raw=sum(estimate_tokens(segment) for segment in segments),
+            tokens_in_compressed=sum(estimate_tokens(segment) for segment in out),
+            latency_s=0.0,
+        )
+
+
+_V2 = _V2Compressor()
+
+
+def test_a_config_version_the_build_cannot_produce_is_refused() -> None:
+    # The id alone does not identify the bytes. An artifact stamped against a version this
+    # build does not run was fitted in a DIFFERENT implementation's geometry, which is the same
+    # failure as serving a different compressor and is invisible without this check.
+    with pytest.raises(ValueError, match="version 1 in this build.*fitted against version 99"):
+        servable_compressor(CompressionConfig(compressor_id="truncate", compressor_version="99"))
+
+
+def test_a_version_bumped_implementation_refuses_the_old_stamp() -> None:
+    # The other direction: the build moved forward and the artifact did not.
+    register_compressor(_V2)
+    assert (
+        servable_compressor(CompressionConfig(compressor_id=_V2.id, compressor_version="2"))
+        is not None
+    )
+    with pytest.raises(ValueError, match="version 2 in this build.*fitted against version 1"):
+        servable_compressor(CompressionConfig(compressor_id=_V2.id, compressor_version="1"))

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -1,0 +1,86 @@
+"""Tests for the segment-aware compression seam (protocol, identity, truncate, registry)."""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.optimize.compression import (
+    CompressionConfig,
+    Compressor,
+    IdentityCompressor,
+    TruncateCompressor,
+    estimate_tokens,
+    get_compressor,
+)
+
+
+def test_identity_returns_segments_bit_for_bit() -> None:
+    segments = ["  leading space", "tabs\tand\nnewlines ", ""]
+    result = IdentityCompressor().compress(
+        segments, CompressionConfig(compressor_id="identity", aggressiveness=1.0)
+    )
+    # Bit-for-bit even at max aggressiveness: identity is the compression-off contract.
+    assert result.segments == segments
+    assert result.tokens_in_compressed == result.tokens_in_raw
+    assert result.cost_usd == 0.0
+
+
+def test_truncate_drops_the_trailing_fraction() -> None:
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    result = TruncateCompressor().compress(["one two three four", "a b"], config)
+    assert result.segments == ["one two", "a"]
+    assert result.tokens_in_compressed < result.tokens_in_raw
+
+
+def test_truncate_at_zero_aggressiveness_is_a_no_op() -> None:
+    segments = ["exact bytes  preserved\twhen nothing is removed"]
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.0)
+    result = TruncateCompressor().compress(segments, config)
+    # keep >= len(words) short-circuits to the original string, whitespace intact.
+    assert result.segments == segments
+    assert result.tokens_in_compressed == result.tokens_in_raw
+
+
+def test_truncate_is_deterministic_per_segment() -> None:
+    # Append-stability: an unchanged segment compresses to the same bytes on every call,
+    # regardless of what other segments accompany it.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.3)
+    compressor = TruncateCompressor()
+    alone = compressor.compress(["stable segment with several words here"], config)
+    with_neighbor = compressor.compress(
+        ["stable segment with several words here", "another later segment"], config
+    )
+    assert alone.segments[0] == with_neighbor.segments[0]
+
+
+def test_compressors_preserve_segment_count_and_order() -> None:
+    segments = ["first has words", "second", "", "fourth trailing"]
+    for compressor_id in ("identity", "truncate"):
+        config = CompressionConfig(compressor_id=compressor_id, aggressiveness=0.5)
+        result = get_compressor(compressor_id).compress(segments, config)
+        assert len(result.segments) == len(segments), compressor_id
+
+
+def test_registry_resolves_known_ids_and_satisfies_the_protocol() -> None:
+    for compressor_id in ("identity", "truncate"):
+        compressor = get_compressor(compressor_id)
+        assert isinstance(compressor, Compressor)
+        assert compressor.id == compressor_id
+
+
+def test_registry_rejects_unknown_id_with_guidance() -> None:
+    with pytest.raises(ValueError, match="unknown compressor 'llmzip'.*identity, truncate"):
+        get_compressor("llmzip")
+
+
+def test_aggressiveness_is_bounded() -> None:
+    with pytest.raises(ValueError):
+        CompressionConfig(compressor_id="truncate", aggressiveness=1.5)
+    with pytest.raises(ValueError):
+        CompressionConfig(compressor_id="truncate", aggressiveness=-0.1)
+
+
+def test_estimate_tokens_is_ceil_of_quarter_chars() -> None:
+    assert estimate_tokens("") == 0
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens("abcde") == 2

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -171,3 +171,29 @@ def test_compressing_embedder_embeds_the_compressed_text() -> None:
     config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
     CompressingEmbedder(inner, config).embed(["one two three four", "alpha beta"])
     assert inner.seen == [["one two", "alpha"]]
+
+
+def test_the_dial_invariants_hold_for_every_reference_compressor() -> None:
+    # `aggressiveness` is a compressor-defined dial, not a removal fraction, so these two
+    # invariants are the whole contract an implementation has to honor: 0.0 is a strict
+    # bit-for-bit no-op, and higher never removes less.
+    segments = ["one two three four five six seven eight", "alpha beta gamma", ""]
+    for compressor_id in ("identity", "truncate"):
+        compressor = get_compressor(compressor_id)
+        removed = []
+        for level in (0.0, 0.25, 0.5, 0.75, 1.0):
+            config = CompressionConfig(compressor_id=compressor_id, aggressiveness=level)
+            result = compressor.compress(segments, config)
+            if level == 0.0:
+                assert result.segments == segments, compressor_id
+            removed.append(result.tokens_in_raw - result.tokens_in_compressed)
+        assert removed == sorted(removed), f"{compressor_id} dial is not monotone: {removed}"
+
+
+def test_one_call_carries_every_segment() -> None:
+    # The batching contract a network-backed compressor depends on: the caller hands over all
+    # of a request's mutable segments at once, so the implementation pays one round trip and
+    # can batch internally.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    result = get_compressor("truncate").compress(["one two", "three four", "five six"], config)
+    assert len(result.segments) == 3

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from wmo.optimize.compression import (
+    CompressingEmbedder,
     CompressionConfig,
+    CompressionResult,
     Compressor,
     IdentityCompressor,
     TruncateCompressor,
     estimate_tokens,
     get_compressor,
+    register_compressor,
+    same_compression,
+    servable_compressor,
 )
 
 
@@ -84,3 +91,83 @@ def test_estimate_tokens_is_ceil_of_quarter_chars() -> None:
     assert estimate_tokens("") == 0
     assert estimate_tokens("abcd") == 1
     assert estimate_tokens("abcde") == 2
+
+
+class _CountingEmbedder:
+    """Records exactly which texts it was asked to embed."""
+
+    def __init__(self) -> None:
+        self.seen: list[list[str]] = []
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.seen.append(list(texts))
+        return [[float(len(text))] for text in texts]
+
+
+class _Churny:
+    """A compressor that admits it rewrites already-emitted bytes (C1's percentile family)."""
+
+    id = "churny-compression-test"
+    version = "1"
+    append_stable = False
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        raw = sum(estimate_tokens(segment) for segment in segments)
+        return CompressionResult(
+            segments=list(segments), tokens_in_raw=raw, tokens_in_compressed=raw, latency_s=0.0
+        )
+
+
+_CHURNY = _Churny()
+
+
+def test_the_reference_compressors_attest_append_stability() -> None:
+    # Both are servable in v1: identity changes nothing, and truncate is head-absolute per
+    # segment (C1 round 0 measured churn 0.000 on all five corpora for head-keep truncation).
+    assert IdentityCompressor.append_stable is True
+    assert TruncateCompressor.append_stable is True
+    assert servable_compressor(CompressionConfig(compressor_id="truncate")) is not None
+    assert servable_compressor(None) is None
+
+
+def test_a_churny_compressor_is_not_servable() -> None:
+    register_compressor(_CHURNY)
+    with pytest.raises(ValueError, match="not attested append-stable"):
+        servable_compressor(CompressionConfig(compressor_id=_CHURNY.id))
+
+
+def test_register_compressor_refuses_to_rebind_an_id() -> None:
+    register_compressor(_CHURNY)
+    register_compressor(_CHURNY)  # idempotent for the same object
+    assert get_compressor(_CHURNY.id) is _CHURNY
+
+    class _Impostor:
+        id = _CHURNY.id
+        version = "2"
+        append_stable = True
+
+        def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+            raise NotImplementedError
+
+    with pytest.raises(ValueError, match="already registered"):
+        register_compressor(cast("Compressor", _Impostor()))
+
+
+def test_same_compression_compares_the_whole_triple() -> None:
+    base = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    assert same_compression(base, base.model_copy())
+    assert same_compression(None, None)
+    assert not same_compression(base, None)
+    assert not same_compression(base, base.model_copy(update={"aggressiveness": 0.25}))
+    # A version bump changes the emitted bytes exactly as a different id would.
+    assert not same_compression(base, base.model_copy(update={"compressor_version": "2"}))
+
+
+def test_compressing_embedder_embeds_the_compressed_text() -> None:
+    # The fit-side half of representation consistency: the bank rows must be the geometry of
+    # what serving will send, not of the raw task text.
+    inner = _CountingEmbedder()
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    CompressingEmbedder(inner, config).embed(["one two three four", "alpha beta"])
+    assert inner.seen == [["one two", "alpha"]]

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.policy import (
     DEFAULT_KNN_MIN_PAIRS,
     DEFAULT_KNN_Z,
@@ -292,6 +293,7 @@ def fit_knn_artifact(
     min_pairs: int = DEFAULT_KNN_MIN_PAIRS,
     se_floor: bool = True,
     floor_q: float = 0.05,
+    compression: CompressionConfig | None = None,
 ) -> KnnFitOutcome:
     """Fit a knn policy, write it and its bank sidecar, and replay it over the fit matrix.
 
@@ -332,6 +334,11 @@ def fit_knn_artifact(
             f"{embed_tag}"
         ),
     )
+    if compression is not None:
+        # Stamped BEFORE the save, because the artifact on disk is what serving mounts and what
+        # the mount gate compares. `model_copy` skips validators, so the caller has already
+        # resolved the compressor id (an unknown one must fail before anything is written).
+        policy = policy.model_copy(update={"compression": compression})
     policy.save(out_path)
     result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
     return KnnFitOutcome(

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
-from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.compression import CompressingEmbedder, CompressionConfig
 from wmo.optimize.policy import (
     DEFAULT_KNN_MIN_PAIRS,
     DEFAULT_KNN_Z,
@@ -315,6 +315,14 @@ def fit_knn_artifact(
     if rag_thres <= 0.0:
         raise ValueError("rag_thres must be greater than 0")
     built = embedder.build()
+    if compression is not None:
+        # Representation consistency, the C2 rule that makes or breaks a compressed arm: the
+        # bank rows and the novelty-floor quantile have to live in the geometry of the text
+        # SERVING will embed, which is the compressed text. One wrapped embedder covers the fit
+        # and the replay below. Serving does not wrap, because its compression stage runs ahead
+        # of the router. Fitting the bank uncompressed while serving compresses is the failure
+        # this exists to prevent: the floor abstains, and routing silently stops happening.
+        built = CompressingEmbedder(built, compression)
     embed_tag = embedder_provenance(embedder)
     policy = fit_knn_policy(
         matrix,
@@ -336,9 +344,14 @@ def fit_knn_artifact(
     )
     if compression is not None:
         # Stamped BEFORE the save, because the artifact on disk is what serving mounts and what
-        # the mount gate compares. `model_copy` skips validators, so the caller has already
-        # resolved the compressor id (an unknown one must fail before anything is written).
-        policy = policy.model_copy(update={"compression": compression})
+        # the mount gate compares. Both halves: what this endpoint serves, and what its evidence
+        # was fitted under. They are the same config here by construction, since the fit just
+        # embedded through it, and that identity is what the mount gate re-checks.
+        # `model_copy` skips validators, so the caller has already resolved the compressor id
+        # (an unknown one must fail before anything is written).
+        policy = policy.model_copy(
+            update={"compression": compression, "fit_compression": compression}
+        )
     policy.save(out_path)
     result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
     return KnnFitOutcome(

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, model_validator
 
+from wmo.optimize.compression import CompressionConfig
 from wmo.providers.base import TokenUsage
 from wmo.providers.pool import PoolEntry
 
@@ -90,6 +91,40 @@ class OutcomeMatrix(BaseModel):
                 f"pool models are {sorted(names)}"
             )
         return self
+
+    def measured_compression(self) -> CompressionConfig | None:
+        """The compression config every scored row was measured under (None = uncompressed).
+
+        A matrix is ONE arm of the grid: its rewards were produced by episodes that all ran
+        under the same conditions, which is what makes the rows comparable and what a policy
+        fitted from them is entitled to claim. Rows that disagree about compression are two arms
+        in one file, so this raises rather than picking a winner.
+
+        Reads the scored rows only: an unscored row never produced a reward, so whatever it ran
+        under cannot bias a fit.
+        """
+        configs = {
+            (o.compressor_id, o.compressor_version, o.aggressiveness)
+            for o in self.outcomes
+            if o.scored
+        }
+        if len(configs) > 1:
+            readable = sorted(f"{cid or 'uncompressed'}/{ver}/{agg:g}" for cid, ver, agg in configs)
+            raise ValueError(
+                "this matrix mixes compression configs across its scored rows "
+                f"({', '.join(readable)}), so its rows are not comparable and no single policy "
+                "can be fitted from them. Capture one matrix per arm."
+            )
+        if not configs:
+            return None
+        compressor_id, compressor_version, aggressiveness = configs.pop()
+        if not compressor_id:
+            return None
+        return CompressionConfig(
+            compressor_id=compressor_id,
+            compressor_version=compressor_version,
+            aggressiveness=aggressiveness,
+        )
 
     def model_names(self) -> list[str]:
         return [entry.name for entry in self.pool]

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -46,6 +46,18 @@ class ScenarioOutcome(BaseModel):
     # fitting). Reasoning models that emit thought before the JSON action keep it here.
     replies: list[str] = []
     error: str | None = None
+    # D-COMPRESS fields, additive with defaults so pre-compression matrices load unchanged;
+    # 0/"" = the episode ran uncompressed. Token counts are the compressor's deterministic
+    # proxy totals summed over the episode's calls (wmo.optimize.compression); billable truth
+    # stays in `usage`/`cost_usd`. Latency and cost are the compressor's OWN, which sit inside
+    # effective cost per the compression track's accounting rules.
+    tokens_in_raw: int = 0
+    tokens_in_compressed: int = 0
+    compressor_id: str = ""
+    compressor_version: str = ""
+    aggressiveness: float = 0.0
+    compressor_latency_s: float = 0.0
+    compressor_cost_usd: float = 0.0
 
     @property
     def scored(self) -> bool:

--- a/wmo/optimize/outcomes_test.py
+++ b/wmo/optimize/outcomes_test.py
@@ -75,3 +75,108 @@ def test_outcomes_must_name_pool_models() -> None:
             pool=matrix.pool,
             outcomes=[*matrix.outcomes, _outcome("s1", "ghost-model")],
         )
+
+
+def test_measured_compression_reads_the_arm_off_the_scored_rows() -> None:
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="a",
+                kind=ProviderKind.OPENAI,
+                model="a",
+                input_per_mtok=1.0,
+                output_per_mtok=1.0,
+            )
+        ],
+        outcomes=[
+            ScenarioOutcome(
+                scenario_id="s1",
+                task="t",
+                model="a",
+                reward=1.0,
+                compressor_id="truncate",
+                compressor_version="1",
+                aggressiveness=0.5,
+            )
+        ],
+    )
+    config = matrix.measured_compression()
+    assert config is not None
+    assert config.compressor_id == "truncate"
+    assert config.aggressiveness == 0.5
+
+
+def test_a_matrix_with_no_compression_fields_reads_as_the_uncompressed_arm() -> None:
+    # Every matrix captured before D-COMPRESS existed, which must keep fitting exactly as before.
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="a",
+                kind=ProviderKind.OPENAI,
+                model="a",
+                input_per_mtok=1.0,
+                output_per_mtok=1.0,
+            )
+        ],
+        outcomes=[ScenarioOutcome(scenario_id="s1", task="t", model="a", reward=1.0)],
+    )
+    assert matrix.measured_compression() is None
+
+
+def test_a_matrix_that_mixes_arms_refuses_to_name_one() -> None:
+    # Two arms in one file: the rows are not comparable, so no single policy can be fitted
+    # from them and picking a winner here would hide that.
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="a",
+                kind=ProviderKind.OPENAI,
+                model="a",
+                input_per_mtok=1.0,
+                output_per_mtok=1.0,
+            )
+        ],
+        outcomes=[
+            ScenarioOutcome(scenario_id="s1", task="t", model="a", reward=1.0),
+            ScenarioOutcome(
+                scenario_id="s2",
+                task="t",
+                model="a",
+                reward=1.0,
+                compressor_id="truncate",
+                compressor_version="1",
+                aggressiveness=0.5,
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="mixes compression configs"):
+        matrix.measured_compression()
+
+
+def test_an_unscored_row_does_not_decide_the_arm() -> None:
+    # An unscored episode produced no reward, so whatever it ran under cannot bias a fit.
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="a",
+                kind=ProviderKind.OPENAI,
+                model="a",
+                input_per_mtok=1.0,
+                output_per_mtok=1.0,
+            )
+        ],
+        outcomes=[
+            ScenarioOutcome(scenario_id="s1", task="t", model="a", reward=1.0),
+            ScenarioOutcome(
+                scenario_id="s2",
+                task="t",
+                model="a",
+                reward=None,
+                error="provider throttled",
+                compressor_id="truncate",
+                compressor_version="1",
+                aggressiveness=0.5,
+            ),
+        ],
+    )
+    assert matrix.measured_compression() is None

--- a/wmo/optimize/pipeline.py
+++ b/wmo/optimize/pipeline.py
@@ -107,6 +107,12 @@ class StageRecord(BaseModel):
     # the candidate models charged (the serving cost a customer would pay) and what the world
     # model charged to run the evaluation (eval infrastructure). Both are 0.0 for the free stages.
     spend_usd: float = 0.0
+    # The compressor's share of `spend_usd`, which is folded INTO it (D-COMPRESS accounting:
+    # every savings number carries the compressor's inference cost). Recorded separately for one
+    # reason: the plan table cannot project a compressor's per-call cost, so a forecast built
+    # from this stage has to divide the folded total back down to the projectable part or it
+    # compares two different quantities (see `project_sweep_spend`).
+    compressor_spend_usd: float = 0.0
     world_model_spend_usd: float = 0.0
 
     @property
@@ -370,7 +376,15 @@ def project_sweep_spend(candidate_usd: float, prior: StageRecord | None) -> Swee
     """
     if prior is None or prior.stage is not Stage.SWEEP or prior.spend_usd <= 0.0:
         return SweepSpendProjection(candidate_usd=candidate_usd, world_model_usd=0.0, basis=None)
-    ratio = prior.world_model_spend_usd / prior.spend_usd
+    # Divide by the PROJECTABLE part of the prior candidate spend, not the folded total. The
+    # number this ratio multiplies is a projection that excludes the compressor by construction
+    # (nothing predicts a compressor's per-call cost in advance), so a folded denominator would
+    # shrink the forecast by the compressor's share of the last run: systematically short, on the
+    # term that dominates the bill.
+    projectable = prior.spend_usd - prior.compressor_spend_usd
+    if projectable <= 0.0:
+        return SweepSpendProjection(candidate_usd=candidate_usd, world_model_usd=0.0, basis=None)
+    ratio = prior.world_model_spend_usd / projectable
     return SweepSpendProjection(
         candidate_usd=candidate_usd,
         world_model_usd=candidate_usd * ratio,
@@ -379,7 +393,7 @@ def project_sweep_spend(candidate_usd: float, prior: StageRecord | None) -> Swee
         # itself and looks exactly like the divide-by-zero this function refuses to do.
         basis=(
             f"the last sweep of this model measured ${prior.world_model_spend_usd:.4f} "
-            f"world-model against ${prior.spend_usd:.4f} candidate ({ratio:.1f}x)"
+            f"world-model against ${projectable:.4f} projectable candidate ({ratio:.1f}x)"
         ),
     )
 

--- a/wmo/optimize/pipeline_test.py
+++ b/wmo/optimize/pipeline_test.py
@@ -233,12 +233,13 @@ def test_the_reserved_slots_are_named_but_not_built() -> None:
     assert order.index(Stage.SWEEP) < order.index(Stage.DISTILL)
 
 
-def _sweep_record(*, candidate: float, world_model: float) -> StageRecord:
+def _sweep_record(*, candidate: float, world_model: float, compressor: float = 0.0) -> StageRecord:
     return StageRecord(
         stage=Stage.SWEEP,
         fingerprint={"pool": "abc"},
         completed_at="2026-07-27T00:00:00+00:00",
         spend_usd=candidate,
+        compressor_spend_usd=compressor,
         world_model_spend_usd=world_model,
     )
 
@@ -263,7 +264,7 @@ def test_a_prior_sweep_projects_the_world_model_side_from_its_measured_ratio() -
     assert projection.basis is not None
     assert "7.0x" in projection.basis
     # Four decimals: a sub-cent side must not render as "$0.00" beside a nonzero ratio.
-    assert "$1.8076" in projection.basis and "$0.2581" in projection.basis
+    assert "$1.8076" in projection.basis and "$0.2581 projectable candidate" in projection.basis
 
 
 def test_the_projection_scales_with_the_size_of_the_sweep_being_planned() -> None:
@@ -303,4 +304,33 @@ def test_a_sub_cent_candidate_side_is_not_rendered_as_zero_in_the_basis() -> Non
     basis = project_sweep_spend(1.0, _sweep_record(candidate=0.00132, world_model=0.12)).basis
     assert basis is not None
     assert "$0.00 candidate" not in basis
-    assert "$0.0013 candidate" in basis
+    assert "$0.0013 projectable candidate" in basis
+
+
+def test_a_compressed_prior_forecasts_on_like_units_not_the_folded_total() -> None:
+    """The ratio's denominator has to match the units of the number it multiplies.
+
+    D-COMPRESS folds the compressor's bill into candidate spend, but nothing can project a
+    compressor's per-call cost in advance, so the projection this ratio multiplies is the model
+    half alone. Dividing by the FOLDED total would shrink every forecast by the compressor's
+    share of the last run: systematically short, on the term that dominates the bill.
+
+    Concrete rather than re-derived: asserting the formula the implementation uses would pass
+    even if both were wrong together.
+    """
+    prior = _sweep_record(candidate=1.00, world_model=7.00, compressor=0.30)
+    projection = project_sweep_spend(0.70, prior)
+    # 7.00 / (1.00 - 0.30) = 10.0x on the projectable part; 10.0 x 0.70 = $7.00 like-for-like.
+    # A folded denominator would give 7.00 / 1.00 = 7.0x -> $4.90, a 30% shortfall.
+    assert projection.world_model_usd == pytest.approx(7.00)
+    assert projection.total_usd == pytest.approx(7.70)
+    assert projection.basis is not None
+    assert "$0.7000 projectable candidate" in projection.basis and "10.0x" in projection.basis
+
+
+def test_a_prior_that_was_all_compressor_supplies_no_ratio() -> None:
+    # Projectable part is zero, so there is nothing to divide by and nothing honest to forecast.
+    projection = project_sweep_spend(
+        1.0, _sweep_record(candidate=0.5, world_model=9.0, compressor=0.5)
+    )
+    assert projection.basis is None and projection.world_model_usd == 0.0

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -43,6 +43,7 @@ from uuid import uuid4
 import numpy as np
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
+from wmo.optimize.compression import CompressionConfig, get_compressor
 from wmo.providers.base import Embedder, ProviderConfig, ProviderKind
 from wmo.providers.pool import PoolEntry
 from wmo.providers.registry import get_provider
@@ -285,6 +286,10 @@ class ClusterRanking(BaseModel):
     # so `rerank_policy` can re-apply the identical check without the outcome matrix.
     support: dict[str, int] = Field(default_factory=dict)
     total: int = 0  # fit scenarios that landed in this cluster
+    # D-COMPRESS: this cluster's compression choice, fitted jointly with the model ranking.
+    # None (the default) = no cluster-level choice; consumers fall back to the policy-level
+    # `compression`. Additive: pre-compression artifacts load unchanged.
+    compression: CompressionConfig | None = None
 
 
 # How a non-baseline candidate fared, as `RoutingEvidence.gate` records it. "passed" and
@@ -379,6 +384,11 @@ class RoutingPolicy(BaseModel):
     min_support: int | None = None  # scored episodes a challenger needs to lead its cluster
     guard_margin: float | None = None  # reward the challenger must beat the guard by
     fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
+    # D-COMPRESS: the endpoint-level compression choice, applied by the serving compress stage
+    # BEFORE routing (the router embeds what the model will see), so it cannot vary by cluster
+    # at serve time; per-cluster overrides live on ClusterRanking for the joint fit and eval
+    # grids. None (the default) = compression off, today's behavior exactly.
+    compression: CompressionConfig | None = None
 
     # kNN policies only (see module docstring and `wmo.optimize.knn`). The fitter records the
     # bank it actually wrote (`knn_bank_path_for(<policy path>)`), so serving resolves the
@@ -448,6 +458,11 @@ class RoutingPolicy(BaseModel):
                 f"guard_model '{self.guard_model}' is not in the policy pool "
                 f"(available: {sorted(names)})"
             )
+        if self.compression is not None:
+            get_compressor(self.compression.compressor_id)  # raises naming the known ids
+        for cluster in self.clusters:
+            if cluster.compression is not None:
+                get_compressor(cluster.compression.compressor_id)
         if self.kind != "rank" and self.clusters:
             raise ValueError(f"a {self.kind} policy carries no clusters; use kind='rank'")
         if self.kind == "knn":

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -43,7 +43,13 @@ from uuid import uuid4
 import numpy as np
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
-from wmo.optimize.compression import CompressionConfig, get_compressor
+from wmo.optimize.compression import (
+    CompressionConfig,
+    Compressor,
+    compression_signature,
+    same_compression,
+    servable_compressor,
+)
 from wmo.providers.base import Embedder, ProviderConfig, ProviderKind
 from wmo.providers.pool import PoolEntry
 from wmo.providers.registry import get_provider
@@ -389,6 +395,13 @@ class RoutingPolicy(BaseModel):
     # at serve time; per-cluster overrides live on ClusterRanking for the joint fit and eval
     # grids. None (the default) = compression off, today's behavior exactly.
     compression: CompressionConfig | None = None
+    # D-COMPRESS representation consistency: the compression config the ROUTING EVIDENCE was
+    # fitted under (bank rows, cluster centroids, and the novelty floor quantile all live in the
+    # embedding geometry of whatever text the fit embedded). None (the default) = fitted on raw
+    # text, which is every artifact written before this field existed, so they load unchanged.
+    # A policy that routes may only serve the config it was fitted under: see
+    # `_check_compression`.
+    fit_compression: CompressionConfig | None = None
 
     # kNN policies only (see module docstring and `wmo.optimize.knn`). The fitter records the
     # bank it actually wrote (`knn_bank_path_for(<policy path>)`), so serving resolves the
@@ -458,11 +471,7 @@ class RoutingPolicy(BaseModel):
                 f"guard_model '{self.guard_model}' is not in the policy pool "
                 f"(available: {sorted(names)})"
             )
-        if self.compression is not None:
-            get_compressor(self.compression.compressor_id)  # raises naming the known ids
-        for cluster in self.clusters:
-            if cluster.compression is not None:
-                get_compressor(cluster.compression.compressor_id)
+        self._check_compression()
         if self.kind != "rank" and self.clusters:
             raise ValueError(f"a {self.kind} policy carries no clusters; use kind='rank'")
         if self.kind == "knn":
@@ -505,6 +514,51 @@ class RoutingPolicy(BaseModel):
                         f"{len(cluster.centroid)}, embedder dim is {self.embedder.dim}"
                     )
         return self
+
+    def _check_compression(self) -> None:
+        """The two D-COMPRESS mount gates, applied wherever a policy is built or loaded.
+
+        1. SERVABILITY: every compressor this artifact names must exist and must attest append
+           stability (`servable_compressor`). Unknown ids and churny compressors fail here, at
+           mount, rather than on the first request mid-conversation.
+        2. REPRESENTATION CONSISTENCY: a policy that ROUTES on embeddings may only serve the
+           compression config its evidence was fitted under. A bank, its cluster centroids, and
+           its novelty floor are geometry in the space of the text the fit embedded; serving a
+           different representation against them was measured (C2 Q2) to trip the novelty floor
+           10-13x more often, collapse route-away, and raise cost 11-41% while accuracy sat flat
+           to negative. That is a silently BROKEN policy, not a degraded one, so it does not
+           mount. Static policies embed nothing and are exempt: there is no geometry to mismatch.
+
+        Per-cluster overrides are checked for servability only. They are fit and eval inputs
+        (`ClusterRanking.compression`); the serve-time stage reads the policy-level config,
+        because cluster assignment is not known until after routing.
+        """
+        servable_compressor(self.compression)
+        for cluster in self.clusters:
+            servable_compressor(cluster.compression)
+        if self.kind == "static" or same_compression(self.compression, self.fit_compression):
+            return
+        raise ValueError(
+            f"this {self.kind} policy's routing evidence was fitted on "
+            f"{compression_signature(self.fit_compression)}, but the endpoint would serve "
+            f"{compression_signature(self.compression)}. A routing bank and its novelty floor "
+            "are only valid for the representation they were fitted on. Refit under the serving "
+            "config (`wmo optimize route fit --compressor <id> --aggressiveness <a>`), or serve "
+            "the config the artifact was fitted under."
+        )
+
+    def serving_compressor(self) -> Compressor | None:
+        """The compressor the serving stage applies, or None when this endpoint compresses nothing.
+
+        Runs both mount gates again rather than trusting validation, for two reasons: the
+        cost/quality dial installs a NEW policy object on a live runtime
+        (`wmo.serving.chat.EndpointRuntime._install_policy`), so the compressor has to follow the
+        object requests actually read; and a policy assembled in memory through `model_copy`
+        never went through a validator at all, so this is the only place a hand-built mismatch
+        is caught before it serves traffic.
+        """
+        self._check_compression()
+        return servable_compressor(self.compression)
 
     def save(self, path: Path) -> None:
         """Write the policy artifact atomically (a torn policy.json must not be loadable)."""

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -1237,3 +1237,28 @@ def test_probe_rejects_an_embedder_that_returns_nothing(
         probe_embedder(
             EmbedderSpec(kind="azure", dim=3072, deployment="embed", endpoint="https://x")
         )
+def test_a_policy_stamped_with_an_unrunnable_compressor_version_does_not_mount() -> None:
+    # Requirement A at the version grain: same id, different implementation, different bytes.
+    with pytest.raises(ValidationError, match="fitted against version 99"):
+        RoutingPolicy(
+            kind="static",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            compression=CompressionConfig(compressor_id="truncate", compressor_version="99"),
+        )
+
+
+def test_a_per_cluster_override_is_version_checked_too(tmp_path: Path) -> None:
+    policy = _rank_policy()
+    clusters = [
+        policy.clusters[0].model_copy(
+            update={
+                "compression": CompressionConfig(compressor_id="truncate", compressor_version="99")
+            }
+        ),
+        *policy.clusters[1:],
+    ]
+    path = tmp_path / "policy.json"
+    policy.model_copy(update={"clusters": clusters}).save(path)
+    with pytest.raises(ValidationError, match="fitted against version 99"):
+        RoutingPolicy.load(path)

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.compression import (
+    CompressionConfig,
+    CompressionResult,
+    Compressor,
+    estimate_tokens,
+    register_compressor,
+)
 from wmo.optimize.policy import (
     AZURE_EMBEDDER_DEPLOYMENT,
     AZURE_EMBEDDER_DIM,
@@ -35,6 +41,38 @@ from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
 from wmo.providers.pool import PoolEntry
 from wmo.retrieval.embedders import HashingEmbedder
 from wmo.tracking.pricing import ModelPrice
+
+
+class _ChurnyCompressor:
+    """A compressor that admits it rewrites its own emitted prefix (C1's percentile family).
+
+    Registered by the requirement-B tests to prove the mount gate refuses it. It never runs: the
+    policy is rejected before a request can reach `compress`.
+    """
+
+    id = "churny-for-tests"
+    version = "1"
+    append_stable = False
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        raw = sum(estimate_tokens(segment) for segment in segments)
+        return CompressionResult(
+            segments=list(segments), tokens_in_raw=raw, tokens_in_compressed=raw, latency_s=0.0
+        )
+
+
+_CHURNY = _ChurnyCompressor()
+
+
+def _register_churny() -> str:
+    """Put the churny stand-in in the registry and hand back its id.
+
+    One shared instance: registration is idempotent for the same object but refuses to rebind an
+    id to a different one, so a fresh instance per test would be the rebinding it forbids.
+    """
+    register_compressor(_CHURNY)
+    return _CHURNY.id
 
 
 def _pool() -> list[PoolEntry]:
@@ -306,31 +344,32 @@ def test_pre_compression_policy_json_loads_with_compression_off(tmp_path: Path) 
     path = tmp_path / "policy.json"
     raw = policy.model_dump_json(indent=2)
     assert '"compression"' in raw  # sanity: the field serializes
+    dropped = ("compression", "fit_compression")
     stripped = {
-        key: value for key, value in policy.model_dump(mode="json").items() if key != "compression"
+        key: value for key, value in policy.model_dump(mode="json").items() if key not in dropped
     }
     stripped["clusters"] = [
-        {k: v for k, v in cluster.items() if k != "compression"} for cluster in stripped["clusters"]
+        {k: v for k, v in cluster.items() if k not in dropped} for cluster in stripped["clusters"]
     ]
     path.write_text(json.dumps(stripped), encoding="utf-8")
     loaded = RoutingPolicy.load(path)
     assert loaded.compression is None
+    assert loaded.fit_compression is None  # an old artifact reads as fitted on raw text
     assert all(cluster.compression is None for cluster in loaded.clusters)
 
 
 def test_policy_with_compression_round_trips(tmp_path: Path) -> None:
-    policy = _rank_policy()
-    policy = policy.model_copy(
-        update={
-            "compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
-        }
-    )
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    # Both halves: what the endpoint serves, and what its clusters were fitted under. A rank
+    # policy carrying only the first is the mismatch the next test rejects.
+    policy = _rank_policy().model_copy(update={"compression": config, "fit_compression": config})
     path = tmp_path / "policy.json"
     policy.save(path)
     loaded = RoutingPolicy.load(path)
     assert loaded.compression is not None
     assert loaded.compression.compressor_id == "truncate"
     assert loaded.compression.aggressiveness == 0.5
+    assert loaded.fit_compression == loaded.compression
 
 
 def test_policy_rejects_unknown_compressor_at_load() -> None:
@@ -342,6 +381,111 @@ def test_policy_rejects_unknown_compressor_at_load() -> None:
             pool=_pool(),
             compression=CompressionConfig(compressor_id="nope"),
         )
+
+
+# --- D-COMPRESS requirement A: representation consistency (C2 Q2) ---
+
+
+def test_routing_policy_refuses_to_serve_compression_it_was_not_fitted_under(
+    tmp_path: Path,
+) -> None:
+    # C2 Q2: compressed queries against a raw-fit bank sit farther from every row, so the
+    # novelty floor trips 10-13x more often and the router abstains to the expensive fallback
+    # (+11-41% cost, accuracy flat to negative). A broken policy, so it must not mount.
+    policy = _rank_policy().model_copy(
+        update={"compression": CompressionConfig(compressor_id="truncate")}
+    )
+    path = tmp_path / "policy.json"
+    policy.save(path)
+    with pytest.raises(ValidationError, match="fitted on raw text"):
+        RoutingPolicy.load(path)
+    # And the mount path refuses the same object even though model_copy skipped the validator.
+    with pytest.raises(ValueError, match="fitted on raw text"):
+        policy.serving_compressor()
+
+
+def test_a_compressed_fit_refuses_to_serve_raw_queries(tmp_path: Path) -> None:
+    # The inverse hole, and just as broken: a bank whose rows are compressed text cannot be
+    # queried with raw text either.
+    policy = _rank_policy().model_copy(
+        update={"fit_compression": CompressionConfig(compressor_id="truncate")}
+    )
+    path = tmp_path / "policy.json"
+    policy.save(path)
+    with pytest.raises(ValidationError, match="would serve raw text"):
+        RoutingPolicy.load(path)
+
+
+def test_a_mismatched_aggressiveness_is_a_mismatched_representation(tmp_path: Path) -> None:
+    # Same compressor, different level = different bytes = different geometry.
+    policy = _rank_policy().model_copy(
+        update={
+            "compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+            "fit_compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.25),
+        }
+    )
+    path = tmp_path / "policy.json"
+    policy.save(path)
+    with pytest.raises(ValidationError, match="aggressiveness 0.25"):
+        RoutingPolicy.load(path)
+
+
+def test_a_static_policy_may_compress_without_a_fit_stamp() -> None:
+    # A static policy embeds nothing, so it has no geometry to be inconsistent with. This is the
+    # path the demo endpoint and the seam walk use.
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+    )
+    assert policy.fit_compression is None
+    assert policy.serving_compressor() is not None
+
+
+# --- D-COMPRESS requirement B: append-stability attestation (C2 Q4) ---
+
+
+def test_a_churny_compressor_is_refused_at_mount() -> None:
+    # C2 Q4 measured churny full recompression at up to 2.65x the input cost of compressing
+    # NOTHING on cached providers. v1 has no turn-local-commit path, so it does not mount.
+    churny = _register_churny()
+    with pytest.raises(ValidationError, match="not attested append-stable"):
+        RoutingPolicy(
+            kind="static",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            compression=CompressionConfig(compressor_id=churny),
+        )
+
+
+def test_a_churny_per_cluster_override_is_refused_too(tmp_path: Path) -> None:
+    churny = _register_churny()
+    policy = _rank_policy()
+    clusters = [
+        policy.clusters[0].model_copy(
+            update={"compression": CompressionConfig(compressor_id=churny)}
+        ),
+        *policy.clusters[1:],
+    ]
+    path = tmp_path / "policy.json"
+    policy.model_copy(update={"clusters": clusters}).save(path)
+    with pytest.raises(ValidationError, match="not attested append-stable"):
+        RoutingPolicy.load(path)
+
+
+def test_an_unattested_compressor_cannot_be_registered() -> None:
+    class _Forgetful:
+        id = "forgetful"
+        version = "1"
+
+        def compress(
+            self, segments: list[str], config: CompressionConfig
+        ) -> CompressionResult:  # pragma: no cover - never reached
+            raise NotImplementedError
+
+    with pytest.raises(ValueError, match="does not declare `append_stable`"):
+        register_compressor(cast("Compressor", _Forgetful()))
 
 
 def test_azure_embedder_spec_requires_backend_fields() -> None:

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -1237,6 +1237,8 @@ def test_probe_rejects_an_embedder_that_returns_nothing(
         probe_embedder(
             EmbedderSpec(kind="azure", dim=3072, deployment="embed", endpoint="https://x")
         )
+
+
 def test_a_policy_stamped_with_an_unrunnable_compressor_version_does_not_mount() -> None:
     # Requirement A at the version grain: same id, different implementation, different bytes.
     with pytest.raises(ValidationError, match="fitted against version 99"):

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -307,9 +307,7 @@ def test_pre_compression_policy_json_loads_with_compression_off(tmp_path: Path) 
     raw = policy.model_dump_json(indent=2)
     assert '"compression"' in raw  # sanity: the field serializes
     stripped = {
-        key: value
-        for key, value in policy.model_dump(mode="json").items()
-        if key != "compression"
+        key: value for key, value in policy.model_dump(mode="json").items() if key != "compression"
     }
     stripped["clusters"] = [
         {k: v for k, v in cluster.items() if k != "compression"} for cluster in stripped["clusters"]

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.policy import (
     AZURE_EMBEDDER_DEPLOYMENT,
     AZURE_EMBEDDER_DIM,
@@ -296,6 +297,53 @@ def test_interleaved_bank_writes_do_not_share_a_staging_file(
     # The bank that renamed last is the one on disk, with ITS rewards, not the competitor's.
     assert np.array_equal(KnnBank.load(path).rewards, mine.rewards)
     assert [entry.name for entry in tmp_path.iterdir()] == ["bank.npz"]
+
+
+def test_pre_compression_policy_json_loads_with_compression_off(tmp_path: Path) -> None:
+    # The #259 additive-fields guarantee, pinned for D-COMPRESS: a policy.json written before
+    # the compression fields existed must load with compression defaulted to off everywhere.
+    policy = _rank_policy()
+    path = tmp_path / "policy.json"
+    raw = policy.model_dump_json(indent=2)
+    assert '"compression"' in raw  # sanity: the field serializes
+    stripped = {
+        key: value
+        for key, value in policy.model_dump(mode="json").items()
+        if key != "compression"
+    }
+    stripped["clusters"] = [
+        {k: v for k, v in cluster.items() if k != "compression"} for cluster in stripped["clusters"]
+    ]
+    path.write_text(json.dumps(stripped), encoding="utf-8")
+    loaded = RoutingPolicy.load(path)
+    assert loaded.compression is None
+    assert all(cluster.compression is None for cluster in loaded.clusters)
+
+
+def test_policy_with_compression_round_trips(tmp_path: Path) -> None:
+    policy = _rank_policy()
+    policy = policy.model_copy(
+        update={
+            "compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+        }
+    )
+    path = tmp_path / "policy.json"
+    policy.save(path)
+    loaded = RoutingPolicy.load(path)
+    assert loaded.compression is not None
+    assert loaded.compression.compressor_id == "truncate"
+    assert loaded.compression.aggressiveness == 0.5
+
+
+def test_policy_rejects_unknown_compressor_at_load() -> None:
+    # Fail at mount, not on the first request mid-conversation.
+    with pytest.raises(ValidationError, match="unknown compressor 'nope'"):
+        RoutingPolicy(
+            kind="static",
+            default_model="haiku-4-5",
+            pool=_pool(),
+            compression=CompressionConfig(compressor_id="nope"),
+        )
 
 
 def test_azure_embedder_spec_requires_backend_fields() -> None:

--- a/wmo/optimize/sweep.py
+++ b/wmo/optimize/sweep.py
@@ -34,6 +34,7 @@ from wmo.env.closed_loop import evaluate_pool
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.env.scenarios import Scenario, scenarios_from_traces, tools_hint_from_traces
 from wmo.ingest import get_adapter
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.providers.base import ProviderKind, TokenUsage
 from wmo.providers.pool import ModelPool, load_pool, prepare_pool_provider
@@ -123,6 +124,10 @@ class SweepPlan(BaseModel):
     # changes what the candidates are measured on, so two matrices swept at different values are
     # not comparable and the value has to travel with the run that produced them.
     history_chars: int = DEFAULT_HISTORY_CHARS
+    # The D-COMPRESS arm this sweep measures. Part of what the plan IS, not a detail of how it
+    # runs: it decides what the rewards MEAN, so two matrices swept under different compressors
+    # are different evidence, and a resumed run whose compressor changed must re-measure.
+    compression: CompressionConfig | None = None
     trace_count: int  # traces the corpus ingested, which is what decides `tiny_corpus`
     tiny_corpus: bool  # too small for a held-out band, so the scenarios are not leak-free
     assume_input_tokens: int
@@ -223,6 +228,7 @@ def plan_sweep(
     assume_input_tokens: int,
     assume_output_tokens: int,
     history_chars: int = DEFAULT_HISTORY_CHARS,
+    compression: CompressionConfig | None = None,
 ) -> SweepPlan:
     """Cut the held-out scenario set and project the spend, without touching the filesystem.
 
@@ -257,6 +263,7 @@ def plan_sweep(
         max_steps=max_steps,
         tools_hint=tools_hint_from_traces(train) or None,
         history_chars=history_chars,
+        compression=compression,
         trace_count=len(traces),
         tiny_corpus=tiny_corpus,
         assume_input_tokens=assume_input_tokens,
@@ -286,7 +293,15 @@ class SweepRun(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     matrix: OutcomeMatrix
+    # Candidate-side spend with the compressor's bill IN it. The D-COMPRESS accounting rule is
+    # that every savings number is effective cost per completed task, compressor inference cost
+    # and latency included, and `wmo.serving.savings` already sums both; a sweep reporting only
+    # the model half would be a second, quieter answer to the same question.
     candidate_usd: float
+    # The compressor's share of that total. Kept separately because it is the part the plan
+    # table cannot project, so the spend forecast has to divide it back out to stay like-for-like
+    # (see `wmo.optimize.pipeline.project_sweep_spend`).
+    compressor_usd: float = 0.0
     world_model_usage: RunRecord
     episodes_metered: int  # episodes whose world-model session reported usage
     episodes_unmetered: int  # episodes whose env exposed none (see `metering_gap`)
@@ -362,6 +377,7 @@ def execute_sweep(
                 tools_hint=plan.tools_hint,
                 history_chars=plan.history_chars,
                 on_outcome=on_outcome,
+                compression=plan.compression,
             )
     finally:
         # `evaluate_pool` can raise (a provider that fails to build, an env that does not score),
@@ -372,7 +388,10 @@ def execute_sweep(
     matrix.save(plan.out_path)
     return SweepRun(
         matrix=matrix,
-        candidate_usd=sum(outcome.cost_usd for outcome in matrix.outcomes),
+        candidate_usd=sum(
+            outcome.cost_usd + outcome.compressor_cost_usd for outcome in matrix.outcomes
+        ),
+        compressor_usd=sum(outcome.compressor_cost_usd for outcome in matrix.outcomes),
         world_model_usage=usage,
         episodes_metered=len(harvest.records),
         episodes_unmetered=harvest.unmetered,

--- a/wmo/optimize/sweep_test.py
+++ b/wmo/optimize/sweep_test.py
@@ -17,6 +17,7 @@ import pytest
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
 from wmo.ingest.otel_writer import write_traces_jsonl
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.reward import EpisodeScore
 from wmo.optimize.sweep import (
@@ -86,9 +87,15 @@ def _pool_file(tmp_path: Path) -> Path:
     return path
 
 
-def _plan(tmp_path: Path, **overrides: int) -> SweepPlan:
+def _plan(
+    tmp_path: Path,
+    *,
+    scenarios: int = 3,
+    episodes: int = 1,
+    max_steps: int = 4,
+    compression: CompressionConfig | None = None,
+) -> SweepPlan:
     model_dir = _model_dir(tmp_path)
-    settings = {"scenarios": 3, "episodes": 1, "max_steps": 4} | overrides
     return plan_sweep(
         model_dir=model_dir,
         config=resolve_config(model_dir),
@@ -97,7 +104,10 @@ def _plan(tmp_path: Path, **overrides: int) -> SweepPlan:
         traces_file=None,
         assume_input_tokens=2000,
         assume_output_tokens=250,
-        **settings,
+        scenarios=scenarios,
+        episodes=episodes,
+        max_steps=max_steps,
+        compression=compression,
     )
 
 

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -516,6 +516,16 @@ class RequestLogRecord(BaseModel):
     compressor_id: str = ""
     compressor_version: str = ""
     aggressiveness: float = 0.0
+    # The compressor's OWN bill and wall clock, named as on `ScenarioOutcome` so eval and
+    # serving rows read the same. Both are real money and real time the customer paid: the
+    # track's rule is that every savings number is cache-adjusted effective cost per completed
+    # task, compressor cost and latency INCLUDED, so a row that logged the token reduction
+    # without these would overstate the saving (see `wmo.serving.savings.compute_savings`).
+    compressor_cost_usd: float = 0.0
+    compressor_latency_s: float = 0.0
+    # Wall clock for the whole served request, compression stage included: the client waits for
+    # the compressor's round trip too, so excluding it would make compression read as
+    # latency-neutral no matter what it cost.
     latency_ms: float = 0.0
     ttfb_ms: float | None = None
     status: Literal["ok", "error"] = "ok"
@@ -1356,6 +1366,11 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 err_type="invalid_request_error",
                 code="invalid_messages",
             )
+        # Started BEFORE the compression stage, not after: the compressor's round trip is time
+        # the client spends waiting, so a clock that skipped it would report compression as
+        # latency-neutral however slow it was. `compressor_latency_s` breaks the stage out of
+        # this total for anyone who needs the split.
+        started = time.monotonic()
         try:
             # request -> [compress] -> [route]: the router embeds the compressed text below.
             provider_messages, compression = runtime.compress(request.messages)
@@ -1387,7 +1402,6 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             )
         completion_id = f"chatcmpl-{uuid.uuid4().hex}"
         created = int(time.time())
-        started = time.monotonic()
         # Written once per request, keyed by the id every log row for this call carries, so the
         # vector is stored exactly once no matter which path below reports the outcome.
         embedding_ref = runtime.record_query_embedding(completion_id, decision)
@@ -1425,6 +1439,8 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     compressor_id=compression.compressor_id if compression else "",
                     compressor_version=compression.compressor_version if compression else "",
                     aggressiveness=compression.aggressiveness if compression else 0.0,
+                    compressor_cost_usd=compression.cost_usd if compression else 0.0,
+                    compressor_latency_s=compression.latency_s if compression else 0.0,
                     latency_ms=(time.monotonic() - started) * 1000,
                     ttfb_ms=ttfb_ms,
                     status=status,

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -80,6 +80,7 @@ from wmo.optimize.compression import (
     CompressionConfig,
     CompressionStats,
     Compressor,
+    compress_segments,
     estimate_tokens,
     same_compression,
 )
@@ -954,11 +955,16 @@ def _compress_user_turns(
     and tool results are never touched. A tool payload is a structured contract the model has to
     read back exactly, so shortening it would change what the transcript MEANS, not just how
     long it is. Returns the rewritten messages plus the compressor's own cost.
+
+    Goes through `compress_segments`, which chunks to the compressor's declared cap and enforces
+    the return-shape contract. One request rarely carries enough user turns to need chunking,
+    but a replayed transcript has no bound on its length and a wrong-length return here would
+    otherwise desynchronize the whole conversation.
     """
     segments = [m.content for m in messages if m.role == "user"]
     if not segments:
         return list(messages), 0.0
-    result = compressor.compress(segments, config)
+    result = compress_segments(compressor, segments, config)
     replacements = iter(result.segments)
     rewritten = [
         m.model_copy(update={"content": next(replacements)}) if m.role == "user" else m
@@ -1449,6 +1455,9 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
         # latency-neutral however slow it was. `compressor_latency_s` breaks the stage out of
         # this total for anyone who needs the split.
         started = time.monotonic()
+        # Bound before the try so the failure path can report a compression stage that already
+        # RAN and already cost money before whatever failed next.
+        compression: CompressionStats | None = None
         try:
             # request -> [compress] -> [route]: the router embeds the compressed text below.
             provider_messages, compression = runtime.compress(request.messages)
@@ -1468,6 +1477,18 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     model="",
                     provider_model="",
                     routing_reason="error-before-routing",
+                    # A compressor that ran before the failure was PAID for, on real hardware.
+                    # Leaving these at zero would not be an omission, it would be a row
+                    # asserting that no compression happened, and the savings math reads these
+                    # rows. Still zero when the compression stage itself is what failed.
+                    tokens_in_raw=compression.tokens_in_raw if compression else 0,
+                    tokens_in_compressed=compression.tokens_in_compressed if compression else 0,
+                    compressor_id=compression.compressor_id if compression else "",
+                    compressor_version=compression.compressor_version if compression else "",
+                    aggressiveness=compression.aggressiveness if compression else 0.0,
+                    compressor_cost_usd=compression.cost_usd if compression else 0.0,
+                    compressor_latency_s=compression.latency_s if compression else 0.0,
+                    latency_ms=(time.monotonic() - started) * 1000,
                     status="error",
                     error_message=str(exc),
                 )

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -81,7 +81,6 @@ from wmo.optimize.compression import (
     CompressionStats,
     Compressor,
     estimate_tokens,
-    get_compressor,
 )
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
@@ -634,10 +633,11 @@ class EndpointRuntime:
         # fingerprint as _affinity: the affinity state decides compression segment boundaries.
         # Only populated when the policy carries a compression config.
         self._compressed: OrderedDict[str, list[ChatMessage]] = OrderedDict()
-        # Resolved at mount and re-resolved on every dial-driven policy install (policy
-        # validation already proved the id is known and servable), mirroring the embedder-once
-        # pattern: no per-request registry lookups.
-        self._compressor: Compressor | None = _resolve_compressor(policy.compression)
+        # Resolved at mount and re-resolved on every dial-driven policy install, mirroring the
+        # embedder-once pattern: no per-request registry lookups. Resolving through the policy
+        # re-runs the D-COMPRESS mount gates, so an artifact that was assembled in memory
+        # (`model_copy`, which skips validators) cannot serve an unservable compressor either.
+        self._compressor: Compressor | None = policy.serving_compressor()
         self._lock = threading.Lock()
         # Serializes dial changes end to end (persist + install); _lock alone only protects
         # the in-memory swap and would let two PUTs interleave file writes and installs.
@@ -683,7 +683,7 @@ class EndpointRuntime:
             # Keep the resolved compressor matched to the policy object requests will read;
             # apply_cost_quality carries `compression` through, but the invariant should not
             # depend on that staying true.
-            self._compressor = _resolve_compressor(adjusted.compression)
+            self._compressor = adjusted.serving_compressor()
             self._savings.clear()  # the dial changed, so the quality expectation did too
 
     def savings(self, window: SavingsWindow = "all_time") -> EndpointSavings:
@@ -852,11 +852,6 @@ class EndpointRuntime:
             with self._lock:
                 provider = self._providers.setdefault(pool_name, provider)
         return entry, provider
-
-
-def _resolve_compressor(config: CompressionConfig | None) -> Compressor | None:
-    """The compressor a policy's config names, or None when the policy compresses nothing."""
-    return None if config is None else get_compressor(config.compressor_id)
 
 
 def _compress_user_turns(

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -32,6 +32,17 @@ result as OpenAI SSE (one `choices[0].delta.tool_calls` entry per call, carrying
 client reassembles the arguments exactly as it would from real fragments; the tradeoff is
 time-to-first-byte, which waits for the whole upstream response instead of the first token.
 
+Compression stage (D-COMPRESS): when the policy carries a compression config, the pipeline is
+request -> [compress] -> [route] -> provider call. Only user-message content is compressed;
+system prompts, the model's own prior replies, tool calls, and tool results pass through
+verbatim (v1 scope: a tool payload is a structured contract, not prose to shorten). The affinity
+state decides segment boundaries: an incumbent conversation's compressed prefix is stored
+alongside its fingerprint and REUSED, never recompressed, so the provider-visible prefix stays
+byte-identical across turns (the prompt cache survives by construction). Routing embeds the
+compressed text (the router sees what the model sees) while stickiness keys on the raw
+transcript the client resends. Compression fields go to the request log only, never response
+bodies or headers.
+
 Request log: one JSONL row per call with the D-SERVING-LOG fields (id, ts, endpoint, routed
 model, cluster, tokens incl. cached, cache-adjusted cost, latency, ttfb, status, reason).
 Provider cache CONTROLS (breakpoint placement, TTL) are not exposed yet; they land with the
@@ -65,6 +76,13 @@ from llm_waterfall.types import ChatMessage as ProviderChatMessage
 from pydantic import BaseModel, Field, JsonValue, ValidationError, field_validator, model_validator
 from starlette.background import BackgroundTask
 
+from wmo.optimize.compression import (
+    CompressionConfig,
+    CompressionStats,
+    Compressor,
+    estimate_tokens,
+    get_compressor,
+)
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     CostQualityAnchor,
@@ -490,6 +508,15 @@ class RequestLogRecord(BaseModel):
     cached_tokens: int = 0  # cache-read prompt tokens (subset of input_tokens)
     cost_usd: float = 0.0  # effective cost: cached tokens billed at the cache-read rate
     router_cost_usd: float = 0.0  # the routing decision's own inference cost, passed through
+    # D-COMPRESS fields: stored and OPAQUE like the routing fields above (log only, never in
+    # response bodies or headers). 0/"" defaults = the request served uncompressed. Token
+    # counts are the compressor's deterministic proxy totals (see wmo.optimize.compression);
+    # billable truth stays in input_tokens/cost_usd from the provider-reported usage.
+    tokens_in_raw: int = 0
+    tokens_in_compressed: int = 0
+    compressor_id: str = ""
+    compressor_version: str = ""
+    aggressiveness: float = 0.0
     latency_ms: float = 0.0
     ttfb_ms: float | None = None
     status: Literal["ok", "error"] = "ok"
@@ -603,6 +630,14 @@ class EndpointRuntime:
         self._affinity: OrderedDict[str, str] = OrderedDict()
         # window -> (log revision the summary was computed at, the summary)
         self._savings: dict[SavingsWindow, tuple[int, EndpointSavings]] = {}
+        # Compressed provider-visible transcripts, keyed by the SAME remembered-prefix
+        # fingerprint as _affinity: the affinity state decides compression segment boundaries.
+        # Only populated when the policy carries a compression config.
+        self._compressed: OrderedDict[str, list[ChatMessage]] = OrderedDict()
+        # Resolved at mount and re-resolved on every dial-driven policy install (policy
+        # validation already proved the id is known and servable), mirroring the embedder-once
+        # pattern: no per-request registry lookups.
+        self._compressor: Compressor | None = _resolve_compressor(policy.compression)
         self._lock = threading.Lock()
         # Serializes dial changes end to end (persist + install); _lock alone only protects
         # the in-memory swap and would let two PUTs interleave file writes and installs.
@@ -645,6 +680,10 @@ class EndpointRuntime:
     def _install_policy(self, adjusted: RoutingPolicy) -> None:
         with self._lock:
             self.policy = adjusted
+            # Keep the resolved compressor matched to the policy object requests will read;
+            # apply_cost_quality carries `compression` through, but the invariant should not
+            # depend on that staying true.
+            self._compressor = _resolve_compressor(adjusted.compression)
             self._savings.clear()  # the dial changed, so the quality expectation did too
 
     def savings(self, window: SavingsWindow = "all_time") -> EndpointSavings:
@@ -677,13 +716,21 @@ class EndpointRuntime:
                     self._savings[window] = (revision, computed)
         return computed
 
-    def decide(self, messages: list[ChatMessage]) -> RoutingDecision:
+    def decide(
+        self, messages: list[ChatMessage], *, route_text: str | None = None
+    ) -> RoutingDecision:
+        """Route the request.
+
+        Stickiness keys on the RAW transcript the client resends; `route_text` (the compressed
+        routable text when compression is on) is what gets embedded, so the router scores
+        exactly what the model will see.
+        """
         incumbent = None
         remembered = _remembered_prefix(messages)
         if remembered is not None:
             with self._lock:
                 incumbent = self._affinity.get(_fingerprint(remembered))
-        text = _routable_text(messages)
+        text = route_text if route_text is not None else _routable_text(messages)
         return select_model(self.policy, text, incumbent=incumbent, embedder=self._embedder())
 
     def record_query_embedding(self, record_id: str, decision: RoutingDecision) -> str | None:
@@ -698,6 +745,45 @@ class EndpointRuntime:
         if self._embeddings is None or vector is None:
             return None
         return self._embeddings.append(record_id, vector)
+
+    def compress(
+        self, messages: list[ChatMessage]
+    ) -> tuple[list[ChatMessage], CompressionStats | None]:
+        """The [compress] stage: raw request messages -> provider-visible messages + stats.
+
+        Cache safety by construction: when the conversation's previous exchange is known
+        (affinity hit on the remembered raw prefix), the stored compressed prefix is returned
+        verbatim and only the turns appended since it pass through the compressor. On a miss
+        (new conversation, or affinity evicted) every user message is compressed fresh;
+        per-segment determinism makes that reproduce the same bytes, so the provider-visible
+        prefix stays append-only either way. Returns the input list untouched when compression
+        is off.
+        """
+        config = self.policy.compression
+        if config is None or self._compressor is None:
+            return messages, None
+        started = time.monotonic()
+        prefix: list[ChatMessage] | None = None
+        remembered = _remembered_prefix(messages)
+        if remembered is not None:
+            with self._lock:
+                prefix = self._compressed.get(_fingerprint(remembered))
+        if prefix is not None:
+            # The stored prefix has one entry per remembered message, so the tail is everything
+            # the client appended after the turn we already compressed.
+            tail, cost_usd = _compress_user_turns(messages[len(prefix) :], self._compressor, config)
+            compressed = [*prefix, *tail]
+        else:
+            compressed, cost_usd = _compress_user_turns(messages, self._compressor, config)
+        return compressed, CompressionStats(
+            compressor_id=self._compressor.id,
+            compressor_version=self._compressor.version,
+            aggressiveness=config.aggressiveness,
+            tokens_in_raw=sum(estimate_tokens(m.content) for m in messages),
+            tokens_in_compressed=sum(estimate_tokens(m.content) for m in compressed),
+            latency_s=time.monotonic() - started,
+            cost_usd=cost_usd,
+        )
 
     def _embedder(self) -> Embedder | None:
         """Build the policy's embedder once per runtime, not once per request.
@@ -721,13 +807,25 @@ class EndpointRuntime:
                 embedder = self._policy_embedder
         return embedder
 
-    def remember(self, messages: list[ChatMessage], reply: ChatMessage, model: str) -> None:
+    def remember(
+        self,
+        messages: list[ChatMessage],
+        reply: ChatMessage,
+        model: str,
+        *,
+        compressed: list[ChatMessage] | None = None,
+    ) -> None:
         """Record the finished exchange so the conversation's next request finds its incumbent.
 
         `reply` is the whole assistant turn, not just its text: a tool-calling turn carries
         empty content plus `tool_calls`, and the client replays it verbatim, so remembering the
         text alone would fingerprint a transcript that is never sent again and drop affinity at
         the first tool call.
+
+        `messages` must be the RAW request messages (the client resends that transcript, so the
+        fingerprint must match it). `compressed` is the provider-visible transcript when
+        compression ran; stored under the same key so the next turn reuses the exact bytes the
+        provider's prompt cache was written with.
         """
         transcript = [*messages, reply]
         key = _fingerprint(transcript)
@@ -736,6 +834,11 @@ class EndpointRuntime:
             self._affinity.move_to_end(key)
             while len(self._affinity) > _AFFINITY_CAPACITY:
                 self._affinity.popitem(last=False)
+            if compressed is not None:
+                self._compressed[key] = [*compressed, reply]
+                self._compressed.move_to_end(key)
+                while len(self._compressed) > _AFFINITY_CAPACITY:
+                    self._compressed.popitem(last=False)
 
     def provider_for(self, pool_name: str) -> tuple[PoolEntry, Provider]:
         entry = next(e for e in self.policy.pool if e.name == pool_name)
@@ -749,6 +852,33 @@ class EndpointRuntime:
             with self._lock:
                 provider = self._providers.setdefault(pool_name, provider)
         return entry, provider
+
+
+def _resolve_compressor(config: CompressionConfig | None) -> Compressor | None:
+    """The compressor a policy's config names, or None when the policy compresses nothing."""
+    return None if config is None else get_compressor(config.compressor_id)
+
+
+def _compress_user_turns(
+    messages: list[ChatMessage], compressor: Compressor, config: CompressionConfig
+) -> tuple[list[ChatMessage], float]:
+    """Rewrite user-turn content through the compressor; every other turn passes through.
+
+    v1 scope: system prompts (the most cacheable segment), the model's own replies, tool calls,
+    and tool results are never touched. A tool payload is a structured contract the model has to
+    read back exactly, so shortening it would change what the transcript MEANS, not just how
+    long it is. Returns the rewritten messages plus the compressor's own cost.
+    """
+    segments = [m.content for m in messages if m.role == "user"]
+    if not segments:
+        return list(messages), 0.0
+    result = compressor.compress(segments, config)
+    replacements = iter(result.segments)
+    rewritten = [
+        m.model_copy(update={"content": next(replacements)}) if m.role == "user" else m
+        for m in messages
+    ]
+    return rewritten, result.cost_usd
 
 
 def _remembered_prefix(messages: list[ChatMessage]) -> list[ChatMessage] | None:
@@ -838,8 +968,12 @@ def _split_for_provider(messages: list[ChatMessage]) -> tuple[str, list[Message]
     return "\n\n".join(system_parts), turns
 
 
-def _provider_request(request: ChatCompletionRequest) -> ChatRequest:
+def _provider_request(request: ChatCompletionRequest, messages: list[ChatMessage]) -> ChatRequest:
     """The structured request for a tool-bearing call, for `ToolCallingProvider.complete_chat`.
+
+    `messages` is the provider-visible transcript, which is `request.messages` unless the
+    compression stage rewrote it (tool calls and tool results ride through either way; only
+    user-turn text is ever compressed).
 
     System turns stay INLINE here, unlike `_split_for_provider`: `complete_chat` takes the whole
     OpenAI-shaped transcript and each backend re-splits it for its own wire format (Bedrock
@@ -860,7 +994,7 @@ def _provider_request(request: ChatCompletionRequest) -> ChatRequest:
     sent it, so a pool entry whose backend rejects the field never sees it unasked.
     """
     provider_request = ChatRequest(
-        messages=[m.for_provider() for m in request.messages],
+        messages=[m.for_provider() for m in messages],
         tools=request.tools,
         tool_choice=request.tool_choice if request.tools else None,
         temperature=request.temperature,
@@ -1225,7 +1359,11 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 code="invalid_messages",
             )
         try:
-            decision = runtime.decide(request.messages)
+            # request -> [compress] -> [route]: the router embeds the compressed text below.
+            provider_messages, compression = runtime.compress(request.messages)
+            decision = runtime.decide(
+                request.messages, route_text=_routable_text(provider_messages)
+            )
             entry, provider = runtime.provider_for(decision.model)
         except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502 + log row
             # The likeliest production failure: an unset api_key_env or a failing embed call.
@@ -1284,6 +1422,11 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     output_tokens=usage.output_tokens,
                     cached_tokens=usage.cached_input_tokens,
                     cost_usd=entry.cost_usd(usage),
+                    tokens_in_raw=compression.tokens_in_raw if compression else 0,
+                    tokens_in_compressed=compression.tokens_in_compressed if compression else 0,
+                    compressor_id=compression.compressor_id if compression else "",
+                    compressor_version=compression.compressor_version if compression else "",
+                    aggressiveness=compression.aggressiveness if compression else 0.0,
                     latency_ms=(time.monotonic() - started) * 1000,
                     ttfb_ms=ttfb_ms,
                     status=status,
@@ -1314,7 +1457,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             # usage loss the abandoned-stream path exists to prevent (D-METERING).
             usage = TokenUsage()
             try:
-                structured = provider.complete_chat(_provider_request(request))
+                structured = provider.complete_chat(_provider_request(request, provider_messages))
                 usage = _structured_usage(structured)
                 if not structured.choices:
                     # Content filtering (and some provider error modes) return zero choices.
@@ -1334,7 +1477,12 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     err_type="api_error",
                     code="upstream_error",
                 )
-            runtime.remember(request.messages, reply, decision.model)
+            runtime.remember(
+                request.messages,
+                reply,
+                decision.model,
+                compressed=provider_messages if compression else None,
+            )
             if not request.stream:
                 _record(usage, ttfb_ms=None)
                 return Response(
@@ -1400,7 +1548,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 headers={**headers, "Cache-Control": "no-cache"},
             )
 
-        system, turns = _split_for_provider(request.messages)
+        system, turns = _split_for_provider(provider_messages)
         if not request.stream:
             try:
                 completion = provider.complete(
@@ -1424,6 +1572,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 request.messages,
                 ChatMessage(role="assistant", content=completion.text),
                 decision.model,
+                compressed=provider_messages if compression else None,
             )
             _record(completion.usage, ttfb_ms=None)
             return Response(
@@ -1531,6 +1680,7 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 request.messages,
                 ChatMessage(role="assistant", content="".join(parts)),
                 decision.model,
+                compressed=provider_messages if compression else None,
             )
             stream_state["recorded"] = True
             _record(usage, ttfb_ms=ttfb_ms)

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -81,6 +81,7 @@ from wmo.optimize.compression import (
     CompressionStats,
     Compressor,
     estimate_tokens,
+    same_compression,
 )
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
@@ -118,6 +119,15 @@ logger = logging.getLogger(__name__)
 # Finished-exchange fingerprints remembered per endpoint for conversation affinity. Bounded so
 # a long-running server cannot grow without limit; least-recently-used conversations re-route.
 _AFFINITY_CAPACITY = 4096
+
+# The compressed-transcript cache is bounded by BYTES, not by entry count. An affinity entry is
+# a fingerprint and a model name (tens of bytes, so 4096 of them is nothing), but a compressed
+# transcript is the conversation itself: a measured 40-turn conversation runs about 99KB, and
+# tool results push that much higher, so reusing the count cap would allow 0.41GB of ordinary
+# traffic and multiple GB of tool-heavy traffic. 64MB holds roughly 650 conversations of that
+# measured size, which is far more than the affinity map keeps anyway, and costs a fixed,
+# statable amount of memory per endpoint instead of an unbounded one.
+_COMPRESSED_CAPACITY_BYTES = 64 * 1024 * 1024
 
 
 ChatRole = Literal["system", "user", "assistant", "tool"]
@@ -641,8 +651,11 @@ class EndpointRuntime:
         self._savings: dict[SavingsWindow, tuple[int, EndpointSavings]] = {}
         # Compressed provider-visible transcripts, keyed by the SAME remembered-prefix
         # fingerprint as _affinity: the affinity state decides compression segment boundaries.
-        # Only populated when the policy carries a compression config.
-        self._compressed: OrderedDict[str, list[ChatMessage]] = OrderedDict()
+        # Only populated when the policy carries a compression config. Bounded by BYTES
+        # (_COMPRESSED_CAPACITY_BYTES), so the value is (transcript, its measured size) and
+        # `_compressed_bytes` is their running sum.
+        self._compressed: OrderedDict[str, tuple[list[ChatMessage], int]] = OrderedDict()
+        self._compressed_bytes = 0
         # Resolved at mount and re-resolved on every dial-driven policy install, mirroring the
         # embedder-once pattern: no per-request registry lookups. Resolving through the policy
         # re-runs the D-COMPRESS mount gates, so an artifact that was assembled in memory
@@ -688,13 +701,34 @@ class EndpointRuntime:
             self._install_policy(adjusted)
 
     def _install_policy(self, adjusted: RoutingPolicy) -> None:
+        # Resolved OUTSIDE the lock and before the swap: it re-runs the D-COMPRESS mount gates,
+        # and a policy that fails them must leave the live endpoint exactly as it was rather
+        # than half-installed.
+        compressor = adjusted.serving_compressor()
         with self._lock:
+            stale = not same_compression(self.policy.compression, adjusted.compression)
             self.policy = adjusted
             # Keep the resolved compressor matched to the policy object requests will read;
             # apply_cost_quality carries `compression` through, but the invariant should not
             # depend on that staying true.
-            self._compressor = adjusted.serving_compressor()
+            self._compressor = compressor
+            if stale:
+                # Every stored prefix was produced by the OUTGOING config, so reusing one would
+                # hand the provider a transcript that is half one compression config and half
+                # another. Today's dial carries `compression` through unchanged and this never
+                # fires; it exists so that a dial which ever does vary compression cannot serve
+                # a spliced transcript.
+                self._clear_compressed()
             self._savings.clear()  # the dial changed, so the quality expectation did too
+
+    def _clear_compressed(self) -> None:
+        """Drop every stored compressed transcript. Caller holds `_lock`.
+
+        The map and its running byte total are one piece of state; clearing them apart is how a
+        byte-bounded cache starts evicting for memory it is no longer holding.
+        """
+        self._compressed.clear()
+        self._compressed_bytes = 0
 
     def savings(self, window: SavingsWindow = "all_time") -> EndpointSavings:
         """What this endpoint has saved so far (see `wmo.serving.savings`).
@@ -772,25 +806,36 @@ class EndpointRuntime:
         At most ONE compressor call per request, carrying every segment that needs compressing:
         an endpoint-backed compressor pays one round trip per request, not one per message.
         """
-        config = self.policy.compression
-        if config is None or self._compressor is None:
+        # One snapshot, one lock: `_install_policy` swaps the policy and its compressor together
+        # under this lock, so reading them in two unsynchronized statements could pair a new
+        # config with the previous implementation. Harmless while both dial positions share a
+        # compressor, silently wrong the moment they do not.
+        with self._lock:
+            policy = self.policy
+            compressor = self._compressor
+        config = policy.compression
+        if config is None or compressor is None:
             return messages, None
         started = time.monotonic()
         prefix: list[ChatMessage] | None = None
         remembered = _remembered_prefix(messages)
         if remembered is not None:
+            key = _fingerprint(remembered)
             with self._lock:
-                prefix = self._compressed.get(_fingerprint(remembered))
+                cached = self._compressed.get(key)
+                if cached is not None:
+                    self._compressed.move_to_end(key)  # LRU is by USE, not just by write
+                    prefix = cached[0]
         if prefix is not None:
             # The stored prefix has one entry per remembered message, so the tail is everything
             # the client appended after the turn we already compressed.
-            tail, cost_usd = _compress_user_turns(messages[len(prefix) :], self._compressor, config)
+            tail, cost_usd = _compress_user_turns(messages[len(prefix) :], compressor, config)
             compressed = [*prefix, *tail]
         else:
-            compressed, cost_usd = _compress_user_turns(messages, self._compressor, config)
+            compressed, cost_usd = _compress_user_turns(messages, compressor, config)
         return compressed, CompressionStats(
-            compressor_id=self._compressor.id,
-            compressor_version=self._compressor.version,
+            compressor_id=compressor.id,
+            compressor_version=compressor.version,
             aggressiveness=config.aggressiveness,
             tokens_in_raw=sum(estimate_tokens(m.content) for m in messages),
             tokens_in_compressed=sum(estimate_tokens(m.content) for m in compressed),
@@ -839,6 +884,13 @@ class EndpointRuntime:
         fingerprint must match it). `compressed` is the provider-visible transcript when
         compression ran; stored under the same key so the next turn reuses the exact bytes the
         provider's prompt cache was written with.
+
+        The two caches are bounded independently (entries for affinity, bytes for transcripts),
+        so they can disagree about which conversations they remember. Both directions of
+        disagreement are safe: a compressed prefix evicted while its affinity entry survives
+        falls back to full recompression, which per-segment determinism makes byte-identical,
+        and an affinity entry evicted while its prefix survives simply re-routes while still
+        reusing the exact bytes that fingerprint was stored with.
         """
         transcript = [*messages, reply]
         key = _fingerprint(transcript)
@@ -848,10 +900,16 @@ class EndpointRuntime:
             while len(self._affinity) > _AFFINITY_CAPACITY:
                 self._affinity.popitem(last=False)
             if compressed is not None:
-                self._compressed[key] = [*compressed, reply]
-                self._compressed.move_to_end(key)
-                while len(self._compressed) > _AFFINITY_CAPACITY:
-                    self._compressed.popitem(last=False)
+                transcript = [*compressed, reply]
+                previous = self._compressed.pop(key, None)
+                if previous is not None:
+                    self._compressed_bytes -= previous[1]
+                size = _transcript_bytes(transcript)
+                self._compressed[key] = (transcript, size)
+                self._compressed_bytes += size
+                while self._compressed and self._compressed_bytes > _COMPRESSED_CAPACITY_BYTES:
+                    _, (_, evicted) = self._compressed.popitem(last=False)
+                    self._compressed_bytes -= evicted
 
     def provider_for(self, pool_name: str) -> tuple[PoolEntry, Provider]:
         entry = next(e for e in self.policy.pool if e.name == pool_name)
@@ -865,6 +923,26 @@ class EndpointRuntime:
             with self._lock:
                 provider = self._providers.setdefault(pool_name, provider)
         return entry, provider
+
+
+def _transcript_bytes(messages: list[ChatMessage]) -> int:
+    """Roughly what one stored transcript costs in memory, for the byte-bounded cache.
+
+    Sums the UTF-8 length of everything that varies with conversation size: message content,
+    tool-call ids/names/arguments, and tool_call_id. Tool arguments and results are counted
+    because they are where transcripts actually get large. It is an estimate, not an allocator
+    figure (it ignores per-object overhead, which is roughly constant per message), and it is
+    used only to decide when to evict.
+    """
+    total = 0
+    for message in messages:
+        total += len(message.content.encode("utf-8")) + len(message.role)
+        if message.tool_call_id is not None:
+            total += len(message.tool_call_id)
+        for call in message.tool_calls or ():
+            total += len(call.id) + len(call.function.name)
+            total += len(call.function.arguments.encode("utf-8"))
+    return total
 
 
 def _compress_user_turns(

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -758,6 +758,9 @@ class EndpointRuntime:
         per-segment determinism makes that reproduce the same bytes, so the provider-visible
         prefix stays append-only either way. Returns the input list untouched when compression
         is off.
+
+        At most ONE compressor call per request, carrying every segment that needs compressing:
+        an endpoint-backed compressor pays one round trip per request, not one per message.
         """
         config = self.policy.compression
         if config is None or self._compressor is None:

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -24,7 +24,13 @@ from llm_waterfall.types import (
 )
 
 from wmo.core.types import JsonObject
-from wmo.optimize.compression import CompressionConfig, CompressionResult, Compressor
+from wmo.optimize.compression import (
+    CompressionConfig,
+    CompressionResult,
+    Compressor,
+    get_compressor,
+    register_compressor,
+)
 from wmo.optimize.policy import (
     KNN_BANK_FILENAME,
     POLICY_FILENAME,
@@ -2648,3 +2654,91 @@ def test_the_stage_makes_one_compressor_call_per_request(tmp_path: Path) -> None
     assert response.status_code == 200
     # One call (a cold transcript: no affinity to reuse), carrying BOTH user turns.
     assert spy.calls == [["first user turn here", "second user turn here"]]
+
+
+class _PricedCompressor:
+    """A compressor with a real bill and a real wall clock, so the log fields have something
+    non-zero to carry."""
+
+    id = "priced-for-tests"
+    version = "1"
+    append_stable = True
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        time.sleep(0.02)  # a stand-in for the endpoint round trip
+        inner = get_compressor("truncate").compress(segments, config)
+        return inner.model_copy(update={"cost_usd": 0.00054})
+
+
+_PRICED = _PricedCompressor()
+
+
+def test_the_compressors_bill_and_wall_clock_reach_the_log(tmp_path: Path) -> None:
+    # They were computed and then dropped at the log boundary, which left savings crediting the
+    # token reduction without ever subtracting what the reduction cost.
+    register_compressor(_PRICED)
+    config = CompressionConfig(compressor_id=_PRICED.id, aggressiveness=0.5)
+    client, log_path, _, _ = _compressed_runtime(tmp_path, config)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    )
+
+    assert response.status_code == 200
+    row = _rows(log_path)[-1]
+    assert row["compressor_cost_usd"] == pytest.approx(0.00054)
+    assert cast("float", row["compressor_latency_s"]) >= 0.02
+    # And the request's own clock SPANS the compression stage rather than starting after it.
+    assert cast("float", row["latency_ms"]) >= 20.0
+
+
+def test_an_uncompressed_row_carries_no_compressor_bill(tmp_path: Path) -> None:
+    client, log_path = _client(tmp_path)
+    client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    row = _rows(log_path)[-1]
+    assert row["compressor_cost_usd"] == 0.0
+    assert row["compressor_latency_s"] == 0.0
+
+
+def test_the_compressor_bill_reaches_the_log_on_the_error_path_too(tmp_path: Path) -> None:
+    # The compressor was paid even though the provider call failed, so the row must say so.
+    register_compressor(_PRICED)
+
+    class _FailingProvider(_EchoProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            raise RuntimeError("upstream on fire")
+
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id=_PRICED.id, aggressiveness=0.5),
+    )
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=_FailingProvider, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    )
+    assert response.status_code == 502
+    row = _rows(log_path)[-1]
+    assert row["status"] == "error"
+    assert row["compressor_cost_usd"] == pytest.approx(0.00054)

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -50,6 +50,7 @@ from wmo.providers.base import (
 from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
 from wmo.providers.pool import PoolEntry, load_pool
 from wmo.retrieval.embedders import HashingEmbedder
+from wmo.serving import chat as chat_module
 from wmo.serving.chat import ChatMessage as EndpointMessage
 from wmo.serving.chat import (
     EndpointRuntime,
@@ -2463,7 +2464,7 @@ def test_lost_affinity_recompression_is_byte_identical(tmp_path: Path) -> None:
 
     with runtime._lock:
         runtime._affinity.clear()
-        runtime._compressed.clear()
+        runtime._clear_compressed()
 
     second = client.post(
         "/v1/chat/completions",
@@ -2742,3 +2743,84 @@ def test_the_compressor_bill_reaches_the_log_on_the_error_path_too(tmp_path: Pat
     row = _rows(log_path)[-1]
     assert row["status"] == "error"
     assert row["compressor_cost_usd"] == pytest.approx(0.00054)
+
+
+def _one_exchange(client: TestClient, content: str) -> None:
+    """Drive one full request so the runtime remembers a compressed transcript for it."""
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": content}]},
+    )
+    assert response.status_code == 200
+
+
+def test_the_compressed_cache_is_bounded_by_bytes_not_by_entry_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A compressed transcript is the whole conversation, not a fingerprint: at the affinity
+    # map's 4096-entry cap, measured 99KB conversations would be 0.41GB and tool-heavy ones
+    # multiple GB. The cap is therefore in bytes, and the running total tracks the map.
+    monkeypatch.setattr(chat_module, "_COMPRESSED_CAPACITY_BYTES", 2_000)
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.0)
+    client, _, runtime, _ = _compressed_runtime(tmp_path, config)
+
+    for index in range(12):
+        _one_exchange(client, f"conversation {index} " + "padding word " * 40)
+
+    with runtime._lock:
+        stored = len(runtime._compressed)
+        total = runtime._compressed_bytes
+        measured = sum(size for _, size in runtime._compressed.values())
+    assert 0 < stored < 12  # older conversations were evicted, newer ones kept
+    assert total <= 2_000  # the bound actually binds
+    assert total == measured  # the running total never drifts from what is held
+
+
+def test_the_byte_total_is_repaired_when_a_conversation_is_re_remembered(tmp_path: Path) -> None:
+    # remember() overwrites a key on each turn of the same conversation. Without subtracting the
+    # previous size first, the total would climb forever and start evicting live entries.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.0)
+    client, _, runtime, _ = _compressed_runtime(tmp_path, config)
+    _one_exchange(client, "alpha beta gamma delta")
+    with runtime._lock:
+        after_first = runtime._compressed_bytes
+        measured_first = sum(size for _, size in runtime._compressed.values())
+    _one_exchange(client, "alpha beta gamma delta")  # the identical request again
+    with runtime._lock:
+        assert runtime._compressed_bytes == after_first == measured_first
+        assert runtime._compressed_bytes == sum(size for _, size in runtime._compressed.values())
+
+
+def test_installing_a_different_compression_config_drops_stale_prefixes(tmp_path: Path) -> None:
+    # A stored prefix carries the OUTGOING config's bytes. Reusing one after the config changed
+    # would hand the provider a transcript that is half one compression config and half another.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, _, runtime, _ = _compressed_runtime(tmp_path, config)
+    _one_exchange(client, "alpha beta gamma delta epsilon zeta")
+    with runtime._lock:
+        assert runtime._compressed  # there is something to go stale
+
+    runtime._install_policy(
+        runtime.policy.model_copy(
+            update={"compression": CompressionConfig(compressor_id="identity")}
+        )
+    )
+
+    with runtime._lock:
+        assert not runtime._compressed
+        assert runtime._compressed_bytes == 0
+
+
+def test_installing_the_same_compression_config_keeps_the_prefixes(tmp_path: Path) -> None:
+    # The dial's actual behavior today: it carries `compression` through unchanged, and a dial
+    # move must not throw away every warm prefix (and with it the provider's prompt cache).
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, _, runtime, _ = _compressed_runtime(tmp_path, config)
+    _one_exchange(client, "alpha beta gamma delta epsilon zeta")
+    with runtime._lock:
+        before = dict(runtime._compressed)
+
+    runtime._install_policy(runtime.policy.model_copy(update={"guard_margin": 0.01}))
+
+    with runtime._lock:
+        assert dict(runtime._compressed) == before

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2622,3 +2622,29 @@ def test_mounting_a_mismatched_compression_artifact_fails_loudly(tmp_path: Path)
             provider_factory=_EchoProvider,
             log=RequestLog(tmp_path / "requests.jsonl"),
         )
+
+
+def test_the_stage_makes_one_compressor_call_per_request(tmp_path: Path) -> None:
+    # Round trip dominates for an endpoint-backed compressor, so the stage must hand over a
+    # request's whole segment set in ONE call rather than one call per message.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, _, runtime, _ = _compressed_runtime(tmp_path, config)
+    spy = _SpyCompressor(cast("Compressor", runtime._compressor))
+    runtime._compressor = spy
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "system", "content": "never compressed"},
+                {"role": "user", "content": "first user turn here"},
+                {"role": "assistant", "content": "an earlier reply"},
+                {"role": "user", "content": "second user turn here"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    # One call (a cold transcript: no affinity to reuse), carrying BOTH user turns.
+    assert spy.calls == [["first user turn here", "second user turn here"]]

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -24,6 +24,7 @@ from llm_waterfall.types import (
 )
 
 from wmo.core.types import JsonObject
+from wmo.optimize.compression import CompressionConfig, CompressionResult, Compressor
 from wmo.optimize.policy import (
     KNN_BANK_FILENAME,
     POLICY_FILENAME,
@@ -2273,3 +2274,329 @@ def test_query_embedding_logging_can_be_switched_off(tmp_path: Path) -> None:
     assert row["query_embedding_ref"] is None
     assert row["propensity"] is not None
     assert not (tmp_path / QUERY_EMBEDDING_FILENAME).exists()
+
+
+# --- D-COMPRESS: the serving compression stage ---
+
+
+class _CapturingProvider(_EchoProvider):
+    """Echo provider that also records every (system, messages) it was asked to serve."""
+
+    def __init__(self, entry: PoolEntry) -> None:
+        super().__init__(entry)
+        self.seen: list[tuple[str, list[Message]]] = []
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.seen.append((system, list(messages)))
+        return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Iterator[StreamChunk]:
+        self.seen.append((system, list(messages)))
+        yield from super().stream(system, messages, temperature=temperature, max_tokens=max_tokens)
+
+
+def _app_for(runtime: EndpointRuntime) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    return app
+
+
+def _compressed_runtime(
+    tmp_path: Path, compression: CompressionConfig | None
+) -> tuple[TestClient, Path, EndpointRuntime, dict[str, _CapturingProvider]]:
+    providers: dict[str, _CapturingProvider] = {}
+
+    def factory(entry: PoolEntry) -> _CapturingProvider:
+        provider = _CapturingProvider(entry)
+        providers[entry.name] = provider
+        return provider
+
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static", default_model="haiku-4-5", pool=_pool(), compression=compression
+    )
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=factory, log=RequestLog(log_path)
+    )
+    return TestClient(_app_for(runtime)), log_path, runtime, providers
+
+
+def test_identity_compression_serves_bit_for_bit(tmp_path: Path) -> None:
+    # The seam's do-no-harm proof: identity compression and no compression hand the provider
+    # byte-identical (system, turns), and the log accounts raw == compressed.
+    body = {
+        "model": "tau-bench",
+        "messages": [
+            {"role": "system", "content": "be  terse\twith   spacing"},
+            {"role": "user", "content": "  what is 2+2?  keep my  spacing "},
+        ],
+    }
+    client_off, _, _, providers_off = _compressed_runtime(tmp_path / "off", None)
+    client_off.post("/v1/chat/completions", json=body)
+    identity = CompressionConfig(compressor_id="identity", aggressiveness=1.0)
+    client_on, log_path, _, providers_on = _compressed_runtime(tmp_path / "on", identity)
+    response = client_on.post("/v1/chat/completions", json=body)
+
+    assert response.status_code == 200
+    assert providers_on["haiku-4-5"].seen == providers_off["haiku-4-5"].seen
+    row = _rows(log_path)[-1]
+    assert row["compressor_id"] == "identity"
+    assert row["tokens_in_raw"] == row["tokens_in_compressed"]
+    assert cast("int", row["tokens_in_raw"]) > 0
+
+
+def test_truncate_compresses_what_the_provider_sees(tmp_path: Path) -> None:
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, log_path, _, providers = _compressed_runtime(tmp_path, config)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "system", "content": "system prompts are never compressed"},
+                {"role": "user", "content": "one two three four five six seven eight"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    system, turns = providers["haiku-4-5"].seen[0]
+    assert system == "system prompts are never compressed"  # verbatim
+    assert turns[0].content == "one two three four"  # trailing half dropped
+    row = _rows(log_path)[-1]
+    assert row["compressor_id"] == "truncate"
+    assert row["compressor_version"] == "1"
+    assert row["aggressiveness"] == 0.5
+    assert cast("int", row["tokens_in_compressed"]) < cast("int", row["tokens_in_raw"])
+    # OPAQUE: compression never surfaces in the response body or headers.
+    assert "compress" not in response.text
+    assert not any("compress" in key.lower() for key in response.headers)
+
+
+class _SpyCompressor:
+    """Delegates to the real compressor, recording which segments it was handed."""
+
+    def __init__(self, inner: Compressor) -> None:
+        self.inner = inner
+        self.id = inner.id
+        self.version = inner.version
+        self.calls: list[list[str]] = []
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        self.calls.append(list(segments))
+        return self.inner.compress(segments, config)
+
+
+def test_incumbent_prefix_is_reused_not_recompressed(tmp_path: Path) -> None:
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, _, runtime, providers = _compressed_runtime(tmp_path, config)
+    spy = _SpyCompressor(cast("Compressor", runtime._compressor))
+    runtime._compressor = spy
+
+    first_user = "alpha beta gamma delta epsilon zeta"
+    first = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": first_user}]},
+    )
+    reply = first.json()["choices"][0]["message"]["content"]
+    turn_one = list(providers["haiku-4-5"].seen[0][1])
+
+    second = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": first_user},
+                {"role": "assistant", "content": reply},
+                {"role": "user", "content": "eta theta iota kappa"},
+            ],
+        },
+    )
+
+    assert second.status_code == 200
+    # The compressor only ever saw the turn-local segment on turn two: the cached prefix was
+    # RETRIEVED from the affinity state, not recompressed.
+    assert spy.calls == [[first_user], ["eta theta iota kappa"]]
+    # And the provider-visible prefix is byte-identical across turns (prompt cache survives).
+    second_turns = providers["haiku-4-5"].seen[1][1]
+    assert [(m.role, m.content) for m in second_turns[: len(turn_one)]] == [
+        (m.role, m.content) for m in turn_one
+    ]
+    assert second_turns[0].content == "alpha beta gamma"  # compressed once, reused verbatim
+    assert second_turns[1].content == reply  # the model's own reply is never compressed
+    assert second_turns[2].content == "eta theta"
+
+
+def test_lost_affinity_recompression_is_byte_identical(tmp_path: Path) -> None:
+    # Affinity eviction must not break the provider-visible prefix: per-segment determinism
+    # reproduces the same bytes when the whole transcript is recompressed from scratch.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, _, runtime, providers = _compressed_runtime(tmp_path, config)
+    first_user = "alpha beta gamma delta epsilon zeta"
+    first = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": first_user}]},
+    )
+    reply = first.json()["choices"][0]["message"]["content"]
+    turn_one = providers["haiku-4-5"].seen[0][1]
+
+    with runtime._lock:
+        runtime._affinity.clear()
+        runtime._compressed.clear()
+
+    second = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": first_user},
+                {"role": "assistant", "content": reply},
+                {"role": "user", "content": "eta theta iota kappa"},
+            ],
+        },
+    )
+    assert second.status_code == 200
+    second_turns = providers["haiku-4-5"].seen[1][1]
+    assert [(m.role, m.content) for m in second_turns[: len(turn_one) + 1]] == [
+        *[(m.role, m.content) for m in turn_one],
+        ("assistant", reply),
+    ]
+
+
+def test_compression_fields_populate_on_stream_path(tmp_path: Path) -> None:
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    client, log_path, _, providers = _compressed_runtime(tmp_path, config)
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "stream": True,
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    ) as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+    assert "[DONE]" in body
+    assert "compress" not in body  # opaque on the stream too
+    _, turns = providers["haiku-4-5"].seen[0]
+    assert turns[0].content == "one two three"
+    rows = _rows(log_path)
+    assert len(rows) == 1  # one record per request, stream included
+    assert rows[0]["compressor_id"] == "truncate"
+    assert cast("int", rows[0]["tokens_in_compressed"]) < cast("int", rows[0]["tokens_in_raw"])
+
+
+def test_compression_fields_populate_on_error_path(tmp_path: Path) -> None:
+    class _FailingProvider(_EchoProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            raise RuntimeError("upstream on fire")
+
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+    )
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=_FailingProvider, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    )
+    assert response.status_code == 502
+    rows = _rows(log_path)
+    assert len(rows) == 1  # one record per request, error included
+    assert rows[0]["status"] == "error"
+    assert rows[0]["compressor_id"] == "truncate"
+    assert cast("int", rows[0]["tokens_in_compressed"]) < cast("int", rows[0]["tokens_in_raw"])
+
+
+def test_uncompressed_rows_keep_default_compression_fields(tmp_path: Path) -> None:
+    client, log_path = _client(tmp_path)
+    client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    row = _rows(log_path)[-1]
+    assert row["compressor_id"] == ""
+    assert row["compressor_version"] == ""
+    assert row["tokens_in_raw"] == 0
+    assert row["tokens_in_compressed"] == 0
+    assert row["aggressiveness"] == 0.0
+
+
+def test_dial_swap_keeps_the_compressor_matched_to_the_live_policy(tmp_path: Path) -> None:
+    # #270's dial replaces the whole policy object at runtime (_install_policy); the resolved
+    # compressor must follow it, not stay pinned to the mount-time object.
+    policy = _knn_policy(tmp_path).model_copy(
+        update={"compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5)}
+    )
+    client, runtime = _dial_client(tmp_path, policy)
+
+    response = client.put("/v1/endpoints/tau-bench/config", json={"cost_quality": 1.0})
+    assert response.status_code == 200
+
+    served = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    )
+    assert served.status_code == 200
+    assert runtime.policy.compression is not None  # the dial carried the config through
+    row = _rows(tmp_path / "requests.jsonl")[-1]
+    assert row["compressor_id"] == "truncate"
+    assert cast("int", row["tokens_in_compressed"]) < cast("int", row["tokens_in_raw"])
+
+
+def test_compression_leaves_tool_calls_and_tool_results_verbatim(tmp_path: Path) -> None:
+    # v1 scope (#278 x D-COMPRESS): the compressor shortens user prose only. A tool call's
+    # arguments and a tool result are a structured contract the model reads back exactly, so
+    # truncating them would change what the transcript MEANS, not just how long it is.
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+    )
+    client, log_path, seen = _tool_client(tmp_path, policy)
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": _REPLAYED_TOOL_TRANSCRIPT},
+    )
+
+    assert response.status_code == 200
+    served = seen[0].messages
+    assert served[0].content == "how many superheroes"  # the user turn, compressed
+    assert served[1].tool_calls is not None
+    assert served[1].tool_calls[0].function.arguments == _TOOL_ARGUMENTS  # verbatim
+    assert served[2].content == "42 rows"  # the tool result, verbatim
+    assert _rows(log_path)[-1]["compressor_id"] == "truncate"

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2824,3 +2824,107 @@ def test_installing_the_same_compression_config_keeps_the_prefixes(tmp_path: Pat
 
     with runtime._lock:
         assert dict(runtime._compressed) == before
+
+
+def test_a_pre_routing_failure_still_bills_the_compression_that_ran(tmp_path: Path) -> None:
+    # Finding 13: the compressor ran on real hardware and was paid before routing blew up, so a
+    # row encoding compressor_id="" with zero cost would not be an omission, it would be an
+    # assertion that no compression happened. The savings math reads these rows.
+    register_compressor(_PRICED)
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id=_PRICED.id, aggressiveness=0.5),
+    )
+
+    def _explode(entry: PoolEntry) -> _EchoProvider:
+        raise RuntimeError("api_key_env is unset")
+
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=_explode, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "one two three four five six"}],
+        },
+    )
+
+    assert response.status_code == 502
+    row = _rows(log_path)[-1]
+    assert row["routing_reason"] == "error-before-routing"
+    assert row["compressor_id"] == _PRICED.id
+    assert row["compressor_cost_usd"] == pytest.approx(0.00054)
+    assert cast("float", row["compressor_latency_s"]) >= 0.02
+    assert cast("int", row["tokens_in_compressed"]) < cast("int", row["tokens_in_raw"])
+
+
+def test_a_failure_inside_the_compression_stage_bills_nothing(tmp_path: Path) -> None:
+    # The other half of "the zero encoding must never lie": when the stage itself is what
+    # failed, no compression was delivered and the row must say exactly that.
+    class _Exploding:
+        id = "exploding-for-tests"
+        version = "1"
+        append_stable = True
+
+        def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+            raise RuntimeError("compressor endpoint unreachable")
+
+    register_compressor(cast("Compressor", _Exploding()))
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="exploding-for-tests"),
+    )
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=_EchoProvider, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hello there"}]},
+    )
+
+    assert response.status_code == 502
+    row = _rows(log_path)[-1]
+    assert row["compressor_id"] == ""
+    assert row["compressor_cost_usd"] == 0.0
+    assert row["tokens_in_raw"] == 0
+
+
+def test_a_compressor_that_returns_the_wrong_segment_count_is_named(tmp_path: Path) -> None:
+    # Finding 12 at the serving boundary: one segment too few used to surface as an anonymous
+    # 502 from a StopIteration, one too many was served with the extra silently discarded.
+    class _Splitter:
+        id = "splitter-for-tests"
+        version = "1"
+        append_stable = True
+
+        def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+            out = [part for segment in segments for part in segment.split(" ", 1)]
+            return CompressionResult(
+                segments=out, tokens_in_raw=1, tokens_in_compressed=1, latency_s=0.0
+            )
+
+    register_compressor(cast("Compressor", _Splitter()))
+    log_path = tmp_path / "requests.jsonl"
+    policy = RoutingPolicy(
+        kind="static",
+        default_model="haiku-4-5",
+        pool=_pool(),
+        compression=CompressionConfig(compressor_id="splitter-for-tests"),
+    )
+    runtime = EndpointRuntime(
+        name="tau-bench", policy=policy, provider_factory=_EchoProvider, log=RequestLog(log_path)
+    )
+    response = TestClient(_app_for(runtime)).post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "two words"}]},
+    )
+
+    assert response.status_code == 502  # refused, not served with a corrupted transcript
+    assert "splitter-for-tests" in _error_message(_rows(log_path)[-1])

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -2394,6 +2394,7 @@ class _SpyCompressor:
         self.inner = inner
         self.id = inner.id
         self.version = inner.version
+        self.append_stable = inner.append_stable
         self.calls: list[list[str]] = []
 
     def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
@@ -2555,8 +2556,12 @@ def test_uncompressed_rows_keep_default_compression_fields(tmp_path: Path) -> No
 def test_dial_swap_keeps_the_compressor_matched_to_the_live_policy(tmp_path: Path) -> None:
     # #270's dial replaces the whole policy object at runtime (_install_policy); the resolved
     # compressor must follow it, not stay pinned to the mount-time object.
+    config = CompressionConfig(compressor_id="truncate", aggressiveness=0.5)
+    # Both stamps, as a real `route fit --compressor` writes them: a knn bank is only servable
+    # under the representation it was fitted on, so a policy carrying one without the other
+    # would not mount at all (see the requirement-A tests in policy_test.py).
     policy = _knn_policy(tmp_path).model_copy(
-        update={"compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5)}
+        update={"compression": config, "fit_compression": config}
     )
     client, runtime = _dial_client(tmp_path, policy)
 
@@ -2600,3 +2605,20 @@ def test_compression_leaves_tool_calls_and_tool_results_verbatim(tmp_path: Path)
     assert served[1].tool_calls[0].function.arguments == _TOOL_ARGUMENTS  # verbatim
     assert served[2].content == "42 rows"  # the tool result, verbatim
     assert _rows(log_path)[-1]["compressor_id"] == "truncate"
+
+
+def test_mounting_a_mismatched_compression_artifact_fails_loudly(tmp_path: Path) -> None:
+    # D-COMPRESS requirement A at the serving boundary: an endpoint whose bank was fitted on raw
+    # text must not come up compressing. It would still answer every request, just with routing
+    # quietly collapsed to the expensive fallback, which is the failure C2 measured and the one
+    # nothing downstream would notice.
+    policy = _knn_policy(tmp_path).model_copy(
+        update={"compression": CompressionConfig(compressor_id="truncate", aggressiveness=0.5)}
+    )
+    with pytest.raises(ValueError, match="fitted on raw text"):
+        EndpointRuntime(
+            name="tau-bench",
+            policy=policy,
+            provider_factory=_EchoProvider,
+            log=RequestLog(tmp_path / "requests.jsonl"),
+        )

--- a/wmo/serving/savings.py
+++ b/wmo/serving/savings.py
@@ -96,7 +96,8 @@ class EndpointSavings(BaseModel):
     expected_quality_delta_pt: float
     estimate_basis: list[str]
     window: SavingsWindow
-    # The two sums the cost saving is the difference of: logged spend, and the counterfactual.
+    # The two sums the cost saving is the difference of: logged spend (provider bill plus any
+    # compressor bill, per the track's effective-cost rule), and the counterfactual.
     actual_cost_usd: float = Field(ge=0.0)
     baseline_cost_estimate_usd: float = Field(ge=0.0)
 
@@ -186,6 +187,14 @@ def compute_savings(
     accrues, and until there are fallback requests to take a median of, no figure is reported.
     Differences are summed signed, so a routed model that ran slower subtracts. Requests that
     failed are excluded from every total: nobody was served.
+
+    The compressor's own bill is part of what the endpoint spent. The compression track's
+    accounting rule is explicit about it ("every savings number is cache-adjusted effective cost
+    per completed task, compressor cost and latency included"), so `compressor_cost_usd` is
+    added to the actual side and never to the counterfactual: the fallback-only baseline runs no
+    compressor. Crediting the token reduction while omitting what the reduction cost would
+    inflate every compressed endpoint's savings by the compressor's entire bill. Compressor
+    latency needs no separate handling: `latency_ms` already spans the compression stage.
     """
     entries = {entry.name: entry for entry in policy.pool}
     fallback = policy.guard_model or policy.default_model
@@ -208,7 +217,7 @@ def compute_savings(
             baseline_cost_estimate_usd=0.0,
         )
 
-    actual = sum(record.cost_usd for record in served)
+    actual = sum(record.cost_usd + record.compressor_cost_usd for record in served)
     baseline_entry = entries.get(fallback)
     baseline = actual
     if baseline_entry is not None:

--- a/wmo/serving/savings_test.py
+++ b/wmo/serving/savings_test.py
@@ -73,6 +73,7 @@ def _row(
     latency_ms: float = 1000.0,
     ts: datetime | None = None,
     status: str = "ok",
+    compressor_cost_usd: float = 0.0,
 ) -> RequestLogRecord:
     entry = _OPUS if model == "opus" else _HAIKU
     cost = (
@@ -89,6 +90,7 @@ def _row(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cost_usd=cost,
+        compressor_cost_usd=compressor_cost_usd,
         latency_ms=latency_ms,
         status=status,  # ty: ignore[invalid-argument-type]
     )
@@ -268,3 +270,26 @@ def test_the_counterfactual_states_both_of_its_assumptions() -> None:
     assert "same number of tokens" in counterfactual  # the token assumption
     assert "cached reads" in counterfactual  # the cache assumption
     assert "understate" in counterfactual  # and which way both of them lean
+
+
+def test_the_compressors_own_bill_counts_against_the_saving() -> None:
+    # The track's accounting rule: every savings number is effective cost per completed task,
+    # compressor cost INCLUDED. Crediting the token reduction while omitting what the reduction
+    # cost would inflate a compressed endpoint's savings by the compressor's entire bill.
+    # Same two requests as the exact-dollars test ($96 provider spend, $180 counterfactual),
+    # plus $1 of compression each.
+    rows = [_row("opus", compressor_cost_usd=1.0), _row("haiku", compressor_cost_usd=1.0)]
+    savings = compute_savings(rows, _policy(cost_quality=1.0))
+    assert savings.actual_cost_usd == pytest.approx(98.0)  # 96 provider + 2 compressor
+    # The counterfactual runs no compressor, so it is unchanged and the saving shrinks by $2.
+    assert savings.baseline_cost_estimate_usd == pytest.approx(180.0)
+    assert savings.cost_saved_usd == pytest.approx(82.0)
+
+
+def test_a_compressor_that_costs_more_than_it_saves_shows_a_smaller_saving() -> None:
+    # The honest direction: an expensive compressor must be able to eat the whole saving rather
+    # than hide inside it.
+    cheap = compute_savings([_row("haiku")], _policy(cost_quality=1.0))
+    pricey = compute_savings([_row("haiku", compressor_cost_usd=50.0)], _policy(cost_quality=1.0))
+    assert pricey.cost_saved_usd == pytest.approx(cheap.cost_saved_usd - 50.0)
+    assert pricey.cost_saved_usd < cheap.cost_saved_usd


### PR DESCRIPTION
> **REBASE ROUND 3 (2026-07-26).** Rebased onto current main (post-rename `wmh` -> `wmo`). The pricing commit is **gone**: #274 merged it (`e1671e2d`), so this PR is now 5 commits, 4 of them the original seam. Rebase reconciliation over #278 (tool calls), #281 (route artifact integrity), and #289 (providers-set) is described below. Gate re-run green: **3721 passed / 17 skipped**, ruff and ty clean. Tip = `5a03cf03`.
>
> **Consumption pins (C1/C2)**: branch `compress/c3` @ `5a03cf03`. C1's acceptance benchmark: `evaluate_pool(..., compression=CompressionConfig(...))` in `wmo/env/closed_loop.py`. C2's churn + break-even legs: `wmo.optimize.compression` (identity/truncate). Both must retarget from `wmh.*` to `wmo.*`. **compress/c1-bench should rebase onto this tip**: its `register_compressor()` now lives here, so production and the acceptance runner share one registry. **compress/endpoint** mirrors `CompressionConfig`/`CompressionResult`/`estimate_tokens` from `7f0b0efa`: those three are byte-identical here (verified field by field), so its mirror reconciles trivially. Its endpoint compressor does need to declare `append_stable` to register, see requirement B.

The compression track's production seam (child C3): compression plugs into serving and eval behind the optimizer interface, opaque and cache-safe by construction, WITHOUT shipping any specific compressor. Reference implementations are `identity` (compression off, bit-for-bit) and `truncate` (the ratio-matched trivial control). C1 chooses the real method; C2 fits the joint policy; both measure through this path.

## Binding requirements from C2

C2's round-0 measurements turned two open design questions into hard mount gates. Both are enforced by one check, `RoutingPolicy._check_compression`, run from the pydantic validator **and** from `RoutingPolicy.serving_compressor()`. The second call site is not redundant: `model_copy` skips validators, and that is how the cost/quality dial and most callers build policies, so the validator alone would leave the mount path open.

### A. Representation consistency (C2 Q2)

A routing bank, its cluster centroids, and its novelty floor are geometry in the space of whatever text the fit embedded. C2 measured what happens when serving embeds something else: compressed queries sit farther from every raw-fit bank row, the novelty floor trips **10-13x** more often, route-away collapses, and routing-channel cost rises **+11% to +41%** with accuracy flat to negative. That is a silently broken policy, not a degraded one, so it does not mount.

- **`RoutingPolicy.fit_compression`**: the config the routing evidence was fitted under. Additive, default `None` = fitted on raw text, so every artifact written before this field loads unchanged and keeps serving raw.
- **The gate**: a policy that routes on embeddings may only serve the config it was fitted under. Compared on the whole `(compressor_id, compressor_version, aggressiveness)` triple via `same_compression` (a version bump changes the emitted bytes exactly as a different id would). Static policies are exempt: they embed nothing, so there is no geometry to mismatch, which is what keeps the demo/seam-walk path working.
- **The error names both sides**, e.g. `this knn policy's routing evidence was fitted on raw text (no compression), but the endpoint would serve compressor 'truncate' version 1 at aggressiveness 0.5. ... Refit under the serving config (...), or serve the config the artifact was fitted under.`
- **`wmo optimize route fit --compressor X --aggressiveness a` now moves the FIT**, not just the stamp. `CompressingEmbedder` wraps the single embedder the fit and its evaluation share, so the bank rows, the centroids, and the floor quantile are all calibrated on the served representation; then both `compression` and `fit_compression` are stamped. **This is a judgement call worth review**: stamping without refitting would have shipped exactly the raw-bank + compressed-query configuration this requirement exists to prevent, blessed by a stamp claiming it was fine. Serving does not wrap its embedder, because its compression stage has already run by the time the router embeds.

### B. Churn attestation / turn-local rule (C2 Q4)

C2's cache simulation measured churny full recompression as a net **LOSS of up to 2.65x** the input cost of compressing nothing at all on cached providers: every turn forfeits the whole prompt-cache prefix to save a fraction of the tokens (17 of 25 method x corpus cells lose; all 25 churny cells violate their analytic bound).

- **`Compressor.append_stable: bool`**, an attestation that appending a segment never rewrites already-emitted bytes.
- **v1 rule**: a compressor that does not attest is **refused at mount**, not silently allowed. Turn-local-commit support (which C2 measured as healing every churny cell) can come later; until it exists, "allowed" would mean "quietly costs more than doing nothing".
- **identity and truncate both attest.** Truncate is head-absolute per segment, which C1 round 0 measured at churn 0.000 on all five corpora; C1's correction to the lit review applies here (the "ratio budgets are never append-only" rule is about percentile SELECTION, not head-keep truncation, whose kept prefix only ever extends).
- **`register_compressor`** (reconciled in from `compress/c1-bench` so there is ONE registry) requires the attestation at REGISTRATION, so an implementation that forgot it fails in the researcher's own process rather than on the first served request. It still refuses to rebind an existing id.

## Rebase reconciliation

The `wmh` -> `wmo` rename made git lose the rename detection on the two files main had also changed materially, so these were ported by hand rather than merged:

- **`chat.py` vs #278 (tool calls)**: reconciled, not just re-applied. Affinity now keys on `_remembered_prefix` (the prefix ending at the LAST assistant turn) rather than `messages[:-1]`, so the compressed-prefix cache keys on the same thing, and the turn-local tail is everything appended since rather than exactly one message (a parallel tool round trip appends the assistant turn plus one `role="tool"` result PER CALL). `_provider_request` now takes the provider-visible messages, so the tool path compresses too. **v1 scope held**: only user-role content is compressed; tool calls, tool arguments, and tool results ride verbatim, because a tool payload is a structured contract the model reads back exactly. Pinned by `test_compression_leaves_tool_calls_and_tool_results_verbatim`.
- **`route_app.py` vs #281 / #289**: union, no semantic conflict.
- **Dropped**: the pricing commit (merged as #274) and the standalone dial-swap test commit (its test is folded into the serving commit). The dial-swap invariant itself survives: `_install_policy` re-resolves the compressor, now through `policy.serving_compressor()` so the install re-runs both mount gates.

## Aggressiveness semantics (amended)

The seam documented `aggressiveness` as "the fraction of content the compressor may remove". That quietly demands the one selection rule this track rejected: hitting an exact fraction per input requires percentile selection, which C1 round 0 measured rewriting 24-81% of the already-emitted compressed prefix per appended turn. The cache-safe learned compressors are fixed-threshold ones, whose removal varies with the input by construction, so the old wording described something no servable compressor can do.

Amended contract: `aggressiveness` is a **compressor-defined dial in [0, 1]** with two invariants, **0.0 is a strict bit-for-bit no-op** and the dial is **monotone** (higher never removes less). The **achieved removal ratio is an outcome**, reported per call on `CompressionResult` (`tokens_in_compressed / tokens_in_raw`); ratio-matched controls match on achieved ratio, never on the nominal dial, as C1's acceptance benchmark already registered. Truncate can hit a fraction exactly because it is structural, and its docstring now says that is its own reading of the dial rather than the contract. Pinned by `test_the_dial_invariants_hold_for_every_reference_compressor` over both reference compressors.

**Batching, now contractual and tested**: one `compress` call carries ALL of a request's mutable segments, and `CompressingEmbedder` makes one call per `embed` batch. A network-backed compressor therefore pays one round trip per request and one per bank fit, not one per message. Pinned by `test_the_stage_makes_one_compressor_call_per_request`.

## What's here (13 commits)

1. **Compressor protocol + joint artifact**: `wmo/optimize/compression.py` - `compress(segments, config) -> segments + counts + latency + compressor cost`, deterministic per segment by contract. `RoutingPolicy` gains a policy-level compression config; `ClusterRanking` a per-cluster override. Additive, default off; unknown ids fail at policy validation (mount time).
2. **Serving stage**: `request -> [compress] -> [route] -> provider` in `wmo/serving/chat.py`. The affinity state decides segment boundaries: an incumbent conversation's compressed prefix is stored under the remembered-prefix fingerprint and **retrieved, never recompressed** (byte-identical across turns by construction; a spy-compressor test proves turn 2 only compresses the new turn; a lost-affinity test proves deterministic recompression reproduces the same bytes). Only user content is compressed; system prompts and the model's own replies pass verbatim. The router embeds the compressed text (compress-then-route); stickiness keys on the raw transcript the client resends.
3. **Eval threading**: `evaluate_pool(compression=...)` measures through `agent -> _CompressingProvider -> _TimedProvider -> provider`, so latency and provider usage are those of the actual compressed call (the #259 lesson: research numbers reproduce through the served path). `ScenarioOutcome` gains the D-COMPRESS fields additively; old matrices load.
4. **CLI parity**: `wmo optimize route fit --compressor <id> --aggressiveness <a>`; `wmo serve` stays flag-free, the config rides in `policy.json`, routing's exact convention.
5. **Binding requirements A and B** (above).
6. **Aggressiveness semantics amendment + batching contract** (above).
7. **Production review fixes** (below).

## Production review fixes

Nine findings from the production review of this branch, all fixed here with tests.

**Requirement A at the version grain (major).** `servable_compressor` resolved by id and never compared `config.compressor_version` to the running implementation's `version`, so a policy stamped `truncate` version 99 mounted happily on truncate v1. The id does not identify the bytes: an artifact fitted against a different implementation of the same id has its bank in that implementation's geometry, which is the C2 failure with no visible symptom. Now compared, both versions named, both remedies offered (refit, or deploy the matching build). Per-cluster overrides route through the same call. Tested in both directions.

**The compressor's bill was computed and dropped (major).** `CompressionStats.cost_usd` had nowhere to land, so `compute_savings` credited the token reduction and never subtracted what the reduction cost, about $0.00054 per request of pure unbilled saving at the endpoint's measured rate. `RequestLogRecord` gains `compressor_cost_usd` and `compressor_latency_s` (additive, named as on `ScenarioOutcome`), populated on the non-stream, stream, tool, and error paths; `compute_savings` adds the compressor bill to the ACTUAL side only, since the fallback-only counterfactual runs no compressor. An expensive compressor can now eat a whole saving instead of hiding inside it. The track's accounting rule is quoted in the docstring.

**The latency window excluded compression (major).** The request clock started after `runtime.compress` returned, so `latency_ms` and `ttfb_ms` omitted the compressor round trip entirely and enabling compression read as latency-neutral while clients waited the full trip (most of the wall time, for the centralindia endpoint). The clock now starts before the stage; `compressor_latency_s` breaks the stage out of that total.

**The compressed-transcript cache was bounded by entry count (major).** `_compressed` reused `_AFFINITY_CAPACITY`, a cap sized for fingerprint-and-model-name entries, to hold whole conversations: 0.41GB of ordinary traffic at a measured 99KB per 40-turn conversation, multiple GB with tool results. Now bounded by BYTES (`_COMPRESSED_CAPACITY_BYTES`, 64MB, roughly 650 measured conversations), LRU by size, ordering updated on use rather than only on write, and a running total repaired when a conversation is re-remembered. The two caches are bounded independently and can disagree about which conversations they hold; both directions are safe and the docstring says why.

**A joint fit over an arm nobody measured (minor, real contract gap).** `route fit --compressor` moved the fit-side representation but could not retroactively change what the EPISODES ran under, and `sweep` had no way to produce a compressed matrix at all. `OutcomeMatrix.measured_compression()` reads the arm off the scored rows (unscored rows produced no reward, so they cannot bias a fit) and refuses to name one when rows disagree. `fit` refuses a mismatch in either direction. `sweep` gains `--compressor` / `--aggressiveness`, threaded into the `evaluate_pool` compression parameter that until now had no production caller, with the compressor checked against the serving rule before the first episode is paid for. Matrices with no D-COMPRESS fields read as the uncompressed arm, so every existing matrix fits exactly as before.

**Unlocked read of the live config (minor).** `compress()` read `self.policy.compression` and `self._compressor` in two unsynchronized statements while `_install_policy` swaps both under the lock. Now snapshotted together under one lock. `_install_policy` also resolves the incoming compressor before taking the lock (a policy that fails the mount gates leaves the endpoint as it was, not half-installed) and clears stored prefixes when the incoming compression config differs, so a dial that ever varies compression cannot serve a transcript spliced from two configs.

**Chunking to the compressor's cap (major).** Making one-call-per-batch contractual collided with the fact that a served compressor caps how many segments a call may carry: the endpoint 413s past 256, and a bank fit compresses every scenario in the matrix. `compress_segments` chunks to an OPTIONAL `max_segments_per_call` declared by the compressor (absent or None = unlimited, so existing implementations are unaffected) and sums the per-chunk accounting. Chunking is safe because the protocol already requires per-segment determinism, so where the boundaries fall cannot change the bytes; for the compressor this matters for, that is measured rather than assumed (fixed-threshold selection is per token, fp32 verified batch-invariant at batch 1/4/16). Contract wording moves from "one call" to "as few calls as the cap allows, chunked deterministically". Driven end to end: a 24-scenario bank fit against a cap-5 compressor chunks 5/5/5/5/4 and mounts.

**Return-shape enforcement (major).** The protocol said a call returns exactly as many segments as it was given and nothing checked it: one short surfaced as a StopIteration, an anonymous 502 blaming nothing; one long was silently discarded, serving a transcript nobody checked. Both are now a named error carrying the compressor id and both lengths, enforced inside `compress_segments` so the fit path is covered too.

**The pre-routing error row lied about compression (minor, extends the billing fix).** A request that compressed and then failed before routing logged `compressor_id=""` with zero cost after real GPU spend. Once every other path bills the compressor, that is not a uniform omission but an inconsistency in the savings math, since the zero encoding asserts no compression happened. The row now carries the stats when the stage ran before the failure, and still zeroes them when the compression stage is itself what failed.

**Version stamp regression (caught by the reviewer in my own fix).** `fit` and `sweep` built `CompressionConfig` without a version, so it defaulted to `"1"`, and the new version gate would then hard-stop any fit against a version-bumped compressor with a remedy the CLI cannot execute. Both call sites now read the version off the resolved implementation. Latent while everything is v1, which is why the test registers a v3 compressor, fits against it, and mounts the result.

**Lazy registration hook (for the endpoint client).** `register_compressor_factory(id, factory)` builds a compressor on first resolution rather than at import, so a served compressor can reach its server to verify the selection rule before attesting `append_stable` without putting a network call into every `import wmo`. Signature settled directly with compressor-endpoint. Contracts their client depends on, all pinned by tests: the factory runs at most once on SUCCESS and failures are never cached (an endpoint that was down at first resolution is retried after the operator fixes it); the original message survives verbatim in the wrapper with the original exception reachable as `__cause__`; rebinding is refused against both registries, so neither a second factory nor a shadowed live instance can displace what is there; the unknown-compressor error lists factory-registered ids alongside instances; a factory that builds a compressor under the wrong id is caught; and `max_segments_per_call` is read off the CONSTRUCTED instance rather than required as a class-level constant, because a served compressor learns its cap from the server it just contacted. One deviation from their ask, agreed with them: the exception TYPE is normalized to `ValueError`, because resolution happens inside a pydantic validator (which converts `ValueError` to `ValidationError` and lets anything else escape raw) and the CLI catches `ValueError` to render a usage error, so a `RuntimeError` would bypass both.

Finding 9 (the `--aggressiveness` help wording) was already fixed by the amendment commit; the reviewer's worktree predated it.

## D-SERVING-LOG / opacity

`RequestLogRecord` gains `tokens_in_raw`, `tokens_in_compressed`, `compressor_id`, `compressor_version`, `aggressiveness`, populated on non-stream, stream, tool, and error paths under the existing one-record-per-request invariant, and asserted ABSENT from response bodies and headers. Token counts in these fields are a deterministic chars/4 proxy (documented); billable truth stays in `input_tokens`/`cost_usd` from provider-reported usage on the same row.

## Justification ledger

- `wmo/optimize/compression.py`: consumers = serving stage, eval threading, route-fit CLI, C1/C2's research programs.
- `RoutingPolicy.compression` (policy-level, a delta vs the D-COMPRESS entry's per-cluster-only shape): consumer = the serve-time stage, which runs BEFORE routing per the track architecture and therefore cannot take a per-cluster choice; also the only way the currently-served knn kind (zero clusters) can compress at all. Flagged in DECISIONS.md for master ratification.
- `ClusterRanking.compression`: consumer = C2's joint fit + eval grids (serving-side per-cluster application = route-then-compress, deferred to C2's ordering ablation). Checked for servability only, never for fit consistency: it is a fit/eval input, not a serve-time input.
- `RoutingPolicy.fit_compression` (NEW): consumer = the requirement-A mount gate. The alternative considered and rejected was versioning the whole artifact on the compression config, which would have invalidated every existing policy instead of defaulting them to raw.
- `Compressor.append_stable` (NEW): consumer = the requirement-B mount gate and `register_compressor`. Class-level rather than registry-level so the attestation travels with the implementation that has to honor it.
- `CompressingEmbedder` (NEW): consumer = `route fit --compressor`, which must fit on the served representation. One wrapper covers both the fit and its evaluation, and it is reusable by C2's grid.
- `compressor_id` on log + outcome rows (a delta vs the entry, which lists only `compressor_version`): a version without an id does not identify what ran. Flagged in DECISIONS.md.
- `estimate_tokens` proxy: consumer = compressor accounting where no provider tokenizer exists; documented as proxy, never billable truth.
- Non-removals: `packages/llm-waterfall`'s duplicate pricing table left untouched (standalone PyPI member with its own version; its adapters structurally zero cache fields, flagged in findings/c3.md as a known limit). `router_cost_usd` still never assigned (pre-existing #248 gap, out of scope).

## Verification

Full gate: `uv run ruff check .` clean, `uv run ty check` clean, `uv run pytest -q` = **3721 passed / 17 skipped**.

Requirement tests: mismatched mount rejected (both directions: compressed-serve on a raw fit, and raw-serve on a compressed fit), mismatched aggressiveness rejected, static policy exempt, old artifact loads as raw, churny compressor refused at mount, churny per-cluster override refused, unattested compressor refused at registration, `route fit` stamps both halves.

The arm contract, driven end to end: `fit --compressor truncate` over a raw matrix refuses ("rewards were measured with raw text ... one matrix per arm"), a raw fit over a truncate-stamped matrix refuses ("would stamp raw text"), and the fit over the matching arm succeeds.

Two real fits off one matrix, showing the fit actually moves:

```
uv run wmo optimize route fit matrix.json --kind knn --out raw/policy.json  --dim 64
uv run wmo optimize route fit matrix.json --kind knn --out comp/policy.json --dim 64 \
    --compressor truncate --aggressiveness 0.5
```

| fit | floor_sim | routed away | fit_compression |
|---|---|---|---|
| raw | 0.99999976 | 12.5% | `null` |
| truncate @ 0.5 | 0.99999988 | 25.0% | `truncate/1/0.5` |

Live walk (real mount + real HTTP through the served app, stub provider, the compressed artifact above): turn 1 sends the compressed user turn; turn 2 reuses that prefix **byte-identically** and routes `sticky: conversation affinity`; both rows carry the compression fields (`raw 19 -> compressed 10`, `raw 37 -> compressed 20`); compression is absent from the body and the headers. The earlier real-Bedrock walk (input -41%, cost -31%) still stands from round 1.

Endpoint tests only: `uv run pytest wmo/serving/chat_test.py -k "compress or identity or incumbent" -q`.

Track: master gates before the coordinator; findings ledger at `wmh-compression-data/findings/c3.md` (round 3 entry). Phase 2 (platform surfacing) deferred. No test stack was brought up.


---

## Rebase 2026-07-27 (onto post-#298 main)

Rebased onto `main` after #294, #295, #296, #300 and #298 landed. Structure kept as the original 13 commits plus one integration commit on top, so the integration work is reviewable as its own diff; the repo squash-merges, so no intermediate state reaches main. Pre-rebase tip `5a03cf03` is preserved in the local ref `backup/c3-pre-rebase-5a03cf03`.

Conflicts were in 7 files: `route_app.py`, `closed_loop.py`, `chat.py` and the four matching test files. `outcomes.py`, `policy.py`, `knn.py` and `savings.py` auto-merged clean. Confirmed along the way: the wmh→wmo rename was already handled (zero occurrences), the redundant pricing commit was already gone, and no `Representation` residue remains for `fit_compression` to collide with (#298 dropped that table).

### 1. Accounting: candidate spend now folds in the compressor

The D-COMPRESS rule is that every savings number is cache-adjusted effective cost per completed task with the compressor's inference cost and latency included, and `wmo/serving/savings.py` already sums `cost_usd + compressor_cost_usd`. The sweep previously summed only `cost_usd`, so on a compressed arm the compressor's bill was invisible to the printed spend, to the run manifest, to `--max-usd`, and to the world-model forecast. That is the same rule answered two different ways, so the sweep now folds it in.

`StageRecord` records the folded total **and** a sibling `compressor_spend_usd`. The sibling is not redundant: the spend forecast multiplies a projection that excludes the compressor by construction (nothing predicts a compressor's per-call cost in advance), so it divides by `spend_usd - compressor_spend_usd` to keep numerator and denominator in the same units. A folded denominator would run every forecast short by the compressor's share of the previous sweep, on the term that dominates the bill: with a prior of $1.00 candidate ($0.30 of it compressor) against $7.00 world-model, the like-for-like forecast on a $0.70 projection is $7.00, where a folded denominator gives $4.90.

The spend line reads `(incl. $X compressor)` only when a row actually carries a nonzero compressor cost, keyed on the bill rather than the flag. The plan's estimate note gains a clause on a compressed arm, because the projection is then wrong in two directions at once: the candidate figure over-estimates (it assumes uncompressed tokens) while the compressor's own cost is absent entirely.

The uncompressed path is pinned byte-identical to what #300 shipped, same number and same string, with no stray `(incl. compressor)`.

### 2. `SweepPlan.compression` and the resume fingerprint

`evaluate_pool` is no longer called from `route_app.py`; #300 moved that into `wmo/optimize/sweep.py`. Rather than pass compression as a bare argument to `execute_sweep`, it goes on `SweepPlan`, because a matrix's rewards belong to exactly one D-COMPRESS arm and the arm decides what the evidence *means*. `wmo optimize model` fingerprints its sweep off the plan, so the arm's `compression_signature` is now part of that fingerprint and a resumed run whose compressor changed re-measures instead of reusing rows from a different arm. The reserved `COMPACT` stage stays unwired; this only makes the data reachable when it is.

### 3. The kNN fit: policy stamp and compressed-geometry bank (load-bearing)

`fit_knn_artifact` builds its own embedder and saves its own artifact, returning before the rank path's stamping line. Applying the seam as written would therefore have given a `--kind knn` fit **neither** C2 rule: no `fit_compression` on the policy, and a bank fitted in **uncompressed** geometry while serving compresses.

The missing stamp is visible. The bank is not, and it is the more expensive half: fitting the bank in a different representation from the one served is the representation-consistency failure that makes the novelty floor abstain, measured at +11-41% cost with routing silently switched off. It would have shipped looking fine.

Both now happen inside `fit_knn_artifact` before it saves, with the rank path wrapping its own embedder under the same rule. Two tests pin it: `test_route_fit_knn_stamps_the_compression_it_was_fitted_under` (both halves set and equal) and `test_route_fit_knn_leaves_the_stamp_null_without_the_flag` as the negative control.

Related: `_CompressingProvider` sits above `_TimedProvider` (agent → compressing → timed → real), so #295's replies/`call_seconds` alignment guard is untouched, and the agent construction takes a true union of #295's `history_chars` with the compressor wrapper.

### 4. Driven in a real terminal

- compressed kNN fit → policy carries `compression` and `fit_compression`, same config in both
- raw fit over compressed rewards → measured-arm gate refuses, with the one-matrix-per-arm remedy
- uncompressed kNN fit → both fields null, unchanged
- `wmo optimize model` uncompressed → spend line byte-identical to #300

Gates on the rebased tip: `ruff check` clean, 529 files formatted, `ty check` clean, `pytest -q` 3990 passed / 18 skipped.

One bug the rebase introduced and this branch's own test caught: a stale `CompressionConfig` construction survived after the later `_compression_for` call and overwrote the resolved version with the default, so every compressed fit stamped version 1. `test_route_fit_stamps_the_running_compressor_version` failed and named it.
