### PR TITLE
Add 'just setup': the repo's first-command entry point

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ AZURE_OPENAI_ENDPOINT=
 # OpenAI direct (GPT 5.5)
 OPENAI_API_KEY=
 
+# OpenRouter (serves pool candidates like GLM-5.2 / Kimi, priced from its own catalog)
+OPENROUTER_API_KEY=
+
+# Tinker (distillation: student sampling, training, and serving trained adapters)
+TINKER_API_KEY=
+
+# E2B sandboxes (distillation rollouts and optimizer/eval runs with the e2b backend)
+E2B_API_KEY=
+
 # Key for OpenAI-COMPATIBLE custom endpoints (Azure Foundry resources, self-hosted vLLM).
 # Used whenever an `openai`-kind provider has an explicit `endpoint` — the real OPENAI_API_KEY
 # is never sent to non-OpenAI hosts. Role endpoints live in .wmo/settings.toml [models.*].

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ the new versioned champion harness.
 Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).
 
 ```bash
+just setup               # first time: .env from the template + uv sync
 uv sync --extra dev      # env + dev tools
 uv run ruff check .      # lint
 uv run ruff format .     # format

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ the new versioned champion harness.
 
 ## Development
 
-Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty). Conventions live in [AGENTS.md](./AGENTS.md).
+Managed with [uv](https://docs.astral.sh/uv/); linting/formatting with [ruff](https://docs.astral.sh/ruff/); type checking with [ty](https://github.com/astral-sh/ty); tasks run through [just](https://github.com/casey/just) (`brew install just` / `cargo install just`). Conventions live in [AGENTS.md](./AGENTS.md).
 
 ```bash
 just setup               # first time: .env from the template + uv sync

--- a/justfile
+++ b/justfile
@@ -3,6 +3,13 @@
 default:
     @just --list
 
+# First-time setup (pipeline step 0): create .env from the template, install everything.
+# Idempotent: an existing .env is never touched.
+setup:
+    @test -f .env && echo ".env exists, leaving it alone" || (cp .env.example .env && echo "created .env from .env.example; fill in the keys you have")
+    uv sync --extra dev
+    @echo "next: put credentials in .env, then register models with 'uv run wmo providers set'"
+
 # The whole-repo gate (AGENTS.md rule 1): flagship + every Python member.
 gate:
     uv run ruff check .


### PR DESCRIPTION
## Why

Silen's directive (joint-tau track, 2026-07-27): the repo needs one canonical command that sets everything up and creates the env, documented as step 0 of the pipeline. No such entry point existed; the justfile is the repo's designated task runner ("tasks in the justfile", repo_layout_test.py), so the command lands there rather than as a new top-level script.

## What

- `just setup`: idempotent first-run recipe. Creates `.env` from `.env.example` (never touches an existing `.env`), runs `uv sync --extra dev`, prints the next step (`wmo providers set`).
- `.env.example` gains the three keys that already have live consumers, one consumer-naming comment each: `OPENROUTER_API_KEY` (the OpenRouter provider, #284), `TINKER_API_KEY` (distillation + serving trained adapters, #250/#272), `E2B_API_KEY` (e2b rollout/eval backends).
- README Development block leads with `just setup`.

## Justification ledger

| Addition | Named consumer |
|---|---|
| `setup` recipe | the docs/cookbook step 0 (joint-tau canonical example, PR to follow) and every fresh clone |
| `.env.example` keys | wmo/providers/openrouter.py, wmo/providers/tinker.py + `wmo optimize route student` entries, the e2b backend paths |
| README line | same |

Deliberately NOT added: `WMO_COMPRESSOR_URL`/`WMO_COMPRESSOR_API_KEY` (no consumer on main yet; they ride with the compaction chat's H100 compressor-endpoint PR).

## Verification

repo_layout_test (11 passed; root-file allowlist already carries justfile/.env.example), ruff clean. The recipe body was executed directly line by line: create-from-template works, all three keys present, second run leaves .env alone. The `just` binary itself is not installed on this machine, so the recipe was not run through just; it copies the syntax patterns of the existing recipes verbatim.

Merges only after coordinator /ready-for-merge (AGENTS rule 13) + Silen eyeball.