### PR TITLE
Real-episode runner: forward the canonical tau2 protocol pins and label the cohort

### DIFF
--- a/packages/environment-capture/tau-bench/README.md
+++ b/packages/environment-capture/tau-bench/README.md
@@ -177,8 +177,18 @@ What makes it a validation leg rather than a second, differently-shaped experime
 - **`scenario_id` is `"<domain>:<task_id>"`.** Airline and retail both number tasks from "0" and
   all 50 airline ids collide with retail ids, so bare ids would merge two tasks into one cell.
 - **One environment for every candidate.** The user simulator is part of the environment, so it
-  is pinned (`--user-sim`, default `gpt-5.4-mini`) and both streams pass `{}` LLM args, which
-  drops tau2's default temperature for candidates that reject sampling params.
+  is pinned (`--user-sim`, default `gpt-5.4-mini`). Neither stream is given a temperature, which
+  keeps candidates that reject sampling params on the same footing as the rest.
+- **The protocol pins are forwarded, and the pin set is recorded.** `max_turns=100` (tau2
+  `--max-steps`), `episode_timeout_s=1800` (`--timeout`), `max_tokens=8192` (candidate stream
+  only), user simulator `gpt-5.4-mini`, and tau2's own retries off (`--max-retries 0`), which is
+  the canonical protocol every real-tau2 leg in the project runs. tau2's defaults are different
+  (200 steps, no per-episode timeout, no token cap, 3 retries), so each pin is passed explicitly.
+  Every row records the pin set as a `cohort` label, each pin has a flag for moving it
+  deliberately, and `rl/sim_to_real.py` refuses to pair rows whose labels differ (override:
+  `--allow-mixed-cohorts`). With tau2's retries off, retry is the runner's job: `--retry-failed`
+  re-buys the cells whose latest row has no reward, and each attempt gets its own tau2 save
+  directory so it never collides with the previous attempt's checkpoint.
 - **tau2's reward, never a wmo judge.** Rewards are read from `reward_info.reward` in tau2's
   `results.json`. Caveat worth carrying into any writeup: tau2's reward is not uniformly
   deterministic. 7 of the 20 pinned tasks carry `NL_ASSERTION` in their `reward_basis` and tau2
@@ -196,6 +206,7 @@ leaves a usable partial grid and a rerun buys only what is missing.
 # from the repo root; needs the Setup venv above (or --capture-dir pointing at an existing clone)
 uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --dry-run
 uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --episodes 2
+uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --retry-failed
 uv run python packages/environment-capture/tau-bench/rl/real_episodes.py --write-matrix-only
 ```
 

--- a/packages/environment-capture/tau-bench/rl/real_episodes.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes.py
@@ -17,9 +17,22 @@ What makes this the validation leg rather than a second, differently-shaped expe
 - **One environment for every candidate.** The user simulator is part of the environment, so it is
   pinned to one cheap model (`--user-sim`, default `gpt-5.4-mini`) for every run. Letting it vary
   per candidate would change the environment per candidate and make the rewards incomparable.
-  Empty LLM args (`{}`) for both streams drop tau2's default temperature: several pool models
-  reject sampling params, and dropping it everywhere removes a source of cross-model variation
-  rather than only working around the strict ones.
+  Neither stream is given a temperature: several pool models reject sampling params, and dropping
+  it everywhere removes a source of cross-model variation rather than only working around the
+  strict ones.
+
+Protocol pins and capture cohort: what an episode IS here is fixed by five values, adopted as
+canonical for every real-tau2 leg (joint-tau master, 2026-07-27 "cross-lane weave" ack 2):
+`max_turns=100`, `episode_timeout_s=1800`, `max_tokens=8192`, user simulator `azure/gpt-5.4-mini`,
+and tau2's own retries OFF with retry owned by this runner. All five are forwarded explicitly
+because tau2's defaults are different (200 steps, no per-episode timeout, no token cap, 3 retries),
+so inheriting them would quietly produce rows from a different environment than the training lane's
+runs. Every row records the pin set as a `cohort` label, and `sim_to_real.py` refuses to pair rows
+whose labels differ. The flags exist so the pins can be moved deliberately; any move is a NEW
+cohort, not a variation of this one. The one knowing difference from the training lane
+(`wmo/distill/tau2.py`, which shells the same clone with the same pins) is sampling temperature:
+that lane pins its Tinker student to 1.0, while pool candidates here run at each provider's own
+default for the reason above. Temperature is not part of the canonical pin set.
 
 Reward provenance: this leg NEVER runs a wmo judge. It reads `reward_info.reward` out of tau2's
 `results.json` and nothing else. Note that tau2's own reward is not uniformly deterministic:
@@ -38,7 +51,11 @@ to this benchmark dir, so the README's setup block is all that is needed.
 
 Resumable and budgeted: rows are appended to `rows.jsonl` after every batch and keyed by
 (scenario, model, episode), so a stop or a crash leaves a usable partial grid and a rerun picks up
-exactly what is missing. `--budget-usd` is checked between batches, and models run cheapest-first
+exactly what is missing. Every attempt at a cell gets its own tau2 save directory, because tau2
+treats an existing one as a checkpoint and refuses a run whose task list is a subset of it, which
+is precisely what a resumed cell asks for. `--retry-failed` re-buys the cells whose latest row
+carries no reward: with tau2's own retries pinned off, that is where a transiently dead episode
+gets its second chance. `--budget-usd` is checked between batches, and models run cheapest-first
 for the same reason.
 
 Run from the repo root:
@@ -53,12 +70,13 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
 import os
 import subprocess
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from pydantic import BaseModel, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from wmo.core.types import JsonObject, JsonValue
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
@@ -76,7 +94,28 @@ DEFAULT_OUT_DIR = Path(".wmo/evals/tau-bench-real")
 DEFAULT_USER_SIM = "gpt-5.4-mini"
 DEFAULT_BUDGET_USD = 140.0
 DEFAULT_MAX_CONCURRENCY = 4
-BATCH_TIMEOUT_S = 5400
+
+# The CANONICAL real-tau2 protocol pins (joint-tau master, DECISIONS.md 2026-07-27 "cross-lane
+# weave" ack 2). Every real-tau2 leg in the project runs these exact values; the training lane
+# carries the same numbers as its `rollout`/`sampling` config defaults.
+CANONICAL_MAX_TURNS = 100
+CANONICAL_EPISODE_TIMEOUT_S = 1800.0
+CANONICAL_MAX_TOKENS = 8192
+CANONICAL_TAU2_MAX_RETRIES = 0
+
+# Rows written before the pins were forwarded carry no label. They are their own cohort: their
+# episodes ran on tau2's defaults, which is a different environment, not a noisier sample of this
+# one.
+UNLABELED_COHORT = "unlabeled"
+
+# Wall clock granted past the batch's own graceful per-episode budget before the subprocess is
+# killed. A kill forfeits every episode tau2 had not yet written, so this covers tau2's startup,
+# its evaluation pass, and its save, not a second wave of episodes.
+BATCH_KILL_MARGIN_S = 300.0
+
+# How many attempts one cell may make before its save-directory search gives up. Reaching this
+# means something is failing every time, and silently piling up directories would hide it.
+MAX_ATTEMPTS_PER_CELL = 100
 
 # A realistic agent-side episode mix, used only to order the pool cheapest-first. Ordering by
 # input price alone would let a model with a cheap input rate and an expensive output rate look
@@ -88,6 +127,67 @@ _EPISODE_MIX = TokenUsage(input_tokens=30_000, output_tokens=1_000)
 # against a silen-resource candidate inside one tau2 process without either clobbering the other.
 _AZURE_OPENAI_HOST = ".openai.azure.com"
 _AZURE_AI_HOST = ".services.ai.azure.com"
+
+
+class ProtocolPins(BaseModel):
+    """The five values that define what a real-tau2 episode is, plus the cohort label they name.
+
+    Defaults are the canonical pins. Constructing this with anything else is legal and explicit:
+    it produces a different `label`, which is how every downstream consumer learns that those rows
+    are a separate capture cohort.
+    """
+
+    max_turns: int = Field(default=CANONICAL_MAX_TURNS, ge=1)
+    episode_timeout_s: float = Field(default=CANONICAL_EPISODE_TIMEOUT_S, gt=0)
+    # 0 means "send no cap at all"; see agent_llm_args.
+    max_tokens: int = Field(default=CANONICAL_MAX_TOKENS, ge=0)
+    tau2_max_retries: int = Field(default=CANONICAL_TAU2_MAX_RETRIES, ge=0)
+    user_sim: str = DEFAULT_USER_SIM
+
+    @property
+    def label(self) -> str:
+        """The cohort label recorded on every row: short, greppable, and complete."""
+        return (
+            f"turns{self.max_turns}-t{self.episode_timeout_s:.0f}-tok{self.max_tokens}"
+            f"-r{self.tau2_max_retries}-sim-{self.user_sim}"
+        )
+
+    @property
+    def is_canonical(self) -> bool:
+        """Whether these are the canonical pins every other real-tau2 leg runs."""
+        return self.label == ProtocolPins().label
+
+
+def agent_llm_args(pins: ProtocolPins) -> str:
+    """The `--agent-llm-args` JSON for the candidate stream: the token cap, and nothing else.
+
+    `max_tokens=0` drops the key entirely. That escape hatch is deliberate: litellm rewrites
+    `max_tokens` to `max_completion_tokens` only for the reasoning models its table knows, so a
+    deployment name it has never seen is rejected outright by Azure, and a grid that cannot start
+    at all is worse than a second cohort that says so in its label.
+    """
+    args: JsonObject = {} if pins.max_tokens <= 0 else {"max_tokens": pins.max_tokens}
+    return json.dumps(args)
+
+
+def batch_timeout_s(task_count: int, max_concurrency: int, episode_timeout_s: float) -> float:
+    """Hard-kill deadline for one batch subprocess, derived from the per-episode pin.
+
+    tau2's own `--timeout` ends each episode gracefully and still scores it, so this deadline is
+    only for a wedged runner, and firing it forfeits every episode in the batch tau2 had not
+    written yet. It therefore has to cover the whole batch: as many waves of the per-episode
+    budget as the concurrency needs, plus the margin.
+
+    Args:
+        task_count: Tasks in this batch.
+        max_concurrency: Episodes tau2 runs at once.
+        episode_timeout_s: The per-episode pin handed to tau2.
+
+    Returns:
+        Seconds to allow the subprocess before killing it.
+    """
+    waves = max(1, math.ceil(task_count / max(1, max_concurrency)))
+    return waves * episode_timeout_s + BATCH_KILL_MARGIN_S
 
 
 def _zero_if_null(value: JsonValue) -> JsonValue:
@@ -185,6 +285,10 @@ class RealEpisodeRow(BaseModel):
     call_seconds: list[float]
     replies: list[str]
     user_sim: str
+    # The protocol pins this episode ran under (`ProtocolPins.label`). Rows from before the pins
+    # were forwarded have no label and default to UNLABELED_COHORT rather than failing to load:
+    # they are readable evidence of a different cohort, and consumers refuse to pair across them.
+    cohort: str = UNLABELED_COHORT
 
     @property
     def key(self) -> tuple[str, str, int]:
@@ -424,8 +528,9 @@ def batch_command(
     task_ids: Sequence[str],
     save_to: str,
     max_concurrency: int,
+    pins: ProtocolPins,
 ) -> list[str]:
-    """The exact tau2 CLI invocation for one (candidate, domain) batch."""
+    """The exact tau2 CLI invocation for one (candidate, domain) batch, pins included."""
     return [
         str(capture_dir / ".venv" / "bin" / "tau2"),
         "run",
@@ -434,9 +539,11 @@ def batch_command(
         "--agent-llm",
         litellm_route(entry),
         "--agent-llm-args",
-        "{}",
+        agent_llm_args(pins),
         "--user-llm",
         litellm_route(user_sim),
+        # The user stream carries no args at all, matching the training lane's `user_llm_args`
+        # default, so both legs' user simulators are the same environment.
         "--user-llm-args",
         "{}",
         "--num-trials",
@@ -447,13 +554,65 @@ def batch_command(
         str(max_concurrency),
         "--save-to",
         save_to,
+        # The canonical pins. tau2's own defaults are 200 steps, no per-episode timeout, and 3
+        # retries, so every one of these has to be argv: inheriting a default would silently
+        # capture a different environment than the training lane measures.
+        "--max-steps",
+        str(pins.max_turns),
+        "--timeout",
+        f"{pins.episode_timeout_s:.0f}",
+        # tau2's internal retry re-runs the whole simulation inside this subprocess, which
+        # multiplies the batch wall clock past its deadline and appends the abandoned attempt's
+        # episodes to the same results.json. Retry is the runner's job instead (--retry-failed),
+        # one fresh save directory per attempt.
+        "--max-retries",
+        str(pins.tau2_max_retries),
+        # A headless batch must never block on tau2's interactive resume prompt: it reads the
+        # parent's stdin and would hang until the hard-kill deadline. `next_save_to` already keeps
+        # every attempt on an unused directory, so there should be nothing to resume.
+        "--auto-resume",
     ]
 
 
-def save_to_name(entry: PoolEntry, domain: str, episode: int) -> str:
-    """tau2 `--save-to` slug, unique per candidate, domain, and episode index."""
+def save_to_name(entry: PoolEntry, domain: str, episode: int, attempt: int = 0) -> str:
+    """tau2 `--save-to` slug, unique per candidate, domain, episode index, and attempt."""
     safe = "".join(ch if ch.isalnum() else "_" for ch in entry.name)
-    return f"real_{safe}_{domain}_e{episode}"
+    return f"real_{safe}_{domain}_e{episode}_a{attempt}"
+
+
+def next_save_to(capture_dir: Path, entry: PoolEntry, domain: str, episode: int) -> str:
+    """The first unused `--save-to` slug for a cell, so an attempt never lands on a checkpoint.
+
+    tau2 reads an existing save directory as a checkpoint to resume: it prompts on stdin, and then
+    refuses the run outright when the new task list is a subset of the checkpointed one. A resumed
+    cell asks for exactly that subset (only the tasks with no row yet), so sharing a directory
+    across attempts makes the second attempt impossible, which matters much more now that tau2's
+    own retries are pinned off. Each attempt therefore gets its own directory and its own
+    results.json, and the previous attempt's evidence stays on disk.
+
+    Args:
+        capture_dir: Directory holding the `tau2-bench/` clone.
+        entry: The candidate this batch measures.
+        domain: tau2 domain for this batch.
+        episode: Episode index.
+
+    Returns:
+        A slug whose simulations directory does not exist yet.
+
+    Raises:
+        SystemExit: When the cell has already used every attempt slot.
+    """
+    simulations = capture_dir / "tau2-bench" / "data" / "simulations"
+    for attempt in range(MAX_ATTEMPTS_PER_CELL):
+        name = save_to_name(entry, domain, episode, attempt)
+        if not (simulations / name).exists():
+            return name
+    raise SystemExit(
+        f"candidate '{entry.name}' has used all {MAX_ATTEMPTS_PER_CELL} attempt slots for "
+        f"{domain} episode {episode}. Something is failing on every attempt: read the newest "
+        f"{simulations / save_to_name(entry, domain, episode, MAX_ATTEMPTS_PER_CELL - 1)} before "
+        "clearing the older directories."
+    )
 
 
 def _stream_tokens(messages: Sequence[Tau2Message], role: str) -> tuple[int, int]:
@@ -472,11 +631,23 @@ def rows_from_results(
     episode: int,
     by_task_id: dict[str, RealScenario],
     user_sim: PoolEntry,
+    cohort: str = UNLABELED_COHORT,
 ) -> list[RealEpisodeRow]:
     """Turn one tau2 `results.json` into metered sidecar rows.
 
     Simulations of tasks outside the pinned split are dropped rather than recorded: tau2 filters
     by task id already, so their presence would mean the run drifted off the split.
+
+    Args:
+        results: The batch's parsed `results.json`.
+        entry: The candidate this batch measured.
+        episode: Episode index.
+        by_task_id: The pinned scenarios this batch requested, keyed by tau2 task id.
+        user_sim: The pinned user simulator, part of the environment.
+        cohort: `ProtocolPins.label` for the pins the batch ran under.
+
+    Returns:
+        One row per on-split simulation.
     """
     rows: list[RealEpisodeRow] = []
     for sim in results.simulations:
@@ -518,6 +689,7 @@ def rows_from_results(
                 ],
                 replies=[m.text() for m in assistant if m.text()],
                 user_sim=user_sim.name,
+                cohort=cohort,
             )
         )
     return rows
@@ -562,13 +734,43 @@ def append_rows(path: Path, rows: Iterable[RealEpisodeRow]) -> None:
 
 
 def spend_usd(rows: Iterable[RealEpisodeRow]) -> float:
-    """Total run cost: our priced candidate side plus tau2's figure for the user simulator."""
+    """Total run cost: our priced candidate side plus tau2's figure for the user simulator.
+
+    Counts EVERY row, including an attempt a later retry superseded: both were bought.
+    """
     return sum(row.cost_usd_pool + (row.cost_usd_tau2_user or 0.0) for row in rows)
+
+
+def latest_per_cell(rows: Sequence[RealEpisodeRow]) -> list[RealEpisodeRow]:
+    """One row per (scenario, candidate, episode): the last one written wins.
+
+    Only a `--retry-failed` pass writes a second row for a cell, and the retry is what supersedes
+    the attempt that failed. Collapsing here is what keeps a retried cell from being counted as two
+    episodes; `spend_usd` still counts both attempts, because both were paid for.
+    """
+    latest: dict[tuple[str, str, int], RealEpisodeRow] = {}
+    for row in rows:
+        latest[row.key] = row
+    return list(latest.values())
+
+
+def resume_keys(rows: Sequence[RealEpisodeRow], retry_failed: bool) -> set[tuple[str, str, int]]:
+    """The cells resume treats as already bought.
+
+    With `retry_failed`, a cell whose latest row has no reward (tau2 could not score it: an
+    infrastructure failure, a killed batch) counts as unrun, so this pass buys it once more. One
+    pass, one retry: a cell that fails again simply stays unscored, and the operator decides
+    whether to run the flag again.
+    """
+    return {
+        row.key for row in latest_per_cell(rows) if not (retry_failed and row.reward is None)
+    }
 
 
 def to_matrix(rows: Sequence[RealEpisodeRow], pool: Sequence[PoolEntry]) -> OutcomeMatrix:
     """Sidecar rows -> OutcomeMatrix. Rows with no reward stay unscored, never zeroed."""
     named = {entry.name for entry in pool}
+    rows = latest_per_cell(rows)
     outcomes = [
         ScenarioOutcome(
             scenario_id=row.scenario_id,
@@ -598,7 +800,11 @@ def price_order(pool: Sequence[PoolEntry]) -> list[PoolEntry]:
 
 
 def _run_batch(
-    command: Sequence[str], capture_dir: Path, save_to: str, env: dict[str, str]
+    command: Sequence[str],
+    capture_dir: Path,
+    save_to: str,
+    env: dict[str, str],
+    timeout_s: float,
 ) -> Tau2Results | None:
     """Run one tau2 batch and read its results.json back, or None when it produced none.
 
@@ -620,11 +826,11 @@ def _run_batch(
             env=env,
             capture_output=True,
             text=True,
-            timeout=BATCH_TIMEOUT_S,
+            timeout=timeout_s,
             check=False,
         )
     except subprocess.TimeoutExpired:
-        logger.error("  tau2 exceeded %ds and was killed; skipping this batch", BATCH_TIMEOUT_S)
+        logger.error("  tau2 exceeded %.0fs and was killed; skipping this batch", timeout_s)
         return None
     except OSError as error:
         raise SystemExit(
@@ -691,14 +897,58 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         default=None,
         help="restrict to these '<domain>:<task_id>' scenario ids (smokes and single-cell reruns)",
     )
-    parser.add_argument("--user-sim", default=DEFAULT_USER_SIM, help="pool name of the user sim")
     parser.add_argument("--max-concurrency", type=int, default=DEFAULT_MAX_CONCURRENCY)
     parser.add_argument("--budget-usd", type=float, default=DEFAULT_BUDGET_USD)
+    parser.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="re-run the cells whose latest row has no reward, once (tau2's own retries are off)",
+    )
     parser.add_argument(
         "--dry-run", action="store_true", help="resolve the split and print the tau2 commands"
     )
     parser.add_argument(
         "--write-matrix-only", action="store_true", help="rebuild the matrix from rows.jsonl"
+    )
+    pins = parser.add_argument_group(
+        "protocol pins",
+        "The canonical real-tau2 protocol, shared with the training lane. Changing ANY of these "
+        "defines a NEW capture cohort: the rows get a different cohort label, and sim_to_real.py "
+        "refuses to pair them with canonical rows.",
+    )
+    pins.add_argument(
+        "--max-turns",
+        type=int,
+        default=CANONICAL_MAX_TURNS,
+        help=f"tau2 --max-steps; PIN {CANONICAL_MAX_TURNS} (tau2's own default is 200). "
+        "Changing it is a new capture cohort.",
+    )
+    pins.add_argument(
+        "--episode-timeout-s",
+        type=float,
+        default=CANONICAL_EPISODE_TIMEOUT_S,
+        help=f"tau2 --timeout, per episode; PIN {CANONICAL_EPISODE_TIMEOUT_S:.0f} (tau2 has no "
+        "timeout by default). Changing it is a new capture cohort.",
+    )
+    pins.add_argument(
+        "--max-tokens",
+        type=int,
+        default=CANONICAL_MAX_TOKENS,
+        help=f"candidate completion cap; PIN {CANONICAL_MAX_TOKENS}. 0 omits the key entirely, "
+        "for a deployment that rejects max_tokens. Changing it is a new capture cohort.",
+    )
+    pins.add_argument(
+        "--tau2-max-retries",
+        type=int,
+        default=CANONICAL_TAU2_MAX_RETRIES,
+        help=f"tau2 --max-retries; PIN {CANONICAL_TAU2_MAX_RETRIES} (tau2's own default is 3), "
+        "because retry belongs to --retry-failed. Changing it is a new capture cohort.",
+    )
+    pins.add_argument(
+        "--user-sim",
+        default=DEFAULT_USER_SIM,
+        help=f"pool name of the user simulator; PIN {DEFAULT_USER_SIM}. It is the environment, "
+        "not a candidate. Changing it is a new capture cohort.",
     )
     return parser.parse_args(argv)
 
@@ -714,6 +964,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     rows = load_rows(rows_path)
 
     if args.write_matrix_only:
+        # A run refuses to append across cohorts, so a mixed file here was merged by hand. Salvage
+        # is still the right default (the episodes were bought), but the matrix must say so.
+        present = sorted({row.cohort for row in rows})
+        if len(present) > 1:
+            logger.warning(
+                "these %d rows span %d capture cohorts %s, which measure different environments. "
+                "The matrix will pool them; split rows.jsonl by cohort if that is not what you "
+                "want.",
+                len(rows),
+                len(present),
+                present,
+            )
         to_matrix(rows, pool).save(matrix_path)
         logger.info("wrote %s from %d rows", matrix_path, len(rows))
         return 0
@@ -722,6 +984,38 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("user simulator '%s' is not in the pool %s", args.user_sim, sorted(by_name))
         return 2
     user_sim = by_name[args.user_sim]
+
+    try:
+        pins = ProtocolPins(
+            max_turns=args.max_turns,
+            episode_timeout_s=args.episode_timeout_s,
+            max_tokens=args.max_tokens,
+            tau2_max_retries=args.tau2_max_retries,
+            user_sim=args.user_sim,
+        )
+    except ValidationError as error:
+        logger.error("protocol pins are out of range: %s", error)
+        return 2
+    if pins.is_canonical:
+        logger.info("protocol pins: cohort '%s' (canonical)", pins.label)
+    else:
+        logger.warning(
+            "NON-CANONICAL protocol pins: cohort '%s', canonical is '%s'. These rows are a "
+            "separate capture cohort; sim_to_real.py will refuse to pair them with canonical rows.",
+            pins.label,
+            ProtocolPins().label,
+        )
+    foreign = sorted({row.cohort for row in rows} - {pins.label})
+    if foreign:
+        logger.error(
+            "%s already holds rows from cohort(s) %s, but this run is cohort '%s'. One rows.jsonl "
+            "holds one cohort: point --out-dir at a new directory for this pin set, or match the "
+            "pins that produced the existing rows.",
+            rows_path,
+            foreign,
+            pins.label,
+        )
+        return 2
 
     # A typo in --only would otherwise be silently ignored and quietly buy a smaller grid than
     # the operator asked for, which is only discovered after the spend.
@@ -748,7 +1042,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         sum(1 for s in scenarios if s.nl_assertion_reward),
     )
 
-    done = {row.key for row in rows}
+    done = resume_keys(rows, args.retry_failed)
     spent = spend_usd(rows)
     logger.info(
         "resume: %d rows on disk, $%.2f already spent, budget stop $%.0f",
@@ -756,6 +1050,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         spent,
         args.budget_usd,
     )
+    if args.retry_failed:
+        logger.info(
+            "--retry-failed: %d cell(s) whose latest row is unscored will be bought again",
+            len(latest_per_cell(rows)) - len(done),
+        )
 
     # The user simulator is the environment, so it is never also measured as a candidate.
     candidates = [
@@ -781,7 +1080,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ]
                 if not missing:
                     continue
-                save_to = save_to_name(entry, domain, episode)
+                save_to = next_save_to(args.capture_dir, entry, domain, episode)
                 command = batch_command(
                     args.capture_dir,
                     entry,
@@ -790,6 +1089,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     [s.task_id for s in missing],
                     save_to,
                     args.max_concurrency,
+                    pins,
                 )
                 if args.dry_run:
                     logger.info("  would run: %s", " ".join(command))
@@ -807,11 +1107,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                     save_to,
                 )
                 env = build_env(args.capture_dir, entry, user_sim, dict(os.environ))
-                payload = _run_batch(command, args.capture_dir, save_to, env)
+                payload = _run_batch(
+                    command,
+                    args.capture_dir,
+                    save_to,
+                    env,
+                    batch_timeout_s(len(missing), args.max_concurrency, pins.episode_timeout_s),
+                )
                 if payload is None:
                     continue
                 batch = rows_from_results(
-                    payload, entry, episode, {s.task_id: s for s in missing}, user_sim
+                    payload,
+                    entry,
+                    episode,
+                    {s.task_id: s for s in missing},
+                    user_sim,
+                    pins.label,
                 )
                 append_rows(rows_path, batch)
                 done.update(row.key for row in batch)

--- a/packages/environment-capture/tau-bench/rl/real_episodes_test.py
+++ b/packages/environment-capture/tau-bench/rl/real_episodes_test.py
@@ -12,18 +12,29 @@ from pathlib import Path
 
 import pytest
 from real_episodes import (
+    CANONICAL_EPISODE_TIMEOUT_S,
+    CANONICAL_MAX_TOKENS,
+    CANONICAL_MAX_TURNS,
+    CANONICAL_TAU2_MAX_RETRIES,
     EVAL_SCENARIOS,
+    UNLABELED_COHORT,
+    ProtocolPins,
     RealEpisodeRow,
     Tau2Results,
+    agent_llm_args,
     append_rows,
     batch_command,
+    batch_timeout_s,
     build_env,
     domains_dir,
+    latest_per_cell,
     litellm_route,
     load_pinned_scenarios,
     load_rows,
     main,
+    next_save_to,
     price_order,
+    resume_keys,
     rows_from_results,
     save_to_name,
     spend_usd,
@@ -210,12 +221,25 @@ def test_build_env_names_the_missing_credential(tmp_path: Path) -> None:
         build_env(tmp_path, _AZURE_AI, _AZURE_OPENAI, {"AZURE_GOOGLE_SHEETS_API_KEY": "k"})
 
 
+def _command(tmp_path: Path, pins: ProtocolPins | None = None) -> list[str]:
+    return batch_command(
+        tmp_path,
+        _AZURE_AI,
+        _AZURE_OPENAI,
+        "airline",
+        ["0", "3"],
+        "s",
+        4,
+        pins or ProtocolPins(),
+    )
+
+
 def test_batch_command_pins_the_environment(tmp_path: Path) -> None:
-    command = batch_command(tmp_path, _AZURE_AI, _AZURE_OPENAI, "airline", ["0", "3"], "s", 4)
+    command = _command(tmp_path)
     assert command[command.index("--user-llm") + 1] == "azure/gpt-5.4-mini"
     assert command[command.index("--agent-llm") + 1] == "azure_ai/FW-GLM-5.2"
-    # Empty LLM args drop tau2's default temperature for BOTH streams.
-    assert command[command.index("--agent-llm-args") + 1] == "{}"
+    # No temperature on either stream; the agent stream carries only the token pin.
+    assert command[command.index("--agent-llm-args") + 1] == '{"max_tokens": 8192}'
     assert command[command.index("--user-llm-args") + 1] == "{}"
     assert command[command.index("--num-trials") + 1] == "1"
     assert command[command.index("--task-ids") + 1 : command.index("--max-concurrency")] == [
@@ -224,9 +248,98 @@ def test_batch_command_pins_the_environment(tmp_path: Path) -> None:
     ]
 
 
-def test_save_to_name_is_unique_per_cell() -> None:
-    assert save_to_name(_AZURE_AI, "airline", 0) == "real_glm_5_2_airline_e0"
+def test_canonical_pins_are_the_decisions_values() -> None:
+    # DECISIONS.md 2026-07-27 "cross-lane weave" ack 2: max_turns=100, episode_timeout_s=1800,
+    # max_tokens=8192, user sim azure/gpt-5.4-mini, tau2 --max-retries 0. Every real-tau2 leg in
+    # the project runs these exact values, so a drift here silently splits the cohort.
+    assert (CANONICAL_MAX_TURNS, CANONICAL_MAX_TOKENS, CANONICAL_TAU2_MAX_RETRIES) == (100, 8192, 0)
+    assert CANONICAL_EPISODE_TIMEOUT_S == 1800.0
+    pins = ProtocolPins()
+    assert pins.user_sim == "gpt-5.4-mini"
+    assert pins.is_canonical
+    assert pins.label == "turns100-t1800-tok8192-r0-sim-gpt-5.4-mini"
+
+
+def test_canonical_pins_reach_the_tau2_argv(tmp_path: Path) -> None:
+    # tau2's own defaults are 200 steps, no timeout, and 3 retries, so an absent flag is not a
+    # neutral choice: it is a different capture cohort.
+    command = _command(tmp_path)
+    assert command[command.index("--max-steps") + 1] == "100"
+    assert command[command.index("--timeout") + 1] == "1800"
+    assert command[command.index("--max-retries") + 1] == "0"
+    # A headless batch must not block on tau2's interactive resume prompt.
+    assert "--auto-resume" in command
+
+
+def test_moved_pins_reach_the_argv_and_rename_the_cohort(tmp_path: Path) -> None:
+    pins = ProtocolPins(max_turns=200, episode_timeout_s=600, max_tokens=4096, tau2_max_retries=3)
+    command = _command(tmp_path, pins)
+    assert command[command.index("--max-steps") + 1] == "200"
+    assert command[command.index("--timeout") + 1] == "600"
+    assert command[command.index("--max-retries") + 1] == "3"
+    assert command[command.index("--agent-llm-args") + 1] == '{"max_tokens": 4096}'
+    assert not pins.is_canonical
+    assert pins.label == "turns200-t600-tok4096-r3-sim-gpt-5.4-mini"
+
+
+def test_a_different_user_simulator_is_a_different_cohort() -> None:
+    # The user simulator IS the environment, so it belongs in the label even though it is also
+    # recorded per row.
+    assert not ProtocolPins(user_sim="gpt-5.5").is_canonical
+    assert ProtocolPins(user_sim="gpt-5.5").label.endswith("-sim-gpt-5.5")
+
+
+def test_max_tokens_zero_omits_the_key_for_a_strict_deployment() -> None:
+    # litellm rewrites max_tokens to max_completion_tokens only for reasoning models its table
+    # knows; an unrecognized deployment rejects the key outright, and a grid that cannot start is
+    # worse than a labelled second cohort.
+    assert agent_llm_args(ProtocolPins(max_tokens=0)) == "{}"
+    assert ProtocolPins(max_tokens=0).label == "turns100-t1800-tok0-r0-sim-gpt-5.4-mini"
+
+
+def test_an_impossible_pin_is_refused_not_run(tmp_path: Path) -> None:
+    _fake_capture_from_pinned_split(tmp_path)
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--max-turns",
+                "0",  # an episode with no turns is not a cohort, it is a typo
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_batch_deadline_covers_every_wave_of_the_episode_pin() -> None:
+    # A hard kill forfeits the episodes tau2 has not written yet, so the deadline has to cover the
+    # whole batch, not one episode: 20 tasks at concurrency 4 is five 1800s waves.
+    assert batch_timeout_s(20, 4, 1800.0) == 5 * 1800.0 + 300.0
+    assert batch_timeout_s(3, 4, 1800.0) == 1800.0 + 300.0
+    assert batch_timeout_s(0, 0, 1800.0) == 1800.0 + 300.0
+
+
+def test_save_to_name_is_unique_per_cell_and_attempt() -> None:
+    assert save_to_name(_AZURE_AI, "airline", 0) == "real_glm_5_2_airline_e0_a0"
     assert save_to_name(_AZURE_AI, "airline", 1) != save_to_name(_AZURE_AI, "airline", 0)
+    assert save_to_name(_AZURE_AI, "airline", 0, 1) == "real_glm_5_2_airline_e0_a1"
+
+
+def test_next_save_to_skips_a_cells_used_attempts(tmp_path: Path) -> None:
+    # Sharing a save directory across attempts makes the retry impossible: tau2 reads the old one
+    # as a checkpoint and refuses a task list that is a subset of it, which is exactly what a
+    # resumed cell asks for.
+    simulations = tmp_path / "tau2-bench" / "data" / "simulations"
+    (simulations / save_to_name(_AZURE_AI, "airline", 0, 0)).mkdir(parents=True)
+    assert next_save_to(tmp_path, _AZURE_AI, "airline", 0) == "real_glm_5_2_airline_e0_a1"
+    # A different cell is untouched by another cell's attempts.
+    assert next_save_to(tmp_path, _AZURE_AI, "airline", 1) == "real_glm_5_2_airline_e1_a0"
 
 
 def _results_payload(reward: float | None) -> Tau2Results:
@@ -331,6 +444,78 @@ def test_load_rows_on_a_fresh_run() -> None:
     assert load_rows(Path("/nonexistent/rows.jsonl")) == []
 
 
+def test_cohort_label_round_trips_through_rows_jsonl(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    label = ProtocolPins().label
+    rows = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI, label)
+    assert [row.cohort for row in rows] == [label]
+    path = tmp_path / "rows.jsonl"
+    append_rows(path, rows)
+    assert [row.cohort for row in load_rows(path)] == [label]
+
+
+def test_rows_written_before_the_pins_still_load(tmp_path: Path) -> None:
+    # A row with no cohort field is readable evidence of a DIFFERENT cohort (it ran on tau2's
+    # defaults); dropping it as unreadable would lose episodes that were paid for.
+    index = _scenario_index(tmp_path)
+    [row] = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    payload = json.loads(row.model_dump_json())
+    del payload["cohort"]
+    path = tmp_path / "rows.jsonl"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    assert [r.cohort for r in load_rows(path)] == [UNLABELED_COHORT]
+
+
+def test_a_run_refuses_to_append_to_another_cohorts_rows(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    index = _scenario_index(tmp_path)
+    _fake_capture_from_pinned_split(tmp_path)
+    append_rows(
+        out / "rows.jsonl",
+        rows_from_results(
+            _results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI, "turns200-t0-tok0-r3-sim-x"
+        ),
+    )
+    assert (
+        main(
+            [
+                "--capture-dir",
+                str(tmp_path),
+                "--pool",
+                str(_pool_file(tmp_path / "pool.toml")),
+                "--out-dir",
+                str(out),
+                "--only",
+                "glm-5.2",
+                "--dry-run",
+            ]
+        )
+        == 2
+    )
+
+
+def test_retry_failed_re_runs_only_the_unscored_cells(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    scored = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    unscored = rows_from_results(_results_payload(None), _ANTHROPIC, 0, index, _AZURE_OPENAI)
+    rows = scored + unscored
+    assert resume_keys(rows, retry_failed=False) == {row.key for row in rows}
+    # Without tau2's own retries, this flag is the only second chance a dead episode gets.
+    assert resume_keys(rows, retry_failed=True) == {row.key for row in scored}
+
+
+def test_a_retried_cell_counts_as_one_episode_but_two_purchases(tmp_path: Path) -> None:
+    index = _scenario_index(tmp_path)
+    failed = rows_from_results(_results_payload(None), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    retried = rows_from_results(_results_payload(1.0), _AZURE_AI, 0, index, _AZURE_OPENAI)
+    rows = failed + retried
+    assert [row.reward for row in latest_per_cell(rows)] == [1.0]  # the retry supersedes
+    [outcome] = to_matrix(rows, [_AZURE_AI]).outcomes
+    assert outcome.reward == 1.0
+    # Both attempts were billed, so the spend meter counts both.
+    assert spend_usd(rows) == pytest.approx(2 * spend_usd(retried))
+
+
 def test_price_order_is_cheapest_first() -> None:
     ordered = price_order([_ANTHROPIC, _AZURE_AI, _AZURE_OPENAI])
     assert [entry.name for entry in ordered] == ["gpt-5.4-mini", "glm-5.2", "fable-5"]
@@ -375,6 +560,9 @@ def test_dry_run_resolves_the_split_and_spends_nothing(
     assert "pinned eval split: 20 scenarios" in printed
     assert "azure_ai/FW-GLM-5.2" in printed
     assert "--user-llm azure/gpt-5.4-mini" in printed
+    # The cohort the operator is about to buy is stated before anything is bought.
+    assert f"protocol pins: cohort '{ProtocolPins().label}' (canonical)" in printed
+    assert "--max-steps 100 --timeout 1800 --max-retries 0" in printed
     # The user simulator is environment, so it is never also run as a candidate.
     assert "--agent-llm azure/gpt-5.4-mini" not in printed
 
@@ -565,7 +753,7 @@ def test_telecom_task_ids_survive_argv_construction(tmp_path: Path) -> None:
         "[mobile_data_issue]airplane_mode_on|bad_network_preference|data_mode_off[PERSONA:Hard]"
     )
     command = batch_command(
-        tmp_path, _AZURE_AI, _AZURE_OPENAI, "telecom", [telecom_id], "s", 4
+        tmp_path, _AZURE_AI, _AZURE_OPENAI, "telecom", [telecom_id], "s", 4, ProtocolPins()
     )
     assert command[command.index("--task-ids") + 1] == telecom_id
 

--- a/packages/environment-capture/tau-bench/rl/sim_to_real.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real.py
@@ -13,6 +13,11 @@ The headline is rank agreement over MODEL MEANS. When both legs run the same pin
 number; when they do not, tasks are matched on a normalized `reason_for_call` and the paired
 overlap is reported as a secondary check.
 
+One cohort per report: every real row carries the protocol pins it ran under
+(`real_episodes.ProtocolPins.label`), and rows whose labels differ are refused rather than pooled.
+Different pins are different environments, so a mixed set is not a noisier estimate of one number,
+it is two numbers averaged by accident. `--allow-mixed-cohorts` overrides it, loudly.
+
 Sampling unit is the SCENARIO, not the episode: a model is scored several times on each scenario,
 so the SE over per-scenario means (rather than over all episodes) is the one that does not pretend
 two trials of one task are independent draws.
@@ -64,7 +69,7 @@ import statistics as st
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from real_episodes import RealEpisodeRow, load_rows
+from real_episodes import UNLABELED_COHORT, RealEpisodeRow, load_rows
 from scipy import stats  # present in every wmo install: scikit-learn requires it
 
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
@@ -82,6 +87,51 @@ INLINE_CALL = re.compile(
 
 def has_inline_call(outcome: ScenarioOutcome) -> bool:
     return any(INLINE_CALL.search(reply or "") for reply in outcome.replies)
+
+
+def require_one_cohort(real: Sequence[RealEpisodeRow], allow_mixed: bool) -> str:
+    """The single capture cohort every real row must share, or a hard error.
+
+    A cohort label (`real_episodes.ProtocolPins.label`) records the turn cap, the per-episode
+    timeout, the completion cap, tau2's retry setting, and the user simulator. Rows with different
+    labels ran in different environments, so averaging or pairing them is a category error rather
+    than a noisier estimate: a 200-turn episode and a 100-turn episode are not two draws of the
+    same measurement. Rows captured before the pins were forwarded carry no label and are their own
+    cohort for exactly that reason.
+
+    Args:
+        real: The real-episode rows about to be reported on.
+        allow_mixed: Proceed anyway, loudly. For an operator who has established that the mix is
+            harmless for the question being asked, never for a quoted headline.
+
+    Returns:
+        The shared cohort label, or the joined labels when the mix was allowed.
+
+    Raises:
+        SystemExit: When the rows span more than one cohort and the override was not passed.
+    """
+    present = sorted({row.cohort for row in real})
+    if not present:
+        return UNLABELED_COHORT
+    if len(present) == 1:
+        return present[0]
+    counts = {label: sum(1 for row in real if row.cohort == label) for label in present}
+    if allow_mixed:
+        logger.warning(
+            "pairing rows across %d capture cohorts because --allow-mixed-cohorts was passed: "
+            "%s. These episodes ran in different environments; do not quote the result as one "
+            "measurement.",
+            len(present),
+            counts,
+        )
+        return "+".join(present)
+    raise SystemExit(
+        f"the real rows span {len(present)} capture cohorts {counts}, which measure different "
+        "environments (turn cap, episode timeout, completion cap, tau2 retries, user simulator). "
+        "Report each cohort separately by filtering rows.jsonl, recapture the odd cohort under the "
+        "canonical pins, or pass --allow-mixed-cohorts if the mix is genuinely harmless for the "
+        "question you are asking."
+    )
 
 
 def scenario_clustered_stats(
@@ -235,8 +285,14 @@ def paired_scores(
     return real_means, wm_means, len(shared)
 
 
-def report(real: Sequence[RealEpisodeRow], matrix: OutcomeMatrix, glm_clean: bool) -> list[str]:
+def report(
+    real: Sequence[RealEpisodeRow],
+    matrix: OutcomeMatrix,
+    glm_clean: bool,
+    allow_mixed_cohorts: bool = False,
+) -> list[str]:
     """Build the whole report as lines, so callers (and tests) can assert on it."""
+    cohort = require_one_cohort(real, allow_mixed_cohorts)
     scored = [row for row in real if row.reward is not None]
     # Both sides must be SCORED, not merely present. `wmo.env.closed_loop` leaves a cell
     # unscored on a provider throttle or an agent crash, so a candidate that was rate-limited
@@ -251,7 +307,7 @@ def report(real: Sequence[RealEpisodeRow], matrix: OutcomeMatrix, glm_clean: boo
         logger.warning("world-model models with no scored episode, excluded: %s", silent)
 
     lines = [
-        f"== REAL (tau2 reward, {len(scored)} rows) vs WM (LLM judge), per model",
+        f"== REAL (tau2 reward, {len(scored)} rows, cohort {cohort}) vs WM (LLM judge), per model",
         f"{'model':16} {'real':>16} {'eps':>5} {'wm':>16} {'inline%':>8}",
     ]
     real_mean: dict[str, float] = {}
@@ -325,12 +381,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--real", type=Path, default=Path(".wmo/evals/tau-bench-real/rows.jsonl"))
     parser.add_argument("--wm", type=Path, required=True, help="world-model OutcomeMatrix json")
     parser.add_argument("--glm-clean", action="store_true", help="add the format-corrected arm")
+    parser.add_argument(
+        "--allow-mixed-cohorts",
+        action="store_true",
+        help="report rows captured under different protocol pins together (refused by default: "
+        "they measure different environments)",
+    )
     args = parser.parse_args(argv)
 
     rows = load_rows(args.real)
     if not rows:
         parser.error(f"no real episodes at {args.real}; run real_episodes.py first")
-    for line in report(rows, OutcomeMatrix.load(args.wm), args.glm_clean):
+    lines = report(rows, OutcomeMatrix.load(args.wm), args.glm_clean, args.allow_mixed_cohorts)
+    for line in lines:
         print(line)  # noqa: T201 - operator-run CLI, this report IS the product output
     return 0
 

--- a/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
+++ b/packages/environment-capture/tau-bench/rl/sim_to_real_test.py
@@ -6,13 +6,14 @@ import json
 from pathlib import Path
 
 import pytest
-from real_episodes import RealEpisodeRow
+from real_episodes import ProtocolPins, RealEpisodeRow
 from sim_to_real import (
     RankAgreement,
     has_inline_call,
     main,
     paired_scores,
     report,
+    require_one_cohort,
     scenario_clustered_stats,
 )
 
@@ -33,7 +34,16 @@ _POOL = [
 ]
 
 
-def _real_row(model: str, scenario: str, reward: float | None, episode: int = 0) -> RealEpisodeRow:
+_CANONICAL_COHORT = ProtocolPins().label
+
+
+def _real_row(
+    model: str,
+    scenario: str,
+    reward: float | None,
+    episode: int = 0,
+    cohort: str = _CANONICAL_COHORT,
+) -> RealEpisodeRow:
     return RealEpisodeRow(
         scenario_id=scenario,
         domain=scenario.split(":")[0],
@@ -58,6 +68,7 @@ def _real_row(model: str, scenario: str, reward: float | None, episode: int = 0)
         call_seconds=[0.5],
         replies=[],
         user_sim="gpt-5.4-mini",
+        cohort=cohort,
     )
 
 
@@ -159,6 +170,56 @@ def test_report_headline_agreement() -> None:
     assert "spearman  +1.000" in text
     assert "8 real rows" in text
     assert "paired overlap (2 scenarios" in text
+
+
+def test_report_names_the_cohort_it_measured() -> None:
+    rows, matrix = _agreeing_corpus()
+    text = "\n".join(report(rows, matrix, glm_clean=False))
+    assert f"cohort {_CANONICAL_COHORT}" in text
+
+
+def test_pairing_across_capture_cohorts_is_refused() -> None:
+    # A 100-turn episode and a 200-turn episode are not two draws of one measurement, so mixing
+    # them is a category error rather than a noisier estimate.
+    rows, matrix = _agreeing_corpus()
+    rows.append(_real_row("alpha", "airline:0", 0.9, episode=1, cohort="turns200-t0-tok0-r3-sim-x"))
+    with pytest.raises(SystemExit, match="capture cohorts"):
+        report(rows, matrix, glm_clean=False)
+
+
+def test_mixed_cohorts_can_be_forced_but_say_so(caplog: pytest.LogCaptureFixture) -> None:
+    rows, matrix = _agreeing_corpus()
+    rows.append(_real_row("alpha", "airline:0", 0.9, episode=1, cohort="turns200-t0-tok0-r3-sim-x"))
+    with caplog.at_level("WARNING", logger="sim-to-real"):
+        text = "\n".join(report(rows, matrix, glm_clean=False, allow_mixed_cohorts=True))
+    assert "different environments" in caplog.text
+    assert "+" in text.splitlines()[0]  # the header names both cohorts
+
+
+def test_unlabeled_rows_are_their_own_cohort() -> None:
+    # Rows captured before the pins were forwarded ran on tau2's defaults: a different
+    # environment, and the label says only that it is unknown.
+    labeled = _real_row("alpha", "airline:0", 0.5)
+    unlabeled = _real_row("beta", "airline:0", 0.5, cohort="unlabeled")
+    assert require_one_cohort([unlabeled], allow_mixed=False) == "unlabeled"
+    with pytest.raises(SystemExit, match="capture cohorts"):
+        require_one_cohort([labeled, unlabeled], allow_mixed=False)
+
+
+def test_an_empty_row_set_has_no_cohort_to_refuse() -> None:
+    assert require_one_cohort([], allow_mixed=False) == "unlabeled"
+
+
+def test_main_refuses_mixed_cohorts_before_reporting(tmp_path: Path) -> None:
+    rows, matrix = _agreeing_corpus()
+    rows.append(_real_row("alpha", "airline:0", 0.9, episode=1, cohort="turns200-t0-tok0-r3-sim-x"))
+    rows_path = tmp_path / "rows.jsonl"
+    rows_path.write_text("\n".join(row.model_dump_json() for row in rows) + "\n", encoding="utf-8")
+    matrix_path = tmp_path / "matrix.json"
+    matrix.save(matrix_path)
+    with pytest.raises(SystemExit, match="capture cohorts"):
+        main(["--real", str(rows_path), "--wm", str(matrix_path)])
+    assert main(["--real", str(rows_path), "--wm", str(matrix_path), "--allow-mixed-cohorts"]) == 0
 
 
 def test_report_flags_disagreement() -> None:


### PR DESCRIPTION
## Why

`rl/real_episodes.py` (merged in #295) shells out to the tau2 CLI but never passed the protocol
pins the joint-tau master adopted as canonical for every real-tau2 leg (DECISIONS.md 2026-07-27
"cross-lane weave", ack 2). It inherited tau2's defaults instead, so its rows were a **different
capture cohort** than the training lane's runs (`wmo/distill/tau2.py`, PR #297), which is the one
thing the shared pins exist to prevent. Verified against the installed CLI
(`packages/environment-capture/tau-bench/.venv/bin/tau2 run --help`): tau2's own defaults are 200
steps, no per-episode timeout, and 3 retries.

## The pin table

| Pin (DECISIONS) | tau2 mechanism | tau2 default | Now |
| --- | --- | --- | --- |
| `max_turns=100` | `--max-steps` | 200 | `--max-turns`, default 100 |
| `episode_timeout_s=1800` | `--timeout` (per simulation) | none | `--episode-timeout-s`, default 1800 |
| `max_tokens=8192` | no flag: `--agent-llm-args` JSON | none | `--max-tokens`, default 8192, candidate stream only |
| user sim `azure/gpt-5.4-mini` | `--user-llm` | n/a | `--user-sim`, already pinned, now part of the cohort label |
| tau2 `--max-retries 0` + episode retry | `--max-retries` for the first half; the second half has **no tau2 mechanism** | 3 | `--tau2-max-retries`, default 0, plus `--retry-failed` |

Two pins needed a mechanism tau2 does not provide:

- **`max_tokens`** has no flag. It goes into the `--agent-llm-args` JSON, which used to be `{}`.
  The user stream stays `{}`, matching the training lane's `Tau2Config.user_llm_args` default, so
  both legs' user simulators are the same environment. `--max-tokens 0` omits the key entirely: an
  escape hatch for an Azure reasoning deployment litellm's table does not know (it wants
  `max_completion_tokens`), and it renders as `tok0` in the label so the cohort is never silent
  about it. Not currently reachable by the pool: `gpt-5.4-mini` is only the user simulator.
- **Episode-level retry** does not exist in tau2 at all, and the runner did not have a working one
  either. Pinning tau2's retries off made that load-bearing, so this PR adds it.

## Cohort labeling and the refusal

Every row now carries `cohort`, e.g. `turns100-t1800-tok8192-r0-sim-gpt-5.4-mini`. Rows written
before this PR have no label and read back as `unlabeled` (their own cohort: they ran on tau2's
defaults) rather than failing to load.

- A run refuses (exit 2) to append into a `rows.jsonl` that already holds another cohort.
- `sim_to_real.py` refuses to report rows spanning cohorts; `--allow-mixed-cohorts` overrides with
  a warning, and the report header names the cohort it measured either way.
- `--write-matrix-only` still salvages a hand-merged mixed file (those episodes were bought) but
  warns that it is pooling cohorts.

## Retry and resume, which were broken

A resumed cell asks tau2 for only the tasks with no row yet. tau2 reads the existing save
directory as a checkpoint, prompts on stdin (inherited: it would hang until the kill deadline),
and then raises on a task list that is a **subset** of the checkpointed one. So a partially
completed cell could never be re-bought, which mattered much more once tau2's own retries went
off. Fixes: each attempt takes the first unused `--save-to` slug (`..._e0_a0`, `_a1`, ...),
`--auto-resume` guarantees no batch can block on the prompt, and `--retry-failed` re-buys cells
whose latest row has no reward. Rows stay append-only; the matrix takes the latest row per cell
(so a retried cell is one episode) while `spend_usd` counts every attempt (both were billed).

Also: the batch kill deadline was a fixed 5400s, which the 1800s pin overruns (20 tasks at
concurrency 4 is five waves = 9000s). It is now derived from the pin, so a hard kill cannot
forfeit paid episodes mid-batch.

## Justification ledger

- Pin values, canonical status, and the "any change is a new cohort" rule: DECISIONS.md 2026-07-27
  "cross-lane weave" ack 2.
- Flag spellings and semantics: read from the tau2 clone at
  `wmh-bench-infra/tools/tau2-capture/tau2-bench` (read-only) and confirmed against the installed
  CLI's `--help`.
- Cross-lane parity (user stream args, `--auto-resume`, retries-off rationale): #297's
  `wmo/distill/tau2.py` `_tau2_command` / `_agent_llm_args`.
- Known cohort difference, recorded in the module docstring rather than hidden: sampling
  temperature. The training lane pins its Tinker student to 1.0; pool candidates here get no
  temperature, because several reject sampling params. Temperature is not in the canonical pin set.

## Tests

Extends the existing offline argv tests: canonical defaults asserted against the DECISIONS values
by name, pins present in the built argv, a moved pin renaming the cohort, `max_tokens=0` omitting
the key, cohort label round-tripping through `rows.jsonl`, unlabeled rows still loading, a run
refusing another cohort's file, an out-of-range pin refused before anything is bought,
`--retry-failed` selecting exactly the unscored cells, a retried cell counting as one episode but
two purchases, attempt-slug selection, and the derived deadline. Cross-cohort pairing refusal and
the forced-mix warning on the `sim_to_real` side.

Gates: `ruff check`, `ruff format --check`, `ty check` clean; `pytest -q` 4042 passed, 19 skipped.
Driven end to end as a `--dry-run` against the real tau2 clone and pool: the argv comes out as
`... --max-steps 100 --timeout 1800 --max-retries 0 --auto-resume` with
`--agent-llm-args {"max_tokens": 8192}` for all 20 pinned scenarios.

**Spend: $0.** No real episodes were run; every test is offline.

Merges only after the joint-tau master's review.