### PR TITLE
Add OpenRouter as a first-class provider, priced from its own catalog

### DIFF
--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -131,6 +131,9 @@ PROVIDER_ENV_VARS: dict[ProviderKind, list[str]] = {
     ProviderKind.AZURE_OPENAI: ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
     ProviderKind.OPENAI: ["OPENAI_API_KEY"],
     ProviderKind.OPENAI_RESPONSES: ["OPENAI_API_KEY"],
+    # Same literal-not-import rule as TINKER below; `wmo.providers.openrouter
+    # .OPENROUTER_API_KEY_ENV` is what the provider reads, and a test pins the two together.
+    ProviderKind.OPENROUTER: ["OPENROUTER_API_KEY"],
     # Kept as a literal like every other entry (importing the provider module here would
     # invert the config -> providers dependency); `wmo.providers.tinker.TINKER_API_KEY_ENV`
     # is the name the provider actually reads, and a test pins the two together.

--- a/wmo/conftest.py
+++ b/wmo/conftest.py
@@ -1,8 +1,8 @@
 """Suite-wide fixtures.
 
-The default failover chain lives in a developer-local, gitignored `.wmo/fallback.toml`; tests must
-behave identically whether or not the developer running them has one, so the default lookup path is
-pointed at a nonexistent file for every test. Chain tests pass an explicit `path=`.
+Both fixtures here enforce the same rule: a test must behave identically on a machine that has
+developer state (a failover chain, a fetched OpenRouter price catalog) and one that does not,
+and no test may reach the network.
 """
 
 from __future__ import annotations
@@ -11,9 +11,36 @@ from pathlib import Path
 
 import pytest
 
+from wmo.providers import openrouter_pricing
+
 
 @pytest.fixture(autouse=True)
 def _no_local_fallback_chain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the default failover-chain lookup at a nonexistent `.wmo/fallback.toml`.
+
+    The real one is developer-local and gitignored; chain tests pass an explicit `path=`.
+    """
     monkeypatch.setattr(
         "wmo.providers.waterfall.FALLBACK_CONFIG_PATH", tmp_path / "no-fallback.toml"
     )
+
+
+@pytest.fixture(autouse=True)
+def _offline_openrouter_catalog(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Cut every test off from the live OpenRouter price catalog and the user's cached copy.
+
+    Pricing tests opt back in by pointing `WMO_OPENROUTER_CATALOG` at their own fixture file or
+    by replacing `_fetch_catalog` themselves; a later `monkeypatch.setattr` wins. The
+    `_FETCH_ERROR` latch is reset through monkeypatch so the "already failed once" state cannot
+    leak from one test into the next.
+    """
+    monkeypatch.setenv(
+        openrouter_pricing.CATALOG_PATH_ENV, str(tmp_path / "no-openrouter-prices.json")
+    )
+    monkeypatch.setattr(openrouter_pricing, "_FETCH_ERROR", None)
+    monkeypatch.setattr(openrouter_pricing, "_fetch_catalog", _refuse_network)
+
+
+def _refuse_network() -> openrouter_pricing.PriceCatalog:
+    """Stand-in for the live catalog fetch: tests never reach openrouter.ai."""
+    raise RuntimeError("the test suite does not fetch the OpenRouter catalog")

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Literal
 
@@ -20,8 +21,10 @@ from wmo.optimize.policy import (
     select_model,
 )
 from wmo.providers.base import ProviderKind
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
 from wmo.providers.pool import PoolEntry
 from wmo.retrieval.embedders import HashingEmbedder
+from wmo.tracking.pricing import ModelPrice
 
 
 def _pool() -> list[PoolEntry]:
@@ -162,6 +165,48 @@ def test_policy_round_trips_through_json(tmp_path: Path) -> None:
     path = tmp_path / "policy.json"
     policy.save(path)
     assert RoutingPolicy.load(path) == policy
+
+
+def test_openrouter_candidate_keeps_the_price_it_was_fitted_under(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OpenRouter candidate is priced once, at fit, and the policy carries that price.
+
+    The pool snapshot on the artifact is the record: serving reloads it, so a live catalog
+    fetch (or a vendor price change) can never silently re-price a policy already deployed.
+    """
+    catalog = tmp_path / "openrouter-prices.json"
+    catalog.write_text(
+        PriceCatalog(
+            fetched_at=time.time(),
+            source="test fixture",
+            prices={"z-ai/glm-4.6": ModelPrice(input_per_mtok=0.4, output_per_mtok=1.75)},
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(catalog))
+    pool = [
+        PoolEntry(name="haiku-4-5", kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5"),
+        PoolEntry(name="or-glm", kind=ProviderKind.OPENROUTER, model="z-ai/glm-4.6"),
+    ]
+    policy = RoutingPolicy(kind="static", default_model="or-glm", pool=pool)
+    path = tmp_path / "policy.json"
+    policy.save(path)
+
+    # The catalog doubles its price after the fit; the deployed artifact must not follow.
+    catalog.write_text(
+        PriceCatalog(
+            fetched_at=time.time(),
+            source="test fixture",
+            prices={"z-ai/glm-4.6": ModelPrice(input_per_mtok=0.8, output_per_mtok=3.5)},
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+    served = RoutingPolicy.load(path)
+
+    assert select_model(served, "anything").model == "or-glm"
+    assert served.pool[1].price().input_per_mtok == 0.4
+    assert served.pool[1].price().output_per_mtok == 1.75
 
 
 def test_azure_embedder_spec_requires_backend_fields() -> None:

--- a/wmo/providers/base.py
+++ b/wmo/providers/base.py
@@ -16,6 +16,7 @@ class ProviderKind(StrEnum):
     AZURE_OPENAI = "azure"  # GPT 5.5 via the Azure OpenAI service
     OPENAI = "openai"  # GPT 5.5 direct
     OPENAI_RESPONSES = "openai_responses"  # GPT 5.x direct via the Responses API
+    OPENROUTER = "openrouter"  # any OpenRouter-fronted model, on one OPENROUTER_API_KEY
     TINKER = "tinker"  # Tinker LoRA sampling for distillation rollouts (lazy distill extra)
 
 

--- a/wmo/providers/openrouter.py
+++ b/wmo/providers/openrouter.py
@@ -1,0 +1,192 @@
+"""OpenRouter provider: one key, one base URL, every model OpenRouter fronts.
+
+OpenRouter is a first-party vendor with its own credential, its own base URL, its own
+app-attribution headers, and its own model catalog, so it is a backend in its own right rather
+than a self-hosted host behind `ProviderConfig.endpoint`. That generic path deliberately
+authenticates from `WMO_ENDPOINT_API_KEY` so a real vendor key never reaches a stranger's
+server, which is the opposite of what a known vendor needs: this provider reads
+`OPENROUTER_API_KEY` directly, exactly as the Anthropic and Bedrock backends read theirs.
+
+The wire format IS OpenAI chat-completions, so the request mapping comes from the neutral
+`wmo.providers._openai_common` helpers that `OpenAIProvider` and `AzureOpenAIProvider` already
+share. There is no class relationship between the three backends; each owns its own client
+construction and its own vendor rules.
+
+Two OpenRouter specifics the shared helpers do not cover:
+
+- `max_tokens` is the output-budget parameter in OpenRouter's request schema (OpenAI's newer
+  `max_completion_tokens` is not), so every call names it.
+- `HTTP-Referer` and `X-Title` identify the calling app on openrouter.ai. They are read from
+  `WMO_OPENROUTER_REFERER` / `WMO_OPENROUTER_TITLE` and default to this open-source project,
+  never to anything about the machine or the person running it.
+
+Pricing for `kind = "openrouter"` pool entries is resolved from OpenRouter's published catalog
+by `wmo.providers.openrouter_pricing`, so a pool entry needs only a model id.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from openai import OpenAI
+
+from wmo.providers import _openai_common
+from wmo.providers.base import (
+    DEFAULT_MAX_TOKENS,
+    ChatRequest,
+    ChatResponse,
+    Completion,
+    Message,
+    ProviderConfig,
+    StreamChunk,
+    VerifyResult,
+    normalize_chat_temperature,
+    verify_via_ping,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
+"""The credential this backend reads. `wmo.config.PROVIDER_ENV_VARS` pins the same literal."""
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+"""OpenRouter's OpenAI-compatible base URL; `ProviderConfig.endpoint` overrides it (proxies)."""
+
+OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
+"""The public model catalog, source of the prices in `wmo.providers.openrouter_pricing`."""
+
+# App attribution. OpenRouter shows these on its public app leaderboard, so the default must
+# name the project rather than a developer, a hostname, or a customer; both are overridable.
+OPENROUTER_REFERER_ENV = "WMO_OPENROUTER_REFERER"
+OPENROUTER_TITLE_ENV = "WMO_OPENROUTER_TITLE"
+DEFAULT_REFERER = "https://github.com/experientiallabs/world-model-optimizer"
+DEFAULT_TITLE = "world-model-optimizer"
+
+# OpenRouter's documented output-budget field. Sending OpenAI's `max_completion_tokens` instead
+# would leave the request with no cap at all on providers that ignore unknown fields.
+_MAX_TOKENS_FIELD = "max_tokens"
+
+# Bound every request the way the other OpenAI-shaped backends do: an upstream provider behind
+# OpenRouter can hold a connection open with no output, and an unbounded stall turns an eval
+# into a silent multi-hour hang. One same-endpoint retry, since cross-model failover is the
+# llm-waterfall chain's job (and OpenRouter's own `models` fallback list), not this client's.
+_TIMEOUT_SECONDS = 240.0
+_MAX_RETRIES = 1
+
+
+def attribution_headers() -> dict[str, str]:
+    """The app-identity headers OpenRouter reads, from environment configuration."""
+    return {
+        "HTTP-Referer": os.environ.get(OPENROUTER_REFERER_ENV) or DEFAULT_REFERER,
+        "X-Title": os.environ.get(OPENROUTER_TITLE_ENV) or DEFAULT_TITLE,
+    }
+
+
+class OpenRouterProvider:
+    """Any OpenRouter-fronted model, addressed by its `vendor/model` catalog id."""
+
+    def __init__(self, config: ProviderConfig, *, api_key: str | None = None) -> None:
+        """Configure the backend.
+
+        Args:
+            config: The provider config. `model` is the OpenRouter catalog id
+                (`anthropic/claude-sonnet-4`); `endpoint` overrides the base URL for a proxy
+                and defaults to OpenRouter's own.
+            api_key: Explicit credential from `get_provider` (a pool entry's `api_key_env`).
+                It wins over the environment so a multi-account pool can name one key per
+                entry; None reads `OPENROUTER_API_KEY`.
+        """
+        self.config = config
+        self._api_key = api_key
+        self._client: OpenAI | None = None
+        self._forward_temperature = config.resolved_chat_forward_temperature()
+
+    def _resolved_key(self) -> str:
+        """The OpenRouter credential, explicit argument first, else the environment."""
+        key = self._api_key or os.environ.get(OPENROUTER_API_KEY_ENV)
+        if not key:
+            raise ValueError(
+                f"OpenRouterProvider needs a key: set {OPENROUTER_API_KEY_ENV} (create one at "
+                "https://openrouter.ai/keys), or name the variable holding it with "
+                "`api_key_env` on the pool entry."
+            )
+        return key
+
+    def _get_client(self) -> OpenAI:
+        """Construct the client on first use (never at import, never without a key)."""
+        if self._client is None:
+            self._client = OpenAI(
+                base_url=self.config.endpoint or OPENROUTER_BASE_URL,
+                api_key=self._resolved_key(),
+                timeout=_TIMEOUT_SECONDS,
+                max_retries=_MAX_RETRIES,
+                default_headers=attribution_headers(),
+            )
+        return self._client
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Completion:
+        """Generate one completion from the configured OpenRouter model."""
+        return _openai_common.complete(
+            self._get_client().chat.completions,
+            self.config.model,
+            system,
+            messages,
+            max_tokens,
+            # OpenRouter forwards sampling params to the upstream provider and drops the ones a
+            # model rejects; the shared helper still retries without temperature on the 400 that
+            # a strict upstream (a reasoning model) returns anyway.
+            temperature=temperature if self._forward_temperature else None,
+            max_tokens_field=_MAX_TOKENS_FIELD,
+        )
+
+    def stream(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> Iterator[StreamChunk]:
+        """Stream a completion natively (same temperature rule as `complete`)."""
+        return _openai_common.stream(
+            self._get_client().chat.completions,
+            self.config.model,
+            system,
+            messages,
+            max_tokens,
+            temperature=temperature if self._forward_temperature else None,
+            max_tokens_field=_MAX_TOKENS_FIELD,
+        )
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        """Run one structured tool-calling request against the configured model."""
+        request = normalize_chat_temperature(
+            request,
+            forward_temperature=self._forward_temperature,
+        )
+        return _openai_common.complete_chat(
+            self._get_client().chat.completions,
+            self.config.model,
+            request,
+            max_tokens_field=_MAX_TOKENS_FIELD,
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Not available: OpenRouter fronts chat models only, with no embeddings route."""
+        raise ValueError(
+            "OpenRouter has no embeddings API; configure openai/azure/bedrock for phi, or "
+            "keep the offline hashing embedder (embed_provider = 'hashing')."
+        )
+
+    def verify(self) -> VerifyResult:
+        """Cheap creds/model check (`wmo providers verify`)."""
+        return verify_via_ping(self)

--- a/wmo/providers/openrouter.py
+++ b/wmo/providers/openrouter.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from llm_waterfall import ChatMaxTokensField
 from openai import OpenAI
 
 from wmo.providers import _openai_common
@@ -66,7 +67,7 @@ DEFAULT_TITLE = "world-model-optimizer"
 
 # OpenRouter's documented output-budget field. Sending OpenAI's `max_completion_tokens` instead
 # would leave the request with no cap at all on providers that ignore unknown fields.
-_MAX_TOKENS_FIELD = "max_tokens"
+_MAX_TOKENS_FIELD: ChatMaxTokensField = "max_tokens"
 
 # Bound every request the way the other OpenAI-shaped backends do: an upstream provider behind
 # OpenRouter can hold a connection open with no output, and an unbounded stall turns an eval
@@ -115,7 +116,12 @@ class OpenRouterProvider:
         return key
 
     def _get_client(self) -> OpenAI:
-        """Construct the client on first use (never at import, never without a key)."""
+        """Construct the client on first use (never at import, never without a key).
+
+        The SDK import is at module scope rather than deferred here: `openai` is a core
+        dependency that `_openai_common` already imports eagerly, so a local import would buy
+        nothing and only hide the dependency (AGENTS.md rule 8).
+        """
         if self._client is None:
             self._client = OpenAI(
                 base_url=self.config.endpoint or OPENROUTER_BASE_URL,

--- a/wmo/providers/openrouter_pricing.py
+++ b/wmo/providers/openrouter_pricing.py
@@ -52,7 +52,8 @@ FETCH_TIMEOUT_SECONDS = 10.0
 """A price lookup is a validation step, not a request. It fails fast rather than blocking."""
 
 # Set to the reason the last fetch failed, so the rest of the process degrades immediately
-# instead of paying the timeout once per unpriced entry. Reset per test by the autouse fixture
+# instead of paying the timeout once per unpriced entry. Deliberately unlocked: the worst a race
+# can do is a second redundant fetch, never a wrong price. Reset per test by the autouse fixture
 # in `wmo/conftest.py`.
 _FETCH_ERROR: str | None = None
 

--- a/wmo/providers/openrouter_pricing.py
+++ b/wmo/providers/openrouter_pricing.py
@@ -1,0 +1,268 @@
+"""Prices for OpenRouter models, resolved from its published catalog and cached on disk.
+
+The launch promise is "pass in traces and an OpenRouter key". Hand-writing
+`input_per_mtok`/`output_per_mtok` on every `[[model]]` table is what breaks that promise, so a
+`kind = "openrouter"` pool entry that declares no price gets one from OpenRouter's public
+catalog (`GET /api/v1/models`, which publishes per-token prices for every model it fronts).
+
+Three properties matter more than the fetch itself:
+
+- **Lazy.** Nothing here runs at import. The only caller is `PoolEntry._validate_price`, and it
+  calls only for an OpenRouter entry that supplied no price, so validating any other provider's
+  config never touches the network or the disk.
+- **Bounded and degrading.** One HTTP request per process at most: a failure is remembered in
+  `_FETCH_ERROR`, so a pool of twenty entries on an offline machine pays one timeout, not
+  twenty. `resolve_price` never raises. When there is no price it returns the reason, and the
+  caller folds that into its existing "supply the prices explicitly" error.
+- **Recorded once.** The resolved numbers are stamped onto the `PoolEntry`, and the pool entry
+  is what `RoutingPolicy.pool` and `OutcomeMatrix.pool` serialize. A fitted policy therefore
+  carries the prices it was fitted under and never re-resolves them at serve time.
+
+The cache is OUR normalized table, not OpenRouter's payload: `$WMO_OPENROUTER_CATALOG`, else
+`openrouter-prices.json` under `$WMO_HOME` (`~/.wmo`). Pointing that variable at a checked-in
+file is also the air-gapped path, and it is how the test suite stays offline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmo.core.types import JsonValue
+from wmo.platform.credentials import wmo_home
+from wmo.providers.openrouter import OPENROUTER_MODELS_URL
+from wmo.tracking.pricing import ModelPrice
+
+logger = logging.getLogger(__name__)
+
+CATALOG_PATH_ENV = "WMO_OPENROUTER_CATALOG"
+CATALOG_FILENAME = "openrouter-prices.json"
+CATALOG_TTL_SECONDS = 24 * 60 * 60
+"""How long a cached table is used without refetching. Prices move on vendor announcements,
+not hourly, and every routing artifact records the numbers it used, so a day is plenty."""
+
+FETCH_TIMEOUT_SECONDS = 10.0
+"""A price lookup is a validation step, not a request. It fails fast rather than blocking."""
+
+# Set to the reason the last fetch failed, so the rest of the process degrades immediately
+# instead of paying the timeout once per unpriced entry. Reset per test by the autouse fixture
+# in `wmo/conftest.py`.
+_FETCH_ERROR: str | None = None
+
+
+class _CatalogPricing(BaseModel):
+    """The `pricing` object of one catalog row: USD per TOKEN, as decimal strings.
+
+    `extra="ignore"`: this mirrors a third-party payload that carries tiers we do not price
+    (`request`, `image`, `web_search`, ...) and gains new ones without notice.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    prompt: str | None = None
+    completion: str | None = None
+    input_cache_read: str | None = None
+    input_cache_write: str | None = None
+
+
+class _CatalogRow(BaseModel):
+    """One model in OpenRouter's catalog (only the fields we consume)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    pricing: _CatalogPricing = Field(default_factory=_CatalogPricing)
+
+
+class _CatalogResponse(BaseModel):
+    """The `GET /api/v1/models` envelope."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    data: list[_CatalogRow] = Field(default_factory=list)
+
+
+class PriceCatalog(BaseModel):
+    """The normalized price table we persist: model id -> price row, plus when it was fetched."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fetched_at: float  # unix seconds
+    source: str  # the URL it came from (provenance for a hand-seeded file)
+    prices: dict[str, ModelPrice]
+
+    def is_stale(self, *, now: float | None = None) -> bool:
+        """Whether this table is older than `CATALOG_TTL_SECONDS`."""
+        return (now if now is not None else time.time()) - self.fetched_at > CATALOG_TTL_SECONDS
+
+
+class PriceResolution(BaseModel):
+    """One lookup's outcome: the price row, or `detail` explaining why there is none.
+
+    `detail` is written as a mid-sentence clause, because its job is to be spliced into the
+    caller's own "declare the prices explicitly" error rather than stand alone.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    price: ModelPrice | None = None
+    detail: str = ""
+
+
+def catalog_path() -> Path:
+    """Where the normalized price table is cached."""
+    override = os.environ.get(CATALOG_PATH_ENV)
+    return Path(override) if override else wmo_home() / CATALOG_FILENAME
+
+
+def _per_mtok(value: str | None) -> float | None:
+    """OpenRouter's USD-per-token decimal string -> USD per 1M tokens, or None if unusable.
+
+    A negative price ("-1") marks variable pricing (the auto router), which cannot be recorded
+    as a number; zero is a real price (free models) and is kept as one. The scaling goes
+    through `Decimal` so a published "0.0000001" lands on 0.1 rather than 0.09999999999999999
+    in every artifact that records it.
+    """
+    if value is None:
+        return None
+    try:
+        per_token = Decimal(value)
+    except InvalidOperation:
+        return None
+    if per_token < 0:
+        return None
+    return float(per_token * 1_000_000)
+
+
+def _row_price(row: _CatalogRow) -> ModelPrice | None:
+    """A catalog row's price, or None when it does not publish both completion tiers."""
+    input_per_mtok = _per_mtok(row.pricing.prompt)
+    output_per_mtok = _per_mtok(row.pricing.completion)
+    if input_per_mtok is None or output_per_mtok is None:
+        return None
+    return ModelPrice(
+        input_per_mtok=input_per_mtok,
+        output_per_mtok=output_per_mtok,
+        cache_read_per_mtok=_per_mtok(row.pricing.input_cache_read),
+        cache_write_per_mtok=_per_mtok(row.pricing.input_cache_write),
+    )
+
+
+def parse_catalog(payload: JsonValue, *, source: str = OPENROUTER_MODELS_URL) -> PriceCatalog:
+    """Normalize a `GET /api/v1/models` payload into a price table.
+
+    Args:
+        payload: The decoded JSON body.
+        source: Where it came from, recorded on the table for provenance.
+
+    Returns:
+        The normalized table, stamped with the current time.
+
+    Raises:
+        ValueError: If the payload has no usable priced model, which means the shape changed
+            and silently caching an empty table would look exactly like "model not listed".
+    """
+    parsed = _CatalogResponse.model_validate(payload)
+    prices = {row.id: price for row in parsed.data if (price := _row_price(row)) is not None}
+    if not prices:
+        raise ValueError(f"{source} returned no priced models ({len(parsed.data)} rows)")
+    return PriceCatalog(fetched_at=time.time(), source=source, prices=prices)
+
+
+def _fetch_catalog() -> PriceCatalog:
+    """Fetch the live catalog. The suite replaces this attribute; nothing else calls it.
+
+    Sent unauthenticated on purpose: the catalog is public, and a price lookup is no reason to
+    put the user's key on the wire.
+    """
+    response = httpx.get(OPENROUTER_MODELS_URL, timeout=FETCH_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return parse_catalog(response.json())
+
+
+def _read_cache(path: Path) -> PriceCatalog | None:
+    """Read the cached table, or None when it is absent or unreadable."""
+    if not path.is_file():
+        return None
+    try:
+        return PriceCatalog.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.warning("ignoring unreadable OpenRouter price cache at %s: %s", path, exc)
+        return None
+
+
+def _write_cache(path: Path, catalog: PriceCatalog) -> None:
+    """Persist the table atomically. A cache that cannot be written is a warning, not an error."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        staging = path.with_name(f"{path.name}.partial")
+        staging.write_text(json.dumps(catalog.model_dump(mode="json")), encoding="utf-8")
+        staging.replace(path)
+    except OSError as exc:
+        logger.warning("could not cache the OpenRouter price table at %s: %s", path, exc)
+
+
+def _catalog() -> tuple[PriceCatalog | None, str]:
+    """The price table to answer lookups from, or None and the reason there is none.
+
+    Fresh cache wins outright. A stale or missing cache triggers at most one fetch per process;
+    if that fails, a stale table still beats no prices at all (loudly, and the caller records
+    whatever it uses), and only a failure with nothing cached returns None.
+    """
+    global _FETCH_ERROR  # noqa: PLW0603 - one process-wide "already failed" latch, see above
+    path = catalog_path()
+    cached = _read_cache(path)
+    if cached is not None and not cached.is_stale():
+        return cached, ""
+    if _FETCH_ERROR is None:
+        try:
+            fresh = _fetch_catalog()
+        except Exception as exc:  # noqa: BLE001 - degrading is the contract; nothing may raise
+            _FETCH_ERROR = f"{type(exc).__name__}: {exc}"
+            logger.warning("could not fetch the OpenRouter model catalog: %s", _FETCH_ERROR)
+        else:
+            _write_cache(path, fresh)
+            return fresh, ""
+    if cached is not None:
+        logger.warning(
+            "serving OpenRouter prices from the stale cache at %s (refresh failed: %s)",
+            path,
+            _FETCH_ERROR,
+        )
+        return cached, ""
+    return None, (
+        f"the OpenRouter price catalog at {OPENROUTER_MODELS_URL} is unreachable "
+        f"({_FETCH_ERROR}) and nothing is cached at {path}"
+    )
+
+
+def resolve_price(model: str) -> PriceResolution:
+    """Look up `model`'s published price. Never raises, never blocks past one fetch.
+
+    Args:
+        model: The OpenRouter catalog id, e.g. `anthropic/claude-sonnet-4`.
+
+    Returns:
+        The price row, or an empty resolution whose `detail` says whether the catalog was
+        unreachable or the model simply is not listed.
+    """
+    catalog, detail = _catalog()
+    if catalog is None:
+        return PriceResolution(detail=detail)
+    price = catalog.prices.get(model)
+    if price is None:
+        return PriceResolution(
+            detail=(
+                f"it is not in the OpenRouter model catalog ({len(catalog.prices)} models, "
+                f"cached at {catalog_path()}), so check the exact id at "
+                "https://openrouter.ai/models"
+            )
+        )
+    return PriceResolution(price=price)

--- a/wmo/providers/openrouter_pricing_test.py
+++ b/wmo/providers/openrouter_pricing_test.py
@@ -144,7 +144,8 @@ def test_resolve_price_fetches_once_and_caches_the_result(
     assert PriceCatalog.model_validate_json(path.read_text(encoding="utf-8")).prices[_SONNET]
 
 
-def test_resolve_price_offline_says_so_instead_of_raising(tmp_path: Path) -> None:
+def test_resolve_price_offline_says_so_instead_of_raising() -> None:
+    # The conftest fixture is the offline machine: no cache file, and a fetch that refuses.
     resolution = resolve_price(_SONNET)
     assert resolution.price is None
     assert "unreachable" in resolution.detail

--- a/wmo/providers/openrouter_pricing_test.py
+++ b/wmo/providers/openrouter_pricing_test.py
@@ -1,0 +1,238 @@
+"""Tests for OpenRouter price resolution: parsing, the disk cache, and offline degradation.
+
+Never touches the network. `wmo/conftest.py` already points `WMO_OPENROUTER_CATALOG` at a
+per-test temp path and replaces `_fetch_catalog` with a refusal; tests that need a live-looking
+fetch install their own stub on top.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from wmo.core.types import JsonObject
+from wmo.providers import openrouter_pricing
+from wmo.providers.openrouter_pricing import (
+    CATALOG_PATH_ENV,
+    CATALOG_TTL_SECONDS,
+    PriceCatalog,
+    catalog_path,
+    parse_catalog,
+    resolve_price,
+)
+from wmo.tracking.pricing import ModelPrice
+
+_SONNET = "anthropic/claude-sonnet-4"
+
+
+def _payload() -> JsonObject:
+    """A trimmed `GET /api/v1/models` body: prices are USD per TOKEN, as decimal strings."""
+    return {
+        "data": [
+            {
+                "id": _SONNET,
+                "name": "Anthropic: Claude Sonnet 4",
+                "context_length": 200000,
+                "pricing": {
+                    "prompt": "0.000003",
+                    "completion": "0.000015",
+                    "request": "0",
+                    "image": "0.0048",
+                    "input_cache_read": "0.0000003",
+                    "input_cache_write": "0.00000375",
+                },
+            },
+            {
+                "id": "z-ai/glm-4.6:free",
+                "pricing": {"prompt": "0", "completion": "0"},
+            },
+            {
+                "id": "openrouter/auto",
+                "pricing": {"prompt": "-1", "completion": "-1"},
+            },
+            {
+                "id": "vendor/unparsable",
+                "pricing": {"prompt": "cheap", "completion": "0.00001"},
+            },
+            {
+                "id": "vendor/no-completion-price",
+                "pricing": {"prompt": "0.00001"},
+            },
+        ]
+    }
+
+
+def _cache(tmp_path: Path, prices: dict[str, ModelPrice], *, age_seconds: float = 0.0) -> Path:
+    """Write a cache file and point the resolver at it."""
+    path = tmp_path / "prices.json"
+    catalog = PriceCatalog(
+        fetched_at=time.time() - age_seconds, source="test fixture", prices=prices
+    )
+    path.write_text(catalog.model_dump_json(), encoding="utf-8")
+    return path
+
+
+def test_parse_catalog_converts_per_token_strings_to_per_mtok() -> None:
+    # Exact, not approximate: the scaling runs through Decimal so a published "0.0000003" is
+    # recorded as 0.3, and every artifact that persists the number reads cleanly.
+    price = parse_catalog(_payload()).prices[_SONNET]
+    assert price.input_per_mtok == 3.0
+    assert price.output_per_mtok == 15.0
+    assert price.cache_read_per_mtok == 0.3
+    assert price.cache_write_per_mtok == 3.75
+
+
+def test_parse_catalog_keeps_free_models_priced_at_zero() -> None:
+    # $0 is a real published price, unlike "unknown"; recording it keeps a free candidate
+    # comparable in the cost columns instead of dropping it from the pool entirely.
+    free = parse_catalog(_payload()).prices["z-ai/glm-4.6:free"]
+    assert free.input_per_mtok == 0.0
+    assert free.output_per_mtok == 0.0
+
+
+def test_parse_catalog_drops_rows_it_cannot_price() -> None:
+    # "-1" marks the variable-priced auto router; the other two are malformed or partial. None
+    # can be recorded as a number, and a wrong number is worse than no number.
+    prices = parse_catalog(_payload()).prices
+    assert "openrouter/auto" not in prices
+    assert "vendor/unparsable" not in prices
+    assert "vendor/no-completion-price" not in prices
+
+
+def test_parse_catalog_rejects_a_payload_with_no_priced_model() -> None:
+    # A shape change must not cache an empty table, which would read as "model not listed".
+    with pytest.raises(ValueError, match="no priced models"):
+        parse_catalog({"data": [{"id": "openrouter/auto", "pricing": {"prompt": "-1"}}]})
+
+
+def test_resolve_price_reads_the_cache_without_fetching(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The conftest fetch stub raises, so reaching the network here would fail the test.
+    monkeypatch.setenv(
+        CATALOG_PATH_ENV,
+        str(_cache(tmp_path, {_SONNET: ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0)})),
+    )
+    resolution = resolve_price(_SONNET)
+    assert resolution.price is not None
+    assert resolution.price.input_per_mtok == 3.0
+    assert resolution.detail == ""
+
+
+def test_resolve_price_fetches_once_and_caches_the_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "nested" / "prices.json"
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(path))
+    calls: list[int] = []
+
+    def _fetch() -> PriceCatalog:
+        calls.append(1)
+        return parse_catalog(_payload())
+
+    monkeypatch.setattr(openrouter_pricing, "_fetch_catalog", _fetch)
+
+    first = resolve_price(_SONNET)
+    second = resolve_price("z-ai/glm-4.6:free")
+
+    assert first.price is not None
+    assert second.price is not None
+    assert len(calls) == 1  # the second lookup read the cache the first one wrote
+    assert path.is_file()
+    assert PriceCatalog.model_validate_json(path.read_text(encoding="utf-8")).prices[_SONNET]
+
+
+def test_resolve_price_offline_says_so_instead_of_raising(tmp_path: Path) -> None:
+    resolution = resolve_price(_SONNET)
+    assert resolution.price is None
+    assert "unreachable" in resolution.detail
+    assert "nothing is cached" in resolution.detail
+
+
+def test_one_failed_fetch_is_remembered_for_the_whole_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A twenty-entry pool on an offline machine must pay one timeout, not twenty.
+    attempts: list[int] = []
+
+    def _fetch() -> PriceCatalog:
+        attempts.append(1)
+        raise TimeoutError("connect timeout")
+
+    monkeypatch.setattr(openrouter_pricing, "_fetch_catalog", _fetch)
+
+    assert resolve_price(_SONNET).price is None
+    assert resolve_price("z-ai/glm-4.6:free").price is None
+    assert len(attempts) == 1
+
+
+def test_a_stale_cache_is_refreshed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        CATALOG_PATH_ENV,
+        str(
+            _cache(
+                tmp_path,
+                {_SONNET: ModelPrice(input_per_mtok=99.0, output_per_mtok=99.0)},
+                age_seconds=CATALOG_TTL_SECONDS + 60,
+            )
+        ),
+    )
+    monkeypatch.setattr(openrouter_pricing, "_fetch_catalog", lambda: parse_catalog(_payload()))
+
+    resolution = resolve_price(_SONNET)
+
+    assert resolution.price is not None
+    assert resolution.price.input_per_mtok == pytest.approx(3.0)
+
+
+def test_a_stale_cache_still_answers_when_the_refresh_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Yesterday's published price beats no price at all, and whatever is used gets recorded on
+    # the pool entry anyway, so the artifact still says exactly what it was priced with.
+    monkeypatch.setenv(
+        CATALOG_PATH_ENV,
+        str(
+            _cache(
+                tmp_path,
+                {_SONNET: ModelPrice(input_per_mtok=2.5, output_per_mtok=12.5)},
+                age_seconds=CATALOG_TTL_SECONDS + 60,
+            )
+        ),
+    )
+    resolution = resolve_price(_SONNET)
+    assert resolution.price is not None
+    assert resolution.price.input_per_mtok == 2.5
+
+
+def test_an_unlisted_model_is_reported_as_unlisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        CATALOG_PATH_ENV,
+        str(_cache(tmp_path, {_SONNET: ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0)})),
+    )
+    resolution = resolve_price("vendor/typo")
+    assert resolution.price is None
+    assert "not in the OpenRouter model catalog (1 models" in resolution.detail
+
+
+def test_a_corrupt_cache_is_ignored_rather_than_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "prices.json"
+    path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(path))
+    monkeypatch.setattr(openrouter_pricing, "_fetch_catalog", lambda: parse_catalog(_payload()))
+
+    resolution = resolve_price(_SONNET)
+
+    assert resolution.price is not None
+
+
+def test_catalog_path_defaults_under_wmo_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CATALOG_PATH_ENV, raising=False)
+    monkeypatch.setenv("WMO_HOME", "/tmp/wmo-home-fixture")
+    assert catalog_path() == Path("/tmp/wmo-home-fixture/openrouter-prices.json")

--- a/wmo/providers/openrouter_test.py
+++ b/wmo/providers/openrouter_test.py
@@ -249,7 +249,8 @@ def test_complete_sends_max_tokens_not_max_completion_tokens(
 def test_stream_yields_deltas_then_a_usage_bearing_terminal_chunk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    provider, completions = _faked(monkeypatch, _FakeStream(["he", "llo"], _FakeUsage(3, 2)))
+    upstream = _FakeStream(["he", "llo"], _FakeUsage(3, 2))
+    provider, completions = _faked(monkeypatch, upstream)
 
     chunks = list(provider.stream("", [Message(role="user", content="yo")], max_tokens=64))
 
@@ -259,6 +260,8 @@ def test_stream_yields_deltas_then_a_usage_bearing_terminal_chunk(
     assert chunks[-1].usage.output_tokens == 2
     assert completions.last_kwargs["max_tokens"] == 64
     assert completions.last_kwargs["stream_options"] == {"include_usage": True}
+    # The SDK stream holds an httpx response; an abandoned one must not wait for the collector.
+    assert upstream.closed is True
 
 
 def test_complete_chat_preserves_tools_and_uses_max_tokens(

--- a/wmo/providers/openrouter_test.py
+++ b/wmo/providers/openrouter_test.py
@@ -1,0 +1,292 @@
+"""Unit tests for OpenRouterProvider. No network: the SDK client is faked via _get_client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from wmo.config.config import PROVIDER_ENV_VARS
+from wmo.providers.base import (
+    ChatRequest,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+)
+from wmo.providers.openrouter import (
+    DEFAULT_REFERER,
+    DEFAULT_TITLE,
+    OPENROUTER_API_KEY_ENV,
+    OPENROUTER_BASE_URL,
+    OPENROUTER_REFERER_ENV,
+    OPENROUTER_TITLE_ENV,
+    OpenRouterProvider,
+    attribution_headers,
+)
+from wmo.providers.registry import get_provider
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeMessage(content)
+
+
+class _FakeUsage:
+    def __init__(self, prompt: int, completion: int) -> None:
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+
+
+class _FakeChatResponse:
+    def __init__(self, content: str, usage: _FakeUsage) -> None:
+        self.choices = [_FakeChoice(content)]
+        self.usage = usage
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": self.choices[0].message.content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": self.usage.prompt_tokens,
+                "completion_tokens": self.usage.completion_tokens,
+            },
+        }
+
+
+class _FakeStreamChunk:
+    def __init__(self, delta: str) -> None:
+        self.choices = [_FakeStreamChoice(delta)]
+        self.usage = None
+
+
+class _FakeStreamDelta:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeStreamChoice:
+    def __init__(self, content: str) -> None:
+        self.delta = _FakeStreamDelta(content)
+
+
+class _FakeStream:
+    def __init__(self, deltas: list[str], usage: _FakeUsage) -> None:
+        self._deltas = deltas
+        self._usage = usage
+        self.closed = False
+
+    def __iter__(self) -> Iterator[object]:
+        for delta in self._deltas:
+            yield _FakeStreamChunk(delta)
+        yield _FakeUsageChunk(self._usage)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeUsageChunk:
+    def __init__(self, usage: _FakeUsage) -> None:
+        self.choices: list[object] = []
+        self.usage = usage
+
+
+class _FakeChatCompletions:
+    def __init__(self, response: _FakeChatResponse | _FakeStream) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, object] = {}
+
+    def create(self, **kwargs: object) -> _FakeChatResponse | _FakeStream:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeChat:
+    def __init__(self, completions: _FakeChatCompletions) -> None:
+        self.completions = completions
+
+
+class _FakeClient:
+    def __init__(self, completions: _FakeChatCompletions) -> None:
+        self.chat = _FakeChat(completions)
+
+
+def _config(endpoint: str | None = None) -> ProviderConfig:
+    return ProviderConfig(
+        kind=ProviderKind.OPENROUTER, model="anthropic/claude-sonnet-4", endpoint=endpoint
+    )
+
+
+def _faked(
+    monkeypatch: pytest.MonkeyPatch, response: _FakeChatResponse | _FakeStream
+) -> tuple[OpenRouterProvider, _FakeChatCompletions]:
+    completions = _FakeChatCompletions(response)
+    provider = OpenRouterProvider(_config())
+    monkeypatch.setattr(provider, "_get_client", lambda: _FakeClient(completions))
+    return provider, completions
+
+
+def test_registry_constructs_the_openrouter_backend() -> None:
+    provider = get_provider(_config())
+    assert isinstance(provider, OpenRouterProvider)
+
+
+def test_provider_env_vars_pin_the_variable_the_provider_actually_reads() -> None:
+    # PROVIDER_ENV_VARS keeps literals (importing providers from config would invert the
+    # dependency), so only this pin catches the two drifting apart and silently degrading the
+    # credential prompt, the picker annotation, and the `providers verify` hint.
+    assert PROVIDER_ENV_VARS[ProviderKind.OPENROUTER] == [OPENROUTER_API_KEY_ENV]
+
+
+def test_client_uses_openrouter_base_url_key_and_attribution_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "sk-or-env")
+    monkeypatch.delenv(OPENROUTER_REFERER_ENV, raising=False)
+    monkeypatch.delenv(OPENROUTER_TITLE_ENV, raising=False)
+
+    client = OpenRouterProvider(_config())._get_client()  # noqa: SLF001 - asserting the wiring
+
+    assert str(client.base_url).rstrip("/") == OPENROUTER_BASE_URL
+    assert client.api_key == "sk-or-env"
+    assert client.default_headers["HTTP-Referer"] == DEFAULT_REFERER
+    assert client.default_headers["X-Title"] == DEFAULT_TITLE
+
+
+def test_attribution_headers_are_configurable_and_never_personal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The defaults name the open-source project; an operator can point the leaderboard entry at
+    # their own app, but nothing about the machine or the user leaks in by default.
+    assert "http" in DEFAULT_REFERER
+    monkeypatch.setenv(OPENROUTER_REFERER_ENV, "https://acme.example")
+    monkeypatch.setenv(OPENROUTER_TITLE_ENV, "Acme Router")
+    assert attribution_headers() == {
+        "HTTP-Referer": "https://acme.example",
+        "X-Title": "Acme Router",
+    }
+
+
+def test_explicit_api_key_wins_over_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The pool's `api_key_env` channel: one entry per OpenRouter account.
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "sk-or-env")
+    provider = OpenRouterProvider(_config(), api_key="sk-or-entry")
+    assert provider._get_client().api_key == "sk-or-entry"  # noqa: SLF001 - asserting the wiring
+
+
+def test_endpoint_overrides_the_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "sk-or-env")
+    provider = OpenRouterProvider(_config(endpoint="https://proxy.example/api/v1"))
+    assert str(provider._get_client().base_url).rstrip("/") == (  # noqa: SLF001 - asserting wiring
+        "https://proxy.example/api/v1"
+    )
+
+
+def test_missing_key_names_the_variable_and_where_to_get_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    with pytest.raises(ValueError, match=OPENROUTER_API_KEY_ENV):
+        OpenRouterProvider(_config())._get_client()  # noqa: SLF001 - asserting the wiring
+
+
+def test_never_falls_back_to_the_generic_endpoint_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # WMO_ENDPOINT_API_KEY exists for arbitrary self-hosted OpenAI-compatible servers. OpenRouter
+    # is a named vendor with its own credential, so an unset OPENROUTER_API_KEY must fail loudly
+    # rather than quietly authenticating with somebody else's placeholder key.
+    monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    monkeypatch.setenv("WMO_ENDPOINT_API_KEY", "sk-not-mine")
+    with pytest.raises(ValueError, match=OPENROUTER_API_KEY_ENV):
+        OpenRouterProvider(_config())._get_client()  # noqa: SLF001 - asserting the wiring
+
+
+def test_verify_reports_a_missing_key_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    result = OpenRouterProvider(_config()).verify()
+    assert result.ok is False
+    assert result.kind is ProviderKind.OPENROUTER
+    assert OPENROUTER_API_KEY_ENV in result.detail
+
+
+def test_complete_sends_max_tokens_not_max_completion_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `max_tokens` is the field in OpenRouter's request schema; sending OpenAI's newer name
+    # would leave the call uncapped on any upstream that ignores unknown fields.
+    provider, completions = _faked(monkeypatch, _FakeChatResponse("hi", _FakeUsage(9, 4)))
+
+    completion = provider.complete("be nice", [Message(role="user", content="yo")], max_tokens=128)
+
+    assert completion.text == "hi"
+    assert completion.usage.input_tokens == 9
+    assert completion.usage.output_tokens == 4
+    sent = completions.last_kwargs
+    assert sent["model"] == "anthropic/claude-sonnet-4"
+    assert sent["max_tokens"] == 128
+    assert "max_completion_tokens" not in sent
+    assert sent["temperature"] == 0.7
+    assert sent["messages"] == [
+        {"role": "system", "content": "be nice"},
+        {"role": "user", "content": "yo"},
+    ]
+
+
+def test_stream_yields_deltas_then_a_usage_bearing_terminal_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, completions = _faked(monkeypatch, _FakeStream(["he", "llo"], _FakeUsage(3, 2)))
+
+    chunks = list(provider.stream("", [Message(role="user", content="yo")], max_tokens=64))
+
+    assert "".join(c.delta for c in chunks) == "hello"
+    assert chunks[-1].done is True
+    assert chunks[-1].usage is not None
+    assert chunks[-1].usage.output_tokens == 2
+    assert completions.last_kwargs["max_tokens"] == 64
+    assert completions.last_kwargs["stream_options"] == {"include_usage": True}
+
+
+def test_complete_chat_preserves_tools_and_uses_max_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, completions = _faked(monkeypatch, _FakeChatResponse("done", _FakeUsage(5, 1)))
+    request = ChatRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "read it"}],
+            "max_completion_tokens": 256,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "read_file", "parameters": {"type": "object"}},
+                }
+            ],
+        }
+    )
+
+    response = provider.complete_chat(request)
+
+    assert response.choices[0].message.content == "done"
+    sent = completions.last_kwargs
+    assert sent["max_tokens"] == 256
+    assert "max_completion_tokens" not in sent
+    assert sent["tools"] is not None
+
+
+def test_embed_explains_that_openrouter_has_no_embeddings_api() -> None:
+    with pytest.raises(ValueError, match="no embeddings API"):
+        OpenRouterProvider(_config()).embed(["hi"])

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -15,6 +15,12 @@ anything else must declare `input_per_mtok`/`output_per_mtok` so downstream cost
 honest (an unpriced candidate would silently report $0). `cached_input_per_mtok` is the provider
 cache-READ price and `cache_write_per_mtok` the cache-WRITE price, carried for cache-aware
 routing and compression costs.
+
+`kind = "openrouter"` entries are the one exception, because OpenRouter publishes prices for
+every model it fronts: an entry that declares none resolves them from that catalog at load
+(`wmo.providers.openrouter_pricing`) and keeps them, so a pool entry needs only a model id and
+downstream artifacts still record exact numbers. Offline with nothing cached, the entry falls
+back to the same "declare the prices" error, with the catalog failure named.
 """
 
 from __future__ import annotations
@@ -27,6 +33,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from wmo.providers.base import Provider, ProviderConfig, ProviderKind, TokenUsage
+from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
 from wmo.providers.registry import get_provider
 from wmo.tracking.pricing import ModelPrice, price_for
 
@@ -66,10 +73,13 @@ class PoolEntry(BaseModel):
             raise ValueError(
                 f"pool model '{self.name}': set both input_per_mtok and output_per_mtok, or neither"
             )
+        catalog_note = ""
+        if self.input_per_mtok is None and self.kind is ProviderKind.OPENROUTER:
+            catalog_note = self._resolve_openrouter_price()
         if self.input_per_mtok is None and price_for(self.model) is None:
             raise ValueError(
-                f"pool model '{self.name}': '{self.model}' has no built-in price; add "
-                "input_per_mtok and output_per_mtok (USD per 1M tokens) to its pool entry"
+                f"pool model '{self.name}': '{self.model}' has no built-in price;{catalog_note} "
+                "add input_per_mtok and output_per_mtok (USD per 1M tokens) to its pool entry"
             )
         if self.kind is ProviderKind.AZURE_OPENAI and self.deployment is None:
             # Without this the entry loads fine and the first request routed to it 500s
@@ -79,6 +89,37 @@ class PoolEntry(BaseModel):
                 "deployment name to call)"
             )
         return self
+
+    def _resolve_openrouter_price(self) -> str:
+        """Stamp this entry with OpenRouter's published price, returning "" or why it could not.
+
+        Reached only from `_validate_price`, and only for an OpenRouter entry that declared no
+        price: no other provider's config validation touches the catalog, and nothing fetches
+        at import time.
+
+        Stamping (rather than looking the price up per call) is what makes a fitted policy
+        stable. `RoutingPolicy.pool` and `OutcomeMatrix.pool` serialize these entries verbatim,
+        so the numbers a policy was fitted under travel with it and re-validating that artifact
+        finds the prices already set, which short-circuits this method entirely. A later vendor
+        price change cannot silently re-price a policy already in production; refitting or a
+        fresh `load_pool` is what picks it up.
+
+        Returns:
+            An empty string on success, else a clause naming the catalog failure, ready to be
+            spliced into the caller's "declare the prices explicitly" error.
+        """
+        resolution = resolve_openrouter_price(self.model)
+        if resolution.price is None:
+            return f" {resolution.detail};"
+        self.input_per_mtok = resolution.price.input_per_mtok
+        self.output_per_mtok = resolution.price.output_per_mtok
+        # Cache tiers are published per model too, but an explicit entry value stays the
+        # operator's (a negotiated rate must not be overwritten by the public list price).
+        if self.cached_input_per_mtok is None:
+            self.cached_input_per_mtok = resolution.price.cache_read_per_mtok
+        if self.cache_write_per_mtok is None:
+            self.cache_write_per_mtok = resolution.price.cache_write_per_mtok
+        return ""
 
     def price(self) -> ModelPrice:
         """This entry's price row: the explicit override, else the built-in pricing table."""

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -9,8 +10,11 @@ from pydantic import ValidationError
 
 from wmo.providers.azure_openai import AzureOpenAIProvider
 from wmo.providers.base import ProviderConfig, ProviderKind, TokenUsage
+from wmo.providers.openrouter import OPENROUTER_API_KEY_ENV, OpenRouterProvider
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
 from wmo.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool, pool_provider
 from wmo.providers.registry import get_provider
+from wmo.tracking.pricing import ModelPrice
 
 _POOL_TOML = """
 [[model]]
@@ -248,3 +252,146 @@ def test_azure_entry_requires_deployment() -> None:
             input_per_mtok=1.0,
             output_per_mtok=2.0,
         )
+
+
+# --- OpenRouter entries: priced from the published catalog, not by hand -----------------------
+
+_OPENROUTER_POOL = """
+[[model]]
+name = "or-sonnet"
+kind = "openrouter"
+model = "anthropic/claude-sonnet-4"
+
+[[model]]
+name = "or-glm-free"
+kind = "openrouter"
+model = "z-ai/glm-4.6:free"
+tier = "open"
+"""
+
+
+_SONNET_PRICE = ModelPrice(
+    input_per_mtok=3.0,
+    output_per_mtok=15.0,
+    cache_read_per_mtok=0.3,
+    cache_write_per_mtok=3.75,
+)
+_FREE_PRICE = ModelPrice(input_per_mtok=0.0, output_per_mtok=0.0)
+
+
+def _catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    prices: dict[str, ModelPrice] | None = None,
+) -> Path:
+    """Point price resolution at a fixture catalog on disk (the suite never fetches)."""
+    path = tmp_path / "openrouter-prices.json"
+    catalog = PriceCatalog(
+        fetched_at=time.time(),
+        source="test fixture",
+        prices=prices
+        if prices is not None
+        else {"anthropic/claude-sonnet-4": _SONNET_PRICE, "z-ai/glm-4.6:free": _FREE_PRICE},
+    )
+    path.write_text(catalog.model_dump_json(), encoding="utf-8")
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(path))
+    return path
+
+
+def test_openrouter_entry_needs_only_a_model_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The launch promise: a pool entry is a name, a kind, and a model id. Both tiers, including
+    # the cache rates, come from OpenRouter's published catalog.
+    _catalog(tmp_path, monkeypatch)
+    pool = load_pool(_write_pool(tmp_path, _OPENROUTER_POOL))
+
+    entry = pool.entry("or-sonnet")
+    assert entry.price().input_per_mtok == 3.0
+    assert entry.price().output_per_mtok == 15.0
+    assert entry.cached_input_per_mtok == pytest.approx(0.3)
+    assert entry.cache_write_per_mtok == pytest.approx(3.75)
+    # 500k fresh @ $3 + 500k cached @ $0.30 = 1.5 + 0.15 = $1.65.
+    usage = TokenUsage(input_tokens=1_000_000, output_tokens=0, cached_input_tokens=500_000)
+    assert entry.cost_usd(usage) == pytest.approx(1.65)
+    assert pool.entry("or-glm-free").price().input_per_mtok == 0.0
+
+
+def test_openrouter_entry_offline_falls_back_to_the_explicit_price_error(tmp_path: Path) -> None:
+    # No cache and no network (the conftest fetch stub refuses): the entry must fail with the
+    # ordinary "declare the prices" instruction, and say WHY the automatic route did not apply.
+    with pytest.raises(ValidationError) as excinfo:
+        load_pool(_write_pool(tmp_path, _OPENROUTER_POOL))
+    message = str(excinfo.value)
+    assert "OpenRouter price catalog" in message
+    assert "unreachable" in message
+    assert "add input_per_mtok and output_per_mtok" in message
+
+
+def test_openrouter_entry_with_explicit_prices_keeps_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A negotiated rate is the operator's, and the catalog is never consulted for it (the
+    # fixture below prices the same model very differently, and must lose).
+    _catalog(tmp_path, monkeypatch)
+    entry = PoolEntry(
+        name="or-sonnet",
+        kind=ProviderKind.OPENROUTER,
+        model="anthropic/claude-sonnet-4",
+        input_per_mtok=1.0,
+        output_per_mtok=2.0,
+    )
+    assert entry.price().input_per_mtok == 1.0
+    assert entry.cached_input_per_mtok is None
+
+
+def test_a_priced_entry_is_never_repriced_by_a_later_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The persistence property behind a fitted policy: the resolved numbers live ON the entry,
+    # and RoutingPolicy/OutcomeMatrix serialize entries verbatim. Re-validating a persisted
+    # entry against a catalog that has since doubled its price must not move it.
+    _catalog(tmp_path, monkeypatch)
+    fitted = load_pool(_write_pool(tmp_path, _OPENROUTER_POOL)).entry("or-sonnet")
+    snapshot = fitted.model_dump_json()
+
+    _catalog(
+        tmp_path,
+        monkeypatch,
+        {"anthropic/claude-sonnet-4": ModelPrice(input_per_mtok=6.0, output_per_mtok=30.0)},
+    )
+    reloaded = PoolEntry.model_validate_json(snapshot)
+
+    assert reloaded.input_per_mtok == 3.0
+    assert reloaded.price().output_per_mtok == 15.0
+
+
+def test_openrouter_pool_entry_resolves_to_the_openrouter_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _catalog(tmp_path, monkeypatch)
+    monkeypatch.setenv("OPENROUTER_ACCOUNT_B_KEY", "sk-or-account-b")
+    pool = load_pool(
+        _write_pool(tmp_path, _OPENROUTER_POOL + '\napi_key_env = "OPENROUTER_ACCOUNT_B_KEY"\n')
+    )
+
+    provider = pool_provider(pool.entry("or-glm-free"))
+
+    assert isinstance(provider, OpenRouterProvider)
+    assert provider.config.kind is ProviderKind.OPENROUTER
+    assert provider.config.model == "z-ai/glm-4.6:free"
+    assert provider._get_client().api_key == "sk-or-account-b"  # noqa: SLF001 - asserting wiring
+
+
+def test_openrouter_provider_falls_back_to_the_shared_account_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No api_key_env on the entry: the single-key launch path, straight from the environment.
+    _catalog(tmp_path, monkeypatch)
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "sk-or-shared")
+    pool = load_pool(_write_pool(tmp_path, _OPENROUTER_POOL))
+
+    provider = pool_provider(pool.entry("or-sonnet"))
+
+    assert isinstance(provider, OpenRouterProvider)
+    assert provider._get_client().api_key == "sk-or-shared"  # noqa: SLF001 - asserting wiring

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -371,9 +371,11 @@ def test_openrouter_pool_entry_resolves_to_the_openrouter_provider(
 ) -> None:
     _catalog(tmp_path, monkeypatch)
     monkeypatch.setenv("OPENROUTER_ACCOUNT_B_KEY", "sk-or-account-b")
-    pool = load_pool(
-        _write_pool(tmp_path, _OPENROUTER_POOL + '\napi_key_env = "OPENROUTER_ACCOUNT_B_KEY"\n')
+    per_account = (
+        '[[model]]\nname = "or-glm-free"\nkind = "openrouter"\nmodel = "z-ai/glm-4.6:free"\n'
+        'api_key_env = "OPENROUTER_ACCOUNT_B_KEY"\n'
     )
+    pool = load_pool(_write_pool(tmp_path, per_account))
 
     provider = pool_provider(pool.entry("or-glm-free"))
 

--- a/wmo/providers/registry.py
+++ b/wmo/providers/registry.py
@@ -12,6 +12,7 @@ from wmo.providers.base import Provider, ProviderConfig, ProviderKind, VerifyRes
 from wmo.providers.bedrock import BedrockProvider
 from wmo.providers.openai import OpenAIProvider
 from wmo.providers.openai_responses import OpenAIResponsesProvider
+from wmo.providers.openrouter import OpenRouterProvider
 from wmo.providers.tinker import TinkerChatProvider
 
 _BACKENDS = {
@@ -20,6 +21,7 @@ _BACKENDS = {
     ProviderKind.AZURE_OPENAI: AzureOpenAIProvider,
     ProviderKind.OPENAI: OpenAIProvider,
     ProviderKind.OPENAI_RESPONSES: OpenAIResponsesProvider,
+    ProviderKind.OPENROUTER: OpenRouterProvider,
     ProviderKind.TINKER: TinkerChatProvider,
 }
 

--- a/wmo/serving/chat_test.py
+++ b/wmo/serving/chat_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -29,7 +30,8 @@ from wmo.providers.base import (
     TokenUsage,
     VerifyResult,
 )
-from wmo.providers.pool import PoolEntry
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+from wmo.providers.pool import PoolEntry, load_pool
 from wmo.retrieval.embedders import HashingEmbedder
 from wmo.serving.chat import (
     EndpointRuntime,
@@ -40,6 +42,7 @@ from wmo.serving.chat import (
 )
 from wmo.serving.endpoint_config import ENDPOINT_CONFIG_FILENAME, EndpointConfig
 from wmo.serving.savings import EndpointSavings, SavingsWindow
+from wmo.tracking.pricing import ModelPrice
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -934,3 +937,50 @@ def test_the_seven_day_savings_window_is_never_served_from_cache(tmp_path: Path)
         assert reads["n"] == 3  # all_time cached after the first
     finally:
         RequestLog.replay = original
+
+
+def test_an_openrouter_candidate_is_served_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `kind = "openrouter"` pool entry survives the whole serving path.
+
+    Catalog-resolved price -> valid PoolEntry -> policy artifact on disk -> mounted endpoint ->
+    an OpenAI-compatible completion attributed to that candidate. The provider factory is the
+    usual echo fake (no network); `pool_test.py` covers the real `pool_provider` resolution.
+    """
+    catalog = tmp_path / "openrouter-prices.json"
+    catalog.write_text(
+        PriceCatalog(
+            fetched_at=time.time(),
+            source="test fixture",
+            prices={"z-ai/glm-4.6": ModelPrice(input_per_mtok=0.4, output_per_mtok=1.75)},
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(catalog))
+    pool_file = tmp_path / "pool.toml"
+    pool_file.write_text(
+        '[[model]]\nname = "or-glm"\nkind = "openrouter"\nmodel = "z-ai/glm-4.6"\ntier = "open"\n',
+        encoding="utf-8",
+    )
+    policy_path = tmp_path / POLICY_FILENAME
+    RoutingPolicy(kind="static", default_model="or-glm", pool=load_pool(pool_file).models).save(
+        policy_path
+    )
+
+    runtime = EndpointRuntime(
+        name="tau-bench",
+        policy=RoutingPolicy.load(policy_path),
+        provider_factory=_EchoProvider,
+        log=RequestLog(tmp_path / "requests.jsonl"),
+    )
+    app = FastAPI()
+    app.include_router(create_chat_router({"tau-bench": runtime}))
+    response = TestClient(app).post(
+        "/v1/chat/completions",
+        json={"model": "tau-bench", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-wmo-routed-model"] == "or-glm"
+    assert response.json()["choices"][0]["message"]["content"] == "served by or-glm"


### PR DESCRIPTION
`git grep -ci openrouter wmo/` returned zero on main while the launch pitch is literally "pass in
traces and an OpenRouter key". This wires that sentence to code: OpenRouter is now a
`ProviderKind`, usable both as a routing-pool candidate and as any model role, and a pool entry
for it needs only a model id.

## The shape: its own client, not a specialization of `OpenAIProvider`

`OpenRouterProvider` is a standalone backend, a structural sibling of `AzureOpenAIProvider`, with
no inheritance or delegation relationship to `OpenAIProvider`. The reasons are semantic, not
stylistic:

- It reads `OPENROUTER_API_KEY` directly. The generic `endpoint` path deliberately authenticates
  from `WMO_ENDPOINT_API_KEY` precisely so a real vendor key never reaches an arbitrary
  self-hosted server. OpenRouter is a named first-party vendor with its own credential, like
  Anthropic or Bedrock, so that protection is the wrong shape for it. A test pins this:
  `test_never_falls_back_to_the_generic_endpoint_credential`.
- Its request schema is its own. `max_tokens` is the output-budget field OpenRouter documents;
  OpenAI's newer `max_completion_tokens` is not in it, and sending the wrong name leaves a call
  uncapped on any upstream that ignores unknown fields. `OpenAIProvider` hardcodes
  `max_completion_tokens`.
- `HTTP-Referer` / `X-Title` app attribution, the `/api/v1/models` catalog, upstream-provider
  selection, and an error taxonomy where failures originate in an upstream provider all have no
  analogue in the OpenAI client. Coupling them would put every future OpenAI change in the blast
  radius of the launch path.

What it does reuse is `wmo/providers/_openai_common.py`, which is already a neutral module of
standalone functions that `OpenAIProvider` and `AzureOpenAIProvider` both call for the shared
OpenAI-format request mapping, streaming, and usage parsing. Nothing new was extracted; nothing
was copied.

Attribution headers come from `WMO_OPENROUTER_REFERER` / `WMO_OPENROUTER_TITLE` and default to
the project's public repo URL and package name, never to anything about the machine or the person
running it.

## Pricing: how it resolves, and what happens offline

`PoolEntry._validate_price` rejects any model with no built-in price unless the entry declares
`input_per_mtok`/`output_per_mtok`. Hand-writing those for every OpenRouter model is exactly the
friction that makes the launch sentence a lie, so an OpenRouter entry that declares no price
resolves one from `GET /api/v1/models` (`wmo/providers/openrouter_pricing.py`), which publishes
per-token prices for every model OpenRouter fronts.

- **Lazy.** Nothing runs at import. The only caller is that validator, and it calls only for an
  entry whose `kind is OPENROUTER` and whose price is unset, so validating any other provider's
  config never touches the network or the disk.
- **Cached.** The normalized table (our shape, not OpenRouter's payload) is written to
  `$WMO_OPENROUTER_CATALOG`, else `openrouter-prices.json` under `$WMO_HOME`. Fresh within 24h
  wins outright; a stale one triggers at most one refresh.
- **Bounded.** One HTTP request per process, 10s timeout, and a failure is latched, so a
  twenty-entry pool on an offline machine pays one timeout, not twenty.
- **Degrading, never raising.** Offline with a stale cache, the stale prices are used with a
  logged warning (and recorded, see below). Offline with nothing cached, the entry falls back to
  the existing error, with the reason spliced in:

  ```
  pool model 'or-sonnet': 'anthropic/claude-sonnet-4' has no built-in price; the OpenRouter
  price catalog at https://openrouter.ai/api/v1/models is unreachable (ConnectError: ...) and
  nothing is cached at /Users/x/.wmo/openrouter-prices.json; add input_per_mtok and
  output_per_mtok (USD per 1M tokens) to its pool entry
  ```

  A typo'd model id gets its own clause ("it is not in the OpenRouter model catalog (338 models,
  cached at ...), so check the exact id at https://openrouter.ai/models").
- **Explicit prices always win.** A negotiated rate on the entry short-circuits the catalog
  entirely; the same holds per cache tier.
- Prices scale through `Decimal`, so a published `"0.0000001"` is recorded as `0.1`, not
  `0.09999999999999999`, in every artifact that persists it. Unpriceable rows are dropped rather
  than guessed: `"-1"` (the variable-priced auto router), malformed strings, and rows missing a
  completion price. `$0` free models are kept, because that is a real price.

## Where the resolved price is persisted

The resolved numbers are **stamped onto the `PoolEntry` itself**, not looked up per call.
`RoutingPolicy.pool` and `OutcomeMatrix.pool` are `list[PoolEntry]` and serialize entries
verbatim, so the prices a policy was fitted under travel inside `policy.json` and the outcome
matrix. Re-validating a persisted entry finds the prices already set, which short-circuits
resolution entirely, so a vendor price change or a live fetch cannot silently re-price a policy
already in production. Refitting or a fresh `load_pool` is what picks up a new price.
`test_a_priced_entry_is_never_repriced_by_a_later_catalog` and
`test_openrouter_candidate_keeps_the_price_it_was_fitted_under` both double the catalog price
after the fit and assert the artifact does not move.

## End to end

- `wmo/providers/pool_test.py`: a `.wmo/pool.toml` with two `kind = "openrouter"` entries and no
  price fields loads, validates, prices itself (including cache tiers), costs a `TokenUsage`
  correctly, and resolves through `pool_provider` to an `OpenRouterProvider` holding the right
  key, both from `api_key_env` and from the shared `OPENROUTER_API_KEY`.
- `wmo/serving/chat_test.py`: that pool becomes a policy artifact on disk, gets mounted as an
  endpoint, and serves an OpenAI-compatible completion attributed to the OpenRouter candidate.
- As a model role, `[models.agent] provider = "openrouter"` in `.wmo/settings.toml` already
  resolves through `resolve_required_model_config`; driven manually and confirmed.

Verified against the live service (not in the suite): the real catalog parses to 338 priced
models with rates matching the published pages (`anthropic/claude-sonnet-4.5` $3/$15,
`openai/gpt-5` $1.25/$10, `z-ai/glm-4.6` $0.50/$2.00), the cache lands at 49KB, and a chat call
with a deliberately bad key reaches openrouter.ai and comes back 401 through `verify()` as
`ok=False` (identical response to a raw `httpx` call with the same header, so the auth and
attribution headers are on the wire). No live completion was billed: there is no OpenRouter key
on this machine.

## Tests never hit the network

An autouse fixture in `wmo/conftest.py` points `WMO_OPENROUTER_CATALOG` at a per-test temp path
and replaces `_fetch_catalog` with a refusal, the same contract as the existing
`_no_local_fallback_chain` fixture: the suite behaves identically whether or not the developer
running it has ever fetched the catalog. Pricing tests opt back in with their own fixture file or
stub.

## Falsification

Reverting only `wmo/providers/pool.py` to `origin/main` and running the new pool tests:

```
FAILED wmo/providers/pool_test.py::test_openrouter_entry_needs_only_a_model_id
FAILED wmo/providers/pool_test.py::test_openrouter_entry_offline_falls_back_to_the_explicit_price_error
FAILED wmo/providers/pool_test.py::test_openrouter_pool_entry_resolves_to_the_openrouter_provider
FAILED wmo/providers/pool_test.py::test_openrouter_provider_falls_back_to_the_shared_account_key
4 failed, 1 passed, 21 deselected

E   pydantic_core._pydantic_core.ValidationError: 2 validation errors for ModelPool
E   models.0
E     Value error, pool model 'or-sonnet': 'anthropic/claude-sonnet-4' has no built-in price;
E     add input_per_mtok and output_per_mtok (USD per 1M tokens) to its pool entry
```

And `wmo/providers/openrouter_test.py` dropped into a pristine `origin/main` worktree:

```
E   ModuleNotFoundError: No module named 'wmo.providers.openrouter'
```

## Gates

```
uv run --no-sync pytest -q          3391 passed, 18 skipped
uv run --no-sync ruff check .       All checks passed!
uv run --no-sync ty check           All checks passed!
uv run --no-sync ruff format --check wmo/
                                    Would reformat: wmo/distill/config_test.py
```

That one formatting miss is pre-existing on `origin/main` (confirmed by checking with this branch
stashed) and belongs to the distill lane, which this PR is explicitly out of scope for, so it is
left alone.

## Scope

No changes to `wmo/distill/**`, the Tinker provider, or any other provider's behavior. Touched
files outside the new modules are the four wiring points (`ProviderKind`, the registry,
`PROVIDER_ENV_VARS`, `PoolEntry._validate_price`), the conftest guard, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)