### PR TITLE
feat(build): add --endpoint option for OpenAI-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ export E2B_API_KEY=...
 wmo optimize harness my-agent my-environment --tasks tasks.jsonl --backend e2b
 ```
 
+### Provider credentials
+
+Each provider backend reads its API key from a specific environment variable:
+
+| Provider | Credential env var | Notes |
+|----------|-------------------|-------|
+| OpenAI (real) | `OPENAI_API_KEY` | Used for direct OpenAI API access. |
+| OpenAI-compatible endpoints | `WMO_ENDPOINT_API_KEY` | Used when `--endpoint` is configured (Gemini, vLLM, etc.). Never sends `OPENAI_API_KEY` to custom hosts. |
+| Anthropic | `ANTHROPIC_API_KEY` | |
+| Bedrock | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` | |
+| OpenRouter | `OPENROUTER_API_KEY` | |
+
+> **Important:** `WMO_ENDPOINT_API_KEY` is only read when an explicit `--endpoint` is configured. Real OpenAI API calls use `OPENAI_API_KEY` directly. This separation ensures your real API key never leaks to a third-party host.
+
 ## Use a world model as an API
 
 `world-model-optimizer` includes world models that can be used to simulate your agent environment

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -574,6 +574,7 @@ def build(
         "--interactive/--no-interactive",
         help="Guided creation wizard. Default: on at a TTY when inputs are missing.",
     ),
+    endpoint: str = typer.Option(None, "--endpoint", help="OpenAI-compatible API endpoint base URL (e.g. https://generativelanguage.googleapis.com/v1beta/openai/). Sets WMO_ENDPOINT_API_KEY as the credential."),
 ) -> None:
     """Ingest traces (file upload or vendor SDK pull) and build a named world model.
 
@@ -588,6 +589,12 @@ def build(
     if vendor:
         source = vendor
         pull = True
+
+    if endpoint is not None and not endpoint.strip():
+        raise typer.BadParameter(
+            '--endpoint is empty; give the OpenAI-compatible base URL, '
+            'or drop the flag to use the provider default endpoint'
+        )
 
     # Decide whether to run the wizard: explicit flag wins; otherwise auto when at a TTY and the
     # essential inputs (a name and a trace source — a file or a live pull) were not supplied.
@@ -623,6 +630,7 @@ def build(
         embed_provider=embed_provider,
         embed_model=embed_model,
         embed_dim=embed_dim,
+        endpoint=endpoint,
     )
     if use_wizard:
         params = run_build_wizard(_console, params)
@@ -698,6 +706,7 @@ def build(
         train_split=params.train_split,
         judge_model=params.judge_model or judge_model_default(params.provider, params.model),
         trace_adapter=params.source,
+        endpoint=params.endpoint,
     )
     if use_configured_worker and configured_worker is not None:
         config.providers[0] = config.providers[0].model_copy(

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -138,6 +138,7 @@ class BuildParams(BaseModel):
     embed_provider: str = "hashing"
     embed_model: str | None = None
     embed_dim: int = 512
+    endpoint: str | None = None
 
 
 # Trace sources offered in the build wizard: name -> (label, can-pull-live). File-only sources

--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -221,6 +221,7 @@ class HarnessConfig(BaseModel):
         train_split: float = _DEFAULT_TRAIN_SPLIT,
         judge_model: str | None = None,
         trace_adapter: str = "otel-genai",
+        endpoint: str | None = None,
     ) -> HarnessConfig:
         """Assemble a build config from the choices `wmo build` collects.
 
@@ -236,6 +237,7 @@ class HarnessConfig(BaseModel):
             model_type=serve_spec.model_type,
             model=serve_spec.model_id,
             region=region,
+            endpoint=endpoint,
         )
         providers = [serve]
         if embed_provider is not EmbedderKind.HASHING:


### PR DESCRIPTION
## Summary

Adds `--endpoint` option to `wmo build` so users with custom OpenAI-compatible endpoints (Gemini, vLLM, etc.) can use the main `wmo workflow`.

## Changes

1. **`wmo/cli/app.py`** — Added `--endpoint` CLI parameter to `wmo build` command with validation for empty values.
2. **`wmo/config/config.py`** — `HarnessConfig.for_build()` accepts `endpoint` parameter and persists it in the `ProviderConfig`.
3. **`wmo/cli/ui.py`** — `BuildParams` now includes an `endpoint` field.
4. **`README.md`** — Added provider credentials table explaining `OPENAI_API_KEY` vs `WMO_ENDPOINT_API_KEY`.

## Usage

```bash
wmo build \
  --provider openai \
  --model gemini-3.1-flash-lite \
  --endpoint https://generativelanguage.googleapis.com/v1beta/openai/ \
  --source otel-genai \
  --file traces.otel.jsonl
```

The endpoint is persisted in `.wmo/config.toml` so runtime commands (`wmo play`, `wmo demo`, `wmo serve`) pick it up automatically.

Closes #165