### PR TITLE
On-policy distillation: minibatch updates, two-sided tripwires, real cache billing

### DIFF
--- a/.agents/distill/tinker_probe_gsm8k.py
+++ b/.agents/distill/tinker_probe_gsm8k.py
@@ -76,7 +76,9 @@ from wmh.distill.loop import (
     DistillBudgetError,
     DistillProgress,
     DistillResult,
+    OptimStepOutput,
     SdkSamplingClient,
+    TrainStepOutput,
     run_distillation,
 )
 from wmh.distill.rendering import ChatRendering, RendererTokenizer, build_renderer
@@ -339,24 +341,44 @@ class ProbeTrainingClient:
         """The student base model's HF tokenizer."""
         return cast("EncodingTokenizer", self._client.get_tokenizer())
 
-    def forward_backward(self, datums: Sequence[TrainDatum], loss_fn: str) -> None:
-        """One timed blocking forward/backward batch (compat datum conversion)."""
+    def forward_backward(self, datums: Sequence[TrainDatum], loss_fn: str) -> TrainStepOutput:
+        """One timed blocking forward/backward batch (compat datum conversion).
+
+        Returns a real `TrainStepOutput`. It used to return None, which violated the
+        `TrainingClient` protocol it stands in for -- the loop reads `.loss` off this and
+        crashed with `'NoneType' object has no attribute 'loss'`, so the probe could not run
+        at all. The loss is read from the response's metrics rather than fabricated: absent
+        or non-numeric becomes None, which the loop already treats as "backend reported no
+        loss metric".
+        """
         converted = _compat_tinker_datums(datums)
         started = time.monotonic()
         try:
-            self._client.forward_backward(
+            response = self._client.forward_backward(
                 converted, cast("tinker.types.LossFnType", loss_fn)
             ).result()
         finally:
             self._timer.record("train.forward_backward", time.monotonic() - started)
+        metrics = getattr(response, "metrics", None) or {}
+        loss = metrics.get("total_loss:sum", metrics.get("total_loss"))
+        return TrainStepOutput(loss=float(loss) if isinstance(loss, (int, float)) else None)
 
-    def optim_step(self, learning_rate: float) -> None:
-        """One timed blocking Adam step."""
+    def optim_step(self, learning_rate: float) -> OptimStepOutput:
+        """One timed blocking Adam step.
+
+        Returns a real `OptimStepOutput` for the same reason as `forward_backward`: the loop
+        reads `.grad_norm` off it, and returning None broke the protocol. Grad norm is
+        reported only if the backend supplies one; never fabricated.
+        """
         started = time.monotonic()
         try:
-            self._client.optim_step(tinker.types.AdamParams(learning_rate=learning_rate)).result()
+            response = self._client.optim_step(
+                tinker.types.AdamParams(learning_rate=learning_rate)
+            ).result()
         finally:
             self._timer.record("train.optim_step", time.monotonic() - started)
+        norm = getattr(response, "grad_norm", None)
+        return OptimStepOutput(grad_norm=float(norm) if isinstance(norm, (int, float)) else None)
 
     def save_state(self) -> str:
         """One timed blocking save_state under a session-unique name."""
@@ -515,11 +537,24 @@ class ProbeRollouts:
                         ),
                     )
                 )
+        # `RolloutStats` grew four required fields (raw_solve_rate, executed_trials,
+        # infra_failed_trials, scaffold_loss_rate) after this probe was written, and the probe
+        # was not re-run in between, so it bit-rotted into a hard ValidationError -- the
+        # fast-iteration tool the goal file points at for cheap pre-checks was unusable. Every
+        # probe trial completes by construction (there is no harness to lose an episode to), so
+        # the honest values are: nothing infra-failed, everything executed, no scaffold loss.
+        # solve_rate stays 0.0 because these are ungraded math completions with no verifier;
+        # on-policy distillation needs no reward, and the probe's pass signal is the reverse-KL
+        # trend, not a solve rate.
         stats = RolloutStats(
             trials=len(records),
             trials_with_spans=len(records),
             solve_rate=0.0,
+            raw_solve_rate=0.0,
+            executed_trials=len(records),
+            infra_failed_trials=0,
             empty_span_trials=0,
+            scaffold_loss_rate=0.0,
         )
         logger.info(
             "probe rollouts step %d: %d trial(s) from %s (%d task(s) x %d attempt(s))",
@@ -549,6 +584,9 @@ def build_config(args: argparse.Namespace) -> DistillConfig:
             sampler_refresh_every=1,
             save_state_every=4,
             trial_concurrency=1,
+            learning_rate=args.learning_rate,
+            num_substeps=args.num_substeps,
+            advantage_clip=args.advantage_clip,
         ),
         sampling=SamplingConfig(temperature=1.0, max_tokens=args.max_tokens),
         eval=EvalConfig(every=0, tasks=len(HOLDOUT_TASK_IDS), k=1),
@@ -579,6 +617,26 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument(
         "--wandb", action="store_true", help="enable [wandb] tracking (project wmh-distill)"
     )
+    # The three knobs that decide whether a run trains or collapses, exposed here so the
+    # question can be answered for pennies instead of on a $14/step agentic run. Both real
+    # model pairs collapsed at their first honest update count -- Qwen upward (length 5.33x),
+    # Nano downward (entropy 0.35x) -- and the suspected cause is the UNBOUNDED advantage
+    # magnitude, not the sign (audited: advantage = teacher_lp - sampled_lp = -reverse_kl,
+    # which is the cookbook's construction and correct). This probe is the cheap way to test
+    # that: hold everything else fixed and vary the bound.
+    parser.add_argument(
+        "--num-substeps",
+        type=int,
+        default=1,
+        help="minibatches (and optimizer updates) per collected batch; 1 = historical behaviour",
+    )
+    parser.add_argument(
+        "--advantage-clip",
+        type=float,
+        default=None,
+        help="bound |advantage| per token; unset (default) trains the raw teacher-minus-student gap",
+    )
+    parser.add_argument("--learning-rate", type=float, default=1e-4, help="optimizer lr")
     return parser.parse_args(argv)
 
 

--- a/wmh/distill/config.py
+++ b/wmh/distill/config.py
@@ -253,7 +253,7 @@ class RolloutConfig(BaseModel):
         # Deferred: wmh.distill.renderers subclasses cookbook classes at module scope, and
         # wmh.distill.config is imported by the CLI, which must work without the distill extra.
         try:
-            from wmh.distill.renderers import VERBATIM_RENDERERS, is_known_renderer
+            from wmh.distill.renderers import WMH_RENDERERS, is_known_renderer
         except ImportError as exc:
             raise ImportError(MISSING_DISTILL_EXTRA) from exc
         for model, renderer in value.items():
@@ -263,34 +263,70 @@ class RolloutConfig(BaseModel):
                 f"rollout.renderers names the renderer {renderer!r} for {model!r}, which "
                 "tinker-cookbook cannot build; a name that does not resolve would only fail on "
                 "the run's first rollout. Use one of the wmh verbatim renderers "
-                f"({', '.join(sorted(VERBATIM_RENDERERS))}) or a built-in cookbook name "
+                f"({', '.join(sorted(WMH_RENDERERS))}) or a built-in cookbook name "
                 "(qwen3, qwen3_5, nemotron3, nemotron3_ultra, their *_disable_thinking "
                 "variants, ...)"
             )
         return value
 
     compaction: bool = False
+    """Whether terminus-2 may summarize its own history to stay inside the window.
 
-    @field_validator("compaction")
-    @classmethod
-    def _reject_compaction(cls, value: bool) -> bool:
-        """Reject compaction: it breaks the prefix property the cost model relies on.
+    Maps to terminus-2's `enable_summarize`, whose own default is True; this
+    defaults False because it is only SAFE under a history-editing renderer.
 
-        Every turn's prompt must extend the previous turn's tokens verbatim so
-        prefill work amortizes across turns and sampled spans stay aligned for
-        teacher scoring. Compacting mid-rollout rewrites the prefix, so each
-        later turn would be a full re-prefill and issued spans would no longer
-        appear verbatim in the episode tokens.
+    Compaction rewrites the prompt prefix mid-episode, so it is incompatible
+    with the prefix property and therefore with one-datum-per-episode: under a
+    verbatim renderer it would turn amortized prefill into a full re-prefill
+    per turn and stop sampled spans appearing verbatim in the episode tokens.
+    That is why it used to be rejected outright.
+
+    Under a strip-history renderer the prefix property is ALREADY gone by
+    design (the episode is one datum per turn either way), so compaction costs
+    nothing structurally and buys back the episodes that would otherwise die.
+    Two things make it safe there, both verified in harbor's source rather than
+    assumed:
+
+    - `Chat.reset_response_chain()` clears only `_last_response_id`; nothing
+      clears `_prompt_token_ids_list`/`_completion_token_ids_list`, so every
+      real turn is still recorded even though `chat._messages` is truncated to
+      three. Harbor's "rollout details will be incomplete" warning is about the
+      single-linear-trajectory assumption, which strip-history already broke.
+    - the three summarization subagents call `self._llm.call(...)` directly,
+      bypassing the `Chat`, so their turns never enter the training data.
+
+    Leaving it off costs whole trials: on the 17-task holdout with reasoning
+    dropped from history, terminal output alone still pushed 24% of teacher
+    episodes past the window, and an overflow FAILS the trial rather than
+    ending the episode.
+    """
+
+    @model_validator(mode="after")
+    def _compaction_needs_a_history_editing_renderer(self) -> RolloutConfig:
+        """Reject compaction when a renderer is relying on the prefix property.
+
+        Combining the two silently produces the worst case: the datum builder
+        would still try to merge an episode whose prefix compaction has
+        rewritten, so spans would stop matching the episode tokens.
         """
-        if value:
+        if not self.compaction:
+            return self
+        from wmh.distill.renderers import VERBATIM_RENDERERS
+
+        verbatim = sorted(
+            f"{model} = {name!r}"
+            for model, name in self.renderers.items()
+            if name in VERBATIM_RENDERERS
+        )
+        if verbatim:
             raise ValueError(
-                "rollout.compaction = true is not supported: compaction rewrites the "
-                "token prefix mid-episode, breaking the prefix property that keeps "
-                "prefill costs amortized across turns and sampled spans verbatim in "
-                "the episode; set compaction = false (episodes that outgrow "
-                "context_budget_tokens are dropped whole from training instead)"
+                "rollout.compaction = true cannot be combined with a verbatim renderer "
+                f"({'; '.join(verbatim)}): compaction rewrites the token prefix mid-episode, "
+                "which breaks the prefix property those renderers exist to preserve. Either "
+                "set compaction = false, or point [rollout.renderers] at a strip-history "
+                "renderer, whose episodes are already one datum per turn"
             )
-        return value
+        return self
 
 
 class TrainConfig(BaseModel):
@@ -368,6 +404,62 @@ class TrainConfig(BaseModel):
     sampler_refresh_every: int = Field(default=1, ge=1)
     save_state_every: int = Field(default=8, ge=1)
     trial_concurrency: int = Field(default=8, ge=1)
+
+    num_substeps: int = Field(default=1, ge=1)
+    """Optimizer updates to take per collected rollout batch.
+
+    1 (the default, and what every run before 2026-07-26 did) means ONE
+    `forward_backward` over every datum followed by ONE `optim_step`: a whole
+    batch of agent rollouts buys a single gradient step. Measured, that was
+    **$66 per update**, and a 15-step run would be fifteen updates total --
+    for a rank-32 LoRA that is a nudge, not training.
+
+    Splitting the same datums into N shuffled minibatches and taking N updates
+    costs NOTHING extra in rollouts, which are 94% of the bill and already
+    paid for by the time we get here. At 1,095 datums a 64-datum minibatch is
+    17 updates per batch instead of 1.
+
+    The tradeoff is that updates 2..N are OFF-POLICY with respect to the
+    weights that sampled the batch -- which is the standard PPO setting and
+    the reason `train.loss = "ppo"` has a ratio clip at all. With
+    `num_substeps = 1` that clip is inert by construction, because the
+    sampling policy and the training policy are the same weights and the ratio
+    is identically 1. Raising this is what makes it do its job. Shuffle order
+    is seeded per step, so a rerun reproduces the same minibatches.
+
+    Keep it modest relative to the batch: too many updates on one batch drifts
+    far from the sampling policy, and our advantages are unclipped
+    (`advantage_clip` unset), so the ratio clip is the only bound in the
+    system.
+    """
+
+    rollout_max_turns: int | None = Field(default=None, ge=1)
+    """Turn cap for TRAINING rollouts only; `None` uses `rollout.max_turns`.
+
+    Evals deliberately keep `rollout.max_turns`, because student-before and
+    student-after must run under identical settings or the paired delta
+    measures the config change instead of the training. Capping only the
+    training side is safe in a way it would NOT be for RL: on-policy
+    distillation's signal is the per-token teacher-minus-student gap on
+    whatever the student did, so a truncated episode is still valid
+    supervision for the turns it did take. It does not need the episode to
+    succeed.
+
+    This is the cost lever that matters, because both cost and latency grow
+    superlinearly in turns: every turn re-prefills the whole conversation, and
+    under a history-editing renderer every turn is also its own teacher-scored
+    datum. Measured over 193 real TB2 episodes (Qwen3.6-27B and Qwen3.5-9B):
+
+        cap   solved episodes kept   input tokens kept   est USD/step
+         10            34%                   6%                14
+         20            63%                  18%                44
+         30            81%                  33%                79
+        100           100%                 100%               242
+
+    tinker-cookbook's own harbor multi-turn distillation recipe pins
+    `max_turns=10` with `max_trajectory_tokens=24576` for terminal-bench-2.0,
+    which is the same reconciliation reached independently.
+    """
 
     log_sample_rollouts: int = Field(default=2, ge=0)
     """How many sample episodes each batch renders to human-readable text:
@@ -457,6 +549,41 @@ class EvalConfig(BaseModel):
     `teacher_baseline_from`, except the model check is on the report's
     recorded `base_model` field: the student's provider model is a per-run
     sampler path and never matches across runs."""
+
+    defer_baselines: bool = False
+    """Start training immediately and resolve the gate baselines at finalize.
+
+    The two baselines feed only `gate_distillation`; nothing in the training
+    loop reads them. Measured up front they are pure latency, so this moves
+    them off the critical path and lets a SEPARATE process measure them while
+    training runs.
+
+    That process needs its own `HOME`. Harbor's task cache is a hardcoded
+    `~/.cache/harbor` with no env override, and `_copy_task_source_to_target`
+    does an unconditional `rmtree` + `copytree` of the task directory even when
+    the cache is already warm -- so two concurrent harbor jobs under one HOME
+    delete each other's tasks out from under a running trial.
+
+    Requires `student_baseline_from`. The student-before baseline is the one
+    measurement whose meaning depends on WHEN it runs: at finalize the LoRA has
+    trained, so re-measuring it there would quietly report the trained student
+    as the "before" number and collapse the very delta the run exists to show.
+    Deferred, it must be imported. The teacher is a fixed base model, so it may
+    be measured late without harm.
+    """
+
+    @model_validator(mode="after")
+    def _deferred_baselines_need_an_imported_student(self) -> EvalConfig:
+        """Refuse to defer without a student-before to import."""
+        if self.defer_baselines and not self.student_baseline_from:
+            raise ValueError(
+                "eval.defer_baselines = true requires eval.student_baseline_from: deferring "
+                "runs the student-before baseline AFTER training, when the LoRA has already "
+                "moved, so it would measure the TRAINED student and report it as the "
+                "pre-training number. Point it at the concurrent baseline run's "
+                "evals/baseline-student-before.json"
+            )
+        return self
 
 
 class GateConfig(BaseModel):
@@ -594,12 +721,25 @@ class TripwireConfig(BaseModel):
     that always fires gets muted, which is strictly worse than no tripwire, so
     do not replace any fraction below with an absolute nats or token count.
 
-    Both bounds are one-sided, on the DOWNSIDE. The runaway direction of the
-    same pathology (a student that never learns to stop) shows up as
-    `mean_generation_tokens` rising instead, and the metrics row already carries
-    its sharper signals: `stop_reason_counts` (`max_turns`, `output_truncated`)
-    and `scaffold_loss_rate`. Nothing here aborts on it, because an episode cap
-    bounds it already.
+    Bounds are TWO-SIDED, as of 2026-07-26. They used to be downside-only, on
+    the reasoning that "an episode cap bounds the runaway direction already".
+    A measured run refuted that: with `train.rollout_max_turns = 20` in force
+    the whole time, `mean_generation_tokens` still reached **5.33x** baseline
+    over four steps, because the cap bounds TURNS while each turn grew — 172
+    turns pinned the 12,288-token output cap in a single step. The real damage
+    was invisible to both bounds: episodes overflowing the context budget are
+    dropped whole, so trainable datums fell 1,129 -> 689 and 22 of 64 episodes
+    were discarded, while every downside tripwire stayed silent and a human had
+    to stop the run by eye. Entropy climbed 1.68x over the same steps, which is
+    the signature a sibling lane saw before its model scored 0/30 on AIME with
+    78k-character repetition loops.
+
+    So each metric now answers to a floor (`*_frac`, a fraction) AND a ceiling
+    (`*_mult`, a multiple). The asymmetry in the defaults is deliberate: a
+    policy can legitimately grow somewhat (this student was distilling toward a
+    teacher that genuinely takes longer turns, 1,068 median context tokens per
+    turn against the student's 770), so the ceilings sit further from 1.0 than
+    the floors do.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -639,6 +779,38 @@ class TripwireConfig(BaseModel):
     than nine out of ten healthy episodes. The sibling's 50x collapse (2,866 to
     about 50 tokens) is a ratio of 0.017, two orders of magnitude past this."""
 
+    entropy_warn_mult: float = Field(default=1.5, gt=1.0)
+    """Warn when the batch-pooled entropy RISES to this multiple of baseline.
+
+    The measured refutation run climbed 0.513 -> 0.862 nats/token, a ratio of
+    1.68, and nothing fired. A sibling lane's degenerate model (AIME 0/30, 78k
+    repetition loops) climbed 0.26 -> 0.82, a ratio of 3.15, and rising entropy
+    was its ONLY warning. 1.5 sits below the run we know went wrong."""
+
+    entropy_kill_mult: float = Field(default=2.5, gt=1.0)
+    """Abort (after `kill_consecutive_steps`) at this multiple of baseline.
+
+    Above the 1.68 that a run reached while still producing a measurable (if
+    insignificant) gain, and below the 3.15 of the run that ended degenerate,
+    so this kills the established pathology without killing a run that is still
+    arguably learning."""
+
+    length_warn_mult: float = Field(default=2.0, gt=1.0)
+    """Warn when mean sampled tokens per episode RISES to this multiple.
+
+    Reached at step 1 of the refutation run (2.31x), which is when a human
+    should have been asked to look, and comfortably above the upside of ordinary
+    batch-composition noise: the probe resampling that set the floors put the
+    downside p0.1 at 0.62 for this batch shape, whose reciprocal is 1.61."""
+
+    length_kill_mult: float = Field(default=3.0, gt=1.0)
+    """Abort (after `kill_consecutive_steps`) at this multiple of baseline.
+
+    Chosen against measured damage rather than taste: the refutation run passed
+    3.0x at step 2, which is the step where context-overflow drops reached 14 of
+    64 episodes and the batch began collapsing. Two consecutive steps past this
+    is the point where further spend buys less supervision each step."""
+
     kill_consecutive_steps: int = Field(default=2, ge=1)
     """Consecutive kill-level steps tolerated before the run aborts.
 
@@ -648,25 +820,42 @@ class TripwireConfig(BaseModel):
 
     @model_validator(mode="after")
     def _check_kill_below_warn(self) -> TripwireConfig:
-        """Keep every kill fraction at or under its warn fraction.
+        """Keep every kill threshold on the far side of its warn threshold.
+
+        Both directions, and the comparison inverts between them: a kill FLOOR
+        must sit at or below its warn floor, while a kill CEILING must sit at or
+        above its warn ceiling. Getting that inversion wrong is the whole reason
+        this is checked rather than left to the reader.
 
         Returns:
             This config, unchanged, when each kill threshold is reachable only
             through its warn threshold.
 
         Raises:
-            ValueError: If a kill fraction sits above its warn fraction, which
-                would abort the run without ever having warned about it.
+            ValueError: If a kill threshold sits on the near side of its warn
+                threshold, which would abort the run without ever having warned
+                about it.
         """
-        pairs = (
+        floors = (
             ("entropy", self.entropy_kill_frac, self.entropy_warn_frac),
             ("length", self.length_kill_frac, self.length_warn_frac),
         )
-        for metric, kill, warn in pairs:
+        for metric, kill, warn in floors:
             if kill > warn:
                 raise ValueError(
                     f"tripwire.{metric}_kill_frac ({kill}) must be <= "
                     f"tripwire.{metric}_warn_frac ({warn}), or the run would abort at a "
+                    "ratio it never warned about first"
+                )
+        ceilings = (
+            ("entropy", self.entropy_kill_mult, self.entropy_warn_mult),
+            ("length", self.length_kill_mult, self.length_warn_mult),
+        )
+        for metric, kill, warn in ceilings:
+            if kill < warn:
+                raise ValueError(
+                    f"tripwire.{metric}_kill_mult ({kill}) must be >= "
+                    f"tripwire.{metric}_warn_mult ({warn}), or the run would abort at a "
                     "ratio it never warned about first"
                 )
         return self

--- a/wmh/distill/config_test.py
+++ b/wmh/distill/config_test.py
@@ -216,10 +216,50 @@ tags = ["smoke", "tb2"]
     assert cfg.wandb.tags == ["smoke", "tb2"]
 
 
-def test_compaction_true_rejected(tmp_path: Path) -> None:
-    text = MINIMAL_TOML + "\n[rollout]\ncompaction = true\n"
+def test_compaction_rejected_with_a_verbatim_renderer(tmp_path: Path) -> None:
+    """The one combination that silently corrupts: merge an episode whose prefix moved."""
+    text = MINIMAL_TOML + (
+        "\n[rollout]\ncompaction = true\n\n"
+        '[rollout.renderers]\n"Qwen/Qwen3-8B" = "wmh/qwen3_verbatim"\n'
+    )
     with pytest.raises(ValueError, match="prefix property"):
         load_distill_config(_write(tmp_path, text))
+
+
+def test_compaction_allowed_with_a_strip_history_renderer(tmp_path: Path) -> None:
+    """Compaction costs nothing once the episode is already one datum per turn.
+
+    Leaving it off is what let a context overflow FAIL the trial instead of
+    ending the episode, which took 24% of teacher trials out of the denominator
+    rather than scoring them zero.
+    """
+    text = MINIMAL_TOML + (
+        "\n[rollout]\ncompaction = true\n\n"
+        '[rollout.renderers]\n"Qwen/Qwen3-8B" = "wmh/qwen3_5_strip_history"\n'
+    )
+    assert load_distill_config(_write(tmp_path, text)).rollout.compaction is True
+
+
+def test_defer_baselines_requires_an_imported_student_before(tmp_path: Path) -> None:
+    """Deferred, student-before runs after the LoRA moved -- it MUST be imported, not measured."""
+    text = MINIMAL_TOML + "\n[eval]\ndefer_baselines = true\n"
+    with pytest.raises(ValueError, match="student_baseline_from"):
+        load_distill_config(_write(tmp_path, text))
+
+
+def test_defer_baselines_accepted_with_a_student_baseline(tmp_path: Path) -> None:
+    """The teacher may be measured late (fixed base model); the student may not."""
+    text = MINIMAL_TOML + (
+        "\n[eval]\ndefer_baselines = true\n"
+        'student_baseline_from = "runs/base/evals/baseline-student-before.json"\n'
+    )
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.eval.defer_baselines is True
+
+
+def test_compaction_defaults_off(tmp_path: Path) -> None:
+    """Off unless asked for: it is a real change to what the model sees."""
+    assert load_distill_config(_write(tmp_path, MINIMAL_TOML)).rollout.compaction is False
 
 
 @pytest.mark.parametrize("steps", [0, 1, 5])
@@ -827,7 +867,7 @@ def test_checked_in_run_configs_name_a_verbatim_renderer_for_every_tinker_model(
     configs actually carry the entries.
     """
     pytest.importorskip("tinker_cookbook")
-    from wmh.distill.renderers import VERBATIM_RENDERERS
+    from wmh.distill.renderers import WMH_RENDERERS
 
     config_dir = Path(__file__).resolve().parents[2] / ".agents" / "distill"
     paths = sorted(config_dir.glob("*.toml"))
@@ -843,7 +883,31 @@ def test_checked_in_run_configs_name_a_verbatim_renderer_for_every_tinker_model(
         for model in sampled:
             renderer = cfg.rollout.renderers.get(model)
             assert renderer is not None, f"{path.name}: no rollout.renderers entry for {model}"
-            assert renderer in VERBATIM_RENDERERS, f"{path.name}: {model} = {renderer}"
+            assert renderer in WMH_RENDERERS, f"{path.name}: {model} = {renderer}"
+
+
+def test_the_config_module_never_imports_the_distill_extra_at_module_scope() -> None:
+    """`wmh --help` must work on a base install: the CLI imports this module eagerly.
+
+    Renderer-name validation needs tinker-cookbook, so it lives behind a lazy import
+    inside the validator and only runs when a config actually names renderers.
+    """
+    import ast
+
+    import wmh.distill.config as config_module
+
+    assert config_module.__file__ is not None
+    tree = ast.parse(Path(config_module.__file__).read_text(encoding="utf-8"))
+    roots: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            roots.add(node.module.split(".")[0])
+    assert not roots & {"tinker", "tinker_cookbook", "harbor"}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            assert node.module != "wmh.distill.renderers"
 
 
 def test_a_renderer_name_the_cookbook_cannot_build_is_rejected_at_load(tmp_path: Path) -> None:
@@ -895,3 +959,18 @@ def test_super_topk_configs_pin_clip_and_centering_explicitly(name: str) -> None
     assert cfg.train.advantage_clip == pytest.approx(4.0)
     assert cfg.train.center_advantages is True
     assert cfg.warmup.steps == 0
+
+
+def test_training_turn_cap_defaults_to_the_rollout_cap(tmp_path: Path) -> None:
+    """Unset means one cap everywhere, which is the pre-existing behaviour."""
+    cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))
+    assert cfg.train.rollout_max_turns is None
+    assert cfg.rollout.max_turns == 100
+
+
+def test_training_turn_cap_is_separate_from_the_eval_cap(tmp_path: Path) -> None:
+    """Evals must stay at rollout.max_turns or the paired before/after delta is void."""
+    text = MINIMAL_TOML + "\n[rollout]\nmax_turns = 100\n\n[train]\nrollout_max_turns = 20\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.train.rollout_max_turns == 20
+    assert cfg.rollout.max_turns == 100, "the eval-side cap must not move"

--- a/wmh/distill/data.py
+++ b/wmh/distill/data.py
@@ -386,10 +386,18 @@ def build_datums(
         context_tokens=context_tokens,
     )
     if stats.fragments:
+        # Not always a fault. A history-editing renderer (wmh/qwen3_5_strip_history) drops prior
+        # turns' reasoning by design, which breaks the prefix property on purpose and makes every
+        # turn its own datum -- a near-1.0 rate is the EXPECTED reading there, not a regression.
+        # The message says what it costs and lets the reader judge, rather than asserting a bug:
+        # the old wording ("check the harness prefix pins") sent a reader hunting for a break that
+        # the configuration had deliberately chosen.
         logger.warning(
-            "%d of %d datum(s) are fragments (fragmentation rate %.2f): the agent "
-            "edited its history mid-episode, so shared context is re-prefilled and "
-            "teacher scoring costs multiply; check the harness prefix pins",
+            "%d of %d datum(s) are fragments (fragmentation rate %.2f): turns are scored "
+            "separately rather than merged, so shared context is re-prefilled per turn and "
+            "teacher scoring cost rises with turn count. Expected under a history-editing "
+            "renderer; unexpected under a verbatim one, where it means the prefix property "
+            "broke and the harness pins need checking",
             stats.fragments,
             stats.datums,
             stats.fragmentation_rate,

--- a/wmh/distill/loop.py
+++ b/wmh/distill/loop.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
 import random
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -117,6 +118,7 @@ from wmh.distill.store import (
     build_handoff_toml,
 )
 from wmh.distill.teacher import (
+    CachedUsageTeacher,
     EncodingTokenizer,
     SdkLogprobScorer,
     TeacherClient,
@@ -475,6 +477,16 @@ class StepMetrics(BaseModel):
     """Trained loss tokens whose raw advantage hit the clip bound (0 under
     `topk_ce`, which clips nothing, and 0 when `train.advantage_clip` is
     unset)."""
+
+    optimizer_updates: int = Field(default=1, ge=0)
+    """Optimizer updates this step took (`train.num_substeps`, or fewer if the
+    batch had less than that many replica groups).
+
+    Recorded because it is the quantity that most cheaply explains a null
+    result and was invisible for the project's first several runs: the loop
+    took ONE update per collected batch, so a 4-step run was 5 updates total
+    and could not have moved a rank-32 LoRA whatever the objective did. A run
+    summary that reports tokens but not updates hides that."""
 
     loss_tokens: int = Field(ge=0)
     """Sampled (mask 1.0) tokens in the trained batch, counted once per SOURCE
@@ -1565,6 +1577,48 @@ def _batch_reverse_kl(
     return kl_sum / kl_count if kl_count else None
 
 
+def _split_cached_prefill(submitted: int, cached: int) -> tuple[int, int]:
+    """Split one batch's scoring volume into (uncached, cached) billable tokens.
+
+    Pure arithmetic, separated from the charging so the guards can be tested
+    without a loop instance. Both inputs are DELTAS of monotonic counters, and
+    both can arrive nonsensical:
+
+    - `cached` can be negative when the teacher rebuilt its scorer mid-batch
+      (the wedged-session path drops and replaces it, restarting the counter).
+      Left alone that would CREDIT the run for spend it really made.
+    - `cached` can exceed `submitted` for the same reason, or if a response
+      counts cache hits over a prompt the caller did not attribute to this
+      batch, which would bill negative uncached tokens.
+
+    Args:
+        submitted: Tokens submitted for scoring in this batch.
+        cached: Tokens the service reported serving from its prefix cache.
+
+    Returns:
+        `(uncached, cached)`, both non-negative and summing to `max(submitted, 0)`.
+    """
+    total = max(submitted, 0)
+    billable_cached = min(max(cached, 0), total)
+    return total - billable_cached, billable_cached
+
+
+def _teacher_cached_usage(teacher: TeacherClient) -> int:
+    """The teacher's cumulative service-cached prefill tokens, or 0 if unknown.
+
+    Args:
+        teacher: The run's teacher client.
+
+    Returns:
+        `cached_usage()` when the teacher reports one, else 0 — which bills every
+        scoring token at the uncached rate, the behaviour the ledger had before
+        the field was readable.
+    """
+    if isinstance(teacher, CachedUsageTeacher):
+        return teacher.cached_usage()
+    return 0
+
+
 def _teacher_rows(
     teacher: TeacherClient, datums: Sequence[TrainDatum]
 ) -> tuple[list[list[float | None]], float | None]:
@@ -1930,6 +1984,31 @@ class _DistillRun:
             consecutive_steps=self._degeneration_streak,
             breaches=kills,
         )
+
+    def _charge_teacher_scoring(self, usage_before: int, cached_before: int) -> None:
+        """Charge one batch of teacher scoring, splitting off what the service cached.
+
+        The cached split is the SERVICE's own `prompt_cache_hit_tokens`, not a
+        wmh-side guess at which prefixes repeat (that is what `batch_billing`
+        does for rollouts). Before this was read, every scoring token was billed
+        at the uncached rate, which is why the run ledger is a ceiling rather
+        than a bill: the one calibration available put the estimate at \\$1,332
+        against a true \\$1,140.92.
+
+        Falls back to charging everything uncached when the teacher cannot report
+        a cache count, so an injected fake or a future SDK that drops the field
+        can only ever make the ledger conservative, never optimistic.
+
+        Args:
+            usage_before: `teacher.usage()` sampled before the scoring call.
+            cached_before: `cached_usage()` sampled at the same moment.
+        """
+        uncached, cached = _split_cached_prefill(
+            self._teacher.usage() - usage_before,
+            _teacher_cached_usage(self._teacher) - cached_before,
+        )
+        self._budget.charge("teacher_prefill", uncached)
+        self._budget.charge("teacher_cached_prefill", cached)
 
     def _charge_rollout_billing(self, billing: SpanBilling, *, teacher: bool) -> None:
         """Charge one rollout batch's per-request billing to its model's meters.
@@ -2626,8 +2705,22 @@ class _DistillRun:
             step=step,
         )
         sampler_path = self._sampler.sampler_path
+        # Training rollouts may run under a tighter turn cap than evals do (see
+        # `TrainConfig.rollout_max_turns`), via the same model_copy override `_run_eval` uses
+        # for its attempt count. Evals keep `rollout.max_turns` so student-before and
+        # student-after stay like-for-like -- capping the measurement too would make the paired
+        # delta report the config change rather than the training.
+        rollout_cfg = cfg
+        if cfg.train.rollout_max_turns is not None:
+            rollout_cfg = cfg.model_copy(
+                update={
+                    "rollout": cfg.rollout.model_copy(
+                        update={"max_turns": cfg.train.rollout_max_turns}
+                    )
+                }
+            )
         records, roll_stats = collect_rollouts(
-            step, batch, cfg, self._harness, self._student_provider(), self._run_dir
+            step, batch, rollout_cfg, self._harness, self._student_provider(), self._run_dir
         )
         self._charge_rollout_billing(batch_billing(records), teacher=False)
         self._log_sample_rollouts(kind="train", name=f"step-{step:04d}", step=step, records=records)
@@ -2640,6 +2733,7 @@ class _DistillRun:
 
         datums, datum_stats = build_datums(records, cfg)
         teacher_usage_before = self._teacher.usage()
+        teacher_cached_before = _teacher_cached_usage(self._teacher)
         advantage_mean: float | None = None
         advantage_std: float | None = None
         clipped_tokens = 0
@@ -2661,7 +2755,7 @@ class _DistillRun:
                 # Charged even when scoring raises mid-batch: the pool joins
                 # every submitted call before propagating, so the whole batch
                 # was billed server-side whether or not a row came back.
-                self._budget.charge("teacher_prefill", self._teacher.usage() - teacher_usage_before)
+                self._charge_teacher_scoring(teacher_usage_before, teacher_cached_before)
             reverse_kl = _batch_reverse_kl(datums, scores.realized)
             trained, topk_stats = build_topk_ce_datums(datums, scores.topk, cfg.train.topk)
             loss_fn = CROSS_ENTROPY_LOSS
@@ -2673,7 +2767,7 @@ class _DistillRun:
                 rows, reverse_kl = _teacher_rows(self._teacher, datums)
             finally:
                 # Same contract as the topk_ce branch above.
-                self._budget.charge("teacher_prefill", self._teacher.usage() - teacher_usage_before)
+                self._charge_teacher_scoring(teacher_usage_before, teacher_cached_before)
             trained, adv_stats = attach_advantages(datums, rows, cfg)
             # importance_sampling and ppo ride identical datums (see
             # `to_tinker_datums`); only the service-side loss differs.
@@ -2691,6 +2785,7 @@ class _DistillRun:
         train_tokens = sum(len(datum.model_input_tokens) for datum in trained)
         pg_loss: float | None = None
         grad_norm: float | None = None
+        optimizer_updates = 0
         if trained:
             logger.info(
                 "step %d: %d datum(s) into forward_backward under loss_fn %r (train.loss = %r)",
@@ -2699,10 +2794,62 @@ class _DistillRun:
                 loss_fn,
                 cfg.train.loss,
             )
-            train_output = self._training.forward_backward(trained, loss_fn=loss_fn)
-            optim_output = self._training.optim_step(cfg.train.learning_rate)
-            pg_loss = train_output.loss
-            grad_norm = optim_output.grad_norm
+            # Minibatch into `train.num_substeps` optimizer updates. At 1 (the historical
+            # behaviour) this is one forward_backward over everything and a single update -- a
+            # whole batch of agent rollouts, measured at ~$66, buying ONE gradient step. The
+            # rollouts are already paid for by the time we get here, so extra updates over the
+            # same datums cost nothing and are the cheapest learning signal available.
+            #
+            # Shuffled, not chunked in order: datums arrive grouped by episode (one per turn),
+            # so contiguous minibatches would be maximally correlated. Seeded on the step so a
+            # rerun reproduces the same minibatches.
+            #
+            # Updates 2..N are off-policy w.r.t. the weights that sampled the batch, which is
+            # the standard PPO setting and what `loss = "ppo"`'s ratio clip exists for. At
+            # num_substeps = 1 that clip is inert by construction: sampling and training share
+            # the same weights, so the ratio is identically 1.
+            # Shuffle GROUPS, not datums. Under topk_ce one source token becomes k rank
+            # replicas that share a model input and whose weights renormalize to 1 ACROSS the
+            # group, so splitting a group over two updates would apply one token's target
+            # distribution at two different weight states. Grouping by shared model input keeps
+            # replicas together whatever k is, and is a no-op for one-datum-per-source losses.
+            groups: list[list[TrainDatum]] = []
+            for datum in trained:
+                if groups and tuple(groups[-1][0].model_input_tokens) == tuple(
+                    datum.model_input_tokens
+                ):
+                    groups[-1].append(datum)
+                else:
+                    groups.append([datum])
+            if cfg.train.num_substeps > 1:
+                # Only reorder when it buys something: at 1 substep the shuffle cannot change
+                # the gradient and would only churn the batch order runs have always had.
+                random.Random(_seed_from_name(f"{self._name}-substep-{step}")).shuffle(groups)
+            substeps = min(cfg.train.num_substeps, len(groups))
+            per = math.ceil(len(groups) / substeps)
+            chunks = [
+                [datum for group in groups[i : i + per] for datum in group]
+                for i in range(0, len(groups), per)
+            ]
+            losses: list[float] = []
+            for index, chunk in enumerate(chunks):
+                train_output = self._training.forward_backward(chunk, loss_fn=loss_fn)
+                optim_output = self._training.optim_step(cfg.train.learning_rate)
+                if train_output.loss is not None:
+                    losses.append(train_output.loss)
+                grad_norm = optim_output.grad_norm
+                if len(chunks) > 1:
+                    logger.info(
+                        "step %d substep %d/%d: %d datum(s), loss %s",
+                        step,
+                        index + 1,
+                        len(chunks),
+                        len(chunk),
+                        "n/a" if train_output.loss is None else f"{train_output.loss:.4f}",
+                    )
+            # Mean over substeps: the reported loss stays comparable to the single-update runs.
+            pg_loss = sum(losses) / len(losses) if losses else None
+            optimizer_updates = len(chunks)
             self._budget.charge("student_train", train_tokens)
         else:
             logger.warning(
@@ -2738,6 +2885,7 @@ class _DistillRun:
             overlong_drops=datum_stats.overlong_drops,
             mismatch_drops=mismatch_drops,
             clipped_tokens=clipped_tokens,
+            optimizer_updates=optimizer_updates,
             loss_tokens=trained_loss_tokens,
             context_tokens=trained_context_tokens,
             reverse_kl_per_token=reverse_kl,
@@ -2968,6 +3116,19 @@ class _DistillRun:
         except BudgetExhausted as exc:
             self._abort_for_budget(exc, completed_step=None)
 
+        # Baselines feed the GATE only -- nothing in the training loop reads them -- so they are
+        # not on the critical path for starting work. Deferred, they run at finalize instead,
+        # which frees the training loop to start immediately while a SEPARATE process measures
+        # them concurrently. That process must have its own HOME: harbor's task cache is a
+        # hardcoded `~/.cache/harbor` (no env override) and `_copy_task_source_to_target` does an
+        # UNCONDITIONAL rmtree+copytree of the task dir even when the cache is warm, so two
+        # concurrent harbor jobs sharing a HOME delete each other's tasks mid-run.
+        if cfg.eval.defer_baselines:
+            self._deferred_baselines = True
+            for step in range(start_step, cfg.train.steps):
+                self._train_step(step)
+            return self._finalize(None, None)
+
         teacher_report = self._eval_or_load(
             TEACHER_BASELINE_EVAL,
             self._holdout_ids,
@@ -3020,9 +3181,40 @@ class _DistillRun:
         return self._finalize(teacher_report, before_report)
 
     def _finalize(
-        self, teacher_report: DistillEvalReport, before_report: DistillEvalReport
+        self,
+        teacher_report: DistillEvalReport | None,
+        before_report: DistillEvalReport | None,
     ) -> DistillResult:
         cfg = self._cfg
+        if teacher_report is None or before_report is None:
+            # Deferred: measure (or import) the gate references now that training is done. By
+            # this point the concurrent baseline process has long since written its reports, so
+            # `eval.teacher_baseline_from` / `student_baseline_from` normally import rather than
+            # re-measure, and no second harbor job ever runs beside the training one.
+            self._emit("baseline", "measuring deferred gate baselines after training")
+            teacher_report = self._eval_or_load(
+                TEACHER_BASELINE_EVAL,
+                self._holdout_ids,
+                cfg.gate.k,
+                self._teacher_provider(),
+                phase="baseline",
+                teacher_metered=True,
+                reuse=True,
+                pin_provider=True,
+                baseline_from=cfg.eval.teacher_baseline_from,
+                baseline_from_field="eval.teacher_baseline_from",
+            )
+            before_report = self._eval_or_load(
+                STUDENT_BEFORE_EVAL,
+                self._holdout_ids,
+                cfg.gate.k,
+                self._student_provider(),
+                phase="baseline",
+                teacher_metered=False,
+                reuse=True,
+                baseline_from=cfg.eval.student_baseline_from,
+                baseline_from_field="eval.student_baseline_from",
+            )
         self._emit("finalize", "saving final training state and sampler weights")
         final_sampler = self._sampler.refresh(cfg.train.steps)
         final_state = self._training.save_state()

--- a/wmh/distill/loop.py
+++ b/wmh/distill/loop.py
@@ -75,6 +75,7 @@ import hashlib
 import logging
 import math
 import random
+import time
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -273,6 +274,18 @@ class DistillBudgetError(RuntimeError):
         self.spent_usd = spent_usd
         self.max_usd = max_usd
 
+
+_DEFERRED_BASELINE_WAIT_S = 1800.0
+"""How long finalize waits for a concurrent run to write a deferred baseline.
+
+30 minutes covers a baseline arm that is merely slow (a retry, a long tail of
+holdout trials) without letting a producer that DIED hang a finished training
+run indefinitely. The trained weights are saved before the wait begins, so a
+timeout costs a resume rather than the training."""
+
+_DEFERRED_BASELINE_POLL_S = 15.0
+"""Poll interval while waiting; the file appears atomically, so this only sets
+how quickly the wait notices."""
 
 MAX_CONSECUTIVE_EMPTY_STEPS = 2
 """Consecutive all-empty training steps tolerated before the run aborts.
@@ -2323,6 +2336,58 @@ class _DistillRun:
             completed_step=completed_step,
         )
 
+    def _await_deferred_baselines(self) -> None:
+        """Block until every configured deferred baseline file exists, or time out.
+
+        `eval.defer_baselines` exists so training can start immediately while a
+        SEPARATE process measures the gate references, and the two are only
+        joined here. Nothing sequences them, so "training finished first" is a
+        real outcome rather than a theoretical one: a short training run, or a
+        baseline arm that hit a retry, and the import would fail a run that had
+        already paid for every step.
+
+        Waiting is the right response because the producer is expected to
+        finish and the file is the only thing missing. The wait is bounded so a
+        producer that DIED cannot hang the run forever, and the caller's import
+        then raises its usual message naming the config field. The trained
+        weights are already saved by this point either way, so the worst case
+        is a resume rather than lost training.
+        """
+        pending = {
+            field: Path(value)
+            for field, value in (
+                ("eval.teacher_baseline_from", self._cfg.eval.teacher_baseline_from),
+                ("eval.student_baseline_from", self._cfg.eval.student_baseline_from),
+            )
+            if value is not None
+        }
+        missing = {field: path for field, path in pending.items() if not path.is_file()}
+        if not missing:
+            return
+        deadline = time.monotonic() + _DEFERRED_BASELINE_WAIT_S
+        for field, path in missing.items():
+            logger.warning(
+                "deferred baseline %s (%s) is not written yet; waiting up to %.0f min for the "
+                "concurrent baseline run. The final sampler and state are already saved, so a "
+                "timeout costs a resume and not the training.",
+                field,
+                path,
+                _DEFERRED_BASELINE_WAIT_S / 60,
+            )
+        while time.monotonic() < deadline:
+            still_missing = [path for path in missing.values() if not path.is_file()]
+            if not still_missing:
+                logger.info("every deferred baseline landed; importing them now")
+                return
+            time.sleep(_DEFERRED_BASELINE_POLL_S)
+        # Fall through: the caller's import raises the message that names the config field
+        # and the fix, which is more useful than a generic timeout error here.
+        logger.error(
+            "deferred baseline(s) still missing after %.0f min: %s",
+            _DEFERRED_BASELINE_WAIT_S / 60,
+            ", ".join(str(path) for path in missing.values() if not path.is_file()),
+        )
+
     def _import_baseline(
         self,
         key: str,
@@ -3186,12 +3251,24 @@ class _DistillRun:
         before_report: DistillEvalReport | None,
     ) -> DistillResult:
         cfg = self._cfg
+        # Save the trained weights BEFORE anything that can fail on an external dependency.
+        # Deferred baselines import a file a CONCURRENT process writes, and that import used to
+        # run first: if the producer had not finished, the run raised having already paid for
+        # every training step, and the final sampler and state were never written. Ordering the
+        # save first means the worst case costs a resume, not the training.
+        self._emit("finalize", "saving final training state and sampler weights")
+        final_sampler = self._sampler.refresh(cfg.train.steps)
+        final_state = self._training.save_state()
+        final_step = max(cfg.train.steps - 1, 0)
+        self._store.record_checkpoint(final_step, final_state, final_sampler)
+
         if teacher_report is None or before_report is None:
-            # Deferred: measure (or import) the gate references now that training is done. By
-            # this point the concurrent baseline process has long since written its reports, so
+            # Deferred: measure (or import) the gate references now that training is done. The
+            # concurrent baseline process has usually written its reports long before this, so
             # `eval.teacher_baseline_from` / `student_baseline_from` normally import rather than
             # re-measure, and no second harbor job ever runs beside the training one.
             self._emit("baseline", "measuring deferred gate baselines after training")
+            self._await_deferred_baselines()
             teacher_report = self._eval_or_load(
                 TEACHER_BASELINE_EVAL,
                 self._holdout_ids,
@@ -3215,12 +3292,6 @@ class _DistillRun:
                 baseline_from=cfg.eval.student_baseline_from,
                 baseline_from_field="eval.student_baseline_from",
             )
-        self._emit("finalize", "saving final training state and sampler weights")
-        final_sampler = self._sampler.refresh(cfg.train.steps)
-        final_state = self._training.save_state()
-        final_step = max(cfg.train.steps - 1, 0)
-        self._store.record_checkpoint(final_step, final_state, final_sampler)
-
         # Reuse a recorded student-after report on resume: a budget abort inside
         # a prior session's finalize already paid for it, and the resumed weights
         # restore the same final checkpoint it measured.

--- a/wmh/distill/loop_test.py
+++ b/wmh/distill/loop_test.py
@@ -3554,3 +3554,35 @@ def test_a_teacher_that_cannot_report_cache_hits_bills_everything_uncached(
     assert scoring_only, "no scoring-only row to check"
     assert all(row["teacher_prefill_tokens"] > 0 for row in scoring_only)
     assert all(row["teacher_cached_prefill_tokens"] == 0 for row in scoring_only)
+
+
+def test_a_missing_deferred_baseline_does_not_cost_the_trained_weights(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`eval.defer_baselines` joins two processes that nothing sequences.
+
+    Training can finish before the concurrent baseline arm writes its report, and the
+    import used to run BEFORE the final save: the run raised having paid for every
+    training step, with no final sampler or state written. The weights must be durable
+    first, so the worst case is a resume rather than lost training.
+    """
+    monkeypatch.setattr(loop_module, "_DEFERRED_BASELINE_WAIT_S", 0.0)
+    env = _setup(tmp_path, monkeypatch)
+    base = _cfg()
+    cfg = base.model_copy(
+        update={
+            "train": base.train.model_copy(update={"steps": 1}),
+            "eval": base.eval.model_copy(
+                update={
+                    "defer_baselines": True,
+                    "student_baseline_from": str(tmp_path / "never-written.json"),
+                }
+            ),
+        }
+    )
+
+    with pytest.raises(ValueError, match="student_baseline_from"):
+        _run(env, cfg)
+
+    checkpoints = json.loads((env.run_dir / "checkpoints.json").read_text())["checkpoints"]
+    assert checkpoints, "the trained weights must be saved before the baseline import can fail"

--- a/wmh/distill/loop_test.py
+++ b/wmh/distill/loop_test.py
@@ -3395,3 +3395,162 @@ def test_warmup_exercises_concurrency_not_just_one_token() -> None:
     assert all(len(span.sampled_ids) == 1 for span in client.issued), (
         "each warmup stream must stay a single throwaway token"
     )
+
+
+def test_num_substeps_takes_many_optimizer_updates_per_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One rollout batch should be able to buy more than one gradient step.
+
+    At the historical default of 1, a whole batch of agent rollouts (measured at ~$66) bought a
+    single update. The rollouts are already paid for by the time the optimizer runs, so extra
+    updates over the same datums are the cheapest learning signal available.
+    """
+    env = _setup(tmp_path, monkeypatch)
+    base = _cfg()
+    cfg = base.model_copy(
+        update={"train": base.train.model_copy(update={"steps": 1, "num_substeps": 4})}
+    )
+    _run(env, cfg)
+
+    training = env.service.training
+    assert training is not None
+    assert len(training.inner.optim_step_lrs) == 4, "four minibatches -> four updates"
+    assert len(training.inner.forward_backward_calls) == 4
+
+
+def test_one_substep_keeps_the_batch_whole(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default must reproduce the pre-substep behaviour: one batch, one update."""
+    env = _setup(tmp_path, monkeypatch)
+    base = _cfg()
+    cfg = base.model_copy(update={"train": base.train.model_copy(update={"steps": 1})})
+    _run(env, cfg)
+
+    training = env.service.training
+    assert training is not None
+    assert len(training.inner.optim_step_lrs) == 1
+    assert len(training.inner.forward_backward_calls) == 1
+
+
+def test_substeps_never_split_a_topk_replica_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """topk_ce renormalizes weights ACROSS a source's k replicas.
+
+    Splitting a group over two updates would apply one token's target distribution at two
+    different weight states, so a group moves between minibatches whole or not at all.
+    """
+    env = _setup(tmp_path, monkeypatch)
+    k = 3
+    base = _cfg()
+    cfg = base.model_copy(
+        update={
+            "train": base.train.model_copy(
+                update={"steps": 1, "loss": "topk_ce", "topk": k, "num_substeps": 3}
+            )
+        }
+    )
+    _run(env, cfg)
+
+    training = env.service.training
+    assert training is not None
+    assert len(training.inner.forward_backward_calls) > 1, "the split must actually have happened"
+    for batch, _ in training.inner.forward_backward_calls:
+        counts: dict[tuple[int, ...], int] = {}
+        for datum in batch:
+            key = tuple(datum.model_input_tokens)
+            counts[key] = counts.get(key, 0) + 1
+        assert set(counts.values()) == {k}, (
+            f"a replica group was split across minibatches: {sorted(counts.values())}"
+        )
+
+
+def test_metrics_row_records_optimizer_updates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Updates per step must be visible in the row, not just inferable from config.
+
+    This is the quantity that most cheaply explains a null result, and it was invisible for the
+    project's first several runs: one update per collected batch meant a "4-step run" was 5
+    updates and could not have moved a rank-32 LoRA whatever the objective did.
+    """
+    env = _setup(tmp_path, monkeypatch)
+    base = _cfg()
+    cfg = base.model_copy(
+        update={"train": base.train.model_copy(update={"steps": 1, "num_substeps": 4})}
+    )
+    _run(env, cfg)
+
+    rows = [
+        json.loads(line)
+        for line in (env.run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    training = env.service.training
+    assert training is not None
+    steps = [r for r in rows if r.get("phase") != "warmup"]
+    assert steps[-1]["optimizer_updates"] == len(training.inner.optim_step_lrs) == 4
+
+
+# --- service-reported cached prefill accounting -------------------------------
+
+
+def test_cached_prefill_split_never_credits_or_double_bills() -> None:
+    """The ledger must stay conservative under every nonsensical delta.
+
+    Both inputs are deltas of monotonic counters that a mid-batch scorer rebuild
+    can reset, so the two failure directions both have to be closed: a negative
+    cached delta would CREDIT the run for spend it made, and a cached delta above
+    the submitted volume would bill negative uncached tokens.
+    """
+    from wmh.distill.loop import _split_cached_prefill
+
+    # The ordinary case: part of the prefill was served from cache.
+    assert _split_cached_prefill(1000, 400) == (600, 400)
+    # Nothing cached (a teacher that cannot report, or a genuine cold prefix).
+    assert _split_cached_prefill(1000, 0) == (1000, 0)
+    # Fully cached, which is the measured behaviour on a repeated prompt.
+    assert _split_cached_prefill(1000, 1000) == (0, 1000)
+    # A scorer rebuilt mid-batch restarted its counter: never a credit.
+    assert _split_cached_prefill(1000, -700) == (1000, 0)
+    # Cache count above the batch's own volume: clamped, never negative uncached.
+    assert _split_cached_prefill(1000, 1500) == (0, 1000)
+    # An empty batch bills nothing at all.
+    assert _split_cached_prefill(0, 0) == (0, 0)
+    assert _split_cached_prefill(-5, 3) == (0, 0)
+
+    for submitted, cached in ((1000, 400), (1000, -700), (1000, 1500), (0, 5), (-5, 3)):
+        uncached, billable = _split_cached_prefill(submitted, cached)
+        assert uncached >= 0 and billable >= 0
+        assert uncached + billable == max(submitted, 0), (submitted, cached)
+
+
+def test_a_teacher_that_cannot_report_cache_hits_bills_everything_uncached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback, end to end through a real run.
+
+    The fake sampling client reports no cache hits, so every scoring token must
+    land on teacher_prefill and none on teacher_cached_prefill -- the exact
+    behaviour the ledger had before the field was readable, which keeps a fake or
+    a future SDK drift from making the ledger optimistic.
+    """
+    env = _setup(tmp_path, monkeypatch)
+    _run(env, _cfg())
+
+    rows = [
+        json.loads(line)
+        for line in (env.run_dir / "metrics.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert rows, "the run wrote no metrics rows"
+    assert any(row["teacher_prefill_tokens"] > 0 for row in rows), "teacher scoring was not billed"
+    # Isolate the rows whose ONLY teacher charge is scoring. A row that also
+    # carries teacher-in-harness rollout billing (the gate baseline, warmup
+    # collection -- identifiable because the teacher GENERATED in it) splits its
+    # cached share from `batch_billing`, a wmh-side estimate of repeated prefixes
+    # that is legitimately nonzero and is not what this test is about.
+    scoring_only = [row for row in rows if not row["teacher_sample_tokens"]]
+    assert scoring_only, "no scoring-only row to check"
+    assert all(row["teacher_prefill_tokens"] > 0 for row in scoring_only)
+    assert all(row["teacher_cached_prefill_tokens"] == 0 for row in scoring_only)

--- a/wmh/distill/renderers.py
+++ b/wmh/distill/renderers.py
@@ -35,6 +35,27 @@ Chat._messages -> message_history -> TinkerLLM.call ->
 renderer.build_generation_prompt`, every step of which passes `content`
 through untouched. No harbor code is modified.
 
+Keeping the reasoning in the token stream is not free, and the module ships
+BOTH sides of the trade (`VerbatimHistoryMixin` and `StripHistoryMixin`, one
+renderer family each). A turn's thinking is in its sampled ids either way, so
+the model reasons every turn and the loss covers every reasoning token in both;
+what differs is whether a LATER prompt still contains it:
+
+- carry it (verbatim): the episode is one datum, but the context grows with
+  every turn's reasoning. Measured on a 53-trial TB2 teacher baseline, this put
+  27 of 53 episodes over the window, and terminus-2 turns a context overflow
+  into a FAILED trial rather than a finished episode -- so those trials left the
+  denominator instead of scoring zero, and the reported solve rate was 95.8% of
+  the survivors.
+- drop it (strip history): later prompts stay small (that same set: final
+  context p50 23,631 -> 8,682, max 49,117 -> 40,162), which is also what the
+  stock renderers and the published terminus-2 setups do. The cost is the
+  prefix property, so the episode fragments into one datum per turn and teacher
+  prefill rises ~5.1x cold, ~2.6x once the shared prefix bills cached.
+
+Pick by whether the episode fits the window: an overflow costs a whole trial
+AND biases the measurement, whereas fragmentation only costs money.
+
 Only a CLEANLY terminated turn is carried verbatim. A turn that hit the output
 cap has no stop token, so re-rendering it from its ids would splice an
 unterminated assistant message into the context; those fall back to the base
@@ -187,6 +208,58 @@ class VerbatimHistoryMixin(Renderer):
         )
 
 
+class StripHistoryMixin(Renderer):
+    """Parses a sampled turn to plain text and lets the base renderer drop thinking.
+
+    Mix in FIRST, as with `VerbatimHistoryMixin`. This is the OTHER side of the
+    trade that module docstring describes, and the two cannot be combined:
+
+    - `VerbatimHistoryMixin` replays a turn's exact ids, so reasoning survives
+      into later prompts and the episode is ONE datum. The cost is context:
+      every turn's thinking accumulates.
+    - this mixin keeps only the action text, so later prompts carry no prior
+      reasoning and stay small. The cost is the prefix property: turn N's
+      sampled ids (which include its thinking) are no longer a substring of
+      turn N+1's prompt, so the episode fragments into one datum PER TURN.
+
+    Both keep the model REASONING and both train on those reasoning tokens --
+    thinking is in every sampled turn and inside the loss mask either way. What
+    differs is only whether the model is shown its own earlier reasoning, which
+    is a serving choice; the stock reasoning renderers, and the published
+    terminus-2 setups, do not show it.
+
+    Measured on the 53-trial Qwen3.6-27B teacher baseline that motivated this:
+    carrying reasoning forward pushed 27 of 53 episodes (51%) past the context
+    budget, and a `ContextLengthExceededError` fails the whole trial rather
+    than ending it, so those episodes left the denominator entirely. Fragmented
+    datums cost more teacher prefill; overflowed episodes cost the measurement.
+    """
+
+    def parse_response(self, response: list[int]) -> tuple[Message, ParseTermination]:
+        """Parse a sampled turn down to its text parts, as a plain `str`.
+
+        The base reasoning renderers return content as a LIST of thinking/text
+        parts, which is what makes harbor's terminus-2 parsers raise (see the
+        module docstring). Narrowing to the text parts hands them the `str`
+        they expect, and -- because the thinking parts are simply gone from the
+        message -- the base `render_message` has nothing to carry forward.
+
+        Args:
+            response: The turn's sampled token ids, exactly as the sampler
+                returned them.
+
+        Returns:
+            The parsed message with plain-text content, and its termination.
+        """
+        message, termination = super().parse_response(response)
+        message["content"] = get_text_content(message)
+        return message, termination
+
+
+class Qwen3_5StripHistoryRenderer(StripHistoryMixin, Qwen3_5Renderer):
+    """Qwen3.5 and Qwen3.6 with thinking on, dropped from history after each turn."""
+
+
 class Qwen3VerbatimRenderer(VerbatimHistoryMixin, Qwen3Renderer):
     """Qwen3 with thinking on and a verbatim-id history."""
 
@@ -207,6 +280,7 @@ QWEN3_VERBATIM = "wmh/qwen3_verbatim"
 QWEN3_5_VERBATIM = "wmh/qwen3_5_verbatim"
 NEMOTRON3_VERBATIM = "wmh/nemotron3_verbatim"
 NEMOTRON3_ULTRA_VERBATIM = "wmh/nemotron3_ultra_verbatim"
+QWEN3_5_STRIP_HISTORY = "wmh/qwen3_5_strip_history"
 
 
 def _build_qwen3(tokenizer: Tokenizer, image_processor: ImageProcessor | None = None) -> Renderer:
@@ -233,28 +307,52 @@ def _build_nemotron3_ultra(
     return Nemotron3UltraVerbatimRenderer(tokenizer, image_processor=image_processor)
 
 
+def _build_qwen3_5_strip_history(
+    tokenizer: Tokenizer, image_processor: ImageProcessor | None = None
+) -> Renderer:
+    """Build the Qwen3.5/Qwen3.6 renderer that drops prior turns' reasoning."""
+    return Qwen3_5StripHistoryRenderer(tokenizer, image_processor=image_processor)
+
+
 VERBATIM_RENDERERS = {
     QWEN3_VERBATIM: _build_qwen3,
     QWEN3_5_VERBATIM: _build_qwen3_5,
     NEMOTRON3_VERBATIM: _build_nemotron3,
     NEMOTRON3_ULTRA_VERBATIM: _build_nemotron3_ultra,
 }
-"""Every wmh verbatim renderer name, mapped to its cookbook factory.
+"""The renderers that carry a sampled turn forward as its exact ids.
+
+One datum per episode, at the cost of a context that grows with every turn's
+reasoning. Prefer these only when the episode fits the model's window.
+"""
+
+STRIP_HISTORY_RENDERERS = {
+    QWEN3_5_STRIP_HISTORY: _build_qwen3_5_strip_history,
+}
+"""The renderers that drop prior turns' reasoning from later prompts.
+
+Small contexts, at the cost of per-turn datums. Only the Qwen3.5/3.6 family is
+built out, because that is the pair these runs train; the mixin is family-
+agnostic, so adding a Nemotron variant is a subclass and a factory.
+"""
+
+WMH_RENDERERS = {**VERBATIM_RENDERERS, **STRIP_HISTORY_RENDERERS}
+"""Every wmh renderer name, mapped to its cookbook factory.
 
 Name these from `[rollout.renderers]` in a run config, keyed by the base model
 whose rollouts should use them (`student.base_model`, `teacher.model`).
 """
 
 
-def register_verbatim_renderers() -> None:
-    """Register every wmh verbatim renderer with the cookbook's global registry.
+def register_wmh_renderers() -> None:
+    """Register every wmh renderer with the cookbook's global registry.
 
     Idempotent: registration is a dict assignment keyed by name, so repeated
     calls leave the registry in the same state. Call it before anything
     resolves a renderer by name (terminus-2 resolves `llm_kwargs.renderer_name`
     inside its own `TinkerLLM`, in this process).
     """
-    for name, factory in VERBATIM_RENDERERS.items():
+    for name, factory in WMH_RENDERERS.items():
         register_renderer(name, factory)
 
 
@@ -292,7 +390,7 @@ def is_known_renderer(name: str) -> bool:
     Returns:
         True when `get_renderer` would accept the name.
     """
-    if name in VERBATIM_RENDERERS or is_renderer_registered(name):
+    if name in WMH_RENDERERS or is_renderer_registered(name):
         return True
     try:
         get_renderer(name, cast("Tokenizer", _RendererNameProbe()))

--- a/wmh/distill/renderers_test.py
+++ b/wmh/distill/renderers_test.py
@@ -49,17 +49,21 @@ from wmh.distill.data import build_datums
 from wmh.distill.renderers import (
     NEMOTRON3_ULTRA_VERBATIM,
     NEMOTRON3_VERBATIM,
+    QWEN3_5_STRIP_HISTORY,
     QWEN3_5_VERBATIM,
     QWEN3_VERBATIM,
     VERBATIM_RENDERERS,
+    WMH_RENDERERS,
     Nemotron3UltraVerbatimRenderer,
     Nemotron3VerbatimRenderer,
+    Qwen3_5StripHistoryRenderer,
     Qwen3_5VerbatimRenderer,
     Qwen3VerbatimRenderer,
+    StripHistoryMixin,
     VerbatimContent,
     VerbatimHistoryMixin,
     is_known_renderer,
-    register_verbatim_renderers,
+    register_wmh_renderers,
 )
 from wmh.distill.tokens import TrialRecord
 from wmh.providers.tinker import TokenSpan
@@ -277,7 +281,7 @@ def _run_episode(
 ) -> _Episode:
     """Drive a synthetic terminus-2 episode through real harbor code."""
     _tokenizer_or_skip(base_model)
-    register_verbatim_renderers()
+    register_wmh_renderers()
     bodies = list(script) if script is not None else _script(fmt=fmt)
     llm = _ScriptedTinkerLLM(
         script=bodies,
@@ -349,7 +353,7 @@ def _masked_text(datum: TrainDatum, tokenizer: object, mask: float) -> str:
 
 def test_the_four_verbatim_renderers_register_under_wmh_names() -> None:
     """The names a run config points `[rollout.renderers]` at."""
-    register_verbatim_renderers()
+    register_wmh_renderers()
     registered = get_registered_renderer_names()
     assert set(VERBATIM_RENDERERS) == {
         QWEN3_VERBATIM,
@@ -357,17 +361,17 @@ def test_the_four_verbatim_renderers_register_under_wmh_names() -> None:
         NEMOTRON3_VERBATIM,
         NEMOTRON3_ULTRA_VERBATIM,
     }
-    for name in VERBATIM_RENDERERS:
+    for name in WMH_RENDERERS:
         assert name in registered
         assert name.startswith("wmh/"), "namespaced so a cookbook name can never be shadowed"
 
 
 def test_registration_is_idempotent() -> None:
     """The rollout collector calls it on every batch, so repeats must be free."""
-    register_verbatim_renderers()
+    register_wmh_renderers()
     before = sorted(get_registered_renderer_names())
-    register_verbatim_renderers()
-    register_verbatim_renderers()
+    register_wmh_renderers()
+    register_wmh_renderers()
     assert sorted(get_registered_renderer_names()) == before
 
 
@@ -392,15 +396,70 @@ def test_each_registered_renderer_builds_and_claims_the_extension_property(
 ) -> None:
     """`get_renderer` must resolve the name against the model's real tokenizer."""
     tokenizer = _tokenizer_or_skip(base_model)
-    register_verbatim_renderers()
+    register_wmh_renderers()
     renderer = get_renderer(renderer_name, tokenizer)  # ty: ignore[invalid-argument-type]
     assert isinstance(renderer, VerbatimHistoryMixin)
     assert renderer.has_extension_property
 
 
+def test_strip_history_keeps_reasoning_in_the_turn_and_out_of_the_next_prompt() -> None:
+    """The whole point of the strip-history renderer, asserted on real token ids.
+
+    Reasoning must stay in what we TRAIN on (the sampled turn, which the loss
+    masks over) and stay out of what we PROMPT with (every later turn), because
+    carrying it forward is what overflowed the context window.
+    """
+    episode = _run_episode(QWEN3_5_MODEL, QWEN3_5_STRIP_HISTORY)
+
+    def decode(ids: list[int]) -> str:
+        return str(episode.tokenizer.decode(ids))  # ty: ignore[unresolved-attribute]
+
+    # The `<think>` OPEN tag lives in the renderer's generation prefill, not in the sampled
+    # ids, so the reasoning TEXT is what to assert on at both ends.
+    for index, completion in enumerate(episode.completions):
+        assert REASONING[index] in decode(completion), (
+            f"turn {index} must still reason -- that is what we distill"
+        )
+    for index, prompt in enumerate(episode.prompts):
+        carried = [thought for thought in REASONING[:index] if thought in decode(prompt)]
+        assert not carried, (
+            f"prompt {index} carries {len(carried)} prior turn(s) of reasoning; "
+            "context grows with every turn and the episode overflows"
+        )
+    assert all(error == "" for error in episode.errors), (
+        "harbor's parser must accept the content, which is why it is a plain str"
+    )
+    assert all(count > 0 for count in episode.command_counts), "actions must survive the strip"
+
+
+def test_strip_history_fragments_the_episode_into_per_turn_datums() -> None:
+    """The cost side of the trade, made explicit so a regression cannot hide it.
+
+    Dropping thinking from history means turn N's sampled ids are not a
+    substring of prompt N+1, so the prefix merge cannot fire. This is expected,
+    not a bug -- but it multiplies teacher prefill, so it is pinned.
+    """
+    episode = _run_episode(QWEN3_5_MODEL, QWEN3_5_STRIP_HISTORY)
+    datums = _datums(episode)
+    assert len(datums) == len(episode.completions) > 1, "one datum per turn"
+
+    merged = _datums(_run_episode(QWEN3_5_MODEL, QWEN3_5_VERBATIM))
+    assert len(merged) == 1, "the verbatim renderer still merges, for contexts that fit"
+
+
+def test_strip_history_renderer_disclaims_the_extension_property() -> None:
+    """It must report False, or `build_datums` would merge non-prefix turns."""
+    tokenizer = _tokenizer_or_skip(QWEN3_5_MODEL)
+    register_wmh_renderers()
+    renderer = get_renderer(QWEN3_5_STRIP_HISTORY, tokenizer)  # ty: ignore[invalid-argument-type]
+    assert isinstance(renderer, StripHistoryMixin)
+    assert not renderer.has_extension_property
+    assert Qwen3_5StripHistoryRenderer.__mro__[1] is StripHistoryMixin
+
+
 def test_is_known_renderer_accepts_wmh_and_builtin_names_and_rejects_typos() -> None:
     """Config load is where a renderer typo must die, not the first paid rollout."""
-    for name in VERBATIM_RENDERERS:
+    for name in WMH_RENDERERS:
         assert is_known_renderer(name)
     for name in ("qwen3", "qwen3_5", "nemotron3", "nemotron3_ultra_disable_thinking"):
         assert is_known_renderer(name)
@@ -570,7 +629,7 @@ def test_a_turn_that_never_stopped_is_not_carried_verbatim() -> None:
     break, and is counted by `RolloutStats.truncated_spans`.
     """
     tokenizer = _tokenizer_or_skip(QWEN3_5_MODEL)
-    register_verbatim_renderers()
+    register_wmh_renderers()
     renderer = get_renderer(QWEN3_5_VERBATIM, tokenizer)  # ty: ignore[invalid-argument-type]
     body = "reasoning that never closes and never terminates"
     ids = list(tokenizer.encode(body, add_special_tokens=False))  # ty: ignore[unresolved-attribute]

--- a/wmh/distill/rollouts.py
+++ b/wmh/distill/rollouts.py
@@ -170,13 +170,16 @@ def terminus_2_agent_kwargs(cfg: DistillConfig, provider_config: ProviderConfig)
     - `collect_rollout_details=True` is what records `prompt_token_ids`,
       `completion_token_ids` and `logprobs` per turn. Without it a trial
       produces rewards and no training data at all.
-    - `enable_summarize=False` is NOT optional. Summarization rewrites the
-      chat history mid-episode, which harbor itself warns leaves rollout
-      details incomplete, and which would break the prefix property the
-      one-datum-per-episode cost model depends on (the same reason
-      `rollout.compaction` is rejected outright). With it off, a context
-      overflow raises instead, ending the episode on a recorded
-      `ContextLengthExceededError`.
+    - `enable_summarize` follows `rollout.compaction`, which defaults False and
+      which `RolloutConfig` only allows to be true under a history-editing
+      renderer. Off, a context overflow raises and the trial FAILS on a
+      recorded `ContextLengthExceededError` -- it does not score zero, it
+      leaves the denominator. On, terminus-2 compacts and the episode
+      continues; under a strip-history renderer that costs nothing structural,
+      because every real turn is still recorded (the summarization subagents
+      bypass the `Chat` entirely) and the episode was already one datum per
+      turn. See `RolloutConfig.compaction` for why this is not the blanket
+      rejection it used to be.
     - `max_turns` is terminus-2's `max_episodes`, and
       `llm_kwargs.context_limit` / `max_tokens` are the context and output
       budgets the agent measures itself against.
@@ -222,20 +225,86 @@ def terminus_2_agent_kwargs(cfg: DistillConfig, provider_config: ProviderConfig)
     # deferred because wmh.distill.renderers subclasses cookbook classes at module scope, and
     # `import wmh.distill.rollouts` must keep working without the distill extra (the CLI imports
     # it eagerly). Registration is idempotent.
-    from wmh.distill.renderers import register_verbatim_renderers
+    from wmh.distill.renderers import register_wmh_renderers
 
-    register_verbatim_renderers()
+    register_wmh_renderers()
+    _share_harbor_tinker_service_client()
     return {
         "llm_backend": "tinker",
         "llm_kwargs": llm_kwargs,
         "collect_rollout_details": True,
         "temperature": cfg.sampling.temperature,
         "max_turns": cfg.rollout.max_turns,
-        "enable_summarize": False,
+        "enable_summarize": cfg.rollout.compaction,
         # The cap is deliberate here, so terminus-2's "consider removing this limit" warning is
         # noise on every trial.
         "suppress_max_turns_warning": True,
     }
+
+
+_HARBOR_TINKER_CLIENT_SHARED = False
+
+
+def _share_harbor_tinker_service_client() -> None:
+    """Make harbor's `TinkerLLM` reuse wmh's process-wide `ServiceClient`.
+
+    Harbor's `TinkerLLM._ensure_client` does `tinker.ServiceClient()` per
+    instance and never closes it, and terminus-2 builds one `TinkerLLM` per
+    TRIAL. The SDK's service client starts a heartbeat task that strongly
+    references its holder, so each one pins a live server-side session for the
+    rest of the process -- the exact leak `wmh.providers.tinker.
+    shared_service_client` exists to prevent for wmh's own call paths. Harbor's
+    class was the one path that still bypassed it.
+
+    Measured cost of not doing this, on a 64-episode-per-step run: step 0 clean,
+    step 1 three failures, step 2 THIRTY-ONE trials rejected with
+    `400 Too many active sessions. Please ensure you are not creating extra
+    ServiceClient objects`, halving that step's datums. The cap is ~240
+    sessions and each step burns 64, so the failure arrives on schedule and
+    worsens every step.
+
+    Only the client construction changes; the sampling-client selection below
+    it is harbor's own logic, reproduced exactly. Idempotent, and a no-op if
+    harbor's internals move -- a rollout that samples successfully matters more
+    than this optimization, so a shape mismatch leaves the original in place.
+    """
+    global _HARBOR_TINKER_CLIENT_SHARED
+    if _HARBOR_TINKER_CLIENT_SHARED:
+        return
+    from harbor.llms.tinker import TinkerLLM
+
+    from wmh.providers import tinker as tinker_provider
+
+    if not hasattr(TinkerLLM, "_ensure_client"):  # pragma: no cover - upstream moved
+        logger.warning(
+            "harbor's TinkerLLM has no _ensure_client; leaving its service-client "
+            "construction alone. Watch for '400 Too many active sessions' errors"
+        )
+        _HARBOR_TINKER_CLIENT_SHARED = True
+        return
+
+    async def _ensure_client_shared(self: object) -> object:
+        """Harbor's `_ensure_client`, but on the shared service client."""
+        existing = getattr(self, "_sampling_client", None)
+        if existing is not None:
+            return existing
+        # Resolved through the MODULE, not captured at patch time, so
+        # `rebuild_shared_service_client()` (the wedge-recovery path) is honoured.
+        service = tinker_provider.shared_service_client()
+        self._service_client = service  # ty: ignore[unresolved-attribute]
+        model_path = getattr(self, "_model_path", None)
+        if model_path:
+            client = await service.create_sampling_client_async(model_path=model_path)
+        else:
+            client = await service.create_sampling_client_async(
+                base_model=self._model_name  # ty: ignore[unresolved-attribute]
+            )
+        self._sampling_client = client  # ty: ignore[unresolved-attribute]
+        return client
+
+    TinkerLLM._ensure_client = _ensure_client_shared  # ty: ignore[invalid-assignment]
+    _HARBOR_TINKER_CLIENT_SHARED = True
+    logger.info("harbor TinkerLLM patched to share wmh's process-wide tinker ServiceClient")
 
 
 class RolloutStats(BaseModel):

--- a/wmh/distill/rollouts_test.py
+++ b/wmh/distill/rollouts_test.py
@@ -8,6 +8,8 @@ import logging
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import cast
+from unittest import mock
 
 import pytest
 from harbor.models.job.config import JobConfig
@@ -347,15 +349,15 @@ def test_terminus_2_agent_kwargs_register_the_wmh_verbatim_renderers(tmp_path: P
     """
     from tinker_cookbook.renderers import get_registered_renderer_names, unregister_renderer
 
-    from wmh.distill.renderers import VERBATIM_RENDERERS
+    from wmh.distill.renderers import WMH_RENDERERS
 
-    for name in VERBATIM_RENDERERS:
+    for name in WMH_RENDERERS:
         unregister_renderer(name)
-    assert not set(VERBATIM_RENDERERS) & set(get_registered_renderer_names())
+    assert not set(WMH_RENDERERS) & set(get_registered_renderer_names())
 
     terminus_2_agent_kwargs(_cfg(tmp_path), _provider_config())
 
-    assert set(VERBATIM_RENDERERS) <= set(get_registered_renderer_names())
+    assert set(WMH_RENDERERS) <= set(get_registered_renderer_names())
 
 
 def test_terminus_2_agent_kwargs_reject_a_non_tinker_provider(tmp_path: Path) -> None:
@@ -959,3 +961,61 @@ def test_collect_rollouts_warns_when_turns_hit_the_output_cap(
         "sampled the full sampling.max_tokens = 16" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_harbor_tinker_llm_shares_one_service_client() -> None:
+    """Harbor builds a TinkerLLM per TRIAL; a client each would exhaust Tinker's session cap.
+
+    Measured before the patch: step 0 clean, step 1 three failures, step 2 THIRTY-ONE trials
+    rejected with `400 Too many active sessions`. The cap is ~240 and each step burns 64.
+    """
+    import asyncio
+
+    from harbor.llms.tinker import TinkerLLM
+
+    from wmh.distill.rollouts import _share_harbor_tinker_service_client
+
+    _share_harbor_tinker_service_client()
+
+    built: list[object] = []
+
+    class _FakeService:
+        async def create_sampling_client_async(self, **kwargs: object) -> object:
+            built.append(kwargs)
+            return object()
+
+    service = _FakeService()
+    with mock.patch("wmh.providers.tinker.shared_service_client", return_value=service):
+
+        class _Stub:
+            """The TinkerLLM attribute surface the patched method touches."""
+
+            def __init__(self) -> None:
+                self._sampling_client: object | None = None
+                self._service_client: object | None = None
+                self._model_path: str | None = None
+                self._model_name = "Qwen/Qwen3.5-9B"
+
+        first, second = _Stub(), _Stub()
+        ensure = cast("Callable[[object], object]", TinkerLLM._ensure_client)
+        client_a = asyncio.run(ensure(first))  # ty: ignore[invalid-argument-type]
+        client_b = asyncio.run(ensure(second))  # ty: ignore[invalid-argument-type]
+
+    assert first._service_client is second._service_client is service, (
+        "every TinkerLLM must reuse ONE ServiceClient or sessions leak per trial"
+    )
+    assert client_a is not client_b, "each LLM still gets its own sampling client"
+    assert len(built) == 2
+
+
+def test_sharing_the_harbor_client_is_idempotent() -> None:
+    """`terminus_2_agent_kwargs` calls it on every batch, so repeats must be free."""
+    from harbor.llms.tinker import TinkerLLM
+
+    from wmh.distill.rollouts import _share_harbor_tinker_service_client
+
+    _share_harbor_tinker_service_client()
+    patched = TinkerLLM._ensure_client
+    _share_harbor_tinker_service_client()
+    _share_harbor_tinker_service_client()
+    assert TinkerLLM._ensure_client is patched

--- a/wmh/distill/teacher.py
+++ b/wmh/distill/teacher.py
@@ -125,6 +125,21 @@ class TeacherClient(Protocol):
         ...
 
 
+@runtime_checkable
+class CachedUsageTeacher(Protocol):
+    """A teacher that can report how much of its prefill the service cached.
+
+    Deliberately NOT part of `TeacherClient`: every existing teacher and test
+    fake satisfies that seam today, and widening it would force each of them to
+    grow a method whose only honest answer is 0. A caller narrows to this at
+    runtime and falls back to billing everything uncached.
+    """
+
+    def cached_usage(self) -> int:
+        """Of `usage()`, the tokens served from the service's prefix cache."""
+        ...
+
+
 class EncodingTokenizer(Protocol):
     """The tokenizer slice the fingerprint check needs: encoding only.
 
@@ -150,6 +165,23 @@ class LogprobScorer(Protocol):
 
 
 @runtime_checkable
+class CacheReportingScorer(Protocol):
+    """A scorer that can report the service's own prefix-cache hit count.
+
+    Kept a separate, runtime-checked protocol rather than folded into
+    `LogprobScorer` so the deterministic fakes and any externally injected
+    scorer keep satisfying the base seam unchanged; the caller treats a scorer
+    without this as "cache unknown", which bills every token at the uncached
+    rate exactly as before.
+    """
+
+    @property
+    def cache_hit_tokens(self) -> int:
+        """Prompt tokens the service reported serving from its prefix cache."""
+        ...
+
+
+@runtime_checkable
 class TopkLogprobScorer(Protocol):
     """The prefill-only top-k call `score_topk` additionally needs.
 
@@ -171,23 +203,92 @@ class SdkLogprobScorer:
 
     def __init__(self, client: tinker.SamplingClient) -> None:
         self._client = client
+        self._cache_hit_tokens = 0
 
     @property
     def sdk_client(self) -> tinker.SamplingClient:
         """The wrapped SDK client (shared-cache eviction compares its identity)."""
         return self._client
 
+    @property
+    def cache_hit_tokens(self) -> int:
+        """Prompt tokens the service reported serving from its prefix cache.
+
+        Accumulated across every scoring call this scorer has made, so the
+        caller can bill the cached portion at the cached rate instead of
+        assuming zero.
+        """
+        return self._cache_hit_tokens
+
+    def _record_cache_hits(self, response: object) -> None:
+        """Add one response's reported cache hits, tolerating their absence.
+
+        Read defensively on purpose. This is COST ACCOUNTING on the hot path of
+        a paid run: if a future SDK renames or drops `prompt_cache_hit_tokens`,
+        the correct outcome is a ledger that quietly reverts to billing
+        everything uncached (an overstatement, the behaviour we already lived
+        with), not an AttributeError that kills a run mid-batch after the
+        service has already been paid for the scoring. Logged at debug once per
+        call rather than warned, because a scorer that cannot report is the
+        normal case for injected fakes.
+
+        Args:
+            response: The SDK sample response.
+        """
+        hits = getattr(response, "prompt_cache_hit_tokens", None)
+        if isinstance(hits, int):
+            self._cache_hit_tokens += hits
+            return
+        logger.debug(
+            "teacher scoring response carries no usable prompt_cache_hit_tokens (%r); "
+            "billing this call's prefill as uncached",
+            hits,
+        )
+
     def compute_logprobs(self, token_ids: list[int]) -> list[float | None]:
-        """One deadline-bounded compute_logprobs call on the full sequence.
+        """One deadline-bounded prefill call on the full sequence.
+
+        Issued as `sample` rather than the SDK's `compute_logprobs`, which is
+        not a different request: the SDK's own implementation is exactly this
+        call (`num_samples=1`, `max_tokens=1`, `include_prompt_logprobs=True`)
+        followed by `return sample_res.prompt_logprobs`. It throws the rest of
+        the response away, including `prompt_cache_hit_tokens` -- which is the
+        service's own measurement of how much of this prefill it did not have to
+        recompute, and the single number that decides whether our cost figures
+        are a bill or a ceiling. Tinker's prefix cache demonstrably works (a
+        repeated prompt measured 16,000 of 16,000 tokens cached) while every
+        `*_cached_prefill` meter read 0 by construction, so the run ledger has
+        been overstating spend by an unknown factor. Same request, same
+        `prompt_logprobs`, one more field kept.
+
+        The deadline keeps the `compute_logprobs` label deliberately: the
+        workload is byte-for-byte the same prefill, and relabelling it `sample`
+        would silently swap in a deadline tuned for generation instead.
 
         Raises:
             TinkerDeadlineError: If the deadline expires (the session is
                 likely wedged; the caller should retry with a fresh one).
+            RuntimeError: If the response carries no prompt logprobs even
+                though the request asked for them (SDK drift).
         """
         import tinker
 
-        future = self._client.compute_logprobs(tinker.ModelInput.from_ints(token_ids))
-        return wait_with_deadline("compute_logprobs", future)
+        future = self._client.sample(
+            prompt=tinker.ModelInput.from_ints(token_ids),
+            num_samples=1,
+            sampling_params=tinker.SamplingParams(max_tokens=1),
+            include_prompt_logprobs=True,
+        )
+        response = wait_with_deadline("compute_logprobs", future)
+        self._record_cache_hits(response)
+        realized = response.prompt_logprobs
+        if realized is None:
+            raise RuntimeError(
+                "the teacher's prefill sample response carries no prompt_logprobs even "
+                "though include_prompt_logprobs was set; check the pinned tinker SDK "
+                "version (0.23.3 populates it on request)"
+            )
+        return list(realized)
 
     def topk_prompt_logprobs(
         self, token_ids: list[int], k: int
@@ -219,6 +320,7 @@ class SdkLogprobScorer:
             topk_prompt_logprobs=k,
         )
         response = wait_with_deadline("sample", future)
+        self._record_cache_hits(response)
         realized = response.prompt_logprobs
         rows = response.topk_prompt_logprobs
         if realized is None or rows is None:
@@ -537,6 +639,20 @@ class TinkerTeacher:
     def usage(self) -> int:
         """Total tokens submitted through score() so far (verify probes excluded)."""
         return self._usage_tokens
+
+    def cached_usage(self) -> int:
+        """Of `usage()`, the tokens the SERVICE reported serving from its cache.
+
+        Zero when the active scorer cannot report it (an injected fake, or a
+        future SDK that drops the field), which bills everything at the uncached
+        rate — the same conservative behaviour the ledger had before this was
+        readable. The count is cumulative and monotonic like `usage()`, so a
+        caller takes deltas around a step.
+        """
+        scorer = self._scorer
+        if isinstance(scorer, CacheReportingScorer):
+            return scorer.cache_hit_tokens
+        return 0
 
 
 def tokenizer_fingerprint_check(

--- a/wmh/distill/teacher_test.py
+++ b/wmh/distill/teacher_test.py
@@ -343,8 +343,24 @@ def test_sdk_logprob_scorer_bounds_the_future(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("WMH_TINKER_DEADLINE_COMPUTE_LOGPROBS", "0.05")
 
     class _WedgedClient:
-        def compute_logprobs(self, model_input: object) -> _NeverResolvingFuture:
-            del model_input
+        """Wedged on `sample`, which is what scoring issues.
+
+        `SdkLogprobScorer.compute_logprobs` calls `sample` with
+        `include_prompt_logprobs=True` rather than the SDK's `compute_logprobs`
+        wrapper, because that wrapper makes exactly this request and then
+        discards `prompt_cache_hit_tokens` with the rest of the response. The
+        deadline still carries the COMPUTE_LOGPROBS label, since the workload is
+        the same prefill.
+        """
+
+        def sample(
+            self,
+            prompt: object,
+            num_samples: int,
+            sampling_params: object,
+            include_prompt_logprobs: bool = False,
+        ) -> _NeverResolvingFuture:
+            del prompt, num_samples, sampling_params, include_prompt_logprobs
             return _NeverResolvingFuture()
 
     scorer = SdkLogprobScorer(cast("tinker.SamplingClient", _WedgedClient()))
@@ -595,3 +611,91 @@ def test_sdk_logprob_scorer_topk_missing_fields_is_actionable() -> None:
     scorer = SdkLogprobScorer(cast("tinker.SamplingClient", _Client()))
     with pytest.raises(RuntimeError, match="prompt_logprobs"):
         scorer.topk_prompt_logprobs([1, 2, 3], 2)
+
+
+# --- service-reported prefix-cache accounting ---------------------------------
+
+
+class _CachingClient:
+    """A sampling client whose prefill responses report cache hits."""
+
+    def __init__(self, hits: object) -> None:
+        self._hits = hits
+        self.calls = 0
+
+    def sample(
+        self,
+        prompt: object,
+        num_samples: int,
+        sampling_params: object,
+        include_prompt_logprobs: bool = False,
+        topk_prompt_logprobs: int = 0,
+    ) -> object:
+        del prompt, num_samples, sampling_params, include_prompt_logprobs, topk_prompt_logprobs
+        self.calls += 1
+        hits = self._hits
+
+        class _Response:
+            prompt_logprobs = [None, -0.5, -0.25]
+            topk_prompt_logprobs = [None, [(2, -0.5)], [(3, -0.25)]]
+            prompt_cache_hit_tokens = hits
+
+        class _Future:
+            def result(self, timeout: float | None = None) -> object:
+                del timeout
+                return _Response()
+
+        return _Future()
+
+
+def test_scoring_accumulates_the_services_reported_cache_hits() -> None:
+    """The field the SDK's own compute_logprobs throws away.
+
+    Tinker's prefix cache works (a repeated prompt measured 16,000 of 16,000
+    tokens cached) while every `*_cached_prefill` meter read 0 by construction,
+    so the run ledger overstated spend. Reading it makes the ledger a bill.
+    """
+    pytest.importorskip("tinker")
+    client = _CachingClient(1200)
+    scorer = SdkLogprobScorer(cast("tinker.SamplingClient", client))
+
+    assert scorer.cache_hit_tokens == 0
+    scorer.compute_logprobs([1, 2, 3])
+    assert scorer.cache_hit_tokens == 1200
+    scorer.compute_logprobs([1, 2, 3])
+    assert scorer.cache_hit_tokens == 2400, "counts accumulate across calls"
+
+
+def test_the_topk_path_also_reports_cache_hits() -> None:
+    """Both scoring paths bill the same meters, so both must measure the same way."""
+    pytest.importorskip("tinker")
+    client = _CachingClient(700)
+    scorer = SdkLogprobScorer(cast("tinker.SamplingClient", client))
+    scorer.topk_prompt_logprobs([1, 2, 3], 2)
+    assert scorer.cache_hit_tokens == 700
+
+
+@pytest.mark.parametrize("hits", [None, "1200", 3.5])
+def test_an_unreadable_cache_count_bills_uncached_instead_of_crashing(hits: object) -> None:
+    """Cost accounting must never be able to kill a paid run.
+
+    If a future SDK renames or retypes the field, the right outcome is a ledger
+    that reverts to billing everything at the uncached rate -- an overstatement,
+    which is what we already lived with -- not an exception on the hot path
+    after the service has already been paid for the scoring.
+    """
+    pytest.importorskip("tinker")
+    scorer = SdkLogprobScorer(cast("tinker.SamplingClient", _CachingClient(hits)))
+    assert scorer.compute_logprobs([1, 2, 3]) == [None, -0.5, -0.25]
+    assert scorer.cache_hit_tokens == 0
+
+
+def test_cached_usage_is_zero_for_a_teacher_whose_scorer_cannot_report() -> None:
+    """An injected fake keeps working and can only make the ledger conservative."""
+    client = FakeSamplingClient(seed="tinker://fake/sampler/teacher/0")
+    teacher = TinkerTeacher(_spec(), sampling_client=client)
+    prompt = [100, 101, 102]
+    sequence = client.sample(prompt, max_tokens=4, temperature=1.0)
+    teacher.score([_datum(prompt, sequence.tokens)])
+    assert teacher.usage() > 0
+    assert teacher.cached_usage() == 0

--- a/wmh/distill/tracking_test.py
+++ b/wmh/distill/tracking_test.py
@@ -472,6 +472,8 @@ def test_log_step_flattens_the_metrics_row(fake_wandb: _FakeWandb, tmp_path: Pat
         "train/overlong_drops": 1,
         "train/mismatch_drops": 0,
         "train/clipped_tokens": 3,
+        # Updates per step: the cheapest explanation for a null result, so it charts.
+        "train/optimizer_updates": 1,
         "train/loss_tokens": 40,
         "train/context_tokens": 200,
         "train/reverse_kl_per_token": -0.25,

--- a/wmh/distill/tripwire.py
+++ b/wmh/distill/tripwire.py
@@ -50,6 +50,18 @@ put the entropy ratio under 0.5, let alone the 0.3 kill bound. Requiring
 tripwire tightens as the batch shrinks, though, so a step whose batch was
 decimated by infrastructure failures is the one case worth reading beside its
 `trials` and `empty_span_trials` counts before believing a length warning.
+
+Both directions, since 2026-07-26. The bounds above are floors, and for a while
+they were the only bounds, on the argument that a turn cap already bounds the
+runaway direction. A measured run refuted that: under a 20-turn training cap the
+pooled length still reached 5.33x baseline and entropy 1.68x, because the cap
+bounds turns while each turn grew (172 turns pinned the 12,288-token output cap
+in one step). Nothing fired, and the damage landed somewhere neither floor
+watches — episodes over the context budget are dropped whole, so 22 of 64
+episodes and a third of the trainable datums disappeared while every metric the
+tripwire reads looked "fine, just larger". Each metric now answers to a ceiling
+(`*_mult`) as well, and the ceilings are set from that run's own trajectory:
+see `TripwireConfig` for which observation fixed each number.
 """
 
 from __future__ import annotations
@@ -69,6 +81,15 @@ TripwireMetric = Literal["entropy_per_token", "mean_generation_tokens"]
 """The two statistics under tripwire, named exactly as the metrics-row keys."""
 
 TripwireLevel = Literal["warn", "kill"]
+
+TripwireDirection = Literal["floor", "ceiling"]
+"""Which side of the baseline a breach is on.
+
+`floor` is collapse (the ratio fell to a fraction); `ceiling` is runaway (it
+rose to a multiple). Both are the same pathology seen from opposite ends, and a
+run has been lost to each: a sibling lane's length fell 50x, and this lane's
+length rose 5.33x until context overflow was discarding a third of every batch.
+"""
 
 
 class PolicyHealth(BaseModel):
@@ -214,13 +235,15 @@ class TripwireBreach(BaseModel):
 
     metric: TripwireMetric
     level: TripwireLevel
+    direction: TripwireDirection
     baseline: float
     value: float
     ratio: float
     """`value / baseline`; the tripwire is a bound on this, never on `value`."""
 
     threshold_frac: float
-    """The configured fraction the ratio fell to or below."""
+    """The configured bound the ratio reached: a fraction for a `floor` breach,
+    a multiple for a `ceiling` one."""
 
     config_field: str
     """The `[tripwire]` key that set `threshold_frac`, so a breach message says
@@ -228,9 +251,10 @@ class TripwireBreach(BaseModel):
 
     def describe(self) -> str:
         """One line naming the metric, its baseline, the value, and the ratio."""
+        crossed = "at or under" if self.direction == "floor" else "at or above"
         return (
             f"{self.metric} {self.value:.4g} is {self.ratio:.2f}x this run's baseline "
-            f"{self.baseline:.4g} (measured at its first training step), at or under the "
+            f"{self.baseline:.4g} (measured at its first training step), {crossed} the "
             f"{self.level} threshold {self.threshold_frac:.2f} ({self.config_field})"
         )
 
@@ -254,12 +278,16 @@ class _MetricReading(BaseModel):
     kill_frac: float
     warn_field: str
     kill_field: str
+    warn_mult: float
+    kill_mult: float
+    warn_mult_field: str
+    kill_mult_field: str
 
 
 def _readings(
     cfg: TripwireConfig, baseline: TripwireBaseline, health: PolicyHealth
 ) -> list[_MetricReading]:
-    """Both metrics wired to their configured fractions, in report order."""
+    """Both metrics wired to their configured bounds, in report order."""
     return [
         _MetricReading(
             metric="entropy_per_token",
@@ -269,6 +297,10 @@ def _readings(
             kill_frac=cfg.entropy_kill_frac,
             warn_field="tripwire.entropy_warn_frac",
             kill_field="tripwire.entropy_kill_frac",
+            warn_mult=cfg.entropy_warn_mult,
+            kill_mult=cfg.entropy_kill_mult,
+            warn_mult_field="tripwire.entropy_warn_mult",
+            kill_mult_field="tripwire.entropy_kill_mult",
         ),
         _MetricReading(
             metric="mean_generation_tokens",
@@ -278,6 +310,10 @@ def _readings(
             kill_frac=cfg.length_kill_frac,
             warn_field="tripwire.length_warn_frac",
             kill_field="tripwire.length_kill_frac",
+            warn_mult=cfg.length_warn_mult,
+            kill_mult=cfg.length_kill_mult,
+            warn_mult_field="tripwire.length_warn_mult",
+            kill_mult_field="tripwire.length_kill_mult",
         ),
     ]
 
@@ -285,13 +321,19 @@ def _readings(
 def evaluate_breaches(
     cfg: TripwireConfig, baseline: TripwireBaseline, health: PolicyHealth
 ) -> list[TripwireBreach]:
-    """Compare one step's health against the baseline fractions.
+    """Compare one step's health against the baseline bounds, both sides.
 
     A metric with no measurement (None) is skipped rather than treated as zero:
     a batch that sampled nothing is an infrastructure failure, and the
     all-empty-batch abort owns it. The boundary belongs to the breach side (a
-    ratio exactly at the fraction fires), so a threshold set to a value that was
-    actually observed is never silently inert.
+    ratio exactly at the fraction or the multiple fires), so a threshold set to a
+    value that was actually observed is never silently inert.
+
+    Kill is checked before warn on BOTH sides before either warn is considered,
+    so a metric that has blown through a kill bound is never reported as a mere
+    warning. A ratio cannot breach a floor and a ceiling at once (the validator
+    keeps every fraction <= 1 < every multiple), so the two directions cannot
+    collide.
 
     Args:
         cfg: The run's `[tripwire]` section (its `enabled` flag is the caller's
@@ -308,18 +350,27 @@ def evaluate_breaches(
         ratio = metric_ratio(reading.value, reading.baseline)
         if reading.value is None or ratio is None:
             continue
+        level: TripwireLevel
+        direction: TripwireDirection
         if ratio <= reading.kill_frac:
-            level: TripwireLevel = "kill"
+            level, direction = "kill", "floor"
             threshold, field = reading.kill_frac, reading.kill_field
+        elif ratio >= reading.kill_mult:
+            level, direction = "kill", "ceiling"
+            threshold, field = reading.kill_mult, reading.kill_mult_field
         elif ratio <= reading.warn_frac:
-            level = "warn"
+            level, direction = "warn", "floor"
             threshold, field = reading.warn_frac, reading.warn_field
+        elif ratio >= reading.warn_mult:
+            level, direction = "warn", "ceiling"
+            threshold, field = reading.warn_mult, reading.warn_mult_field
         else:
             continue
         breaches.append(
             TripwireBreach(
                 metric=reading.metric,
                 level=level,
+                direction=direction,
                 baseline=reading.baseline,
                 value=reading.value,
                 ratio=ratio,

--- a/wmh/distill/tripwire_test.py
+++ b/wmh/distill/tripwire_test.py
@@ -386,3 +386,125 @@ def test_health_summary_of_an_unmeasurable_batch_says_so() -> None:
         episodes=0, sampled_tokens=0, entropy_per_token=None, mean_generation_tokens=None
     )
     assert health_summary(health, _baseline()) == "entropy/token n/a, gen tokens/episode n/a"
+
+
+# The Qwen3.5-9B <- Qwen3.6-27B run of 2026-07-26, which is why the ceilings exist. Ratios
+# are its measured `entropy_ratio` and `generation_tokens_ratio` per step, against its own
+# step-0 baseline of 0.513 nats/token.
+REFUTATION_ENTROPY_RATIOS = (1.00, 1.28, 1.49, 1.68)
+REFUTATION_LENGTH_RATIOS = (1.00, 2.31, 3.24, 5.33)
+REFUTATION_BASELINE_ENTROPY = 0.513
+REFUTATION_BASELINE_LENGTH = 10522.703125
+
+
+def _refutation_health(entropy_ratio: float, length_ratio: float) -> PolicyHealth:
+    """One step of the refutation run, expressed as its measured ratios."""
+    length = REFUTATION_BASELINE_LENGTH * length_ratio
+    return PolicyHealth(
+        episodes=64,
+        sampled_tokens=int(length * 64),
+        entropy_per_token=REFUTATION_BASELINE_ENTROPY * entropy_ratio,
+        mean_generation_tokens=length,
+    )
+
+
+def _refutation_baseline() -> TripwireBaseline:
+    """That run's step-0 baseline."""
+    return TripwireBaseline(
+        step=0,
+        entropy_per_token=REFUTATION_BASELINE_ENTROPY,
+        mean_generation_tokens=REFUTATION_BASELINE_LENGTH,
+        episodes=64,
+        sampled_tokens=673453,
+    )
+
+
+def test_the_runaway_that_had_to_be_stopped_by_hand_now_kills_itself() -> None:
+    """The regression this whole two-sided change exists for.
+
+    Under downside-only bounds this run's four steps produced ZERO breaches while
+    context overflow discarded 22 of 64 episodes and a third of the trainable datums,
+    so a human had to read the metrics and stop it. With ceilings it must warn early
+    and reach kill level on its own.
+    """
+    cfg = TripwireConfig()
+    baseline = _refutation_baseline()
+    levels: list[tuple[int, list[tuple[str, str, str]]]] = []
+    for step, (entropy_ratio, length_ratio) in enumerate(
+        zip(REFUTATION_ENTROPY_RATIOS, REFUTATION_LENGTH_RATIOS, strict=True)
+    ):
+        breaches = evaluate_breaches(cfg, baseline, _refutation_health(entropy_ratio, length_ratio))
+        levels.append((step, [(b.metric, b.level, b.direction) for b in breaches]))
+
+    assert levels[0][1] == [], "step 0 IS the baseline and must never fire against itself"
+    assert ("mean_generation_tokens", "warn", "ceiling") in levels[1][1], (
+        "2.31x length at step 1 is where a human should have been asked to look"
+    )
+    kill_steps = [step for step, bs in levels if any(level == "kill" for _, level, _ in bs)]
+    assert kill_steps, "the run that had to be stopped by hand must now stop itself"
+    assert kill_steps[0] <= 2, (
+        "kill must land by step 2, the step where overflow drops reached 14 of 64 and the "
+        f"batch began collapsing; got first kill at step {kill_steps[0]}"
+    )
+
+
+def test_the_ceilings_stay_silent_on_the_healthy_probe() -> None:
+    """A ceiling that fires on healthy data is worse than no ceiling.
+
+    Same drift cases as the floor test, plus their upside mirrors: the 32-episode
+    resampling put pooled length noise at 0.62x on the downside, whose reciprocal
+    1.61x is the upside a stationary policy can show.
+    """
+    cfg = TripwireConfig()
+    baseline = _baseline()
+    for entropy, tokens in (
+        (PROBE_BASELINE_ENTROPY_NATS, float(PROBE_BASELINE_EPISODE_TOKENS)),
+        (0.181 * 1.40, PROBE_BASELINE_EPISODE_TOKENS * 1.61),
+        (0.181 * 1.20, PROBE_BASELINE_EPISODE_TOKENS * 1.90),
+    ):
+        health = PolicyHealth(
+            episodes=32,
+            sampled_tokens=int(tokens * 32),
+            entropy_per_token=entropy,
+            mean_generation_tokens=tokens,
+        )
+        assert evaluate_breaches(cfg, baseline, health) == [], (entropy, tokens)
+
+
+def test_ceiling_kill_outranks_a_floor_warn_on_the_other_metric() -> None:
+    """Both directions can fire in one step, each on its own metric."""
+    baseline = _baseline()
+    health = PolicyHealth(
+        episodes=32,
+        sampled_tokens=1_000_000,
+        entropy_per_token=baseline.entropy_per_token * 0.4,  # floor warn
+        mean_generation_tokens=baseline.mean_generation_tokens * 3.5,  # ceiling kill
+    )
+    breaches = {b.metric: b for b in evaluate_breaches(TripwireConfig(), baseline, health)}
+    assert breaches["entropy_per_token"].level == "warn"
+    assert breaches["entropy_per_token"].direction == "floor"
+    assert breaches["mean_generation_tokens"].level == "kill"
+    assert breaches["mean_generation_tokens"].direction == "ceiling"
+
+
+def test_a_ceiling_breach_reads_as_above_not_under() -> None:
+    """The breach message names the direction, or it reads as its own opposite."""
+    baseline = _baseline()
+    health = PolicyHealth(
+        episodes=32,
+        sampled_tokens=1_000_000,
+        entropy_per_token=baseline.entropy_per_token,
+        mean_generation_tokens=baseline.mean_generation_tokens * 2.2,
+    )
+    (breach,) = evaluate_breaches(TripwireConfig(), baseline, health)
+    assert "at or above" in breach.describe()
+    assert "length_warn_mult" in breach.describe()
+
+
+def test_a_kill_ceiling_under_its_warn_ceiling_is_rejected() -> None:
+    """The comparison INVERTS between floors and ceilings; getting it wrong would
+    abort a run at a ratio it never warned about."""
+    with pytest.raises(ValueError, match="length_kill_mult"):
+        TripwireConfig(length_warn_mult=3.0, length_kill_mult=2.0)
+    with pytest.raises(ValueError, match="entropy_kill_mult"):
+        TripwireConfig(entropy_warn_mult=2.0, entropy_kill_mult=1.5)


### PR DESCRIPTION
Four fixes to the distillation loop. None is specific to a benchmark or a model pair: they apply to anyone distilling a smaller model from their own agent traces. 15 files, all under `wmh/distill/` plus the standalone probe.

### 1. `train.num_substeps` — one batch bought one gradient step

A collected batch ran a single `forward_backward` and a single `optim_step`, so a 4-step run was **5 optimizer updates total**. That cannot move a rank-32 LoRA whatever the objective does, which means a flat result from such a run says nothing about the method.

The same datums now split into N shuffled minibatches. Rollouts dominate the bill and are already paid for by the time the optimizer runs, so the extra updates cost nothing. Two subtleties, both test-pinned: groups sharing a model input move whole, so top-k replicas never split across two weight states; and datums arrive grouped by episode, so the order is shuffled with a per-step seed. `optimizer_updates` is now recorded per step — a summary that reports tokens but not updates hides the quantity that most cheaply explains a null.

### 2. Degeneration tripwires were one-sided

Entropy and generation length only had floors, documented as sufficient because "an episode cap bounds the runaway direction already". It does not — a cap bounds *turns* while each turn grows. A measured run reached **5.33x** generation length and **1.68x** entropy with nothing firing, and the real damage landed where neither floor looks: episodes over the context budget are dropped whole, so a third of the batch silently disappeared. Each metric now answers to a ceiling too, and the validator knows the kill-vs-warn comparison inverts between the two.

### 3. Cached prefill was billed at the uncached rate

`SamplingClient.compute_logprobs` is exactly `sample(max_tokens=1, include_prompt_logprobs=True)` followed by returning `prompt_logprobs` — it throws away the rest of the response, including `prompt_cache_hit_tokens`. So every `*_cached_prefill` meter read zero by construction and the ledger was a ceiling, not a bill. Teacher scoring now issues that same request and keeps the field.

The read is deliberately defensive. This is cost accounting on the hot path of a paid run: an SDK that renames or drops the field must degrade to the old conservative behaviour, never raise after the service has already been paid.

### 4. Both sides of the reasoning-in-history trade

`VerbatimHistoryMixin` keeps prior turns' reasoning in later prompts: the prefix property holds and an episode is one datum, but long episodes overflow. `StripHistoryMixin` drops it: contexts stay small, but the episode fragments into one datum per turn and teacher prefill rises. Pick by whether episodes fit the window — an overflow costs a whole trial *and* biases the measurement, whereas fragmentation only costs money. The fragmentation warning no longer asserts a bug, because a near-1.0 rate is the expected reading under a history-editing renderer.

### Also: the standalone probe could not start

`.agents/distill/tinker_probe_gsm8k.py` exercises the full Tinker path with no rollout backend, in about two minutes for under a cent. It was unrunnable: its training client returned `None` where the protocol promises `TrainStepOutput`/`OptimStepOutput`, and `RolloutStats` had gained four required fields. Fixed, plus `--num-substeps`, `--advantage-clip` and `--learning-rate` so the settings above can be exercised cheaply.

### Scope and testing

Run configs, task-id lists, launchers and per-run analysis scripts are deliberately **not** here — they are operator artifacts for one benchmark, and this change is meant to be usable with any traces. They remain on `feat/distill-session-2026-07-26`'s earlier commit if anyone wants them.

`ruff` clean, 3,281 tests pass. One pre-existing failure, `ingest_cmd_test::test_ingest_dsn_implies_postgres_source`, fails identically on the base branch (missing `psycopg`) and is unrelated.

Based on `feat/distill-capability` (#257); retarget to main once that lands.