### PR TITLE
Pricing cache tiers: capture cache writes, bill read and write tiers on every cost path

### DIFF
--- a/wmo/providers/anthropic.py
+++ b/wmo/providers/anthropic.py
@@ -64,13 +64,15 @@ class AnthropicProvider:
             max_tokens=max_tokens,
         )
         text = "".join(block.text for block in response.content if block.type == "text")
-        # Anthropic reports cache reads BESIDE input_tokens (input_tokens excludes them);
-        # TokenUsage's contract is cached-as-subset, so normalize by summing.
+        # Anthropic reports cache reads and writes BESIDE input_tokens (input_tokens excludes
+        # them); TokenUsage's contract is cached-as-subset, so normalize by summing.
         cache_read = getattr(response.usage, "cache_read_input_tokens", None) or 0
+        cache_write = getattr(response.usage, "cache_creation_input_tokens", None) or 0
         usage = TokenUsage(
-            input_tokens=response.usage.input_tokens + cache_read,
+            input_tokens=response.usage.input_tokens + cache_read + cache_write,
             output_tokens=response.usage.output_tokens,
             cached_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
         )
         return Completion(text=text, usage=usage)
 
@@ -105,9 +107,12 @@ class AnthropicProvider:
                 kind = getattr(event, "type", "")
                 if kind == "message_start":
                     # Same sibling-to-subset normalization as complete().
-                    cache_read = getattr(event.message.usage, "cache_read_input_tokens", None) or 0
-                    usage.input_tokens = event.message.usage.input_tokens + cache_read
+                    start_usage = event.message.usage
+                    cache_read = getattr(start_usage, "cache_read_input_tokens", None) or 0
+                    cache_write = getattr(start_usage, "cache_creation_input_tokens", None) or 0
+                    usage.input_tokens = start_usage.input_tokens + cache_read + cache_write
                     usage.cached_input_tokens = cache_read
+                    usage.cache_write_input_tokens = cache_write
                 elif kind == "content_block_delta":
                     delta = event.delta
                     if getattr(delta, "type", "") == "text_delta" and delta.text:

--- a/wmo/providers/base.py
+++ b/wmo/providers/base.py
@@ -56,9 +56,14 @@ class TokenUsage(BaseModel):
     # cache usage leave it 0, which prices the whole prompt at the full input rate.
     # Providers whose APIs report cache reads BESIDE the input count (Anthropic Messages,
     # Bedrock Converse) normalize at the construction site: input_tokens = fresh + cache_read.
-    # Cache WRITES (billed at a premium) are not captured yet; nothing sends cache_control
-    # today, and the field lands with the cache-aware routing work.
     cached_input_tokens: int = 0
+    # Prompt tokens WRITTEN to the provider's cache this call (Anthropic
+    # cache_creation_input_tokens / Bedrock cacheWriteInputTokens). Same subset contract as
+    # cached_input_tokens: a subset of input_tokens, disjoint from the read subset, normalized
+    # at the construction site (input_tokens = fresh + cache_read + cache_write). Writes bill
+    # at a PREMIUM (Anthropic 5m TTL: 1.25x input), so cache-adjusted cost needs this split
+    # too; providers that don't report writes (OpenAI charges no write premium) leave it 0.
+    cache_write_input_tokens: int = 0
 
 
 class Completion(BaseModel):

--- a/wmo/providers/bedrock.py
+++ b/wmo/providers/bedrock.py
@@ -42,6 +42,7 @@ class _Usage(TypedDict):
     input_tokens: int
     output_tokens: int
     cache_read_input_tokens: NotRequired[int]
+    cache_creation_input_tokens: NotRequired[int]
 
 
 class _BedrockResponse(TypedDict):
@@ -159,13 +160,15 @@ class BedrockProvider:
         raw = self._get_client().invoke_model(modelId=self.config.model, body=json.dumps(body))
         data = cast("_BedrockResponse", json.loads(raw["body"].read()))
         text = "".join(block["text"] for block in data["content"] if block["type"] == "text")
-        # Anthropic-native semantics: cache reads reported BESIDE input_tokens; normalize to
-        # TokenUsage's cached-as-subset contract by summing.
+        # Anthropic-native semantics: cache reads and writes reported BESIDE input_tokens;
+        # normalize to TokenUsage's cached-as-subset contract by summing.
         cache_read = data["usage"].get("cache_read_input_tokens", 0)
+        cache_write = data["usage"].get("cache_creation_input_tokens", 0)
         usage = TokenUsage(
-            input_tokens=data["usage"]["input_tokens"] + cache_read,
+            input_tokens=data["usage"]["input_tokens"] + cache_read + cache_write,
             output_tokens=data["usage"]["output_tokens"],
             cached_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
         )
         return Completion(text=text, usage=usage)
 
@@ -213,13 +216,15 @@ class BedrockProvider:
                 elif "metadata" in event:
                     event_usage = event["metadata"].get("usage")
                     if event_usage is not None:
-                        # Converse reports cacheReadInputTokens beside inputTokens; normalize
-                        # to the cached-as-subset contract.
+                        # Converse reports cacheReadInputTokens / cacheWriteInputTokens beside
+                        # inputTokens; normalize to the cached-as-subset contract.
                         cache_read = int(event_usage.get("cacheReadInputTokens", 0) or 0)
+                        cache_write = int(event_usage.get("cacheWriteInputTokens", 0) or 0)
                         usage = TokenUsage(
-                            input_tokens=int(event_usage["inputTokens"]) + cache_read,
+                            input_tokens=int(event_usage["inputTokens"]) + cache_read + cache_write,
                             output_tokens=int(event_usage["outputTokens"]),
                             cached_input_tokens=cache_read,
+                            cache_write_input_tokens=cache_write,
                         )
         finally:
             # botocore's EventStream pins the HTTP connection until closed.
@@ -252,10 +257,12 @@ class BedrockProvider:
         blocks = response["output"]["message"]["content"]
         text = "".join(block["text"] for block in blocks if "text" in block)
         cache_read = int(response["usage"].get("cacheReadInputTokens", 0) or 0)
+        cache_write = int(response["usage"].get("cacheWriteInputTokens", 0) or 0)
         usage = TokenUsage(
-            input_tokens=int(response["usage"]["inputTokens"]) + cache_read,
+            input_tokens=int(response["usage"]["inputTokens"]) + cache_read + cache_write,
             output_tokens=int(response["usage"]["outputTokens"]),
             cached_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
         )
         return Completion(text=text, usage=usage)
 

--- a/wmo/providers/bedrock_test.py
+++ b/wmo/providers/bedrock_test.py
@@ -142,3 +142,59 @@ def test_structured_chat_preserves_temperature_for_supported_model() -> None:
     )
 
     assert stub.requests[0]["inferenceConfig"] == {"maxTokens": 64, "temperature": 0.3}
+
+
+def test_claude_invoke_normalizes_cache_read_and_write_to_subsets() -> None:
+    # Bedrock's Anthropic body reports cache reads/writes BESIDE input_tokens; TokenUsage's
+    # contract is subsets of input_tokens, so the provider must sum at the boundary.
+    provider = BedrockProvider(
+        ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8")
+    )
+    stub = _StubClient(
+        {
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 3,
+                "cache_read_input_tokens": 40,
+                "cache_creation_input_tokens": 50,
+            },
+        }
+    )
+    provider._client = cast("BaseClient", stub)
+
+    completion = provider.complete("sys", [Message(role="user", content="hi")])
+
+    assert completion.usage.input_tokens == 100  # 10 fresh + 40 read + 50 written
+    assert completion.usage.cached_input_tokens == 40
+    assert completion.usage.cache_write_input_tokens == 50
+
+
+class _StubCacheConverseClient:
+    """Converse stub whose usage carries both cache tiers."""
+
+    def converse(self, **kwargs: object) -> dict[str, object]:
+        del kwargs
+        return {
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 7,
+                "outputTokens": 2,
+                "cacheReadInputTokens": 20,
+                "cacheWriteInputTokens": 30,
+            },
+        }
+
+
+def test_converse_normalizes_cache_read_and_write_to_subsets() -> None:
+    provider = BedrockProvider(
+        ProviderConfig(kind=ProviderKind.BEDROCK, model="us.moonshotai.kimi-k2-6")
+    )
+    provider._client = cast("BaseClient", _StubCacheConverseClient())
+
+    completion = provider.complete("sys", [Message(role="user", content="hi")])
+
+    assert completion.usage.input_tokens == 57  # 7 fresh + 20 read + 30 written
+    assert completion.usage.cached_input_tokens == 20
+    assert completion.usage.cache_write_input_tokens == 30

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -13,7 +13,8 @@ choose which env var gets read or where its value gets sent.
 Pricing: entries for models in the built-in `wmo.tracking.pricing` table need no price fields;
 anything else must declare `input_per_mtok`/`output_per_mtok` so downstream cost numbers stay
 honest (an unpriced candidate would silently report $0). `cached_input_per_mtok` is the provider
-cache-READ price, carried for cache-aware routing costs.
+cache-READ price and `cache_write_per_mtok` the cache-WRITE price, carried for cache-aware
+routing and compression costs.
 """
 
 from __future__ import annotations
@@ -57,6 +58,7 @@ class PoolEntry(BaseModel):
     input_per_mtok: float | None = None
     output_per_mtok: float | None = None
     cached_input_per_mtok: float | None = None  # provider cache-read price, USD per 1M tokens
+    cache_write_per_mtok: float | None = None  # provider cache-write price, USD per 1M tokens
 
     @model_validator(mode="after")
     def _validate_price(self) -> PoolEntry:
@@ -92,22 +94,35 @@ class PoolEntry(BaseModel):
     def cost_usd(self, usage: TokenUsage) -> float:
         """Effective USD cost of `usage` priced by THIS entry's row (overrides included).
 
-        Cache-adjusted: cached prompt tokens (`usage.cached_input_tokens`) bill at
-        `cached_input_per_mtok` when the entry carries a cache-read price, and at the full
-        input rate otherwise (never silently free). The global `wmo.tracking.pricing.cost_usd`
-        only knows the built-in table; pool entries with explicit prices must be costed here
-        or they would silently read $0.
+        Cache-adjusted on both tiers: cache-read tokens (`usage.cached_input_tokens`) bill at
+        `cached_input_per_mtok` and cache-write tokens (`usage.cache_write_input_tokens`) at
+        `cache_write_per_mtok`; each tier falls back to the built-in price row's rate when the
+        entry carries no override, and to the full input rate when the row has no tier either
+        (never silently free). The global `wmo.tracking.pricing.cost_usd` only knows the
+        built-in table; pool entries with explicit prices must be costed here or they would
+        silently read $0.
         """
         price = self.price()
-        cached = min(usage.cached_input_tokens, usage.input_tokens)
-        cached_rate = (
-            self.cached_input_per_mtok
-            if self.cached_input_per_mtok is not None
-            else price.input_per_mtok
-        )
+        read = min(usage.cached_input_tokens, usage.input_tokens)
+        write = min(usage.cache_write_input_tokens, usage.input_tokens - read)
+        read_rate = self.cached_input_per_mtok
+        if read_rate is None:
+            read_rate = (
+                price.cache_read_per_mtok
+                if price.cache_read_per_mtok is not None
+                else price.input_per_mtok
+            )
+        write_rate = self.cache_write_per_mtok
+        if write_rate is None:
+            write_rate = (
+                price.cache_write_per_mtok
+                if price.cache_write_per_mtok is not None
+                else price.input_per_mtok
+            )
         return (
-            (usage.input_tokens - cached) * price.input_per_mtok
-            + cached * cached_rate
+            (usage.input_tokens - read - write) * price.input_per_mtok
+            + read * read_rate
+            + write * write_rate
             + usage.output_tokens * price.output_per_mtok
         ) / 1_000_000
 

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -25,6 +25,7 @@ tier = "open"
 input_per_mtok = 1.2
 output_per_mtok = 4.8
 cached_input_per_mtok = 0.12
+cache_write_per_mtok = 1.5
 
 [[model]]
 name = "gpt-5.5"
@@ -56,6 +57,7 @@ def test_load_pool_parses_entries(tmp_path: Path) -> None:
     assert deepseek.tier == "open"
     assert deepseek.api_key_env == "AZURE_SILEN_RESOURCE_API_KEY"
     assert deepseek.cached_input_per_mtok == 0.12
+    assert deepseek.cache_write_per_mtok == 1.5
     # Entries default to the frontier tier (the D-REPORT ModelRef vocabulary).
     assert pool.entry("fable").tier == "frontier"
 
@@ -183,6 +185,35 @@ def test_cost_usd_without_cache_price_bills_cached_tokens_at_full_rate() -> None
     )
     usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=400_000)
     assert entry.cost_usd(usage) == pytest.approx(10.0)  # honest fallback, never free
+
+
+def test_cost_usd_bills_cache_writes_at_entry_override() -> None:
+    entry = PoolEntry(
+        name="write-priced",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+        input_per_mtok=10.0,
+        output_per_mtok=20.0,
+        cache_write_per_mtok=12.5,
+    )
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cache_write_input_tokens=400_000)
+    # 600k fresh @ $10/M + 400k written @ $12.5/M = 6.0 + 5.0 = $11.00.
+    assert entry.cost_usd(usage) == pytest.approx(11.0)
+
+
+def test_cost_usd_falls_back_to_builtin_cache_tiers() -> None:
+    # An entry with NO explicit prices uses the built-in table, including its cache tiers
+    # (fable: reads 0.1x -> $1/M, writes 1.25x -> $12.5/M on a $10/M input rate).
+    entry = PoolEntry(name="fable", kind=ProviderKind.ANTHROPIC, model="claude-fable-5")
+    usage = TokenUsage(
+        input_tokens=1_000_000,
+        output_tokens=0,
+        cached_input_tokens=300_000,
+        cache_write_input_tokens=200_000,
+    )
+    # 500k fresh @ $10 + 300k read @ $1 + 200k write @ $12.5 = 5.0 + 0.3 + 2.5 = $7.80.
+    assert entry.cost_usd(usage) == pytest.approx(7.8)
 
 
 def test_bedrock_entry_pins_region() -> None:

--- a/wmo/tracking/pricing.py
+++ b/wmo/tracking/pricing.py
@@ -21,10 +21,46 @@ _BEDROCK_SUFFIX = re.compile(r"(-\d{8})?(-v\d+)?(:\d+)?$")
 
 
 class ModelPrice(BaseModel):
-    """USD per 1,000,000 tokens, split by input/output."""
+    """USD per 1,000,000 tokens, split by input/output plus optional prompt-cache tiers.
+
+    `cache_read_per_mtok` prices prompt tokens served from the provider cache;
+    `cache_write_per_mtok` prices tokens written to it (a premium on Anthropic). None means
+    "no known cache rate": `cost_usd` then bills that tier at the full input rate, never $0.
+    """
 
     input_per_mtok: float
     output_per_mtok: float
+    cache_read_per_mtok: float | None = None
+    cache_write_per_mtok: float | None = None
+
+
+def _claude_price(input_per_mtok: float, output_per_mtok: float) -> ModelPrice:
+    """A Claude row with Anthropic's published cache multipliers applied.
+
+    Cache reads bill at 0.1x the base input rate; cache writes at 1.25x for the default
+    5-minute TTL (the 1h TTL bills 2x; nothing in the harness requests it, and a pool entry
+    can override per model if that changes).
+    """
+    return ModelPrice(
+        input_per_mtok=input_per_mtok,
+        output_per_mtok=output_per_mtok,
+        cache_read_per_mtok=input_per_mtok * 0.1,
+        cache_write_per_mtok=input_per_mtok * 1.25,
+    )
+
+
+def _openai_price(input_per_mtok: float, output_per_mtok: float) -> ModelPrice:
+    """A GPT-5.x row with OpenAI's published cached-input discount applied.
+
+    Cached input bills at 0.1x the base input rate (the gpt-5 family's 90% discount).
+    OpenAI charges no cache-write premium and reports no write tokens, so the write tier
+    stays None (moot in practice: cache_write_input_tokens is always 0 on OpenAI usage).
+    """
+    return ModelPrice(
+        input_per_mtok=input_per_mtok,
+        output_per_mtok=output_per_mtok,
+        cache_read_per_mtok=input_per_mtok * 0.1,
+    )
 
 
 # Keyed by normalized model id (see `_normalize`). USD per 1M tokens.
@@ -32,26 +68,29 @@ class ModelPrice(BaseModel):
 # Completion prices verified 2026-06-25 against the live vendor pricing pages:
 #   - Claude: platform.claude.com/docs/en/about-claude/models/overview
 #   - OpenAI GPT-5.x: developers.openai.com/api/docs/pricing (Standard tier, short context)
+# Cache tiers (added 2026-07-25) are the vendors' published multipliers on those verified base
+# rates, not independently re-fetched per model: Anthropic reads 0.1x / writes 1.25x (5m TTL),
+# OpenAI cached input 0.1x with no write charge. Re-verify per model if cache cost is headline.
 # Embedding prices are long-stable list prices NOT re-fetched in that pass (the OpenAI pricing
 # page no longer surfaces them); treat as approximate and re-verify if embed cost matters.
 _PRICES: dict[str, ModelPrice] = {
     # --- Anthropic / Bedrock (Claude) ---
-    "claude-fable-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
-    "claude-mythos-5": ModelPrice(input_per_mtok=10.0, output_per_mtok=50.0),
-    "claude-opus-4-8": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-7": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-6": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-5": ModelPrice(input_per_mtok=5.0, output_per_mtok=25.0),
-    "claude-opus-4-1": ModelPrice(input_per_mtok=15.0, output_per_mtok=75.0),
-    "claude-sonnet-5": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
-    "claude-sonnet-4-6": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
-    "claude-haiku-4-5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
+    "claude-fable-5": _claude_price(input_per_mtok=10.0, output_per_mtok=50.0),
+    "claude-mythos-5": _claude_price(input_per_mtok=10.0, output_per_mtok=50.0),
+    "claude-opus-4-8": _claude_price(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-7": _claude_price(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-6": _claude_price(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-5": _claude_price(input_per_mtok=5.0, output_per_mtok=25.0),
+    "claude-opus-4-1": _claude_price(input_per_mtok=15.0, output_per_mtok=75.0),
+    "claude-sonnet-5": _claude_price(input_per_mtok=3.0, output_per_mtok=15.0),
+    "claude-sonnet-4-6": _claude_price(input_per_mtok=3.0, output_per_mtok=15.0),
+    "claude-haiku-4-5": _claude_price(input_per_mtok=1.0, output_per_mtok=5.0),
     # --- OpenAI / Azure OpenAI (GPT-5.x; Azure deployments reuse the base model's price) ---
-    "gpt-5.5": ModelPrice(input_per_mtok=5.0, output_per_mtok=30.0),
-    "gpt-5.5-pro": ModelPrice(input_per_mtok=30.0, output_per_mtok=180.0),
-    "gpt-5.4": ModelPrice(input_per_mtok=2.5, output_per_mtok=15.0),
-    "gpt-5.4-mini": ModelPrice(input_per_mtok=0.75, output_per_mtok=4.5),
-    "gpt-5.4-nano": ModelPrice(input_per_mtok=0.2, output_per_mtok=1.25),
+    "gpt-5.5": _openai_price(input_per_mtok=5.0, output_per_mtok=30.0),
+    "gpt-5.5-pro": _openai_price(input_per_mtok=30.0, output_per_mtok=180.0),
+    "gpt-5.4": _openai_price(input_per_mtok=2.5, output_per_mtok=15.0),
+    "gpt-5.4-mini": _openai_price(input_per_mtok=0.75, output_per_mtok=4.5),
+    "gpt-5.4-nano": _openai_price(input_per_mtok=0.2, output_per_mtok=1.25),
     # Self-hosted models (vLLM on our own GPUs) intentionally have NO row: their cost is amortized
     # GPU time, not a per-token API price. `price_for` returns None for them, which the eval grid
     # renders as "no cost"; a 0.0 ModelPrice would instead report a misleading $0.00.
@@ -90,10 +129,28 @@ def price_for(model: str) -> ModelPrice | None:
 
 
 def cost_usd(model: str, usage: TokenUsage) -> float:
-    """USD cost of `usage` on `model`. Unknown models cost 0.0 (see `price_for` to detect that)."""
+    """USD cost of `usage` on `model`. Unknown models cost 0.0 (see `price_for` to detect that).
+
+    Cache-adjusted: cache-read and cache-write subsets of `input_tokens` bill at their tier
+    rates when the price row carries them, and at the full input rate otherwise (never $0).
+    With no cache traffic this reduces exactly to input*input_rate + output*output_rate.
+    """
     price = price_for(model)
     if price is None:
         return 0.0
+    read = min(usage.cached_input_tokens, usage.input_tokens)
+    write = min(usage.cache_write_input_tokens, usage.input_tokens - read)
+    read_rate = (
+        price.cache_read_per_mtok if price.cache_read_per_mtok is not None else price.input_per_mtok
+    )
+    write_rate = (
+        price.cache_write_per_mtok
+        if price.cache_write_per_mtok is not None
+        else price.input_per_mtok
+    )
     return (
-        usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+        (usage.input_tokens - read - write) * price.input_per_mtok
+        + read * read_rate
+        + write * write_rate
+        + usage.output_tokens * price.output_per_mtok
     ) / 1_000_000

--- a/wmo/tracking/pricing_test.py
+++ b/wmo/tracking/pricing_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from wmo.providers.base import TokenUsage
-from wmo.tracking.pricing import cost_usd, price_for
+from wmo.tracking.pricing import _PRICES, cost_usd, price_for
 
 
 def test_opus_4_8_cost_is_5_in_25_out_per_mtok() -> None:
@@ -58,3 +58,61 @@ def test_partial_usage_is_prorated() -> None:
     # 500k input + 200k output on Opus 4.8 = 0.5*5 + 0.2*25 = 2.5 + 5.0 = 7.5.
     cost = cost_usd("claude-opus-4-8", TokenUsage(input_tokens=500_000, output_tokens=200_000))
     assert cost == pytest.approx(7.5)
+
+
+def test_no_cache_traffic_costs_are_bit_identical_to_the_two_term_formula() -> None:
+    # The D-COMPRESS item-0 regression guarantee: adding cache tiers must not move any cost
+    # number when there is no cache traffic. Exact equality (==) on every table row, not approx:
+    # the formula must REDUCE to the pre-change arithmetic, not merely land close to it.
+    usage = TokenUsage(input_tokens=123_457, output_tokens=76_543)
+    for model, price in _PRICES.items():
+        expected = (
+            usage.input_tokens * price.input_per_mtok + usage.output_tokens * price.output_per_mtok
+        ) / 1_000_000
+        assert cost_usd(model, usage) == expected, model
+
+
+def test_claude_cache_reads_bill_at_one_tenth_input_rate() -> None:
+    # 1M input, all served from cache, on fable ($10/M input): 0.1x -> $1.00.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=1_000_000)
+    assert cost_usd("claude-fable-5", usage) == pytest.approx(1.0)
+
+
+def test_claude_cache_writes_bill_at_premium() -> None:
+    # 1M input, all written to cache, on fable ($10/M input): 1.25x (5m TTL) -> $12.50.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cache_write_input_tokens=1_000_000)
+    assert cost_usd("claude-fable-5", usage) == pytest.approx(12.5)
+
+
+def test_mixed_cache_tiers_split_the_input() -> None:
+    # 1M input on opus-4-8 ($5/M): 500k fresh @ $5 + 300k read @ $0.5 + 200k write @ $6.25
+    # = 2.5 + 0.15 + 1.25 = $3.90.
+    usage = TokenUsage(
+        input_tokens=1_000_000,
+        output_tokens=0,
+        cached_input_tokens=300_000,
+        cache_write_input_tokens=200_000,
+    )
+    assert cost_usd("claude-opus-4-8", usage) == pytest.approx(3.9)
+
+
+def test_missing_cache_tier_bills_at_full_input_rate() -> None:
+    # Embedding rows carry no cache tiers; cache traffic on them bills at the input rate,
+    # never silently free.
+    usage = TokenUsage(
+        input_tokens=1_000_000, cached_input_tokens=600_000, cache_write_input_tokens=400_000
+    )
+    assert cost_usd("text-embedding-3-large", usage) == pytest.approx(0.13)
+
+
+def test_cache_subsets_are_clamped_to_input() -> None:
+    # Malformed usage claiming more cache traffic than input must not go negative: the read
+    # subset clamps to input and the write subset to what remains.
+    usage = TokenUsage(
+        input_tokens=100_000,
+        output_tokens=0,
+        cached_input_tokens=80_000,
+        cache_write_input_tokens=80_000,
+    )
+    # fable: 80k read @ $1/M-effective (0.1*10) + 20k write @ $12.5/M, 0 fresh.
+    assert cost_usd("claude-fable-5", usage) == pytest.approx(0.08 + 0.25)

--- a/wmo/tracking/tracker.py
+++ b/wmo/tracking/tracker.py
@@ -46,11 +46,15 @@ class UsageEvent(BaseModel):
 
 
 class UsageTotals(BaseModel):
-    """Rolled-up usage: tokens, cost, and call count."""
+    """Rolled-up usage: tokens (with the cache subsets), cost, and call count."""
 
     calls: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    # Cache subsets of input_tokens (same subset contract as TokenUsage), kept so persisted
+    # RunRecords can reconstruct cache behavior; old records load with these defaulted to 0.
+    cached_input_tokens: int = 0
+    cache_write_input_tokens: int = 0
     cost_usd: float = 0.0
 
     @property
@@ -61,6 +65,8 @@ class UsageTotals(BaseModel):
         self.calls += 1
         self.input_tokens += event.usage.input_tokens
         self.output_tokens += event.usage.output_tokens
+        self.cached_input_tokens += event.usage.cached_input_tokens
+        self.cache_write_input_tokens += event.usage.cache_write_input_tokens
         self.cost_usd += event.cost_usd
 
 

--- a/wmo/tracking/tracker_test.py
+++ b/wmo/tracking/tracker_test.py
@@ -35,6 +35,24 @@ def test_totals_sum_tokens_and_cost_across_events() -> None:
     assert total.cost_usd == pytest.approx(0.015)
 
 
+def test_totals_carry_cache_subsets() -> None:
+    tracker = RunTracker(run_id="r", kind="serve")
+    tracker.record(
+        Phase.SERVE,
+        "claude-opus-4-8",
+        TokenUsage(input_tokens=1000, cached_input_tokens=600, cache_write_input_tokens=100),
+    )
+    tracker.record(
+        Phase.SERVE,
+        "claude-opus-4-8",
+        TokenUsage(input_tokens=500, cached_input_tokens=200),
+    )
+
+    total = tracker.totals()
+    assert total.cached_input_tokens == 800
+    assert total.cache_write_input_tokens == 100
+
+
 def test_by_phase_buckets_events() -> None:
     tracker = RunTracker(run_id="r", kind="build")
     tracker.record(Phase.GEPA, "claude-opus-4-8", TokenUsage(input_tokens=1000, output_tokens=0))


### PR DESCRIPTION
Split out of #265 (the D-COMPRESS seam) so it can merge first: this is the compression track's item 0, but it is independently valuable - the routing track's cache-adjusted claims and D-METERING want the same fix, and it has zero compression dependencies. One commit, additive, defaults preserve current numbers exactly.

## The gap it closes

- Cache WRITE tokens (billed at a premium) were captured NOWHERE: the Anthropic and Bedrock construction sites dropped `cache_creation_input_tokens` / `cacheWriteInputTokens`, and Bedrock's usage TypedDict would not even pass them through.
- The global tracker path (`wmh.tracking.pricing.cost_usd`) was fully cache-blind: cache reads billed at the full input rate.
- `UsageTotals` dropped even the cache-READ subset, so persisted RunRecords could not reconstruct cache behavior.

## What's here

- `TokenUsage.cache_write_input_tokens`, same subset-of-input contract as the existing read field, normalized at all five capture sites (Anthropic complete + stream; Bedrock invoke, converse, converse_stream). OpenAI reports no write tokens and charges no write premium; nothing to capture there.
- `ModelPrice.cache_read_per_mtok` / `cache_write_per_mtok`; the built-in table applies the vendors' published multipliers to the already-verified base rates (Anthropic 0.1x read / 1.25x write at the default 5m TTL; OpenAI 0.1x cached input). Multipliers verified against the claude-api reference, not recalled from memory; basis documented in the table comment. Embedding rows carry no tiers (no caching).
- `cost_usd` (tracking) bills three input tiers + output; each tier falls back to the full input rate when unpriced, never $0.
- `UsageTotals` accumulates both cache subsets (old persisted records load, defaults 0).
- `PoolEntry.cache_write_per_mtok` (the serving cost source of truth gains the write tier); fallback chain per tier: entry override -> built-in table tier -> full input rate.

## Justification ledger

Every field has a named consumer: `cache_write_input_tokens` -> both cost paths + UsageTotals + the compression track's cache-adjusted accounting rule; `ModelPrice` tiers -> `cost_usd` both paths; `UsageTotals` subsets -> persisted RunRecords; `PoolEntry.cache_write_per_mtok` -> `PoolEntry.cost_usd` (serving's only cost computation). Non-removal: `packages/llm-waterfall`'s near-duplicate pricing table is deliberately untouched - it is a standalone PyPI member with its own version, and its adapters structurally zero cached tokens anyway; a DECISIONS.md entry proposes that fix as the member's own small PR.

## Verification for Silen

- Full gate on current main: ruff + format + ty clean, **3294 passed / 17 skipped**.
- The load-bearing test: `test_no_cache_traffic_costs_are_bit_identical_to_the_two_term_formula` pins every price-table row's no-cache-traffic cost EXACTLY (`==`, not approx) to the pre-change arithmetic - the additive guarantee is a theorem of the formula, not a hope.
- Behavior change to know about (intended): rows with real cache-read traffic (today: OpenAI automatic prompt caching) were previously billed at full input rate by the TRACKER path and now bill at the table's read tier; the pool/serving path also now consults the table's tier when a pool entry carries no explicit cache price. Both directions make reported cost lower and truer, never higher.
- Reproduce: `uv run pytest wmh/tracking/pricing_test.py wmh/providers/pool_test.py wmh/tracking/tracker_test.py wmh/providers/bedrock_test.py -q` (58 tests).