### PR TITLE
Effective cost per completed task: the D-COMPRESS accounting rule, a three-objective scorecard, and the ablation ladder

### DIFF
--- a/wmo/optimize/routing.py
+++ b/wmo/optimize/routing.py
@@ -324,17 +324,31 @@ def route_scenarios(
     the scoring math is shared rather than reimplemented).
 
     `embedder` overrides the function built from `policy.embedder`, exactly as in `select_model`:
-    one client for the whole replay, or cached vectors in research code.
+    one client for the whole replay, or cached vectors in research code. It must be the function
+    this policy's spec describes, or the fitted centroids (rank) and neighbor bank (knn) are
+    meaningless.
 
     Raises:
-        ValueError: when none of `ids` names a scenario the matrix measured.
+        ValueError: when none of `ids` names a scenario the matrix measured, or when `ids`
+            repeats a scenario. The return is keyed by scenario, so a repeat cannot be
+            represented and would weight that scenario differently for different callers.
     """
+    repeated = sorted({sid for sid, count in Counter(ids).items() if count > 1})
+    if repeated:
+        raise ValueError(
+            f"scenario ids repeat in this replay request: {repeated[:5]}; a policy decides once "
+            f"per scenario and the result is keyed by scenario id, so pass each id once (to "
+            f"weight a scenario more heavily, add episodes to the matrix instead)"
+        )
     scenario_tasks: dict[str, str] = {}
     for outcome in matrix.outcomes:
         scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
     wanted = [sid for sid in ids if sid in scenario_tasks]
     if not wanted:
-        raise ValueError("none of the requested ids are in the matrix")
+        raise ValueError(
+            f"none of the {len(ids)} requested ids are in the matrix; the matrix measured "
+            f"{len(scenario_tasks)} scenarios, so check the ids come from this matrix"
+        )
 
     if policy.kind == "static":
         return {
@@ -356,7 +370,12 @@ def evaluate_policy(
 ) -> PolicyEval:
     """Replay `policy` over the scenarios in `ids`, scoring via each routed model's rows.
 
-    Selection is `route_scenarios`; this adds the scoring pass over the routed rows.
+    Selection is `route_scenarios` (the shared offline replay); this adds the scoring pass over
+    the routed rows.
+
+    `embedder` is forwarded to `route_scenarios`: one client for the whole replay, or cached
+    vectors in research code. It must be the function `policy.embedder` describes, or the fitted
+    centroids (rank) and neighbor bank (knn) are meaningless.
     """
     decisions = route_scenarios(policy, matrix, ids, embedder=embedder)
     wanted = list(decisions)

--- a/wmo/optimize/routing.py
+++ b/wmo/optimize/routing.py
@@ -306,6 +306,47 @@ class PolicyEval(BaseModel):
     unscored_scenarios: int  # scenario/model pairs the routed choice had no scored row for
 
 
+def route_scenarios(
+    policy: RoutingPolicy,
+    matrix: OutcomeMatrix,
+    ids: list[str],
+    *,
+    embedder: Embedder | None = None,
+) -> dict[str, RoutingDecision]:
+    """Replay `policy`'s serve-time choice over the scenarios in `ids`, in `ids` order.
+
+    The single owner of offline policy replay: `evaluate_policy` scores through it, and the
+    ablation scorecard builds a routed arm's rows from it, so a routed number never depends on
+    which caller reimplemented selection.
+
+    Selection runs through the SAME decision code serving uses (`rank_decision` or
+    `knn_decision`; queries are batch embedded once for speed, and both normalize internally, so
+    the scoring math is shared rather than reimplemented).
+
+    `embedder` overrides the function built from `policy.embedder`, exactly as in `select_model`:
+    one client for the whole replay, or cached vectors in research code.
+
+    Raises:
+        ValueError: when none of `ids` names a scenario the matrix measured.
+    """
+    scenario_tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+    wanted = [sid for sid in ids if sid in scenario_tasks]
+    if not wanted:
+        raise ValueError("none of the requested ids are in the matrix")
+
+    if policy.kind == "static":
+        return {
+            sid: RoutingDecision(model=policy.default_model, reason="static policy")
+            for sid in wanted
+        }
+    decide = knn_decision if policy.kind == "knn" else rank_decision
+    built = embedder or policy.embedder.build()
+    embeddings = np.asarray(built.embed([scenario_tasks[sid] for sid in wanted]))
+    return {sid: decide(policy, embeddings[index]) for index, sid in enumerate(wanted)}
+
+
 def evaluate_policy(
     policy: RoutingPolicy,
     matrix: OutcomeMatrix,
@@ -315,31 +356,10 @@ def evaluate_policy(
 ) -> PolicyEval:
     """Replay `policy` over the scenarios in `ids`, scoring via each routed model's rows.
 
-    Selection runs through the SAME decision code serving uses (`rank_decision` or
-    `knn_decision`; queries are batch embedded once for speed, and both normalize internally, so
-    the scoring math is shared rather than reimplemented).
-
-    `embedder` overrides the function built from `policy.embedder`, exactly as in `select_model`:
-    one client for the whole replay, or cached vectors in research code.
+    Selection is `route_scenarios`; this adds the scoring pass over the routed rows.
     """
-    scenario_tasks: dict[str, str] = {}
-    for outcome in matrix.outcomes:
-        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
-    wanted = [sid for sid in ids if sid in scenario_tasks]
-    if not wanted:
-        raise ValueError("none of the requested ids are in the matrix")
-
-    decisions: dict[str, RoutingDecision]
-    if policy.kind == "static":
-        decisions = {
-            sid: RoutingDecision(model=policy.default_model, reason="static policy")
-            for sid in wanted
-        }
-    else:
-        decide = knn_decision if policy.kind == "knn" else rank_decision
-        built = embedder or policy.embedder.build()
-        embeddings = np.asarray(built.embed([scenario_tasks[sid] for sid in wanted]))
-        decisions = {sid: decide(policy, embeddings[index]) for index, sid in enumerate(wanted)}
+    decisions = route_scenarios(policy, matrix, ids, embedder=embedder)
+    wanted = list(decisions)
 
     by_scenario_model: dict[tuple[str, str], list[float]] = {}
     costs: dict[tuple[str, str], list[float]] = {}

--- a/wmo/optimize/routing_test.py
+++ b/wmo/optimize/routing_test.py
@@ -6,7 +6,12 @@ import pytest
 
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
-from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
+from wmo.optimize.routing import (
+    evaluate_policy,
+    fit_rank_policy,
+    rerank_policy,
+    route_scenarios,
+)
 from wmo.providers.base import ProviderKind
 from wmo.providers.pool import PoolEntry
 from wmo.retrieval.embedders import HashingEmbedder
@@ -294,3 +299,33 @@ def test_baseline_guard_keeps_real_winners() -> None:
     # The prose-majority cluster has strong prose evidence (support >= 2, mean 1.0 vs 0.0):
     # prose-model must survive the guard there.
     assert any(c.ranking[0] == "prose-model" for c in policy.clusters)
+
+
+def test_evaluate_policy_scores_the_decisions_route_scenarios_returns() -> None:
+    """The two consumers of the shared replay must agree on who was routed where.
+
+    `evaluate_policy` and `wmo.optimize.scorecard.rows_for_policy` both build on
+    `route_scenarios`. A rebase that reinstated an inline selection block inside
+    `evaluate_policy` would silently give the two different mixes; this turns that into a red
+    test rather than a discrepancy nobody notices.
+    """
+    matrix = _matrix()
+    policy = _fit()
+    ids = matrix.scenario_ids()
+
+    decisions = route_scenarios(policy, matrix, ids)
+    result = evaluate_policy(policy, matrix, ids)
+
+    expected: dict[str, float] = {}
+    for decision in decisions.values():
+        expected[decision.model] = expected.get(decision.model, 0.0) + 1 / len(decisions)
+    assert result.model_mix == pytest.approx(expected)
+    assert result.scenarios == len(decisions)
+
+
+def test_route_scenarios_rejects_repeated_ids() -> None:
+    matrix = _matrix()
+    policy = RoutingPolicy(kind="static", default_model="sql-model", pool=_entries())
+    ids = matrix.scenario_ids()
+    with pytest.raises(ValueError, match="scenario ids repeat"):
+        route_scenarios(policy, matrix, [*ids, ids[0]])

--- a/wmo/optimize/scorecard.py
+++ b/wmo/optimize/scorecard.py
@@ -1,0 +1,772 @@
+"""The three-objective scorecard and the ablation ladder it reports through.
+
+The accounting rule (D-COMPRESS, binding for every savings claim this project makes): savings
+are **cache-adjusted effective cost per completed task, compressor inference cost and latency
+included**. The rule was written for the compression track, but it binds any optimizer that
+buys cheaper tokens by spending inference somewhere else, so this module generalizes its
+"compressor" to an *optimizer overhead*: cost and wall time an arm incurs OUTSIDE the worker
+model's own bill (a compactor pass, a router's embedding call). Nothing aggregated the rule
+before this module existed; report.py's `Headline` reports mean cost per RUN against one
+baseline model, which is a different (and, for an ablation, misleading) quantity: an arm that
+fails half its tasks looks cheap per run and is ruinous per completed task.
+
+Three objectives, never one:
+
+1. Quality: mean reward plus task success rate over scored episodes.
+2. Effective cost per completed task: cache-adjusted provider spend plus optimizer overhead,
+   divided by the number of tasks actually completed.
+3. Latency: p50 and p95 of per-task wall seconds, optimizer overhead included.
+
+Discipline inherited from the surrounding code, and where this module deliberately differs:
+
+- Unscored episodes (`reward is None`) are an infrastructure failure, not a judge verdict of 0.
+  They are excluded from every numerator and denominator, counted, and their unattributed spend
+  is reported separately so the money never vanishes silently.
+- "Same scenarios" is literal and enforced, as in `report.py`: an arm and its anchor are
+  compared over the intersection of scenarios scored on BOTH sides, and the counts in and out
+  are on the artifact. A LADDER goes further and holds every rung to one common scenario set,
+  because its Pareto front compares rungs against each other and not only against the anchor.
+- Comparability invariants fail loudly rather than merge, as in `wmo.evals.grid.merge_results`.
+  A `wm_simulated` arm never silently scores against a `real_episode` anchor, and two arms whose
+  condition labels collide are rejected: the GEPA program lost runs to colliding labels, so a
+  `ConditionLabel` here is structured and must name every experimental axis.
+- Costs are consumed, never re-derived. `ScenarioOutcome.cost_usd` was priced at record time by
+  `PoolEntry.cost_usd`, which bills cache reads and cache writes at their own tiers; that is
+  where "cache-adjusted" comes from and re-pricing here would drop negotiated rates.
+- Every estimate names its basis, as in `wmo.serving.savings`: `cost_assumptions` is composed
+  from what the rows actually contained and is mandatory non-empty.
+- Latency is per TASK (seconds), not per call as in `report.py`. Cost per completed task and
+  seconds per task are the pair an operator reasons about; a per-call p95 cannot be compared
+  against a per-task cost.
+
+Call site (the joint tau-bench ablation ladder):
+
+    tau = ConditionLabel(
+        dataset="tau-bench-retail", split="test", judge="tau2-verifier",
+        provenance="real_episode", base_model="qwen3-8b", optimizer="none",
+    )
+    ladder = build_ladder(
+        "joint-tau",
+        anchor=Arm(name="teacher", condition=tau.replace(base_model="glm-5.2"),
+                   rows=rows_for_model(matrix, "glm-5.2")),
+        arms=[distill_only, plus_routing, plus_compaction],
+    )
+    front = {
+        rung.scorecard.arm: rung.scorecard.cost.cost_per_completed_task_usd
+        for rung in ladder.pareto()
+    }
+"""
+
+from __future__ import annotations
+
+from statistics import median, quantiles
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from wmo.optimize.knn import CostQualityAnchor
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Whether an arm's numbers came from episodes against a world-model simulation or against the
+# real environment. Mixing the two in one comparison is the single easiest way to publish a
+# number nobody can reproduce, so it is a required axis and an enforced invariant.
+Provenance = Literal["wm_simulated", "real_episode"]
+
+# Which latency statistic the Pareto front dominates on. p95 is reported on every scorecard but
+# is not the dominance coordinate by default: at ablation sample sizes it is one slow episode.
+LatencyObjective = Literal["p50", "p95"]
+
+# The rule, shipped verbatim on every result. Specifics measured from the rows are appended.
+EFFECTIVE_COST_RULE = (
+    "Effective cost is cache-adjusted provider spend plus optimizer-side inference, divided by "
+    "the number of COMPLETED tasks. Provider spend is the amount recorded per episode at the "
+    "serving pool's own per-token prices, which bill cache reads and cache writes at their "
+    "separate tiers. Unscored episodes are excluded from both the numerator and the denominator "
+    "and reported separately, because an infrastructure failure is not a judge verdict of 0."
+)
+
+
+class ConditionLabel(BaseModel):
+    """Every experimental axis of one arm, structured so two arms cannot silently collide.
+
+    A free-text condition string is how an ablation program loses data: two runs that differ in
+    a seed or a judge get the same label, the second overwrites the first, and the loss is
+    invisible until someone tries to reproduce a number. Every axis here is therefore a named
+    field, `key()` is the identity, and `build_ladder` rejects a ladder whose arms collide on it.
+
+    `notes` is the escape hatch for an axis this model does not name (a prompt revision, a
+    decoding change). It is part of the identity, so using it separates two arms correctly.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    base_model: str = Field(min_length=1)
+    optimizer: str = Field(min_length=1)  # "none", "distill", "distill+routing", ...
+    dataset: str = Field(min_length=1)
+    split: str = Field(min_length=1)
+    judge: str = Field(min_length=1)  # the verifier or judge that produced the rewards
+    provenance: Provenance
+    seed: int = 0
+    notes: str = ""
+
+    def key(self) -> str:
+        """This condition's identity: two arms sharing it are the same experiment."""
+        return (
+            f"base_model={self.base_model}|optimizer={self.optimizer}|dataset={self.dataset}"
+            f"|split={self.split}|judge={self.judge}|provenance={self.provenance}"
+            f"|seed={self.seed}|notes={self.notes}"
+        )
+
+    def replace(self, **axes: str | int) -> ConditionLabel:
+        """A copy with some axes changed: how ladder rungs are derived from a shared base."""
+        return self.model_copy(update=dict(axes))
+
+
+class RowOverhead(BaseModel):
+    """Optimizer-side inference charged to one episode, outside the worker model's bill.
+
+    Keyed to a row by (scenario_id, model, episode) rather than carried on `ScenarioOutcome`, so
+    the ladder works on outcome matrices recorded before any optimizer overhead existed and so
+    ROUTER overhead has a home too (the compression track's per-row compressor fields describe a
+    compactor only). One row may carry several components.
+    """
+
+    scenario_id: str
+    model: str
+    episode: int = 0
+    component: str = Field(min_length=1)  # "compressor", "router", ...
+    cost_usd: float = Field(default=0.0, ge=0.0)
+    latency_s: float = Field(default=0.0, ge=0.0)
+
+
+class CompletionRule(BaseModel):
+    """When a scored episode counts as a completed task.
+
+    `verifier_flag` reads the verifier's own binary verdict (`ScenarioOutcome.success`), which is
+    what a tau-bench style checker produces and the default. `reward_at_least` is for rubric
+    rewards with partial credit, where the binary flag is not the quantity of interest.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["verifier_flag", "reward_at_least"] = "verifier_flag"
+    threshold: float = 1.0
+
+    def completed(self, outcome: ScenarioOutcome) -> bool:
+        """Whether `outcome` (already known to be scored) counts as a completed task."""
+        if self.kind == "verifier_flag":
+            return outcome.success
+        return outcome.reward is not None and outcome.reward >= self.threshold
+
+
+DEFAULT_COMPLETION = CompletionRule()
+
+
+class Arm(BaseModel):
+    """One condition under test: its rows, its overhead, and the label that identifies it.
+
+    An arm is a set of measured rows, not a policy: the caller decides what "the routed mix"
+    means (replaying a policy, selecting one pool model via `rows_for_model`) and this module
+    stays pure aggregation with no embedder, no network, and no fitting.
+    """
+
+    name: str = Field(min_length=1)
+    condition: ConditionLabel
+    rows: list[ScenarioOutcome] = Field(min_length=1)
+    overheads: list[RowOverhead] = []
+    # Where this arm sits on the cost/quality dial, when it is a dial position at all. Only arms
+    # that declare one can become a D-DIAL `CostQualityAnchor`; a ladder rung is generally an
+    # ablation step, not a dial setting, and synthesizing a position for it would read as a
+    # measurement that was never taken.
+    dial_position: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _overheads_name_rows(self) -> Arm:
+        """Overhead must attach to a row of THIS arm, or the cost lands on nothing.
+
+        Silently ignoring an unmatched key would understate effective cost, which is exactly the
+        direction of error this module exists to prevent.
+        """
+        keys = {_row_key(row) for row in self.rows}
+        orphans = sorted(
+            {str(_overhead_key(o)) for o in self.overheads if _overhead_key(o) not in keys}
+        )
+        if orphans:
+            raise ValueError(
+                f"arm '{self.name}': overhead rows name episodes this arm does not contain: "
+                f"{orphans[:5]}; keys are (scenario_id, model, episode) and must match the arm's "
+                f"own rows, so attach the overhead to the arm whose episodes it was spent on"
+            )
+        return self
+
+
+class EffectiveCost(BaseModel):
+    """Cache-adjusted effective cost per completed task, with everything it excluded."""
+
+    n_scored: int
+    n_excluded: int  # unscored episodes: counted here, never averaged in as zeros
+    n_completed: int
+    provider_cost_usd: float
+    overhead_cost_usd: float
+    total_cost_usd: float
+    # Spend on unscored episodes. Real money that no completed task can be charged for; surfaced
+    # so an arm that burns budget on episodes it never scores cannot look cheap.
+    excluded_cost_usd: float
+    # None when nothing completed: a cost per completed task over zero tasks is not infinity or
+    # zero, it is undefined, and quoting either would be a fabricated number.
+    cost_per_completed_task_usd: float | None
+    overhead_components: list[str] = []
+    # Scored episodes that recorded tokens but $0. Legitimate for a self-hosted model, and the
+    # signature of an unpriced pool entry otherwise, so it is reported rather than guessed at.
+    zero_cost_rows: int = 0
+    cost_assumptions: str = Field(min_length=1)
+
+
+class QualityBlock(BaseModel):
+    """Mean reward and task success rate over an arm's scored episodes."""
+
+    mean_reward: float
+    task_success_rate: float
+    n_scored: int
+    n_excluded: int
+
+
+class LatencyBlock(BaseModel):
+    """Per-task wall seconds, optimizer overhead included."""
+
+    p50_s: float
+    p95_s: float
+    n_tasks: int
+
+
+class Scorecard(BaseModel):
+    """One arm on all three objectives against a NAMED anchor arm, over the same scenarios."""
+
+    arm: str
+    anchor: str
+    condition: ConditionLabel
+    anchor_condition: ConditionLabel
+    provenance: Provenance  # shared by both sides; enforced, not assumed
+    judge: str  # ditto: the verifier that produced every reward on this card
+    scenarios_compared: int  # scenarios scored on BOTH sides: what every number below covers
+    scenarios_excluded: int  # held out because one side went unscored
+
+    quality: QualityBlock
+    anchor_quality: QualityBlock
+    cost: EffectiveCost
+    anchor_cost: EffectiveCost
+    latency: LatencyBlock
+    anchor_latency: LatencyBlock
+
+    # Deltas in the D-DIAL sign convention: quality points positive = better, cost percent
+    # negative = cheaper. None when the anchor's own figure is undefined or zero.
+    quality_delta_points: float
+    cost_delta_percent: float | None
+    latency_p50_delta_percent: float | None
+    cost_assumptions: str = Field(min_length=1)
+
+
+class LadderRung(BaseModel):
+    """One step of an ablation ladder: an ordered scorecard plus its dial position, if any."""
+
+    index: int
+    scorecard: Scorecard
+    dial_position: float | None = None
+
+
+class OperatingPoint(BaseModel):
+    """A named point on the cost/quality frontier, in the D-DIAL delta shape.
+
+    Compatible with `CostQualityAnchor` rather than pretending to be one: an ablation rung has
+    the two deltas the platform contract carries but usually has no dial coordinate, and
+    `as_cost_quality_anchor` refuses to invent one.
+    """
+
+    name: str
+    quality_delta_points: float
+    cost_delta_percent: float | None
+    dial_position: float | None = None
+
+    def as_cost_quality_anchor(self) -> CostQualityAnchor:
+        """This point as a D-DIAL anchor row. Requires a measured dial position and cost delta."""
+        if self.dial_position is None:
+            raise ValueError(
+                f"operating point '{self.name}' has no dial position, so it cannot become a "
+                f"CostQualityAnchor (whose `s` field is a dial setting); set `dial_position` on "
+                f"the arm when the rung IS a dial setting, and otherwise report it as an "
+                f"operating point"
+            )
+        if self.cost_delta_percent is None:
+            raise ValueError(
+                f"operating point '{self.name}' has no cost delta (its anchor completed no "
+                f"tasks, so there is no cost to compare against); it cannot become a "
+                f"CostQualityAnchor"
+            )
+        return CostQualityAnchor(
+            cost_quality=self.dial_position,
+            named_point=self.name,
+            quality_delta_points=self.quality_delta_points,
+            cost_delta_percent=self.cost_delta_percent,
+        )
+
+
+class Ladder(BaseModel):
+    """An ordered ablation ladder plus its Pareto front over the three objectives.
+
+    Every rung is measured over `scenarios_compared`, the ONE scenario set scored by the anchor
+    and by every rung (see `build_ladder`). Pareto dominance compares rungs against each other,
+    so pairwise "same scenarios" against the anchor is not enough: it would let a rung that went
+    unscored on the hard scenarios be graded on an easier subset than the rung it dominates.
+    """
+
+    name: str
+    anchor: str
+    anchor_condition: ConditionLabel
+    scenarios_compared: int  # the common set every rung and the anchor were scored on
+    scenarios_excluded: int  # scenarios some side left unscored, held out of the whole ladder
+    rungs: list[LadderRung]
+
+    def pareto(self, *, latency: LatencyObjective = "p50") -> list[LadderRung]:
+        """The non-dominated rungs, in ladder order.
+
+        Rung A dominates rung B when A is no worse on all three objectives (reward higher, cost
+        per completed task lower, latency lower) and strictly better on at least one. Rungs whose
+        cost per completed task is undefined (nothing completed) cannot be placed on the frontier
+        and are omitted; they remain in `rungs`.
+        """
+        placed = [r for r in self.rungs if r.scorecard.cost.cost_per_completed_task_usd is not None]
+        return [
+            rung
+            for rung in placed
+            if not any(_dominates(other, rung, latency) for other in placed if other is not rung)
+        ]
+
+    def operating_points(
+        self, *, pareto_only: bool = True, latency: LatencyObjective = "p50"
+    ) -> list[OperatingPoint]:
+        """Named operating points, by default only the ones on the frontier."""
+        rungs = self.pareto(latency=latency) if pareto_only else self.rungs
+        return [
+            OperatingPoint(
+                name=rung.scorecard.arm,
+                quality_delta_points=rung.scorecard.quality_delta_points,
+                cost_delta_percent=rung.scorecard.cost_delta_percent,
+                dial_position=rung.dial_position,
+            )
+            for rung in rungs
+        ]
+
+
+def rows_for_model(matrix: OutcomeMatrix, model: str) -> list[ScenarioOutcome]:
+    """Every row one pool model produced: the usual way to build a single-model arm."""
+    names = matrix.model_names()
+    if model not in names:
+        raise KeyError(f"no pool model named '{model}' in this matrix; available: {names}")
+    return [o for o in matrix.outcomes if o.model == model]
+
+
+def effective_cost_per_completed_task(
+    rows: Sequence[ScenarioOutcome],
+    *,
+    overheads: Sequence[RowOverhead] = (),
+    completion: CompletionRule = DEFAULT_COMPLETION,
+) -> EffectiveCost:
+    """Aggregate `rows` into cache-adjusted effective cost per completed task.
+
+    Cost is consumed from `ScenarioOutcome.cost_usd`, which the recording pool entry already
+    priced with its cache tiers, plus every `RowOverhead` attached to an included row. Rows with
+    `reward is None` are excluded from the numerator and the denominator alike; their count and
+    their spend are reported rather than dropped.
+
+    Args:
+        rows: the episodes of one arm, scored and unscored.
+        overheads: optimizer-side inference charged to those episodes, keyed by
+            (scenario_id, model, episode). Overhead on an excluded row is excluded with it.
+        completion: what counts as a completed task. Defaults to the verifier's binary flag.
+
+    Returns:
+        An `EffectiveCost` whose `cost_per_completed_task_usd` is None when nothing completed.
+    """
+    by_row: dict[tuple[str, str, int], list[RowOverhead]] = {}
+    for overhead in overheads:
+        by_row.setdefault(_overhead_key(overhead), []).append(overhead)
+
+    scored = [row for row in rows if row.reward is not None]
+    excluded = [row for row in rows if row.reward is None]
+
+    provider_cost = sum(row.cost_usd for row in scored)
+    overhead_cost = sum(o.cost_usd for row in scored for o in by_row.get(_row_key(row), ()))
+    excluded_cost = sum(
+        row.cost_usd + sum(o.cost_usd for o in by_row.get(_row_key(row), ())) for row in excluded
+    )
+    components = sorted({o.component for row in scored for o in by_row.get(_row_key(row), ())})
+    zero_cost = sum(
+        1
+        for row in scored
+        if row.cost_usd == 0.0 and (row.usage.input_tokens + row.usage.output_tokens) > 0
+    )
+
+    n_completed = sum(1 for row in scored if completion.completed(row))
+    total = provider_cost + overhead_cost
+    per_task = total / n_completed if n_completed else None
+
+    return EffectiveCost(
+        n_scored=len(scored),
+        n_excluded=len(excluded),
+        n_completed=n_completed,
+        provider_cost_usd=provider_cost,
+        overhead_cost_usd=overhead_cost,
+        total_cost_usd=total,
+        excluded_cost_usd=excluded_cost,
+        cost_per_completed_task_usd=per_task,
+        overhead_components=components,
+        zero_cost_rows=zero_cost,
+        cost_assumptions=_assumptions(
+            components=components,
+            completion=completion,
+            n_excluded=len(excluded),
+            excluded_cost=excluded_cost,
+            n_completed=n_completed,
+            zero_cost=zero_cost,
+        ),
+    )
+
+
+def build_scorecard(
+    *,
+    arm: Arm,
+    anchor: Arm,
+    completion: CompletionRule = DEFAULT_COMPLETION,
+    restrict_to: Sequence[str] | None = None,
+) -> Scorecard:
+    """Score `arm` against `anchor` on quality, effective cost, and latency, same scenarios.
+
+    Both sides are aggregated over the intersection of scenarios scored on BOTH sides, for the
+    reason report.py states: unscored episodes are not random, so per-side means over different
+    subsets let an arm that times out on the hard scenarios out-score an anchor that answered
+    everything.
+
+    Args:
+        arm: the condition under test.
+        anchor: the named arm every number is stated against.
+        completion: what counts as a completed task.
+        restrict_to: narrow the comparison further to these scenario ids. `build_ladder` passes
+            the set common to every rung so that rungs are comparable with each other and not
+            merely with the anchor; a standalone pairwise scorecard leaves it None.
+
+    Raises:
+        ValueError: when the two arms are not comparable (different provenance, judge, dataset,
+            or split), when they carry the same condition label, or when no scenario survives.
+    """
+    _require_comparable(arm, anchor)
+
+    arm_rows = _by_scenario(arm.rows)
+    anchor_rows = _by_scenario(anchor.rows)
+    all_ids = list(arm_rows) + [sid for sid in anchor_rows if sid not in arm_rows]
+    compared = _pairwise_scored(arm_rows, anchor_rows, all_ids)
+    if not compared:
+        raise ValueError(
+            f"arm '{arm.name}' and anchor '{anchor.name}' share no scenario scored on BOTH "
+            f"sides, so there is nothing to compare over {len(all_ids)} scenarios; check the "
+            f"matrix for unscored episodes before reporting this ladder"
+        )
+    if restrict_to is not None:
+        allowed = set(restrict_to)
+        compared = [sid for sid in compared if sid in allowed]
+        if not compared:
+            raise ValueError(
+                f"arm '{arm.name}' and anchor '{anchor.name}' share no scored scenario inside "
+                f"the {len(allowed)} the comparison was restricted to; the restriction is the "
+                f"set every rung of the ladder scored, so this arm scored none of them"
+            )
+
+    kept = set(compared)
+    arm_kept = [o for sid in compared for o in arm_rows.get(sid, ())]
+    anchor_kept = [o for sid in compared for o in anchor_rows.get(sid, ())]
+    arm_overhead = [o for o in arm.overheads if o.scenario_id in kept]
+    anchor_overhead = [o for o in anchor.overheads if o.scenario_id in kept]
+
+    cost = effective_cost_per_completed_task(
+        arm_kept, overheads=arm_overhead, completion=completion
+    )
+    anchor_cost = effective_cost_per_completed_task(
+        anchor_kept, overheads=anchor_overhead, completion=completion
+    )
+    quality = _quality(arm_kept, completion)
+    anchor_quality = _quality(anchor_kept, completion)
+    latency = _latency(arm_kept, arm_overhead)
+    anchor_latency = _latency(anchor_kept, anchor_overhead)
+
+    return Scorecard(
+        arm=arm.name,
+        anchor=anchor.name,
+        condition=arm.condition,
+        anchor_condition=anchor.condition,
+        provenance=arm.condition.provenance,
+        judge=arm.condition.judge,
+        scenarios_compared=len(compared),
+        scenarios_excluded=len(all_ids) - len(compared),
+        quality=quality,
+        anchor_quality=anchor_quality,
+        cost=cost,
+        anchor_cost=anchor_cost,
+        latency=latency,
+        anchor_latency=anchor_latency,
+        quality_delta_points=(quality.mean_reward - anchor_quality.mean_reward) * 100.0,
+        cost_delta_percent=_percent_delta(
+            cost.cost_per_completed_task_usd, anchor_cost.cost_per_completed_task_usd
+        ),
+        latency_p50_delta_percent=_percent_delta(latency.p50_s, anchor_latency.p50_s),
+        cost_assumptions=cost.cost_assumptions,
+    )
+
+
+def build_ladder(
+    name: str,
+    *,
+    anchor: Arm,
+    arms: Sequence[Arm],
+    completion: CompletionRule = DEFAULT_COMPLETION,
+) -> Ladder:
+    """Score an ordered ablation ladder (distill-only, +routing, +compaction) against one anchor.
+
+    Rung order is `arms` order and is meaningful: a ladder is read as a sequence of additions.
+
+    Every rung is measured over ONE scenario set: those scored by the anchor and by every rung.
+    A per-rung pairwise intersection with the anchor is not sufficient here, because `pareto()`
+    compares rungs against each other; a rung whose episodes went unscored on the hard scenarios
+    would otherwise be graded on an easier subset than the rung it is said to dominate. The
+    scenarios that drop out are counted on the ladder, not discarded quietly.
+
+    Raises:
+        ValueError: when `arms` is empty, when two arms share a name, when two arms (or an arm
+            and the anchor) share a condition label, or when no scenario was scored by the anchor
+            and every rung. A collision means two rungs are the same experiment under different
+            display names, which is how ablation results get silently overwritten.
+    """
+    if not arms:
+        raise ValueError(f"ladder '{name}' needs at least one arm besides the anchor")
+
+    seen_names = {anchor.name: "anchor"}
+    seen_keys = {anchor.condition.key(): anchor.name}
+    for arm in arms:
+        if arm.name in seen_names:
+            raise ValueError(
+                f"ladder '{name}': two rungs are both named '{arm.name}'; rung names are the "
+                f"display handles for the ladder, so give each one a distinct name"
+            )
+        seen_names[arm.name] = arm.name
+        key = arm.condition.key()
+        if key in seen_keys:
+            raise ValueError(
+                f"ladder '{name}': rungs '{seen_keys[key]}' and '{arm.name}' carry the SAME "
+                f"condition label ({key}), so they name the same experiment and one would "
+                f"overwrite the other; a condition must encode every axis the rungs differ on "
+                f"(use `optimizer`, `seed`, or `notes` to record what actually changed)"
+            )
+        seen_keys[key] = arm.name
+
+    # The one scenario set the whole ladder is measured on. Ordered by the anchor's own rows so
+    # the artifact is deterministic, and intersected rung by rung so a single arm that went
+    # unscored somewhere narrows every rung equally rather than only its own.
+    anchor_rows = _by_scenario(anchor.rows)
+    universe = list(anchor_rows)
+    common = set(universe)
+    for arm in arms:
+        _require_comparable(arm, anchor)
+        arm_rows = _by_scenario(arm.rows)
+        for sid in arm_rows:
+            if sid not in common and sid not in universe:
+                universe.append(sid)
+        common &= set(_pairwise_scored(arm_rows, anchor_rows, universe))
+    if not common:
+        raise ValueError(
+            f"ladder '{name}': no scenario was scored by anchor '{anchor.name}' AND by every "
+            f"rung ({', '.join(a.name for a in arms)}), so the rungs cannot be compared with "
+            f"each other; every number on a ladder is measured on one common scenario set, so "
+            f"rerun the unscored episodes or drop the rung that scored none of them"
+        )
+    ordered = [sid for sid in universe if sid in common]
+
+    return Ladder(
+        name=name,
+        anchor=anchor.name,
+        anchor_condition=anchor.condition,
+        scenarios_compared=len(ordered),
+        scenarios_excluded=len(universe) - len(ordered),
+        rungs=[
+            LadderRung(
+                index=index,
+                scorecard=build_scorecard(
+                    arm=arm, anchor=anchor, completion=completion, restrict_to=ordered
+                ),
+                dial_position=arm.dial_position,
+            )
+            for index, arm in enumerate(arms)
+        ],
+    )
+
+
+def _row_key(row: ScenarioOutcome) -> tuple[str, str, int]:
+    return (row.scenario_id, row.model, row.episode)
+
+
+def _overhead_key(overhead: RowOverhead) -> tuple[str, str, int]:
+    return (overhead.scenario_id, overhead.model, overhead.episode)
+
+
+def _pairwise_scored(
+    arm_rows: dict[str, list[ScenarioOutcome]],
+    anchor_rows: dict[str, list[ScenarioOutcome]],
+    order: Sequence[str],
+) -> list[str]:
+    """The scenarios in `order` with at least one scored episode on BOTH sides."""
+    return [
+        sid
+        for sid in order
+        if any(o.reward is not None for o in arm_rows.get(sid, ()))
+        and any(o.reward is not None for o in anchor_rows.get(sid, ()))
+    ]
+
+
+def _by_scenario(rows: Sequence[ScenarioOutcome]) -> dict[str, list[ScenarioOutcome]]:
+    grouped: dict[str, list[ScenarioOutcome]] = {}
+    for row in rows:
+        grouped.setdefault(row.scenario_id, []).append(row)
+    return grouped
+
+
+def _quality(rows: Sequence[ScenarioOutcome], completion: CompletionRule) -> QualityBlock:
+    scored = [row for row in rows if row.reward is not None]
+    rewards = [row.reward for row in scored if row.reward is not None]
+    return QualityBlock(
+        mean_reward=sum(rewards) / len(rewards) if rewards else 0.0,
+        task_success_rate=(
+            sum(1 for row in scored if completion.completed(row)) / len(scored) if scored else 0.0
+        ),
+        n_scored=len(scored),
+        n_excluded=sum(1 for row in rows if row.reward is None),
+    )
+
+
+def _latency(rows: Sequence[ScenarioOutcome], overheads: Sequence[RowOverhead]) -> LatencyBlock:
+    """Per-task seconds over scored rows: the episode's own calls plus its optimizer overhead."""
+    by_row: dict[tuple[str, str, int], float] = {}
+    for overhead in overheads:
+        key = _overhead_key(overhead)
+        by_row[key] = by_row.get(key, 0.0) + overhead.latency_s
+    per_task = [
+        sum(row.call_seconds) + by_row.get(_row_key(row), 0.0)
+        for row in rows
+        if row.reward is not None
+    ]
+    if not per_task:
+        return LatencyBlock(p50_s=0.0, p95_s=0.0, n_tasks=0)
+    p95 = quantiles(per_task, n=20)[-1] if len(per_task) > 1 else per_task[0]
+    return LatencyBlock(p50_s=median(per_task), p95_s=p95, n_tasks=len(per_task))
+
+
+def _percent_delta(value: float | None, anchor: float | None) -> float | None:
+    """Percent change of `value` against `anchor`; None when the anchor cannot be divided by."""
+    if value is None or anchor is None or anchor == 0.0:
+        return None
+    return (value - anchor) / anchor * 100.0
+
+
+def _dominates(a: LadderRung, b: LadderRung, latency: LatencyObjective) -> bool:
+    """Whether rung `a` is no worse than `b` on all three objectives and better on one."""
+    a_cost = a.scorecard.cost.cost_per_completed_task_usd
+    b_cost = b.scorecard.cost.cost_per_completed_task_usd
+    if a_cost is None or b_cost is None:  # unreachable: `pareto` filters these out first
+        return False
+    a_lat = a.scorecard.latency.p50_s if latency == "p50" else a.scorecard.latency.p95_s
+    b_lat = b.scorecard.latency.p50_s if latency == "p50" else b.scorecard.latency.p95_s
+    pairs = (
+        (b.scorecard.quality.mean_reward, a.scorecard.quality.mean_reward),  # higher is better
+        (a_cost, b_cost),  # lower is better
+        (a_lat, b_lat),
+    )
+    return all(x <= y for x, y in pairs) and any(x < y for x, y in pairs)
+
+
+def _require_comparable(arm: Arm, anchor: Arm) -> None:
+    """Fail loudly on any axis that must match for the two sides to be one comparison.
+
+    Follows `wmo.evals.grid.merge_results`: an invariant that would produce a plausible but
+    meaningless number is checked, not documented. `base_model`, `optimizer`, and `seed` are
+    free to differ, because differing on them is what an ablation IS.
+    """
+    if arm.name == anchor.name:
+        raise ValueError(
+            f"arm and anchor are both named '{arm.name}'; a scorecard names the anchor it was "
+            f"measured against, so the two need distinct names"
+        )
+    mine = arm.condition
+    theirs = anchor.condition
+    comparability: tuple[tuple[str, str, str], ...] = (
+        ("provenance", mine.provenance, theirs.provenance),
+        ("judge", mine.judge, theirs.judge),
+        ("dataset", mine.dataset, theirs.dataset),
+        ("split", mine.split, theirs.split),
+    )
+    for field, ours, other in comparability:
+        if ours != other:
+            raise ValueError(
+                f"arm '{arm.name}' has {field}={ours!r} but anchor '{anchor.name}' has "
+                f"{field}={other!r}; those numbers were not measured on the same footing, so "
+                f"comparing them would report a difference in the setup as a difference in the "
+                f"optimizer (measure both sides under one {field}, or anchor against an arm "
+                f"that shares it)"
+            )
+    if arm.condition.key() == anchor.condition.key():
+        raise ValueError(
+            f"arm '{arm.name}' and anchor '{anchor.name}' carry the SAME condition label "
+            f"({arm.condition.key()}), so they are the same experiment and the scorecard would "
+            f"compare an arm against itself"
+        )
+
+
+def _assumptions(
+    *,
+    components: Sequence[str],
+    completion: CompletionRule,
+    n_excluded: int,
+    excluded_cost: float,
+    n_completed: int,
+    zero_cost: int,
+) -> str:
+    """Compose the basis sentence from what the rows actually contained."""
+    parts = [EFFECTIVE_COST_RULE]
+    if completion.kind == "verifier_flag":
+        parts.append("A task counts as completed when the verifier marked the episode a success.")
+    else:
+        parts.append(
+            f"A task counts as completed when its verified reward is at least "
+            f"{completion.threshold:g}."
+        )
+    if components:
+        parts.append(f"Optimizer-side inference recorded here covers: {', '.join(components)}.")
+    else:
+        parts.append(
+            "No optimizer-side inference was recorded for these episodes, so the figure is "
+            "provider spend alone."
+        )
+    if n_excluded:
+        parts.append(
+            f"{n_excluded} unscored episode(s) were excluded, along with ${excluded_cost:.4f} of "
+            f"spend that no completed task is charged for."
+        )
+    if not n_completed:
+        parts.append(
+            "No task completed, so there is no cost per completed task to quote and the figure "
+            "is reported as undefined rather than as zero."
+        )
+    if zero_cost:
+        parts.append(
+            f"{zero_cost} scored episode(s) recorded tokens but $0, which is expected for a "
+            f"self-hosted model and otherwise means a pool entry carried no price."
+        )
+    return " ".join(parts)

--- a/wmo/optimize/scorecard.py
+++ b/wmo/optimize/scorecard.py
@@ -39,11 +39,22 @@ Discipline inherited from the surrounding code, and where this module deliberate
   seconds per task are the pair an operator reasons about; a per-call p95 cannot be compared
   against a per-task cost.
 
+A rung is a CONFIG evaluated offline against one existing matrix, never a rerun: a single-model
+arm selects its rows with `rows_for_model`, and a routed arm replays its policy's own choices
+with `rows_for_policy`. Buy the matrix once, then every rung is a lookup.
+
 Call site (the joint tau-bench ablation ladder):
 
     tau = ConditionLabel(
         dataset="tau-bench-retail", split="test", judge="tau2-verifier",
         provenance="real_episode", base_model="qwen3-8b", optimizer="none",
+    )
+    plus_routing = Arm(
+        name="+routing",
+        condition=tau.replace(optimizer="distill+routing"),
+        rows=rows_for_policy(matrix, champion_policy),
+        overheads=router_overheads,
+        dial_position=0.25,
     )
     ladder = build_ladder(
         "joint-tau",
@@ -66,9 +77,13 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from wmo.optimize.knn import CostQualityAnchor
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.routing import route_scenarios
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from wmo.optimize.policy import RoutingPolicy
+    from wmo.providers.base import Embedder
 
 # Whether an arm's numbers came from episodes against a world-model simulation or against the
 # real environment. Mixing the two in one comparison is the single easiest way to publish a
@@ -366,6 +381,42 @@ def rows_for_model(matrix: OutcomeMatrix, model: str) -> list[ScenarioOutcome]:
     if model not in names:
         raise KeyError(f"no pool model named '{model}' in this matrix; available: {names}")
     return [o for o in matrix.outcomes if o.model == model]
+
+
+def rows_for_policy(
+    matrix: OutcomeMatrix,
+    policy: RoutingPolicy,
+    *,
+    ids: Sequence[str] | None = None,
+    embedder: Embedder | None = None,
+) -> list[ScenarioOutcome]:
+    """The rows a routing policy's own choices select: how a routed ladder rung is built.
+
+    Replays the policy through `wmo.optimize.routing.route_scenarios`, the shared offline replay
+    that `evaluate_policy` also scores through, and takes each scenario's rows for the model the
+    policy chose. A rung is therefore a POLICY CONFIG evaluated offline against an existing
+    matrix: no episode is rerun, and the routed arm is measured on exactly the rows the pool
+    already produced.
+
+    Args:
+        matrix: the precomputed pool x scenario grid.
+        policy: the routing policy this rung represents.
+        ids: which scenarios to route, defaulting to every scenario in the matrix.
+        embedder: one embedder for the whole replay (an azure spec otherwise builds an HTTP
+            client per call). Must be the function `policy.embedder` describes.
+
+    Note:
+        This is the one function in this module that can touch the network, since a non-static
+        policy embeds its queries. Single-model arms via `rows_for_model` stay pure.
+    """
+    wanted = list(ids) if ids is not None else matrix.scenario_ids()
+    decisions = route_scenarios(policy, matrix, wanted, embedder=embedder)
+    return [
+        row
+        for scenario_id, decision in decisions.items()
+        for row in matrix.for_scenario(scenario_id)
+        if row.model == decision.model
+    ]
 
 
 def effective_cost_per_completed_task(

--- a/wmo/optimize/scorecard.py
+++ b/wmo/optimize/scorecard.py
@@ -4,28 +4,34 @@ The accounting rule (D-COMPRESS, binding for every savings claim this project ma
 are **cache-adjusted effective cost per completed task, compressor inference cost and latency
 included**. The rule was written for the compression track, but it binds any optimizer that
 buys cheaper tokens by spending inference somewhere else, so this module generalizes its
-"compressor" to an *optimizer overhead*: cost and wall time an arm incurs OUTSIDE the worker
-model's own bill (a compactor pass, a router's embedding call). Nothing aggregated the rule
-before this module existed; report.py's `Headline` reports mean cost per RUN against one
-baseline model, which is a different (and, for an ablation, misleading) quantity: an arm that
-fails half its tasks looks cheap per run and is ruinous per completed task.
+"compressor" to an *optimizer overhead*: cost and time an arm incurs OUTSIDE the worker model's
+own bill (a compactor pass, a router's embedding call). Nothing aggregated the rule before this
+module existed; report.py's `Headline` reports mean cost per RUN against one baseline model,
+which is a different (and, for an ablation, misleading) quantity: an arm that fails half its
+tasks looks cheap per run and is ruinous per completed task.
 
 Three objectives, never one:
 
-1. Quality: mean reward plus task success rate over scored episodes.
+1. Quality: mean reward plus task success rate, averaged per scenario (see below).
 2. Effective cost per completed task: cache-adjusted provider spend plus optimizer overhead,
    divided by the number of tasks actually completed.
-3. Latency: p50 and p95 of per-task wall seconds, optimizer overhead included.
+3. Latency: p50 and p95 of per-task MODEL seconds, optimizer overhead included.
 
 Discipline inherited from the surrounding code, and where this module deliberately differs:
 
 - Unscored episodes (`reward is None`) are an infrastructure failure, not a judge verdict of 0.
-  They are excluded from every numerator and denominator, counted, and their unattributed spend
-  is reported separately so the money never vanishes silently.
+  They are excluded from every numerator and denominator, counted, and their spend is reported
+  separately. Money is conserved: for either side of a scorecard,
+  `cost.total_cost_usd + cost.excluded_cost_usd + withheld_cost_usd` equals everything that
+  side spent, so no dollar can leave the artifact silently.
 - "Same scenarios" is literal and enforced, as in `report.py`: an arm and its anchor are
   compared over the intersection of scenarios scored on BOTH sides, and the counts in and out
   are on the artifact. A LADDER goes further and holds every rung to one common scenario set,
   because its Pareto front compares rungs against each other and not only against the anchor.
+- Quality is averaged per SCENARIO, not per episode. Cost per completed task is legitimately
+  episode-level (each episode is a task attempt that cost money), but a mean reward over
+  episodes silently reweights the comparison when two arms ran different episode counts on the
+  same scenario, which is the scenario-level version of the bug the common set exists to stop.
 - Comparability invariants fail loudly rather than merge, as in `wmo.evals.grid.merge_results`.
   A `wm_simulated` arm never silently scores against a `real_episode` anchor, and two arms whose
   condition labels collide are rejected: the GEPA program lost runs to colliding labels, so a
@@ -35,15 +41,20 @@ Discipline inherited from the surrounding code, and where this module deliberate
   where "cache-adjusted" comes from and re-pricing here would drop negotiated rates.
 - Every estimate names its basis, as in `wmo.serving.savings`: `cost_assumptions` is composed
   from what the rows actually contained and is mandatory non-empty.
-- Latency is per TASK (seconds), not per call as in `report.py`. Cost per completed task and
-  seconds per task are the pair an operator reasons about; a per-call p95 cannot be compared
-  against a per-task cost.
+- Latency is per TASK, not per call as in `report.py`, and it is MODEL time: `call_seconds`
+  excludes environment and tool time by contract (`outcomes.py`), so these numbers understate
+  an operator's wall clock and flatter any optimizer that only shortens prompts. Cost per
+  completed task and seconds per task are still the pair to reason about together; a per-call
+  p95 cannot be compared against a per-task cost at all.
 
 A rung is a CONFIG evaluated offline against one existing matrix, never a rerun: a single-model
 arm selects its rows with `rows_for_model`, and a routed arm replays its policy's own choices
 with `rows_for_policy`. Buy the matrix once, then every rung is a lookup.
 
 Call site (the joint tau-bench ablation ladder):
+
+    from wmo.optimize.scorecard import Arm, ConditionLabel, build_ladder, rows_for_model
+    from wmo.optimize.scorecard import rows_for_policy
 
     tau = ConditionLabel(
         dataset="tau-bench-retail", split="test", judge="tau2-verifier",
@@ -70,6 +81,7 @@ Call site (the joint tau-bench ablation ladder):
 
 from __future__ import annotations
 
+from math import isclose
 from statistics import median, quantiles
 from typing import TYPE_CHECKING, Literal
 
@@ -93,6 +105,11 @@ Provenance = Literal["wm_simulated", "real_episode"]
 # Which latency statistic the Pareto front dominates on. p95 is reported on every scorecard but
 # is not the dominance coordinate by default: at ablation sample sizes it is one slow episode.
 LatencyObjective = Literal["p50", "p95"]
+
+# Floats that differ by less than this are a tie, not an improvement. Summation order differs
+# between the arm side and the anchor side, so two genuinely equal rungs can land 1 ULP apart;
+# without a tolerance one of them would silently fall off the frontier.
+DOMINANCE_TOLERANCE = 1e-9
 
 # The rule, shipped verbatim on every result. Specifics measured from the rows are appended.
 EFFECTIVE_COST_RULE = (
@@ -136,8 +153,25 @@ class ConditionLabel(BaseModel):
         )
 
     def replace(self, **axes: str | int) -> ConditionLabel:
-        """A copy with some axes changed: how ladder rungs are derived from a shared base."""
-        return self.model_copy(update=dict(axes))
+        """A copy with some axes changed: how ladder rungs are derived from a shared base.
+
+        Re-validates rather than using `model_copy(update=...)` directly. An unrecognized axis
+        name is rejected instead of silently doing nothing: a typo would otherwise leave the
+        intended field unchanged and surface later as an inexplicable ladder label collision,
+        which is the exact failure this class exists to prevent.
+
+        Raises:
+            ValueError: when an axis is not a field of this model, or when the new value fails
+                the field's own validation (an empty string, a bad provenance).
+        """
+        unknown = sorted(set(axes) - set(type(self).model_fields))
+        if unknown:
+            raise ValueError(
+                f"unknown condition axes {unknown}; the axes are "
+                f"{sorted(type(self).model_fields)}, so fix the spelling or record the change "
+                f"in `notes`, which is part of the label identity"
+            )
+        return ConditionLabel.model_validate({**self.model_dump(), **axes})
 
 
 class RowOverhead(BaseModel):
@@ -184,8 +218,8 @@ class Arm(BaseModel):
     """One condition under test: its rows, its overhead, and the label that identifies it.
 
     An arm is a set of measured rows, not a policy: the caller decides what "the routed mix"
-    means (replaying a policy, selecting one pool model via `rows_for_model`) and this module
-    stays pure aggregation with no embedder, no network, and no fitting.
+    means (replaying a policy via `rows_for_policy`, selecting one pool model via
+    `rows_for_model`) and this module stays pure aggregation with no fitting.
     """
 
     name: str = Field(min_length=1)
@@ -199,22 +233,33 @@ class Arm(BaseModel):
     dial_position: float | None = Field(default=None, ge=0.0, le=1.0)
 
     @model_validator(mode="after")
-    def _overheads_name_rows(self) -> Arm:
-        """Overhead must attach to a row of THIS arm, or the cost lands on nothing.
+    def _rows_are_well_formed(self) -> Arm:
+        """Reject row sets whose aggregation would be quietly wrong.
 
-        Silently ignoring an unmatched key would understate effective cost, which is exactly the
-        direction of error this module exists to prevent.
+        Three checks, all guarding the same direction of error (a plausible number nobody can
+        reproduce): duplicate episode keys would charge one overhead twice, an out-of-range
+        reward would inflate `quality_delta_points` (which is scaled by 100 and read as
+        percentage points by the D-DIAL contract), and orphan overhead would land real spend on
+        no episode at all.
         """
-        keys = {_row_key(row) for row in self.rows}
-        orphans = sorted(
-            {str(_overhead_key(o)) for o in self.overheads if _overhead_key(o) not in keys}
-        )
-        if orphans:
-            raise ValueError(
-                f"arm '{self.name}': overhead rows name episodes this arm does not contain: "
-                f"{orphans[:5]}; keys are (scenario_id, model, episode) and must match the arm's "
-                f"own rows, so attach the overhead to the arm whose episodes it was spent on"
-            )
+        seen: set[tuple[str, str, int]] = set()
+        for row in self.rows:
+            key = _row_key(row)
+            if key in seen:
+                raise ValueError(
+                    f"arm '{self.name}': two rows share the episode key {key}; overhead is "
+                    f"charged per (scenario_id, model, episode), so a duplicate would be billed "
+                    f"twice. Give the repeat run a distinct `episode` number."
+                )
+            seen.add(key)
+            if row.reward is not None and not 0.0 <= row.reward <= 1.0:
+                raise ValueError(
+                    f"arm '{self.name}': row {key} has reward {row.reward}, outside [0, 1]. "
+                    f"Quality deltas are reported in points (reward x 100) against the D-DIAL "
+                    f"contract, so a rubric on another scale would be published as a wildly "
+                    f"wrong percentage. Normalize the reward to [0, 1] before building the arm."
+                )
+        _require_overheads_match(self.rows, self.overheads, owner=f"arm '{self.name}'")
         return self
 
 
@@ -237,23 +282,32 @@ class EffectiveCost(BaseModel):
     # Scored episodes that recorded tokens but $0. Legitimate for a self-hosted model, and the
     # signature of an unpriced pool entry otherwise, so it is reported rather than guessed at.
     zero_cost_rows: int = 0
+    # True when EVERY scored episode was unpriced, which makes `cost_per_completed_task_usd`
+    # exactly $0 and any saving against it read as -100%. A typed flag rather than a sentence
+    # in `cost_assumptions`, because a renderer can check a field and cannot check prose.
+    cost_is_unpriced: bool = False
     cost_assumptions: str = Field(min_length=1)
 
 
 class QualityBlock(BaseModel):
-    """Mean reward and task success rate over an arm's scored episodes."""
+    """Mean reward and task success rate, averaged per scenario then across scenarios."""
 
     mean_reward: float
     task_success_rate: float
-    n_scored: int
-    n_excluded: int
+    n_scenarios: int  # what the two means above are averaged over
+    n_scored: int  # scored EPISODES behind those scenarios
+    n_excluded: int  # unscored episodes inside the compared scenarios
 
 
 class LatencyBlock(BaseModel):
-    """Per-task wall seconds, optimizer overhead included."""
+    """Per-task model seconds, optimizer overhead included, environment time excluded.
 
-    p50_s: float
-    p95_s: float
+    Named `_model_s` on purpose: `ScenarioOutcome.call_seconds` is model call time only, so
+    these are not an operator's wall clock (see the module docstring).
+    """
+
+    p50_model_s: float
+    p95_model_s: float
     n_tasks: int
 
 
@@ -276,8 +330,17 @@ class Scorecard(BaseModel):
     latency: LatencyBlock
     anchor_latency: LatencyBlock
 
+    # Spend on scenarios held OUT of the comparison entirely (one side left them unscored, so
+    # neither side's rows for them are aggregated). Distinct from `cost.excluded_cost_usd`,
+    # which is spend on unscored episodes INSIDE the compared scenarios. Both are needed for
+    # the conservation identity in the module docstring: without this bucket, a scenario the
+    # anchor failed to score would take the arm's real (possibly large) spend with it silently.
+    withheld_cost_usd: float = 0.0
+    anchor_withheld_cost_usd: float = 0.0
+
     # Deltas in the D-DIAL sign convention: quality points positive = better, cost percent
-    # negative = cheaper. None when the anchor's own figure is undefined or zero.
+    # negative = cheaper. A percent delta is None when either side's figure is undefined, or
+    # when the anchor's is zero and the ratio would divide by nothing.
     quality_delta_points: float
     cost_delta_percent: float | None
     latency_p50_delta_percent: float | None
@@ -290,6 +353,10 @@ class LadderRung(BaseModel):
     index: int
     scorecard: Scorecard
     dial_position: float | None = None
+    # Whether the ANCHOR is at least as good on all three objectives and strictly better on one,
+    # at the default p50 latency objective. Such a rung bought nothing and is kept off the
+    # frontier (`pareto`). Stored so a serialized ladder says so without recomputation.
+    dominated_by_anchor: bool = False
 
 
 class OperatingPoint(BaseModel):
@@ -306,7 +373,18 @@ class OperatingPoint(BaseModel):
     dial_position: float | None = None
 
     def as_cost_quality_anchor(self) -> CostQualityAnchor:
-        """This point as a D-DIAL anchor row. Requires a measured dial position and cost delta."""
+        """This point as a D-DIAL anchor row. Requires a measured dial position and cost delta.
+
+        Contract the caller must satisfy, which this method cannot check: `CostQualityAnchor`
+        rows state their deltas against the BEST SINGLE POOL MODEL on the same held-out split
+        (see `wmo.optimize.knn`). A ladder anchor is whatever arm the caller passed, so convert
+        only when that anchor IS the best single pool model. Mixing a differently-anchored row
+        into `COST_QUALITY_ANCHORS` would put two baselines on one frontier.
+
+        Raises:
+            ValueError: when this point has no measured dial position, or when its cost delta is
+                undefined because one side completed no task.
+        """
         if self.dial_position is None:
             raise ValueError(
                 f"operating point '{self.name}' has no dial position, so it cannot become a "
@@ -316,9 +394,10 @@ class OperatingPoint(BaseModel):
             )
         if self.cost_delta_percent is None:
             raise ValueError(
-                f"operating point '{self.name}' has no cost delta (its anchor completed no "
-                f"tasks, so there is no cost to compare against); it cannot become a "
-                f"CostQualityAnchor"
+                f"operating point '{self.name}' has no cost delta: one side of its scorecard "
+                f"completed no task, so there is no cost per completed task to compare and the "
+                f"ratio is undefined. Rerun that side's failed episodes, or drop this rung from "
+                f"the dial rather than publishing a point with no measured saving."
             )
         return CostQualityAnchor(
             cost_quality=self.dial_position,
@@ -342,17 +421,28 @@ class Ladder(BaseModel):
     anchor_condition: ConditionLabel
     scenarios_compared: int  # the common set every rung and the anchor were scored on
     scenarios_excluded: int  # scenarios some side left unscored, held out of the whole ladder
-    rungs: list[LadderRung]
+    rungs: list[LadderRung] = Field(min_length=1)
 
     def pareto(self, *, latency: LatencyObjective = "p50") -> list[LadderRung]:
         """The non-dominated rungs, in ladder order.
 
         Rung A dominates rung B when A is no worse on all three objectives (reward higher, cost
-        per completed task lower, latency lower) and strictly better on at least one. Rungs whose
-        cost per completed task is undefined (nothing completed) cannot be placed on the frontier
-        and are omitted; they remain in `rungs`.
+        per completed task lower, latency lower) and strictly better on at least one. Floats
+        within `DOMINANCE_TOLERANCE` count as equal, so two genuinely tied rungs both stay on
+        the frontier.
+
+        Two kinds of rung never appear. One whose cost per completed task is undefined (nothing
+        completed) cannot be placed on a cost axis at all. One the ANCHOR dominates bought
+        nothing: it is not an operating point a reader should be offered, and including it would
+        let a ladder advertise a frontier the untouched baseline beats. Both remain in `rungs`.
+        An empty result is the honest answer that no rung improved on the anchor.
         """
-        placed = [r for r in self.rungs if r.scorecard.cost.cost_per_completed_task_usd is not None]
+        placed = [
+            rung
+            for rung in self.rungs
+            if rung.scorecard.cost.cost_per_completed_task_usd is not None
+            and not _anchor_dominates(rung.scorecard, latency)
+        ]
         return [
             rung
             for rung in placed
@@ -398,6 +488,12 @@ def rows_for_policy(
     matrix: no episode is rerun, and the routed arm is measured on exactly the rows the pool
     already produced.
 
+    When the policy routes a scenario to a model the matrix never measured there, this emits an
+    UNSCORED placeholder row rather than nothing. Dropping it would shrink the routed arm's
+    scenario set invisibly, which is the same silent-narrowing bug `build_ladder`'s common set
+    exists to prevent, and it would make the arm disagree with `evaluate_policy`, which counts
+    that case as `unscored_scenarios`.
+
     Args:
         matrix: the precomputed pool x scenario grid.
         policy: the routing policy this rung represents.
@@ -411,12 +507,27 @@ def rows_for_policy(
     """
     wanted = list(ids) if ids is not None else matrix.scenario_ids()
     decisions = route_scenarios(policy, matrix, wanted, embedder=embedder)
-    return [
-        row
-        for scenario_id, decision in decisions.items()
-        for row in matrix.for_scenario(scenario_id)
-        if row.model == decision.model
-    ]
+
+    rows: list[ScenarioOutcome] = []
+    for scenario_id, decision in decisions.items():
+        scenario_rows = matrix.for_scenario(scenario_id)
+        chosen = [row for row in scenario_rows if row.model == decision.model]
+        if chosen:
+            rows.extend(chosen)
+            continue
+        rows.append(
+            ScenarioOutcome(
+                scenario_id=scenario_id,
+                task=scenario_rows[0].task if scenario_rows else "",
+                model=decision.model,
+                reward=None,
+                error=(
+                    f"policy routed to '{decision.model}', which the matrix never measured on "
+                    f"this scenario; the choice is unmeasured, not failed"
+                ),
+            )
+        )
+    return rows
 
 
 def effective_cost_per_completed_task(
@@ -440,7 +551,13 @@ def effective_cost_per_completed_task(
 
     Returns:
         An `EffectiveCost` whose `cost_per_completed_task_usd` is None when nothing completed.
+
+    Raises:
+        ValueError: when an overhead names an episode absent from `rows`. Ignoring it would
+            understate effective cost, so this matches the identical guard on `Arm`.
     """
+    _require_overheads_match(rows, overheads, owner="these rows")
+
     by_row: dict[tuple[str, str, int], list[RowOverhead]] = {}
     for overhead in overheads:
         by_row.setdefault(_overhead_key(overhead), []).append(overhead)
@@ -463,6 +580,7 @@ def effective_cost_per_completed_task(
     n_completed = sum(1 for row in scored if completion.completed(row))
     total = provider_cost + overhead_cost
     per_task = total / n_completed if n_completed else None
+    unpriced = bool(scored) and provider_cost == 0.0 and zero_cost == len(scored)
 
     return EffectiveCost(
         n_scored=len(scored),
@@ -475,6 +593,7 @@ def effective_cost_per_completed_task(
         cost_per_completed_task_usd=per_task,
         overhead_components=components,
         zero_cost_rows=zero_cost,
+        cost_is_unpriced=unpriced,
         cost_assumptions=_assumptions(
             components=components,
             completion=completion,
@@ -482,6 +601,7 @@ def effective_cost_per_completed_task(
             excluded_cost=excluded_cost,
             n_completed=n_completed,
             zero_cost=zero_cost,
+            unpriced=unpriced,
         ),
     )
 
@@ -498,7 +618,8 @@ def build_scorecard(
     Both sides are aggregated over the intersection of scenarios scored on BOTH sides, for the
     reason report.py states: unscored episodes are not random, so per-side means over different
     subsets let an arm that times out on the hard scenarios out-score an anchor that answered
-    everything.
+    everything. Spend on the scenarios that drop out is reported in `withheld_cost_usd` rather
+    than vanishing.
 
     Args:
         arm: the condition under test.
@@ -550,6 +671,8 @@ def build_scorecard(
     anchor_quality = _quality(anchor_kept, completion)
     latency = _latency(arm_kept, arm_overhead)
     anchor_latency = _latency(anchor_kept, anchor_overhead)
+    withheld = _withheld_cost(arm, kept)
+    anchor_withheld = _withheld_cost(anchor, kept)
 
     return Scorecard(
         arm=arm.name,
@@ -566,12 +689,22 @@ def build_scorecard(
         anchor_cost=anchor_cost,
         latency=latency,
         anchor_latency=anchor_latency,
+        withheld_cost_usd=withheld,
+        anchor_withheld_cost_usd=anchor_withheld,
         quality_delta_points=(quality.mean_reward - anchor_quality.mean_reward) * 100.0,
         cost_delta_percent=_percent_delta(
             cost.cost_per_completed_task_usd, anchor_cost.cost_per_completed_task_usd
         ),
-        latency_p50_delta_percent=_percent_delta(latency.p50_s, anchor_latency.p50_s),
-        cost_assumptions=cost.cost_assumptions,
+        latency_p50_delta_percent=_percent_delta(latency.p50_model_s, anchor_latency.p50_model_s),
+        cost_assumptions=_card_assumptions(
+            arm=arm.name,
+            anchor=anchor.name,
+            cost=cost,
+            anchor_cost=anchor_cost,
+            scenarios_excluded=len(all_ids) - len(compared),
+            withheld=withheld,
+            anchor_withheld=anchor_withheld,
+        ),
     )
 
 
@@ -593,17 +726,24 @@ def build_ladder(
     scenarios that drop out are counted on the ladder, not discarded quietly.
 
     Raises:
-        ValueError: when `arms` is empty, when two arms share a name, when two arms (or an arm
-            and the anchor) share a condition label, or when no scenario was scored by the anchor
-            and every rung. A collision means two rungs are the same experiment under different
-            display names, which is how ablation results get silently overwritten.
+        ValueError: when `arms` is empty, when two arms share a name or a condition label, when
+            an arm collides with the anchor on either, or when no scenario was scored by the
+            anchor and every rung. A label collision means two rungs are the same experiment
+            under different display names, which is how ablation results get silently
+            overwritten.
     """
     if not arms:
         raise ValueError(f"ladder '{name}' needs at least one arm besides the anchor")
 
-    seen_names = {anchor.name: "anchor"}
+    seen_names: dict[str, str] = {}
     seen_keys = {anchor.condition.key(): anchor.name}
     for arm in arms:
+        if arm.name == anchor.name:
+            raise ValueError(
+                f"ladder '{name}': rung '{arm.name}' has the same name as the anchor; every "
+                f"scorecard names the anchor it was measured against, so the rung and the "
+                f"anchor need distinct names"
+            )
         if arm.name in seen_names:
             raise ValueError(
                 f"ladder '{name}': two rungs are both named '{arm.name}'; rung names are the "
@@ -629,9 +769,7 @@ def build_ladder(
     for arm in arms:
         _require_comparable(arm, anchor)
         arm_rows = _by_scenario(arm.rows)
-        for sid in arm_rows:
-            if sid not in common and sid not in universe:
-                universe.append(sid)
+        universe.extend(sid for sid in arm_rows if sid not in universe)
         common &= set(_pairwise_scored(arm_rows, anchor_rows, universe))
     if not common:
         raise ValueError(
@@ -642,31 +780,54 @@ def build_ladder(
         )
     ordered = [sid for sid in universe if sid in common]
 
+    rungs: list[LadderRung] = []
+    for index, arm in enumerate(arms):
+        card = build_scorecard(arm=arm, anchor=anchor, completion=completion, restrict_to=ordered)
+        rungs.append(
+            LadderRung(
+                index=index,
+                scorecard=card,
+                dial_position=arm.dial_position,
+                dominated_by_anchor=_anchor_dominates(card, "p50"),
+            )
+        )
     return Ladder(
         name=name,
         anchor=anchor.name,
         anchor_condition=anchor.condition,
         scenarios_compared=len(ordered),
         scenarios_excluded=len(universe) - len(ordered),
-        rungs=[
-            LadderRung(
-                index=index,
-                scorecard=build_scorecard(
-                    arm=arm, anchor=anchor, completion=completion, restrict_to=ordered
-                ),
-                dial_position=arm.dial_position,
-            )
-            for index, arm in enumerate(arms)
-        ],
+        rungs=rungs,
     )
 
 
 def _row_key(row: ScenarioOutcome) -> tuple[str, str, int]:
+    """The episode identity overhead is charged against."""
     return (row.scenario_id, row.model, row.episode)
 
 
 def _overhead_key(overhead: RowOverhead) -> tuple[str, str, int]:
+    """The episode an overhead claims to belong to; matched against `_row_key`."""
     return (overhead.scenario_id, overhead.model, overhead.episode)
+
+
+def _require_overheads_match(
+    rows: Sequence[ScenarioOutcome], overheads: Sequence[RowOverhead], *, owner: str
+) -> None:
+    """Reject overhead that names an episode absent from `rows`.
+
+    Silently ignoring an unmatched key would understate effective cost, which is exactly the
+    direction of error this module exists to prevent, so both entry points (the `Arm` validator
+    and `effective_cost_per_completed_task`) run this same check.
+    """
+    keys = {_row_key(row) for row in rows}
+    orphans = sorted({str(_overhead_key(o)) for o in overheads if _overhead_key(o) not in keys})
+    if orphans:
+        raise ValueError(
+            f"{owner}: overhead rows name episodes not present here: {orphans[:5]}; keys are "
+            f"(scenario_id, model, episode) and must match the rows they are charged to, so "
+            f"attach the overhead to the episodes it was actually spent on"
+        )
 
 
 def _pairwise_scored(
@@ -684,27 +845,64 @@ def _pairwise_scored(
 
 
 def _by_scenario(rows: Sequence[ScenarioOutcome]) -> dict[str, list[ScenarioOutcome]]:
+    """Group rows by scenario id, preserving first-seen scenario order."""
     grouped: dict[str, list[ScenarioOutcome]] = {}
     for row in rows:
         grouped.setdefault(row.scenario_id, []).append(row)
     return grouped
 
 
+def _withheld_cost(arm: Arm, kept: set[str]) -> float:
+    """What `arm` spent on scenarios held out of the comparison, overhead included."""
+    overhead_by_row: dict[tuple[str, str, int], float] = {}
+    for overhead in arm.overheads:
+        key = _overhead_key(overhead)
+        overhead_by_row[key] = overhead_by_row.get(key, 0.0) + overhead.cost_usd
+    return sum(
+        row.cost_usd + overhead_by_row.get(_row_key(row), 0.0)
+        for row in arm.rows
+        if row.scenario_id not in kept
+    )
+
+
 def _quality(rows: Sequence[ScenarioOutcome], completion: CompletionRule) -> QualityBlock:
+    """Mean reward and success rate, averaged within each scenario then across scenarios.
+
+    Per-scenario first (see the module docstring): an arm that ran three episodes on an easy
+    scenario and one on a hard one would otherwise weight the easy scenario three times against
+    an anchor that ran one of each.
+    """
     scored = [row for row in rows if row.reward is not None]
-    rewards = [row.reward for row in scored if row.reward is not None]
+    by_scenario = _by_scenario(scored)
+    scenario_rewards: list[float] = []
+    scenario_success: list[float] = []
+    for scenario_rows in by_scenario.values():
+        rewards = [row.reward for row in scenario_rows if row.reward is not None]
+        scenario_rewards.append(sum(rewards) / len(rewards))
+        scenario_success.append(
+            sum(1.0 for row in scenario_rows if completion.completed(row)) / len(scenario_rows)
+        )
+    # 0.0 on empty is unreachable through `build_scorecard`, which raises before it can pass an
+    # unscored-only side; kept total rather than raising in a helper no caller can trip.
     return QualityBlock(
-        mean_reward=sum(rewards) / len(rewards) if rewards else 0.0,
-        task_success_rate=(
-            sum(1 for row in scored if completion.completed(row)) / len(scored) if scored else 0.0
-        ),
+        mean_reward=sum(scenario_rewards) / len(scenario_rewards) if scenario_rewards else 0.0,
+        task_success_rate=sum(scenario_success) / len(scenario_success)
+        if scenario_success
+        else 0.0,
+        n_scenarios=len(by_scenario),
         n_scored=len(scored),
         n_excluded=sum(1 for row in rows if row.reward is None),
     )
 
 
 def _latency(rows: Sequence[ScenarioOutcome], overheads: Sequence[RowOverhead]) -> LatencyBlock:
-    """Per-task seconds over scored rows: the episode's own calls plus its optimizer overhead."""
+    """Per-task model seconds over scored rows: the episode's calls plus its optimizer overhead.
+
+    p95 uses the INCLUSIVE quantile method, which is bounded by the observed data. The default
+    exclusive method extrapolates past the sample at the small n an ablation runs on: three
+    tasks at 1s, 1s and 9s report a p95 of 15.4s, a tail longer than anything measured, and p95
+    is a supported Pareto dominance coordinate.
+    """
     by_row: dict[tuple[str, str, int], float] = {}
     for overhead in overheads:
         key = _overhead_key(overhead)
@@ -714,10 +912,10 @@ def _latency(rows: Sequence[ScenarioOutcome], overheads: Sequence[RowOverhead]) 
         for row in rows
         if row.reward is not None
     ]
-    if not per_task:
-        return LatencyBlock(p50_s=0.0, p95_s=0.0, n_tasks=0)
-    p95 = quantiles(per_task, n=20)[-1] if len(per_task) > 1 else per_task[0]
-    return LatencyBlock(p50_s=median(per_task), p95_s=p95, n_tasks=len(per_task))
+    if not per_task:  # unreachable via `build_scorecard`, as in `_quality`
+        return LatencyBlock(p50_model_s=0.0, p95_model_s=0.0, n_tasks=0)
+    p95 = quantiles(per_task, n=20, method="inclusive")[-1] if len(per_task) > 1 else per_task[0]
+    return LatencyBlock(p50_model_s=median(per_task), p95_model_s=p95, n_tasks=len(per_task))
 
 
 def _percent_delta(value: float | None, anchor: float | None) -> float | None:
@@ -727,20 +925,55 @@ def _percent_delta(value: float | None, anchor: float | None) -> float | None:
     return (value - anchor) / anchor * 100.0
 
 
+def _no_worse(x: float, y: float) -> bool:
+    """Whether `x` is at least as good as `y` on a lower-is-better axis, ties included."""
+    return x <= y or isclose(x, y, rel_tol=DOMINANCE_TOLERANCE)
+
+
+def _strictly_better(x: float, y: float) -> bool:
+    """Whether `x` beats `y` on a lower-is-better axis by more than float noise."""
+    return x < y and not isclose(x, y, rel_tol=DOMINANCE_TOLERANCE)
+
+
+def _objectives(card: Scorecard, latency: LatencyObjective) -> tuple[float, float, float]:
+    """The arm's three objectives, all as lower-is-better numbers."""
+    cost = card.cost.cost_per_completed_task_usd
+    if cost is None:  # guarded by every caller; keeps the tuple total
+        raise ValueError(f"scorecard '{card.arm}' has no cost per completed task to compare")
+    lat = card.latency.p50_model_s if latency == "p50" else card.latency.p95_model_s
+    return (-card.quality.mean_reward, cost, lat)
+
+
+def _anchor_objectives(card: Scorecard, latency: LatencyObjective) -> tuple[float, float, float]:
+    """The same three objectives for the card's anchor side."""
+    cost = card.anchor_cost.cost_per_completed_task_usd
+    if cost is None:
+        raise ValueError(f"scorecard '{card.arm}' has no anchor cost per completed task")
+    lat = card.anchor_latency.p50_model_s if latency == "p50" else card.anchor_latency.p95_model_s
+    return (-card.anchor_quality.mean_reward, cost, lat)
+
+
+def _pareto_dominates(
+    better: tuple[float, float, float], worse: tuple[float, float, float]
+) -> bool:
+    """Whether `better` is no worse on all three axes and strictly better on at least one."""
+    pairs = tuple(zip(better, worse, strict=True))
+    return all(_no_worse(x, y) for x, y in pairs) and any(_strictly_better(x, y) for x, y in pairs)
+
+
 def _dominates(a: LadderRung, b: LadderRung, latency: LatencyObjective) -> bool:
     """Whether rung `a` is no worse than `b` on all three objectives and better on one."""
-    a_cost = a.scorecard.cost.cost_per_completed_task_usd
-    b_cost = b.scorecard.cost.cost_per_completed_task_usd
-    if a_cost is None or b_cost is None:  # unreachable: `pareto` filters these out first
+    return _pareto_dominates(_objectives(a.scorecard, latency), _objectives(b.scorecard, latency))
+
+
+def _anchor_dominates(card: Scorecard, latency: LatencyObjective) -> bool:
+    """Whether the anchor beats this arm outright, making the rung a non-operating-point."""
+    if (
+        card.cost.cost_per_completed_task_usd is None
+        or card.anchor_cost.cost_per_completed_task_usd is None
+    ):
         return False
-    a_lat = a.scorecard.latency.p50_s if latency == "p50" else a.scorecard.latency.p95_s
-    b_lat = b.scorecard.latency.p50_s if latency == "p50" else b.scorecard.latency.p95_s
-    pairs = (
-        (b.scorecard.quality.mean_reward, a.scorecard.quality.mean_reward),  # higher is better
-        (a_cost, b_cost),  # lower is better
-        (a_lat, b_lat),
-    )
-    return all(x <= y for x, y in pairs) and any(x < y for x, y in pairs)
+    return _pareto_dominates(_anchor_objectives(card, latency), _objectives(card, latency))
 
 
 def _require_comparable(arm: Arm, anchor: Arm) -> None:
@@ -780,6 +1013,13 @@ def _require_comparable(arm: Arm, anchor: Arm) -> None:
         )
 
 
+def _usd(amount: float) -> str:
+    """Format dollars so a nonzero figure never renders as $0.0000 in an honesty string."""
+    if 0.0 < amount < 0.0001:
+        return "less than $0.0001"
+    return f"${amount:.4f}"
+
+
 def _assumptions(
     *,
     components: Sequence[str],
@@ -788,6 +1028,7 @@ def _assumptions(
     excluded_cost: float,
     n_completed: int,
     zero_cost: int,
+    unpriced: bool,
 ) -> str:
     """Compose the basis sentence from what the rows actually contained."""
     parts = [EFFECTIVE_COST_RULE]
@@ -807,17 +1048,53 @@ def _assumptions(
         )
     if n_excluded:
         parts.append(
-            f"{n_excluded} unscored episode(s) were excluded, along with ${excluded_cost:.4f} of "
-            f"spend that no completed task is charged for."
+            f"{n_excluded} unscored episode(s) were excluded, along with {_usd(excluded_cost)} "
+            f"of spend that no completed task is charged for."
         )
     if not n_completed:
         parts.append(
             "No task completed, so there is no cost per completed task to quote and the figure "
             "is reported as undefined rather than as zero."
         )
-    if zero_cost:
+    if unpriced:
+        parts.append(
+            "Every scored episode recorded tokens but $0, so the cost per completed task is $0 "
+            "and any saving against it would read as -100%. Treat the cost figures as absent, "
+            "not as free, unless this arm really did run on hardware you do not pay per token "
+            "for."
+        )
+    elif zero_cost:
         parts.append(
             f"{zero_cost} scored episode(s) recorded tokens but $0, which is expected for a "
             f"self-hosted model and otherwise means a pool entry carried no price."
+        )
+    return " ".join(parts)
+
+
+def _card_assumptions(
+    *,
+    arm: str,
+    anchor: str,
+    cost: EffectiveCost,
+    anchor_cost: EffectiveCost,
+    scenarios_excluded: int,
+    withheld: float,
+    anchor_withheld: float,
+) -> str:
+    """Both sides' bases plus what the comparison itself held out.
+
+    A card states a DELTA over two sides, so quoting only the arm's basis would hide an anchor
+    that went unscored on half its episodes.
+    """
+    parts = [
+        f"Arm '{arm}': {cost.cost_assumptions}",
+        f"Anchor '{anchor}': {anchor_cost.cost_assumptions}",
+    ]
+    if scenarios_excluded:
+        parts.append(
+            f"{scenarios_excluded} scenario(s) were held out of this comparison because one "
+            f"side left them unscored, taking {_usd(withheld)} of arm spend and "
+            f"{_usd(anchor_withheld)} of anchor spend with them; that money bought no "
+            f"comparable measurement."
         )
     return " ".join(parts)

--- a/wmo/optimize/scorecard_test.py
+++ b/wmo/optimize/scorecard_test.py
@@ -1,0 +1,541 @@
+"""Tests for the three-objective scorecard and the ablation ladder.
+
+Pure offline aggregation over synthetic outcome matrices: no provider, no judge, no spend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.scorecard import (
+    Arm,
+    CompletionRule,
+    ConditionLabel,
+    OperatingPoint,
+    RowOverhead,
+    build_ladder,
+    build_scorecard,
+    effective_cost_per_completed_task,
+    rows_for_model,
+)
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry
+
+_BASE = ConditionLabel(
+    base_model="qwen3-8b",
+    optimizer="none",
+    dataset="tau-bench-retail",
+    split="test",
+    judge="tau2-verifier",
+    provenance="real_episode",
+)
+
+
+def _row(
+    sid: str,
+    model: str,
+    *,
+    reward: float | None,
+    cost: float = 0.01,
+    seconds: list[float] | None = None,
+    episode: int = 0,
+    tokens: int = 100,
+) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=sid,
+        task=f"task for {sid}",
+        model=model,
+        episode=episode,
+        reward=reward,
+        success=reward is not None and reward >= 0.5,
+        usage=TokenUsage(input_tokens=tokens, output_tokens=tokens // 2),
+        cost_usd=cost,
+        call_seconds=seconds if seconds is not None else [0.5, 0.5],
+        error=None if reward is not None else "sandbox timeout",
+    )
+
+
+def _arm(name: str, rows: list[ScenarioOutcome], **axes: str | int) -> Arm:
+    return Arm(name=name, condition=_BASE.replace(optimizer=name, **axes), rows=rows)
+
+
+# --- effective cost: exclusion semantics -------------------------------------------------
+
+
+def test_unscored_rows_leave_both_numerator_and_denominator() -> None:
+    rows = [
+        _row("s1", "m", reward=1.0, cost=0.10),
+        _row("s2", "m", reward=0.0, cost=0.10),
+        _row("s3", "m", reward=None, cost=0.10),  # infrastructure failure, not a 0
+    ]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert cost.n_scored == 2
+    assert cost.n_excluded == 1
+    assert cost.n_completed == 1
+    # The unscored row's $0.10 is out of the numerator but visible, never silently dropped.
+    assert cost.provider_cost_usd == pytest.approx(0.20)
+    assert cost.excluded_cost_usd == pytest.approx(0.10)
+    assert cost.cost_per_completed_task_usd == pytest.approx(0.20)
+    assert "unscored episode(s) were excluded" in cost.cost_assumptions
+
+
+def test_no_completed_tasks_reports_undefined_not_zero_or_infinity() -> None:
+    cost = effective_cost_per_completed_task([_row("s1", "m", reward=0.0, cost=0.10)])
+
+    assert cost.n_scored == 1
+    assert cost.n_completed == 0
+    assert cost.cost_per_completed_task_usd is None
+    assert cost.total_cost_usd == pytest.approx(0.10)
+    assert "reported as undefined rather than as zero" in cost.cost_assumptions
+
+
+def test_overhead_is_added_to_the_numerator_and_named_in_the_basis() -> None:
+    rows = [_row("s1", "m", reward=1.0, cost=0.10), _row("s2", "m", reward=1.0, cost=0.10)]
+    overheads = [
+        RowOverhead(scenario_id="s1", model="m", component="compressor", cost_usd=0.01),
+        RowOverhead(scenario_id="s1", model="m", component="router", cost_usd=0.002),
+        RowOverhead(scenario_id="s2", model="m", component="compressor", cost_usd=0.01),
+    ]
+    cost = effective_cost_per_completed_task(rows, overheads=overheads)
+
+    assert cost.provider_cost_usd == pytest.approx(0.20)
+    assert cost.overhead_cost_usd == pytest.approx(0.022)
+    assert cost.total_cost_usd == pytest.approx(0.222)
+    assert cost.cost_per_completed_task_usd == pytest.approx(0.111)
+    assert cost.overhead_components == ["compressor", "router"]
+    assert "compressor, router" in cost.cost_assumptions
+
+
+def test_overhead_on_an_unscored_row_is_excluded_with_it() -> None:
+    rows = [_row("s1", "m", reward=1.0, cost=0.10), _row("s2", "m", reward=None, cost=0.10)]
+    overheads = [
+        RowOverhead(scenario_id="s1", model="m", component="compressor", cost_usd=0.01),
+        RowOverhead(scenario_id="s2", model="m", component="compressor", cost_usd=0.05),
+    ]
+    cost = effective_cost_per_completed_task(rows, overheads=overheads)
+
+    assert cost.overhead_cost_usd == pytest.approx(0.01)
+    assert cost.excluded_cost_usd == pytest.approx(0.15)
+
+
+def test_reward_threshold_completion_rule_changes_the_denominator() -> None:
+    # `success` is False on both rows (reward < 0.5), so the flag rule completes nothing while a
+    # partial-credit rubric threshold completes one.
+    rows = [_row("s1", "m", reward=0.4, cost=0.10), _row("s2", "m", reward=0.1, cost=0.10)]
+
+    flag = effective_cost_per_completed_task(rows)
+    assert flag.n_completed == 0
+    assert flag.cost_per_completed_task_usd is None
+
+    rubric = effective_cost_per_completed_task(
+        rows, completion=CompletionRule(kind="reward_at_least", threshold=0.3)
+    )
+    assert rubric.n_completed == 1
+    assert rubric.cost_per_completed_task_usd == pytest.approx(0.20)
+    assert "verified reward is at least 0.3" in rubric.cost_assumptions
+
+
+def test_priced_tokens_recorded_at_zero_dollars_are_surfaced() -> None:
+    rows = [_row("s1", "m", reward=1.0, cost=0.0, tokens=1000)]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert cost.zero_cost_rows == 1
+    assert "recorded tokens but $0" in cost.cost_assumptions
+
+
+def test_overhead_naming_an_episode_the_arm_lacks_is_rejected() -> None:
+    with pytest.raises(ValueError, match="overhead rows name episodes this arm does not contain"):
+        Arm(
+            name="a",
+            condition=_BASE,
+            rows=[_row("s1", "m", reward=1.0)],
+            overheads=[
+                RowOverhead(scenario_id="s9", model="m", component="compressor", cost_usd=1.0)
+            ],
+        )
+
+
+# --- scorecard: same scenarios, comparability --------------------------------------------
+
+
+def test_scorecard_compares_only_scenarios_scored_on_both_sides() -> None:
+    # s3 is scored for the arm and unscored for the anchor, so it leaves the comparison; a
+    # per-side mean would have let the arm bank an easy win the anchor never got graded on.
+    arm = _arm(
+        "distill",
+        [
+            _row("s1", "student", reward=1.0, cost=0.01),
+            _row("s2", "student", reward=0.0, cost=0.01),
+            _row("s3", "student", reward=1.0, cost=0.01),
+        ],
+    )
+    anchor = _arm(
+        "teacher",
+        [
+            _row("s1", "teacher", reward=1.0, cost=0.10),
+            _row("s2", "teacher", reward=1.0, cost=0.10),
+            _row("s3", "teacher", reward=None, cost=0.10),
+        ],
+        base_model="glm-5.2",
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.scenarios_compared == 2
+    assert card.scenarios_excluded == 1
+    assert card.quality.mean_reward == pytest.approx(0.5)
+    assert card.anchor_quality.mean_reward == pytest.approx(1.0)
+    assert card.quality_delta_points == pytest.approx(-50.0)
+    # One completed of two on the arm at $0.01 each; two of two on the anchor at $0.10 each.
+    assert card.cost.cost_per_completed_task_usd == pytest.approx(0.02)
+    assert card.anchor_cost.cost_per_completed_task_usd == pytest.approx(0.10)
+    assert card.cost_delta_percent == pytest.approx(-80.0)
+    assert card.provenance == "real_episode"
+    assert card.judge == "tau2-verifier"
+
+
+def test_scorecard_raises_when_no_scenario_is_scored_on_both_sides() -> None:
+    arm = _arm("distill", [_row("s1", "student", reward=1.0), _row("s2", "student", reward=None)])
+    anchor = _arm(
+        "teacher",
+        [_row("s1", "teacher", reward=None), _row("s2", "teacher", reward=1.0)],
+        base_model="glm-5.2",
+    )
+    with pytest.raises(ValueError, match="share no scenario scored on BOTH sides"):
+        build_scorecard(arm=arm, anchor=anchor)
+
+
+def test_simulated_arm_never_silently_scores_against_a_real_anchor() -> None:
+    arm = Arm(
+        name="distill",
+        condition=_BASE.replace(optimizer="distill", provenance="wm_simulated"),
+        rows=[_row("s1", "student", reward=1.0)],
+    )
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),  # real_episode
+        rows=[_row("s1", "teacher", reward=1.0)],
+    )
+    with pytest.raises(ValueError, match="provenance='wm_simulated'"):
+        build_scorecard(arm=arm, anchor=anchor)
+
+
+@pytest.mark.parametrize("axis", ["judge", "dataset", "split"])
+def test_mismatched_comparability_axes_raise(axis: str) -> None:
+    arm = _arm("distill", [_row("s1", "student", reward=1.0)])
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2", **{axis: "other"}),
+        rows=[_row("s1", "teacher", reward=1.0)],
+    )
+    with pytest.raises(ValueError, match=f"{axis}='other'"):
+        build_scorecard(arm=arm, anchor=anchor)
+
+
+def test_arm_and_anchor_with_the_same_condition_label_raise() -> None:
+    rows_a = [_row("s1", "student", reward=1.0)]
+    rows_b = [_row("s1", "teacher", reward=1.0)]
+    arm = Arm(name="a", condition=_BASE, rows=rows_a)
+    anchor = Arm(name="b", condition=_BASE, rows=rows_b)
+    with pytest.raises(ValueError, match="carry the SAME condition label"):
+        build_scorecard(arm=arm, anchor=anchor)
+
+
+def test_latency_is_per_task_and_includes_optimizer_overhead() -> None:
+    arm = Arm(
+        name="compact",
+        condition=_BASE.replace(optimizer="compact"),
+        rows=[
+            _row("s1", "student", reward=1.0, seconds=[1.0, 1.0]),
+            _row("s2", "student", reward=1.0, seconds=[2.0]),
+        ],
+        overheads=[
+            RowOverhead(scenario_id="s1", model="student", component="compressor", latency_s=0.5),
+            RowOverhead(scenario_id="s2", model="student", component="compressor", latency_s=0.5),
+        ],
+    )
+    anchor = _arm(
+        "teacher",
+        [
+            _row("s1", "teacher", reward=1.0, seconds=[3.0]),
+            _row("s2", "teacher", reward=1.0, seconds=[3.0]),
+        ],
+        base_model="glm-5.2",
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    # Per task: s1 = 1.0 + 1.0 + 0.5 = 2.5, s2 = 2.0 + 0.5 = 2.5. A per-CALL p50 would have
+    # read 1.0 here and understated the arm against the anchor's single 3.0s call.
+    assert card.latency.p50_s == pytest.approx(2.5)
+    assert card.latency.n_tasks == 2
+    assert card.anchor_latency.p50_s == pytest.approx(3.0)
+    assert card.latency_p50_delta_percent == pytest.approx((2.5 - 3.0) / 3.0 * 100.0)
+
+
+# --- ladder: label collisions and Pareto --------------------------------------------------
+
+
+def _ladder_arm(
+    name: str, *, reward: float, cost: float, seconds: float, dial: float | None = None
+) -> Arm:
+    return Arm(
+        name=name,
+        condition=_BASE.replace(optimizer=name),
+        rows=[
+            _row(f"s{i}", name, reward=reward, cost=cost, seconds=[seconds]) for i in range(1, 3)
+        ],
+        dial_position=dial,
+    )
+
+
+def _anchor_arm(
+    *, reward: float = 1.0, cost: float = 0.10, seconds: float = 3.0, scenarios: int = 2
+) -> Arm:
+    return Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),
+        rows=[
+            _row(f"s{i}", "teacher", reward=reward, cost=cost, seconds=[seconds])
+            for i in range(1, scenarios + 1)
+        ],
+    )
+
+
+def test_ladder_rejects_colliding_condition_labels() -> None:
+    # Two rungs whose displayed names differ but whose experimental axes are identical: the
+    # failure mode that cost the GEPA program runs.
+    first = Arm(
+        name="+routing", condition=_BASE.replace(optimizer="d"), rows=[_row("s1", "m", reward=1.0)]
+    )
+    second = Arm(
+        name="+compaction",
+        condition=_BASE.replace(optimizer="d"),
+        rows=[_row("s1", "m", reward=1.0)],
+    )
+    with pytest.raises(ValueError, match="carry the SAME condition label"):
+        build_ladder("joint-tau", anchor=_anchor_arm(), arms=[first, second])
+
+
+def test_ladder_rejects_duplicate_rung_names() -> None:
+    a = Arm(name="same", condition=_BASE.replace(optimizer="a"), rows=[_row("s1", "m", reward=1.0)])
+    b = Arm(name="same", condition=_BASE.replace(optimizer="b"), rows=[_row("s1", "m", reward=1.0)])
+    with pytest.raises(ValueError, match="two rungs are both named 'same'"):
+        build_ladder("joint-tau", anchor=_anchor_arm(), arms=[a, b])
+
+
+def test_ladder_rejects_a_rung_colliding_with_the_anchor() -> None:
+    anchor = _anchor_arm()
+    clash = Arm(name="rung", condition=anchor.condition, rows=[_row("s1", "m", reward=1.0)])
+    with pytest.raises(ValueError, match="carry the SAME condition label"):
+        build_ladder("joint-tau", anchor=anchor, arms=[clash])
+
+
+def test_every_rung_is_measured_on_one_common_scenario_set() -> None:
+    # The hole a pairwise-only intersection leaves: `patchy` goes unscored on s1 (the scenario it
+    # fails) and would otherwise be graded on {s2, s3} while `full` is graded on {s1, s2, s3},
+    # handing `patchy` a Pareto win it did not earn. The ladder must narrow BOTH to {s2, s3}.
+    anchor = _anchor_arm(scenarios=3)
+    full = Arm(
+        name="full",
+        condition=_BASE.replace(optimizer="full"),
+        rows=[
+            _row("s1", "full", reward=0.0, cost=0.01),
+            _row("s2", "full", reward=1.0, cost=0.01),
+            _row("s3", "full", reward=1.0, cost=0.01),
+        ],
+    )
+    patchy = Arm(
+        name="patchy",
+        condition=_BASE.replace(optimizer="patchy"),
+        rows=[
+            _row("s1", "patchy", reward=None, cost=0.01),
+            _row("s2", "patchy", reward=1.0, cost=0.01),
+            _row("s3", "patchy", reward=1.0, cost=0.01),
+        ],
+    )
+    ladder = build_ladder("joint-tau", anchor=anchor, arms=[full, patchy])
+
+    assert ladder.scenarios_compared == 2
+    assert ladder.scenarios_excluded == 1
+    assert {rung.scorecard.scenarios_compared for rung in ladder.rungs} == {2}
+    # Both rungs now read 1.0 on the shared pair, so neither buys a quality edge from an
+    # exclusion. Without the common set `full` would have read 2/3 against `patchy`'s 2/2.
+    assert [rung.scorecard.quality.mean_reward for rung in ladder.rungs] == [1.0, 1.0]
+    # A standalone pairwise scorecard still reports the wider, un-narrowed comparison.
+    assert build_scorecard(arm=full, anchor=anchor).scenarios_compared == 3
+
+
+def test_ladder_raises_when_no_scenario_is_common_to_every_rung() -> None:
+    anchor = _anchor_arm(scenarios=2)
+    first = Arm(
+        name="a",
+        condition=_BASE.replace(optimizer="a"),
+        rows=[_row("s1", "a", reward=1.0), _row("s2", "a", reward=None)],
+    )
+    second = Arm(
+        name="b",
+        condition=_BASE.replace(optimizer="b"),
+        rows=[_row("s1", "b", reward=None), _row("s2", "b", reward=1.0)],
+    )
+    with pytest.raises(ValueError, match="no scenario was scored by anchor"):
+        build_ladder("joint-tau", anchor=anchor, arms=[first, second])
+
+
+def test_ladder_needs_at_least_one_rung() -> None:
+    with pytest.raises(ValueError, match="needs at least one arm besides the anchor"):
+        build_ladder("joint-tau", anchor=_anchor_arm(), arms=[])
+
+
+def test_pareto_front_on_a_hand_built_matrix() -> None:
+    # Objectives are (mean reward up, cost per completed task down, latency down).
+    #   cheap-fast : 0.5 reward, $0.02/task, 1.0s  -> best on cost and latency
+    #   balanced   : 0.8 reward, $0.05/task, 2.0s  -> best on nothing alone, dominated by nobody
+    #   dominated  : 0.5 reward, $0.06/task, 3.0s  -> worse than cheap-fast on all three
+    #   best-quality: 1.0 reward, $0.09/task, 4.0s -> best on quality
+    arms = [
+        _ladder_arm("cheap-fast", reward=0.5, cost=0.01, seconds=1.0),
+        _ladder_arm("balanced", reward=0.8, cost=0.025, seconds=2.0),
+        _ladder_arm("dominated", reward=0.5, cost=0.03, seconds=3.0),
+        _ladder_arm("best-quality", reward=1.0, cost=0.045, seconds=4.0),
+    ]
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=arms)
+
+    assert [rung.index for rung in ladder.rungs] == [0, 1, 2, 3]
+    assert [rung.scorecard.arm for rung in ladder.pareto()] == [
+        "cheap-fast",
+        "balanced",
+        "best-quality",
+    ]
+
+
+def test_pareto_omits_rungs_whose_cost_per_completed_task_is_undefined() -> None:
+    completes = _ladder_arm("completes", reward=1.0, cost=0.01, seconds=1.0)
+    # Scored, cheap, and fast, but nothing completed: it cannot sit on a cost frontier at all.
+    never_completes = _ladder_arm("never-completes", reward=0.0, cost=0.001, seconds=0.1)
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=[completes, never_completes])
+
+    assert len(ladder.rungs) == 2
+    assert [rung.scorecard.arm for rung in ladder.pareto()] == ["completes"]
+
+
+def test_pareto_can_dominate_on_p95_instead_of_p50() -> None:
+    steady = Arm(
+        name="steady",
+        condition=_BASE.replace(optimizer="steady"),
+        rows=[_row(f"s{i}", "steady", reward=1.0, cost=0.01, seconds=[1.0]) for i in range(1, 4)],
+    )
+    # Identical p50 and cheaper, but one very slow tail episode: only the p95 objective sees it
+    # (three tasks, so the 9.0s outlier moves p95 to 15.4s and leaves the median at 1.0s).
+    spiky = Arm(
+        name="spiky",
+        condition=_BASE.replace(optimizer="spiky"),
+        rows=[
+            _row("s1", "spiky", reward=1.0, cost=0.005, seconds=[1.0]),
+            _row("s2", "spiky", reward=1.0, cost=0.005, seconds=[1.0]),
+            _row("s3", "spiky", reward=1.0, cost=0.005, seconds=[9.0]),
+        ],
+    )
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(scenarios=3), arms=[steady, spiky])
+
+    assert ladder.rungs[0].scorecard.latency.p50_s == pytest.approx(1.0)
+    assert ladder.rungs[1].scorecard.latency.p50_s == pytest.approx(1.0)
+    assert ladder.rungs[1].scorecard.latency.p95_s == pytest.approx(15.4)
+
+    # On p50 the two tie on latency and spiky is strictly cheaper, so steady drops off.
+    assert [r.scorecard.arm for r in ladder.pareto(latency="p50")] == ["spiky"]
+    # On p95 steady's tail is better, so neither dominates.
+    assert [r.scorecard.arm for r in ladder.pareto(latency="p95")] == ["steady", "spiky"]
+
+
+def test_operating_points_carry_the_dial_shape_only_when_a_dial_was_measured() -> None:
+    dialed = _ladder_arm("balanced", reward=0.9, cost=0.02, seconds=1.0, dial=0.25)
+    undialed = _ladder_arm("+compaction", reward=1.0, cost=0.01, seconds=0.5)
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=[dialed, undialed])
+
+    points = {p.name: p for p in ladder.operating_points(pareto_only=False)}
+    anchor_row = points["balanced"].as_cost_quality_anchor()
+    assert anchor_row.cost_quality == pytest.approx(0.25)
+    assert anchor_row.named_point == "balanced"
+    assert anchor_row.quality_delta_points == pytest.approx(-10.0)
+    assert anchor_row.cost_delta_percent == pytest.approx(-80.0)
+    # The D-DIAL wire contract the platform reads.
+    assert set(anchor_row.model_dump(by_alias=True)) == {
+        "s",
+        "label",
+        "quality_delta_pt",
+        "cost_delta_pct",
+    }
+
+    with pytest.raises(ValueError, match="has no dial position"):
+        points["+compaction"].as_cost_quality_anchor()
+
+
+def test_operating_point_without_a_cost_delta_refuses_to_become_an_anchor() -> None:
+    point = OperatingPoint(
+        name="p", quality_delta_points=1.0, cost_delta_percent=None, dial_position=0.5
+    )
+    with pytest.raises(ValueError, match="has no cost delta"):
+        point.as_cost_quality_anchor()
+
+
+def test_operating_points_default_to_the_frontier() -> None:
+    good = _ladder_arm("good", reward=1.0, cost=0.01, seconds=1.0)
+    worse = _ladder_arm("worse", reward=0.5, cost=0.02, seconds=2.0)
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=[good, worse])
+
+    assert [p.name for p in ladder.operating_points()] == ["good"]
+    assert [p.name for p in ladder.operating_points(pareto_only=False)] == ["good", "worse"]
+
+
+# --- matrix helper ------------------------------------------------------------------------
+
+
+def test_rows_for_model_selects_one_pool_model_and_names_a_bad_handle() -> None:
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="student",
+                kind=ProviderKind.OPENAI,
+                model="custom-student",
+                tier="open",
+                input_per_mtok=0.1,
+                output_per_mtok=0.2,
+            ),
+            PoolEntry(name="teacher", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        ],
+        outcomes=[
+            _row("s1", "student", reward=1.0),
+            _row("s1", "teacher", reward=1.0),
+            _row("s2", "student", reward=0.0),
+        ],
+    )
+    assert [o.scenario_id for o in rows_for_model(matrix, "student")] == ["s1", "s2"]
+    with pytest.raises(KeyError, match="no pool model named 'ghost'"):
+        rows_for_model(matrix, "ghost")
+
+
+def test_multiple_episodes_of_one_scenario_are_separate_tasks() -> None:
+    rows = [
+        _row("s1", "m", reward=1.0, cost=0.02, episode=0),
+        _row("s1", "m", reward=0.0, cost=0.02, episode=1),
+    ]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert cost.n_scored == 2
+    assert cost.n_completed == 1
+    assert cost.cost_per_completed_task_usd == pytest.approx(0.04)
+
+
+def test_overhead_keys_on_episode_not_just_scenario() -> None:
+    rows = [
+        _row("s1", "m", reward=1.0, cost=0.02, episode=0),
+        _row("s1", "m", reward=1.0, cost=0.02, episode=1),
+    ]
+    overheads = [
+        RowOverhead(scenario_id="s1", model="m", episode=1, component="compressor", cost_usd=0.05)
+    ]
+    cost = effective_cost_per_completed_task(rows, overheads=overheads)
+
+    assert cost.overhead_cost_usd == pytest.approx(0.05)
+    assert cost.cost_per_completed_task_usd == pytest.approx(0.045)

--- a/wmo/optimize/scorecard_test.py
+++ b/wmo/optimize/scorecard_test.py
@@ -10,6 +10,7 @@ import pytest
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
 from wmo.optimize.scorecard import (
+    EFFECTIVE_COST_RULE,
     Arm,
     CompletionRule,
     ConditionLabel,
@@ -149,7 +150,7 @@ def test_priced_tokens_recorded_at_zero_dollars_are_surfaced() -> None:
 
 
 def test_overhead_naming_an_episode_the_arm_lacks_is_rejected() -> None:
-    with pytest.raises(ValueError, match="overhead rows name episodes this arm does not contain"):
+    with pytest.raises(ValueError, match="overhead rows name episodes not present here"):
         Arm(
             name="a",
             condition=_BASE,
@@ -270,9 +271,9 @@ def test_latency_is_per_task_and_includes_optimizer_overhead() -> None:
 
     # Per task: s1 = 1.0 + 1.0 + 0.5 = 2.5, s2 = 2.0 + 0.5 = 2.5. A per-CALL p50 would have
     # read 1.0 here and understated the arm against the anchor's single 3.0s call.
-    assert card.latency.p50_s == pytest.approx(2.5)
+    assert card.latency.p50_model_s == pytest.approx(2.5)
     assert card.latency.n_tasks == 2
-    assert card.anchor_latency.p50_s == pytest.approx(3.0)
+    assert card.anchor_latency.p50_model_s == pytest.approx(3.0)
     assert card.latency_p50_delta_percent == pytest.approx((2.5 - 3.0) / 3.0 * 100.0)
 
 
@@ -391,11 +392,12 @@ def test_ladder_needs_at_least_one_rung() -> None:
 
 
 def test_pareto_front_on_a_hand_built_matrix() -> None:
-    # Objectives are (mean reward up, cost per completed task down, latency down).
-    #   cheap-fast : 0.5 reward, $0.02/task, 1.0s  -> best on cost and latency
-    #   balanced   : 0.8 reward, $0.05/task, 2.0s  -> best on nothing alone, dominated by nobody
-    #   dominated  : 0.5 reward, $0.06/task, 3.0s  -> worse than cheap-fast on all three
-    #   best-quality: 1.0 reward, $0.09/task, 4.0s -> best on quality
+    # Objectives are (mean reward up, cost per completed task down, latency down). Each arm has
+    # two scenarios, both completed, so cost per task equals the per-row cost.
+    #   cheap-fast  : 0.5 reward, $0.010/task, 1.0s -> best on cost and latency
+    #   balanced    : 0.8 reward, $0.025/task, 2.0s -> best on nothing alone, dominated by nobody
+    #   dominated   : 0.5 reward, $0.030/task, 3.0s -> worse than cheap-fast on all three
+    #   best-quality: 1.0 reward, $0.045/task, 4.0s -> best on quality
     arms = [
         _ladder_arm("cheap-fast", reward=0.5, cost=0.01, seconds=1.0),
         _ladder_arm("balanced", reward=0.8, cost=0.025, seconds=2.0),
@@ -429,7 +431,7 @@ def test_pareto_can_dominate_on_p95_instead_of_p50() -> None:
         rows=[_row(f"s{i}", "steady", reward=1.0, cost=0.01, seconds=[1.0]) for i in range(1, 4)],
     )
     # Identical p50 and cheaper, but one very slow tail episode: only the p95 objective sees it
-    # (three tasks, so the 9.0s outlier moves p95 to 15.4s and leaves the median at 1.0s).
+    # (three tasks, so the 9.0s outlier moves p95 to 8.2s and leaves the median at 1.0s).
     spiky = Arm(
         name="spiky",
         condition=_BASE.replace(optimizer="spiky"),
@@ -441,9 +443,9 @@ def test_pareto_can_dominate_on_p95_instead_of_p50() -> None:
     )
     ladder = build_ladder("joint-tau", anchor=_anchor_arm(scenarios=3), arms=[steady, spiky])
 
-    assert ladder.rungs[0].scorecard.latency.p50_s == pytest.approx(1.0)
-    assert ladder.rungs[1].scorecard.latency.p50_s == pytest.approx(1.0)
-    assert ladder.rungs[1].scorecard.latency.p95_s == pytest.approx(15.4)
+    assert ladder.rungs[0].scorecard.latency.p50_model_s == pytest.approx(1.0)
+    assert ladder.rungs[1].scorecard.latency.p50_model_s == pytest.approx(1.0)
+    assert ladder.rungs[1].scorecard.latency.p95_model_s == pytest.approx(8.2)
 
     # On p50 the two tie on latency and spiky is strictly cheaper, so steady drops off.
     assert [r.scorecard.arm for r in ladder.pareto(latency="p50")] == ["spiky"]
@@ -628,3 +630,344 @@ def test_overhead_keys_on_episode_not_just_scenario() -> None:
 
     assert cost.overhead_cost_usd == pytest.approx(0.05)
     assert cost.cost_per_completed_task_usd == pytest.approx(0.045)
+
+
+# --- invariants the mutation pass found unprotected -----------------------------------------
+
+
+def test_effective_cost_rule_is_shipped_verbatim_in_every_basis() -> None:
+    cost = effective_cost_per_completed_task([_row("s1", "m", reward=1.0)])
+    assert EFFECTIVE_COST_RULE in cost.cost_assumptions
+
+
+def test_unscored_episode_inside_a_kept_scenario_is_not_averaged_in_as_zero() -> None:
+    # Invariant #1 at the one place it is reachable: a scenario the anchor scored, where the arm
+    # has one scored episode and one that never returned. Averaging the failure in as 0 would
+    # halve the arm's reward and manufacture a regression out of an infrastructure fault.
+    arm = Arm(
+        name="flaky",
+        condition=_BASE.replace(optimizer="flaky"),
+        rows=[
+            _row("s1", "flaky", reward=1.0, episode=0),
+            _row("s1", "flaky", reward=None, episode=1),
+        ],
+    )
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),
+        rows=[_row("s1", "teacher", reward=1.0)],
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.quality.mean_reward == pytest.approx(1.0)
+    assert card.quality.n_scored == 1
+    assert card.quality.n_excluded == 1
+    assert card.quality.task_success_rate == pytest.approx(1.0)
+    assert card.quality_delta_points == pytest.approx(0.0)
+
+
+def test_quality_is_averaged_per_scenario_not_per_episode() -> None:
+    # The arm ran three episodes on the easy scenario and one on the hard one. Episode-weighted
+    # means would read 0.75 and hand the arm a win it did not earn; scenario-weighted reads 0.5.
+    arm = Arm(
+        name="lopsided",
+        condition=_BASE.replace(optimizer="lopsided"),
+        rows=[
+            _row("easy", "lopsided", reward=1.0, episode=0),
+            _row("easy", "lopsided", reward=1.0, episode=1),
+            _row("easy", "lopsided", reward=1.0, episode=2),
+            _row("hard", "lopsided", reward=0.0, episode=0),
+        ],
+    )
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),
+        rows=[
+            _row("easy", "teacher", reward=1.0),
+            _row("hard", "teacher", reward=0.0),
+        ],
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.quality.mean_reward == pytest.approx(0.5)
+    assert card.quality.n_scenarios == 2
+    assert card.quality.n_scored == 4
+    assert card.quality_delta_points == pytest.approx(0.0)
+
+
+def test_tied_rungs_both_stay_on_the_frontier() -> None:
+    # Strict improvement is what keeps mutual domination from emptying the front. Two rungs
+    # equal on all three objectives dominate nobody, so both belong on it.
+    first = _ladder_arm("tie-a", reward=1.0, cost=0.01, seconds=1.0)
+    second = _ladder_arm("tie-b", reward=1.0, cost=0.01, seconds=1.0)
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=[first, second])
+
+    assert [r.scorecard.arm for r in ladder.pareto()] == ["tie-a", "tie-b"]
+
+
+def test_one_strict_improvement_is_enough_to_dominate() -> None:
+    # Equal on quality and latency, strictly cheaper: that alone removes the costlier rung.
+    cheap = _ladder_arm("cheap", reward=1.0, cost=0.01, seconds=1.0)
+    dear = _ladder_arm("dear", reward=1.0, cost=0.02, seconds=1.0)
+    ladder = build_ladder("joint-tau", anchor=_anchor_arm(), arms=[cheap, dear])
+
+    assert [r.scorecard.arm for r in ladder.pareto()] == ["cheap"]
+
+
+# --- money is conserved ----------------------------------------------------------------------
+
+
+def test_spend_on_scenarios_held_out_of_the_comparison_is_still_reported() -> None:
+    # The arm scored s3 and paid $5.00 there; the anchor left s3 unscored, so the scenario drops
+    # out entirely. Without the withheld bucket that $5.00 would leave no trace on the card,
+    # while n_excluded stayed 0 and the assumptions string claimed a clean accounting.
+    arm = Arm(
+        name="expensive",
+        condition=_BASE.replace(optimizer="expensive"),
+        rows=[
+            _row("s1", "expensive", reward=1.0, cost=0.01),
+            _row("s3", "expensive", reward=1.0, cost=5.00),
+        ],
+    )
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),
+        rows=[
+            _row("s1", "teacher", reward=1.0, cost=0.10),
+            _row("s3", "teacher", reward=None, cost=7.00),
+        ],
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.scenarios_compared == 1
+    assert card.scenarios_excluded == 1
+    assert card.withheld_cost_usd == pytest.approx(5.00)
+    assert card.anchor_withheld_cost_usd == pytest.approx(7.00)
+    assert "held out of this comparison" in card.cost_assumptions
+    # Conservation: nothing either side spent is missing from the card.
+    assert card.cost.total_cost_usd + card.cost.excluded_cost_usd + card.withheld_cost_usd == (
+        pytest.approx(sum(r.cost_usd for r in arm.rows))
+    )
+    assert (
+        card.anchor_cost.total_cost_usd
+        + card.anchor_cost.excluded_cost_usd
+        + card.anchor_withheld_cost_usd
+    ) == pytest.approx(sum(r.cost_usd for r in anchor.rows))
+
+
+def test_scorecard_assumptions_quote_both_sides() -> None:
+    arm = _arm("distill", [_row("s1", "student", reward=1.0)])
+    anchor = _arm(
+        "teacher",
+        [_row("s1", "teacher", reward=1.0), _row("s2", "teacher", reward=None)],
+        base_model="glm-5.2",
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert "Arm 'distill':" in card.cost_assumptions
+    assert "Anchor 'teacher':" in card.cost_assumptions
+
+
+def test_tiny_excluded_spend_never_renders_as_zero_dollars() -> None:
+    rows = [_row("s1", "m", reward=1.0), _row("s2", "m", reward=None, cost=0.00002)]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert "less than $0.0001" in cost.cost_assumptions
+    assert "$0.0000" not in cost.cost_assumptions
+
+
+# --- unpriced arms ----------------------------------------------------------------------------
+
+
+def test_a_wholly_unpriced_arm_is_flagged_not_reported_as_free() -> None:
+    # Every scored row has tokens and $0, so cost per task is $0 and the saving against a priced
+    # anchor reads -100%. The number is arithmetically right and substantively meaningless, so a
+    # renderer needs a field it can branch on, not a sentence it will not parse.
+    arm = Arm(
+        name="unpriced",
+        condition=_BASE.replace(optimizer="unpriced"),
+        rows=[
+            _row("s1", "unpriced", reward=1.0, cost=0.0, tokens=1000),
+            _row("s2", "unpriced", reward=1.0, cost=0.0, tokens=1000),
+        ],
+    )
+    anchor = Arm(
+        name="teacher",
+        condition=_BASE.replace(base_model="glm-5.2"),
+        rows=[
+            _row("s1", "teacher", reward=1.0, cost=0.10),
+            _row("s2", "teacher", reward=1.0, cost=0.10),
+        ],
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.cost.cost_is_unpriced is True
+    assert card.cost_delta_percent == pytest.approx(-100.0)
+    assert "Treat the cost figures as absent, not as free" in card.cost_assumptions
+    assert card.anchor_cost.cost_is_unpriced is False
+
+
+def test_a_partially_priced_arm_is_not_flagged_unpriced() -> None:
+    rows = [
+        _row("s1", "m", reward=1.0, cost=0.0, tokens=1000),
+        _row("s2", "m", reward=1.0, cost=0.01, tokens=1000),
+    ]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert cost.zero_cost_rows == 1
+    assert cost.cost_is_unpriced is False
+
+
+# --- arm hygiene --------------------------------------------------------------------------------
+
+
+def test_duplicate_episode_keys_are_rejected_so_overhead_cannot_double_bill() -> None:
+    with pytest.raises(ValueError, match="share the episode key"):
+        Arm(
+            name="dupe",
+            condition=_BASE,
+            rows=[_row("s1", "m", reward=1.0), _row("s1", "m", reward=1.0)],
+        )
+
+
+@pytest.mark.parametrize("reward", [1.5, -0.5, 8.0])
+def test_rewards_outside_the_unit_interval_are_rejected(reward: float) -> None:
+    with pytest.raises(ValueError, match=r"outside \[0, 1\]"):
+        Arm(name="rubric", condition=_BASE, rows=[_row("s1", "m", reward=reward)])
+
+
+def test_public_effective_cost_rejects_orphan_overhead_like_the_arm_does() -> None:
+    with pytest.raises(ValueError, match="overhead rows name episodes not present here"):
+        effective_cost_per_completed_task(
+            [_row("s1", "m", reward=1.0)],
+            overheads=[
+                RowOverhead(scenario_id="TYPO", model="m", component="router", cost_usd=99.0)
+            ],
+        )
+
+
+def test_condition_label_replace_rejects_an_unknown_axis() -> None:
+    with pytest.raises(ValueError, match="unknown condition axes"):
+        _BASE.replace(optimzer="typo")
+
+
+def test_condition_label_replace_revalidates_the_new_value() -> None:
+    with pytest.raises(ValueError):
+        _BASE.replace(base_model="")
+
+
+# --- the anchor is an operating point too ------------------------------------------------------
+
+
+def test_a_rung_the_anchor_dominates_is_kept_off_the_frontier() -> None:
+    # Worse than the teacher on quality, cost, and latency. Reporting it as a frontier point
+    # would advertise an operating point the untouched baseline beats on every axis.
+    anchor = _anchor_arm(reward=1.0, cost=0.001, seconds=0.5)
+    loser = _ladder_arm("worse-everywhere", reward=0.5, cost=1.0, seconds=9.0)
+    ladder = build_ladder("joint-tau", anchor=anchor, arms=[loser])
+
+    assert ladder.rungs[0].dominated_by_anchor is True
+    assert ladder.pareto() == []
+    assert ladder.operating_points() == []
+    # It is still on the ladder: suppressed from the frontier, not hidden from the report.
+    assert [r.scorecard.arm for r in ladder.rungs] == ["worse-everywhere"]
+
+
+def test_a_rung_that_beats_the_anchor_on_one_axis_stays_on_the_frontier() -> None:
+    anchor = _anchor_arm(reward=1.0, cost=0.10, seconds=3.0)
+    cheaper = _ladder_arm("cheaper", reward=0.9, cost=0.01, seconds=1.0)
+    ladder = build_ladder("joint-tau", anchor=anchor, arms=[cheaper])
+
+    assert ladder.rungs[0].dominated_by_anchor is False
+    assert [r.scorecard.arm for r in ladder.pareto()] == ["cheaper"]
+
+
+# --- restrict_to --------------------------------------------------------------------------------
+
+
+def test_restrict_to_narrows_a_standalone_scorecard() -> None:
+    arm = _arm(
+        "distill",
+        [_row("s1", "student", reward=1.0), _row("s2", "student", reward=0.0)],
+    )
+    anchor = _arm(
+        "teacher",
+        [_row("s1", "teacher", reward=1.0), _row("s2", "teacher", reward=1.0)],
+        base_model="glm-5.2",
+    )
+    assert build_scorecard(arm=arm, anchor=anchor).scenarios_compared == 2
+    narrowed = build_scorecard(arm=arm, anchor=anchor, restrict_to=["s1"])
+    assert narrowed.scenarios_compared == 1
+    assert narrowed.quality.mean_reward == pytest.approx(1.0)
+
+
+def test_restrict_to_that_excludes_everything_raises() -> None:
+    arm = _arm("distill", [_row("s1", "student", reward=1.0)])
+    anchor = _arm("teacher", [_row("s1", "teacher", reward=1.0)], base_model="glm-5.2")
+    with pytest.raises(ValueError, match="share no scored scenario inside"):
+        build_scorecard(arm=arm, anchor=anchor, restrict_to=["nowhere"])
+
+
+# --- routed rungs: unmeasured choices ------------------------------------------------------------
+
+
+def test_a_routed_choice_the_matrix_never_measured_becomes_an_unscored_row() -> None:
+    # The policy sends everything to "strong", but the matrix only measured "strong" on s1.
+    # Emitting nothing for s2 would shrink the routed arm's scenario set invisibly.
+    matrix = OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="cheap",
+                kind=ProviderKind.OPENAI,
+                model="custom-cheap",
+                tier="open",
+                input_per_mtok=0.1,
+                output_per_mtok=0.2,
+            ),
+            PoolEntry(name="strong", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        ],
+        outcomes=[
+            _row("s1", "cheap", reward=0.2),
+            _row("s1", "strong", reward=1.0),
+            _row("s2", "cheap", reward=1.0),
+        ],
+    )
+    policy = RoutingPolicy(kind="static", default_model="strong", pool=matrix.pool)
+    rows = rows_for_policy(matrix, policy)
+
+    assert [(r.scenario_id, r.model, r.reward) for r in rows] == [
+        ("s1", "strong", 1.0),
+        ("s2", "strong", None),
+    ]
+    assert "never measured on this scenario" in (rows[1].error or "")
+    cost = effective_cost_per_completed_task(rows)
+    assert cost.n_excluded == 1
+
+
+def test_cost_delta_is_undefined_when_the_anchor_itself_cost_nothing() -> None:
+    # A free anchor makes the ratio a division by zero. None is the only honest answer; a raw
+    # divide would crash the report and a 0.0 would claim the arm matched a free baseline.
+    arm = Arm(
+        name="priced",
+        condition=_BASE.replace(optimizer="priced"),
+        rows=[_row("s1", "priced", reward=1.0, cost=0.05)],
+    )
+    anchor = Arm(
+        name="free-teacher",
+        condition=_BASE.replace(base_model="local"),
+        rows=[_row("s1", "free-teacher", reward=1.0, cost=0.0, tokens=1000)],
+    )
+    card = build_scorecard(arm=arm, anchor=anchor)
+
+    assert card.anchor_cost.cost_per_completed_task_usd == pytest.approx(0.0)
+    assert card.cost_delta_percent is None
+
+
+def test_an_episode_with_no_tokens_is_not_counted_as_unpriced() -> None:
+    # $0 with zero tokens is an episode that never called the model, not a missing price.
+    # Counting it would let an empty run masquerade as an unpriced pool entry.
+    rows = [_row("s1", "m", reward=1.0, cost=0.0, tokens=0)]
+    cost = effective_cost_per_completed_task(rows)
+
+    assert cost.zero_cost_rows == 0
+    assert cost.cost_is_unpriced is False

--- a/wmo/optimize/scorecard_test.py
+++ b/wmo/optimize/scorecard_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
 from wmo.optimize.scorecard import (
     Arm,
     CompletionRule,
@@ -18,9 +19,11 @@ from wmo.optimize.scorecard import (
     build_scorecard,
     effective_cost_per_completed_task,
     rows_for_model,
+    rows_for_policy,
 )
 from wmo.providers.base import ProviderKind, TokenUsage
 from wmo.providers.pool import PoolEntry
+from wmo.retrieval.embedders import HashingEmbedder
 
 _BASE = ConditionLabel(
     base_model="qwen3-8b",
@@ -513,6 +516,92 @@ def test_rows_for_model_selects_one_pool_model_and_names_a_bad_handle() -> None:
     assert [o.scenario_id for o in rows_for_model(matrix, "student")] == ["s1", "s2"]
     with pytest.raises(KeyError, match="no pool model named 'ghost'"):
         rows_for_model(matrix, "ghost")
+
+
+def _routing_matrix() -> OutcomeMatrix:
+    return OutcomeMatrix(
+        pool=[
+            PoolEntry(
+                name="cheap",
+                kind=ProviderKind.OPENAI,
+                model="custom-cheap",
+                tier="open",
+                input_per_mtok=0.1,
+                output_per_mtok=0.2,
+            ),
+            PoolEntry(name="strong", kind=ProviderKind.ANTHROPIC, model="claude-fable-5"),
+        ],
+        outcomes=[
+            _row("s1", "cheap", reward=0.2, cost=0.001),
+            _row("s1", "strong", reward=1.0, cost=0.050),
+            _row("s2", "cheap", reward=1.0, cost=0.001),
+            _row("s2", "strong", reward=1.0, cost=0.050),
+        ],
+    )
+
+
+def test_rows_for_policy_selects_the_rows_the_policy_would_have_routed_to() -> None:
+    matrix = _routing_matrix()
+    embedder = HashingEmbedder(dim=64)
+    sql, prose = embedder.embed(["task for s1", "task for s2"])
+    policy = RoutingPolicy(
+        kind="rank",
+        default_model="cheap",
+        pool=matrix.pool,
+        embedder=EmbedderSpec(dim=64),
+        top_k_clusters=1,
+        clusters=[
+            ClusterRanking(cluster_id=0, label="hard", centroid=sql, ranking=["strong", "cheap"]),
+            ClusterRanking(cluster_id=1, label="easy", centroid=prose, ranking=["cheap", "strong"]),
+        ],
+    )
+    rows = rows_for_policy(matrix, policy, embedder=embedder)
+
+    # s1 routes to strong, s2 to cheap: one row per scenario, from the model actually chosen.
+    assert [(r.scenario_id, r.model) for r in rows] == [("s1", "strong"), ("s2", "cheap")]
+    # The routed mix beats either single model on effective cost: it buys the expensive model
+    # only where the cheap one fails.
+    routed = effective_cost_per_completed_task(rows)
+    assert routed.n_completed == 2
+    assert routed.cost_per_completed_task_usd == pytest.approx(0.0255)
+    assert effective_cost_per_completed_task(
+        rows_for_model(matrix, "strong")
+    ).cost_per_completed_task_usd == pytest.approx(0.050)
+
+
+def test_rows_for_policy_honors_a_static_policy_and_an_id_subset() -> None:
+    matrix = _routing_matrix()
+    policy = RoutingPolicy(kind="static", default_model="cheap", pool=matrix.pool)
+
+    assert [(r.scenario_id, r.model) for r in rows_for_policy(matrix, policy)] == [
+        ("s1", "cheap"),
+        ("s2", "cheap"),
+    ]
+    assert [r.scenario_id for r in rows_for_policy(matrix, policy, ids=["s2"])] == ["s2"]
+
+
+def test_a_routed_rung_composes_into_a_ladder() -> None:
+    matrix = _routing_matrix()
+    policy = RoutingPolicy(kind="static", default_model="cheap", pool=matrix.pool)
+    routed = Arm(
+        name="+routing",
+        condition=_BASE.replace(optimizer="distill+routing"),
+        rows=rows_for_policy(matrix, policy),
+    )
+    anchor = Arm(
+        name="strong-only",
+        condition=_BASE.replace(base_model="claude-fable-5"),
+        rows=rows_for_model(matrix, "strong"),
+    )
+    ladder = build_ladder("joint-tau", anchor=anchor, arms=[routed])
+
+    assert ladder.scenarios_compared == 2
+    card = ladder.rungs[0].scorecard
+    # Static-to-cheap completes only s2, so its effective cost per completed task is $0.002
+    # against the anchor's $0.050 while quality drops 40 points. Both objectives visible.
+    assert card.cost.n_completed == 1
+    assert card.cost.cost_per_completed_task_usd == pytest.approx(0.002)
+    assert card.quality_delta_points == pytest.approx(-40.0)
 
 
 def test_multiple_episodes_of_one_scenario_are_separate_tasks() -> None:


### PR DESCRIPTION
## Why

The repo has a binding methodology rule with no implementation: **savings are cache-adjusted effective cost per completed task, compressor inference cost and latency included** (D-COMPRESS, stated in the docs and DECISIONS ledgers). Nothing aggregated it.

`report.py`'s `Headline` is the closest thing, and it reports mean cost **per run** against one baseline model. That is a different quantity, and for an ablation it is a misleading one: an arm that fails half its tasks looks cheap per run and is ruinous per completed task.

This adds the aggregation plus the three-objective scorecard that the canonical tau-bench ablation ladder (distill-only, +routing, +compaction) will report through.

## What

`wmo/optimize/scorecard.py`, pure offline aggregation over an `OutcomeMatrix`. No fitting, no rerun of any episode.

1. `effective_cost_per_completed_task(rows, *, overheads=(), completion=...)` returns a typed `EffectiveCost`: cache-adjusted provider spend plus optimizer-side inference, divided by completed tasks. Provider cost is **consumed** from the row's recorded `cost_usd` (priced at record time by `PoolEntry.cost_usd` with its three cache tiers), never re-derived, so negotiated rates survive. Rows with `reward is None` leave both numerator and denominator; their count and their spend are reported.
2. `Scorecard`: quality (mean reward + task success rate), effective cost per completed task, and latency p50/p95, each against a **named anchor arm** on the same scenarios, carrying a `Literal["wm_simulated", "real_episode"]` provenance label and the judge that produced every reward.
3. `Ladder`: ordered named rungs plus Pareto extraction over the three objectives, and named operating points that compose with the D-DIAL `CostQualityAnchor` shape.

### Public surface

```python
cost   = effective_cost_per_completed_task(rows_for_model(matrix, "student"))
card   = build_scorecard(arm=distill_only, anchor=teacher)
ladder = build_ladder("joint-tau", anchor=teacher, arms=[distill, routing, compaction])

ladder.pareto(latency="p50")                             # non-dominated rungs, ladder order
ladder.operating_points()[0].as_cost_quality_anchor()    # -> D-DIAL anchor row
```

Arms are built by `rows_for_model(matrix, model)` for a single model, or `rows_for_policy(matrix, policy)` for a routed mix. A rung is therefore a **config evaluated offline against one existing matrix**: buy the matrix once, then every rung is a lookup.

## The bug that driving it found

Unit tests passed. Then I drove a 60-scenario three-rung ladder end to end per AGENTS rules 11 and 12, and the scenario counts did not match: `distill-only` was compared over 57 scenarios (3 unscored episodes) while `+routing` and `+compaction` used 60.

Each rung correctly enforced "same scenarios" against the anchor **pairwise**, but `pareto()` compares rungs **against each other**. A rung that went unscored on the hard scenarios was being graded on an easier subset than the rung it dominated.

`build_ladder` now holds every rung to one common scenario set, with the counts on the artifact (`Ladder.scenarios_compared` / `scenarios_excluded`). This **changed the front**: `+routing` dropped off once it was held to the same 57. Regression test: `test_every_rung_is_measured_on_one_common_scenario_set`.

## Heads-up for the open routing PRs (#262, #263, #264)

**This PR touches `wmo/optimize/routing.py`.** One extraction, no behavior change:

`evaluate_policy` computed routing decisions and discarded them, and `build_report` carried a second copy of the same replay. Rather than add a third copy for routed ladder rungs, I extracted

```python
route_scenarios(policy, matrix, ids, *, embedder=None) -> dict[str, RoutingDecision]
```

as the single owner of offline policy replay. `evaluate_policy` now scores through it and **its 16 tests pass unmodified**. `rows_for_policy` builds routed rungs on it.

If you own #262/#263/#264 and are editing `evaluate_policy`, this is the conflict to expect. It is a ~40 line diff in that file and the resolution should be mechanical.

## Design decisions and why

**Optimizer overhead is keyed to a row, not carried on `ScenarioOutcome`.** Main has no compression fields; PR #265 (`compress/c3`) already adds `tokens_in_raw`, `tokens_in_compressed`, `compressor_id`, `compressor_version`, `aggressiveness`, `compressor_latency_s`, `compressor_cost_usd`. Redefining them here would collide with that contract. Instead: `RowOverhead(scenario_id, model, episode, component, cost_usd, latency_s)`, supplied on the `Arm`. Two reasons beyond conflict avoidance: it works on matrices recorded before compression existed, and **#265's fields describe a compactor only** while the `+routing` rung needs router overhead too. When #265 lands, the adapter reading its fields into `RowOverhead` is about ten lines. That is the one follow-up this module needs.

**Latency is per task in seconds, not per call in ms as in `report.py`.** Cost per completed task and seconds per task are the pair an operator reasons about; a per-call p95 cannot be compared against a per-task cost. A test pins this: an arm at `[1.0, 1.0]` plus 0.5s overhead reads 2.5s per task, where a per-call p50 would read 1.0s and understate it against a 3.0s anchor.

**Zero completed tasks yields `None`.** Same discipline as `reward is None`: undefined is not zero and not infinity, and quoting either fabricates a number.

**`ConditionLabel` is structured, not a free-text string.** Every experimental axis is a named field, `key()` is the identity, and collisions among rungs (or against the anchor) are rejected. This is the direct answer to the GEPA program losing runs to colliding condition labels.

**Comparability invariants raise rather than merge,** following `evals/grid.py` `merge_results`. A `wm_simulated` arm cannot silently score against a `real_episode` anchor; judge, dataset, and split mismatches also raise. `base_model`, `optimizer`, and `seed` are free to differ, because differing on them is what an ablation is.

**Operating points compose with D-DIAL without faking it.** `as_cost_quality_anchor()` emits the wire shape (`s`, `label`, `quality_delta_pt`, `cost_delta_pct`) but **refuses** when the rung has no measured dial position, rather than synthesizing a coordinate that would read as a measurement.

**Two honesty fields the rule did not ask for but the math needs:** `excluded_cost_usd` (real spend on unscored episodes, so an arm that burns budget on episodes it never scores cannot look cheap) and `zero_cost_rows` (tokens recorded at $0, legitimate for self-hosted and the signature of an unpriced pool entry otherwise). Both surface in the composed `cost_assumptions`, following the `serving/savings.py` discipline that every estimate names its basis.

## Justification ledger

Named consumer for every addition. The two consumers are the **joint-tau ablation ladder** and the **`wmo optimize model` report stage**.

| Addition | Named consumer |
|---|---|
| `effective_cost_per_completed_task`, `EffectiveCost` | ladder's cost axis; report stage's savings figure |
| `Scorecard`, `build_scorecard` | ladder's per-rung artifact; report stage's quality/cost/latency triple |
| `Ladder`, `build_ladder`, `pareto()` | the canonical tau-bench ablation ladder |
| `OperatingPoint.as_cost_quality_anchor()` | platform endpoint config response, which reads `CostQualityAnchor` rows |
| `ConditionLabel` | the ladder's collision invariant; consumed by every rung |
| `RowOverhead`, `CompletionRule`, `Arm` | inputs to the above; `RowOverhead` is fed by the compression track once #265 lands |
| `rows_for_model`, `rows_for_policy` | arm construction in the ladder and the report stage |
| `route_scenarios` (routing.py) | `evaluate_policy` and `rows_for_policy`; removes a duplicated replay |

No CLI command, no new top-level directory, no dependency changes.

## Testing

33 tests inline in `wmo/optimize/scorecard_test.py`, all synthetic fixtures, **zero LLM spend**. Coverage: exclusion semantics for `None` rewards, overhead accounting and orphan rejection, same-scenario enforcement, provenance and comparability raising, the ladder common-scenario invariant, label and name collisions, Pareto correctness on a hand-built matrix (including p50 vs p95 dominance disagreement and undefined-cost omission), operating points and the D-DIAL wire shape, per-task latency, episode-level keying, and the routed-rung path.

## Gates

- `uv run ruff check .` clean
- `uv run ruff format --check` clean
- `uv run ty check` clean
- `uv run pytest -q`: **3670 passed, 17 skipped**

One intermediate full-suite run showed 4 failures in `wmo/harness/pi_runtime_test.py` from a port-bind `OSError`. That file is untouched by this diff and passes 18/18 on repeat; it was a port collision from parallel work on the same machine. Flagging it because it appeared in a run I was using as a gate.

## Not ready to merge yet

Per house rule this does **not** merge until the coordinator runs `/ready-for-merge` (AGENTS rule 13) and Silen has eyeballed it. Opening it for review only.

## Known follow-ups and hazards

1. **`RowOverhead` needs its adapter when #265 merges.** Until then a `+compaction` rung reports provider spend alone, and says so in `cost_assumptions`.
2. **The ladder's common scenario set only shrinks** as rungs are added. Watch `Ladder.scenarios_compared` with flaky infrastructure, and consider whether a rung that scores almost nothing belongs on the ladder.
3. **Default completion is the verifier's binary `success` flag**, not a reward threshold. Partial-credit rubric corpora need `CompletionRule(kind="reward_at_least", threshold=...)` or the denominator is wrong. The choice is stated in every `cost_assumptions` string.
4. **Pareto dominates on p50 by default**, since at ablation sample sizes p95 is often one slow episode. `pareto(latency="p95")` is available and a test shows the two can disagree.
5. **`rows_for_policy` is the only function here that can touch the network** (a non-static policy embeds its queries). Single-model arms stay pure offline.
6. **Latency units differ from `report.py`** deliberately (seconds here, milliseconds there). Do not mix them in one chart.
