### PR TITLE
README: add the routing path to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ Then optimize an agent harness against that model and a set of tasks:
 wmo optimize harness my-agent my-environment --tasks tasks.jsonl
 ```
 
+### Route to a cheaper model
+
+Optimizing the harness makes one model better at a task. Routing picks a *different* model per
+request, so the cheap one handles what it can and a frontier model handles the rest.
+
+Three steps, starting from a world model you have already built. First measure every candidate in
+your pool against your tasks. This is the only thing that produces an outcome matrix, and it costs
+real API calls, so it prints an estimate and asks before it spends:
+
+```bash
+wmo optimize route sweep my-environment --pool .wmo/pool.toml --out matrix.json
+```
+
+Fit a policy on that matrix. `--fallback` is the model served whenever the evidence is too thin to
+justify anything cheaper, so make it one you trust. Write it into the model's artifact dir, which is
+where `serve` looks:
+
+```bash
+wmo optimize route fit matrix.json --kind knn --fallback gpt-5.5 \
+  --out .wmo/models/my-environment/policy.json
+```
+
+Then serve it. Any model directory holding a `policy.json` also answers as an OpenAI-compatible
+endpoint, so point your agent's base URL at it and change nothing else:
+
+```bash
+wmo serve --name my-environment
+```
+
+`wmo optimize route report matrix.json .wmo/models/my-environment/policy.json` prints what the
+policy buys you against the single best model: accuracy, cost per run, and which models it actually
+picked. Read it before you believe the endpoint is cheaper.
+
 ### Hosted platform
 
 Create an account at [platform.experientiallabs.ai](https://platform.experientiallabs.ai), then


### PR DESCRIPTION
Getting started covers install, run, build and harness optimization. It says nothing about
routing, which is the path to a cheaper endpoint for a model you already have, and the one the
router work exists to serve.

**Stacked on #277**, deliberately. The section documents `wmo optimize route sweep`, which only
exists on that branch. Basing this on `main` would ship a README naming a command a reader cannot
run. Retarget to `main` once #277 lands.

## The section

Three steps from an existing world model: sweep the pool into an outcome matrix, fit a policy,
serve it.

It states two things a reader would otherwise hit as surprises:

- **The sweep spends real API calls.** It measures every pool candidate closed-loop, so the section
  says so and notes it prints an estimate and confirms first.
- **`fit --out` must be written into `.wmo/models/<name>/policy.json`.** `--out` defaults to a bare
  relative `policy.json`, while `serve` discovers policies at `<model_dir>/POLICY_FILENAME`. Writing
  it to the default location and then running `serve` gets you a server with no routing and no
  error, so the README gives the full path.

It ends by pointing at `route report`, so a reader checks what the policy actually buys against the
best single model before believing the endpoint is cheaper.

## Verification

Every command and flag was run against the real CLI on this branch, not read out of source:
`route sweep`, `route fit`, `route report`, `serve --name`, `--pool`, `--kind`, `--fallback`. The
`.wmo/models/<name>/` path was traced through `ARTIFACT_DIR` and `WorldModelStore` rather than
assumed.

`3378 passed, 18 skipped`; `ruff check` clean. Docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)