### PR TITLE
Add wmo optimize route sweep: the missing OutcomeMatrix producer

### DIFF
--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -1,21 +1,39 @@
-"""`wmo optimize route`: fit, tune, and report learned inference policies from outcome matrices.
+"""`wmo optimize route`: sweep, fit, tune, and report learned inference policies.
 
 The routing optimizer's CLI face, sitting beside `wmo optimize harness` in the optimizer
-family. Consumes a persisted `OutcomeMatrix` (produced by closed-loop pool evaluation or a
-research adapter such as RouterBench) and emits the policy artifact serving loads, plus the
-improvement report the endpoint cites. `tune` is the one post-fit control: it moves a fitted
-policy's cost/quality dial without refitting. Vocabulary note: "route" is developer-facing CLI
-only; customer copy never says router.
+family. The workflow chains in one direction:
+
+    sweep -> OutcomeMatrix -> fit -> policy.json -> tune (the dial) / report (the evidence)
+
+`sweep` is the producer: it measures every candidate in the pool on the world model's own
+held-out scenarios and writes the `OutcomeMatrix` everything downstream consumes (a research
+adapter such as RouterBench can write the same artifact instead). `fit` emits the policy
+artifact serving loads, `report` the improvement report the endpoint cites, and `tune` is the
+one post-fit control: it moves a fitted policy's cost/quality dial without refitting.
+Vocabulary note: "route" is developer-facing CLI only; customer copy never says router.
 """
 
 from __future__ import annotations
 
+import itertools
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
+from pydantic import BaseModel, ConfigDict
 from rich.console import Console
+from rich.markup import escape
+from rich.prompt import Confirm
+from rich.table import Table
 
+from wmo.config import ARTIFACT_DIR, WorldModelStore, load_config
+from wmo.core.types import Trace
+from wmo.engine import load_world_model, split_holdout
+from wmo.env import WorldModelEnv
+from wmo.env.closed_loop import evaluate_pool
+from wmo.env.scenarios import scenarios_from_traces, tools_hint_from_traces
+from wmo.ingest import get_adapter
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     apply_cost_quality,
@@ -23,7 +41,7 @@ from wmo.optimize.knn import (
     cost_quality_named_point,
     fit_knn_policy,
 )
-from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import (
     KNN_BANK_FILENAME,
     POLICY_FILENAME,
@@ -32,13 +50,562 @@ from wmo.optimize.policy import (
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+from wmo.providers.base import TokenUsage
+from wmo.providers.pool import DEFAULT_POOL_PATH, ModelPool, load_pool, pool_provider
+from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
 
 route_app = typer.Typer(
-    help="Fit and report learned inference policies from closed-loop outcome matrices.",
+    help="Measure a candidate pool closed-loop, then fit and report the inference policy.",
     no_args_is_help=True,
 )
 
 _console = Console()
+
+DEFAULT_MATRIX_FILENAME = "matrix.json"
+"""Default `sweep --out`: the outcome matrix `fit` takes as its argument."""
+
+
+@route_app.command("sweep")
+def sweep(
+    model: str = typer.Argument(
+        None, help="World model to measure against (default: the only one built under --root)."
+    ),
+    pool_file: str = typer.Option(
+        str(DEFAULT_POOL_PATH),
+        "--pool",
+        # The doubled brackets are escaped: typer renders help through rich markup, which
+        # otherwise swallows them and prints an empty pair.
+        help="Candidate pool TOML: one \\[\\[model]] table per candidate.",
+    ),
+    traces_file: str = typer.Option(
+        None,
+        "--traces",
+        help="Trace corpus the scenarios come from (default: the model's own "
+        "traces.otel.jsonl, as `wmo demo --traces` resolves it). A build does not keep a copy "
+        "of the corpus it read, so pass the file here.",
+    ),
+    scenarios: int = typer.Option(
+        20,
+        "--scenarios",
+        min=1,
+        help="Cap on held-out scenarios measured (a deterministic prefix by trace id).",
+    ),
+    episodes: int = typer.Option(
+        1, "--episodes", min=1, help="Episodes per (candidate, scenario) cell."
+    ),
+    max_steps: int = typer.Option(
+        20, "--max-steps", min=1, help="Step budget per episode (also the cost estimate's cap)."
+    ),
+    assume_input_tokens: int = typer.Option(
+        2000,
+        "--assume-input-tokens",
+        min=0,
+        help="ASSUMED input tokens per policy call, for the cost estimate only.",
+    ),
+    assume_output_tokens: int = typer.Option(
+        250,
+        "--assume-output-tokens",
+        min=0,
+        help="ASSUMED output tokens per policy call, for the cost estimate only.",
+    ),
+    out: str = typer.Option(
+        DEFAULT_MATRIX_FILENAME, "--out", help="Where to write the OutcomeMatrix JSON."
+    ),
+    root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir."),
+    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation."),
+    allow_uneven_coverage: bool = typer.Option(
+        False,
+        "--allow-uneven-coverage",
+        help="Hand the matrix to `fit` even when candidates were scored on DIFFERENT scenarios. "
+        "The ranking is then biased (both fitters skip unscored rows); the coverage table prints "
+        "either way.",
+    ),
+) -> None:
+    """Measure every pool candidate closed-loop and write the outcome matrix `fit` consumes.
+
+    This is step one of the routing workflow: nothing else produces an `OutcomeMatrix`.
+
+        wmo optimize route sweep support --traces traces.otel.jsonl --pool .wmo/pool.toml
+        wmo optimize route fit matrix.json --kind knn
+
+    Every (candidate, scenario, episode) cell runs one full episode against the world model,
+    which scores it (`WorldModelEnv(..., score_on_close=True)`): a matrix without verified
+    rewards is not evidence. Scenarios are the task prompts of the corpus's TEST band, the third
+    band of the build's deterministic 3-way split, which prompt optimization and knowledge
+    extraction never saw; the candidates' tool surface is summarized from the TRAIN band only
+    (the same discipline), so a candidate is not scored on guessing what tools exist. What that
+    buys is a policy fitted on prompts no GEPA candidate was SELECTED on. It is not isolation
+    from the environment: a build indexes the full corpus for serving, so the world model can
+    still retrieve a held-out trace's own recorded steps as demos when it simulates that
+    scenario. Bands are also cut per trace id, not per task text, so a task repeated across
+    traces can appear on both sides. The whole sweep runs the world model frozen, so no cell's
+    predictions become another cell's retrieved demos and the result does not depend on sweep
+    order.
+
+    Spend is confirmed before the first episode runs (`--yes` skips, as in
+    `wmo optimize harness --mode distill`). What that estimate multiplies is ASSUMED tokens per
+    policy call by the real cell and call counts, so it is a projection, never a measurement;
+    the measured candidate spend is printed when the sweep finishes. Every candidate's provider is
+    CONSTRUCTED before that question is asked, so a backend that cannot be built at all is a usage
+    error rather than a mid-sweep abort with earlier candidates already paid for.
+
+    Fit-readiness is a coverage contract, not a nonzero count. A cell goes unscored when its
+    episode errored (provider throttle, agent crash, judge failure) and both fitters SKIP unscored
+    rows, so a matrix where candidate A was scored on 20 scenarios and B on 11 ranks the two on
+    DIFFERENT task sets. That is not a comparison: the policy it fits is biased by whichever
+    scenarios each candidate happened to lose. So per-candidate scored counts ALWAYS print, and
+    when candidates lost different scenarios the command still writes the matrix (those cells were
+    paid for, and their `error` fields are the diagnosis) but WITHHOLDS the `fit` handoff and exits
+    non-zero, naming each candidate and the scenarios it has no scored episode for.
+    `--allow-uneven-coverage` is the opt-out for an operator who knows the bias and wants the
+    partial data anyway (one candidate's backend down for the whole sweep, say): it prints the same
+    coverage table and stops treating the difference as fatal. Losing the SAME scenarios for every
+    candidate is not uneven, since the comparison stays like-for-like on fewer scenarios and the
+    counts show the loss. Differing episode counts within a commonly scored scenario change that
+    cell's noise, not which scenarios a candidate was ranked on, so they show in the Unscored
+    column without blocking.
+
+    Exit code 1 when the matrix is not fit-ready: no cell scored at all, or unequal scored coverage
+    without `--allow-uneven-coverage`. `sweep && fit` in a script then stops instead of fitting on
+    it, and the matrix is written either way.
+    """
+    out_path = Path(out)
+    store = WorldModelStore(root)
+    try:
+        model_dir = store.resolve(model)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except ValueError as exc:
+        # `resolve` says "pass --name", the option `wmo serve`/`play`/`demo` carry. Here the
+        # model is a POSITIONAL, so say what a user of this command actually types.
+        names = store.list_names()
+        raise typer.BadParameter(
+            f"multiple world models built ({', '.join(names)}); name one as the MODEL argument, "
+            f"e.g. `wmo optimize route sweep {names[0]}`"
+        ) from exc
+    try:
+        config = load_config(model_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    try:
+        pool = load_pool(Path(pool_file))
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    # Everything knowable without spending is checked BEFORE the cost question: a candidate whose
+    # backend cannot even be constructed, or an --out that cannot be written, would otherwise
+    # surface after the sweep had already paid for cells it then throws away.
+    _check_pool_backends(pool)
+    _check_out_writable(out_path)
+
+    traces = _corpus_traces(model_dir, config.trace_adapter, traces_file)
+    train, holdout, tiny_corpus = split_holdout(
+        traces, config.train_split, (1.0 - config.train_split) / 2
+    )
+    # Sorted by trace id first, so `--scenarios` always cuts the same prefix of the same corpus.
+    ordered = sorted(holdout, key=lambda trace: trace.trace_id)
+    sweep_scenarios = scenarios_from_traces(ordered)[:scenarios]
+    if not sweep_scenarios:
+        raise typer.BadParameter(
+            f"the {len(holdout)} held-out trace(s) of world model '{model_dir.name}' carry no "
+            "task prompt, so there is nothing to measure; rebuild from a corpus whose traces "
+            "record the instruction they were given"
+        )
+    if tiny_corpus:
+        _console.print(
+            f"[yellow]note[/yellow] {len(traces)} trace(s) is too few for a held-out band, so "
+            "these scenarios come from the FULL corpus: they are not leak-free, and a policy "
+            "fitted on them is a smoke test, not evidence"
+        )
+    world_model, _serve_provider = load_world_model(model_dir)
+
+    lines = _estimate_cost(
+        pool,
+        episodes_per_candidate=len(sweep_scenarios) * episodes,
+        calls_per_episode=max_steps,
+        input_tokens=assume_input_tokens,
+        output_tokens=assume_output_tokens,
+    )
+    _print_cost_estimate(
+        lines,
+        scenario_count=len(sweep_scenarios),
+        episodes=episodes,
+        max_steps=max_steps,
+        input_tokens=assume_input_tokens,
+        output_tokens=assume_output_tokens,
+    )
+    _confirm_cost(yes=yes)
+
+    cells = len(pool.models) * len(sweep_scenarios) * episodes
+    _console.print(
+        f"sweeping {len(pool.models)} candidate(s) over {len(sweep_scenarios)} held-out "
+        f"scenario(s) of [bold]{escape(model_dir.name)}[/bold], {episodes} episode(s) each…"
+    )
+    done = itertools.count(1)
+
+    def _on_outcome(outcome: ScenarioOutcome) -> None:
+        reward = "unscored" if outcome.reward is None else f"{outcome.reward:.2f}"
+        _console.print(
+            f"  [{next(done)}/{cells}] {escape(outcome.model)} {escape(outcome.scenario_id)} "
+            f"ep{outcome.episode}: reward={reward} ${outcome.cost_usd:.5f} "
+            f"steps={outcome.steps}"
+        )
+
+    # Frozen for the whole sweep (the `wmo.evals.closed_loop` precedent): without it a
+    # candidate's PREDICTED steps enter the shared retrieval buffer and become demos for the next
+    # candidate, so the comparison this matrix exists to make would depend on sweep order.
+    with world_model.frozen():
+        matrix = evaluate_pool(
+            lambda: WorldModelEnv(world_model, score_on_close=True),
+            pool,
+            sweep_scenarios,
+            episodes_per_scenario=episodes,
+            max_steps=max_steps,
+            tools_hint=tools_hint_from_traces(train) or None,
+            on_outcome=_on_outcome,
+        )
+    matrix.save(out_path)
+    scored = sum(1 for outcome in matrix.outcomes if outcome.scored)
+    spent = sum(outcome.cost_usd for outcome in matrix.outcomes)
+    # `escape(out)`: a bracketed path segment would otherwise be read as markup and dropped, so
+    # the line would print a path that does not exist (and this one is meant to be copied).
+    _console.print(
+        f"[green]✓[/green] {len(matrix.outcomes)} cell(s), {scored} scored -> {escape(out)}\n"
+        f"  measured candidate spend ${spent:.4f} (the world model's own serve/judge cost is "
+        "metered separately)",
+        soft_wrap=True,  # a path a user copies must not be wrapped
+    )
+    coverage = _coverage(matrix)
+    _print_coverage(coverage)
+    if scored == 0:
+        # Exit non-zero: a matrix with no verified reward is not evidence, so `sweep && fit` in a
+        # script must stop here rather than fit on it. The rows are on disk for their `error`s.
+        # No --allow-uneven-coverage escape: there is nothing to fit, so `fit` would fail anyway.
+        _console.print(
+            "[yellow]warning[/yellow] no cell was scored, so this matrix is not evidence and "
+            "fitting will fail; read the `error` field of a row to see what broke"
+        )
+        raise typer.Exit(1)
+    if _uneven_coverage(coverage):
+        counts = ", ".join(f"{escape(row.candidate)} {row.scored}" for row in coverage)
+        _console.print(
+            "[yellow]warning[/yellow] candidates were scored on DIFFERENT scenarios (scored cells: "
+            f"{counts}), so `fit` would rank them on different task sets: it skips unscored rows, "
+            "and the policy that comes out is biased by which scenarios each candidate lost. The "
+            "paid cells are on disk and their `error` field says what broke."
+        )
+        if not allow_uneven_coverage:
+            _console.print(
+                "  fix the lost cells and sweep again, drop the candidate that lost them, or "
+                "re-run with [bold]--allow-uneven-coverage[/bold] to fit on this matrix anyway"
+            )
+            raise typer.Exit(1)
+        _console.print(
+            "  --allow-uneven-coverage was passed: fitting on it anyway, with that bias accepted"
+        )
+    _console.print(
+        f"  next: [bold]wmo optimize route fit {escape(out)} --kind knn[/bold]", soft_wrap=True
+    )
+
+
+def _check_pool_backends(pool: ModelPool) -> None:
+    """Construct every candidate's provider BEFORE the sweep spends anything.
+
+    `evaluate_pool` builds a candidate's provider lazily, at that candidate's FIRST CELL, so any
+    reason a backend cannot be built (an unset `api_key_env`, a kind that refuses the explicit key
+    the entry names, a config its backend rejects) used to abort the run as a raw traceback after
+    every earlier candidate had been fully paid for, with no matrix written. Building all of them
+    here turns that into a usage error at the boundary, before the cost question.
+
+    Construction only, never a request. Every backend in `wmo.providers.registry` only stores its
+    config in `__init__` and defers the SDK import, the credential read, and the client itself to
+    `_get_client()`, so building the whole pool costs nothing and touches no network. Verifying a
+    candidate over the wire is deliberately NOT done here: `wmo providers verify` bills a real call
+    per model, which would spend money inside a pre-flight whose whole job is to run before any
+    spend is authorized, and would make the cost estimate printed next understate what the command
+    had already spent. The residual gap is worth stating plainly: whatever a backend resolves
+    lazily (a Bedrock region and AWS credentials, an optional SDK extra, an Azure api-version)
+    still surfaces at that candidate's first cell, because seeing it earlier needs either a request
+    or a copy of each backend's lazy resolution that would drift from it.
+
+    Every constructed provider is discarded: `evaluate_pool` still builds its own per cell, so
+    per-cell provider state (the tinker provider's per-episode prompt history) is unchanged.
+
+    Reports EVERY unusable candidate, not just the first: a pool is edited as a file, so an
+    operator fixing one entry at a time pays a full round trip per typo.
+
+    Raises:
+        typer.BadParameter: One or more candidates cannot be used, each named with its kind.
+    """
+    problems: list[str] = []
+    for entry in pool.models:
+        try:
+            pool_provider(entry)
+        except Exception as exc:  # noqa: BLE001 - anything here is a usage error, never a spend
+            # `pool_provider` already prefixes its own failures with the entry name and kind; a
+            # surprise from deeper down gets the same identification so the file is editable.
+            detail = str(exc)
+            problems.append(
+                detail
+                if detail.startswith(f"pool model '{entry.name}'")
+                else f"pool model '{entry.name}' (kind={entry.kind.value}): {detail}"
+            )
+    if problems:
+        raise typer.BadParameter(
+            "; ".join(problems)
+            + ". Fix or remove those entries in the pool file, then re-run (checked all "
+            + f"{len(pool.models)} candidate(s) before spending anything)"
+        )
+
+
+class _CandidateCoverage(BaseModel):
+    """One candidate's scored coverage: what a fitter would actually rank it on."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate: str
+    scored: int  # cells with a verified reward
+    unscored: int  # cells whose episode or scoring failed (skipped by both fitters)
+    lost_scenarios: tuple[str, ...]  # scenarios with NO scored episode for this candidate
+
+
+# Lost scenario ids shown per candidate before the column summarizes the rest: enough to see the
+# pattern in a table an operator reads, without a 20-id line per row.
+_LOST_SHOWN = 5
+
+
+def _coverage(matrix: OutcomeMatrix) -> list[_CandidateCoverage]:
+    """Per-candidate scored coverage over the swept scenarios, in pool order."""
+    swept = matrix.scenario_ids()
+    rows: list[_CandidateCoverage] = []
+    for name in matrix.model_names():
+        cells = [outcome for outcome in matrix.outcomes if outcome.model == name]
+        has_reward = {cell.scenario_id for cell in cells if cell.scored}
+        rows.append(
+            _CandidateCoverage(
+                candidate=name,
+                scored=sum(1 for cell in cells if cell.scored),
+                unscored=sum(1 for cell in cells if not cell.scored),
+                lost_scenarios=tuple(sid for sid in swept if sid not in has_reward),
+            )
+        )
+    return rows
+
+
+def _uneven_coverage(coverage: list[_CandidateCoverage]) -> bool:
+    """Whether the candidates were scored on DIFFERENT scenarios, which is not a comparison.
+
+    Compared as SETS of lost scenarios, not counts: two candidates can lose the same number of
+    scenarios and still have been ranked on disjoint task subsets. A scenario every candidate lost
+    is even (the comparison is like-for-like on what is left), and an episode-count difference
+    inside a commonly scored scenario is noise on that cell rather than a different task set, so
+    neither blocks (see `sweep`).
+    """
+    return len({row.lost_scenarios for row in coverage}) > 1
+
+
+def _print_coverage(coverage: list[_CandidateCoverage]) -> None:
+    """Show what each candidate would be ranked on: its scored cells and the scenarios it lost."""
+    table = Table(title="Scored coverage per candidate (`fit` SKIPS unscored cells)")
+    table.add_column("Candidate", no_wrap=True)
+    table.add_column("Scored", justify="right")
+    table.add_column("Unscored", justify="right")
+    table.add_column("Scenarios with no scored episode")
+    for row in coverage:
+        lost = ", ".join(row.lost_scenarios[:_LOST_SHOWN])
+        if len(row.lost_scenarios) > _LOST_SHOWN:
+            lost += f" (+{len(row.lost_scenarios) - _LOST_SHOWN} more)"
+        # Scenario ids are corpus data (trace ids) and candidate names are operator strings: both
+        # reach a rich console, where `[a]` is markup that would silently drop from the table.
+        table.add_row(
+            escape(row.candidate),
+            f"{row.scored:,}",
+            f"{row.unscored:,}",
+            escape(lost) if lost else "-",
+        )
+    _console.print(table)
+
+
+def _check_out_writable(out_path: Path) -> None:
+    """Prove `--out` can be written BEFORE the sweep spends anything.
+
+    `OutcomeMatrix.save` creates the parent directory and writes, but only once every episode has
+    run: a destination that cannot be created (a parent component that is a regular file, an
+    unwritable directory, a path that is itself a directory) would throw the whole paid sweep
+    away with an OS error and no message. Checked without creating anything, so declining the
+    cost confirmation still leaves the filesystem untouched.
+
+    Raises:
+        typer.BadParameter: The matrix could not be written there.
+    """
+    resolved = out_path if out_path.is_absolute() else Path.cwd() / out_path
+    existing = resolved.parent
+    while not existing.exists() and existing != existing.parent:
+        existing = existing.parent
+    problem: str | None = None
+    if not existing.is_dir():
+        problem = f"{existing} is not a directory"
+    elif not os.access(existing, os.W_OK):
+        problem = f"{existing} is not writable"
+    elif resolved.is_dir():
+        problem = f"{resolved} is a directory"
+    elif resolved.exists() and not os.access(resolved, os.W_OK):
+        problem = f"{resolved} is not writable"
+    if problem is not None:
+        raise typer.BadParameter(
+            f"cannot write the outcome matrix to {out_path}: {problem}. --out must name a "
+            "writable JSON file path"
+        )
+
+
+def _corpus_traces(model_dir: Path, adapter_name: str, explicit: str | None) -> list[Trace]:
+    """Ingest the corpus the sweep takes its scenarios from: `--traces`, else the model's own.
+
+    A build does NOT persist the corpus it read (it keeps prompts, metrics and the retrieval
+    index), so `local_traces_path` finds a file only for a Hub-downloaded model or a shipped
+    example. `--traces` is the same escape hatch `wmo demo` carries for exactly this reason, and
+    the failure names it.
+    """
+    if explicit is not None:
+        path = Path(explicit)
+        if not path.is_file():
+            raise typer.BadParameter(f"no trace file at {path} (--traces)")
+    else:
+        found = local_traces_path(model_dir)
+        if found is None:
+            raise typer.BadParameter(
+                f"no trace corpus for world model '{model_dir.name}': looked for "
+                f"{model_dir / TRACES_FILENAME} and {model_dir.parent.parent / TRACES_FILENAME}. "
+                "Sweep scenarios are the model's OWN held-out task prompts, and a build keeps no "
+                "copy of the corpus it read, so pass `--traces <the file wmo build --file read>` "
+                f"or put that file at {model_dir / TRACES_FILENAME}"
+            )
+        path = found
+    try:
+        traces = get_adapter(adapter_name).from_file(str(path))
+    except (OSError, ValueError) as exc:  # unknown adapter, unreadable or malformed corpus
+        raise typer.BadParameter(f"cannot ingest {path}: {exc}") from exc
+    if not traces:
+        raise typer.BadParameter(
+            f"{path} ingested no traces with the '{adapter_name}' adapter, so there are no "
+            "scenarios to sweep"
+        )
+    return traces
+
+
+class _CostLine(BaseModel):
+    """One candidate's projected sweep spend under the stated per-call token assumption."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidate: str
+    episodes: int
+    calls: int
+    input_per_mtok: float
+    output_per_mtok: float
+    usd: float
+
+
+def _estimate_cost(
+    pool: ModelPool,
+    *,
+    episodes_per_candidate: int,
+    calls_per_episode: int,
+    input_tokens: int,
+    output_tokens: int,
+) -> list[_CostLine]:
+    """Project each candidate's spend, priced by its OWN pool entry (overrides included)."""
+    per_call = TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+    calls = episodes_per_candidate * calls_per_episode
+    lines: list[_CostLine] = []
+    for entry in pool.models:
+        price = entry.price()
+        lines.append(
+            _CostLine(
+                candidate=entry.name,
+                episodes=episodes_per_candidate,
+                calls=calls,
+                input_per_mtok=price.input_per_mtok,
+                output_per_mtok=price.output_per_mtok,
+                usd=calls * entry.cost_usd(per_call),
+            )
+        )
+    return lines
+
+
+def _print_cost_estimate(
+    lines: list[_CostLine],
+    *,
+    scenario_count: int,
+    episodes: int,
+    max_steps: int,
+    input_tokens: int,
+    output_tokens: int,
+) -> None:
+    """Render the projected spend, stating exactly which parts are assumed.
+
+    Honest by construction: the CELL and CALL counts are real (`--max-steps` is the per-episode
+    cap, so calls are an upper bound), the tokens per call are an assumption the flags name, and
+    the per-candidate $/Mtok is the pool entry's own price row. The world model's serve and judge
+    calls are a separate meter (the D12 cost split) and are deliberately absent.
+    """
+    table = Table(title="Route sweep cost estimate (ASSUMED tokens, not a measurement)")
+    table.add_column("Candidate", no_wrap=True)
+    table.add_column("Episodes", justify="right")
+    table.add_column("Calls (max)", justify="right")
+    table.add_column("$/Mtok in", justify="right")
+    table.add_column("$/Mtok out", justify="right")
+    table.add_column("USD (est)", justify="right")
+    for line in lines:
+        table.add_row(
+            # A rich cell renders markup: an operator-chosen name like `gpt[a]` would print as
+            # `gpt`, making two candidates indistinguishable in the table they confirm spend from
+            # (and a name containing a closing tag would abort the command outright).
+            escape(line.candidate),
+            f"{line.episodes:,}",
+            f"{line.calls:,}",
+            f"{line.input_per_mtok:.3f}",
+            f"{line.output_per_mtok:.3f}",
+            f"{line.usd:.2f}",
+        )
+    _console.print(table)
+    _console.print(
+        f"{len(lines) * scenario_count * episodes} cell(s) = {len(lines)} candidate(s) x "
+        f"{scenario_count} held-out scenario(s) x {episodes} episode(s); estimated total "
+        f"${sum(line.usd for line in lines):.2f}"
+    )
+    _console.print(
+        f"  ASSUMPTION: {input_tokens:,} input + {output_tokens:,} output token(s) per policy "
+        f"call, and every episode running its full {max_steps}-call budget. Calls are capped, "
+        "tokens per call are NOT measured: set --assume-input-tokens/--assume-output-tokens from "
+        "your own numbers, or read the measured spend this command prints when it finishes."
+    )
+    _console.print(
+        "  Candidate side only: the world model's own serve and judge calls are metered "
+        "separately and are NOT in this figure."
+    )
+
+
+def _confirm_cost(*, yes: bool) -> None:
+    """Confirm the projected spend before any episode runs.
+
+    Every pool entry is priced (`load_pool` refuses an unpriced candidate), so the spend is
+    accountable and `--yes` always applies, the rule `wmo optimize harness --mode distill`
+    uses. A non-interactive session cannot answer a prompt, so it proceeds and says so instead
+    of hanging.
+
+    Raises:
+        typer.Exit: The user declined (exit code 0).
+    """
+    if yes:
+        return
+    if not _console.is_terminal:
+        _console.print(
+            "non-interactive session: proceeding without confirmation (pass --yes to say so "
+            "explicitly)"
+        )
+        return
+    if not Confirm.ask("Proceed?", default=True):
+        raise typer.Exit(0)
 
 
 @route_app.command("fit")

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import itertools
 import os
+from collections import Counter
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 
 import typer
@@ -50,8 +52,13 @@ from wmo.optimize.policy import (
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
-from wmo.providers.base import TokenUsage
-from wmo.providers.pool import DEFAULT_POOL_PATH, ModelPool, load_pool, pool_provider
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import (
+    DEFAULT_POOL_PATH,
+    ModelPool,
+    load_pool,
+    prepare_pool_provider,
+)
 from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
 
 route_app = typer.Typer(
@@ -116,9 +123,10 @@ def sweep(
     allow_uneven_coverage: bool = typer.Option(
         False,
         "--allow-uneven-coverage",
-        help="Hand the matrix to `fit` even when candidates were scored on DIFFERENT scenarios. "
-        "The ranking is then biased (both fitters skip unscored rows); the coverage table prints "
-        "either way.",
+        help="Hand the matrix to `fit` even when the candidates were not scored on the same "
+        "evidence: different scenarios, or different numbers of surviving episodes on the same "
+        "scenarios. The fit is then biased (both fitters skip unscored rows and weigh the rest per "
+        "episode); the coverage table prints either way.",
     ),
 ) -> None:
     """Measure every pool candidate closed-loop and write the outcome matrix `fit` consumes.
@@ -145,27 +153,37 @@ def sweep(
     Spend is confirmed before the first episode runs (`--yes` skips, as in
     `wmo optimize harness --mode distill`). What that estimate multiplies is ASSUMED tokens per
     policy call by the real cell and call counts, so it is a projection, never a measurement;
-    the measured candidate spend is printed when the sweep finishes. Every candidate's provider is
-    CONSTRUCTED before that question is asked, so a backend that cannot be built at all is a usage
-    error rather than a mid-sweep abort with earlier candidates already paid for.
+    the measured candidate spend is printed when the sweep finishes. Before that question is asked,
+    every candidate's backend is resolved as far as it goes without a request: its kind's static
+    requirements from the entry alone, then its lazy SDK client forced to BUILD, which imports the
+    SDK and resolves credentials locally. So a candidate that could never be called is a usage
+    error at the boundary, not a mid-sweep abort with earlier candidates already paid for. Two
+    things stay first-cell failures because seeing them needs a request (bedrock AWS credentials,
+    tinker service reachability); the pre-flight names them per entry when the pool has one.
 
     Fit-readiness is a coverage contract, not a nonzero count. A cell goes unscored when its
-    episode errored (provider throttle, agent crash, judge failure) and both fitters SKIP unscored
-    rows, so a matrix where candidate A was scored on 20 scenarios and B on 11 ranks the two on
-    DIFFERENT task sets. That is not a comparison: the policy it fits is biased by whichever
-    scenarios each candidate happened to lose. So per-candidate scored counts ALWAYS print, and
-    when candidates lost different scenarios the command still writes the matrix (those cells were
-    paid for, and their `error` fields are the diagnosis) but WITHHOLDS the `fit` handoff and exits
-    non-zero, naming each candidate and the scenarios it has no scored episode for.
+    episode errored (provider throttle, agent crash, judge failure), both fitters SKIP unscored
+    rows, and what they do with the rest is episode-weighted, so the contract is that every
+    candidate has the same number of scored episodes on the same scenarios. Two ways to break it,
+    both blocked: a matrix where candidate A was scored on 20 scenarios and B on 11 ranks them on
+    DIFFERENT task sets, and a matrix where both cover all 20 but A kept 3 episodes on a scenario
+    where B kept 1 weighs that scenario three times as heavily for A, because `--kind rank`
+    averages every surviving episode into its cluster mean and both kinds pick their
+    default/fallback model off episode-weighted means (`routing._overall_best`,
+    `knn.best_single_on_fit`). A knn BANK cell is that pair's own mean, so the bank is milder, but
+    milder is not unbiased and it is the same matrix either way. Either break leaves the policy
+    decided by whichever cells each candidate happened to lose. So per-candidate scored counts
+    ALWAYS print, and when the evidence differs the command still writes the matrix (those cells
+    were paid for, and their `error` fields are the diagnosis) but WITHHOLDS the `fit` handoff and
+    exits non-zero, naming each candidate, the scenarios it has no scored episode for, and the
+    scenarios where it kept fewer episodes than the best-covered candidate.
     `--allow-uneven-coverage` is the opt-out for an operator who knows the bias and wants the
     partial data anyway (one candidate's backend down for the whole sweep, say): it prints the same
-    coverage table and stops treating the difference as fatal. Losing the SAME scenarios for every
-    candidate is not uneven, since the comparison stays like-for-like on fewer scenarios and the
-    counts show the loss. Differing episode counts within a commonly scored scenario change that
-    cell's noise, not which scenarios a candidate was ranked on, so they show in the Unscored
-    column without blocking.
+    coverage table and stops treating the difference as fatal. Losing the SAME cells for every
+    candidate is not uneven, since the comparison stays like-for-like on less data and the counts
+    show the loss.
 
-    Exit code 1 when the matrix is not fit-ready: no cell scored at all, or unequal scored coverage
+    Exit code 1 when the matrix is not fit-ready: no cell scored at all, or unequal scored evidence
     without `--allow-uneven-coverage`. `sweep && fit` in a script then stops instead of fitting on
     it, and the matrix is written either way.
     """
@@ -285,14 +303,9 @@ def sweep(
             "fitting will fail; read the `error` field of a row to see what broke"
         )
         raise typer.Exit(1)
-    if _uneven_coverage(coverage):
-        counts = ", ".join(f"{escape(row.candidate)} {row.scored}" for row in coverage)
-        _console.print(
-            "[yellow]warning[/yellow] candidates were scored on DIFFERENT scenarios (scored cells: "
-            f"{counts}), so `fit` would rank them on different task sets: it skips unscored rows, "
-            "and the policy that comes out is biased by which scenarios each candidate lost. The "
-            "paid cells are on disk and their `error` field says what broke."
-        )
+    warning = _uneven_warning(coverage)
+    if warning is not None:
+        _console.print(warning)
         if not allow_uneven_coverage:
             _console.print(
                 "  fix the lost cells and sweep again, drop the candidate that lost them, or "
@@ -307,27 +320,42 @@ def sweep(
     )
 
 
+# What each kind still cannot know before its first cell, and why. Both are measured properties
+# of the backend (see `BedrockProvider.prepare` and `TinkerChatProvider.prepare`), not caution: a
+# pre-flight that resolved them would have to make a request, which is the one thing it may not do.
+_DEFERRED_RISK: dict[ProviderKind, str] = {
+    ProviderKind.BEDROCK: (
+        "AWS credentials (boto3 resolves them by walking a chain that can reach the "
+        "instance-metadata endpoint over the network, and it builds a client with no credentials "
+        "at all)"
+    ),
+    ProviderKind.TINKER: (
+        "the Tinker service being reachable and serving this model (constructing the client "
+        "connects and pins a server-side session for the whole process)"
+    ),
+}
+
+
 def _check_pool_backends(pool: ModelPool) -> None:
-    """Construct every candidate's provider BEFORE the sweep spends anything.
+    """Resolve every candidate's backend as far as it goes locally, BEFORE anything is spent.
 
-    `evaluate_pool` builds a candidate's provider lazily, at that candidate's FIRST CELL, so any
-    reason a backend cannot be built (an unset `api_key_env`, a kind that refuses the explicit key
-    the entry names, a config its backend rejects) used to abort the run as a raw traceback after
-    every earlier candidate had been fully paid for, with no matrix written. Building all of them
-    here turns that into a usage error at the boundary, before the cost question.
+    `evaluate_pool` builds a candidate's provider lazily at that candidate's FIRST CELL, and every
+    backend then builds its SDK client lazily inside that first call, so any reason a candidate
+    cannot be used (an unset `api_key_env`, a kind that refuses the explicit key the entry names,
+    a missing SDK extra, an Azure config with no api_version, a Bedrock entry whose region
+    resolves nowhere) used to abort the run as a raw traceback after every earlier candidate had
+    been fully paid for, with no matrix written. `prepare_pool_provider` closes that: it checks the
+    kind's static requirements from the entry alone, then forces the lazy client to be BUILT, which
+    imports the SDK and resolves credentials from the environment and local credential files.
 
-    Construction only, never a request. Every backend in `wmo.providers.registry` only stores its
-    config in `__init__` and defers the SDK import, the credential read, and the client itself to
-    `_get_client()`, so building the whole pool costs nothing and touches no network. Verifying a
-    candidate over the wire is deliberately NOT done here: `wmo providers verify` bills a real call
-    per model, which would spend money inside a pre-flight whose whole job is to run before any
-    spend is authorized, and would make the cost estimate printed next understate what the command
-    had already spent. The residual gap is worth stating plainly: whatever a backend resolves
-    lazily (a Bedrock region and AWS credentials, an optional SDK extra, an Azure api-version)
-    still surfaces at that candidate's first cell, because seeing it earlier needs either a request
-    or a copy of each backend's lazy resolution that would drift from it.
+    No request, ever. Every `prepare` is documented network-free, and verifying a candidate over
+    the wire is deliberately NOT done here: `wmo providers verify` bills a real call per model,
+    which would spend money inside a pre-flight whose whole job is to run before any spend is
+    authorized, and would make the cost estimate printed next understate what the command had
+    already spent. Two backends therefore keep a residual gap (`_DEFERRED_RISK`), and this prints
+    it per entry rather than leaving the operator to discover it mid-sweep.
 
-    Every constructed provider is discarded: `evaluate_pool` still builds its own per cell, so
+    Every prepared provider is discarded: `evaluate_pool` still builds its own per cell, so
     per-cell provider state (the tinker provider's per-episode prompt history) is unchanged.
 
     Reports EVERY unusable candidate, not just the first: a pool is edited as a file, so an
@@ -339,10 +367,11 @@ def _check_pool_backends(pool: ModelPool) -> None:
     problems: list[str] = []
     for entry in pool.models:
         try:
-            pool_provider(entry)
+            prepare_pool_provider(entry)
         except Exception as exc:  # noqa: BLE001 - anything here is a usage error, never a spend
-            # `pool_provider` already prefixes its own failures with the entry name and kind; a
-            # surprise from deeper down gets the same identification so the file is editable.
+            # `prepare_pool_provider` already prefixes its own failures with the entry name and
+            # kind; a surprise from deeper down gets the same identification so the file is
+            # editable from the message.
             detail = str(exc)
             problems.append(
                 detail
@@ -355,22 +384,49 @@ def _check_pool_backends(pool: ModelPool) -> None:
             + ". Fix or remove those entries in the pool file, then re-run (checked all "
             + f"{len(pool.models)} candidate(s) before spending anything)"
         )
+    deferred = [entry for entry in pool.models if entry.kind in _DEFERRED_RISK]
+    if deferred:
+        _console.print(
+            "[yellow]note[/yellow] the pre-flight makes no request, so one thing per candidate "
+            "below can still fail at its first cell (the matrix records it as that cell's `error`):"
+        )
+        for entry in deferred:
+            _console.print(
+                f"  {escape(entry.name)} (kind={entry.kind.value}): {_DEFERRED_RISK[entry.kind]}"
+            )
 
 
 class _CandidateCoverage(BaseModel):
-    """One candidate's scored coverage: what a fitter would actually rank it on."""
+    """One candidate's scored coverage: what a fitter would actually weigh it on."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     candidate: str
     scored: int  # cells with a verified reward
     unscored: int  # cells whose episode or scoring failed (skipped by both fitters)
-    lost_scenarios: tuple[str, ...]  # scenarios with NO scored episode for this candidate
+    # Scored EPISODE COUNT per swept scenario, in sweep order. Counts, not presence: both fitters
+    # weigh episodes, not scenarios (see `_unevenness`), so `X: 3` and `X: 1` are different
+    # evidence even though both "cover" X.
+    scored_episodes: tuple[tuple[str, int], ...]
+    first_error: str | None  # first error text among this candidate's unscored cells, if any
+
+    @property
+    def lost_scenarios(self) -> tuple[str, ...]:
+        """Swept scenarios this candidate has NO scored episode for."""
+        return tuple(sid for sid, count in self.scored_episodes if count == 0)
 
 
-# Lost scenario ids shown per candidate before the column summarizes the rest: enough to see the
-# pattern in a table an operator reads, without a 20-id line per row.
+# Scenario ids shown per candidate before the column summarizes the rest: enough to see the pattern
+# in a table an operator reads, without a 20-id line per row.
 _LOST_SHOWN = 5
+
+
+class _Unevenness(StrEnum):
+    """How the candidates' scored evidence differs, when it does."""
+
+    EVEN = "even"
+    SCENARIOS = "scenarios"  # candidates were scored on different scenario SETS
+    EPISODES = "episodes"  # same scenarios, different numbers of scored episodes
 
 
 def _coverage(matrix: OutcomeMatrix) -> list[_CandidateCoverage]:
@@ -379,41 +435,99 @@ def _coverage(matrix: OutcomeMatrix) -> list[_CandidateCoverage]:
     rows: list[_CandidateCoverage] = []
     for name in matrix.model_names():
         cells = [outcome for outcome in matrix.outcomes if outcome.model == name]
-        has_reward = {cell.scenario_id for cell in cells if cell.scored}
+        per_scenario: Counter[str] = Counter(cell.scenario_id for cell in cells if cell.scored)
+        errors = [cell.error for cell in cells if not cell.scored and cell.error]
         rows.append(
             _CandidateCoverage(
                 candidate=name,
                 scored=sum(1 for cell in cells if cell.scored),
                 unscored=sum(1 for cell in cells if not cell.scored),
-                lost_scenarios=tuple(sid for sid in swept if sid not in has_reward),
+                scored_episodes=tuple((sid, per_scenario[sid]) for sid in swept),
+                first_error=errors[0] if errors else None,
             )
         )
     return rows
 
 
-def _uneven_coverage(coverage: list[_CandidateCoverage]) -> bool:
-    """Whether the candidates were scored on DIFFERENT scenarios, which is not a comparison.
+def _unevenness(coverage: list[_CandidateCoverage]) -> _Unevenness:
+    """Whether the candidates were scored on the same evidence, and if not, how it differs.
 
-    Compared as SETS of lost scenarios, not counts: two candidates can lose the same number of
-    scenarios and still have been ranked on disjoint task subsets. A scenario every candidate lost
-    is even (the comparison is like-for-like on what is left), and an episode-count difference
-    inside a commonly scored scenario is noise on that cell rather than a different task set, so
-    neither blocks (see `sweep`).
+    Compared as per-(candidate, scenario) scored EPISODE COUNTS, because that is what the fitters
+    weigh. Presence is not enough: `fit_rank_policy` averages every surviving EPISODE
+    independently, so a candidate that kept 3 episodes on a scenario and one that kept 1 carry
+    different effective scenario weights into the same cluster mean, and the models chosen as
+    `default_model` (`routing.py:_overall_best`) and as the knn fallback/guard
+    (`knn.py:best_single_on_fit`) are picked off those same episode-weighted means. The knn BANK is
+    milder, since its cells are per-scenario means, but "milder" is not "unbiased", and it is the
+    same matrix either way.
+
+    Losing the same episodes of the same scenarios for EVERY candidate is even: the comparison
+    stays like-for-like on less data, and the counts show the loss.
     """
-    return len({row.lost_scenarios for row in coverage}) > 1
+    if len({row.scored_episodes for row in coverage}) <= 1:
+        return _Unevenness.EVEN
+    if len({row.lost_scenarios for row in coverage}) > 1:
+        return _Unevenness.SCENARIOS
+    return _Unevenness.EPISODES
+
+
+def _uneven_warning(coverage: list[_CandidateCoverage]) -> str | None:
+    """The warning for coverage that is not a comparison, or None when it is one.
+
+    Two different failures, so two different messages: candidates ranked on different scenario
+    SETS, and candidates ranked on the same scenarios with different numbers of surviving EPISODES.
+    Both bias a fit; naming which one happened is what makes the message actionable.
+    """
+    counts = ", ".join(f"{escape(row.candidate)} {row.scored}" for row in coverage)
+    match _unevenness(coverage):
+        case _Unevenness.EVEN:
+            return None
+        case _Unevenness.SCENARIOS:
+            return (
+                "[yellow]warning[/yellow] candidates were scored on DIFFERENT scenarios (scored "
+                f"cells: {counts}), so `fit` would rank them on different task sets: it skips "
+                "unscored rows, and the policy that comes out is biased by which scenarios each "
+                "candidate lost. The paid cells are on disk and their `error` field says what "
+                "broke."
+            )
+        case _Unevenness.EPISODES:
+            return (
+                "[yellow]warning[/yellow] candidates cover the same scenarios but kept DIFFERENT "
+                f"numbers of scored episodes on them (scored cells: {counts}; the table above "
+                "says which scenarios were thinned, as kept/most). Both fitters weigh EPISODES: "
+                "--kind rank averages every surviving episode into its cluster mean, so a "
+                "scenario one candidate kept 1 of 3 episodes on counts a third as much for it, "
+                "and both kinds pick their default/fallback model off the same episode-weighted "
+                "means. What comes out then turns on which episodes happened to fail."
+            )
 
 
 def _print_coverage(coverage: list[_CandidateCoverage]) -> None:
-    """Show what each candidate would be ranked on: its scored cells and the scenarios it lost."""
+    """Show what each candidate would be weighed on: its scored cells, and what it lost.
+
+    The last column names every scenario where this candidate holds less evidence than the
+    best-covered candidate does: a bare id is a scenario with no scored episode at all, and
+    `id 1/3` is a scenario where it kept 1 of the 3 episodes another candidate kept. Both change
+    what a fitter weighs, so both are per candidate here rather than summed into Unscored.
+    """
+    most: Counter[str] = Counter()
+    for row in coverage:
+        for sid, count in row.scored_episodes:
+            most[sid] = max(most[sid], count)
     table = Table(title="Scored coverage per candidate (`fit` SKIPS unscored cells)")
     table.add_column("Candidate", no_wrap=True)
     table.add_column("Scored", justify="right")
     table.add_column("Unscored", justify="right")
-    table.add_column("Scenarios with no scored episode")
+    table.add_column("Scenarios lost, or thinned (kept/most)")
     for row in coverage:
-        lost = ", ".join(row.lost_scenarios[:_LOST_SHOWN])
-        if len(row.lost_scenarios) > _LOST_SHOWN:
-            lost += f" (+{len(row.lost_scenarios) - _LOST_SHOWN} more)"
+        gaps = [
+            sid if count == 0 else f"{sid} {count}/{most[sid]}"
+            for sid, count in row.scored_episodes
+            if count == 0 or count < most[sid]
+        ]
+        lost = ", ".join(gaps[:_LOST_SHOWN])
+        if len(gaps) > _LOST_SHOWN:
+            lost += f" (+{len(gaps) - _LOST_SHOWN} more)"
         # Scenario ids are corpus data (trace ids) and candidate names are operator strings: both
         # reach a rich console, where `[a]` is markup that would silently drop from the table.
         table.add_row(
@@ -423,6 +537,16 @@ def _print_coverage(coverage: list[_CandidateCoverage]) -> None:
             escape(lost) if lost else "-",
         )
     _console.print(table)
+    for row in coverage:
+        if row.scored == 0 and row.first_error is not None:
+            # A candidate that was never scored at all is the one failure a coverage table cannot
+            # explain, and its cause is already on disk. Surfacing the first one names the entry
+            # and points at the pool file, which is where the fix is.
+            _console.print(
+                f"  [yellow]{escape(row.candidate)}[/yellow] was never scored; its first cell "
+                f"failed with: {escape(row.first_error)}\n"
+                "    fix that entry in the pool file, drop it, or retry once the cause has cleared"
+            )
 
 
 def _check_out_writable(out_path: Path) -> None:

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 import json
+from collections import Counter
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -554,6 +555,7 @@ def _patch_seams(
     reward: float = 0.75,
     no_scoring: bool = False,
     throttled_models: frozenset[str] = frozenset(),
+    throttled_episodes: dict[str, tuple[bool, ...]] | None = None,
     judge_fails_on: frozenset[str] = frozenset(),
     real_kinds: frozenset[ProviderKind] = frozenset(),
 ) -> _Seams:
@@ -566,13 +568,20 @@ def _patch_seams(
             would amount to: it exists so a test can show the difference is observable.
         throttled_models: Provider model ids (`PoolEntry.model`) whose completions raise, so that
             candidate's cells come back unscored while the others are scored.
+        throttled_episodes: Per-model cycle of throttled flags over each scenario's episodes:
+            `{"pricey-1": (False, True, True)}` keeps episode 0 and loses episodes 1 and 2 of EVERY
+            scenario. `evaluate_pool` builds one provider per episode in scenario-major order, so
+            the cycle position is the episode index within the scenario. This is how a candidate
+            comes back with the same scenarios as the others but FEWER scored episodes on them.
         judge_fails_on: Scenario tasks whose episode SCORING raises, for every candidate: the
             whole pool loses those scenarios together.
         real_kinds: Provider kinds to construct for real instead of faking, so a test can exercise
-            a backend that refuses its own config. Construction is side-effect free, and no real
-            provider is ever called (the sweep must fail before any cell runs).
+            a backend that refuses its own config or cannot build its lazy client. Construction and
+            preparation are both request-free, and no real provider is ever called (the sweep must
+            fail before any cell runs).
     """
     seams = _Seams(_FakeWorldModel(reward=reward, judge_fails_on=judge_fails_on))
+    episode_cycles = throttled_episodes or {}
 
     def _load(model_dir: Path) -> tuple[WorldModel, Provider]:
         provider = _ScriptedCandidate(
@@ -584,9 +593,17 @@ def _patch_seams(
         if config.kind in real_kinds:
             return registry_get_provider(config, api_key=api_key)
         seams.built_providers.append(config.model)
+        cycle = episode_cycles.get(config.model)
+        throttled = config.model in throttled_models
+        if cycle:
+            # The pre-flight builds one provider per candidate before any episode runs, so the
+            # sweep's first episode is this model's SECOND construction; from there the count is
+            # the episode index (`evaluate_pool` builds one provider per episode).
+            episode = seams.built_providers.count(config.model) - 2
+            throttled = throttled or (episode >= 0 and cycle[episode % len(cycle)])
         return cast(
             "Provider",
-            _ScriptedCandidate(config, seams.systems, throttled=config.model in throttled_models),
+            _ScriptedCandidate(config, seams.systems, throttled=throttled),
         )
 
     monkeypatch.setattr(route_module, "load_world_model", _load)
@@ -747,6 +764,11 @@ def test_route_sweep_withholds_the_fit_handoff_on_uneven_scored_coverage(
     assert _says(result.output, "Scored coverage per candidate")
     assert _says(result.output, ", ".join(_HELD_OUT_IDS[:3]))
     assert "DIFFERENTscenarios" in flat and "cheap3,pricey0" in flat
+    # A candidate the coverage table can only show as all-zero gets its cause quoted from the
+    # matrix, named, with what to do: it is the one failure the table itself cannot explain.
+    assert _says(result.output, "pricey was never scored; its first cell failed with")
+    assert "ratelimitexceeded(429)" in flat
+    assert _says(result.output, "fix that entry in the pool file")
     # The handoff is withheld, so `sweep && fit` in a script stops instead of fitting on it, and
     # the message names the one flag that proceeds anyway.
     assert "wmooptimizeroutefit" not in flat
@@ -768,6 +790,95 @@ def test_route_sweep_allow_uneven_coverage_hands_off_and_still_states_the_bias(
     assert result.exit_code == 0, result.output
     flat = _flat(result.output)
     assert "DIFFERENTscenarios" in flat and "biasaccepted" in flat
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
+
+
+def test_route_sweep_withholds_the_fit_handoff_on_uneven_scored_episodes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Uneven EPISODES, not uneven scenario presence: `pricey` keeps episode 0 of every scenario and
+    # loses episodes 1 and 2, so both candidates cover BOTH scenarios and a presence-only gate sees
+    # nothing wrong. What differs is the scored episode COUNT per (candidate, scenario), which is
+    # exactly what the fitters weigh: `fit_rank_policy` averages every surviving episode into its
+    # cluster mean (so a scenario counts three times as much for `cheap` as for `pricey`), and
+    # `_overall_best` / `best_single_on_fit` pick the default and knn fallback off the same
+    # episode-weighted means. Which episodes happened to fail must not decide the policy.
+    seams = _patch_seams(monkeypatch, throttled_episodes={"pricey-1": (False, True, True)})
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "2", "--episodes", "3", "--yes")
+    assert result.exit_code == 1, result.output
+    # Every cell ran and the artifact is on disk: 2 candidates x 2 scenarios x 3 episodes.
+    matrix = OutcomeMatrix.load(out)
+    assert len(matrix.outcomes) == 12
+    assert len(seams.world_model.tasks) == 12
+    assert Counter(
+        (outcome.model, outcome.scenario_id) for outcome in matrix.outcomes if outcome.scored
+    ) == Counter(
+        {
+            ("cheap", _HELD_OUT_IDS[0]): 3,
+            ("cheap", _HELD_OUT_IDS[1]): 3,
+            ("pricey", _HELD_OUT_IDS[0]): 1,
+            ("pricey", _HELD_OUT_IDS[1]): 1,
+        }
+    )
+    # Presence is identical for both candidates, so nothing but the counts could have caught this.
+    scored_scenarios = {
+        name: {o.scenario_id for o in matrix.outcomes if o.scored and o.model == name}
+        for name in ("cheap", "pricey")
+    }
+    assert scored_scenarios["cheap"] == scored_scenarios["pricey"] == set(_HELD_OUT_IDS[:2])
+    flat = _flat(result.output)
+    assert _says(result.output, "DIFFERENT numbers of scored episodes")
+    # The table says WHICH candidate thinned WHICH scenario, and by how much.
+    assert "pricey24" in flat  # 2 scored cells, 4 unscored
+    assert _says(result.output, f"{_HELD_OUT_IDS[0]} 1/3")
+    assert _says(result.output, f"{_HELD_OUT_IDS[1]} 1/3")
+    # The handoff is withheld, so `sweep && fit` stops here, and the one opt-out is named.
+    assert "wmooptimizeroutefit" not in flat
+    assert "--allow-uneven-coverage" in flat
+
+
+def test_route_sweep_allow_uneven_coverage_also_covers_uneven_episodes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Same opt-out, same bias statement, for the episode-count case: an operator who knows one
+    # candidate was throttled through part of the sweep and wants the partial data anyway.
+    _patch_seams(monkeypatch, throttled_episodes={"pricey-1": (False, True, True)})
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(
+        tmp_path,
+        root,
+        "support",
+        "--scenarios",
+        "2",
+        "--episodes",
+        "3",
+        "--yes",
+        "--allow-uneven-coverage",
+    )
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    assert _says(result.output, "DIFFERENT numbers of scored episodes")
+    assert "biasaccepted" in flat
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
+
+
+def test_route_sweep_hands_off_when_every_candidate_lost_the_same_episodes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The negative control for the two tests above: EVERY candidate loses episodes 1 and 2 of every
+    # scenario, so the per-(candidate, scenario) counts are identical. That is still a comparison,
+    # like-for-like on one episode per scenario, so the handoff stands and only the counts show it.
+    _patch_seams(
+        monkeypatch,
+        throttled_episodes={"cheap-1": (False, True, True), "pricey-1": (False, True, True)},
+    )
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "2", "--episodes", "3", "--yes")
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    assert "cheap24-" in flat and "pricey24-" in flat  # 2 scored, 4 unscored, nothing thinner
+    assert "DIFFERENT" not in flat
     assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
 
 
@@ -1115,6 +1226,200 @@ def test_route_sweep_constructs_every_backend_before_it_spends(
     assert seams.systems == []
     assert seams.world_model.tasks == []
     assert not out.exists()
+
+
+def test_route_sweep_rejects_a_config_no_backend_could_use_before_it_spends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The STATIC half of the pre-flight. An azure entry with a deployment but no `api_version`
+    # loads (the load-time rule only covers `deployment`) and CONSTRUCTS (the provider's __init__
+    # just stores the config); only `_get_client` refuses without an api-version, and that runs
+    # inside this candidate's first call, after `cheap` has been paid for. Nothing about this needs
+    # an SDK or a credential, so it is knowable from the entry alone.
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "gpt-azure"\n'
+        'kind = "azure"\n'
+        'model = "gpt-5.5"\n'
+        'deployment = "gpt-5.5"\n'  # present, so this is not the load-time rule
+        'endpoint = "https://example.openai.azure.com"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    # Names the offending entry, its kind, and the field to add.
+    assert "'gpt-azure'" in flat and "kind=azure" in flat and "api_version" in flat
+    # Before the cost confirmation, and before any cell: the cost table never printed, no candidate
+    # was ever called, no episode was ever opened, and no matrix exists.
+    assert "USD(est)" not in flat
+    assert seams.systems == []
+    assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_builds_every_lazy_client_before_it_spends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The LAZY-CLIENT half of the pre-flight. Constructing an `OpenAIProvider` does not read its
+    # credential: `__init__` only stores the config, and `OpenAI()` (which REFUSES to construct
+    # without a resolvable key) is built inside the first call. So with OPENAI_API_KEY unset, a
+    # pre-flight that only constructs providers passes and the whole sweep then fails cell by cell.
+    # Both candidates are the real backend here; no request is made either way, because the SDK
+    # raises while building its own client.
+    seams = _patch_seams(monkeypatch, real_kinds=frozenset({ProviderKind.OPENAI}))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "2", "--yes")
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    # EVERY unusable candidate is named with its kind, not just the first one an operator would fix.
+    assert "'cheap'" in flat and "'pricey'" in flat and "kind=openai" in flat
+    assert "OPENAI_API_KEY" in flat  # the SDK's own advice survives into the message
+    assert "USD(est)" not in flat
+    assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_rejects_a_bedrock_candidate_whose_region_resolves_nowhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Bedrock is the backend whose client CANNOT be built in a pre-flight (boto3 resolves
+    # credentials by walking a chain that reaches the instance-metadata endpoint, and builds fine
+    # with no credentials anyway), so its region is resolved through boto3's own session instead:
+    # entry, then AWS_DEFAULT_REGION, then the active profile. Without that check, botocore's
+    # NoRegionError lands in this candidate's first cell. Every source is pointed at nothing here so
+    # the check has the same answer on any machine, and metadata lookups are disabled as a belt:
+    # this test may not touch the network.
+    seams = _patch_seams(monkeypatch, real_kinds=frozenset({ProviderKind.BEDROCK}))
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-aws-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-aws-credentials"))
+    for name in ("AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE"):
+        monkeypatch.delenv(name, raising=False)
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "opus-bedrock"\n'
+        'kind = "bedrock"\n'
+        'model = "us.anthropic.claude-opus-4-8"\n'  # no region anywhere
+        "input_per_mtok = 15.0\n"
+        "output_per_mtok = 75.0\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    assert "'opus-bedrock'" in flat and "kind=bedrock" in flat
+    assert "region" in flat and "AWS_DEFAULT_REGION" in flat  # what went wrong and what to do
+    assert "USD(est)" not in flat
+    assert seams.systems == []
+    assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_states_what_the_preflight_cannot_know_before_the_first_cell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two backends keep a residual gap because closing it needs a request (bedrock AWS credentials,
+    # tinker service reachability). A usable bedrock entry therefore passes the pre-flight and the
+    # sweep runs, and the command says which entry still carries which unknown rather than leaving
+    # an operator to find out mid-sweep. Faked provider construction: nothing is called for real.
+    seams = _patch_seams(monkeypatch)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")  # so the region check passes
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "opus-bedrock"\n'
+        'kind = "bedrock"\n'
+        'model = "us.anthropic.claude-opus-4-8"\n'
+        "input_per_mtok = 15.0\n"
+        "output_per_mtok = 75.0\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "1",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "opus-bedrock (kind=bedrock): AWS credentials")
+    assert _says(result.output, "the pre-flight makes no request")
+    assert seams.world_model.tasks == ["task tr-010"]  # the sweep did run
 
 
 def test_route_sweep_checks_the_out_path_before_it_spends(

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -1,18 +1,56 @@
-"""CLI tests for `wmo optimize route` (fit + report), driven via CliRunner."""
+"""CLI tests for `wmo optimize route` (sweep + fit + tune + report), driven via CliRunner.
+
+The `sweep` tests stub two seams and nothing else: the world model (a `WorldModel`-shaped fake,
+so `WorldModelEnv` is the real one) and the pool's provider construction (scripted candidate
+replies). Everything between them is production code: the split reconstruction, scenario
+extraction, `evaluate_pool`, the cost table, and the matrix artifact. No network, no spend.
+"""
 
 from __future__ import annotations
 
+import importlib
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import cast
 
-from typer.testing import CliRunner
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner, Result
 
 from wmo.cli.app import app
+from wmo.config import HarnessConfig, save_config
+from wmo.core.types import (
+    Action,
+    ActionKind,
+    EnvState,
+    Observation,
+    Session,
+    Step,
+    Trace,
+)
+from wmo.engine.world_model import WorldModel
+from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import KNN_BANK_FILENAME, POLICY_FILENAME, RoutingPolicy
+from wmo.optimize.reward import EpisodeScore
 from wmo.optimize.routing import evaluate_policy
-from wmo.providers.base import ProviderKind
+from wmo.providers.base import (
+    Completion,
+    Message,
+    Provider,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+    VerifyResult,
+)
 from wmo.providers.pool import PoolEntry
+from wmo.providers.registry import get_provider as registry_get_provider
+from wmo.serving.traces_source import TRACES_FILENAME
+from wmo.tracking import RunRecord
+
+route_module = importlib.import_module("wmo.cli.route_app")
 
 runner = CliRunner()
 
@@ -317,3 +355,854 @@ def test_route_tune_rejects_a_dial_outside_the_range(tmp_path: Path) -> None:
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "2"]
     )
     assert result.exit_code != 0
+
+
+# -- `wmo optimize route sweep` --------------------------------------------------------------
+
+# Trace ids whose stable hash lands in the held-out band of the default 0.8 / 0.1 / 0.1 split
+# (see `wmo.engine.build.split_traces_3way`); the other 26 ids of `_corpus` land in train/val.
+_HELD_OUT_IDS = ("tr-010", "tr-018", "tr-020", "tr-027")
+
+# Tool name that appears ONLY on held-out traces, so an assertion on the tools hint can tell the
+# TRAIN band from the held-out one instead of passing either way.
+_HELD_OUT_TOOL = "holdout_only"
+
+
+def _corpus(count: int = 30) -> list[Trace]:
+    """A trace corpus whose split has a real held-out band, one task prompt per trace.
+
+    Emitted in DESCENDING id order on purpose: the sweep sorts the held-out band by trace id
+    before applying `--scenarios`, and a corpus already in id order would make that sort
+    unobservable (any assertion on which prefix was cut would hold without it).
+    """
+    traces: list[Trace] = []
+    for index in reversed(range(count)):
+        trace_id = f"tr-{index:03d}"
+        # Held-out traces call a tool no train trace does, so a tools hint derived from the wrong
+        # band is visible in the candidate's system prompt.
+        tool = _HELD_OUT_TOOL if trace_id in _HELD_OUT_IDS else "ls"
+        traces.append(
+            Trace(
+                trace_id=trace_id,
+                steps=[
+                    Step(
+                        action=Action(
+                            kind=ActionKind.TOOL_CALL, name=tool, arguments={"path": "."}
+                        ),
+                        observation=Observation(content="a.txt"),
+                        task=f"task {trace_id}",
+                    ),
+                    Step(
+                        action=Action(kind=ActionKind.MESSAGE, content="done"),
+                        observation=Observation(content="ok"),
+                        task=f"task {trace_id}",
+                    ),
+                ],
+            )
+        )
+    return traces
+
+
+def _project(tmp_path: Path, *, traces: list[Trace] | None, train_split: float = 0.8) -> Path:
+    """Write a minimal built-model artifact (config + its own corpus) and return the root."""
+    root = tmp_path / ".wmo"
+    model_dir = root / "models" / "support"
+    save_config(
+        HarnessConfig(
+            providers=[ProviderConfig(kind=ProviderKind.ANTHROPIC, model="fake-serve")],
+            serve_provider=ProviderKind.ANTHROPIC,
+            train_split=train_split,
+        ),
+        model_dir,
+    )
+    if traces is not None:
+        write_traces_jsonl(traces, model_dir / TRACES_FILENAME)
+    return root
+
+
+def _pool_file(tmp_path: Path) -> Path:
+    """Two priced candidates: 1/2 and 10/20 USD per Mtok, so cost lines are distinguishable."""
+    path = tmp_path / "pool.toml"
+    path.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "pricey"\n'
+        'kind = "openai"\n'
+        'model = "pricey-1"\n'
+        "input_per_mtok = 10.0\n"
+        "output_per_mtok = 20.0\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class _FakeWorldModel:
+    """`WorldModel`-shaped stub: in-memory sessions, a canned episode score, no LLM at all."""
+
+    def __init__(self, reward: float = 0.75, judge_fails_on: frozenset[str] = frozenset()) -> None:
+        self._reward = reward
+        self._frozen = False
+        # Tasks whose judge call raises, for every candidate: a scenario the whole pool loses.
+        self._judge_fails_on = judge_fails_on
+        self._task_of: dict[str, str | None] = {}
+        self.tasks: list[str | None] = []
+        self.scored: list[str] = []
+        self.opened_frozen: list[bool] = []  # was index enrichment suspended for this episode?
+
+    @contextmanager
+    def frozen(self) -> Iterator[_FakeWorldModel]:
+        self._frozen = True
+        try:
+            yield self
+        finally:
+            self._frozen = False
+
+    def new_session(
+        self, task: str | None = None, seed_state: EnvState | None = None, *, enrich: bool = True
+    ) -> Session:
+        self.tasks.append(task)
+        self.opened_frozen.append(self._frozen)
+        session = Session(id=f"s{len(self.tasks)}", task=task, enrich=enrich)
+        self._task_of[session.id] = task
+        return session
+
+    def step(self, session_id: str, action: Action) -> Observation:
+        return Observation(content="ok")
+
+    def score_session(self, session_id: str) -> EpisodeScore:
+        task = self._task_of.get(session_id)
+        if task is not None and task in self._judge_fails_on:
+            # WorldModelEnv.close preserves this and `last_score` re-raises it, which is how a
+            # throttled judge leaves a cell unscored for every candidate that ran the scenario.
+            raise RuntimeError("judge throttled (429)")
+        self.scored.append(session_id)
+        return EpisodeScore(reward=self._reward, success=True, critique="fine")
+
+    def end_session(self, session_id: str) -> RunRecord:
+        return RunRecord(run_id=session_id, kind="serve")
+
+    def session_usage(self, session_id: str) -> RunRecord:
+        return RunRecord(run_id=session_id, kind="serve")
+
+
+class _ScriptedCandidate:
+    """A candidate model that calls one tool and then declares itself done.
+
+    `throttled` makes every completion raise instead, the way a rate-limited candidate does: the
+    episode errors, `run_episode` records it, and the cell comes back unscored.
+    """
+
+    def __init__(
+        self, config: ProviderConfig, systems: list[str], *, throttled: bool = False
+    ) -> None:
+        self.config = config
+        self._systems = systems
+        self._throttled = throttled
+        self._script = ['{"tool": "ls", "arguments": {}}', '{"done": true, "summary": "ok"}']
+        self._index = 0
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self._systems.append(system)
+        if self._throttled:
+            raise RuntimeError("rate limit exceeded (429)")
+        text = self._script[min(self._index, len(self._script) - 1)]
+        self._index += 1
+        return Completion(text=text, usage=TokenUsage(input_tokens=10, output_tokens=5))
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+class _Answer:
+    """A `rich.prompt.Confirm` stand-in that always answers the same way."""
+
+    def __init__(self, answer: bool) -> None:
+        self._answer = answer
+
+    def ask(self, prompt: str, *, default: bool = True) -> bool:
+        return self._answer
+
+
+class _Seams:
+    """What the sweep's two stubbed seams recorded, for post-run assertions."""
+
+    def __init__(self, world_model: _FakeWorldModel) -> None:
+        self.world_model = world_model
+        self.built_providers: list[str] = []  # one entry per candidate provider constructed
+        self.systems: list[str] = []  # every system prompt a candidate was called with
+
+
+def _patch_seams(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    reward: float = 0.75,
+    no_scoring: bool = False,
+    throttled_models: frozenset[str] = frozenset(),
+    judge_fails_on: frozenset[str] = frozenset(),
+    real_kinds: frozenset[ProviderKind] = frozenset(),
+) -> _Seams:
+    """Stub the world model and the pool's provider construction; return the recorder.
+
+    Args:
+        monkeypatch: The patcher whose lifetime the stubs live for.
+        reward: Reward the fake judge returns for every scored episode.
+        no_scoring: Build the env WITHOUT `score_on_close`, which is what the pre-change code path
+            would amount to: it exists so a test can show the difference is observable.
+        throttled_models: Provider model ids (`PoolEntry.model`) whose completions raise, so that
+            candidate's cells come back unscored while the others are scored.
+        judge_fails_on: Scenario tasks whose episode SCORING raises, for every candidate: the
+            whole pool loses those scenarios together.
+        real_kinds: Provider kinds to construct for real instead of faking, so a test can exercise
+            a backend that refuses its own config. Construction is side-effect free, and no real
+            provider is ever called (the sweep must fail before any cell runs).
+    """
+    seams = _Seams(_FakeWorldModel(reward=reward, judge_fails_on=judge_fails_on))
+
+    def _load(model_dir: Path) -> tuple[WorldModel, Provider]:
+        provider = _ScriptedCandidate(
+            ProviderConfig(kind=ProviderKind.ANTHROPIC, model="fake-serve"), []
+        )
+        return cast("WorldModel", seams.world_model), cast("Provider", provider)
+
+    def _get_provider(config: ProviderConfig, api_key: str | None = None) -> Provider:
+        if config.kind in real_kinds:
+            return registry_get_provider(config, api_key=api_key)
+        seams.built_providers.append(config.model)
+        return cast(
+            "Provider",
+            _ScriptedCandidate(config, seams.systems, throttled=config.model in throttled_models),
+        )
+
+    monkeypatch.setattr(route_module, "load_world_model", _load)
+    monkeypatch.setattr("wmo.providers.pool.get_provider", _get_provider)
+    if no_scoring:
+        real = route_module.WorldModelEnv
+        monkeypatch.setattr(
+            route_module,
+            "WorldModelEnv",
+            lambda world_model, *, score_on_close=False: real(world_model),
+        )
+    return seams
+
+
+def _sweep(tmp_path: Path, root: Path, *extra: str) -> tuple[Path, Result]:
+    """Invoke `wmo optimize route sweep` against the temp project; return (out path, result)."""
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "--root",
+            str(root),
+            "--pool",
+            str(_pool_file(tmp_path)),
+            "--out",
+            str(out),
+            *extra,
+        ],
+    )
+    return out, result
+
+
+_FRAME_CHARS = frozenset("│┃╭╮╰╯─━┏┓┗┛┡┩┢┪╇╈├┤┬┴┼")
+
+
+def _flat(text: str) -> str:
+    """Text with whitespace and rich's box-drawing frame removed.
+
+    Typer renders a usage error inside a rich panel and the cost estimate inside a rich table,
+    both of which wrap (and frame) long values, so a literal substring check against the raw
+    output is a coin flip on where the wrap landed. Assert against this instead.
+    """
+    return "".join(ch for ch in text if not ch.isspace() and ch not in _FRAME_CHARS)
+
+
+def _says(result_output: str, phrase: str) -> bool:
+    """Whether the CLI said `phrase`, ignoring wherever rich wrapped the line."""
+    return _flat(phrase) in _flat(result_output)
+
+
+def test_route_sweep_writes_a_matrix_fit_can_consume(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "3", "--max-steps", "4", "--yes")
+    assert result.exit_code == 0, result.output
+
+    matrix = OutcomeMatrix.load(out)
+    # Leak-free AND deterministic: the first three held-out traces by id, never a train task.
+    assert matrix.scenario_ids() == list(_HELD_OUT_IDS[:3])
+    assert {o.task for o in matrix.outcomes} == {f"task {tid}" for tid in _HELD_OUT_IDS[:3]}
+    assert matrix.model_names() == ["cheap", "pricey"]
+    assert len(matrix.outcomes) == 6  # 2 candidates x 3 scenarios x 1 episode
+    assert all(o.reward == 0.75 for o in matrix.outcomes)
+    assert matrix.mean_reward("cheap") == 0.75
+    # The candidates saw the corpus's tool surface, summarized from the TRAIN split only: the
+    # held-out band's own tool never reaches them (deriving the hint from the measured band would
+    # leak, and would make the hint depend on where `--scenarios` cut).
+    assert seams.systems
+    assert all("ls(path)" in system for system in seams.systems)
+    assert not any(_HELD_OUT_TOOL in system for system in seams.systems)
+    # Progress streamed per cell, and the printed handoff chains the workflow.
+    assert "[1/6]" in result.output and "[6/6]" in result.output
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
+    # Per-candidate scored counts print even on a clean sweep, so "3 of 3 each" is visible rather
+    # than inferred from a total that cannot distinguish 3+3 from 5+1.
+    assert _says(result.output, "Scored coverage per candidate")
+    assert _flat(result.output).count("cheap30-") == 1  # cheap: 3 scored, 0 unscored, none lost
+
+    # The whole point of the matrix: `fit` consumes it without further preparation.
+    policy_file = tmp_path / "policy.json"
+    fitted = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(out),
+            "--out",
+            str(policy_file),
+            "--clusters",
+            "2",
+            "--top-k-clusters",
+            "1",
+        ],
+    )
+    assert fitted.exit_code == 0, fitted.output
+    assert RoutingPolicy.load(policy_file).kind == "rank"
+
+
+def test_route_sweep_scores_every_episode_through_a_scoring_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `WorldModelEnv(..., score_on_close=True)` is the contract `evaluate_pool` needs: the env
+    # must judge each episode as it closes, or no cell is evidence.
+    seams = _patch_seams(monkeypatch, reward=0.5)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "2", "--yes")
+    assert result.exit_code == 0, result.output
+    matrix = OutcomeMatrix.load(out)
+    assert len(seams.world_model.scored) == len(matrix.outcomes) == 4
+    assert all(o.scored and o.error is None and o.success for o in matrix.outcomes)
+    assert [o.reward for o in matrix.outcomes] == [0.5] * 4
+    # Every episode ran with index enrichment suspended, so no candidate's predictions can
+    # become the next candidate's retrieved demos (which would make scores sweep-order dependent).
+    assert seams.world_model.opened_frozen == [True] * 4
+
+
+def test_route_sweep_without_a_scoring_env_produces_no_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The negative control for the test above: drop `score_on_close` and every cell comes back
+    # unscored, so the failure the assertion catches is a real behavioral difference.
+    seams = _patch_seams(monkeypatch, no_scoring=True)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "2", "--yes")
+    # A sweep that scored nothing exits NON-ZERO, so `sweep && fit` in a script stops instead of
+    # fitting on a matrix the command itself says is not evidence.
+    assert result.exit_code == 1, result.output
+    assert seams.world_model.scored == []
+    # ... and the paid rows are still on disk, carrying the `error` that explains them.
+    matrix = OutcomeMatrix.load(out)
+    assert all(not o.scored for o in matrix.outcomes)
+    assert _says(result.output, "no cell was scored")
+
+
+def test_route_sweep_withholds_the_fit_handoff_on_uneven_scored_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `pricey` is throttled on every call, so its episodes error and its cells go UNSCORED while
+    # `cheap` is scored on all three scenarios. Both fitters SKIP unscored rows, so ranking these
+    # two against each other would compare 3 scenarios of cheap with 0 of pricey.
+    seams = _patch_seams(monkeypatch, throttled_models=frozenset({"pricey-1"}))
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert result.exit_code == 1, result.output
+    # The artifact is still written: those cells were paid for, and their `error` is the diagnosis.
+    matrix = OutcomeMatrix.load(out)
+    assert [o.scored for o in matrix.outcomes if o.model == "cheap"] == [True] * 3
+    assert [o.scored for o in matrix.outcomes if o.model == "pricey"] == [False] * 3
+    assert all("429" in (o.error or "") for o in matrix.outcomes if o.model == "pricey")
+    flat = _flat(result.output)
+    # The user can see WHICH candidate lost WHICH scenarios, not just a total.
+    assert _says(result.output, "Scored coverage per candidate")
+    assert _says(result.output, ", ".join(_HELD_OUT_IDS[:3]))
+    assert "DIFFERENTscenarios" in flat and "cheap3,pricey0" in flat
+    # The handoff is withheld, so `sweep && fit` in a script stops instead of fitting on it, and
+    # the message names the one flag that proceeds anyway.
+    assert "wmooptimizeroutefit" not in flat
+    assert "--allow-uneven-coverage" in flat
+    # A real sweep, not an aborted one: every cell ran (the cells are the paid evidence).
+    assert len(seams.world_model.tasks) == 6
+
+
+def test_route_sweep_allow_uneven_coverage_hands_off_and_still_states_the_bias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The opt-out for an operator who knows a candidate's backend was down all sweep and wants the
+    # partial data anyway: same coverage table, same warning, but the handoff stands.
+    _patch_seams(monkeypatch, throttled_models=frozenset({"pricey-1"}))
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(
+        tmp_path, root, "support", "--scenarios", "3", "--yes", "--allow-uneven-coverage"
+    )
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    assert "DIFFERENTscenarios" in flat and "biasaccepted" in flat
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
+
+
+def test_route_sweep_hands_off_when_every_candidate_lost_the_same_scenario(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The judge throttles on ONE scenario, so every candidate loses that scenario and none of the
+    # others. Coverage stays like-for-like on what is left, which IS a comparison: the handoff
+    # stands, and the counts still show the loss.
+    lost = f"task {_HELD_OUT_IDS[1]}"
+    _patch_seams(monkeypatch, judge_fails_on=frozenset({lost}))
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert result.exit_code == 0, result.output
+    matrix = OutcomeMatrix.load(out)
+    unscored = [o for o in matrix.outcomes if not o.scored]
+    assert {o.model for o in unscored} == {"cheap", "pricey"}
+    assert {o.scenario_id for o in unscored} == {_HELD_OUT_IDS[1]}
+    flat = _flat(result.output)
+    assert f"cheap21{_HELD_OUT_IDS[1]}" in flat  # 2 scored, 1 unscored, and which one it lost
+    assert "DIFFERENTscenarios" not in flat
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")
+
+
+def test_route_sweep_declining_the_confirmation_spends_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    monkeypatch.setattr(route_module, "_console", Console(force_terminal=True))
+    monkeypatch.setattr(route_module, "Confirm", _Answer(False))
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "3")
+    assert result.exit_code == 0, result.output
+    assert not out.exists()  # nothing written
+    # The pre-flight DID construct both candidates (that is how an unusable backend becomes a usage
+    # error before the cost question), but construction is side-effect free: what proves nothing
+    # was spent is that no candidate was ever CALLED and no episode ever opened.
+    assert seams.built_providers == ["cheap-1", "pricey-1"]
+    assert seams.systems == []
+    assert seams.world_model.tasks == []
+
+
+def test_route_sweep_confirming_at_a_tty_runs_the_sweep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    monkeypatch.setattr(route_module, "_console", Console(force_terminal=True))
+    monkeypatch.setattr(route_module, "Confirm", _Answer(True))
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "1")
+    assert result.exit_code == 0, result.output
+    assert len(OutcomeMatrix.load(out).outcomes) == 2
+    # Both candidates constructed twice: once by the pre-flight (before the cost question) and
+    # once per cell by `evaluate_pool`, which still owns per-cell provider state.
+    assert seams.built_providers == ["cheap-1", "pricey-1", "cheap-1", "pricey-1"]
+
+
+def test_route_sweep_non_interactive_without_yes_says_it_could_not_ask(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No TTY to prompt at and no --yes: every pool entry is priced, so the spend is accountable
+    # and the run proceeds (the distill CLI's rule), but the log has to say that out loud.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "support", "--scenarios", "1")
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "non-interactive session: proceeding without confirmation")
+    assert len(OutcomeMatrix.load(out).outcomes) == 2
+
+
+def test_route_sweep_cost_estimate_states_its_assumption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    _out, result = _sweep(
+        tmp_path,
+        root,
+        "support",
+        "--scenarios",
+        "3",
+        "--max-steps",
+        "20",
+        "--assume-input-tokens",
+        "2000",
+        "--assume-output-tokens",
+        "250",
+        "--yes",
+    )
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    # 3 scenarios x 1 episode x 20 calls = 60 calls; cheap = 60 x (2000x1 + 250x2)/1e6 = $0.15,
+    # pricey = 10x that, so the projected total is $1.65.
+    assert "0.15" in flat and "1.50" in flat and "1.65" in flat
+    assert "ASSUMED" in flat and "ASSUMPTION" in flat
+    # The world model's own meter is excluded, and the table says so in plain words (no internal
+    # decision id: "D12" means nothing to an operator reading a cost table).
+    assert _says(result.output, "meteredseparatelyandareNOTinthisfigure")
+    assert "D12" not in flat
+    # ... and the measured spend is reported separately from the projection.
+    assert "measuredcandidatespend" in flat
+
+
+def test_route_sweep_rejects_a_missing_pool_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(tmp_path / "nope.toml"),
+            "--out",
+            str(out),
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "nope.toml" in flat  # names the file it wanted
+    assert "[[model]]" in flat and "input_per_mtok" in flat  # and how to write one
+    assert not out.exists()
+
+
+def test_route_sweep_rejects_a_missing_trace_corpus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=None)  # a built model whose corpus was never kept
+    out, result = _sweep(tmp_path, root, "support", "--yes")
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "notracecorpus" in flat
+    assert flat.count(TRACES_FILENAME) >= 2  # both places it looked, so the fix is obvious
+    assert not out.exists()
+
+
+def test_route_sweep_rejects_an_unbuilt_world_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(tmp_path, root, "ghost", "--yes")
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "ghost" in flat and "wmobuild" in flat  # names the model and the command that fixes it
+    assert not out.exists()
+
+
+def test_route_sweep_says_when_a_tiny_corpus_is_not_leak_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Three train-band traces: the split leaves no held-out band, so the sweep falls back to the
+    # whole corpus the way `wmo eval` does and must say the scenarios are not leak-free.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus(3))
+    out, result = _sweep(tmp_path, root, "--scenarios", "2", "--yes")  # default model resolution
+    assert result.exit_code == 0, result.output
+    assert "notleak-free" in _flat(result.output)
+    # Deterministic even here: the corpus is written newest-id-first, and `--scenarios` still cuts
+    # the same by-trace-id prefix.
+    assert OutcomeMatrix.load(out).scenario_ids() == ["tr-000", "tr-001"]
+
+
+def test_route_sweep_takes_the_corpus_from_traces_for_a_locally_built_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `wmo build` keeps prompts, metrics and the index but NOT the corpus it read, so a model
+    # built the canonical way has no sibling traces file. `--traces` is the only thing that makes
+    # the documented call site work on such a project.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=None)  # built the canonical way: no corpus kept
+    corpus_file = tmp_path / "elsewhere" / "traces.otel.jsonl"
+    write_traces_jsonl(_corpus(), corpus_file)
+    out, result = _sweep(
+        tmp_path, root, "support", "--traces", str(corpus_file), "--scenarios", "2", "--yes"
+    )
+    assert result.exit_code == 0, result.output
+    assert OutcomeMatrix.load(out).scenario_ids() == list(_HELD_OUT_IDS[:2])
+
+
+def test_route_sweep_rejects_a_traces_file_that_is_not_there(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=None)
+    out, result = _sweep(
+        tmp_path, root, "support", "--traces", str(tmp_path / "gone.jsonl"), "--yes"
+    )
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "gone.jsonl" in flat and "--traces" in flat
+    assert not out.exists()
+
+
+def test_route_sweep_names_the_positional_when_the_model_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `WorldModelStore.resolve` says "pass --name", the option `wmo serve`/`play`/`demo` carry.
+    # This command takes the model positionally, so following that advice fails; the message has
+    # to name what a user of THIS command types.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    _project(tmp_path, traces=_corpus())  # same root
+    save_config(
+        HarnessConfig(
+            providers=[ProviderConfig(kind=ProviderKind.ANTHROPIC, model="fake-serve")],
+            serve_provider=ProviderKind.ANTHROPIC,
+        ),
+        root / "models" / "other",
+    )
+    out, result = _sweep(tmp_path, root, "--yes")  # no MODEL, two models built
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "MODEL" in flat and "other,support" in flat
+    assert "--name" not in flat
+    assert "wmooptimizeroutesweepother" in flat  # a command that actually works
+    assert not out.exists()
+
+
+def test_route_sweep_checks_candidate_credentials_before_it_spends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `pool_provider` reads `api_key_env` per cell, so an unset variable on the SECOND candidate
+    # used to abort mid-sweep with a raw ValueError after the first was fully paid for.
+    seams = _patch_seams(monkeypatch)
+    monkeypatch.delenv("WMO_TEST_MISSING_KEY", raising=False)
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "pricey"\n'
+        'kind = "openai"\n'
+        'model = "pricey-1"\n'
+        'api_key_env = "WMO_TEST_MISSING_KEY"\n'
+        "input_per_mtok = 10.0\n"
+        "output_per_mtok = 20.0\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    assert "WMO_TEST_MISSING_KEY" in flat and "pricey" in flat
+    # Nothing was paid for: the check runs before the cost table, so no candidate was ever called
+    # and no episode ever opened. (The pre-flight does construct the candidates it can, which is
+    # free; `cheap` resolves, `pricey` never gets that far.)
+    assert seams.built_providers == ["cheap-1"]
+    assert seams.systems == []
+    assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_constructs_every_backend_before_it_spends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A credential check is not an availability check. `TinkerChatProvider` REFUSES an explicit
+    # api_key (it authenticates through the shared service client), and nothing rejects that
+    # combination at load, so the failure used to land at this candidate's FIRST CELL: after
+    # `cheap` had run every scenario and been paid for, as a raw traceback, with no matrix.
+    # `real_kinds` builds the real tinker backend here; `cheap` stays faked, and no candidate is
+    # ever called, so the test makes no network request either way.
+    seams = _patch_seams(monkeypatch, real_kinds=frozenset({ProviderKind.TINKER}))
+    monkeypatch.setenv("WMO_TEST_TINKER_KEY", "sk-present")
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "student"\n'
+        'kind = "tinker"\n'
+        'model = "Qwen/Qwen3-8B"\n'
+        'api_key_env = "WMO_TEST_TINKER_KEY"\n'  # set, so this is NOT a credential failure
+        "input_per_mtok = 0.1\n"
+        "output_per_mtok = 0.2\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    # Names the offending entry AND its kind, so the pool file is editable from the message, plus
+    # what to do about it (the backend's own advice: drop api_key_env, export TINKER_API_KEY).
+    assert "'student'" in flat and "kind=tinker" in flat
+    assert "TINKER_API_KEY" in flat and "dropapi_key_env" in flat
+    # Not one cell was paid for: the cost table never printed and no episode ever opened.
+    assert "USD(est)" not in flat
+    assert seams.systems == []
+    assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_checks_the_out_path_before_it_spends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `OutcomeMatrix.save` mkdirs the parent at the END of the sweep, so a parent component that
+    # is a regular file used to discard every cell already paid for with a bare OS error.
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a regular file, not a directory", encoding="utf-8")
+    out = blocker / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(_pool_file(tmp_path)),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    assert _says(result.output, "cannot write the outcome matrix")
+    assert seams.world_model.tasks == []  # no episode ever opened
+    # The check is pure: an --out it refuses is not half-created on the way out.
+    assert blocker.is_file() and not out.exists()
+
+
+def test_route_sweep_prints_names_and_paths_rich_cannot_swallow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Pool names are free-form operator strings and --out is a path: both reach a rich console,
+    # where `[a]` is markup. Unescaped, the cost table showed two candidates as one name and the
+    # handoff line printed a path that does not exist.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "gpt[a]"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "gpt[/bold]"\n'
+        'kind = "openai"\n'
+        'model = "pricey-1"\n'
+        "input_per_mtok = 10.0\n"
+        "output_per_mtok = 20.0\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "[run1]" / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "1",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    flat = _flat(result.output)
+    # Both candidates are distinguishable in the table the operator confirms spend from, and the
+    # closing-tag name no longer aborts the command before any episode runs.
+    assert "gpt[a]" in flat and "gpt[/bold]" in flat
+    # The printed path is the path the matrix is actually at, so it can be copied.
+    assert out.is_file()
+    assert _says(result.output, str(out))
+    assert _says(result.output, f"wmo optimize route fit {out} --kind knn")

--- a/wmo/distill/config_test.py
+++ b/wmo/distill/config_test.py
@@ -926,8 +926,6 @@ def _checked_in_config(name: str) -> DistillConfig:
     return load_distill_config(Path(__file__).parent / "configs" / name)
 
 
-
-
 def test_training_turn_cap_defaults_to_the_rollout_cap(tmp_path: Path) -> None:
     """Unset means one cap everywhere, which is the pre-existing behaviour."""
     cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))

--- a/wmo/engine/__init__.py
+++ b/wmo/engine/__init__.py
@@ -3,7 +3,7 @@
 Evaluation of a built world model (open-loop replay fidelity + closed-loop task success) lives in
 `wmo.evals`."""
 
-from wmo.engine.build import build, ingest, split_traces, split_traces_3way
+from wmo.engine.build import build, ingest, split_holdout, split_traces, split_traces_3way
 from wmo.engine.demo import DemoReplay, DemoStep, run_demo
 from wmo.engine.loader import load_world_model
 from wmo.engine.play import PlayTurn, parse_action, play_turn
@@ -13,6 +13,7 @@ from wmo.engine.world_model import WorldModel
 __all__ = [
     "build",
     "ingest",
+    "split_holdout",
     "split_traces",
     "split_traces_3way",
     "DemoReplay",

--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -101,6 +101,28 @@ def split_traces_3way(
     return train, val, test
 
 
+def split_holdout(
+    traces: list[Trace], train_frac: float, val_frac: float | None = None
+) -> tuple[list[Trace], list[Trace], bool]:
+    """Split into (train, the band a measurement may score, tiny-corpus fallback flag).
+
+    One owner for the "cut the corpus, then fall back to everything when it is too small" idiom
+    every measurement path needs (`wmo eval`, the eval grid, `wmo optimize route sweep`).
+
+    A positive `val_frac` cuts 3-way on the build's hash line and returns the reserved TEST band,
+    the one prompt selection never saw; `None` or `0` keeps the plain 2-way split. A corpus too
+    small to leave a held-out band falls back to the WHOLE corpus on both sides and the third
+    element is True, because those scores are NOT leak-free and a caller may need to say so.
+    """
+    if val_frac:
+        train, _val, holdout = split_traces_3way(traces, train_frac, val_frac)
+    else:
+        train, holdout = split_traces(traces, train_frac)
+    if not holdout:
+        return traces, traces, True
+    return train, holdout, False
+
+
 def build(
     config: HarnessConfig,
     *,

--- a/wmo/engine/build_test.py
+++ b/wmo/engine/build_test.py
@@ -8,7 +8,7 @@ import pytest
 
 from wmo.config import ArtifactPaths, HarnessConfig
 from wmo.core.types import Action, ActionKind, Observation, Step, Trace
-from wmo.engine.build import build, split_traces, split_traces_3way
+from wmo.engine.build import build, split_holdout, split_traces, split_traces_3way
 from wmo.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmo.retrieval import HashingEmbedder
 
@@ -96,6 +96,40 @@ def test_split_traces_3way_rejects_degenerate_fractions() -> None:
         split_traces_3way(traces, 0.7, 0.4)  # sums to > 1 -> empty test
     with pytest.raises(ValueError, match="train_frac"):
         split_traces_3way(traces, 0.0, 0.5)
+
+
+def test_split_holdout_returns_the_test_band_of_the_3way_cut() -> None:
+    # The one owner of "the band a measurement may score on": with a positive val band it is the
+    # reserved TEST band, never the val band a prompt was selected on.
+    traces = [Trace(trace_id=f"t{i}") for i in range(60)]
+    train, holdout, tiny_corpus = split_holdout(traces, 0.6, 0.2)
+    three_train, three_val, three_test = split_traces_3way(traces, 0.6, 0.2)
+    ids = lambda ts: {t.trace_id for t in ts}  # noqa: E731
+    assert ids(train) == ids(three_train)
+    assert ids(holdout) == ids(three_test)
+    assert not ids(holdout) & ids(three_val)
+    assert tiny_corpus is False
+
+
+def test_split_holdout_without_a_val_band_is_the_plain_2way_split() -> None:
+    traces = [Trace(trace_id=f"t{i}") for i in range(60)]
+    two_train, two_test = split_traces(traces, 0.6)
+    ids = lambda ts: {t.trace_id for t in ts}  # noqa: E731
+    for val_frac in (None, 0.0):
+        train, holdout, tiny_corpus = split_holdout(traces, 0.6, val_frac)
+        assert ids(train) == ids(two_train)
+        assert ids(holdout) == ids(two_test)
+        assert tiny_corpus is False
+
+
+def test_split_holdout_falls_back_to_the_whole_corpus_and_says_so() -> None:
+    # A corpus too small to leave a held-out band scores everything (the established `wmo eval`
+    # behavior), and the flag lets a caller warn that those scores are not leak-free.
+    traces = [Trace(trace_id="t2"), Trace(trace_id="t4")]  # both hash into the train band
+    assert split_traces_3way(traces, 0.8, 0.1)[2] == []  # so the 3-way cut leaves no test band
+    train, holdout, tiny_corpus = split_holdout(traces, 0.8, 0.1)
+    assert tiny_corpus is True
+    assert train is traces and holdout is traces
 
 
 def test_cap_gepa_valset_bounds_steps_and_keeps_at_least_one_trace() -> None:

--- a/wmo/evals/grid.py
+++ b/wmo/evals/grid.py
@@ -295,7 +295,7 @@ def run_grid(
     """
     from pathlib import Path
 
-    from wmo.engine.build import split_traces, split_traces_3way
+    from wmo.engine.build import split_holdout
     from wmo.ingest import get_adapter
 
     if val_frac is None:
@@ -326,11 +326,9 @@ def run_grid(
     adapter = get_adapter("otel-genai")
     for path in paths:
         traces = adapter.from_file(str(path))
-        if use_3way:
-            _, _, holdout = split_traces_3way(traces, train_split, val_frac)
-        else:
-            _, holdout = split_traces(traces, train_split)
-        holdout = holdout or traces
+        # `val_frac` is 0.0 exactly when the 3-way cut was not usable, which is the 2-way branch
+        # of `split_holdout`; a corpus with no held-out band scores everything.
+        _train, holdout, _tiny_corpus = split_holdout(traces, train_split, val_frac)
         if max_holdout_traces is not None:
             holdout = holdout[:max_holdout_traces]
         result.total_test_traces += len(holdout)

--- a/wmo/evals/open_loop.py
+++ b/wmo/evals/open_loop.py
@@ -15,7 +15,7 @@ from statistics import fmean, pstdev
 
 from pydantic import BaseModel, Field
 
-from wmo.engine.build import split_traces, split_traces_3way
+from wmo.engine.build import split_holdout
 from wmo.engine.knowledge import seeded_knowledge_text
 from wmo.engine.replay import ReplayReport, replay, valid_scores
 from wmo.ingest import get_adapter
@@ -98,12 +98,9 @@ def evaluate_files(
         traces = adapter.from_file(str(path))
         if not traces:
             continue
-        if val_frac:  # truthy (a positive val band); None or 0.0 keeps the plain 2-way split
-            train, _val, holdout = split_traces_3way(traces, train_split, val_frac)
-        else:
-            train, holdout = split_traces(traces, train_split)
-        if not holdout:  # tiny corpus: evaluate on everything
-            train, holdout = traces, traces
+        # 3-way when `val_frac` is a positive band, 2-way otherwise; a tiny corpus with no
+        # held-out trace falls back to scoring everything (see `split_holdout`).
+        train, holdout, _tiny_corpus = split_holdout(traces, train_split, val_frac)
         if max_holdout_traces is not None:
             holdout = sorted(holdout, key=lambda t: t.trace_id)[:max_holdout_traces]
         retriever = EmbeddingRetriever(embedder) if embedder is not None else None

--- a/wmo/providers/anthropic.py
+++ b/wmo/providers/anthropic.py
@@ -44,6 +44,25 @@ class AnthropicProvider:
                 self._client = Anthropic()  # picks up ANTHROPIC_API_KEY from the environment
         return self._client
 
+    def prepare(self) -> None:
+        """Build the SDK client and prove a credential resolved. No request is sent.
+
+        Satisfies `wmo.providers.base.PreparableProvider`. Building the client alone is not enough
+        here, unlike the OpenAI backends: `Anthropic()` accepts a missing key, leaves `api_key`
+        None, and fails only when it signs a request. So the check reads the credential the SDK
+        itself resolved (from `api_key`/`auth_token`, which it fills from ANTHROPIC_API_KEY /
+        ANTHROPIC_AUTH_TOKEN) rather than re-deriving the variable list here, where it would drift.
+
+        Raises:
+            ValueError: The SDK resolved no credential for this configuration.
+        """
+        client = self._get_client()
+        if client.api_key is None and client.auth_token is None:
+            raise ValueError(
+                "AnthropicProvider resolved no credential: export ANTHROPIC_API_KEY, or name the "
+                "variable holding it explicitly (a pool entry's `api_key_env` field)"
+            )
+
     def complete(
         self,
         system: str,

--- a/wmo/providers/azure_openai.py
+++ b/wmo/providers/azure_openai.py
@@ -145,6 +145,27 @@ class AzureOpenAIProvider:
             )
         return self._responses_client
 
+    def prepare(self) -> None:
+        """Resolve deployment, api_version, endpoint, and key by building this config's client.
+
+        Satisfies `wmo.providers.base.PreparableProvider`. Branches exactly like `verify`: a
+        `reasoning_effort` config dispatches through the Azure v1 Responses client, everything else
+        through the api-versioned chat client, so the thing that gets prepared is the thing the
+        request will use. All four failures are local, which is what makes this free: `_deployment`
+        rejects a config with no deployment name, `_get_client` rejects a missing api_version and a
+        missing endpoint before it reaches for the SDK, and `AzureOpenAI(...)` itself refuses to
+        construct without a resolvable key. No connection is opened.
+
+        Raises:
+            ValueError: The config is missing a deployment, an api_version, or an endpoint.
+            openai.OpenAIError: No key resolved for this endpoint.
+        """
+        self._deployment()
+        if self.config.reasoning_effort is not None:
+            self._get_responses_client()
+            return
+        self._get_client()
+
     def _deployment(self) -> str:
         # On Azure, the `model` arg to the API is the deployment name, not the base model id.
         if self.config.deployment is None:

--- a/wmo/providers/base.py
+++ b/wmo/providers/base.py
@@ -246,6 +246,31 @@ it rides `wire_payload()` to the runner untouched."""
 
 
 @runtime_checkable
+class PreparableProvider(Protocol):
+    """Provider capability for resolving a backend's prerequisites WITHOUT issuing a request.
+
+    Every backend builds its SDK client lazily on first use, so constructing a provider proves
+    almost nothing: a missing SDK extra, an unset credential, or an incomplete config still
+    surfaces at the first call. This capability exists for the one caller shape that cannot live
+    with that, code about to spend money on a whole roster of models (`wmo optimize route sweep`'s
+    pre-flight), where a backend that can never be called must be a usage error at the boundary
+    instead of a mid-run abort with the earlier candidates already paid for.
+
+    `prepare()` must stay free: it may import the SDK, read the environment and the local AWS/SDK
+    credential files, and build the client, and it must NOT touch the network, because a
+    pre-flight that bills a call cannot run before spend is authorized. A backend whose client
+    cannot be built without a request prepares the locally knowable part only and documents what
+    it deliberately leaves for the first call (see `wmo.providers.bedrock` and
+    `wmo.providers.tinker`). Kept separate from :class:`Provider` for that reason: not every
+    backend can honor the whole contract.
+    """
+
+    def prepare(self) -> None:
+        """Resolve every prerequisite knowable locally, or raise saying what is missing."""
+        ...
+
+
+@runtime_checkable
 class ContextWindowProvider(Protocol):
     """Provider capability for reporting the context window its model is actually served with.
 

--- a/wmo/providers/bedrock.py
+++ b/wmo/providers/bedrock.py
@@ -133,6 +133,42 @@ class BedrockProvider:
             )
         return self._client
 
+    def prepare(self) -> None:
+        """Resolve the region locally. Deliberately does NOT build the boto3 client.
+
+        Satisfies `wmo.providers.base.PreparableProvider` for the part that is free, and only that
+        part. Two measured reasons the client itself is not built here:
+
+        1. `boto3.client()` walks the credential chain, whose instance-metadata provider makes an
+           HTTP request to the link-local metadata endpoint when nothing local resolves (measured
+           2.11s on a machine with no AWS config, 0.03s with AWS_EC2_METADATA_DISABLED=true). A
+           pre-flight's whole job is to run before any request, so it may not pay that.
+        2. It would not even answer the question. With no credentials the client is built anyway
+           (`credentials=None`, measured) and raises `NoCredentialsError` only when it signs the
+           first request, so absent AWS credentials are NOT locally knowable and stay a first-call
+           failure.
+
+        The region is a different story: free to resolve and fatal when missing, because botocore
+        raises `NoRegionError` while creating a bedrock-runtime client with no region. It is
+        resolved through boto3's own session so this check cannot drift from what the client does
+        (`config.region` first, then AWS_DEFAULT_REGION, then the active profile's `region`; note
+        botocore's session config does NOT read AWS_REGION).
+
+        Raises:
+            ValueError: No region resolves for this configuration.
+        """
+        # Lazy for the same reason as `_get_client`: importing boto3 costs real time, and the
+        # registry constructs every backend on any `wmo` command.
+        import boto3
+
+        if self.config.region or boto3.Session().region_name:
+            return
+        raise ValueError(
+            "BedrockProvider has no region, and botocore refuses to build a bedrock-runtime "
+            "client without one: set the region on the entry/config, export AWS_DEFAULT_REGION, "
+            "or set `region` in the AWS profile this run uses"
+        )
+
     def complete(
         self,
         system: str,

--- a/wmo/providers/openai.py
+++ b/wmo/providers/openai.py
@@ -82,6 +82,19 @@ class OpenAIProvider:
                 self._client = OpenAI(timeout=240.0, max_retries=1)
         return self._client
 
+    def prepare(self) -> None:
+        """Import the SDK and build the client, which resolves the key. No request is sent.
+
+        Satisfies `wmo.providers.base.PreparableProvider`. Building the client is the whole check
+        here: `OpenAI()` refuses to construct when no key resolves ("Missing credentials. Please
+        pass an `api_key` ... or set the `OPENAI_API_KEY` ... environment variables"), and it opens
+        no connection, so the answer costs nothing. The cached client is the one later calls use.
+
+        Raises:
+            openai.OpenAIError: No key resolved for this configuration.
+        """
+        self._get_client()
+
     def complete(
         self,
         system: str,

--- a/wmo/providers/openai_responses.py
+++ b/wmo/providers/openai_responses.py
@@ -48,6 +48,18 @@ class OpenAIResponsesProvider:
                 self._client = OpenAI()  # picks up OPENAI_API_KEY from the environment
         return self._client
 
+    def prepare(self) -> None:
+        """Import the SDK and build the client, which resolves the key. No request is sent.
+
+        Satisfies `wmo.providers.base.PreparableProvider`, exactly as in `wmo.providers.openai`:
+        `OpenAI()` refuses to construct without a resolvable key and opens no connection, so this
+        turns a missing credential into a local failure instead of a first-call one.
+
+        Raises:
+            openai.OpenAIError: No key resolved for this configuration.
+        """
+        self._get_client()
+
     def complete(
         self,
         system: str,

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -78,6 +78,14 @@ class PoolEntry(BaseModel):
                 f"pool model '{self.name}': azure entries need `deployment` (the Azure "
                 "deployment name to call)"
             )
+        if self.kind is ProviderKind.BEDROCK and self.api_key_env is not None:
+            # Same boundary: `BedrockProvider.__init__` refuses an explicit key, and a sweep
+            # constructs providers lazily per cell, so this would abort mid-run after the
+            # candidates ahead of it had already been paid for.
+            raise ValueError(
+                f"pool model '{self.name}': bedrock authenticates with AWS credentials "
+                "(profile/role), not an API key; drop api_key_env from this entry"
+            )
         return self
 
     def price(self) -> ModelPrice:
@@ -171,15 +179,46 @@ def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
     return ModelPool.model_validate({"models": data.get("model", [])})
 
 
+def pool_api_key(entry: PoolEntry) -> str | None:
+    """One entry's own API key, read from its `api_key_env`; None means backend defaults.
+
+    Separate from `pool_provider` so a caller about to spend money on a WHOLE pool can resolve
+    every candidate's credentials up front (`wmo optimize route sweep` does, before its cost
+    confirmation) instead of discovering an unset variable at the first cell of a candidate it
+    already paid to reach. The lookup is local `os.environ`, so it costs nothing to run early.
+
+    Raises:
+        ValueError: `api_key_env` names a variable that is unset or empty.
+    """
+    if not entry.api_key_env:
+        return None
+    api_key = os.environ.get(entry.api_key_env)
+    if not api_key:
+        raise ValueError(
+            f"pool model '{entry.name}': environment variable {entry.api_key_env} is unset "
+            "or empty; export that account's API key or drop api_key_env to use the "
+            "backend's default credentials"
+        )
+    return api_key
+
+
 def pool_provider(entry: PoolEntry) -> Provider:
-    """Construct the provider for one pool entry, resolving its per-account API key."""
-    api_key: str | None = None
-    if entry.api_key_env:
-        api_key = os.environ.get(entry.api_key_env)
-        if not api_key:
-            raise ValueError(
-                f"pool model '{entry.name}': environment variable {entry.api_key_env} is unset "
-                "or empty; export that account's API key or drop api_key_env to use the "
-                "backend's default credentials"
-            )
-    return get_provider(entry.provider_config(), api_key=api_key)
+    """Construct the provider for one pool entry, resolving its per-account API key.
+
+    Construction is side-effect free for every backend (`wmo.providers.registry`): each one only
+    stores its config and defers the SDK import, the credential read, and the client to its first
+    request. That is what lets a caller about to spend money construct a whole pool up front as a
+    pre-flight (`wmo optimize route sweep` does) without issuing a single request.
+
+    A construction failure is re-raised naming the entry and its kind: a backend that refuses to
+    be built ("Bedrock authenticates with AWS credentials, not an API key") knows nothing about
+    the pool it came from, and the caller is usually looping over candidates.
+
+    Raises:
+        ValueError: The entry names an unset `api_key_env`, or its backend refuses this config.
+    """
+    api_key = pool_api_key(entry)
+    try:
+        return get_provider(entry.provider_config(), api_key=api_key)
+    except ValueError as exc:
+        raise ValueError(f"pool model '{entry.name}' (kind={entry.kind.value}): {exc}") from exc

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -26,7 +26,13 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from wmo.providers.base import Provider, ProviderConfig, ProviderKind, TokenUsage
+from wmo.providers.base import (
+    PreparableProvider,
+    Provider,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+)
 from wmo.providers.registry import get_provider
 from wmo.tracking.pricing import ModelPrice, price_for
 
@@ -207,8 +213,8 @@ def pool_provider(entry: PoolEntry) -> Provider:
 
     Construction is side-effect free for every backend (`wmo.providers.registry`): each one only
     stores its config and defers the SDK import, the credential read, and the client to its first
-    request. That is what lets a caller about to spend money construct a whole pool up front as a
-    pre-flight (`wmo optimize route sweep` does) without issuing a single request.
+    request. Which is also why construction alone is a weak pre-flight: use
+    `prepare_pool_provider` when the point is to learn whether a candidate can be CALLED.
 
     A construction failure is re-raised naming the entry and its kind: a backend that refuses to
     be built ("Bedrock authenticates with AWS credentials, not an API key") knows nothing about
@@ -222,3 +228,100 @@ def pool_provider(entry: PoolEntry) -> Provider:
         return get_provider(entry.provider_config(), api_key=api_key)
     except ValueError as exc:
         raise ValueError(f"pool model '{entry.name}' (kind={entry.kind.value}): {exc}") from exc
+
+
+def static_requirements(entry: PoolEntry) -> list[str]:
+    """What one entry's KIND needs from the entry alone, worded for the file it is edited in.
+
+    Read before any SDK is imported and before any client is built, so an entry that could never
+    be called fails on its own config. Each item is derived from the backend's request path, not
+    guessed:
+
+    - azure needs `deployment` (on the wire, Azure's `model` IS the deployment name, so
+      `AzureOpenAIProvider._deployment` refuses without it) and `api_version` (its client cannot be
+      built without one). `endpoint` is NOT required here: it legitimately comes from
+      AZURE_OPENAI_ENDPOINT, which the provider resolves.
+    - tinker needs a base model name, because `TinkerChatProvider` resolves its renderer and
+      tokenizer from `ProviderConfig.model_type` and a pool entry has no field that fills it, so a
+      `tinker://` weights path in `model` can never render a prompt.
+    - bedrock, openai, openai_responses and anthropic need nothing from the entry: a region (for
+      bedrock) or a credential (for the rest) is what they need, and both are resolved from the
+      local environment by `PreparableProvider.prepare`, not from this file.
+
+    Kept out of `PoolEntry`'s own validation on purpose, unlike the two rules that are there: a
+    saved `OutcomeMatrix` carries its pool inline, so tightening load-time validation would
+    retroactively refuse matrices whose entries only ever supplied prices. Being callable matters
+    where a candidate is about to be called.
+
+    Returns:
+        One human-readable complaint per unmet requirement; empty when the entry is complete.
+    """
+    match entry.kind:
+        case ProviderKind.AZURE_OPENAI:
+            missing: list[str] = []
+            if entry.deployment is None:
+                missing.append(
+                    "`deployment` (the Azure deployment name every request names as its model)"
+                )
+            if entry.api_version is None:
+                missing.append(
+                    "`api_version` (AzureOpenAIProvider cannot build its client without one)"
+                )
+            return [f"azure entries need {item}" for item in missing]
+        case ProviderKind.TINKER:
+            if entry.model.startswith("tinker://"):
+                return [
+                    "a tinker entry's `model` cannot be a tinker:// weights path: the renderer and "
+                    "tokenizer resolve from the BASE model name, which a pool entry has no field "
+                    "to carry, so name the base model (e.g. 'Qwen/Qwen3-8B') instead"
+                ]
+            return []
+        case (
+            ProviderKind.BEDROCK
+            | ProviderKind.OPENAI
+            | ProviderKind.OPENAI_RESPONSES
+            | ProviderKind.ANTHROPIC
+        ):
+            return []
+
+
+def prepare_pool_provider(entry: PoolEntry) -> Provider:
+    """Construct one entry's provider AND resolve every prerequisite that needs no request.
+
+    The pre-flight seam for a caller about to spend money on a whole roster (`wmo optimize route
+    sweep`). `pool_provider` alone is too weak for that: every backend builds its SDK client
+    lazily, so an uninstalled SDK extra, an unset credential, or a region that resolves nowhere
+    still lands at that candidate's FIRST CALL, after the candidates ahead of it have been paid
+    for. This runs the kind's `static_requirements` and then `PreparableProvider.prepare`, which
+    forces the lazy client to be built where that is free.
+
+    Free, and provably so: no backend's `prepare` issues a request (see each one's docstring).
+    Verifying a candidate over the wire is deliberately NOT done here, because `wmo providers
+    verify` bills a real call per model, which a pre-flight that runs before spend is authorized
+    may not do. Two backends therefore keep a documented residual gap, and callers should say so:
+    bedrock cannot resolve AWS CREDENTIALS locally (building the client walks a chain that reaches
+    the instance-metadata endpoint over the network, and succeeds with no credentials anyway), and
+    tinker cannot resolve SERVICE REACHABILITY (constructing the client connects and pins a
+    server-side session). Both stay first-call failures.
+
+    Returns:
+        The prepared provider. Callers that only wanted the check may discard it; the sweep does,
+        because `evaluate_pool` builds its own per cell to keep per-episode provider state fresh.
+
+    Raises:
+        ValueError: This entry cannot be used, named with its kind and what to do about it.
+    """
+    problems = static_requirements(entry)
+    if problems:
+        raise ValueError(
+            f"pool model '{entry.name}' (kind={entry.kind.value}): {'; '.join(problems)}"
+        )
+    provider = pool_provider(entry)
+    if isinstance(provider, PreparableProvider):
+        try:
+            provider.prepare()
+        except Exception as exc:  # noqa: BLE001 - every backend raises its own SDK's type here
+            # Re-raised as one usage error naming the entry: the SDK's own message says what is
+            # missing, and the caller is looping over candidates in a file it wants to edit.
+            raise ValueError(f"pool model '{entry.name}' (kind={entry.kind.value}): {exc}") from exc
+    return provider

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -15,6 +15,8 @@ from wmo.providers.pool import (
     load_pool,
     pool_api_key,
     pool_provider,
+    prepare_pool_provider,
+    static_requirements,
 )
 from wmo.providers.registry import get_provider
 
@@ -172,6 +174,88 @@ def test_pool_provider_names_the_entry_when_a_backend_refuses_its_config(
         pool_provider(entry)
     # The backend's own advice is preserved, not replaced by the identification.
     assert "TINKER_API_KEY" in str(failure.value)
+
+
+def test_static_requirements_pass_a_complete_entry() -> None:
+    # Nothing is required of the kinds whose only prerequisite (a credential, a region) lives in
+    # the environment rather than the entry, and a complete azure entry is complete.
+    assert (
+        static_requirements(
+            PoolEntry(name="fable", kind=ProviderKind.ANTHROPIC, model="claude-fable-5")
+        )
+        == []
+    )
+    complete_azure = PoolEntry(
+        name="gpt",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+        api_version="2024-10-21",
+    )
+    assert static_requirements(complete_azure) == []
+
+
+def test_static_requirements_name_the_azure_api_version() -> None:
+    # `AzureOpenAIProvider._get_client` refuses without an api-version, and that check runs inside
+    # the FIRST call: a swept candidate would abort mid-run. Knowable from the entry alone.
+    entry = PoolEntry(
+        name="gpt",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+    )
+    assert [problem for problem in static_requirements(entry) if "api_version" in problem]
+
+
+def test_static_requirements_reject_a_tinker_weights_path() -> None:
+    # A `tinker://` path can never render a prompt from a pool entry: the renderer and tokenizer
+    # resolve from `ProviderConfig.model_type`, and a pool entry has no field that fills it.
+    entry = PoolEntry(
+        name="student",
+        kind=ProviderKind.TINKER,
+        model="tinker://abc/sampler_weights/42",
+        input_per_mtok=0.1,
+        output_per_mtok=0.2,
+    )
+    problems = static_requirements(entry)
+    assert len(problems) == 1
+    assert "model_type" not in problems[0]  # worded for the pool file, not the provider config
+    assert "base model" in problems[0]
+
+
+def test_prepare_pool_provider_forces_the_lazy_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The point of the seam: an azure entry with no endpoint (and no AZURE_OPENAI_ENDPOINT)
+    # CONSTRUCTS fine, because `__init__` only stores the config, and fails only when the client is
+    # built. `prepare_pool_provider` builds it, without a request, and names the entry.
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    entry = PoolEntry(
+        name="gpt-azure",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+        api_version="2024-10-21",
+    )
+    assert isinstance(pool_provider(entry), AzureOpenAIProvider)  # construction alone says nothing
+    with pytest.raises(ValueError, match=r"pool model 'gpt-azure' \(kind=azure\)") as failure:
+        prepare_pool_provider(entry)
+    assert "AZURE_OPENAI_ENDPOINT" in str(failure.value)  # the backend's own advice survives
+
+
+def test_prepare_pool_provider_returns_a_usable_entrys_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WMO_POOL_TEST_KEY", "sk-present")
+    entry = PoolEntry(
+        name="gpt-azure",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        deployment="gpt-5.5",
+        endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        api_key_env="WMO_POOL_TEST_KEY",
+    )
+    provider = prepare_pool_provider(entry)
+    assert isinstance(provider, AzureOpenAIProvider)
 
 
 def test_pool_api_key_checks_credentials_without_building_a_provider(

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -9,7 +9,13 @@ from pydantic import ValidationError
 
 from wmo.providers.azure_openai import AzureOpenAIProvider
 from wmo.providers.base import ProviderConfig, ProviderKind, TokenUsage
-from wmo.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool, pool_provider
+from wmo.providers.pool import (
+    DEFAULT_POOL_PATH,
+    PoolEntry,
+    load_pool,
+    pool_api_key,
+    pool_provider,
+)
 from wmo.providers.registry import get_provider
 
 _POOL_TOML = """
@@ -147,6 +153,42 @@ def test_pool_provider_passes_explicit_key(tmp_path: Path, monkeypatch: pytest.M
     assert client.api_key == "sk-pool-test"
 
 
+def test_pool_provider_names_the_entry_when_a_backend_refuses_its_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A backend that refuses to be built says nothing about WHICH candidate did it, and callers
+    # loop over a whole pool (`wmo optimize route sweep` constructs all of them as a pre-flight),
+    # so the entry name and kind have to survive into the message an operator reads.
+    monkeypatch.setenv("WMO_POOL_TEST_KEY", "sk-present")
+    entry = PoolEntry(
+        name="student",
+        kind=ProviderKind.TINKER,
+        model="Qwen/Qwen3-8B",
+        api_key_env="WMO_POOL_TEST_KEY",  # set: this is a backend refusal, not a missing key
+        input_per_mtok=0.1,
+        output_per_mtok=0.2,
+    )
+    with pytest.raises(ValueError, match=r"pool model 'student' \(kind=tinker\)") as failure:
+        pool_provider(entry)
+    # The backend's own advice is preserved, not replaced by the identification.
+    assert "TINKER_API_KEY" in str(failure.value)
+
+
+def test_pool_api_key_checks_credentials_without_building_a_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The seam a caller about to spend on a whole pool uses to check every candidate up front:
+    # same verdict as `pool_provider`, no provider constructed and no network client touched.
+    pool = load_pool(_write_pool(tmp_path))
+    monkeypatch.delenv("AZURE_SILEN_RESOURCE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="AZURE_SILEN_RESOURCE_API_KEY"):
+        pool_api_key(pool.entry("deepseek-v4-pro"))
+    monkeypatch.setenv("AZURE_SILEN_RESOURCE_API_KEY", "sk-pool-test")
+    assert pool_api_key(pool.entry("deepseek-v4-pro")) == "sk-pool-test"
+    # An entry with no api_key_env uses the backend's default credentials, and says so with None.
+    assert pool_api_key(pool.entry("fable")) is None
+
+
 def test_pool_entry_unknown_name_lists_available(tmp_path: Path) -> None:
     pool = load_pool(_write_pool(tmp_path))
     with pytest.raises(KeyError, match="deepseek-v4-pro"):
@@ -245,6 +287,21 @@ def test_azure_entry_requires_deployment() -> None:
             name="no-deploy",
             kind=ProviderKind.AZURE_OPENAI,
             model="gpt-5.5",
+            input_per_mtok=1.0,
+            output_per_mtok=2.0,
+        )
+
+
+def test_bedrock_entry_rejects_api_key_env_at_load() -> None:
+    # `BedrockProvider.__init__` refuses an explicit key, and providers are built lazily per
+    # eval cell: caught at load this is a config typo, caught at the first cell it aborts a
+    # paid-for sweep. Same boundary as the azure `deployment` rule above.
+    with pytest.raises(ValidationError, match="api_key_env"):
+        PoolEntry(
+            name="claude-bedrock",
+            kind=ProviderKind.BEDROCK,
+            model="us.anthropic.claude-opus-4-8",
+            api_key_env="AWS_SOMETHING",
             input_per_mtok=1.0,
             output_per_mtok=2.0,
         )

--- a/wmo/providers/tinker.py
+++ b/wmo/providers/tinker.py
@@ -103,6 +103,28 @@ _shared_samplers: dict[str, tinker.SamplingClient] = {}
 """Process-wide `SamplingClient` cache, keyed by the exact model string."""
 
 
+def check_tinker_prerequisites() -> None:
+    """Check what the shared service client needs that resolves LOCALLY: the SDK and the key.
+
+    The local half of `shared_service_client`, split out so a caller that must NOT connect (a
+    provider pre-flight, `TinkerChatProvider.prepare`) runs exactly these checks instead of a copy
+    of them that drifts. Nothing here touches the network.
+
+    Raises:
+        ImportError: If the tinker SDK is not installed (the distill extra).
+        RuntimeError: If TINKER_API_KEY is missing from the environment.
+    """
+    try:
+        import tinker  # noqa: F401 - presence IS the check; callers import it for real
+    except ImportError as exc:
+        raise ImportError(_MISSING_TINKER_EXTRA) from exc
+    if not os.environ.get(TINKER_API_KEY_ENV):
+        raise RuntimeError(
+            f"{TINKER_API_KEY_ENV} is not set in the environment; set it to "
+            "your Tinker API key to use the tinker provider"
+        )
+
+
 def shared_service_client() -> tinker.ServiceClient:
     """The process-wide `tinker.ServiceClient`, constructed at most once.
 
@@ -125,15 +147,9 @@ def shared_service_client() -> tinker.ServiceClient:
         TinkerDeadlineError: If construction exceeds the connect deadline
             (nothing is cached, so the next call rebuilds).
     """
-    try:
-        import tinker
-    except ImportError as exc:
-        raise ImportError(_MISSING_TINKER_EXTRA) from exc
-    if not os.environ.get(TINKER_API_KEY_ENV):
-        raise RuntimeError(
-            f"{TINKER_API_KEY_ENV} is not set in the environment; set it to "
-            "your Tinker API key to use the tinker provider"
-        )
+    check_tinker_prerequisites()
+    import tinker
+
     global _shared_service
     with _shared_lock:
         if _shared_service is None:
@@ -649,6 +665,24 @@ class TinkerChatProvider:
             if window is not None:
                 return window
         return served_context_window(self.config.model)
+
+    def prepare(self) -> None:
+        """Check the SDK and the API key locally. Deliberately does NOT open a service session.
+
+        Satisfies `wmo.providers.base.PreparableProvider` for the part that is free, and only that
+        part. Constructing the client is not free in either sense: `tinker.ServiceClient()`
+        connects, and its heartbeat pins one server-side session for the life of the process
+        against a roughly 240 cumulative cap (see `shared_service_client`), so a pre-flight that
+        built one per candidate would spend a run's session budget before the first cell.
+
+        What that leaves for the first call, deliberately: the service being reachable, this model
+        being served, and the sampling client being constructible.
+
+        Raises:
+            ImportError: If the tinker SDK is not installed (the distill extra).
+            RuntimeError: If TINKER_API_KEY is missing from the environment.
+        """
+        check_tinker_prerequisites()
 
     def _get_sampler(self) -> TinkerSampler:
         if self._sampler is None:


### PR DESCRIPTION
## The gap this closes

`wmo optimize route fit` takes an `OutcomeMatrix` file as argument 1, and nothing in the product wrote one. `evaluate_pool` (`wmo/env/closed_loop.py`) existed, was tested, and had **zero non-test callers**. So no policy could be fitted, so no endpoint could exist. This wires the producer.

## What `wmo optimize route sweep` does

Resolves a world model, loads the candidate pool, derives scenarios from the model's OWN held-out trace band (the build's deterministic 3-way split, reconstructed from the model's `config.toml` `train_split`, sorted by trace id and capped by `--scenarios`), prints a cost estimate, confirms, streams each cell through `on_outcome`, and writes the matrix plus the exact next command.

## Three things this needed that were not in the brief

**The sweep runs inside `world_model.frozen()`.** `WorldModelEnv.reset` opens sessions with `enrich=True` and has no opt-out, so without the freeze the first candidate's PREDICTED steps enter the shared retrieval buffer and become demonstrations for the next candidate. The matrix would be sweep-order dependent, which makes it useless as the comparison it exists to be. AGENTS.md requires closed-loop runs to be frozen or `enrich=False`, and `wmo/evals/closed_loop.py` already does this. Pinned by a test asserting every episode opened while frozen.

**Credentials resolve before the spend confirmation.** Providers are constructed lazily per cell, so an unset `api_key_env` on the third candidate aborted the run *after the first two had been fully paid for*, with no matrix written. `pool_api_key` is split out of `pool_provider` so the whole pool's credentials resolve up front; the lookup is local `os.environ` and costs nothing to run early.

**A bedrock entry carrying `api_key_env` is rejected at load.** `BedrockProvider.__init__` refuses an explicit key, so that misconfiguration also landed mid-sweep rather than at the validation boundary.

## The cost estimate is labeled, not invented

This spends real money (pool x scenarios x episodes of full episodes), so it confirms first, matching the distill CLI's pattern (`Confirm.ask`, `--yes` to skip, non-TTY handling). The estimate is honest about what it does and does not know: `--max-steps` genuinely bounds CALLS per episode, but tokens per call are an assumption. So the table is titled "ASSUMED tokens, not a measurement", states the per-call assumption, says it is overridable, notes that the world model's own serve and judge cost is metered separately (the D12 split), and prints the MEASURED spend when it finishes. No number is presented as measured that was not.

## Falsification

The 22 new tests fail against pre-change code. With `wmo/cli/route_app.py` reverted and the tests kept:

```
$ uv run --no-sync wmo optimize route sweep --help
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ No such command 'sweep'.                                                     │
╰──────────────────────────────────────────────────────────────────────────────╯

$ uv run --no-sync pytest wmo/cli/route_app_test.py -k sweep -q
FFFFFFFFFFF                                                              [100%]
11 failed, 11 deselected
```

## Gates

CI runs no tests, so these were run locally, rebased onto `7950d6c`:

```
3304 passed, 18 skipped     (main baseline 3282, measured on 7950d6c, + 22 new)
uv run --no-sync ruff check .          All checks passed!
uv run --no-sync ruff format --check wmo/   417 files already formatted
uv run --no-sync ty check              All checks passed!
```

## The verified command sequence

Run end to end against a local stub OpenAI-compatible server standing in for every model (agent, world model, judge, and both pool candidates), so it costs nothing and touches no network. All three Tier 1 branches merged into one tree.

```bash
wmo providers set --provider openai --model <model> --endpoint <base-url>
wmo build --file traces.otel.jsonl --name support
wmo optimize route student .wmo/distill/support --input-per-mtok 0.10 --output-per-mtok 0.40
# plus one frontier candidate in .wmo/pool.toml, so the router has a real choice
wmo optimize route sweep support --scenarios 4 --out matrix.json
wmo optimize route fit matrix.json --kind knn --out .wmo/models/support/policy.json
wmo serve --name support
# then point a tool-calling agent at http://127.0.0.1:8801/v1
```

Observed:

```
### 2) ingest traces and build a world model
✓ ingested 30 traces → normalized 93 steps
✓ split 22 train / 4 val / 4 test traces

### 3) make the distilled student a routable pool candidate
✓ added pool candidate student -> .wmo/pool.toml
  Qwen/Qwen3-8B adapter at tinker://fake/sampler/final/0

### 4) add a frontier candidate beside it
  pool: ['student', 'frontier']

### 5) sweep the pool into an outcome matrix
8 cell(s) = 2 candidate(s) x 4 held-out scenario(s) x 1 episode(s); estimated total $0.74
  ASSUMPTION: 2,000 input + 250 output token(s) per policy call ... Calls are capped,
  tokens per call are NOT measured
  [1/8] student ...006 ep0: reward=0.75 $0.00003 steps=2
  ...
  [8/8] frontier ...014 ep0: reward=0.75 $0.00079 steps=2
✓ 8 cell(s), 8 scored -> matrix.json
  measured candidate spend $0.0033

### 6) fit a routing policy where wmo serve reads it
✓ fitted knn policy over 4 scenarios -> .wmo/models/support/policy.json
  bank .wmo/models/support/policy_knn_bank.npz, fallback student, z=0.5

### 7) serve
{"object":"list","data":[{"id":"support","object":"model","created":0,"owned_by":"wmo"}]}

### 8) point a TOOL-CALLING agent at the endpoint, through the real openai client
  -- non-streaming tool round trip --
  finish_reason=tool_calls tool_calls=1
  model called get_order({"id": "A-1"})
  final answer: 'order A-1 is shipped and arrives Friday.'
  -- streamed tool round trip --
  finish_reason=tool_calls reassembled={0: {'name': 'get_order', 'arguments': '{"id": "A-1"}', ...}}
  reassembled arguments parse to {'id': 'A-1'}
  OK: tool calls round trip on both the plain and streamed paths
```

The distilled student is one of the two routable models, and the fitted policy chose it as the fallback.

**Scope note on that combined run:** it exercises the three branches' SOURCE together. I did not hand-merge the two branches' `route_app_test.py` additions (this PR and #272 both extend that file), so the combined tree carries only one side's tests. Each branch's own suite is green on its own branch, which is the gate that matters; the second of the two to merge needs a trivial rebase of that test file.

## Known limits

- The matrix is persisted only after `evaluate_pool` returns, so a crash mid-sweep loses cells already paid for. That is inherited from `evaluate_pool`; the `on_outcome` hook this command already uses is the seam if streaming persistence is wanted.
- There is no hard budget cap and no `--dry-run`. Sizing is the operator's job through `--scenarios`, `--episodes`, and `--max-steps`.
- A tiny corpus with no held-out band falls back to the full corpus and says so explicitly, because those scenarios are NOT leak-free.
- No cost or quality number is claimed for routing or distillation here. This PR produces the evidence artifact; it does not interpret one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
