### PR TITLE
Fix three artifact-integrity bugs in `wmo optimize route`

### DIFF
--- a/docs/reference/cost_quality_dial.md
+++ b/docs/reference/cost_quality_dial.md
@@ -93,9 +93,12 @@ already-dialed policy lands on the same artifact instead of compounding.
 uv run wmo optimize route tune models/support/policy.json --cost-quality 0.6
 ```
 
-The first run copies the artifact to `policy.base.json` and every later run re-reads *that*, so
-the dial is always applied to the policy as fitted. Tuning twice equals tuning once, and sliding
-back down lands exactly where a first-time slide would.
+The first successful run copies the artifact to `policy.base.json` and every later run re-reads
+*that*, so the dial is always applied to the policy as fitted. Tuning twice equals tuning once,
+and sliding back down lands exactly where a first-time slide would. A tune that is rejected
+writes nothing, and a snapshot left over from a superseded fit is refused rather than dialed
+back over the current one: refit the policy and the command tells you to delete
+`policy.base.json` first.
 
 **Per served endpoint**, without touching the policy file, via `endpoint.toml` beside
 `policy.json` in the model's directory:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -759,16 +759,27 @@ def _confirm_cost(*, yes: bool) -> None:
 _MATRIX_DIGEST_CHARS = 16
 
 
-def _matrix_provenance(matrix_file: str) -> str:
-    """`<path> sha256=<digest>`: the source half of a fitted policy's `fitted_from`.
+def _load_matrix(matrix_file: str) -> tuple[OutcomeMatrix, str]:
+    """The outcome matrix and its `<path> sha256=<digest>` provenance, from ONE read of the file.
 
     The digest is what makes `fitted_from` an identity rather than a label. `tune` compares it
     against the as-fitted snapshot beside a policy, and two fits of the same path with different
     contents (or the same contents at two paths) have to come out different for that check to
     protect anything.
+
+    Both come out of the same bytes on purpose. Digesting a SECOND read would let a corpus
+    rebuilt in place between the two describe the fit as having seen bytes it never saw: the
+    policy would be fitted from the old matrix and stamped with the new one's digest, so the
+    next fit of that new matrix would match its provenance and `tune` would accept the
+    superseded snapshot -- the exact failure the digest exists to catch, reintroduced by
+    reading twice.
     """
-    digest = hashlib.sha256(Path(matrix_file).read_bytes()).hexdigest()
-    return f"{matrix_file} sha256={digest[:_MATRIX_DIGEST_CHARS]}"
+    payload = Path(matrix_file).read_bytes()
+    digest = hashlib.sha256(payload).hexdigest()
+    return (
+        OutcomeMatrix.model_validate_json(payload),
+        f"{matrix_file} sha256={digest[:_MATRIX_DIGEST_CHARS]}",
+    )
 
 
 def _embedder_provenance(spec: EmbedderSpec) -> str:
@@ -1024,7 +1035,7 @@ def fit(
     """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
     if kind not in ("rank", "knn"):
         raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
-    matrix = OutcomeMatrix.load(Path(matrix_file))
+    matrix, source = _load_matrix(matrix_file)
     if embedder not in ("hashing", "azure"):
         raise typer.BadParameter(f"unknown embedder '{embedder}'; use hashing or azure")
     spec = (
@@ -1044,7 +1055,6 @@ def fit(
         # writes a sidecar it will then abandon.
         raise typer.BadParameter("--rag-thres must be greater than 0")
     built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
-    source = _matrix_provenance(matrix_file)
     embed_tag = _embedder_provenance(spec)
     if kind == "knn":
         if cost_weight > 0.0:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -1185,25 +1185,26 @@ def tune(
         raise typer.BadParameter(f"no policy file at {path}")
     policy = RoutingPolicy.load(path)
     base_path = path.with_name(f"{path.stem}.base{path.suffix}")
-    base = policy
-    if base_path.is_file():
-        base = RoutingPolicy.load(base_path)
-        if (base.kind, fit_provenance(base)) != (policy.kind, fit_provenance(policy)):
-            # `fit` overwrites the policy without touching this snapshot, so a refit leaves one
-            # behind that describes a policy that no longer exists. Dialing it would report
-            # success while replacing the new fit with a slid copy of the superseded one.
-            raise typer.BadParameter(
-                f"{base_path} is the as-fitted snapshot of a different fit than {path}: the "
-                f"snapshot holds kind='{base.kind}' from '{fit_provenance(base)}', the policy "
-                f"holds kind='{policy.kind}' from '{fit_provenance(policy)}'. Tuning it would "
-                f"overwrite the current fit with a dialed copy of the old one. Delete "
-                f"{base_path} to re-baseline the dial on the fit that is on disk now."
-            )
+    as_fitted = RoutingPolicy.load(base_path) if base_path.is_file() else None
+    if as_fitted is not None and (as_fitted.kind, fit_provenance(as_fitted)) != (
+        policy.kind,
+        fit_provenance(policy),
+    ):
+        # `fit` overwrites the policy without touching this snapshot, so a refit leaves one
+        # behind that describes a policy that no longer exists. Dialing it would report success
+        # while replacing the new fit with a slid copy of the superseded one.
+        raise typer.BadParameter(
+            f"{base_path} is the as-fitted snapshot of a different fit than {path}: the "
+            f"snapshot holds kind='{as_fitted.kind}' from '{fit_provenance(as_fitted)}', the "
+            f"policy holds kind='{policy.kind}' from '{fit_provenance(policy)}'. Tuning it "
+            f"would overwrite the current fit with a dialed copy of the old one. Delete "
+            f"{base_path} to re-baseline the dial on the fit that is on disk now."
+        )
     try:
-        tuned = apply_cost_quality(base, cost_quality)
+        tuned = apply_cost_quality(policy if as_fitted is None else as_fitted, cost_quality)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
-    if not base_path.is_file():
+    if as_fitted is None:
         # Preserve the artifact as fitted, so `tune` is always re-appliable from the fit and
         # never from an already-slid copy of itself. Written only now that the dial has applied:
         # a snapshot left behind by a FAILED tune would poison the path for the next fit.

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -771,6 +771,20 @@ def _matrix_provenance(matrix_file: str) -> str:
     return f"{matrix_file} sha256={digest[:_MATRIX_DIGEST_CHARS]}"
 
 
+def _embedder_provenance(spec: EmbedderSpec) -> str:
+    """The embedding-function half of `fitted_from`, taken from the spec serving rebuilds.
+
+    Derived from `EmbedderSpec` rather than from the flags, so it cannot describe an embedder
+    different from the one recorded in the artifact. The azure RESOURCE is part of the identity
+    and not just the deployment name: two accounts routinely hold a deployment of the same name
+    and dimension, their embeddings are not interchangeable, and a refit that only repointed
+    `--endpoint` therefore has to read as a different fit. The credential variable is left out
+    on purpose -- renaming it does not move a single vector.
+    """
+    tag = f"{spec.kind}-{spec.dim}"
+    return tag if spec.kind == "hashing" else f"{tag}/{spec.deployment}@{spec.endpoint}"
+
+
 @route_app.command("student")
 def student(
     card_dir: str = typer.Argument(
@@ -1031,7 +1045,7 @@ def fit(
         raise typer.BadParameter("--rag-thres must be greater than 0")
     built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
     source = _matrix_provenance(matrix_file)
-    embed_tag = f"{embedder}-{dim}" + (f"/{deployment}" if embedder == "azure" else "")
+    embed_tag = _embedder_provenance(spec)
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -20,6 +20,7 @@ customer copy never says router.
 
 from __future__ import annotations
 
+import hashlib
 import itertools
 import os
 from collections import Counter
@@ -58,6 +59,7 @@ from wmo.optimize.policy import (
     EmbedderSpec,
     RoutingPolicy,
     knn_bank_path_for,
+    write_artifact_atomically,
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
@@ -751,6 +753,24 @@ def _confirm_cost(*, yes: bool) -> None:
         raise typer.Exit(0)
 
 
+# Provenance carries a digest of the matrix, not just its path: a corpus is routinely rebuilt in
+# place under the same filename, and a fit is identified by the data it saw. 16 hex characters
+# is 64 bits, far past collision risk for the handful of matrices one artifact directory sees.
+_MATRIX_DIGEST_CHARS = 16
+
+
+def _matrix_provenance(matrix_file: str) -> str:
+    """`<path> sha256=<digest>`: the source half of a fitted policy's `fitted_from`.
+
+    The digest is what makes `fitted_from` an identity rather than a label. `tune` compares it
+    against the as-fitted snapshot beside a policy, and two fits of the same path with different
+    contents (or the same contents at two paths) have to come out different for that check to
+    protect anything.
+    """
+    digest = hashlib.sha256(Path(matrix_file).read_bytes()).hexdigest()
+    return f"{matrix_file} sha256={digest[:_MATRIX_DIGEST_CHARS]}"
+
+
 @route_app.command("student")
 def student(
     card_dir: str = typer.Argument(
@@ -1010,6 +1030,8 @@ def fit(
         # writes a sidecar it will then abandon.
         raise typer.BadParameter("--rag-thres must be greater than 0")
     built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
+    source = _matrix_provenance(matrix_file)
+    embed_tag = f"{embedder}-{dim}" + (f"/{deployment}" if embedder == "azure" else "")
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(
@@ -1032,7 +1054,11 @@ def fit(
             min_pairs=min_pairs,
             se_floor=se_floor,
             floor_q=floor_q,
-            fitted_from=f"{matrix_file} knn z={z} k={rag_num} q={floor_q} {embedder}-{dim}",
+            fitted_from=(
+                f"{source} knn fallback={fallback or 'auto'} z={z:g} k={rag_num} "
+                f"thres={rag_thres:g} pairs={min_pairs} se_floor={se_floor} q={floor_q:g} "
+                f"{embed_tag}"
+            ),
         )
     else:
         policy = fit_rank_policy(
@@ -1042,7 +1068,10 @@ def fit(
             seed=seed,
             top_k_clusters=top_k_clusters,
             beta=beta,
-            fitted_from=f"{matrix_file} seed={seed} k={clusters} {embedder}-{dim}",
+            fitted_from=(
+                f"{source} rank seed={seed} k={clusters} topk={top_k_clusters} beta={beta:g} "
+                f"cost_weight={cost_weight:g} {embed_tag}"
+            ),
         )
         if cost_weight > 0.0:
             policy = rerank_policy(policy, cost_weight=cost_weight)
@@ -1175,7 +1204,8 @@ def tune(
 
     That snapshot is only a valid baseline for the fit it came from, so this command refuses to
     run when the two disagree (refit the policy and the stale snapshot must be deleted, not
-    silently dialed back over the new fit). A tune that fails writes nothing at all.
+    silently dialed back over the new fit). A tune that is rejected writes nothing at all, and
+    every write it does make is atomic.
 
     The evidence bank is untouched, so this is instant. A served endpoint can be dialed without
     touching files at all: `PUT /v1/endpoints/{name}/config`.
@@ -1207,8 +1237,11 @@ def tune(
     if as_fitted is None:
         # Preserve the artifact as fitted, so `tune` is always re-appliable from the fit and
         # never from an already-slid copy of itself. Written only now that the dial has applied:
-        # a snapshot left behind by a FAILED tune would poison the path for the next fit.
-        base_path.write_bytes(path.read_bytes())
+        # a snapshot left behind by a REJECTED tune would poison the path for the next fit.
+        # Both writes are atomic, so the only interruption that leaves a snapshot behind is one
+        # where the policy is still the as-fitted bytes the snapshot copied, which is consistent
+        # rather than stale.
+        write_artifact_atomically(base_path, path.read_bytes())
     tuned.save(path)
     knobs = cost_quality_knobs(cost_quality)
     _console.print(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -50,13 +50,14 @@ from wmo.optimize.knn import (
     cost_quality_knobs,
     cost_quality_named_point,
     fit_knn_policy,
+    fit_provenance,
 )
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import (
-    KNN_BANK_FILENAME,
     POLICY_FILENAME,
     EmbedderSpec,
     RoutingPolicy,
+    knn_bank_path_for,
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
@@ -1016,10 +1017,12 @@ def fit(
                 "policy trades cost through its dial instead: fit it, then "
                 "`wmo optimize route tune <policy.json> --cost-quality <0..1>`"
             )
-        # The sidecar goes beside the policy file: that is where serving resolves it from.
+        # The sidecar is named after --out and beside it, and the fit records that name in the
+        # policy JSON: serving then resolves THIS policy's evidence explicitly, so a second knn
+        # fit into the same directory gets its own bank instead of overwriting this one's.
         policy = fit_knn_policy(
             matrix,
-            bank_path=out_path.parent / KNN_BANK_FILENAME,
+            bank_path=knn_bank_path_for(out_path),
             embedder=spec,
             embed_with=built,
             guard_model=fallback,
@@ -1049,8 +1052,7 @@ def fit(
         routed = 1.0 - result.model_mix.get(policy.default_model, 0.0)
         _console.print(
             f"[green]✓[/green] fitted knn policy over {result.scenarios} scenarios -> {out}\n"
-            f"  bank {out_path.parent / KNN_BANK_FILENAME}, fallback {policy.default_model}, "
-            f"z={z}\n"
+            f"  bank {policy.bank_path()}, fallback {policy.default_model}, z={z}\n"
             f"  routed away from the fallback {routed:.1%} of the time; cost/scenario "
             f"${result.cost_per_scenario:.5f}\n"
             f"  fit-set accuracy {result.accuracy:.4f} is IN-SAMPLE (every request retrieves its "
@@ -1165,11 +1167,15 @@ def tune(
     """Set a fitted policy's cost/quality dial in place, without refitting anything.
 
     The dial maps to the policy's knobs along the measured frontier (see
-    `wmo.optimize.knn.apply_cost_quality`). The first run copies the un-tuned artifact to
-    `policy.base.json` and every later run re-reads THAT, so the dial is always applied to the
+    `wmo.optimize.knn.apply_cost_quality`). The first successful run copies the un-tuned artifact
+    to `policy.base.json` and every later run re-reads THAT, so the dial is always applied to the
     policy as fitted and sliding twice never compounds:
 
         wmo optimize route tune models/support/policy.json --cost-quality 0.6
+
+    That snapshot is only a valid baseline for the fit it came from, so this command refuses to
+    run when the two disagree (refit the policy and the stale snapshot must be deleted, not
+    silently dialed back over the new fit). A tune that fails writes nothing at all.
 
     The evidence bank is untouched, so this is instant. A served endpoint can be dialed without
     touching files at all: `PUT /v1/endpoints/{name}/config`.
@@ -1177,16 +1183,31 @@ def tune(
     path = Path(policy_file)
     if not path.is_file():
         raise typer.BadParameter(f"no policy file at {path}")
+    policy = RoutingPolicy.load(path)
     base_path = path.with_name(f"{path.stem}.base{path.suffix}")
-    if not base_path.is_file():
-        # Preserve the artifact as fitted the first time, so `tune` is always re-appliable from
-        # the fit and never from an already-slid copy of itself.
-        base_path.write_bytes(path.read_bytes())
-    base = RoutingPolicy.load(base_path)
+    base = policy
+    if base_path.is_file():
+        base = RoutingPolicy.load(base_path)
+        if (base.kind, fit_provenance(base)) != (policy.kind, fit_provenance(policy)):
+            # `fit` overwrites the policy without touching this snapshot, so a refit leaves one
+            # behind that describes a policy that no longer exists. Dialing it would report
+            # success while replacing the new fit with a slid copy of the superseded one.
+            raise typer.BadParameter(
+                f"{base_path} is the as-fitted snapshot of a different fit than {path}: the "
+                f"snapshot holds kind='{base.kind}' from '{fit_provenance(base)}', the policy "
+                f"holds kind='{policy.kind}' from '{fit_provenance(policy)}'. Tuning it would "
+                f"overwrite the current fit with a dialed copy of the old one. Delete "
+                f"{base_path} to re-baseline the dial on the fit that is on disk now."
+            )
     try:
         tuned = apply_cost_quality(base, cost_quality)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    if not base_path.is_file():
+        # Preserve the artifact as fitted, so `tune` is always re-appliable from the fit and
+        # never from an already-slid copy of itself. Written only now that the dial has applied:
+        # a snapshot left behind by a FAILED tune would poison the path for the next fit.
+        base_path.write_bytes(path.read_bytes())
     tuned.save(path)
     knobs = cost_quality_knobs(cost_quality)
     _console.print(

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -23,12 +23,7 @@ from wmo.distill.store import DistillModelCard
 from wmo.engine.world_model import WorldModel
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
-from wmo.optimize.policy import (
-    KNN_BANK_FILENAME,
-    POLICY_FILENAME,
-    RoutingPolicy,
-    select_model,
-)
+from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
 from wmo.optimize.reward import EpisodeScore
 from wmo.optimize.routing import evaluate_policy
 from wmo.providers import pool as pool_module
@@ -47,6 +42,11 @@ from wmo.serving.traces_source import TRACES_FILENAME
 from wmo.tracking import RunRecord
 
 runner = CliRunner()
+
+
+def _flat(output: str) -> str:
+    """CLI errors render inside a wrapped rich panel; flatten one so a phrase matches."""
+    return " ".join(output.replace("│", " ").split())
 
 
 def _matrix_file(tmp_path: Path) -> Path:
@@ -138,8 +138,13 @@ def test_route_fit_rejects_unknown_embedder(tmp_path: Path) -> None:
     assert "hashing or azure" in result.output
 
 
-def _knn_matrix_file(tmp_path: Path) -> Path:
-    """Twelve scenarios: enough neighbors per query for a guarded fit to route at all."""
+def _knn_matrix_file(tmp_path: Path, *, flip: bool = False, name: str = "knn_matrix.json") -> Path:
+    """Twelve scenarios: enough neighbors per query for a guarded fit to route at all.
+
+    `flip` swaps which model wins each half, so two matrices built here disagree on every cell.
+    That is what makes an artifact mix-up observable: a policy fitted on one and served the
+    other's evidence routes every request the wrong way.
+    """
     pool = [
         PoolEntry(
             name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
@@ -168,7 +173,7 @@ def _knn_matrix_file(tmp_path: Path) -> Path:
     for group, tasks in (("sql", sql), ("prose", prose)):
         for index, task in enumerate(tasks):
             for model in ("a", "b"):
-                wins = (model == "a") == (group == "sql")
+                wins = ((model == "a") == (group == "sql")) != flip
                 outcomes.append(
                     ScenarioOutcome(
                         scenario_id=f"{group}:{index}",
@@ -179,7 +184,7 @@ def _knn_matrix_file(tmp_path: Path) -> Path:
                         cost_usd=0.001,
                     )
                 )
-    path = tmp_path / "knn_matrix.json"
+    path = tmp_path / name
     OutcomeMatrix(pool=pool, outcomes=outcomes).save(path)
     return path
 
@@ -212,7 +217,10 @@ def test_route_fit_knn_writes_policy_and_sidecar(tmp_path: Path) -> None:
     policy = RoutingPolicy.load(policy_file)
     assert policy.kind == "knn"
     assert policy.default_model == "a" == policy.guard_model  # the pinned fallback
-    assert (tmp_path / KNN_BANK_FILENAME).is_file()  # sidecar beside the policy
+    # The sidecar is named after --out and recorded in the policy, not resolved by convention.
+    assert policy.knn_bank_path == "policy.bank.npz"
+    assert policy.bank_path() == tmp_path / "policy.bank.npz"
+    assert policy.bank_path().is_file()  # sidecar beside the policy
     assert len(policy.knn_bank().scenario_ids) == 12
     assert "routed away from the fallback" in result.output
     # The prose neighborhoods carry unanimous evidence for b, so that traffic leaves the
@@ -333,6 +341,148 @@ def test_route_tune_rejects_a_policy_kind_without_a_dial(tmp_path: Path) -> None
     )
     assert result.exit_code != 0
     assert "kind='rank'" in result.output
+
+
+def test_route_fit_knn_gives_each_policy_its_own_evidence_bank(tmp_path: Path) -> None:
+    """Two knn fits into one directory must not share (and overwrite) one sidecar.
+
+    Regression: the bank name used to be hard-coded, so the second fit clobbered the first
+    policy's evidence and both policies recorded the same relative path. Policy A then served
+    matrix B's rewards, which inverts every routing decision on this pair of matrices.
+    """
+    a_matrix = _knn_matrix_file(tmp_path, name="matrix_a.json")
+    _knn_matrix_file(tmp_path, flip=True, name="matrix_b.json")
+    for name, matrix, fallback in (
+        ("policy_a.json", "matrix_a.json", "a"),
+        ("policy_b.json", "matrix_b.json", "b"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "optimize",
+                "route",
+                "fit",
+                str(tmp_path / matrix),
+                "--kind",
+                "knn",
+                "--fallback",
+                fallback,
+                "--rag-num",
+                "3",
+                "--min-pairs",
+                "2",
+                "--out",
+                str(tmp_path / name),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    policy_a = RoutingPolicy.load(tmp_path / "policy_a.json")
+    policy_b = RoutingPolicy.load(tmp_path / "policy_b.json")
+    assert (policy_a.knn_bank_path, policy_b.knn_bank_path) == (
+        "policy_a.bank.npz",
+        "policy_b.bank.npz",
+    )
+    assert policy_a.bank_path().is_file() and policy_b.bank_path().is_file()
+    # Policy A still routes on ITS evidence: prose is b's half of matrix_a, and matrix_b says
+    # the opposite, so this is 1.0 only if the second fit left A's bank alone.
+    matrix = OutcomeMatrix.load(a_matrix)
+    prose_ids = [sid for sid in matrix.scenario_ids() if sid.startswith("prose:")]
+    assert evaluate_policy(policy_a, matrix, prose_ids).model_mix == {"b": 1.0}
+
+
+def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path) -> None:
+    """fit -> tune -> refit -> tune must not silently dial the pre-refit artifact.
+
+    Regression: `tune` always re-read `<stem>.base.json`, which `fit` never invalidates, so the
+    second tune reported success while overwriting the new fit with a dialed copy of the old one.
+    """
+    policy_file = _fitted_knn_policy(tmp_path)
+    tuned = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.6"]
+    )
+    assert tuned.exit_code == 0, tuned.output
+
+    refit = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_knn_matrix_file(tmp_path, flip=True, name="refit_matrix.json")),
+            "--kind",
+            "knn",
+            "--fallback",
+            "b",
+            "--rag-num",
+            "3",
+            "--min-pairs",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert refit.exit_code == 0, refit.output
+    assert RoutingPolicy.load(policy_file).default_model == "b"
+
+    stale = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
+    )
+    assert stale.exit_code != 0
+    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
+    assert "policy.base.json" in _flat(stale.output)  # names the file to delete
+    # The refit survives untouched rather than being replaced by a dialed copy of the old fit.
+    after = RoutingPolicy.load(policy_file)
+    assert after.default_model == "b"
+    assert after.cost_quality is None
+
+
+def test_route_tune_that_fails_leaves_no_base_snapshot_behind(tmp_path: Path) -> None:
+    """A rejected tune must not poison the path for the next fit.
+
+    Regression: the base snapshot was copied before validation, so a failed tune left a stray
+    `policy.base.json`. A later `fit --kind knn` into the same path could never be tuned: the
+    error reported kind='rank' while the policy on disk was demonstrably kind='knn'.
+    """
+    policy_file = tmp_path / POLICY_FILENAME
+    fit = runner.invoke(
+        app,
+        ["optimize", "route", "fit", str(_matrix_file(tmp_path)), "--out", str(policy_file)],
+    )
+    assert fit.exit_code == 0, fit.output
+    rejected = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.5"]
+    )
+    assert rejected.exit_code != 0
+    assert "kind='rank'" in rejected.output
+    assert not (tmp_path / "policy.base.json").exists()
+
+    # The path is still tunable once a knn policy is fitted into it.
+    refit = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_knn_matrix_file(tmp_path)),
+            "--kind",
+            "knn",
+            "--fallback",
+            "a",
+            "--rag-num",
+            "3",
+            "--min-pairs",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert refit.exit_code == 0, refit.output
+    tuned = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.5"]
+    )
+    assert tuned.exit_code == 0, tuned.output
+    assert RoutingPolicy.load(policy_file).cost_quality == 0.5
 
 
 def test_route_tune_rejects_a_missing_policy_file(tmp_path: Path) -> None:

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -444,6 +444,38 @@ def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
     assert RoutingPolicy.load(policy_file).cost_quality is None  # the refit is untouched
 
 
+def test_route_tune_survives_a_matrix_path_that_looks_like_a_dial_suffix(tmp_path: Path) -> None:
+    """An operator-supplied path must not be able to truncate the fit identity it opens.
+
+    Regression: `fit_provenance` split on the FIRST ` | cost_quality=`, and `fitted_from` starts
+    with the matrix path. A path containing that substring therefore discarded the digest and
+    every fit flag behind it, collapsing unrelated fits onto one identity, and `tune` dialed the
+    superseded snapshot over the refit. This name carries a COMPLETE, well-formed dial suffix,
+    which is the worst case: the fit flags follow the path, so the real suffix is still the only
+    one at the end of the string.
+    """
+    hostile = "m | cost_quality=0.5 (floor_q=0.05, lam=0, guard=symmetric).json"
+    policy_file = tmp_path / POLICY_FILENAME
+    assert _fit_knn(_knn_matrix_file(tmp_path, name=hostile), policy_file).exit_code == 0
+    for dial in ("0.6", "0.2"):  # no refit between these: the dial must still move freely
+        tuned = runner.invoke(
+            app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", dial]
+        )
+        assert tuned.exit_code == 0, tuned.output
+    assert RoutingPolicy.load(policy_file).cost_quality == 0.2
+
+    rebuilt = _knn_matrix_file(tmp_path, flip=True, name=hostile)  # same path, opposite labels
+    assert _fit_knn(rebuilt, policy_file, fallback="b").exit_code == 0
+    stale = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
+    )
+    assert stale.exit_code != 0
+    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
+    after = RoutingPolicy.load(policy_file)
+    assert after.default_model == "b"  # the refit survives, not a dialed copy of the old fit
+    assert after.cost_quality is None
+
+
 def test_embedder_provenance_separates_two_azure_resources() -> None:
     """A deployment name is not an embedder identity; the resource behind it is.
 

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -17,13 +17,14 @@ from rich.console import Console
 from typer.testing import CliRunner, Result
 
 from wmo.cli.app import app
+from wmo.cli.route_app import _embedder_provenance
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
 from wmo.distill.store import DistillModelCard
 from wmo.engine.world_model import WorldModel
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
-from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
+from wmo.optimize.policy import POLICY_FILENAME, EmbedderSpec, RoutingPolicy, select_model
 from wmo.optimize.reward import EpisodeScore
 from wmo.optimize.routing import evaluate_policy
 from wmo.providers import pool as pool_module
@@ -441,6 +442,31 @@ def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
     assert stale.exit_code != 0
     assert "as-fitted snapshot of a different fit" in _flat(stale.output)
     assert RoutingPolicy.load(policy_file).cost_quality is None  # the refit is untouched
+
+
+def test_embedder_provenance_separates_two_azure_resources() -> None:
+    """A deployment name is not an embedder identity; the resource behind it is.
+
+    Two Azure accounts routinely hold a deployment of the same name and dimension, and their
+    embeddings are not interchangeable. If both fits render the same `fitted_from`, `tune`
+    accepts the pre-refit snapshot and dials the superseded fit over the new one.
+    """
+
+    def azure(endpoint: str, api_key_env: str | None = None) -> EmbedderSpec:
+        return EmbedderSpec(
+            kind="azure",
+            dim=3072,
+            deployment="text-embedding-3-large",  # the SAME deployment name on both resources
+            endpoint=endpoint,
+            api_key_env=api_key_env,
+        )
+
+    east = _embedder_provenance(azure("https://east.openai.azure.com"))
+    assert east != _embedder_provenance(azure("https://west.openai.azure.com"))
+    # ...and the axes that do not move a vector stay out of it: renaming the credential variable
+    # must not read as a refit.
+    assert _embedder_provenance(azure("https://east.openai.azure.com", "OTHER_KEY")) == east
+    assert _embedder_provenance(EmbedderSpec(dim=512)) == "hashing-512"
 
 
 def test_route_tune_that_fails_leaves_no_base_snapshot_behind(tmp_path: Path) -> None:

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -412,6 +412,43 @@ def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path
     assert after.cost_quality is None
 
 
+def test_route_fit_digests_the_bytes_it_actually_fitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The recorded digest must describe the matrix the fit SAW, not a later read of the path.
+
+    Regression: `fit` parsed the matrix and then re-read the file to digest it. A corpus rebuilt
+    in place between the two stamped the old fit with the new file's digest, so the next fit of
+    that new matrix matched its provenance and `tune` accepted the superseded snapshot -- the
+    very failure the digest exists to catch. The two now come out of one read.
+    """
+    matrix_file = _knn_matrix_file(tmp_path)
+    fitted_bytes = matrix_file.read_bytes()
+    real = {name: getattr(Path, name) for name in ("read_bytes", "read_text")}
+
+    def _rebuilding(name: str):  # noqa: ANN202 - the wrapped reader's own signature
+        def _read(self: Path, *args: object, **kwargs: object):  # noqa: ANN202
+            payload = real[name](self, *args, **kwargs)
+            if self == matrix_file:  # swap the corpus the instant the fit has read it
+                monkeypatch.undo()  # ...once, whichever reader the fit happens to use
+                _knn_matrix_file(tmp_path, flip=True)
+            return payload
+
+        return _read
+
+    for name in real:
+        monkeypatch.setattr(Path, name, _rebuilding(name))
+    policy_file = tmp_path / POLICY_FILENAME
+    assert _fit_knn(matrix_file, policy_file).exit_code == 0
+    assert matrix_file.read_bytes() != fitted_bytes  # the file on disk did change under the fit
+
+    # The digest is of the bytes that were fitted, so a later fit of the REPLACEMENT differs.
+    fitted_from = RoutingPolicy.load(policy_file).fitted_from or ""
+    other = tmp_path / "other.json"
+    assert _fit_knn(matrix_file, other).exit_code == 0
+    assert fitted_from != (RoutingPolicy.load(other).fitted_from or "")
+
+
 def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
     tmp_path: Path,
 ) -> None:

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -45,11 +45,6 @@ from wmo.tracking import RunRecord
 runner = CliRunner()
 
 
-def _flat(output: str) -> str:
-    """CLI errors render inside a wrapped rich panel; flatten one so a phrase matches."""
-    return " ".join(output.replace("│", " ").split())
-
-
 def _matrix_file(tmp_path: Path) -> Path:
     pool = [
         PoolEntry(
@@ -409,8 +404,8 @@ def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
     )
     assert stale.exit_code != 0
-    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
-    assert "policy.base.json" in _flat(stale.output)  # names the file to delete
+    assert _says(stale.output, "as-fitted snapshot of a different fit")
+    assert _says(stale.output, "policy.base.json")  # names the file to delete
     # The refit survives untouched rather than being replaced by a dialed copy of the old fit.
     after = RoutingPolicy.load(policy_file)
     assert after.default_model == "b"
@@ -440,7 +435,7 @@ def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
     )
     assert stale.exit_code != 0
-    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
+    assert _says(stale.output, "as-fitted snapshot of a different fit")
     assert RoutingPolicy.load(policy_file).cost_quality is None  # the refit is untouched
 
 
@@ -470,7 +465,7 @@ def test_route_tune_survives_a_matrix_path_that_looks_like_a_dial_suffix(tmp_pat
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
     )
     assert stale.exit_code != 0
-    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
+    assert _says(stale.output, "as-fitted snapshot of a different fit")
     after = RoutingPolicy.load(policy_file)
     assert after.default_model == "b"  # the refit survives, not a dialed copy of the old fit
     assert after.cost_quality is None

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -218,8 +218,8 @@ def test_route_fit_knn_writes_policy_and_sidecar(tmp_path: Path) -> None:
     assert policy.kind == "knn"
     assert policy.default_model == "a" == policy.guard_model  # the pinned fallback
     # The sidecar is named after --out and recorded in the policy, not resolved by convention.
-    assert policy.knn_bank_path == "policy.bank.npz"
-    assert policy.bank_path() == tmp_path / "policy.bank.npz"
+    assert policy.knn_bank_path == "policy.json.bank.npz"
+    assert policy.bank_path() == tmp_path / "policy.json.bank.npz"
     assert policy.bank_path().is_file()  # sidecar beside the policy
     assert len(policy.knn_bank().scenario_ids) == 12
     assert "routed away from the fallback" in result.output
@@ -257,19 +257,19 @@ def test_route_fit_rejects_unknown_kind(tmp_path: Path) -> None:
     assert "knn or rank" in result.output
 
 
-def _fitted_knn_policy(tmp_path: Path) -> Path:
-    policy_file = tmp_path / POLICY_FILENAME
-    result = runner.invoke(
+def _fit_knn(matrix_file: Path, policy_file: Path, *, fallback: str = "a") -> Result:
+    """Run `route fit --kind knn` with the neighbor budget this twelve-scenario matrix needs."""
+    return runner.invoke(
         app,
         [
             "optimize",
             "route",
             "fit",
-            str(_knn_matrix_file(tmp_path)),
+            str(matrix_file),
             "--kind",
             "knn",
             "--fallback",
-            "a",
+            fallback,
             "--rag-num",
             "3",
             "--min-pairs",
@@ -278,6 +278,11 @@ def _fitted_knn_policy(tmp_path: Path) -> Path:
             str(policy_file),
         ],
     )
+
+
+def _fitted_knn_policy(tmp_path: Path) -> Path:
+    policy_file = tmp_path / POLICY_FILENAME
+    result = _fit_knn(_knn_matrix_file(tmp_path), policy_file)
     assert result.exit_code == 0, result.output
     return policy_file
 
@@ -351,44 +356,32 @@ def test_route_fit_knn_gives_each_policy_its_own_evidence_bank(tmp_path: Path) -
     matrix B's rewards, which inverts every routing decision on this pair of matrices.
     """
     a_matrix = _knn_matrix_file(tmp_path, name="matrix_a.json")
-    _knn_matrix_file(tmp_path, flip=True, name="matrix_b.json")
-    for name, matrix, fallback in (
-        ("policy_a.json", "matrix_a.json", "a"),
-        ("policy_b.json", "matrix_b.json", "b"),
-    ):
-        result = runner.invoke(
-            app,
-            [
-                "optimize",
-                "route",
-                "fit",
-                str(tmp_path / matrix),
-                "--kind",
-                "knn",
-                "--fallback",
-                fallback,
-                "--rag-num",
-                "3",
-                "--min-pairs",
-                "2",
-                "--out",
-                str(tmp_path / name),
-            ],
-        )
+    b_matrix = _knn_matrix_file(tmp_path, flip=True, name="matrix_b.json")
+    # The third fit shares a STEM with the first: the bank name is appended to the policy
+    # filename rather than substituted for its extension, so it still gets its own sidecar.
+    fits = (
+        ("policy_a.json", a_matrix, "a"),
+        ("policy_b.json", b_matrix, "b"),
+        ("policy_a.yaml", b_matrix, "b"),
+    )
+    for name, matrix_file, fallback in fits:
+        result = _fit_knn(matrix_file, tmp_path / name, fallback=fallback)
         assert result.exit_code == 0, result.output
 
-    policy_a = RoutingPolicy.load(tmp_path / "policy_a.json")
-    policy_b = RoutingPolicy.load(tmp_path / "policy_b.json")
-    assert (policy_a.knn_bank_path, policy_b.knn_bank_path) == (
-        "policy_a.bank.npz",
-        "policy_b.bank.npz",
-    )
-    assert policy_a.bank_path().is_file() and policy_b.bank_path().is_file()
+    policies = [RoutingPolicy.load(tmp_path / name) for name, _, _ in fits]
+    assert [policy.knn_bank_path for policy in policies] == [
+        "policy_a.json.bank.npz",
+        "policy_b.json.bank.npz",
+        "policy_a.yaml.bank.npz",
+    ]
+    banks = [policy.bank_path() for policy in policies]
+    assert len(set(banks)) == len(banks)
+    assert all(bank.is_file() for bank in banks)
     # Policy A still routes on ITS evidence: prose is b's half of matrix_a, and matrix_b says
-    # the opposite, so this is 1.0 only if the second fit left A's bank alone.
+    # the opposite, so this is 1.0 only if the later fits left A's bank alone.
     matrix = OutcomeMatrix.load(a_matrix)
     prose_ids = [sid for sid in matrix.scenario_ids() if sid.startswith("prose:")]
-    assert evaluate_policy(policy_a, matrix, prose_ids).model_mix == {"b": 1.0}
+    assert evaluate_policy(policies[0], matrix, prose_ids).model_mix == {"b": 1.0}
 
 
 def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path) -> None:
@@ -403,24 +396,10 @@ def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path
     )
     assert tuned.exit_code == 0, tuned.output
 
-    refit = runner.invoke(
-        app,
-        [
-            "optimize",
-            "route",
-            "fit",
-            str(_knn_matrix_file(tmp_path, flip=True, name="refit_matrix.json")),
-            "--kind",
-            "knn",
-            "--fallback",
-            "b",
-            "--rag-num",
-            "3",
-            "--min-pairs",
-            "2",
-            "--out",
-            str(policy_file),
-        ],
+    refit = _fit_knn(
+        _knn_matrix_file(tmp_path, flip=True, name="refit_matrix.json"),
+        policy_file,
+        fallback="b",
     )
     assert refit.exit_code == 0, refit.output
     assert RoutingPolicy.load(policy_file).default_model == "b"
@@ -435,6 +414,33 @@ def test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit(tmp_path: Path
     after = RoutingPolicy.load(policy_file)
     assert after.default_model == "b"
     assert after.cost_quality is None
+
+
+def test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place(
+    tmp_path: Path,
+) -> None:
+    """Same matrix path, same flags, different contents: still a different fit.
+
+    A corpus is routinely rebuilt under the filename it already had, so a path alone cannot
+    identify a fit. `fitted_from` carries a digest of the matrix, which is what makes the
+    snapshot check catch this.
+    """
+    policy_file = _fitted_knn_policy(tmp_path)
+    tuned = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.6"]
+    )
+    assert tuned.exit_code == 0, tuned.output
+
+    rebuilt = _knn_matrix_file(tmp_path, flip=True)  # same default filename, opposite labels
+    refit = _fit_knn(rebuilt, policy_file)  # and the same fit flags as `_fitted_knn_policy`
+    assert refit.exit_code == 0, refit.output
+
+    stale = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.3"]
+    )
+    assert stale.exit_code != 0
+    assert "as-fitted snapshot of a different fit" in _flat(stale.output)
+    assert RoutingPolicy.load(policy_file).cost_quality is None  # the refit is untouched
 
 
 def test_route_tune_that_fails_leaves_no_base_snapshot_behind(tmp_path: Path) -> None:
@@ -458,25 +464,7 @@ def test_route_tune_that_fails_leaves_no_base_snapshot_behind(tmp_path: Path) ->
     assert not (tmp_path / "policy.base.json").exists()
 
     # The path is still tunable once a knn policy is fitted into it.
-    refit = runner.invoke(
-        app,
-        [
-            "optimize",
-            "route",
-            "fit",
-            str(_knn_matrix_file(tmp_path)),
-            "--kind",
-            "knn",
-            "--fallback",
-            "a",
-            "--rag-num",
-            "3",
-            "--min-pairs",
-            "2",
-            "--out",
-            str(policy_file),
-        ],
-    )
+    refit = _fit_knn(_knn_matrix_file(tmp_path), policy_file)
     assert refit.exit_code == 0, refit.output
     tuned = runner.invoke(
         app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.5"]

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -275,7 +275,22 @@ COST_QUALITY_DEFAULT_FLOOR_Q = 0.05  # the shipped novelty floor
 # ran past the turn would sell an operator a worse policy on both axes.
 COST_QUALITY_MAX_LAM = 0.03
 
+# What `apply_cost_quality` appends to `fitted_from` to record the dial position. Sliding is
+# absolute, so the suffix is rewritten (never stacked) and `fit_provenance` strips it back off.
+COST_QUALITY_PROVENANCE_MARK = " | cost_quality="
+
 CostQualityPointName = str
+
+
+def fit_provenance(policy: RoutingPolicy) -> str:
+    """The fit a policy came from, with any dial suffix stripped off.
+
+    `fitted_from` records the outcome matrix and fit parameters, and `apply_cost_quality`
+    appends the dial position to it. This returns the fit half alone, which is the identity two
+    artifacts must share to be the same fit at different dial positions: a tuned policy and the
+    as-fitted snapshot it was dialed from agree here, a refit does not.
+    """
+    return (policy.fitted_from or "unknown").split(COST_QUALITY_PROVENANCE_MARK)[0]
 
 
 class CostQualityKnobs(BaseModel):
@@ -447,7 +462,7 @@ def apply_cost_quality(policy: RoutingPolicy, cost_quality: float) -> RoutingPol
     bank = policy.knn_bank()
     # Absolute, not relative: the knobs come from the dial alone, so re-applying any setting to
     # an already-slid policy lands on the same artifact instead of compounding.
-    provenance = (policy.fitted_from or "unknown").split(" | cost_quality=")[0]
+    provenance = fit_provenance(policy)
     adjusted = policy.model_copy(
         update={
             "knn_z": knobs.knn_z,
@@ -457,7 +472,7 @@ def apply_cost_quality(policy: RoutingPolicy, cost_quality: float) -> RoutingPol
             "guard_mode": knobs.guard_mode,
             "cost_quality": cost_quality,
             "fitted_from": (
-                f"{provenance} | cost_quality={cost_quality:g} "
+                f"{provenance}{COST_QUALITY_PROVENANCE_MARK}{cost_quality:g} "
                 f"(floor_q={knobs.floor_q:g}, lam={knobs.pick_lam:g}, guard={knobs.guard_mode})"
             ),
         }

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -279,6 +280,17 @@ COST_QUALITY_MAX_LAM = 0.03
 # absolute, so the suffix is rewritten (never stacked) and `fit_provenance` strips it back off.
 COST_QUALITY_PROVENANCE_MARK = " | cost_quality="
 
+# The WHOLE trailer that mark introduces, anchored to the end of the string. `fit_provenance`
+# matches this shape rather than searching for the mark alone, because the mark can also occur
+# inside the fit half: `fitted_from` opens with an operator-supplied matrix path, and splitting
+# on the first occurrence of a substring that path contains would throw away the digest and
+# every fit flag after it, collapsing two unrelated fits onto one identity. The fit flags always
+# follow the path, so an occurrence inside the path is never at the end and never matches here.
+_DIAL_SUFFIX = re.compile(
+    re.escape(COST_QUALITY_PROVENANCE_MARK) + r"[\d.eE+-]+ "
+    r"\(floor_q=[\d.eE+-]+, lam=[\d.eE+-]+, guard=(?:symmetric|asymmetric)\)$"
+)
+
 CostQualityPointName = str
 
 
@@ -290,7 +302,7 @@ def fit_provenance(policy: RoutingPolicy) -> str:
     artifacts must share to be the same fit at different dial positions: a tuned policy and the
     as-fitted snapshot it was dialed from agree here, a refit does not.
     """
-    return (policy.fitted_from or "unknown").split(COST_QUALITY_PROVENANCE_MARK)[0]
+    return _DIAL_SUFFIX.sub("", policy.fitted_from or "unknown")
 
 
 class CostQualityKnobs(BaseModel):

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -60,9 +60,12 @@ DEFAULT_RANK = 999
 # (+1.0 accuracy point over the best single model at -27% cost, 5/5 split seeds).
 KNN_BANK_FILENAME = "policy_knn_bank.npz"
 # The sidecar suffix a fit DERIVES from its policy path, so two policies fitted into one
-# directory own two banks (`support.json` -> `support.bank.npz`) instead of racing for one
-# shared name. `KNN_BANK_FILENAME` above stays the resolution fallback for artifacts that
-# record no path of their own; see `RoutingPolicy.knn_bank_path`.
+# directory own two banks instead of racing for one shared name. APPENDED rather than
+# substituted for the policy's extension (`support.json` -> `support.json.bank.npz`): appending
+# is injective on filenames, while replacing the extension would map `support.json` and
+# `support.yaml` onto one bank and reintroduce the collision. `KNN_BANK_FILENAME` above stays
+# the resolution fallback for artifacts that record no path of their own; see
+# `RoutingPolicy.knn_bank_path`.
 KNN_BANK_SUFFIX = ".bank.npz"
 DEFAULT_RAG_NUM = 50
 DEFAULT_RAG_THRES = 0.95
@@ -81,14 +84,29 @@ SE_FLOOR_MAX_PAIRS = 30
 _BANK_LOAD_LOCK = threading.Lock()
 
 
+def write_artifact_atomically(path: Path, payload: bytes) -> None:
+    """Write `payload` to `path` through a staging file, replacing it in one step.
+
+    Serving reads an artifact directory while the optimizer writes it, and a half-written
+    policy.json is a mount failure rather than a slightly stale endpoint. It is also what lets
+    a command that writes several artifacts promise that a failure leaves the old ones intact.
+    `KnnBank.save` stages the same way for the sidecar it streams through numpy.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staging = path.with_name(f"{path.name}.partial")
+    staging.write_bytes(payload)
+    staging.replace(path)
+
+
 def knn_bank_path_for(policy_path: Path) -> Path:
     """The evidence sidecar that belongs to one policy file.
 
-    `models/support.json` -> `models/support.bank.npz`. One owner for the derivation so the
-    fitter, the CLI's console line, and any tooling that cleans an artifact directory cannot
+    `models/support.json` -> `models/support.json.bank.npz`. Distinct policy filenames always
+    give distinct bank filenames (see `KNN_BANK_SUFFIX`), and one owner for the derivation means
+    the fitter, the CLI's console line, and any tooling that cleans an artifact directory cannot
     disagree about which `.npz` belongs to which policy.
     """
-    return policy_path.with_suffix(KNN_BANK_SUFFIX)
+    return policy_path.with_name(f"{policy_path.name}{KNN_BANK_SUFFIX}")
 
 
 class EmbedderSpec(BaseModel):
@@ -383,8 +401,8 @@ class RoutingPolicy(BaseModel):
         return self
 
     def save(self, path: Path) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        """Write the policy artifact atomically (a torn policy.json must not be loadable)."""
+        write_artifact_atomically(path, self.model_dump_json(indent=2).encode("utf-8"))
         self._source_dir = path.parent
 
     @classmethod

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -219,19 +219,30 @@ class KnnBank:
         return np.where(counts > 0, totals / np.maximum(counts, 1), np.nan)
 
     def save(self, path: Path) -> None:
-        """Write the sidecar atomically (a half-written 10MB bank must not be loadable)."""
+        """Write the sidecar atomically (a half-written 10MB bank must not be loadable).
+
+        Staged under a name unique to this call, for the reason spelled out in
+        `write_artifact_atomically`: two fits racing on one `--out` derive the same bank path,
+        and a shared staging file would let one publish the OTHER's evidence under its own name.
+        A bank is streamed through numpy rather than buffered into bytes, so it stages itself
+        instead of going through that helper.
+        """
         path.parent.mkdir(parents=True, exist_ok=True)
-        staging = path.with_name(f"{path.name}.partial")
-        with staging.open("wb") as handle:
-            np.savez(
-                handle,
-                embeddings=self.embeddings.astype(np.float32),
-                rewards=self.rewards.astype(np.float32),
-                costs=self.costs.astype(np.float32),
-                models=np.asarray(self.models),
-                scenario_ids=np.asarray(self.scenario_ids),
-            )
-        staging.replace(path)
+        staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
+        try:
+            with staging.open("wb") as handle:
+                np.savez(
+                    handle,
+                    embeddings=self.embeddings.astype(np.float32),
+                    rewards=self.rewards.astype(np.float32),
+                    costs=self.costs.astype(np.float32),
+                    models=np.asarray(self.models),
+                    scenario_ids=np.asarray(self.scenario_ids),
+                )
+            staging.replace(path)
+        except BaseException:
+            staging.unlink(missing_ok=True)
+            raise
 
     @classmethod
     def load(cls, path: Path) -> KnnBank:

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -38,6 +38,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+from uuid import uuid4
 
 import numpy as np
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
@@ -91,11 +92,21 @@ def write_artifact_atomically(path: Path, payload: bytes) -> None:
     policy.json is a mount failure rather than a slightly stale endpoint. It is also what lets
     a command that writes several artifacts promise that a failure leaves the old ones intact.
     `KnnBank.save` stages the same way for the sidecar it streams through numpy.
+
+    The staging name is unique PER CALL. `replace` is atomic, but a staging path shared between
+    two concurrent writers is not: they would interleave on one file, so one could publish the
+    other's bytes under its own name and the loser would fail on a file already renamed away.
+    It is also hidden and cleaned up on failure, so an interrupted write cannot leave litter in
+    an artifact directory that serving and the fitter both scan.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    staging = path.with_name(f"{path.name}.partial")
-    staging.write_bytes(payload)
-    staging.replace(path)
+    staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
+    try:
+        staging.write_bytes(payload)
+        staging.replace(path)
+    except BaseException:
+        staging.unlink(missing_ok=True)
+        raise
 
 
 def knn_bank_path_for(policy_path: Path) -> Path:

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -59,6 +59,11 @@ DEFAULT_RANK = 999
 # kNN champion defaults: the exact configuration validated on routerbench-ours9
 # (+1.0 accuracy point over the best single model at -27% cost, 5/5 split seeds).
 KNN_BANK_FILENAME = "policy_knn_bank.npz"
+# The sidecar suffix a fit DERIVES from its policy path, so two policies fitted into one
+# directory own two banks (`support.json` -> `support.bank.npz`) instead of racing for one
+# shared name. `KNN_BANK_FILENAME` above stays the resolution fallback for artifacts that
+# record no path of their own; see `RoutingPolicy.knn_bank_path`.
+KNN_BANK_SUFFIX = ".bank.npz"
 DEFAULT_RAG_NUM = 50
 DEFAULT_RAG_THRES = 0.95
 DEFAULT_KNN_Z = 0.5
@@ -74,6 +79,16 @@ SE_FLOOR_MAX_PAIRS = 30
 # policy no per-instance state (a lock stored on the model would make two otherwise identical
 # policies compare unequal).
 _BANK_LOAD_LOCK = threading.Lock()
+
+
+def knn_bank_path_for(policy_path: Path) -> Path:
+    """The evidence sidecar that belongs to one policy file.
+
+    `models/support.json` -> `models/support.bank.npz`. One owner for the derivation so the
+    fitter, the CLI's console line, and any tooling that cleans an artifact directory cannot
+    disagree about which `.npz` belongs to which policy.
+    """
+    return policy_path.with_suffix(KNN_BANK_SUFFIX)
 
 
 class EmbedderSpec(BaseModel):
@@ -256,9 +271,13 @@ class RoutingPolicy(BaseModel):
     guard_margin: float | None = None  # reward the challenger must beat the guard by
     fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
 
-    # kNN policies only (see module docstring and `wmo.optimize.knn`). The bank path is a bare
-    # FILENAME resolved next to policy.json, so a model directory stays portable; an absolute
-    # path is honored as given (research code and tests point at banks elsewhere).
+    # kNN policies only (see module docstring and `wmo.optimize.knn`). The fitter records the
+    # bank it actually wrote (`knn_bank_path_for(<policy path>)`), so serving resolves the
+    # sidecar EXPLICITLY instead of by convention and two policies can share a directory. The
+    # value is a bare FILENAME resolved next to policy.json, so a model directory stays
+    # portable; an absolute path is honored as given (research code and tests point at banks
+    # elsewhere). The default is the legacy conventional name, which is what an artifact
+    # written before the fitter recorded a derived name resolves to.
     knn_bank_path: str = KNN_BANK_FILENAME
     rag_num: int = Field(default=DEFAULT_RAG_NUM, ge=1)  # neighbor budget
     # A neighbor is a fit scenario with similarity above `rag_thres` times the `rag_num`-th best

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -20,6 +20,7 @@ from wmo.optimize.policy import (
     knn_decision,
     rank_decision,
     select_model,
+    write_artifact_atomically,
 )
 from wmo.providers.base import ProviderKind
 from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
@@ -225,6 +226,38 @@ def test_a_failed_policy_save_leaves_the_previous_artifact_intact(
     with pytest.raises(OSError, match="disk full"):
         _static().save(path)
     assert RoutingPolicy.load(path) == served  # the staged write never replaced it
+    assert [entry.name for entry in tmp_path.iterdir()] == ["policy.json"]  # no staging litter
+
+
+def test_interleaved_artifact_writes_do_not_share_a_staging_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two writers mid-flight on one path must not stage through the same file.
+
+    Regression: the staging name was a fixed `<name>.partial`, so a second writer overwrote the
+    first's staged bytes before the first renamed. One save then published the OTHER's payload
+    under its own success message, and the loser failed on a file already renamed away.
+
+    The second write is driven to completion inside the first one's `replace`, which is the
+    interleaving that breaks a shared staging path, without depending on thread timing.
+    """
+    path = tmp_path / "policy.json"
+    staged: list[Path] = []
+    real_replace = Path.replace
+
+    def _replace(self: Path, target: Path) -> Path:
+        staged.append(self)
+        if len(staged) == 1:  # the first writer is mid-flight: run the second start to finish
+            write_artifact_atomically(path, b'{"second": true}')
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _replace)
+    write_artifact_atomically(path, b'{"first": true}')
+
+    assert len({entry.name for entry in staged}) == 2  # two writers, two staging files
+    # The first writer renamed last, so its own bytes are what landed -- not the second's.
+    assert path.read_bytes() == b'{"first": true}'
+    assert [entry.name for entry in tmp_path.iterdir()] == ["policy.json"]
 
 
 def test_azure_embedder_spec_requires_backend_fields() -> None:

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -260,6 +260,37 @@ def test_interleaved_artifact_writes_do_not_share_a_staging_file(
     assert [entry.name for entry in tmp_path.iterdir()] == ["policy.json"]
 
 
+def test_interleaved_bank_writes_do_not_share_a_staging_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two fits racing on one `--out` derive one bank path; they must not stage through one file.
+
+    Regression: `KnnBank.save` staged through a fixed `<bank>.partial`, so one fit could publish
+    the OTHER fit's evidence under its own bank name while the loser raised `FileNotFoundError`.
+    A policy serving a competing fit's rewards is the failure this whole change is about, and
+    the derived bank name does not prevent it when both fits target the same policy path.
+    """
+    path = tmp_path / "bank.npz"
+    mine = _knn_bank([[1.0, 0.0]] * 12)  # fable-5 wins every neighbor
+    theirs = _knn_bank([[0.0, 1.0]] * 12)  # ...and haiku-4-5 wins every neighbor
+    staged: list[Path] = []
+    real_replace = Path.replace
+
+    def _replace(self: Path, target: Path) -> Path:
+        staged.append(self)
+        if len(staged) == 1:  # this fit is mid-flight: run the competing one start to finish
+            theirs.save(path)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _replace)
+    mine.save(path)
+
+    assert len({entry.name for entry in staged}) == 2  # two fits, two staging files
+    # The bank that renamed last is the one on disk, with ITS rewards, not the competitor's.
+    assert np.array_equal(KnnBank.load(path).rewards, mine.rewards)
+    assert [entry.name for entry in tmp_path.iterdir()] == ["bank.npz"]
+
+
 def test_azure_embedder_spec_requires_backend_fields() -> None:
     with pytest.raises(ValueError, match="deployment"):
         EmbedderSpec(kind="azure", dim=3072)

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -210,6 +210,23 @@ def test_openrouter_candidate_keeps_the_price_it_was_fitted_under(
     assert served.pool[1].price().output_per_mtok == 1.75
 
 
+def test_a_failed_policy_save_leaves_the_previous_artifact_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Serving reads the artifact dir while the optimizer writes it: no torn policy.json."""
+    path = tmp_path / "policy.json"
+    _rank_policy().save(path)
+    served = RoutingPolicy.load(path)
+
+    def _die(self: Path, data: bytes) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_bytes", _die)
+    with pytest.raises(OSError, match="disk full"):
+        _static().save(path)
+    assert RoutingPolicy.load(path) == served  # the staged write never replaced it
+
+
 def test_azure_embedder_spec_requires_backend_fields() -> None:
     with pytest.raises(ValueError, match="deployment"):
         EmbedderSpec(kind="azure", dim=3072)

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Literal
@@ -550,6 +551,23 @@ def test_knn_bank_loads_lazily_from_the_sidecar_and_stays_cached(tmp_path: Path)
     # Cached after the first decision: the sidecar is read once per policy instance, not per
     # request (a 3072-dimensional bank is megabytes).
     (tmp_path / KNN_BANK_FILENAME).unlink()
+    assert select_model(loaded, "anything", embedder=_UnitEmbedder()).model == "haiku-4-5"
+
+
+def test_knn_bank_path_falls_back_to_the_legacy_sidecar_name(tmp_path: Path) -> None:
+    """A policy artifact that records no bank path still resolves the conventional sidecar.
+
+    Backward compatibility: policies fitted before the bank name was derived from the policy
+    file live beside `policy_knn_bank.npz`, and hand-built artifacts may omit the field.
+    """
+    bank = _knn_bank([[0.0, 1.0]] * 12)
+    bank.save(tmp_path / KNN_BANK_FILENAME)
+    document = _knn_policy(bank).model_dump(mode="json")
+    document.pop("knn_bank_path")
+    (tmp_path / "policy.json").write_text(json.dumps(document), encoding="utf-8")
+
+    loaded = RoutingPolicy.load(tmp_path / "policy.json")
+    assert loaded.bank_path() == tmp_path / KNN_BANK_FILENAME
     assert select_model(loaded, "anything", embedder=_UnitEmbedder()).model == "haiku-4-5"
 
 


### PR DESCRIPTION
## The bugs

Three ways `wmo optimize route` could leave the wrong bytes on disk while printing a green
checkmark. All three were reproduced end to end through the CLI before being fixed.

**1. `tune` silently discarded a re-fit.** `tune` copies the un-tuned artifact to
`<stem>.base.json` and every later run re-reads *that*, so the dial is always applied to the
policy as fitted. But `fit` never invalidated the snapshot. So:

```bash
wmo optimize route fit  matrix.json --kind knn --out policy.json   # fit A
wmo optimize route tune policy.json --cost-quality 0.6             # snapshots A
wmo optimize route fit  other.json  --kind knn --out policy.json   # fit B replaces A
wmo optimize route tune policy.json --cost-quality 0.3             # ✓ "dial set"
```

That last command re-read A's snapshot, dialed **A**, and wrote it over B. The operator gets a
success message and an artifact fitted on a matrix they replaced, with the old fallback and the
old routing behavior.

**2. A rejected `tune` poisoned the path forever.** The snapshot was copied *before* the dial was
validated, so tuning a `kind="rank"` policy failed with `kind='rank'` and still left a stray
`policy.base.json`. A later `fit --kind knn` into that same path could then never be tuned: every
attempt reported `kind='rank'` while the policy on disk was demonstrably `kind='knn'`. Nothing in
the message named the stale file, and nothing else in the directory hinted at it.

**3. The kNN evidence bank collided.** `fit --kind knn` wrote its sidecar to a hard-coded
`policy_knn_bank.npz` that ignored `--out`. Two knn fits into one directory therefore raced for
one filename: the second overwrote the first policy's evidence, and both policies recorded the
same relative path, so policy A loaded matrix B's rewards. On a pair of matrices that disagree,
reloading A inverts every routing decision and scores **0.0 accuracy on its own fit data**.

## The fix

**`tune` validates the snapshot before it trusts it.** The base snapshot must agree with the
policy beside it on `kind` and on `fit_provenance` — the fit half of `fitted_from`, with the
`| cost_quality=` dial suffix stripped, which is exactly the identity a tuned policy and the
snapshot it came from share while a refit does not. When they disagree, `tune` refuses, prints
both provenance strings, and names the file to delete.

**`tune` writes nothing when it is rejected, and every write it does make is atomic.** The
snapshot copy moved after the dial has applied. `RoutingPolicy.save` now stages and replaces via
a new `write_artifact_atomically`, mirroring what `KnnBank.save` already did for the sidecar. This
matters beyond the ordering fix: serving reads an artifact directory while the optimizer writes
it, so a torn `policy.json` is a mount failure rather than a slightly stale endpoint.

**The bank name is derived from `--out` and recorded in the policy.** `knn_bank_path_for` maps
`support.json` -> `support.json.bank.npz`, and `fit` writes that name into the policy JSON, so
serving resolves *this* policy's evidence explicitly instead of by convention.

Backward compatible: `knn_bank_path` keeps `policy_knn_bank.npz` as its field default, so an
artifact that records no path — a hand-built one, or anything written by the old fitter, which
recorded the legacy name explicitly — resolves exactly as it did before.

## Review round

Greptile raised four findings on the first push and four more across the rebased heads. All
valid, all addressed, each with a regression test that fails against the pre-fix code:

- **Path provenance admits stale fits** (P1). A corpus is routinely rebuilt in place under the
  filename it already had, and two such fits had identical path-based provenance. Worse than
  reported: `--fallback` was not in the provenance string at all, so refitting the same matrix
  against a different baseline also produced identical `fitted_from`. `fitted_from` now carries a
  sha256 digest of the matrix file plus every flag that shapes the artifact:
  `matrix.json sha256=12987f38f2357dad knn fallback=a z=0.5 k=3 thres=0.95 pairs=2 se_floor=True
  q=0.05 hashing-512`.
- **Bank derivation still permits collisions** (P1). `with_suffix` is not injective on filenames,
  so `policy.json` and `policy.yaml` in one directory both mapped to `policy.bank.npz`. The
  suffix is now **appended** rather than substituted, which is injective by construction.
- **Tune writes are not failure-atomic** (P2). Handled by `write_artifact_atomically` above. With
  both of `tune`'s writes atomic, an interruption after the snapshot lands leaves the policy as
  the as-fitted bytes that snapshot copied — self-consistent, not stale — and an interruption
  during the snapshot write leaves nothing. The docstring claims that, rather than claiming
  nothing is ever left behind.
- **Azure refits share stale provenance** (P1). The digest commit added the deployment name to
  `embed_tag`, which was not enough: two accounts routinely hold a deployment of the same name
  and dimension, so a refit that only repointed `--endpoint` still rendered identical
  provenance. `_embedder_provenance` now derives the tag from the `EmbedderSpec` serving
  rebuilds and includes the resource endpoint. The credential variable stays out on purpose --
  renaming it does not move a vector, and a fit that only renamed it is the same fit.
- **Provenance marker truncates fit identity** (P1, raised on the rebased head). `fit_provenance`
  split `fitted_from` on the FIRST ` | cost_quality=`, and `fitted_from` *opens* with the
  operator-supplied matrix path. A path containing that substring therefore truncated the
  identity to a bare prefix, dropping the digest and every flag behind it, so unrelated fits
  compared equal and `tune` dialed a superseded snapshot over the current policy -- this PR's own
  bug, reachable through a filename. The strip now matches the whole trailer
  `apply_cost_quality` writes, anchored to the end of the string; the fit flags always follow the
  path, so an occurrence inside the path is never last.
- **Concurrent saves share staging file** (P1, raised on the rebased head), in this PR's own
  `write_artifact_atomically`. `replace` is atomic but the staging path was a fixed
  `<name>.partial` shared by every writer, so two saves of one policy interleaved on that single
  file: one published the OTHER's bytes under its own success message and the loser raised
  `FileNotFoundError` on a file already renamed away. The staging name now carries a `uuid4()`,
  and it is hidden and unlinked on failure so an interrupted write leaves no litter in a
  directory serving and the fitter both scan.
- **Digest identifies the wrong matrix** (P1, raised on the rebased head). `fit` parsed the
  matrix with `OutcomeMatrix.load` and then re-read the same path to digest it. A corpus rebuilt
  in place between the two reads stamped a fit of the OLD matrix with the NEW file's digest, so
  the next fit of that new matrix matched its provenance and `tune` accepted the superseded
  snapshot: the digest was reintroducing the failure it exists to catch. `_load_matrix` now
  returns the parsed matrix and its provenance from one read, so digesting anything other than
  the fitted bytes is not expressible.
- **Evidence bank staging still collides** (P1, raised on the rebased head). `KnnBank.save`
  streams a 10MB sidecar through numpy rather than buffering it, so it stages itself instead of
  going through `write_artifact_atomically` -- and kept the fixed `<bank>.partial`. The derived
  bank name does not separate two fits that share one `--out`, so they collided there. Same
  treatment. Both atomic writers in the module now stage uniquely, closing this on both
  artifacts a knn fit produces.

### One finding deliberately left open

**Policy-bank publication still races** (P1). Two `fit --kind knn` processes on the *same*
`--out` can interleave their two `replace` calls so the surviving policy came from one fit and
the surviving bank from the other. It is real, but it is not introduced here (`fit` published
two files before this change; this PR changes the bank's name, not the number of publications),
and the reported bug -- two fits to *different* paths sharing one hard-coded bank -- is fixed
and tested. Closing what remains means choosing between a cross-process lock spanning the
embedding step, unique-per-fit bank names that orphan 10MB per loser, or a bank digest verified
at load that costs serving startup a 10MB hash. That is an artifact-lifecycle decision for the
owner rather than something to settle inside a rebase, so [the thread](https://github.com/experientiallabs/world-model-optimizer/pull/281#discussion_r3653473690)
is left open with the trade-offs written out.

## Regression coverage

Seven tests, each verified to FAIL against the pre-change behaviour it pins (plus one
backward-compatibility pin):

| test | fails before the fix with |
| --- | --- |
| `test_route_tune_refuses_a_base_snapshot_from_a_superseded_fit` | the stale tune exits 0 and `default_model` flips back |
| `test_route_tune_refuses_a_snapshot_after_the_matrix_was_rebuilt_in_place` | `assert 0 != 0` on the stale tune's exit code |
| `test_route_tune_that_fails_leaves_no_base_snapshot_behind` | a stray `policy.base.json` survives the rejected tune |
| `test_route_fit_knn_gives_each_policy_its_own_evidence_bank` | `At index 0 diff: 'policy_a.bank.npz' != 'policy_a.json.bank.npz'` |
| `test_a_failed_policy_save_leaves_the_previous_artifact_intact` | `DID NOT RAISE` against the old non-atomic `write_text` |
| `test_knn_bank_path_falls_back_to_the_legacy_sidecar_name` | (pins the backward-compatible default) |
| `test_embedder_provenance_separates_two_azure_resources` | both resources render `azure-3072/text-embedding-3-large` |
| `test_route_tune_survives_a_matrix_path_that_looks_like_a_dial_suffix` | `assert 0 != 0` on the stale tune's exit code |
| `test_interleaved_artifact_writes_do_not_share_a_staging_file` | `FileNotFoundError: ... policy.json.partial -> ... policy.json` |
| `test_route_fit_digests_the_bytes_it_actually_fitted` | both fits report the same `sha256=3e2e63a8...` |
| `test_interleaved_bank_writes_do_not_share_a_staging_file` | `FileNotFoundError: ... bank.npz.partial -> ... bank.npz` |

The bank test fits three policies into one directory, two of which share a stem, and then asserts
policy A still scores `{"b": 1.0}` on its own prose half — which is 1.0 only if the later fits
left A's bank alone.

## Gates

Rebased onto `00a92983`, then re-run:

- `uv run --no-sync pytest -q` -> **3563 passed, 18 skipped**. Deselecting exactly the eleven
  new tests gives 3552 passed / 18 skipped / 11 deselected, so the delta is the new coverage and
  nothing else.
- `uv run --no-sync ruff check .` -> `All checks passed!`
- `uv run --no-sync ruff format --check wmo/` -> `423 files already formatted`
- `uv run --no-sync ty check` -> `All checks passed!`

Rebase notes, against `#272` (`route student`/`pin`), `#277` (`route sweep`) and `#278`:

- Import blocks in `route_app.py` and `route_app_test.py` conflicted four times; every one was
  resolved as a union (this branch drops `KNN_BANK_FILENAME`, main adds `select_model`,
  `EpisodeScore`, `pytest`, `Result` and the sweep's imports).
- `#277` inserted the whole `sweep` command at the same anchor as `_matrix_provenance`; both
  kept, sweep first.
- `#277` also landed its own `_flat` in `route_app_test.py`. Two definitions of that name in one
  module: main's is second, so it won at call time and quietly changed what three of these
  assertions tested. Resolved toward main's (it covers a wrapped rich table, not just a usage
  panel) with the assertions moved to the `_says(output, phrase)` helper it ships beside it.
- `sweep` introduces no assumption about the policy or bank filename, so the derived bank path
  still owns that name; `assert policy.knn_bank_path == "policy.json.bank.npz"` is unchanged.

Each regression test was re-verified after the rebase by reverting its fix in the working tree
and confirming the test fails -- not merely that the suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
