### PR TITLE
Give OpenRouter a prepare seam so the sweep pre-flight can rule it out

### DIFF
--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -347,10 +347,6 @@ _DEFERRED_RISK: dict[ProviderKind, str] = {
         "the Tinker service being reachable and serving this model (constructing the client "
         "connects and pins a server-side session for the whole process)"
     ),
-    ProviderKind.OPENROUTER: (
-        "the OpenRouter credential, because that backend has no `prepare` seam for the pre-flight "
-        "to force its lazy client through yet"
-    ),
 }
 
 

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -41,6 +41,7 @@ from wmo.providers.base import (
     TokenUsage,
     VerifyResult,
 )
+from wmo.providers.openrouter import OPENROUTER_API_KEY_ENV
 from wmo.providers.pool import PoolEntry, load_pool
 from wmo.providers.registry import get_provider as registry_get_provider
 from wmo.serving.traces_source import TRACES_FILENAME
@@ -1719,6 +1720,64 @@ def test_route_sweep_builds_every_lazy_client_before_it_spends(
     assert "OPENAI_API_KEY" in flat  # the SDK's own advice survives into the message
     assert "USD(est)" not in flat
     assert seams.world_model.tasks == []
+    assert not out.exists()
+
+
+def test_route_sweep_rejects_an_openrouter_candidate_with_no_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # OpenRouter joined the pre-flight late: it shipped with no `prepare` seam, so
+    # `prepare_pool_provider` skipped it and an unset key landed at that candidate's FIRST CELL,
+    # after `cheap` had run every scenario and been paid for. Unlike bedrock's credential this one
+    # IS locally knowable: `OpenRouterProvider._get_client` resolves the key itself and refuses,
+    # opening no connection, so no request is made either way.
+    seams = _patch_seams(monkeypatch, real_kinds=frozenset({ProviderKind.OPENROUTER}))
+    monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    root = _project(tmp_path, traces=_corpus())
+    pool = tmp_path / "pool.toml"
+    pool.write_text(
+        "[[model]]\n"
+        'name = "cheap"\n'
+        'kind = "openai"\n'
+        'model = "cheap-1"\n'
+        "input_per_mtok = 1.0\n"
+        "output_per_mtok = 2.0\n"
+        "\n"
+        "[[model]]\n"
+        'name = "router"\n'
+        'kind = "openrouter"\n'
+        'model = "z-ai/glm-4.6"\n'
+        "input_per_mtok = 0.1\n"
+        "output_per_mtok = 0.2\n",
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "matrix.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "sweep",
+            "support",
+            "--root",
+            str(root),
+            "--pool",
+            str(pool),
+            "--out",
+            str(out),
+            "--scenarios",
+            "2",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)  # no traceback
+    flat = _flat(result.output)
+    assert "'router'" in flat and "kind=openrouter" in flat
+    assert "USD(est)" not in flat  # refused before the cost confirmation
+    assert seams.world_model.tasks == []  # zero cells ran, so `cheap` was never paid for
     assert not out.exists()
 
 

--- a/wmo/providers/openrouter.py
+++ b/wmo/providers/openrouter.py
@@ -132,6 +132,20 @@ class OpenRouterProvider:
             )
         return self._client
 
+    def prepare(self) -> None:
+        """Resolve the credential and build the client, with no request sent.
+
+        Satisfies `wmo.providers.base.PreparableProvider`, so `prepare_pool_provider` can rule
+        this candidate in or out BEFORE a sweep spends anything. Building the client is the whole
+        check: `_resolved_key` refuses when neither the entry's `api_key_env` nor
+        `OPENROUTER_API_KEY` resolves, and the SDK opens no connection at construction, so the
+        answer is free. The cached client is the one later calls use.
+
+        Raises:
+            ValueError: No OpenRouter credential resolved for this configuration.
+        """
+        self._get_client()
+
     def complete(
         self,
         system: str,

--- a/wmo/providers/openrouter_test.py
+++ b/wmo/providers/openrouter_test.py
@@ -324,4 +324,6 @@ def test_prepare_builds_the_client_when_the_credential_is_there(
 
     provider.prepare()  # no request, no exception
 
-    assert str(provider._get_client().base_url).startswith("https://openrouter.ai")
+    # Exact, not a prefix: a startswith check on a URL is both weaker than it looks (CodeQL
+    # flags it as incomplete sanitization) and looser than the sibling assertion above.
+    assert str(provider._get_client().base_url).rstrip("/") == OPENROUTER_BASE_URL

--- a/wmo/providers/openrouter_test.py
+++ b/wmo/providers/openrouter_test.py
@@ -10,6 +10,7 @@ from wmo.config.config import PROVIDER_ENV_VARS
 from wmo.providers.base import (
     ChatRequest,
     Message,
+    PreparableProvider,
     ProviderConfig,
     ProviderKind,
 )
@@ -293,3 +294,34 @@ def test_complete_chat_preserves_tools_and_uses_max_tokens(
 def test_embed_explains_that_openrouter_has_no_embeddings_api() -> None:
     with pytest.raises(ValueError, match="no embeddings API"):
         OpenRouterProvider(_config()).embed(["hi"])
+
+
+def test_prepare_refuses_locally_when_no_credential_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sweep pre-flight can rule an OpenRouter candidate out before it spends anything.
+
+    Building the client resolves the key and opens no connection, so this costs nothing and needs
+    no network: without it an unset credential lands at that candidate's first paid cell.
+    """
+    monkeypatch.delenv(OPENROUTER_API_KEY_ENV, raising=False)
+    provider = OpenRouterProvider(
+        ProviderConfig(kind=ProviderKind.OPENROUTER, model="z-ai/glm-4.6")
+    )
+
+    assert isinstance(provider, PreparableProvider)
+    with pytest.raises(ValueError, match=OPENROUTER_API_KEY_ENV):
+        provider.prepare()
+
+
+def test_prepare_builds_the_client_when_the_credential_is_there(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OPENROUTER_API_KEY_ENV, "sk-or-test")
+    provider = OpenRouterProvider(
+        ProviderConfig(kind=ProviderKind.OPENROUTER, model="z-ai/glm-4.6")
+    )
+
+    provider.prepare()  # no request, no exception
+
+    assert str(provider._get_client().base_url).startswith("https://openrouter.ai")


### PR DESCRIPTION
## What this closes

Greptile's last open item on #277 was that some candidate backend failures are still only detectable after paid sweep cells have run, naming **Bedrock credentials and OpenRouter credential preparation**. #277 merged with that gap. This closes the OpenRouter half, which turned out to be locally checkable after all.

#277's pre-flight forces every candidate's lazy SDK client to be built before `wmo optimize route sweep` spends anything, so an unusable backend is a usage error instead of a failure at that candidate's first paid cell. OpenRouter landed separately in #284 and has no `prepare`, so `prepare_pool_provider` silently skipped it: an unset credential surfaced only after the candidates ahead of it had run every one of their cells and been paid for.

## Why this one is fixable and Bedrock's is not

`OpenRouterProvider._get_client` resolves the key itself and refuses when neither the entry's `api_key_env` nor `OPENROUTER_API_KEY` is set, and the SDK opens no connection at construction. So the check is free and makes no request, which is the constraint the pre-flight runs under: it happens before the operator has authorized any spend, so it may not bill a call the way `wmo providers verify` does. `prepare` is therefore just that build, matching `OpenAIProvider.prepare`.

Bedrock stays in `_DEFERRED_RISK`, and that is a measurement rather than a shrug: boto3 resolves credentials by walking a chain that reaches the instance-metadata endpoint over the network (**2.11s** with no local AWS config versus **0.03s** with `AWS_EC2_METADATA_DISABLED=true`) and builds a client with no credentials at all. It cannot be answered locally. The command keeps saying so per entry rather than implying the pre-flight is complete.

Dropping OpenRouter from that list matters for the same reason: the command should only claim a gap it actually has.

## Falsification

With the source reverted and the test kept, the sweep runs anyway and the candidate fails mid-sweep, which is the exact bug:

```
>       assert "'router'" in flat and "kind=openrouter" in flat
E       assert ("'router'" in "notethepre-flightmakesnorequest,soonethingpercandidatebelowcanstillfailatits
E       firstcell(thematrixrecordsitasthatcell's`...e.fixthelostcellsandsweepagain,dropthecandidatethatlost
E       them,orre-runwith--allow-uneven-coverage...")
1 failed
```

The passing test asserts the stronger property, that nothing was spent: `seams.world_model.tasks == []` (zero cells ran, so the `cheap` candidate ahead of it was never paid for), `"USD(est)" not in flat` (refused before the cost confirmation), and no matrix written.

## Gates

CI runs no tests, so these were run locally on this branch, based on `00a92983`:

```
3555 passed, 18 skipped     (main baseline 3552, measured, + 3 new)
uv run --no-sync ruff check .          All checks passed!
uv run --no-sync ruff format --check wmo/   423 files already formatted
uv run --no-sync ty check              All checks passed!
```

## Not in scope

Reducing the blast radius for what genuinely cannot be pre-flighted (Bedrock) is a separate change: `evaluate_pool` iterates candidate-major, so a broken later candidate is found only after every earlier candidate finished. Making it scenario-major would surface it after roughly one cell per candidate. That touches shared code and is being evaluated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
