### PR TITLE
Make Bedrock actually read AWS_REGION

### DIFF
--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -133,6 +133,13 @@ FIDELITY_TIERS: dict[FidelityTier, TierSpec] = {
 # Env var names each provider backend reads its credentials from (documented for the user).
 PROVIDER_ENV_VARS: dict[ProviderKind, list[str]] = {
     ProviderKind.ANTHROPIC: ["ANTHROPIC_API_KEY"],
+    # AWS_REGION is the region variable the Bedrock provider reads itself
+    # (`wmo.providers.bedrock.AWS_REGION_ENV`, pinned by a test; same literal-not-import rule as
+    # OPENROUTER and TINKER below). AWS_DEFAULT_REGION is accepted by the provider too but is
+    # deliberately NOT listed: this dict is an ALL-must-be-set presence contract
+    # (`wmo.cli.ui.has_credentials`) whose prompt writes every missing name into `.env`, so an
+    # ALTERNATIVE spelling of the same value would report "credentials missing" for a correct
+    # environment and then ask the user to duplicate the region under a second name.
     ProviderKind.BEDROCK: ["AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
     ProviderKind.AZURE_OPENAI: ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
     ProviderKind.OPENAI: ["OPENAI_API_KEY"],

--- a/wmo/providers/bedrock.py
+++ b/wmo/providers/bedrock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 from wmo.core.types import JsonValue
@@ -31,6 +32,29 @@ _ANTHROPIC_BEDROCK_VERSION = "bedrock-2023-05-31"
 
 # Default Titan text-embeddings model (confirmed reachable; v2 supports `dimensions` 256/512/1024).
 _DEFAULT_EMBED_MODEL = "amazon.titan-embed-text-v2:0"
+
+AWS_REGION_ENV = "AWS_REGION"
+"""The region variable WMO reads itself. `wmo.config.PROVIDER_ENV_VARS` pins the same literal."""
+
+AWS_DEFAULT_REGION_ENV = "AWS_DEFAULT_REGION"
+"""The only region variable boto3 reads on its own; accepted here so both names work."""
+
+REGION_SOURCES: tuple[str, ...] = (
+    "the entry/config `region`",
+    AWS_REGION_ENV,
+    AWS_DEFAULT_REGION_ENV,
+    "the active AWS profile's `region` (~/.aws/config), then the instance role",
+)
+"""Every region source, in the order they are consulted. Named in the no-region error."""
+
+NO_REGION_ERROR = (
+    "BedrockProvider has no region, and botocore refuses to build a bedrock-runtime client "
+    "without one. Region is resolved in this order, first hit wins: "
+    + ", ".join(REGION_SOURCES)
+    + ". Set one of them."
+)
+"""The user-facing no-region failure. Replaces botocore's `NoRegionError`, whose whole message
+is "You must specify a region." and which names no variable to set."""
 
 
 class _ContentBlock(TypedDict):
@@ -81,6 +105,32 @@ def _is_nova(model_id: str) -> bool:
     return ".nova-" in model_id or model_id.startswith("amazon.nova-")
 
 
+def resolve_region(configured: str | None) -> str | None:
+    """The region to hand boto3 explicitly, or None to defer to boto3's own resolution.
+
+    boto3 reads exactly one region variable from the environment: botocore's session mapping for
+    `region` is `("region", "AWS_DEFAULT_REGION", None, None)`, so `AWS_REGION` set on its own has
+    no effect and a client built with `region_name=None` dies with `NoRegionError` ("You must
+    specify a region."). `AWS_REGION` is nonetheless the name WMO documents, prompts for, writes
+    into `.env`, and points at in its failure hints, so reading it here is what makes the
+    documented variable true. Both names work; nothing boto3 resolves for itself is taken away.
+
+    Order, first hit wins:
+
+    1. `configured`: an explicit `region` on the pool entry or `ProviderConfig`.
+    2. `AWS_REGION`.
+    3. Returning None, which leaves `AWS_DEFAULT_REGION` and the rest of boto3's chain (the
+       active profile's `region` in `~/.aws/config`, then the instance role) untouched.
+
+    Args:
+        configured: The explicit region carried by the entry or config, if any.
+
+    Returns:
+        The region to pass as boto3's `region_name`, or None to let boto3 resolve it.
+    """
+    return configured or os.environ.get(AWS_REGION_ENV) or None
+
+
 class BedrockProvider:
     """Claude 4.8 via the Bedrock Runtime (InvokeModel with the Anthropic Messages body)."""
 
@@ -100,11 +150,13 @@ class BedrockProvider:
         self._forward_temperature = config.resolved_chat_forward_temperature()
 
     def _get_client(self) -> BaseClient:
-        # Lazy: import boto3 and open the client only on first use. region falls back to
-        # AWS_REGION / the default boto3 chain when config.region is unset.
+        # Lazy: import boto3 and open the client only on first use. The region comes from
+        # `resolve_region` (config, then AWS_REGION), and None hands the rest of the chain
+        # (AWS_DEFAULT_REGION, profile, instance role) back to boto3.
         if self._client is None:
             import boto3
             from botocore.config import Config
+            from botocore.exceptions import NoRegionError
 
             # Bound each request so a stalled connection RAISES instead of blocking forever. Without
             # this, a single hung InvokeModel wedges the whole run (long GEPA/eval jobs never
@@ -128,9 +180,19 @@ class BedrockProvider:
                 read_timeout=600,
                 retries={"max_attempts": 1, "mode": "standard"},
             )
-            self._client = boto3.client(
-                "bedrock-runtime", region_name=self.config.region, config=client_config
-            )
+            try:
+                self._client = boto3.client(
+                    "bedrock-runtime",
+                    region_name=resolve_region(self.config.region),
+                    config=client_config,
+                )
+            except NoRegionError as exc:
+                # botocore's whole message here is "You must specify a region.", which names
+                # nothing to set. It reaches the user verbatim through `verify_via_ping`'s detail
+                # (so through `wmo build`'s pre-flight, `wmo providers set` and
+                # `wmo providers verify`) and raw from any call that skipped `prepare`. Restate it
+                # once, here, as the full resolution order.
+                raise ValueError(NO_REGION_ERROR) from exc
         return self._client
 
     def prepare(self) -> None:
@@ -149,25 +211,23 @@ class BedrockProvider:
            failure.
 
         The region is a different story: free to resolve and fatal when missing, because botocore
-        raises `NoRegionError` while creating a bedrock-runtime client with no region. It is
-        resolved through boto3's own session so this check cannot drift from what the client does
-        (`config.region` first, then AWS_DEFAULT_REGION, then the active profile's `region`; note
-        botocore's session config does NOT read AWS_REGION).
+        raises `NoRegionError` while creating a bedrock-runtime client with no region. It goes
+        through the same two steps `_get_client` uses, so this check cannot drift from what the
+        client does: `resolve_region` (the entry/config, then AWS_REGION), then a fresh boto3
+        session for everything boto3 owns (AWS_DEFAULT_REGION, then the active profile's
+        `region`). A fresh `Session` is deliberate: `boto3.client` goes through the cached
+        process-wide default session, which snapshots the environment as it was at first use.
 
         Raises:
-            ValueError: No region resolves for this configuration.
+            ValueError: No region resolves for this configuration, from any source.
         """
         # Lazy for the same reason as `_get_client`: importing boto3 costs real time, and the
         # registry constructs every backend on any `wmo` command.
         import boto3
 
-        if self.config.region or boto3.Session().region_name:
+        if resolve_region(self.config.region) or boto3.Session().region_name:
             return
-        raise ValueError(
-            "BedrockProvider has no region, and botocore refuses to build a bedrock-runtime "
-            "client without one: set the region on the entry/config, export AWS_DEFAULT_REGION, "
-            "or set `region` in the AWS profile this run uses"
-        )
+        raise ValueError(NO_REGION_ERROR)
 
     def complete(
         self,

--- a/wmo/providers/bedrock_test.py
+++ b/wmo/providers/bedrock_test.py
@@ -1,4 +1,8 @@
-"""Tests for the Bedrock provider's Nova request/response path (no network)."""
+"""Tests for the Bedrock provider's Nova request/response path and region resolution (no network).
+
+The region tests never reach a backend either: building a boto3 client signs nothing, and every
+ambient AWS source is pointed at nothing so the answers do not depend on the machine.
+"""
 
 from __future__ import annotations
 
@@ -6,10 +10,24 @@ import io
 import json
 from typing import TYPE_CHECKING, cast
 
+import boto3
+import pytest
+
+from wmo.config.config import PROVIDER_ENV_VARS
 from wmo.providers.base import ChatRequest, Message, ProviderConfig, ProviderKind
-from wmo.providers.bedrock import BedrockProvider, _is_nova
+from wmo.providers.bedrock import (
+    AWS_DEFAULT_REGION_ENV,
+    AWS_REGION_ENV,
+    NO_REGION_ERROR,
+    REGION_SOURCES,
+    BedrockProvider,
+    _is_nova,
+    resolve_region,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from botocore.client import BaseClient
 
 
@@ -198,3 +216,115 @@ def test_converse_normalizes_cache_read_and_write_to_subsets() -> None:
     assert completion.usage.input_tokens == 57  # 7 fresh + 20 read + 30 written
     assert completion.usage.cached_input_tokens == 20
     assert completion.usage.cache_write_input_tokens == 30
+
+
+def _regionless_config() -> ProviderConfig:
+    """A Bedrock config carrying no region of its own, so the environment decides."""
+    return ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8")
+
+
+@pytest.fixture
+def no_ambient_aws(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point every AWS region source at nothing, so these tests answer the same on any machine.
+
+    boto3 falls back to `~/.aws/config`, so on a developer box with a configured profile a region
+    resolves no matter what the environment says and every assertion below would pass by
+    accident. Both credential files are aimed at paths that do not exist and the metadata
+    endpoint is disabled (a belt: no test may touch the network). boto3's cached process-wide
+    default session is cleared too, because `boto3.client` resolves through it and it snapshots
+    the environment as of whenever some earlier test first built a client.
+    """
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-aws-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-aws-credentials"))
+    for name in (AWS_REGION_ENV, AWS_DEFAULT_REGION_ENV, "AWS_PROFILE"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(boto3, "DEFAULT_SESSION", None)
+
+
+def test_client_is_built_in_the_region_aws_region_names(
+    no_ambient_aws: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The bug this fixes: botocore's session reads only AWS_DEFAULT_REGION (its mapping for
+    # `region` is `("region", "AWS_DEFAULT_REGION", None, None)`), so passing `region_name=None`
+    # with AWS_REGION correctly set raised NoRegionError, "You must specify a region."
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+
+    client = BedrockProvider(_regionless_config())._get_client()
+
+    assert client.meta.region_name == "us-east-1"
+
+
+def test_explicit_config_region_beats_aws_region(
+    no_ambient_aws: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The entry/config region is the most specific source, so an ambient AWS_REGION may not
+    # silently redirect a pool entry that named its own region.
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+    config = ProviderConfig(
+        kind=ProviderKind.BEDROCK, model="us.anthropic.claude-opus-4-8", region="eu-central-1"
+    )
+
+    assert BedrockProvider(config)._get_client().meta.region_name == "eu-central-1"
+
+
+def test_aws_region_beats_aws_default_region(
+    no_ambient_aws: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+    monkeypatch.setenv(AWS_DEFAULT_REGION_ENV, "ap-southeast-2")
+
+    assert BedrockProvider(_regionless_config())._get_client().meta.region_name == "us-east-1"
+
+
+def test_aws_default_region_still_resolves_through_boto3(
+    no_ambient_aws: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reading AWS_REGION ourselves must not take anything away from boto3: with AWS_REGION unset,
+    # `resolve_region` returns None and the whole boto3 chain (AWS_DEFAULT_REGION, the active
+    # profile, an instance role) is still what decides.
+    monkeypatch.setenv(AWS_DEFAULT_REGION_ENV, "ap-southeast-2")
+
+    assert resolve_region(None) is None
+    assert BedrockProvider(_regionless_config())._get_client().meta.region_name == "ap-southeast-2"
+
+
+def test_prepare_accepts_aws_region_alone(
+    no_ambient_aws: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pre-flight resolves the region the same way the client does, or a `route sweep` would
+    # refuse a Bedrock candidate that is in fact perfectly callable.
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+
+    BedrockProvider(_regionless_config()).prepare()  # does not raise
+
+
+def test_no_region_anywhere_names_every_source_in_resolution_order(no_ambient_aws: None) -> None:
+    with pytest.raises(ValueError, match=AWS_REGION_ENV) as excinfo:
+        BedrockProvider(_regionless_config()).prepare()
+
+    message = str(excinfo.value)
+    positions = [message.find(source) for source in REGION_SOURCES]
+    assert all(position >= 0 for position in positions), message  # every source is named
+    assert positions == sorted(positions), message  # in the order they are consulted
+
+
+def test_verify_reports_the_actionable_region_failure_not_botocores(no_ambient_aws: None) -> None:
+    # `verify_via_ping` reports whatever the first call raised, and that detail is what
+    # `wmo build`'s pre-flight, `wmo providers set` and `wmo providers verify` all print.
+    result = BedrockProvider(_regionless_config()).verify()
+
+    assert result.ok is False
+    assert result.detail == NO_REGION_ERROR
+    assert "You must specify a region." not in result.detail
+
+
+def test_provider_env_vars_name_the_region_variable_this_provider_reads() -> None:
+    # PROVIDER_ENV_VARS holds literals (importing a provider module from config would invert the
+    # dependency), so the pair is pinned here, as openrouter's and tinker's key vars are.
+    assert PROVIDER_ENV_VARS[ProviderKind.BEDROCK][0] == AWS_REGION_ENV
+    # AWS_DEFAULT_REGION is honoured by `resolve_region` but deliberately absent here: the dict
+    # is an all-must-be-set presence contract (`wmo.cli.ui.has_credentials`) whose prompt writes
+    # each missing name into `.env`, so listing an ALTERNATIVE spelling of the same value would
+    # call a correct environment incomplete and ask for the region twice.
+    assert AWS_DEFAULT_REGION_ENV not in PROVIDER_ENV_VARS[ProviderKind.BEDROCK]

--- a/wmo/providers/waterfall.py
+++ b/wmo/providers/waterfall.py
@@ -48,6 +48,7 @@ from wmo.providers.base import (
     TokenUsage,
     VerifyResult,
 )
+from wmo.providers.bedrock import resolve_region
 from wmo.providers.registry import get_provider
 
 # ProviderKinds with a REAL llm-waterfall adapter, mapped to the package's provider names
@@ -67,6 +68,12 @@ def to_backend(config: ProviderConfig, *, profile: str | None = None) -> Backend
 
     `profile` selects a named AWS profile (Bedrock), letting one chain span multiple accounts —
     wmo configs don't model that, so it's a separate argument (see `WaterfallProvider(profiles=)`).
+
+    A Bedrock rung's region goes through `resolve_region`, the same order the direct provider
+    uses. The package hands `Backend.region` straight to `boto3.Session`, and boto3 reads only
+    AWS_DEFAULT_REGION, so a rung with no explicit region would otherwise die with NoRegionError
+    on a machine where AWS_REGION alone is set: exactly the failure this resolution order exists
+    to remove, and worse inside a chain, where it takes down the fallback as well as the primary.
     """
     provider = _KIND_TO_PROVIDER.get(config.kind)
     if provider is None:
@@ -74,11 +81,14 @@ def to_backend(config: ProviderConfig, *, profile: str | None = None) -> Backend
             f"provider kind {config.kind.value!r} has no llm-waterfall backend; supported: "
             f"{', '.join(sorted(k.value for k in _SUPPORTED_KINDS))}"
         )
+    region = config.region
+    if config.kind is ProviderKind.BEDROCK:
+        region = resolve_region(region)
     return Backend(
         provider,
         config.model,
         profile=profile,
-        region=config.region,
+        region=region,
         endpoint=config.endpoint,
         deployment=config.deployment,
         api_version=config.api_version,

--- a/wmo/providers/waterfall_test.py
+++ b/wmo/providers/waterfall_test.py
@@ -20,6 +20,7 @@ from llm_waterfall import TokenUsage as WfTokenUsage
 from llm_waterfall import VerifyResult as WfVerifyResult
 
 from wmo.providers.base import Message, ProviderConfig, ProviderKind
+from wmo.providers.bedrock import AWS_DEFAULT_REGION_ENV, AWS_REGION_ENV
 from wmo.providers.waterfall import WaterfallProvider, provider_or_chain, to_backend
 
 
@@ -130,6 +131,27 @@ def test_to_backend_rejects_kinds_without_real_adapters() -> None:
     # openai_responses has no package equivalent (the package speaks chat-completions).
     with pytest.raises(ValueError, match="no llm-waterfall backend"):
         to_backend(ProviderConfig(kind=ProviderKind.OPENAI_RESPONSES, model="m"))
+
+
+def test_to_backend_resolves_a_bedrock_rungs_region_from_aws_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The package hands `Backend.region` straight to `boto3.Session`, and boto3 reads only
+    # AWS_DEFAULT_REGION: leaving None here would fail a regionless rung with NoRegionError on a
+    # machine where AWS_REGION alone is set, taking the fallback down with the primary.
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+    monkeypatch.delenv(AWS_DEFAULT_REGION_ENV, raising=False)
+
+    backend = to_backend(ProviderConfig(kind=ProviderKind.BEDROCK, model="us.anthropic.opus"))
+
+    assert backend.region == "us-east-1"
+
+
+def test_to_backend_leaves_a_non_bedrock_region_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only Bedrock reads AWS_REGION; an OpenAI rung's region stays exactly what the config said.
+    monkeypatch.setenv(AWS_REGION_ENV, "us-east-1")
+
+    assert to_backend(ProviderConfig(kind=ProviderKind.OPENAI, model="gpt-5.5")).region is None
 
 
 def test_complete_maps_to_wmo_completion() -> None:


### PR DESCRIPTION
## The bug

With `AWS_REGION` genuinely set in the environment, every Bedrock path failed:

```
$ wmo build --name tau --source otel-genai --file traces.otel.jsonl --provider bedrock \
    --model us.anthropic.claude-haiku-4-5-20251001-v1:0 --fidelity low
verifying bedrock...
  x bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) failed: You must specify a region.
    check the model id and that your credentials are set (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
```

The worst shape of error message: it names a variable that has no effect and tells you to check something that is already correct. Exporting `AWS_DEFAULT_REGION` with the same value fixed it instantly.

## The mechanism

boto3 reads exactly one region variable from the environment. Confirmed against the pinned botocore:

```
$ python -c "from botocore.configprovider import BOTOCORE_DEFAUT_SESSION_VARIABLES as V; print(V['region'])"
('region', 'AWS_DEFAULT_REGION', None, None)
```

and end to end, with `~/.aws` pointed at nothing so no profile could mask it:

```
$ env -i AWS_REGION=us-east-1 AWS_CONFIG_FILE=/nope AWS_SHARED_CREDENTIALS_FILE=/nope2 python -c ...
session.region_name with only AWS_REGION set: None
NoRegionError You must specify a region.
```

`BedrockProvider._get_client` passed `region_name=self.config.region`, which is `None` for every entry that did not spell out a region. That `None` handed the decision to boto3, and boto3 has never heard of `AWS_REGION`. Note this is invisible on a developer box with a configured `~/.aws/config` profile, which is why it survived.

## Resolution order implemented

`wmo.providers.bedrock.resolve_region`, first hit wins:

1. an explicit `region` on the pool entry / `ProviderConfig`
2. `AWS_REGION`
3. `None`, which hands the rest back to boto3 untouched: `AWS_DEFAULT_REGION`, then the active profile's `region` in `~/.aws/config`, then the instance role

Nothing is taken away from boto3, so profiles and instance roles keep working exactly as before. `prepare()` (the `route sweep` pre-flight) now resolves through the same two steps, so it cannot drift from what the client does.

Bedrock rungs of a failover chain go through the same order in `to_backend`: llm-waterfall hands `Backend.region` straight to `boto3.Session`, so a regionless rung had the identical bug, and inside a chain it takes down the fallback as well as the primary.

## The error message

When no source supplies a region at all, botocore's `NoRegionError` is replaced at the one place the client is built, so every surface inherits it (`wmo build`'s pre-flight, `wmo providers set`, `wmo providers verify`, `route sweep`, and a raw call that skipped all of them):

```
$ env -u AWS_REGION -u AWS_DEFAULT_REGION -u AWS_PROFILE AWS_CONFIG_FILE=/tmp/nope \
    wmo providers set --provider bedrock --model us.anthropic.claude-haiku-4-5-20251001-v1:0
provider verification failed: BedrockProvider has no region, and botocore
refuses to build a bedrock-runtime client without one. Region is resolved in
this order, first hit wins: the entry/config `region`, AWS_REGION,
AWS_DEFAULT_REGION, the active AWS profile's `region` (~/.aws/config), then the
instance role. Set one of them.
```

## `PROVIDER_ENV_VARS`

Keeps `AWS_REGION` alone, which is now truthful (a test pins it against `bedrock.AWS_REGION_ENV`, the same literal-not-import rule openrouter and tinker use). `AWS_DEFAULT_REGION` is deliberately NOT added: the dict is an all-must-be-set presence contract (`wmo.cli.ui.has_credentials`) whose prompt writes every missing name into `.env`, so listing an alternative spelling of one value would report "credentials missing" for a correct environment and then ask the user to duplicate the region under a second name. A test pins that absence with the reason.

## Before / after, real CLI, `AWS_DEFAULT_REGION` explicitly unset

Same shell, same corpus, `AWS_REGION=us-east-1` and no `~/.aws` on the box.

Before (`origin/main`'s provider):

```
### BEFORE, AWS_REGION set, AWS_DEFAULT_REGION unset
verifying bedrock...
  x bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) failed: You must
specify a region.
    check the model id and that your credentials are set (AWS_REGION,
AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
```

After:

```
### AFTER, AWS_REGION set, AWS_DEFAULT_REGION unset
verifying bedrock...
  v bedrock (us.anthropic.claude-haiku-4-5-20251001-v1:0) reachable
v ingested 6 traces -> normalized 12 steps
v split 4 train / 1 val / 1 test traces
v indexed 12 steps into the replay buffer
v GEPA done: val 0.000 (selection sample), 0 frontier candidates, 0 rollouts used
              name  tau
          artifact  /tmp/fix-region-after/.wmo/models/tau
    serve provider  bedrock (claude-haiku-4-5)
```

And the cheap live-ping check, which is a real Bedrock call:

```
$ env -u AWS_DEFAULT_REGION wmo providers set --provider bedrock \
    --model us.anthropic.claude-haiku-4-5-20251001-v1:0
set local worker provider to bedrock (claude-haiku-4-5) in .../settings.toml
exit=0
```

## Falsification

The new tests were run against `main`'s behavior at the three decision points (constants left defined so they collect and fail on behavior, not on `ImportError`). 6 failed:

```
FAILED wmo/providers/bedrock_test.py::test_client_is_built_in_the_region_aws_region_names
FAILED wmo/providers/bedrock_test.py::test_aws_region_beats_aws_default_region
FAILED wmo/providers/bedrock_test.py::test_prepare_accepts_aws_region_alone
FAILED wmo/providers/bedrock_test.py::test_no_region_anywhere_names_every_source_in_resolution_order
FAILED wmo/providers/bedrock_test.py::test_verify_reports_the_actionable_region_failure_not_botocores
FAILED wmo/providers/waterfall_test.py::test_to_backend_resolves_a_bedrock_rungs_region_from_aws_region
6 failed, 28 passed
```

The headline one, with only `AWS_REGION` set:

```
>       client = BedrockProvider(_regionless_config())._get_client()
wmo/providers/bedrock.py:184: in _get_client
    self._client = boto3.client(
E   botocore.exceptions.NoRegionError: You must specify a region.
```

and the message assertion:

```
>       assert result.detail == NO_REGION_ERROR
E       AssertionError: assert 'You must specify a region.' == 'BedrockProvi... one of them.'
```

The tests do not depend on ambient AWS config: a `no_ambient_aws` fixture aims `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` at paths that do not exist, deletes `AWS_REGION` / `AWS_DEFAULT_REGION` / `AWS_PROFILE`, disables the metadata endpoint, and clears boto3's cached process-wide default session (which otherwise snapshots the environment as of whenever some earlier test first built a client). Same recipe `route_app_test.py` already uses for its regionless-Bedrock case. No network: building a client signs nothing.

## Gates

Measured in the same clean environment (no AWS vars, so the two live smoke tests stay skipped in both runs).

- merge-base `396ae07a`: `3636 passed, 18 skipped, 2 warnings in 82.33s`
- this branch: `3646 passed, 18 skipped, 2 warnings in 39.55s` (+10 new tests)
- `ruff check .` -> All checks passed
- `ruff format --check wmo/` -> 427 files already formatted
- `ty check` -> All checks passed

## Behavior note

A Bedrock rung pinned to a named AWS `profile` with no explicit `region` now takes `AWS_REGION` over that profile's `region`, if `AWS_REGION` is set. That is the same precedence botocore already applies to `AWS_DEFAULT_REGION` over a profile, so it keeps the two spellings interchangeable, which is the whole point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
