### PR TITLE
optimize model: refuse to spend without consent on a non-TTY, add --dry-run

### DIFF
--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -192,6 +192,12 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir holding the built models."),
     yes: bool = typer.Option(False, "--yes", help="Skip the one spend confirmation."),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the plan table (what would run, what it is projected to cost) and exit "
+        "without spending anything or touching any artifact.",
+    ),
 ) -> None:
     """Measure, fit, tune, and report a routing policy for a world model, in one command.
 
@@ -312,6 +318,13 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         projection=projection,
         paths=paths,
     )
+    # After the plan, before any consent or spend question: the whole point of a dry run is
+    # reading the table above without committing to anything, so it exits here even when the
+    # budget check below would have refused the real run (the table already shows the numbers).
+    if dry_run:
+        _console.print("\ndry run: nothing was run and nothing was spent")
+        raise typer.Exit(0)
+
     # Seeded from every dollar this model's optimization has already spent, both sides:
     # --max-usd bounds the optimization, not one invocation of it (see `SpendLedger`).
     ledger = SpendLedger(max_usd=max_usd, spent_usd=manifest.lifetime_spend_usd)
@@ -779,8 +792,13 @@ def _confirm(decisions: list[StageDecision], *, yes: bool) -> bool:
     number would skip it precisely when it matters most. Fit, tune, and report cost nothing, so a
     run of only those does not need permission to happen.
 
-    A non-interactive session cannot answer, so it proceeds and says so rather than hanging (the
-    `route sweep` rule: every pool entry is priced, so the spend is accountable).
+    A non-interactive session cannot answer, so a spending run REFUSES rather than proceeding:
+    consent must be said (`--yes`), never inferred from the absence of a terminal. This is
+    `route sweep`'s own rule, and this command briefly shipped the opposite, which cost a
+    scripted caller real money it never agreed to.
+
+    Raises:
+        typer.Exit: code 2 when a spending run cannot ask and was not told `--yes`.
     """
     if not any(decision.will_run for decision in decisions):
         return False
@@ -788,10 +806,10 @@ def _confirm(decisions: list[StageDecision], *, yes: bool) -> bool:
         return True
     if not _console.is_terminal:
         _console.print(
-            "\nnon-interactive session: proceeding without confirmation (pass --yes to say so "
-            "explicitly)"
+            "\nnon-interactive session: cannot ask for spend consent. Re-run with --yes to "
+            "consent explicitly, or --dry-run to see the plan without spending."
         )
-        return True
+        raise typer.Exit(2)
     return Confirm.ask("\nProceed?", default=True)
 
 

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -1081,3 +1081,38 @@ def test_the_cap_counts_spend_from_runs_whose_records_were_superseded(
     assert sweep is not None
     # One sweep's record survives, but both sweeps' spend does.
     assert manifest.lifetime_spend_usd == pytest.approx(sweep.total_spend_usd * 2, rel=1e-6)
+
+
+def test_a_non_tty_spending_run_without_yes_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Consent is said, never inferred: no terminal + no --yes + a sweep to buy = exit 2.
+
+    This command briefly shipped the opposite (proceed-and-note), which spent a scripted
+    caller's money without agreement; the refusal message names both honest paths out.
+    """
+    world_model = _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    # CliRunner's stdin is not a terminal, and _console is left at its non-terminal default.
+    result = _run(tmp_path, root)
+    assert result.exit_code == 2, result.output
+    assert "cannot ask for spend consent" in result.output
+    assert "--yes" in result.output and "--dry-run" in result.output
+    assert world_model.tasks == []  # no episode ran
+    assert not _paths(root)[0].exists()  # no matrix bought
+
+
+def test_dry_run_prints_the_plan_and_spends_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--dry-run is the read-only view of the plan table: exit 0, no episodes, no artifacts."""
+    world_model = _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--dry-run")
+    assert result.exit_code == 0, result.output
+    assert "sweep" in result.output  # the plan table rendered
+    assert "dry run: nothing was run and nothing was spent" in result.output
+    assert world_model.tasks == []
+    matrix_path, manifest_path = _paths(root)[0], _paths(root)[1]
+    assert not matrix_path.exists()
+    assert not manifest_path.exists()  # a dry run leaves no resume state behind


### PR DESCRIPTION
## Why

Found by the cookbook agent at real cost: piping stdin into `wmo optimize model` printed 'non-interactive session: proceeding without confirmation' and started the sweep. Spend consent must be said (--yes), never inferred from the absence of a terminal - this is route sweep's own contract and the orchestrator shipped the opposite.

## What

- Non-TTY + no --yes + a sweep to buy => exit 2, message naming both honest paths (--yes / --dry-run). Free-stage-only runs are unaffected.
- New --dry-run: prints the plan table (including the spend projection and its basis) and exits 0, touching no artifact and no manifest.

## Verification

2 new regression tests (refusal: exit 2, zero episodes, no matrix; dry-run: exit 0, plan rendered, no artifacts, no resume state). Both behaviors also driven live against the real tau-bench WM: dry-run exit 0 reading the prior manifest read-only for its forecast basis; refusal exit 2. Gates: ruff, format, ty clean; wmo/cli + wmo/optimize suites pass.

Justification ledger: consumer = every scripted caller of the flagship command (the canonical grid runs, CI, the cookbook's documented workflow). Merges under the joint-tau master's delegated authority as a money-safety fix.