### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "world-model-optimizer"
-version = "0.1.0"
+version = "0.2.0"
 description = "Run agents, build world models from traces, and optimize agent harnesses."
 readme = "README.md"
 # harbor 0.20.0 requires Python >=3.12; the harbor evaluator is a first-class optimize

--- a/uv.lock
+++ b/uv.lock
@@ -3913,7 +3913,7 @@ wheels = [
 
 [[package]]
 name = "world-model-optimizer"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Version bump only — `pyproject.toml` + the matching `uv.lock` line.

## Why 0.2.0 and not 0.1.0

The rename is breaking for anyone with an existing install: `.wmh/` → `.wmo/`, all 46 `WMH_*`
environment variables → `WMO_*`, plus renderer registry keys, harbor job dirs and OTel attribute
keys. A minor bump says that honestly.

It also avoids a collision: the `v0.1.0` tag already points at `c9cfcf5`, the commit that built
`world-model-harness` 0.1.0 on PyPI. Keeping 0.1.0 would have meant either a tag that disagrees
with the published version, or deleting the record of a release whose artifact is still live.

| | project | version | tag |
|---|---|---|---|
| previous | `world-model-harness` | 0.1.0 | `v0.1.0` → `c9cfcf5` (untouched) |
| this | `world-model-optimizer` | 0.2.0 | `v0.2.0` → this merge |

## Verification

- `just gate` green: ruff, ruff format, `ty`, 3282 passed / 18 skipped
- `uv build` produces `world_model_optimizer-0.2.0-{py3-none-any.whl,tar.gz}`
- `uv lock` touched exactly one line

## Note

Publishing needs a PyPI **pending trusted publisher** for `world-model-optimizer`
(owner `experientiallabs`, repo `world-model-optimizer`, workflow `python-package.yml`,
environment `pypi`). Without it the `publish` job fails at the OIDC exchange.