### PR TITLE
Let `wmo providers verify` run before anything is built

### DIFF
--- a/.agents/docs/reference/embeddings.md
+++ b/.agents/docs/reference/embeddings.md
@@ -60,6 +60,12 @@ never a raw numpy mismatch.
 produced `dim` (or the failure detail). It never raises — a missing key or wrong model comes back as
 `fail`.
 
+The embedder is chosen by `wmo build`, so the embed half only runs once a world model exists. The
+completion half does not wait for one: the command also pings the `[models.<role>]` roles in
+`<root>/settings.toml`, which is how a brand-new project checks its credentials before it spends
+anything on a build. With nothing built, the embed check is skipped with a note rather than
+failing the command; with nothing configured at all, the command says so and exits 1.
+
 ## Wiring at build time
 
 `wmo build --embed-provider <kind> [--embed-model <id>] [--embed-dim N]` constructs the embedder via

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -43,6 +43,7 @@ from wmo.cli.e2b_cmds import register as register_e2b_commands
 from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
 from wmo.cli.harness_app import harness_app, optimize_app
 from wmo.cli.ingest_cmd import ingest as _ingest_command
+from wmo.cli.model_roles import configured_role_configs
 from wmo.cli.platform_cmds import register as register_platform_commands
 from wmo.cli.ui import (
     BuildParams,
@@ -96,7 +97,7 @@ from wmo.evals.grid_plot import plot_grid, plot_grid_heatmap
 from wmo.evals.open_loop import EvalReport, OpenLoopEval
 from wmo.ingest import VendorPull, get_adapter, list_adapters
 from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
-from wmo.providers import ProviderConfig, ProviderKind, verify_all, verify_embedder
+from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
 from wmo.providers.base import Embedder, EmbedderKind, Provider
 from wmo.providers.models import resolve_provider_model
 from wmo.providers.pool import Tier
@@ -426,15 +427,18 @@ def providers_verify(
 ) -> None:
     """Ping every configured provider (completion + embed path) and report status.
 
-    Gathers provider configs from the built world models (one `--name`, or all of them, deduped by
-    kind+model), so a brand-new project with nothing built yet has nothing to verify. The phi embed
-    path of each model is checked too, unless it is the offline (creds-free) hashing embedder.
+    Two sources count as "configured", because checking that credentials work is what you do
+    BEFORE spending anything on `wmo build`: the `[models.<role>]` roles in
+    `<root>/settings.toml` (what `wmo providers set` writes), and the providers persisted inside
+    every built world model. Completion providers are deduped by kind+model across both, so a
+    role naming the same backend as a built model costs one ping, not two. The phi embed path
+    belongs to a BUILT model, so on a project with nothing built that half is skipped with a
+    note instead of aborting the command; otherwise every distinct provider-backed embedder is
+    checked (the offline hashing embedder needs no credentials and is skipped). `--name` scopes
+    the whole report to that one world model.
     """
     store = WorldModelStore(root)
     names = [name] if name is not None else store.list_names()
-    if not names:
-        _console.print("[yellow]no world models built yet[/yellow]; run `wmo build --name <name>`")
-        return
     configs: list[HarnessConfig] = []
     for model_name in names:
         try:
@@ -443,22 +447,50 @@ def providers_verify(
             raise typer.BadParameter(str(exc)) from exc
         configs.append(load_config(model_dir))
 
-    # Dedup completion providers by kind+model across all selected models.
-    seen: set[tuple[str, str]] = set()
-    providers: list[ProviderConfig] = []
-    for config in configs:
-        for pc in config.providers:
-            key = (pc.kind.value, pc.model)
-            if key not in seen:
-                seen.add(key)
-                providers.append(pc)
-    for result in verify_all(providers):
-        mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
-        _console.print(f"{mark} {result.kind.value} ({result.model}) {result.detail}")
+    # Dedup completion providers by kind+model across all selected models, then across the
+    # settings roles. World models come FIRST so a pair configured in both is pinged with the
+    # built artifact's own config, exactly as before roles were a source.
+    labelled = [
+        (model_name, pc)
+        for model_name, cfg in zip(names, configs, strict=True)
+        for pc in cfg.providers
+    ]
+    # `--name` asks about one world model; widening it to the project's roles would answer a
+    # question the caller did not ask (and bill for it).
+    if name is None:
+        labelled += [(f"models.{role}", pc) for role, pc in configured_role_configs(root)]
+    index: dict[tuple[str, str], int] = {}
+    provider_configs: list[ProviderConfig] = []
+    sources: list[list[str]] = []
+    for label, pc in labelled:
+        key = (pc.kind.value, pc.model)
+        if key not in index:
+            index[key] = len(provider_configs)
+            provider_configs.append(pc)
+            sources.append([])
+        if label not in sources[index[key]]:
+            sources[index[key]].append(label)
+
+    if not provider_configs:
+        _console.print(
+            "[yellow]nothing configured[/yellow]; run `wmo providers set` to choose a provider, "
+            "or `wmo build --name <name>` to build a world model"
+        )
+        raise typer.Exit(1)
+
+    for result, origin in zip(verify_all(provider_configs), sources, strict=True):
+        _print_verify_result(result, origin)
+
+    if not configs:
+        _console.print(
+            "[dim]embed path: skipped, no world model built yet "
+            "(the embedder is chosen by `wmo build`)[/dim]"
+        )
+        return
 
     # Verify each distinct provider-backed embed path (skip the offline hashing embedder).
     embed_seen: set[tuple[str, str]] = set()
-    for config in configs:
+    for model_name, config in zip(names, configs, strict=True):
         if config.embed_provider is EmbedderKind.HASHING:
             continue
         embed_config = config.embed_provider_config()
@@ -467,8 +499,23 @@ def providers_verify(
             continue
         embed_seen.add(key)
         result = verify_embedder(embed_config)
-        mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
-        _console.print(f"{mark} embed:{result.kind.value} ({result.model}) {result.detail}")
+        _print_verify_result(result, [model_name], prefix="embed:")
+
+
+def _print_verify_result(result: VerifyResult, sources: list[str], *, prefix: str = "") -> None:
+    """Print one `providers verify` line, plus the next step to take when the ping failed.
+
+    `sources` names what asked for this provider (world model names, `models.<role>` settings
+    roles) so a failure points at the thing to fix. The detail is escaped: it carries raw
+    provider error text, and an unescaped `[...]` in it would be read as rich markup and crash
+    the report.
+    """
+    mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
+    origin = f" [dim]({', '.join(sources)})[/dim]" if sources else ""
+    detail = f" {escape(result.detail)}" if result.detail else ""
+    _console.print(f"{mark} {prefix}{result.kind.value} ({result.model}){origin}{detail}")
+    if not result.ok:
+        _console.print(f"  [yellow]{_credential_hint(result.kind, result.detail)}[/yellow]")
 
 
 @examples_app.command("list")
@@ -858,17 +905,22 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
             continue
         failed = True
         _console.print(f"  [red]✗ {label} ({result.model}) failed[/red]: {result.detail}")
-        if "No module named" in result.detail:
-            # SDKs are core deps; a missing module means the env is stale or hand-rolled.
-            _console.print("    [yellow]run `uv sync` to install the provider SDKs[/yellow]")
-        else:
-            envs = ", ".join(PROVIDER_ENV_VARS.get(cfg.kind, []))
-            hint = f" ({envs})" if envs else ""
-            _console.print(
-                f"    [yellow]check the model id and that your credentials are set{hint}[/yellow]"
-            )
+        _console.print(f"    [yellow]{_credential_hint(cfg.kind, result.detail)}[/yellow]")
     if failed:
         raise typer.Exit(1)
+
+
+def _credential_hint(kind: ProviderKind, detail: str) -> str:
+    """The next step for a failed provider ping: install the SDKs, or fix creds/model id.
+
+    Shared by the pre-build guard and `wmo providers verify` so both name the same env vars.
+    """
+    if "No module named" in detail:
+        # SDKs are core deps; a missing module means the env is stale or hand-rolled.
+        return "run `uv sync` to install the provider SDKs"
+    envs = ", ".join(PROVIDER_ENV_VARS.get(kind, []))
+    hint = f" ({envs})" if envs else ""
+    return f"check the model id and that your credentials are set{hint}"
 
 
 @app.command("list")

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -447,9 +447,9 @@ def providers_verify(
             raise typer.BadParameter(str(exc)) from exc
         configs.append(load_config(model_dir))
 
-    # Dedup completion providers by kind+model across all selected models, then across the
-    # settings roles. World models come FIRST so a pair configured in both is pinged with the
-    # built artifact's own config, exactly as before roles were a source.
+    # Dedup identical completion calls across all selected models, then across the settings
+    # roles. World models come FIRST so a config present in both is pinged with the built
+    # artifact's own copy, exactly as before roles were a source.
     labelled = [
         (model_name, pc)
         for model_name, cfg in zip(names, configs, strict=True)
@@ -459,11 +459,11 @@ def providers_verify(
     # question the caller did not ask (and bill for it).
     if name is None:
         labelled += [(f"models.{role}", pc) for role, pc in configured_role_configs(root)]
-    index: dict[tuple[str, str], int] = {}
+    index: dict[str, int] = {}
     provider_configs: list[ProviderConfig] = []
     sources: list[list[str]] = []
     for label, pc in labelled:
-        key = (pc.kind.value, pc.model)
+        key = _completion_identity(pc)
         if key not in index:
             index[key] = len(provider_configs)
             provider_configs.append(pc)
@@ -489,17 +489,30 @@ def providers_verify(
         return
 
     # Verify each distinct provider-backed embed path (skip the offline hashing embedder).
-    embed_seen: set[tuple[str, str]] = set()
+    embed_seen: set[str] = set()
     for model_name, config in zip(names, configs, strict=True):
         if config.embed_provider is EmbedderKind.HASHING:
             continue
         embed_config = config.embed_provider_config()
-        key = (embed_config.kind.value, embed_config.model)
+        key = embed_config.model_dump_json()
         if key in embed_seen:
             continue
         embed_seen.add(key)
         result = verify_embedder(embed_config)
         _print_verify_result(result, [model_name], prefix="embed:")
+
+
+def _completion_identity(config: ProviderConfig) -> str:
+    """What makes two provider configs the SAME completion call, for `providers verify` dedup.
+
+    Everything the config carries except the embed-only fields, which do not reach a completion
+    request. Keying on kind+model alone would collapse one model served from two Bedrock regions,
+    or one Azure model behind two deployments or endpoints, into a single ping, and then report
+    the config that was never called as verified on the other one's result. Deriving the key
+    from the whole config rather than a hand-listed subset means a field added later splits the
+    key by default instead of silently widening that collapse.
+    """
+    return config.model_copy(update={"embed_model": None, "embed_dim": None}).model_dump_json()
 
 
 def _print_verify_result(result: VerifyResult, sources: list[str], *, prefix: str = "") -> None:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1189,10 +1189,82 @@ def test_providers_verify_unknown_model_is_clean_error(tmp_path) -> None:  # noq
     assert not isinstance(result.exception, FileNotFoundError)
 
 
-def test_providers_verify_empty_project_is_friendly(tmp_path) -> None:  # noqa: ANN001
+def _record_verify_all(monkeypatch: pytest.MonkeyPatch, pinged: list[ProviderConfig]) -> None:
+    """Record exactly which providers `providers verify` decided to ping, and report them ok."""
+
+    def fake_verify_all(configs: list[ProviderConfig]) -> list[VerifyResult]:
+        pinged.extend(configs)
+        return [VerifyResult(ok=True, kind=c.kind, model=c.model) for c in configs]
+
+    monkeypatch.setattr(cli_app_module, "verify_all", fake_verify_all)
+
+
+def test_providers_verify_nothing_configured_is_actionable(tmp_path: Path) -> None:
+    # Nothing to check at all is a usage problem, not a pass: say which command fixes it and
+    # exit non-zero so a setup script does not read silence as "credentials are fine".
     result = runner.invoke(app, ["providers", "verify", "--root", str(tmp_path / ".wmo")])
-    assert result.exit_code == 0
-    assert "no world models built yet" in result.output
+    assert result.exit_code == 1
+    assert "nothing configured" in result.output
+    assert "wmo providers set" in result.output
+
+
+def test_providers_verify_without_a_world_model_checks_settings_roles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The repro this fixes: verifying credentials is what you do BEFORE `wmo build` (which
+    # aborts outright on bad ones), so an unbuilt project must still check what it has.
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="openai", model="gpt-5.4-mini")
+    settings.models.judge = ModelRole(provider="bedrock", model="claude-opus-4-8")
+    save_settings(settings, root)
+    pinged: list[ProviderConfig] = []
+    _record_verify_all(monkeypatch, pinged)
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert not (root / "models").exists()
+    # Both configured roles are pinged, the bedrock one at its runtime id (settings hold the
+    # canonical type), and each line names the role that asked for it.
+    assert [(c.kind, c.model) for c in pinged] == [
+        (ProviderKind.OPENAI, "gpt-5.4-mini"),
+        (ProviderKind.BEDROCK, "us.anthropic.claude-opus-4-8"),
+    ]
+    assert "ok openai (gpt-5.4-mini) (models.worker)" in result.output
+    assert "models.judge" in result.output
+    # The embed path belongs to a built model: skipped with a note, not fatal.
+    assert "embed path: skipped" in result.output
+
+
+def test_providers_verify_reports_a_role_failure_with_its_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="bedrock", model="claude-opus-4-8")
+    save_settings(settings, root)
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: [
+            VerifyResult(
+                ok=False,
+                kind=c.kind,
+                model=c.model,
+                # Rich markup in raw provider error text must not be interpreted.
+                detail="denied [foo]",
+            )
+            for c in configs
+        ],
+    )
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "fail bedrock" in result.output
+    assert "[foo]" in result.output
+    assert "AWS_ACCESS_KEY_ID" in result.output
 
 
 def test_providers_verify_reports_built_model_provider(patched_provider, tmp_path) -> None:  # noqa: ANN001
@@ -1202,6 +1274,82 @@ def test_providers_verify_reports_built_model_provider(patched_provider, tmp_pat
     assert result.exit_code == 0, result.output
     # The bedrock provider configured at build time shows up in the verify report.
     assert "bedrock" in result.output
+
+
+def test_providers_verify_checks_a_built_model_embed_path(
+    patched_provider: None, tmp_path: Path
+) -> None:
+    # A provider-backed embedder is verified alongside the completion provider; that check is
+    # the half a world model is genuinely needed for.
+    root = tmp_path / ".wmo"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "airline",
+            "--file",
+            _traces_file(tmp_path),
+            "--root",
+            str(root),
+            "--provider",
+            "bedrock",
+            "--embed-provider",
+            "bedrock",
+            "--embed-model",
+            "amazon.titan-embed-text-v2:0",
+            "--fidelity",
+            "low",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "embed:bedrock (amazon.titan-embed-text-v2:0)" in result.output
+    assert "embed path: skipped" not in result.output
+
+
+def test_providers_verify_pings_a_role_shared_with_a_built_model_once(
+    patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Dedup spans both sources, so pointing the worker role at the model you already built does
+    # not bill a second ping, and the built artifact's own config is the one exercised.
+    root = tmp_path / ".wmo"
+    _build(root, "airline", tmp_path)
+    built = load_config(str(root / "models" / "airline")).providers[0]
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider=built.kind.value, model=built.model)
+    save_settings(settings, root)
+    pinged: list[ProviderConfig] = []
+    _record_verify_all(monkeypatch, pinged)
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert [(c.kind, c.model) for c in pinged] == [(built.kind, built.model)]
+    assert "(airline, models.worker)" in result.output
+
+
+def test_providers_verify_name_scopes_the_report_to_one_world_model(
+    patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # `--name` answers "is THIS model's provider reachable?"; pulling the project's roles in
+    # would bill for a question the caller did not ask.
+    root = tmp_path / ".wmo"
+    _build(root, "airline", tmp_path)
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="openai", model="gpt-5.4-mini")
+    save_settings(settings, root)
+    pinged: list[ProviderConfig] = []
+    _record_verify_all(monkeypatch, pinged)
+
+    result = runner.invoke(app, ["providers", "verify", "--name", "airline", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert [c.kind for c in pinged] == [ProviderKind.BEDROCK]
+    assert "models.worker" not in result.output
 
 
 def test_research_concurrency_rejects_level_above_scenarios_fixed_n() -> None:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1332,6 +1332,96 @@ def test_providers_verify_pings_a_role_shared_with_a_built_model_once(
     assert "(airline, models.worker)" in result.output
 
 
+def test_providers_verify_does_not_collapse_two_regions_of_one_model(
+    patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Same kind and model, different region: two different backends that fail independently.
+    # Collapsing them would ping one and report the OTHER as verified, which is a false pass on
+    # exactly the credential question this command exists to answer.
+    root = tmp_path / ".wmo"
+    _build(root, "airline", tmp_path)
+    built = load_config(str(root / "models" / "airline")).providers[0]
+    assert built.region is None
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(
+        provider=built.kind.value, model=built.model, region="eu-west-1"
+    )
+    save_settings(settings, root)
+    pinged: list[ProviderConfig] = []
+    _record_verify_all(monkeypatch, pinged)
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert [c.region for c in pinged] == [None, "eu-west-1"]
+
+
+def test_providers_verify_does_not_collapse_two_azure_deployments(
+    patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Two roles on one Azure model, each behind its own operator-named deployment and endpoint.
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(
+        provider="azure", model="gpt-5.5", endpoint="https://a.example", deployment="dep-a"
+    )
+    settings.models.judge = ModelRole(
+        provider="azure", model="gpt-5.5", endpoint="https://b.example", deployment="dep-b"
+    )
+    save_settings(settings, root)
+    pinged: list[ProviderConfig] = []
+    _record_verify_all(monkeypatch, pinged)
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert [(c.endpoint, c.deployment) for c in pinged] == [
+        ("https://a.example", "dep-a"),
+        ("https://b.example", "dep-b"),
+    ]
+
+
+def test_providers_verify_checks_both_embed_models_on_one_backend(
+    patched_provider: None, tmp_path: Path
+) -> None:
+    # Two world models sharing a completion backend but embedding through different models: one
+    # completion ping, and BOTH embed paths checked (embed_model is what the embed call sends).
+    root = tmp_path / ".wmo"
+    for model_name, embed_model in (
+        ("a", "amazon.titan-embed-text-v1"),
+        ("b", "amazon.titan-embed-text-v2:0"),
+    ):
+        built = runner.invoke(
+            app,
+            [
+                "build",
+                "--name",
+                model_name,
+                "--file",
+                _traces_file(tmp_path),
+                "--root",
+                str(root),
+                "--provider",
+                "bedrock",
+                "--embed-provider",
+                "bedrock",
+                "--embed-model",
+                embed_model,
+                "--fidelity",
+                "low",
+            ],
+        )
+        assert built.exit_code == 0, built.output
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "embed:bedrock (amazon.titan-embed-text-v1)" in result.output
+    assert "embed:bedrock (amazon.titan-embed-text-v2:0)" in result.output
+    # The shared completion provider is still pinged once, under both model names.
+    assert result.output.count("ok bedrock (") == 1
+
+
 def test_providers_verify_name_scopes_the_report_to_one_world_model(
     patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -8,9 +8,14 @@ import typer
 
 from wmo.config.settings import ModelRole, load_settings
 from wmo.providers.base import Provider, ProviderConfig, ProviderKind
+from wmo.providers.models import resolve_provider_model
 from wmo.providers.registry import get_provider
 
 OptInModelRole = Literal["agent", "meta"]
+ModelRoleName = Literal["worker", "judge", "summary", "meta", "agent"]
+
+MODEL_ROLE_NAMES: tuple[ModelRoleName, ...] = ("worker", "judge", "summary", "meta", "agent")
+"""Every role `ModelsSettings` carries, in report order. Pinned to that model by a test."""
 
 # Azure OpenAI chat completions need an API version on every call. When an opt-in role (or a
 # pool entry, or the local worker role) does not pin one, this shared default applies. Imported
@@ -58,7 +63,52 @@ def resolve_required_model_config(root: str, role: OptInModelRole) -> ProviderCo
     return _model_config(configured, role=role)
 
 
-def _model_config(configured: ModelRole, *, role: OptInModelRole) -> ProviderConfig:
+def configured_role_configs(root: str) -> list[tuple[ModelRoleName, ProviderConfig]]:
+    """Resolve every model role a project has actually written down, in `MODEL_ROLE_NAMES` order.
+
+    This is the "what has this project configured?" view, as opposed to the "what serves this
+    call?" view of `ModelsSettings.resolve`: unset `judge`/`summary` fall back to `worker` at USE
+    time, and resolving that fallback here would report one backend three times under three role
+    names. So this reads the raw fields and returns only the roles the settings file sets.
+
+    The model is canonicalized through the built-in catalog, because that is what a role holds:
+    `wmo providers set` stores the canonical TYPE (`claude-opus-4-8`), not the backend's runtime
+    id (`us.anthropic.claude-opus-4-8`), so a caller that wants to reach the backend has to
+    resolve it (`wmo scenarios` does the same). Unknown ids pass through unchanged, which is
+    what a self-hosted model or a `tinker://` weights path needs.
+
+    Args:
+        root: Project artifact root containing ``settings.toml``.
+
+    Returns:
+        One ``(role, config)`` pair per configured role; empty when nothing is configured.
+
+    Raises:
+        typer.BadParameter: A configured role names an unknown provider kind.
+    """
+    models = load_settings(root).models
+    resolved: list[tuple[ModelRoleName, ProviderConfig]] = []
+    for role in MODEL_ROLE_NAMES:
+        configured: ModelRole | None = getattr(models, role)
+        if configured is None:
+            continue
+        config = _model_config(configured, role=role)
+        spec = resolve_provider_model(config.kind, config.model)
+        resolved.append(
+            (
+                role,
+                config.model_copy(
+                    update={
+                        "model": spec.model_id,
+                        "model_type": config.model_type or spec.model_type,
+                    }
+                ),
+            )
+        )
+    return resolved
+
+
+def _model_config(configured: ModelRole, *, role: ModelRoleName) -> ProviderConfig:
     """Turn one configured role into provider-neutral config with the Azure default."""
     try:
         kind = ProviderKind(configured.provider)

--- a/wmo/cli/model_roles_test.py
+++ b/wmo/cli/model_roles_test.py
@@ -9,8 +9,10 @@ import typer
 
 import wmo.cli.model_roles as model_roles_module
 from wmo.cli.model_roles import (
+    MODEL_ROLE_NAMES,
     OptInModelRole,
     _model_config,
+    configured_role_configs,
     resolve_opt_in_model_provider,
 )
 from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
@@ -220,3 +222,104 @@ def test_role_without_the_field_still_resolves_from_the_catalog() -> None:
 
     assert config.chat_max_tokens_field == "max_completion_tokens"
     assert config.resolved_chat_max_tokens_field() == "max_completion_tokens"
+
+
+def test_model_role_names_covers_every_settings_role() -> None:
+    # A role added to ModelsSettings but not here would silently drop out of every
+    # "what has this project configured?" report, `wmo providers verify` included.
+    assert set(MODEL_ROLE_NAMES) == set(ModelsSettings.model_fields)
+
+
+def test_configured_role_configs_is_empty_for_a_project_with_no_settings(tmp_path: Path) -> None:
+    assert configured_role_configs(str(tmp_path / ".wmo")) == []
+
+
+def test_configured_role_configs_reports_only_roles_the_file_sets(tmp_path: Path) -> None:
+    # `judge`/`summary` fall back to `worker` at USE time; reporting that fallback here would
+    # list one backend three times under three role names.
+    root = tmp_path / ".wmo"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                worker=ModelRole(provider="openai", model="gpt-5.4-mini"),
+                judge=ModelRole(provider="anthropic", model="claude-opus-4-8"),
+            )
+        ),
+        root,
+    )
+
+    assert [(role, cfg.kind, cfg.model) for role, cfg in configured_role_configs(str(root))] == [
+        ("worker", ProviderKind.OPENAI, "gpt-5.4-mini"),
+        ("judge", ProviderKind.ANTHROPIC, "claude-opus-4-8"),
+    ]
+
+
+def test_configured_role_configs_canonicalizes_the_stored_model_type(tmp_path: Path) -> None:
+    # `wmo providers set` stores the canonical type; pinging Bedrock with "claude-opus-4-8"
+    # instead of its runtime id would report a healthy provider as broken.
+    root = tmp_path / ".wmo"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="bedrock", model="claude-opus-4-8"))
+        ),
+        root,
+    )
+
+    [(_role, config)] = configured_role_configs(str(root))
+
+    assert config.model == "us.anthropic.claude-opus-4-8"
+    assert config.model_type == "claude-opus-4-8"
+
+
+def test_configured_role_configs_passes_through_an_uncatalogued_model(tmp_path: Path) -> None:
+    # A self-hosted model or a tinker:// weights path is not in the catalog and must reach the
+    # backend byte for byte, with its declared model_type intact.
+    root = tmp_path / ".wmo"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                agent=ModelRole(
+                    provider="tinker",
+                    model="tinker://run/weights/42",
+                    model_type="Qwen/Qwen3-8B",
+                )
+            )
+        ),
+        root,
+    )
+
+    [(role, config)] = configured_role_configs(str(root))
+
+    assert role == "agent"
+    assert config.model == "tinker://run/weights/42"
+    assert config.model_type == "Qwen/Qwen3-8B"
+
+
+def test_configured_role_configs_defaults_the_azure_api_version(tmp_path: Path) -> None:
+    root = tmp_path / ".wmo"
+    save_settings(
+        ProjectSettings(
+            models=ModelsSettings(
+                worker=ModelRole(provider="azure", model="gpt-5.5", deployment="gpt-5-5")
+            )
+        ),
+        root,
+    )
+
+    [(_role, config)] = configured_role_configs(str(root))
+
+    assert config.api_version == "2024-05-01-preview"
+    assert config.deployment == "gpt-5-5"
+
+
+def test_configured_role_configs_names_the_role_with_the_bad_provider(tmp_path: Path) -> None:
+    root = tmp_path / ".wmo"
+    save_settings(
+        ProjectSettings(models=ModelsSettings(summary=ModelRole(provider="bogus", model="m"))),
+        root,
+    )
+
+    with pytest.raises(
+        typer.BadParameter, match=r"settings \[models\.summary\] has unknown provider 'bogus'"
+    ):
+        configured_role_configs(str(root))


### PR DESCRIPTION
## Reproduction

On a clean checkout, in a directory with no `.wmo/models/`:

```
$ wmo providers verify
no world models built yet; run `wmo build --name <name>`
$ echo $?
0
```

It stays that way even with a provider configured:

```
$ cat .wmo/settings.toml
[models.worker]
provider = "bedrock"
model = "claude-haiku-4-5"
region = "us-east-1"

$ wmo providers verify
no world models built yet; run `wmo build --name <name>`
```

That is backwards. Confirming that your credentials work is precisely what you do *before*
building, and `wmo build` fails outright when they are wrong. This came out of an end-to-end run:
`verify` refused to help, then `build` died on a credential problem. The command's own help text
says "Ping every configured provider (completion + embed path) and report", which does not
describe something that needs a world model.

## Why the world model was required

`providers_verify` in `wmo/cli/app.py` had exactly one source of provider configs: `load_config()`
on each built world model's artifact dir.

```python
store = WorldModelStore(root)
names = [name] if name is not None else store.list_names()
if not names:
    _console.print("[yellow]no world models built yet[/yellow]; run `wmo build --name <name>`")
    return
```

So `store.list_names() == []` meant "nothing to verify" and the command returned early with exit 0.
The `[models.<role>]` roles that `wmo providers set` writes into `<root>/settings.toml` were never
consulted, even though that is the other half of what "configured" means in this project (and the
only half a pre-build user has). The suspicion in the report was right about the mechanism: it
resolves a world model to get `HarnessConfig.providers` and `HarnessConfig.embed_provider_config()`.
Only the second of those genuinely needs a built model.

## What changed

**`wmo/cli/app.py`**

- `providers verify` now draws completion providers from two sources: the `[models.<role>]` roles
  in `<root>/settings.toml`, and the providers persisted in built world models. Identical configs
  dedup across both, so a role naming the same backend as a built model costs one ping, not two.
  World models are ordered first, so a config present in both is pinged with the built artifact's
  own copy, exactly as before roles were a source.
- Dedup keys on the whole `ProviderConfig` minus the embed-only fields, not kind+model. Keying on
  kind+model collapsed one model served from two Bedrock regions (or one Azure model behind two
  deployments) into a single ping and then labelled the config that was never called as verified.
  The embed dedup had the same defect on `main`: it keyed on the COMPLETION model, so two world
  models sharing a backend but embedding through different models had only the first embed path
  checked. Both are fixed.
- Each line now names what asked for that provider (`(airline, models.worker)`), so a failure
  points at the thing to fix.
- The phi embed path is a property of a *built* model. With nothing built, that half is skipped
  with a note instead of aborting the whole command; with a world model present it is unchanged.
- `--name` still scopes the whole report to that one world model. Widening it to the project's
  roles would answer a question the caller did not ask, and bill for it.
- Nothing configured anywhere is no longer a silent pass: it prints which command fixes it and
  exits 1.
- Failure lines now carry the actionable hint the pre-build guard already had (`uv sync` for a
  missing SDK, otherwise the backend's credential env vars from `PROVIDER_ENV_VARS`). That logic
  moved into a shared `_credential_hint` used by both surfaces, so they cannot drift.
- The provider detail is now escaped. It is raw provider error text, and an unescaped `[...]` in
  it would be parsed as rich markup and crash the report.
- The local `providers` list variable was shadowing the `wmo.providers` module import inside the
  function; it is now `provider_configs`.

**`wmo/cli/model_roles.py`**

- New `configured_role_configs(root)`, the "what has this project configured?" view. It reads the
  raw role fields rather than `ModelsSettings.resolve`, because unset `judge`/`summary` fall back
  to `worker` at use time and reporting that fallback would list one backend three times.
- It canonicalizes the model through the built-in catalog. This matters: `wmo providers set`
  stores the canonical type (`claude-opus-4-8`), not the Bedrock runtime id
  (`us.anthropic.claude-opus-4-8`), so without the resolution a perfectly healthy role would have
  been reported as broken. Uncatalogued ids (self-hosted models, `tinker://` weights paths) pass
  through byte for byte, with their declared `model_type` intact.
- `MODEL_ROLE_NAMES` is pinned to `ModelsSettings`' fields by a test, so a role added later cannot
  silently drop out of the report.

Ping failures still exit 0, as before. Only "nothing configured at all" changed exit code; that is
a usage problem, not a verification result.

## Before / after

Driven against real AWS Bedrock credentials, not mocks.

No world model, `[models.worker]` configured:

```
# before
$ wmo providers verify
no world models built yet; run `wmo build --name <name>`
exit=0

# after
$ wmo providers verify
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (models.worker)
embed path: skipped, no world model built yet (the embedder is chosen by `wmo build`)
exit=0
```

Nothing configured at all:

```
# before
no world models built yet; run `wmo build --name <name>`
exit=0

# after
nothing configured; run `wmo providers set` to choose a provider, or `wmo build --name <name>` to build a world model
exit=1
```

Broken credentials, two roles, still no world model (`AWS_*` and `OPENAI_API_KEY` unset):

```
# before
no world models built yet; run `wmo build --name <name>`
exit=0

# after
fail bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (models.worker) Unable to locate credentials
  check the model id and that your credentials are set (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
fail openai (gpt-5.4-mini) (models.judge) Missing credentials. Please pass an `api_key`, ... or set the `OPENAI_API_KEY` ... environment variable.
  check the model id and that your credentials are set (OPENAI_API_KEY)
embed path: skipped, no world model built yet (the embedder is chosen by `wmo build`)
exit=0
```

World model present (`wmo build --embed-provider bedrock --embed-model amazon.titan-embed-text-v2:0`),
with the worker role pointing at the same backend. Same two checks, same verdicts, plus the source
annotation and the dedup:

```
# before
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0)
ok embed:bedrock (amazon.titan-embed-text-v2:0) dim=512
exit=0

# after
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (airline, models.worker)
ok embed:bedrock (amazon.titan-embed-text-v2:0) (airline) dim=512
exit=0
```

`--name` after the change, unchanged in what it checks:

```
$ wmo providers verify --name airline
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (airline)
ok embed:bedrock (amazon.titan-embed-text-v2:0) (airline) dim=512
```

## The false pass Greptile caught

Live repro of the dedup defect, before the follow-up commit. A world model on `us-east-1` plus a
worker role on `eu-west-1` naming the same Bedrock model:

```
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (airline, models.worker)
```

One ping, and the label asserts the role was verified. It was not: the `us.` inference-profile id
does not exist in eu-west-1. After the fix:

```
ok bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (airline)
fail bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) (models.worker) An error occurred (ValidationException) when calling the InvokeModel operation: The provided model identifier is invalid.
  check the model id and that your credentials are set (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
ok embed:bedrock (amazon.titan-embed-text-v2:0) (airline) dim=512
```

## Tests

Fifteen new tests. Run against the pre-change `app.py` with the new tests in place, four fail:

```
FAILED wmo/cli/app_test.py::test_providers_verify_nothing_configured_is_actionable
FAILED wmo/cli/app_test.py::test_providers_verify_without_a_world_model_checks_settings_roles
FAILED wmo/cli/app_test.py::test_providers_verify_reports_a_role_failure_with_its_credentials
FAILED wmo/cli/app_test.py::test_providers_verify_pings_a_role_shared_with_a_built_model_once
4 failed, 4 passed, 64 deselected in 1.26s
```

```
>       assert [(c.kind, c.model) for c in pinged] == [
            (ProviderKind.OPENAI, "gpt-5.4-mini"),
            (ProviderKind.BEDROCK, "us.anthropic.claude-opus-4-8"),
        ]
E       AssertionError: assert [] == [(<ProviderKi...de-opus-4-8')]

>       assert result.exit_code == 1
E       assert 0 == 1
```

The other four in that selection pass on the old code too, which is the point: they pin the
behaviour that had to survive (`--name` scoping, the built-model report, the embed-path check,
the unknown-`--name` usage error).

The three dedup regressions were falsified the same way, against the kind+model key:

```
FAILED wmo/cli/app_test.py::test_providers_verify_does_not_collapse_two_regions_of_one_model
FAILED wmo/cli/app_test.py::test_providers_verify_does_not_collapse_two_azure_deployments
FAILED wmo/cli/app_test.py::test_providers_verify_checks_both_embed_models_on_one_backend
3 failed, 72 deselected in 0.87s
```

`test_providers_verify_empty_project_is_friendly` asserted the old "no world models built yet" +
exit 0 behaviour. It encoded the bug, so it is replaced by
`test_providers_verify_nothing_configured_is_actionable`.

## Gates

| | merge-base (396ae07) | this branch |
|---|---|---|
| `uv run --no-sync pytest -q` | `3636 passed, 18 skipped, 2 warnings in 84.69s` | `3651 passed, 18 skipped, 2 warnings in 41.28s` |

`uv run --no-sync ruff check .` → All checks passed
`uv run --no-sync ruff format --check wmo/` → 427 files already formatted
`uv run --no-sync ty check` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
