### PR TITLE
Make a distilled student a routable pool candidate

### DIFF
--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -57,6 +57,7 @@ from wmo.distill.loop import (
 from wmo.distill.rollouts import E2B_SANDBOXES_PER_TRIAL
 from wmo.distill.store import (
     DEFAULT_TINKER_OPENAI_ENDPOINT,
+    STUDENT_CHAT_MAX_TOKENS_FIELD,
     AdapterStore,
     DistillRunStore,
     build_handoff_toml,
@@ -791,6 +792,9 @@ def _maybe_promote(console: Console, result: DistillResult, cfg: DistillConfig, 
         model=result.final_sampler_path,
         model_type=cfg.student.base_model,
         endpoint=DEFAULT_TINKER_OPENAI_ENDPOINT,
+        # A tinker:// path is outside the built-in catalog, so capability resolution would fall
+        # back to `max_completion_tokens`, which Tinker's endpoint 400s on. Pin the name it takes.
+        chat_max_tokens_field=STUDENT_CHAT_MAX_TOKENS_FIELD,
     )
     save_settings(settings, root)
     console.print(

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -70,7 +70,7 @@ def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderCon
     api_version = configured.api_version
     if api_version is None and kind is ProviderKind.AZURE_OPENAI:
         api_version = _DEFAULT_AZURE_API_VERSION
-    return ProviderConfig(
+    config = ProviderConfig(
         kind=kind,
         model=configured.model,
         model_type=configured.model_type,
@@ -80,3 +80,8 @@ def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderCon
         api_version=api_version,
         reasoning_effort=configured.reasoning_effort,
     )
+    if configured.chat_max_tokens_field is None:
+        # Unset keeps meaning "resolve from the built-in catalog", which is right for every named
+        # model; forcing the field here would override the catalog for all of them.
+        return config
+    return config.model_copy(update={"chat_max_tokens_field": configured.chat_max_tokens_field})

--- a/wmo/cli/model_roles_test.py
+++ b/wmo/cli/model_roles_test.py
@@ -8,7 +8,11 @@ import pytest
 import typer
 
 import wmo.cli.model_roles as model_roles_module
-from wmo.cli.model_roles import OptInModelRole, resolve_opt_in_model_provider
+from wmo.cli.model_roles import (
+    OptInModelRole,
+    _model_config,
+    resolve_opt_in_model_provider,
+)
 from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
 from wmo.providers.base import (
     DEFAULT_MAX_TOKENS,
@@ -187,3 +191,32 @@ def test_unknown_provider_names_the_configured_role(tmp_path: Path, role: OptInM
         match=rf"settings \[models\.{role}\] has unknown provider 'bogus'",
     ):
         resolve_opt_in_model_provider(str(root), role, _Provider())
+
+
+def test_role_pins_the_output_budget_field_for_a_model_outside_the_catalog() -> None:
+    """A promoted tinker:// student must reach the provider with the field its endpoint takes.
+
+    Without this the role resolves `max_completion_tokens` (the catalog fallback for an unknown
+    model id) and every agent call to Tinker's serving endpoint 400s.
+    """
+    config = _model_config(
+        ModelRole(
+            provider="openai",
+            model="tinker://runs/abc/sampler/final",
+            model_type="Qwen/Qwen3-8B",
+            endpoint="https://tinker.example/oai/api/v1",
+            chat_max_tokens_field="max_tokens",
+        ),
+        role="agent",
+    )
+
+    assert config.chat_max_tokens_field == "max_tokens"
+    assert config.resolved_chat_max_tokens_field() == "max_tokens"
+
+
+def test_role_without_the_field_still_resolves_from_the_catalog() -> None:
+    """Unset must keep meaning "ask the catalog", so this cannot override every named model."""
+    config = _model_config(ModelRole(provider="openai", model="gpt-5.5"), role="agent")
+
+    assert config.chat_max_tokens_field == "max_completion_tokens"
+    assert config.resolved_chat_max_tokens_field() == "max_completion_tokens"

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -6,16 +6,28 @@ research adapter such as RouterBench) and emits the policy artifact serving load
 improvement report the endpoint cites. `tune` is the one post-fit control: it moves a fitted
 policy's cost/quality dial without refitting. Vocabulary note: "route" is developer-facing CLI
 only; customer copy never says router.
+
+Two commands bracket the fit rather than consuming a matrix. `student` puts a freshly distilled
+adapter into the candidate pool, which is what makes a trained model routable at all. `pin`
+installs a `kind="static"` policy for one pool model, so a single candidate is serveable before
+any measurement exists: the honest zero-evidence starting point a fit is compared against.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import typer
+from llm_waterfall import ChatMaxTokensField
+from pydantic import ValidationError
 from rich.console import Console
+from rich.markup import escape
+from rich.prompt import Confirm
 
+from wmo.config import ARTIFACT_DIR, WorldModelStore
+from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_entry
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     apply_cost_quality,
@@ -32,13 +44,189 @@ from wmo.optimize.policy import (
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+from wmo.providers.pool import (
+    DEFAULT_POOL_PATH,
+    PoolEntry,
+    PoolLockTimeout,
+    load_pool,
+    upsert_pool_entry,
+)
+
+# The two output-budget parameter names any OpenAI-compatible backend accepts.
+_MAX_TOKENS_FIELDS: tuple[ChatMaxTokensField, ...] = ("max_tokens", "max_completion_tokens")
 
 route_app = typer.Typer(
-    help="Fit and report learned inference policies from closed-loop outcome matrices.",
+    help="Make models routable, then fit, tune, and report inference policies over them.",
     no_args_is_help=True,
 )
 
 _console = Console()
+
+
+@route_app.command("student")
+def student(
+    card_dir: str = typer.Argument(
+        ...,
+        help="The distillation run dir, or an adapter version dir: whichever holds "
+        "model_card.json.",
+    ),
+    input_per_mtok: float = typer.Option(
+        ...,
+        "--input-per-mtok",
+        min=0.0,
+        help="Prompt-token price at the serving endpoint, USD per 1M tokens. Required: an "
+        "unpriced candidate reports $0 and a cost-aware policy would route everything to it.",
+    ),
+    output_per_mtok: float = typer.Option(
+        ...,
+        "--output-per-mtok",
+        min=0.0,
+        help="Completion-token price at the serving endpoint, USD per 1M tokens.",
+    ),
+    name: str = typer.Option(
+        "student", "--name", help="Pool handle: what policy artifacts and request logs call it."
+    ),
+    pool: str = typer.Option(
+        str(DEFAULT_POOL_PATH), "--pool", help="Candidate pool TOML to add the entry to."
+    ),
+    endpoint: str = typer.Option(
+        None,
+        "--endpoint",
+        help="OpenAI-compatible base URL. Default: Tinker's serving endpoint.",
+    ),
+    api_key_env: str = typer.Option(
+        None,
+        "--api-key-env",
+        help="Env var holding the endpoint's API key. Default: TINKER_API_KEY on Tinker's own "
+        "endpoint; on any other --endpoint the provider's WMO_ENDPOINT_API_KEY fallback is used, "
+        "so a Tinker key is never sent to a host you named.",
+    ),
+    chat_max_tokens_field: str = typer.Option(
+        None,
+        "--chat-max-tokens-field",
+        help="Output-budget parameter the endpoint accepts: max_tokens | max_completion_tokens. "
+        "Default: max_tokens on Tinker's endpoint, max_completion_tokens on any other.",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", help="Skip the confirmation when an entry of this name already exists."
+    ),
+) -> None:
+    """Add a distilled student to the candidate pool, so the router can select it.
+
+    The keystone step between training and serving: a run produces a `tinker://` adapter, and this
+    turns it into a `[[model]]` entry the sweep measures, the fitter routes to, and the endpoint
+    calls, with no hand-edited TOML in between:
+
+        wmo optimize route student .wmo/distill/support --input-per-mtok 0.1 --output-per-mtok 0.4
+
+    On Tinker's own endpoint the entry reads its credential from `TINKER_API_KEY`, so export that
+    before serving. Point `--endpoint` somewhere else and the Tinker defaults do NOT follow: the
+    entry falls back to `WMO_ENDPOINT_API_KEY` and to `max_completion_tokens`, so a Tinker key is
+    never sent to a host you named. `--api-key-env` and `--chat-max-tokens-field` set either
+    explicitly.
+
+    To serve the student on its own with no measurement at all, follow this with
+    `wmo optimize route pin <world-model> --model student`; to have the router CHOOSE between the
+    student and the rest of the roster, run `wmo optimize route fit` on a matrix that covers both.
+    """
+    card_path = Path(card_dir) / MODEL_CARD_FILE
+    if not card_path.is_file():
+        raise typer.BadParameter(
+            f"no {MODEL_CARD_FILE} at {card_path}; pass a distillation run directory (the one "
+            "holding config.toml and metrics.jsonl) or an adapter version directory "
+            "(.wmo/adapters/<name>/vN)"
+        )
+    if endpoint is not None and not endpoint.strip():
+        # `--endpoint "$UNSET_VAR"` is the way this happens. Falling back to Tinker's endpoint
+        # would silently serve a different host than the script meant to name.
+        raise typer.BadParameter(
+            "--endpoint is empty; give the OpenAI-compatible base URL, or drop the flag to use "
+            "Tinker's serving endpoint"
+        )
+    if api_key_env is not None and not api_key_env.strip():
+        # Same accident as an empty --endpoint. An empty string reaches `pool_provider` as a
+        # falsy api_key_env, which it reads as "no explicit credential" and skips its own
+        # unset-variable check, so the misconfiguration would only surface as a 401 at request
+        # time with no hint.
+        raise typer.BadParameter(
+            "--api-key-env is empty; name the environment variable holding the endpoint's key, "
+            "or drop the flag to use the provider's default credentials"
+        )
+    if chat_max_tokens_field is not None and chat_max_tokens_field not in _MAX_TOKENS_FIELDS:
+        raise typer.BadParameter(
+            f"unknown --chat-max-tokens-field {chat_max_tokens_field!r}; use "
+            f"{' or '.join(_MAX_TOKENS_FIELDS)}"
+        )
+    try:
+        card = DistillModelCard.model_validate_json(card_path.read_text(encoding="utf-8"))
+    except ValidationError as exc:
+        raise typer.BadParameter(f"cannot read the model card at {card_path}: {exc}") from exc
+    try:
+        entry = student_pool_entry(
+            card,
+            name=name,
+            input_per_mtok=input_per_mtok,
+            output_per_mtok=output_per_mtok,
+            endpoint=endpoint,
+            api_key_env=api_key_env,
+            chat_max_tokens_field=cast("ChatMaxTokensField | None", chat_max_tokens_field),
+        )
+    except ValidationError as exc:
+        raise typer.BadParameter(f"cannot build a pool entry for '{name}': {exc}") from exc
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    pool_path = Path(pool)
+    if _pool_has(pool_path, name) and not yes and not _confirm_replace(pool_path, name):
+        _console.print(
+            f"left {pool_path} unchanged; pass --yes to replace '{name}' (comments in the file "
+            "are not preserved by a replacement), or --name <other> to keep both"
+        )
+        raise typer.Exit(0)
+    try:
+        replaced = upsert_pool_entry(entry, pool_path)
+    except PoolLockTimeout as exc:
+        # Nothing is wrong with the flags, so this is not a BadParameter: another writer is in the
+        # way. Exit non-zero (and say to retry) so a script does not read it as a registration.
+        _console.print(f"[red]pool busy[/red] {escape(str(exc))}")
+        raise typer.Exit(1) from exc
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    verb = "replaced" if replaced else "added"
+    _console.print(
+        f"[green]✓[/green] {verb} pool candidate [bold]{name}[/bold] -> {pool_path}\n"
+        f"  {card.base_model} adapter at {entry.model}\n"
+        f"  ${input_per_mtok:g}/${output_per_mtok:g} per 1M in/out tokens, "
+        f"{_credential_note(entry)}\n"
+        f"  serve it directly: wmo optimize route pin <world-model> --model {name}",
+        soft_wrap=True,
+    )
+
+
+def _credential_note(entry: PoolEntry) -> str:
+    """How this entry authenticates, so the summary never names a key it will not send."""
+    if entry.api_key_env is not None:
+        return f"credential from {entry.api_key_env}"
+    return "credential from WMO_ENDPOINT_API_KEY (the custom-endpoint fallback)"
+
+
+def _pool_has(path: Path, name: str) -> bool:
+    """Whether `path` already carries an entry called `name` (False when there is no pool yet)."""
+    if not path.is_file():
+        return False
+    try:
+        return any(entry.name == name for entry in load_pool(path).models)
+    except (ValueError, FileNotFoundError):
+        # An unreadable pool is upsert_pool_entry's error to raise, with its own message; do not
+        # pre-empt it here with a confirmation prompt about an entry we cannot see.
+        return False
+
+
+def _confirm_replace(path: Path, name: str) -> bool:
+    """Confirm repointing an existing pool handle; a non-interactive run declines."""
+    try:
+        return Confirm.ask(f"Replace the existing '{name}' entry in {path}?", default=False)
+    except EOFError:
+        return False
 
 
 @route_app.command("fit")
@@ -187,6 +375,92 @@ def fit(
         f"{result.scenarios} scenarios -> {out}\n"
         f"  fit-set accuracy {result.accuracy:.4f}, cost/scenario ${result.cost_per_scenario:.5f}"
     )
+
+
+@route_app.command("pin")
+def pin(
+    world_model: str = typer.Argument(
+        None, help="Built world model whose endpoint serves this policy. Default: the only one."
+    ),
+    model: str = typer.Option(
+        ...,
+        "--model",
+        help="Pool entry every request goes to (a `wmo optimize route student` name).",
+    ),
+    pool: str = typer.Option(
+        str(DEFAULT_POOL_PATH), "--pool", help="Candidate pool TOML to snapshot into the policy."
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir holding the built models."),
+    out: str = typer.Option(
+        None, "--out", help="Override where the policy JSON lands (default: the model's own dir)."
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", help="Skip the confirmation when a policy is already installed."
+    ),
+) -> None:
+    """Serve one pool model as an endpoint, with no matrix and no fit.
+
+    A `kind="static"` policy sends every request to `--model`, which is all a single distilled
+    student needs to be reachable through the OpenAI-compatible endpoint:
+
+        wmo optimize route student .wmo/distill/support --input-per-mtok 0.1 --output-per-mtok 0.4
+        wmo optimize route pin support --model student
+        wmo serve --name support
+
+    The policy is written to the world model's artifact dir, because that is where `wmo serve`
+    looks for one. This is the honest "before" state the routing story is told against: a static
+    endpoint has learned nothing and saves nothing, and `GET /v1/endpoints/<name>/savings` will
+    say so. Replace it with `wmo optimize route fit` on a real outcome matrix to let the router
+    choose per request.
+    """
+    try:
+        model_dir = WorldModelStore(root).resolve(world_model)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    pool_path = Path(pool)
+    try:
+        roster = load_pool(pool_path)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except ValueError as exc:
+        raise typer.BadParameter(f"cannot read the pool at {pool_path}: {exc}") from exc
+    if all(entry.name != model for entry in roster.models):
+        available = ", ".join(entry.name for entry in roster.models)
+        raise typer.BadParameter(
+            f"no pool model named '{model}' in {pool_path}; available: {available}"
+        )
+    out_path = Path(out) if out else model_dir / POLICY_FILENAME
+    if out_path.is_file() and not yes and not _confirm_overwrite(out_path):
+        _console.print(f"left {out_path} in place")
+        raise typer.Exit(0)
+    policy = RoutingPolicy(
+        kind="static",
+        default_model=model,
+        pool=roster.models,
+        fitted_from=f"pinned to {model} from {pool_path} (no outcome matrix)",
+    )
+    policy.save(out_path)
+    _console.print(
+        f"[green]✓[/green] pinned endpoint [bold]{model_dir.name}[/bold] to "
+        f"[bold]{model}[/bold] -> {out_path}\n"
+        f"  every request goes to {model}; nothing is measured and nothing is saved yet\n"
+        f"  serve it: wmo serve --name {model_dir.name}\n"
+        "  to let the router choose per request instead, replace this with "
+        "`wmo optimize route fit <matrix.json>`",
+        soft_wrap=True,
+    )
+
+
+def _confirm_overwrite(path: Path) -> bool:
+    """Confirm replacing an installed policy; a non-interactive run declines.
+
+    Worth asking about: the file being replaced may be a fitted knn policy, whose evidence bank
+    sidecar this static policy will not use and does not remove.
+    """
+    try:
+        return Confirm.ask(f"Replace the policy already at {path}?", default=False)
+    except EOFError:
+        return False
 
 
 @route_app.command("tune")

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
 from pathlib import Path
 
-from typer.testing import CliRunner
+import pytest
+from typer.testing import CliRunner, Result
 
 from wmo.cli.app import app
+from wmo.distill.store import DistillModelCard
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
-from wmo.optimize.policy import KNN_BANK_FILENAME, POLICY_FILENAME, RoutingPolicy
+from wmo.optimize.policy import (
+    KNN_BANK_FILENAME,
+    POLICY_FILENAME,
+    RoutingPolicy,
+    select_model,
+)
 from wmo.optimize.routing import evaluate_policy
+from wmo.providers import pool as pool_module
 from wmo.providers.base import ProviderKind
-from wmo.providers.pool import PoolEntry
+from wmo.providers.pool import PoolEntry, load_pool
 
 runner = CliRunner()
 
@@ -317,3 +327,421 @@ def test_route_tune_rejects_a_dial_outside_the_range(tmp_path: Path) -> None:
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "2"]
     )
     assert result.exit_code != 0
+
+
+def _run_dir(tmp_path: Path, sampler: str = "tinker://fake/sampler/final/0") -> Path:
+    """A distillation run dir with just the artifact `route student` reads."""
+    run_dir = tmp_path / "distill" / "support"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    card = DistillModelCard(
+        base_model="Qwen/Qwen3-8B",
+        lora_rank=32,
+        teacher_model="glm-5.2",
+        sampler_path=sampler,
+        steps_completed=200,
+    )
+    (run_dir / "model_card.json").write_text(card.model_dump_json(indent=2), encoding="utf-8")
+    return run_dir
+
+
+def _built_model(tmp_path: Path, name: str = "support") -> Path:
+    """A world model dir as `WorldModelStore` recognizes one (a dir carrying config.toml)."""
+    model_dir = tmp_path / "models" / name
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.toml").write_text("", encoding="utf-8")
+    return model_dir
+
+
+def _add_student(tmp_path: Path, pool_file: Path, *, name: str = "student") -> Result:
+    return runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+            "--name",
+            name,
+            "--pool",
+            str(pool_file),
+        ],
+    )
+
+
+def test_route_student_makes_a_trained_adapter_routable(tmp_path: Path) -> None:
+    """The keystone: a run dir becomes a loadable pool candidate with no hand-edited TOML."""
+    pool_file = tmp_path / "pool.toml"
+
+    result = _add_student(tmp_path, pool_file)
+
+    assert result.exit_code == 0, result.output
+    entry = load_pool(pool_file).entry("student")
+    assert entry.kind is ProviderKind.OPENAI
+    assert entry.model == "tinker://fake/sampler/final/0"
+    assert entry.model_type == "Qwen/Qwen3-8B"
+    assert entry.chat_max_tokens_field == "max_tokens"
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.price().input_per_mtok == 0.1
+
+
+def test_route_student_requires_prices(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["optimize", "route", "student", str(_run_dir(tmp_path)), "--pool", str(tmp_path / "p")],
+    )
+    assert result.exit_code != 0
+    assert "--input-per-mtok" in result.output
+
+
+def test_route_student_names_the_missing_model_card(tmp_path: Path) -> None:
+    empty = tmp_path / "not-a-run"
+    empty.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(empty),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "model_card.json" in result.output
+    assert "adapter version directory" in result.output  # says what to pass instead
+
+
+def test_route_student_rejects_a_run_with_no_trained_weights(tmp_path: Path) -> None:
+    run_dir = _run_dir(tmp_path, sampler="Qwen/Qwen3-8B")
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(run_dir),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "tinker://" in result.output
+
+
+def test_route_student_declining_the_replacement_leaves_the_pool_alone(tmp_path: Path) -> None:
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    before = pool_file.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "9.9",
+            "--output-per-mtok",
+            "9.9",
+            "--pool",
+            str(pool_file),
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    assert pool_file.read_text(encoding="utf-8") == before  # the 9.9 price never landed
+
+
+def test_route_student_replaces_the_same_name_under_yes(tmp_path: Path) -> None:
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "0.2",
+            "--output-per-mtok",
+            "0.8",
+            "--pool",
+            str(pool_file),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "replaced" in result.output
+    models = load_pool(pool_file).models
+    assert len(models) == 1  # replaced, not duplicated
+    assert models[0].price().output_per_mtok == 0.8
+
+
+def test_route_pin_writes_a_serveable_static_policy(tmp_path: Path) -> None:
+    """One step from pool candidate to endpoint: the policy lands where `wmo serve` reads it."""
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    model_dir = _built_model(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "support",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(model_dir / POLICY_FILENAME)
+    assert policy.kind == "static"
+    assert policy.default_model == "student"
+    assert [entry.name for entry in policy.pool] == ["student"]
+    assert policy.fitted_from is not None
+    assert "no outcome matrix" in policy.fitted_from  # provenance says it measured nothing
+
+
+def test_route_pin_serves_through_the_endpoint_it_installed(tmp_path: Path) -> None:
+    """The pinned policy is not just well formed: `select_model` actually routes on it."""
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    model_dir = _built_model(tmp_path)
+    runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "support",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+
+    policy = RoutingPolicy.load(model_dir / POLICY_FILENAME)
+    decision = select_model(policy, "anything at all")
+
+    assert decision.model == "student"
+
+
+def test_route_pin_rejects_a_model_outside_the_pool(tmp_path: Path) -> None:
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    _built_model(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "support",
+            "--model",
+            "ghost",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "no pool model named 'ghost'" in result.output
+    assert "student" in result.output  # lists what IS available
+
+
+def test_route_pin_names_the_missing_world_model(tmp_path: Path) -> None:
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "nope",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "no world model named 'nope'" in result.output
+
+
+def test_route_pin_declining_keeps_a_fitted_policy(tmp_path: Path) -> None:
+    """Pinning over a fitted knn policy would orphan its evidence bank, so it must ask first."""
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    model_dir = _built_model(tmp_path)
+    installed = model_dir / POLICY_FILENAME
+    fitted = _fitted_knn_policy(tmp_path)
+    installed.write_text(fitted.read_text(encoding="utf-8"), encoding="utf-8")
+    before = installed.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "support",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    assert installed.read_text(encoding="utf-8") == before
+
+
+def test_route_student_rejects_an_empty_endpoint(tmp_path: Path) -> None:
+    """`--endpoint "$UNSET_VAR"` must not silently fall back to a different host."""
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+            "--endpoint",
+            "",
+            "--pool",
+            str(tmp_path / "pool.toml"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--endpoint is empty" in result.output
+    assert not (tmp_path / "pool.toml").exists()  # nothing was written
+
+
+def test_route_student_summary_does_not_claim_a_key_it_will_not_send(tmp_path: Path) -> None:
+    """A custom endpoint authenticates via WMO_ENDPOINT_API_KEY, and the summary must say so."""
+    pool_file = tmp_path / "pool.toml"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+            "--endpoint",
+            "https://my-vllm.example/v1",
+            "--pool",
+            str(pool_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "WMO_ENDPOINT_API_KEY" in result.output
+    assert "TINKER_API_KEY" not in result.output
+    assert load_pool(pool_file).entry("student").api_key_env is None
+
+
+def test_route_student_reports_a_busy_pool_without_claiming_it_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held roster lock is a retryable busy state, so it must exit non-zero and say to retry.
+
+    The lock is real here (taken with flock, from this process, on the file the command writes);
+    only the wait is shortened, so the CLI runs the same path an operator hits when a second
+    registration is in flight. What matters is that it never prints its "added pool candidate"
+    line for a write that did not happen, and never reports a lock holder as a bad flag.
+    """
+    monkeypatch.setattr(pool_module, "POOL_LOCK_TIMEOUT_S", 0.05)
+    pool_file = tmp_path / "pool.toml"
+    lock_path = pool_file.with_name(f"{pool_file.name}.lock")
+    pool_file.parent.mkdir(parents=True, exist_ok=True)
+    holder = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+    fcntl.flock(holder, fcntl.LOCK_EX)
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "optimize",
+                "route",
+                "student",
+                str(_run_dir(tmp_path)),
+                "--input-per-mtok",
+                "0.1",
+                "--output-per-mtok",
+                "0.4",
+                "--pool",
+                str(pool_file),
+            ],
+        )
+    finally:
+        os.close(holder)
+
+    assert result.exit_code == 1, result.output
+    assert "pool busy" in result.output
+    assert "retry" in result.output
+    assert "added pool candidate" not in result.output
+    assert not pool_file.exists()  # nothing was written
+
+
+def test_route_student_rejects_an_unknown_output_budget_field(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "student",
+            str(_run_dir(tmp_path)),
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+            "--chat-max-tokens-field",
+            "max_output_tokens",
+            "--pool",
+            str(tmp_path / "pool.toml"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "max_tokens or max_completion_tokens" in result.output

--- a/wmo/config/settings.py
+++ b/wmo/config/settings.py
@@ -7,6 +7,7 @@ import uuid
 from pathlib import Path
 
 import tomli_w
+from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, Field, ValidationError
 
 from wmo.config.config import ARTIFACT_DIR
@@ -34,6 +35,11 @@ class ModelRole(BaseModel):
     deployment: str | None = None  # Azure OpenAI deployment name
     api_version: str | None = None  # Azure OpenAI API version (azure roles get a default)
     reasoning_effort: str | None = None  # structured reasoning effort, when supported
+    # The output-budget parameter this backend accepts. Unset means "resolve it from the built-in
+    # catalog", which is right for every named model; a custom `endpoint` outside the catalog (a
+    # tinker:// student on Tinker's serving endpoint wants the classic `max_tokens`) has to say so
+    # here, or every call to it 400s on the wrong parameter name.
+    chat_max_tokens_field: ChatMaxTokensField | None = None
 
 
 class ModelsSettings(BaseModel):

--- a/wmo/distill/config_test.py
+++ b/wmo/distill/config_test.py
@@ -926,8 +926,6 @@ def _checked_in_config(name: str) -> DistillConfig:
     return load_distill_config(Path(__file__).parent / "configs" / name)
 
 
-
-
 def test_training_turn_cap_defaults_to_the_rollout_cap(tmp_path: Path) -> None:
     """Unset means one cap everywhere, which is the pre-existing behaviour."""
     cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))

--- a/wmo/distill/store.py
+++ b/wmo/distill/store.py
@@ -811,7 +811,12 @@ def build_handoff_toml(sampler_path: str, *, base_model: str, endpoint: str | No
             "path returned by save_weights_for_sampler (recorded in the run's "
             "checkpoints.json and model card)"
         )
-    resolved_endpoint = endpoint if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
+    # Stripped before it is STORED, not just before it is classified. `is_tinker_endpoint`
+    # tolerates surrounding whitespace so a pasted URL still gets Tinker's credential and
+    # output-budget defaults, but the entry's endpoint becomes the OpenAI client's base_url
+    # verbatim, so persisting the padded string would classify correctly and then fail every
+    # routed call on an unusable URL.
+    resolved_endpoint = endpoint.strip() if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
     budget_field = (
         STUDENT_CHAT_MAX_TOKENS_FIELD
         if is_tinker_endpoint(resolved_endpoint)
@@ -969,7 +974,12 @@ def student_pool_entry(
             "routable student needs the path save_weights_for_sampler returned (recorded in the "
             "run's checkpoints.json and model card)"
         )
-    resolved_endpoint = endpoint if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
+    # Stripped before it is STORED, not just before it is classified. `is_tinker_endpoint`
+    # tolerates surrounding whitespace so a pasted URL still gets Tinker's credential and
+    # output-budget defaults, but the entry's endpoint becomes the OpenAI client's base_url
+    # verbatim, so persisting the padded string would classify correctly and then fail every
+    # routed call on an unusable URL.
+    resolved_endpoint = endpoint.strip() if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
     on_tinker = is_tinker_endpoint(resolved_endpoint)
     if api_key_env is None and on_tinker:
         api_key_env = STUDENT_API_KEY_ENV

--- a/wmo/distill/store.py
+++ b/wmo/distill/store.py
@@ -33,8 +33,10 @@ import logging
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import tomli_w
+from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from wmo.config.store import validate_name
@@ -43,6 +45,8 @@ from wmo.distill.config import DistillConfig, load_distill_config, snapshot_toml
 from wmo.distill.gate import DistillGateRecord
 from wmo.distill.tokens import TrialRecord
 from wmo.distill.tripwire import TripwireBaseline
+from wmo.providers.base import ProviderKind
+from wmo.providers.pool import PoolEntry
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +81,8 @@ DEFAULT_TINKER_OPENAI_ENDPOINT = (
 )
 
 _ALIASES_FILE = "aliases.toml"
-_CARD_FILE = "model_card.json"
+MODEL_CARD_FILE = "model_card.json"
+"""The per-run and per-adapter-version model card filename."""
 
 _CONFIG_FILE = "config.toml"
 _METRICS_FILE = "metrics.jsonl"
@@ -86,7 +91,6 @@ _WARMUP_FILE = "warmup.json"
 _WARMUP_TRIALS_FILE = "warmup-trials.json"
 _CHECKPOINTS_FILE = "checkpoints.json"
 _GATE_FILE = "gate.json"
-_MODEL_CARD_FILE = "model_card.json"
 _HANDOFF_FILE = "handoff.toml"
 _EVALS_DIR = "evals"
 _SAMPLES_DIR = "samples"
@@ -251,7 +255,7 @@ class DistillRunStore:
 
     @property
     def model_card_path(self) -> Path:
-        return self.run_dir / _MODEL_CARD_FILE
+        return self.run_dir / MODEL_CARD_FILE
 
     @property
     def handoff_path(self) -> Path:
@@ -733,12 +737,12 @@ class AdapterStore:
             The version's model card, stamped with its name and version.
         """
         version = self.resolve_version(name, ref)
-        path = self.dir_for(name) / f"v{version}" / _CARD_FILE
+        path = self.dir_for(name) / f"v{version}" / MODEL_CARD_FILE
         try:
             text = path.read_text(encoding="utf-8")
         except FileNotFoundError as exc:
             raise FileNotFoundError(
-                f"adapter {name!r} v{version} has no {_CARD_FILE} at {path}; the version "
+                f"adapter {name!r} v{version} has no {MODEL_CARD_FILE} at {path}; the version "
                 "directory is corrupt, so re-save the adapter or remove the broken version"
             ) from exc
         card = DistillModelCard.model_validate_json(text)
@@ -767,7 +771,7 @@ class AdapterStore:
         stamped = card.model_copy(update={"name": name, "version": version})
         directory = self.dir_for(name) / f"v{version}"
         directory.mkdir(parents=True, exist_ok=False)  # append-only: collision is a bug
-        write_text_atomic(directory / _CARD_FILE, stamped.model_dump_json(indent=2))
+        write_text_atomic(directory / MODEL_CARD_FILE, stamped.model_dump_json(indent=2))
         if alias is not None:
             self.set_alias(name, alias, version)
         return version
@@ -786,6 +790,10 @@ def build_handoff_toml(sampler_path: str, *, base_model: str, endpoint: str | No
         base_model: The student's base model name, written as `model_type` so
             capability resolution keys on the model family, not the raw
             weights path (the same shape the CLI's `--promote` writes).
+            The snippet also pins `chat_max_tokens_field`, because a
+            `tinker://` path is outside the built-in catalog: on Tinker's
+            endpoint the resolved default would be `max_completion_tokens`,
+            which that endpoint answers with a 400 on every call.
         endpoint: The OpenAI-compatible base URL; defaults to
             `DEFAULT_TINKER_OPENAI_ENDPOINT`.
 
@@ -804,6 +812,11 @@ def build_handoff_toml(sampler_path: str, *, base_model: str, endpoint: str | No
             "checkpoints.json and model card)"
         )
     resolved_endpoint = endpoint if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
+    budget_field = (
+        STUDENT_CHAT_MAX_TOKENS_FIELD
+        if is_tinker_endpoint(resolved_endpoint)
+        else "max_completion_tokens"
+    )
     values = (
         ("sampler path", sampler_path),
         ("base model", base_model),
@@ -826,4 +839,157 @@ def build_handoff_toml(sampler_path: str, *, base_model: str, endpoint: str | No
         f'model = "{sampler_path}"\n'
         f'model_type = "{base_model}"\n'
         f'endpoint = "{resolved_endpoint}"\n'
+        f'chat_max_tokens_field = "{budget_field}"\n'
+    )
+
+
+# Tinker's OpenAI-compatible endpoint takes the classic `max_tokens`; answering with
+# `max_completion_tokens` (what the built-in catalog defaults to, and what a `tinker://` weights
+# path resolves to since the catalog has never heard of it) is a 400 on every routed call.
+STUDENT_CHAT_MAX_TOKENS_FIELD: ChatMaxTokensField = "max_tokens"
+
+# The pool entry reads the Tinker API key straight from its own env var through the pool's
+# trusted explicit-credential channel (`PoolEntry.api_key_env` -> `pool_provider` ->
+# `get_provider(api_key=...)`). The `[models.agent]` handoff has no such channel and falls back
+# to `WMO_ENDPOINT_API_KEY`, so routing a student needs one fewer copy of the key.
+STUDENT_API_KEY_ENV = "TINKER_API_KEY"
+
+
+def is_tinker_endpoint(endpoint: str) -> bool:
+    """Whether `endpoint` addresses Tinker's own OpenAI-compatible service.
+
+    This answer decides which credential gets sent and which output-budget parameter is used, so
+    it is compared on URL equivalence rather than string equality. An exact match would read a
+    pasted `.../oai/api/v1/`, or a host typed in different case, as somebody else's host: it would
+    quietly swap `TINKER_API_KEY` for the `WMO_ENDPOINT_API_KEY` fallback and `max_tokens` for
+    `max_completion_tokens`, and leave the student 400ing on a URL that is Tinker's.
+
+    Scheme and host are case-insensitive per RFC 3986 section 3.1 and 3.2.2, so they are lowered.
+    The scheme's own default port is redundant (section 3.2.3), so `https://...:443/...` is the
+    same endpoint as the canonical URL and keeps its defaults. Any OTHER port is a different
+    service and stays significant: `:8443` on Tinker's host is somebody's proxy, not Tinker.
+    The PATH is not case-insensitive, and is compared as written: `/oai/api/v1` and `/OAI/API/V1`
+    are different resources on a server that chooses to distinguish them, and reading one as the
+    other would hand a credential to a route the operator did not name. Trailing slashes and
+    surrounding whitespace are stripped either way.
+    """
+    return _normalize_endpoint(endpoint) == _normalize_endpoint(DEFAULT_TINKER_OPENAI_ENDPOINT)
+
+
+# The port each scheme already implies, which a URL may spell out without changing what it
+# addresses (RFC 3986 section 3.2.3).
+_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
+
+
+def _normalize_endpoint(endpoint: str) -> tuple[str, str, str]:
+    """An OpenAI-compatible base URL as (scheme, authority, path), normalized where URLs let it."""
+    parsed = urlsplit(endpoint.strip())
+    scheme = parsed.scheme.lower()
+    return scheme, _normalize_authority(scheme, parsed.netloc), parsed.path.rstrip("/")
+
+
+def _normalize_authority(scheme: str, netloc: str) -> str:
+    """`netloc` lowercased, with only the port `scheme` already implies dropped.
+
+    Dropping the redundant default port is what keeps a pasted `:443` on Tinker's own defaults.
+    Only that exact spelling is dropped, so a non-default port (`:8443`) stays part of the host
+    and reads as a custom endpoint, and so does anything unparseable as the default port
+    (`:0443`, `:notaport`): comparing those as written keeps a credential decision on the safe
+    side rather than guessing what the operator meant.
+    """
+    authority = netloc.lower()
+    default = _DEFAULT_PORTS.get(scheme)
+    if default is None:  # a scheme with no implied port: nothing is redundant
+        return authority
+    # rpartition leaves a bracketed IPv6 literal alone: "[::1]" splits to a "1]" port, which
+    # never matches a default port, so only a real trailing ":443"/":80" is removed.
+    host, separator, port = authority.rpartition(":")
+    if separator and port == str(default):
+        return host
+    return authority
+
+
+def student_pool_entry(
+    card: DistillModelCard,
+    *,
+    name: str,
+    input_per_mtok: float,
+    output_per_mtok: float,
+    endpoint: str | None = None,
+    api_key_env: str | None = None,
+    chat_max_tokens_field: ChatMaxTokensField | None = None,
+) -> PoolEntry:
+    """Build the routable pool entry for a distilled student, from its model card.
+
+    This is the seam that makes a trained adapter a routing candidate: the card records the
+    `tinker://` weights path and the base model, and this turns that pair into a `PoolEntry` the
+    router can select and serving can call, with no hand-edited TOML in between. The entry
+    addresses the student as any OpenAI-compatible server is addressed (`kind="openai"` plus an
+    `endpoint`), which is the same shape `build_handoff_toml` writes for `[models.agent]`.
+
+    Prices are REQUIRED and have no default. A candidate whose cost is unknown reports $0, which
+    would make it unconditionally the cheapest model in the pool and let a cost-aware policy route
+    everything to it on evidence that does not exist. `PoolEntry` refuses an unpriced non-built-in
+    model for the same reason, and a `tinker://` path is never in the built-in price table.
+
+    The Tinker-specific defaults apply ONLY when the entry actually points at Tinker. Reading
+    `TINKER_API_KEY` for a host the caller named would send a Tinker bearer token to that host,
+    and the pool's whole credential rule is that an operator pairs a key with an endpoint
+    deliberately (see the module docstring of `wmo.providers.pool`), never that a helper picks
+    the pairing. A custom endpoint therefore gets `api_key_env=None`, which is the documented
+    custom-endpoint convention: the openai provider falls back to `WMO_ENDPOINT_API_KEY` and
+    never sends a key the caller did not put there. Its output-budget field likewise falls back
+    to the repo-wide default rather than inheriting Tinker's `max_tokens`. Pass `api_key_env` or
+    `chat_max_tokens_field` explicitly to override either.
+
+    Args:
+        card: The run's model card (`<run_dir>/model_card.json`), or an adapter version's.
+        name: The pool handle: the stable name policy artifacts and request logs key on.
+        input_per_mtok: Prompt-token price, USD per 1M tokens, at the serving endpoint.
+        output_per_mtok: Completion-token price, USD per 1M tokens, at the serving endpoint.
+        endpoint: The OpenAI-compatible base URL; defaults to
+            `DEFAULT_TINKER_OPENAI_ENDPOINT`.
+        api_key_env: Env var holding the endpoint's key. Defaults to `TINKER_API_KEY` on
+            Tinker's own endpoint and to None (the provider's `WMO_ENDPOINT_API_KEY`
+            fallback) on any other.
+        chat_max_tokens_field: Output-budget parameter the endpoint accepts. Defaults to
+            `max_tokens` on Tinker's own endpoint and to the repo-wide
+            `max_completion_tokens` on any other.
+
+    Returns:
+        A validated `PoolEntry` ready for `upsert_pool_entry`.
+
+    Raises:
+        ValueError: If the card's sampler path is not a `tinker://` weights path, so there is
+            nothing servable to point an entry at.
+    """
+    if not card.sampler_path.startswith("tinker://"):
+        raise ValueError(
+            f"model card sampler path {card.sampler_path!r} is not a tinker:// weights path; a "
+            "routable student needs the path save_weights_for_sampler returned (recorded in the "
+            "run's checkpoints.json and model card)"
+        )
+    resolved_endpoint = endpoint if endpoint is not None else DEFAULT_TINKER_OPENAI_ENDPOINT
+    on_tinker = is_tinker_endpoint(resolved_endpoint)
+    if api_key_env is None and on_tinker:
+        api_key_env = STUDENT_API_KEY_ENV
+    if chat_max_tokens_field is None:
+        chat_max_tokens_field = (
+            STUDENT_CHAT_MAX_TOKENS_FIELD if on_tinker else "max_completion_tokens"
+        )
+    return PoolEntry(
+        name=name,
+        kind=ProviderKind.OPENAI,
+        model=card.sampler_path,
+        # The weights path carries no capability information, so the base model is what
+        # temperature and output-budget resolution key on.
+        model_type=card.base_model,
+        chat_max_tokens_field=chat_max_tokens_field,
+        endpoint=resolved_endpoint,
+        api_key_env=api_key_env,
+        # A distilled student is the small open model in the pool, not the frontier anchor: the
+        # improvement report's comparison reads `tier` to tell those roles apart.
+        tier="open",
+        input_per_mtok=input_per_mtok,
+        output_per_mtok=output_per_mtok,
     )

--- a/wmo/distill/store_test.py
+++ b/wmo/distill/store_test.py
@@ -26,9 +26,13 @@ from wmo.distill.store import (
     WarmupRecord,
     WarmupTrialsManifest,
     build_handoff_toml,
+    is_tinker_endpoint,
+    student_pool_entry,
 )
 from wmo.distill.tokens import TrialRecord
 from wmo.distill.tripwire import TripwireBaseline
+from wmo.providers.base import ProviderKind
+from wmo.providers.pool import load_pool, upsert_pool_entry
 from wmo.providers.tinker import TokenSpan
 
 
@@ -478,6 +482,11 @@ def test_handoff_snippet_content_and_default_endpoint() -> None:
                 "model": "tinker://runs/abc/sampler/final",
                 "model_type": "Qwen/Qwen3-4B",
                 "endpoint": DEFAULT_TINKER_OPENAI_ENDPOINT,
+                # Added deliberately, not loosened: a tinker:// path is outside the built-in
+                # catalog, so capability resolution falls back to `max_completion_tokens`, which
+                # Tinker's endpoint answers with a 400 on every call. The snippet has to pin the
+                # name that endpoint takes or the promoted student is unusable.
+                "chat_max_tokens_field": "max_tokens",
             }
         }
     }
@@ -504,3 +513,260 @@ def test_handoff_rejects_non_tinker_sampler_path() -> None:
 def test_handoff_rejects_unembeddable_values() -> None:
     with pytest.raises(ValueError, match="cannot be embedded"):
         build_handoff_toml('tinker://bad"path', base_model="Qwen/Qwen3-4B")
+
+
+def test_student_pool_entry_addresses_the_adapter_as_an_openai_endpoint() -> None:
+    entry = student_pool_entry(_card(), name="student", input_per_mtok=0.1, output_per_mtok=0.4)
+
+    assert entry.name == "student"
+    assert entry.kind is ProviderKind.OPENAI
+    assert entry.model == "tinker://fake/sampler/final/0"  # the weights, not a family name
+    assert entry.model_type == "Qwen/Qwen3-8B"  # capability resolution keys on the base model
+    assert entry.endpoint == DEFAULT_TINKER_OPENAI_ENDPOINT
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.tier == "open"
+
+
+def test_student_pool_entry_asks_for_the_classic_output_budget_field() -> None:
+    """Tinker's OpenAI-compatible endpoint 400s on `max_completion_tokens`.
+
+    A `tinker://` path is not in the built-in catalog, so nothing else can supply this: without
+    the explicit field every routed call to the student fails.
+    """
+    entry = student_pool_entry(_card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4)
+
+    assert entry.chat_max_tokens_field == "max_tokens"
+    assert entry.provider_config().resolved_chat_max_tokens_field() == "max_tokens"
+
+
+def test_student_pool_entry_prices_are_required_and_carried() -> None:
+    """An unpriced candidate reports $0 and a cost-aware policy would route everything to it."""
+    entry = student_pool_entry(_card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4)
+
+    assert entry.price().input_per_mtok == 0.1
+    assert entry.price().output_per_mtok == 0.4
+    with pytest.raises(TypeError):  # no default: the caller must state a price
+        student_pool_entry(_card(), name="s")  # ty: ignore[missing-argument]
+
+
+def test_student_pool_entry_honors_an_endpoint_override() -> None:
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint="https://self-hosted.example/v1",
+    )
+
+    assert entry.endpoint == "https://self-hosted.example/v1"
+
+
+def test_student_pool_entry_rejects_a_non_tinker_sampler_path() -> None:
+    with pytest.raises(ValueError, match="tinker://"):
+        student_pool_entry(
+            _card(sampler="Qwen/Qwen3-8B"), name="s", input_per_mtok=0.1, output_per_mtok=0.4
+        )
+
+
+def test_student_pool_entry_round_trips_through_the_pool_file(tmp_path: Path) -> None:
+    """The end of the keystone path: card -> entry -> pool.toml -> loadable candidate."""
+    path = tmp_path / "pool.toml"
+    entry = student_pool_entry(_card(), name="student", input_per_mtok=0.1, output_per_mtok=0.4)
+
+    upsert_pool_entry(entry, path)
+
+    assert load_pool(path).entry("student") == entry
+
+
+def test_student_pool_entry_never_sends_the_tinker_key_to_another_host() -> None:
+    """A custom --endpoint must not inherit TINKER_API_KEY.
+
+    `pool_provider` resolves `api_key_env` and hands the value straight to the client as an
+    explicit credential, so inheriting the default here would send a Tinker bearer token to
+    whatever host the caller named.
+    """
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint="https://someone-elses-host.example/v1",
+    )
+
+    assert entry.api_key_env is None  # falls back to WMO_ENDPOINT_API_KEY in the provider
+    assert entry.chat_max_tokens_field == "max_completion_tokens"  # not Tinker's convention
+
+
+def test_student_pool_entry_takes_an_explicit_credential_for_a_custom_host() -> None:
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint="https://my-vllm.example/v1",
+        api_key_env="MY_VLLM_KEY",
+        chat_max_tokens_field="max_tokens",
+    )
+
+    assert entry.api_key_env == "MY_VLLM_KEY"
+    assert entry.chat_max_tokens_field == "max_tokens"
+
+
+def test_student_pool_entry_keeps_the_tinker_defaults_on_an_explicit_tinker_endpoint() -> None:
+    """Naming Tinker's endpoint by hand is still Tinker, so the defaults must still apply."""
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint=DEFAULT_TINKER_OPENAI_ENDPOINT,
+    )
+
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.chat_max_tokens_field == "max_tokens"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        DEFAULT_TINKER_OPENAI_ENDPOINT,
+        DEFAULT_TINKER_OPENAI_ENDPOINT + "/",
+        DEFAULT_TINKER_OPENAI_ENDPOINT + "//",
+        f"  {DEFAULT_TINKER_OPENAI_ENDPOINT}  ",
+    ],
+)
+def test_equivalent_spellings_of_the_tinker_endpoint_keep_its_defaults(endpoint: str) -> None:
+    """A pasted trailing slash must not reclassify Tinker's own endpoint as somebody else's host.
+
+    Getting this wrong is silent: the entry would swap TINKER_API_KEY for the
+    WMO_ENDPOINT_API_KEY fallback and `max_tokens` for `max_completion_tokens`, so the student
+    400s on a URL that is Tinker's.
+    """
+    entry = student_pool_entry(
+        _card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4, endpoint=endpoint
+    )
+
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.chat_max_tokens_field == "max_tokens"
+    parsed = tomllib.loads(
+        build_handoff_toml("tinker://w/1", base_model="Qwen/Qwen3-8B", endpoint=endpoint)
+    )
+    assert parsed["models"]["agent"]["chat_max_tokens_field"] == "max_tokens"
+
+
+def test_a_genuinely_different_host_is_not_read_as_tinker() -> None:
+    """The normalization must not become a prefix match: a lookalike host is still custom."""
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint=DEFAULT_TINKER_OPENAI_ENDPOINT + "/proxy",
+    )
+
+    assert entry.api_key_env is None
+    assert entry.chat_max_tokens_field == "max_completion_tokens"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "HTTPS://tinker.thinkingmachines.dev/services/tinker-prod/oai/api/v1",
+        "https://Tinker.ThinkingMachines.Dev/services/tinker-prod/oai/api/v1",
+        "https://TINKER.THINKINGMACHINES.DEV/services/tinker-prod/oai/api/v1/",
+    ],
+)
+def test_case_variant_tinker_urls_keep_its_defaults(endpoint: str) -> None:
+    """Scheme and host are case-insensitive per RFC 3986, so these are all Tinker's endpoint."""
+    entry = student_pool_entry(
+        _card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4, endpoint=endpoint
+    )
+
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.chat_max_tokens_field == "max_tokens"
+
+
+def test_a_case_variant_PATH_is_not_read_as_tinker() -> None:
+    """The path is case-SENSITIVE, so a different route is a different resource, not Tinker's.
+
+    Treating it as Tinker's would hand `TINKER_API_KEY` to a route the operator never named.
+    """
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint="https://tinker.thinkingmachines.dev/services/tinker-prod/OAI/API/V1",
+    )
+
+    assert entry.api_key_env is None
+    assert entry.chat_max_tokens_field == "max_completion_tokens"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://tinker.thinkingmachines.dev:443/services/tinker-prod/oai/api/v1",
+        "https://tinker.thinkingmachines.dev:443/services/tinker-prod/oai/api/v1/",
+        "  HTTPS://TINKER.THINKINGMACHINES.DEV:443/services/tinker-prod/oai/api/v1  ",
+    ],
+)
+def test_the_spelled_out_default_https_port_keeps_the_tinker_defaults(endpoint: str) -> None:
+    """`:443` on an https URL is redundant (RFC 3986 section 3.2.3), so this IS Tinker's endpoint.
+
+    A URL copied out of a proxy config or a log line often carries the port. Reading it as a
+    custom host is silent: the entry swaps TINKER_API_KEY for the WMO_ENDPOINT_API_KEY fallback
+    and `max_tokens` for `max_completion_tokens`, so every routed call to the student fails auth
+    or 400s on a URL that is Tinker's own.
+    """
+    assert is_tinker_endpoint(endpoint)
+    entry = student_pool_entry(
+        _card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4, endpoint=endpoint
+    )
+
+    assert entry.api_key_env == "TINKER_API_KEY"
+    assert entry.chat_max_tokens_field == "max_tokens"
+    parsed = tomllib.loads(
+        build_handoff_toml("tinker://w/1", base_model="Qwen/Qwen3-8B", endpoint=endpoint)
+    )
+    assert parsed["models"]["agent"]["chat_max_tokens_field"] == "max_tokens"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://tinker.thinkingmachines.dev:8443/services/tinker-prod/oai/api/v1",
+        # Not parseable as the default port, so it is compared as written: guessing what an
+        # operator meant is the wrong side to err on when a credential rides on the answer.
+        "https://tinker.thinkingmachines.dev:0443/services/tinker-prod/oai/api/v1",
+        "https://tinker.thinkingmachines.dev:notaport/services/tinker-prod/oai/api/v1",
+    ],
+)
+def test_a_port_that_is_not_the_scheme_default_is_a_different_service(endpoint: str) -> None:
+    """Only the redundant port may be dropped: `:8443` on that host is a proxy, not Tinker."""
+    assert not is_tinker_endpoint(endpoint)  # must also not raise on an unparseable port
+    entry = student_pool_entry(
+        _card(), name="s", input_per_mtok=0.1, output_per_mtok=0.4, endpoint=endpoint
+    )
+
+    assert entry.api_key_env is None
+    assert entry.chat_max_tokens_field == "max_completion_tokens"
+
+
+def test_only_the_schemes_own_default_port_is_redundant() -> None:
+    """http implies 80 and https implies 443; each other combination is a distinct endpoint."""
+    from wmo.distill.store import _normalize_endpoint
+
+    assert _normalize_endpoint("http://h.example/v1") == _normalize_endpoint(
+        "http://h.example:80/v1"
+    )
+    assert _normalize_endpoint("https://h.example/v1") == _normalize_endpoint(
+        "https://h.example:443/v1"
+    )
+    # 443 is not http's default port, nor 80 https's: those name a real port on that host.
+    assert _normalize_endpoint("http://h.example/v1") != _normalize_endpoint(
+        "http://h.example:443/v1"
+    )
+    assert _normalize_endpoint("https://h.example/v1") != _normalize_endpoint(
+        "https://h.example:80/v1"
+    )

--- a/wmo/distill/store_test.py
+++ b/wmo/distill/store_test.py
@@ -770,3 +770,46 @@ def test_only_the_schemes_own_default_port_is_redundant() -> None:
     assert _normalize_endpoint("https://h.example/v1") != _normalize_endpoint(
         "https://h.example:80/v1"
     )
+
+
+@pytest.mark.parametrize("padded", ["  {}  ", "\t{}\n", "{} "])
+def test_a_padded_endpoint_is_stripped_before_it_is_stored(padded: str) -> None:
+    """Classification tolerates whitespace, so storage must remove it, not preserve it.
+
+    The entry's endpoint becomes the OpenAI client's `base_url` verbatim. Persisting the padded
+    string would pick Tinker's defaults correctly and then fail every routed call on a URL the
+    client cannot use.
+    """
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint=padded.format(DEFAULT_TINKER_OPENAI_ENDPOINT),
+    )
+
+    assert entry.endpoint == DEFAULT_TINKER_OPENAI_ENDPOINT
+    assert entry.api_key_env == "TINKER_API_KEY"  # still classified as Tinker
+
+
+def test_a_padded_custom_endpoint_is_also_stripped() -> None:
+    entry = student_pool_entry(
+        _card(),
+        name="s",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+        endpoint="  https://my-vllm.example/v1  ",
+    )
+
+    assert entry.endpoint == "https://my-vllm.example/v1"
+    assert entry.api_key_env is None  # and still a custom host
+
+
+def test_a_padded_endpoint_is_stripped_in_the_handoff_snippet() -> None:
+    text = build_handoff_toml(
+        "tinker://w/1", base_model="Qwen/Qwen3-8B", endpoint=f"  {DEFAULT_TINKER_OPENAI_ENDPOINT} "
+    )
+    parsed = tomllib.loads(text)
+
+    assert parsed["models"]["agent"]["endpoint"] == DEFAULT_TINKER_OPENAI_ENDPOINT
+    assert parsed["models"]["agent"]["chat_max_tokens_field"] == "max_tokens"

--- a/wmo/providers/openai.py
+++ b/wmo/providers/openai.py
@@ -4,6 +4,12 @@ With `ProviderConfig.endpoint` set, the same provider speaks to any OpenAI-compa
 (vLLM, llama.cpp, a proxy) instead: the endpoint becomes the client's base_url, auth comes from
 `WMO_ENDPOINT_API_KEY` (never `OPENAI_API_KEY` — the real key must not leak to arbitrary hosts),
 and `temperature` IS forwarded (self-hosted servers accept sampling params; GPT 5.5 rejects them).
+
+Every call path resolves the output-budget parameter name once, from
+`ProviderConfig.resolved_chat_max_tokens_field`, and passes it down. GPT-5.x wants
+`max_completion_tokens`, but a server outside the built-in catalog can want the classic
+`max_tokens` (Tinker's OpenAI-compatible endpoint does) and answers the wrong name with a 400,
+so `complete` and `stream` must honor the config exactly as `complete_chat` does.
 """
 
 from __future__ import annotations
@@ -42,6 +48,7 @@ class OpenAIProvider:
         self._api_key = api_key
         self._client: OpenAI | None = None
         self._forward_temperature = config.resolved_chat_forward_temperature()
+        self._max_tokens_field = config.resolved_chat_max_tokens_field()
 
     def _get_client(self) -> OpenAI:
         # Lazy: don't import the SDK or read the key env vars until first use.
@@ -99,6 +106,7 @@ class OpenAIProvider:
             # Self-hosted OpenAI-compatible servers honor sampling params (a policy being
             # trained NEEDS temperature diversity); real OpenAI GPT-5.5 rejects them.
             temperature=temperature if self.config.endpoint else None,
+            max_tokens_field=self._max_tokens_field,
         )
 
     def stream(
@@ -117,6 +125,7 @@ class OpenAIProvider:
             messages,
             max_tokens,
             temperature=temperature if self.config.endpoint else None,
+            max_tokens_field=self._max_tokens_field,
         )
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
@@ -129,7 +138,7 @@ class OpenAIProvider:
             self._get_client().chat.completions,
             self.config.model,
             request,
-            max_tokens_field=self.config.resolved_chat_max_tokens_field(),
+            max_tokens_field=self._max_tokens_field,
         )
 
     def embed(self, texts: list[str]) -> list[list[float]]:

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -19,18 +19,31 @@ routing and compression costs.
 
 from __future__ import annotations
 
+import fcntl
 import os
+import time
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+import tomli_w
+from llm_waterfall import ChatMaxTokensField
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from wmo.core.types import JsonObject
 from wmo.providers.base import Provider, ProviderConfig, ProviderKind, TokenUsage
 from wmo.providers.registry import get_provider
 from wmo.tracking.pricing import ModelPrice, price_for
 
 DEFAULT_POOL_PATH = Path(".wmo/pool.toml")
+
+# How long an upsert waits for another process to finish its write. A write is a few file
+# operations, so two racing `wmo optimize route student` runs never come close to this; the bound
+# exists so a hung holder is REPORTED instead of hanging the terminal forever.
+POOL_LOCK_TIMEOUT_S = 10.0
+_LOCK_POLL_S = 0.01
 
 # D-REPORT ModelRef vocabulary: "frontier" anchors the improvement report's comparison; "open"
 # models carry the run-10x-more-for-the-same-budget story.
@@ -49,6 +62,14 @@ class PoolEntry(BaseModel):
     name: str = Field(min_length=1)
     kind: ProviderKind
     model: str = Field(min_length=1)  # provider runtime id (on Azure: the base model id)
+    # Canonical model identity for capability resolution, when `model` is a runtime id that does
+    # not carry it: a distilled student's `model` is a `tinker://` weights path, and only its base
+    # model determines which request shape and sampling params the backend accepts.
+    model_type: str | None = None
+    # The output-budget parameter this backend accepts. Built-in models resolve it from the
+    # catalog; a self-hosted or beta OpenAI-compatible server that wants the classic `max_tokens`
+    # (Tinker's serving endpoint does) declares it here, because the catalog has never heard of it.
+    chat_max_tokens_field: ChatMaxTokensField = "max_completion_tokens"
     endpoint: str | None = None
     deployment: str | None = None  # Azure deployment name
     api_version: str | None = None  # Azure api-version
@@ -130,6 +151,8 @@ class PoolEntry(BaseModel):
         return ProviderConfig(
             kind=self.kind,
             model=self.model,
+            model_type=self.model_type,
+            chat_max_tokens_field=self.chat_max_tokens_field,
             endpoint=self.endpoint,
             deployment=self.deployment,
             api_version=self.api_version,
@@ -169,6 +192,184 @@ def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
         )
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     return ModelPool.model_validate({"models": data.get("model", [])})
+
+
+class PoolLockTimeout(RuntimeError):
+    """Another writer held the roster's lock for longer than the bounded wait."""
+
+
+def upsert_pool_entry(
+    entry: PoolEntry,
+    path: Path = DEFAULT_POOL_PATH,
+    *,
+    lock_timeout_s: float | None = None,
+) -> bool:
+    """Add `entry` to the pool roster at `path`, replacing any entry with the same name.
+
+    The one write path for the roster, so a trained model becomes routable without hand-editing
+    TOML. Entries already in the file are carried through as the exact tables they were written
+    as: re-serializing them through `PoolEntry` would stamp every default (`tier`,
+    `chat_max_tokens_field`) into a file an operator maintains by hand.
+
+    Adding a NEW entry appends its one table and touches nothing else, so comments, key order,
+    and spacing all survive byte for byte. REPLACING an entry has to remove the old table, which
+    means re-rendering the file through `tomllib` -> `tomli_w`: that keeps every entry's fields
+    but DROPS comments, because neither library round-trips them. Callers that can prompt should
+    say so before replacing (`wmo optimize route student` does).
+
+    The merged roster is validated as a whole `ModelPool` BEFORE anything is written, and the
+    write itself goes through a temp file, so a rejected entry can never leave the pool
+    unloadable. That matters more than it looks: `load_pool` is what serving and the routing
+    optimizer both call, so a broken pool file takes every endpoint down, not just the candidate
+    being added.
+
+    The whole read-validate-write cycle runs under an exclusive cross-process lock (see
+    `_pool_write_lock`), so two registrations racing each other both land. Without it each reads
+    the same roster and the later write erases the earlier entry, while both commands report
+    success: a model an operator registered is simply not in the pool, and nothing says so.
+
+    Args:
+        entry: The candidate to add, or to replace an existing entry of the same name with.
+        path: The pool TOML. Created, with its parent directory, when absent.
+        lock_timeout_s: Seconds to wait for another writer's lock before giving up; the default
+            is `POOL_LOCK_TIMEOUT_S`.
+
+    Returns:
+        True when an entry of the same name was replaced, False when `entry` was appended.
+
+    Raises:
+        ValueError: If `path` exists but is not a readable pool file, if it is already an invalid
+            roster before this entry is added, or if adding `entry` would make it one.
+        PoolLockTimeout: If another writer holds the roster's lock for the whole wait.
+    """
+    timeout_s = POOL_LOCK_TIMEOUT_S if lock_timeout_s is None else lock_timeout_s
+    path.parent.mkdir(parents=True, exist_ok=True)  # the lock file lives beside the roster
+    with _pool_write_lock(path, timeout_s=timeout_s):
+        return _upsert_locked(entry, path)
+
+
+@contextmanager
+def _pool_write_lock(path: Path, *, timeout_s: float) -> Iterator[None]:
+    """Hold the exclusive cross-process write lock for the roster at `path`.
+
+    The lock sits in a sibling `<pool>.lock` file, not in the roster: writing goes through an
+    atomic rename, which swaps the roster's inode, so a lock taken on the file itself would stop
+    protecting anything the moment the first writer landed.
+
+    `flock` belongs to the open file description, so the kernel drops it when the holder exits,
+    crashes, or is killed. A leftover `.lock` FILE is therefore never a held lock and can never
+    wedge a later run (which is also why it is left in place: unlinking it would let a waiter
+    block on an inode nobody else can reach). A live holder that hangs still could wedge us, so
+    the wait is bounded and reports what to do instead of blocking forever.
+
+    Args:
+        path: The pool TOML being written.
+        timeout_s: Seconds to keep retrying the lock before raising.
+
+    Yields:
+        None, with the lock held; it is released when the block exits, on any path.
+
+    Raises:
+        PoolLockTimeout: If the lock is still held after `timeout_s`.
+    """
+    lock_path = path.with_name(f"{path.name}.lock")
+    deadline = time.monotonic() + timeout_s
+    fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC, 0o600)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise PoolLockTimeout(
+                        f"another process has been writing the model pool at {path} for more "
+                        f"than {timeout_s:g}s (lock file {lock_path}); a registration takes "
+                        "milliseconds, so retry, and if it keeps failing look for a stuck "
+                        "process holding that lock (the lock is released automatically when "
+                        "that process exits, so the lock file itself is never the problem)"
+                    ) from None
+                time.sleep(_LOCK_POLL_S)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _upsert_locked(entry: PoolEntry, path: Path) -> bool:
+    """The read-validate-write cycle of `upsert_pool_entry`, with the roster's lock held."""
+    tables = _raw_tables(path)
+    if tables:
+        # Validate what is ALREADY there first, so a pre-existing bad row is reported as a
+        # pre-existing bad row. Otherwise a typo an operator left in some other entry surfaces as
+        # "adding 'student' would make this an invalid pool", pointing at the flags they just got
+        # right instead of at the line that is actually wrong.
+        try:
+            ModelPool.model_validate({"models": tables})
+        except ValidationError as exc:
+            raise ValueError(
+                f"pool file {path} is already invalid, before adding '{entry.name}': {exc}"
+            ) from exc
+    kept = [table for table in tables if table.get("name") != entry.name]
+    replaced = len(kept) != len(tables)
+    # exclude_defaults keeps the written table as small as the hand-written ones around it, and
+    # exclude_none drops the backend knobs this kind does not use. mode="json" turns the
+    # ProviderKind enum into the plain string TOML can hold.
+    table = entry.model_dump(mode="json", exclude_defaults=True, exclude_none=True)
+    merged = [*kept, table]
+    try:
+        ModelPool.model_validate({"models": merged})
+    except ValidationError as exc:
+        raise ValueError(f"adding '{entry.name}' would make {path} an invalid pool: {exc}") from exc
+    rendered = tomli_w.dumps({"model": [table]})
+    if replaced or not path.is_file():
+        # A replacement has to remove the old table, which means re-rendering the whole file.
+        body = tomli_w.dumps({"model": merged})
+    else:
+        # The common case is a first registration, and appending the one new table byte-preserves
+        # everything already in the file: an operator's comments, key order, and spacing. Rewriting
+        # would silently destroy the comments that say which account a row bills to, and nothing
+        # would tell them it happened.
+        existing = path.read_text(encoding="utf-8")
+        if existing.endswith("\n\n"):
+            separator = ""
+        else:
+            separator = "\n" if existing.endswith("\n") else "\n\n"
+        body = f"{existing}{separator}{rendered}"
+    # The temp name carries this process's pid. The lock already keeps writers off each other, so
+    # this is defense in depth for anything that writes the roster without taking it: a shared
+    # fixed `.tmp` path would let each writer rename the other's half-written file into place,
+    # turning a lost update into a CORRUPT roster.
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp_path.write_text(body, encoding="utf-8")
+        tmp_path.replace(path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)  # never leave a stray temp beside the roster
+        raise
+    return replaced
+
+
+def _raw_tables(path: Path) -> list[JsonObject]:
+    """The `[[model]]` tables in `path`, exactly as written; empty when the file does not exist."""
+    if not path.is_file():
+        return []
+    try:
+        parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(
+            f"pool file {path} is not valid TOML ({exc}); fix the file, or move it aside to "
+            "start a fresh roster"
+        ) from exc
+    tables = parsed.get("model", [])
+    if not isinstance(tables, list) or not all(isinstance(table, dict) for table in tables):
+        raise ValueError(
+            f"pool file {path} does not hold an array of [[model]] tables; every candidate is its "
+            "own [[model]] table (fields: name, kind, model, and prices for non-built-in models)"
+        )
+    return [dict(table) for table in tables]
 
 
 def pool_provider(entry: PoolEntry) -> Provider:

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
+import os
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -9,7 +16,14 @@ from pydantic import ValidationError
 
 from wmo.providers.azure_openai import AzureOpenAIProvider
 from wmo.providers.base import ProviderConfig, ProviderKind, TokenUsage
-from wmo.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool, pool_provider
+from wmo.providers.pool import (
+    DEFAULT_POOL_PATH,
+    PoolEntry,
+    PoolLockTimeout,
+    load_pool,
+    pool_provider,
+    upsert_pool_entry,
+)
 from wmo.providers.registry import get_provider
 
 _POOL_TOML = """
@@ -248,3 +262,385 @@ def test_azure_entry_requires_deployment() -> None:
             input_per_mtok=1.0,
             output_per_mtok=2.0,
         )
+
+
+def _student_entry(name: str = "student") -> PoolEntry:
+    """A distilled-student shaped entry: a weights path the catalog cannot resolve."""
+    return PoolEntry(
+        name=name,
+        kind=ProviderKind.OPENAI,
+        model="tinker://weights/abc123",
+        model_type="Qwen/Qwen3-30B-A3B",
+        chat_max_tokens_field="max_tokens",
+        endpoint="https://tinker.example/oai/api/v1",
+        api_key_env="TINKER_API_KEY",
+        tier="open",
+        input_per_mtok=0.1,
+        output_per_mtok=0.4,
+    )
+
+
+def test_provider_config_forwards_model_type_and_max_tokens_field() -> None:
+    """Both new fields must reach ProviderConfig, or a routed student 400s on every call.
+
+    `model` is a tinker:// weights path the built-in catalog cannot resolve, so capability
+    resolution has only `model_type` and the explicit field to go on.
+    """
+    config = _student_entry().provider_config()
+
+    assert config.model_type == "Qwen/Qwen3-30B-A3B"
+    assert config.chat_max_tokens_field == "max_tokens"
+    assert config.resolved_chat_max_tokens_field() == "max_tokens"
+
+
+def test_pool_entry_defaults_keep_the_built_in_contract() -> None:
+    """An entry that says nothing keeps the catalog's answer, so this cannot regress GPT-5.x."""
+    entry = PoolEntry(name="gpt", kind=ProviderKind.OPENAI, model="gpt-5.5")
+
+    assert entry.model_type is None
+    assert entry.provider_config().resolved_chat_max_tokens_field() == "max_completion_tokens"
+
+
+def test_upsert_pool_entry_creates_the_file_and_appends(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "pool.toml"
+
+    assert upsert_pool_entry(_student_entry(), path) is False
+
+    assert [m.name for m in load_pool(path).models] == ["student"]
+    entry = load_pool(path).entry("student")
+    assert entry.model_type == "Qwen/Qwen3-30B-A3B"
+    assert entry.chat_max_tokens_field == "max_tokens"
+    assert entry.api_key_env == "TINKER_API_KEY"
+
+
+def test_upsert_pool_entry_replaces_by_name_and_keeps_the_others(tmp_path: Path) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text(_POOL_TOML, encoding="utf-8")
+    before = [m.name for m in load_pool(path).models]
+
+    assert upsert_pool_entry(_student_entry(), path) is False
+    assert upsert_pool_entry(_student_entry(), path) is True
+
+    after = [m.name for m in load_pool(path).models]
+    assert after == [*before, "student"]  # replaced in place, nothing duplicated or dropped
+
+
+def test_upsert_pool_entry_does_not_stamp_defaults_onto_existing_entries(tmp_path: Path) -> None:
+    """Hand-maintained entries must not gain every default just because a student was added.
+
+    Byte-level preservation of the whole file is covered by
+    `test_upsert_pool_entry_appends_without_touching_a_byte_of_the_existing_file`; this checks the
+    narrower property that survives even a REPLACEMENT, which has to re-render the roster.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text(_POOL_TOML, encoding="utf-8")
+
+    upsert_pool_entry(_student_entry(), path)
+
+    written = path.read_text(encoding="utf-8")
+    assert 'tier = "frontier"' not in written  # the default was never stamped onto gpt-5.5
+    assert "chat_max_tokens_field" in written  # but the student's explicit value is there
+    gpt = load_pool(path).entry("gpt-5.5")
+    assert gpt.input_per_mtok is None  # still priced from the built-in table, as authored
+
+
+def test_upsert_pool_entry_names_the_file_when_it_is_not_valid_toml(tmp_path: Path) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text("[[model]\nname = broken", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"is not valid TOML"):
+        upsert_pool_entry(_student_entry(), path)
+
+
+def test_upsert_pool_entry_rejects_a_file_that_is_not_a_model_array(tmp_path: Path) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text('model = "not-an-array"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"\[\[model\]\] tables"):
+        upsert_pool_entry(_student_entry(), path)
+
+
+def test_upsert_pool_entry_uses_a_process_private_temp_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two concurrent upserts must not be able to rename each other's half-written file.
+
+    A shared fixed `.tmp` path turns a lost update into a CORRUPT roster: writer A can rename
+    B's partially written file into place. Distinct temps bound the damage to last-writer-wins.
+    """
+    seen: list[str] = []
+    real_write = Path.write_text
+
+    def _record(self: Path, data: str, **kwargs: object) -> int:
+        if self.suffix == ".tmp":
+            seen.append(self.name)
+        return real_write(self, data, **kwargs)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(Path, "write_text", _record)
+    upsert_pool_entry(_student_entry(), tmp_path / "pool.toml")
+
+    assert seen == [f"pool.toml.{os.getpid()}.tmp"]
+    assert list(tmp_path.glob("*.tmp")) == []  # the temp is gone once renamed
+
+
+def test_upsert_pool_entry_leaves_no_temp_behind_when_the_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text(_POOL_TOML, encoding="utf-8")
+    real_replace = Path.replace
+
+    def _boom(self: Path, target: object) -> Path:
+        if self.suffix == ".tmp":
+            raise OSError("disk full")
+        return real_replace(self, target)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        upsert_pool_entry(_student_entry(), path)
+
+    assert list(tmp_path.glob("*.tmp")) == []
+    assert load_pool(path).models  # the roster is untouched and still loadable
+
+
+_COMMENTED_POOL = """# Roster for the support endpoint. Keep this file under review.
+[[model]]
+name = "gpt-5.5"
+kind = "azure"
+model = "gpt-5.5"
+deployment = "gpt-5.5"
+# billed to the prod OpenAI account
+api_key_env = "AZURE_PROD_KEY"
+
+# Cheap tier. DO NOT delete: the savings figure is quoted against this row.
+[[model]]
+name = "haiku"
+kind = "anthropic"
+model = "claude-haiku-4-5"
+"""
+
+
+def test_upsert_pool_entry_appends_without_touching_a_byte_of_the_existing_file(
+    tmp_path: Path,
+) -> None:
+    """An operator's comments say which account a row bills to; losing them silently is not ok."""
+    path = tmp_path / "pool.toml"
+    path.write_text(_COMMENTED_POOL, encoding="utf-8")
+
+    assert upsert_pool_entry(_student_entry(), path) is False
+
+    written = path.read_text(encoding="utf-8")
+    assert written.startswith(_COMMENTED_POOL)  # byte-identical prefix, comments included
+    assert "DO NOT delete" in written
+    assert "billed to the prod OpenAI account" in written
+    assert [m.name for m in load_pool(path).models] == ["gpt-5.5", "haiku", "student"]
+
+
+def test_upsert_pool_entry_append_round_trips_when_the_file_has_no_trailing_newline(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text(
+        '[[model]]\nname = "haiku"\nkind = "anthropic"\nmodel = "claude-haiku-4-5"',
+        encoding="utf-8",
+    )
+
+    upsert_pool_entry(_student_entry(), path)
+
+    assert [m.name for m in load_pool(path).models] == ["haiku", "student"]
+
+
+def test_upsert_pool_entry_blames_a_pre_existing_bad_row_on_the_file_not_the_new_entry(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "pool.toml"
+    path.write_text(
+        '[[model]]\nname = "mine"\nkind = "openai"\nmodel = "some/self-hosted-model"\n',
+        encoding="utf-8",
+    )
+
+    original = path.read_text(encoding="utf-8")
+    with pytest.raises(ValueError, match=r"already invalid, before adding 'student'"):
+        upsert_pool_entry(_student_entry(), path)
+
+    # Validate-before-write: a rejected upsert must leave the roster exactly as it was, and must
+    # not strand a temp file beside it.
+    assert path.read_text(encoding="utf-8") == original
+    assert list(path.parent.glob("*.tmp")) == []
+
+
+def test_upsert_pool_entry_keeps_both_registrations_when_two_threads_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two concurrent writers adding different entries must BOTH land in the roster.
+
+    An unlocked read-modify-write loses one of them and reports success to both, so a model an
+    operator registered is simply absent from the pool with nothing saying so.
+
+    The race is forced, not hoped for: every read of the roster parks on a barrier, so both
+    writers provably hold the SAME snapshot before either writes, which is exactly the
+    interleaving that drops an entry. With the write lock held across the whole cycle the second
+    writer cannot reach its first read until the first writer has finished, so the barrier times
+    out (its wait is far shorter than the lock's), the reads happen in sequence, and the second
+    writer merges onto the roster it can now see.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text(_COMMENTED_POOL, encoding="utf-8")
+    read_together = threading.Barrier(2, timeout=1.0)
+    real_read = Path.read_text
+
+    def _park_on_every_roster_read(self: Path, **kwargs: object) -> str:
+        text = real_read(self, **kwargs)  # ty: ignore[invalid-argument-type]
+        if self.name == path.name:
+            with contextlib.suppress(threading.BrokenBarrierError):
+                read_together.wait()
+        return text
+
+    monkeypatch.setattr(Path, "read_text", _park_on_every_roster_read)
+    failures: list[BaseException] = []
+
+    def _register(name: str) -> None:
+        try:
+            upsert_pool_entry(_student_entry(name), path)
+        except BaseException as exc:  # noqa: BLE001 - reported by the main thread's assertions
+            failures.append(exc)
+
+    writers = [
+        threading.Thread(target=_register, args=(name,), name=name)
+        for name in ("student-a", "student-b")
+    ]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join(timeout=60)
+        assert not writer.is_alive(), f"{writer.name} never finished; the lock wait is not bounded"
+    monkeypatch.undo()  # the assertions below read the roster without parking on the barrier
+
+    registered = sorted(entry.name for entry in load_pool(path).models)
+    assert registered == ["gpt-5.5", "haiku", "student-a", "student-b"], (
+        f"a concurrent registration was lost (writer errors: {failures})"
+    )
+    assert failures == []
+    assert "DO NOT delete" in path.read_text(encoding="utf-8")  # appends, so comments survive
+    # The lock file is the only extra artifact: no half-written temp survives a race.
+    assert sorted(child.name for child in tmp_path.iterdir()) == ["pool.toml", "pool.toml.lock"]
+
+
+# The child of `test_upsert_pool_entry_keeps_every_registration_from_concurrent_processes`: one
+# real `wmo` process registering one candidate. It signals readiness, then spins until the parent
+# releases every writer at once, so the processes collide on the roster instead of queueing.
+_WRITER_PROGRAM = """
+import sys
+import time
+from pathlib import Path
+
+from wmo.providers.base import ProviderKind
+from wmo.providers.pool import PoolEntry, upsert_pool_entry
+
+pool_path, name, ready_path, start_path = (
+    Path(sys.argv[1]),
+    sys.argv[2],
+    Path(sys.argv[3]),
+    Path(sys.argv[4]),
+)
+entry = PoolEntry(
+    name=name,
+    kind=ProviderKind.OPENAI,
+    model="tinker://weights/" + name,
+    input_per_mtok=0.1,
+    output_per_mtok=0.4,
+)
+ready_path.write_text("ready", encoding="utf-8")
+while not start_path.exists():
+    time.sleep(0.001)
+upsert_pool_entry(entry, pool_path)
+"""
+
+
+def test_upsert_pool_entry_keeps_every_registration_from_concurrent_processes(
+    tmp_path: Path,
+) -> None:
+    """The cross-process half: separate `wmo optimize route student` runs must not erase each other.
+
+    The threaded test above pins the interleaving; this one proves the lock is held against other
+    PROCESSES, which is the situation an operator actually hits (two terminals, or a script
+    registering several students at once). Nothing is patched here, so the loss it guards against
+    is timing-dependent: with the roster unlocked, eight writers released together keep whichever
+    entry landed last and drop the rest.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text(_COMMENTED_POOL, encoding="utf-8")
+    start = tmp_path / "start"
+    names = [f"student-{index}" for index in range(8)]
+    environment = {**os.environ, "PYTHONPATH": str(Path(__file__).parents[2])}
+    writers = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _WRITER_PROGRAM,
+                str(path),
+                name,
+                str(tmp_path / f"ready-{name}"),
+                str(start),
+            ],
+            env=environment,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for name in names
+    ]
+    try:
+        deadline = time.monotonic() + 60.0
+        while not all((tmp_path / f"ready-{name}").exists() for name in names):
+            assert time.monotonic() < deadline, "the concurrent writers never became ready"
+            time.sleep(0.01)
+        start.write_text("go", encoding="utf-8")
+        for writer in writers:
+            stderr = writer.communicate(timeout=60.0)[1]
+            assert writer.returncode == 0, stderr
+    finally:
+        for writer in writers:
+            if writer.poll() is None:
+                writer.kill()
+
+    assert sorted(entry.name for entry in load_pool(path).models) == sorted(
+        ["gpt-5.5", "haiku", *names]
+    )
+    assert "DO NOT delete" in path.read_text(encoding="utf-8")
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_upsert_pool_entry_reports_a_stuck_writer_instead_of_hanging(tmp_path: Path) -> None:
+    """A held lock must fail with an actionable message inside the bound, never wedge the CLI."""
+    path = tmp_path / "pool.toml"
+    path.write_text(_COMMENTED_POOL, encoding="utf-8")
+    lock_path = path.with_name(f"{path.name}.lock")
+    holder = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+    fcntl.flock(holder, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(PoolLockTimeout, match=r"writing the model pool at .*pool\.toml"):
+            upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05)
+    finally:
+        os.close(holder)
+
+    assert [entry.name for entry in load_pool(path).models] == ["gpt-5.5", "haiku"]  # untouched
+    assert list(tmp_path.glob("*.tmp")) == []
+    # Once the holder is gone the lock is free again: the kernel owns that release, so a leftover
+    # lock FILE is never a held lock and cannot wedge the next run.
+    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05) is False
+
+
+def test_upsert_pool_entry_releases_the_lock_when_it_rejects_the_roster(tmp_path: Path) -> None:
+    """A rejected upsert must not leave the roster locked, or one bad row wedges every later run."""
+    path = tmp_path / "pool.toml"
+    path.write_text(
+        '[[model]]\nname = "mine"\nkind = "openai"\nmodel = "some/self-hosted-model"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"already invalid"):
+        upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05)
+
+    path.write_text(_COMMENTED_POOL, encoding="utf-8")  # the operator fixes the row
+    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05) is False

--- a/wmo/providers/tests/openai_test.py
+++ b/wmo/providers/tests/openai_test.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+from llm_waterfall import ChatMaxTokensField
 
 from wmo.providers.base import (
     DEFAULT_MAX_TOKENS,
@@ -12,6 +15,9 @@ from wmo.providers.base import (
     ProviderKind,
 )
 from wmo.providers.openai import OpenAIProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class _FakeMessage:
@@ -62,6 +68,43 @@ class _FakeChatCompletions:
         return self.response
 
 
+class _FakeStreamDelta:
+    def __init__(self, content: str | None) -> None:
+        self.content = content
+
+
+class _FakeStreamChoice:
+    def __init__(self, content: str | None) -> None:
+        self.delta = _FakeStreamDelta(content)
+
+
+class _FakeStreamChunk:
+    """One wire chunk: a content delta, or the terminal usage-bearing chunk with no choices."""
+
+    def __init__(self, content: str | None, usage: _FakeUsage | None = None) -> None:
+        self.choices = [_FakeStreamChoice(content)] if content is not None else []
+        self.usage = usage
+
+
+class _FakeStreamingCompletions:
+    """A chat.completions whose `create` returns the chunk sequence a stream would yield."""
+
+    def __init__(self, chunks: list[_FakeStreamChunk]) -> None:
+        self.chunks = chunks
+        self.last_kwargs: dict[str, object] = {}
+        self.closed = False
+
+    def create(self, **kwargs: object) -> _FakeStreamingCompletions:
+        self.last_kwargs = kwargs
+        return self
+
+    def __iter__(self) -> Iterator[_FakeStreamChunk]:
+        return iter(self.chunks)
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _FakeEmbeddingItem:
     def __init__(self, embedding: list[float]) -> None:
         self.embedding = embedding
@@ -83,12 +126,16 @@ class _FakeEmbeddings:
 
 
 class _FakeChat:
-    def __init__(self, completions: _FakeChatCompletions) -> None:
+    def __init__(self, completions: _FakeChatCompletions | _FakeStreamingCompletions) -> None:
         self.completions = completions
 
 
 class _FakeClient:
-    def __init__(self, chat: _FakeChatCompletions, embeddings: _FakeEmbeddings) -> None:
+    def __init__(
+        self,
+        chat: _FakeChatCompletions | _FakeStreamingCompletions,
+        embeddings: _FakeEmbeddings,
+    ) -> None:
         self.chat = _FakeChat(chat)
         self.embeddings = embeddings
 
@@ -274,3 +321,77 @@ def test_structured_chat_applies_temperature_capability_before_wire(
     )
 
     assert ("temperature" in chat.last_kwargs) is expects_temperature
+
+
+def _student_provider(field: ChatMaxTokensField) -> OpenAIProvider:
+    """A student-shaped config: a weights path the catalog cannot resolve, plus explicit field."""
+    return OpenAIProvider(
+        ProviderConfig(
+            kind=ProviderKind.OPENAI,
+            model="tinker://weights/abc123",
+            model_type="Qwen/Qwen3-30B-A3B",
+            chat_max_tokens_field=field,
+            endpoint="https://tinker.example/oai/api/v1",
+        )
+    )
+
+
+def test_complete_honors_the_configured_output_budget_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server that wants classic `max_tokens` must get it from `complete`, not just chat.
+
+    An OpenAI-compatible endpoint outside the built-in catalog (Tinker's serving endpoint, a
+    vLLM build) 400s on the name it does not accept, so a routed student would fail every
+    non-structured call while `complete_chat` worked.
+    """
+    provider = _student_provider("max_tokens")
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(3, 2)))
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([]))),
+    )
+
+    provider.complete("sys", [Message(role="user", content="hi")], max_tokens=77)
+
+    assert chat.last_kwargs["max_tokens"] == 77
+    assert "max_completion_tokens" not in chat.last_kwargs
+
+
+def test_stream_honors_the_configured_output_budget_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract on the streaming path, which the endpoint uses for `stream=True`."""
+    provider = _student_provider("max_tokens")
+    chat = _FakeStreamingCompletions(
+        [_FakeStreamChunk("hi"), _FakeStreamChunk(None, _FakeUsage(3, 2))]
+    )
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([]))),
+    )
+
+    chunks = list(provider.stream("sys", [Message(role="user", content="hi")], max_tokens=55))
+
+    assert [c.delta for c in chunks if c.delta] == ["hi"]
+    assert chunks[-1].done is True
+    assert chat.last_kwargs["max_tokens"] == 55
+    assert "max_completion_tokens" not in chat.last_kwargs
+
+
+def test_built_in_models_still_send_max_completion_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The catalog still wins for a known model, so this fix cannot regress GPT-5.x."""
+    provider = OpenAIProvider(_config())
+    chat = _FakeChatCompletions(_FakeChatResponse("ok", _FakeUsage(1, 1)))
+    monkeypatch.setattr(
+        provider,
+        "_get_client",
+        lambda: _FakeClient(chat, _FakeEmbeddings(_FakeEmbeddingResponse([]))),
+    )
+
+    provider.complete("sys", [Message(role="user", content="hi")], max_tokens=64)
+
+    assert chat.last_kwargs["max_completion_tokens"] == 64
+    assert "max_tokens" not in chat.last_kwargs


### PR DESCRIPTION
## The gap this closes

Routing works (#248, #259, #270) and distillation trains (#252, #257, #271), but nothing connected them. A trained adapter could not become a `PoolEntry` the router selects over, so a distilled student could never be reached through the OpenAI-compatible endpoint. This is the keystone of that path.

## What changed

**`PoolEntry` gains `model_type` and `chat_max_tokens_field`**, both forwarded by `provider_config()`. `ProviderConfig` already had both; the pool could not express them. It matters because a student's `model` is a `tinker://` weights path: it carries no capability information, and the built-in catalog has never heard of it, so nothing downstream could tell the provider which request shape the backend accepts. Defaults are unchanged, so a built-in model resolves exactly as before.

**`upsert_pool_entry` is the first write path for the roster.** Nothing in the repo wrote `pool.toml` before, which is why adding a candidate meant hand-editing TOML. It validates the merged roster as a whole `ModelPool` before writing anything and writes through a temp file, because `load_pool` is what serving and the fitter both call: a bad entry would take every endpoint down, not just the new candidate. Existing tables are carried through exactly as authored rather than re-serialized, so a hand-maintained file does not gain every default just because a student was added.

**`student_pool_entry`** turns a run's `DistillModelCard` into that entry: `kind="openai"`, `endpoint` = `DEFAULT_TINKER_OPENAI_ENDPOINT` (the constant already in the repo), `api_key_env="TINKER_API_KEY"`, `chat_max_tokens_field="max_tokens"`, `tier="open"`. Prices are required keyword arguments with no default: an unpriced candidate reports $0, which would make it unconditionally the cheapest model in the pool and let a cost-aware policy route everything to it on evidence that does not exist.

**Two commands close the loop:**
- `wmo optimize route student <run-dir>` adds the trained student to the pool.
- `wmo optimize route pin <world-model> --model <name>` writes a `kind="static"` policy into the world model's artifact dir, which is where `wmo serve` reads one, so a single student is serveable with no matrix and no fit.

Both confirm before overwriting: `student` before repointing an existing pool handle, `pin` before replacing an installed policy (which may be a fitted knn policy whose evidence bank sidecar a static policy will not use and does not remove).

## The output-budget bug

`OpenAIProvider.complete` and `.stream` never passed `max_tokens_field` to `_openai_common`, so both always sent `max_completion_tokens`. Only `complete_chat` honored `ProviderConfig.resolved_chat_max_tokens_field`. `AzureOpenAIProvider` already passed it on all three paths, so this was specific to the OpenAI provider. A routed student would have 400ed on every plain and streamed call while structured calls worked. All three paths now resolve the field once in `__init__` and pass it down.

## Falsification

Two independent proofs, both run against pre-change code.

`PoolEntry` rejects the new fields outright (`extra="forbid"`), with `wmo/providers/pool.py` reverted to main:

```
ValidationError: ['model_type', "  Extra inputs are not permitted [type=extra_forbidden, input_value='Qwen/Qwen3-30B-A3B', input_type=str]", 'chat_max_tokens_field']
```

The two new provider tests fail, with `wmo/providers/openai.py` reverted to main:

```
        assert [c.delta for c in chunks if c.delta] == ["hi"]
        assert chunks[-1].done is True
>       assert chat.last_kwargs["max_tokens"] == 55
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       KeyError: 'max_tokens'

wmo/providers/tests/openai_test.py:375: KeyError
=========================== short test summary info ============================
FAILED wmo/providers/tests/openai_test.py::test_complete_honors_the_configured_output_budget_field
FAILED wmo/providers/tests/openai_test.py::test_stream_honors_the_configured_output_budget_field
2 failed, 15 deselected in 0.55s
```

And the end-to-end run below, against the same reverted provider, shows the wire body a real routed call would have sent:

```
  call 0 model=tinker://fake/sampler/final/0 stream=False -> {'max_completion_tokens': 321}
AssertionError: call 0 sent the wrong output-budget field: {'max_completion_tokens': 321}
```

## Verified end to end, not just unit tested

Commands actually run, in a scratch dir, against a stub OpenAI-compatible server standing in for Tinker (no money spent, no network):

```bash
wmo optimize route student .wmo/distill/support --input-per-mtok 0.10 --output-per-mtok 0.40
wmo optimize route pin support --model student
# then: serve the policy that landed in .wmo/models/support/policy.json and call it
#       with the real `openai` python client
```

Observed:

```
✓ added pool candidate student -> .wmo/pool.toml
  Qwen/Qwen3-8B adapter at tinker://fake/sampler/final/0
  $0.1/$0.4 per 1M in/out tokens, credential from TINKER_API_KEY

✓ pinned endpoint support to student -> .wmo/models/support/policy.json
  every request goes to student; nothing is measured and nothing is saved yet

loaded static policy from disk, default_model=student
non-streaming reply: 'hello from the student'
usage: prompt=11 completion=5
streamed reply: 'hello from the student'

WHAT THE UPSTREAM (Tinker stand-in) ACTUALLY RECEIVED:
  call 0 model=tinker://fake/sampler/final/0 stream=False -> {'max_tokens': 321}
  call 1 model=tinker://fake/sampler/final/0 stream=True -> {'max_tokens': 654}
```

With `TINKER_API_KEY` unset the endpoint returns an OpenAI-shaped 502 and a log row rather than a bare 500, which is the `api_key_env` channel behaving as designed.

## Review round: three more defects, all fixed

Greptile and an adversarial review pass found real problems. Each fix has its own test and its own falsification.

**The Tinker key followed a custom endpoint.** `student_pool_entry` hard-coded `api_key_env="TINKER_API_KEY"` regardless of `--endpoint`, and `pool_provider` hands that value to the client as an explicit credential, so pointing the student at any other OpenAI-compatible host sent a Tinker bearer token to that host. The Tinker-specific defaults now apply only when the entry actually points at Tinker; a custom endpoint gets the documented `WMO_ENDPOINT_API_KEY` fallback and `max_completion_tokens`. Verified at the provider level:

```
Tinker endpoint        api_key_env=TINKER_API_KEY  -> client sends 'sk-tinker-SECRET'
someone elses host     api_key_env=None            -> client sends 'sk-my-own-host'
```

**`upsert_pool_entry` silently deleted every comment in the pool file.** The docstring claimed existing entries were "carried through as the exact tables they were written as"; that was false, and the test asserting it did not actually check byte identity. Adding a new entry now appends its one table and preserves the file byte for byte. A replacement still has to re-render, so the docstring says so and the confirmation prompt warns.

**The `[models.agent]` handoff for the same adapter was still broken.** This branch established that Tinker's endpoint 400s on `max_completion_tokens`, then fixed only the pool path. `ModelRole` had no field to express the output-budget name, so a `--promote`d student resolved `max_completion_tokens` and every agent call 400ed. `ModelRole` gains `chat_max_tokens_field`, `_model_config` forwards it only when set, and `--promote` plus `build_handoff_toml` pin it. Falsified against the pre-fix code:

```
E       AssertionError: assert 'max_completion_tokens' == 'max_tokens'
```

Also: a concurrent-write path that could rename a half-written temp file into place, `--api-key-env ""` accepted silently, `route pin` printing a command that does not exist on this branch, an error blaming the new entry for a pre-existing bad row, and two duplicate `model_card.json` constants collapsed into one exported `MODEL_CARD_FILE`.

One pre-existing test changed: `test_handoff_snippet_content_and_default_endpoint` asserted the exact handoff dict, which now carries `chat_max_tokens_field`. The assertion is still exact equality, with a comment saying why the key is there. No test was weakened.

## Gates

CI runs no tests, so these were run locally on this branch, rebased onto `7950d6c`:

```
3331 passed, 18 skipped     (main baseline 3282, measured on 7950d6c, + 49 new)
uv run --no-sync ruff check .          All checks passed!
uv run --no-sync ruff format --check wmo/   417 files already formatted
uv run --no-sync ty check              All checks passed!
```

## Two places the task brief was wrong about the code

- The brief said `--promote` writes `[models.agent]` "which is NOT the served roster". `[models.agent]` is not inert: it is the agent-under-test role that `resolve_required_model_config` feeds into `HarborScorer`. It is still not the router's candidate roster, which is the gap this PR closes, but the distinction is "different role" rather than "unused".
- The brief said the descriptor should be emitted by the run. A run cannot know its serving price, and an unpriced entry is exactly the failure mode to avoid, so the price is supplied at the command instead and the run's existing `model_card.json` is the single source of truth for identity. No new artifact file, no new config fields.

## Not in scope

No cross-tokenizer path, nothing under `wmo/distill/xtoken/`, nothing under `.agents/`. No cost or quality number is claimed: this PR makes a student reachable, it does not measure one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rebased across the wmo rename

Main landed the world-model-harness -> world-model-optimizer rename (#273) and Release 0.2.0 (#276) under this branch. The whole diff was re-applied onto the renamed tree and the result was verified to be an identical tree to an independent rebase of it, then merged (not force-pushed) so this PR and its review thread survive. Every gate was re-run on the merged tree and both commands were re-driven end to end as `wmo optimize route student` and `wmo optimize route pin`.

Note: this PR and #277 both extend `wmo/cli/route_app.py` and `route_app_test.py`, so whichever merges second needs a trivial rebase.

