### PR TITLE
Reproduce a Tinker-trained LoRA off Tinker, on local vLLM

### DIFF
--- a/.agents/distill/tb2-vllm-repro/README.md
+++ b/.agents/distill/tb2-vllm-repro/README.md
@@ -1,0 +1,87 @@
+# Reproducing a Tinker-trained LoRA off Tinker, on local vLLM
+
+Takes an on-policy-distilled LoRA checkpoint produced on Tinker, merges it into a full
+HuggingFace model, serves base and merged side by side in vLLM, and evaluates both on the
+TerminalBench-2 holdout through harbor's `terminus-2` agent with E2B sandboxes.
+
+The point is to answer a question Tinker itself cannot: **does the trained policy survive
+leaving the training service?** Tinker's sampler and our vLLM are different inference stacks,
+so a lift that only exists on Tinker is not a property of the weights.
+
+Run of record: student `Qwen/Qwen3.5-9B`, teacher `Qwen/Qwen3.6-27B`, LoRA rank 32,
+sampler `pi-step-0004-b1604882` from `qwen-train-v3`. Numbers live in Notion, not here.
+
+## Two findings worth not rediscovering
+
+**vLLM cannot serve this adapter as a LoRA — you must merge it.** Tinker trains with
+`train_unembed=True`, so the adapter carries `unembed_tokens.lora_A/B`, which the export
+remaps to `lm_head`. vLLM only admits LoRA on embedding modules when the model class declares
+a non-empty `embedding_modules`, and `Qwen3_5ForConditionalGeneration` declares `{}` — so
+`LoRAModel.from_local_checkpoint` rejects the adapter outright. Independently, the adapter
+stores split `linear_attn.in_proj_q/k/v` while the base and vLLM use a fused `in_proj_qkv`,
+which is not exactly representable as a rank-32 LoRA on the fused tensor. Merging sidesteps
+both: `merge_strategy="auto"` concatenates the split deltas into the fused weight.
+
+**A merge can silently no-op, so assert coverage rather than eyeballing the output.**
+`verify_merge.py` checks that the set of base tensors that actually changed equals the set the
+adapter targets, after applying the split→fused and unembed→lm_head remaps. Sampling a few
+tensor names by hand is not enough: an obvious pick like `layers.0.*` hits `input_layernorm`,
+which `all-linear` never targets and which is *correctly* unchanged. A green "weights differ"
+from the wrong tensor is worse than no check.
+
+## Sequence
+
+```bash
+# 1. Export + merge  (CPU-only, ~19 GB out; output_path must not exist)
+python export_and_merge.py \
+  --tinker-path 'tinker://<uuid>:train:0/sampler_weights/<name>' \
+  --base-model  /scratch/hf_cache/hub/models--Qwen--Qwen3.5-9B/snapshots/<sha> \
+  --output      /scratch/repro-tb2/qwen35-9b-distill-v3
+
+# 2. Prove the merge landed before spending sandbox budget
+python verify_merge.py \
+  --base /scratch/hf_cache/hub/models--Qwen--Qwen3.5-9B/snapshots/<sha> \
+  --merged /scratch/repro-tb2/qwen35-9b-distill-v3 \
+  --adapter /scratch/repro-tb2/adapter-raw
+
+# 3. Serve both arms, one model per GPU (TP=1 each so the arms run concurrently)
+./serve_arms.sh
+
+# 4. Confirm the arms are not the same model
+python tripwire.py            # greedy decode, must differ on every prompt
+
+# 5. Evaluate  (arm-base.yaml is the canonical config; derive the other arm from it)
+harbor run -c arm-base.yaml --yes
+harbor run -c arm-distill.yaml --yes
+
+# 6. Score, paired over tasks
+python score.py --base-jobs <dir> --distill-jobs <dir>
+```
+
+## Environment notes
+
+These bit a real run; they are cheap to pre-empt.
+
+- vLLM's flashinfer sampling kernels are JIT-compiled at startup and need **both** `ninja` and
+  the CUDA **dev** headers. A box can have a working CUDA runtime and still be missing
+  `curand.h` (`libcurand-dev-13-0`). Put `$CUDA_HOME/bin` on `PATH` for the server process.
+  Do not reach for `enforce_eager` or a triton fallback to make the error go away — that
+  changes throughput, not the missing toolchain.
+- **Serve with headroom above the agent's context budget, or compaction dies silently.** vLLM
+  rejects a request when `prompt + max_tokens > max_model_len`, so setting `max_model_len` to
+  the agent's `context_budget_tokens + max_tokens` exactly leaves no room: terminus-2's
+  proactive summarization sends slightly *more* than the budget and gets a 400. litellm
+  swallows the body, so the only symptom is `Error in proactively summarizing:` with an empty
+  message, followed by `Even fallback chat failed:` — and the run continues at full speed with
+  compaction disabled. Trials still complete and `exception_info` stays null, so nothing marks
+  the results as invalid. Reproducing a Tinker run is where this bites hardest: Tinker's 65,530
+  ceiling forces budgets that sum to just under it, and copying that sum to `max_model_len`
+  reproduces the ceiling without reproducing the behaviour. Serve well above it (we used 81,920
+  against a 53,240 + 12,288 envelope) and leave the agent's own budget untouched.
+- Harbor task names are namespaced: `terminal-bench/<task>`, not `<task>`. An unprefixed
+  filter raises rather than silently selecting a subset, but assert the resolved count anyway.
+- Concurrent harbor runs can `rmtree` each other's task cache. Give each arm its own
+  `download_dir` and `jobs_dir`, pre-warmed with `install_only: true`.
+- Keep `n_concurrent_trials` at or below the server's `--max-num-seqs`. Oversubscribing raises
+  per-token latency, which pushes episodes into the wall clock and biases the result toward
+  whichever arm happens to be faster.

--- a/.agents/distill/tb2-vllm-repro/README.md
+++ b/.agents/distill/tb2-vllm-repro/README.md
@@ -58,6 +58,23 @@ harbor run -c arm-distill.yaml --yes
 python score.py --base-jobs <dir> --distill-jobs <dir>
 ```
 
+## Condition an attrition rate on winnability before calling it a bias
+
+`score.py` reports errored counts per arm, and it is tempting to read a large asymmetry as a
+large bias. Don't, without checking *where* the losses fall. On this run the distilled arm
+errored on 55.1% of trials against the base arm's 14.0% — every one of them an
+`AgentTimeoutError` at the episode wall, in both arms, with no other mechanism. That looks like
+it must dominate the result. It did not: **68 of those 75 timeouts landed on the 12 tasks that
+score 0.000 in both arms**, so the truncation happened where there was nothing to win.
+Conditioning on winnability, the distilled arm lost at most 7 trials and the base arm 1, worth
+roughly +0.04 on the paired delta rather than the "this is only a floor" reading the raw rate
+invites.
+
+The same crosstab is what separates capability from speed. A task where one arm times out 8/8
+and the other 4/8 produces a solve-rate delta that is substantially "finishes inside the
+budget", not "solves better" — a real advantage for a deployed agent, but a different claim.
+Cross timeouts against per-task rates before attributing any mover.
+
 ## Environment notes
 
 These bit a real run; they are cheap to pre-empt.

--- a/.agents/distill/tb2-vllm-repro/arm-base.yaml
+++ b/.agents/distill/tb2-vllm-repro/arm-base.yaml
@@ -1,0 +1,56 @@
+job_name: tb2-repro-base
+jobs_dir: /scratch/repro-tb2/jobs-base
+n_attempts: 8
+n_concurrent_trials: 17
+install_only: false
+
+retry:
+  max_retries: 1
+
+environment:
+  type: e2b
+  delete: true
+
+agents:
+- name: terminus-2
+  override_timeout_sec: 2700
+  max_timeout_sec: null
+  model_name: hosted_vllm/base-student
+  kwargs:
+    api_base: http://127.0.0.1:8000/v1
+    temperature: 1.0
+    max_turns: 100
+    enable_summarize: true
+    collect_rollout_details: true
+    store_all_messages: true
+    model_info:
+      max_input_tokens: 53240
+      max_output_tokens: 12288
+      input_cost_per_token: 0.0
+      output_cost_per_token: 0.0
+    llm_call_kwargs:
+      top_p: 1.0
+      max_tokens: 12288
+
+datasets:
+- name: terminal-bench/terminal-bench-2-1
+  ref: sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a
+  download_dir: /scratch/repro-tb2/tbcache-base
+  task_names:
+  - terminal-bench/build-pov-ray
+  - terminal-bench/constraints-scheduling
+  - terminal-bench/distribution-search
+  - terminal-bench/dna-assembly
+  - terminal-bench/fix-ocaml-gc
+  - terminal-bench/gcode-to-text
+  - terminal-bench/kv-store-grpc
+  - terminal-bench/make-mips-interpreter
+  - terminal-bench/merge-diff-arc-agi-task
+  - terminal-bench/nginx-request-logging
+  - terminal-bench/path-tracing-reverse
+  - terminal-bench/pytorch-model-cli
+  - terminal-bench/raman-fitting
+  - terminal-bench/schemelike-metacircular-eval
+  - terminal-bench/sparql-university
+  - terminal-bench/winning-avg-corewars
+  - terminal-bench/write-compressor

--- a/.agents/distill/tb2-vllm-repro/export_and_merge.py
+++ b/.agents/distill/tb2-vllm-repro/export_and_merge.py
@@ -1,0 +1,105 @@
+"""Take a Tinker LoRA checkpoint to a vLLM-servable HuggingFace model directory.
+
+Downloads the adapter archive, then merges it into the base model. Merging is not an
+optimization here, it is the only option: Tinker trains with ``train_unembed=True``, so the
+adapter carries ``unembed_tokens`` LoRA that exports as ``lm_head``, and vLLM refuses LoRA on
+embedding modules unless the model class declares a non-empty ``embedding_modules``. See the
+README for the full reasoning.
+
+The merge is CPU-only and shard-by-shard, so it needs disk (~2x the model) but little RAM.
+Point ``--output`` at a large volume; the base model's own snapshot directory is not it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def download(tinker_path: str, dest_parent: Path, python: str, force: bool) -> Path:
+    """Download + extract a Tinker checkpoint; return the extracted directory."""
+    dest_parent.mkdir(parents=True, exist_ok=True)
+    before = set(dest_parent.iterdir())
+
+    cmd = [
+        python,
+        "-m",
+        "tinker.cli",
+        "checkpoint",
+        "download",
+        tinker_path,
+        "--output",
+        str(dest_parent),
+    ]
+    if force:
+        cmd.append("--force")
+    print("+ " + " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+    new = [p for p in dest_parent.iterdir() if p.is_dir() and p not in before]
+    if len(new) != 1:
+        candidates = [
+            p
+            for p in dest_parent.iterdir()
+            if p.is_dir() and (p / "adapter_model.safetensors").exists()
+        ]
+        if len(candidates) != 1:
+            raise RuntimeError(
+                f"expected exactly one extracted checkpoint dir under {dest_parent}, "
+                f"found new={new} with-adapter={candidates}"
+            )
+        return candidates[0]
+    return new[0]
+
+
+def merge(base_model: str, adapter_dir: Path, output: Path, trust_remote_code: bool) -> None:
+    from tinker_cookbook.weights import build_hf_model
+
+    if output.exists():
+        raise SystemExit(f"--output already exists, refusing to overwrite: {output}")
+
+    print(f"merging {adapter_dir} into {base_model} -> {output}", flush=True)
+    build_hf_model(
+        base_model=base_model,
+        adapter_path=str(adapter_dir),
+        output_path=str(output),
+        merge_strategy="auto",
+        trust_remote_code=trust_remote_code,
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--tinker-path", help="tinker://<uuid>:train:0/sampler_weights/<name>")
+    src.add_argument("--adapter-dir", type=Path, help="already-downloaded adapter directory")
+    ap.add_argument("--base-model", required=True, help="HF id or local snapshot path")
+    ap.add_argument("--output", type=Path, required=True, help="merged model dir (must not exist)")
+    ap.add_argument("--download-dir", type=Path, default=Path("./tinker-adapters"))
+    ap.add_argument("--python", default=sys.executable, help="interpreter holding the tinker SDK")
+    ap.add_argument("--force", action="store_true", help="re-download over an existing dir")
+    ap.add_argument("--no-trust-remote-code", action="store_true")
+    args = ap.parse_args()
+
+    adapter = (
+        args.adapter_dir
+        if args.adapter_dir
+        else download(args.tinker_path, args.download_dir, args.python, args.force)
+    )
+
+    weights = adapter / "adapter_model.safetensors"
+    if not weights.exists():
+        raise SystemExit(f"no adapter_model.safetensors in {adapter}")
+    print(f"adapter: {adapter}  ({weights.stat().st_size / 1e6:.0f} MB)")
+
+    merge(args.base_model, adapter, args.output, not args.no_trust_remote_code)
+
+    print(f"\nmerged model written to {args.output}")
+    print("next: verify_merge.py --base <base> --merged <output> --adapter <adapter>")
+    print("      a merge that silently no-ops looks identical to a good one on disk")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/distill/tb2-vllm-repro/merge_fidelity.py
+++ b/.agents/distill/tb2-vllm-repro/merge_fidelity.py
@@ -1,0 +1,213 @@
+"""Quantify how much of a LoRA update actually survived being baked into bf16 weights.
+
+`verify_merge.py` answers "did every targeted module move at all". That is necessary but weak:
+a merge can touch every tensor and still lose most of the update to rounding. This answers the
+quantitative version, and it matters whenever the adapter is small relative to bf16's ~0.4%
+relative resolution -- which is the normal case for a few-step on-policy-distillation LoRA.
+
+Two statistics, and the second is the one to trust:
+
+* **element change fraction** -- what share of adapted elements differ from base. Intuitive but
+  misleading on its own: a genuine small delta legitimately rounds away on most elements, so a
+  low fraction is not evidence of failure. A sibling lane's >=40% gate was calibrated on a
+  checkpoint trained 66-200 steps and does not transfer to a 4-step one.
+* **delta norm ratio** ``||merged - base|| / ||(alpha/r) B A||`` -- what share of the update's
+  magnitude landed. ~1.0 means the merge is faithful in aggregate whatever the element count
+  says. This is the number that distinguishes "small update, correctly merged" from
+  "update evaporated".
+
+Also reported: cosine between intended and realized delta. Well below 1.0 means bf16 rounding
+noise is comparable in scale to the update itself, so the merged model is not bit-equivalent to
+runtime LoRA application. That is a real caveat to state, not necessarily a defect -- a merged
+bf16 model is what actually gets deployed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+# Adapter module -> merged tensor. Multiple sources mean the merge concatenated them.
+FUSED = {
+    "linear_attn.in_proj_qkv": [
+        "linear_attn.in_proj_q",
+        "linear_attn.in_proj_k",
+        "linear_attn.in_proj_v",
+    ]
+}
+RENAME = {"unembed_tokens": "lm_head"}
+
+
+def _weight_map(root: Path) -> dict[str, str]:
+    return json.loads((root / "model.safetensors.index.json").read_text())["weight_map"]
+
+
+class Reader:
+    def __init__(self) -> None:
+        self._h: dict[tuple[Path, str], object] = {}
+
+    def get(self, root: Path, wmap: dict[str, str], name: str) -> torch.Tensor:
+        key = (root, wmap[name])
+        if key not in self._h:
+            self._h[key] = safe_open(root / wmap[name], framework="pt")
+        return self._h[key].get_tensor(name)  # type: ignore[attr-defined]
+
+
+def element_fraction(base: Path, merged: Path, adapted: list[str], r: Reader) -> float:
+    bmap, mmap = _weight_map(base), _weight_map(merged)
+    per_class: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    changed = total = 0
+    unchanged: list[str] = []
+    for name in adapted:
+        a, b = r.get(base, bmap, name), r.get(merged, mmap, name)
+        nch, ne = int((a != b).sum()), a.numel()
+        changed += nch
+        total += ne
+        cls = ".".join(p for p in name.split(".") if not p.isdigit())
+        per_class[cls][0] += nch
+        per_class[cls][1] += ne
+        if nch == 0:
+            unchanged.append(name)
+
+    print(f"\n{'class':58s} {'elements changed':>17s}")
+    print("-" * 78)
+    for cls, (c, e) in sorted(per_class.items()):
+        print(f"{cls:58s} {100.0 * c / e:>16.2f}%")
+    print("-" * 78)
+    print(f"{'OVERALL':58s} {100.0 * changed / total:>16.2f}%")
+    if unchanged:
+        print(f"\nFAIL: {len(unchanged)} adapted tensor(s) entirely unchanged: {unchanged[:8]}")
+    return 100.0 * changed / total
+
+
+def norm_ratios(
+    base: Path, merged: Path, adapter: Path, scaling: float, layers: list[int], r: Reader
+) -> list[float]:
+    bmap, mmap = _weight_map(base), _weight_map(merged)
+    ad = safe_open(adapter / "adapter_model.safetensors", framework="pt")
+    keys = set(ad.keys())
+
+    def delta(module: str) -> torch.Tensor:
+        a = ad.get_tensor(f"base_model.model.{module}.lora_A.weight").double()
+        b = ad.get_tensor(f"base_model.model.{module}.lora_B.weight").double()
+        return scaling * (b @ a)
+
+    cases: list[tuple[str, str, list[str]]] = []
+    for li in layers:
+        ap, mp = f"model.layers.{li}", f"model.language_model.layers.{li}"
+        for suffix in (
+            "linear_attn.in_proj_qkv",
+            "linear_attn.in_proj_z",
+            "mlp.gate_proj",
+            "mlp.down_proj",
+            "self_attn.q_proj",
+        ):
+            srcs = FUSED.get(suffix, [suffix])
+            cases.append((f"L{li} {suffix}", f"{mp}.{suffix}.weight", [f"{ap}.{s}" for s in srcs]))
+    cases.append(("lm_head", "lm_head.weight", ["model.unembed_tokens"]))
+
+    print(f"\n{'tensor':40s} {'norm ratio':>12s} {'cosine':>9s} {'||d||/||W||':>13s}")
+    print("-" * 78)
+    ratios: list[float] = []
+    for label, tensor, modules in cases:
+        if tensor not in bmap or tensor not in mmap:
+            continue
+        if not all(f"base_model.model.{m}.lora_A.weight" in keys for m in modules):
+            continue
+        w = r.get(base, bmap, tensor).double()
+        realized = r.get(merged, mmap, tensor).double() - w
+        parts = [delta(m) for m in modules]
+        intended = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
+        if intended.shape != realized.shape:
+            print(f"{label:40s} shape {tuple(intended.shape)} vs {tuple(realized.shape)}")
+            continue
+        ni = intended.norm().item()
+        ratio = realized.norm().item() / ni if ni else float("nan")
+        # float64 throughout: an fp32 dot over ~1e9 elements accumulates enough error to
+        # report a cosine above 1.
+        cos = float(
+            torch.dot(intended.flatten(), realized.flatten()) / (intended.norm() * realized.norm())
+        )
+        ratios.append(ratio)
+        print(f"{label:40s} {ratio:>12.4f} {cos:>9.4f} {ni / w.norm().item():>13.2e}")
+    return ratios
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", type=Path, required=True)
+    ap.add_argument("--merged", type=Path, required=True)
+    ap.add_argument("--adapter", type=Path, required=True)
+    ap.add_argument("--layers", type=int, nargs="*", default=[0, 11, 23])
+    ap.add_argument(
+        "--min-norm-ratio",
+        type=float,
+        default=0.80,
+        help="fail below this; the update's magnitude did not land",
+    )
+    args = ap.parse_args()
+
+    cfg = json.loads((args.adapter / "adapter_config.json").read_text())
+    scaling = cfg["lora_alpha"] / cfg["r"]
+    print(f"adapter r={cfg['r']} alpha={cfg['lora_alpha']} scaling={scaling:g}")
+
+    with safe_open(args.adapter / "adapter_model.safetensors", framework="pt") as f:
+        zero_b = sum(
+            1 for k in f.keys() if ".lora_B." in k and f.get_tensor(k).abs().max().item() == 0
+        )
+        n_b = sum(1 for k in f.keys() if ".lora_B." in k)
+    print(f"lora_B matrices: {n_b}, exactly zero: {zero_b}")
+
+    bmap, mmap = _weight_map(args.base), _weight_map(args.merged)
+    adapted = sorted(
+        n
+        for n in bmap
+        if n in mmap
+        and (
+            n == "lm_head.weight"
+            or (
+                "model.language_model.layers." in n
+                and n.endswith(".weight")
+                and any(
+                    s in n
+                    for s in (
+                        "linear_attn.in_proj_qkv",
+                        "linear_attn.in_proj_z",
+                        "linear_attn.out_proj",
+                        "mlp.down_proj",
+                        "mlp.gate_proj",
+                        "mlp.up_proj",
+                        "self_attn.k_proj",
+                        "self_attn.o_proj",
+                        "self_attn.q_proj",
+                        "self_attn.v_proj",
+                    )
+                )
+            )
+        )
+    )
+    print(f"adapted tensors: {len(adapted)}")
+
+    reader = Reader()
+    element_fraction(args.base, args.merged, adapted, reader)
+    ratios = norm_ratios(args.base, args.merged, args.adapter, scaling, args.layers, reader)
+
+    if ratios:
+        mean = sum(ratios) / len(ratios)
+        print("-" * 78)
+        print(f"mean norm ratio {mean:.4f}  (min {min(ratios):.4f}, max {max(ratios):.4f})")
+        verdict = "PASS" if mean >= args.min_norm_ratio and zero_b == 0 else "FAIL"
+        print(f"\nMERGE FIDELITY: {verdict}  (threshold {args.min_norm_ratio})")
+        print(
+            "Judge on the norm ratio, not the element fraction -- a small update correctly "
+            "merged\nlegitimately leaves most individual elements at their base value."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/distill/tb2-vllm-repro/score.py
+++ b/.agents/distill/tb2-vllm-repro/score.py
@@ -1,0 +1,138 @@
+"""Score a two-arm TerminalBench-2 job pair, paired over tasks.
+
+Reports binary solve rate, graded ``ctrf`` (fraction of individual tests passed), and the
+paired per-task delta with a bootstrap CI resampled over *tasks* rather than trials — the
+attempts within a task share a task, so treating them as independent understates the interval.
+
+Also reports executed-vs-graded counts per arm. A trial that vanishes from the denominator
+inflates the rate, and the trials that vanish are the long, hard ones, so a rate quoted without
+its denominator can rise as the harness breaks more often.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Trial:
+    task: str
+    reward: float | None
+    graded: float | None
+    excepted: bool
+    stop_reasons: list[str] = field(default_factory=list)
+
+
+def _ctrf_score(trial_dir: Path) -> float | None:
+    for path in sorted(trial_dir.glob("verifier/*.json")):
+        try:
+            doc = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        summary = doc.get("results", {}).get("summary")
+        if isinstance(summary, dict) and summary.get("tests"):
+            return summary.get("passed", 0) / summary["tests"]
+    return None
+
+
+def load_arm(jobs_dir: Path) -> list[Trial]:
+    trials: list[Trial] = []
+    for result in sorted(jobs_dir.rglob("result.json")):
+        try:
+            doc = json.loads(result.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if "task_name" not in doc:
+            continue
+        rewards = (doc.get("verifier_result") or {}).get("rewards") or {}
+        details = (doc.get("agent_result") or {}).get("rollout_details") or [{}]
+        raw_stops = (details[0].get("extra") or {}).get("stop_reason") or []
+        trials.append(
+            Trial(
+                task=doc["task_name"].split("/")[-1],
+                reward=rewards.get("reward"),
+                graded=_ctrf_score(result.parent),
+                excepted=doc.get("exception_info") is not None,
+                stop_reasons=[s for s in raw_stops if s],
+            )
+        )
+    return trials
+
+
+def per_task(trials: list[Trial], key) -> dict[str, float]:
+    buckets: dict[str, list[float]] = defaultdict(list)
+    for t in trials:
+        v = key(t)
+        if v is not None:
+            buckets[t.task].append(v)
+    return {task: sum(vs) / len(vs) for task, vs in buckets.items()}
+
+
+def bootstrap_ci(deltas: list[float], n: int, seed: int) -> tuple[float, float]:
+    rng = random.Random(seed)
+    means = []
+    for _ in range(n):
+        sample = [deltas[rng.randrange(len(deltas))] for _ in deltas]
+        means.append(sum(sample) / len(sample))
+    means.sort()
+    return means[int(0.025 * n)], means[int(0.975 * n)]
+
+
+def _rate(trials: list[Trial], key) -> tuple[float, int, int]:
+    vals = [v for v in (key(t) for t in trials) if v is not None]
+    return (sum(vals) / len(vals) if vals else 0.0), len(vals), len(trials)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base-jobs", type=Path, required=True)
+    ap.add_argument("--distill-jobs", type=Path, required=True)
+    ap.add_argument("--bootstrap", type=int, default=20000)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    arms = {"base": load_arm(args.base_jobs), "distill": load_arm(args.distill_jobs)}
+
+    binary = lambda t: None if t.reward is None else float(t.reward == 1.0)
+    graded = lambda t: t.graded
+
+    print(f"{'arm':10s} {'binary':>18s} {'graded ctrf':>13s} {'graded/exec':>13s} {'excepted':>9s}")
+    print("-" * 70)
+    for name, trials in arms.items():
+        b, nb, total = _rate(trials, binary)
+        g, _, _ = _rate(trials, graded)
+        exc = sum(t.excepted for t in trials)
+        print(f"{name:10s} {b:>10.1%} ({nb:3d}) {g:>12.1%} {nb:>6d}/{total:<6d} {exc:>9d}")
+
+    tb, td = per_task(arms["base"], binary), per_task(arms["distill"], binary)
+    shared = sorted(set(tb) & set(td))
+    if not shared:
+        print("\nno shared tasks scored yet")
+        return
+
+    deltas = [td[t] - tb[t] for t in shared]
+    mean = sum(deltas) / len(deltas)
+    lo, hi = bootstrap_ci(deltas, args.bootstrap, args.seed)
+
+    print(f"\npaired per-task delta over {len(shared)} tasks: {mean:+.4f}")
+    print(
+        f"95% bootstrap CI (resampled over tasks): [{lo:+.4f}, {hi:+.4f}]"
+        f"{'  <- includes zero' if lo <= 0 <= hi else '  <- excludes zero'}"
+    )
+
+    moved = [(t, tb[t], td[t]) for t in shared if tb[t] != td[t]]
+    pinned = sum(1 for t in shared if tb[t] == td[t] and tb[t] in (0.0, 1.0))
+    print(
+        f"\ntasks that moved: {len(moved)} of {len(shared)}   (pinned at floor/ceiling: {pinned})"
+    )
+    for task, before, after in sorted(moved, key=lambda r: r[2] - r[1], reverse=True):
+        print(f"  {task:36s} {before:.2f} -> {after:.2f}   ({after - before:+.2f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/distill/tb2-vllm-repro/score_from_summary.py
+++ b/.agents/distill/tb2-vllm-repro/score_from_summary.py
@@ -1,0 +1,132 @@
+"""Final scoring for the TB2 off-Tinker reproduction.
+
+Binary rates come from harbor's own job-level summary (reward_stats buckets list trial names,
+and trial names carry the task), which avoids parsing 272 multi-megabyte per-trial result.json
+files. Graded ctrf comes from the small verifier/*.json files. Paired delta is bootstrapped over
+TASKS, not trials, because attempts within a task share a task.
+"""
+
+import glob
+import json
+import os
+import random
+import re
+from collections import defaultdict
+
+ROOT = "/scratch/repro-tb2"
+ARMS = ("base", "distill")
+TRIAL_RE = re.compile(r"^(?P<task>.+)__[A-Za-z0-9]+$")
+
+
+def task_of(trial_name):
+    m = TRIAL_RE.match(trial_name)
+    return m.group("task") if m else trial_name
+
+
+def load_binary(arm):
+    """task -> list of 0/1, from harbor's reward_stats buckets."""
+    p = "%s/jobs-%s/tb2-repro-%s/result.json" % (ROOT, arm, arm)
+    d = json.load(open(p))
+    stats = d["stats"]
+    per_task = defaultdict(list)
+    total = 0
+    for ev in stats.get("evals", {}).values():
+        for reward_str, trials in ev.get("reward_stats", {}).get("reward", {}).items():
+            val = 1.0 if float(reward_str) == 1.0 else 0.0
+            for tn in trials:
+                per_task[task_of(tn)].append(val)
+                total += 1
+    return per_task, total, stats
+
+
+def load_ctrf(arm):
+    """task -> list of passed/total test fractions."""
+    per_task = defaultdict(list)
+    base = "%s/jobs-%s/tb2-repro-%s" % (ROOT, arm, arm)
+    for trial_dir in sorted(glob.glob(base + "/*/")):
+        name = os.path.basename(trial_dir.rstrip("/"))
+        if "__" not in name:
+            continue
+        for jf in sorted(glob.glob(trial_dir + "verifier/*.json")):
+            try:
+                doc = json.load(open(jf))
+            except Exception:
+                continue
+            s = doc.get("results", {}).get("summary")
+            if isinstance(s, dict) and s.get("tests"):
+                per_task[task_of(name)].append(s.get("passed", 0) / s["tests"])
+                break
+    return per_task
+
+
+def rate(per_task):
+    vals = [v for vs in per_task.values() for v in vs]
+    return (sum(vals) / len(vals) if vals else 0.0), int(sum(vals)), len(vals)
+
+
+def bootstrap(deltas, n=20000, seed=0):
+    rng = random.Random(seed)
+    means = []
+    k = len(deltas)
+    for _ in range(n):
+        means.append(sum(deltas[rng.randrange(k)] for _ in range(k)) / k)
+    means.sort()
+    return means[int(0.025 * n)], means[int(0.975 * n)]
+
+
+bin_ = {}
+ctrf = {}
+stats = {}
+for a in ARMS:
+    bin_[a], tot, stats[a] = load_binary(a)
+    ctrf[a] = load_ctrf(a)
+    print("%s: loaded %d trials across %d tasks" % (a, tot, len(bin_[a])))
+
+print("\n%-10s %-20s %-18s %-14s" % ("arm", "binary", "graded ctrf", "errored"))
+print("-" * 68)
+for a in ARMS:
+    br, bs, bn = rate(bin_[a])
+    gr, _, gn = rate(ctrf[a])
+    ne = stats[a].get("n_errored_trials")
+    nt = stats[a].get("n_completed_trials")
+    print("%-10s %5.1f%% (%3d/%3d)   %5.1f%% (n=%3d)   %3d/%3d = %4.1f%%"
+          % (a, 100 * br, bs, bn, 100 * gr, gn, ne, nt, 100.0 * ne / nt))
+
+shared = sorted(set(bin_["base"]) & set(bin_["distill"]))
+rows = []
+for t in shared:
+    b = sum(bin_["base"][t]) / len(bin_["base"][t])
+    d = sum(bin_["distill"][t]) / len(bin_["distill"][t])
+    rows.append((t, b, d, len(bin_["base"][t]), len(bin_["distill"][t])))
+
+deltas = [d - b for _, b, d, _, _ in rows]
+mean = sum(deltas) / len(deltas)
+lo, hi = bootstrap(deltas)
+
+print("\n%-34s %6s %6s %8s   n(b/d)" % ("task", "base", "distill", "delta"))
+print("-" * 74)
+for t, b, d, nb, nd in rows:
+    star = " *" if abs(d - b) > 1e-9 else ""
+    print("%-34s %6.3f %6.3f %+8.3f   %d/%d%s" % (t, b, d, d - b, nb, nd, star))
+print("-" * 74)
+print("paired per-task delta: %+.4f   95%% bootstrap CI [%+.4f, %+.4f]  %s"
+      % (mean, lo, hi, "INCLUDES ZERO" if lo <= 0 <= hi else "EXCLUDES ZERO"))
+
+pinned = sum(1 for _, b, d, _, _ in rows if b == d and b in (0.0, 1.0))
+moved = sum(1 for _, b, d, _, _ in rows if abs(d - b) > 1e-9)
+print("tasks moved: %d/%d   pinned at floor/ceiling in both arms: %d" % (moved, len(rows), pinned))
+
+# graded paired
+gshared = sorted(set(ctrf["base"]) & set(ctrf["distill"]))
+if gshared:
+    gd = [sum(ctrf["distill"][t]) / len(ctrf["distill"][t])
+          - sum(ctrf["base"][t]) / len(ctrf["base"][t]) for t in gshared]
+    gm = sum(gd) / len(gd)
+    glo, ghi = bootstrap(gd)
+    print("\ngraded ctrf paired delta over %d tasks: %+.4f  95%% CI [%+.4f, %+.4f]"
+          % (len(gshared), gm, glo, ghi))
+
+teacher = 0.490
+print("\ngate: 0.7 x teacher(%.3f) = %.3f -> distill %.3f : %s"
+      % (teacher, 0.7 * teacher, rate(bin_["distill"])[0],
+         "MET" if rate(bin_["distill"])[0] >= 0.7 * teacher else "NOT MET"))

--- a/.agents/distill/tb2-vllm-repro/serve_arms.sh
+++ b/.agents/distill/tb2-vllm-repro/serve_arms.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# v4: max-model-len 81920 so terminus-2's compaction call (prompt ~53.2k + 12,288 output)
+# is not rejected. The AGENT envelope is unchanged: context_budget 53,240 / max_tokens 12,288.
+set -euo pipefail
+
+VLLM=/mnt/azureuser/venvs/vllm/bin/vllm
+BASE=/scratch/hf_cache/hub/models--Qwen--Qwen3.5-9B/snapshots/c202236235762e1c871ad0ccb60c8ee5ba337b9a
+MERGED=/scratch/repro-tb2/qwen35-9b-distill-v3
+LOGS=/scratch/repro-tb2/logs
+
+ENVS="PATH=/usr/local/cuda-13.0/bin:$PATH CUDA_HOME=/usr/local/cuda-13.0 \
+HF_HOME=/scratch/hf_cache TMPDIR=/scratch/repro-tb2/tmp"
+ARGS="--max-model-len 81920 --gpu-memory-utilization 0.85 --max-num-seqs 32 --enable-prefix-caching"
+
+tmux kill-session -t vllm-base 2>/dev/null || true
+tmux kill-session -t vllm-distill 2>/dev/null || true
+sleep 5
+
+tmux new-session -d -s vllm-base \
+  "CUDA_VISIBLE_DEVICES=0 $ENVS $VLLM serve $BASE \
+   --served-model-name base-student --port 8000 $ARGS 2>&1 | tee $LOGS/vllm-base.log"
+tmux new-session -d -s vllm-distill \
+  "CUDA_VISIBLE_DEVICES=1 $ENVS $VLLM serve $MERGED \
+   --served-model-name distill-student --port 8001 $ARGS 2>&1 | tee $LOGS/vllm-distill.log"
+echo "relaunched"; tmux ls

--- a/.agents/distill/tb2-vllm-repro/tripwire.py
+++ b/.agents/distill/tb2-vllm-repro/tripwire.py
@@ -1,0 +1,57 @@
+import json, urllib.request
+
+PROMPTS = [
+    "List three shell commands to find large files.",
+    "You are in a Linux terminal. Write a one-liner to count lines in every .py file under src/.",
+    "Explain in one sentence what `set -euo pipefail` does.",
+    "A test is failing with 'ModuleNotFoundError: No module named requests'. What is your first command?",
+    "Write a bash loop that retries a command up to 5 times with exponential backoff.",
+]
+
+ARMS = [("base-student", 8000), ("distill-student", 8001)]
+
+
+def ask(model, port, prompt, max_tokens=256):
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": max_tokens,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=300) as r:
+        d = json.load(r)
+    m = d["choices"][0]["message"]
+    return (m.get("reasoning_content") or "") + "\n<<<ANSWER>>>\n" + (m.get("content") or "")
+
+
+n_diff = 0
+for i, p in enumerate(PROMPTS, 1):
+    outs = {}
+    for model, port in ARMS:
+        try:
+            outs[model] = ask(model, port, p)
+        except Exception as e:
+            outs[model] = f"<ERROR {type(e).__name__}: {e}>"
+    a, b = outs["base-student"], outs["distill-student"]
+    same = a == b
+    if not same:
+        n_diff += 1
+    print(
+        f"--- prompt {i}: {'IDENTICAL' if same else 'DIFFERS'} | len base={len(a)} distill={len(b)}"
+    )
+    print(f"    Q: {p}")
+    print(f"    base   : {a[:220].replace(chr(10), ' | ')}")
+    print(f"    distill: {b[:220].replace(chr(10), ' | ')}")
+    print()
+
+print("=" * 90)
+print(f"RESULT: {n_diff}/{len(PROMPTS)} prompts produced different greedy output")
+if n_diff == 0:
+    print("FATAL: the two arms are the same model. Do NOT spend E2B budget.")

--- a/.agents/distill/tb2-vllm-repro/verify_merge.py
+++ b/.agents/distill/tb2-vllm-repro/verify_merge.py
@@ -1,0 +1,160 @@
+"""Assert a Tinker LoRA merge actually landed on every module the adapter targets.
+
+A merge that silently no-ops produces a model directory that looks perfect: right size, right
+shard count, loads fine in vLLM. Every downstream number is then a duplicate of the base arm,
+and nothing about the run says so. This compares the set of base tensors that changed against
+the set the adapter targets, so a partial merge fails loudly instead of quietly.
+
+Two remaps have to be applied before the sets can be compared:
+
+* ``unembed_tokens`` in the adapter is ``lm_head`` in the model.
+* ``linear_attn.in_proj_{q,k,v}`` are three separate adapter modules that merge into the single
+  fused ``linear_attn.in_proj_qkv`` weight.
+
+Exits non-zero on any adapter module whose target did not move.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from safetensors import safe_open
+
+# Adapter module suffix -> base tensor suffix it merges into.
+SUFFIX_REMAP = {
+    "unembed_tokens": "lm_head",
+    "linear_attn.in_proj_q": "linear_attn.in_proj_qkv",
+    "linear_attn.in_proj_k": "linear_attn.in_proj_qkv",
+    "linear_attn.in_proj_v": "linear_attn.in_proj_qkv",
+}
+
+_ADAPTER_PREFIX = re.compile(r"^base_model\.model\.")
+_LORA_SUFFIX = re.compile(r"\.lora_[AB]\.weight$")
+_PARAM_SUFFIX = re.compile(r"\.(weight|bias)$")
+# Container segments that differ between adapter naming and model naming. A VL checkpoint
+# nests the text stack under `language_model`, which the adapter names never carry.
+_CONTAINERS = ("model", "language_model")
+
+
+def _strip_layer_index(name: str) -> str:
+    return ".".join(p for p in name.split(".") if not p.isdigit())
+
+
+def _canonical(name: str) -> str:
+    """Drop leading container segments so adapter and model naming can be compared."""
+    parts = _strip_layer_index(name).split(".")
+    while parts and parts[0] in _CONTAINERS:
+        parts.pop(0)
+    return ".".join(parts)
+
+
+def model_class(tensor_name: str) -> str:
+    return _canonical(_PARAM_SUFFIX.sub("", tensor_name))
+
+
+def adapter_targets(adapter_dir: Path) -> set[str]:
+    """Module classes the adapter touches, in canonical (container-stripped) naming."""
+    with safe_open(adapter_dir / "adapter_model.safetensors", framework="pt") as f:
+        keys = list(f.keys())
+
+    targets: set[str] = set()
+    for key in keys:
+        name = _LORA_SUFFIX.sub("", _ADAPTER_PREFIX.sub("", key))
+        name = _strip_layer_index(name)
+        for src, dst in SUFFIX_REMAP.items():
+            if name.endswith(src):
+                name = name[: -len(src)] + dst
+                break
+        targets.add(_canonical(name))
+    return targets
+
+
+def _weight_map(root: Path) -> dict[str, str]:
+    index = root / "model.safetensors.index.json"
+    if index.exists():
+        return json.loads(index.read_text())["weight_map"]
+    single = "model.safetensors"
+    with safe_open(root / single, framework="pt") as f:
+        return {k: single for k in f.keys()}
+
+
+def changed_classes(base: Path, merged: Path, per_class: int) -> tuple[set[str], set[str]]:
+    """Return (classes sampled, classes where at least one sampled tensor moved)."""
+    bmap, mmap = _weight_map(base), _weight_map(merged)
+    shared = sorted(set(bmap) & set(mmap))
+
+    groups: dict[str, list[str]] = defaultdict(list)
+    for name in shared:
+        groups[model_class(name)].append(name)
+
+    handles: dict[tuple[Path, str], object] = {}
+
+    def tensor(root: Path, wmap: dict[str, str], name: str):
+        key = (root, wmap[name])
+        if key not in handles:
+            handles[key] = safe_open(root / wmap[name], framework="pt")
+        return handles[key].get_tensor(name)  # type: ignore[attr-defined]
+
+    sampled: set[str] = set()
+    moved: set[str] = set()
+    for cls, names in sorted(groups.items()):
+        names.sort()
+        # First / middle / last layer is enough to catch a layer-range miss.
+        picks = list(dict.fromkeys([names[0], names[len(names) // 2], names[-1]]))[:per_class]
+        sampled.add(cls)
+        for name in picks:
+            a = tensor(base, bmap, name).float()
+            b = tensor(merged, mmap, name).float()
+            if a.shape != b.shape:
+                print(f"  SHAPE MISMATCH {name}: {tuple(a.shape)} vs {tuple(b.shape)}")
+                continue
+            if (a - b).abs().max().item() > 0:
+                moved.add(cls)
+                break
+    return sampled, moved
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", type=Path, required=True, help="base HF model dir")
+    ap.add_argument("--merged", type=Path, required=True, help="merged HF model dir")
+    ap.add_argument("--adapter", type=Path, required=True, help="raw Tinker adapter dir")
+    ap.add_argument("--per-class", type=int, default=3, help="tensors sampled per module class")
+    args = ap.parse_args()
+
+    targets = adapter_targets(args.adapter)
+    sampled, moved = changed_classes(args.base, args.merged, args.per_class)
+
+    unknown = sorted(t for t in targets if t not in sampled)
+    missed = sorted(t for t in targets if t in sampled and t not in moved)
+    spurious = sorted(moved - targets)
+
+    print(f"adapter targets      : {len(targets)}")
+    print(f"changed in merge     : {len(moved)}")
+    for t in sorted(targets):
+        state = "ok" if t in moved else ("NOT IN MODEL" if t in unknown else "UNCHANGED")
+        print(f"  [{state:12s}] {t}")
+
+    ok = True
+    if missed:
+        print(f"\nFAIL: {len(missed)} targeted module(s) did not change: {missed}")
+        ok = False
+    if unknown:
+        print(f"\nFAIL: {len(unknown)} adapter target(s) absent from the model: {unknown}")
+        print("      the remap table is probably incomplete for this architecture")
+        ok = False
+    if spurious:
+        # Not fatal, but it means the merge touched something the adapter did not target.
+        print(f"\nWARN: {len(spurious)} untargeted module(s) changed: {spurious}")
+
+    print("\nPASS: merge covers every adapter target" if ok else "\nMERGE IS NOT TRUSTWORTHY")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Tooling to take the on-policy-distilled Qwen3.5-9B LoRA off Tinker and measure it on
TerminalBench-2 through harbor/terminus-2 against a self-hosted vLLM — checking the trained
policy against a second inference stack rather than only the one it was trained on.

**Request:** eval the Qwen3.5-9B LoRA (Tinker sampler `pi-step-0004-b1604882`, run
`qwen-train-v3`, teacher Qwen3.6-27B) on the 17-task TB2 holdout with and without the adapter,
served in vLLM on 2×H100.

**Criteria:** reproduce the published Tinker-side result — student-before 21.6% (11/51),
student-after 27.5% (14/51), paired delta +0.059, 95% CI [+0.000, +0.157].

**Machine:** `azureuser@4.154.170.26` (h100-dev-box), 2× H100 NVL 95GB.

Numbers and the run journal live in Notion, not here — this PR is tooling only.

## The adapter is not vLLM-LoRA-servable

Tinker trains with `train_unembed=True`, so the export carries `lm_head` LoRA. vLLM only
admits LoRA on embedding modules when the model class declares a non-empty `embedding_modules`,
and `Qwen3_5ForConditionalGeneration` declares `{}`. It also stores split
`linear_attn.in_proj_{q,k,v}` against the base's fused `in_proj_qkv`. Merge-then-serve handles
both.

This contradicts the current lane page and HF model card, which both state the published
adapter is loadable with `--enable-lora`. Correction posted to the lane.

## Merge verification is split in two, deliberately

`verify_merge.py` asserts every targeted module actually moved, applying the
`unembed → lm_head` rename and the split→fused qkv concat. Necessary but weak.

`merge_fidelity.py` answers the quantitative question. For a 4-step LoRA whose delta is
~0.1–0.6% of the weight norm — near bf16's ~0.4% relative resolution — most individual elements
legitimately round straight back to base. On this checkpoint only **39.97%** of adapted elements
changed, which would fail a sibling lane's ≥40% gate, yet the **delta norm ratio is 0.962**: the
update landed essentially intact and bf16 merely redistributed it. The element fraction is the
misleading statistic; the norm ratio is the honest one.

Reported alongside: the cosine between intended and realized delta (0.70–0.97 here), which says
bf16 rounding noise is comparable in scale to a few-step update — so a merged model is not
bit-equivalent to runtime LoRA application. Worth stating in any writeup.

## Environment failures recorded because they cost real time

- flashinfer's sampling kernels JIT at startup and need **both** `ninja` and the CUDA **dev**
  headers. A box can have a working CUDA runtime and still lack `curand.h`.
- Serving with `max_model_len` equal to the agent's `context_budget + max_tokens` leaves no room
  for terminus-2's proactive summarization, which sends slightly more than the budget and gets a
  400. litellm swallows the body, so the symptom is an empty `Error in proactively summarizing:`
  — trials still complete, `exception_info` stays null, and the run continues at full speed with
  compaction silently disabled. This is a trap specific to reproducing Tinker runs, whose budgets
  are tuned to sit just under Tinker's 65,530 ceiling.

## Verification

Everything here was exercised end-to-end on the box, not just written:

- merge verified: 11/11 adapter target classes changed, `mtp` and vision tower correctly
  untouched, 0 all-zero `lora_B`, norm ratio 0.962
- behavioural tripwire: 5/5 prompts produce different greedy output between the arms
- `verify_merge.py` caught its own naming bug on first run (the VL wrapper nests the text stack
  under `language_model`) and `merge_fidelity.py` caught an fp32 accumulation error that reported
  a cosine of 1.33; both fixed and re-run
- `.agents/` is `extend-exclude`d from ruff/ty per `pyproject.toml`, so the print-based CLI
  scripts do not gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)