### PR TITLE
Run route sweep cells candidate-minor so a dead candidate costs one cell each

### DIFF
--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -173,7 +173,12 @@ def sweep(
     SDK and resolves credentials locally. So a candidate that could never be called is a usage
     error at the boundary, not a mid-sweep abort with earlier candidates already paid for. Two
     things stay first-cell failures because seeing them needs a request (bedrock AWS credentials,
-    tinker service reachability); the pre-flight names them per entry when the pool has one.
+    tinker service reachability); the pre-flight names them per entry when the pool has one. The
+    sweep then bounds what one of those costs before it is SEEN: cells run candidate-minor, so
+    every candidate's first cell runs before any candidate's second, a first-cell failure lands
+    in the first N cells of an N-candidate pool, and the command calls it out there. Nothing is
+    aborted (a single throttle is not a dead backend, and the paid cells carry the diagnosis), so
+    stopping is the operator's call: Ctrl-C, fix the entry, sweep again.
 
     Fit-readiness is a coverage contract, not a nonzero count. A cell goes unscored when its
     episode errored (provider throttle, agent crash, judge failure), both fitters SKIP unscored
@@ -273,6 +278,7 @@ def sweep(
         f"scenario(s) of [bold]{escape(model_dir.name)}[/bold], {episodes} episode(s) each…"
     )
     done = itertools.count(1)
+    started: set[str] = set()
 
     def _on_outcome(outcome: ScenarioOutcome) -> None:
         reward = "unscored" if outcome.reward is None else f"{outcome.reward:.2f}"
@@ -281,6 +287,20 @@ def sweep(
             f"ep{outcome.episode}: reward={reward} ${outcome.cost_usd:.5f} "
             f"steps={outcome.steps}"
         )
+        first_cell = outcome.model not in started
+        started.add(outcome.model)
+        if first_cell and outcome.error is not None:
+            # `evaluate_pool` runs candidate-minor, so this line is the EARLIEST a failure that
+            # only shows up when a backend is called (the `_DEFERRED_RISK` cases) can be reported,
+            # and it is early enough to be worth acting on. Distinct from the coverage table's
+            # closing note, which explains an all-zero row after the bill is already spent.
+            _console.print(
+                f"  [yellow]warning[/yellow] the FIRST cell of {escape(outcome.model)} failed: "
+                f"{escape(outcome.error)}\n"
+                "    the sweep keeps going (one throttled call costs one cell), but if the cause "
+                "is permanent every remaining cell of this candidate is lost too: stop with "
+                "Ctrl-C, fix its pool entry, and sweep again"
+            )
 
     # Frozen for the whole sweep (the `wmo.evals.closed_loop` precedent): without it a
     # candidate's PREDICTED steps enter the shared retrieval buffer and become demos for the next
@@ -371,7 +391,9 @@ def _check_pool_backends(pool: ModelPool) -> None:
     which would spend money inside a pre-flight whose whole job is to run before any spend is
     authorized, and would make the cost estimate printed next understate what the command had
     already spent. Some backends therefore keep a residual gap (`_DEFERRED_RISK`), and this prints
-    it per entry rather than leaving the operator to discover it mid-sweep.
+    it per entry rather than leaving the operator to discover it mid-sweep, together with WHEN it
+    would land: `evaluate_pool` runs candidate-minor, so a first-cell failure is reported within
+    the first `len(pool.models)` cells whatever `--scenarios` and `--episodes` are.
 
     Every prepared provider is discarded: `evaluate_pool` still builds its own per cell, so
     per-cell provider state (the tinker provider's per-episode prompt history) is unchanged.
@@ -412,6 +434,12 @@ def _check_pool_backends(pool: ModelPool) -> None:
             _console.print(
                 f"  {escape(entry.name)} (kind={entry.kind.value}): {_DEFERRED_RISK[entry.kind]}"
             )
+        _console.print(
+            "  every candidate runs its first cell before any candidate runs its second, so a "
+            f"failure like that lands in the first {len(pool.models)} cell(s) of the sweep and is "
+            "called out there; the sweep does not abort, so stop it yourself if the cause looks "
+            "permanent"
+        )
 
 
 class _CandidateCoverage(BaseModel):

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -979,9 +979,11 @@ def _patch_seams(
             candidate's cells come back unscored while the others are scored.
         throttled_episodes: Per-model cycle of throttled flags over each scenario's episodes:
             `{"pricey-1": (False, True, True)}` keeps episode 0 and loses episodes 1 and 2 of EVERY
-            scenario. `evaluate_pool` builds one provider per episode in scenario-major order, so
-            the cycle position is the episode index within the scenario. This is how a candidate
-            comes back with the same scenarios as the others but FEWER scored episodes on them.
+            scenario. `evaluate_pool` builds one provider per cell and a candidate meets its own
+            cells scenario by scenario, episode by episode (whatever the other candidates are
+            doing between them), so counting THIS model's constructions gives the episode index
+            within the scenario. This is how a candidate comes back with the same scenarios as
+            the others but FEWER scored episodes on them.
         judge_fails_on: Scenario tasks whose episode SCORING raises, for every candidate: the
             whole pool loses those scenarios together.
         real_kinds: Provider kinds to construct for real instead of faking, so a test can exercise
@@ -1184,6 +1186,29 @@ def test_route_sweep_withholds_the_fit_handoff_on_uneven_scored_coverage(
     assert "--allow-uneven-coverage" in flat
     # A real sweep, not an aborted one: every cell ran (the cells are the paid evidence).
     assert len(seams.world_model.tasks) == 6
+
+
+def test_route_sweep_calls_out_a_first_cell_failure_while_the_rest_can_still_be_saved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The residual the pre-flight cannot close: a bedrock candidate's missing AWS credentials are
+    # only knowable over the wire (measured: boto3 reaches the instance-metadata endpoint and
+    # builds a client with no credentials at all), so that entry passes the pre-flight and dies at
+    # its FIRST CELL. `pricey` stands in for it. What must not happen is the operator learning
+    # only after `cheap` has run the whole scenario set: cells run candidate-minor, so the failure
+    # is cell 2 of 8 and is named there, with six cells of spend still recoverable by Ctrl-C.
+    _patch_seams(monkeypatch, throttled_models=frozenset({"pricey-1"}))
+    root = _project(tmp_path, traces=_corpus())
+    _out, result = _sweep(tmp_path, root, "support", "--scenarios", "4", "--yes")
+    assert result.exit_code == 1, result.output  # uneven coverage, so no fit handoff either
+    flat = _flat(result.output)
+    assert "theFIRSTcellofpriceyfailed" in flat
+    assert "ratelimitexceeded(429)" in flat  # what broke, quoted from the cell itself
+    assert _says(result.output, "stop with Ctrl-C, fix its pool entry, and sweep again")
+    # Before the third cell ever ran, which is the whole point of the ordering.
+    assert flat.index("theFIRSTcellofpriceyfailed") < flat.index("[3/8]")
+    # Once per candidate, not once per lost cell: pricey loses all four and is called out once.
+    assert flat.count("theFIRSTcellofpriceyfailed") == 1
 
 
 def test_route_sweep_allow_uneven_coverage_hands_off_and_still_states_the_bias(
@@ -1828,6 +1853,8 @@ def test_route_sweep_states_what_the_preflight_cannot_know_before_the_first_cell
     assert result.exit_code == 0, result.output
     assert _says(result.output, "opus-bedrock (kind=bedrock): AWS credentials")
     assert _says(result.output, "the pre-flight makes no request")
+    # ... and WHEN it would land, so the note is a bound rather than an open-ended caveat.
+    assert _says(result.output, "lands in the first 1 cell(s) of the sweep")
     assert seams.world_model.tasks == ["task tr-010"]  # the sweep did run
 
 

--- a/wmo/env/closed_loop.py
+++ b/wmo/env/closed_loop.py
@@ -5,6 +5,10 @@ Each (candidate model, scenario, episode) cell runs one `run_episode` with the c
 `OutcomeMatrix` the routing optimizer fits on and the improvement report cites.
 
 Measurement notes:
+- Cells run candidate-MINOR (scenario, then episode, then candidate), so every candidate runs its
+  Nth cell before any candidate runs its (N+1)th. The order is ours to choose only because the
+  caller freezes the world model (see `evaluate_pool`), and this is the choice that bounds what a
+  backend which can only fail once it is CALLED costs before anyone sees it fail.
 - Latency is measured per POLICY CALL (the candidate's own completions), not per episode: episode
   wall time is dominated by the world model's simulation latency, which production traffic never
   pays, so quoting it would flatter nobody honestly.
@@ -167,12 +171,30 @@ def evaluate_pool(
     and never abort the sweep. `on_outcome` fires after each cell for progress display; a
     callback that raises is logged and ignored, since a broken progress pipe must not throw away
     the cells already paid for.
+
+    Cells run candidate-MINOR: scenario, then episode, then candidate. Every candidate therefore
+    runs its Nth cell before any candidate runs its (N+1)th, which is what bounds a backend that
+    can only fail once it is CALLED. Bedrock with no AWS credentials is the measured example
+    (boto3 walks a credential chain that reaches the instance-metadata endpoint over the network
+    and builds a client with no credentials at all, so no request-free pre-flight can see it):
+    that candidate now surfaces through `on_outcome` after one cell per earlier candidate,
+    instead of after every earlier candidate has run every one of its cells. Its own remaining
+    cells still run, because one throttled call is not a dead backend and the paid cells are the
+    diagnosis either way; a caller that wants to stop watches `on_outcome`.
+
+    ORDER SAFETY: which order to run cells in is only ours to choose while the environment cannot
+    LEARN between them. `wmo optimize route sweep` wraps this whole call in
+    `world_model.frozen()`, which suspends index enrichment and knowledge writes, so no cell's
+    predicted steps become another cell's retrieved demos and the matrix is the same whatever
+    order produced it. Against an enriching env the scores are order-dependent either way, and
+    this order changes which cells feed which: freeze the model, or open its sessions with
+    `enrich=False`.
     """
     outcomes: list[ScenarioOutcome] = []
-    for entry in pool.models:
-        for scenario in scenarios:
-            sid = scenario_id(scenario)
-            for episode in range(episodes_per_scenario):
+    for scenario in scenarios:
+        sid = scenario_id(scenario)
+        for episode in range(episodes_per_scenario):
+            for entry in pool.models:
                 timed = _TimedProvider(provider_factory(entry))
                 agent = LLMAgent(timed, temperature=agent_temperature, tools_hint=tools_hint)
                 env = env_factory()

--- a/wmo/env/closed_loop_test.py
+++ b/wmo/env/closed_loop_test.py
@@ -102,6 +102,25 @@ class _FailFirstProvider(_ScriptedProvider):
         raise RuntimeError("RateLimitError: 429 too many requests")
 
 
+class _UnusableBackendProvider(_ScriptedProvider):
+    """Provider that raises the moment it is CALLED: the missing-AWS-credentials shape.
+
+    The one failure a request-free pre-flight cannot catch. boto3 resolves credentials by walking
+    a chain that reaches the instance-metadata endpoint over the network, and builds a Bedrock
+    client with no credentials at all, so the entry looks fine until a cell is spent on it.
+    """
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        raise RuntimeError("NoCredentialsError: Unable to locate credentials")
+
+
 def _pool() -> ModelPool:
     return ModelPool(
         models=[
@@ -249,6 +268,78 @@ def test_broken_progress_callback_does_not_abort_the_sweep() -> None:
     assert len(seen) == 4  # every cell still reported
     assert len(matrix.outcomes) == 4
     assert all(o.reward == pytest.approx(0.8) for o in matrix.outcomes)
+
+
+def test_cells_run_candidate_minor_so_no_candidate_gets_a_cell_ahead() -> None:
+    # The order invariant the blast radius rests on: scenario, then episode, then candidate.
+    # Safe to pin because the sweep runs frozen, so no cell's predictions reach another cell.
+    order: list[tuple[str, int, str]] = []
+    evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        episodes_per_scenario=2,
+        provider_factory=_ScriptedProvider,
+        on_outcome=lambda o: order.append((o.scenario_id, o.episode, o.model)),
+    )
+    assert order == [
+        ("trace-1", 0, "candidate-a"),
+        ("trace-1", 0, "candidate-b"),
+        ("trace-1", 1, "candidate-a"),
+        ("trace-1", 1, "candidate-b"),
+        ("trace-2", 0, "candidate-a"),
+        ("trace-2", 0, "candidate-b"),
+        ("trace-2", 1, "candidate-a"),
+        ("trace-2", 1, "candidate-b"),
+    ]
+
+
+def test_a_later_broken_candidate_surfaces_after_one_cell_per_candidate() -> None:
+    """The blast radius of a backend that can only fail once it is CALLED.
+
+    `candidate-c` is the Bedrock-with-no-credentials case: nothing local can see it, so it costs
+    a cell. What must be bounded is how many cells the OTHER candidates burn before anyone
+    watching `on_outcome` learns about it. Candidate-minor order makes that one cell each, and it
+    does not depend on the grid: with candidate-major order the same pool hid the failure until
+    cell 9 of 12, and any larger `--scenarios` would hide it for longer still.
+    """
+    pool = ModelPool(
+        models=[
+            *_pool().models,
+            PoolEntry(
+                name="candidate-c",
+                kind=ProviderKind.BEDROCK,
+                model="us.anthropic.claude-opus-4-8",
+                input_per_mtok=15.0,
+                output_per_mtok=75.0,
+            ),
+        ]
+    )
+    scenarios = [Scenario(task=f"task {i}", provenance=[f"trace-{i}"]) for i in range(4)]
+
+    def _factory(entry: PoolEntry) -> _ScriptedProvider:
+        if entry.name == "candidate-c":
+            return _UnusableBackendProvider(entry)
+        return _ScriptedProvider(entry)
+
+    order: list[str] = []
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        pool,
+        scenarios,
+        provider_factory=_factory,
+        on_outcome=lambda o: order.append(o.model),
+    )
+
+    # Two cells ran before the broken candidate reported: one per earlier candidate.
+    assert order.index("candidate-c") == 2
+    # The sweep still completes, so the working candidates keep the evidence they were paid for
+    # and the broken one's cells carry the diagnosis on every row.
+    assert len(matrix.outcomes) == 12  # 3 candidates x 4 scenarios x 1 episode
+    broken = [o for o in matrix.outcomes if o.model == "candidate-c"]
+    assert len(broken) == 4
+    assert all(not o.scored and "NoCredentialsError" in (o.error or "") for o in broken)
+    assert all(o.scored for o in matrix.outcomes if o.model != "candidate-c")
 
 
 def test_wrong_typed_score_yields_unscored_row_with_reason() -> None:


### PR DESCRIPTION
## The problem

`wmo optimize route sweep` pre-flights every candidate before it spends, but it cannot catch everything, and the gap is measured rather than assumed: boto3 resolves AWS credentials by walking a chain that reaches the instance-metadata endpoint over the network (**4.07s** with no local AWS config versus **0.04s** with `AWS_EC2_METADATA_DISABLED=true`) and still returns a client whose `get_credentials()` is `None`. The pre-flight may not make that call, because it runs before the operator has authorized any spend.

So a Bedrock candidate can still die at its first cell. The damage is not that it fails, it is **when**: `evaluate_pool` iterated candidate-major, so a broken third candidate was found only after candidates one and two had run every one of their cells. On a real sweep that is most of the bill.

## What changed

`evaluate_pool` now runs cells **candidate-minor** (scenario, then episode, then candidate). A first-cell failure therefore always lands within the first `len(pool.models)` cells, whatever `--scenarios` and `--episodes` are.

That is deliberately not the more obvious `for scenario: for entry: for episode`, whose "every candidate runs its first cell before any candidate runs its second" is only literally true at `--episodes 1`; at `--episodes 3` it still costs three cells per earlier candidate. Candidate-minor makes the invariant exact and grid-independent. Each candidate's own cell sequence is unchanged.

The sweep also calls out a first-cell failure once per candidate, quoting that cell's error. Early detection is worthless if it is one grey line in a progress stream.

## Ordering safety, confirmed rather than assumed

The only cross-cell state a cell can write is the shared retrieval buffer and the knowledge base, and both sit behind one gate (`wmo/engine/world_model.py:385`: `if self._enrich_index and session.enrich:`). `frozen()` clears `_enrich_index`. Session ids are uuid4, the grounding budget is per session, trackers are per session, and a fresh provider is built per cell.

The load-bearing detail: `WorldModelEnv.reset` does not pass `enrich`, so the sweep's sessions are `enrich=True` and **`world_model.frozen()` is the only thing that makes order free here**. That is now stated in `evaluate_pool`'s docstring under an ORDER SAFETY paragraph, because it is a public function and a future caller could run it unfrozen.

`evaluate_pool` has exactly one non-test caller (`wmo/cli/route_app.py`), verified by repo-wide grep.

Driven end to end against the real `WorldModel`, `WorldModelEnv` and OpenAI SDK pointed at a local stub, with three candidates and the third answering 403. Before and after produce **identical outcome rows in every field, differing only in row order**:

```
before: [1/9] cheap tr-010 ... [6/9] pricey tr-020 ... [7/9] broken tr-010 ep0: reward=unscored
after : [3/9] broken tr-010 ep0: reward=unscored $0.00000 steps=0
        warning the FIRST cell of broken failed: PermissionDeniedError: Error code: 403 - ...
identical row multisets: True | rows: 9
```

## What was rejected, and why

- **Auto-abort on a first-cell failure.** `evaluate_pool`'s contract is that an errored episode never aborts the sweep, one throttled call is not a dead backend, and `--allow-uneven-coverage` exists so an operator whose candidate was down can still fit on the partial data. The uneven-coverage gate already blocks the bad handoff, so the remaining value was money; the reorder plus the alert hands that decision to the operator at the earliest possible moment.
- **A dedicated "probe each candidate once, then sweep" pass.** That is what candidate-minor order already produces, with no extra machinery and no extra spend.
- **Reordering in the CLI.** Duplicates matrix assembly and leaves the bad default in the public function.
- **A real one-token pre-flight request.** Spends before authorization and would make the cost estimate understate what was already spent.

## Falsification

Source stashed, tests kept. `assert 8 == 2` is the blast radius: 9th cell of 12 before, 3rd after.

```
        # Two cells ran before the broken candidate reported: one per earlier candidate.
>       assert order.index("candidate-c") == 2
E       AssertionError: assert 8 == 2
E        +  where 8 = [...].index('candidate-c')

FAILED wmo/env/closed_loop_test.py::test_a_later_broken_candidate_surfaces_after_one_cell_per_candidate
FAILED wmo/env/closed_loop_test.py::test_cells_run_candidate_minor_so_no_candidate_gets_a_cell_ahead
FAILED wmo/cli/route_app_test.py::test_route_sweep_calls_out_a_first_cell_failure_while_the_rest_can_still_be_saved
FAILED wmo/cli/route_app_test.py::test_route_sweep_states_what_the_preflight_cannot_know_before_the_first_cell
4 failed
```

No existing test asserted the old cell order, so none was weakened or rewritten.

## Gates

CI runs no tests, so these were run locally, based on `00a92983`:

```
3555 passed, 18 skipped     (main baseline 3552, measured, + 3 new)
uv run --no-sync ruff check .          All checks passed!
uv run --no-sync ruff format --check wmo/   423 files already formatted
uv run --no-sync ty check              All checks passed!
```

## What is still undetectable before the first cell

`_DEFERRED_RISK` is untouched and still printed per entry: Bedrock AWS credentials, Tinker service reachability, and the OpenRouter credential (closed separately in #287). All three still fail on first use. This change only bounds and announces **when**. Two residuals worth naming:

1. Anything that fails on a **later** cell (mid-sweep throttle, quota exhaustion, a model deprecated mid-run) is unchanged, and should be: those are the cases `evaluate_pool` deliberately survives.
2. If `provider_factory` itself raises at cell time rather than the completion raising, the exception still propagates out of `evaluate_pool` and no matrix is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
