### PR TITLE
Restore ruff format on main

### DIFF
--- a/wmo/distill/config_test.py
+++ b/wmo/distill/config_test.py
@@ -926,8 +926,6 @@ def _checked_in_config(name: str) -> DistillConfig:
     return load_distill_config(Path(__file__).parent / "configs" / name)
 
 
-
-
 def test_training_turn_cap_defaults_to_the_rollout_cap(tmp_path: Path) -> None:
     """Unset means one cap everywhere, which is the pre-existing behaviour."""
     cfg = load_distill_config(_write(tmp_path, MINIMAL_TOML))


### PR DESCRIPTION
`uv run ruff format --check wmo/` currently fails on `main`:

```
1 file would be reformatted, 422 files already formatted
Would reformat: wmo/distill/config_test.py
```

Two stray blank lines, left by #275 when it removed the test that pinned the two topk configs it
also deleted. My fault, and it slipped through because I ran the check before that edit rather
than after.

It is worth fixing rather than tolerating: three separate PRs in this batch (#280, #282, #284) each
hit it, had to verify it was not theirs, and reported it as a pre-existing failure. A red gate that
everyone learns to look past stops being a gate.

Two-line deletion, `ruff format` output verbatim. `config_test.py` still passes; the check is clean
after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)