### PR TITLE
Promote the real tau2-episode leg onto the pinned eval split

### DIFF
--- a/packages/environment-capture/tau-bench/README.md
+++ b/packages/environment-capture/tau-bench/README.md
@@ -161,6 +161,60 @@ blake2b train/holdout split inline so trace selection matches the world-model si
 standup 1.74s + 10 tool calls, 1.74s total. tau2's env is an in-memory DB, so the comparison here is
 less about speed than about not needing to stand up Sierra's stack at all.
 
+## The real-episode leg (sim-to-real validation)
+
+Everything above compares ONE scenario at a time. `rl/real_episodes.py` is the full leg: it runs
+the whole pinned eval split through real tau2 for every candidate in `.wmo/pool.toml`, so a
+world-model matrix can be checked against the benchmark it is supposed to stand in for.
+
+What makes it a validation leg rather than a second, differently-shaped experiment:
+
+- **Same scenarios as every other tau arm.** Selection comes from `rl/scenarios_eval.jsonl` (the
+  pinned split from `rl/pin_scenarios.py`, seed 4405, ALL of the test split: 20 scenarios, 7
+  airline / 8 retail / 5 telecom). Each pinned line stores the tau2 `user_scenario.instructions`
+  blob verbatim, so it resolves back to a tau2 task id by exact match against the domain's
+  `tasks.json`. A scenario that fails to resolve aborts the run.
+- **`scenario_id` is `"<domain>:<task_id>"`.** Airline and retail both number tasks from "0" and
+  all 50 airline ids collide with retail ids, so bare ids would merge two tasks into one cell.
+- **One environment for every candidate.** The user simulator is part of the environment, so it
+  is pinned (`--user-sim`, default `gpt-5.4-mini`) and both streams pass `{}` LLM args, which
+  drops tau2's default temperature for candidates that reject sampling params.
+- **tau2's reward, never a wmo judge.** Rewards are read from `reward_info.reward` in tau2's
+  `results.json`. Caveat worth carrying into any writeup: tau2's reward is not uniformly
+  deterministic. 7 of the 20 pinned tasks carry `NL_ASSERTION` in their `reward_basis` and tau2
+  scores those with its own NL-assertion judge; every row records `nl_assertion_reward` so the
+  fully deterministic rows (DB / ACTION / COMMUNICATE / ENV_ASSERTION) can be split out.
+- **Our prices, not litellm's.** `cost_usd_pool` prices the recorded token usage at pool rates.
+  litellm does not know our Azure MaaS deployments and reported `agent_cost` 0.0 for FW-GLM-5.2
+  on the verification run; tau2's figures are kept beside ours for audit.
+
+Runs are resumable (rows are appended per batch and keyed by scenario, model, and episode) and
+budgeted (`--budget-usd`, checked between batches, candidates run cheapest-first), so a stop
+leaves a usable partial grid and a rerun buys only what is missing.
+
+```bash
+# from the repo root; needs the Setup venv above (or --capture-dir pointing at an existing clone)
+uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --dry-run
+uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --episodes 2
+uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --write-matrix-only
+```
+
+Outputs land under `.wmo/evals/tau-bench-real/`: `rows.jsonl` (one metered row per episode, with
+per-call latency and both cost figures) and `matrix.json` (an `OutcomeMatrix`, unscored episodes
+left as `reward: null` rather than zeroed).
+
+`rl/sim_to_real.py` then compares that matrix against a world-model one:
+
+```bash
+uv run python packages/environment-capture/tau-bench/rl/sim_to_real.py \
+    --real .wmo/evals/tau-bench-real/rows.jsonl --wm .wmo/evals/tau-bench/matrix.json
+```
+
+It reports rank agreement (Spearman, Kendall, Pearson) over model means, clustered on scenarios
+rather than episodes, plus the paired overlap. **Quote the row count with any correlation**: the
+widely repeated Spearman +0.639 was a 630-row snapshot taken mid-capture, and the finished 720-row
+corpus gives +0.630 raw, +0.743 excluding glm-5.2.
+
 ## License — read before redistributing
 
 [tau²-bench](https://github.com/sierra-research/tau2-bench) is published under **MIT**. The

--- a/packages/environment-capture/tau-bench/rl/README.md
+++ b/packages/environment-capture/tau-bench/rl/README.md
@@ -1,4 +1,17 @@
-# RL smoke harness (tau-bench)
+# tau-bench RL arms: pinned split, smoke harness, real-episode leg
+
+What lives here:
+
+- `pin_scenarios.py` + `scenarios_train.jsonl` / `scenarios_eval.jsonl` / `tools.json`: the
+  pinned split every arm trains and evaluates on (seed 4405). Load the FILES, never re-derive.
+- `smoke.py`: the wmo-side data-path smoke described below.
+- `icl.py`: the in-context-learning arm.
+- `real_episodes.py`: the REAL tau2 leg, running the same pinned eval scenarios through Sierra's
+  benchmark for every pool candidate, scored by tau2's own reward. See
+  [`../README.md`](../README.md) § The real-episode leg.
+- `sim_to_real.py`: rank agreement between a world-model `OutcomeMatrix` and those real rows.
+
+## RL smoke harness (tau-bench)
 
 `smoke.py` exercises every wmo-side data path each downstream training chat will consume
 end-to-end against the real tau-bench world model on Bedrock, at tiny scale (~30 haiku calls,

--- a/packages/environment-capture/tau-bench/rl/real_episodes.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes.py
@@ -1,0 +1,721 @@
+"""Real tau2-bench episodes for the pinned eval split: the sim-to-real leg of the tau benchmark.
+
+Every other matrix in this project scores candidates INSIDE a world model with an LLM judge. This
+one runs Sierra's actual benchmark and takes tau2's own reward (DB state check plus action,
+communicate, and env-assertion checks). Fit on the world-model matrices, validate here.
+
+What makes this the validation leg rather than a second, differently-shaped experiment:
+
+- **Same scenarios.** Selection comes from `scenarios_eval.jsonl`, the pinned eval split every
+  tau arm evaluates on (`pin_scenarios.py`, seed 4405, ALL of the test split). Each pinned
+  scenario carries the tau2 `user_scenario.instructions` blob verbatim, so it resolves back to a
+  tau2 task id by exact match against the domain's `tasks.json`. An unmatched scenario is a hard
+  error: silently running a different task set is exactly the failure this leg exists to rule out.
+- **Same ids.** `scenario_id` is `"<domain>:<task_id>"`, never the bare tau2 id. Airline and
+  retail both number their tasks from "0" and all 50 airline ids collide with retail ids, so bare
+  ids would merge two different tasks into one matrix cell.
+- **One environment for every candidate.** The user simulator is part of the environment, so it is
+  pinned to one cheap model (`--user-sim`, default `gpt-5.4-mini`) for every run. Letting it vary
+  per candidate would change the environment per candidate and make the rewards incomparable.
+  Empty LLM args (`{}`) for both streams drop tau2's default temperature: several pool models
+  reject sampling params, and dropping it everywhere removes a source of cross-model variation
+  rather than only working around the strict ones.
+
+Reward provenance: this leg NEVER runs a wmo judge. It reads `reward_info.reward` out of tau2's
+`results.json` and nothing else. Note that tau2's own reward is not uniformly deterministic:
+7 of the 20 pinned eval tasks carry `NL_ASSERTION` in their `reward_basis`, which tau2 scores with
+its built-in NL-assertion judge. Every row records `nl_assertion_reward` so analysis can split
+the fully deterministic rows (DB / ACTION / COMMUNICATE / ENV_ASSERTION) from the rest.
+
+Cost: `cost_usd_pool` is computed from recorded token usage at OUR pool prices, not taken from
+tau2's `agent_cost`. tau2 gets its number from litellm's price table, which does not know our
+Azure MaaS deployments (measured: it priced Kimi-K2.6 at $0.0197 where the published eastus2
+meters give $0.0351). tau2's figures are kept alongside ours for audit.
+
+Isolation: `wmo` never imports `tau2` (see ../README.md). This shells out to the tau2 CLI in its
+own venv. `--capture-dir` points at the directory holding `tau2-bench/` and `.venv/`; it defaults
+to this benchmark dir, so the README's setup block is all that is needed.
+
+Resumable and budgeted: rows are appended to `rows.jsonl` after every batch and keyed by
+(scenario, model, episode), so a stop or a crash leaves a usable partial grid and a rerun picks up
+exactly what is missing. `--budget-usd` is checked between batches, and models run cheapest-first
+for the same reason.
+
+Run from the repo root:
+
+    uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --dry-run
+    uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --episodes 2
+    uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --write-matrix-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from pydantic import BaseModel, ValidationError
+
+from wmo.core.types import JsonValue
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool
+
+logger = logging.getLogger("tau-real")
+
+_HERE = Path(__file__).resolve().parent
+EVAL_SCENARIOS = _HERE / "scenarios_eval.jsonl"
+DEFAULT_CAPTURE_DIR = _HERE.parent
+DEFAULT_OUT_DIR = Path(".wmo/evals/tau-bench-real")
+
+# The user simulator is environment, not candidate: one cheap model, identical for every run.
+DEFAULT_USER_SIM = "gpt-5.4-mini"
+DEFAULT_BUDGET_USD = 140.0
+DEFAULT_MAX_CONCURRENCY = 4
+BATCH_TIMEOUT_S = 5400
+
+# A realistic agent-side episode mix, used only to order the pool cheapest-first. Ordering by
+# input price alone would let a model with a cheap input rate and an expensive output rate look
+# cheaper than it is.
+_EPISODE_MIX = TokenUsage(input_tokens=30_000, output_tokens=1_000)
+
+# Microsoft fronts two different Azure services and litellm addresses them with DIFFERENT env
+# prefixes (AZURE_* vs AZURE_AI_*). That split is what lets a google-sheets user simulator run
+# against a silen-resource candidate inside one tau2 process without either clobbering the other.
+_AZURE_OPENAI_HOST = ".openai.azure.com"
+_AZURE_AI_HOST = ".services.ai.azure.com"
+
+
+class Tau2Usage(BaseModel):
+    """Per-message token counts as tau2 records them."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
+class Tau2Message(BaseModel):
+    """The fields of a tau2 transcript message this leg meters. Everything else is ignored."""
+
+    role: str = ""
+    content: str | None = None
+    generation_time_seconds: float | None = None
+    tool_calls: list[JsonValue] | None = None
+    usage: Tau2Usage | None = None
+
+
+class Tau2RewardInfo(BaseModel):
+    """tau2's verdict. `reward` is None only when tau2 could not score the episode."""
+
+    reward: float | None = None
+
+
+class Tau2Simulation(BaseModel):
+    """One tau2 episode. Lenient by design: tau2 owns this schema and may extend it."""
+
+    task_id: str = ""
+    duration: float = 0.0
+    termination_reason: str = ""
+    agent_cost: float | None = None
+    user_cost: float | None = None
+    reward_info: Tau2RewardInfo | None = None
+    messages: list[Tau2Message] = []
+
+
+class Tau2Results(BaseModel):
+    """The subset of tau2's `results.json` this leg reads."""
+
+    simulations: list[Tau2Simulation] = []
+
+
+class RealScenario(BaseModel):
+    """One pinned eval scenario, resolved to the tau2 task it was captured from."""
+
+    scenario_id: str  # "<domain>:<task_id>"
+    domain: str
+    task_id: str
+    task: str  # the tau2 user_scenario.instructions blob, verbatim from the pinned split
+    provenance: list[str]  # source trace ids, the pinned split's identity key
+    nl_assertion_reward: bool  # tau2 scores part of this task with its NL-assertion judge
+
+
+class RealEpisodeRow(BaseModel):
+    """One (scenario, candidate, episode) real-benchmark episode, with its meter readings."""
+
+    scenario_id: str
+    domain: str
+    task_id: str
+    task: str
+    provenance: list[str]
+    model: str  # pool entry name
+    route: str  # the litellm route tau2 was given
+    episode: int
+    reward: float | None  # None = unscored (infrastructure failure), never treated as 0
+    nl_assertion_reward: bool
+    termination_reason: str
+    duration_s: float
+    agent_input_tokens: int
+    agent_output_tokens: int
+    user_input_tokens: int
+    user_output_tokens: int
+    cost_usd_pool: float  # authoritative: our pool prices
+    cost_usd_tau2_agent: float | None  # litellm's guess, kept for audit
+    cost_usd_tau2_user: float | None
+    steps: int
+    call_seconds: list[float]
+    replies: list[str]
+    user_sim: str
+
+    @property
+    def key(self) -> tuple[str, str, int]:
+        """The resume key: one row per scenario, candidate, and episode index."""
+        return (self.scenario_id, self.model, self.episode)
+
+
+def domains_dir(capture_dir: Path) -> Path:
+    """The tau2 domain data root inside a capture directory."""
+    return capture_dir / "tau2-bench" / "data" / "tau2" / "domains"
+
+
+def _instructions_key(instructions: object) -> str:
+    return json.dumps(instructions, sort_keys=True, ensure_ascii=False)
+
+
+def _task_index(capture_dir: Path, domain: str) -> dict[str, dict[str, object]]:
+    """Canonical instructions blob -> tau2 task, for one domain's `tasks.json`."""
+    path = domains_dir(capture_dir) / domain / "tasks.json"
+    if not path.is_file():
+        raise SystemExit(
+            f"no tau2 task file at {path}. Clone tau2-bench into the capture dir first "
+            "(see packages/environment-capture/tau-bench/README.md § Setup), or pass "
+            "--capture-dir pointing at an existing clone."
+        )
+    index: dict[str, dict[str, object]] = {}
+    for task in json.loads(path.read_text(encoding="utf-8")):
+        scenario = task.get("user_scenario") or {}
+        index[_instructions_key(scenario.get("instructions") or {})] = task
+    return index
+
+
+def _has_nl_assertion(task: dict[str, object]) -> bool:
+    criteria = task.get("evaluation_criteria")
+    if not isinstance(criteria, dict):
+        return False
+    basis = criteria.get("reward_basis")
+    return isinstance(basis, list) and "NL_ASSERTION" in basis
+
+
+def load_pinned_scenarios(
+    capture_dir: Path, scenarios_path: Path = EVAL_SCENARIOS
+) -> list[RealScenario]:
+    """Resolve every pinned eval scenario to its tau2 task id.
+
+    The pinned split stores the tau2 `user_scenario.instructions` blob verbatim, so the match is
+    exact on canonicalized JSON rather than fuzzy on prose. Any scenario that fails to resolve
+    aborts the run: quietly dropping it would run this leg on a different task set than the world
+    model was evaluated on, which is the one thing a sim-to-real comparison cannot survive.
+
+    Args:
+        capture_dir: Directory holding the `tau2-bench/` clone.
+        scenarios_path: The pinned eval split JSONL.
+
+    Returns:
+        Resolved scenarios, ordered by scenario id.
+
+    Raises:
+        SystemExit: When the task data is missing or a scenario does not resolve.
+    """
+    lines = [
+        line for line in scenarios_path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    indexes: dict[str, dict[str, dict[str, object]]] = {}
+    resolved: list[RealScenario] = []
+    unmatched: list[str] = []
+    for line in lines:
+        pinned = json.loads(line)
+        domain = str(pinned["domain"])
+        if domain not in indexes:
+            indexes[domain] = _task_index(capture_dir, domain)
+        task_text = str(pinned["task"])
+        task = indexes[domain].get(_instructions_key(json.loads(task_text)))
+        if task is None:
+            unmatched.append(f"{domain}/{pinned['provenance'][0]}")
+            continue
+        task_id = str(task["id"])
+        resolved.append(
+            RealScenario(
+                scenario_id=f"{domain}:{task_id}",
+                domain=domain,
+                task_id=task_id,
+                task=task_text,
+                provenance=[str(p) for p in pinned["provenance"]],
+                nl_assertion_reward=_has_nl_assertion(task),
+            )
+        )
+    if unmatched:
+        raise SystemExit(
+            f"{len(unmatched)} pinned eval scenario(s) do not match any tau2 task: "
+            f"{unmatched[:5]}. The tau2 clone's tasks.json has drifted from the corpus the "
+            "split was pinned on; re-pin against the same tau2 revision, or pass --capture-dir "
+            "pointing at the clone the corpus was captured with."
+        )
+    return sorted(resolved, key=lambda s: s.scenario_id)
+
+
+def litellm_route(entry: PoolEntry) -> str:
+    """The litellm model string tau2 needs for a pool entry.
+
+    Raises:
+        SystemExit: When the entry's backend has no tau2/litellm equivalent.
+    """
+    if entry.kind is ProviderKind.ANTHROPIC:
+        return f"anthropic/{entry.model}"
+    if entry.kind is ProviderKind.OPENAI or entry.kind is ProviderKind.OPENAI_RESPONSES:
+        return f"openai/{entry.model}"
+    if entry.kind is ProviderKind.OPENROUTER:
+        return f"openrouter/{entry.model}"
+    if entry.kind is ProviderKind.BEDROCK:
+        return f"bedrock/{entry.model}"
+    if entry.kind is ProviderKind.AZURE_OPENAI:
+        deployment = entry.deployment or entry.model
+        endpoint = entry.endpoint or ""
+        if _AZURE_AI_HOST in endpoint:
+            return f"azure_ai/{deployment}"
+        if _AZURE_OPENAI_HOST in endpoint:
+            return f"azure/{deployment}"
+        # Guessing here would send the request to the wrong service with the wrong credential
+        # variable and surface as an opaque 401 inside tau2.
+        raise SystemExit(
+            f"pool model '{entry.name}' has azure endpoint '{endpoint}', which is neither "
+            f"'*{_AZURE_OPENAI_HOST}' (litellm azure/) nor '*{_AZURE_AI_HOST}' (litellm "
+            "azure_ai/). Set `endpoint` to the account URL so the route can be resolved."
+        )
+    raise SystemExit(
+        f"pool model '{entry.name}' has kind '{entry.kind}', which tau2 cannot call. "
+        "Drop it from the run with --only, or give it an OpenAI-compatible pool entry."
+    )
+
+
+def _credentials(entry: PoolEntry, environ: dict[str, str]) -> dict[str, str]:
+    """The env vars litellm needs to reach one pool entry's account.
+
+    Raises:
+        SystemExit: When the entry names an API key variable that is not set.
+    """
+    route = litellm_route(entry)
+    family = route.split("/", 1)[0]
+    if family == "anthropic":
+        key = environ.get(entry.api_key_env or "ANTHROPIC_API_KEY")
+        if not key:
+            raise SystemExit(
+                f"pool model '{entry.name}' needs {entry.api_key_env or 'ANTHROPIC_API_KEY'} "
+                "in the environment"
+            )
+        return {"ANTHROPIC_API_KEY": key}
+    if family in ("azure", "azure_ai"):
+        variable = entry.api_key_env or (
+            "AZURE_API_KEY" if family == "azure" else "AZURE_AI_API_KEY"
+        )
+        key = environ.get(variable)
+        if not key:
+            raise SystemExit(f"pool model '{entry.name}' needs {variable} in the environment")
+        endpoint = entry.endpoint or ""
+        if family == "azure":
+            return {
+                "AZURE_API_KEY": key,
+                "AZURE_API_BASE": endpoint,
+                "AZURE_API_VERSION": entry.api_version or "2024-10-21",
+            }
+        # The Azure AI inference endpoint litellm calls is the account URL plus /models; pool
+        # entries record the account URL because that is what the wmo provider wants.
+        base = endpoint if endpoint.endswith("/models") else f"{endpoint}/models"
+        return {"AZURE_AI_API_KEY": key, "AZURE_AI_API_BASE": base}
+    if family == "openai":
+        key = environ.get(entry.api_key_env or "OPENAI_API_KEY")
+        if not key:
+            raise SystemExit(
+                f"pool model '{entry.name}' needs {entry.api_key_env or 'OPENAI_API_KEY'} "
+                "in the environment"
+            )
+        return {"OPENAI_API_KEY": key}
+    if family == "openrouter":
+        key = environ.get(entry.api_key_env or "OPENROUTER_API_KEY")
+        if not key:
+            raise SystemExit(
+                f"pool model '{entry.name}' needs {entry.api_key_env or 'OPENROUTER_API_KEY'} "
+                "in the environment"
+            )
+        return {"OPENROUTER_API_KEY": key}
+    return {}  # bedrock reads the ambient AWS profile/role
+
+
+def build_env(
+    capture_dir: Path, agent: PoolEntry, user_sim: PoolEntry, environ: dict[str, str]
+) -> dict[str, str]:
+    """The subprocess environment for one batch: tau2's data dir plus both streams' credentials.
+
+    Raises:
+        SystemExit: When the two streams need the same credential variable with different values
+            (one tau2 process cannot hold two accounts on one Azure family), or when a key is
+            missing.
+    """
+    env = dict(environ)
+    env["TAU2_DATA_DIR"] = str(capture_dir / "tau2-bench" / "data")
+    agent_credentials = _credentials(agent, environ)
+    user_credentials = _credentials(user_sim, environ)
+    for name, value in agent_credentials.items():
+        clash = user_credentials.get(name)
+        if clash is not None and clash != value:
+            raise SystemExit(
+                f"candidate '{agent.name}' and user simulator '{user_sim.name}' both need "
+                f"{name} but with different values. One tau2 process holds one account per "
+                "credential family; pin the user simulator to a model on the candidate's "
+                "account, or run that candidate separately."
+            )
+    env.update(user_credentials)
+    env.update(agent_credentials)
+    return env
+
+
+def batch_command(
+    capture_dir: Path,
+    entry: PoolEntry,
+    user_sim: PoolEntry,
+    domain: str,
+    task_ids: Sequence[str],
+    save_to: str,
+    max_concurrency: int,
+) -> list[str]:
+    """The exact tau2 CLI invocation for one (candidate, domain) batch."""
+    return [
+        str(capture_dir / ".venv" / "bin" / "tau2"),
+        "run",
+        "--domain",
+        domain,
+        "--agent-llm",
+        litellm_route(entry),
+        "--agent-llm-args",
+        "{}",
+        "--user-llm",
+        litellm_route(user_sim),
+        "--user-llm-args",
+        "{}",
+        "--num-trials",
+        "1",
+        "--task-ids",
+        *task_ids,
+        "--max-concurrency",
+        str(max_concurrency),
+        "--save-to",
+        save_to,
+    ]
+
+
+def save_to_name(entry: PoolEntry, domain: str, episode: int) -> str:
+    """tau2 `--save-to` slug, unique per candidate, domain, and episode index."""
+    safe = "".join(ch if ch.isalnum() else "_" for ch in entry.name)
+    return f"real_{safe}_{domain}_e{episode}"
+
+
+def _stream_tokens(messages: Sequence[Tau2Message], role: str) -> tuple[int, int]:
+    prompt = completion = 0
+    for message in messages:
+        if message.role != role or message.usage is None:
+            continue
+        prompt += message.usage.prompt_tokens
+        completion += message.usage.completion_tokens
+    return prompt, completion
+
+
+def rows_from_results(
+    results: Tau2Results,
+    entry: PoolEntry,
+    episode: int,
+    by_task_id: dict[str, RealScenario],
+    user_sim: PoolEntry,
+) -> list[RealEpisodeRow]:
+    """Turn one tau2 `results.json` into metered sidecar rows.
+
+    Simulations of tasks outside the pinned split are dropped rather than recorded: tau2 filters
+    by task id already, so their presence would mean the run drifted off the split.
+    """
+    rows: list[RealEpisodeRow] = []
+    for sim in results.simulations:
+        scenario = by_task_id.get(sim.task_id)
+        if scenario is None:
+            logger.warning("  dropping off-split simulation for task %s", sim.task_id)
+            continue
+        agent_in, agent_out = _stream_tokens(sim.messages, "assistant")
+        user_in, user_out = _stream_tokens(sim.messages, "user")
+        assistant = [m for m in sim.messages if m.role == "assistant"]
+        rows.append(
+            RealEpisodeRow(
+                scenario_id=scenario.scenario_id,
+                domain=scenario.domain,
+                task_id=sim.task_id,
+                task=scenario.task,
+                provenance=scenario.provenance,
+                model=entry.name,
+                route=litellm_route(entry),
+                episode=episode,
+                reward=sim.reward_info.reward if sim.reward_info is not None else None,
+                nl_assertion_reward=scenario.nl_assertion_reward,
+                termination_reason=sim.termination_reason,
+                duration_s=sim.duration,
+                agent_input_tokens=agent_in,
+                agent_output_tokens=agent_out,
+                user_input_tokens=user_in,
+                user_output_tokens=user_out,
+                cost_usd_pool=entry.cost_usd(
+                    TokenUsage(input_tokens=agent_in, output_tokens=agent_out)
+                ),
+                cost_usd_tau2_agent=sim.agent_cost,
+                cost_usd_tau2_user=sim.user_cost,
+                steps=sum(1 for m in sim.messages if m.tool_calls),
+                call_seconds=[
+                    m.generation_time_seconds
+                    for m in assistant
+                    if m.generation_time_seconds is not None
+                ],
+                replies=[m.content for m in assistant if m.content],
+                user_sim=user_sim.name,
+            )
+        )
+    return rows
+
+
+def load_rows(path: Path) -> list[RealEpisodeRow]:
+    """Read the resumable sidecar, or an empty list when nothing has run yet."""
+    if not path.exists():
+        return []
+    return [
+        RealEpisodeRow.model_validate_json(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def append_rows(path: Path, rows: Iterable[RealEpisodeRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(row.model_dump_json() + "\n")
+
+
+def spend_usd(rows: Iterable[RealEpisodeRow]) -> float:
+    """Total run cost: our priced candidate side plus tau2's figure for the user simulator."""
+    return sum(row.cost_usd_pool + (row.cost_usd_tau2_user or 0.0) for row in rows)
+
+
+def to_matrix(rows: Sequence[RealEpisodeRow], pool: Sequence[PoolEntry]) -> OutcomeMatrix:
+    """Sidecar rows -> OutcomeMatrix. Rows with no reward stay unscored, never zeroed."""
+    named = {entry.name for entry in pool}
+    outcomes = [
+        ScenarioOutcome(
+            scenario_id=row.scenario_id,
+            task=row.task,
+            model=row.model,
+            episode=row.episode,
+            reward=row.reward,
+            success=row.reward is not None and row.reward >= 1.0,
+            steps=row.steps,
+            stop_reason=row.termination_reason,
+            usage=TokenUsage(
+                input_tokens=row.agent_input_tokens, output_tokens=row.agent_output_tokens
+            ),
+            cost_usd=row.cost_usd_pool,
+            call_seconds=row.call_seconds,
+            replies=row.replies,
+        )
+        for row in rows
+        if row.model in named
+    ]
+    return OutcomeMatrix(pool=list(pool), outcomes=outcomes)
+
+
+def price_order(pool: Sequence[PoolEntry]) -> list[PoolEntry]:
+    """Cheapest candidate first, so a budget stop leaves the widest usable grid."""
+    return sorted(pool, key=lambda entry: entry.cost_usd(_EPISODE_MIX))
+
+
+def _run_batch(
+    command: Sequence[str], capture_dir: Path, save_to: str, env: dict[str, str]
+) -> Tau2Results | None:
+    """Run one tau2 batch and read its results.json back, or None when it produced none.
+
+    A failed batch is reported and skipped rather than raised: earlier batches are already on
+    disk, and the rerun that resumes them will retry exactly this cell.
+    """
+    completed = subprocess.run(
+        list(command),
+        cwd=capture_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=BATCH_TIMEOUT_S,
+        check=False,
+    )
+    results = capture_dir / "tau2-bench" / "data" / "simulations" / save_to / "results.json"
+    if not results.is_file():
+        logger.error("  no results.json (exit %d); stderr tail:", completed.returncode)
+        logger.error("  %s", (completed.stderr or "")[-600:])
+        return None
+    try:
+        return Tau2Results.model_validate_json(results.read_text(encoding="utf-8"))
+    except ValidationError as error:
+        logger.error("  %s does not match the tau2 results schema: %s", results, error)
+        return None
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, default=DEFAULT_CAPTURE_DIR)
+    parser.add_argument("--pool", type=Path, default=DEFAULT_POOL_PATH)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--episodes", type=int, default=1, help="episode indices 0..N-1")
+    parser.add_argument("--only", nargs="*", default=None, help="restrict to these pool names")
+    parser.add_argument(
+        "--scenario",
+        nargs="*",
+        default=None,
+        help="restrict to these '<domain>:<task_id>' scenario ids (smokes and single-cell reruns)",
+    )
+    parser.add_argument("--user-sim", default=DEFAULT_USER_SIM, help="pool name of the user sim")
+    parser.add_argument("--max-concurrency", type=int, default=DEFAULT_MAX_CONCURRENCY)
+    parser.add_argument("--budget-usd", type=float, default=DEFAULT_BUDGET_USD)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="resolve the split and print the tau2 commands"
+    )
+    parser.add_argument(
+        "--write-matrix-only", action="store_true", help="rebuild the matrix from rows.jsonl"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _parse_args(argv)
+    rows_path = args.out_dir / "rows.jsonl"
+    matrix_path = args.out_dir / "matrix.json"
+
+    pool = load_pool(args.pool).models
+    by_name = {entry.name: entry for entry in pool}
+    rows = load_rows(rows_path)
+
+    if args.write_matrix_only:
+        to_matrix(rows, pool).save(matrix_path)
+        logger.info("wrote %s from %d rows", matrix_path, len(rows))
+        return 0
+
+    if args.user_sim not in by_name:
+        logger.error("user simulator '%s' is not in the pool %s", args.user_sim, sorted(by_name))
+        return 2
+    user_sim = by_name[args.user_sim]
+
+    scenarios = load_pinned_scenarios(args.capture_dir)
+    if args.scenario:
+        wanted = set(args.scenario)
+        unknown = sorted(wanted - {s.scenario_id for s in scenarios})
+        if unknown:
+            logger.error("--scenario ids are not in the pinned eval split: %s", unknown)
+            return 2
+        scenarios = [s for s in scenarios if s.scenario_id in wanted]
+    by_domain: dict[str, list[RealScenario]] = {}
+    for scenario in scenarios:
+        by_domain.setdefault(scenario.domain, []).append(scenario)
+    logger.info(
+        "pinned eval split: %d scenarios over %s (%d NL-assertion scored)",
+        len(scenarios),
+        ", ".join(f"{d} {len(v)}" for d, v in sorted(by_domain.items())),
+        sum(1 for s in scenarios if s.nl_assertion_reward),
+    )
+
+    done = {row.key for row in rows}
+    spent = spend_usd(rows)
+    logger.info(
+        "resume: %d rows on disk, $%.2f already spent, budget stop $%.0f",
+        len(rows),
+        spent,
+        args.budget_usd,
+    )
+
+    # The user simulator is the environment, so it is never also measured as a candidate.
+    candidates = [
+        entry
+        for entry in price_order(pool)
+        if entry.name != user_sim.name and (not args.only or entry.name in args.only)
+    ]
+    if not candidates:
+        logger.error(
+            "no candidates left to run: --only %s selects nothing outside the pinned user "
+            "simulator '%s'. Pool models are %s.",
+            args.only,
+            user_sim.name,
+            sorted(by_name),
+        )
+        return 2
+
+    for episode in range(args.episodes):
+        for entry in candidates:
+            for domain, domain_scenarios in sorted(by_domain.items()):
+                missing = [
+                    s for s in domain_scenarios if (s.scenario_id, entry.name, episode) not in done
+                ]
+                if not missing:
+                    continue
+                save_to = save_to_name(entry, domain, episode)
+                command = batch_command(
+                    args.capture_dir,
+                    entry,
+                    user_sim,
+                    domain,
+                    [s.task_id for s in missing],
+                    save_to,
+                    args.max_concurrency,
+                )
+                if args.dry_run:
+                    logger.info("  would run: %s", " ".join(command))
+                    continue
+                if spent >= args.budget_usd:
+                    logger.warning("BUDGET STOP at $%.2f; leaving the grid partial", spent)
+                    to_matrix(load_rows(rows_path), pool).save(matrix_path)
+                    return 0
+                logger.info(
+                    "  %s / %s e%d: %d tasks -> %s",
+                    entry.name,
+                    domain,
+                    episode,
+                    len(missing),
+                    save_to,
+                )
+                env = build_env(args.capture_dir, entry, user_sim, dict(os.environ))
+                payload = _run_batch(command, args.capture_dir, save_to, env)
+                if payload is None:
+                    continue
+                batch = rows_from_results(
+                    payload, entry, episode, {s.task_id: s for s in missing}, user_sim
+                )
+                append_rows(rows_path, batch)
+                done.update(row.key for row in batch)
+                spent += spend_usd(batch)
+                scored = [row.reward for row in batch if row.reward is not None]
+                logger.info(
+                    "  -> %d sims, mean reward %s, running total $%.2f",
+                    len(batch),
+                    f"{sum(scored) / len(scored):.3f}" if scored else "n/a",
+                    spent,
+                )
+
+    if args.dry_run:
+        logger.info("dry run: nothing executed, nothing spent")
+        return 0
+    to_matrix(load_rows(rows_path), pool).save(matrix_path)
+    logger.info("wrote %s; total spend $%.2f", matrix_path, spent)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/environment-capture/tau-bench/rl/real_episodes.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes.py
@@ -58,9 +58,9 @@ import subprocess
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 
-from wmo.core.types import JsonValue
+from wmo.core.types import JsonObject, JsonValue
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.providers.base import ProviderKind, TokenUsage
 from wmo.providers.pool import DEFAULT_POOL_PATH, PoolEntry, load_pool
@@ -90,21 +90,36 @@ _AZURE_OPENAI_HOST = ".openai.azure.com"
 _AZURE_AI_HOST = ".services.ai.azure.com"
 
 
+def _zero_if_null(value: JsonValue) -> JsonValue:
+    """Treat an explicitly null meter as zero: providers omit usage on errored/streamed turns."""
+    return 0 if value is None else value
+
+
 class Tau2Usage(BaseModel):
     """Per-message token counts as tau2 records them."""
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
+    _null_is_zero = field_validator("prompt_tokens", "completion_tokens", mode="before")(
+        _zero_if_null
+    )
+
 
 class Tau2Message(BaseModel):
     """The fields of a tau2 transcript message this leg meters. Everything else is ignored."""
 
     role: str = ""
-    content: str | None = None
+    # Multimodal/structured replies arrive as a list of content blocks rather than a string;
+    # kept as raw JSON so one such message cannot invalidate the episode around it.
+    content: JsonValue = None
     generation_time_seconds: float | None = None
     tool_calls: list[JsonValue] | None = None
     usage: Tau2Usage | None = None
+
+    def text(self) -> str:
+        """The reply as text, or "" when this message carries no plain-string content."""
+        return self.content if isinstance(self.content, str) else ""
 
 
 class Tau2RewardInfo(BaseModel):
@@ -123,6 +138,8 @@ class Tau2Simulation(BaseModel):
     user_cost: float | None = None
     reward_info: Tau2RewardInfo | None = None
     messages: list[Tau2Message] = []
+
+    _null_is_zero = field_validator("duration", mode="before")(_zero_if_null)
 
 
 class Tau2Results(BaseModel):
@@ -180,11 +197,11 @@ def domains_dir(capture_dir: Path) -> Path:
     return capture_dir / "tau2-bench" / "data" / "tau2" / "domains"
 
 
-def _instructions_key(instructions: object) -> str:
+def _instructions_key(instructions: JsonValue) -> str:
     return json.dumps(instructions, sort_keys=True, ensure_ascii=False)
 
 
-def _task_index(capture_dir: Path, domain: str) -> dict[str, dict[str, object]]:
+def _task_index(capture_dir: Path, domain: str) -> dict[str, JsonObject]:
     """Canonical instructions blob -> tau2 task, for one domain's `tasks.json`."""
     path = domains_dir(capture_dir) / domain / "tasks.json"
     if not path.is_file():
@@ -193,14 +210,14 @@ def _task_index(capture_dir: Path, domain: str) -> dict[str, dict[str, object]]:
             "(see packages/environment-capture/tau-bench/README.md § Setup), or pass "
             "--capture-dir pointing at an existing clone."
         )
-    index: dict[str, dict[str, object]] = {}
+    index: dict[str, JsonObject] = {}
     for task in json.loads(path.read_text(encoding="utf-8")):
         scenario = task.get("user_scenario") or {}
         index[_instructions_key(scenario.get("instructions") or {})] = task
     return index
 
 
-def _has_nl_assertion(task: dict[str, object]) -> bool:
+def _has_nl_assertion(task: JsonObject) -> bool:
     criteria = task.get("evaluation_criteria")
     if not isinstance(criteria, dict):
         return False
@@ -228,10 +245,15 @@ def load_pinned_scenarios(
     Raises:
         SystemExit: When the task data is missing or a scenario does not resolve.
     """
+    if not scenarios_path.is_file():
+        raise SystemExit(
+            f"no pinned eval split at {scenarios_path}. Regenerate it with "
+            "`uv run python packages/environment-capture/tau-bench/rl/pin_scenarios.py`."
+        )
     lines = [
         line for line in scenarios_path.read_text(encoding="utf-8").splitlines() if line.strip()
     ]
-    indexes: dict[str, dict[str, dict[str, object]]] = {}
+    indexes: dict[str, dict[str, JsonObject]] = {}
     resolved: list[RealScenario] = []
     unmatched: list[str] = []
     for line in lines:
@@ -240,7 +262,14 @@ def load_pinned_scenarios(
         if domain not in indexes:
             indexes[domain] = _task_index(capture_dir, domain)
         task_text = str(pinned["task"])
-        task = indexes[domain].get(_instructions_key(json.loads(task_text)))
+        try:
+            instructions = json.loads(task_text)
+        except ValueError as error:
+            raise SystemExit(
+                f"pinned scenario {pinned.get('provenance')} has a `task` field that is not the "
+                f"tau2 instructions JSON ({error}). Re-pin the split with pin_scenarios.py."
+            ) from error
+        task = indexes[domain].get(_instructions_key(instructions))
         if task is None:
             unmatched.append(f"{domain}/{pinned['provenance'][0]}")
             continue
@@ -340,7 +369,14 @@ def _credentials(entry: PoolEntry, environ: dict[str, str]) -> dict[str, str]:
                 f"pool model '{entry.name}' needs {entry.api_key_env or 'OPENAI_API_KEY'} "
                 "in the environment"
             )
-        return {"OPENAI_API_KEY": key}
+        credentials = {"OPENAI_API_KEY": key}
+        if entry.endpoint:
+            # A self-hosted OpenAI-compatible server (a Tinker-served student, a local vLLM).
+            # Dropping its endpoint would send this candidate's episodes to api.openai.com
+            # under the wrong key and quietly measure a different model.
+            credentials["OPENAI_API_BASE"] = entry.endpoint
+            credentials["OPENAI_BASE_URL"] = entry.endpoint
+        return credentials
     if family == "openrouter":
         key = environ.get(entry.api_key_env or "OPENROUTER_API_KEY")
         if not key:
@@ -480,7 +516,7 @@ def rows_from_results(
                     for m in assistant
                     if m.generation_time_seconds is not None
                 ],
-                replies=[m.content for m in assistant if m.content],
+                replies=[m.text() for m in assistant if m.text()],
                 user_sim=user_sim.name,
             )
         )
@@ -488,21 +524,41 @@ def rows_from_results(
 
 
 def load_rows(path: Path) -> list[RealEpisodeRow]:
-    """Read the resumable sidecar, or an empty list when nothing has run yet."""
+    """Read the resumable sidecar, or an empty list when nothing has run yet.
+
+    A kill during the append leaves a torn final line. Refusing to load it would brick both the
+    resume and `--write-matrix-only`, losing every episode already bought, so an unreadable line
+    is dropped with a warning instead: its cell simply looks unrun and gets bought again, which
+    costs one episode rather than the whole grid.
+    """
     if not path.exists():
         return []
-    return [
-        RealEpisodeRow.model_validate_json(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    rows: list[RealEpisodeRow] = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            rows.append(RealEpisodeRow.model_validate_json(line))
+        except ValidationError:
+            logger.warning(
+                "  %s line %d is unreadable (torn write?); dropping it, so its cell will be "
+                "treated as unrun and bought again",
+                path,
+                number,
+            )
+    return rows
 
 
 def append_rows(path: Path, rows: Iterable[RealEpisodeRow]) -> None:
+    """Append a batch as ONE write, then fsync, so a kill lands between batches not mid-line."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "".join(row.model_dump_json() + "\n" for row in rows)
+    if not payload:
+        return
     with path.open("a", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(row.model_dump_json() + "\n")
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
 
 
 def spend_usd(rows: Iterable[RealEpisodeRow]) -> float:
@@ -548,26 +604,78 @@ def _run_batch(
 
     A failed batch is reported and skipped rather than raised: earlier batches are already on
     disk, and the rerun that resumes them will retry exactly this cell.
+
+    `--save-to` is deterministic per cell, so a previous attempt may have left a `results.json`
+    at this path. Accepting that file when tau2 dies before rewriting it would append episodes
+    from an OLD run as though this run had just produced them, and the grid would report
+    coverage it never bought. The modification time before the run is therefore the guard: a
+    file that did not change is a leftover, not a result.
     """
-    completed = subprocess.run(
-        list(command),
-        cwd=capture_dir,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=BATCH_TIMEOUT_S,
-        check=False,
-    )
     results = capture_dir / "tau2-bench" / "data" / "simulations" / save_to / "results.json"
+    before = results.stat().st_mtime_ns if results.is_file() else None
+    try:
+        completed = subprocess.run(
+            list(command),
+            cwd=capture_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=BATCH_TIMEOUT_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error("  tau2 exceeded %ds and was killed; skipping this batch", BATCH_TIMEOUT_S)
+        return None
+    except OSError as error:
+        raise SystemExit(
+            f"could not launch tau2 ({error}). Expected the CLI at {command[0]}; create the "
+            "venv per packages/environment-capture/tau-bench/README.md § Setup, or pass "
+            "--capture-dir pointing at an existing clone."
+        ) from error
+
     if not results.is_file():
         logger.error("  no results.json (exit %d); stderr tail:", completed.returncode)
         logger.error("  %s", (completed.stderr or "")[-600:])
         return None
-    try:
-        return Tau2Results.model_validate_json(results.read_text(encoding="utf-8"))
-    except ValidationError as error:
-        logger.error("  %s does not match the tau2 results schema: %s", results, error)
+    if before is not None and results.stat().st_mtime_ns == before:
+        logger.error(
+            "  tau2 exited %d without rewriting %s; refusing to reuse the previous run's "
+            "results. stderr tail:",
+            completed.returncode,
+            results,
+        )
+        logger.error("  %s", (completed.stderr or "")[-600:])
         return None
+    if completed.returncode != 0:
+        # Fresh output from a nonzero exit is a PARTIAL batch: the episodes it holds were paid
+        # for and are worth keeping, and resume will retry whatever is still missing.
+        logger.warning("  tau2 exited %d; keeping the partial batch it wrote", completed.returncode)
+    return _parse_results(results)
+
+
+def _parse_results(results: Path) -> Tau2Results | None:
+    """Read `results.json`, keeping the simulations that validate and naming the ones that fail.
+
+    tau2 owns this schema. Rejecting the whole file over one unexpected field would discard a
+    batch of episodes already paid for, and because `--save-to` is deterministic the rerun would
+    overwrite the evidence, so per-simulation validation is what keeps a schema surprise cheap.
+    """
+    try:
+        payload = json.loads(results.read_text(encoding="utf-8"))
+    except ValueError as error:
+        logger.error("  %s is not valid JSON: %s", results, error)
+        return None
+    simulations = payload.get("simulations") if isinstance(payload, dict) else None
+    if not isinstance(simulations, list):
+        logger.error("  %s has no 'simulations' list", results)
+        return None
+    kept: list[Tau2Simulation] = []
+    for index, raw in enumerate(simulations):
+        try:
+            kept.append(Tau2Simulation.model_validate(raw))
+        except ValidationError as error:
+            logger.error("  dropping simulation %d of %s: %s", index, results, error)
+    return Tau2Results(simulations=kept)
 
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
@@ -614,6 +722,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("user simulator '%s' is not in the pool %s", args.user_sim, sorted(by_name))
         return 2
     user_sim = by_name[args.user_sim]
+
+    # A typo in --only would otherwise be silently ignored and quietly buy a smaller grid than
+    # the operator asked for, which is only discovered after the spend.
+    unknown_models = sorted(set(args.only or []) - set(by_name))
+    if unknown_models:
+        logger.error("--only names models that are not in the pool: %s", unknown_models)
+        return 2
 
     scenarios = load_pinned_scenarios(args.capture_dir)
     if args.scenario:

--- a/packages/environment-capture/tau-bench/rl/real_episodes_test.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes_test.py
@@ -1,0 +1,501 @@
+"""Tests for the real tau2-episode runner: split resolution, routing, metering, resume.
+
+Everything here runs offline. The fake capture directory is synthesized from the REAL committed
+`scenarios_eval.jsonl`, so the split-resolution tests exercise the actual pinned blobs without
+needing the gitignored tau2 clone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from real_episodes import (
+    EVAL_SCENARIOS,
+    RealEpisodeRow,
+    Tau2Results,
+    append_rows,
+    batch_command,
+    build_env,
+    domains_dir,
+    litellm_route,
+    load_pinned_scenarios,
+    load_rows,
+    main,
+    price_order,
+    rows_from_results,
+    save_to_name,
+    spend_usd,
+    to_matrix,
+)
+
+from wmo.providers.base import ProviderKind
+from wmo.providers.pool import PoolEntry
+
+_AZURE_OPENAI = PoolEntry(
+    name="gpt-5.4-mini",
+    kind=ProviderKind.AZURE_OPENAI,
+    model="gpt-5.4-mini",
+    deployment="gpt-5.4-mini",
+    endpoint="https://google-sheets.openai.azure.com",
+    api_key_env="AZURE_GOOGLE_SHEETS_API_KEY",
+    input_per_mtok=0.75,
+    output_per_mtok=3.0,
+)
+_AZURE_AI = PoolEntry(
+    name="glm-5.2",
+    kind=ProviderKind.AZURE_OPENAI,
+    model="FW-GLM-5.2",
+    deployment="FW-GLM-5.2",
+    endpoint="https://silen-resource.services.ai.azure.com",
+    api_key_env="AZURE_SILEN_RESOURCE_API_KEY",
+    tier="open",
+    input_per_mtok=1.54,
+    output_per_mtok=4.84,
+)
+_ANTHROPIC = PoolEntry(
+    name="fable-5",
+    kind=ProviderKind.ANTHROPIC,
+    model="claude-fable-5",
+    input_per_mtok=15.0,
+    output_per_mtok=75.0,
+)
+
+_ENVIRON = {
+    "AZURE_GOOGLE_SHEETS_API_KEY": "sheets-key",
+    "AZURE_SILEN_RESOURCE_API_KEY": "silen-key",
+    "ANTHROPIC_API_KEY": "anthropic-key",
+}
+
+
+def _write_tasks(capture_dir: Path, domain: str, tasks: list[dict[str, object]]) -> None:
+    path = domains_dir(capture_dir) / domain / "tasks.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tasks), encoding="utf-8")
+
+
+def _task(task_id: str, instructions: dict[str, object], basis: list[str]) -> dict[str, object]:
+    return {
+        "id": task_id,
+        "user_scenario": {"instructions": instructions},
+        "evaluation_criteria": {"reward_basis": basis},
+    }
+
+
+def _fake_capture_from_pinned_split(capture_dir: Path) -> list[dict[str, object]]:
+    """Build a tau2 task tree that contains exactly the committed pinned eval scenarios."""
+    pinned = [
+        json.loads(line)
+        for line in EVAL_SCENARIOS.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    by_domain: dict[str, list[dict[str, object]]] = {}
+    for index, row in enumerate(pinned):
+        by_domain.setdefault(str(row["domain"]), []).append(
+            _task(f"t{index}", json.loads(str(row["task"])), ["DB"])
+        )
+    for domain, tasks in by_domain.items():
+        _write_tasks(capture_dir, domain, tasks)
+    return pinned
+
+
+def test_every_committed_pinned_scenario_resolves(tmp_path: Path) -> None:
+    pinned = _fake_capture_from_pinned_split(tmp_path)
+    scenarios = load_pinned_scenarios(tmp_path)
+    assert len(scenarios) == len(pinned)
+    assert all(s.scenario_id == f"{s.domain}:{s.task_id}" for s in scenarios)
+    assert {s.domain for s in scenarios} == {row["domain"] for row in pinned}
+
+
+def test_scenario_ids_disambiguate_colliding_task_ids(tmp_path: Path) -> None:
+    # Airline and retail both number tasks from "0"; bare ids would merge two different
+    # tasks into one matrix cell.
+    airline = {"domain": "airline", "reason_for_call": "cancel"}
+    retail = {"domain": "retail", "reason_for_call": "return"}
+    _write_tasks(tmp_path, "airline", [_task("0", airline, ["DB"])])
+    _write_tasks(tmp_path, "retail", [_task("0", retail, ["DB"])])
+    split = tmp_path / "split.jsonl"
+    split.write_text(
+        json.dumps({"domain": "airline", "provenance": ["a"], "task": json.dumps(airline)})
+        + "\n"
+        + json.dumps({"domain": "retail", "provenance": ["b"], "task": json.dumps(retail)})
+        + "\n",
+        encoding="utf-8",
+    )
+    ids = [s.scenario_id for s in load_pinned_scenarios(tmp_path, split)]
+    assert ids == ["airline:0", "retail:0"]
+
+
+def test_nl_assertion_scoring_is_recorded(tmp_path: Path) -> None:
+    deterministic = {"domain": "airline", "reason_for_call": "a"}
+    judged = {"domain": "airline", "reason_for_call": "b"}
+    _write_tasks(
+        tmp_path,
+        "airline",
+        [
+            _task("0", deterministic, ["DB", "COMMUNICATE"]),
+            _task("1", judged, ["DB", "NL_ASSERTION"]),
+        ],
+    )
+    split = tmp_path / "split.jsonl"
+    split.write_text(
+        "\n".join(
+            json.dumps({"domain": "airline", "provenance": [f"p{i}"], "task": json.dumps(task)})
+            for i, task in enumerate((deterministic, judged))
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    flags = {s.task_id: s.nl_assertion_reward for s in load_pinned_scenarios(tmp_path, split)}
+    assert flags == {"0": False, "1": True}
+
+
+def test_unmatched_pinned_scenario_aborts(tmp_path: Path) -> None:
+    # Running a different task set than the world model was evaluated on is the one failure a
+    # sim-to-real comparison cannot survive, so it must abort rather than silently shrink.
+    _write_tasks(tmp_path, "airline", [_task("0", {"domain": "airline", "x": 1}, ["DB"])])
+    split = tmp_path / "split.jsonl"
+    split.write_text(
+        json.dumps({"domain": "airline", "provenance": ["ghost"], "task": json.dumps({"x": 2})})
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit, match="do not match any tau2 task"):
+        load_pinned_scenarios(tmp_path, split)
+
+
+def test_missing_tau2_clone_says_what_to_do(tmp_path: Path) -> None:
+    split = tmp_path / "split.jsonl"
+    split.write_text(
+        json.dumps({"domain": "airline", "provenance": ["a"], "task": "{}"}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit, match="--capture-dir"):
+        load_pinned_scenarios(tmp_path, split)
+
+
+def test_litellm_route_splits_the_two_azure_families() -> None:
+    assert litellm_route(_AZURE_OPENAI) == "azure/gpt-5.4-mini"
+    assert litellm_route(_AZURE_AI) == "azure_ai/FW-GLM-5.2"
+    assert litellm_route(_ANTHROPIC) == "anthropic/claude-fable-5"
+
+
+def test_unrecognized_azure_endpoint_is_refused() -> None:
+    # Guessing the family would send the call to the wrong service with the wrong credential
+    # variable and surface as an opaque 401 inside tau2.
+    entry = _AZURE_AI.model_copy(update={"endpoint": "https://example.invalid"})
+    with pytest.raises(SystemExit, match="neither"):
+        litellm_route(entry)
+
+
+def test_build_env_carries_both_azure_families(tmp_path: Path) -> None:
+    env = build_env(tmp_path, _AZURE_AI, _AZURE_OPENAI, _ENVIRON)
+    assert env["AZURE_AI_API_KEY"] == "silen-key"
+    assert env["AZURE_AI_API_BASE"] == "https://silen-resource.services.ai.azure.com/models"
+    assert env["AZURE_API_KEY"] == "sheets-key"
+    assert env["TAU2_DATA_DIR"] == str(tmp_path / "tau2-bench" / "data")
+
+
+def test_build_env_rejects_two_accounts_on_one_family(tmp_path: Path) -> None:
+    other = _AZURE_OPENAI.model_copy(
+        update={"name": "gpt-5.5", "api_key_env": "AZURE_SILEN_RESOURCE_API_KEY"}
+    )
+    with pytest.raises(SystemExit, match="AZURE_API_KEY"):
+        build_env(tmp_path, other, _AZURE_OPENAI, _ENVIRON)
+
+
+def test_build_env_names_the_missing_credential(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="AZURE_SILEN_RESOURCE_API_KEY"):
+        build_env(tmp_path, _AZURE_AI, _AZURE_OPENAI, {"AZURE_GOOGLE_SHEETS_API_KEY": "k"})
+
+
+def test_batch_command_pins_the_environment(tmp_path: Path) -> None:
+    command = batch_command(tmp_path, _AZURE_AI, _AZURE_OPENAI, "airline", ["0", "3"], "s", 4)
+    assert command[command.index("--user-llm") + 1] == "azure/gpt-5.4-mini"
+    assert command[command.index("--agent-llm") + 1] == "azure_ai/FW-GLM-5.2"
+    # Empty LLM args drop tau2's default temperature for BOTH streams.
+    assert command[command.index("--agent-llm-args") + 1] == "{}"
+    assert command[command.index("--user-llm-args") + 1] == "{}"
+    assert command[command.index("--num-trials") + 1] == "1"
+    assert command[command.index("--task-ids") + 1 : command.index("--max-concurrency")] == [
+        "0",
+        "3",
+    ]
+
+
+def test_save_to_name_is_unique_per_cell() -> None:
+    assert save_to_name(_AZURE_AI, "airline", 0) == "real_glm_5_2_airline_e0"
+    assert save_to_name(_AZURE_AI, "airline", 1) != save_to_name(_AZURE_AI, "airline", 0)
+
+
+def _results_payload(reward: float | None) -> Tau2Results:
+    reward_info = {"reward": reward} if reward is not None else None
+    return Tau2Results.model_validate(
+        {
+            "simulations": [
+                {
+                    "task_id": "0",
+                    "duration": 42.5,
+                    "termination_reason": "user_stop",
+                    "agent_cost": 0.019,
+                    "user_cost": 0.002,
+                    "reward_info": reward_info,
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": "looking that up",
+                            "generation_time_seconds": 1.5,
+                            "tool_calls": [{"name": "get_user_details"}],
+                            "usage": {"prompt_tokens": 30000, "completion_tokens": 1000},
+                        },
+                        {"role": "user", "usage": {"prompt_tokens": 800, "completion_tokens": 40}},
+                    ],
+                }
+            ]
+        }
+    )
+
+
+def _scenario_index(tmp_path: Path) -> dict[str, object]:
+    task = {"domain": "airline", "reason_for_call": "cancel"}
+    _write_tasks(tmp_path, "airline", [_task("0", task, ["DB", "NL_ASSERTION"])])
+    split = tmp_path / "split.jsonl"
+    split.write_text(
+        json.dumps({"domain": "airline", "provenance": ["p"], "task": json.dumps(task)}) + "\n",
+        encoding="utf-8",
+    )
+    return {s.task_id: s for s in load_pinned_scenarios(tmp_path, split)}
+
+
+def test_rows_from_results_meters_the_episode(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    [row] = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    assert row.scenario_id == "airline:0"
+    assert row.reward == 1.0
+    assert row.nl_assertion_reward is True
+    assert row.duration_s == 42.5
+    assert row.call_seconds == [1.5]
+    assert row.steps == 1
+    assert (row.agent_input_tokens, row.agent_output_tokens) == (30000, 1000)
+    assert (row.user_input_tokens, row.user_output_tokens) == (800, 40)
+    # Our pool prices, not tau2's litellm guess, which is kept alongside for audit.
+    assert row.cost_usd_pool == pytest.approx(30 * 1.54 / 1000 + 1 * 4.84 / 1000)
+    assert row.cost_usd_tau2_agent == 0.019
+    assert row.user_sim == "gpt-5.4-mini"
+
+
+def test_unscored_episode_is_never_zeroed(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    [row] = rows_from_results(_results_payload(None), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    assert row.reward is None
+    [outcome] = to_matrix([row], [_AZURE_AI, _AZURE_OPENAI]).outcomes
+    assert outcome.reward is None
+    assert outcome.scored is False
+    assert outcome.success is False
+
+
+def test_matrix_carries_cost_and_latency(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    [row] = rows_from_results(_results_payload(0.5), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    [outcome] = to_matrix([row], [_AZURE_AI]).outcomes
+    assert outcome.cost_usd == row.cost_usd_pool
+    assert outcome.call_seconds == [1.5]
+    assert outcome.usage.input_tokens == 30000
+
+
+def test_off_split_simulations_are_dropped(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    payload = _results_payload(1.0)
+    payload.simulations[0].task_id = "99"
+    assert rows_from_results(payload, _AZURE_AI, 0, index, _AZURE_OPENAI) == []
+
+
+def test_rows_round_trip_and_resume_keys(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    rows = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    path = tmp_path / "rows.jsonl"
+    append_rows(path, rows)
+    append_rows(path, rows_from_results(_results_payload(0.0), _ANTHROPIC, 1, index, _AZURE_OPENAI))
+    reloaded = load_rows(path)
+    assert {row.key for row in reloaded} == {
+        ("airline:0", "glm-5.2", 0),
+        ("airline:0", "fable-5", 1),
+    }
+    assert spend_usd(reloaded) == pytest.approx(
+        sum(row.cost_usd_pool for row in reloaded) + 2 * 0.002
+    )
+
+
+def test_load_rows_on_a_fresh_run() -> None:
+    assert load_rows(Path("/nonexistent/rows.jsonl")) == []
+
+
+def test_price_order_is_cheapest_first() -> None:
+    ordered = price_order([_ANTHROPIC, _AZURE_AI, _AZURE_OPENAI])
+    assert [entry.name for entry in ordered] == ["gpt-5.4-mini", "glm-5.2", "fable-5"]
+
+
+def _pool_file(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            f"[[model]]\nname = '{e.name}'\nkind = '{e.kind.value}'\nmodel = '{e.model}'\n"
+            + (f"deployment = '{e.deployment}'\n" if e.deployment else "")
+            + (f"endpoint = '{e.endpoint}'\n" if e.endpoint else "")
+            + (f"api_key_env = '{e.api_key_env}'\n" if e.api_key_env else "")
+            + f"input_per_mtok = {e.input_per_mtok}\noutput_per_mtok = {e.output_per_mtok}\n"
+            for e in (_AZURE_OPENAI, _AZURE_AI, _ANTHROPIC)
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_dry_run_resolves_the_split_and_spends_nothing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    with caplog.at_level("INFO", logger="tau-real"):
+        exit_code = main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--only",
+                "glm-5.2",
+                "--dry-run",
+            ]
+        )
+    assert exit_code == 0
+    assert not (tmp_path / "out").exists()  # nothing executed, nothing written
+    printed = caplog.text
+    assert "pinned eval split: 20 scenarios" in printed
+    assert "azure_ai/FW-GLM-5.2" in printed
+    assert "--user-llm azure/gpt-5.4-mini" in printed
+    # The user simulator is environment, so it is never also run as a candidate.
+    assert "--agent-llm azure/gpt-5.4-mini" not in printed
+
+
+def test_scenario_flag_restricts_the_run(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    scenarios = load_pinned_scenarios(tmp_path)
+    wanted = scenarios[0].scenario_id
+    with caplog.at_level("INFO", logger="tau-real"):
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--only",
+                "glm-5.2",
+                "--scenario",
+                wanted,
+                "--dry-run",
+            ]
+        )
+    assert "pinned eval split: 1 scenarios" in caplog.text
+    assert caplog.text.count("would run:") == 1
+
+
+def test_scenario_flag_rejects_ids_outside_the_split(tmp_path: Path) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--scenario",
+                "airline:999",
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_only_selecting_just_the_user_simulator_is_refused(tmp_path: Path) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--only",
+                "gpt-5.4-mini",
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_write_matrix_only_rebuilds_from_rows(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    out = tmp_path / "out"
+    append_rows(
+        out / "rows.jsonl",
+        rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI),
+    )
+    exit_code = main(
+        [
+            "--capture-dir",
+            str(tmp_path),
+            "--pool",
+            str(_pool_file(tmp_path / "pool.toml")),
+            "--out-dir",
+            str(out),
+            "--write-matrix-only",
+        ]
+    )
+    assert exit_code == 0
+    matrix = json.loads((out / "matrix.json").read_text(encoding="utf-8"))
+    assert [o["scenario_id"] for o in matrix["outcomes"]] == ["airline:0"]
+
+
+def test_unknown_user_simulator_is_reported(tmp_path: Path) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--user-sim",
+                "not-in-the-pool",
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_resolves_against_the_real_tau2_clone_when_present() -> None:
+    """End-to-end split resolution against a real clone, when one is available locally."""
+    capture_dir = Path(__file__).resolve().parent.parent
+    if not (domains_dir(capture_dir) / "airline" / "tasks.json").is_file():
+        pytest.skip("no local tau2-bench clone (see ../README.md § Setup)")
+    scenarios = load_pinned_scenarios(capture_dir)
+    assert len(scenarios) == 20
+    assert all(s.task_id for s in scenarios)
+
+
+def test_row_model_rejects_a_missing_meter() -> None:
+    with pytest.raises(ValueError, match="duration_s"):
+        RealEpisodeRow.model_validate({"scenario_id": "airline:0"})

--- a/packages/environment-capture/tau-bench/rl/real_episodes_test.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes_test.py
@@ -499,3 +499,113 @@ def test_resolves_against_the_real_tau2_clone_when_present() -> None:
 def test_row_model_rejects_a_missing_meter() -> None:
     with pytest.raises(ValueError, match="duration_s"):
         RealEpisodeRow.model_validate({"scenario_id": "airline:0"})
+
+
+def test_torn_final_line_does_not_brick_resume(tmp_path: Path) -> None:
+    # A kill during the append leaves a truncated record. Refusing to load it would lose every
+    # episode already bought, including for --write-matrix-only.
+    index = _scenario_index(tmp_path)
+    path = tmp_path / "rows.jsonl"
+    append_rows(path, rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"scenario_id": "airline:0", "domain": "air')  # torn write, no newline
+    rows = load_rows(path)
+    assert len(rows) == 1
+    assert rows[0].reward == 1.0
+
+
+def test_append_rows_writes_a_batch_atomically(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    path = tmp_path / "rows.jsonl"
+    batch = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    append_rows(path, batch * 3)
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 3
+    append_rows(path, [])  # an empty batch must not leave a stray newline
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 3
+
+
+def test_null_token_meters_do_not_lose_the_episode() -> None:
+    # A provider that omits usage on an errored turn serializes nulls; rejecting them would
+    # discard a whole paid batch.
+    results = Tau2Results.model_validate(
+        {
+            "simulations": [
+                {
+                    "task_id": "0",
+                    "duration": None,
+                    "reward_info": {"reward": 1.0},
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "usage": {"prompt_tokens": None, "completion_tokens": 5},
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    [sim] = results.simulations
+    assert sim.duration == 0.0
+    assert sim.messages[0].usage is not None
+    assert sim.messages[0].usage.prompt_tokens == 0
+
+
+def test_structured_content_blocks_do_not_lose_the_episode(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    payload = _results_payload(1.0)
+    payload.simulations[0].messages[0].content = [{"type": "text", "text": "hi"}]
+    [row] = rows_from_results(payload, _AZURE_AI, 0, index, _AZURE_OPENAI)
+    assert row.reward == 1.0
+    assert row.replies == []  # non-string content is not a text reply
+
+
+def test_telecom_task_ids_survive_argv_construction(tmp_path: Path) -> None:
+    # Telecom is 5 of the 20 pinned scenarios and its ids carry | [ ] : characters.
+    telecom_id = (
+        "[mobile_data_issue]airplane_mode_on|bad_network_preference|data_mode_off[PERSONA:Hard]"
+    )
+    command = batch_command(
+        tmp_path, _AZURE_AI, _AZURE_OPENAI, "telecom", [telecom_id], "s", 4
+    )
+    assert command[command.index("--task-ids") + 1] == telecom_id
+
+
+def test_only_rejects_a_model_that_is_not_in_the_pool(tmp_path: Path) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--only",
+                "glm-5.2",
+                "gml-5.2",  # typo
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_self_hosted_openai_endpoint_is_not_dropped(tmp_path: Path) -> None:
+    student = PoolEntry(
+        name="student",
+        kind=ProviderKind.OPENAI,
+        model="qwen3.5-9b",
+        endpoint="https://tinker.example/v1",
+        api_key_env="TINKER_API_KEY",
+        input_per_mtok=0.1,
+        output_per_mtok=0.2,
+    )
+    env = build_env(tmp_path, student, _AZURE_OPENAI, {**_ENVIRON, "TINKER_API_KEY": "tk"})
+    assert env["OPENAI_API_KEY"] == "tk"
+    assert env["OPENAI_BASE_URL"] == "https://tinker.example/v1"
+
+
+def test_missing_pinned_split_says_how_to_regenerate(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="pin_scenarios.py"):
+        load_pinned_scenarios(tmp_path, tmp_path / "absent.jsonl")

--- a/packages/environment-capture/tau-bench/rl/sim_to_real.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real.py
@@ -1,0 +1,297 @@
+"""Sim-to-real: does the world-model tau matrix rank the pool the way real tau2 does?
+
+Two matrices, two very different measurements of the same candidates:
+
+- REAL: `real_episodes.py`'s `rows.jsonl`, Sierra's tau2-bench, tau2's own reward (DB state,
+  action, communicate, and env-assertion checks; NL-assertion tasks additionally use tau2's
+  built-in judge, flagged per row). Binary per episode.
+- WM: an `OutcomeMatrix` produced by `wmo.env.closed_loop`: our world model, LLM judge,
+  continuous.
+
+The headline is rank agreement over MODEL MEANS. When both legs run the same pinned eval split
+(`scenarios_eval.jsonl`), scenario ids line up exactly and the paired comparison is the stronger
+number; when they do not, tasks are matched on a normalized `reason_for_call` and the paired
+overlap is reported as a secondary check.
+
+Sampling unit is the SCENARIO, not the episode: a model is scored several times on each scenario,
+so the SE over per-scenario means (rather than over all episodes) is the one that does not pretend
+two trials of one task are independent draws.
+
+Headline number caveat (read before quoting a correlation): the widely quoted Spearman +0.639 was
+a 630-row snapshot taken mid-capture. On the finished 720-row corpus the same computation gives
++0.630 raw and +0.743 excluding glm-5.2. Quote the row count with the number, always.
+
+`--glm-clean` reruns the correlations with glm-5.2's wm mean recomputed to net out its inline
+tool-call format failures. Two estimators, because the obvious one is biased:
+
+- `clean_only` simply drops the broken episodes. It overstates glm badly: the format failure is
+  concentrated on the HARD scenarios (the other models average 0.23-0.39 on the scenarios where
+  glm inlined both episodes, against 0.59 where it never did), so dropping them also drops the
+  tasks glm would have found hardest.
+- `clean_if_available` keeps every scenario and, for those with one good and one broken episode,
+  scores the scenario on its clean episode only. This is the number to report.
+
+Two `wmo/env/llm_agent.py` changes split world-model matrices into a before and an after, so do
+not pool them:
+
+1. It now parses inline `tool_name({...})` calls and executes them, so matrices built after the
+   change should show `inline%` near zero. The correction arms above exist for older matrices.
+2. Its observation/history cap went from 500 to 2000 characters, which gives the agent strictly
+   more context per turn on tool-heavy domains. A matrix captured before that change measured a
+   different (more starved) agent; recapture rather than mix.
+
+Run from the repo root:
+
+    uv run python packages/environment-capture/tau-bench/rl/sim_to_real.py \\
+        --real .wmo/evals/tau-bench-real/rows.jsonl \\
+        --wm .wmo/evals/tau-bench/matrix.json --glm-clean
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics as st
+from collections.abc import Sequence
+from pathlib import Path
+
+from real_episodes import RealEpisodeRow, load_rows
+from scipy import stats  # present in every wmo install: scikit-learn requires it
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+
+# A tool call the model wrote into its prose instead of emitting as a structured call, e.g.
+# `get_user_details({"user_id": ...})`. Harnesses without the bare-call parser never execute
+# these, so the episode dies.
+INLINE_CALL = re.compile(
+    r"\b(get|list|search|update|cancel|book|modify|return|exchange|transfer|calculate|find|send"
+    r"|think)_?\w*\(\s*[{\"]"
+)
+
+
+def has_inline_call(outcome: ScenarioOutcome) -> bool:
+    return any(INLINE_CALL.search(reply or "") for reply in outcome.replies)
+
+
+def scenario_clustered_stats(
+    values_by_scenario: dict[str, list[float]],
+) -> tuple[float, float, int]:
+    """Mean of per-scenario means, plus the SE of that mean across scenarios."""
+    per_scenario = [st.mean(values) for values in values_by_scenario.values()]
+    mean = st.mean(per_scenario)
+    se = (
+        st.stdev(per_scenario) / len(per_scenario) ** 0.5 if len(per_scenario) > 1 else float("nan")
+    )
+    return mean, se, len(per_scenario)
+
+
+def group_real(rows: Sequence[RealEpisodeRow], model: str) -> dict[str, list[float]]:
+    grouped: dict[str, list[float]] = {}
+    for row in rows:
+        if row.model == model and row.reward is not None:
+            grouped.setdefault(row.scenario_id, []).append(float(row.reward))
+    return grouped
+
+
+def group_wm(outcomes: Sequence[ScenarioOutcome], model: str) -> dict[str, list[float]]:
+    grouped: dict[str, list[float]] = {}
+    for outcome in outcomes:
+        if outcome.model == model and outcome.reward is not None:
+            grouped.setdefault(outcome.scenario_id, []).append(float(outcome.reward))
+    return grouped
+
+
+class RankAgreement:
+    """Rank agreement between two per-model score maps over their shared models."""
+
+    def __init__(self, real: dict[str, float], wm: dict[str, float]) -> None:
+        self.models = sorted(set(real) & set(wm))
+        left = [real[m] for m in self.models]
+        right = [wm[m] for m in self.models]
+        self.spearman = stats.spearmanr(left, right)
+        self.kendall = stats.kendalltau(left, right)
+        self.pearson = stats.pearsonr(left, right)
+        self.top3_real = sorted(sorted(self.models, key=lambda m: real[m], reverse=True)[:3])
+        self.top3_wm = sorted(sorted(self.models, key=lambda m: wm[m], reverse=True)[:3])
+        self.top3_overlap = len(set(self.top3_real) & set(self.top3_wm))
+        self.best_real = max(self.models, key=lambda m: real[m])
+        self.best_wm = max(self.models, key=lambda m: wm[m])
+
+    def lines(self, label: str, rows: int) -> list[str]:
+        out = [f"== rank agreement ({label}; {len(self.models)} models, {rows} real rows)"]
+        for name, result in (
+            ("spearman", self.spearman),
+            ("kendall", self.kendall),
+            ("pearson", self.pearson),
+        ):
+            out.append(f"  {name:9} {result.statistic:+.3f}  (p={result.pvalue:.3f})")
+        out.append(f"  top-3 real: {self.top3_real}")
+        out.append(f"  top-3 wm:   {self.top3_wm}")
+        out.append(
+            f"  overlap:    {self.top3_overlap}/3   "
+            f"best real={self.best_real} best wm={self.best_wm}"
+        )
+        return out
+
+
+def _reason(blob: str) -> str:
+    try:
+        parsed = json.loads(blob)
+    except json.JSONDecodeError:
+        return ""
+    reason = parsed.get("reason_for_call") if isinstance(parsed, dict) else None
+    return re.sub(r"\W+", "", reason or "").lower()
+
+
+def paired_scores(
+    real: Sequence[RealEpisodeRow], wm: Sequence[ScenarioOutcome]
+) -> tuple[dict[str, float], dict[str, float], int]:
+    """Per-model means restricted to scenarios both legs measured.
+
+    Scenario ids match directly when both legs ran the pinned eval split. Older world-model
+    matrices hash the task instead, so those fall back to matching on a normalized
+    `reason_for_call`; a real task whose text is shared by more than one scenario is dropped as
+    ambiguous rather than double-counted.
+
+    Returns:
+        (real means, wm means, number of shared scenarios). Empty maps when nothing is shared.
+    """
+    real_ids = {row.scenario_id for row in real}
+    wm_ids = {outcome.scenario_id for outcome in wm}
+    shared_ids = real_ids & wm_ids
+    if shared_ids:
+        real_key = {row.scenario_id: row.scenario_id for row in real}
+        wm_key = {outcome.scenario_id: outcome.scenario_id for outcome in wm}
+        shared = shared_ids
+    else:
+        real_key = {row.scenario_id: _reason(row.task) for row in real}
+        wm_key = {outcome.scenario_id: _reason(outcome.task) for outcome in wm}
+        shared = (set(real_key.values()) & set(wm_key.values())) - {""}
+        counts: dict[str, int] = {}
+        for key in real_key.values():
+            counts[key] = counts.get(key, 0) + 1
+        shared -= {key for key in shared if counts[key] > 1}
+    if not shared:
+        return {}, {}, 0
+
+    real_means: dict[str, float] = {}
+    wm_means: dict[str, float] = {}
+    for model in sorted({row.model for row in real} & {o.model for o in wm}):
+        left, right = [], []
+        for key in sorted(shared):
+            rv = [
+                float(row.reward)
+                for row in real
+                if row.model == model
+                and row.reward is not None
+                and real_key[row.scenario_id] == key
+            ]
+            wv = [
+                float(o.reward)
+                for o in wm
+                if o.model == model and o.reward is not None and wm_key[o.scenario_id] == key
+            ]
+            if rv and wv:
+                left.append(st.mean(rv))
+                right.append(st.mean(wv))
+        if left:
+            real_means[model] = st.mean(left)
+            wm_means[model] = st.mean(right)
+    return real_means, wm_means, len(shared)
+
+
+def report(real: Sequence[RealEpisodeRow], matrix: OutcomeMatrix, glm_clean: bool) -> list[str]:
+    """Build the whole report as lines, so callers (and tests) can assert on it."""
+    scored = [row for row in real if row.reward is not None]
+    models = sorted({row.model for row in scored} & {o.model for o in matrix.outcomes})
+    if not models:
+        return ["no model appears in both the real rows and the world-model matrix"]
+
+    lines = [
+        f"== REAL (tau2 reward, {len(scored)} rows) vs WM (LLM judge), per model",
+        f"{'model':16} {'real':>16} {'eps':>5} {'wm':>16} {'inline%':>8}",
+    ]
+    real_mean: dict[str, float] = {}
+    wm_mean: dict[str, float] = {}
+    wm_clean: dict[str, float] = {}
+    for model in models:
+        rmean, rse, _ = scenario_clustered_stats(group_real(scored, model))
+        wm_rows = [o for o in matrix.outcomes if o.model == model and o.reward is not None]
+        wmean, wse, _ = scenario_clustered_stats(group_wm(wm_rows, model))
+        episodes = sum(1 for row in scored if row.model == model)
+        inline = sum(1 for o in wm_rows if has_inline_call(o))
+        by_scenario: dict[str, list[ScenarioOutcome]] = {}
+        for outcome in wm_rows:
+            by_scenario.setdefault(outcome.scenario_id, []).append(outcome)
+        # clean_if_available: keep every scenario, score it on its unbroken episodes when it has
+        # any. Dropping broken episodes outright would also drop the hard scenarios, which is
+        # where the format failure concentrates.
+        wm_clean[model] = st.mean(
+            st.mean(
+                float(e.reward or 0.0)
+                for e in ([c for c in episodes_of if not has_inline_call(c)] or episodes_of)
+            )
+            for episodes_of in by_scenario.values()
+        )
+        real_mean[model], wm_mean[model] = rmean, wmean
+        lines.append(
+            f"{model:16} {rmean:.3f} +/- {rse:.3f} {episodes:5d} "
+            f"{wmean:.3f} +/- {wse:.3f} {100 * inline / len(wm_rows):7.0f}%"
+        )
+
+    if len(models) < 3:
+        lines.append("")
+        lines.append(f"only {len(models)} shared models: too few for a rank correlation")
+        return lines
+
+    arms = [("headline", wm_mean)]
+    if glm_clean and "glm-5.2" in wm_mean:
+        arms.append(("glm-format-corrected", {**wm_mean, "glm-5.2": wm_clean["glm-5.2"]}))
+    for label, scores in arms:
+        lines.append("")
+        lines.extend(RankAgreement(real_mean, scores).lines(label, len(scored)))
+
+    paired_real, paired_wm, shared = paired_scores(scored, matrix.outcomes)
+    lines.append("")
+    if shared and len(paired_real) >= 3:
+        lines.append(f"== paired overlap ({shared} scenarios measured by both legs)")
+        for model in sorted(paired_real):
+            lines.append(f"  {model:16} real {paired_real[model]:.3f}   wm {paired_wm[model]:.3f}")
+        lines.extend(RankAgreement(paired_real, paired_wm).lines("paired", len(scored)))
+    else:
+        lines.append("== paired overlap: no scenario measured by both legs")
+
+    lines.append("")
+    lines.append("== per-episode real means (episode noise)")
+    for model in models:
+        parts = []
+        for episode in sorted({row.episode for row in scored}):
+            values = [
+                float(row.reward)
+                for row in scored
+                if row.model == model and row.episode == episode and row.reward is not None
+            ]
+            if values:
+                parts.append(f"e{episode}={st.mean(values):.3f} (n={len(values)})")
+        lines.append(f"  {model:16} {'  '.join(parts)}")
+    return lines
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--real", type=Path, default=Path(".wmo/evals/tau-bench-real/rows.jsonl"))
+    parser.add_argument("--wm", type=Path, required=True, help="world-model OutcomeMatrix json")
+    parser.add_argument("--glm-clean", action="store_true", help="add the format-corrected arm")
+    args = parser.parse_args(argv)
+
+    rows = load_rows(args.real)
+    if not rows:
+        parser.error(f"no real episodes at {args.real}; run real_episodes.py first")
+    for line in report(rows, OutcomeMatrix.load(args.wm), args.glm_clean):
+        print(line)  # noqa: T201 - operator-run CLI, this report IS the product output
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/environment-capture/tau-bench/rl/sim_to_real.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real.py
@@ -31,14 +31,20 @@ tool-call format failures. Two estimators, because the obvious one is biased:
 - `clean_if_available` keeps every scenario and, for those with one good and one broken episode,
   scores the scenario on its clean episode only. This is the number to report.
 
-Two `wmo/env/llm_agent.py` changes split world-model matrices into a before and an after, so do
+Three `wmo/env/llm_agent.py` changes split world-model matrices into a before and an after, so do
 not pool them:
 
-1. It now parses inline `tool_name({...})` calls and executes them, so matrices built after the
-   change should show `inline%` near zero. The correction arms above exist for older matrices.
+1. It now parses inline `tool_name({...})` calls and EXECUTES them. Note what this does and does
+   not do to `inline%` below: the column counts replies whose TEXT contains call syntax, and the
+   change alters how such a reply is dispatched, not whether the model writes one, so `inline%`
+   stays roughly flat across the change. What changes is that those episodes stop scoring 0 for
+   a formatting reason. Consequently `--glm-clean` is only meaningful on a matrix captured
+   BEFORE the change; run against a newer one it would correct away episodes that ran fine.
 2. Its observation/history cap went from 500 to 2000 characters, which gives the agent strictly
    more context per turn on tool-heavy domains. A matrix captured before that change measured a
    different (more starved) agent; recapture rather than mix.
+3. It retries a blank completion up to twice. That shifts both cost (the blank attempts are
+   billed) and per-call latency for models that blank often.
 
 Run from the repo root:
 
@@ -51,15 +57,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+import math
 import re
 import statistics as st
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from real_episodes import RealEpisodeRow, load_rows
 from scipy import stats  # present in every wmo install: scikit-learn requires it
 
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+
+logger = logging.getLogger("sim-to-real")
 
 # A tool call the model wrote into its prose instead of emitting as a structured call, e.g.
 # `get_user_details({"user_id": ...})`. Harnesses without the bare-call parser never execute
@@ -125,7 +135,13 @@ class RankAgreement:
             ("kendall", self.kendall),
             ("pearson", self.pearson),
         ):
-            out.append(f"  {name:9} {result.statistic:+.3f}  (p={result.pvalue:.3f})")
+            # A correlation is undefined when either side is constant (every candidate scored
+            # the same). Printing "+nan (p=nan)" in a column of real numbers reads as a
+            # measurement that came out near zero, so say what actually happened.
+            if math.isnan(result.statistic):
+                out.append(f"  {name:9} n/a (undefined: one side is constant)")
+            else:
+                out.append(f"  {name:9} {result.statistic:+.3f}  (p={result.pvalue:.3f})")
         out.append(f"  top-3 real: {self.top3_real}")
         out.append(f"  top-3 wm:   {self.top3_wm}")
         out.append(
@@ -133,6 +149,14 @@ class RankAgreement:
             f"best real={self.best_real} best wm={self.best_wm}"
         )
         return out
+
+
+def _repeated(keys: Iterable[str]) -> set[str]:
+    """The keys that appear more than once, i.e. cannot identify a single scenario."""
+    counts: dict[str, int] = {}
+    for key in keys:
+        counts[key] = counts.get(key, 0) + 1
+    return {key for key, count in counts.items() if count > 1}
 
 
 def _reason(blob: str) -> str:
@@ -168,10 +192,20 @@ def paired_scores(
         real_key = {row.scenario_id: _reason(row.task) for row in real}
         wm_key = {outcome.scenario_id: _reason(outcome.task) for outcome in wm}
         shared = (set(real_key.values()) & set(wm_key.values())) - {""}
-        counts: dict[str, int] = {}
-        for key in real_key.values():
-            counts[key] = counts.get(key, 0) + 1
-        shared -= {key for key in shared if counts[key] > 1}
+        # A key must identify ONE scenario on BOTH sides. Checking only the real side let two
+        # distinct world-model scenarios that share a `reason_for_call` average into a single
+        # paired cell. On the committed split this is not hypothetical: two telecom pairs
+        # normalize to the same text, so 4 of 20 scenarios are ambiguous.
+        ambiguous = _repeated(real_key.values()) | _repeated(wm_key.values())
+        dropped = sorted(shared & ambiguous)
+        shared -= ambiguous
+        if dropped:
+            logger.warning(
+                "dropping %d scenario(s) whose reason_for_call is shared by more than one "
+                "scenario on one side: %s",
+                len(dropped),
+                [key[:40] for key in dropped],
+            )
     if not shared:
         return {}, {}, 0
 
@@ -204,9 +238,17 @@ def paired_scores(
 def report(real: Sequence[RealEpisodeRow], matrix: OutcomeMatrix, glm_clean: bool) -> list[str]:
     """Build the whole report as lines, so callers (and tests) can assert on it."""
     scored = [row for row in real if row.reward is not None]
-    models = sorted({row.model for row in scored} & {o.model for o in matrix.outcomes})
+    # Both sides must be SCORED, not merely present. `wmo.env.closed_loop` leaves a cell
+    # unscored on a provider throttle or an agent crash, so a candidate that was rate-limited
+    # across the whole sweep appears in the matrix with nothing to average, and taking its mean
+    # used to abort the entire report after a capture that had already been paid for.
+    wm_scored = {o.model for o in matrix.outcomes if o.reward is not None}
+    models = sorted({row.model for row in scored} & wm_scored)
     if not models:
-        return ["no model appears in both the real rows and the world-model matrix"]
+        return ["no model is scored in both the real rows and the world-model matrix"]
+    silent = sorted({o.model for o in matrix.outcomes} - wm_scored)
+    if silent:
+        logger.warning("world-model models with no scored episode, excluded: %s", silent)
 
     lines = [
         f"== REAL (tau2 reward, {len(scored)} rows) vs WM (LLM judge), per model",

--- a/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
@@ -1,0 +1,212 @@
+"""Tests for the sim-to-real rank-agreement report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from real_episodes import RealEpisodeRow
+from sim_to_real import (
+    RankAgreement,
+    has_inline_call,
+    main,
+    paired_scores,
+    report,
+    scenario_clustered_stats,
+)
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.providers.base import ProviderKind
+from wmo.providers.pool import PoolEntry
+
+_MODELS = ("alpha", "beta", "gamma", "delta")
+_POOL = [
+    PoolEntry(
+        name=name,
+        kind=ProviderKind.ANTHROPIC,
+        model=f"claude-{name}",
+        input_per_mtok=1.0,
+        output_per_mtok=2.0,
+    )
+    for name in _MODELS
+]
+
+
+def _real_row(model: str, scenario: str, reward: float | None, episode: int = 0) -> RealEpisodeRow:
+    return RealEpisodeRow(
+        scenario_id=scenario,
+        domain=scenario.split(":")[0],
+        task_id=scenario.split(":")[1],
+        task=json.dumps({"reason_for_call": f"do {scenario}"}),
+        provenance=["p"],
+        model=model,
+        route=f"anthropic/{model}",
+        episode=episode,
+        reward=reward,
+        nl_assertion_reward=False,
+        termination_reason="user_stop",
+        duration_s=1.0,
+        agent_input_tokens=10,
+        agent_output_tokens=1,
+        user_input_tokens=5,
+        user_output_tokens=1,
+        cost_usd_pool=0.01,
+        cost_usd_tau2_agent=0.01,
+        cost_usd_tau2_user=0.001,
+        steps=1,
+        call_seconds=[0.5],
+        replies=[],
+        user_sim="gpt-5.4-mini",
+    )
+
+
+def _wm_outcome(
+    model: str, scenario: str, reward: float, replies: list[str] | None = None, episode: int = 0
+) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=scenario,
+        task=json.dumps({"reason_for_call": f"do {scenario}"}),
+        model=model,
+        episode=episode,
+        reward=reward,
+        success=reward >= 1.0,
+        replies=replies or [],
+    )
+
+
+def _agreeing_corpus(
+    flip: bool = False,
+) -> tuple[list[RealEpisodeRow], OutcomeMatrix]:
+    """Four models with a clean quality ordering, optionally reversed in the world model."""
+    scenarios = ["airline:0", "retail:3"]
+    scores = {"alpha": 0.2, "beta": 0.4, "gamma": 0.6, "delta": 0.8}
+    rows = [
+        _real_row(model, scenario, scores[model]) for model in _MODELS for scenario in scenarios
+    ]
+    outcomes = [
+        _wm_outcome(model, scenario, 1.0 - scores[model] if flip else scores[model])
+        for model in _MODELS
+        for scenario in scenarios
+    ]
+    return rows, OutcomeMatrix(pool=_POOL, outcomes=outcomes)
+
+
+def test_scenario_clustered_stats_averages_scenarios_not_episodes() -> None:
+    # Two episodes of one scenario are not two independent draws: the scenario with two
+    # episodes must not outweigh the one with a single episode.
+    mean, se, count = scenario_clustered_stats({"a": [0.0, 0.0], "b": [1.0]})
+    assert mean == pytest.approx(0.5)
+    assert count == 2
+    assert se == pytest.approx(0.5)
+
+
+def test_rank_agreement_detects_a_matching_ordering() -> None:
+    real = {"alpha": 0.2, "beta": 0.4, "gamma": 0.6}
+    agreement = RankAgreement(real, {"alpha": 0.1, "beta": 0.5, "gamma": 0.9})
+    assert agreement.spearman.statistic == pytest.approx(1.0)
+    assert agreement.best_real == "gamma"
+    assert agreement.best_wm == "gamma"
+
+
+def test_rank_agreement_detects_an_inverted_ordering() -> None:
+    real = {"alpha": 0.2, "beta": 0.4, "gamma": 0.6}
+    agreement = RankAgreement(real, {"alpha": 0.9, "beta": 0.5, "gamma": 0.1})
+    assert agreement.spearman.statistic == pytest.approx(-1.0)
+    assert agreement.top3_overlap == 3  # the same three models, ranked backwards
+
+
+def test_rank_agreement_uses_only_shared_models() -> None:
+    agreement = RankAgreement({"a": 1.0, "b": 2.0, "ghost": 3.0}, {"a": 1.0, "b": 2.0})
+    assert agreement.models == ["a", "b"]
+
+
+def test_inline_call_detection() -> None:
+    assert has_inline_call(_wm_outcome("a", "airline:0", 1.0, ['get_user_details({"id": 1})']))
+    assert not has_inline_call(
+        _wm_outcome("a", "airline:0", 1.0, ['{"tool": "get_user_details", "arguments": {}}'])
+    )
+
+
+def test_paired_scores_prefer_exact_scenario_ids() -> None:
+    rows, matrix = _agreeing_corpus()
+    real, wm, shared = paired_scores(rows, matrix.outcomes)
+    assert shared == 2
+    assert sorted(real) == sorted(_MODELS)
+
+
+def test_paired_scores_fall_back_to_reason_matching() -> None:
+    # An older world-model matrix hashes the task instead of using "<domain>:<task_id>".
+    rows, matrix = _agreeing_corpus()
+    rehashed = OutcomeMatrix(
+        pool=_POOL,
+        outcomes=[
+            outcome.model_copy(update={"scenario_id": f"hash-{outcome.scenario_id}"})
+            for outcome in matrix.outcomes
+        ],
+    )
+    real, wm, shared = paired_scores(rows, rehashed.outcomes)
+    assert shared == 2
+    assert real["delta"] == pytest.approx(0.8)
+
+
+def test_report_headline_agreement() -> None:
+    rows, matrix = _agreeing_corpus()
+    text = "\n".join(report(rows, matrix, glm_clean=False))
+    assert "spearman  +1.000" in text
+    assert "8 real rows" in text
+    assert "paired overlap (2 scenarios" in text
+
+
+def test_report_flags_disagreement() -> None:
+    rows, matrix = _agreeing_corpus(flip=True)
+    text = "\n".join(report(rows, matrix, glm_clean=False))
+    assert "spearman  -1.000" in text
+
+
+def test_report_skips_unscored_real_rows() -> None:
+    rows, matrix = _agreeing_corpus()
+    rows.append(_real_row("alpha", "airline:9", None))
+    text = "\n".join(report(rows, matrix, glm_clean=False))
+    assert "8 real rows" in text  # the unscored row is not counted, and never scored as 0
+
+
+def test_glm_clean_arm_scores_broken_scenarios_on_their_clean_episode() -> None:
+    scenarios = ["airline:0", "retail:3"]
+    real_scores = {"glm-5.2": 0.5, "alpha": 0.2, "beta": 0.8}
+    rows = [_real_row(m, s, real_scores[m]) for m in real_scores for s in scenarios]
+    pool = [
+        PoolEntry(
+            name=name,
+            kind=ProviderKind.ANTHROPIC,
+            model=f"claude-{name}",
+            input_per_mtok=1.0,
+            output_per_mtok=2.0,
+        )
+        for name in ("glm-5.2", "alpha", "beta")
+    ]
+    outcomes = [_wm_outcome(m, s, real_scores[m]) for m in ("alpha", "beta") for s in scenarios]
+    for scenario in scenarios:
+        outcomes.append(_wm_outcome("glm-5.2", scenario, 0.0, ['get_user({"id": 1})'], episode=0))
+        outcomes.append(_wm_outcome("glm-5.2", scenario, 0.9, episode=1))
+    text = "\n".join(report(rows, OutcomeMatrix(pool=pool, outcomes=outcomes), glm_clean=True))
+    assert "glm-format-corrected" in text
+    # headline averages the broken and clean episodes (0.45); corrected keeps only the clean one.
+    assert "glm-5.2          0.500 +/- 0.000     2 0.450" in text
+
+
+def test_main_writes_the_report(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rows, matrix = _agreeing_corpus()
+    rows_path = tmp_path / "rows.jsonl"
+    rows_path.write_text("\n".join(row.model_dump_json() for row in rows) + "\n", encoding="utf-8")
+    matrix_path = tmp_path / "matrix.json"
+    matrix.save(matrix_path)
+    assert main(["--real", str(rows_path), "--wm", str(matrix_path)]) == 0
+    assert "spearman  +1.000" in capsys.readouterr().out
+
+
+def test_main_says_what_to_run_when_there_are_no_rows(tmp_path: Path) -> None:
+    matrix_path = tmp_path / "matrix.json"
+    _agreeing_corpus()[1].save(matrix_path)
+    with pytest.raises(SystemExit):
+        main(["--real", str(tmp_path / "missing.jsonl"), "--wm", str(matrix_path)])

--- a/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
@@ -123,9 +123,12 @@ def test_rank_agreement_uses_only_shared_models() -> None:
 
 def test_inline_call_detection() -> None:
     assert has_inline_call(_wm_outcome("a", "airline:0", 1.0, ['get_user_details({"id": 1})']))
+    # The discriminating negative: a proper envelope whose STRING VALUES name a tool. It has
+    # no call syntax, so a regex that merely looks for a tool name must not fire.
     assert not has_inline_call(
         _wm_outcome("a", "airline:0", 1.0, ['{"tool": "get_user_details", "arguments": {}}'])
     )
+    assert not has_inline_call(_wm_outcome("a", "airline:0", 1.0, ["I will get_user_details."]))
 
 
 def test_paired_scores_prefer_exact_scenario_ids() -> None:
@@ -191,8 +194,11 @@ def test_glm_clean_arm_scores_broken_scenarios_on_their_clean_episode() -> None:
         outcomes.append(_wm_outcome("glm-5.2", scenario, 0.9, episode=1))
     text = "\n".join(report(rows, OutcomeMatrix(pool=pool, outcomes=outcomes), glm_clean=True))
     assert "glm-format-corrected" in text
-    # headline averages the broken and clean episodes (0.45); corrected keeps only the clean one.
-    assert "glm-5.2          0.500 +/- 0.000     2 0.450" in text
+    # headline averages the broken and clean episodes (0.45); corrected keeps only the clean
+    # one (0.9). Assert the numbers, not the column padding.
+    glm_row = next(line for line in text.splitlines() if line.startswith("glm-5.2"))
+    assert "0.450" in glm_row
+    assert "50%" in glm_row  # one of each scenario's two wm episodes carries an inline call
 
 
 def test_main_writes_the_report(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -210,3 +216,41 @@ def test_main_says_what_to_run_when_there_are_no_rows(tmp_path: Path) -> None:
     _agreeing_corpus()[1].save(matrix_path)
     with pytest.raises(SystemExit):
         main(["--real", str(tmp_path / "missing.jsonl"), "--wm", str(matrix_path)])
+
+
+def test_paired_fallback_drops_keys_ambiguous_on_the_world_model_side() -> None:
+    # Two DISTINCT wm scenarios sharing a reason_for_call must not average into one paired
+    # cell. The real side alone cannot detect that.
+    rows = [_real_row(m, "airline:0", 0.5) for m in ("alpha", "beta", "gamma")]
+    outcomes = [
+        _wm_outcome(m, sid, 0.5)
+        for m in ("alpha", "beta", "gamma")
+        for sid in ("hash-a", "hash-b")  # both normalize to "do airline:0"
+    ]
+    for outcome in outcomes:
+        outcome.task = json.dumps({"reason_for_call": "do airline:0"})
+    _real, _wm, shared = paired_scores(rows, outcomes)
+    assert shared == 0
+
+
+def test_report_survives_a_model_whose_wm_cells_are_all_unscored() -> None:
+    # closed_loop leaves a cell unscored on a throttle; a candidate rate-limited across the
+    # sweep must not take down a report over an already-paid capture.
+    rows, matrix = _agreeing_corpus()
+    matrix.outcomes.append(
+        ScenarioOutcome(scenario_id="airline:0", task="{}", model="alpha", reward=None)
+    )
+    ghost = ScenarioOutcome(scenario_id="airline:0", task="{}", model="delta", reward=None)
+    silent = OutcomeMatrix(
+        pool=_POOL, outcomes=[o for o in matrix.outcomes if o.model != "delta"] + [ghost]
+    )
+    text = "\n".join(report(rows, silent, glm_clean=False))
+    assert "delta" not in text.split("== rank agreement")[0]
+    assert "spearman" in text
+
+
+def test_constant_input_correlation_is_reported_as_undefined() -> None:
+    agreement = RankAgreement({"a": 0.2, "b": 0.4, "c": 0.6}, {"a": 0.5, "b": 0.5, "c": 0.5})
+    text = "\n".join(agreement.lines("flat", 6))
+    assert "n/a (undefined: one side is constant)" in text
+    assert "nan" not in text

--- a/wmo/env/llm_agent.py
+++ b/wmo/env/llm_agent.py
@@ -9,13 +9,15 @@ simple — no planning scaffold — because its role is "a competent baseline ag
 from __future__ import annotations
 
 import json
+import re
+from typing import NamedTuple
 
 from pydantic import BaseModel, ValidationError
 
 from wmo.core.parsing import extract_json_object
 from wmo.core.types import Action, ActionKind, EnvState, JsonObject, Step
 from wmo.env.episode import DONE_SIGNAL
-from wmo.providers.base import Message, Provider
+from wmo.providers.base import Completion, Message, Provider
 
 AGENT_SYSTEM = """You are an agent operating in a tool environment to complete a task.
 
@@ -26,7 +28,15 @@ Each turn, respond with ONLY a JSON object, no prose around it — one of:
 Choose tool names and arguments consistent with the environment's responses so far. Work
 efficiently: no redundant calls, finish as soon as the task is done."""
 
-_MAX_HISTORY_CHARS = 500
+# Observation/history truncation. 500 chars starved tool-heavy environments (a tau-bench
+# `get_user_details` payload is several times that), so the agent never saw the answer it had
+# just fetched and re-fetched it verbatim until the step budget died. Callers with even bigger
+# observations can raise it per instance via `history_chars`.
+_MAX_HISTORY_CHARS = 2000
+
+# How many extra completions to buy when a provider returns blank text. Measured at 24% of
+# replies for one pool model; without the retry every blank burns a step as an empty message.
+_EMPTY_RETRIES = 2
 
 
 class _AgentReply(BaseModel):
@@ -38,29 +48,74 @@ class _AgentReply(BaseModel):
     summary: str = ""
 
 
+class _BareCall(NamedTuple):
+    """A `tool_name({...})` call recovered from prose, and where its argument object starts."""
+
+    name: str
+    arguments: JsonObject
+    arguments_at: int
+
+
+_CALL_HEAD = re.compile(r"([A-Za-z_]\w*)\s*\(\s*\{")
+
+
+def _parse_bare_call(text: str) -> _BareCall | None:
+    """Parse `tool_name({...})` syntax, bare or fused with prose.
+
+    Some models emit function-call syntax instead of the JSON envelope the system prompt asks
+    for. Without this the turn is wasted: the call never executes and the argument object gets
+    read as an envelope or echoed back as a message. Returns the FIRST well-formed call, which
+    is the one a sequential executor would have run when a reply stacks several.
+
+    Args:
+        text: The raw completion text.
+
+    Returns:
+        The recovered call, or None when the text holds no well-formed one.
+    """
+    decoder = json.JSONDecoder()
+    for match in _CALL_HEAD.finditer(text):
+        start = text.index("{", match.end() - 1)
+        try:
+            arguments, end = decoder.raw_decode(text, start)
+        except ValueError:
+            continue
+        rest = text[end:].lstrip()
+        if isinstance(arguments, dict) and rest.startswith(")"):
+            return _BareCall(name=match.group(1), arguments=arguments, arguments_at=start)
+    return None
+
+
 class LLMAgent:
     """`Agent`-protocol adapter around a provider: history in, one JSON tool call out."""
 
     def __init__(
-        self, provider: Provider, *, temperature: float = 0.0, tools_hint: str | None = None
+        self,
+        provider: Provider,
+        *,
+        temperature: float = 0.0,
+        tools_hint: str | None = None,
+        history_chars: int = _MAX_HISTORY_CHARS,
     ) -> None:
         self._provider = provider
         self._temperature = temperature
+        self._history_chars = history_chars
         # Corpus-derived tool surface (names + argument keys observed in the traces). Without
         # it, capable models honestly refuse to invent tools while weaker ones hallucinate
         # them, and closed-loop rewards measure affordance-guessing instead of capability.
         self._system = AGENT_SYSTEM if not tools_hint else f"{AGENT_SYSTEM}\n\n{tools_hint}"
 
     def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
-        prompt = _render_turn(task, state, history)
-        completion = self._provider.complete(
-            self._system,
-            [Message(role="user", content=prompt)],
-            temperature=self._temperature,
-            max_tokens=1024,
-        )
+        prompt = _render_turn(task, state, history, self._history_chars)
+        completion = self._complete_retrying_empty(prompt)
+        bare = _parse_bare_call(completion.text)
         raw = extract_json_object(completion.text)
-        if raw is not None:
+        # An object that a bare call opens is that call's ARGUMENTS, never the envelope, even
+        # when its keys happen to collide with the envelope's ("tool", "done"). Reading
+        # `book_trip({"tool": "train"})` as an envelope would run a tool named "train".
+        if raw is not None and not (
+            bare is not None and _text_starts_object(completion.text, bare)
+        ):
             try:
                 reply = _AgentReply.model_validate_json(raw)
             except ValidationError:
@@ -76,14 +131,49 @@ class LLMAgent:
                 # that write prose-style calls (`get_user(...)` around a bare argument object)
                 # land here, and treating it as done ended their episodes unexecuted at step 1
                 # and scored them 0 (measured: 34% of glm-5.2 wm episodes, 0% for other pool
-                # models). Fall through to the message path so the env can answer and the
-                # episode recovers.
+                # models). Fall through so the call is recovered or the env answers.
+        if bare is not None:
+            return Action(kind=ActionKind.TOOL_CALL, name=bare.name, arguments=bare.arguments)
         # Unparseable reply: surface it as a message action; the env will answer and the episode
         # continues rather than crashing the batch.
-        return Action(kind=ActionKind.MESSAGE, content=completion.text.strip()[:_MAX_HISTORY_CHARS])
+        return Action(
+            kind=ActionKind.MESSAGE, content=completion.text.strip()[: self._history_chars]
+        )
+
+    def _complete_retrying_empty(self, prompt: str) -> Completion:
+        """Buy up to `_EMPTY_RETRIES` extra completions while the provider returns blank text.
+
+        A blank reply is indistinguishable from an unparseable one downstream, so it costs a
+        step doing nothing; retrying converts an intermittent provider hiccup into a real turn
+        instead of a slow death by step budget. Returns the last completion either way, so a
+        persistently blank provider still yields an (empty) message action rather than raising.
+        """
+        completion = self._provider.complete(
+            self._system,
+            [Message(role="user", content=prompt)],
+            temperature=self._temperature,
+            max_tokens=1024,
+        )
+        for _attempt in range(_EMPTY_RETRIES):
+            if completion.text.strip():
+                break
+            completion = self._provider.complete(
+                self._system,
+                [Message(role="user", content=prompt)],
+                temperature=self._temperature,
+                max_tokens=1024,
+            )
+        return completion
 
 
-def _render_turn(task: str | None, state: EnvState, history: list[Step]) -> str:
+def _text_starts_object(text: str, bare: _BareCall) -> bool:
+    """True when the first JSON object in `text` is the one `bare`'s call opens."""
+    return text.find("{") == bare.arguments_at
+
+
+def _render_turn(
+    task: str | None, state: EnvState, history: list[Step], history_chars: int = _MAX_HISTORY_CHARS
+) -> str:
     lines = [f"TASK: {task or '(none)'}"]
     if state.scratchpad:
         lines.append(f"ENVIRONMENT NOTES: {state.scratchpad}")
@@ -95,7 +185,7 @@ def _render_turn(task: str | None, state: EnvState, history: list[Step]) -> str:
                 call = f"{action.name}({json.dumps(action.arguments, default=str)})"
             else:
                 call = f"message: {action.content}"
-            observation = step.observation.content[:_MAX_HISTORY_CHARS]
+            observation = step.observation.content[:history_chars]
             error_mark = " [ERROR]" if step.observation.is_error else ""
             lines.append(f"{index}. {call} -> {observation}{error_mark}")
     lines.append("Your next move (JSON only):")

--- a/wmo/env/llm_agent.py
+++ b/wmo/env/llm_agent.py
@@ -49,14 +49,18 @@ class _AgentReply(BaseModel):
 
 
 class _BareCall(NamedTuple):
-    """A `tool_name({...})` call recovered from prose, and where its argument object starts."""
+    """A `tool_name({...})` call recovered from prose."""
 
     name: str
     arguments: JsonObject
-    arguments_at: int
 
 
-_CALL_HEAD = re.compile(r"([A-Za-z_]\w*)\s*\(\s*\{")
+# `tool_name({` with no space before the paren: real call syntax never has one, while prose
+# ("use the search tool ({...})") always does, and allowing it made the reply's own envelope
+# parse as a call to a tool named "tool". The lookbehind stops a hyphenated or dotted name from
+# matching only its last segment, which turned `get-user-details({...})` into a call to
+# `details`; an unknown-but-whole name is a tool error the env can report honestly.
+_CALL_HEAD = re.compile(r"(?<![\w.\-])([A-Za-z_][\w\-]*)\(\s*\{")
 
 
 def _parse_bare_call(text: str) -> _BareCall | None:
@@ -64,8 +68,8 @@ def _parse_bare_call(text: str) -> _BareCall | None:
 
     Some models emit function-call syntax instead of the JSON envelope the system prompt asks
     for. Without this the turn is wasted: the call never executes and the argument object gets
-    read as an envelope or echoed back as a message. Returns the FIRST well-formed call, which
-    is the one a sequential executor would have run when a reply stacks several.
+    echoed back as a message. Returns the FIRST well-formed call, which is the one a sequential
+    executor would have run when a reply stacks several.
 
     Args:
         text: The raw completion text.
@@ -75,14 +79,46 @@ def _parse_bare_call(text: str) -> _BareCall | None:
     """
     decoder = json.JSONDecoder()
     for match in _CALL_HEAD.finditer(text):
-        start = text.index("{", match.end() - 1)
+        start = match.end() - 1
         try:
             arguments, end = decoder.raw_decode(text, start)
         except ValueError:
             continue
         rest = text[end:].lstrip()
         if isinstance(arguments, dict) and rest.startswith(")"):
-            return _BareCall(name=match.group(1), arguments=arguments, arguments_at=start)
+            return _BareCall(name=match.group(1), arguments=arguments)
+    return None
+
+
+def _parse_envelope(text: str) -> _AgentReply | None:
+    """The first object in `text` that speaks the envelope's language, or None.
+
+    Scans EVERY balanced object rather than only the first, because a reasoning model states its
+    conclusion after its deliberation: the leading object is often an example or a rejected
+    hypothesis, and the envelope it actually chose comes later in the reply.
+    """
+    offset = 0
+    while offset < len(text):
+        relative = text[offset:].find("{")
+        if relative == -1:
+            return None
+        start = offset + relative
+        raw = extract_json_object(text[start:])
+        if raw is None:
+            return None
+        offset = start + len(raw)
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            continue
+        # An object with neither key is not the envelope: a bare argument payload validates
+        # against `_AgentReply`'s all-optional fields and would read as a silent finish.
+        if not (isinstance(data, dict) and ("tool" in data or "done" in data)):
+            continue
+        try:
+            return _AgentReply.model_validate(data)
+        except ValidationError:
+            continue
     return None
 
 
@@ -96,10 +132,14 @@ class LLMAgent:
         temperature: float = 0.0,
         tools_hint: str | None = None,
         history_chars: int = _MAX_HISTORY_CHARS,
+        empty_retries: int = _EMPTY_RETRIES,
     ) -> None:
         self._provider = provider
         self._temperature = temperature
         self._history_chars = history_chars
+        # Callers measuring per-call latency can set this to 0: each retry is one more timed
+        # provider call at the metering boundary (see `wmo.optimize.report`).
+        self._empty_retries = empty_retries
         # Corpus-derived tool surface (names + argument keys observed in the traces). Without
         # it, capable models honestly refuse to invent tools while weaker ones hallucinate
         # them, and closed-loop rewards measure affordance-guessing instead of capability.
@@ -108,30 +148,23 @@ class LLMAgent:
     def act(self, task: str | None, state: EnvState, history: list[Step]) -> Action:
         prompt = _render_turn(task, state, history, self._history_chars)
         completion = self._complete_retrying_empty(prompt)
+        # Precedence: an envelope anywhere in the reply is the model's DECISION and always wins.
+        # A call written in prose is only ever a fallback, because prose that mentions a call is
+        # routinely deliberation about one ("the schema is update_order({...}), not applicable
+        # here") rather than an instruction to run it. Letting such a mention outrank a later
+        # envelope executed a hypothesis the model had just rejected, and turned
+        # `finish({"done": true})` into a tool call that never terminated the episode.
+        reply = _parse_envelope(completion.text)
+        if reply is not None:
+            if reply.done:
+                return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
+            if reply.tool is not None:
+                return Action(kind=ActionKind.TOOL_CALL, name=reply.tool, arguments=reply.arguments)
+        # No envelope. A JSON object with neither `done` nor `tool` is NOT a finish signal:
+        # models that write prose-style calls (`get_user(...)` around a bare argument object)
+        # land here, and treating it as done ended their episodes unexecuted at step 1 and
+        # scored them 0 (measured: 34% of glm-5.2 wm episodes, 0% for other pool models).
         bare = _parse_bare_call(completion.text)
-        raw = extract_json_object(completion.text)
-        # An object that a bare call opens is that call's ARGUMENTS, never the envelope, even
-        # when its keys happen to collide with the envelope's ("tool", "done"). Reading
-        # `book_trip({"tool": "train"})` as an envelope would run a tool named "train".
-        if raw is not None and not (
-            bare is not None and _text_starts_object(completion.text, bare)
-        ):
-            try:
-                reply = _AgentReply.model_validate_json(raw)
-            except ValidationError:
-                reply = None
-            if reply is not None:
-                if reply.done:
-                    return Action(kind=ActionKind.MESSAGE, content=DONE_SIGNAL)
-                if reply.tool is not None:
-                    return Action(
-                        kind=ActionKind.TOOL_CALL, name=reply.tool, arguments=reply.arguments
-                    )
-                # A JSON object with neither `done` nor `tool` is NOT a finish signal: models
-                # that write prose-style calls (`get_user(...)` around a bare argument object)
-                # land here, and treating it as done ended their episodes unexecuted at step 1
-                # and scored them 0 (measured: 34% of glm-5.2 wm episodes, 0% for other pool
-                # models). Fall through so the call is recovered or the env answers.
         if bare is not None:
             return Action(kind=ActionKind.TOOL_CALL, name=bare.name, arguments=bare.arguments)
         # Unparseable reply: surface it as a message action; the env will answer and the episode
@@ -154,7 +187,7 @@ class LLMAgent:
             temperature=self._temperature,
             max_tokens=1024,
         )
-        for _attempt in range(_EMPTY_RETRIES):
+        for _attempt in range(self._empty_retries):
             if completion.text.strip():
                 break
             completion = self._provider.complete(
@@ -164,11 +197,6 @@ class LLMAgent:
                 max_tokens=1024,
             )
         return completion
-
-
-def _text_starts_object(text: str, bare: _BareCall) -> bool:
-    """True when the first JSON object in `text` is the one `bare`'s call opens."""
-    return text.find("{") == bare.arguments_at
 
 
 def _render_turn(

--- a/wmo/env/llm_agent_test.py
+++ b/wmo/env/llm_agent_test.py
@@ -152,20 +152,56 @@ def test_envelope_wins_over_a_later_prose_call() -> None:
     assert action.name == "search"
 
 
-def test_call_arguments_are_never_read_as_the_envelope() -> None:
-    # The envelope guard: `book_trip({"tool": "train"})` extracts an object carrying a "tool"
-    # key, which would otherwise validate as an envelope and run a tool named "train".
-    action = LLMAgent(FakeProvider('book_trip({"tool": "train", "seats": 2})')).act(
+def test_a_rejected_hypothesis_does_not_outrank_the_chosen_envelope() -> None:
+    # A reasoning model deliberates before it decides. An earlier draft let the mentioned call
+    # suppress the envelope, so this reply issued a DB write the model had just ruled out.
+    reply = (
+        'Thinking: the schema is update_order({"order_id": "A1"}). Not applicable here.\n'
+        '```json\n{"done": true, "summary": "nothing to do"}\n```'
+    )
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
+    assert action.kind is ActionKind.MESSAGE
+    assert action.content == DONE_SIGNAL
+
+
+def test_envelope_is_found_after_a_leading_non_envelope_object() -> None:
+    reply = 'Let me think about search({"q": 1}) as an option.\n{"tool": "list_orders"}'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "list_orders"
+
+
+def test_a_done_envelope_wrapped_in_call_syntax_still_terminates() -> None:
+    # `finish({"done": true})` must not become a call to a tool named "finish": that stopped
+    # terminating the episode and burned the rest of the step budget.
+    action = LLMAgent(FakeProvider('finish({"done": true, "summary": "all set"})')).act(
         "task", EnvState(), []
     )
+    assert action.content == DONE_SIGNAL
+
+
+def test_prose_naming_a_tool_before_an_envelope_does_not_become_the_tool() -> None:
+    # The space before "(" is what tells prose apart from call syntax. Without that, this ran
+    # a tool literally named "tool" with the whole envelope as its arguments.
+    reply = 'I will use the search tool ({"tool": "search", "arguments": {"q": "x"}})'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
     assert action.kind is ActionKind.TOOL_CALL
-    assert action.name == "book_trip"
-    assert action.arguments == {"tool": "train", "seats": 2}
+    assert action.name == "search"
+    assert action.arguments == {"q": "x"}
+
+
+def test_a_hyphenated_call_name_is_not_truncated_to_its_last_segment() -> None:
+    # Matching only "details" invented a tool nobody offers; the whole name at least produces
+    # an honest unknown-tool error from the env.
+    action = LLMAgent(FakeProvider('get-user-details({"id": "x"})')).act("task", EnvState(), [])
+    assert action.name == "get-user-details"
 
 
 def test_unclosed_prose_call_still_falls_back_to_a_message() -> None:
-    action = LLMAgent(FakeProvider('get_user_details({"user_id": "x"')).act("task", EnvState(), [])
+    reply = 'get_user_details({"user_id": "x"'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
     assert action.kind is ActionKind.MESSAGE
+    assert action.content == reply
 
 
 def test_explicit_done_still_terminates() -> None:
@@ -226,3 +262,10 @@ def test_history_chars_bounds_the_rendered_observation() -> None:
 def test_history_chars_bounds_the_message_fallback() -> None:
     action = LLMAgent(FakeProvider("z" * 40), history_chars=10).act("task", EnvState(), [])
     assert action.content == "z" * 10
+
+
+def test_empty_retries_can_be_disabled_for_latency_measurement() -> None:
+    provider = ScriptedProvider([""])
+    action = LLMAgent(provider, empty_retries=0).act("task", EnvState(), [])
+    assert provider.calls == 1
+    assert action.kind is ActionKind.MESSAGE

--- a/wmo/env/llm_agent_test.py
+++ b/wmo/env/llm_agent_test.py
@@ -32,6 +32,28 @@ class FakeProvider:
         raise NotImplementedError
 
 
+class ScriptedProvider(FakeProvider):
+    """Returns a fixed sequence of replies (last one repeats) and counts the calls it served."""
+
+    def __init__(self, replies: list[str]) -> None:
+        super().__init__(replies[0])
+        self._replies = replies
+        self.calls = 0
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        self.last_user = messages[0].content
+        index = min(self.calls, len(self._replies) - 1)
+        self.calls += 1
+        return Completion(text=self._replies[index])
+
+
 def test_agent_parses_tool_call() -> None:
     agent = LLMAgent(FakeProvider('{"tool": "search", "arguments": {"q": "x"}}'))
     action = agent.act("find x", EnvState(), [])
@@ -100,20 +122,107 @@ def test_tools_hint_lands_in_the_system_prompt() -> None:
     assert bare is not None  # no hint -> unchanged system (covered by existing tests)
 
 
-def test_prose_tool_call_is_not_a_finish_signal() -> None:
-    # glm-5.2 sometimes writes `get_user_details({"user_id": "x"})`: extract_json_object
-    # grabs the bare ARGUMENT object, which validates with tool=None and done unset. That
-    # must fall through to a message action (the env answers, the episode recovers) - the
-    # old `tool is None -> DONE` read ended 34% of glm's episodes unexecuted at step 1.
+def test_prose_tool_call_executes_instead_of_stalling() -> None:
+    # glm-5.2 sometimes writes `get_user_details({"user_id": "x"})` instead of the envelope.
+    # Reading that as done ended 34% of glm's wm episodes unexecuted at step 1; falling
+    # through to a message action merely wasted the turn. Run the call the model meant.
     agent = LLMAgent(FakeProvider('get_user_details({"user_id": "chen_silva_2201"})'))
     action = agent.act("task", EnvState(), [])
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "get_user_details"
+    assert action.arguments == {"user_id": "chen_silva_2201"}
+
+
+def test_prose_tool_call_fused_with_prose_is_recovered() -> None:
+    reply = 'Let me look them up first. get_user_details({"user_id": "x"}) and then decide.'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "get_user_details"
+
+
+def test_first_of_several_prose_calls_wins() -> None:
+    reply = 'search({"q": "a"}) then update_order({"id": "b"})'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
+    assert action.name == "search"
+
+
+def test_envelope_wins_over_a_later_prose_call() -> None:
+    reply = '{"tool": "search", "arguments": {"q": "x"}} (not get_user_details({"id": "y"}))'
+    action = LLMAgent(FakeProvider(reply)).act("task", EnvState(), [])
+    assert action.name == "search"
+
+
+def test_call_arguments_are_never_read_as_the_envelope() -> None:
+    # The envelope guard: `book_trip({"tool": "train"})` extracts an object carrying a "tool"
+    # key, which would otherwise validate as an envelope and run a tool named "train".
+    action = LLMAgent(FakeProvider('book_trip({"tool": "train", "seats": 2})')).act(
+        "task", EnvState(), []
+    )
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "book_trip"
+    assert action.arguments == {"tool": "train", "seats": 2}
+
+
+def test_unclosed_prose_call_still_falls_back_to_a_message() -> None:
+    action = LLMAgent(FakeProvider('get_user_details({"user_id": "x"')).act("task", EnvState(), [])
     assert action.kind is ActionKind.MESSAGE
-    assert action.content is not None
-    assert action.content != DONE_SIGNAL
-    assert "chen_silva_2201" in action.content
 
 
 def test_explicit_done_still_terminates() -> None:
     agent = LLMAgent(FakeProvider('{"done": true}'))
     action = agent.act("task", EnvState(), [])
     assert action.content == DONE_SIGNAL
+
+
+def test_empty_completion_is_retried() -> None:
+    provider = ScriptedProvider(["", "   ", '{"tool": "search", "arguments": {}}'])
+    action = LLMAgent(provider).act("task", EnvState(), [])
+    assert provider.calls == 3
+    assert action.kind is ActionKind.TOOL_CALL
+    assert action.name == "search"
+
+
+def test_empty_completion_retries_are_bounded() -> None:
+    provider = ScriptedProvider([""])
+    action = LLMAgent(provider).act("task", EnvState(), [])
+    assert provider.calls == 3  # the first call plus two retries, then give up
+    assert action.kind is ActionKind.MESSAGE
+    assert action.content == ""
+
+
+def test_a_good_first_completion_is_not_retried() -> None:
+    provider = ScriptedProvider(['{"done": true}'])
+    LLMAgent(provider).act("task", EnvState(), [])
+    assert provider.calls == 1
+
+
+def test_history_observations_survive_a_tau_sized_payload() -> None:
+    # The 500-char cap truncated `get_user_details` payloads before their useful fields, so
+    # the agent re-fetched the same record verbatim until the step budget died.
+    payload = "x" * 900 + "MEMBERSHIP=gold"
+    provider = FakeProvider('{"done": true}')
+    history = [
+        Step(
+            action=Action(kind=ActionKind.TOOL_CALL, name="get_user_details", arguments={}),
+            observation=Observation(content=payload),
+        )
+    ]
+    LLMAgent(provider).act("task", EnvState(), history)
+    assert "MEMBERSHIP=gold" in (provider.last_user or "")
+
+
+def test_history_chars_bounds_the_rendered_observation() -> None:
+    provider = FakeProvider('{"done": true}')
+    history = [
+        Step(
+            action=Action(kind=ActionKind.TOOL_CALL, name="get_user_details", arguments={}),
+            observation=Observation(content="y" * 50 + "TAIL"),
+        )
+    ]
+    LLMAgent(provider, history_chars=10).act("task", EnvState(), history)
+    assert "TAIL" not in (provider.last_user or "")
+
+
+def test_history_chars_bounds_the_message_fallback() -> None:
+    action = LLMAgent(FakeProvider("z" * 40), history_chars=10).act("task", EnvState(), [])
+    assert action.content == "z" * 10

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -116,9 +116,32 @@ def _aggregate(outcomes: list[ScenarioOutcome]) -> tuple[float, float, float, fl
     accuracy = _mean(rewards)
     success = _mean([1.0 if o.success else 0.0 for o in scored])
     cost = _mean([o.cost_usd for o in scored])
-    calls = [s for o in scored for s in o.call_seconds]
-    p50, p95 = _p50_p95_ms(calls)
+    p50, p95 = _p50_p95_ms(_productive_call_seconds(scored))
     return accuracy, success, cost, p50, p95
+
+
+def _productive_call_seconds(scored: list[ScenarioOutcome]) -> list[float]:
+    """Per-call seconds, skipping calls the provider answered with blank text.
+
+    `wmo.env.closed_loop._TimedProvider` appends `call_seconds` and `replies` in lockstep per
+    provider call, so there a blank reply is identifiable by index. Those calls return fast and
+    carry no action, and `LLMAgent` buys another completion to replace them, so counting them
+    would report a latency at which the endpoint never delivered work: a model that blanks often
+    would look FASTER than one that answers first time. Cost is deliberately left alone, because
+    the blank attempts were really paid for.
+
+    Other producers do not promise that pairing (the real-episode runner records one reply per
+    message that HAS content but one duration per timed call), so equal lengths are required
+    before attributing a duration to a reply; otherwise every call counts.
+    """
+    seconds: list[float] = []
+    for outcome in scored:
+        if len(outcome.replies) != len(outcome.call_seconds):
+            seconds.extend(outcome.call_seconds)
+            continue
+        paired = zip(outcome.call_seconds, outcome.replies, strict=True)
+        seconds.extend(value for value, reply in paired if reply.strip())
+    return seconds
 
 
 def build_report(

--- a/wmo/optimize/report_test.py
+++ b/wmo/optimize/report_test.py
@@ -211,3 +211,35 @@ def test_report_requires_baseline_in_matrix() -> None:
             endpoint="e",
             generated_at="2026-07-24T00:00:00Z",
         )
+
+
+def test_blank_retry_calls_do_not_deflate_latency() -> None:
+    # `LLMAgent` retries a blank completion, and the metering wrapper records each attempt as
+    # its own fast call. Counting those would make a model that blanks often look FASTER.
+    from wmo.optimize.report import _productive_call_seconds
+
+    outcome = ScenarioOutcome(
+        scenario_id="s",
+        task="t",
+        model="m",
+        reward=1.0,
+        call_seconds=[0.01, 0.01, 2.0],
+        replies=["", "   ", '{"done": true}'],
+    )
+    assert _productive_call_seconds([outcome]) == [2.0]
+
+
+def test_latency_counts_every_call_when_replies_are_not_call_aligned() -> None:
+    # The real-episode runner records one reply per message that HAS content but one duration
+    # per timed call, so durations must not be attributed to replies by index there.
+    from wmo.optimize.report import _productive_call_seconds
+
+    outcome = ScenarioOutcome(
+        scenario_id="s",
+        task="t",
+        model="m",
+        reward=1.0,
+        call_seconds=[1.0, 2.0, 3.0],
+        replies=["only one reply"],
+    )
+    assert _productive_call_seconds([outcome]) == [1.0, 2.0, 3.0]


### PR DESCRIPTION
Salvages the unmerged real-episode runner and sim-to-real analysis from research branch `routing/r3` into `packages/environment-capture/tau-bench/rl/`, unified with the pinned eval split, plus the `LLMAgent` hardening that branch never landed.

## Justification ledger

| Decision | Why |
|---|---|
| Select from `scenarios_eval.jsonl`, not first-N task ids in file order | r3 measured a different task set than the world model was evaluated on |
| Exact canonical-JSON instructions match; hard error on a miss | Pinned lines store the tau2 blob verbatim; all 20 resolve, and drift must abort rather than shrink the set |
| `scenario_id` = `"<domain>:<task_id>"` | Airline and retail both number from "0"; bare ids merge two tasks into one matrix cell |
| Telecom included | r3 ran airline and retail only; 5 pinned eval scenarios are telecom |
| Derive routes and credentials from the pool entry | r3's hardcoded 9-model table silently skips any new pool model |
| Refuse two accounts on one Azure family | One tau2 process holds one account per credential family; clobbering surfaces as an opaque 401 |
| Refuse an unrecognized Azure endpoint host | Guessing sends the request to the wrong service with the wrong credential variable |
| Price at pool rates, keep tau2's for audit | litellm does not know our MaaS deployments; it reported `agent_cost: 0.0` for FW-GLM-5.2 on the verification run |
| Unscored episodes stay `reward: null` | An infrastructure failure is not a judge verdict |
| Parse `results.json` with pydantic | tau2 owns the schema; lenient models give a named error instead of an `AttributeError` deep in a loop |
| Bare-call parse before the message fallback | #260 stopped misreading prose calls as done; this executes them instead of wasting the turn |
| Envelope guard via `_text_starts_object`, not r3's `_speaks_envelope` | #260 made `_speaks_envelope` redundant but left the colliding-keys half of the bug class open |
| History cap 500 to 2000 | 500 truncated tau `get_user_details` payloads, causing verbatim re-fetch loops until the step budget died |
| Rewrote one existing test | It asserted the old, weaker prose-call behavior; reason stated in the diff |

## Verification

3687 passed / 18 skipped; ruff, ruff format, and ty clean project-wide. Real-benchmark smoke: 2 airline episodes on glm-5.2, both reward 1.0, $0.16; rerun spent $0.00.

## Reviewer notes

The history-cap change makes OutcomeMatrix artifacts captured before and after this PR non-comparable. Recapture rather than pool.

7 of the 20 pinned eval tasks carry `NL_ASSERTION` in `reward_basis` (scored by tau2's built-in judge on `azure/gpt-5.4-mini`); every row records `nl_assertion_reward` so the fully-deterministic subset is recoverable.


Merges only after coordinator `/ready-for-merge` plus a Silen eyeball.
