### PR TITLE
Serve tool calls through the OpenAI-compatible endpoint

### DIFF
--- a/wmo/distill/config_test.py
+++ b/wmo/distill/config_test.py
@@ -926,8 +926,6 @@ def _checked_in_config(name: str) -> DistillConfig:
     return load_distill_config(Path(__file__).parent / "configs" / name)
 
 
-
-
 def test_training_turn_cap_defaults_to_the_rollout_cap(tmp_path: Path) -> None:
     """Unset means one cap everywhere, which is the pre-existing behaviour."""
     cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -229,6 +229,17 @@ def _tool_choice_demands_a_call(tool_choice: JsonValue) -> bool:
     return tool_choice is not None and tool_choice not in ("auto", "none")
 
 
+def _is_function_choice_shape(tool_choice: JsonValue) -> bool:
+    """Whether `tool_choice` uses OpenAI's `{"type": "function", ...}` object shape.
+
+    Separate from `_named_tool_choice` because the two answer different questions: this one says
+    the client MEANT to name a single tool, that one says whether a name can actually be read out.
+    A choice that is this shape but yields no name is malformed rather than permissive, and the
+    difference decides whether it is refused or forwarded.
+    """
+    return isinstance(tool_choice, dict) and tool_choice.get("type") == "function"
+
+
 def _named_tool_choice(tool_choice: JsonValue) -> str | None:
     """The function name an OpenAI `{"type": "function", ...}` tool_choice names.
 
@@ -350,6 +361,18 @@ class ChatCompletionRequest(BaseModel):
             )
         named = _named_tool_choice(self.tool_choice)
         if named is None:
+            if _is_function_choice_shape(self.tool_choice):
+                # Function-SHAPED but nameless: `{"type": "function", "function": {}}` or an empty
+                # name. It demands a call and identifies nothing to call, so no provider can honor
+                # it. Forwarding it reaches an OpenAI-compatible backend as a malformed request,
+                # which this endpoint surfaces as a 502 blaming the model, while Bedrock discards
+                # the requirement and can answer in prose to a client that requires a call.
+                return (
+                    "tool_choice is a function choice with no usable `function.name`; give the "
+                    'name of the tool it must call, or use "auto" or "required"'
+                )
+            # Not this shape at all: an unrecognized future vocabulary word. Forward it rather
+            # than rewrite it, which is the same call `_tool_choice_demands_a_call` documents.
             return ""
         declared = [tool.function.name for tool in self.tools]
         if named in declared:

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -209,15 +209,35 @@ class StreamOptions(BaseModel):
     include_usage: bool = False
 
 
+# Every `tool_choice` string OpenAI defines. A value outside this set, and outside the
+# `{"type": "function", ...}` object shape, is refused rather than forwarded: no backend this
+# endpoint routes to can honor one. OpenAI-compatible servers reject it, which surfaces as a 502
+# that blames the model for a client mistake, and Bedrock drops the field and can answer in prose
+# to a client that required a call. Forwarding an unrecognized word to stay
+# forward-compatible sounds generous and in practice only converts a clear 400 into one of those
+# two. When OpenAI adds a word, it is added here.
+_TOOL_CHOICE_WORDS = ("none", "auto", "required")
+
+
+def _tool_choice_is_recognized(tool_choice: JsonValue) -> bool:
+    """Whether `tool_choice` is a value this endpoint can actually route (see `_TOOL_CHOICE_WORDS`).
+
+    Note `tool_choice in _TOOL_CHOICE_WORDS` is deliberately not the whole test: `True` compares
+    equal to `1` but not to any of these strings, so booleans and numbers fall through to False as
+    they should.
+    """
+    return tool_choice in _TOOL_CHOICE_WORDS or _is_function_choice_shape(tool_choice)
+
+
 def _tool_choice_demands_a_call(tool_choice: JsonValue) -> bool:
     """Whether a `tool_choice` can only be honored by actually calling a tool.
 
     `"none"` and `"auto"` are both satisfied by not calling one, so neither demands anything: an
     empty tool registry (the `tools: []` this endpoint normalizes away) is served as plain chat
     rather than refused, and `"none"` (literally "do not call tools") is never refused for having
-    none. `"required"` and a named `{"type": "function", ...}` cannot be honored with nothing to
-    choose from, and anything unrecognized is treated the same way: a client that must get a call
-    back would otherwise read a prose answer as the model's own choice.
+    none. `"required"` and a `{"type": "function", ...}` object cannot be honored with nothing to
+    choose from. Unrecognized values never reach here: they are refused up front by
+    `_tool_choice_is_recognized`.
 
     Args:
         tool_choice: The request's `tool_choice` exactly as the client sent it, or None when it
@@ -352,6 +372,12 @@ class ChatCompletionRequest(BaseModel):
             A message naming what went wrong and what to send instead, or '' when the choice is
             serveable (including every non-demanding choice, see `_tool_choice_demands_a_call`).
         """
+        if self.tool_choice is not None and not _tool_choice_is_recognized(self.tool_choice):
+            words = ", ".join(f'"{word}"' for word in _TOOL_CHOICE_WORDS)
+            return (
+                f"tool_choice {self.tool_choice!r} is not a value this endpoint can route; use "
+                f'{words}, or {{"type": "function", "function": {{"name": "<tool>"}}}}'
+            )
         if not _tool_choice_demands_a_call(self.tool_choice):
             return ""
         if self.tools is None:

--- a/wmo/serving/chat.py
+++ b/wmo/serving/chat.py
@@ -8,8 +8,29 @@ the mechanism (routed model, cluster, reason) goes to the request log and the
 
 Conversation affinity: provider prompt caches are per-model, so switching mid-conversation
 forfeits warm cache reads. The runtime fingerprints each finished exchange (full transcript
-including the assistant reply) and, when the next request arrives with that transcript as its
-prefix, `select_model` sees the incumbent and sticks to it by default.
+including the assistant reply, tool calls and all) and, when the next request arrives with that
+transcript as its prefix, `select_model` sees the incumbent and sticks to it by default. A tool
+round trip is such a prefix: the client appends the assistant's `tool_calls` turn plus one
+`role="tool"` result PER CALL, so the reply is remembered with its tool calls and the prefix is
+looked up at the last assistant turn rather than one message back, or a parallel round trip would
+route fresh and forfeit the cache exactly when the transcript is longest.
+
+Tool calling: `tools`, `tool_choice`, `parallel_tool_calls`, assistant `tool_calls`, and
+`role="tool"` results all round-trip. A request carrying any of them is served through the
+provider's structured `complete_chat`, the only seam that preserves tool calls, instead of the
+text `complete`; a routed pool entry whose provider has no structured backend fails loudly (501,
+naming that entry) because silently dropping tools turns a compatibility gap into an apparent
+model-quality problem. A `tool_choice` that DEMANDS a call (`"required"`, or a named function) is
+checked against the tools that request declares, replayed transcript or not, and refused with a
+400 when nothing there can satisfy it: `tool_choice` with `tools: null` is malformed upstream, so
+the alternative is a 502 that reads as a model failure (or, on Bedrock, prose returned to a client
+that requires a call). Streamed tool calls are RE-EMITTED, not forwarded: no provider exposes a
+streaming tool-call surface (`StreamingProvider.stream` yields text deltas only), so a
+tool-bearing streamed request makes one non-streamed `complete_chat` call and re-frames the
+result as OpenAI SSE (one `choices[0].delta.tool_calls` entry per call, carrying `index`, `id`,
+`function.name` and the whole `function.arguments` string, then the `finish_reason` chunk). A
+client reassembles the arguments exactly as it would from real fragments; the tradeoff is
+time-to-first-byte, which waits for the whole upstream response instead of the first token.
 
 Request log: one JSONL row per call with the D-SERVING-LOG fields (id, ts, endpoint, routed
 model, cluster, tokens incl. cached, cache-adjusted cost, latency, ttfb, status, reason).
@@ -39,7 +60,9 @@ from typing import TYPE_CHECKING, Literal
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, JsonValue, field_validator
+from llm_waterfall.types import ChatChoice, ChatRequest, ChatResponse, ChatTool, ChatToolCall
+from llm_waterfall.types import ChatMessage as ProviderChatMessage
+from pydantic import BaseModel, Field, JsonValue, ValidationError, field_validator, model_validator
 from starlette.background import BackgroundTask
 
 from wmo.optimize.knn import (
@@ -55,6 +78,7 @@ from wmo.providers.base import (
     Provider,
     StreamingProvider,
     TokenUsage,
+    ToolCallingProvider,
 )
 from wmo.providers.pool import PoolEntry, pool_provider
 from wmo.serving.endpoint_config import EndpointConfig
@@ -71,7 +95,7 @@ logger = logging.getLogger(__name__)
 _AFFINITY_CAPACITY = 4096
 
 
-ChatRole = Literal["system", "user", "assistant"]
+ChatRole = Literal["system", "user", "assistant", "tool"]
 
 
 class ChatMessage(BaseModel):
@@ -79,11 +103,43 @@ class ChatMessage(BaseModel):
 
     `developer` (OpenAI's system replacement on gpt-5-class models) maps to `system`, and
     multi-part text content (`[{"type": "text", "text": ...}]`, emitted by LangChain and the
-    Vercel AI SDK) is joined; a non-text part is a hard error, not a silent drop.
+    Vercel AI SDK) is joined; a non-text part is a hard error, not a silent drop. `content` is
+    also the empty string when a client sends null, which is what an assistant turn that only
+    calls tools looks like on the wire.
+
+    The tool-calling half is the shape an agent replays: `tool_calls` on the assistant turn it
+    got back, then one `role="tool"` message per result carrying the `tool_call_id` it answers.
+    Both reuse llm-waterfall's models (`ChatToolCall`), the same types `complete_chat` takes, so
+    a call survives the hop to the provider without a second parallel definition of the format.
     """
 
     role: ChatRole
-    content: str
+    content: str = ""
+    tool_calls: list[ChatToolCall] | None = None
+    tool_call_id: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _content_is_required_off_a_tool_call_turn(cls, data: object) -> object:
+        """Reject a turn with no text unless it is the one turn that legitimately has none.
+
+        Checked on the RAW payload so both spellings of "no content" answer the same way: an
+        omitted key and an explicit `null` (what an SDK puts on the wire for an unset value) are
+        the same request, and `_normalize_content` turns the second into "" before any
+        field-level check could tell them apart. Either way an empty billed turn is a client bug
+        this endpoint has to name, not forward.
+
+        The one exception is an assistant turn whose whole output is `tool_calls`, and it is the
+        calls that earn it: `tool_calls: []` advertises no call, so a turn carrying one still
+        needs its text.
+        """
+        if not isinstance(data, dict) or data.get("content") is not None:
+            return data
+        if data.get("role") == "assistant" and data.get("tool_calls"):
+            return data
+        raise ValueError(
+            "a message needs `content` (only an assistant turn carrying tool_calls may omit it)"
+        )
 
     @field_validator("role", mode="before")
     @classmethod
@@ -92,7 +148,9 @@ class ChatMessage(BaseModel):
 
     @field_validator("content", mode="before")
     @classmethod
-    def _join_text_parts(cls, value: object) -> object:
+    def _normalize_content(cls, value: object) -> object:
+        if value is None:
+            return ""
         if not isinstance(value, list):
             return value
         parts: list[str] = []
@@ -105,6 +163,45 @@ class ChatMessage(BaseModel):
             parts.append(str(part.get("text", "")))
         return "".join(parts)
 
+    @model_validator(mode="after")
+    def _tool_fields_match_the_role(self) -> ChatMessage:
+        """Reject the tool-field placements that would silently misrepresent a transcript.
+
+        A tool result carried on an assistant turn (or a result with no `tool_call_id`) still
+        reaches the model, as prose in the wrong voice with no link to the call it answers, so
+        accepting it would degrade the model's own output rather than fail. `content` is kept
+        mandatory by `_content_is_required_off_a_tool_call_turn`, which has to read the raw
+        payload.
+        """
+        if self.role == "tool" and not self.tool_call_id:
+            raise ValueError(
+                "a role='tool' message needs the tool_call_id of the call it answers; "
+                "copy it from the assistant turn's tool_calls[].id"
+            )
+        if self.tool_call_id is not None and self.role != "tool":
+            raise ValueError(
+                f"tool_call_id is only valid on a role='tool' message, not on role="
+                f"'{self.role}'; send the tool's output as a role='tool' message"
+            )
+        if self.tool_calls is not None and self.role != "assistant":
+            raise ValueError(
+                f"tool_calls are only valid on a role='assistant' message, not on role="
+                f"'{self.role}'; replay the assistant turn the model returned them on"
+            )
+        return self
+
+    def for_provider(self) -> ProviderChatMessage:
+        """This turn as the provider-neutral structured message `complete_chat` takes."""
+        return ProviderChatMessage(
+            role=self.role,
+            # An assistant turn that only calls tools has no text: send null rather than "", so
+            # `ChatRequest.provider_payload` (exclude_none) drops the field entirely instead of
+            # asking a backend to accept an empty content block.
+            content=self.content if self.content or not self.tool_calls else None,
+            tool_calls=self.tool_calls,
+            tool_call_id=self.tool_call_id,
+        )
+
 
 class StreamOptions(BaseModel):
     """OpenAI `stream_options`: opt-in for the trailing usage chunk on streamed responses."""
@@ -112,11 +209,68 @@ class StreamOptions(BaseModel):
     include_usage: bool = False
 
 
+def _tool_choice_demands_a_call(tool_choice: JsonValue) -> bool:
+    """Whether a `tool_choice` can only be honored by actually calling a tool.
+
+    `"none"` and `"auto"` are both satisfied by not calling one, so neither demands anything: an
+    empty tool registry (the `tools: []` this endpoint normalizes away) is served as plain chat
+    rather than refused, and `"none"` (literally "do not call tools") is never refused for having
+    none. `"required"` and a named `{"type": "function", ...}` cannot be honored with nothing to
+    choose from, and anything unrecognized is treated the same way: a client that must get a call
+    back would otherwise read a prose answer as the model's own choice.
+
+    Args:
+        tool_choice: The request's `tool_choice` exactly as the client sent it, or None when it
+            sent none.
+
+    Returns:
+        True when honoring the choice requires a tool call.
+    """
+    return tool_choice is not None and tool_choice not in ("auto", "none")
+
+
+def _named_tool_choice(tool_choice: JsonValue) -> str | None:
+    """The function name an OpenAI `{"type": "function", ...}` tool_choice names.
+
+    Args:
+        tool_choice: The request's `tool_choice` exactly as the client sent it. Arbitrary JSON,
+            because OpenAI's own vocabulary has grown (`"required"` postdates `"auto"`) and an
+            unrecognized value is still forwarded rather than rewritten.
+
+    Returns:
+        The demanded function name, or None when the choice names no single function: the
+        `"auto"`/`"none"`/`"required"` strings, and any shape no name can be read out of.
+    """
+    if not isinstance(tool_choice, dict) or tool_choice.get("type") != "function":
+        return None
+    function = tool_choice.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) and name else None
+
+
 class ChatCompletionRequest(BaseModel):
-    """The OpenAI request subset the endpoint serves (text chat; tools are future work).
+    """The OpenAI request subset the endpoint serves: text chat plus function tool calling.
 
     Unsupported FUNCTIONAL parameters are declared here so they can be rejected explicitly
     (see `unsupported_features`); genuinely unknown extra fields are ignored like OpenAI does.
+
+    What is still rejected, and why each one is a 400 rather than a silent drop:
+
+    * `n != 1`: the endpoint meters one request-log row and remembers one incumbent reply per
+      call, so extra choices would be billed and cached against a transcript nobody sent.
+    * `logprobs`: no provider seam returns per-token logprobs, and an absent `logprobs` field
+      reads to a client as "this model has none" rather than "this endpoint cannot".
+    * `response_format`: support would have to hold for every entry in the pool (the routed
+      model is not the client's choice) and the text `complete` path cannot carry it at all, so
+      a schema honored only on some routes is worse than a refusal a client can act on.
+
+    `parallel_tool_calls` is the other kind of functional parameter: it is honored, forwarded to
+    the provider by `_provider_request`. Declaring it is what makes that possible, since pydantic
+    would otherwise ignore it as an unknown extra and the endpoint would hand a client that asked
+    for one call at a time a multi-call turn. With no tools in play it needs no forwarding at all:
+    no call can happen, so "one at a time" is already true.
     """
 
     model: str  # the ENDPOINT name
@@ -126,10 +280,12 @@ class ChatCompletionRequest(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
-    # Declared only to be REJECTED with a clear 400 (silently ignoring tools would make a
-    # tool-calling client read prose where it expects tool_calls).
-    tools: list[JsonValue] | None = None
+    tools: list[ChatTool] | None = None
     tool_choice: JsonValue | None = None
+    # Forwarded to the provider (see `_provider_request`), not dropped: an agent whose executor
+    # answers one call per turn sets it to false and would otherwise get a multi-call turn back.
+    parallel_tool_calls: bool | None = None
+    # Declared only to be REJECTED with a clear 400 (see the class docstring).
     response_format: JsonValue | None = None
     n: int = 1
     logprobs: bool | None = None
@@ -140,13 +296,74 @@ class ChatCompletionRequest(BaseModel):
     def wants_stream_usage(self) -> bool:
         return self.stream_options is not None and self.stream_options.include_usage
 
+    @field_validator("tools", mode="after")
+    @classmethod
+    def _an_empty_tool_list_is_no_tools(cls, value: list[ChatTool] | None) -> list[ChatTool] | None:
+        """`tools: []` advertises nothing, so it is not a tool request.
+
+        Clients whose tool registry happens to be empty send the empty list, and forwarding it
+        would send an empty `tools` array to a backend that rejects one: an upstream error on a
+        request that is really plain chat.
+        """
+        return value or None
+
+    def needs_tool_calling(self) -> bool:
+        """Whether this request must be served through `complete_chat`.
+
+        True for advertised tools AND for a transcript that merely REPLAYS them: the text
+        `complete` seam takes role+content messages only, so an assistant `tool_calls` turn or a
+        `role="tool"` result would be dropped or mangled on the way to the model even when the
+        client stopped sending `tools` (some agents omit them once the loop is under way).
+        `tool_choice` alone does not qualify: with nothing to choose from there is no call to
+        make, so it is either satisfied by plain chat or a client mistake (see
+        `unsatisfiable_tool_choice`), never a reason to demand a tool-calling backend.
+        """
+        return self.tools is not None or any(
+            m.tool_calls or m.role == "tool" for m in self.messages
+        )
+
+    def unsatisfiable_tool_choice(self) -> str:
+        """Why this request's `tool_choice` cannot be honored, '' when it can.
+
+        Judged against the tools THIS request declares, never against the transcript: a mid-loop
+        turn that replays an assistant `tool_calls` turn plus its results but stops re-sending
+        `tools` (some agents do) still has nothing for a demanding choice to select, so keying the
+        check on the presence of a tool transcript let exactly that request through to the provider
+        as `tool_choice` with `tools: null`. An OpenAI-compatible backend rejects that pair as a
+        malformed request, which surfaces here as a 502 that reads as a model failure, and Bedrock
+        Converse discards the required choice and answers in prose to a client that cannot use one.
+
+        A named choice is checked by NAME for the same reason: no provider can call a function it
+        was never given, so `{"type": "function", "function": {"name": "delete_rows"}}` alongside a
+        `tools` array that declares only `lookup` is the same unhonorable request, one 400 earlier.
+
+        Returns:
+            A message naming what went wrong and what to send instead, or '' when the choice is
+            serveable (including every non-demanding choice, see `_tool_choice_demands_a_call`).
+        """
+        if not _tool_choice_demands_a_call(self.tool_choice):
+            return ""
+        if self.tools is None:
+            return (
+                "tool_choice needs tools: declare the tool definitions this call may choose "
+                "from, or drop tool_choice"
+            )
+        named = _named_tool_choice(self.tool_choice)
+        if named is None:
+            return ""
+        declared = [tool.function.name for tool in self.tools]
+        if named in declared:
+            return ""
+        return (
+            f"tool_choice names {named!r}, which this call does not declare; add its definition "
+            f"to `tools` or name one of the tools you did declare: {', '.join(declared)}"
+        )
+
     def unsupported_features(self) -> str:
         """Name the requested-but-unsupported params, '' when the request is serveable."""
         used = [
             name
             for name, value in (
-                ("tools", self.tools),
-                ("tool_choice", self.tool_choice),
                 ("response_format", self.response_format),
                 ("logprobs", self.logprobs),
             )
@@ -375,9 +592,10 @@ class EndpointRuntime:
 
     def decide(self, messages: list[ChatMessage]) -> RoutingDecision:
         incumbent = None
-        if len(messages) > 1:
+        remembered = _remembered_prefix(messages)
+        if remembered is not None:
             with self._lock:
-                incumbent = self._affinity.get(_fingerprint(messages[:-1]))
+                incumbent = self._affinity.get(_fingerprint(remembered))
         text = _routable_text(messages)
         return select_model(self.policy, text, incumbent=incumbent, embedder=self._embedder())
 
@@ -403,9 +621,15 @@ class EndpointRuntime:
                 embedder = self._policy_embedder
         return embedder
 
-    def remember(self, messages: list[ChatMessage], assistant_text: str, model: str) -> None:
-        """Record the finished exchange so the conversation's next request finds its incumbent."""
-        transcript = [*messages, ChatMessage(role="assistant", content=assistant_text)]
+    def remember(self, messages: list[ChatMessage], reply: ChatMessage, model: str) -> None:
+        """Record the finished exchange so the conversation's next request finds its incumbent.
+
+        `reply` is the whole assistant turn, not just its text: a tool-calling turn carries
+        empty content plus `tool_calls`, and the client replays it verbatim, so remembering the
+        text alone would fingerprint a transcript that is never sent again and drop affinity at
+        the first tool call.
+        """
+        transcript = [*messages, reply]
         key = _fingerprint(transcript)
         with self._lock:
             self._affinity[key] = model
@@ -427,23 +651,233 @@ class EndpointRuntime:
         return entry, provider
 
 
+def _remembered_prefix(messages: list[ChatMessage]) -> list[ChatMessage] | None:
+    """The prefix of `messages` that a previous reply would have been remembered under.
+
+    `remember` stores `[*request, assistant_reply]`, so every remembered transcript ENDS on an
+    assistant turn and the prefix to look up is the one that ends at the last assistant message,
+    whatever the client appended after it. Stripping a fixed one message instead would only ever
+    match a transcript that grew by exactly one, which a PARALLEL tool round trip never is: the
+    client appends the assistant turn plus one `role="tool"` result per call, so a two-call turn
+    would miss its incumbent and re-route mid-loop, forfeiting the prompt cache exactly when the
+    transcript is longest and handing the new model tool_call ids the old one produced.
+
+    None when there is nothing that could have been remembered: no assistant turn, or one at index
+    0 (`remember` never stores a single-message transcript, since a request carries >= 1 message).
+    """
+    for index in range(len(messages) - 1, 0, -1):
+        if messages[index].role == "assistant":
+            return messages[: index + 1]
+    return None
+
+
 def _fingerprint(messages: list[ChatMessage]) -> str:
-    canonical = json.dumps([(m.role, m.content) for m in messages], ensure_ascii=False)
+    """Hash a transcript for conversation affinity.
+
+    Tool calls are part of a turn's identity. An assistant turn that only calls tools has empty
+    content, so hashing (role, content) alone would give every branch out of one prefix the same
+    key: two different tool calls, or two results for different `tool_call_id`s, would collide
+    and the map would hand back an incumbent it never chose for that branch.
+    """
+    canonical = json.dumps(
+        [
+            (
+                m.role,
+                m.content,
+                [call.model_dump(mode="json") for call in m.tool_calls] if m.tool_calls else None,
+                m.tool_call_id,
+            )
+            for m in messages
+        ],
+        ensure_ascii=False,
+    )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _routable_text(messages: list[ChatMessage]) -> str:
+    """The text the router reads: this conversation's own request, never a tool result.
+
+    A tool result is machine output the model asked for (a file dump, a stack trace), not what
+    the customer asked for, so routing on it would send successive turns of ONE conversation to
+    different models as the tool output varies and would feed the policy features it was never
+    fitted on. The last user turn still describes the request, so a tool round trip keeps
+    routing on it (and affinity pins the incumbent anyway).
+    """
     for message in reversed(messages):
         if message.role == "user":
+            return message.content
+    # No user turn at all (a replayed or synthetic transcript): fall back to the last turn that
+    # carries the request's own words, still skipping tool results for the reason above.
+    for message in reversed(messages):
+        if message.role != "tool":
             return message.content
     return messages[-1].content
 
 
 def _split_for_provider(messages: list[ChatMessage]) -> tuple[str, list[Message]]:
-    """Fold system turns into the provider's system string; keep user/assistant order."""
+    """Fold system turns into the provider's system string; keep user/assistant order.
+
+    Text path only: `Message` has no tool role, so a `needs_tool_calling` request never reaches
+    here (it is served through `_provider_request` and `complete_chat` instead). A tool result
+    that arrives anyway raises rather than being dropped, because dropping it would hand the
+    model a transcript with the answer to its own call missing.
+    """
     system_parts = [m.content for m in messages if m.role == "system"]
-    turns = [Message(role=m.role, content=m.content) for m in messages if m.role != "system"]
+    turns: list[Message] = []
+    for message in messages:
+        match message.role:
+            case "system":
+                continue
+            case "user" | "assistant":
+                turns.append(Message(role=message.role, content=message.content))
+            case "tool":
+                raise ValueError(
+                    "a tool result reached the text completion path; tool-bearing requests must "
+                    "route through complete_chat (ChatCompletionRequest.needs_tool_calling)"
+                )
     return "\n\n".join(system_parts), turns
+
+
+def _provider_request(request: ChatCompletionRequest) -> ChatRequest:
+    """The structured request for a tool-bearing call, for `ToolCallingProvider.complete_chat`.
+
+    System turns stay INLINE here, unlike `_split_for_provider`: `complete_chat` takes the whole
+    OpenAI-shaped transcript and each backend re-splits it for its own wire format (Bedrock
+    Converse lifts system turns into `system`, tool results into `toolResult` blocks), so
+    flattening them first would lose the order the client sent. `temperature` rides through as
+    sent, None included: no field on the wire is both OpenAI's own default and what a reasoning
+    model that rejects the parameter needs.
+
+    `tool_choice` goes out only ALONGSIDE the tools it selects from. A replayed tool transcript
+    reaches here with no `tools` at all, and `tool_choice` with `tools: null` is a malformed
+    request to an OpenAI-compatible backend; a DEMANDING choice never gets this far (the route
+    400s it), so the only one dropped here is an `"auto"`/`"none"` that no absent tool can
+    contradict.
+
+    `parallel_tool_calls` rides through as one of `ChatRequest`'s extras, which is where the
+    providers already read it from (`wmo.providers._responses_common`) and where
+    `ChatRequest.provider_payload` puts it on a chat-completions wire. Set only when the client
+    sent it, so a pool entry whose backend rejects the field never sees it unasked.
+    """
+    provider_request = ChatRequest(
+        messages=[m.for_provider() for m in request.messages],
+        tools=request.tools,
+        tool_choice=request.tool_choice if request.tools else None,
+        temperature=request.temperature,
+        max_completion_tokens=request.output_budget(),
+    )
+    extras = provider_request.model_extra
+    if extras is not None and request.parallel_tool_calls is not None:
+        # Written into `model_extra` rather than passed to the constructor: it is not a declared
+        # field, so the constructor keeps type-checking the ones that are.
+        extras["parallel_tool_calls"] = request.parallel_tool_calls
+    return provider_request
+
+
+class _PromptTokensDetails(BaseModel):
+    """The cached-prompt split an OpenAI-shaped `usage` object carries beside its totals."""
+
+    cached_tokens: int = 0
+
+
+def _structured_usage(response: ChatResponse) -> TokenUsage:
+    """Real token usage from a structured response, cached-prompt split included.
+
+    `ChatResponse.token_usage()` keeps only the two totals, but cache reads bill at a discount
+    and the request log prices each row with them (`PoolEntry.cost_usd`), so the split is read
+    off the provider's own `prompt_tokens_details`. A shape this build cannot parse costs the
+    row its cached split (priced at the full input rate, never silently free), not the request.
+    """
+    counts = response.token_usage()
+    cached = 0
+    if response.usage is not None:
+        raw = (response.usage.model_extra or {}).get("prompt_tokens_details")
+        if isinstance(raw, dict):
+            with contextlib.suppress(ValidationError):
+                cached = _PromptTokensDetails.model_validate(raw).cached_tokens
+    return TokenUsage(
+        input_tokens=counts.input_tokens,
+        output_tokens=counts.output_tokens,
+        cached_input_tokens=cached,
+    )
+
+
+def _reply_message(choice: ChatChoice) -> ChatMessage:
+    """The assistant turn a client will replay, as this module's own message type.
+
+    Validated rather than constructed so the provider's content (a string or text parts) goes
+    through the same normalizer a client's messages do, and so a shape this endpoint cannot
+    represent fails inside the upstream-call guard (a 502 plus its log row) instead of escaping
+    as a bare 500.
+
+    A null content becomes "" here instead of being refused: the mandatory-content rule catches a
+    CLIENT sending an empty billed turn, while an upstream reply with neither text nor calls is
+    still something this endpoint can render (it goes back out as content null), so rejecting it
+    would invent a 502 for a response the client can read.
+    """
+    return ChatMessage.model_validate(
+        {
+            "role": "assistant",
+            "content": choice.message.content if choice.message.content is not None else "",
+            "tool_calls": choice.message.tool_calls,
+        }
+    )
+
+
+# The finish reasons OpenAI's own schema declares; the SDK types the field as this exact set,
+# so a value outside it is a value a typed client cannot represent.
+_OPENAI_FINISH_REASONS = frozenset(
+    {"stop", "length", "tool_calls", "content_filter", "function_call"}
+)
+
+
+def _finish_reason(upstream: str | None, *, has_tool_calls: bool) -> str:
+    """Map a provider's finish reason onto OpenAI's vocabulary.
+
+    `length` outranks `tool_calls`: a call cut off at the output cap has truncated (invalid)
+    JSON arguments, and a client that reads "tool_calls" would parse them as complete. Anything
+    outside OpenAI's set (Bedrock's `end_turn`, Anthropic's `stop_sequence`) reports `stop`
+    rather than a value a typed client cannot represent.
+
+    The reason is DERIVED from the reply in both directions: an upstream `tool_calls` on a turn
+    that carries none reports `stop`. Reporting it verbatim is what a self-hosted backend whose
+    tool parser failed to extract the call sends, and the standard agent loop
+    (`if finish_reason == "tool_calls": for call in message.tool_calls`) raises TypeError on the
+    null `tool_calls` that reply really has.
+    """
+    if upstream == "length":
+        return "length"
+    if has_tool_calls:
+        return "tool_calls"
+    if upstream == "tool_calls":
+        return "stop"
+    return upstream if upstream in _OPENAI_FINISH_REASONS else "stop"
+
+
+def _message_payload(reply: ChatMessage) -> dict[str, JsonValue]:
+    """One OpenAI response message: content null (not "") when the turn is tool calls only."""
+    payload: dict[str, JsonValue] = {"role": "assistant", "content": reply.content or None}
+    if reply.tool_calls:
+        payload["tool_calls"] = [call.model_dump(mode="json") for call in reply.tool_calls]
+    return payload
+
+
+def _tool_call_deltas(tool_calls: list[ChatToolCall]) -> list[JsonValue]:
+    """Streaming tool-call entries: `index`, `id`, and the whole `function.arguments` string.
+
+    OpenAI splits `arguments` across many chunks and a client concatenates them per `index`;
+    one complete fragment is that same contract with one fragment, which is the honest framing
+    for a call the endpoint could not stream (see the module docstring).
+    """
+    return [
+        {
+            "index": index,
+            "id": call.id,
+            "type": call.type,
+            "function": {"name": call.function.name, "arguments": call.function.arguments},
+        }
+        for index, call in enumerate(tool_calls)
+    ]
 
 
 def _usage_dict(usage: TokenUsage) -> dict[str, object]:
@@ -464,7 +898,7 @@ def _chunk_payload(
     completion_id: str,
     created: int,
     endpoint: str,
-    delta: dict[str, str],
+    delta: dict[str, JsonValue],
     *,
     finish_reason: str | None = None,
 ) -> dict[str, object]:
@@ -475,6 +909,29 @@ def _chunk_payload(
         "model": endpoint,
         "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
     }
+
+
+def _completion_body(
+    completion_id: str,
+    created: int,
+    endpoint: str,
+    message: dict[str, JsonValue],
+    *,
+    finish_reason: str,
+    usage: TokenUsage,
+) -> str:
+    """One non-streamed `chat.completion` body, naming the ENDPOINT and never the routed model."""
+    return json.dumps(
+        {
+            "id": completion_id,
+            "object": "chat.completion",
+            "created": created,
+            "model": endpoint,
+            "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+            "usage": _usage_dict(usage),
+        },
+        ensure_ascii=False,
+    )
 
 
 class ServedKnobs(BaseModel):
@@ -637,16 +1094,30 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
             )
         unsupported = request.unsupported_features()
         if unsupported:
-            # Silently dropping tools/n/response_format would make a tool-calling client read
-            # plain text where it expects tool_calls: a compatibility gap disguised as a
-            # model-quality problem. Reject loudly instead.
+            # Silently dropping n/response_format/logprobs would make a client read a shape it
+            # did not ask for: a compatibility gap disguised as a model-quality problem. Reject
+            # loudly instead (see ChatCompletionRequest for why each one is still out).
             return _error_response(
                 400,
                 f"this endpoint does not support {unsupported} yet",
                 err_type="invalid_request_error",
                 code="unsupported_parameter",
             )
-        if not any(m.role != "system" for m in request.messages):
+        unsatisfiable = request.unsatisfiable_tool_choice()
+        if unsatisfiable:
+            # Honoring it is impossible (the tool it demands is not on this request) and dropping
+            # it would be a functional parameter silently ignored, so name the missing half here
+            # rather than let the provider answer with a 502 or with prose (see
+            # `unsatisfiable_tool_choice`).
+            return _error_response(
+                400,
+                unsatisfiable,
+                err_type="invalid_request_error",
+                code="invalid_tool_choice",
+            )
+        if not any(m.role in ("user", "assistant") for m in request.messages):
+            # Tool results do not count: a result with no assistant call to answer is a client
+            # bug, and there would be nothing for the router to read (see `_routable_text`).
             return _error_response(
                 400,
                 "at least one user or assistant message is required",
@@ -678,7 +1149,6 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                 err_type="api_error",
                 code="routing_error",
             )
-        system, turns = _split_for_provider(request.messages)
         completion_id = f"chatcmpl-{uuid.uuid4().hex}"
         created = int(time.time())
         started = time.monotonic()
@@ -713,6 +1183,114 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
 
         headers = {"x-wmo-routed-model": decision.model}
 
+        if request.needs_tool_calling():
+            if not isinstance(provider, ToolCallingProvider):
+                # The routed pool entry cannot carry tool calls at all. Dropping the tools and
+                # answering in prose would read as a bad model; 501 + a log row says which entry
+                # and what to change (mirrors the streaming capability gap below).
+                detail = (
+                    f"pool model '{entry.name}' (kind '{entry.kind.value}') cannot serve tool "
+                    "calls: its provider has no structured chat backend. Retry without `tools`, "
+                    "or give this endpoint a pool whose entries all support tool calling"
+                )
+                _record(TokenUsage(), ttfb_ms=None, status="error", error_message=detail)
+                return _error_response(
+                    501, detail, err_type="api_error", code="tool_calling_unsupported"
+                )
+            # Zero until the call comes back, then the provider's own counts, so a response that
+            # arrived and cannot be USED still meters what it billed. Zero choices is the normal
+            # shape of an upstream content filter, which charges for the prompt it read; recording
+            # TokenUsage() there would under-report the row and its cost as free, the same silent
+            # usage loss the abandoned-stream path exists to prevent (D-METERING).
+            usage = TokenUsage()
+            try:
+                structured = provider.complete_chat(_provider_request(request))
+                usage = _structured_usage(structured)
+                if not structured.choices:
+                    # Content filtering (and some provider error modes) return zero choices.
+                    raise ValueError(f"{entry.model} returned no choices")
+                choice = structured.choices[0]
+                reply = _reply_message(choice)
+                finish_reason = _finish_reason(
+                    choice.finish_reason, has_tool_calls=bool(reply.tool_calls)
+                )
+            except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502
+                # Same split as the text path: detail to the log, class name to the client.
+                _record(usage, ttfb_ms=None, status="error", error_message=str(exc))
+                logger.error("tool-calling call for %s failed: %s", entry.name, exc)
+                return _error_response(
+                    502,
+                    f"upstream model call failed ({type(exc).__name__})",
+                    err_type="api_error",
+                    code="upstream_error",
+                )
+            runtime.remember(request.messages, reply, decision.model)
+            if not request.stream:
+                _record(usage, ttfb_ms=None)
+                return Response(
+                    content=_completion_body(
+                        completion_id,
+                        created,
+                        runtime.name,
+                        _message_payload(reply),
+                        finish_reason=finish_reason,
+                        usage=usage,
+                    ),
+                    media_type="application/json",
+                    headers=headers,
+                )
+
+            # Re-emitted, not forwarded (module docstring): the upstream call is already
+            # finished, so the row lands here and cannot be lost to a client disconnect, and
+            # ttfb is the whole upstream latency because that is when the first byte can go out.
+            _record(usage, ttfb_ms=(time.monotonic() - started) * 1000)
+
+            def _tool_events() -> Iterator[str]:
+                yield _sse(
+                    _chunk_payload(
+                        completion_id, created, runtime.name, {"role": "assistant", "content": ""}
+                    )
+                )
+                if reply.content:
+                    yield _sse(
+                        _chunk_payload(
+                            completion_id, created, runtime.name, {"content": reply.content}
+                        )
+                    )
+                if reply.tool_calls:
+                    yield _sse(
+                        _chunk_payload(
+                            completion_id,
+                            created,
+                            runtime.name,
+                            {"tool_calls": _tool_call_deltas(reply.tool_calls)},
+                        )
+                    )
+                yield _sse(
+                    _chunk_payload(
+                        completion_id, created, runtime.name, {}, finish_reason=finish_reason
+                    )
+                )
+                if request.wants_stream_usage():
+                    yield _sse(
+                        {
+                            "id": completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": runtime.name,
+                            "choices": [],
+                            "usage": _usage_dict(usage),
+                        }
+                    )
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(
+                _tool_events(),
+                media_type="text/event-stream",
+                headers={**headers, "Cache-Control": "no-cache"},
+            )
+
+        system, turns = _split_for_provider(request.messages)
         if not request.stream:
             try:
                 completion = provider.complete(
@@ -732,25 +1310,20 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     err_type="api_error",
                     code="upstream_error",
                 )
-            runtime.remember(request.messages, completion.text, decision.model)
+            runtime.remember(
+                request.messages,
+                ChatMessage(role="assistant", content=completion.text),
+                decision.model,
+            )
             _record(completion.usage, ttfb_ms=None)
             return Response(
-                content=json.dumps(
-                    {
-                        "id": completion_id,
-                        "object": "chat.completion",
-                        "created": created,
-                        "model": runtime.name,
-                        "choices": [
-                            {
-                                "index": 0,
-                                "message": {"role": "assistant", "content": completion.text},
-                                "finish_reason": "stop",
-                            }
-                        ],
-                        "usage": _usage_dict(completion.usage),
-                    },
-                    ensure_ascii=False,
+                content=_completion_body(
+                    completion_id,
+                    created,
+                    runtime.name,
+                    {"role": "assistant", "content": completion.text},
+                    finish_reason="stop",
+                    usage=completion.usage,
                 ),
                 media_type="application/json",
                 headers=headers,
@@ -844,7 +1417,11 @@ def create_chat_router(endpoints: Mapping[str, EndpointRuntime]) -> APIRouter:
                     }
                 )
             yield "data: [DONE]\n\n"
-            runtime.remember(request.messages, "".join(parts), decision.model)
+            runtime.remember(
+                request.messages,
+                ChatMessage(role="assistant", content="".join(parts)),
+                decision.model,
+            )
             stream_state["recorded"] = True
             _record(usage, ttfb_ms=ttfb_ms)
 

--- a/wmo/serving/chat_openai_client_test.py
+++ b/wmo/serving/chat_openai_client_test.py
@@ -3,14 +3,16 @@
 `chat_test.py` exercises the route with FastAPI's TestClient, which only proves we can parse
 our own output. These tests boot an actual uvicorn server and drive it with the official
 `openai` SDK - the same code path a customer's integration uses - covering non-streaming
-response parsing, streaming chunk framing with `stream_options.include_usage`, and error body
-shapes (the SDK must raise its typed exception AND surface our message from
-`body["error"]["message"]`). The upstream provider is a deterministic in-process fake, so the
-tests prove wire compatibility without network or keys.
+response parsing, streaming chunk framing with `stream_options.include_usage`, tool calling
+(including the SDK's own replay idiom, where the assistant message it parsed goes straight back
+into `messages`), and error body shapes (the SDK must raise its typed exception AND surface our
+message from `body["error"]["message"]`). The upstream provider is a deterministic in-process
+fake, so the tests prove wire compatibility without network or keys.
 """
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from collections.abc import Iterator
@@ -20,6 +22,16 @@ import openai
 import pytest
 import uvicorn
 from fastapi import FastAPI
+from llm_waterfall.types import (
+    ChatChoice,
+    ChatFunctionCall,
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ChatToolCall,
+    ChatUsage,
+)
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolUnionParam
 
 from wmo.optimize.policy import RoutingPolicy
 from wmo.providers.base import (
@@ -82,18 +94,85 @@ class _FakeProvider:
         raise NotImplementedError
 
 
+_TOOL_ARGUMENTS = '{"table": "superheroes", "limit": 10}'
+
+_TOOLS: list[ChatCompletionToolUnionParam] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "read rows from a table",
+            "parameters": {
+                "type": "object",
+                "properties": {"table": {"type": "string"}, "limit": {"type": "integer"}},
+            },
+        },
+    }
+]
+
+
+class _ToolFakeProvider(_FakeProvider):
+    """Deterministic structured upstream: calls `lookup`, then answers from the tool result."""
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        results = [m for m in request.messages if m.role == "tool"]
+        if results:
+            return ChatResponse(
+                choices=[
+                    ChatChoice(
+                        message=ChatMessage(
+                            role="assistant", content=f"{self.name} read {results[-1].content}"
+                        ),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=ChatUsage(prompt_tokens=13, completion_tokens=9),
+            )
+        return ChatResponse(
+            choices=[
+                ChatChoice(
+                    message=ChatMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatToolCall(
+                                id="call_1",
+                                function=ChatFunctionCall(name="lookup", arguments=_TOOL_ARGUMENTS),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=ChatUsage(prompt_tokens=11, completion_tokens=7),
+        )
+
+
 @pytest.fixture(scope="module")
 def live_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
-    """A real uvicorn server on an ephemeral port, serving one static endpoint."""
+    """A real uvicorn server on an ephemeral port, serving two static endpoints.
+
+    `tau-bench`'s pool model is text-only (no `complete_chat`, like the direct anthropic
+    backend); `tools-bench`'s speaks the structured contract. Both are needed to prove the two
+    halves of the tool surface: a real round trip, and the honest error when the routed model
+    cannot make one.
+    """
     pool = [PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5")]
+    log = RequestLog(tmp_path_factory.mktemp("serving") / "requests.jsonl")
     runtime = EndpointRuntime(
         name="tau-bench",
         policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=pool),
         provider_factory=_FakeProvider,
-        log=RequestLog(tmp_path_factory.mktemp("serving") / "requests.jsonl"),
+        log=log,
+    )
+    tool_runtime = EndpointRuntime(
+        name="tools-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=pool),
+        provider_factory=_ToolFakeProvider,
+        log=log,
     )
     app = FastAPI()
-    app.include_router(create_chat_router({"tau-bench": runtime}))
+    app.include_router(create_chat_router({"tau-bench": runtime, "tools-bench": tool_runtime}))
     install_openai_error_shapes(app)
     server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error"))
     thread = threading.Thread(target=server.run, daemon=True)
@@ -189,16 +268,93 @@ def test_real_client_validation_error_is_openai_shaped_400(live_server: str) -> 
     assert "messages" in body["message"]
 
 
-def test_real_client_tools_rejected_not_silently_dropped(live_server: str) -> None:
-    with pytest.raises(openai.BadRequestError) as excinfo:
+def test_real_client_round_trips_a_tool_call(live_server: str) -> None:
+    """The SDK's own agent loop: parse tool_calls, replay the message it parsed, get the answer.
+
+    Appending `completion.choices[0].message` verbatim is the documented idiom, and it sends
+    fields our schema never declared (`refusal`, `annotations`, a null `content`), so this also
+    proves the endpoint tolerates them instead of 400ing a client's own output.
+    """
+    client = _client(live_server)
+    completion = client.chat.completions.create(
+        model="tools-bench",
+        messages=[{"role": "user", "content": "how many superheroes are there?"}],
+        tools=_TOOLS,
+    )
+    choice = completion.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content is None
+    assert choice.message.tool_calls is not None
+    call = choice.message.tool_calls[0]
+    assert call.id == "call_1"
+    assert call.type == "function"
+    assert call.function.name == "lookup"
+    assert json.loads(call.function.arguments) == {"table": "superheroes", "limit": 10}
+
+    followup = client.chat.completions.create(
+        model="tools-bench",
+        messages=[
+            {"role": "user", "content": "how many superheroes are there?"},
+            cast("ChatCompletionMessageParam", choice.message),
+            {"role": "tool", "tool_call_id": call.id, "content": "42 rows"},
+        ],
+        tools=_TOOLS,
+    )
+    assert followup.choices[0].message.content == "haiku-4-5 read 42 rows"
+    assert followup.choices[0].finish_reason == "stop"
+    assert followup.usage is not None and followup.usage.completion_tokens == 9
+
+
+def test_real_client_reassembles_streamed_tool_call_arguments(live_server: str) -> None:
+    stream = _client(live_server).chat.completions.create(
+        model="tools-bench",
+        messages=[{"role": "user", "content": "how many superheroes are there?"}],
+        tools=_TOOLS,
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+    arguments: dict[int, str] = {}
+    names: dict[int, str] = {}
+    ids: dict[int, str] = {}
+    finish_reasons: list[str] = []
+    usage = None
+    for chunk in stream:
+        if chunk.usage is not None:
+            assert chunk.choices == []
+            usage = chunk.usage
+        for choice in chunk.choices:
+            for call in choice.delta.tool_calls or []:
+                if call.id is not None:
+                    ids[call.index] = call.id
+                if call.function is not None and call.function.name is not None:
+                    names[call.index] = call.function.name
+                if call.function is not None and call.function.arguments:
+                    arguments[call.index] = arguments.get(call.index, "") + call.function.arguments
+            if choice.finish_reason:
+                finish_reasons.append(choice.finish_reason)
+    assert ids == {0: "call_1"} and names == {0: "lookup"}
+    assert json.loads(arguments[0]) == {"table": "superheroes", "limit": 10}
+    assert finish_reasons == ["tool_calls"]
+    assert usage is not None and usage.completion_tokens == 7
+
+
+def test_real_client_tools_on_a_text_only_pool_model_are_not_silently_dropped(
+    live_server: str,
+) -> None:
+    # `tau-bench`'s pool model has no structured backend. Answering in prose would look like a
+    # weak model, so the endpoint fails with the pool entry named (501, not a 400: the request is
+    # valid, the routed model cannot serve it).
+    with pytest.raises(openai.InternalServerError) as excinfo:
         _client(live_server).chat.completions.create(
             model="tau-bench",
             messages=[{"role": "user", "content": "hi"}],
-            tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+            tools=_TOOLS,
         )
+    assert excinfo.value.status_code == 501
     body = cast("dict[str, str]", excinfo.value.body)
-    assert body["code"] == "unsupported_parameter"
-    assert "tools" in body["message"]
+    assert body["code"] == "tool_calling_unsupported"
+    assert "haiku-4-5" in body["message"]
+    assert "cannot serve tool calls" in body["message"]
 
 
 def test_real_client_developer_role_and_content_parts(live_server: str) -> None:

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -952,11 +952,15 @@ def test_the_seven_day_savings_window_is_never_served_from_cache(tmp_path: Path)
 
 _TOOL_ARGUMENTS = '{"table": "superheroes", "limit": 10}'
 
+# The one tool name `_TOOLS` declares, named so a tool_choice can reference it without indexing
+# into loosely typed wire JSON.
+_TOOL_NAME = "lookup"
+
 _TOOLS = [
     {
         "type": "function",
         "function": {
-            "name": "lookup",
+            "name": _TOOL_NAME,
             "description": "read rows from a table",
             "parameters": {
                 "type": "object",
@@ -1487,6 +1491,76 @@ def test_tool_choice_without_tools_is_a_400(tmp_path: Path) -> None:
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "invalid_tool_choice"
     assert "declare the tool definitions" in response.json()["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "function", "function": {}},
+        {"type": "function", "function": {"name": ""}},
+        {"type": "function"},
+        {"type": "function", "function": {"name": None}},
+    ],
+)
+def test_a_function_tool_choice_with_no_usable_name_is_a_400(
+    tmp_path: Path, tool_choice: dict[str, object]
+) -> None:
+    """A function-shaped choice that names nothing demands a call it cannot identify.
+
+    Forwarded, it reaches an OpenAI-compatible backend as a malformed request that this endpoint
+    reports as a 502 blaming the model, while Bedrock discards the requirement and can answer in
+    prose to a client that requires a call. Refuse it at the door instead.
+    """
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+            "tool_choice": tool_choice,
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_tool_choice"
+    assert "no usable `function.name`" in response.json()["error"]["message"]
+
+
+def test_a_function_tool_choice_naming_a_declared_tool_still_serves(tmp_path: Path) -> None:
+    """The guard must not start refusing the well-formed named choice it sits next to."""
+    client, _, provider = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": _TOOL_NAME},
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_an_unrecognized_tool_choice_word_is_still_forwarded(tmp_path: Path) -> None:
+    """An unknown future vocabulary word is not function-shaped, so it is forwarded, not refused.
+
+    OpenAI's own vocabulary has grown (`required` postdates `auto`); rewriting or refusing a word
+    this build has not heard of would break a client the provider could have served.
+    """
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+            "tool_choice": "some_future_mode",
+        },
+    )
+    assert response.status_code == 200, response.text
 
 
 def test_a_tool_call_streams_from_a_provider_with_no_streaming_backend(tmp_path: Path) -> None:

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -12,7 +12,17 @@ import numpy as np
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from llm_waterfall.types import (
+    ChatChoice,
+    ChatFunctionCall,
+    ChatMessage,
+    ChatRequest,
+    ChatResponse,
+    ChatToolCall,
+    ChatUsage,
+)
 
+from wmo.core.types import JsonObject
 from wmo.optimize.policy import (
     KNN_BANK_FILENAME,
     POLICY_FILENAME,
@@ -31,6 +41,7 @@ from wmo.providers.base import (
 )
 from wmo.providers.pool import PoolEntry
 from wmo.retrieval.embedders import HashingEmbedder
+from wmo.serving.chat import ChatMessage as EndpointMessage
 from wmo.serving.chat import (
     EndpointRuntime,
     RequestLog,
@@ -934,3 +945,1082 @@ def test_the_seven_day_savings_window_is_never_served_from_cache(tmp_path: Path)
         assert reads["n"] == 3  # all_time cached after the first
     finally:
         RequestLog.replay = original
+
+
+# --- tool calling: tools/tool_choice in, tool_calls out, tool results replayed ----------------
+
+
+_TOOL_ARGUMENTS = '{"table": "superheroes", "limit": 10}'
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "read rows from a table",
+            "parameters": {
+                "type": "object",
+                "properties": {"table": {"type": "string"}, "limit": {"type": "integer"}},
+                "required": ["table"],
+            },
+        },
+    }
+]
+
+
+class _ToolProvider(_EchoProvider):
+    """Fake structured provider: calls `lookup` once, then answers from the tool result.
+
+    Every request it receives lands in `seen`, so a test can assert what actually reached the
+    provider: the tool path exists precisely so nothing is flattened away on the way there.
+    """
+
+    def __init__(
+        self,
+        entry: PoolEntry,
+        seen: list[ChatRequest],
+        *,
+        finish_reason: str | None = "tool_calls",
+        n_tool_calls: int = 1,
+    ) -> None:
+        super().__init__(entry)
+        self._seen = seen
+        self._finish_reason = finish_reason
+        self._n_tool_calls = n_tool_calls
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        self._seen.append(request)
+        results = [m for m in request.messages if m.role == "tool"]
+        if results:
+            answer = f"{self.name} read {results[-1].content}"
+            return ChatResponse(
+                choices=[
+                    ChatChoice(
+                        message=ChatMessage(role="assistant", content=answer),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=ChatUsage(prompt_tokens=13, completion_tokens=9),
+            )
+        return ChatResponse(
+            choices=[
+                ChatChoice(
+                    message=ChatMessage(
+                        role="assistant",
+                        content=None,  # the shape a tool-only turn really has on the wire
+                        tool_calls=[
+                            ChatToolCall(
+                                id=f"call_{index}",
+                                function=ChatFunctionCall(name="lookup", arguments=_TOOL_ARGUMENTS),
+                            )
+                            for index in range(1, self._n_tool_calls + 1)
+                        ],
+                    ),
+                    finish_reason=self._finish_reason,
+                )
+            ],
+            usage=ChatUsage.model_validate(
+                {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 7,
+                    "prompt_tokens_details": {"cached_tokens": 4},
+                }
+            ),
+        )
+
+
+def _tool_client(
+    tmp_path: Path,
+    policy: RoutingPolicy | None = None,
+    *,
+    finish_reason: str | None = "tool_calls",
+    n_tool_calls: int = 1,
+) -> tuple[TestClient, Path, list[ChatRequest]]:
+    """A client whose pool models all speak the structured tool-calling contract."""
+    seen: list[ChatRequest] = []
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=policy or RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _ToolProvider(
+            entry, seen, finish_reason=finish_reason, n_tool_calls=n_tool_calls
+        ),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    install_openai_error_shapes(app)
+    return TestClient(app), log_path, seen
+
+
+def _rows(log_path: Path) -> list[JsonObject]:
+    """The request log's rows as raw JSON, so a test reads the on-disk field names verbatim."""
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+def _error_message(row: JsonObject) -> str:
+    """One row's `error_message`, narrowed: an error row always carries one, as a string."""
+    message = row["error_message"]
+    assert isinstance(message, str)
+    return message
+
+
+def test_a_tools_request_is_served_not_rejected(tmp_path: Path) -> None:
+    # The whole point: a tool-calling agent could not use this endpoint at all before.
+    client, log_path, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "how many superheroes are there?"}],
+            "tools": _TOOLS,
+            "tool_choice": "auto",
+        },
+    )
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message["content"] is None  # tool-only turn: null, not an empty string
+    assert message["tool_calls"] == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+        }
+    ]
+    assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+    assert response.json()["model"] == "tau-bench"  # still the endpoint, never the routed model
+    # The tools reached the provider as tools, and tool_choice rode along with them.
+    assert seen[0].tools is not None
+    assert [tool.function.name for tool in seen[0].tools] == ["lookup"]
+    assert seen[0].tool_choice == "auto"
+    assert seen[0].max_completion_tokens == 8192
+    # One row per request, with the provider's real usage including its cached-prompt split.
+    rows = _rows(log_path)
+    assert len(rows) == 1
+    assert (rows[0]["input_tokens"], rows[0]["output_tokens"]) == (11, 7)
+    assert rows[0]["cached_tokens"] == 4
+    assert rows[0]["status"] == "ok"
+
+
+def test_a_tool_result_message_reaches_the_provider(tmp_path: Path) -> None:
+    client, log_path, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "how many superheroes are there?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "42 rows"},
+            ],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "haiku-4-5 read 42 rows"
+    assert response.json()["choices"][0]["finish_reason"] == "stop"
+    # What the provider saw: the tool result kept its role and its tool_call_id, the assistant
+    # turn kept its call, and the system turn stayed inline and in order.
+    sent = seen[0].messages
+    assert [m.role for m in sent] == ["system", "user", "assistant", "tool"]
+    assert sent[2].content is None  # an empty content string is not sent in its place
+    assert sent[2].tool_calls is not None
+    assert sent[2].tool_calls[0].id == "call_1"
+    assert (sent[3].tool_call_id, sent[3].content) == ("call_1", "42 rows")
+    assert len(_rows(log_path)) == 1
+
+
+def test_streaming_a_tool_call_emits_reassemblable_deltas(tmp_path: Path) -> None:
+    client, log_path, _ = _tool_client(tmp_path)
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "messages": [{"role": "user", "content": "how many superheroes are there?"}],
+            "tools": _TOOLS,
+        },
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        payloads = [
+            line.removeprefix("data: ") for line in response.iter_lines() if line.startswith("data")
+        ]
+    assert payloads[-1] == "[DONE]"
+    chunks = [json.loads(payload) for payload in payloads[:-1]]
+    assert all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
+    # Reassemble exactly as an OpenAI client does: concatenate function.arguments per index.
+    arguments: dict[int, str] = {}
+    names: dict[int, str] = {}
+    ids: dict[int, str] = {}
+    for chunk in chunks:
+        for choice in chunk["choices"]:
+            for call in choice["delta"].get("tool_calls") or []:
+                index = call["index"]
+                ids.setdefault(index, call["id"])
+                names.setdefault(index, call["function"]["name"])
+                arguments[index] = arguments.get(index, "") + call["function"]["arguments"]
+    assert ids == {0: "call_1"} and names == {0: "lookup"}
+    assert json.loads(arguments[0]) == {"table": "superheroes", "limit": 10}
+    assert chunks[-2]["choices"][0]["finish_reason"] == "tool_calls"
+    assert chunks[-1]["choices"] == [] and chunks[-1]["usage"]["total_tokens"] == 18
+    rows = _rows(log_path)
+    assert len(rows) == 1
+    assert rows[0]["ttfb_ms"] is not None  # a re-emitted stream still reports when it could start
+    assert rows[0]["output_tokens"] == 7
+
+
+def test_affinity_survives_a_tool_round_trip(tmp_path: Path) -> None:
+    # remember() has to store the assistant turn's tool_calls, not just its (empty) text, or the
+    # next request's prefix fingerprints to a transcript that was never sent and the conversation
+    # re-routes at exactly the point its prompt cache is warmest.
+    client, log_path, _ = _tool_client(tmp_path, policy=_cluster_policy())
+    first = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "SELECT count(*) FROM superheroes"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert first.headers["x-wmo-routed-model"] == "fable-5"
+    call = first.json()["choices"][0]["message"]["tool_calls"][0]
+    second = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "SELECT count(*) FROM superheroes"},
+                {"role": "assistant", "content": None, "tool_calls": [call]},
+                {"role": "tool", "tool_call_id": call["id"], "content": "42 rows"},
+            ],
+            "tools": _TOOLS,
+        },
+    )
+    assert second.headers["x-wmo-routed-model"] == "fable-5"
+    rows = _rows(log_path)
+    assert [row["routing_reason"] for row in rows] == [
+        "rank router: nearest cluster 0 (sql)",
+        "sticky: conversation affinity",
+    ]
+
+
+def test_routing_reads_the_user_turn_not_the_tool_result(tmp_path: Path) -> None:
+    # A tool result is machine output the model asked for, not the customer's request: routing on
+    # it would send one conversation to a different model on every turn. This transcript's user
+    # turn is SQL (fable-5's cluster) while its tool result is prose (haiku-4-5's), and the
+    # prefix was never remembered here, so only _routable_text decides.
+    client, log_path, _ = _tool_client(tmp_path, policy=_cluster_policy())
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "SELECT count(*) FROM superheroes"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "write a friendly email about it",
+                },
+            ],
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["x-wmo-routed-model"] == "fable-5"
+    assert _rows(log_path)[0]["cluster_label"] == "sql"  # not a sticky decision: a fresh one
+
+
+def test_tools_on_a_pool_model_without_a_structured_backend(tmp_path: Path) -> None:
+    # _EchoProvider has complete/stream but no complete_chat, like the direct anthropic backend.
+    client, log_path = _client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 501
+    error = response.json()["error"]
+    assert error["code"] == "tool_calling_unsupported"
+    assert "haiku-4-5" in error["message"]  # names the pool entry an operator has to change
+    assert "anthropic" in error["message"]
+    rows = _rows(log_path)
+    assert len(rows) == 1  # a capability gap is still one metered request
+    assert rows[0]["status"] == "error"
+    assert rows[0]["model"] == "haiku-4-5"
+    assert "cannot serve tool calls" in _error_message(rows[0])
+
+
+def test_a_tool_transcript_without_tools_still_takes_the_structured_path(tmp_path: Path) -> None:
+    # Some agents stop re-sending `tools` once the loop is under way; the transcript alone must
+    # be enough, because the text path cannot represent a tool result at all.
+    client, _, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "how many superheroes are there?"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "42 rows"},
+            ],
+        },
+    )
+    assert response.status_code == 200
+    assert seen[0].tools is None
+    assert [m.role for m in seen[0].messages] == ["user", "assistant", "tool"]
+
+
+def test_finish_reason_length_outranks_tool_calls(tmp_path: Path) -> None:
+    # Arguments truncated at the output cap are invalid JSON; a client that reads "tool_calls"
+    # would parse them as complete, so the truncation signal wins.
+    client, _, _ = _tool_client(tmp_path, finish_reason="length")
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.json()["choices"][0]["finish_reason"] == "length"
+    assert response.json()["choices"][0]["message"]["tool_calls"]  # still reported
+
+
+def test_finish_reason_is_derived_when_the_provider_omits_it(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path, finish_reason=None)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_a_provider_returning_no_choices_is_a_502_with_a_log_row(tmp_path: Path) -> None:
+    class _EmptyProvider(_ToolProvider):
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            return ChatResponse(choices=[])
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _EmptyProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "upstream_error"
+    rows = _rows(log_path)
+    assert len(rows) == 1
+    assert "no choices" in _error_message(rows[0])
+
+
+def test_a_tool_message_without_a_tool_call_id_is_a_400(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "tool", "content": "42 rows"},
+            ],
+        },
+    )
+    assert response.status_code == 400
+    message = response.json()["error"]["message"]
+    assert "tool_call_id" in message and "messages.1" in message
+
+
+def test_a_tool_result_sent_as_an_assistant_turn_is_a_400(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "tool_call_id": "call_1", "content": "42 rows"},
+            ],
+        },
+    )
+    assert response.status_code == 400
+    assert "role='tool'" in response.json()["error"]["message"]
+
+
+def test_tool_results_alone_are_not_a_conversation(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "tool", "tool_call_id": "call_1", "content": "42 rows"}],
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_messages"
+
+
+def test_the_remaining_unsupported_parameters_are_still_rejected(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path)
+    for payload, expected in (
+        ({"n": 2}, "n != 1"),
+        ({"logprobs": True}, "logprobs"),
+        ({"response_format": {"type": "json_object"}}, "response_format"),
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": [{"role": "user", "content": "hi"}],
+                **payload,
+            },
+        )
+        assert response.status_code == 400, payload
+        assert response.json()["error"]["code"] == "unsupported_parameter"
+        assert expected in response.json()["error"]["message"]
+
+
+def test_fingerprints_separate_tool_branches(tmp_path: Path) -> None:
+    # Affinity is keyed on the transcript, so two different calls out of the same prefix (or two
+    # results for different calls) must not share a key: they are different conversations.
+    from wmo.serving.chat import _fingerprint
+
+    def call(name: str) -> ChatToolCall:
+        return ChatToolCall(id=f"call_{name}", function=ChatFunctionCall(name=name, arguments="{}"))
+
+    prefix = [EndpointMessage(role="user", content="hi")]
+    lookup = [*prefix, EndpointMessage(role="assistant", tool_calls=[call("lookup")])]
+    write = [*prefix, EndpointMessage(role="assistant", tool_calls=[call("write")])]
+    assert _fingerprint(lookup) != _fingerprint(write)
+    assert _fingerprint(lookup) == _fingerprint(
+        [*prefix, EndpointMessage(role="assistant", tool_calls=[call("lookup")])]
+    )
+    # Same result text, different call answered: still different conversations.
+    first = [*lookup, EndpointMessage(role="tool", tool_call_id="call_lookup", content="42")]
+    second = [*lookup, EndpointMessage(role="tool", tool_call_id="call_other", content="42")]
+    assert _fingerprint(first) != _fingerprint(second)
+    # And a text-only transcript keeps hashing to one stable key.
+    text = [*prefix, EndpointMessage(role="assistant", content="hello")]
+    assert _fingerprint(text) == _fingerprint(
+        [*prefix, EndpointMessage(role="assistant", content="hello")]
+    )
+
+
+def test_an_empty_tool_list_is_served_as_plain_chat(tmp_path: Path) -> None:
+    # A client whose tool registry is empty sends `tools: []`. That advertises nothing, so it must
+    # not demand a tool-calling backend (this pool model has none) nor reach one as an empty array.
+    client, log_path = _client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "served by haiku-4-5"
+    assert _rows(log_path)[0]["status"] == "ok"
+
+
+def test_tool_choice_without_tools_is_a_400(tmp_path: Path) -> None:
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "required",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_tool_choice"
+    assert "declare the tool definitions" in response.json()["error"]["message"]
+
+
+def test_a_tool_call_streams_from_a_provider_with_no_streaming_backend(tmp_path: Path) -> None:
+    # The re-emitted stream needs no native streaming surface at all (the module docstring's
+    # tradeoff), so a structured-only provider can serve a streamed tool call; a streamed request
+    # with no tools on that same provider still gets the honest 501.
+    class _NoStreamProvider(_ToolProvider):
+        stream = None  # type: ignore[assignment]  # not a StreamingProvider at all
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _NoStreamProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    client = TestClient(app)
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    ) as response:
+        assert response.status_code == 200
+        chunks = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.iter_lines()
+            if line.startswith("data: ") and not line.endswith("[DONE]")
+        ]
+    assert chunks[1]["choices"][0]["delta"]["tool_calls"][0]["function"]["name"] == "lookup"
+    plain = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert plain.status_code == 501
+    assert plain.json()["error"]["code"] == "streaming_unsupported"
+
+
+def test_content_is_still_required_except_on_a_tool_call_turn(tmp_path: Path) -> None:
+    # Only the assistant turn whose whole output is tool_calls may omit content; a user turn that
+    # forgot it is the client bug the old required field caught, and must keep 400ing.
+    client, _, _ = _tool_client(tmp_path)
+    missing = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user"}]},
+    )
+    assert missing.status_code == 400
+    assert "needs `content`" in missing.json()["error"]["message"]
+    allowed = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "how many superheroes are there?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "42 rows"},
+            ],
+        },
+    )
+    assert allowed.status_code == 200
+
+
+def test_parallel_tool_calls_reaches_the_provider(tmp_path: Path) -> None:
+    # An agent whose executor answers one call per turn sends parallel_tool_calls=false. The
+    # endpoint used to declare no such field, so pydantic dropped it and the client got a
+    # multi-call turn back: a parameter the stack already carries, lost at the endpoint.
+    client, _, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "how many superheroes are there?"}],
+            "tools": _TOOLS,
+            "parallel_tool_calls": False,
+        },
+    )
+    assert response.status_code == 200
+    # On the wire, not just on the model: provider_payload is what a backend actually receives.
+    assert (seen[0].model_extra or {}).get("parallel_tool_calls") is False
+    assert seen[0].provider_payload("claude-haiku-4-5")["parallel_tool_calls"] is False
+
+
+def test_parallel_tool_calls_is_only_sent_when_the_client_sent_it(tmp_path: Path) -> None:
+    # A backend that rejects the field must never see it unasked, so an absent one stays absent.
+    client, _, seen = _tool_client(tmp_path)
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert seen[0].model_extra == {}
+    assert "parallel_tool_calls" not in seen[0].provider_payload("claude-haiku-4-5")
+
+
+def test_an_upstream_tool_calls_reason_with_no_calls_reports_stop(tmp_path: Path) -> None:
+    # A self-hosted backend whose tool parser failed to extract the call reports finish_reason
+    # tool_calls on a plain text turn. Passing that through emits a response no typed client can
+    # handle: the agent loop idiom iterates message.tool_calls, which is null here.
+    class _UnparsedProvider(_ToolProvider):
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            return ChatResponse(
+                choices=[
+                    ChatChoice(
+                        message=ChatMessage(role="assistant", content="I will call a tool"),
+                        finish_reason="tool_calls",
+                    )
+                ],
+                usage=ChatUsage(prompt_tokens=11, completion_tokens=7),
+            )
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _UnparsedProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"  # never a reason the message cannot back up
+    assert "tool_calls" not in choice["message"]
+
+
+def test_affinity_survives_a_parallel_tool_round_trip(tmp_path: Path) -> None:
+    # Parallel calls are OpenAI's default, and answering N of them appends N+1 messages (the
+    # assistant turn plus one result each). A lookup that strips a fixed one message matches only
+    # the single-call case, so a two-call turn re-routed mid-loop: the prompt cache is forfeited
+    # exactly when the transcript is longest, and the new model is handed tool_call ids the old
+    # one produced.
+    client, log_path, _ = _tool_client(tmp_path, policy=_cluster_policy(), n_tool_calls=2)
+    first = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "SELECT count(*) FROM superheroes"}],
+            "tools": _TOOLS,
+        },
+    )
+    calls = first.json()["choices"][0]["message"]["tool_calls"]
+    assert [call["id"] for call in calls] == ["call_1", "call_2"]
+    assert first.headers["x-wmo-routed-model"] == "fable-5"
+    messages: list[JsonObject] = [
+        {"role": "user", "content": "SELECT count(*) FROM superheroes"},
+        {"role": "assistant", "content": None, "tool_calls": calls},
+    ]
+    messages += [
+        {"role": "tool", "tool_call_id": call["id"], "content": "42 rows"} for call in calls
+    ]
+    second = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": messages, "tools": _TOOLS},
+    )
+    assert second.headers["x-wmo-routed-model"] == "fable-5"
+    assert [row["routing_reason"] for row in _rows(log_path)] == [
+        "rank router: nearest cluster 0 (sql)",
+        "sticky: conversation affinity",
+    ]
+
+
+def test_affinity_survives_a_parallel_round_trip_that_would_re_route(tmp_path: Path) -> None:
+    # The sharp version: here the routable user turn is PROSE, so a missed incumbent does not
+    # merely re-decide, it hands haiku-4-5 an assistant turn whose tool_call ids fable-5 made.
+    client, log_path, _ = _tool_client(tmp_path, policy=_cluster_policy(), n_tool_calls=2)
+    sql = {"role": "user", "content": "SELECT count(*) FROM superheroes"}
+    first = client.post("/v1/chat/completions", json={"model": "tau-bench", "messages": [sql]})
+    assert first.headers["x-wmo-routed-model"] == "fable-5"
+    turn_two: list[JsonObject] = [
+        sql,
+        {"role": "assistant", "content": first.json()["choices"][0]["message"]["content"]},
+        {"role": "user", "content": "write a friendly email about it"},
+    ]
+    second = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": turn_two, "tools": _TOOLS},
+    )
+    assert second.headers["x-wmo-routed-model"] == "fable-5"  # affinity, not the prose cluster
+    calls = second.json()["choices"][0]["message"]["tool_calls"]
+    turn_three: list[JsonObject] = [
+        *turn_two,
+        {"role": "assistant", "content": None, "tool_calls": calls},
+    ]
+    turn_three += [
+        {"role": "tool", "tool_call_id": call["id"], "content": "42 rows"} for call in calls
+    ]
+    third = client.post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": turn_three, "tools": _TOOLS},
+    )
+    assert third.headers["x-wmo-routed-model"] == "fable-5"
+    assert [row["routing_reason"] for row in _rows(log_path)][1:] == [
+        "sticky: conversation affinity",
+        "sticky: conversation affinity",
+    ]
+
+
+def test_an_unusable_structured_response_still_meters_what_it_billed(tmp_path: Path) -> None:
+    # Zero choices is the normal shape of an upstream content filter, and a filtered response
+    # still bills the prompt it read. Recording TokenUsage() on that row reported real spend as
+    # free, the same silent usage loss the abandoned-stream path exists to prevent.
+    class _FilteredProvider(_ToolProvider):
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            return ChatResponse(choices=[], usage=ChatUsage(prompt_tokens=900, completion_tokens=0))
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _FilteredProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 502
+    row = _rows(log_path)[0]
+    assert row["status"] == "error"
+    assert (row["input_tokens"], row["output_tokens"]) == (900, 0)
+    assert row["cost_usd"] == pytest.approx(900 * 1.0 / 1_000_000)
+
+
+def test_a_failure_before_the_call_still_meters_zero(tmp_path: Path) -> None:
+    # The other half of the split: nothing reached the provider, so there is nothing to bill.
+    class _RefusingProvider(_ToolProvider):
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            raise RuntimeError("connection reset")
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _RefusingProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 502
+    row = _rows(log_path)[0]
+    assert (row["input_tokens"], row["output_tokens"], row["cost_usd"]) == (0, 0, 0.0)
+    assert "connection reset" in _error_message(row)
+
+
+def test_an_empty_tool_calls_list_does_not_excuse_missing_content(tmp_path: Path) -> None:
+    # `tool_calls: []` advertises no call, so the turn has neither text nor calls. Accepting it
+    # sent an empty assistant turn down the text path, and most backends reject one: a client bug
+    # would arrive as a 502 naming the pool model instead of a 400 naming the message.
+    client, _, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "tool_calls": []},
+            ],
+        },
+    )
+    assert response.status_code == 400
+    assert "needs `content`" in response.json()["error"]["message"]
+    assert seen == []
+
+
+def test_an_explicit_null_content_is_rejected_like_an_omitted_one(tmp_path: Path) -> None:
+    # `content: null` is what an SDK puts on the wire for an unset value, so it has to answer the
+    # same way as an omitted key; normalizing null to "" first made it a silent empty billed turn.
+    client, log_path, _ = _tool_client(tmp_path)
+    for role in ("user", "system", "assistant"):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": [{"role": "user", "content": "hi"}, {"role": role, "content": None}],
+            },
+        )
+        assert response.status_code == 400, role
+        assert "needs `content`" in response.json()["error"]["message"]
+    assert not log_path.exists()  # nothing was billed
+    # The one turn that legitimately has none still gets through with content null.
+    allowed = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [
+                {"role": "user", "content": "how many superheroes are there?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "42 rows"},
+            ],
+        },
+    )
+    assert allowed.status_code == 200
+
+
+def test_a_provider_reply_with_neither_text_nor_calls_is_not_a_502(tmp_path: Path) -> None:
+    # The mandatory-content rule catches a CLIENT sending an empty turn. An upstream reply with
+    # no text is still renderable (it goes back out as content null), so refusing it here would
+    # invent a 502 for a response the client can read.
+    class _SilentProvider(_ToolProvider):
+        def complete_chat(self, request: ChatRequest) -> ChatResponse:
+            return ChatResponse(
+                choices=[
+                    ChatChoice(
+                        message=ChatMessage(role="assistant", content=None), finish_reason="stop"
+                    )
+                ],
+                usage=ChatUsage(prompt_tokens=11, completion_tokens=0),
+            )
+
+    log_path = tmp_path / "requests.jsonl"
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy(kind="static", default_model="haiku-4-5", pool=_pool()),
+        provider_factory=lambda entry: _SilentProvider(entry, []),
+        log=RequestLog(log_path),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] is None
+    assert _rows(log_path)[0]["status"] == "ok"
+
+
+def test_an_empty_tool_list_with_a_satisfiable_tool_choice_is_plain_chat(tmp_path: Path) -> None:
+    # `tools: []` is normalized away FOR the client whose registry is empty, and that client
+    # often sets tool_choice from config anyway. "auto" and "none" are both satisfied by not
+    # calling a tool, so refusing them defeated the normalization; "none" literally means "do not
+    # call tools", so refusing it for having none is backwards.
+    client, log_path = _client(tmp_path)
+    for tool_choice in ("auto", "none"):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [],
+                "tool_choice": tool_choice,
+            },
+        )
+        assert response.status_code == 200, tool_choice
+        assert response.json()["choices"][0]["message"]["content"] == "served by haiku-4-5"
+    assert [row["status"] for row in _rows(log_path)] == ["ok", "ok"]
+
+
+def test_a_tool_choice_that_demands_a_call_without_tools_is_still_a_400(tmp_path: Path) -> None:
+    # The half that cannot be honored: a client that MUST get a call back would otherwise read a
+    # prose answer as the model's own choice.
+    client, _, _ = _tool_client(tmp_path)
+    for tool_choice in (
+        "required",
+        {"type": "function", "function": {"name": "lookup"}},
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [],
+                "tool_choice": tool_choice,
+            },
+        )
+        assert response.status_code == 400, tool_choice
+        assert response.json()["error"]["code"] == "invalid_tool_choice"
+
+
+# The transcript a mid-loop agent replays: the assistant turn it got back plus the result of the
+# one call on it. It is what makes `needs_tool_calling()` true with no `tools` array in sight.
+_REPLAYED_TOOL_TRANSCRIPT: list[JsonObject] = [
+    {"role": "user", "content": "how many superheroes are there?"},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": _TOOL_ARGUMENTS},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "call_1", "content": "42 rows"},
+]
+
+
+def test_a_replayed_tool_transcript_does_not_bypass_tool_choice_validation(tmp_path: Path) -> None:
+    # The turn that used to slip through: an agent that stops re-sending `tools` once the loop is
+    # under way but keeps a demanding tool_choice from its config. The transcript makes this a
+    # tool-calling request, yet there is still nothing for the choice to select, so forwarding it
+    # would reach the provider as `tool_choice` with `tools: null`: an OpenAI-compatible backend
+    # rejects that pair (a 502 here, blaming the model) and Bedrock drops the required choice and
+    # answers in prose to a client that cannot use one.
+    client, log_path, seen = _tool_client(tmp_path)
+    for tool_choice in (
+        "required",
+        {"type": "function", "function": {"name": "lookup"}},
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": _REPLAYED_TOOL_TRANSCRIPT,
+                "tool_choice": tool_choice,
+            },
+        )
+        assert response.status_code == 400, tool_choice
+        assert response.json()["error"]["code"] == "invalid_tool_choice"
+        assert "declare the tool definitions" in response.json()["error"]["message"]
+    assert seen == []  # refused before the upstream call, so nothing was billed for it
+    assert not log_path.exists()
+
+
+def test_a_replayed_transcript_that_re_sends_tools_serves_a_demanding_choice(
+    tmp_path: Path,
+) -> None:
+    # The same mid-loop turn done right: `tools` re-sent, so "required" IS satisfiable and must
+    # keep being served, with the choice riding through beside the tools it selects from.
+    client, log_path, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": _REPLAYED_TOOL_TRANSCRIPT,
+            "tools": _TOOLS,
+            "tool_choice": "required",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "haiku-4-5 read 42 rows"
+    assert seen[0].tool_choice == "required"
+    assert seen[0].tools is not None
+    assert [tool.function.name for tool in seen[0].tools] == ["lookup"]
+    assert _rows(log_path)[0]["status"] == "ok"
+
+
+def test_a_named_tool_choice_must_name_a_declared_tool(tmp_path: Path) -> None:
+    # No provider can call a function it was never given, so naming one that is absent from `tools`
+    # is the same unhonorable request as naming one with no tools at all, one 400 earlier.
+    client, log_path, seen = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "drop the superheroes table"}],
+            "tools": _TOOLS,
+            "tool_choice": {"type": "function", "function": {"name": "delete_rows"}},
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_tool_choice"
+    message = response.json()["error"]["message"]
+    assert "'delete_rows'" in message  # what went wrong
+    assert "lookup" in message  # and what could be named instead
+    assert seen == []
+    assert not log_path.exists()
+
+
+def test_a_non_demanding_tool_choice_is_not_forwarded_without_tools(tmp_path: Path) -> None:
+    # "auto" and "none" are satisfied by not calling a tool, so a replayed transcript carrying one
+    # must keep serving. It still must not reach the provider as `tool_choice` with `tools: null`,
+    # the same malformed pair a demanding choice is refused for, so the choice is dropped instead:
+    # with no tools advertised there is no call for it to permit or forbid.
+    client, log_path, seen = _tool_client(tmp_path)
+    for tool_choice in ("auto", "none"):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "tau-bench",
+                "messages": _REPLAYED_TOOL_TRANSCRIPT,
+                "tool_choice": tool_choice,
+            },
+        )
+        assert response.status_code == 200, tool_choice
+        assert response.json()["choices"][0]["message"]["content"] == "haiku-4-5 read 42 rows"
+    assert [request.tool_choice for request in seen] == [None, None]
+    assert [request.tools for request in seen] == [None, None]
+    assert [row["status"] for row in _rows(log_path)] == ["ok", "ok"]

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -1544,11 +1544,19 @@ def test_a_function_tool_choice_naming_a_declared_tool_still_serves(tmp_path: Pa
     assert response.status_code == 200, response.text
 
 
-def test_an_unrecognized_tool_choice_word_is_still_forwarded(tmp_path: Path) -> None:
-    """An unknown future vocabulary word is not function-shaped, so it is forwarded, not refused.
+@pytest.mark.parametrize("tool_choice", ["bogus", "", False, 42, 0, [], {"type": "retrieval"}])
+def test_an_unroutable_tool_choice_is_a_400(tmp_path: Path, tool_choice: object) -> None:
+    """REVERSED from an earlier revision of this branch, which forwarded unrecognized values.
 
-    OpenAI's own vocabulary has grown (`required` postdates `auto`); rewriting or refusing a word
-    this build has not heard of would break a client the provider could have served.
+    That was justified as forward-compatibility with OpenAI's growing vocabulary (`required`
+    postdates `auto`), but no backend this endpoint routes to can honor a word it does not know:
+    OpenAI-compatible servers reject it, which this endpoint reports as a 502 blaming the model for
+    a client mistake, and Bedrock drops the field and can answer in prose to a client that required
+    a call. Forwarding only converted a clear 400 into one of those two, so the accepted set is now
+    closed and a new OpenAI word is a one-line addition to `_TOOL_CHOICE_WORDS`.
+
+    `False`/`0` are in here on purpose: `True == 1` compares equal to neither string, so a
+    membership-only test would let booleans and numbers through.
     """
     client, _, _ = _tool_client(tmp_path)
     response = client.post(
@@ -1557,7 +1565,41 @@ def test_an_unrecognized_tool_choice_word_is_still_forwarded(tmp_path: Path) -> 
             "model": "tau-bench",
             "messages": [{"role": "user", "content": "hi"}],
             "tools": _TOOLS,
-            "tool_choice": "some_future_mode",
+            "tool_choice": tool_choice,
+        },
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "invalid_tool_choice"
+    assert "this endpoint can route" in response.json()["error"]["message"]
+
+
+@pytest.mark.parametrize("tool_choice", ["none", "auto", "required"])
+def test_every_tool_choice_word_openai_defines_still_serves(
+    tmp_path: Path, tool_choice: str
+) -> None:
+    """Closing the accepted set must not refuse any value OpenAI actually defines."""
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
+            "tool_choice": tool_choice,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_omitting_tool_choice_entirely_still_serves(tmp_path: Path) -> None:
+    """Absent is not unrecognized: the overwhelmingly common case must not start failing."""
+    client, _, _ = _tool_client(tmp_path)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "tau-bench",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": _TOOLS,
         },
     )
     assert response.status_code == 200, response.text


### PR DESCRIPTION
## The gap this closes

`wmo/serving/chat.py` rejected `tools`, `tool_choice`, `response_format`, `logprobs` and `n != 1` with a 400, so a tool-calling agent could not use the endpoint at all. Reproduced on main before the change:

```
$ curl .../v1/chat/completions -d '{"model":"support", ..., "tools":[...]}'
{"error": {"message": "this endpoint does not support tools yet", ...}}
HTTP 400
```

## Schema

`ChatRole` gains `"tool"`. `ChatMessage` gains `tool_calls` and `tool_call_id`, reusing llm-waterfall's `ChatToolCall`, which are the same types `complete_chat` already takes, and accepts a null or omitted `content` on an assistant tool-call turn (a message with no content at all is still a 400 naming the one case that may omit it). `ChatCompletionRequest.tools` is now `list[ChatTool]` rather than opaque JSON.

Still rejected, deliberately: `n != 1`, `logprobs`, and `response_format`. `complete_chat` could carry `response_format`, but the text path cannot and support would have to hold for every pool entry, so it stays a documented 400 rather than a parameter that works only when routing happens to pick the right model.

## Routing to a seam that can carry tools

`complete_chat` is the only provider seam that preserves tool calls; `_split_for_provider` flattens to role+content `Message`s, which cannot represent a tool turn. So tool-bearing requests go through `complete_chat`.

**A tool TRANSCRIPT also triggers the structured path, not just an advertised `tools` array.** Agents commonly stop sending `tools` once the loop is underway, and those turns still cannot go through the text seam. Without this, the second request of every tool loop would 400 or lose its history.

An empty `tools: []` is normalized to plain chat instead: taking the structured path would send an empty tools array upstream (backends reject it) and demand a tool-calling backend for what is not a tool request, turning a previously working request into a 501.

`tool_choice` with no tools and no tool transcript is a 400 at the door. Forwarding it produces an upstream client error surfaced as a 502, which blames the model for a client mistake; dropping it would silently ignore a functional parameter.

A routed pool entry whose provider has no structured backend gets a **501 naming the entry and its kind**, plus exactly one request-log row. The file's own comment says why: silently dropping tools makes a compatibility gap look like a model-quality problem.

## finish_reason ordering

`"length"` outranks `"tool_calls"`. Arguments truncated at the output budget are invalid JSON, and a client told `tool_calls` will try to parse them.

## Streaming, honestly

No provider exposes a streaming tool-call surface: `StreamingProvider.stream` yields text deltas only. So a tool-bearing streamed request makes **one non-streamed `complete_chat` call and re-emits it as well-formed SSE** (`delta.tool_calls` with index, id, function name, and the whole arguments string, then the finish chunk, then the optional usage chunk). Time to first byte for those requests is the full upstream latency. That tradeoff is stated in the module docstring rather than hidden, and closing it needs a new provider-side surface. Text-only streaming is untouched and still streams natively.

## Routing features over tool turns

`_routable_text` keys on the request's semantic content, and a tool RESULT is not the user's request, so it continues to reach back to the last user message.

The affinity fingerprint had to change: `remember()` appended only the assistant TEXT, so a tool-calling turn (empty content, `tool_calls` set) produced a prefix that the next request could never match, and every tool loop would re-route mid-conversation and forfeit the warm prompt cache. Both decisions have tests that fail if reversed.

## Falsification

The 33 new tests fail against pre-change code. Verified independently by driving the running endpoint with the real `openai` client:

```
  -- non-streaming tool round trip --
  finish_reason=tool_calls tool_calls=1
  model called get_order({"id": "A-1"})
  final answer: 'order A-1 is shipped and arrives Friday.'
  -- streamed tool round trip --
  finish_reason=tool_calls reassembled={0: {'name': 'get_order', 'arguments': '{"id": "A-1"}', ...}}
  reassembled arguments parse to {'id': 'A-1'}

--- request log rows ---
  model=small reason='static policy' in=40 out=12 status=ok
  model=small reason='sticky: conversation affinity' in=40 out=12 status=ok
  model=small reason='static policy' in=40 out=12 status=ok
```

Row 2 is the point: affinity found the incumbent after a full tool round trip, and each request produced exactly one log row with real token counts.

## Gates

CI runs no tests, so these were run locally, rebased onto `7950d6c`:

```
3315 passed, 18 skipped     (main baseline 3282, measured on 7950d6c, + 33 new)
uv run --no-sync ruff check .          All checks passed!
uv run --no-sync ruff format --check wmo/   417 files already formatted
uv run --no-sync ty check              All checks passed!
```

## The verified command sequence

Run end to end against a local stub OpenAI-compatible server standing in for every model (agent, world model, judge, and both pool candidates), so it costs nothing and touches no network. All three Tier 1 branches merged into one tree.

```bash
wmo providers set --provider openai --model <model> --endpoint <base-url>
wmo build --file traces.otel.jsonl --name support
wmo optimize route student .wmo/distill/support --input-per-mtok 0.10 --output-per-mtok 0.40
# plus one frontier candidate in .wmo/pool.toml, so the router has a real choice
wmo optimize route sweep support --scenarios 4 --out matrix.json
wmo optimize route fit matrix.json --kind knn --out .wmo/models/support/policy.json
wmo serve --name support
# then point a tool-calling agent at http://127.0.0.1:8801/v1
```

Observed:

```
### 2) ingest traces and build a world model
✓ ingested 30 traces → normalized 93 steps
✓ split 22 train / 4 val / 4 test traces

### 3) make the distilled student a routable pool candidate
✓ added pool candidate student -> .wmo/pool.toml
  Qwen/Qwen3-8B adapter at tinker://fake/sampler/final/0

### 4) add a frontier candidate beside it
  pool: ['student', 'frontier']

### 5) sweep the pool into an outcome matrix
8 cell(s) = 2 candidate(s) x 4 held-out scenario(s) x 1 episode(s); estimated total $0.74
  ASSUMPTION: 2,000 input + 250 output token(s) per policy call ... Calls are capped,
  tokens per call are NOT measured
  [1/8] student ...006 ep0: reward=0.75 $0.00003 steps=2
  ...
  [8/8] frontier ...014 ep0: reward=0.75 $0.00079 steps=2
✓ 8 cell(s), 8 scored -> matrix.json
  measured candidate spend $0.0033

### 6) fit a routing policy where wmo serve reads it
✓ fitted knn policy over 4 scenarios -> .wmo/models/support/policy.json
  bank .wmo/models/support/policy_knn_bank.npz, fallback student, z=0.5

### 7) serve
{"object":"list","data":[{"id":"support","object":"model","created":0,"owned_by":"wmo"}]}

### 8) point a TOOL-CALLING agent at the endpoint, through the real openai client
  -- non-streaming tool round trip --
  finish_reason=tool_calls tool_calls=1
  model called get_order({"id": "A-1"})
  final answer: 'order A-1 is shipped and arrives Friday.'
  -- streamed tool round trip --
  finish_reason=tool_calls reassembled={0: {'name': 'get_order', 'arguments': '{"id": "A-1"}', ...}}
  reassembled arguments parse to {'id': 'A-1'}
  OK: tool calls round trip on both the plain and streamed paths
```

The distilled student is one of the two routable models, and the fitted policy chose it as the fallback.

**Scope note on that combined run:** it exercises the three branches' SOURCE together. I did not hand-merge the two branches' `route_app_test.py` additions (this PR and #272 both extend that file), so the combined tree carries only one side's tests. Each branch's own suite is green on its own branch, which is the gate that matters; the second of the two to merge needs a trivial rebase of that test file.

## Known limits

- Streamed tool calls do not actually stream (see above).
- The pool carries no capability metadata, so routing can still pick an entry that cannot serve tools. That is a loud 501 plus a log row, not a silent drop, but a capability-aware policy would avoid it. The routing policy is deliberately unchanged here.
- `tool_calls` are re-serialized through llm-waterfall's `ChatToolCall`, so a provider field outside that model is dropped on the way back to the client.
- The affinity fingerprint includes the exact arguments string, so a client that re-serializes an assistant turn with different key order misses the incumbent and re-routes. Text content always had the same sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
