### PR TITLE
Remove hardcoded developer-machine paths from .agents/ tooling

### DIFF
--- a/.agents/distill/export_adapter.py
+++ b/.agents/distill/export_adapter.py
@@ -30,7 +30,7 @@ Usage (from the distill worktree root; venv has tinker + tinker_cookbook):
 TINKER_API_KEY is taken from the environment. If it is unset, the script reads
 it from an env file (never printed): ``$WMO_ENV_FILE`` when set, otherwise
 ``<repo>/.env.local`` and then ``<repo>/../platform/.env.local``. A missing env
-file is only a warning; the hard failure is the key itself being unavailable.
+file is only a warning; the hard failure is the key still being unavailable.
 
 Server ops (box h100-dev-box-6, azureuser@40.80.93.150):
   start:  tmux new-session -d -s nemotron-serve \
@@ -76,24 +76,28 @@ def _env_file_candidates() -> list[Path]:
 
 
 def _ensure_tinker_api_key() -> None:
-    """Put TINKER_API_KEY in the environment, reading an env file only as a fallback."""
+    """Put TINKER_API_KEY in the environment, reading an env file only as a fallback.
+
+    An env file that is absent or silent about the key is a warning naming that file, not a
+    failure: the only hard requirement is that the key ends up in the environment somehow.
+    """
     if os.environ.get("TINKER_API_KEY"):
         return
-    candidates = _env_file_candidates()
-    for path in candidates:
+    problems: list[str] = []
+    for path in _env_file_candidates():
         if not path.exists():
-            print(f"note: no env file at {path}")
+            problems.append(f"{path} (no such file)")
             continue
         for line in path.read_text(encoding="utf-8").splitlines():
             m = re.match(r"^(?:export\s+)?TINKER_API_KEY=(.*)$", line.strip())
             if m:
                 os.environ["TINKER_API_KEY"] = m.group(1).strip().strip("'\"")
                 return
-        print(f"note: {path} exists but has no TINKER_API_KEY line")
-    searched = ", ".join(str(path) for path in candidates)
+        problems.append(f"{path} (no TINKER_API_KEY line)")
+    print("warning: no env file supplied TINKER_API_KEY: " + "; ".join(problems))
     sys.exit(
-        "TINKER_API_KEY is not set. Export it, add a TINKER_API_KEY=... line to one of "
-        f"{searched}, or point {ENV_FILE_VAR} at an env file that has one."
+        "TINKER_API_KEY is not set. Export it, add a TINKER_API_KEY=... line to one of the "
+        f"files above, or point {ENV_FILE_VAR} at an env file that has one."
     )
 
 

--- a/.agents/distill/export_adapter.py
+++ b/.agents/distill/export_adapter.py
@@ -27,8 +27,10 @@ Usage (from the distill worktree root; venv has tinker + tinker_cookbook):
   # old adapter before loading the next one)
   .venv/bin/python .agents/distill/export_adapter.py --unload pi-step-0040
 
-TINKER_API_KEY is taken from the environment, falling back to
-platform/.env.local (never printed).
+TINKER_API_KEY is taken from the environment. If it is unset, the script reads
+it from an env file (never printed): ``$WMO_ENV_FILE`` when set, otherwise
+``<repo>/.env.local`` and then ``<repo>/../platform/.env.local``. A missing env
+file is only a warning; the hard failure is the key itself being unavailable.
 
 Server ops (box h100-dev-box-6, azureuser@40.80.93.150):
   start:  tmux new-session -d -s nemotron-serve \
@@ -57,19 +59,42 @@ DEFAULT_HOST = "azureuser@40.80.93.150"
 DEFAULT_REMOTE_DIR = "/nvme/lora-adapters"
 DEFAULT_PORT = 8100
 BOX_EXPORT_PY = "/nvme/work/nemotron-serve/.export-venv/bin/python"
-ENV_LOCAL = Path("/Users/admin/Documents/experientiallabs/platform/.env.local")
+
+# Env file that can supply TINKER_API_KEY when the environment does not. Resolved from the
+# repo, never from one machine's home directory: an explicit override first, then this
+# checkout's own .env.local, then the sibling platform checkout that holds the shared keys.
+ENV_FILE_VAR = "WMO_ENV_FILE"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _env_file_candidates() -> list[Path]:
+    """Env files to search for TINKER_API_KEY, most specific first."""
+    override = os.environ.get(ENV_FILE_VAR)
+    if override:
+        return [Path(override).expanduser()]
+    return [REPO_ROOT / ".env.local", REPO_ROOT.parent / "platform" / ".env.local"]
 
 
 def _ensure_tinker_api_key() -> None:
+    """Put TINKER_API_KEY in the environment, reading an env file only as a fallback."""
     if os.environ.get("TINKER_API_KEY"):
         return
-    if ENV_LOCAL.exists():
-        for line in ENV_LOCAL.read_text().splitlines():
+    candidates = _env_file_candidates()
+    for path in candidates:
+        if not path.exists():
+            print(f"note: no env file at {path}")
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
             m = re.match(r"^(?:export\s+)?TINKER_API_KEY=(.*)$", line.strip())
             if m:
                 os.environ["TINKER_API_KEY"] = m.group(1).strip().strip("'\"")
                 return
-    sys.exit("TINKER_API_KEY not set and not found in platform/.env.local")
+        print(f"note: {path} exists but has no TINKER_API_KEY line")
+    searched = ", ".join(str(path) for path in candidates)
+    sys.exit(
+        "TINKER_API_KEY is not set. Export it, add a TINKER_API_KEY=... line to one of "
+        f"{searched}, or point {ENV_FILE_VAR} at an env file that has one."
+    )
 
 
 def _slug(tinker_path: str) -> str:

--- a/.agents/docs/proposals/HANDOFF.md
+++ b/.agents/docs/proposals/HANDOFF.md
@@ -3,8 +3,8 @@
 > **STATUS 2026-07-04: EXPERIMENT COMPLETE.** The ablation ran end-to-end; the hypothesis was
 > NOT supported — bc-random (36.5% success / 0.581 pass-rate) ≥ bc-mined (22.2% / 0.488) ≥/≈
 > base (27.0% / 0.425) on the 21 held-out scenarios, k=3, gpt-5.4 WM, Opus 4.8 judge; no paired
-> comparison reaches p<0.05 at n=21. Full numbers + verdict in the journal
-> (`~/Documents/claas-verl/experiments/tau/07_03_2026_wm-mined-scenario-distill.md`) and the
+> comparison reaches p<0.05 at n=21. Full numbers + verdict in the journal (the claas-verl repo,
+> `experiments/tau/07_03_2026_wm-mined-scenario-distill.md`) and the
 > PR #81 comment. Everything below is kept for provenance.
 
 You are taking over an autonomous experiment mid-flight. Read this whole file, verify the live
@@ -20,19 +20,19 @@ experiment the PR needs; earlier work only showed the pipeline runs end-to-end.
 
 ## 2. Where things live
 
-- **Repo (worktree):** `/Users/admin/Documents/experientiallabs/world-model-optimizer-scenario-construction`
-  branch `feature/scenario-set-construction`, PR #81 (`gh pr view 81`). HEAD = `5a6e881`.
+- **Repo (worktree):** a worktree of this repo on branch `feature/scenario-set-construction`,
+  PR #81 (`gh pr view 81`). HEAD = `5a6e881`. Every path below is relative to that root.
   Run `uv run ruff check . && uv run ty check && uv run pytest -q` before any commit (repo rule;
   AGENTS.md governs). `.agents/` is the disposable workspace — experiment scripts + results live
   under `.agents/scripts/` and `.agents/docs/research/distill/`.
-- **Experiment journal:** `~/Documents/claas-verl/experiments/tau/07_03_2026_wm-mined-scenario-distill.md`
-  (append results here; claas-verl is a separate git repo — the RL training stack).
+- **Experiment journal:** `experiments/tau/07_03_2026_wm-mined-scenario-distill.md` in the
+  claas-verl repo (append results there; claas-verl is a separate checkout, the RL stack).
 - **GPU box:** `azureuser@4.154.170.26` (NOT .179 — that's a typo in an earlier instruction),
   2×H100. **GPU 0 is the user's `qwen35pilot` tmux — DO NOT TOUCH.** GPU 1 is ours. Real disk is
   `/mnt/azureuser` (251 GB); `/data` is an empty decoy; root has ~5 GB free (LoRA adapters only).
-- **Credentials:** map is in your memory file
-  `~/.claude/projects/-Users-admin-Documents-experientiallabs/memory/platform-secrets-env-local.md`.
-  Never print key values. The scripts load keys themselves (see `collect_teacher.py::_load_gemini_key`).
+- **Credentials:** map is in this project's agent memory, file
+  `memory/platform-secrets-env-local.md`. Never print key values. The scripts load keys
+  themselves (see `collect_teacher.py::_load_gemini_key`).
 
 ## 3. The approved model stack (the user was very specific — do not substitute)
 

--- a/.agents/docs/research/gev_bench_results/exec/exec_scorecard.md
+++ b/.agents/docs/research/gev_bench_results/exec/exec_scorecard.md
@@ -143,7 +143,8 @@ consistent with a simulator that is pessimistic rather than optimistic.
 
 ## Reproduction
 
-From the worktree root (`~/Desktop/Projects/wmo-gev-bench`), Bedrock creds in `.env` / ambient AWS:
+From the repo root of a checkout on branch `research/gev-benchmarks`, Bedrock creds in `.env` or
+ambient AWS:
 
 ```bash
 # 1. Materialize the real BIRD mini-dev databases + splits + gold (gitignored / not committed).

--- a/.agents/docs/research/gev_bench_results/gen/report.md
+++ b/.agents/docs/research/gev_bench_results/gen/report.md
@@ -149,7 +149,7 @@ not a bug in synthesis or verification.
 ## Reproduce
 
 ```bash
-cd ~/Desktop/Projects/wmo-gev-bench   # worktree on branch research/gev-benchmarks
+# Run every command below from the repo root of a checkout on branch research/gev-benchmarks.
 
 # Corpus: packages/environment-capture/tau-bench/traces.otel.jsonl is an untracked local capture
 # (10578 span-lines -> 1033 traces); copied from the main checkout at the same path.

--- a/.agents/scripts/gev_bench/write_report.py
+++ b/.agents/scripts/gev_bench/write_report.py
@@ -162,7 +162,7 @@ not a bug in synthesis or verification.
 ## Reproduce
 
 ```bash
-cd ~/Desktop/Projects/wmo-gev-bench   # worktree on branch research/gev-benchmarks
+# Run every command below from the repo root of a checkout on branch research/gev-benchmarks.
 
 # Corpus: packages/environment-capture/tau-bench/traces.otel.jsonl is an untracked local capture
 # (10578 span-lines -> 1033 traces); copied from the main checkout at the same path.

--- a/.agents/scripts/validate_cost_quality.py
+++ b/.agents/scripts/validate_cost_quality.py
@@ -22,8 +22,9 @@ R1's own `r1-knn3-asym-lam*` rows (same family, no novelty floor) and the R3 `r3
 sweep that motivated the lam range (a DIFFERENT family: kNN-P probabilities under a fixed-margin
 guard over hashing embeddings, which is why its numbers do not transfer).
 
-Split identity, the embedding cache, and the recorded-run loaders are reused from
-`validate_knn_promotion.py` rather than copied, so the two gates cannot drift apart.
+Split identity, the embedding cache, the recorded-run loaders, and the routing-corpus location
+are reused from `validate_knn_promotion.py` rather than copied, so the two gates cannot drift
+apart. That corpus is untracked research data: see `$WMO_ROUTING_DATA` in the sibling gate.
 
 Usage:
     uv run python .agents/scripts/validate_cost_quality.py
@@ -54,7 +55,6 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger("validate-cost-quality")
 
 PROMOTION_GATE = Path(__file__).with_name("validate_knn_promotion.py")
-DATA = Path("~/Desktop/Projects/wmo-routing-data").expanduser()
 SEEDS = [0, 1, 2, 3, 4]
 SHIPPED_FLOOR_Q = 0.05  # the `wmo optimize route fit` default, i.e. dial 0.25
 # Every advertised anchor, plus one position on each leg whose only claim is that it sits
@@ -90,8 +90,9 @@ def recorded_iid(variant: str, params_filter: str | None = None) -> tuple[float,
     """
     deltas: list[float] = []
     costs: list[float] = []
+    runs = _promotion_gate().routing_data() / "runs"  # ty: ignore[unresolved-attribute]
     for name in ("r1.jsonl", "r3.jsonl"):
-        path = DATA / "runs" / name
+        path = runs / name
         if not path.is_file():
             continue
         with path.open(encoding="utf-8") as handle:
@@ -110,15 +111,16 @@ def recorded_iid(variant: str, params_filter: str | None = None) -> tuple[float,
                 deltas.append(record["result"]["accuracy"] - base["accuracy"])
                 costs.append(record["result"]["cost_per_call"] / base["cost_per_call"] - 1.0)
     if not deltas:
-        raise AssertionError(f"no iid rows recorded for variant {variant}")
+        raise AssertionError(f"no iid rows recorded for variant {variant} under {runs}")
     return statistics.mean(deltas) * 100, statistics.mean(costs) * 100, len(deltas)
 
 
 def measure() -> dict[float, tuple[float, float, float]]:
     """Sweep the dial on ours9: dial -> (mean delta points, mean cost percent, routed away)."""
     gate = _promotion_gate()
-    matrix = OutcomeMatrix.load(DATA / "matrices" / "routerbench-ours9_matrix.json")
-    embedder = gate.CachedEmbedder(matrix, DATA / "cache" / "routerbench-ours9-oai3l-tasks.npy")  # ty: ignore[unresolved-attribute]
+    data = gate.routing_data()  # ty: ignore[unresolved-attribute]
+    matrix = OutcomeMatrix.load(data / "matrices" / "routerbench-ours9_matrix.json")
+    embedder = gate.CachedEmbedder(matrix, data / "cache" / "routerbench-ours9-oai3l-tasks.npy")  # ty: ignore[unresolved-attribute]
     spec = EmbedderSpec(
         kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
     )
@@ -181,8 +183,9 @@ def reference_rows() -> None:
     This is the knob-level check; `measure()` covers the operator-facing dial built on top.
     """
     gate = _promotion_gate()
-    matrix = OutcomeMatrix.load(DATA / "matrices" / "routerbench-ours9_matrix.json")
-    embedder = gate.CachedEmbedder(matrix, DATA / "cache" / "routerbench-ours9-oai3l-tasks.npy")  # ty: ignore[unresolved-attribute]
+    data = gate.routing_data()  # ty: ignore[unresolved-attribute]
+    matrix = OutcomeMatrix.load(data / "matrices" / "routerbench-ours9_matrix.json")
+    embedder = gate.CachedEmbedder(matrix, data / "cache" / "routerbench-ours9-oai3l-tasks.npy")  # ty: ignore[unresolved-attribute]
     spec = EmbedderSpec(
         kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
     )

--- a/.agents/scripts/validate_cost_quality.py
+++ b/.agents/scripts/validate_cost_quality.py
@@ -32,6 +32,7 @@ Usage:
 
 from __future__ import annotations
 
+import functools
 import importlib.util
 import json
 import logging
@@ -72,8 +73,13 @@ COST_TOLERANCE = 2.0  # percentage points of the cost ratio
 FAILURES: list[str] = []
 
 
+@functools.cache
 def _promotion_gate() -> object:
-    """Load the sibling gate as a module (its split, cache reader, and record loaders)."""
+    """Load the sibling gate as a module (its split, cache reader, and record loaders).
+
+    Cached: the module is loaded once per process, so the per-variant record reads below do
+    not re-execute it.
+    """
     spec = importlib.util.spec_from_file_location("validate_knn_promotion", PROMOTION_GATE)
     if spec is None or spec.loader is None:
         raise SystemExit(f"cannot import the promotion gate from {PROMOTION_GATE}")

--- a/.agents/scripts/validate_knn_promotion.py
+++ b/.agents/scripts/validate_knn_promotion.py
@@ -10,8 +10,12 @@ the same `knn_decision` serving calls. If the numbers move, the promotion change
 Split identity is proven, not assumed: the stratified 70/30 split is reimplemented here (the
 research helper lives on the feat/routing-research branch, not on main) and every seed's fit/test
 sizes and best-single baseline accuracy are checked against the recorded runs in
-`~/Desktop/Projects/wmo-routing-data/runs/r1.jsonl`. Query embeddings come from R1's cached
-text-embedding-3-large vectors, so no text is re-embedded.
+`<routing-data>/runs/r1.jsonl`. Query embeddings come from R1's cached text-embedding-3-large
+vectors, so no text is re-embedded.
+
+The routing data (`runs/`, `matrices/`, `cache/`) is a multi-GB research corpus that is not in
+git. It defaults to the gitignored `.wmo/routing-data/` under the repo root; point
+`$WMO_ROUTING_DATA` at it if you keep it elsewhere.
 
 Usage:
     uv run python .agents/scripts/validate_knn_promotion.py            # ours9 gate + curves
@@ -22,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import statistics
 import sys
@@ -40,11 +45,32 @@ FAILURES: list[str] = []
 
 logger = logging.getLogger("validate-knn")
 
-DATA = Path("~/Desktop/Projects/wmo-routing-data").expanduser()
+ENV_ROUTING_DATA = "WMO_ROUTING_DATA"
+# The corpus is untracked research data, so it defaults to the gitignored .wmo/ artifact root of
+# whatever checkout this script runs from; ENV_ROUTING_DATA moves it anywhere else.
+DEFAULT_ROUTING_DATA = Path(__file__).resolve().parents[2] / ".wmo" / "routing-data"
 SEEDS = [0, 1, 2, 3, 4]
 # The champion's measured result, as recorded in runs/r1.jsonl (variant r1-knn-statz05-oai).
 CHAMPION_DELTA = 0.0104
 DELTA_TOLERANCE = 0.003
+
+
+def routing_data() -> Path:
+    """Root of the routing research corpus, holding `runs/`, `matrices/`, and `cache/`.
+
+    Raises:
+        SystemExit: if the corpus is not where the environment says it is, naming the
+            directory that is missing and the variable that redirects the lookup.
+    """
+    override = os.environ.get(ENV_ROUTING_DATA)
+    root = Path(override).expanduser() if override else DEFAULT_ROUTING_DATA
+    if not root.is_dir():
+        raise SystemExit(
+            f"routing corpus not found at {root}. It is multi-GB research data that git does "
+            f"not carry: set {ENV_ROUTING_DATA} to the directory holding runs/, matrices/, and "
+            "cache/, or place the corpus at that default path."
+        )
+    return root
 
 
 def stratified_split(
@@ -122,7 +148,7 @@ def baseline_on_test(matrix: OutcomeMatrix, model: str, test_ids: list[str]) -> 
 def recorded_runs(variant: str, matrix_name: str) -> dict[int, dict[str, float]]:
     """Per-seed headline numbers R1 recorded for `variant`, keyed by split seed."""
     out: dict[int, dict[str, float]] = {}
-    with (DATA / "runs" / "r1.jsonl").open(encoding="utf-8") as handle:
+    with (routing_data() / "runs" / "r1.jsonl").open(encoding="utf-8") as handle:
         for line in handle:
             record = json.loads(line)
             if (
@@ -144,8 +170,9 @@ def recorded_runs(variant: str, matrix_name: str) -> dict[int, dict[str, float]]
 
 def ours9_gate(*, se_floor: bool) -> None:
     """The gate: 5 seeds of routerbench-ours9 through fit_knn_policy + evaluate_policy."""
-    matrix = OutcomeMatrix.load(DATA / "matrices" / "routerbench-ours9_matrix.json")
-    embedder = CachedEmbedder(matrix, DATA / "cache" / "routerbench-ours9-oai3l-tasks.npy")
+    data = routing_data()
+    matrix = OutcomeMatrix.load(data / "matrices" / "routerbench-ours9_matrix.json")
+    embedder = CachedEmbedder(matrix, data / "cache" / "routerbench-ours9-oai3l-tasks.npy")
     spec = EmbedderSpec(
         kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
     )
@@ -225,8 +252,9 @@ def ours9_gate(*, se_floor: bool) -> None:
 
 def confidence_curve(matrix_name: str, cache_name: str, *, rag_num: int, fallback: str) -> None:
     """Routed-away fraction and quality/cost as the z knob tightens, with `fallback` pinned."""
-    matrix = OutcomeMatrix.load(DATA / "matrices" / f"{matrix_name}_matrix.json")
-    embedder = CachedEmbedder(matrix, DATA / "cache" / cache_name)
+    data = routing_data()
+    matrix = OutcomeMatrix.load(data / "matrices" / f"{matrix_name}_matrix.json")
+    embedder = CachedEmbedder(matrix, data / "cache" / cache_name)
     spec = EmbedderSpec(
         kind="azure", dim=embedder.dim, deployment="text-embedding-3-large", endpoint="https://x"
     )


### PR DESCRIPTION
## The bug

`wmo optimize harness <agent> harbor --backend local --episode-timeout 1800` was rejected:

```
Invalid value: --episode-timeout requires --backend e2b
```

The interlock outlived its cause. It dates from when the local SSH pi transport hardcoded
`timeout 300 node`, so a configured wall budget was silently ignored on that path. Both halves of
the engine now honour the configured budget on either backend:

- `wmo/evals/harbor/scorer.py:233` : "Both harness backends honor the wall budget now: the local
  SSH transport applies it as the remote node timeout instead of the fixed 300s it used to
  hardcode."
- `wmo/harness/pi_runtime.py:451` : the node wall budget is `int(self._episode_timeout_s)`, and the
  runtime's own comment records that the old constant "killed 30% of them mid-turn" on
  TerminalBench-2 tasks that compile toolchains and boot VMs.

So the guard was rejecting a flag the engine already supports, on the exact backend where the
default is most likely to be too small.

## The default-value-comparison subtlety

The guard compared the resolved VALUE against the default constant rather than checking whether the
flag had been PASSED:

```python
if config.backend == "local" and config.episode_timeout_s != DEFAULT_EVAL_EPISODE_TIMEOUT_S:
    raise typer.BadParameter("--episode-timeout requires --backend e2b")
```

`--episode-timeout 300` is exactly the default, so it compared equal and was silently ACCEPTED on
`--backend local`, while every other value was rejected. The rule the help text advertised
("needs --backend e2b") was therefore not the rule the code enforced. Probed on `main`:

```
--backend local --episode-timeout     300 -> exit 0 ACCEPTED
--backend local --episode-timeout   300.0 -> exit 0 ACCEPTED
--backend local --episode-timeout    1800 -> exit 2 REJECTED
```

The module already has `_explicit(ctx, "name")` (`harness_app.py:668`) for passed-vs-default
questions, but nothing here needs to distinguish the two any more: the flag is simply legal on both
backends, so the guard is deleted outright rather than rewritten against `_explicit`.

## A second clamp behind the guard

`_build_harbor_scorer` carried the same stale backend split one layer down and clamped the recorded
budget back to `DEFAULT_EVAL_EPISODE_TIMEOUT_S` for local runs. Deleting only the CLI guard would
have accepted `--episode-timeout 1800`, written `1800.0` into `run-config.json`, and then still
scored every episode on a 300s wall. It now forwards `config.episode_timeout_s` unconditionally.

## Changes

- Delete the interlock in `_optimize_harbor`.
- Drop the "needs --backend e2b" clause from the `--episode-timeout` help.
- `_build_harbor_scorer` passes the configured budget through on both backends.
- Two regression tests in `wmo/cli/harness_app_test.py`: the CLI accepts and records a non-default
  budget on `--backend local`, and that budget reaches `HarborScorer.create` verbatim.

## Falsification

Both new tests fail on `main`.

```
$ uv run --no-sync pytest -q wmo/cli/harness_app_test.py -k episode_timeout

>       assert result.exit_code == 0, result.output
E       AssertionError: Usage: root optimize harness [OPTIONS] [NAME] [MODEL]
E         Try 'root optimize harness --help' for help.
E         ╭─ Error ──────────────────────────────────────────────────────────────────────╮
E         │ Invalid value: --episode-timeout requires --backend e2b                      │
E         ╰──────────────────────────────────────────────────────────────────────────────╯
E       assert 2 == 0
E        +  where 2 = <Result SystemExit(2)>.exit_code
wmo/cli/harness_app_test.py:825: AssertionError

>       assert scorer.kwargs["episode_timeout_s"] == pytest.approx(1800.0)
E       assert 300.0 == 1800.0 ± 0.0018
E         comparison failed
E         Obtained: 300.0
E         Expected: 1800.0 ± 0.0018
wmo/cli/harness_app_test.py:884: AssertionError

=========================== short test summary info ============================
FAILED wmo/cli/harness_app_test.py::test_harbor_local_backend_accepts_a_non_default_episode_timeout
FAILED wmo/cli/harness_app_test.py::test_harbor_scorer_receives_the_local_backend_episode_timeout
2 failed, 1 passed, 27 deselected in 1.49s
```

## Gates

CI runs no tests, so this local run is the evidence.

```
uv run --no-sync pytest -q                 3297 passed, 18 skipped, 2 warnings in 40.88s
                                           (same tree before the change: 3295 passed, 18 skipped)
uv run --no-sync ruff check .              All checks passed!
uv run --no-sync ruff format --check wmo/  417 files already formatted
uv run --no-sync ty check                  All checks passed!
```

End-to-end through the real CLI, after the change:

```
--backend local --episode-timeout     300 -> exit 0 ACCEPTED
--backend local --episode-timeout   300.0 -> exit 0 ACCEPTED
--backend local --episode-timeout    1800 -> exit 0 ACCEPTED
```

```
$ wmo optimize harness --help
--episode-timeout  FLOAT RANGE [x>=0.001]  (harbor) Wall seconds per evaluated episode, on
                                           either backend (default 300).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
