### PR TITLE
Fix `wmo download`: fall back to the pre-rename `wmh-` dataset repos

### DIFF
--- a/packages/environment-capture/README.md
+++ b/packages/environment-capture/README.md
@@ -89,8 +89,9 @@ from environment_capture import (
 python -m environment_capture.hub fetch dabstep
 python -m environment_capture.hub fetch all --force   # explicit overwrite
 
-# or straight from the Hub with no dependencies at all
-curl -LO https://huggingface.co/datasets/experiential-labs/wmo-dabstep-traces/resolve/main/traces.otel.jsonl
+# or straight from the Hub with no dependencies at all (the org's repos still carry the
+# pre-rename `wmh-` prefix; `fetch` tries `wmo-` first and falls back to it)
+curl -LO https://huggingface.co/datasets/experiential-labs/wmh-dabstep-traces/resolve/main/traces.otel.jsonl
 ```
 
 Fetching is plain-HTTP stdlib: no extra dependency, no token for public repos, per-chunk

--- a/packages/environment-capture/environment_capture/hub.py
+++ b/packages/environment-capture/environment_capture/hub.py
@@ -27,7 +27,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from http.client import HTTPMessage
 from pathlib import Path
@@ -40,6 +40,17 @@ _CORPUS_FILE = "traces.otel.jsonl"
 # Honors enterprise/mirror endpoints the way huggingface_hub does.
 _HUB = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")
 _CHUNK_BYTES = 1 << 20
+
+# Dataset-repo name prefixes, most-preferred first. LEGACY FALLBACK: the project renamed
+# `wmh` -> `wmo`, but the org's dataset repos on the Hub are still published under the old
+# `wmh-<benchmark>-traces` name, so every read must try both. Once the Hub repos are renamed,
+# drop "wmh" from this tuple and the fallback disappears with it.
+_REPO_PREFIXES = ("wmo", "wmh")
+_REPO_SUFFIX = "-traces"
+# What the Hub answers for a repo id that does not resolve: 404 anonymously, 401 when a token
+# is attached (it will not admit a repo is missing to a caller that might lack access), 403
+# for a gated repo. Any of these means "try the next candidate name", not "the Hub is broken".
+_MISSING_REPO_CODES = frozenset({401, 403, 404})
 
 # on_progress(bytes_done, bytes_total): called after every streamed chunk, across ALL files in
 # the fetch (front-ends render one bar for the whole bundle).
@@ -182,9 +193,63 @@ class PublishedCorpus:
     last_modified: str  # ISO date, "" when the Hub omits it
 
 
+class CorpusRepoUnavailable(urllib.error.HTTPError):
+    """Every candidate dataset repo for one benchmark was refused by the Hub.
+
+    Subclasses ``HTTPError`` so front-ends that already catch it (``wmo download`` skips the
+    benchmark and keeps fetching the rest) behave exactly as before. A bare code cannot say
+    WHICH name was wrong once there is more than one candidate, so the message and
+    ``attempted`` name every repo id that was tried.
+    """
+
+    def __init__(
+        self,
+        benchmark: str,
+        revision: str,
+        failures: Sequence[tuple[str, urllib.error.HTTPError]],
+    ) -> None:
+        """Build the combined error from each (repo id, Hub refusal) attempt, in order."""
+        last = failures[-1][1]
+        tried = ", ".join(f"{repo_id} answered {error.code}" for repo_id, error in failures)
+        super().__init__(
+            last.url,
+            last.code,
+            f"no dataset repo for {benchmark!r} at revision {revision!r}: {tried}",
+            last.headers,
+            None,
+        )
+        self.attempted: tuple[str, ...] = tuple(repo_id for repo_id, _ in failures)
+
+
 def repo_id_for(benchmark: str) -> str:
-    """The dataset repo backing one benchmark's corpus."""
-    return f"{_ORG}/wmo-{benchmark}-traces"
+    """The canonical dataset repo backing one benchmark's corpus (the id we publish to)."""
+    return candidate_repo_ids(benchmark)[0]
+
+
+def candidate_repo_ids(benchmark: str) -> tuple[str, ...]:
+    """Every dataset repo id that may hold this benchmark's bundle, most-preferred first.
+
+    Reads walk this tuple and take the first id the Hub resolves; see ``_REPO_PREFIXES`` for
+    why there is more than one.
+    """
+    return tuple(f"{_ORG}/{prefix}-{benchmark}{_REPO_SUFFIX}" for prefix in _REPO_PREFIXES)
+
+
+def _benchmark_from_repo_name(name: str) -> str | None:
+    """The benchmark a bare repo name encodes, or ``None`` when it is not a corpus repo.
+
+    Args:
+        name: Repo name without the org prefix, e.g. ``wmo-gaia2-traces``.
+
+    Returns:
+        The benchmark name, or ``None`` when ``name`` matches no known prefix convention.
+    """
+    if not name.endswith(_REPO_SUFFIX):
+        return None
+    for prefix in _REPO_PREFIXES:
+        if name.startswith(f"{prefix}-"):
+            return name[len(prefix) + 1 : -len(_REPO_SUFFIX)]
+    return None
 
 
 def corpus_path(benchmark: str) -> Path:
@@ -199,28 +264,30 @@ def corpus_path(benchmark: str) -> Path:
 def published_corpora(*, token: str | None = None) -> list[PublishedCorpus]:
     """The org's live corpus datasets (Hub REST API), newest first, mapped to benchmark names.
 
-    Only repos that follow the ``wmo-<benchmark>-traces`` convention AND appear in the local
-    manifest are returned — those are the ones ``fetch_corpus`` knows where to place.
+    Only repos that follow a ``<prefix>-<benchmark>-traces`` convention (see
+    ``_REPO_PREFIXES``) AND appear in the local manifest are returned: those are the ones
+    ``fetch_corpus`` knows where to place. A benchmark published under two prefixes at once
+    (mid-rename) is listed once, under the most-preferred repo.
     """
     token = token if token is not None else _default_token()
     listing = _http_json_pages(f"{_HUB}/api/datasets?author={_ORG}&limit=100", token=token)
-    published: list[PublishedCorpus] = []
+    by_benchmark: dict[str, PublishedCorpus] = {}
     for entry in listing:
         if not isinstance(entry, dict):
             continue
         repo_id = str(entry.get("id", ""))
-        name = repo_id.removeprefix(f"{_ORG}/")
-        if not (name.startswith("wmo-") and name.endswith("-traces")):
+        benchmark = _benchmark_from_repo_name(repo_id.removeprefix(f"{_ORG}/"))
+        if benchmark is None or benchmark not in CORPORA:
             continue
-        benchmark = name.removeprefix("wmo-").removesuffix("-traces")
-        if benchmark not in CORPORA:
-            continue
+        candidates = candidate_repo_ids(benchmark)
+        kept = by_benchmark.get(benchmark)
+        if kept is not None and candidates.index(kept.repo_id) <= candidates.index(repo_id):
+            continue  # already listed under a more-preferred repo name
         modified = str(entry.get("lastModified") or "")
-        published.append(
-            PublishedCorpus(benchmark=benchmark, repo_id=repo_id, last_modified=modified[:10])
+        by_benchmark[benchmark] = PublishedCorpus(
+            benchmark=benchmark, repo_id=repo_id, last_modified=modified[:10]
         )
-    published.sort(key=lambda c: c.last_modified, reverse=True)
-    return published
+    return sorted(by_benchmark.values(), key=lambda c: c.last_modified, reverse=True)
 
 
 def fetch_corpus(
@@ -242,20 +309,20 @@ def fetch_corpus(
     streamed chunk across the whole bundle.
 
     Raises ``ValueError`` for unknown/unpublished corpora and ``urllib.error.URLError`` (incl.
-    ``HTTPError``) when the Hub is unreachable — front-ends translate those for their users.
+    ``HTTPError``, and ``CorpusRepoUnavailable`` when no candidate repo id resolves) when the
+    Hub is unreachable: front-ends translate those for their users.
     """
     spec = CORPORA.get(benchmark)
     if spec is None:
         publishable = ", ".join(sorted(CORPORA))
         raise ValueError(f"{benchmark!r} has no published corpus (available: {publishable})")
     token = token if token is not None else _default_token()
-    repo_id = repo_id_for(benchmark)
     root = _data_root()
     target = dest or corpus_path(benchmark)
 
     # One recursive tree call covers the whole repo; sizes make the total known up front so a
     # single progress bar can span the bundle.
-    sizes = dict(_repo_tree(repo_id, revision, token=token))
+    repo_id, sizes = _resolve_repo(benchmark, revision, token=token)
     work: list[tuple[str, Path, int]] = []
     if not target.exists() or force:
         if _CORPUS_FILE not in sizes:
@@ -312,6 +379,31 @@ def fetch_corpus(
                 "truncated transfer; re-run the fetch"
             )
     return target
+
+
+def _resolve_repo(
+    benchmark: str, revision: str, *, token: str | None
+) -> tuple[str, dict[str, int]]:
+    """The repo id that actually serves this benchmark, plus its file tree (path -> size).
+
+    Catch-and-retry over ``candidate_repo_ids``, not probe-then-fetch: the tree call the fetch
+    already needs IS the existence check, so the preferred id costs exactly one request and
+    only a miss pays for a second lookup. The resolved id is returned so every file in the
+    bundle streams from the same repo the tree came from.
+
+    Raises:
+        CorpusRepoUnavailable: every candidate id was refused (404/401/403), naming them all.
+        urllib.error.HTTPError: any other Hub failure, from the first candidate that hit it.
+    """
+    failures: list[tuple[str, urllib.error.HTTPError]] = []
+    for repo_id in candidate_repo_ids(benchmark):
+        try:
+            return repo_id, dict(_repo_tree(repo_id, revision, token=token))
+        except urllib.error.HTTPError as error:
+            if error.code not in _MISSING_REPO_CODES:
+                raise
+            failures.append((repo_id, error))
+    raise CorpusRepoUnavailable(benchmark, revision, failures)
 
 
 def _data_root() -> Path:

--- a/packages/environment-capture/environment_capture/hub_test.py
+++ b/packages/environment-capture/environment_capture/hub_test.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import urllib.error
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Callable, Container
+from dataclasses import dataclass, field
+from http.client import HTTPMessage
 from pathlib import Path
 
 import pytest
 
 from environment_capture import hub
-from environment_capture.hub import CORPORA, fetch_corpus, published_corpora, repo_id_for
+from environment_capture.hub import (
+    CORPORA,
+    CorpusRepoUnavailable,
+    candidate_repo_ids,
+    fetch_corpus,
+    published_corpora,
+    repo_id_for,
+)
 
 
 @pytest.fixture()
@@ -18,11 +28,42 @@ def data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def _fake_hub(monkeypatch: pytest.MonkeyPatch, files: dict[str, bytes]) -> None:
-    """Stand in for the Hub REST API: a tree listing plus resolve-URL streaming."""
+@dataclass
+class _HubCalls:
+    """The repo ids the fake Hub was asked for, in order (one entry per request)."""
+
+    trees: list[str] = field(default_factory=list)
+    resolves: list[str] = field(default_factory=list)
+
+
+def _fake_hub(
+    monkeypatch: pytest.MonkeyPatch,
+    files: dict[str, bytes],
+    *,
+    live_repos: Container[str] | None = None,
+    missing_code: int = 404,
+) -> _HubCalls:
+    """Stand in for the Hub REST API: a tree listing plus resolve-URL streaming.
+
+    Args:
+        monkeypatch: The patcher used to swap the module's HTTP seams.
+        files: Repo path -> content, served by every live repo.
+        live_repos: Repo ids that resolve; every other id answers ``missing_code``. ``None``
+            (the default) means every id resolves.
+        missing_code: Status the Hub returns for a repo id outside ``live_repos``.
+
+    Returns:
+        A live record of the repo ids requested, so a test can assert the request COUNT and
+        not just the downloaded bytes.
+    """
+    calls = _HubCalls()
 
     def http_json_page(url: str, *, token: str | None) -> tuple[object, None]:
         assert "/api/datasets/" in url and "/tree/main?recursive=true" in url
+        repo_id = url.split("/api/datasets/", 1)[1].split("/tree/", 1)[0]
+        calls.trees.append(repo_id)
+        if live_repos is not None and repo_id not in live_repos:
+            raise urllib.error.HTTPError(url, missing_code, "not found", HTTPMessage(), None)
         listing = [
             {"type": "file", "path": path, "size": len(content)} for path, content in files.items()
         ]
@@ -31,6 +72,7 @@ def _fake_hub(monkeypatch: pytest.MonkeyPatch, files: dict[str, bytes]) -> None:
     def stream_to(
         url: str, dest: Path, *, token: str | None, chunk_done: Callable[[int], None]
     ) -> int:
+        calls.resolves.append(url.split("/datasets/", 1)[1].split("/resolve/", 1)[0])
         remote_path = urllib.parse.unquote(url.split("/resolve/main/", 1)[1])
         dest.parent.mkdir(parents=True, exist_ok=True)
         content = files[remote_path]
@@ -40,6 +82,7 @@ def _fake_hub(monkeypatch: pytest.MonkeyPatch, files: dict[str, bytes]) -> None:
 
     monkeypatch.setattr(hub, "_http_json_page", http_json_page)
     monkeypatch.setattr(hub, "_stream_to", stream_to)
+    return calls
 
 
 def test_fetch_downloads_corpus_and_data_dirs_with_one_progress_bar(
@@ -97,6 +140,78 @@ def test_fetch_with_dest_writes_only_the_corpus_file(
     assert not (data_root / "gaia2" / "data").exists()
 
 
+def test_fetch_falls_back_to_the_legacy_repo_name(
+    data_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The org's datasets are still published under the pre-rename ``wmh-`` name (the code
+    renamed wmh -> wmo, the Hub repos did not), so the canonical id 404s and the whole bundle
+    must come from the legacy repo instead of failing the download."""
+    canonical, legacy = candidate_repo_ids("gaia2")
+    calls = _fake_hub(
+        monkeypatch,
+        {"traces.otel.jsonl": b"spans\n", "data/train.jsonl": b"tasks\n"},
+        live_repos={legacy},
+    )
+
+    path = fetch_corpus("gaia2")
+
+    assert path.read_bytes() == b"spans\n"
+    assert (data_root / "gaia2" / "data" / "train.jsonl").read_bytes() == b"tasks\n"
+    assert calls.trees == [canonical, legacy]
+    # every file streams from the repo that actually resolved, not the preferred name
+    assert set(calls.resolves) == {legacy}
+
+
+def test_fetch_asks_once_when_the_canonical_repo_resolves(
+    data_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Catch-and-retry, not probe-then-fetch: once the Hub repos are renamed the fallback
+    costs nothing, because a resolving canonical id is never followed by a legacy lookup."""
+    canonical, _legacy = candidate_repo_ids("gaia2")
+    calls = _fake_hub(monkeypatch, {"traces.otel.jsonl": b"spans\n"}, live_repos={canonical})
+
+    fetch_corpus("gaia2")
+
+    assert calls.trees == [canonical]
+
+
+@pytest.mark.parametrize("code", [404, 401])
+def test_fetch_names_every_repo_id_it_tried_when_none_resolve(
+    data_root: Path, monkeypatch: pytest.MonkeyPatch, code: int
+) -> None:
+    """A miss on BOTH names is a real error (404 anonymously, 401 with a token attached), and
+    it has to say which ids were looked for or the user cannot tell what to publish."""
+    calls = _fake_hub(
+        monkeypatch, {"traces.otel.jsonl": b"spans\n"}, live_repos=set(), missing_code=code
+    )
+
+    with pytest.raises(CorpusRepoUnavailable) as caught:
+        fetch_corpus("gaia2")
+
+    assert isinstance(caught.value, urllib.error.HTTPError)  # front-ends still catch it
+    assert caught.value.code == code
+    assert caught.value.attempted == candidate_repo_ids("gaia2")
+    assert all(repo_id in str(caught.value) for repo_id in candidate_repo_ids("gaia2"))
+    assert calls.trees == list(candidate_repo_ids("gaia2"))
+
+
+def test_fetch_does_not_try_another_name_on_a_non_missing_hub_error(
+    data_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rate limiting is the Hub misbehaving, not the wrong repo name: surface it as-is rather
+    than burning a second request and reporting it as an unpublished corpus."""
+    calls = _fake_hub(
+        monkeypatch, {"traces.otel.jsonl": b"spans\n"}, live_repos=set(), missing_code=429
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        fetch_corpus("gaia2")
+
+    assert not isinstance(caught.value, CorpusRepoUnavailable)
+    assert caught.value.code == 429
+    assert calls.trees == [repo_id_for("gaia2")]
+
+
 def test_fetch_unknown_benchmark_names_the_available_ones(data_root: Path) -> None:
     with pytest.raises(ValueError, match="no published corpus"):
         fetch_corpus("nope")
@@ -135,6 +250,43 @@ def test_published_corpora_maps_repos_to_benchmarks(monkeypatch: pytest.MonkeyPa
         ("bird-sql", "2026-07-05"),
     ]
     assert published[0].repo_id == repo_id_for("gaia2")
+
+
+def test_published_corpora_accepts_the_legacy_repo_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`wmo download` with no arguments lists what the org publishes; everything it publishes
+    today still carries the pre-rename ``wmh-`` prefix, and dropping those empties the picker."""
+    listing = [
+        {"id": "experiential-labs/wmh-gaia2-traces", "lastModified": "2026-07-07T06:00:00.000Z"},
+        {
+            "id": "experiential-labs/wmh-bird-sql-traces",
+            "lastModified": "2026-07-05T00:00:00.000Z",
+        },
+        {"id": "experiential-labs/unrelated-dataset", "lastModified": "2026-07-06T00:00:00.000Z"},
+        {"id": "experiential-labs/wmh-not-a-benchmark-traces", "lastModified": ""},
+    ]
+    monkeypatch.setattr(hub, "_http_json_page", lambda url, *, token: (listing, None))
+
+    published = published_corpora()
+    assert [(c.benchmark, c.repo_id) for c in published] == [
+        ("gaia2", "experiential-labs/wmh-gaia2-traces"),
+        ("bird-sql", "experiential-labs/wmh-bird-sql-traces"),
+    ]
+
+
+def test_published_corpora_lists_a_double_published_benchmark_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-rename both repo names can exist at once; the picker shows one row per benchmark,
+    under the canonical id (which is also the one a fetch resolves first)."""
+    listing = [
+        {"id": "experiential-labs/wmh-gaia2-traces", "lastModified": "2026-07-01T00:00:00.000Z"},
+        {"id": "experiential-labs/wmo-gaia2-traces", "lastModified": "2026-07-07T00:00:00.000Z"},
+    ]
+    monkeypatch.setattr(hub, "_http_json_page", lambda url, *, token: (listing, None))
+
+    assert [(c.benchmark, c.repo_id) for c in published_corpora()] == [
+        ("gaia2", repo_id_for("gaia2"))
+    ]
 
 
 def test_every_committed_corpus_is_publishable_or_documented_local_only() -> None:

--- a/packages/environment-capture/pyproject.toml
+++ b/packages/environment-capture/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "environment-capture"
-version = "0.1.0"
+version = "0.1.1"
 description = "Run benchmarks for real and record agent-environment transitions as OTel GenAI JSONL."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ wheels = [
 
 [[package]]
 name = "environment-capture"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/environment-capture" }
 
 [package.optional-dependencies]

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -25,7 +25,6 @@ import typer
 import uvicorn
 from environment_capture.hub import (
     CORPORA,
-    CorpusRepoUnavailable,
     corpus_path,
     fetch_corpus,
     published_corpora,
@@ -934,8 +933,12 @@ def download(
             raise typer.BadParameter(str(exc)) from exc
         except urllib.error.HTTPError as exc:
             # One unpublished/broken dataset must not abort the REST of a multi-download:
-            # record it, keep fetching, and fail (with every name) at the end.
-            failures.append(f"{name}: {_hub_failure_detail(exc)}")
+            # record it, keep fetching, and fail (with every name) at the end. The reason is
+            # quoted rather than summarized here: a fetch tries more than one dataset repo id
+            # and only the error it raises knows which ones the Hub refused. Reading it off
+            # plain HTTPError attributes keeps this working against the PUBLISHED
+            # environment-capture, which the WMO wheel resolves from PyPI.
+            failures.append(f"{name}: the Hub answered {exc.code} for {exc.url} ({exc.reason})")
             _console.print(f"[yellow]skipping {name}: Hub answered {exc.code}[/yellow]")
             continue
         except urllib.error.URLError as exc:
@@ -950,13 +953,6 @@ def download(
             "some datasets could not be downloaded (unpublished? `wmo download` with no "
             "arguments lists what is):\n  " + "\n  ".join(failures)
         )
-
-
-def _hub_failure_detail(exc: urllib.error.HTTPError) -> str:
-    """One line saying what the Hub refused, naming every repo id the fetch tried."""
-    if isinstance(exc, CorpusRepoUnavailable):
-        return exc.reason  # already names every attempted repo id and its code
-    return f"the Hub answered {exc.code} for {exc.url}"
 
 
 def _fetch_with_progress(name: str, *, force: bool) -> Path:

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -25,6 +25,7 @@ import typer
 import uvicorn
 from environment_capture.hub import (
     CORPORA,
+    CorpusRepoUnavailable,
     corpus_path,
     fetch_corpus,
     published_corpora,
@@ -934,7 +935,7 @@ def download(
         except urllib.error.HTTPError as exc:
             # One unpublished/broken dataset must not abort the REST of a multi-download:
             # record it, keep fetching, and fail (with every name) at the end.
-            failures.append(f"{name}: the Hub answered {exc.code} for {exc.url}")
+            failures.append(f"{name}: {_hub_failure_detail(exc)}")
             _console.print(f"[yellow]skipping {name}: Hub answered {exc.code}[/yellow]")
             continue
         except urllib.error.URLError as exc:
@@ -949,6 +950,13 @@ def download(
             "some datasets could not be downloaded (unpublished? `wmo download` with no "
             "arguments lists what is):\n  " + "\n  ".join(failures)
         )
+
+
+def _hub_failure_detail(exc: urllib.error.HTTPError) -> str:
+    """One line saying what the Hub refused, naming every repo id the fetch tried."""
+    if isinstance(exc, CorpusRepoUnavailable):
+        return exc.reason  # already names every attempted repo id and its code
+    return f"the Hub answered {exc.code} for {exc.url}"
 
 
 def _fetch_with_progress(name: str, *, force: bool) -> Path:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1367,7 +1367,9 @@ def test_download_multi_skips_a_404_and_fetches_the_rest(monkeypatch, tmp_path: 
 
 def test_download_failure_names_every_repo_id_it_tried(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
     # A fetch now tries more than one dataset repo name (the wmh -> wmo rename), so a bare
-    # "404" cannot be acted on: the report must say which ids were looked for.
+    # "404" cannot be acted on: the report must say which ids were looked for. The CLI reads
+    # that off plain HTTPError attributes (no import of the newer member symbol), so this also
+    # covers the wheel, which resolves environment-capture from PyPI.
     import urllib.error
     from http.client import HTTPMessage
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1365,6 +1365,30 @@ def test_download_multi_skips_a_404_and_fetches_the_rest(monkeypatch, tmp_path: 
     assert "broken" in result.output
 
 
+def test_download_failure_names_every_repo_id_it_tried(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
+    # A fetch now tries more than one dataset repo name (the wmh -> wmo rename), so a bare
+    # "404" cannot be acted on: the report must say which ids were looked for.
+    import urllib.error
+    from http.client import HTTPMessage
+
+    from environment_capture.hub import CorpusRepoUnavailable, candidate_repo_ids
+
+    attempts = [
+        (repo_id, urllib.error.HTTPError(f"https://hub/{repo_id}", 404, "nf", HTTPMessage(), None))
+        for repo_id in candidate_repo_ids("dabstep")
+    ]
+
+    def fetch(name, force=False, on_progress=None):  # noqa: ANN001, ANN202
+        raise CorpusRepoUnavailable(name, "main", attempts)
+
+    monkeypatch.setattr(cli_app_module, "fetch_corpus", fetch)
+    monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
+    result = runner.invoke(app, ["download", "dabstep"])
+    assert result.exit_code != 0
+    for repo_id in candidate_repo_ids("dabstep"):
+        assert repo_id in result.output
+
+
 def test_download_unknown_benchmark_is_a_usage_error(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001
     monkeypatch.setattr(cli_app_module, "corpus_path", lambda name: tmp_path / name / "missing")
     result = runner.invoke(app, ["download", "nope"])


### PR DESCRIPTION
## The bug

`wmo download <anything>` fails for **every** one of the 9 published benchmarks, which takes
`wmo eval`, `wmo examples`, `wmo demo`, `wmo play` and `wmo research concurrency` down with it:
none of them have a corpus to read.

PR #273 renamed `wmh` -> `wmo` throughout the code, including the HuggingFace dataset ids, but
**the datasets on HuggingFace were never renamed.**

```
$ wmo download tau-bench
skipping tau-bench: Hub answered 404
  tau-bench: the Hub answered 404 for .../experiential-labs/wmo-tau-bench-traces/tree/main?recursive=true

$ wmo download          # no args, the listing path
Invalid value: no published corpora found on the Hub; pass benchmark names directly
```

Live HF API, checked today:

| id | status |
| --- | --- |
| `experiential-labs/wmh-tau-bench-traces` | **200** |
| `experiential-labs/wmo-tau-bench-traces` | **401** |

`GET /api/datasets?author=experiential-labs` returns exactly 9 repos, all
`experiential-labs/wmh-<benchmark>-traces` (bird-sql, continual-learning, crmarena, dabstep,
financebench, gaia2, swe-bench, tau-bench, terminal-tasks).

## The fix

`packages/environment-capture/environment_capture/hub.py` now derives repo ids from an ordered
prefix tuple instead of a hardcoded `wmo-`:

- `candidate_repo_ids(benchmark)` -> `("<org>/wmo-<b>-traces", "<org>/wmh-<b>-traces")`,
  most-preferred first. `repo_id_for` is the first entry (still the canonical id we publish to).
- `fetch_corpus` resolves through `_resolve_repo`, which returns the id that actually served the
  tree so every file in the bundle streams from that same repo.
- The org listing accepts either prefix and strips whichever matched, so the no-args picker
  lists the 9 datasets again. A benchmark published under both names at once (mid-rename) is
  deduped to one row, under the canonical repo.
- Nothing hardcodes the benchmark names: the manifest (`CORPORA`) is still the only list.

### Fallback strategy: catch-and-retry, not probe-then-fetch

A probe (`HEAD`/repo-info before fetching) would cost a second round trip on **every** download
forever, including after the rename. Catch-and-retry costs nothing on the happy path: the
recursive tree call `fetch_corpus` already has to make IS the existence check, so a resolving
`wmo-` id is exactly one request and only a miss pays for the fallback lookup. Today that means
one wasted 404 per benchmark; after the datasets are renamed the fallback is never reached and
latency returns to the pre-#273 baseline.
`hub_test.py::test_fetch_asks_once_when_the_canonical_repo_resolves` pins that (it asserts the
tree was requested exactly once).

Only 401/403/404 fall through to the next candidate. Any other status (429, or 5xx after the
existing retries) is the Hub misbehaving, not the wrong name, and propagates from the first
candidate that hit it.

### Both names missing is still a real error

`CorpusRepoUnavailable` subclasses `urllib.error.HTTPError`, so `wmo download`'s
skip-one-and-keep-going path is unchanged, but the message now names every id it tried and the
code each answered:

```
$ wmo download kimi-gui-control
skipping kimi-gui-control: Hub answered 404
Error: Invalid value: some datasets could not be downloaded (unpublished? `wmo download` with
no arguments lists what is):
  kimi-gui-control: the Hub answered 404 for
  https://huggingface.co/api/datasets/experiential-labs/wmh-kimi-gui-control-traces/tree/main?recursive=true
  (no dataset repo for 'kimi-gui-control' at revision 'main':
  experiential-labs/wmo-kimi-gui-control-traces answered 404,
  experiential-labs/wmh-kimi-gui-control-traces answered 404)
```

(That benchmark is genuinely unpublished under either name, despite what
`packages/environment-capture/kimi-gui-control/README.md` claims. Pre-existing, not touched here.)

The CLI reads that detail off plain `HTTPError` attributes (`code`, `url`, `reason`) rather than
importing the new type. That matters: the WMO wheel resolves `environment-capture` from **PyPI**,
so `wmo/cli/app.py` must not import a symbol the published member lacks. The first push did, and
CI's wheel smoke test correctly failed with `ImportError: cannot import name
'CorpusRepoUnavailable'`. The second commit fixes it, and I reproduced CI's exact steps locally
(`uv build --package world-model-optimizer --no-sources`, install the wheel into a clean venv,
`wmo --help`) resolving `environment-capture 0.1.0` from PyPI.

## Verification against the live Hub

```
$ ENVCAP_DATA_ROOT=/tmp/fix-hub-final uv run --no-sync wmo download tau-bench
✓ fetched tau-bench -> /tmp/fix-hub-final/tau-bench/traces.otel.jsonl
exit=0
-rw-r--r--@ 1 admin  wheel  10706836 Jul 26 21:57 traces.otel.jsonl     # 10,578 OTel span lines

$ uv run --no-sync wmo download          # no args
Download which data bundle?:
  1. bird-sql  (not downloaded, updated 2026-07-07)
  2. continual-learning  (not downloaded, updated 2026-07-07)
  3. crmarena  (not downloaded, updated 2026-07-07)
  4. dabstep  (not downloaded, updated 2026-07-07)
  5. financebench  (not downloaded, updated 2026-07-07)
  6. gaia2  (not downloaded, updated 2026-07-07)
  7. swe-bench  (not downloaded, updated 2026-07-07)
  8. tau-bench  (local copy present, updated 2026-07-07)
  9. terminal-tasks  (not downloaded, updated 2026-07-07)
  10. all
```

Picking `continual-learning` from that menu fetched its corpus plus the `data/` and `gold/`
payload dirs, so the multi-file bundle path streams from the fallback repo too.

## Falsification

The new behavior tests, written against only the pre-existing public API so they collect on both
revisions, run against `origin/main`'s `hub.py`:

```
FAILED test_fetch_falls_back_to_the_live_wmh_dataset
E   urllib.error.HTTPError: HTTP Error 404: not found
FAILED test_listing_sees_the_live_wmh_datasets
E   AssertionError: assert [] == ['gaia2', 'bird-sql']
E     Right contains 2 more items, first extra item: 'gaia2'
2 failed in 0.64s
```

and against this branch: `2 passed`.

## Gates

| | merge-base `396ae07` | this branch |
| --- | --- | --- |
| `uv run --no-sync pytest -q` | `3636 passed, 18 skipped` | `3644 passed, 18 skipped` (+8) |

`uv run --no-sync ruff check .`, `ruff format --check wmo/ packages/`, `uv run --no-sync ty check`
all clean.

## The long-term fix

`environment-capture` is bumped to **0.1.1** because PyPI already carries 0.1.0: pip users only
get this fix once the member is republished. The repo / `uv run` path resolves the member from
source and is fixed now.

**Rename the 9 datasets on HuggingFace** (`wmh-<benchmark>-traces` -> `wmo-<benchmark>-traces`;
the Hub keeps a redirect), then delete `"wmh"` from `_REPO_PREFIXES` in `hub.py`. The fallback,
the dedupe branch in `published_corpora`, and the two legacy-prefix tests all fall out with it.
The `_REPO_PREFIXES` comment says exactly that, so it can be deleted confidently. Note that
`hub_push` still publishes to the canonical `wmo-` id, so a re-push is one way to perform the
migration (reads prefer the new repo the moment it exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
