### PR TITLE
Share one DEFAULT_TRAIN_SPLIT between wmo build and wmo eval (eval 0.7 -> 0.8)

### DIFF
--- a/docs/reference/eval_suites.md
+++ b/docs/reference/eval_suites.md
@@ -24,10 +24,14 @@ examples/
 title = "Tau Bench default replay"
 description = "Open-loop reconstruction fidelity over the bundled tau-bench trace corpus."
 files = ["../traces.otel.jsonl"]   # resolved relative to this file
-train_split = 0.7
 sample_turns = "all"
 seed = 0
 ```
+
+`train_split` is omitted on purpose. It defaults to the same `DEFAULT_TRAIN_SPLIT` (0.8) that
+`wmo build` cuts, and both cut the SAME deterministic `trace_id` hash line, so a suite that pins a
+lower value scores traces GEPA trained on and reports an inflated fidelity. Pin it only when the
+model under test was genuinely built with a different ratio.
 
 There is no judge knob: every suite is scored by the single `RubricJudge`. A pre-overhaul
 `judge = "..."` line makes the suite fail validation: loading the file directly (`wmo eval

--- a/packages/environment-capture/appworld/evals/default.toml
+++ b/packages/environment-capture/appworld/evals/default.toml
@@ -1,6 +1,5 @@
 title = "AppWorld default replay"
 description = "Open-loop reconstruction fidelity over the appworld trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/bird-sql/evals/default.toml
+++ b/packages/environment-capture/bird-sql/evals/default.toml
@@ -1,6 +1,5 @@
 title = "BIRD-SQL default replay"
 description = "Open-loop reconstruction fidelity over the bird-sql trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/continual-learning/evals/default.toml
+++ b/packages/environment-capture/continual-learning/evals/default.toml
@@ -1,6 +1,5 @@
 title = "Continual-learning default replay"
 description = "Open-loop reconstruction fidelity over the continual-learning trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/crmarena/evals/default.toml
+++ b/packages/environment-capture/crmarena/evals/default.toml
@@ -1,6 +1,5 @@
 title = "CRMArena default replay"
 description = "Open-loop reconstruction fidelity over the crmarena trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/dabstep/evals/default.toml
+++ b/packages/environment-capture/dabstep/evals/default.toml
@@ -1,6 +1,5 @@
 title = "DABstep default replay"
 description = "Open-loop reconstruction fidelity over the dabstep trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/financebench/evals/default.toml
+++ b/packages/environment-capture/financebench/evals/default.toml
@@ -1,6 +1,5 @@
 title = "FinanceBench default replay"
 description = "Open-loop reconstruction fidelity over the financebench trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/gaia2/evals/default.toml
+++ b/packages/environment-capture/gaia2/evals/default.toml
@@ -1,6 +1,5 @@
 title = "GAIA2 default replay"
 description = "Open-loop reconstruction fidelity over the gaia2 trace corpus (train-split real runs)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/kimi-gui-control/evals/default.toml
+++ b/packages/environment-capture/kimi-gui-control/evals/default.toml
@@ -1,6 +1,5 @@
 title = "kimi-gui-control default replay"
 description = "Open-loop reconstruction fidelity over the bundled Kimi-K2.6 screenpipe GUI-control trace corpus (macOS Accessibility API + shell)."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0

--- a/packages/environment-capture/swe-bench/evals/default.toml
+++ b/packages/environment-capture/swe-bench/evals/default.toml
@@ -1,7 +1,6 @@
 title = "SWE-bench default replay"
 description = "Open-loop reconstruction fidelity over the bundled SWE-bench trace corpus."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0
 

--- a/packages/environment-capture/tau-bench/evals/default.toml
+++ b/packages/environment-capture/tau-bench/evals/default.toml
@@ -1,7 +1,6 @@
 title = "Tau Bench default replay"
 description = "Open-loop reconstruction fidelity over the bundled tau-bench trace corpus."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0
 

--- a/packages/environment-capture/terminal-tasks/evals/default.toml
+++ b/packages/environment-capture/terminal-tasks/evals/default.toml
@@ -1,7 +1,6 @@
 title = "Terminal tasks default replay"
 description = "Open-loop reconstruction fidelity over the bundled terminal task trace corpus."
 files = ["../traces.otel.jsonl"]
-train_split = 0.7
 sample_turns = "all"
 seed = 0
 

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -75,8 +75,8 @@ from wmo.config import (
 )
 from wmo.config.card import make_build_card, save_card
 from wmo.core.types import JsonObject
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT, ingest, split_traces
 from wmo.engine.build import build as run_build
-from wmo.engine.build import ingest, split_traces
 from wmo.engine.demo import run_demo
 from wmo.engine.eval_suites import (
     discover_eval_suites,
@@ -432,7 +432,10 @@ def build(
         None, "--chain", help="Named failover chain from .wmo/fallback.toml (default: its default)."
     ),
     train_split: float = typer.Option(
-        0.8, help="Train/held-out ratio for GEPA's internal split (lower = bigger valset)."
+        DEFAULT_TRAIN_SPLIT,
+        help="Train/held-out ratio for GEPA's internal split (lower = bigger valset). Shares "
+        "`wmo eval`'s default: both cut the same trace-id hash line, so a mismatch leaks train "
+        "traces into the eval holdout.",
     ),
     embed_provider: str = typer.Option(
         "hashing", help="phi embedder: hashing (offline) | bedrock | openai | azure."
@@ -911,7 +914,9 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
         None, "--chain", help="Named failover chain from .wmo/fallback.toml (default: its default)."
     ),
     train_split: float | None = typer.Option(
-        None, help="Train/holdout ratio per file (default: 0.7, or suite config)."
+        None,
+        help=f"Train/holdout ratio per file (default: {DEFAULT_TRAIN_SPLIT}, or suite config). "
+        "Must match the ratio the model was built with, or the holdout contains train traces.",
     ),
     val_frac: float | None = typer.Option(
         None,
@@ -1473,7 +1478,7 @@ def _eval_options(
     knowledge: bool | None = None,
     reasoning: bool | None = None,
 ) -> _EvalOptions:
-    split = 0.7 if train_split is None else train_split
+    split = DEFAULT_TRAIN_SPLIT if train_split is None else train_split
     dim = 512 if embed_dim is None else embed_dim
     retrieval = True if rag is None else rag
     turns = "all" if sample_turns is None else sample_turns

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import json
 import os
 import subprocess
@@ -16,7 +17,10 @@ from typer.testing import CliRunner
 
 from wmo.cli import app
 from wmo.cli.app import _CONCURRENCY_ISOLATION_FLAGS
-from wmo.config import ModelRole, load_config, load_settings, save_settings
+from wmo.config import HarnessConfig, ModelRole, load_config, load_settings, save_settings
+from wmo.core.types import Trace
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3way
+from wmo.engine.eval_suites import EvalSuiteConfig
 from wmo.providers.base import (
     Completion,
     Message,
@@ -1068,3 +1072,54 @@ def test_parse_model_specs_validates_provider_and_resolves_model() -> None:
     # Malformed entry (wrong arity) still rejected.
     with pytest.raises(typer.BadParameter, match="bad --models entry"):
         _parse_model_specs("Opus:bedrock")
+
+
+def _build_cli_train_split_default() -> float:
+    """The `--train-split` default `wmo build` registers, read off the Typer option itself."""
+    option = inspect.signature(cli_app_module.build).parameters["train_split"].default
+    return cast(float, option.default)
+
+
+def _eval_cli_train_split_default() -> float:
+    """The train split `wmo eval` resolves when the user passes no `--train-split`."""
+    # `_eval_options` is the resolver under test: it is where `wmo eval` turns "no flag given"
+    # into a concrete split, so asserting on its output is asserting on the real default.
+    options = cli_app_module._eval_options(
+        prompt_file=None,
+        train_split=None,
+        embed_dim=None,
+        rag=None,
+        sample_turns=None,
+        seed=None,
+        top_k=None,
+    )
+    return options.train_split
+
+
+def test_build_and_eval_share_one_default_train_split() -> None:
+    # `wmo build` and `wmo eval` cut the SAME deterministic trace-id hash line of the SAME corpus,
+    # so their defaults are not two independent knobs: they are one number. They drifted apart
+    # (build 0.8, eval 0.7), which leaked the [0.7, 0.8) band of GEPA's training traces into every
+    # default eval as "held-out". Both must read `DEFAULT_TRAIN_SPLIT` and nothing else.
+    assert _build_cli_train_split_default() == DEFAULT_TRAIN_SPLIT
+    assert _eval_cli_train_split_default() == DEFAULT_TRAIN_SPLIT
+    # Pinned to each other too, so a future edit to one alone is a failure and not a silent leak.
+    assert _build_cli_train_split_default() == _eval_cli_train_split_default()
+    # Suites and the Python-API config default sit on the same line and must agree as well.
+    assert EvalSuiteConfig().train_split == DEFAULT_TRAIN_SPLIT
+    assert HarnessConfig().train_split == DEFAULT_TRAIN_SPLIT
+
+
+def test_default_eval_holdout_contains_no_build_training_trace() -> None:
+    # The measurement-validity invariant behind the shared constant, checked end to end on the
+    # real split functions: nothing GEPA trained on may be scored as held-out.
+    traces = [Trace(trace_id=f"trace-{i}") for i in range(400)]
+    build_split = _build_cli_train_split_default()
+    # Mirrors `wmo.engine.build.build`: train / val / test on one hash line.
+    gepa_train, _val, _test = split_traces_3way(traces, build_split, (1.0 - build_split) / 2)
+    # Mirrors `wmo.evals.open_loop.evaluate_files` on the ad hoc `wmo eval <file>` path.
+    _eval_train, holdout = split_traces(traces, _eval_cli_train_split_default())
+    assert gepa_train, "sanity: the corpus must actually produce a training split"
+    assert holdout, "sanity: the corpus must actually produce a holdout"
+    leaked = {t.trace_id for t in gepa_train} & {t.trace_id for t in holdout}
+    assert leaked == set(), f"{len(leaked)} GEPA training traces scored as held-out"

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -50,6 +50,7 @@ from wmo.config import (
     validate_name,
 )
 from wmo.core.types import Action, ActionKind, Session
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT
 from wmo.engine.play import PlayTurn, parse_action, play_turn
 from wmo.engine.world_model import WorldModel
 from wmo.providers import verify_all, verify_embedder
@@ -133,7 +134,7 @@ class BuildParams(BaseModel):
     judge_model: str | None = None
     region: str | None = None
     fidelity: str = "medium"
-    train_split: float = 0.8
+    train_split: float = DEFAULT_TRAIN_SPLIT
     embed_provider: str = "hashing"
     embed_model: str | None = None
     embed_dim: int = 512

--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -19,6 +19,12 @@ from wmo.providers.models import resolve_provider_model
 
 ARTIFACT_DIR = ".wmo"
 
+# Mirror of `wmo.engine.build.DEFAULT_TRAIN_SPLIT`, the one cut point on the trace-id hash line
+# that `wmo build` and `wmo eval` share. The canonical constant lives next to the split functions
+# and cannot be imported here (build.py imports this module, so the arrow would be a cycle), so
+# `config_test.py` asserts the two stay equal instead.
+_DEFAULT_TRAIN_SPLIT = 0.8
+
 
 class FidelityTier(StrEnum):
     """Build-effort tiers: how much is spent making the artifact faithful.
@@ -152,7 +158,7 @@ class HarnessConfig(BaseModel):
     embed_dim: int = 512  # phi dimensionality; index + query embedder must agree on this
     top_k: int = 5  # demos retrieved per step (DreamGym k)
     # train/held-out ratio for GEPA; a proper fraction so both splits can be non-empty
-    train_split: float = Field(default=0.8, gt=0.0, lt=1.0)
+    train_split: float = Field(default=_DEFAULT_TRAIN_SPLIT, gt=0.0, lt=1.0)
     gepa_budget: int = 10  # GEPA iterations; ~valset_cap calls each (see _cap_gepa_valset)
     # Model id the GEPA judge runs on (same provider kind as serve). None = the serve model.
     judge_model: str | None = None
@@ -209,7 +215,7 @@ class HarnessConfig(BaseModel):
         embed_model: str | None,
         embed_dim: int,
         gepa_budget: int,
-        train_split: float = 0.8,
+        train_split: float = _DEFAULT_TRAIN_SPLIT,
         judge_model: str | None = None,
         trace_adapter: str = "otel-genai",
     ) -> HarnessConfig:

--- a/wmo/config/config_test.py
+++ b/wmo/config/config_test.py
@@ -8,12 +8,14 @@ import pytest
 from pydantic import ValidationError
 
 from wmo.config.config import (
+    _DEFAULT_TRAIN_SPLIT,
     PROVIDER_ENV_VARS,
     ArtifactPaths,
     HarnessConfig,
     load_config,
     save_config,
 )
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT
 from wmo.providers.base import EmbedderKind, ProviderConfig, ProviderKind
 
 
@@ -209,8 +211,18 @@ def test_for_build_hashing_embedder_needs_no_embed_provider_config() -> None:
     assert config.embed_provider is EmbedderKind.HASHING
 
 
+def test_config_train_split_default_mirrors_the_canonical_constant() -> None:
+    # `_DEFAULT_TRAIN_SPLIT` is a mirror: the canonical value lives next to the split functions in
+    # `wmo.engine.build`, which this module cannot import (build.py imports it, so the arrow would
+    # cycle). A build config that cuts the hash line somewhere other than where `wmo eval` cuts it
+    # hands GEPA's training traces back as scored "held-out" steps, so pin the mirror here.
+    assert _DEFAULT_TRAIN_SPLIT == DEFAULT_TRAIN_SPLIT
+    assert HarnessConfig().train_split == DEFAULT_TRAIN_SPLIT
+
+
 def test_for_build_threads_train_split() -> None:
-    # train_split defaults to 0.8 but is overridable (so `wmo build --train-split` reaches GEPA).
+    # train_split defaults to DEFAULT_TRAIN_SPLIT but is overridable (so `wmo build --train-split`
+    # reaches GEPA).
     default = HarnessConfig.for_build(
         serve_provider=ProviderKind.BEDROCK,
         serve_model="opus",

--- a/wmo/engine/__init__.py
+++ b/wmo/engine/__init__.py
@@ -3,7 +3,13 @@
 Evaluation of a built world model (open-loop replay fidelity + closed-loop task success) lives in
 `wmo.evals`."""
 
-from wmo.engine.build import build, ingest, split_traces, split_traces_3way
+from wmo.engine.build import (
+    DEFAULT_TRAIN_SPLIT,
+    build,
+    ingest,
+    split_traces,
+    split_traces_3way,
+)
 from wmo.engine.demo import DemoReplay, DemoStep, run_demo
 from wmo.engine.loader import load_world_model
 from wmo.engine.play import PlayTurn, parse_action, play_turn
@@ -11,6 +17,7 @@ from wmo.engine.reporting import BuildReporter, NullReporter
 from wmo.engine.world_model import WorldModel
 
 __all__ = [
+    "DEFAULT_TRAIN_SPLIT",
     "build",
     "ingest",
     "split_traces",

--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -30,6 +30,15 @@ from wmo.providers import get_provider
 from wmo.providers.base import Embedder, Provider
 from wmo.retrieval import EmbeddingRetriever, HashingEmbedder
 
+# The single cut point on the `_trace_fraction` hash line that every train/held-out default reads.
+# `wmo build` trains GEPA on `[0, DEFAULT_TRAIN_SPLIT)` and `wmo eval` scores from
+# `DEFAULT_TRAIN_SPLIT` up, over the SAME corpus and the SAME deterministic line, so the two must
+# be one number. They were not: build defaulted to 0.8 and eval to 0.7, which handed eval the
+# `[0.7, 0.8)` band (about 10% of any corpus) as "held-out" when GEPA had trained on it, inflating
+# every reconstruction-fidelity number produced on the documented happy path by an unknown amount.
+# `wmo/cli/app_test.py` pins both CLI paths here so they cannot drift apart again.
+DEFAULT_TRAIN_SPLIT = 0.8
+
 
 def _count_steps(traces: list[Trace]) -> int:
     return sum(len(trace.steps) for trace in traces)
@@ -57,7 +66,9 @@ def split_traces(traces: list[Trace], train_split: float) -> tuple[list[Trace], 
     """Deterministic train/held-out split for GEPA (held-out is never seen during evolution).
 
     Assignment is by a stable hash of `trace_id`, so the same corpus always splits the same way
-    regardless of order and rebuilds are reproducible. `train_split` is the target train fraction.
+    regardless of order and rebuilds are reproducible. `train_split` is the target train fraction,
+    and callers that have no reason to pick their own should pass `DEFAULT_TRAIN_SPLIT`: a build
+    and an eval that cut this line at different points overlap, and the overlap is a leak.
     """
     train: list[Trace] = []
     test: list[Trace] = []

--- a/wmo/engine/eval_suites.py
+++ b/wmo/engine/eval_suites.py
@@ -16,6 +16,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT
+
 logger = logging.getLogger(__name__)
 
 SampleTurns = Literal["all", "sampled"]
@@ -30,7 +32,8 @@ class EvalSuiteConfig(BaseModel):
     description: str | None = None
     files: list[str] = Field(default_factory=lambda: ["../traces.otel.jsonl"])
     prompt: str | None = None
-    train_split: float = Field(default=0.7, gt=0.0, lt=1.0)
+    # Same cut as `wmo build`: a suite that lowers this scores traces GEPA trained on.
+    train_split: float = Field(default=DEFAULT_TRAIN_SPLIT, gt=0.0, lt=1.0)
     top_k: int = Field(default=5, ge=0)
     sample_turns: SampleTurns = "all"
     seed: int = 0

--- a/wmo/evals/open_loop.py
+++ b/wmo/evals/open_loop.py
@@ -15,7 +15,7 @@ from statistics import fmean, pstdev
 
 from pydantic import BaseModel, Field
 
-from wmo.engine.build import split_traces, split_traces_3way
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3way
 from wmo.engine.knowledge import seeded_knowledge_text
 from wmo.engine.replay import ReplayReport, replay, valid_scores
 from wmo.ingest import get_adapter
@@ -62,7 +62,7 @@ def evaluate_files(
     judge: Judge,
     *,
     embedder: Embedder | None = None,
-    train_split: float = 0.7,
+    train_split: float = DEFAULT_TRAIN_SPLIT,
     val_frac: float | None = None,
     top_k: int = 5,
     sample_turns: str = "all",
@@ -75,7 +75,10 @@ def evaluate_files(
     """Replay-score each trace file's held-out split. `embedder=None` -> zero-shot (no retrieval).
 
     Each file is split deterministically; tiny corpora with no held-out trace fall back to scoring
-    every trace. RAG, when enabled, retrieves from that file's own train split only (leak-free).
+    every trace. `train_split` defaults to `DEFAULT_TRAIN_SPLIT`, the same cut `wmo build` makes on
+    the same hash line: override it only to match a model that was built with a different ratio,
+    because a smaller value here hands GEPA's training traces back as scored "held-out" steps.
+    RAG, when enabled, retrieves from that file's own train split only (leak-free).
     `sample_turns`/`seed` are forwarded to `replay` (see its docstring). `max_holdout_traces` caps
     how many held-out traces are scored per file (a deterministic prefix by trace_id) - for cheap
     dry-runs; the train side stays full so retrieval is unaffected.
@@ -156,7 +159,7 @@ class OpenLoopEval:
         judge: Judge,
         *,
         embedder: Embedder | None = None,
-        train_split: float = 0.7,
+        train_split: float = DEFAULT_TRAIN_SPLIT,
         top_k: int = 5,
         sample_turns: str = "all",
         seed: int = 0,

--- a/wmo/serving/builds.py
+++ b/wmo/serving/builds.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from wmo.config import ArtifactPaths, HarnessConfig, WorldModelStore
 from wmo.config.card import make_build_card, save_card
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT
 from wmo.engine.build import build as run_build
 from wmo.engine.reporting import BuildReporter
 from wmo.providers import get_provider, verify_all
@@ -60,7 +61,7 @@ class BuildRouteRequest(BaseModel):
     model: str = "claude-opus-4-8"
     region: str | None = None
     gepa_budget: int = 50
-    train_split: float = 0.8
+    train_split: float = DEFAULT_TRAIN_SPLIT
     embed_dim: int = 512
 
 


### PR DESCRIPTION
## The leak

`wmo build` and `wmo eval` each expose a `--train-split` flag. Same name, same corpus, and the
same deterministic cut: both go through `wmo.engine.build._trace_fraction`, a blake2b hash of
`trace_id` mapped to `[0, 1)`. They had different defaults, build **0.8** (the typer option in
`wmo/cli/app.py`) and eval **0.7** (`_eval_options`).

On the documented happy path:

```bash
wmo build --file traces.jsonl
wmo eval traces.jsonl
```

build trains GEPA on `[0, 0.8)` of that hash line, and eval then scores `[0.7, 1.0)` as
"held-out". The `[0.7, 0.8)` band, about 10% of any corpus and **one third of the reported eval
denominator**, was GEPA *training* data being graded as held-out. Every reconstruction-fidelity
number produced that way is inflated by an unknown amount. On a synthetic 400-trace corpus the
overlap is 47 traces.

The same divergence was baked into the shipped artifacts: all 11
`packages/environment-capture/*/evals/default.toml` suites pinned `train_split = 0.7`, while all
10 committed prebuilt models (`.../models/*/config.toml`) were built at `0.8`.

## The fix

One `DEFAULT_TRAIN_SPLIT = 0.8` in `wmo/engine/build.py`, sitting with `_trace_fraction`,
`split_traces`, and `split_traces_3way`. That is where the hash line and its semantics are
defined, and it is the module both CLI call sites already import, so the constant travels with
the thing it parameterizes instead of living in one of its callers.

`wmo/config/config.py` keeps a private `_DEFAULT_TRAIN_SPLIT` mirror: `build.py` imports that
module, so the reverse arrow would be an import cycle. `config_test.py` asserts the two are equal
rather than letting the mirror drift.

The 11 shipped suites now omit `train_split` entirely and inherit the shared default, so there is
one number to change instead of twelve.

## Which default, and what it does to the numbers

**0.8. Eval moves 0.7 -> 0.8; build is unchanged.**

- Moving eval up removes the training leak and leaves every existing artifact valid. Moving build
  down would invalidate the 10 committed prebuilt models and shrink GEPA's training set by 10
  points of corpus, and it would not even be safer: `val_frac` is `(1 - train_split) / 2`, so the
  2-way eval holdout always contains GEPA's validation band, and at 0.7 that band is 15% of the
  corpus instead of 10%.
- The eval denominator shrinks from the top 30% of the corpus to the top 20%. Post-change fidelity
  is measured on about a third fewer traces and carries correspondingly more variance.
- **Previously-reported fidelity numbers are not comparable across this change.** They were scored
  on a band that included GEPA's training traces; new numbers are not. Expect them to move down,
  and do not diff an old number against a new one.

Not addressed here, pre-existing and separate: the 2-way eval holdout still contains GEPA's `val`
selection band, so ad hoc `wmo eval <file>` can still reward selection overfitting. `--val-frac`
already exists for that on the grid path.

## Regression coverage

`wmo/cli/app_test.py` pins both CLI paths to the constant (reading the registered typer default
and the resolved `_eval_options` value, not literals) and asserts the real invariant on the real
split functions: no trace in build's GEPA training split may appear in eval's default holdout.

Verified failing before the change:

```
assert 0.7 == 0.8
 +  where 0.7 = _eval_cli_train_split_default()

AssertionError: 47 GEPA training traces scored as held-out
```

## Gates

Rebased onto `993bdf5c`, then re-run:

- `uv run --no-sync pytest -q` -> **3354 passed, 18 skipped**. Deselecting exactly the three new
  tests gives 3351 passed / 18 skipped / 3 deselected, so the delta is the new coverage and
  nothing else.
- `uv run --no-sync ruff check .` -> clean
- `uv run --no-sync ty check` -> clean
- `uv run --no-sync ruff format --check <this PR's .py files>` -> 10 files already formatted.
  Note: `ruff format --check wmo/` currently fails on `wmo/distill/config_test.py` (two stray
  blank lines at line 926). That file is byte-identical to `origin/main` and is not touched here,
  so it is a pre-existing failure on main, recorded rather than folded into this patch.
- Driven end to end: `wmo build --help` and `wmo eval --help` both advertise 0.8, and
  `wmo eval list` reports 0.80 for all 11 shipped suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
