### PR TITLE
C2 joint (compression x routing) policy: round 0 pre-registration + offline results (churn, cache break-even)

### DIFF
--- a/.agents/docs/research/compression-method-tiers.md
+++ b/.agents/docs/research/compression-method-tiers.md
@@ -71,6 +71,81 @@ Track prerequisite discovered: the tracker-side cost path (wmh/tracking/pricing.
 no cache tiers and cache writes are captured nowhere (the pool/serving path is correct).
 C3 item 0; no savings number ships before it lands.
 
+## Joint (compression x routing) policy: C2 pre-registration (2026-07-25, updated 2026-07-26)
+
+Full pre-registration with all thresholds: wmh-compression-data/findings/c2.md
+(registered before any measurement; no bar weakens after results, only reported
+against). C2 designs now and runs through C1's acceptance benchmark when it lands.
+
+Central design decision: C2's live spend buys, per corpus, one COMPRESSION-AUGMENTED
+outcome matrix (cells = scenario x model x method x aggressiveness, 2 episodes/cell,
+captured via the acceptance benchmark's CompressingProvider entry point). Once dense,
+every joint-policy question is offline lookup, the routing program's matrix trick
+extended by a compression axis: interaction curves are row reads, the guarded
+per-cluster aggressiveness sweep replays by lookup, joint-vs-independent is
+joint-argmax vs composed-argmax on the same cells, and the ordering ablation only
+needs live episodes where the routing decision or aggressiveness actually differs.
+Budget scales with models x arms x scenarios, not with the number of questions.
+
+The four pre-registered questions, each paired-by-seed (5 seeds) vs BOTH baselines
+(B1 = fable-5 alone uncompressed, the serving contract's fallback; B2 = the served knn
+champion of #259 at aggressiveness 0), power rule 3+ seeds AND 30+ test scenarios:
+
+1. INTERACTION (do cheap models degrade faster?): 4 models spanning strength and price
+   across 2 families (fable-5, sonnet-5, gpt-5.4-mini, glm-5.2; pilot runs 3) x
+   aggressiveness {0, low, mid, high} on the ACHIEVED-token-ratio axis x the best
+   surviving method per family, on financebench-s80 + one verbatim-critical-ish corpus.
+   Divergence claim needs the cheap-tier slope steeper on 4/5 seeds beyond its seed
+   spread AND a joint-vs-independent policy-value gap clearing its spread; otherwise
+   the finding IS the parallel-curves simplification (joint degenerates to independent
+   choices). Kill bar aligned with C1: loses to truncation at matched achieved ratio =
+   dead in that corpus.
+2. ORDERING (compress-then-route vs route-then-compress): the served router embeds the
+   request, so compression can shift the neighborhood. Round 0 is offline and near
+   free: routing-decision churn per (method, aggressiveness) = % of requests whose
+   routed model flips when knn_decision sees compressed text, plus churn direction
+   (cheaper vs pricier), novelty-floor trip-rate change (the floor quantile was
+   calibrated on raw self-similarities), and a bank-refit-on-compressed-text variant.
+   Recommendation to beat stays compress-then-route; route-then-compress wins only by
+   beating it paired on 4/5 seeds at equal or lower cost.
+3. PER-CLUSTER AGGRESSIVENESS, guarded like routing: clusters = the knn bank's
+   neighborhoods (no new clustering). Deviating from aggressiveness 0 requires paired
+   per-neighbor fit-side evidence clearing a non-inferiority z-test on the routed
+   model (tol in {0, judge-noise floor}; risk-coverage curve per #259's floor-q
+   methodology); the fallback IS uncompressed, mirroring the fable contract. Mechanism
+   claim, thresholds registered: >= 90% of ex-ante verbatim-critical requests get
+   aggressiveness 0 WITHOUT hand rules while >= 30% of headroom requests get > 0; if
+   either fails, hand risk rules keyed to the long-tail categories are the fallback
+   design, stated as such.
+4. CACHE BREAK-EVEN: with cache reads ~0.1x and writes ~1.25x, the hit-rate crossover
+   is rho_cross(r) = (1.25 - 1/r) / 1.15, i.e. ~0.65 at r=2 and ~0.91 at r=5, so the
+   rule is expected segment-scoped, never global. Deliverable: the serving decision
+   rule (candidate to beat: compress turn-local segments only when an incumbent
+   conversation exists; full compression only on cold conversations with projected
+   reuse below crossover), validated on conversation streams replayed from real
+   transcripts through a per-model prefix-cache simulator with #248's affinity
+   fingerprints. Zero live episodes (caching does not touch accuracy). Labeled a
+   pinned-meter projection until C3's pricing cache tiers land; nothing ships before.
+
+C1 round-0 consequences folded in (2026-07-26): the C2 grid draws only from bar-1
+survivors (fixed-threshold variants, head-truncate, dedup-keep-first,
+per-turn-truncate-at-append, json-minify); percentile-selection and rolling-mask
+methods enter only as segment-scoped arms under Q4's rule, never on cacheable
+prefixes. Hosted arm cut per Silen's ruling: the ordering/churn grid is
+open-source-only. Controls match ACHIEVED token ratio per corpus (C1 caveat 6).
+Q4's replay streams inherit C1's caveat 5: stored transcripts carry replies without
+environment observations, so simulated savings understate tool-log mass; the rule's
+thresholds get restated on live-episode transcripts once the acceptance benchmark
+produces them.
+
+Live budget envelope (master approval gates every round): pilot = 3 models x (best
+method x 3 levels + 2 matched-ratio controls) x financebench-s80 x 2 episodes, approx
+$265; worst-case C2 total approx $1,600, shrinking with every C1 kill. Open questions
+to Silen (Q-A model subset, Q-B verbatim corpus: tau-bench-s80 recommended over
+swe-25, Q-C reuse stored s80 matrices as the aggressiveness-0 arm gated on a
+10-scenario recapture probe, Q-D derive the break-even rule now vs after C3) are in
+findings/c2.md with recommendations and steelmen.
+
 ## Verdicts
 
 ### Round 0: the append-stability audit (C1, 2026-07-25, $0, no API calls)

--- a/.agents/docs/research/compression-method-tiers.md
+++ b/.agents/docs/research/compression-method-tiers.md
@@ -146,6 +146,37 @@ swe-25, Q-C reuse stored s80 matrices as the aggressiveness-0 arm gated on a
 10-scenario recapture probe, Q-D derive the break-even rule now vs after C3) are in
 findings/c2.md with recommendations and steelmen.
 
+### C2 round 0 results (2026-07-26, offline legs, ~$3 embeddings, no wm serve spend)
+
+Q4 CACHE BREAK-EVEN (replay of C1's 120 audit conversations through a prefix-cache
+cost model, C1's measured ratio/churn per method, C3's tiers): within-conversation
+prefix share on OUR transcripts is 0.72-0.87 (first first-party number); full
+recompression with any churny method is a measured NET LOSS on cached providers (17
+of 25 cells above 1.0x, up to 2.65x the input cost of not compressing, every cell
+consistent with the bound churn < (c_r/(c_w-c_r))(1/r - 1)); turn-local commit heals
+all of them below 1.0x; append-stable compression multiplies both cache tiers by r,
+so the literature's compress-OR-cache dichotomy dissolves for stable compressors.
+SERVING RULE proposed: scope by measured append churn, never by conversation state;
+churn-zero methods compress everything, churn>0 methods compress turn-local only.
+The pre-registered candidate rule (cold-vs-incumbent) is BEATEN and retired.
+
+Q2 ORDERING round 0 (churn of the served #259 champion under compressed queries,
+5 seeds; ours9 full power, s80 rows candidates): 20-30% of ours9 decisions change at
+mid aggressiveness, and the mechanism is ABSTENTION, not misrouting: the novelty
+floor (calibrated on raw self-similarities) trips 10-13x more often and route-away
+collapses (0.58 -> 0.18-0.48; tau 0.41 -> 0.00 at high), so naive compress-then-route
+silently turns routing off and pays +11-41% routing-channel cost at flat-to-negative
+accuracy (matrix-lookup value; execution channel awaits the live grid). Refitting
+bank + floor on the SAME compressed representation restores floor trips and cost with
+accuracy within noise at low/mid aggressiveness (exception, full power: selective-
+context-absolute loses 0/5 on ours9 even refit). Random removal churns like the
+learned methods at matched ratio. Verdict: the ordering question's real content is
+REPRESENTATION CONSISTENCY: the compression config becomes part of the routing
+artifact's version (bank fitted under (X, a) serves only behind (X, a)); D-COMPRESS
+seam requirement proposed to master. Full detail: findings/c2.md; 781 run records in
+runs/c2.jsonl; scripts c2_churn_variants.py / c2_churn_measure.py /
+c2_cache_breakeven.py on this branch.
+
 ## Verdicts
 
 ### Round 0: the append-stability audit (C1, 2026-07-25, $0, no API calls)

--- a/.agents/scripts/c2_cache_breakeven.py
+++ b/.agents/scripts/c2_cache_breakeven.py
@@ -1,0 +1,189 @@
+"""C2 Q4: the compression-vs-cache break-even, replayed on real transcripts.
+
+Replays C1's audit transcripts (multi-turn conversations reconstructed from the
+routing matrices' stored replies) through a per-conversation provider prefix-cache
+model and computes effective INPUT cost per conversation under three compression
+policies x three provider archetypes, using C1's measured per-(method, corpus)
+token ratio r and append churn c:
+
+Policies
+- no-compress: prompt at turn t = full history; prefix N_{t-1} reads at the cache
+  tier, appended delta writes.
+- full-compress: whole prompt recompressed each turn. An append-stable method
+  (c = 0) keeps the compressed prefix cacheable, so both tiers scale by r. A churny
+  method invalidates fraction c of the compressed prefix per turn: that mass rebills
+  at the write tier instead of the read tier.
+- turn-local-commit: compress each turn once when appended, never retroactively
+  (C1's per-turn-truncate-at-append shape, applicable to any method). Append-only by
+  construction, so c = 0 regardless of the method's own churn; ratio r applies to
+  appended content only, and the task turn (turn 1) is also compressed at r.
+
+Provider archetypes (tiers from C3's pricing table on compress/c3, which carries the
+vendors' published multipliers): anthropic (read 0.1x, write 1.25x), openai (read
+0.1x, new tokens 1.0x, no write premium), no-cache (every prompt token 1.0x, the
+open-model pool rows without a provider prompt cache).
+
+Assumptions, stated: input cost only (output tokens are identical across policies);
+turns arrive within the cache TTL; the conversation is served by one model (affinity,
+#248); token counts via the GPT-2 tokenizer (same counter as C1's ratios). Cross-
+conversation prefix sharing (system prompts reused across conversations) is NOT in
+the transcripts (replies only); that leg stays analytic: the crossover for a
+cache-hostile compressor vs caching alone is rho* = (c_w - r) / (c_w - c_r).
+
+Run inside C1's scratch venv:
+
+    ~/Desktop/Projects/wmh-compression-data/cache/venv-c1/bin/python \
+        .agents/scripts/c2_cache_breakeven.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("c2_cache_breakeven")
+
+DATA_ROOT = Path.home() / "Desktop/Projects/wmh-compression-data"
+CORPUS_PATH = DATA_ROOT / "cache/audit-transcripts.jsonl"
+ROUND0_PATH = DATA_ROOT / "cache/round0-results.json"
+OUT_PATH = DATA_ROOT / "cache/cachesim-results.json"
+
+ARCHETYPES = {
+    "anthropic": {"read": 0.1, "write": 1.25},
+    "openai": {"read": 0.1, "write": 1.0},
+    "no-cache": {"read": 1.0, "write": 1.0},
+}
+
+
+def token_counter():  # noqa: ANN202 - .agents pragma
+    from transformers import GPT2TokenizerFast
+
+    tok = GPT2TokenizerFast.from_pretrained("gpt2")
+    return lambda text: len(tok(text)["input_ids"])
+
+
+def conversation_cost(
+    turn_tokens: list[int], *, r: float, churn: float, policy: str, tiers: dict[str, float]
+) -> float:
+    """Input-cost units (token x rate) for one conversation under one policy.
+
+    `turn_tokens[i]` is the token count of turn i (task, then each reply-turn).
+    """
+    read, write = tiers["read"], tiers["write"]
+    cost = 0.0
+    prefix = 0.0  # tokens currently sitting in the provider cache
+    for i, tokens in enumerate(turn_tokens):
+        if policy == "no-compress":
+            new = float(tokens)
+            stable_prefix = prefix
+        elif policy == "full-compress":
+            new = r * tokens
+            stable_prefix = prefix * (1.0 - churn)
+        elif policy == "turn-local-commit":
+            new = r * tokens
+            stable_prefix = prefix
+        else:
+            raise ValueError(policy)
+        rebilled = prefix - stable_prefix  # churned cache mass rebills at the write tier
+        cost += read * stable_prefix + write * (new + rebilled)
+        prefix = stable_prefix + rebilled + new
+        del i
+    return cost
+
+
+def main() -> None:
+    count = token_counter()
+    transcripts: dict[str, list[list[int]]] = {}
+    with CORPUS_PATH.open() as handle:
+        for line in handle:
+            row = json.loads(line)
+            transcripts.setdefault(row["corpus"], []).append(
+                [count(turn) for turn in row["turns"]]
+            )
+
+    round0 = json.loads(ROUND0_PATH.read_text())
+    results: list[dict] = []
+    prefix_share: dict[str, float] = {}
+    for corpus, convs in transcripts.items():
+        total = sum(sum(t[: i + 1]) for t in convs for i in range(len(t)))
+        reused = sum(sum(t[:i]) for t in convs for i in range(1, len(t)))
+        prefix_share[corpus] = reused / total
+        log.info(
+            "%s: %d conversations, within-conversation prefix share %.3f",
+            corpus, len(convs), prefix_share[corpus],
+        )
+
+    for row in round0:
+        corpus, method = row["corpus"], row["method"]
+        if corpus not in transcripts:
+            continue
+        r, churn = row["token_ratio"], row["churn_mean"]
+        for arch, tiers in ARCHETYPES.items():
+            base = [
+                conversation_cost(t, r=1.0, churn=0.0, policy="no-compress", tiers=tiers)
+                for t in transcripts[corpus]
+            ]
+            for policy in ("full-compress", "turn-local-commit"):
+                cost = [
+                    conversation_cost(t, r=r, churn=churn, policy=policy, tiers=tiers)
+                    for t in transcripts[corpus]
+                ]
+                multipliers = [c / b for c, b in zip(cost, base)]
+                results.append(
+                    {
+                        "corpus": corpus,
+                        "method": method,
+                        "token_ratio": r,
+                        "churn_mean": churn,
+                        "archetype": arch,
+                        "policy": policy,
+                        "cost_multiplier_mean": statistics.mean(multipliers),
+                        "cost_multiplier_max": max(multipliers),
+                        "n_conversations": len(multipliers),
+                    }
+                )
+
+    OUT_PATH.write_text(
+        json.dumps({"prefix_share": prefix_share, "rows": results}, indent=1)
+    )
+    log.info("wrote %d rows -> %s", len(results), OUT_PATH)
+
+    # The headline table: mean input-cost multiplier vs no-compress (values < 1 save money).
+    methods = sorted({r["method"] for r in results})
+    corpora = sorted(transcripts)
+    for arch in ARCHETYPES:
+        print(f"\n=== {arch}: mean input-cost multiplier vs no-compress ===")
+        print(f"{'method':<32} {'policy':<18} " + " ".join(f"{c:>15}" for c in corpora))
+        for method in methods:
+            for policy in ("full-compress", "turn-local-commit"):
+                cells = []
+                for corpus in corpora:
+                    match = [
+                        r for r in results
+                        if (r["method"], r["policy"], r["archetype"], r["corpus"])
+                        == (method, policy, arch, corpus)
+                    ]
+                    cells.append(f"{match[0]['cost_multiplier_mean']:>15.3f}" if match else " " * 15)
+                print(f"{method:<32} {policy:<18} " + " ".join(cells))
+
+    # The analytic churn bound on cached providers: full compression beats no-compress
+    # only when r * (read + (write - read) * c) < read, i.e. c < read/(write-read) * (1/r - 1).
+    print("\nchurn bound (anthropic tiers): full-compress loses to NO compression when "
+          "churn > 0.087 * (1/r - 1) / 0.5 ... printed per method below")
+    for row in round0:
+        if row["corpus"] not in transcripts:
+            continue
+        r, c = row["token_ratio"], row["churn_mean"]
+        if r >= 1.0:
+            continue
+        bound = 0.1 / 1.15 * (1.0 / r - 1.0)
+        if c > 0:
+            print(f"  {row['method']:<32} {row['corpus']:<16} r={r:.2f} churn={c:.2f} "
+                  f"bound={bound:.3f} -> {'NET LOSS' if c > bound else 'ok'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c2_churn_measure.py
+++ b/.agents/scripts/c2_churn_measure.py
@@ -1,0 +1,357 @@
+"""C2 Q2 stage 2: routing-decision churn when the served router sees compressed text.
+
+Consumes stage 1's variants (c2_churn_variants.py), embeds them with the same
+text-embedding-3-large call the routing caches were built with (same [:18000]
+truncation, order-stable npy caches), fits the served champion per split seed on RAW
+fit-side embeddings (guard fable-5, z=0.5, floor_q=0.05, the #259 operating point),
+and measures per (corpus, variant, seed) over the TEST split:
+
+- churn: fraction of requests whose routed model changes vs the raw-text decision
+- direction: of churned requests, how many move to a cheaper vs pricier model
+  (fit-split mean cost per model), and how many enter/leave the fallback
+- floor trips: novelty-floor abstain rate raw vs compressed (the floor quantile was
+  calibrated on raw self-similarities, so compressed queries may trip it more)
+- route-away rate raw vs compressed
+- bank-refit variant: the bank itself refit on compressed fit texts, compressed
+  queries against it, churn measured vs the raw-raw decisions
+
+Run from the MAIN checkout (needs wmh at #259+; feat/compression-track predates the
+knn policy):
+
+    cd ~/Desktop/Projects/world-model-harness && \
+        uv run python ~/Desktop/Projects/wmh-compress-c2/.agents/scripts/c2_churn_measure.py
+
+Reads OPENAI_API_KEY from the environment or the repo .env.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import statistics
+import tempfile
+import time
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+from wmh.optimize.knn import fit_knn_policy
+from wmh.optimize.outcomes import OutcomeMatrix
+from wmh.optimize.policy import KNN_BANK_FILENAME, EmbedderSpec, knn_decision
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("c2_churn_measure")
+
+ROUTING_DATA = Path.home() / "Desktop/Projects/wmh-routing-data"
+DATA_ROOT = Path.home() / "Desktop/Projects/wmh-compression-data"
+VARIANTS_DIR = DATA_ROOT / "cache/churn-variants"
+EMB_DIR = DATA_ROOT / "cache/churn-emb"
+RESULTS_PATH = DATA_ROOT / "cache/churn-results.json"
+CORPORA = ["routerbench-ours9", "financebench-s80", "tau-bench-s80"]
+SEEDS = [0, 1, 2, 3, 4]
+FALLBACK = "fable-5"
+FLOOR_Q = 0.05
+
+
+def api_key() -> str:
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        env = Path.home() / "Desktop/Projects/world-model-harness/.env"
+        for line in env.read_text().splitlines():
+            if line.startswith("OPENAI_API_KEY="):
+                key = line.split("=", 1)[1].strip()
+    if not key:
+        raise ValueError("OPENAI_API_KEY not found")
+    return key
+
+
+def openai_embed(texts: list[str], cache_path: Path) -> np.ndarray:
+    """R1's embedding call, verbatim conventions: batches of 128, [:18000] truncation."""
+    if cache_path.exists():
+        cached = np.load(cache_path)
+        if cached.shape[0] == len(texts):
+            return cached
+    key = api_key()
+    vectors: list[list[float]] = []
+    total_tokens = 0
+    for start in range(0, len(texts), 128):
+        chunk = [t[:18000] if t.strip() else " " for t in texts[start : start + 128]]
+        payload = json.dumps({"model": "text-embedding-3-large", "input": chunk}).encode()
+        request = urllib.request.Request(
+            "https://api.openai.com/v1/embeddings",
+            data=payload,
+            headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        )
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(request, timeout=180) as response:
+                    data = json.loads(response.read())
+                break
+            except Exception as error:  # noqa: BLE001 - retry transients, then raise
+                if attempt == 3:
+                    raise
+                log.warning("embed batch %d retry %d: %s", start, attempt + 1, error)
+                time.sleep(5 * (attempt + 1))
+        vectors.extend(d["embedding"] for d in sorted(data["data"], key=lambda d: d["index"]))
+        total_tokens += data.get("usage", {}).get("total_tokens", 0)
+    array = np.asarray(vectors, dtype=np.float32)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(cache_path, array)
+    log.info("embedded %d texts, %d tokens (~$%.3f) -> %s",
+             len(texts), total_tokens, total_tokens / 1e6 * 0.13, cache_path.name)
+    return array
+
+
+def stratified_split(matrix: OutcomeMatrix, *, train_fraction: float = 0.7, seed: int = 0):
+    """The routing protocol's split (validate_knn_promotion.py's reimplementation)."""
+    by_eval: dict[str, list[str]] = {}
+    for scenario_id in matrix.scenario_ids():
+        prefix = scenario_id.split(":", 1)[0] if ":" in scenario_id else ""
+        by_eval.setdefault(prefix, []).append(scenario_id)
+    rng = random.Random(seed)
+    fit: list[str] = []
+    test: list[str] = []
+    for _name, ids in sorted(by_eval.items()):
+        shuffled = ids[:]
+        rng.shuffle(shuffled)
+        if len(shuffled) > 1:
+            cut = min(max(1, round(len(shuffled) * train_fraction)), len(shuffled) - 1)
+        else:
+            cut = 1
+        fit.extend(shuffled[:cut])
+        test.extend(shuffled[cut:])
+    return sorted(fit), sorted(test)
+
+
+class VectorEmbedder:
+    """Serves precomputed vectors keyed by the RAW task text (fit-time interface)."""
+
+    def __init__(self, raw_task_by_sid: dict[str, str], vec_by_sid: dict[str, np.ndarray]):
+        self._by_text = {raw_task_by_sid[sid]: vec for sid, vec in vec_by_sid.items()}
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [self._by_text[t].tolist() for t in texts]
+
+
+def scenario_order(matrix: OutcomeMatrix) -> tuple[list[str], dict[str, str]]:
+    order: list[str] = []
+    tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        if outcome.scenario_id not in tasks:
+            tasks[outcome.scenario_id] = outcome.task
+            order.append(outcome.scenario_id)
+    return order, tasks
+
+
+def model_costs_on_fit(matrix: OutcomeMatrix, fit_ids: list[str]) -> dict[str, float]:
+    sums: dict[str, tuple[float, int]] = {}
+    wanted = set(fit_ids)
+    for outcome in matrix.outcomes:
+        if outcome.scenario_id in wanted and outcome.reward is not None:
+            total, count = sums.get(outcome.model, (0.0, 0))
+            sums[outcome.model] = (total + outcome.cost_usd, count + 1)
+    return {m: t / c for m, (t, c) in sums.items()}
+
+
+def decide_all(policy, vectors: dict[str, np.ndarray], ids: list[str]):  # noqa: ANN001
+    out: dict[str, tuple[str, bool]] = {}
+    for sid in ids:
+        decision = knn_decision(policy, vectors[sid])
+        out[sid] = (decision.model, decision.reason.startswith("knn novelty abstain"))
+    return out
+
+
+def cell_tables(matrix: OutcomeMatrix):
+    """Per-(scenario, model) mean reward and cost: the outcome-matrix lookup tables."""
+    sums: dict[tuple[str, str], tuple[float, float, int]] = {}
+    for outcome in matrix.outcomes:
+        if outcome.reward is None:
+            continue
+        key = (outcome.scenario_id, outcome.model)
+        reward, cost, count = sums.get(key, (0.0, 0.0, 0))
+        sums[key] = (reward + outcome.reward, cost + outcome.cost_usd, count + 1)
+    return {k: (r / c_n, c / c_n) for k, (r, c, c_n) in sums.items()}
+
+
+def decision_value(cells, decisions, ids):  # noqa: ANN001
+    """ROUTING-CHANNEL value of a decision map: reward/cost of the picked model per
+    scenario, by matrix lookup. Execution stays UNCOMPRESSED (the matrix episodes ran
+    on raw text), so this isolates what compression does to the routing decision; the
+    execution-channel delta needs the live grid."""
+    rewards = [cells[(sid, decisions[sid][0])][0] for sid in ids if (sid, decisions[sid][0]) in cells]
+    costs = [cells[(sid, decisions[sid][0])][1] for sid in ids if (sid, decisions[sid][0]) in cells]
+    return statistics.mean(rewards), statistics.mean(costs)
+
+
+def main() -> None:
+    results: list[dict] = []
+    spec = EmbedderSpec(
+        kind="azure", dim=3072, deployment="text-embedding-3-large", endpoint="https://x"
+    )
+    for corpus in CORPORA:
+        matrix = OutcomeMatrix.load(ROUTING_DATA / "matrices" / f"{corpus}_matrix.json")
+        order, raw_tasks = scenario_order(matrix)
+        raw_vectors = np.load(ROUTING_DATA / "cache" / f"{corpus}-oai3l-tasks.npy").astype(
+            np.float32
+        )
+        assert raw_vectors.shape[0] == len(order), f"{corpus}: cache misaligned"
+        raw_by_sid = {sid: raw_vectors[i] for i, sid in enumerate(order)}
+
+        variants: dict[str, dict[str, str]] = {}
+        with (VARIANTS_DIR / f"{corpus}.jsonl").open() as handle:
+            for line in handle:
+                row = json.loads(line)
+                variants.setdefault(row["variant"], {})[row["scenario_id"]] = row["text"]
+        ratios = json.loads((VARIANTS_DIR / f"{corpus}-ratios.json").read_text())
+
+        variant_vecs: dict[str, dict[str, np.ndarray]] = {}
+        for variant, texts_by_sid in sorted(variants.items()):
+            safe = variant.replace(":", "_")
+            arr = openai_embed(
+                [texts_by_sid[sid] for sid in order], EMB_DIR / f"{corpus}-{safe}.npy"
+            )
+            variant_vecs[variant] = {sid: arr[i] for i, sid in enumerate(order)}
+
+        cells = cell_tables(matrix)
+        for seed in SEEDS:
+            fit_ids, test_ids = stratified_split(matrix, seed=seed)
+            costs = model_costs_on_fit(matrix, fit_ids)
+            with tempfile.TemporaryDirectory() as directory:
+                policy = fit_knn_policy(
+                    matrix,
+                    bank_path=Path(directory) / KNN_BANK_FILENAME,
+                    fit_ids=fit_ids,
+                    embedder=spec,
+                    embed_with=VectorEmbedder(raw_tasks, raw_by_sid),
+                    guard_model=FALLBACK,
+                    floor_q=FLOOR_Q,
+                    fitted_from=f"{corpus} seed={seed} raw",
+                )
+                raw_decisions = decide_all(policy, raw_by_sid, test_ids)
+                raw_reward, raw_cost = decision_value(cells, raw_decisions, test_ids)
+
+                for variant in sorted(variants):
+                    comp_decisions = decide_all(policy, variant_vecs[variant], test_ids)
+                    comp_reward, comp_cost = decision_value(cells, comp_decisions, test_ids)
+                    churned = [
+                        sid for sid in test_ids
+                        if comp_decisions[sid][0] != raw_decisions[sid][0]
+                    ]
+                    to_cheaper = sum(
+                        1 for sid in churned
+                        if costs.get(comp_decisions[sid][0], 0.0)
+                        < costs.get(raw_decisions[sid][0], 0.0)
+                    )
+                    results.append(
+                        {
+                            "corpus": corpus,
+                            "variant": variant,
+                            "seed": seed,
+                            "mode": "query-only",
+                            "n_test": len(test_ids),
+                            "achieved_ratio": ratios[variant],
+                            "churn": len(churned) / len(test_ids),
+                            "to_cheaper": to_cheaper,
+                            "to_pricier": len(churned) - to_cheaper,
+                            "raw_route_away": statistics.mean(
+                                raw_decisions[sid][0] != FALLBACK for sid in test_ids
+                            ),
+                            "comp_route_away": statistics.mean(
+                                comp_decisions[sid][0] != FALLBACK for sid in test_ids
+                            ),
+                            "raw_floor_trips": sum(
+                                raw_decisions[sid][1] for sid in test_ids
+                            ),
+                            "comp_floor_trips": sum(
+                                comp_decisions[sid][1] for sid in test_ids
+                            ),
+                            "comp_pick_counts": dict(
+                                Counter(comp_decisions[sid][0] for sid in test_ids)
+                            ),
+                            "raw_reward": raw_reward,
+                            "comp_reward": comp_reward,
+                            "raw_cost": raw_cost,
+                            "comp_cost": comp_cost,
+                        }
+                    )
+
+                # Bank-refit leg: the bank itself fit on compressed fit texts.
+                for variant in sorted(variants):
+                    with tempfile.TemporaryDirectory() as refit_dir:
+                        refit_policy = fit_knn_policy(
+                            matrix,
+                            bank_path=Path(refit_dir) / KNN_BANK_FILENAME,
+                            fit_ids=fit_ids,
+                            embedder=spec,
+                            embed_with=VectorEmbedder(raw_tasks, variant_vecs[variant]),
+                            guard_model=FALLBACK,
+                            floor_q=FLOOR_Q,
+                            fitted_from=f"{corpus} seed={seed} bank-refit {variant}",
+                        )
+                        refit_decisions = decide_all(
+                            refit_policy, variant_vecs[variant], test_ids
+                        )
+                    refit_reward, refit_cost = decision_value(cells, refit_decisions, test_ids)
+                    churned = [
+                        sid for sid in test_ids
+                        if refit_decisions[sid][0] != raw_decisions[sid][0]
+                    ]
+                    results.append(
+                        {
+                            "corpus": corpus,
+                            "variant": variant,
+                            "seed": seed,
+                            "mode": "bank-refit",
+                            "n_test": len(test_ids),
+                            "achieved_ratio": ratios[variant],
+                            "churn": len(churned) / len(test_ids),
+                            "comp_route_away": statistics.mean(
+                                refit_decisions[sid][0] != FALLBACK for sid in test_ids
+                            ),
+                            "comp_floor_trips": sum(
+                                refit_decisions[sid][1] for sid in test_ids
+                            ),
+                            "raw_reward": raw_reward,
+                            "comp_reward": refit_reward,
+                            "raw_cost": raw_cost,
+                            "comp_cost": refit_cost,
+                        }
+                    )
+            log.info("%s seed %d done", corpus, seed)
+
+    RESULTS_PATH.write_text(json.dumps(results, indent=1))
+    log.info("wrote %d rows -> %s", len(results), RESULTS_PATH)
+
+    # Seed-aggregated summary table. Value columns are the ROUTING-CHANNEL deltas
+    # (matrix lookup, execution uncompressed): paired per-seed comp minus raw.
+    keys = sorted({(r["corpus"], r["variant"], r["mode"]) for r in results})
+    print(f"\n{'corpus':<18} {'variant':<34} {'mode':<11} {'ratio':>5} "
+          f"{'churn mean+-sd':>15} {'away r->c':>11} {'floor r->c':>10} "
+          f"{'d_reward (wins)':>16} {'d_cost%':>8}")
+    for corpus, variant, mode in keys:
+        rows = [
+            r for r in results
+            if (r["corpus"], r["variant"], r["mode"]) == (corpus, variant, mode)
+        ]
+        churns = [r["churn"] for r in rows]
+        away = ""
+        if mode == "query-only":
+            away = (f"{statistics.mean(r['raw_route_away'] for r in rows):.2f}->"
+                    f"{statistics.mean(r['comp_route_away'] for r in rows):.2f}")
+        floors = (f"{sum(r.get('raw_floor_trips', 0) for r in rows)}->"
+                  f"{sum(r['comp_floor_trips'] for r in rows)}")
+        d_reward = [r["comp_reward"] - r["raw_reward"] for r in rows]
+        wins = sum(1 for d in d_reward if d >= 0)
+        d_cost = statistics.mean(r["comp_cost"] / r["raw_cost"] - 1.0 for r in rows)
+        print(f"{corpus:<18} {variant:<34} {mode:<11} {rows[0]['achieved_ratio']:>5.2f} "
+              f"{statistics.mean(churns):>7.3f}+-{statistics.stdev(churns):<6.3f} "
+              f"{away:>11} {floors:>10} "
+              f"{statistics.mean(d_reward):>+8.4f} ({wins}/5) {d_cost:>+7.1%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c2_churn_variants.py
+++ b/.agents/scripts/c2_churn_variants.py
@@ -1,0 +1,135 @@
+"""C2 Q2 stage 1: compressed variants of every routable task text (torch venv).
+
+The served router (#259) embeds the LATEST USER MESSAGE (`_routable_text` in
+wmh/serving/chat.py) and conversation affinity pins the incumbent after turn 1, so
+routing-decision churn under compression is a property of the FIRST request of a
+conversation: the task text, which is also what the knn fit bank embeds. This stage
+produces, per corpus, every (method, aggressiveness) compressed variant of every task
+text, plus achieved token ratios. Stage 2 (c2_churn_measure.py, wmh env) embeds them
+and measures decision churn.
+
+Methods: C1's bar-1 survivors with an aggressiveness knob get 3 levels; single-config
+survivors get 1; random removal is the control, run at 3 levels so churn-vs-ratio
+curves can be compared at matched achieved ratio at analysis time.
+per-turn-truncate-at-append is skipped: on a single-turn request it IS head truncation
+at a different budget, so it would duplicate the head-truncate rows.
+
+Run inside C1's scratch venv (torch + transformers, not wmh deps):
+
+    ~/Desktop/Projects/wmh-compression-data/cache/venv-c1/bin/python \
+        .agents/scripts/c2_churn_variants.py
+
+Scorer configs match C1's audit exactly (CPU fp32, per-turn locality, calibration
+frozen per corpus) so achieved ratios stay comparable with round 0.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import statistics
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("c2_churn_variants")
+
+REPO = Path(__file__).resolve().parents[2]
+DATA_ROOT = Path.home() / "Desktop/Projects/wmh-compression-data"
+ROUTING_MATRICES = Path.home() / "Desktop/Projects/wmh-routing-data/matrices"
+OUT_DIR = DATA_ROOT / "cache/churn-variants"
+CORPORA = ["routerbench-ours9", "financebench-s80", "tau-bench-s80"]
+
+# Aggressiveness levels: nominal keep targets for ratio-style knobs, thresholds for the
+# learned filter (higher threshold = more aggressive; 0.5 is C1's audited config).
+KEEP_LEVELS = {"low": 0.7, "mid": 0.5, "high": 0.3}
+LL2_THRESHOLDS = {"low": 0.35, "mid": 0.5, "high": 0.65}
+
+
+def _load(name: str, path: Path):  # noqa: ANN202 - .agents pragma
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+C = _load("compression", REPO / "wmh/research/compression.py")
+AUDIT = _load("run_compression_audit", REPO / ".agents/scripts/run_compression_audit.py")
+
+
+def task_texts(corpus: str) -> tuple[list[str], list[str]]:
+    """(scenario_ids, tasks) in first-appearance order, the .npy cache row order."""
+    outcomes = json.loads((ROUTING_MATRICES / f"{corpus}_matrix.json").read_text())["outcomes"]
+    order: list[str] = []
+    tasks: dict[str, str] = {}
+    for entry in outcomes:
+        if entry["scenario_id"] not in tasks:
+            tasks[entry["scenario_id"]] = entry["task"]
+            order.append(entry["scenario_id"])
+    return order, [tasks[sid] for sid in order]
+
+
+def build_variants(corpus: str, tasks: list[str], gpt2, ll2) -> dict[str, object]:  # noqa: ANN001
+    median_words = int(statistics.median(len(C.split_words(t)) for t in tasks))
+    all_units = [u for u in C.split_units("\n".join(tasks)) if u.strip()]
+    methods: dict[str, object] = {}
+    for level, keep in KEEP_LEVELS.items():
+        si_threshold = AUDIT.calibrate_absolute_threshold(gpt2.bits_per_token, all_units, keep)
+        methods[f"selective-context-absolute:{level}"] = C.ScoredUnitFilter(
+            score_fn=gpt2.bits_per_token,
+            mode="absolute",
+            threshold=si_threshold,
+            name=f"sc-abs-{level}",
+        )
+        methods[f"head-truncate-absolute:{level}"] = C.HeadTruncateAbsolute(
+            budget_words=max(1, round(median_words * keep))
+        )
+        methods[f"random-removal:{level}"] = C.RandomRemoval(remove_ratio=1 - keep)
+    for level, threshold in LL2_THRESHOLDS.items():
+        methods[f"llmlingua2-fixed-threshold:{level}"] = C.ScoredTokenFilter(
+            token_score_fn=lambda turn: list(ll2.word_probs(turn)),
+            mode="absolute",
+            threshold=threshold,
+            name=f"ll2-fixed-{level}",
+        )
+    methods["dedup-keep-first:only"] = C.DedupKeepFirst(jaccard=0.9)
+    methods["json-minify:only"] = C.JsonMinify()
+    return methods
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    gpt2 = AUDIT.Gpt2SelfInfo()
+    ll2 = AUDIT.LLMLingua2Scorer()
+    for corpus in CORPORA:
+        out_path = OUT_DIR / f"{corpus}.jsonl"
+        if out_path.exists():
+            log.info("%s: exists, skipping", out_path)
+            continue
+        ids, tasks = task_texts(corpus)
+        methods = build_variants(corpus, tasks, gpt2, ll2)
+        ratios: dict[str, float] = {}
+        with out_path.open("w") as handle:
+            for variant, method in methods.items():
+                raw_tok = comp_tok = 0
+                for sid, task in zip(ids, tasks):
+                    compressed = method([task])
+                    raw_tok += AUDIT.count_tokens(gpt2.tokenizer, task)
+                    comp_tok += AUDIT.count_tokens(gpt2.tokenizer, compressed)
+                    handle.write(
+                        json.dumps(
+                            {"scenario_id": sid, "variant": variant, "text": compressed},
+                            ensure_ascii=False,
+                        )
+                        + "\n"
+                    )
+                ratios[variant] = comp_tok / raw_tok if raw_tok else 1.0
+                log.info("%s / %s: achieved token ratio %.3f", corpus, variant, ratios[variant])
+        (OUT_DIR / f"{corpus}-ratios.json").write_text(json.dumps(ratios, indent=2))
+        log.info("wrote %s (%d scenarios x %d variants)", out_path, len(ids), len(methods))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
C2 specialist branch, stacked on #261 (feat/compression-track). Round 0 is now MEASURED: the two offline legs Silen green-lit (Q2 routing churn, Q4 cache break-even) ran for ~$3 of embeddings and zero wm serve spend. All claims live in the shared ledger (`wmh-compression-data/findings/c2.md`, pre-registered bars unchanged) with 781 run records in `runs/c2.jsonl`; the canonical doc section here carries the summary for master's graft.

## What's in the diff

- `.agents/docs/research/compression-method-tiers.md`: the C2 pre-registration section (unchanged bars) plus the round 0 results block.
- `.agents/scripts/c2_churn_variants.py`: stage 1, compressed variants of every routable task text (C1's scorers, torch venv), 14 variants x 3 corpora, achieved-ratio manifest.
- `.agents/scripts/c2_churn_measure.py`: stage 2, fits the served #259 champion per seed on raw embeddings (fable-5 guard, z=0.5, floor_q=0.05) and measures decision churn, floor trips, route-away, and ROUTING-CHANNEL value by matrix lookup, in query-only and bank-refit modes.
- `.agents/scripts/c2_cache_breakeven.py`: Q4, replays C1's 120 audit conversations through a prefix-cache cost model (C3's tiers; anthropic/openai/no-cache archetypes) under no-compress / full-compress / turn-local-commit.

## Round 0 results

**Q4, cache break-even (the pre-registered candidate rule is beaten and retired):**
- Within-conversation prefix share on OUR transcripts: 0.72-0.87. First first-party measurement of the number the cache-first constraint rests on; third-party redundancy figures no longer carry the design.
- Full recompression with any churny method is a measured NET LOSS on cached providers: 17 of 25 method x corpus cells cost MORE than not compressing (up to 2.65x, llmlingua2-percentile on swe-bench) while removing ~half the tokens. Every cell agrees with the analytic bound churn < (c_r/(c_w-c_r))(1/r-1), which is 0.087 at r=0.5; C1 measured churn 0.23-1.0.
- Turn-local commit (compress each segment once at append, never retroactively) heals every churny cell below 1.0x; for churn-zero methods it IS full compression (identical numbers, sanity check passed).
- Append-stable compression multiplies both cache tiers by r: the literature's compress-OR-cache dichotomy exists only for cache-hostile compressors.
- SERVING RULE proposed to master for C3's seam: scope by measured append churn, never by conversation state. No provider cache: compress everything. Churn-zero compressor: compress everything. Churn > 0: turn-local commit only.

**Q2, ordering round 0 (churn; ours9 full power at 359 test scenarios x 5 seeds, s80 rows are candidates at 24):**
- 20-30% of ours9 routing decisions change at mid aggressiveness when the router sees compressed text against the raw served bank. Nobody had this number.
- The mechanism is ABSTENTION, not misrouting: compressed queries look novel to the raw-calibrated floor, floor trips rise 10-13x (95 to 976 at ll2-high; 1238 at sc-abs-high), route-away collapses (0.58 to 0.18-0.48; tau 0.41 to 0.00). Compression silently turns the router off, and because the fallback is fable-5, naive compress-then-route pays +11% to +41% routing-channel cost at flat-to-negative accuracy. The champion's -27% win reverts toward fable-only economics.
- Bank-refit on the SAME compressed representation heals it: floor trips return to raw levels, cost recovers, accuracy within noise at low/mid aggressiveness. Full-power exception: selective-context-absolute loses 0/5 on ours9 at every level even refit.
- Random removal churns like the learned methods at matched ratio: churn tracks token mass, not intelligence.
- VERDICT: the ordering question's real content is representation consistency. The compression config becomes part of the routing artifact version (a bank fitted under compressor X at aggressiveness a serves only behind exactly (X, a)); proposed as a D-COMPRESS seam requirement. Value deltas are routing-channel only (matrix lookup, execution uncompressed); the execution channel is the live grid's job.

## Status and gates

- DONE offline: Q2 churn (both modes), Q4 rule + curve. WAITING on C1's harness: Q1 interaction curves, Q3 guarded aggressiveness; live spend rides C1's approved grid (shared uncompressed baselines per the augmented-matrix design).
- Still open to Silen from the pre-registration: Q-A model subset, Q-B verbatim corpus (rec tau-bench-s80), Q-C stored agg=0 reuse, Q-D now resolved by events (rule derived from pinned meters; restate through wmh accounting when C3 lands).
- Labels: all Q4 numbers are pinned-meter projections; every s80 row is a candidate; judge noise does not apply to either leg (no wm judging in round 0).

## How Silen tests

Reproduce the churn table (cached embeddings, no API spend): `cd ~/Desktop/Projects/world-model-harness && uv run python ~/Desktop/Projects/wmh-compress-c2/.agents/scripts/c2_churn_measure.py`. Look for ours9 floor trips 95 -> 976 on llmlingua2-fixed-threshold:high and the dedup/json-minify sanity rows at churn ~0.000. Then the break-even table ($0): `~/Desktop/Projects/wmh-compression-data/cache/venv-c1/bin/python ~/Desktop/Projects/wmh-compress-c2/.agents/scripts/c2_cache_breakeven.py`, looking for llmlingua2-percentile full-compress at 2.653 on swe-bench healing to 0.631 under turn-local-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)