### PR TITLE
Make `wmo providers set` the model registry that fills the routing pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ pip install world-model-optimizer
 wmo providers set
 ```
 
+That verifies the provider and then offers to register its models as routing candidates in
+`.wmo/pool.toml`, the roster everything below chooses from. It searches the provider's own
+catalog (OpenRouter's 338 published models included) and asks only for what that backend needs.
+Re-run it to add another provider's models beside the ones already registered.
+
 **2. Tune a router on your OTel traces.**
 
 ```bash

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -18,6 +18,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 from uuid import uuid4
 
 import typer
@@ -35,6 +36,7 @@ from rich.panel import Panel
 from rich.progress import BarColumn, DownloadColumn, Progress, TextColumn
 from rich.table import Table
 
+import wmo.cli.pool_registry as pool_registry
 import wmo.providers as providers
 from wmo.cli.agent_session import register as register_agent_session_commands
 from wmo.cli.e2b_cmds import register as register_e2b_commands
@@ -97,6 +99,7 @@ from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmo.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
 from wmo.providers.base import Embedder, EmbedderKind, Provider
 from wmo.providers.models import resolve_provider_model
+from wmo.providers.pool import Tier
 from wmo.providers.retry import wrap_provider_with_retries
 from wmo.research import Side, run_concurrency_scaling
 from wmo.research.concurrency_run import build_real_runner, build_world_runner
@@ -185,6 +188,12 @@ _CONCURRENCY_ISOLATION_FLAGS: dict[str, tuple[str, ...]] = {
 _DOWNLOAD_BENCHMARKS = typer.Argument(
     None, help="Benchmark bundles to download, or 'all'. Omit for a picker."
 )
+# Repeatable option default hoisted out of the signature (ruff B008 forbids the call inline).
+_POOL_MODEL_OPTION = typer.Option(
+    None,
+    "--pool-model",
+    help="Register this model id as a routing candidate, with no prompts; repeat for several.",
+)
 
 
 @dataclass(frozen=True)
@@ -250,9 +259,48 @@ def providers_set(
     endpoint: str = typer.Option(None, "--endpoint", help="OpenAI-compatible API endpoint."),
     deployment: str = typer.Option(None, "--deployment", help="Azure deployment name."),
     api_version: str = typer.Option(None, "--api-version", help="Azure API version."),
+    pool: str = typer.Option(
+        None,
+        "--pool",
+        help="Candidate pool TOML the router picks from (default: <root>/pool.toml).",
+    ),
+    pool_model: list[str] | None = _POOL_MODEL_OPTION,
+    api_key_env: str = typer.Option(
+        None, "--api-key-env", help="Env var holding the pool entries' API key (multi-account)."
+    ),
+    tier: str = typer.Option(
+        None, "--tier", help=f"Pool entry tier: {' | '.join(pool_registry.TIERS)}."
+    ),
+    input_per_mtok: float = typer.Option(
+        None,
+        "--input-per-mtok",
+        min=0.0,
+        help="Prompt-token price of every --pool-model, USD per 1M tokens.",
+    ),
+    output_per_mtok: float = typer.Option(
+        None,
+        "--output-per-mtok",
+        min=0.0,
+        help="Completion-token price of every --pool-model, USD per 1M tokens.",
+    ),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding local settings."),
 ) -> None:
-    """Choose and verify the model provider used by local worker-agent runs."""
+    """Choose the local worker's provider, and register the models the router can choose from.
+
+    Two things a project needs, in one command. The worker provider lands in
+    `<root>/settings.toml` as `[models.worker]`, exactly as before. Then, on a terminal, this
+    offers to register models as ROUTING CANDIDATES in `<root>/pool.toml`, the roster
+    `wmo optimize route` selects over: pick a backend, search its catalog, and answer only what
+    that backend needs (an Azure deployment; a price for a model with no published one, never
+    for OpenRouter, which self-prices). Re-run it to add another provider's models beside the
+    ones already registered.
+
+    Scripts keep the old contract: with `--provider` and `--model` both given, nothing is
+    prompted. Registering non-interactively is `--pool-model <id>`, repeated per model, with
+    `--input-per-mtok`/`--output-per-mtok` when the model has no published price.
+    """
+    if tier is not None and tier not in pool_registry.TIERS:
+        raise typer.BadParameter(f"--tier must be one of: {', '.join(pool_registry.TIERS)}")
     existing = load_settings(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:
@@ -309,6 +357,55 @@ def providers_set(
     _console.print(
         f"[green]set[/green] local worker provider to {config.kind.value} "
         f"({config.model_type or model}) in {settings_path(root)}"
+    )
+    _register_pool_models(
+        pool_path=pool_registry.pool_path_for(root, pool),
+        kind=config.kind,
+        pool_model=list(pool_model or []),
+        options=pool_registry.EntryOptions(
+            endpoint=config.endpoint,
+            region=config.region,
+            deployment=config.deployment,
+            api_version=config.api_version,
+            api_key_env=api_key_env,
+            tier=cast("Tier", tier) if tier is not None else "frontier",
+            input_per_mtok=input_per_mtok,
+            output_per_mtok=output_per_mtok,
+        ),
+        interactive=used_picker,
+    )
+
+
+def _register_pool_models(
+    *,
+    pool_path: Path,
+    kind: ProviderKind,
+    pool_model: list[str],
+    options: pool_registry.EntryOptions,
+    interactive: bool,
+) -> None:
+    """Register routing candidates after the worker provider is saved.
+
+    Explicit `--pool-model` ids win and register with no prompts, so a script gets the same
+    roster a person would build by hand. Otherwise the registry is OFFERED only on the run that
+    already prompted (a bare `wmo providers set` at a terminal): a scripted
+    `--provider ... --model ...` invocation keeps its exact pre-existing behavior and asks
+    nothing.
+    """
+    if pool_model:
+        pool_registry.register_model_ids(
+            _console, pool_path=pool_path, kind=kind, model_ids=pool_model, options=options
+        )
+        return
+    if not interactive:
+        return
+    pool_registry.run_pool_registry(
+        _console,
+        lambda text: _console.input(text),
+        lambda text: _console.input(text, password=True),
+        pool_path=pool_path,
+        default_kind=kind,
+        options=options,
     )
 
 

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -301,6 +301,13 @@ def providers_set(
     """
     if tier is not None and tier not in pool_registry.TIERS:
         raise typer.BadParameter(f"--tier must be one of: {', '.join(pool_registry.TIERS)}")
+    if (input_per_mtok is None) != (output_per_mtok is None):
+        # A pool entry takes both prices or neither, so half a pair would be silently dropped
+        # (interactively) or rejected as an invalid entry (with --pool-model).
+        raise typer.BadParameter(
+            "set both --input-per-mtok and --output-per-mtok, or neither; a pool entry prices "
+            "prompt and completion tokens together"
+        )
     existing = load_settings(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -372,8 +372,11 @@ def providers_set(
         options=pool_registry.EntryOptions(
             endpoint=config.endpoint,
             region=config.region,
-            deployment=config.deployment,
-            api_version=config.api_version,
+            # The RAW flags, not the worker config's: `_worker_provider_config` fills an Azure
+            # deployment in from the model id when none was given, and a pool entry must never
+            # inherit a guessed deployment name (nothing can derive an operator's own).
+            deployment=deployment,
+            api_version=api_version,
             api_key_env=api_key_env,
             tier=cast("Tier", tier) if tier is not None else "frontier",
             input_per_mtok=input_per_mtok,

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -716,6 +716,71 @@ def test_providers_set_rejects_an_unknown_tier(
     assert "frontier, open" in result.output
 
 
+def test_providers_set_never_guesses_an_azure_deployment_for_the_pool(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The worker config fills an Azure deployment in from the model id when none was given; a
+    # pool entry must not inherit that guess, because Azure sends the deployment as the request
+    # model and a guessed name addresses a route that does not exist.
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "azure",
+            "--model",
+            "gpt-5.5",
+            "--pool-model",
+            "gpt-5.5",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "azure needs --deployment" in result.output
+    assert not (root / "pool.toml").exists()
+    # The worker role is still saved with its derived deployment: only the pool is strict.
+    worker = load_settings(root).models.worker
+    assert worker is not None and worker.deployment == "gpt-5.5"
+
+
+def test_providers_set_registers_a_named_azure_deployment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "azure",
+            "--model",
+            "gpt-5.5",
+            "--deployment",
+            "chat-prod",
+            "--api-version",
+            "2025-01-01-preview",
+            "--pool-model",
+            "gpt-5.5",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    entry = read_pool_entries(root / "pool.toml")[0]
+    assert (entry.name, entry.model, entry.deployment) == ("chat-prod", "gpt-5.5", "chat-prod")
+    assert entry.api_version == "2025-01-01-preview"
+
+
 def test_providers_set_rejects_half_a_price_pair(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -16,7 +16,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from wmo.cli import app
+from wmo.cli import app, pool_registry
 from wmo.cli.app import _CONCURRENCY_ISOLATION_FLAGS
 from wmo.cli.pool_registry import read_pool_entries
 from wmo.config import HarnessConfig, ModelRole, load_config, load_settings, save_settings
@@ -531,13 +531,22 @@ def test_providers_set_verifies_and_saves_local_worker(monkeypatch, tmp_path) ->
 
 
 def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Stub the live provider ping so `providers set` reaches the pool-registration step."""
+    """Stub both live pings so `providers set` reaches, and gets through, pool registration.
+
+    Two seams, because the command proves two different things: `verify_all` proves the worker
+    provider, and `verify_pool_entry` proves each routing candidate over its own route.
+    """
     monkeypatch.setattr(
         cli_app_module,
         "verify_all",
         lambda configs: [
             VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs
         ],
+    )
+    monkeypatch.setattr(
+        pool_registry,
+        "verify_pool_entry",
+        lambda entry: VerifyResult(ok=True, kind=entry.kind, model=entry.model),
     )
 
 
@@ -779,6 +788,43 @@ def test_providers_set_registers_a_named_azure_deployment(
     entry = read_pool_entries(root / "pool.toml")[0]
     assert (entry.name, entry.model, entry.deployment) == ("chat-prod", "gpt-5.5", "chat-prod")
     assert entry.api_version == "2025-01-01-preview"
+
+
+def test_providers_set_refuses_a_pool_model_that_cannot_be_called(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A --pool-model can differ from the verified worker in model, endpoint, deployment and
+    # credential, so the worker's ping proves nothing about it. Registering it unproved would
+    # surface as a 401 inside a paid `route sweep`, after the candidates ahead of it were billed.
+    _accept_every_provider(monkeypatch)
+    monkeypatch.setattr(
+        pool_registry,
+        "verify_pool_entry",
+        lambda entry: VerifyResult(
+            ok=False, kind=entry.kind, model=entry.model, detail="401 unauthorized"
+        ),
+    )
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--pool-model",
+            "gpt-5.4",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "not callable" in result.output
+    assert not (root / "pool.toml").exists()
 
 
 def test_providers_set_rejects_half_a_price_pair(

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -716,6 +716,38 @@ def test_providers_set_rejects_an_unknown_tier(
     assert "frontier, open" in result.output
 
 
+def test_providers_set_rejects_half_a_price_pair(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A pool entry prices both token tiers or neither. Half a pair would be dropped silently in
+    # the interactive flow and rejected as an invalid entry with --pool-model, so it is refused
+    # up front, where the message can name the flag.
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--pool-model",
+            "qwen3-32b",
+            "--input-per-mtok",
+            "0.1",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "both --input-per-mtok and --output-per-mtok" in result.output
+    assert not (root / "pool.toml").exists()
+
+
 def test_providers_set_without_pool_flags_leaves_scripted_runs_untouched(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -17,6 +18,7 @@ from typer.testing import CliRunner
 
 from wmo.cli import app
 from wmo.cli.app import _CONCURRENCY_ISOLATION_FLAGS
+from wmo.cli.pool_registry import read_pool_entries
 from wmo.config import HarnessConfig, ModelRole, load_config, load_settings, save_settings
 from wmo.core.types import Trace
 from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3way
@@ -29,6 +31,8 @@ from wmo.providers.base import (
     VerifyResult,
     verify_via_ping,
 )
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+from wmo.tracking.pricing import ModelPrice
 
 # `wmo.cli`'s `app` attribute (the Typer object) shadows the `wmo.cli.app` submodule on
 # plain `import wmo.cli.app as ...`; go through importlib to monkeypatch module globals.
@@ -524,6 +528,220 @@ def test_providers_set_verifies_and_saves_local_worker(monkeypatch, tmp_path) ->
     assert worker.provider == "openai"
     assert worker.model == "gpt-5.4-mini"
     assert worker.endpoint == "https://models.example/v1"
+
+
+def _accept_every_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the live provider ping so `providers set` reaches the pool-registration step."""
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: [
+            VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs
+        ],
+    )
+
+
+def _seed_openrouter_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the OpenRouter price resolver at a fixture catalog (the suite never fetches)."""
+    catalog = PriceCatalog(
+        fetched_at=time.time(),
+        source="test fixture",
+        prices={
+            "anthropic/claude-sonnet-4.5": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0)
+        },
+    )
+    path = tmp_path / "openrouter-prices.json"
+    path.write_text(catalog.model_dump_json(), encoding="utf-8")
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(path))
+
+
+def test_providers_set_registers_pool_models_beside_the_settings_it_writes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The blocker this command exists to remove: nothing wrote `pool.toml` for an ordinary
+    # provider model, so a router had no candidates without hand-authored TOML.
+    _accept_every_provider(monkeypatch)
+    _seed_openrouter_catalog(tmp_path, monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openrouter",
+            "--model",
+            "anthropic/claude-sonnet-4.5",
+            "--pool-model",
+            "anthropic/claude-sonnet-4.5",
+            "--tier",
+            "open",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    worker = load_settings(root).models.worker
+    assert worker is not None and worker.provider == "openrouter"
+    entries = read_pool_entries(root / "pool.toml")
+    assert [(entry.name, entry.model, entry.tier) for entry in entries] == [
+        ("claude-sonnet-4.5", "anthropic/claude-sonnet-4.5", "open")
+    ]
+    # Priced from the published catalog, so the roster never reports $0 for this candidate.
+    assert entries[0].price().input_per_mtok == 3.0
+
+
+def test_providers_set_registers_into_an_explicit_pool_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _accept_every_provider(monkeypatch)
+    roster = tmp_path / "rosters" / "candidates.toml"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "bedrock",
+            "--model",
+            "claude-opus-4-8",
+            "--pool-model",
+            "claude-haiku-4-5",
+            "--pool",
+            str(roster),
+            "--root",
+            str(tmp_path / ".wmo"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    entry = read_pool_entries(roster)[0]
+    assert entry.kind is ProviderKind.BEDROCK
+    # Resolved through the built-in registry, so the entry carries the callable runtime id.
+    assert entry.model == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    assert entry.model_type == "claude-haiku-4-5"
+
+
+def test_providers_set_refuses_a_pool_model_it_cannot_price(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A candidate with no price silently costs $0, and a cost-aware policy routes everything to
+    # it. Non-interactively there is nobody to ask, so the command has to refuse.
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--pool-model",
+            "some-unlisted-model",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "no built-in price" in result.output
+    assert not (root / "pool.toml").exists()
+
+
+def test_providers_set_prices_a_pool_model_from_the_flags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--endpoint",
+            "https://vllm.example/v1",
+            "--pool-model",
+            "qwen3-32b",
+            "--input-per-mtok",
+            "0.1",
+            "--output-per-mtok",
+            "0.4",
+            "--api-key-env",
+            "WMO_ENDPOINT_API_KEY",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    entry = read_pool_entries(root / "pool.toml")[0]
+    assert (entry.input_per_mtok, entry.output_per_mtok) == (0.1, 0.4)
+    assert entry.endpoint == "https://vllm.example/v1"
+    assert entry.api_key_env == "WMO_ENDPOINT_API_KEY"
+
+
+def test_providers_set_rejects_an_unknown_tier(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _accept_every_provider(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--tier",
+            "cheap",
+            "--root",
+            str(tmp_path / ".wmo"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "frontier, open" in result.output
+
+
+def test_providers_set_without_pool_flags_leaves_scripted_runs_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The pre-existing contract: `--provider` + `--model` prompts for nothing and writes only
+    # settings. Registration is an addition, never something a script trips over.
+    _accept_every_provider(monkeypatch)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(
+        app,
+        [
+            "providers",
+            "set",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-5.4-mini",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert load_settings(root).models.worker is not None
+    assert not (root / "pool.toml").exists()
+    assert "Register models" not in result.output
 
 
 def test_providers_set_does_not_save_a_failed_provider(monkeypatch, tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -12,9 +12,10 @@ from wmo.providers.registry import get_provider
 
 OptInModelRole = Literal["agent", "meta"]
 
-# Azure OpenAI chat completions need an API version on every call. When an opt-in role does not
-# pin one in settings, this shared default API version applies.
-_DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
+# Azure OpenAI chat completions need an API version on every call. When an opt-in role (or a
+# pool entry, or the local worker role) does not pin one, this shared default applies. Imported
+# by `wmo.cli.app` and `wmo.cli.pool_registry` so the three surfaces cannot drift apart.
+DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
 
 
 def resolve_opt_in_model_provider(
@@ -69,7 +70,7 @@ def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderCon
         ) from None
     api_version = configured.api_version
     if api_version is None and kind is ProviderKind.AZURE_OPENAI:
-        api_version = _DEFAULT_AZURE_API_VERSION
+        api_version = DEFAULT_AZURE_API_VERSION
     config = ProviderConfig(
         kind=kind,
         model=configured.model,

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -1,0 +1,665 @@
+"""The interactive model registry behind `wmo providers set`: filling `.wmo/pool.toml`.
+
+Two questions used to be unconnected. `wmo providers set` answered "which provider runs my local
+worker agent" and wrote `[models.worker]` into settings; the routing optimizer read a completely
+separate `pool.toml` that nothing wrote for an ordinary provider model, so a user who wanted five
+OpenRouter models and five Azure deployments had to hand-author TOML and get `kind`, `model`,
+prices, `deployment`, `api_version`, and `api_key_env` right unaided. This module makes the one
+command answer both: after a provider is picked and verified, it offers to register models from
+it (or from any other backend) as routing candidates.
+
+Design rules this module holds to:
+
+- **Nothing hardcoded.** Model ids come from `wmo.providers.catalog`, which reads OpenRouter's
+  own published catalog and WMO's canonical registry. A typed id always works, for every kind.
+- **One writer.** Entries go through `wmo.providers.pool.upsert_pool_entry`, so registration
+  inherits its cross-process lock, its whole-roster revalidation, and its atomic write. This
+  module never opens the roster for writing.
+- **Ask only what the kind needs.** Azure is asked for a deployment and an api-version; an
+  OpenRouter entry is asked for neither, and for no price either, because OpenRouter self-prices
+  from its published catalog. A price is prompted exactly when the entry would otherwise report
+  $0.
+- **Idempotent.** A model already in the roster is shown as such and re-registers under its
+  existing handle, so a second pass adds the new provider's models beside the first pass's
+  instead of duplicating or clobbering them.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import typer
+from pydantic import BaseModel, ConfigDict, ValidationError
+from rich.console import Console
+from rich.markup import escape
+from rich.table import Table
+
+from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
+from wmo.cli.ui import PromptReader, creds_note, ensure_credentials, has_credentials, select_option
+from wmo.config import PROVIDER_ENV_VARS
+from wmo.providers.base import ProviderKind
+from wmo.providers.catalog import CatalogModel, CatalogSource, ProviderCatalog, list_provider_models
+from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
+from wmo.providers.pool import (
+    PoolEntry,
+    PoolLockTimeout,
+    Tier,
+    load_pool,
+    static_requirements,
+    upsert_pool_entry,
+)
+from wmo.tracking.pricing import price_for
+
+logger = logging.getLogger(__name__)
+
+POOL_FILENAME = "pool.toml"
+"""The roster's name inside a project root, so `--root <dir>` keeps settings and pool together."""
+
+TIERS: tuple[Tier, ...] = ("frontier", "open")
+"""The `PoolEntry.tier` vocabulary, offered as a picker so the value is never mistyped."""
+
+_MAX_LISTED = 20
+"""Rows one search shows. OpenRouter publishes 338 models, so an unfiltered dump is not a list."""
+
+_CHECK = "[green]✓[/green]"
+
+
+class EntryOptions(BaseModel):
+    """Backend knobs a registration applies to every entry it writes in one pass.
+
+    Seeded from `wmo providers set`'s own flags for the provider being set, then refined by the
+    prompts. Everything here is shared across the models chosen in one pass; anything that
+    genuinely differs per model (an Azure deployment name, a price) is asked per model instead.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint: str | None = None
+    region: str | None = None
+    deployment: str | None = None
+    api_version: str | None = None
+    api_key_env: str | None = None
+    tier: Tier = "frontier"
+    input_per_mtok: float | None = None
+    output_per_mtok: float | None = None
+
+
+def pool_path_for(root: str | Path, override: str | None = None) -> Path:
+    """Where this project's roster lives: `--pool` when given, else `<root>/pool.toml`.
+
+    Derived from the same root as `settings.toml` so one `--root` moves the whole project, and
+    equal to `wmo.providers.pool.DEFAULT_POOL_PATH` at the default root, which is what the
+    routing commands read.
+    """
+    return Path(override) if override else Path(root) / POOL_FILENAME
+
+
+def read_pool_entries(path: Path) -> list[PoolEntry]:
+    """The roster's entries, or an empty list when there is no readable roster yet.
+
+    Tolerant on purpose: this feeds display and duplicate detection, and a roster that cannot be
+    parsed is `upsert_pool_entry`'s error to raise, with its own actionable message. Swallowing
+    it here would only pre-empt that with a worse one.
+    """
+    try:
+        return list(load_pool(path).models)
+    except (FileNotFoundError, ValueError) as exc:
+        logger.debug("no readable model pool at %s: %s", path, exc)
+        return []
+
+
+def print_pool(console: Console, path: Path, entries: list[PoolEntry]) -> None:
+    """Show the roster the router chooses from, so a second pass adds to a visible starting set."""
+    if not entries:
+        console.print(f"[dim]routing pool[/dim] {path} [dim]is empty[/dim]")
+        return
+    table = Table(title=f"routing pool ({path})", title_justify="left", header_style="bold")
+    table.add_column("handle")
+    table.add_column("kind")
+    table.add_column("model")
+    table.add_column("$/Mtok in/out", justify="right")
+    table.add_column("tier")
+    for entry in entries:
+        price = entry.price()
+        table.add_row(
+            entry.name,
+            entry.kind.value,
+            entry.deployment or entry.model,
+            f"{price.input_per_mtok:g} / {price.output_per_mtok:g}",
+            entry.tier,
+        )
+    console.print(table)
+
+
+def run_pool_registry(
+    console: Console,
+    ask: PromptReader,
+    ask_secret: PromptReader,
+    *,
+    pool_path: Path,
+    default_kind: ProviderKind,
+    options: EntryOptions,
+) -> int:
+    """Offer to register routing candidates, one provider at a time, until the user is done.
+
+    The interactive half of the registry. Shows the roster first (a re-run has to start from what
+    is already there), then loops: pick a backend, pick models from its catalog, answer only what
+    that backend needs, write. `options` seeds the FIRST pass, because it carries the flags that
+    described `default_kind`'s backend; a different backend picked later starts from defaults so
+    an Azure api-version can never leak onto an OpenRouter entry.
+
+    Args:
+        console: Where the roster and progress are rendered.
+        ask: Reads one prompt line.
+        ask_secret: Reads one prompt line without echo (credential entry).
+        pool_path: The roster TOML to write.
+        default_kind: The provider just configured; the suggested backend for the first pass.
+        options: Backend knobs from the command's own flags, applied to the first pass.
+
+    Returns:
+        How many entries were written across every pass.
+    """
+    print_pool(console, pool_path, read_pool_entries(pool_path))
+    if not _ask_yes_no(console, ask, "Register models the router can choose from?", default=True):
+        console.print(
+            f"[dim]skipped; run `wmo providers set` again any time to add candidates to "
+            f"{pool_path}[/dim]"
+        )
+        return 0
+    written = 0
+    kind = _pick_kind(console, ask, default=default_kind)
+    while True:
+        if kind is default_kind:
+            pass_options = options
+        else:
+            # A backend the command's flags never described: start from defaults, and make sure
+            # its own credentials are present before offering to register anything against it.
+            pass_options = EntryOptions()
+            ensure_credentials(console, ask_secret, kind.value)
+        written += register_from_provider(
+            console, ask, pool_path=pool_path, kind=kind, options=pass_options
+        )
+        if not _ask_yes_no(console, ask, "Register models from another provider?", default=False):
+            break
+        kind = _pick_kind(console, ask, default=kind)
+    print_pool(console, pool_path, read_pool_entries(pool_path))
+    return written
+
+
+def register_from_provider(
+    console: Console,
+    ask: PromptReader,
+    *,
+    pool_path: Path,
+    kind: ProviderKind,
+    options: EntryOptions,
+) -> int:
+    """One pass: choose `kind`'s models, answer its requirements, write them. Returns the count."""
+    catalog = list_provider_models(kind)
+    _describe_catalog(console, catalog)
+    chosen = choose_models(console, ask, catalog, read_pool_entries(pool_path))
+    if not chosen:
+        console.print("[dim]nothing selected[/dim]")
+        return 0
+    shared = _ask_shared_options(console, ask, kind, options)
+    written = 0
+    for model in chosen:
+        if _register_one(console, ask, pool_path=pool_path, kind=kind, model=model, options=shared):
+            written += 1
+    return written
+
+
+def register_model_ids(
+    console: Console,
+    *,
+    pool_path: Path,
+    kind: ProviderKind,
+    model_ids: list[str],
+    options: EntryOptions,
+) -> int:
+    """Register `model_ids` with no prompts, for `--pool-model` and scripts. Returns the count.
+
+    Every id is resolved against `kind`'s catalog first, so a scripted registration picks up the
+    same canonical model type and published price an interactive one would; an id the catalog
+    does not list is registered verbatim, exactly as a typed id is.
+
+    Raises:
+        typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment) or
+            the roster refuses it. Non-interactively there is nobody to ask, so this fails loudly
+            rather than writing a candidate that cannot be called.
+    """
+    catalog = list_provider_models(kind)
+    written = 0
+    for model_id in model_ids:
+        model = catalog.find(model_id) or CatalogModel(id=model_id)
+        entries = read_pool_entries(pool_path)
+        name = _existing_handle(entries, kind, model, options) or _unique_handle(
+            _handle_base(kind, model, options), {entry.name for entry in entries}
+        )
+        try:
+            entry = build_pool_entry(name=name, kind=kind, model=model, options=options)
+        except (ValidationError, ValueError) as exc:
+            raise typer.BadParameter(
+                f"cannot register '{model.id}' from {kind.value}: {exc}"
+            ) from exc
+        problems = static_requirements(entry)
+        if problems:
+            raise typer.BadParameter(
+                f"cannot register '{model.id}' from {kind.value}: {'; '.join(problems)}"
+            )
+        if _write(console, entry, pool_path):
+            written += 1
+    return written
+
+
+def choose_models(
+    console: Console,
+    ask: PromptReader,
+    catalog: ProviderCatalog,
+    existing: list[PoolEntry],
+) -> list[CatalogModel]:
+    """Search-and-pick over one catalog: type a term to filter, numbers to toggle, blank to finish.
+
+    A picker over OpenRouter's 338 models cannot be a scrollable list, so search comes first and
+    only the matches are numbered. One loop serves every backend: with no catalog to search (a
+    Tinker base model) a typed line IS the id, and with a catalog a term that matches nothing
+    offers to take the line as a literal id, so a model published after this release is never
+    unreachable.
+
+    Args:
+        console: Where matches and the running selection are rendered.
+        ask: Reads one prompt line.
+        catalog: The backend's offerable models.
+        existing: The roster as it stands, used to annotate what is already registered.
+
+    Returns:
+        The chosen models, in selection order.
+    """
+    by_target = {_target(entry.kind, entry.model, entry.deployment): entry for entry in existing}
+    selected: dict[str, CatalogModel] = {}
+    shown: list[CatalogModel] = catalog.models[:_MAX_LISTED]
+    if catalog.models:
+        _list_matches(console, catalog, shown, len(catalog.models), by_target, selected)
+    while True:
+        raw = _read(ask, "[bold]models[/bold] [dim](search / numbers / blank when done)[/dim]> ")
+        if not raw:
+            return list(selected.values())
+        picks = _parse_picks(raw)
+        if picks is not None:
+            # All-or-nothing: "1 99" over twelve rows is a typo, and toggling the valid half
+            # would register a model nobody chose while looking like it worked.
+            if all(1 <= pick <= len(shown) for pick in picks):
+                for index in picks:
+                    _toggle(console, selected, shown[index - 1])
+            else:
+                console.print(f"  [red]pick 1-{len(shown)} from the rows above[/red]")
+            continue
+        listed = catalog.find(raw)
+        if listed is not None:
+            _toggle(console, selected, listed)
+            continue
+        if not catalog.models:
+            _toggle(console, selected, CatalogModel(id=raw))
+            continue
+        matches = catalog.search(raw)
+        if matches:
+            shown = matches[:_MAX_LISTED]
+            _list_matches(console, catalog, shown, len(matches), by_target, selected)
+            continue
+        console.print(f"  [yellow]no {catalog.kind.value} model matches[/yellow] {escape(raw)}")
+        if _ask_yes_no(console, ask, f"Register '{raw}' as a literal model id?", default=False):
+            _toggle(console, selected, CatalogModel(id=raw))
+
+
+def build_pool_entry(
+    *,
+    name: str,
+    kind: ProviderKind,
+    model: CatalogModel,
+    options: EntryOptions,
+) -> PoolEntry:
+    """One resolved candidate as a `PoolEntry`, with only the fields its kind actually uses.
+
+    Backend knobs are applied per kind rather than passed through wholesale: an Azure deployment
+    and api-version belong on an Azure entry and nowhere else, a Bedrock region likewise, and
+    Bedrock refuses an `api_key_env` outright (it authenticates with AWS credentials), so that
+    field is dropped there instead of being written and rejected at load.
+
+    Raises:
+        pydantic.ValidationError: The entry is not a valid candidate, most often a model with no
+            built-in price and no declared one.
+    """
+    azure = kind is ProviderKind.AZURE_OPENAI
+    bedrock = kind is ProviderKind.BEDROCK
+    return PoolEntry(
+        name=name,
+        kind=kind,
+        model=model.id,
+        model_type=model.model_type,
+        endpoint=options.endpoint,
+        deployment=(options.deployment or model.id) if azure else None,
+        api_version=(options.api_version or DEFAULT_AZURE_API_VERSION) if azure else None,
+        region=options.region if bedrock else None,
+        api_key_env=None if bedrock else options.api_key_env,
+        tier=options.tier,
+        input_per_mtok=options.input_per_mtok,
+        output_per_mtok=options.output_per_mtok,
+    )
+
+
+def needs_price(kind: ProviderKind, model: CatalogModel) -> bool:
+    """Whether this candidate has to be GIVEN a price, i.e. would otherwise be costed at $0.
+
+    Deliberately the same two questions `PoolEntry._validate_price` asks, in the same order, so
+    the prompt appears exactly when the entry would be rejected without an answer: is the model
+    in the built-in pricing table, and failing that, does OpenRouter publish a price for it? The
+    catalog row's own `price` is display data and is not consulted, because a row priced by its
+    model TYPE would still leave the entry, which is keyed on the runtime id, unpriced.
+
+    The OpenRouter lookup reads the same cached table the picker listed from, so it costs no
+    second fetch.
+    """
+    if price_for(model.id) is not None:
+        return False
+    if kind is ProviderKind.OPENROUTER:
+        return resolve_openrouter_price(model.id).price is None
+    return True
+
+
+def _register_one(
+    console: Console,
+    ask: PromptReader,
+    *,
+    pool_path: Path,
+    kind: ProviderKind,
+    model: CatalogModel,
+    options: EntryOptions,
+) -> bool:
+    """Ask what this one model still needs, then write it. False when it was skipped."""
+    entries = read_pool_entries(pool_path)
+    taken = {entry.name: entry for entry in entries}
+    per_model = _ask_per_model_options(console, ask, kind, model, options)
+    known = _existing_handle(entries, kind, model, per_model)
+    default_name = known or _unique_handle(_handle_base(kind, model, per_model), set(taken))
+    while True:
+        name = _ask_text(console, ask, f"Handle for {model.id}", default_name)
+        clash = taken.get(name)
+        if clash is None or name == known:
+            break
+        console.print(
+            f"  [yellow]{escape(name)} already names[/yellow] {clash.kind.value} "
+            f"{escape(clash.deployment or clash.model)}[yellow]; replacing it rewrites "
+            f"{pool_path} and drops its comments[/yellow]"
+        )
+        if _ask_yes_no(console, ask, f"Replace '{name}'?", default=False):
+            break
+    try:
+        entry = build_pool_entry(name=name, kind=kind, model=model, options=per_model)
+    except (ValidationError, ValueError) as exc:
+        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape(str(exc))}")
+        return False
+    problems = static_requirements(entry)
+    if problems:
+        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape('; '.join(problems))}")
+        return False
+    return _write(console, entry, pool_path)
+
+
+def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
+    """Hand one entry to the roster's only writer and report what it did.
+
+    An entry the roster already holds VERBATIM is not written at all. That is what makes a re-run
+    free: `upsert_pool_entry` treats a same-name entry as a replacement, which re-renders the
+    whole file, so writing an identical entry would reorder the roster and drop its comments to
+    change nothing.
+
+    Returns:
+        True when the roster changed, False when it was already right or the write was refused.
+    """
+    price = entry.price()
+    summary = (
+        f"[bold]{escape(entry.name)}[/bold] ({entry.kind.value} "
+        f"{escape(entry.deployment or entry.model)}, "
+        f"${price.input_per_mtok:g}/${price.output_per_mtok:g} per Mtok)"
+    )
+    if entry in read_pool_entries(pool_path):
+        console.print(f"  {_CHECK} {summary} [dim]already registered, unchanged[/dim]")
+        return False
+    try:
+        replaced = upsert_pool_entry(entry, pool_path)
+    except PoolLockTimeout as exc:
+        # Another writer is in the way; nothing about the entry is wrong, so say to retry rather
+        # than sending the user back through the prompts.
+        console.print(f"  [red]pool busy[/red] {escape(str(exc))}")
+        return False
+    except ValueError as exc:
+        console.print(f"  [red]skipped {escape(entry.name)}[/red]: {escape(str(exc))}")
+        return False
+    note = " [dim](the roster was rewritten, so its comments are gone)[/dim]" if replaced else ""
+    console.print(f"  {_CHECK} {'replaced' if replaced else 'added'} {summary}{note}")
+    return True
+
+
+def _describe_catalog(console: Console, catalog: ProviderCatalog) -> None:
+    """One line saying where this backend's model list came from, before the picker opens."""
+    match catalog.source:
+        case CatalogSource.PUBLISHED:
+            origin = "published catalog"
+        case CatalogSource.BUILT_IN:
+            origin = "built-in registry"
+        case CatalogSource.NONE:
+            origin = "no catalog"
+    detail = f": {catalog.detail}" if catalog.detail else ""
+    console.print(f"[bold]{catalog.kind.value}[/bold] [dim]{origin}{escape(detail)}[/dim]")
+
+
+def _list_matches(
+    console: Console,
+    catalog: ProviderCatalog,
+    shown: list[CatalogModel],
+    total: int,
+    by_target: dict[tuple[str, str, str], PoolEntry],
+    selected: dict[str, CatalogModel],
+) -> None:
+    """Number the current matches, marking what is already registered and already picked."""
+    for index, model in enumerate(shown, start=1):
+        registered = by_target.get(_target(catalog.kind, model.id, None)) or by_target.get(
+            _target(catalog.kind, model.id, model.id)
+        )
+        notes = []
+        if registered is not None:
+            notes.append(f"in pool as {registered.name}")
+        if model.id in selected:
+            notes.append("selected")
+        suffix = f"  [dim]({', '.join(notes)})[/dim]" if notes else ""
+        console.print(f"  [cyan]{index}[/cyan]. {escape(model.label())}{suffix}")
+    if total > len(shown):
+        console.print(f"  [dim]... {total - len(shown)} more; refine the search[/dim]")
+
+
+def _toggle(console: Console, selected: dict[str, CatalogModel], model: CatalogModel) -> None:
+    """Add or remove one model from the running selection, echoing which happened."""
+    if selected.pop(model.id, None) is not None:
+        console.print(f"  [dim]- {escape(model.id)}[/dim]")
+        return
+    selected[model.id] = model
+    console.print(f"  [green]+[/green] {escape(model.id)}")
+
+
+def _parse_picks(raw: str) -> list[int] | None:
+    """`raw` as row numbers, or None when it is not a list of them (so the caller searches).
+
+    Whether they are IN range is the caller's call, because "1 99" is a mis-typed selection worth
+    saying so about, while "4o" is a search term. ASCII decimals only: "4o".isdecimal() is False,
+    but so is a superscript that `int()` would reject after `isdigit()` accepted it.
+    """
+    tokens = raw.replace(",", " ").split()
+    if not tokens or not all(token.isascii() and token.isdecimal() for token in tokens):
+        return None
+    return [int(token) for token in tokens]
+
+
+def _pick_kind(console: Console, ask: PromptReader, *, default: ProviderKind) -> ProviderKind:
+    """Choose which backend to register from, annotated with whose credentials are present."""
+    kinds = [kind.value for kind in ProviderKind]
+    notes = {kind: creds_note(kind) for kind in kinds if has_credentials(kind)}
+    chosen = select_option(
+        console, "Register models from", kinds, notes=notes, default=default.value, reader=ask
+    )
+    return ProviderKind(chosen)
+
+
+def _ask_shared_options(
+    console: Console,
+    ask: PromptReader,
+    kind: ProviderKind,
+    options: EntryOptions,
+) -> EntryOptions:
+    """Ask the questions that apply to every model of this pass: tier, account, region."""
+    tier = select_option(console, "Tier", list(TIERS), default=options.tier, reader=ask)
+    updates: dict[str, str | None] = {"tier": tier}
+    if kind is ProviderKind.BEDROCK:
+        # Bedrock authenticates with AWS credentials, so it takes a region and refuses a key var.
+        updates["region"] = (
+            _ask_text(console, ask, "AWS region (blank = AWS_REGION)", options.region or "") or None
+        )
+    else:
+        default_env = _default_key_env(kind)
+        updates["api_key_env"] = (
+            _ask_text(
+                console,
+                ask,
+                f"Env var holding the API key (blank = {default_env})",
+                options.api_key_env or "",
+            )
+            or None
+        )
+    return options.model_copy(update=updates)
+
+
+def _ask_per_model_options(
+    console: Console,
+    ask: PromptReader,
+    kind: ProviderKind,
+    model: CatalogModel,
+    options: EntryOptions,
+) -> EntryOptions:
+    """Ask what THIS model needs and nothing else: an Azure deployment, or a missing price."""
+    updates: dict[str, str | float | None] = {}
+    if kind is ProviderKind.AZURE_OPENAI:
+        # On the wire Azure's model IS the deployment name, and every deployment is named by the
+        # operator, so neither field can be derived from the catalog.
+        updates["deployment"] = _ask_text(
+            console, ask, f"Azure deployment serving {model.id}", options.deployment or model.id
+        )
+        updates["api_version"] = _ask_text(
+            console, ask, "Azure api-version", options.api_version or DEFAULT_AZURE_API_VERSION
+        )
+    if options.input_per_mtok is None and needs_price(kind, model):
+        console.print(
+            f"  [yellow]{escape(model.id)} has no published or built-in price[/yellow]"
+            "[dim]; an unpriced candidate reports $0 and a cost-aware policy routes"
+            " everything to it[/dim]"
+        )
+        updates["input_per_mtok"] = _ask_price(console, ask, "Input price, USD per 1M tokens")
+        updates["output_per_mtok"] = _ask_price(console, ask, "Output price, USD per 1M tokens")
+    return options.model_copy(update=updates) if updates else options
+
+
+def _default_key_env(kind: ProviderKind) -> str:
+    """The variable this backend reads by default, named so the blank answer is not a mystery."""
+    env_vars = PROVIDER_ENV_VARS.get(kind, [])
+    return env_vars[0] if env_vars else "the backend default"
+
+
+def _target(kind: ProviderKind, model: str, deployment: str | None) -> tuple[str, str, str]:
+    """What makes two entries the SAME callable candidate, for idempotent re-registration."""
+    return (kind.value, model.lower(), (deployment or model).lower())
+
+
+def _existing_handle(
+    entries: list[PoolEntry],
+    kind: ProviderKind,
+    model: CatalogModel,
+    options: EntryOptions,
+) -> str | None:
+    """The handle this exact candidate already has in the roster, else None.
+
+    Identity includes `api_key_env`, because a multi-account pool deliberately carries the same
+    model twice under two credentials; collapsing those would silently delete one account's
+    candidate.
+    """
+    deployment = options.deployment if kind is ProviderKind.AZURE_OPENAI else None
+    wanted = _target(kind, model.id, deployment)
+    for entry in entries:
+        if _target(entry.kind, entry.model, entry.deployment) != wanted:
+            continue
+        if entry.api_key_env == (None if kind is ProviderKind.BEDROCK else options.api_key_env):
+            return entry.name
+    return None
+
+
+def _handle_base(kind: ProviderKind, model: CatalogModel, options: EntryOptions) -> str:
+    """A readable default handle: the deployment name, the model type, or the id's last segment.
+
+    OpenRouter ids are `vendor/model` and Bedrock ids carry routing prefixes, so the raw id makes
+    a poor handle for the thing policy artifacts and request logs are keyed on.
+    """
+    if kind is ProviderKind.AZURE_OPENAI and options.deployment:
+        base = options.deployment
+    else:
+        base = model.model_type or model.id.rsplit("/", maxsplit=1)[-1]
+    cleaned = "".join(char if char.isalnum() or char in "._-" else "-" for char in base).strip("-")
+    return cleaned or model.id
+
+
+def _unique_handle(base: str, taken: set[str]) -> str:
+    """`base`, or `base-2`, `base-3`, ... : a suggested handle never silently replaces an entry."""
+    if base not in taken:
+        return base
+    suffix = 2
+    while f"{base}-{suffix}" in taken:
+        suffix += 1
+    return f"{base}-{suffix}"
+
+
+def _ask_text(console: Console, ask: PromptReader, label: str, default: str) -> str:
+    """Prompt for a line, showing `default` and returning it when the answer is blank."""
+    suffix = f" [dim]\\[{escape(default)}][/dim]" if default else ""
+    return _read(ask, f"[bold]{label}[/bold]{suffix}: ") or default
+
+
+def _ask_price(console: Console, ask: PromptReader, label: str) -> float:
+    """Prompt until a non-negative price is given; there is no sane default to fall back on."""
+    while True:
+        raw = _read(ask, f"[bold]{label}[/bold]: ")
+        try:
+            value = float(raw)
+        except ValueError:
+            value = -1.0
+        if value >= 0.0:
+            return value
+        console.print("  [red]enter a non-negative number of USD per 1M tokens[/red]")
+
+
+def _ask_yes_no(console: Console, ask: PromptReader, question: str, *, default: bool) -> bool:
+    """Prompt for yes/no, with `default` taken on a blank answer."""
+    hint = "Y/n" if default else "y/N"
+    while True:
+        raw = _read(ask, f"[bold]{question}[/bold] [dim]({hint})[/dim]: ").lower()
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+        console.print("  [red]answer y or n[/red]")
+
+
+def _read(ask: PromptReader, prompt: str) -> str:
+    """Read one prompt line, turning exhausted input into a clean abort instead of a traceback."""
+    try:
+        return ask(prompt).strip()
+    except EOFError:
+        raise typer.Abort() from None

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -27,6 +27,7 @@ Design rules this module holds to:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 import typer
@@ -38,7 +39,7 @@ from rich.table import Table
 from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
 from wmo.cli.ui import PromptReader, creds_note, ensure_credentials, has_credentials, select_option
 from wmo.config import PROVIDER_ENV_VARS
-from wmo.providers.base import ProviderKind
+from wmo.providers.base import ProviderKind, VerifyResult
 from wmo.providers.catalog import CatalogModel, CatalogSource, ProviderCatalog, list_provider_models
 from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
 from wmo.providers.pool import (
@@ -46,12 +47,17 @@ from wmo.providers.pool import (
     PoolLockTimeout,
     Tier,
     load_pool,
+    pool_provider,
     static_requirements,
     upsert_pool_entry,
 )
 from wmo.tracking.pricing import price_for
 
 logger = logging.getLogger(__name__)
+
+# The live provider ping, as a seam: one cheap completion against a built candidate. Injected
+# so tests never reach a backend, mirroring `run_build_wizard`'s `verify` parameter.
+ProviderCheck = Callable[[PoolEntry], VerifyResult]
 
 POOL_FILENAME = "pool.toml"
 """The roster's name inside a project root, so `--root <dir>` keeps settings and pool together."""
@@ -140,6 +146,7 @@ def run_pool_registry(
     pool_path: Path,
     default_kind: ProviderKind,
     options: EntryOptions,
+    verify: ProviderCheck | None = None,
 ) -> int:
     """Offer to register routing candidates, one provider at a time, until the user is done.
 
@@ -156,6 +163,7 @@ def run_pool_registry(
         pool_path: The roster TOML to write.
         default_kind: The provider just configured; the suggested backend for the first pass.
         options: Backend knobs from the command's own flags, applied to the first pass.
+        verify: The live provider ping, one per pass; None uses the real one.
 
     Returns:
         How many entries were written across every pass.
@@ -178,7 +186,7 @@ def run_pool_registry(
             pass_options = EntryOptions()
             ensure_credentials(console, ask_secret, kind.value)
         written += register_from_provider(
-            console, ask, pool_path=pool_path, kind=kind, options=pass_options
+            console, ask, pool_path=pool_path, kind=kind, options=pass_options, verify=verify
         )
         if not _ask_yes_no(console, ask, "Register models from another provider?", default=False):
             break
@@ -194,8 +202,17 @@ def register_from_provider(
     pool_path: Path,
     kind: ProviderKind,
     options: EntryOptions,
+    verify: ProviderCheck | None = None,
 ) -> int:
-    """One pass: choose `kind`'s models, answer its requirements, write them. Returns the count."""
+    """One pass: choose `kind`'s models, answer its requirements, write them. Returns the count.
+
+    Every requirement is collected before anything is verified or written, so the one live ping
+    this pass pays for goes out with the connection details the first entry will actually carry
+    (an Azure deployment is asked for per model, and pinging the base model id instead would
+    verify a route no entry uses).
+
+    `verify` is that ping; None uses the real one.
+    """
     catalog = list_provider_models(kind)
     _describe_catalog(console, catalog)
     chosen = choose_models(console, ask, catalog, read_pool_entries(pool_path))
@@ -203,11 +220,75 @@ def register_from_provider(
         console.print("[dim]nothing selected[/dim]")
         return 0
     shared = _ask_shared_options(console, ask, kind, options)
+    drafts = [
+        (model, _ask_per_model_options(console, ask, kind, model, shared)) for model in chosen
+    ]
+    if not _verify_pass(console, ask, kind=kind, draft=drafts[0], verify=verify):
+        return 0
     written = 0
-    for model in chosen:
-        if _register_one(console, ask, pool_path=pool_path, kind=kind, model=model, options=shared):
+    for model, per_model in drafts:
+        if _register_one(
+            console, ask, pool_path=pool_path, kind=kind, model=model, options=per_model
+        ):
             written += 1
     return written
+
+
+def _verify_pass(
+    console: Console,
+    ask: PromptReader,
+    *,
+    kind: ProviderKind,
+    draft: tuple[CatalogModel, EntryOptions],
+    verify: ProviderCheck | None,
+) -> bool:
+    """Ping this pass's backend once, and say whether to go on registering its candidates.
+
+    `wmo providers set` already bills exactly one ping to prove the WORKER provider works, and
+    the roster is the one artifact where a silently broken candidate is expensive: `wmo optimize
+    route sweep` pays for every candidate ahead of it before reaching the one that 401s. So a
+    pass pays the same single cheap ping for the backend it is about to register, whether or not
+    it is the backend the command just set (the pool models are different models from the
+    worker's, and a switched backend was never checked beyond its environment variables).
+
+    A failure does not discard the selection silently: it is reported and the user decides,
+    because a roster is legitimately built on a machine that does not hold the key.
+    """
+    model, options = draft
+    try:
+        # The candidate itself, so the ping travels the exact route the roster will: this
+        # entry's endpoint, deployment, region, and its own `api_key_env` account.
+        entry = build_pool_entry(name="probe", kind=kind, model=model, options=options)
+    except (ValidationError, ValueError):
+        # Not a valid candidate at all. `_register_one` reports that per model, with the failing
+        # model named; pre-empting it here would blame the whole pass for one bad row.
+        return True
+    console.print(f"verifying {kind.value} ({escape(model.id)})...")
+    result = (verify or verify_pool_entry)(entry)
+    if result.ok:
+        console.print(f"  {_CHECK} {kind.value} ({escape(model.id)}) reachable")
+        return True
+    console.print(
+        f"  [red]x {kind.value} ({escape(model.id)}) failed[/red]: "
+        f"{escape(result.detail or 'unknown error')}"
+    )
+    return _ask_yes_no(console, ask, "Register these candidates anyway?", default=False)
+
+
+def verify_pool_entry(entry: PoolEntry) -> VerifyResult:
+    """One cheap live completion against a candidate exactly as the router would call it.
+
+    Goes through `pool_provider` rather than `verify_all` so the entry's own `api_key_env`
+    account is the one proved: a multi-account roster that verified the default credential
+    would have proved nothing about the key the candidate will actually send.
+
+    Never raises: a backend that refuses to be built at all (an unset `api_key_env`, Bedrock
+    handed a key) comes back as a failure with its own message, like any other.
+    """
+    try:
+        return pool_provider(entry).verify()
+    except ValueError as exc:
+        return VerifyResult(ok=False, kind=entry.kind, model=entry.model, detail=str(exc))
 
 
 def register_model_ids(
@@ -225,10 +306,21 @@ def register_model_ids(
     does not list is registered verbatim, exactly as a typed id is.
 
     Raises:
-        typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment) or
-            the roster refuses it. Non-interactively there is nobody to ask, so this fails loudly
-            rather than writing a candidate that cannot be called.
+        typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment), the
+            roster refuses it, or one explicit Azure deployment was given for several models.
+            Non-interactively there is nobody to ask, so this fails loudly rather than writing a
+            candidate that cannot be called.
     """
+    if kind is ProviderKind.AZURE_OPENAI and options.deployment is not None and len(model_ids) > 1:
+        # On the wire Azure's model IS the deployment name, so one deployment applied to several
+        # models would register several candidates that all call the same deployment while
+        # advertising models it does not serve. Unlike a shared endpoint or price, a shared
+        # deployment name is never a coherent answer.
+        raise typer.BadParameter(
+            "one --deployment cannot describe several --pool-model ids on azure: the deployment "
+            "name IS the model on the wire, so run this once per deployment, or drop --deployment "
+            "to name each deployment after its own model id"
+        )
     catalog = list_provider_models(kind)
     written = 0
     for model_id in model_ids:
@@ -376,12 +468,16 @@ def _register_one(
     model: CatalogModel,
     options: EntryOptions,
 ) -> bool:
-    """Ask what this one model still needs, then write it. False when it was skipped."""
+    """Name one already-resolved candidate and write it. False when it was skipped.
+
+    `options` is this model's own resolved settings (`_ask_per_model_options` has already run for
+    it), because the pass verifies the first candidate's real connection details before writing
+    any of them.
+    """
     entries = read_pool_entries(pool_path)
     taken = {entry.name: entry for entry in entries}
-    per_model = _ask_per_model_options(console, ask, kind, model, options)
-    known = _existing_handle(entries, kind, model, per_model)
-    default_name = known or _unique_handle(_handle_base(kind, model, per_model), set(taken))
+    known = _existing_handle(entries, kind, model, options)
+    default_name = known or _unique_handle(_handle_base(kind, model, options), set(taken))
     while True:
         name = _ask_text(console, ask, f"Handle for {model.id}", default_name)
         clash = taken.get(name)
@@ -395,7 +491,7 @@ def _register_one(
         if _ask_yes_no(console, ask, f"Replace '{name}'?", default=False):
             break
     try:
-        entry = build_pool_entry(name=name, kind=kind, model=model, options=per_model)
+        entry = build_pool_entry(name=name, kind=kind, model=model, options=options)
     except (ValidationError, ValueError) as exc:
         console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape(str(exc))}")
         return False
@@ -556,7 +652,11 @@ def _ask_per_model_options(
         updates["api_version"] = _ask_text(
             console, ask, "Azure api-version", options.api_version or DEFAULT_AZURE_API_VERSION
         )
-    if options.input_per_mtok is None and needs_price(kind, model):
+    # Either side missing, not just the input side: `PoolEntry` refuses a half pair outright, so
+    # suppressing the prompts on a half-supplied price would skip the model instead of asking
+    # for the number it is missing.
+    priced_by_flags = options.input_per_mtok is not None and options.output_per_mtok is not None
+    if not priced_by_flags and needs_price(kind, model):
         console.print(
             f"  [yellow]{escape(model.id)} has no published or built-in price[/yellow]"
             "[dim]; an unpriced candidate reports $0 and a cost-aware policy routes"

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -206,12 +206,10 @@ def register_from_provider(
 ) -> int:
     """One pass: choose `kind`'s models, answer its requirements, write them. Returns the count.
 
-    Every requirement is collected before anything is verified or written, so the one live ping
-    this pass pays for goes out with the connection details the first entry will actually carry
-    (an Azure deployment is asked for per model, and pinging the base model id instead would
-    verify a route no entry uses).
-
-    `verify` is that ping; None uses the real one.
+    `verify` is the live ping (None uses the real one). It runs once per CANDIDATE rather than
+    once per pass, because a pass is not one route: on Azure every candidate names a different
+    operator-chosen deployment, so a first deployment that answers proves nothing about the
+    second. `wmo providers verify` bills a call per model for the same reason.
     """
     catalog = list_provider_models(kind)
     _describe_catalog(console, catalog)
@@ -220,59 +218,41 @@ def register_from_provider(
         console.print("[dim]nothing selected[/dim]")
         return 0
     shared = _ask_shared_options(console, ask, kind, options)
-    drafts = [
-        (model, _ask_per_model_options(console, ask, kind, model, shared)) for model in chosen
-    ]
-    if not _verify_pass(console, ask, kind=kind, draft=drafts[0], verify=verify):
-        return 0
     written = 0
-    for model, per_model in drafts:
+    for model in chosen:
         if _register_one(
-            console, ask, pool_path=pool_path, kind=kind, model=model, options=per_model
+            console, ask, pool_path=pool_path, kind=kind, model=model, options=shared, verify=verify
         ):
             written += 1
     return written
 
 
-def _verify_pass(
+def _verify_candidate(
     console: Console,
     ask: PromptReader,
     *,
-    kind: ProviderKind,
-    draft: tuple[CatalogModel, EntryOptions],
+    entry: PoolEntry,
     verify: ProviderCheck | None,
 ) -> bool:
-    """Ping this pass's backend once, and say whether to go on registering its candidates.
+    """Ping one candidate, and say whether to register it.
 
-    `wmo providers set` already bills exactly one ping to prove the WORKER provider works, and
-    the roster is the one artifact where a silently broken candidate is expensive: `wmo optimize
-    route sweep` pays for every candidate ahead of it before reaching the one that 401s. So a
-    pass pays the same single cheap ping for the backend it is about to register, whether or not
-    it is the backend the command just set (the pool models are different models from the
-    worker's, and a switched backend was never checked beyond its environment variables).
+    `wmo providers set` already bills a ping to prove the WORKER provider works, and the roster
+    is the artifact where an unproved candidate is most expensive: `wmo optimize route sweep`
+    pays for every candidate ahead of the one that 401s before it finds out. So each candidate
+    the registry is about to write pays the same cheap ping, over its own route (its endpoint,
+    deployment, region) and its own `api_key_env` account.
 
-    A failure does not discard the selection silently: it is reported and the user decides,
-    because a roster is legitimately built on a machine that does not hold the key.
+    A failure does not discard the pick silently: it is reported and the user decides, because a
+    roster is legitimately built on a machine that does not hold the key.
     """
-    model, options = draft
-    try:
-        # The candidate itself, so the ping travels the exact route the roster will: this
-        # entry's endpoint, deployment, region, and its own `api_key_env` account.
-        entry = build_pool_entry(name="probe", kind=kind, model=model, options=options)
-    except (ValidationError, ValueError):
-        # Not a valid candidate at all. `_register_one` reports that per model, with the failing
-        # model named; pre-empting it here would blame the whole pass for one bad row.
-        return True
-    console.print(f"verifying {kind.value} ({escape(model.id)})...")
+    console.print(f"verifying {entry.kind.value} ({escape(entry.deployment or entry.model)})...")
     result = (verify or verify_pool_entry)(entry)
+    label = f"{entry.kind.value} ({escape(entry.deployment or entry.model)})"
     if result.ok:
-        console.print(f"  {_CHECK} {kind.value} ({escape(model.id)}) reachable")
+        console.print(f"  {_CHECK} {label} reachable")
         return True
-    console.print(
-        f"  [red]x {kind.value} ({escape(model.id)}) failed[/red]: "
-        f"{escape(result.detail or 'unknown error')}"
-    )
-    return _ask_yes_no(console, ask, "Register these candidates anyway?", default=False)
+    console.print(f"  [red]x {label} failed[/red]: {escape(result.detail or 'unknown error')}")
+    return _ask_yes_no(console, ask, "Register it anyway?", default=False)
 
 
 def verify_pool_entry(entry: PoolEntry) -> VerifyResult:
@@ -305,22 +285,19 @@ def register_model_ids(
     same canonical model type and published price an interactive one would; an id the catalog
     does not list is registered verbatim, exactly as a typed id is.
 
+    Azure is the one backend this cannot do in bulk. On the wire its deployment name IS the
+    model, deployment names are chosen by whoever created them, and nothing in a catalog can
+    guess one: derived from the model id they would silently address deployments that do not
+    exist, and one `--deployment` shared across ids would point several candidates at one route.
+    So a scripted Azure registration is one explicitly named deployment per invocation.
+
     Raises:
         typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment), the
-            roster refuses it, or one explicit Azure deployment was given for several models.
+            roster refuses it, or Azure was given no deployment or several models for one.
             Non-interactively there is nobody to ask, so this fails loudly rather than writing a
             candidate that cannot be called.
     """
-    if kind is ProviderKind.AZURE_OPENAI and options.deployment is not None and len(model_ids) > 1:
-        # On the wire Azure's model IS the deployment name, so one deployment applied to several
-        # models would register several candidates that all call the same deployment while
-        # advertising models it does not serve. Unlike a shared endpoint or price, a shared
-        # deployment name is never a coherent answer.
-        raise typer.BadParameter(
-            "one --deployment cannot describe several --pool-model ids on azure: the deployment "
-            "name IS the model on the wire, so run this once per deployment, or drop --deployment "
-            "to name each deployment after its own model id"
-        )
+    _check_azure_deployment(kind, model_ids, options)
     catalog = list_provider_models(kind)
     written = 0
     for model_id in model_ids:
@@ -343,6 +320,30 @@ def register_model_ids(
         if _write(console, entry, pool_path):
             written += 1
     return written
+
+
+def _check_azure_deployment(
+    kind: ProviderKind, model_ids: list[str], options: EntryOptions
+) -> None:
+    """Refuse a scripted Azure registration that cannot name the deployment it will call.
+
+    Raises:
+        typer.BadParameter: No `--deployment`, or one `--deployment` for several models.
+    """
+    if kind is not ProviderKind.AZURE_OPENAI or not model_ids:
+        return
+    if options.deployment is None:
+        raise typer.BadParameter(
+            "azure needs --deployment alongside --pool-model: an Azure deployment name is chosen "
+            "by whoever created it and is what every request names as its model, so it cannot be "
+            "derived from a model id (deriving it would register a route that does not exist)"
+        )
+    if len(model_ids) > 1:
+        raise typer.BadParameter(
+            "one --deployment cannot describe several --pool-model ids on azure: the deployment "
+            "name IS the model on the wire, so several ids sharing it would all call the same "
+            "deployment; run this once per deployment"
+        )
 
 
 def choose_models(
@@ -467,17 +468,33 @@ def _register_one(
     kind: ProviderKind,
     model: CatalogModel,
     options: EntryOptions,
+    verify: ProviderCheck | None,
 ) -> bool:
-    """Name one already-resolved candidate and write it. False when it was skipped.
+    """Ask what this one model still needs, prove it answers, name it, write it.
 
-    `options` is this model's own resolved settings (`_ask_per_model_options` has already run for
-    it), because the pass verifies the first candidate's real connection details before writing
-    any of them.
+    In that order: the connection details come first because the ping needs them, the ping comes
+    before the handle prompt because there is no point naming a candidate that cannot be called,
+    and the handle comes last because it is the only answer the roster keys on.
+
+    Returns:
+        True when the roster gained or changed this entry, False when it was skipped.
     """
+    per_model = _ask_per_model_options(console, ask, kind, model, options)
+    try:
+        probe = build_pool_entry(name="probe", kind=kind, model=model, options=per_model)
+    except (ValidationError, ValueError) as exc:
+        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape(str(exc))}")
+        return False
+    problems = static_requirements(probe)
+    if problems:
+        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape('; '.join(problems))}")
+        return False
+    if not _verify_candidate(console, ask, entry=probe, verify=verify):
+        return False
     entries = read_pool_entries(pool_path)
     taken = {entry.name: entry for entry in entries}
-    known = _existing_handle(entries, kind, model, options)
-    default_name = known or _unique_handle(_handle_base(kind, model, options), set(taken))
+    known = _existing_handle(entries, kind, model, per_model)
+    default_name = known or _unique_handle(_handle_base(kind, model, per_model), set(taken))
     while True:
         name = _ask_text(console, ask, f"Handle for {model.id}", default_name)
         clash = taken.get(name)
@@ -490,16 +507,7 @@ def _register_one(
         )
         if _ask_yes_no(console, ask, f"Replace '{name}'?", default=False):
             break
-    try:
-        entry = build_pool_entry(name=name, kind=kind, model=model, options=options)
-    except (ValidationError, ValueError) as exc:
-        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape(str(exc))}")
-        return False
-    problems = static_requirements(entry)
-    if problems:
-        console.print(f"  [red]skipped {escape(model.id)}[/red]: {escape('; '.join(problems))}")
-        return False
-    return _write(console, entry, pool_path)
+    return _write(console, probe.model_copy(update={"name": name}), pool_path)
 
 
 def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:

--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -278,12 +278,20 @@ def register_model_ids(
     kind: ProviderKind,
     model_ids: list[str],
     options: EntryOptions,
+    verify: ProviderCheck | None = None,
 ) -> int:
     """Register `model_ids` with no prompts, for `--pool-model` and scripts. Returns the count.
 
     Every id is resolved against `kind`'s catalog first, so a scripted registration picks up the
     same canonical model type and published price an interactive one would; an id the catalog
     does not list is registered verbatim, exactly as a typed id is.
+
+    Every candidate is then live-pinged over its own route, exactly as the interactive flow does.
+    A `--pool-model` can differ from the verified worker in model, deployment, endpoint, and
+    credential, so the worker's ping proves nothing about it, and a script is precisely where
+    nobody is watching for the 401 that would otherwise surface inside a paid `route sweep`. The
+    whole batch is built and proved BEFORE anything is written, so a bad third id cannot leave
+    half a roster behind.
 
     Azure is the one backend this cannot do in bulk. On the wire its deployment name IS the
     model, deployment names are chosen by whoever created them, and nothing in a catalog can
@@ -292,20 +300,23 @@ def register_model_ids(
     So a scripted Azure registration is one explicitly named deployment per invocation.
 
     Raises:
-        typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment), the
-            roster refuses it, or Azure was given no deployment or several models for one.
-            Non-interactively there is nobody to ask, so this fails loudly rather than writing a
-            candidate that cannot be called.
+        typer.BadParameter: An entry cannot be built (a missing price, an Azure deployment), it
+            cannot be called, the roster refuses it, or Azure was given no deployment or several
+            models for one. Non-interactively there is nobody to ask, so this fails loudly rather
+            than writing a candidate that does not work.
     """
     _check_azure_deployment(kind, model_ids, options)
     catalog = list_provider_models(kind)
-    written = 0
+    check = verify or verify_pool_entry
+    existing = read_pool_entries(pool_path)
+    taken = {entry.name for entry in existing}
+    planned: list[PoolEntry] = []
     for model_id in model_ids:
         model = catalog.find(model_id) or CatalogModel(id=model_id)
-        entries = read_pool_entries(pool_path)
-        name = _existing_handle(entries, kind, model, options) or _unique_handle(
-            _handle_base(kind, model, options), {entry.name for entry in entries}
+        name = _existing_handle(existing, kind, model, options) or _unique_handle(
+            _handle_base(kind, model, options), taken
         )
+        taken.add(name)
         try:
             entry = build_pool_entry(name=name, kind=kind, model=model, options=options)
         except (ValidationError, ValueError) as exc:
@@ -317,9 +328,16 @@ def register_model_ids(
             raise typer.BadParameter(
                 f"cannot register '{model.id}' from {kind.value}: {'; '.join(problems)}"
             )
-        if _write(console, entry, pool_path):
-            written += 1
-    return written
+        result = check(entry)
+        if not result.ok:
+            raise typer.BadParameter(
+                f"'{model.id}' from {kind.value} is not callable "
+                f"({result.detail or 'unknown error'}); fix the credential, endpoint, or id, or "
+                "leave --pool-model off and register it from the interactive picker, which lets "
+                "you keep an unreachable candidate deliberately"
+            )
+        planned.append(entry)
+    return sum(1 for entry in planned if _write(console, entry, pool_path))
 
 
 def _check_azure_deployment(

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -9,6 +9,7 @@ reaches the network.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
 
@@ -27,9 +28,10 @@ from wmo.cli.pool_registry import (
     run_pool_registry,
 )
 from wmo.config import PROVIDER_ENV_VARS
-from wmo.providers.base import ProviderKind
+from wmo.providers.base import ProviderKind, VerifyResult
 from wmo.providers.catalog import list_provider_models
 from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+from wmo.providers.pool import PoolEntry
 from wmo.tracking.pricing import ModelPrice
 
 _SONNET = "anthropic/claude-sonnet-4.5"
@@ -85,12 +87,18 @@ def _catalog_and_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
             monkeypatch.setenv(var, "test-value")
 
 
+def _ok(entry: PoolEntry) -> VerifyResult:
+    """A live ping that succeeds. Every test injects one; nothing here reaches a backend."""
+    return VerifyResult(ok=True, kind=entry.kind, model=entry.model)
+
+
 def _drive(
     pool: Path,
     lines: list[str],
     *,
     kind: ProviderKind = ProviderKind.OPENROUTER,
     options: EntryOptions | None = None,
+    verify: Callable[[PoolEntry], VerifyResult] = _ok,
 ) -> tuple[int, str, _Script]:
     """Run the registry against `pool` with `lines` as the user's answers."""
     console = Console(file=StringIO(), width=120, no_color=True, highlight=False)
@@ -102,6 +110,7 @@ def _drive(
         pool_path=pool,
         default_kind=kind,
         options=options or EntryOptions(),
+        verify=verify,
     )
     assert isinstance(console.file, StringIO)
     return written, console.file.getvalue(), script
@@ -532,6 +541,153 @@ def test_register_model_ids_resolves_a_bedrock_id_from_the_built_in_registry(
     assert entry.model == "us.anthropic.claude-opus-4-8"
     assert entry.model_type == "claude-opus-4-8"
     assert entry.region == "us-east-1"
+
+
+def test_every_pass_is_live_verified_including_a_switched_backend(tmp_path: Path) -> None:
+    # Presence of an environment variable is not proof it holds a working key. A backend the
+    # command never verified must not silently contribute candidates that 401 at sweep time,
+    # after the sweep has paid for every candidate ahead of them.
+    pool = tmp_path / "pool.toml"
+    seen: list[PoolEntry] = []
+
+    def record(entry: PoolEntry) -> VerifyResult:
+        seen.append(entry)
+        return _ok(entry)
+
+    _drive(
+        pool,
+        [
+            "y",
+            "openrouter",
+            *_openrouter_pass(_SONNET),
+            "y",
+            "azure",
+            "gpt-5.4",
+            "",
+            "frontier",
+            "",
+            "prod-gpt54",
+            "2025-01-01-preview",
+            "",
+            "n",
+        ],
+        verify=record,
+    )
+
+    assert [(entry.kind, entry.model) for entry in seen] == [
+        (ProviderKind.OPENROUTER, _SONNET),
+        (ProviderKind.AZURE_OPENAI, "gpt-5.4"),
+    ]
+    # The ping goes out with the connection details the entry will be written with.
+    assert seen[1].deployment == "prod-gpt54"
+    assert seen[1].api_version == "2025-01-01-preview"
+
+
+def test_one_ping_covers_a_whole_pass(tmp_path: Path) -> None:
+    # The ping costs real money, so it proves the credential once per pass rather than once per
+    # candidate; `wmo providers verify` is what bills a call per model.
+    pool = tmp_path / "pool.toml"
+    calls = 0
+
+    def count(entry: PoolEntry) -> VerifyResult:
+        nonlocal calls
+        calls += 1
+        return _ok(entry)
+
+    written, _, _ = _drive(
+        pool,
+        ["y", "openrouter", *_openrouter_pass(_SONNET, _DEEPSEEK), "n"],
+        verify=count,
+    )
+
+    assert written == 2
+    assert calls == 1
+
+
+def test_a_failed_ping_registers_nothing_unless_it_is_overridden(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+
+    def refuse(entry: PoolEntry) -> VerifyResult:
+        return VerifyResult(ok=False, kind=entry.kind, model=entry.model, detail="401 bad key")
+
+    written, output, _ = _drive(
+        pool,
+        ["y", "openrouter", _SONNET, "", "frontier", "", "n", "n"],
+        verify=refuse,
+    )
+
+    assert written == 0
+    assert not pool.exists()
+    assert "401 bad key" in output
+
+
+def test_a_failed_ping_can_be_overridden_for_a_machine_without_the_key(tmp_path: Path) -> None:
+    # A roster is legitimately built where the credential is not, so the failure is reported and
+    # the choice is the user's rather than a silent discard of everything they just picked.
+    pool = tmp_path / "pool.toml"
+
+    def refuse(entry: PoolEntry) -> VerifyResult:
+        return VerifyResult(ok=False, kind=entry.kind, model=entry.model, detail="offline")
+
+    written, _, _ = _drive(
+        pool,
+        ["y", "openrouter", _SONNET, "", "frontier", "", "y", "", "n"],
+        verify=refuse,
+    )
+
+    assert written == 1
+    assert read_pool_entries(pool)[0].model == _SONNET
+
+
+def test_half_a_price_pair_still_prompts_for_both(tmp_path: Path) -> None:
+    # `PoolEntry` takes both prices or neither, so treating a supplied input price as "already
+    # priced" would skip the model with a validation error instead of asking for the other half.
+    pool = tmp_path / "pool.toml"
+    written, _, _ = _drive(
+        pool,
+        ["y", "openai", "self-hosted", "y", "", "open", "", "0.2", "0.8", "", "n"],
+        options=EntryOptions(input_per_mtok=0.1),
+    )
+
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert (entry.input_per_mtok, entry.output_per_mtok) == (0.2, 0.8)
+
+
+def test_one_azure_deployment_cannot_describe_several_pool_models(tmp_path: Path) -> None:
+    # Azure sends the deployment as the request's model id, so reusing one deployment across
+    # several ids registers several candidates that all call the same deployment.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    with pytest.raises(typer.BadParameter, match="once per deployment"):
+        register_model_ids(
+            console,
+            pool_path=pool,
+            kind=ProviderKind.AZURE_OPENAI,
+            model_ids=["gpt-5.4", "gpt-5.5"],
+            options=EntryOptions(deployment="prod"),
+        )
+    assert not pool.exists()
+
+
+def test_several_azure_pool_models_default_to_their_own_deployment_names(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.AZURE_OPENAI,
+        model_ids=["gpt-5.4", "gpt-5.5"],
+        options=EntryOptions(),
+    )
+
+    entries = read_pool_entries(pool)
+    assert [(entry.name, entry.deployment) for entry in entries] == [
+        ("gpt-5.4", "gpt-5.4"),
+        ("gpt-5.5", "gpt-5.5"),
+    ]
 
 
 @pytest.mark.parametrize("kind", list(ProviderKind))

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -18,6 +18,7 @@ import typer
 from pydantic import ValidationError
 from rich.console import Console
 
+from wmo.cli import pool_registry
 from wmo.cli.pool_registry import (
     EntryOptions,
     build_pool_entry,
@@ -72,11 +73,13 @@ class _Script:
 
 @pytest.fixture(autouse=True)
 def _catalog_and_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Seed the OpenRouter cache and every provider credential the flow may check.
+    """Seed the OpenRouter cache, fake every credential, and cut the live ping off the network.
 
     Credentials matter because picking a backend other than the one just configured runs the
     wizard's credential prompt, which would otherwise consume script lines and write a `.env`
-    into the working directory.
+    into the working directory. Replacing `verify_pool_entry` is the same rule `wmo/conftest.py`
+    applies to the price catalog: a test that forgets to inject a ping must fail loudly rather
+    than quietly calling openrouter.ai. Tests that want a ping to FAIL pass their own.
     """
     cache = tmp_path / "openrouter-prices.json"
     catalog = PriceCatalog(fetched_at=time.time(), source="test fixture", prices=_fake_prices())
@@ -85,6 +88,12 @@ def _catalog_and_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     for env_vars in PROVIDER_ENV_VARS.values():
         for var in env_vars:
             monkeypatch.setenv(var, "test-value")
+    monkeypatch.setattr(pool_registry, "verify_pool_entry", _refuse_network)
+
+
+def _refuse_network(entry: PoolEntry) -> VerifyResult:
+    """Stand-in for the live ping: the suite never calls a provider."""
+    raise AssertionError(f"the test suite does not ping providers (tried {entry.model})")
 
 
 def _ok(entry: PoolEntry) -> VerifyResult:
@@ -472,6 +481,7 @@ def test_register_model_ids_writes_without_prompting(tmp_path: Path) -> None:
         kind=ProviderKind.OPENROUTER,
         model_ids=[_SONNET, _DEEPSEEK],
         options=EntryOptions(tier="open"),
+        verify=_ok,
     )
 
     assert written == 2
@@ -489,6 +499,7 @@ def test_register_model_ids_is_idempotent(tmp_path: Path) -> None:
         kind=ProviderKind.OPENROUTER,
         model_ids=[_SONNET],
         options=EntryOptions(),
+        verify=_ok,
     )
     before = pool.read_text(encoding="utf-8")
 
@@ -498,10 +509,60 @@ def test_register_model_ids_is_idempotent(tmp_path: Path) -> None:
         kind=ProviderKind.OPENROUTER,
         model_ids=[_SONNET],
         options=EntryOptions(),
+        verify=_ok,
     )
 
     assert written == 0
     assert pool.read_text(encoding="utf-8") == before
+
+
+def test_register_model_ids_pings_every_candidate_on_its_own_route(tmp_path: Path) -> None:
+    # A --pool-model can differ from the verified worker in model, endpoint, deployment and
+    # credential, so the worker's ping proves nothing about it, and a script is exactly where
+    # nobody is watching for the 401 that would otherwise surface inside a paid sweep.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+    pinged: list[str] = []
+
+    def record(entry: PoolEntry) -> VerifyResult:
+        pinged.append(entry.model)
+        return _ok(entry)
+
+    register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.OPENROUTER,
+        model_ids=[_SONNET, _DEEPSEEK],
+        options=EntryOptions(),
+        verify=record,
+    )
+
+    assert pinged == [_SONNET, _DEEPSEEK]
+
+
+def test_register_model_ids_writes_nothing_when_a_candidate_is_not_callable(
+    tmp_path: Path,
+) -> None:
+    # Built and proved before anything is written, so a bad second id cannot leave half a roster
+    # behind for a script that then reports failure.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    def refuse_second(entry: PoolEntry) -> VerifyResult:
+        if entry.model == _DEEPSEEK:
+            return VerifyResult(ok=False, kind=entry.kind, model=entry.model, detail="401")
+        return _ok(entry)
+
+    with pytest.raises(typer.BadParameter, match="is not callable"):
+        register_model_ids(
+            console,
+            pool_path=pool,
+            kind=ProviderKind.OPENROUTER,
+            model_ids=[_SONNET, _DEEPSEEK],
+            options=EntryOptions(),
+            verify=refuse_second,
+        )
+    assert not pool.exists()
 
 
 def test_register_model_ids_refuses_a_model_it_cannot_price(tmp_path: Path) -> None:
@@ -534,6 +595,7 @@ def test_register_model_ids_resolves_a_bedrock_id_from_the_built_in_registry(
         kind=ProviderKind.BEDROCK,
         model_ids=["claude-opus-4-8"],
         options=EntryOptions(region="us-east-1"),
+        verify=_ok,
     )
 
     entry = read_pool_entries(pool)[0]
@@ -734,6 +796,7 @@ def test_one_azure_deployment_registers_cleanly(tmp_path: Path) -> None:
         kind=ProviderKind.AZURE_OPENAI,
         model_ids=["gpt-5.4"],
         options=EntryOptions(deployment="chat-prod", api_version="2025-01-01-preview"),
+        verify=_ok,
     )
 
     entry = read_pool_entries(pool)[0]

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -1,0 +1,564 @@
+"""Tests for the interactive model registry that fills `.wmo/pool.toml`.
+
+Every prompt is driven by a scripted input stream and every assertion is made against the roster
+the run actually wrote, because the point of this surface is the file, not the transcript. The
+OpenRouter catalog is faked through the same disk cache the resolver reads, so nothing here
+reaches the network.
+"""
+
+from __future__ import annotations
+
+import time
+from io import StringIO
+from pathlib import Path
+
+import pytest
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+
+from wmo.cli.pool_registry import (
+    EntryOptions,
+    build_pool_entry,
+    needs_price,
+    pool_path_for,
+    read_pool_entries,
+    register_model_ids,
+    run_pool_registry,
+)
+from wmo.config import PROVIDER_ENV_VARS
+from wmo.providers.base import ProviderKind
+from wmo.providers.catalog import list_provider_models
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+from wmo.tracking.pricing import ModelPrice
+
+_SONNET = "anthropic/claude-sonnet-4.5"
+_DEEPSEEK = "deepseek/deepseek-v3.2"
+
+
+def _fake_prices() -> dict[str, ModelPrice]:
+    """A published catalog big enough that the picker has to filter rather than list."""
+    prices = {
+        _SONNET: ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0, cache_read_per_mtok=0.3),
+        _DEEPSEEK: ModelPrice(input_per_mtok=0.27, output_per_mtok=0.4),
+        "anthropic/claude-haiku-4.5": ModelPrice(input_per_mtok=1.0, output_per_mtok=5.0),
+    }
+    for index in range(25):
+        prices[f"filler/model-{index:02d}"] = ModelPrice(
+            input_per_mtok=float(index), output_per_mtok=float(index * 2)
+        )
+    return prices
+
+
+class _Script:
+    """A scripted stdin: each read pops the next line, and running out raises EOFError.
+
+    EOFError rather than StopIteration on purpose: that is what `rich`'s `Console.input` raises
+    on closed stdin, so a test that under-feeds the prompts exercises the real abort path.
+    """
+
+    def __init__(self, lines: list[str]) -> None:
+        self.remaining = list(lines)
+        self.prompts: list[str] = []
+
+    def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if not self.remaining:
+            raise EOFError(prompt)
+        return self.remaining.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def _catalog_and_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seed the OpenRouter cache and every provider credential the flow may check.
+
+    Credentials matter because picking a backend other than the one just configured runs the
+    wizard's credential prompt, which would otherwise consume script lines and write a `.env`
+    into the working directory.
+    """
+    cache = tmp_path / "openrouter-prices.json"
+    catalog = PriceCatalog(fetched_at=time.time(), source="test fixture", prices=_fake_prices())
+    cache.write_text(catalog.model_dump_json(), encoding="utf-8")
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(cache))
+    for env_vars in PROVIDER_ENV_VARS.values():
+        for var in env_vars:
+            monkeypatch.setenv(var, "test-value")
+
+
+def _drive(
+    pool: Path,
+    lines: list[str],
+    *,
+    kind: ProviderKind = ProviderKind.OPENROUTER,
+    options: EntryOptions | None = None,
+) -> tuple[int, str, _Script]:
+    """Run the registry against `pool` with `lines` as the user's answers."""
+    console = Console(file=StringIO(), width=120, no_color=True, highlight=False)
+    script = _Script(lines)
+    written = run_pool_registry(
+        console,
+        script,
+        script,
+        pool_path=pool,
+        default_kind=kind,
+        options=options or EntryOptions(),
+    )
+    assert isinstance(console.file, StringIO)
+    return written, console.file.getvalue(), script
+
+
+def _openrouter_pass(*models: str, tier: str = "", api_key_env: str = "") -> list[str]:
+    """The answers that register `models` from OpenRouter in one pass (handles defaulted)."""
+    return [*models, "", tier, api_key_env, *["" for _ in models]]
+
+
+def test_registers_openrouter_models_and_never_asks_them_for_a_price(tmp_path: Path) -> None:
+    # OpenRouter self-prices from its published catalog (#284), so a price prompt here would be
+    # asking for a number the entry is about to resolve anyway.
+    pool = tmp_path / "pool.toml"
+    written, output, script = _drive(
+        pool,
+        ["y", "openrouter", *_openrouter_pass(_SONNET, _DEEPSEEK, tier="open"), "n"],
+    )
+
+    assert written == 2
+    entries = {entry.name: entry for entry in read_pool_entries(pool)}
+    assert set(entries) == {"claude-sonnet-4.5", "deepseek-v3.2"}
+    sonnet = entries["claude-sonnet-4.5"]
+    assert sonnet.kind is ProviderKind.OPENROUTER
+    assert sonnet.model == _SONNET
+    assert sonnet.tier == "open"
+    # Stamped from the catalog, so the roster records exact numbers rather than deferring.
+    assert (sonnet.input_per_mtok, sonnet.output_per_mtok) == (3.0, 15.0)
+    assert sonnet.cached_input_per_mtok == 0.3
+    assert sonnet.deployment is None and sonnet.api_version is None
+    assert not any("price" in prompt.lower() for prompt in script.prompts)
+    assert "USD per 1M tokens" not in output
+
+
+def test_a_second_pass_adds_a_second_provider_without_dropping_the_first(tmp_path: Path) -> None:
+    # The whole point of a re-runnable registry: a user accumulates a pool across several
+    # providers in several passes, and pass two must not clobber pass one.
+    pool = tmp_path / "pool.toml"
+    _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET, tier="open"), "n"])
+    assert [entry.name for entry in read_pool_entries(pool)] == ["claude-sonnet-4.5"]
+
+    written, _, _ = _drive(
+        pool,
+        [
+            "y",
+            "azure",
+            "gpt-5.4",  # an exact catalog id picks that model directly
+            "",
+            "frontier",
+            "",  # api key env: the backend default
+            "prod-gpt54",  # deployment
+            "2025-01-01-preview",  # api-version
+            "",  # handle
+            "n",
+        ],
+        kind=ProviderKind.OPENROUTER,
+    )
+
+    assert written == 1
+    entries = {entry.name: entry for entry in read_pool_entries(pool)}
+    assert set(entries) == {"claude-sonnet-4.5", "prod-gpt54"}
+    assert entries["claude-sonnet-4.5"].kind is ProviderKind.OPENROUTER
+    azure = entries["prod-gpt54"]
+    assert azure.kind is ProviderKind.AZURE_OPENAI
+    assert azure.model == "gpt-5.4"
+    assert azure.deployment == "prod-gpt54"
+    assert azure.api_version == "2025-01-01-preview"
+
+
+def test_re_registering_the_same_model_leaves_the_file_byte_identical(tmp_path: Path) -> None:
+    # Idempotence has to be at the FILE level: writing the same entry again would go through
+    # upsert's replacement path, which re-renders the roster and drops its comments.
+    pool = tmp_path / "pool.toml"
+    _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET, _DEEPSEEK), "n"])
+    before = pool.read_text(encoding="utf-8")
+
+    written, output, _ = _drive(
+        pool, ["y", "openrouter", *_openrouter_pass(_SONNET, _DEEPSEEK), "n"]
+    )
+
+    assert written == 0
+    assert pool.read_text(encoding="utf-8") == before
+    assert "already registered, unchanged" in output
+
+
+def test_the_picker_shows_what_is_already_in_the_pool(tmp_path: Path) -> None:
+    # A second pass starts from a visible roster, and an already-registered model is annotated
+    # with the handle it carries so re-picking it is an informed choice.
+    pool = tmp_path / "pool.toml"
+    _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET), "n"])
+
+    _, output, _ = _drive(pool, ["y", "openrouter", "sonnet", "", "n"])
+
+    assert "routing pool" in output
+    assert "in pool as claude-sonnet-4.5" in output
+
+
+def test_search_narrows_the_catalog_and_numbers_pick_from_the_matches(tmp_path: Path) -> None:
+    # 338 models are not a scrollable list. An unfiltered listing is capped and says so, and a
+    # search is what makes numbered picking meaningful.
+    pool = tmp_path / "pool.toml"
+    written, output, _ = _drive(
+        pool, ["y", "openrouter", "claude", "1 2", "", "frontier", "", "", "", "n"]
+    )
+
+    assert "more; refine the search" in output
+    assert written == 2
+    assert {entry.model for entry in read_pool_entries(pool)} == {
+        _SONNET,
+        "anthropic/claude-haiku-4.5",
+    }
+
+
+def test_a_number_outside_the_listing_selects_nothing_at_all(tmp_path: Path) -> None:
+    # "1 99" against one match is a typo, not a half-selection: toggling the valid half would
+    # register a model the user never chose while looking like it worked.
+    pool = tmp_path / "pool.toml"
+    _, output, _ = _drive(pool, ["y", "openrouter", "claude-haiku", "1 99", "", "n"])
+
+    assert "pick 1-1 from the rows above" in output
+    assert read_pool_entries(pool) == []
+
+
+def test_a_typed_id_outside_the_catalog_is_registered_after_confirmation(tmp_path: Path) -> None:
+    # A model published after this release, or a self-hosted OpenAI-compatible server, must be
+    # reachable; a catalog is suggestions, never a whitelist.
+    pool = tmp_path / "pool.toml"
+    written, _, _ = _drive(
+        pool,
+        [
+            "y",
+            "openai",
+            "my-vllm/qwen3-32b",
+            "y",  # yes, take it as a literal id
+            "",
+            "open",
+            "WMO_ENDPOINT_API_KEY",
+            "0.1",  # no built-in price, so both tiers are asked for
+            "0.4",
+            "",
+            "n",
+        ],
+    )
+
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert entry.name == "qwen3-32b"
+    assert entry.kind is ProviderKind.OPENAI
+    assert entry.model == "my-vllm/qwen3-32b"
+    assert entry.api_key_env == "WMO_ENDPOINT_API_KEY"
+    assert (entry.input_per_mtok, entry.output_per_mtok) == (0.1, 0.4)
+
+
+def test_declining_a_literal_id_registers_nothing(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    written, _, _ = _drive(pool, ["y", "openai", "typo-model", "n", "", "n"])
+
+    assert written == 0
+    assert not pool.exists()
+
+
+def test_a_price_is_re_asked_until_it_is_a_non_negative_number(tmp_path: Path) -> None:
+    # There is no safe default: a candidate priced at $0 wins every cost-aware routing decision.
+    pool = tmp_path / "pool.toml"
+    written, output, _ = _drive(
+        pool,
+        ["y", "openai", "self-hosted", "y", "", "open", "", "free", "-2", "0", "1.5", "", "n"],
+    )
+
+    assert "non-negative" in output
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert (entry.input_per_mtok, entry.output_per_mtok) == (0.0, 1.5)
+
+
+def test_a_built_in_priced_model_is_not_asked_for_a_price(tmp_path: Path) -> None:
+    # gpt-5.4 is in `wmo.tracking.pricing`, so the entry is honest without any declared price
+    # and stays as small as a hand-written one.
+    pool = tmp_path / "pool.toml"
+    written, _, _ = _drive(
+        pool, ["y", "openai", "gpt-5.4", "", "frontier", "", "", "n"], kind=ProviderKind.OPENAI
+    )
+
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert entry.input_per_mtok is None
+    assert entry.price().input_per_mtok == 2.5
+
+
+def test_bedrock_is_asked_for_a_region_and_never_for_an_api_key_env(tmp_path: Path) -> None:
+    # Bedrock authenticates with AWS credentials; `PoolEntry` rejects an api_key_env outright,
+    # so asking for one would collect an answer the roster refuses.
+    pool = tmp_path / "pool.toml"
+    written, _, script = _drive(
+        pool,
+        ["y", "bedrock", "claude-haiku-4-5", "", "frontier", "eu-central-1", "", "n"],
+        kind=ProviderKind.BEDROCK,
+    )
+
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert entry.region == "eu-central-1"
+    assert entry.api_key_env is None
+    assert not any("API key" in prompt for prompt in script.prompts)
+
+
+def test_an_openrouter_pass_is_never_asked_azure_questions(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    _, _, script = _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET), "n"])
+
+    assert not any("Azure" in prompt for prompt in script.prompts)
+
+
+def test_the_same_model_under_a_second_account_becomes_a_second_entry(tmp_path: Path) -> None:
+    # Multi-account pools deliberately carry one model twice under two credentials; collapsing
+    # them onto one handle would silently delete an account's candidate.
+    pool = tmp_path / "pool.toml"
+    _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET, api_key_env="ACCOUNT_A"), "n"])
+    written, _, _ = _drive(
+        pool, ["y", "openrouter", *_openrouter_pass(_SONNET, api_key_env="ACCOUNT_B"), "n"]
+    )
+
+    assert written == 1
+    entries = read_pool_entries(pool)
+    assert [entry.name for entry in entries] == ["claude-sonnet-4.5", "claude-sonnet-4.5-2"]
+    assert [entry.api_key_env for entry in entries] == ["ACCOUNT_A", "ACCOUNT_B"]
+
+
+def test_a_handle_that_would_replace_another_entry_is_confirmed_first(tmp_path: Path) -> None:
+    # Reusing a handle repoints everything keyed on it and rewrites the file; declining loops
+    # back to the prompt instead of doing it quietly.
+    pool = tmp_path / "pool.toml"
+    _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET), "n"])
+
+    written, output, _ = _drive(
+        pool,
+        [
+            "y",
+            "openrouter",
+            _DEEPSEEK,
+            "",
+            "frontier",
+            "",
+            "claude-sonnet-4.5",  # a handle that already names a different model
+            "n",  # do not replace it
+            "deepseek",  # a fresh handle instead
+            "n",
+        ],
+    )
+
+    assert "already names" in output
+    assert written == 1
+    entries = {entry.name: entry.model for entry in read_pool_entries(pool)}
+    assert entries == {"claude-sonnet-4.5": _SONNET, "deepseek": _DEEPSEEK}
+
+
+def test_declining_the_offer_writes_no_roster_at_all(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    written, output, script = _drive(pool, ["n"])
+
+    assert written == 0
+    assert not pool.exists()
+    assert "skipped" in output
+    assert script.remaining == []
+
+
+def test_selecting_nothing_writes_no_roster(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    written, output, _ = _drive(pool, ["y", "openrouter", "", "n"])
+
+    assert written == 0
+    assert not pool.exists()
+    assert "nothing selected" in output
+
+
+def test_exhausted_input_aborts_instead_of_leaking_an_eoferror(tmp_path: Path) -> None:
+    # Piped input that runs out, or Ctrl-D, must end the command cleanly rather than printing a
+    # traceback over a half-written roster.
+    pool = tmp_path / "pool.toml"
+    with pytest.raises(typer.Abort):
+        _drive(pool, ["y", "openrouter", _SONNET])
+
+
+def test_an_unreadable_roster_is_left_to_the_writer_to_report(tmp_path: Path) -> None:
+    # Display and duplicate detection degrade quietly; `upsert_pool_entry` owns the actionable
+    # "fix the file, or move it aside" error and must not be pre-empted with a worse one.
+    pool = tmp_path / "pool.toml"
+    pool.write_text("this is not toml [[[", encoding="utf-8")
+
+    written, output, _ = _drive(pool, ["y", "openrouter", *_openrouter_pass(_SONNET), "n"])
+
+    assert written == 0
+    assert "not valid TOML" in output
+    assert pool.read_text(encoding="utf-8") == "this is not toml [[["
+
+
+def test_flag_supplied_knobs_are_dropped_when_the_first_pass_switches_backend(
+    tmp_path: Path,
+) -> None:
+    # The switch can happen on the FIRST pass too: the user configures an Azure worker and then
+    # registers OpenRouter candidates. The Azure knobs must not follow them there.
+    pool = tmp_path / "pool.toml"
+    written, _, _ = _drive(
+        pool,
+        ["y", "openrouter", *_openrouter_pass(_SONNET), "n"],
+        kind=ProviderKind.AZURE_OPENAI,
+        options=EntryOptions(deployment="prod-gpt55", api_version="2030-01-01"),
+    )
+
+    assert written == 1
+    entry = read_pool_entries(pool)[0]
+    assert entry.kind is ProviderKind.OPENROUTER
+    assert entry.deployment is None
+    assert entry.api_version is None
+
+
+def test_flag_supplied_backend_knobs_seed_the_matching_backends_pass(tmp_path: Path) -> None:
+    # `--deployment`/`--api-version` described the provider being SET; letting them follow the
+    # user to a different backend would stamp an Azure api-version onto an OpenRouter entry.
+    pool = tmp_path / "pool.toml"
+    options = EntryOptions(deployment="prod-gpt55", api_version="2030-01-01")
+    written, _, _ = _drive(
+        pool,
+        [
+            "y",
+            "azure",
+            "gpt-5.5",
+            "",
+            "frontier",
+            "",
+            "",  # accept the flag-supplied deployment
+            "",  # accept the flag-supplied api-version
+            "",  # handle
+            "y",
+            "openrouter",
+            *_openrouter_pass(_SONNET),
+            "n",
+        ],
+        kind=ProviderKind.AZURE_OPENAI,
+        options=options,
+    )
+
+    assert written == 2
+    entries = {entry.name: entry for entry in read_pool_entries(pool)}
+    assert entries["prod-gpt55"].deployment == "prod-gpt55"
+    assert entries["prod-gpt55"].api_version == "2030-01-01"
+    assert entries["claude-sonnet-4.5"].deployment is None
+    assert entries["claude-sonnet-4.5"].api_version is None
+
+
+def test_register_model_ids_writes_without_prompting(tmp_path: Path) -> None:
+    # The scripted path: same roster a person would build by hand, no terminal required.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    written = register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.OPENROUTER,
+        model_ids=[_SONNET, _DEEPSEEK],
+        options=EntryOptions(tier="open"),
+    )
+
+    assert written == 2
+    entries = read_pool_entries(pool)
+    assert [entry.name for entry in entries] == ["claude-sonnet-4.5", "deepseek-v3.2"]
+    assert all(entry.tier == "open" for entry in entries)
+
+
+def test_register_model_ids_is_idempotent(tmp_path: Path) -> None:
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+    register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.OPENROUTER,
+        model_ids=[_SONNET],
+        options=EntryOptions(),
+    )
+    before = pool.read_text(encoding="utf-8")
+
+    written = register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.OPENROUTER,
+        model_ids=[_SONNET],
+        options=EntryOptions(),
+    )
+
+    assert written == 0
+    assert pool.read_text(encoding="utf-8") == before
+
+
+def test_register_model_ids_refuses_a_model_it_cannot_price(tmp_path: Path) -> None:
+    # Non-interactively there is nobody to ask, and a silently unpriced candidate reports $0.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    with pytest.raises(typer.BadParameter, match="no built-in price"):
+        register_model_ids(
+            console,
+            pool_path=pool,
+            kind=ProviderKind.OPENAI,
+            model_ids=["mystery-model"],
+            options=EntryOptions(),
+        )
+    assert not pool.exists()
+
+
+def test_register_model_ids_resolves_a_bedrock_id_from_the_built_in_registry(
+    tmp_path: Path,
+) -> None:
+    # A scripted registration must pick up the same runtime id and canonical type the picker
+    # would, so `--pool-model claude-opus-4-8` is callable rather than a literal that is not.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.BEDROCK,
+        model_ids=["claude-opus-4-8"],
+        options=EntryOptions(region="us-east-1"),
+    )
+
+    entry = read_pool_entries(pool)[0]
+    assert entry.name == "claude-opus-4-8"
+    assert entry.model == "us.anthropic.claude-opus-4-8"
+    assert entry.model_type == "claude-opus-4-8"
+    assert entry.region == "us-east-1"
+
+
+@pytest.mark.parametrize("kind", list(ProviderKind))
+def test_a_price_is_prompted_exactly_when_the_entry_would_be_rejected(kind: ProviderKind) -> None:
+    # The invariant behind "ask only what the kind needs": `needs_price` has to agree with
+    # `PoolEntry`'s own validation on every row of every catalog, or the flow either asks for a
+    # number it will not use or skips a model it could have registered.
+    for model in list_provider_models(kind).models:
+        try:
+            build_pool_entry(name="probe", kind=kind, model=model, options=EntryOptions())
+        except ValidationError:
+            accepted = False
+        else:
+            accepted = True
+        assert accepted is not needs_price(kind, model), model.id
+
+
+def test_no_openrouter_model_needs_a_price_while_the_catalog_is_reachable() -> None:
+    # The #284 exception, pinned: OpenRouter self-prices, so its whole catalog registers with
+    # zero price prompts.
+    catalog = list_provider_models(ProviderKind.OPENROUTER)
+    assert catalog.models
+    assert not any(needs_price(ProviderKind.OPENROUTER, model) for model in catalog.models)
+
+
+def test_pool_path_follows_the_root_unless_it_is_overridden(tmp_path: Path) -> None:
+    assert pool_path_for(tmp_path / ".wmo") == tmp_path / ".wmo" / "pool.toml"
+    assert pool_path_for(tmp_path, "elsewhere/roster.toml") == Path("elsewhere/roster.toml")
+    # The default root resolves to exactly what the routing commands read.
+    assert pool_path_for(".wmo") == Path(".wmo/pool.toml")

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -583,25 +583,61 @@ def test_every_pass_is_live_verified_including_a_switched_backend(tmp_path: Path
     assert seen[1].api_version == "2025-01-01-preview"
 
 
-def test_one_ping_covers_a_whole_pass(tmp_path: Path) -> None:
-    # The ping costs real money, so it proves the credential once per pass rather than once per
-    # candidate; `wmo providers verify` is what bills a call per model.
+def test_every_candidate_is_pinged_on_its_own_route(tmp_path: Path) -> None:
+    # A pass is not one route. Every Azure candidate names a different operator-chosen
+    # deployment, so a first deployment that answers proves nothing about the second, and a
+    # once-per-pass ping would wave the rest through.
     pool = tmp_path / "pool.toml"
-    calls = 0
+    pinged: list[str] = []
 
-    def count(entry: PoolEntry) -> VerifyResult:
-        nonlocal calls
-        calls += 1
+    def record(entry: PoolEntry) -> VerifyResult:
+        pinged.append(entry.deployment or entry.model)
         return _ok(entry)
 
     written, _, _ = _drive(
         pool,
-        ["y", "openrouter", *_openrouter_pass(_SONNET, _DEEPSEEK), "n"],
-        verify=count,
+        [
+            "y",
+            "azure",
+            "gpt-5.4",
+            "gpt-5.5",
+            "",
+            "frontier",
+            "",  # api key env
+            "chat-prod",
+            "2025-01-01-preview",
+            "",  # gpt-5.4: deployment, api-version, handle
+            "chat-preview",
+            "2025-01-01-preview",
+            "",  # gpt-5.5
+            "n",
+        ],
+        kind=ProviderKind.AZURE_OPENAI,
+        verify=record,
     )
 
     assert written == 2
-    assert calls == 1
+    assert pinged == ["chat-prod", "chat-preview"]
+
+
+def test_a_candidate_that_fails_its_ping_does_not_take_the_others_down(tmp_path: Path) -> None:
+    # Per-candidate verification means a per-candidate decision: one unreachable deployment is
+    # declined on its own, and the rest of the selection still lands.
+    pool = tmp_path / "pool.toml"
+
+    def refuse_second(entry: PoolEntry) -> VerifyResult:
+        if entry.model == _DEEPSEEK:
+            return VerifyResult(ok=False, kind=entry.kind, model=entry.model, detail="404 model")
+        return _ok(entry)
+
+    written, _, _ = _drive(
+        pool,
+        ["y", "openrouter", _SONNET, _DEEPSEEK, "", "frontier", "", "", "n", "n"],
+        verify=refuse_second,
+    )
+
+    assert written == 1
+    assert [entry.model for entry in read_pool_entries(pool)] == [_SONNET]
 
 
 def test_a_failed_ping_registers_nothing_unless_it_is_overridden(tmp_path: Path) -> None:
@@ -671,7 +707,24 @@ def test_one_azure_deployment_cannot_describe_several_pool_models(tmp_path: Path
     assert not pool.exists()
 
 
-def test_several_azure_pool_models_default_to_their_own_deployment_names(tmp_path: Path) -> None:
+def test_a_scripted_azure_registration_must_name_its_deployment(tmp_path: Path) -> None:
+    # Deployment names are chosen by whoever created them. Defaulting to the model id would
+    # write a candidate addressing a route that does not exist, and a script has nobody to ask.
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    with pytest.raises(typer.BadParameter, match="azure needs --deployment"):
+        register_model_ids(
+            console,
+            pool_path=pool,
+            kind=ProviderKind.AZURE_OPENAI,
+            model_ids=["gpt-5.4"],
+            options=EntryOptions(),
+        )
+    assert not pool.exists()
+
+
+def test_one_azure_deployment_registers_cleanly(tmp_path: Path) -> None:
     pool = tmp_path / "pool.toml"
     console = Console(file=StringIO(), width=120, no_color=True)
 
@@ -679,15 +732,13 @@ def test_several_azure_pool_models_default_to_their_own_deployment_names(tmp_pat
         console,
         pool_path=pool,
         kind=ProviderKind.AZURE_OPENAI,
-        model_ids=["gpt-5.4", "gpt-5.5"],
-        options=EntryOptions(),
+        model_ids=["gpt-5.4"],
+        options=EntryOptions(deployment="chat-prod", api_version="2025-01-01-preview"),
     )
 
-    entries = read_pool_entries(pool)
-    assert [(entry.name, entry.deployment) for entry in entries] == [
-        ("gpt-5.4", "gpt-5.4"),
-        ("gpt-5.5", "gpt-5.5"),
-    ]
+    entry = read_pool_entries(pool)[0]
+    assert (entry.name, entry.model, entry.deployment) == ("chat-prod", "gpt-5.4", "chat-prod")
+    assert entry.api_version == "2025-01-01-preview"
 
 
 @pytest.mark.parametrize("kind", list(ProviderKind))

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -238,10 +238,10 @@ def select_provider_and_model(
     (provider, model, region).
     """
     providers = list(_PROVIDER_MODELS)
-    with_creds = [p for p in providers if _has_credentials(p)]
+    with_creds = [p for p in providers if has_credentials(p)]
     # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
     # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
-    notes = {p: _creds_note(p) for p in with_creds}
+    notes = {p: creds_note(p) for p in with_creds}
     provider_default = default_provider or (with_creds[0] if with_creds else None)
     while True:
         provider = _select(
@@ -253,7 +253,7 @@ def select_provider_and_model(
             interactive=interactive,
             notes=notes,
         )
-        _ensure_credentials(console, ask_secret, provider)
+        ensure_credentials(console, ask_secret, provider)
         model = _select(
             console,
             ask,
@@ -455,7 +455,7 @@ def run_build_wizard(
         if embed_models is None:
             break  # offline hashing embedder: nothing to verify
         if embed_provider != provider:
-            _ensure_credentials(console, ask_secret, embed_provider)
+            ensure_credentials(console, ask_secret, embed_provider)
         embed_model = _select(
             console,
             ask,
@@ -692,19 +692,19 @@ def _provider_env_vars(provider: str) -> list[str]:
         return []
 
 
-def _creds_note(provider: str) -> str:
+def creds_note(provider: str) -> str:
     """Picker annotation for a provider whose credentials are present, naming what was found."""
     env_vars = _provider_env_vars(provider)
     return f"{env_vars[0]} set" if len(env_vars) == 1 else "creds set"
 
 
-def _has_credentials(provider: str) -> bool:
+def has_credentials(provider: str) -> bool:
     """Offline presence check: every credential env var for `provider` is set (not validated)."""
     env_vars = _provider_env_vars(provider)
     return bool(env_vars) and all(os.environ.get(var) for var in env_vars)
 
 
-def _ensure_credentials(console: Console, ask_secret: PromptReader, provider: str) -> None:
+def ensure_credentials(console: Console, ask_secret: PromptReader, provider: str) -> None:
     """Prompt for any missing credential env vars and persist entered values to `.env`.
 
     Presence only — the live ping that confirms the creds actually work happens once before
@@ -736,11 +736,16 @@ def select_option(
     options: list[str],
     *,
     notes: dict[str, str] | None = None,
+    default: str | None = None,
     reader: PromptReader | None = None,
 ) -> str:
-    """Pick one of `options` (arrow-key picker on a TTY, numbered prompt otherwise)."""
+    """Pick one of `options` (arrow-key picker on a TTY, numbered prompt otherwise).
+
+    `default` is the Enter-default; None keeps the historic behavior of requiring an explicit
+    pick. `notes` annotates an option with a dim suffix (e.g. which credential was found).
+    """
     ask = reader if reader is not None else (lambda text: console.input(text))
-    return _select(console, ask, label, options, None, interactive=True, notes=notes)
+    return _select(console, ask, label, options, default, interactive=True, notes=notes)
 
 
 def select_model(

--- a/wmo/providers/catalog.py
+++ b/wmo/providers/catalog.py
@@ -1,0 +1,179 @@
+"""What models each provider kind can offer, so nothing has to ship a second hardcoded roster.
+
+`wmo providers set` registers routing candidates, which means answering "which models can I pick
+from this provider". Three sources answer it, and `ProviderCatalog.source` records which one did
+so the CLI can say where its list came from:
+
+- `PUBLISHED`: the provider's own catalog. OpenRouter is the one backend that publishes a
+  complete and PRICED list (`GET /api/v1/models`), and `wmo.providers.openrouter_pricing`
+  already fetches, normalizes, and caches it, so this reuses that seam rather than fetching
+  again.
+- `BUILT_IN`: WMO's canonical `ProviderModel` registry (`wmo.providers.models`), the same table
+  the worker picker and every capability lookup already resolve against.
+- `NONE`: there is nothing to enumerate (Tinker names weights, not a catalog).
+
+Only OpenRouter is `PUBLISHED` on purpose. The other vendors' list endpoints answer a different
+question than this one asks: OpenAI's `GET /v1/models` returns embeddings, speech, and moderation
+models beside the chat ones, so filtering it back down to routable candidates would need exactly
+the hardcoded model-name knowledge this module exists to avoid, and neither it nor Anthropic's
+publishes prices, so every enumerated row would still stop at a manual price prompt. The built-in
+registry is better data for those kinds, and a typed id covers everything either list would add.
+
+A catalog is a set of SUGGESTIONS, never a whitelist: every kind accepts a typed id, because a
+vendor's lineup moves faster than any release of this package.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmo.providers.base import ProviderKind
+from wmo.providers.models import model_types_for_provider, resolve_provider_model
+from wmo.providers.openrouter import OPENROUTER_MODELS_URL
+from wmo.providers.openrouter_pricing import price_table
+from wmo.tracking.pricing import ModelPrice, price_for
+
+
+class CatalogSource(StrEnum):
+    """Where a `ProviderCatalog`'s rows came from (see the module docstring)."""
+
+    PUBLISHED = "published"
+    BUILT_IN = "built-in"
+    NONE = "none"
+
+
+class CatalogModel(BaseModel):
+    """One offerable model: what a pool entry would put in `model`, plus what we know about it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # The provider runtime id, i.e. exactly what `PoolEntry.model` should carry.
+    id: str = Field(min_length=1)
+    # Canonical identity when `id` does not carry it (Bedrock's `us.anthropic.claude-opus-4-8`
+    # is the runtime id of the `claude-opus-4-8` model type). None when the two are the same.
+    model_type: str | None = None
+    # A price we already know, from the published catalog or the built-in table. None means the
+    # registry has to ask for one, because an unpriced candidate silently reports $0.
+    price: ModelPrice | None = None
+
+    def label(self) -> str:
+        """This row as one line of picker text: the id, and its price when one is known."""
+        if self.price is None:
+            return self.id
+        return (
+            f"{self.id}  ${self.price.input_per_mtok:g} / ${self.price.output_per_mtok:g} per Mtok"
+        )
+
+
+class ProviderCatalog(BaseModel):
+    """Everything one kind can be asked for, plus where the list came from."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ProviderKind
+    source: CatalogSource
+    models: list[CatalogModel] = Field(default_factory=list)
+    # Why the list is empty or short, written to be shown to the user as-is. Empty when the
+    # catalog is exactly what it should be.
+    detail: str = ""
+
+    def find(self, model_id: str) -> CatalogModel | None:
+        """The row whose id or model type is `model_id` (case-insensitive), else None."""
+        wanted = model_id.strip().lower()
+        for model in self.models:
+            if wanted in (model.id.lower(), (model.model_type or "").lower()):
+                return model
+        return None
+
+    def search(self, term: str) -> list[CatalogModel]:
+        """Every row whose id or model type contains `term`, case-insensitively.
+
+        Substring rather than prefix: OpenRouter ids are `vendor/model`, so "sonnet" has to reach
+        `anthropic/claude-sonnet-4.5` for the picker to be usable over 338 rows at all.
+        """
+        needle = term.strip().lower()
+        if not needle:
+            return list(self.models)
+        return [
+            model
+            for model in self.models
+            if needle in model.id.lower() or needle in (model.model_type or "").lower()
+        ]
+
+
+def list_provider_models(kind: ProviderKind) -> ProviderCatalog:
+    """Everything `kind` can offer as a routing candidate, from the best source it has.
+
+    Never raises and never blocks on more than the one bounded catalog fetch
+    `wmo.providers.openrouter_pricing` already owns: an offline machine gets an empty catalog
+    whose `detail` says so, and the caller falls back to a typed id.
+
+    Args:
+        kind: The provider backend to enumerate.
+
+    Returns:
+        The catalog, with `source` naming where its rows came from.
+    """
+    match kind:
+        case ProviderKind.OPENROUTER:
+            return _openrouter_catalog()
+        case ProviderKind.TINKER:
+            return ProviderCatalog(
+                kind=kind,
+                source=CatalogSource.NONE,
+                detail=(
+                    "tinker candidates name a BASE model (the renderer and tokenizer resolve "
+                    "from it), not a catalog entry, so type the base model id"
+                ),
+            )
+        case (
+            ProviderKind.OPENAI
+            | ProviderKind.OPENAI_RESPONSES
+            | ProviderKind.ANTHROPIC
+            | ProviderKind.BEDROCK
+            | ProviderKind.AZURE_OPENAI
+        ):
+            return _built_in_catalog(kind)
+
+
+def _openrouter_catalog() -> ProviderCatalog:
+    """OpenRouter's published catalog, from the same cached table that prices pool entries."""
+    table, detail = price_table()
+    if table is None:
+        return ProviderCatalog(
+            kind=ProviderKind.OPENROUTER, source=CatalogSource.PUBLISHED, detail=detail
+        )
+    models = [
+        CatalogModel(id=model_id, price=price) for model_id, price in sorted(table.prices.items())
+    ]
+    return ProviderCatalog(
+        kind=ProviderKind.OPENROUTER,
+        source=CatalogSource.PUBLISHED,
+        models=models,
+        detail=f"{len(models)} models published at {OPENROUTER_MODELS_URL}",
+    )
+
+
+def _built_in_catalog(kind: ProviderKind) -> ProviderCatalog:
+    """`kind`'s rows in WMO's canonical model registry, priced from the built-in table."""
+    models: list[CatalogModel] = []
+    for model_type in model_types_for_provider(kind):
+        spec = resolve_provider_model(kind, model_type)
+        models.append(
+            CatalogModel(
+                id=spec.model_id,
+                model_type=None if spec.model_id == spec.model_type else spec.model_type,
+                price=price_for(spec.model_id) or price_for(spec.model_type),
+            )
+        )
+    return ProviderCatalog(
+        kind=kind,
+        source=CatalogSource.BUILT_IN,
+        models=models,
+        detail=(
+            f"{len(models)} models from WMO's built-in registry; "
+            f"{kind.value} publishes no priced catalog, so type any id it serves"
+        ),
+    )

--- a/wmo/providers/catalog_test.py
+++ b/wmo/providers/catalog_test.py
@@ -1,0 +1,128 @@
+"""Tests for per-kind model enumeration.
+
+Never touches the network: `wmo/conftest.py` already cuts every test off from the live OpenRouter
+catalog, and the tests that need one seed a cache file at `WMO_OPENROUTER_CATALOG`.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from wmo.providers.base import ProviderKind
+from wmo.providers.catalog import (
+    CatalogModel,
+    CatalogSource,
+    ProviderCatalog,
+    list_provider_models,
+)
+from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+from wmo.tracking.pricing import ModelPrice
+
+_FAKE_PRICES = {
+    "anthropic/claude-sonnet-4.5": ModelPrice(input_per_mtok=3.0, output_per_mtok=15.0),
+    "deepseek/deepseek-v3.2": ModelPrice(input_per_mtok=0.27, output_per_mtok=0.4),
+    "qwen/qwen3-coder": ModelPrice(input_per_mtok=0.3, output_per_mtok=1.2),
+}
+
+
+@pytest.fixture
+def openrouter_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Seed a fresh OpenRouter price cache so enumeration reads it instead of the network."""
+    path = tmp_path / "openrouter-prices.json"
+    catalog = PriceCatalog(fetched_at=time.time(), source="test fixture", prices=_FAKE_PRICES)
+    path.write_text(catalog.model_dump_json(), encoding="utf-8")
+    monkeypatch.setenv(CATALOG_PATH_ENV, str(path))
+    return path
+
+
+def test_openrouter_enumerates_its_published_catalog(openrouter_cache: Path) -> None:
+    # The launch promise is "pass in an OpenRouter key": the picker must offer everything
+    # OpenRouter fronts, priced, without a second fetch or a shipped list of names.
+    catalog = list_provider_models(ProviderKind.OPENROUTER)
+    assert catalog.source is CatalogSource.PUBLISHED
+    assert [model.id for model in catalog.models] == sorted(_FAKE_PRICES)
+    sonnet = catalog.find("anthropic/claude-sonnet-4.5")
+    assert sonnet is not None
+    assert sonnet.price == _FAKE_PRICES["anthropic/claude-sonnet-4.5"]
+
+
+def test_openrouter_degrades_to_an_empty_catalog_with_the_reason() -> None:
+    # Offline with nothing cached, enumeration must not raise: the picker falls back to a typed
+    # id and shows why there is no list. (conftest already points the cache at a missing path.)
+    catalog = list_provider_models(ProviderKind.OPENROUTER)
+    assert catalog.models == []
+    assert "unreachable" in catalog.detail
+
+
+def test_bedrock_rows_carry_the_runtime_id_and_the_canonical_type() -> None:
+    # A pool entry's `model` is the wire id; capability and price lookups need the model type
+    # too, and only Bedrock's ids differ from it.
+    catalog = list_provider_models(ProviderKind.BEDROCK)
+    assert catalog.source is CatalogSource.BUILT_IN
+    opus = catalog.find("claude-opus-4-8")
+    assert opus is not None
+    assert opus.id == "us.anthropic.claude-opus-4-8"
+    assert opus.model_type == "claude-opus-4-8"
+    assert opus.price is not None
+
+
+def test_azure_rows_do_not_repeat_the_id_as_a_model_type() -> None:
+    # model_type is only carried when it adds something; repeating the id would write a
+    # redundant field into every Azure pool entry.
+    catalog = list_provider_models(ProviderKind.AZURE_OPENAI)
+    assert all(model.model_type is None for model in catalog.models)
+
+
+def test_tinker_has_nothing_to_enumerate_and_says_what_to_type() -> None:
+    # A tinker candidate names a BASE model so the renderer and tokenizer resolve; there is no
+    # catalog of those, and an empty list with no explanation would read as a bug.
+    catalog = list_provider_models(ProviderKind.TINKER)
+    assert catalog.source is CatalogSource.NONE
+    assert catalog.models == []
+    assert "base model" in catalog.detail
+
+
+@pytest.mark.parametrize("kind", list(ProviderKind))
+def test_every_kind_enumerates_without_raising(kind: ProviderKind) -> None:
+    # The picker calls this for whichever backend the user chose; a kind added later must not
+    # fall off the end of the match and return None.
+    catalog = list_provider_models(kind)
+    assert catalog.kind is kind
+
+
+def test_search_matches_a_substring_of_a_vendor_prefixed_id(openrouter_cache: Path) -> None:
+    # 338 models are not a scrollable list, and every id is `vendor/model`, so a prefix match
+    # would make "sonnet" find nothing.
+    catalog = list_provider_models(ProviderKind.OPENROUTER)
+    assert [model.id for model in catalog.search("SONNET")] == ["anthropic/claude-sonnet-4.5"]
+    assert len(catalog.search("")) == len(catalog.models)
+    assert catalog.search("no-such-model") == []
+
+
+def test_search_also_matches_the_canonical_model_type() -> None:
+    # Bedrock's ids carry routing prefixes, so searching for what the docs call the model has
+    # to reach `us.anthropic.claude-haiku-4-5-...`.
+    catalog = list_provider_models(ProviderKind.BEDROCK)
+    assert any(model.model_type == "claude-haiku-4-5" for model in catalog.search("haiku"))
+
+
+def test_label_shows_a_price_only_when_one_is_known() -> None:
+    priced = CatalogModel(id="x/y", price=ModelPrice(input_per_mtok=1.5, output_per_mtok=6.0))
+    assert priced.label() == "x/y  $1.5 / $6 per Mtok"
+    assert CatalogModel(id="x/y").label() == "x/y"
+
+
+def test_find_is_case_insensitive_on_both_identities() -> None:
+    # Azure deployments are routinely created with vendor casing, and a user retyping an id
+    # from a dashboard must not get "no match" for a model that is right there.
+    catalog = ProviderCatalog(
+        kind=ProviderKind.BEDROCK,
+        source=CatalogSource.BUILT_IN,
+        models=[CatalogModel(id="us.anthropic.Claude-Opus", model_type="Claude-Opus")],
+    )
+    assert catalog.find("us.anthropic.claude-opus") is not None
+    assert catalog.find("CLAUDE-OPUS") is not None
+    assert catalog.find("opus") is None

--- a/wmo/providers/openrouter_pricing.py
+++ b/wmo/providers/openrouter_pricing.py
@@ -244,6 +244,20 @@ def _catalog() -> tuple[PriceCatalog | None, str]:
     )
 
 
+def price_table() -> tuple[PriceCatalog | None, str]:
+    """The whole published table, or None and the reason there is none. Never raises.
+
+    `resolve_price` answers one id; this exposes the same cached table to a caller that needs to
+    ENUMERATE it (the pool registry's model picker: OpenRouter is the one backend that publishes
+    a complete, priced catalog, and a picker over 338 models must not fetch it a second time).
+    Identical caching, identical one-fetch-per-process bound, identical degradation.
+
+    Returns:
+        The table and an empty string, or None and a clause naming the catalog failure.
+    """
+    return _catalog()
+
+
 def resolve_price(model: str) -> PriceResolution:
     """Look up `model`'s published price. Never raises, never blocks past one fetch.
 


### PR DESCRIPTION
## The problem

The router picks candidates out of `.wmo/pool.toml`. **Nothing wrote that file for an ordinary provider model.** `upsert_pool_entry` existed, locked and validated, but its only caller was `wmo optimize route student`, which adds a distilled student. Anyone who wanted five OpenRouter models and five Azure deployments hand-authored TOML and got `kind`, `model`, prices, `deployment`, `api_version`, and `api_key_env` right unaided.

`wmo providers set` answered the neighbouring question ("which provider runs my worker agent"), wrote `[models.worker]`, and never touched the pool. So "which providers am I set up with" and "which models can the router choose from" were two unconnected concepts.

## The UX, and why

I extended `set` rather than adding `wmo providers add`. The two questions are the same question asked twice: a user who has just proved a provider works is exactly the user who should be asked which of its models the router may use, and the credentials, endpoint, region, deployment, and api-version needed for the pool entry are the ones the command just collected and verified. A separate subcommand would re-ask all of it.

The flow, after the existing pick-and-verify step is untouched:

```
set local worker provider to openrouter (...) in .wmo/settings.toml

routing pool (.wmo/pool.toml)
  handle             kind        model                        $/Mtok in/out  tier
  claude-sonnet-4.5  openrouter  anthropic/claude-sonnet-4.5           1 / 5  open

Register models the router can choose from? (Y/n): y
Register models from: [openrouter]
openrouter published catalog: 338 models published at https://openrouter.ai/api/v1/models
models (search / numbers / blank when done)> deepseek
  1. deepseek/deepseek-r1  $8 / $40 per Mtok
  2. deepseek/deepseek-v3.2  $7 / $35 per Mtok
models (search / numbers / blank when done)> 1 2
  + deepseek/deepseek-r1
  + deepseek/deepseek-v3.2
models (search / numbers / blank when done)>
Tier: open
Env var holding the API key (blank = OPENROUTER_API_KEY):
verifying openrouter (deepseek/deepseek-r1)...
  ✓ openrouter (deepseek/deepseek-r1) reachable
Handle for deepseek/deepseek-r1 [deepseek-r1]:
  ✓ added deepseek-r1 (openrouter deepseek/deepseek-r1, $8/$40 per Mtok)
  ...
Register models from another provider? (y/N): y
```

Six decisions worth naming:

1. **The roster is shown first and last.** A registry a user cannot see is a registry they will duplicate. `providers set` is now also the "what can the router choose from" view, which nothing else was.
2. **Search comes before the list.** 338 OpenRouter models cannot be a scrollable picker, and the existing arrow picker refuses anything taller than the terminal. One loop handles every backend: a term filters, numbers toggle from the matches (capped at 20 with a "refine the search" line), an exact id picks directly, blank finishes. A term that matches nothing offers to take the line as a literal id, so a model published after this release is never unreachable. With no catalog at all (Tinker) the typed line simply IS the id.
3. **The backend is picked inside the registry, defaulting to the one just set.** That is what makes "five via OpenRouter and five via Azure" one sitting, and it reaches OpenRouter at all, which the worker picker does not offer. Switching backends re-checks that backend's credentials and drops the flags that described the previous one, so an Azure api-version can never land on an OpenRouter entry.
4. **Only what the kind needs is asked.** Shared-per-pass questions (tier, `api_key_env`, Bedrock region) are asked once; genuinely per-model ones (an Azure deployment name, a missing price) are asked per model. `needs_price` asks the same two questions `PoolEntry._validate_price` asks, in the same order, so the prompt appears exactly when the entry would be rejected without an answer. A parametrized test pins that equivalence over every catalog row of every kind.
5. **Every candidate is proved before it is written.** One cheap ping per candidate, over that entry's own route (endpoint, deployment, region) and through `pool_provider` so its own `api_key_env` account is the one proved. Per candidate rather than per pass because a pass is not one route: on Azure every candidate names a different deployment. A failure is reported and the user decides per candidate, since a roster is legitimately built on a machine that does not hold the key.
6. **`upsert_pool_entry` is the only writer.** This code never opens `pool.toml` for writing, so it inherits the cross-process lock, the whole-roster revalidation, and the atomic replace.

## Enumeration, per kind

| kind | source | behaviour |
|---|---|---|
| `openrouter` | its own published catalog | `GET /api/v1/models` through the existing `wmo.providers.openrouter_pricing` cache (new public `price_table()` over the same `_catalog()`), so the picker shares the one-fetch-per-process bound, the 24h disk cache, and the offline degradation. Rows carry published prices, and no price is ever prompted. |
| `openai`, `openai_responses`, `anthropic`, `bedrock`, `azure` | WMO's canonical `ProviderModel` registry | The same table every capability lookup already resolves against, priced from `wmo.tracking.pricing`. Bedrock rows carry the runtime id (`us.anthropic.claude-opus-4-8`) plus the model type, so the written entry is callable. |
| `tinker` | none | A tinker candidate names a BASE model, not a catalog entry; the prompt says so and takes the typed id. |

No new hardcoded list of model names ships anywhere in this diff, and no catalog is a whitelist: every kind accepts a typed id.

**Why only OpenRouter enumerates live.** OpenAI's `GET /v1/models` returns embeddings, speech, and moderation models beside the chat ones, so filtering it back down to routable candidates needs exactly the hardcoded model-name knowledge this change exists to avoid; and neither it nor Anthropic's list publishes prices, so every enumerated row would still stop at a manual price prompt. The built-in registry is strictly better data for those kinds. That reasoning is recorded in `wmo/providers/catalog.py`'s module docstring, not just here.

## Re-running

- The roster is printed before anything is asked, and the picker annotates each row that is already registered with the handle it carries (`(in pool as claude-sonnet-4.5)`).
- Re-picking a registered model reuses its existing handle instead of inventing a second one. Identity is `(kind, model, deployment, api_key_env)`, so a deliberate multi-account pool still gets two entries (`claude-sonnet-4.5` and `claude-sonnet-4.5-2`).
- An entry the roster already holds **verbatim is not written at all**. `upsert_pool_entry` treats a same-name entry as a replacement, which re-renders the whole file; writing an identical entry would reorder the roster and drop its comments to change nothing. A repeat pass therefore leaves `pool.toml` byte-identical and reports `already registered, unchanged`.
- Typing a handle that names a DIFFERENT entry warns what it would replace (and that comments do not survive) and confirms before doing it.

## Scriptability

`--provider` + `--model` behaves exactly as before: nothing is prompted, nothing is written but settings (covered by a regression test). Non-interactive registration is `--pool-model <id>`, repeated per model, resolved through the same catalog so a scripted run gets the same canonical ids and published prices a person would. The other new flags map 1:1 to `PoolEntry` fields the command did not already have (`--pool`, `--api-key-env`, `--tier`, `--input-per-mtok`, `--output-per-mtok`); `--endpoint`, `--deployment`, `--api-version`, and `--region` were already there and are reused.

Scripted candidates are held to the same standard as interactive ones: the whole batch is built and live-pinged before any of it is written, so a bad third id cannot leave half a roster behind. Four things it refuses rather than guesses, because there is nobody to ask: a model with no built-in or published price (a $0 candidate wins every cost-aware routing decision), half a price pair, a candidate that does not answer its ping, and an Azure `--pool-model` with no `--deployment` or with one `--deployment` shared across several ids (an Azure deployment name is operator-chosen, is what every request names as its model, and cannot be derived from a model id).

## Verification

Driven end to end, not just unit tested: a local OpenAI-compatible stub server so the real installed `wmo providers set` could verify a provider over the wire, write `settings.toml` and `pool.toml`, be re-run to a byte-identical roster, and have every written entry pass `prepare_pool_provider` (the pre-flight `wmo optimize route sweep` runs). The interactive flow was driven with a scripted reader against a fake catalog and the resulting TOML read back through `load_pool`.

Gates, all local (CI runs no tests): `3636 passed, 18 skipped` against a `3566 passed, 18 skipped` baseline on the `main` this is rebased onto; `ruff check .`, `ruff format --check wmo/`, and `ty check` all clean.

Tests are inline siblings (`catalog_test.py`, `pool_registry_test.py`, plus `app_test.py` additions), drive the prompts through a scripted input stream, and assert against the roster the run actually wrote. Nothing reaches the network: the OpenRouter catalog is faked through the same disk cache the resolver reads, and `verify_pool_entry` is replaced with a refusal in the registry tests (the same rule `wmo/conftest.py` applies to the price catalog), so a test that forgets to inject a ping fails loudly rather than quietly calling openrouter.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
