### PR TITLE
Teacher text to cross-entropy datums: any provider can be a distillation teacher

### DIFF
--- a/.agents/distill/text_bridge_smoke.py
+++ b/.agents/distill/text_bridge_smoke.py
@@ -1,0 +1,141 @@
+"""Smoke the text bridge end to end: real teacher transcripts -> one live CE step.
+
+Proves the tier-1 path with real money and real weights, cheaply: read recorded
+tau2 teacher transcripts (any provider's; cycle 1's Qwen3.6-27B episodes are
+the handy corpus), re-encode them under the STUDENT's renderer through
+`wmo.distill.text_episodes`, then run ONE `forward_backward` +  `optim_step`
+against a live Tinker LoRA using the same cross_entropy wire format the
+supervised phase uses.
+
+What it proves that unit tests cannot: the re-encoded datums are accepted by
+the live cross_entropy loss (the keyset and dtypes are right), a real LoRA
+takes a gradient step on them, and the whole path costs what the forecast says.
+
+Cost: one minibatch of student training tokens (cents; capped by --max-datums).
+
+    uv run python .agents/distill/text_bridge_smoke.py \
+        --episodes-root .wmo/distill-runs/tau2-cycle1/warmup-rollouts/tau2/step-0000 \
+        --teacher-model Qwen/Qwen3.6-27B --max-datums 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from wmo.distill.config import DistillConfig
+from wmo.distill.data import build_datums, to_tinker_sft_datums
+from wmo.distill.rendering import build_offline_rendering
+from wmo.distill.tau2 import episodes_from_tau2_results
+from wmo.distill.text_episodes import text_warmup_manifest
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s: %(message)s")
+logger = logging.getLogger("text_bridge_smoke")
+
+CROSS_ENTROPY_LOSS = "cross_entropy"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episodes-root", required=True, help="dir of <episode>/results.json")
+    parser.add_argument("--teacher-model", required=True, help="who wrote the transcripts")
+    parser.add_argument("--student", default="Qwen/Qwen3.5-9B")
+    parser.add_argument("--lora-rank", type=int, default=32)
+    parser.add_argument("--max-datums", type=int, default=8, help="cost cap: datums per step")
+    parser.add_argument("--learning-rate", type=float, default=1e-5)
+    parser.add_argument("--dry-run", action="store_true", help="build datums, spend nothing")
+    args = parser.parse_args()
+
+    root = Path(args.episodes_root)
+    episode_dirs = sorted(d for d in root.iterdir() if d.is_dir() and (d / "results.json").exists())
+    if not episode_dirs:
+        logger.error("no <episode>/results.json under %s", root)
+        return 2
+
+    episodes = []
+    for episode_dir in episode_dirs:
+        task_id = episode_dir.name.rsplit("-a", 1)[0].replace("-", "/", 1)
+        episodes.extend(
+            episodes_from_tau2_results(
+                episode_dir / "results.json",
+                teacher_model=args.teacher_model,
+                task_id=task_id,
+            )
+        )
+    if not episodes:
+        logger.error("no graded transcripts with resolvable system prompts under %s", root)
+        return 2
+    kept = [episode for episode in episodes if episode.passed]
+    logger.info(
+        "read %d graded episode(s) from %d dir(s); %d passed the keep filter",
+        len(episodes),
+        len(episode_dirs),
+        len(kept),
+    )
+    if not kept:
+        logger.error("no passing episodes to train on")
+        return 2
+
+    rendering = build_offline_rendering(args.student)
+    manifest = text_warmup_manifest(kept, rendering, teacher_model=args.teacher_model)
+    records = manifest.records
+    cfg = DistillConfig.model_validate(
+        {
+            "student": {"base_model": args.student, "lora_rank": args.lora_rank},
+            "teacher": {"model": args.teacher_model},
+            "tau2": {"tau2_bin": "/unused", "data_dir": "/unused"},
+            "train": {"steps": 0, "learning_rate": args.learning_rate},
+            "warmup": {"steps": 1},
+        }
+    )
+    datums, stats = build_datums(records, cfg)
+    logger.info(
+        "datums: %d from %d episode(s) (drops: overflow %d, overlong %d)",
+        len(datums),
+        len(records),
+        stats.overflow_drops,
+        stats.overlong_drops,
+    )
+    batch = datums[: args.max_datums]
+    loss_tokens = sum(int(sum(d.loss_mask)) for d in batch)
+    total_tokens = sum(len(d.model_input_tokens) for d in batch)
+    logger.info(
+        "training batch: %d datum(s), %d total tokens, %d loss tokens; all hard-target: %s",
+        len(batch),
+        total_tokens,
+        loss_tokens,
+        all(d.hard_targets_only for d in batch),
+    )
+    if args.dry_run:
+        logger.info("VERDICT: DRY RUN ok (nothing spent)")
+        return 0
+
+    wire = to_tinker_sft_datums(batch)
+    logger.info("converted %d datum(s) to the live cross_entropy wire format", len(wire))
+
+    from wmo.providers.tinker import shared_service_client
+
+    service = shared_service_client()
+    training = service.create_lora_training_client(
+        base_model=args.student, rank=args.lora_rank
+    )
+    logger.info("training client up for %s (rank %d)", args.student, args.lora_rank)
+    forward = training.forward_backward(wire, loss_fn=CROSS_ENTROPY_LOSS)
+    optim = training.optim_step(dict(learning_rate=args.learning_rate))
+    forward_result = forward.result()
+    optim.result()
+    metrics = getattr(forward_result, "metrics", None) or {}
+    logger.info("forward_backward metrics: %s", metrics)
+    logger.info(
+        "VERDICT: PASS - the live cross_entropy loss accepted %d text-derived datum(s) "
+        "(%d loss tokens) and the LoRA took a step",
+        len(wire),
+        loss_tokens,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wmo/distill/data.py
+++ b/wmo/distill/data.py
@@ -111,6 +111,17 @@ class TrainDatum(BaseModel):
     topk-CE replicas: the renormalized teacher probability of this replica's
     candidate at each loss position, 0.0 everywhere else."""
 
+    hard_targets_only: bool = False
+    """True when this datum's `sampled_logprobs` are placeholders, not real ones.
+
+    Carried up from any contributing span's `TokenSpan.logprobs_are_placeholders`
+    (the text bridge re-encodes a teacher's recorded text under the student's
+    template, so its token ids are real targets that no sampler scored). The
+    tokens are sound supervision for hard-target cross_entropy, which never
+    sends logprobs; the advantage losses derive `teacher_lp - sampled_lp` from
+    them, so `attach_advantages` refuses these datums instead of quietly
+    training against a fabricated baseline."""
+
     @model_validator(mode="after")
     def _check_alignment(self) -> TrainDatum:
         """Reject any misalignment between the token sequence and its per-token lists."""
@@ -259,6 +270,9 @@ def _merge_trial_spans(trial_name: str, spans: Sequence[TokenSpan]) -> list[Trai
     tokens: list[int] = []
     mask: list[float] = []
     logprobs: list[float] = []
+    # One flag per fragment: any contributing span with placeholder logprobs
+    # taints the whole datum, because a fragment is trained as one sequence.
+    placeholders = [False]
 
     def flush() -> None:
         if not tokens:
@@ -277,11 +291,13 @@ def _merge_trial_spans(trial_name: str, spans: Sequence[TokenSpan]) -> list[Trai
                     model_input_tokens=list(tokens),
                     loss_mask=list(mask),
                     sampled_logprobs=list(logprobs),
+                    hard_targets_only=placeholders[0],
                 )
             )
         tokens.clear()
         mask.clear()
         logprobs.clear()
+        placeholders[0] = False
 
     for span in sorted(spans, key=lambda item: item.call_index):
         prompt = span.prompt_token_ids
@@ -296,6 +312,8 @@ def _merge_trial_spans(trial_name: str, spans: Sequence[TokenSpan]) -> list[Trai
         tokens.extend(span.sampled_token_ids)
         mask.extend([1.0] * len(span.sampled_token_ids))
         logprobs.extend(span.sampled_logprobs)
+        if span.logprobs_are_placeholders:
+            placeholders[0] = True
     flush()
     return datums
 
@@ -450,6 +468,20 @@ def attach_advantages(
         raise ValueError(
             f"got {len(teacher_logprobs)} teacher logprob list(s) for {len(datums)} "
             "datum(s); pass exactly one per-position list per datum, in datum order"
+        )
+    hard_target_datums = [datum for datum in datums if datum.hard_targets_only]
+    if hard_target_datums:
+        # These datums' sampled_logprobs are placeholders (text-derived spans),
+        # so `teacher_lp - sampled_lp` below would measure the gap against a
+        # fabricated baseline. Refusing is the point of the flag: hard-target
+        # cross_entropy is the only sound consumer of re-encoded teacher text.
+        names = sorted({datum.trial_name for datum in hard_target_datums})
+        raise ValueError(
+            f"{len(hard_target_datums)} datum(s) carry placeholder logprobs "
+            f"(trial(s) {', '.join(names[:5])}); they came from re-encoded teacher TEXT "
+            "and no sampler scored their tokens, so an advantage loss would train "
+            "against a fabricated baseline. Train them with cross_entropy (the warmup "
+            "or off-policy phase), or collect real sampled spans for on-policy steps"
         )
     clip = cfg.train.advantage_clip
     kept: list[TrainDatum] = []

--- a/wmo/distill/rendering.py
+++ b/wmo/distill/rendering.py
@@ -92,6 +92,17 @@ class ChatRendering(Protocol):
         """Render chat messages (and optional tool schemas) into prompt token ids."""
         ...
 
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render an already-written assistant turn as its sampled-token equivalent.
+
+        The inverse of sampling, for turning recorded teacher TEXT into
+        training data under the student's own template; see the
+        implementation for the honest limits.
+        """
+        ...
+
     def render_suffix(
         self,
         messages: list[ChatMessage],
@@ -317,6 +328,78 @@ class CookbookChatRendering:
                 raise ValueError(
                     "the renderer produced a non-text chunk while rendering a prompt "
                     "suffix; the tinker provider is text-only"
+                )
+            tokens.extend(chunk_tokens)
+        return tokens
+
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render one already-written assistant turn as its SAMPLED-token equivalent.
+
+        The inverse of sampling: given a recorded transcript, produce the token
+        ids a model emitting `messages[index]` would have sampled after
+        `build_generation_prompt(messages[:index], tools)`. That is the turn's
+        rendered OUTPUT chunks without its header, because the header is
+        already the generation prompt's trailing suffix.
+
+        This is what lets a teacher's TEXT episode become training data under
+        the STUDENT's own template (`wmo.distill.text_episodes`):
+        prompt(index) + this turn's ids is exactly the prefix the next turn's
+        prompt extends, which is the property `build_datums` merges on.
+
+        The honest limit: these ids are re-encoded from text, so they are the
+        student's tokenization of the teacher's words, not ids any model
+        sampled. Hard-target cross-entropy is the only sound consumer, which
+        is why spans built this way carry `logprobs_are_placeholders`.
+
+        Args:
+            messages: The transcript, with `messages[index]` the assistant turn.
+            index: Index of the assistant turn to render.
+            tools: Tool schemas the episode ran with (rendered into the prefix).
+
+        Returns:
+            The turn's token ids, framed as the sampled continuation.
+
+        Raises:
+            ImportError: If tinker-cookbook is not installed (distill extra).
+            ValueError: If `index` is out of range, does not name an assistant
+                turn, or the turn renders to non-text chunks.
+        """
+        try:
+            from tinker_cookbook.renderers.base import RenderContext
+        except ImportError as exc:  # pragma: no cover - exercised via sys.modules patching
+            raise ImportError(MISSING_DISTILL_EXTRA) from exc
+
+        if not 0 <= index < len(messages):
+            raise ValueError(f"index {index} is out of range for {len(messages)} message(s)")
+        if messages[index].role != "assistant":
+            raise ValueError(
+                f"index {index} is a {messages[index].role!r} turn, not an assistant turn; "
+                "only assistant turns have sampled-token equivalents"
+            )
+        effective, shift = self._effective_messages(messages, tools)
+        idx = index + shift
+        last_user_index = max(
+            (i for i, msg in enumerate(effective) if msg["role"] == "user"),
+            default=-1,
+        )
+        ctx = RenderContext(
+            idx=idx,
+            is_last=(idx == len(effective) - 1),
+            prev_message=effective[idx - 1] if idx > 0 else None,
+            last_user_index=last_user_index,
+        )
+        # Output chunks ONLY: the header is already the prompt's generation
+        # suffix, so including it here would duplicate it in the token stream.
+        rendered = self._renderer.render_message(effective[idx], ctx)
+        tokens: list[int] = []
+        for chunk in rendered.output:
+            chunk_tokens = getattr(chunk, "tokens", None)
+            if chunk_tokens is None:
+                raise ValueError(
+                    f"assistant turn {index} rendered a non-text chunk; text-derived "
+                    "training data is text-only"
                 )
             tokens.extend(chunk_tokens)
         return tokens
@@ -605,3 +688,32 @@ def build_renderer(base_model: str, tokenizer: RendererTokenizer) -> CookbookCha
     # Any at runtime; RendererTokenizer is the slice it actually calls.
     renderer = get_renderer(renderer_name, cast("Tokenizer", tokenizer), model_name=base_model)
     return CookbookChatRendering(renderer)
+
+
+def build_offline_rendering(base_model: str) -> CookbookChatRendering:
+    """Build a base model's rendering without any Tinker client.
+
+    The rendering only needs a tokenizer, and the cookbook can load one from
+    Hugging Face directly, so text-to-datum work (`wmo.distill.text_episodes`)
+    runs with no training client, no sampler, and no network once the tokenizer
+    is cached. The two production call sites pass a live client's tokenizer
+    because they already hold one, not because a client is required.
+
+    Args:
+        base_model: Base model name in `org/model` form; the STUDENT's, when
+            re-encoding teacher text into training targets.
+
+    Returns:
+        The cookbook-backed `ChatRendering` for that model.
+
+    Raises:
+        ImportError: If tinker-cookbook is not installed (distill extra).
+        ValueError: If the cookbook has no renderer mapping for `base_model`.
+        OSError: If the tokenizer is neither cached nor downloadable.
+    """
+    try:
+        from tinker_cookbook.tokenizer_utils import get_tokenizer
+    except ImportError as exc:  # pragma: no cover - exercised via sys.modules patching
+        raise ImportError(MISSING_DISTILL_EXTRA) from exc
+
+    return build_renderer(base_model, cast("RendererTokenizer", get_tokenizer(base_model)))

--- a/wmo/distill/tau2.py
+++ b/wmo/distill/tau2.py
@@ -54,11 +54,15 @@ from collections.abc import Callable, Sequence
 from hashlib import blake2s
 from pathlib import Path
 
+from llm_waterfall.types import ChatFunctionCall, ChatMessage, ChatToolCall
+from pydantic import JsonValue
+
 from wmo.core.types import JsonObject
 from wmo.distill.config import DistillConfig
 from wmo.distill.data import CONTEXT_OVERFLOW_STOP_REASON
 from wmo.distill.rollouts import RolloutStats, rollout_stats
 from wmo.distill.tau2_proxy import EpisodeProxy
+from wmo.distill.text_episodes import TAU2_TERMINATION_STOP_REASONS, TeacherEpisode
 from wmo.distill.tokens import TrialRecord, load_trial_spans
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.runtime import StopReason
@@ -82,6 +86,12 @@ split raises on the missing ids (see
 RESULTS_FILENAME = "results.json"
 SPANS_SINK_DIR = "spans"
 PROVIDER_SNAPSHOT_FILENAME = "provider.json"
+SYSTEM_PROMPT_FILENAME = "system-prompt.txt"
+"""The episode's exact agent system prompt, captured by the proxy.
+
+tau2's own results record the domain POLICY but not the scaffold's assembled
+system prompt, and off-policy replay of an episode's text needs the exact
+prompt its turns were conditioned on (see `episodes_from_tau2_results`)."""
 RUNNER_LOG_FILENAME = "tau2.log"
 
 _SUBPROCESS_KILL_MARGIN_S = 120.0
@@ -543,7 +553,11 @@ async def _run_batch(
             json.dumps(_provider_snapshot(provider_config), sort_keys=True),
             encoding="utf-8",
         )
-        proxy.register(spec.name, provider)
+        proxy.register(
+            spec.name,
+            provider,
+            system_prompt_sink=spec.episode_dir / SYSTEM_PROMPT_FILENAME,
+        )
         try:
             await _run_episode_subprocess(spec, cfg, proxy.base_url)
         except asyncio.CancelledError:
@@ -626,3 +640,177 @@ def _log_batch_health(step_name: str, stats: RolloutStats) -> None:
             step_name,
             stats.stop_reason_counts,
         )
+
+
+def episodes_from_tau2_results(
+    results_path: Path,
+    *,
+    teacher_model: str,
+    task_id: str,
+    attempt: int = 1,
+    system_prompt: str | None = None,
+) -> list[TeacherEpisode]:
+    """Read a tau2 `results.json` back as text episodes for off-policy training.
+
+    The reverse direction of this module: instead of driving episodes, this
+    reads ones that already ran (by ANY provider, including ones with no
+    logprob surface) so their transcripts can train a student through the text
+    bridge (`wmo.distill.text_episodes`). That is what makes a hosted teacher
+    like Kimi K3 usable as a distillation teacher at all.
+
+    tau2's recorded message shape is close to OpenAI's but not identical, and
+    the differences are load-bearing: its tool calls are flat
+    (`{id, name, arguments}` with arguments as an OBJECT, not a JSON string
+    inside `function`), and its tool results key the call by `id` rather than
+    `tool_call_id`. Both are converted here so the renderer sees canonical
+    chat messages.
+
+    Args:
+        results_path: A tau2 `results.json` (one simulation per file, as this
+            collector writes them).
+        teacher_model: The model that produced the assistant turns; recorded as
+            provenance and checked against the manifest's teacher identity.
+        task_id: The composite `domain/task_id` this episode ran.
+        attempt: 1-based attempt index within the task.
+        system_prompt: The agent system prompt these turns were conditioned on.
+            Required in substance, not in form: when omitted, the episode dir's
+            captured `system-prompt.txt` is used (exact, written by the proxy
+            for episodes this collector ran), else tau2's recorded domain
+            policy wrapped in its own `<policy>` framing, which is the policy
+            without the scaffold's instruction block. An episode with none of
+            the three is SKIPPED rather than trained with no policy context: a
+            student taught to act without its policy would be trained on
+            prompts it will never see at serving time.
+
+    Returns:
+        One episode per graded simulation in the file (empty when the file
+        holds no simulation, the simulation has no verifier evidence, its
+        transcript carries no assistant turn, or no system prompt could be
+        resolved: none of those are training material).
+
+    Raises:
+        ValueError: If the file is unreadable or not tau2 results JSON.
+    """
+    try:
+        payload = json.loads(results_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read tau2 results from {results_path}: {error}") from error
+    simulations = payload.get("simulations") if isinstance(payload, dict) else None
+    if not isinstance(simulations, list):
+        raise ValueError(f"{results_path} is not tau2 results JSON (no simulations list)")
+
+    episodes: list[TeacherEpisode] = []
+    for simulation in simulations:
+        if not isinstance(simulation, dict):
+            continue
+        reward_info = simulation.get("reward_info")
+        reward = reward_info.get("reward") if isinstance(reward_info, dict) else None
+        termination = simulation.get("termination_reason")
+        if not isinstance(reward, int | float) or termination == "infrastructure_error":
+            logger.debug("skipping ungraded simulation in %s", results_path)
+            continue
+        messages = _chat_messages_from_tau2(simulation.get("messages"))
+        if not any(message.role == "assistant" for message in messages):
+            logger.debug("skipping transcript with no assistant turn in %s", results_path)
+            continue
+        resolved_prompt = system_prompt or _resolve_system_prompt(results_path, simulation)
+        if resolved_prompt is None:
+            logger.warning(
+                "skipping %s attempt %d: no system prompt could be resolved (no captured "
+                "%s beside the results, and the simulation records no policy), and "
+                "training on prompts missing the agent's policy context would teach the "
+                "student a task it never faces at serving time",
+                task_id,
+                attempt,
+                SYSTEM_PROMPT_FILENAME,
+            )
+            continue
+        if messages and messages[0].role != "system":
+            messages.insert(0, ChatMessage(role="system", content=resolved_prompt))
+        episodes.append(
+            TeacherEpisode(
+                task_id=task_id,
+                attempt=attempt,
+                messages=messages,
+                reward=max(0.0, min(1.0, float(reward))),
+                passed=float(reward) >= 1.0 - 1e-9,
+                teacher_model=teacher_model,
+                source=f"tau2:{results_path.name}",
+                stop_reason=(
+                    TAU2_TERMINATION_STOP_REASONS.get(termination)
+                    if isinstance(termination, str)
+                    else None
+                ),
+            )
+        )
+    return episodes
+
+
+def _resolve_system_prompt(results_path: Path, simulation: JsonObject) -> str | None:
+    """The episode's system prompt: captured if available, else the recorded policy.
+
+    The captured file is exact (the proxy wrote what the scaffold actually
+    sent). The recorded `policy` is tau2's domain policy only, so it is wrapped
+    in the same `<policy>` framing tau2's own template uses and is honestly a
+    reconstruction: it lacks the instruction block.
+    """
+    captured = results_path.parent / SYSTEM_PROMPT_FILENAME
+    try:
+        text = captured.read_text(encoding="utf-8").strip()
+    except OSError:
+        text = ""
+    if text:
+        return text
+    policy = simulation.get("policy")
+    if isinstance(policy, str) and policy.strip():
+        return f"<policy>\n{policy.strip()}\n</policy>"
+    return None
+
+
+def _chat_messages_from_tau2(messages: JsonValue) -> list[ChatMessage]:
+    """Convert tau2's recorded messages into canonical chat messages.
+
+    Drops nothing and invents nothing: every recorded turn becomes a message,
+    with tau2's flat tool calls nested under `function` (arguments JSON-encoded,
+    as the chat format requires) and tool results keyed by `tool_call_id`.
+    """
+    if not isinstance(messages, list):
+        return []
+    out: list[ChatMessage] = []
+    for raw in messages:
+        if not isinstance(raw, dict):
+            continue
+        role = raw.get("role")
+        if role not in ("system", "user", "assistant", "tool"):
+            continue
+        content = raw.get("content")
+        tool_calls: list[ChatToolCall] = []
+        for call in raw.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            arguments = call.get("arguments")
+            tool_calls.append(
+                ChatToolCall(
+                    id=str(call.get("id") or f"call_{len(tool_calls)}"),
+                    function=ChatFunctionCall(
+                        name=str(call.get("name") or ""),
+                        # The chat format carries arguments as a JSON STRING;
+                        # tau2 records them as an object.
+                        arguments=(
+                            arguments
+                            if isinstance(arguments, str)
+                            else json.dumps(arguments if arguments is not None else {})
+                        ),
+                    ),
+                )
+            )
+        out.append(
+            ChatMessage(
+                role=role,
+                content=content if isinstance(content, str) else None,
+                tool_calls=tool_calls or None,
+                # tau2 keys a tool result by the call's own `id`.
+                tool_call_id=str(raw["id"]) if role == "tool" and raw.get("id") else None,
+            )
+        )
+    return out

--- a/wmo/distill/tau2_proxy.py
+++ b/wmo/distill/tau2_proxy.py
@@ -32,6 +32,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI
@@ -173,17 +174,30 @@ class EpisodeProxy:
 
     host: str = "127.0.0.1"
     _providers: dict[str, ToolCallingProvider] = field(default_factory=dict)
+    _prompt_sinks: dict[str, Path] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _server: uvicorn.Server | None = None
     _thread: threading.Thread | None = None
     _port: int | None = None
 
-    def register(self, alias: str, provider: ToolCallingProvider) -> None:
+    def register(
+        self,
+        alias: str,
+        provider: ToolCallingProvider,
+        *,
+        system_prompt_sink: Path | None = None,
+    ) -> None:
         """Route requests for model `alias` to `provider`.
 
         Args:
             alias: The episode's model alias (sent by tau2 as the request `model`).
             provider: The episode's span-recording provider.
+            system_prompt_sink: Optional file to write the episode's system
+                prompt to, verbatim, on the first request that carries one. The
+                agent scaffold's system prompt is not recorded in tau2's own
+                results (only the domain policy is), and off-policy replay of
+                this episode's TEXT needs the exact prompt its turns were
+                conditioned on, so it is captured here where it is exact.
 
         Raises:
             ValueError: If the alias is empty or already registered; alias reuse
@@ -198,11 +212,34 @@ class EpisodeProxy:
                     "needs its own alias so its spans land on its own recorder"
                 )
             self._providers[alias] = provider
+            if system_prompt_sink is not None:
+                self._prompt_sinks[alias] = system_prompt_sink
 
     def release(self, alias: str) -> None:
         """Drop the provider routed as `alias` (idempotent)."""
         with self._lock:
             self._providers.pop(alias, None)
+            self._prompt_sinks.pop(alias, None)
+
+    def _capture_system_prompt(self, alias: str, request: ChatRequest) -> None:
+        """Write this episode's system prompt to its sink, once, best effort.
+
+        A capture failure must never cost the episode: the prompt is provenance
+        for later off-policy replay, not something the rollout depends on.
+        """
+        with self._lock:
+            sink = self._prompt_sinks.pop(alias, None)
+        if sink is None:
+            return
+        system = next((m for m in request.messages if m.role == "system"), None)
+        content = system.content if system is not None else None
+        if not isinstance(content, str) or not content:
+            return
+        try:
+            sink.parent.mkdir(parents=True, exist_ok=True)
+            sink.write_text(content, encoding="utf-8")
+        except OSError as error:  # pragma: no cover - defensive
+            logger.warning("could not record %s's system prompt to %s: %s", alias, sink, error)
 
     @property
     def base_url(self) -> str:
@@ -220,9 +257,10 @@ class EpisodeProxy:
         # not serialize behind one event loop.
         @app.post("/v1/chat/completions")
         def chat_completions(payload: JsonObject) -> JSONResponse:
-            alias = payload.get("model")
+            raw_alias = payload.get("model")
+            alias = raw_alias if isinstance(raw_alias, str) else ""
             with self._lock:
-                provider = self._providers.get(alias) if isinstance(alias, str) else None
+                provider = self._providers.get(alias) if alias else None
             if provider is None:
                 return JSONResponse(
                     status_code=404,
@@ -238,6 +276,7 @@ class EpisodeProxy:
                 )
             try:
                 chat_request = ChatRequest.model_validate(payload)
+                self._capture_system_prompt(alias, chat_request)
                 response = provider.complete_chat(chat_request)
                 realign_tool_argument_types(response, chat_request.tools)
             except Exception as exc:  # noqa: BLE001 - reported as an OpenAI-shaped 502

--- a/wmo/distill/tau2_test.py
+++ b/wmo/distill/tau2_test.py
@@ -15,6 +15,7 @@ from wmo.distill.tau2 import (
     _tau2_command,
     _wipe_stale_episode_dir,
     collect_tau2_rollouts,
+    episodes_from_tau2_results,
     parse_tau2_task_id,
 )
 from wmo.harness.doc import HarnessDoc
@@ -357,3 +358,106 @@ class TestEpisodeReuse:
         )
         assert launches == [1]
         assert records[0].passed is True
+
+
+class TestEpisodesFromResults:
+    """The reverse direction: recorded tau2 transcripts back out as text episodes."""
+
+    @staticmethod
+    def _write(
+        episode_dir: Path,
+        *,
+        reward: float | None = 1.0,
+        termination: str = "user_stop",
+        policy: str | None = "AIRLINE POLICY",
+        captured_prompt: str | None = None,
+    ) -> Path:
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        simulation: dict[str, object] = {
+            "id": "sim1",
+            "task_id": "7",
+            "termination_reason": termination,
+            "reward_info": ({"reward": reward} if reward is not None else {}),
+            "messages": [
+                {"role": "assistant", "content": "Hi! How can I help?", "turn_idx": 0},
+                {"role": "user", "content": "book it", "turn_idx": 1},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "turn_idx": 2,
+                    "tool_calls": [
+                        {"id": "call_0", "name": "book", "arguments": {"id": 7}},
+                    ],
+                },
+                {"role": "tool", "id": "call_0", "content": '{"ok": true}', "turn_idx": 3},
+                {"role": "assistant", "content": "Booked.", "turn_idx": 4},
+            ],
+        }
+        if policy is not None:
+            simulation["policy"] = policy
+        (episode_dir / "results.json").write_text(
+            json.dumps({"simulations": [simulation]}), encoding="utf-8"
+        )
+        if captured_prompt is not None:
+            (episode_dir / "system-prompt.txt").write_text(captured_prompt, encoding="utf-8")
+        return episode_dir / "results.json"
+
+    def test_converts_tau2_message_shape_and_prepends_the_captured_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        results = self._write(tmp_path / "ep", captured_prompt="EXACT SYSTEM PROMPT")
+        [episode] = episodes_from_tau2_results(
+            results, teacher_model="kimi-k3", task_id="airline/7"
+        )
+        assert episode.messages[0].role == "system"
+        assert episode.messages[0].content == "EXACT SYSTEM PROMPT"
+        assert episode.passed is True
+        assert episode.stop_reason == "submitted"
+        assert episode.source == "tau2:results.json"
+        # tau2 records flat tool calls with OBJECT arguments; the chat format
+        # needs them nested with a JSON string.
+        call = next(m for m in episode.messages if m.tool_calls).tool_calls
+        assert call is not None
+        assert call[0].function.name == "book"
+        assert json.loads(call[0].function.arguments) == {"id": 7}
+        # tau2 keys a tool result by the call's own id
+        tool_msg = next(m for m in episode.messages if m.role == "tool")
+        assert tool_msg.tool_call_id == "call_0"
+
+    def test_falls_back_to_the_recorded_policy(self, tmp_path: Path) -> None:
+        results = self._write(tmp_path / "ep")
+        [episode] = episodes_from_tau2_results(
+            results, teacher_model="kimi-k3", task_id="airline/7"
+        )
+        assert episode.messages[0].content == "<policy>\nAIRLINE POLICY\n</policy>"
+
+    def test_an_explicit_prompt_wins(self, tmp_path: Path) -> None:
+        results = self._write(tmp_path / "ep", captured_prompt="CAPTURED")
+        [episode] = episodes_from_tau2_results(
+            results, teacher_model="k", task_id="airline/7", system_prompt="EXPLICIT"
+        )
+        assert episode.messages[0].content == "EXPLICIT"
+
+    def test_no_resolvable_prompt_skips_the_episode(self, tmp_path: Path) -> None:
+        # Training on prompts missing the agent's policy would teach a task the
+        # student never faces at serving time, so the episode is dropped.
+        results = self._write(tmp_path / "ep", policy=None)
+        assert episodes_from_tau2_results(results, teacher_model="k", task_id="airline/7") == []
+
+    def test_ungraded_simulations_are_not_training_material(self, tmp_path: Path) -> None:
+        infra = self._write(
+            tmp_path / "a", reward=None, termination="infrastructure_error", captured_prompt="P"
+        )
+        assert episodes_from_tau2_results(infra, teacher_model="k", task_id="airline/7") == []
+
+    def test_a_failed_episode_is_kept_but_marked(self, tmp_path: Path) -> None:
+        results = self._write(tmp_path / "ep", reward=0.0, captured_prompt="P")
+        [episode] = episodes_from_tau2_results(results, teacher_model="k", task_id="airline/7")
+        assert episode.passed is False
+        assert episode.reward == 0.0
+
+    def test_unreadable_results_are_actionable(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        with pytest.raises(ValueError, match="cannot read tau2 results"):
+            episodes_from_tau2_results(bad, teacher_model="k", task_id="airline/7")

--- a/wmo/distill/text_episodes.py
+++ b/wmo/distill/text_episodes.py
@@ -1,0 +1,329 @@
+"""Teacher episodes as TEXT to cross-entropy datums, for any provider.
+
+The on-policy path needs the student's own sampled token ids, so its teacher
+must live on Tinker (only `compute_logprobs` can score those exact tokens).
+Off-policy hard-target training needs none of that: the teacher's WORDS are
+the supervision, and the student learns them under its own chat template. That
+makes any provider a usable teacher, including ones that expose no logprobs at
+all (Fireworks, OpenRouter, Azure, or a recorded corpus with no live provider
+behind it).
+
+This module is that bridge, in one direction and one shape:
+
+    TeacherEpisode (text, provider-agnostic)
+        -> keep-filter
+        -> re-tokenize under the STUDENT's renderer
+        -> TrialRecord with synthetic spans
+        -> WarmupTrialsManifest
+
+The last step is the integration: the existing supervised phase already loads
+a manifest through `warmup.trajectories_from` and trains cross-entropy on it
+(`wmo.distill.loop._load_warmup_trials`), so a text corpus reaches training
+through the tested path rather than a parallel one. Nothing in the loop
+changes. When the first-class `[offpolicy]` mode lands (#268), this stays its
+text-input front end: it produces the same `TrialRecord`s that executor
+consumes.
+
+## One datum per TURN, deliberately (read this before reading a fragmentation rate)
+
+A sampled episode merges into one datum because each prompt extends the last
+verbatim. Re-encoded text does NOT, and the reason is worth stating exactly,
+because `build_datums` will report a ~90% fragmentation rate here and that
+number means something different than it does on the sampled path.
+
+Measured on a real Qwen3.5 transcript: a generation prompt ends
+`<|im_start|>assistant\\n<think>\\n` (the reasoning template PRIMES a thinking
+block), while the same turn rendered later as history is
+`<|im_start|>assistant\\nHi! ...` with no thinking block at all. The two token
+streams diverge by exactly those two primed tokens.
+
+So there are two possible constructions, and they trade different things:
+
+- **Per-turn prompts (what this module does).** Each turn trains under the
+  prompt shape the student will actually be given at serving time, primed
+  thinking block included, because that is what `build_generation_prompt`
+  emits for every real request. The cost is fragmentation: one datum per turn,
+  so shared context is prefilled once per turn instead of once per episode.
+- **Chained history prompts.** One datum per episode, but every turn boundary
+  after the first trains on a prompt WITHOUT the primed block the student is
+  always served. That is a train/serve mismatch bought with a cost saving.
+
+The first is correct, and it is also what ordinary multi-turn SFT does (one
+example per assistant turn). Cross-entropy has no teacher-scoring bill at all
+here, so the fragmentation costs student prefill only. Do not "fix" the
+fragmentation rate by chaining: on THIS path a high rate is expected, and on
+the sampled path it still means what it always meant.
+
+## Why the spans are honest about themselves
+
+A recorded transcript has token ids only after somebody tokenizes it, and the
+tokenizer that matters is the STUDENT's: training targets must be ids the
+student can emit. So each assistant turn is re-encoded with the student's
+renderer (`ChatRendering.render_assistant_turn`) under the prompt that
+preceded it, which is what makes the tokens trainable at all.
+
+What re-encoding cannot invent is logprobs. No sampler produced these tokens,
+so `TokenSpan.sampled_logprobs` carries zeros with
+`logprobs_are_placeholders=True`, and `attach_advantages` refuses any datum
+built from them. Cross-entropy never sends logprobs over the wire
+(`to_tinker_sft_datums` sends target_tokens and weights), so the supervised
+path is unaffected. That asymmetry is enforced in code, not documented and
+hoped for.
+
+## What the caller owns
+
+Provenance. `TeacherEpisode.teacher_model` and `.source` are recorded and flow
+into the manifest, because "distilled from X" is only claimable when X's
+transcripts actually trained the student, and a run dir has to be able to
+prove which teacher it consumed.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from typing import Protocol
+
+from llm_waterfall.types import ChatMessage, ChatTool
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from wmo.distill.store import WarmupTrialsManifest
+from wmo.distill.tokens import TrialRecord
+from wmo.harness.runtime import StopReason
+from wmo.providers.tinker import TokenSpan
+
+logger = logging.getLogger(__name__)
+
+PLACEHOLDER_LOGPROB = 0.0
+"""The stand-in logprob for a re-encoded token (never read by cross_entropy)."""
+
+
+class TurnRendering(Protocol):
+    """The two rendering operations turning teacher text into training targets.
+
+    Deliberately narrower than `wmo.distill.rendering.ChatRendering`: this
+    bridge never samples, decodes, or parses, so it asks for nothing it does
+    not use. `CookbookChatRendering` satisfies it structurally, which is how
+    `build_offline_rendering` (no Tinker client) plugs straight in.
+    """
+
+    def build_generation_prompt(
+        self, messages: list[ChatMessage], tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render messages (and tool schemas) into prompt token ids."""
+        ...
+
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        """Render an already-written assistant turn as its sampled-token equivalent."""
+        ...
+
+
+class TeacherEpisode(BaseModel):
+    """One teacher episode as provider-agnostic TEXT, plus its outcome.
+
+    The transcript is the whole conversation in OpenAI chat shape (system,
+    user, assistant, tool turns), exactly as any provider or benchmark harness
+    records it. Which turns become training targets is derived here: every
+    assistant turn, and nothing else.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str = Field(min_length=1)
+    """The benchmark task this episode ran, for provenance and per-task rows."""
+
+    attempt: int = Field(default=1, ge=1)
+    """1-based attempt index within the task (multiple rollouts per task)."""
+
+    messages: list[ChatMessage]
+    """The full recorded transcript, in order."""
+
+    tools: list[ChatTool] = Field(default_factory=list)
+    """Tool schemas the episode ran with; rendered into the prompt prefix."""
+
+    reward: float = Field(ge=0.0, le=1.0, allow_inf_nan=False)
+    """The verifier's reward for the episode (the benchmark's own scale)."""
+
+    passed: bool
+    """Whether the episode met the benchmark's success bar (the keep filter)."""
+
+    teacher_model: str = Field(min_length=1)
+    """The model that produced the assistant turns, e.g. 'kimi-k3'."""
+
+    source: str = Field(min_length=1)
+    """Where the transcript came from, e.g. 'fireworks' or 'tau2:results.json'."""
+
+    stop_reason: str | None = None
+    """The episode's recorded stop reason, mapped to wmo's taxonomy when known."""
+
+    @model_validator(mode="after")
+    def _check_has_assistant_turn(self) -> TeacherEpisode:
+        """Reject a transcript with nothing to learn from.
+
+        Returns:
+            This episode, when at least one assistant turn exists.
+
+        Raises:
+            ValueError: If no assistant turn is present, or the first message
+                is one (an assistant turn with no prompt before it has no
+                context to be trained against).
+        """
+        roles = [message.role for message in self.messages]
+        if "assistant" not in roles:
+            raise ValueError(
+                f"teacher episode {self.task_id!r} attempt {self.attempt} has no assistant "
+                "turn, so it carries no supervision; drop it before building datums"
+            )
+        if roles[0] == "assistant":
+            raise ValueError(
+                f"teacher episode {self.task_id!r} attempt {self.attempt} opens on an "
+                "assistant turn; a trainable turn needs the prompt that preceded it"
+            )
+        return self
+
+    @property
+    def trial_name(self) -> str:
+        """The record name this episode assembles under (filesystem-safe)."""
+        return f"{self.task_id.replace('/', '-')}-a{self.attempt:02d}"
+
+
+def episode_spans(episode: TeacherEpisode, rendering: TurnRendering) -> list[TokenSpan]:
+    """Re-encode one text episode's assistant turns as synthetic token spans.
+
+    Walks the transcript in order and, for every assistant turn, records the
+    prompt that preceded it plus that turn's own rendered tokens. Successive
+    spans therefore extend one another as verbatim prefixes, which is what
+    `build_datums` merges a whole episode into a single datum on.
+
+    Args:
+        episode: The text episode to re-encode.
+        rendering: The STUDENT's rendering (its tokenizer and chat template);
+            training targets must be ids the student can emit.
+
+    Returns:
+        One span per assistant turn, `call_index` contiguous from 0, each
+        flagged `logprobs_are_placeholders`.
+
+    Raises:
+        ValueError: If a turn renders to non-text chunks (see the rendering).
+    """
+    tools = episode.tools or None
+    spans: list[TokenSpan] = []
+    for index, message in enumerate(episode.messages):
+        if message.role != "assistant":
+            continue
+        prompt_ids = rendering.build_generation_prompt(episode.messages[:index], tools)
+        sampled_ids = rendering.render_assistant_turn(episode.messages, index, tools)
+        if not sampled_ids:
+            # An assistant turn that renders to nothing (empty content, no tool
+            # calls) would contribute a mask-1.0-free fragment the datum builder
+            # skips anyway; dropping it here keeps call_index contiguous.
+            logger.debug("skipping empty assistant turn %d of %s", index, episode.trial_name)
+            continue
+        spans.append(
+            TokenSpan(
+                call_index=len(spans),
+                prompt_token_ids=prompt_ids,
+                sampled_token_ids=sampled_ids,
+                sampled_logprobs=[PLACEHOLDER_LOGPROB] * len(sampled_ids),
+                logprobs_are_placeholders=True,
+                tools=list(episode.tools),
+            )
+        )
+    return spans
+
+
+def episodes_to_trial_records(
+    episodes: Iterable[TeacherEpisode], rendering: TurnRendering
+) -> list[TrialRecord]:
+    """Re-encode text episodes into the records the training path consumes.
+
+    Args:
+        episodes: The text episodes, in the order they should train.
+        rendering: The STUDENT's rendering.
+
+    Returns:
+        One `TrialRecord` per episode, in input order. An episode whose turns
+        all render empty yields a record with no spans, which the datum builder
+        skips and the batch stats count as `empty_span_trials` (never silently
+        dropped, so the keep-filter denominator stays honest).
+    """
+    records: list[TrialRecord] = []
+    for episode in episodes:
+        spans = episode_spans(episode, rendering)
+        records.append(
+            TrialRecord(
+                task_id=episode.task_id,
+                attempt=episode.attempt,
+                trial_name=episode.trial_name,
+                reward=episode.reward,
+                passed=episode.passed,
+                spans=spans,
+                stop_reason=episode.stop_reason,
+                infra_failed=False,
+                tests=None,
+                # No disk artifact: these episodes came from text, not a runner.
+                # Nothing downstream reads this on the training path.
+                artifact_dir="",
+            )
+        )
+    return records
+
+
+def text_warmup_manifest(
+    episodes: Sequence[TeacherEpisode], rendering: TurnRendering, *, teacher_model: str
+) -> WarmupTrialsManifest:
+    """Assemble text episodes into a manifest the supervised phase can load.
+
+    The manifest is what `warmup.trajectories_from` reads, and the loading run
+    checks `teacher_model` against its own `teacher.checkpoint or
+    teacher.model` string, so the value passed here must be exactly what that
+    run's config names. Every episode must agree with it: a manifest mixing
+    teachers cannot support a "distilled from X" claim.
+
+    Args:
+        episodes: The text episodes (unfiltered; the loading run applies
+            `warmup.keep`, matching the collect path's own contract).
+        rendering: The STUDENT's rendering.
+        teacher_model: The teacher identity to record.
+
+    Returns:
+        The manifest, ready for `DistillRunStore.write_warmup_trials`.
+
+    Raises:
+        ValueError: If `episodes` is empty or any episode names a different
+            teacher.
+    """
+    if not episodes:
+        raise ValueError("cannot build a warmup manifest from zero teacher episodes")
+    mismatched = sorted({e.teacher_model for e in episodes} - {teacher_model})
+    if mismatched:
+        raise ValueError(
+            f"episodes name teacher(s) {mismatched} but the manifest records "
+            f"{teacher_model!r}; a manifest mixing teachers cannot support a "
+            "'distilled from X' claim, so split the corpus per teacher"
+        )
+    return WarmupTrialsManifest(
+        teacher_model=teacher_model,
+        records=episodes_to_trial_records(episodes, rendering),
+    )
+
+
+TAU2_TERMINATION_STOP_REASONS = {
+    "user_stop": StopReason.SUBMITTED.value,
+    "agent_stop": StopReason.SUBMITTED.value,
+    "max_steps": StopReason.MAX_TURNS.value,
+    "timeout": StopReason.BUDGET.value,
+    "too_many_errors": StopReason.UNPARSED_TOOL_CALL.value,
+    "agent_error": StopReason.ERROR.value,
+    "user_error": StopReason.ERROR.value,
+    "unexpected_error": StopReason.ERROR.value,
+}
+"""tau2 termination reasons mapped onto wmo's stop-reason taxonomy.
+
+Deliberately omits `infrastructure_error` (no verifier evidence, so such an
+episode is not training material) and `context_window_exceeded` (the datum
+builder's own overflow drop keys on its stop reason; see
+`wmo.distill.tau2`)."""

--- a/wmo/distill/text_episodes_test.py
+++ b/wmo/distill/text_episodes_test.py
@@ -1,0 +1,225 @@
+"""Tests for the teacher-text to cross-entropy bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from llm_waterfall.types import ChatFunctionCall, ChatMessage, ChatTool, ChatToolCall
+from llm_waterfall.types import ChatFunctionDefinition as FunctionDef
+
+from wmo.distill.config import DistillConfig
+from wmo.distill.data import attach_advantages, build_datums
+from wmo.distill.store import DistillRunStore
+from wmo.distill.text_episodes import (
+    TeacherEpisode,
+    episode_spans,
+    episodes_to_trial_records,
+    text_warmup_manifest,
+)
+
+
+class _StubRendering:
+    """A deterministic stand-in: one token per character, headers as sentinels.
+
+    Mirrors the shape that matters (a prompt ending in a generation header, a
+    turn rendering to its own output tokens) without a real tokenizer.
+    """
+
+    def build_generation_prompt(
+        self, messages: list[ChatMessage], tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        text = "|".join(f"{m.role}:{m.content or ''}" for m in messages)
+        prefix = "T|" if tools else ""
+        return [ord(c) for c in f"{prefix}{text}|assistant>"]
+
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        message = messages[index]
+        if not (message.content or message.tool_calls):
+            return []
+        content = message.content
+        rendered = content if isinstance(content, str) else ""
+        for call in message.tool_calls or []:
+            rendered = f"{rendered}<{call.function.name}>"
+        return [ord(c) for c in rendered]
+
+
+def _cfg() -> DistillConfig:
+    return DistillConfig.model_validate(
+        {
+            "student": {"base_model": "Qwen/Qwen3.5-9B"},
+            "teacher": {"model": "Qwen/Qwen3.6-27B"},
+            "tau2": {"tau2_bin": "/x/tau2", "data_dir": "/x/data"},
+            "train": {"steps": 0},
+            "warmup": {"steps": 1},
+        }
+    )
+
+
+def _episode(**overrides: object) -> TeacherEpisode:
+    base = {
+        "task_id": "airline/7",
+        "messages": [
+            ChatMessage(role="system", content="policy"),
+            ChatMessage(role="user", content="hello"),
+            ChatMessage(role="assistant", content="hi there"),
+            ChatMessage(role="user", content="do it"),
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatToolCall(
+                        id="c1", function=ChatFunctionCall(name="book", arguments='{"id": "7"}')
+                    )
+                ],
+            ),
+            ChatMessage(role="tool", content="ok", tool_call_id="c1"),
+            ChatMessage(role="assistant", content="done"),
+        ],
+        "reward": 1.0,
+        "passed": True,
+        "teacher_model": "kimi-k3",
+        "source": "fireworks",
+    }
+    return TeacherEpisode.model_validate(base | overrides)
+
+
+class TestEpisodeValidation:
+    def test_transcript_without_an_assistant_turn_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="no assistant turn"):
+            _episode(
+                messages=[
+                    ChatMessage(role="system", content="p"),
+                    ChatMessage(role="user", content="u"),
+                ]
+            )
+
+    def test_transcript_opening_on_an_assistant_turn_is_rejected(self) -> None:
+        # Real tau2 transcripts DO open on the agent's greeting; the reader must
+        # supply the system prompt, and this is the check that forces it to.
+        with pytest.raises(ValueError, match="opens on an assistant turn"):
+            _episode(messages=[ChatMessage(role="assistant", content="hi")])
+
+    def test_trial_name_is_filesystem_safe(self) -> None:
+        assert _episode().trial_name == "airline-7-a01"
+
+
+class TestSpans:
+    def test_one_span_per_assistant_turn_with_placeholder_logprobs(self) -> None:
+        spans = episode_spans(_episode(), _StubRendering())
+        assert len(spans) == 3
+        assert [s.call_index for s in spans] == [0, 1, 2]
+        for span in spans:
+            assert span.logprobs_are_placeholders is True
+            assert len(span.sampled_logprobs) == len(span.sampled_token_ids)
+            assert set(span.sampled_logprobs) == {0.0}
+
+    def test_tool_call_turns_are_trained_on(self) -> None:
+        spans = episode_spans(_episode(), _StubRendering())
+        rendered = "".join(chr(c) for c in spans[1].sampled_token_ids)
+        assert rendered == "<book>", "a turn whose whole output is a tool call must train"
+
+    def test_empty_assistant_turns_are_skipped_and_indices_stay_contiguous(self) -> None:
+        episode = _episode(
+            messages=[
+                ChatMessage(role="system", content="p"),
+                ChatMessage(role="user", content="u"),
+                ChatMessage(role="assistant", content=""),
+                ChatMessage(role="user", content="u2"),
+                ChatMessage(role="assistant", content="real"),
+            ]
+        )
+        spans = episode_spans(episode, _StubRendering())
+        assert [s.call_index for s in spans] == [0]
+
+
+class TestRecordsAndDatums:
+    def test_records_carry_outcome_and_need_no_disk(self) -> None:
+        [record] = episodes_to_trial_records([_episode()], _StubRendering())
+        assert record.task_id == "airline/7"
+        assert record.passed is True
+        assert record.infra_failed is False
+        assert record.artifact_dir == ""
+        assert len(record.spans) == 3
+
+    def test_datums_are_hard_target_only_and_train_the_turns(self) -> None:
+        records = episodes_to_trial_records([_episode()], _StubRendering())
+        datums, _stats = build_datums(records, _cfg())
+        assert datums, "the episode must yield trainable datums"
+        assert all(d.hard_targets_only for d in datums)
+        assert all(sum(d.loss_mask) > 0 for d in datums), "every datum needs loss tokens"
+
+    def test_the_advantage_path_refuses_text_derived_datums(self) -> None:
+        # The guard that makes the whole bridge safe: placeholder logprobs must
+        # never become a reverse-KL baseline.
+        records = episodes_to_trial_records([_episode()], _StubRendering())
+        datums, _ = build_datums(records, _cfg())
+        teacher_logprobs = [[None] * len(d.model_input_tokens) for d in datums]
+        with pytest.raises(ValueError, match="placeholder logprobs"):
+            attach_advantages(datums, teacher_logprobs, _cfg())
+
+
+class TestManifest:
+    def test_manifest_records_the_teacher_and_every_episode(self) -> None:
+        episodes = [_episode(), _episode(attempt=2)]
+        manifest = text_warmup_manifest(episodes, _StubRendering(), teacher_model="kimi-k3")
+        assert manifest.teacher_model == "kimi-k3"
+        assert [r.trial_name for r in manifest.records] == ["airline-7-a01", "airline-7-a02"]
+
+    def test_a_mixed_teacher_corpus_is_rejected(self) -> None:
+        episodes = [_episode(), _episode(attempt=2, teacher_model="Qwen/Qwen3.6-27B")]
+        with pytest.raises(ValueError, match="mixing teachers"):
+            text_warmup_manifest(episodes, _StubRendering(), teacher_model="kimi-k3")
+
+    def test_an_empty_corpus_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="zero teacher episodes"):
+            text_warmup_manifest([], _StubRendering(), teacher_model="kimi-k3")
+
+    def test_manifest_round_trips_through_the_run_store(self, tmp_path: Path) -> None:
+        store = DistillRunStore(tmp_path)
+        manifest = text_warmup_manifest([_episode()], _StubRendering(), teacher_model="kimi-k3")
+        store.write_warmup_trials(manifest)
+        loaded = store.read_warmup_trials()
+        assert loaded is not None
+        assert loaded.teacher_model == "kimi-k3"
+        assert loaded.records[0].spans[0].logprobs_are_placeholders is True
+
+
+class TestRealRenderer:
+    """The property that decides whether this bridge produces trainable data."""
+
+    def test_real_qwen_rendering_produces_loss_bearing_turns(self) -> None:
+        pytest.importorskip("tinker_cookbook")
+        from wmo.distill.rendering import build_offline_rendering
+
+        try:
+            rendering = build_offline_rendering("Qwen/Qwen3.5-9B")
+        except OSError:
+            pytest.skip("the Qwen3.5 tokenizer is not cached locally")
+        episode = _episode(
+            tools=[
+                ChatTool(
+                    function=FunctionDef(
+                        name="book",
+                        parameters={"type": "object", "properties": {"id": {"type": "string"}}},
+                    )
+                )
+            ]
+        )
+        spans = episode_spans(episode, rendering)
+        assert len(spans) == 3
+        for span in spans:
+            assert span.sampled_token_ids, "every kept turn must render to tokens"
+            assert span.prompt_token_ids
+        # The prompt of a later turn extends the earlier prompt (the shared
+        # system/user prefix), even though the primed thinking block means it
+        # does not extend prompt+sampled (see the module docstring).
+        assert (
+            spans[1].prompt_token_ids[: len(spans[0].prompt_token_ids) - 4]
+            == (spans[0].prompt_token_ids[: len(spans[0].prompt_token_ids) - 4])
+        )
+        datums, _ = build_datums(episodes_to_trial_records([episode], rendering), _cfg())
+        assert datums
+        assert all(d.hard_targets_only for d in datums)

--- a/wmo/providers/tinker.py
+++ b/wmo/providers/tinker.py
@@ -323,6 +323,22 @@ class TokenSpan(BaseModel):
     sampled_logprobs: list[float]
     """Sampler-assigned logprob for each sampled token, aligned one to one."""
 
+    logprobs_are_placeholders: bool = False
+    """True when `sampled_logprobs` are stand-ins, not sampler-issued values.
+
+    Set only by the text bridge (`wmo.distill.text_episodes`), which re-encodes
+    a teacher's recorded TEXT under the student's template: the token ids are
+    real training targets but no sampler ever scored them, so there are no
+    logprobs to record and the field carries zeros to satisfy alignment.
+
+    Hard-target cross_entropy is the only sound consumer (its wire format sends
+    target_tokens and weights, never logprobs). The advantage losses
+    (`importance_sampling`, `ppo`) compute a teacher-minus-student gap FROM
+    these values, so training on placeholders would optimize a fabricated
+    objective; `wmo.distill.data.attach_advantages` refuses such spans rather
+    than trusting callers to remember. Default False, so every recorded sink
+    and every previously written manifest loads unchanged."""
+
     delta_start: int | None = None
     """Index into this call's full message list at which `delta_messages`
     begins, i.e. the exact boundary the prompt tokens were built at:

--- a/wmo/providers/tinker_test.py
+++ b/wmo/providers/tinker_test.py
@@ -91,6 +91,13 @@ class _MiniRendering:
         lines.append("assistant:")
         return self._tok.encode("\n".join(lines))
 
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        del tools
+        content = messages[index].content
+        return self._tok.encode(content if isinstance(content, str) else "")
+
     def render_suffix(
         self,
         messages: list[ChatMessage],
@@ -367,6 +374,14 @@ class _FramedRendering(_MiniRendering):
             prefix = "<tools>" + ",".join(tool.function.name for tool in tools) + "</>"
         body = "".join(self._segment(message) for message in messages)
         return self._tok.encode(prefix + body + "<assistant>")
+
+    def render_assistant_turn(
+        self, messages: list[ChatMessage], index: int, tools: list[ChatTool] | None = None
+    ) -> list[int]:
+        del tools
+        content = messages[index].content
+        text = content if isinstance(content, str) else ""
+        return self._tok.encode(f"{text}</>")
 
     def render_suffix(
         self,


### PR DESCRIPTION
## What

Standing infrastructure for off-policy distillation from **any** teacher, including ones with no logprob surface at all (Fireworks, OpenRouter, Azure, or a recorded corpus with no live provider behind it). This is the tier-1 deliverable of the training lane's round-3 brief, and the prerequisite for the Kimi K3 teacher leg.

`wmo/distill/text_episodes.py` takes provider-neutral `TeacherEpisode`s (text), re-encodes each assistant turn under the **student's** renderer, and emits a `WarmupTrialsManifest`. That last step is the integration: the supervised phase already loads a manifest through `warmup.trajectories_from`, so a text corpus trains through the tested path with **zero loop changes**. When #268's first-class `[offpolicy]` executor lands, this stays its text-input front end (it produces the same `TrialRecord`s).

Supporting pieces: `ChatRendering.render_assistant_turn` (the inverse of sampling), `build_offline_rendering` (a renderer with no Tinker client, HF tokenizer only), and `episodes_from_tau2_results` (recorded tau2 transcripts back out as episodes).

## Three things the measurements forced

1. **Placeholder logprobs are structurally quarantined.** Re-encoded text has no sampler logprobs. Cross-entropy never sends them (`target_tokens` + `weights` only), but the advantage losses derive `teacher_lp - sampled_lp` *from* them, so training text-derived datums on `importance_sampling`/`ppo` would optimize a fabricated baseline. `TokenSpan.logprobs_are_placeholders` -> `TrainDatum.hard_targets_only` -> `attach_advantages` **refuses** them. Enforced in code, not documented and hoped for.
2. **One datum per TURN, not per episode.** Measured on a real Qwen3.5 transcript: a generation prompt ends `<|im_start|>assistant\n<think>\n` (the template primes thinking) while the same turn rendered as history has no think block, so the streams diverge by exactly those two tokens. Per-turn prompts match the shape the student is actually served; chaining would buy one datum per episode at the price of a train/serve mismatch. The ~92% fragmentation rate on this path is therefore **expected**, and the module docstring says so loudly so nobody "fixes" it.
3. **Real tau2 transcripts carry no system message.** Only the domain policy, in a separate field. Training on prompts missing 7.7k chars of policy would teach a task the student never faces at serving time. The proxy now captures each episode's **exact** system prompt at rollout time; the reader prefers it, falls back to the recorded policy (wrapped in tau2's own framing, honestly labeled a reconstruction), and **skips** the episode when neither exists.

## Verified

- Unit: 14 new bridge tests + 8 tau2-reader tests, including the real-Qwen offline renderer case and the guard rejecting the advantage path.
- Live, cheap: 122 recorded Qwen3.6-27B tau2 episodes convert, 1488 per-turn datums build with zero overflow drops, and a **live Qwen3.5-9B rank-32 LoRA accepted an 8-datum batch** (21,025 tokens / 244 loss tokens) through the real cross_entropy wire format (`loss:sum` 320.8, clean `optim_step`). Cents.
- Gates: ruff and ty clean; `wmo/distill/` + `wmo/providers/` 1095 passed.

## Justification ledger

- `text_episodes.py` + tests: consumer is the K3 teacher leg (cycle 2, gated on cycle 1's verdict) and the canonical end-to-end pipeline, which must be able to take any strong teacher's transcripts and produce a student cycle without new engineering.
- `render_assistant_turn` on the rendering seam: the one primitive text-to-datums needs; the protocol grew, so the two in-tree test fakes were extended to conform (no behavior change).
- `logprobs_are_placeholders` / `hard_targets_only` / the `attach_advantages` refusal: the safety property that makes the whole path sound. Additive with `False` defaults, so every recorded sink and prior manifest loads unchanged.
- System-prompt capture in the proxy: fidelity for off-policy replay of our own runs; best-effort, and a capture failure can never cost an episode.
- `TurnRendering` protocol (narrower than `ChatRendering`): the bridge never samples, decodes, or parses, so it asks for nothing it does not use.
- Non-removals: nothing became redundant; `[warmup]` stays as-is and this feeds it.
- Seam note for #268/#258 owners: `TokenSpan` and `TrainDatum` each gained one additive boolean, and `attach_advantages` gained a refusal. Coordinated via DECISIONS.md.

## How Silen tests

From the worktree, no money:

    uv run pytest wmo/distill/text_episodes_test.py -q

With a live Tinker key, cents (needs recorded transcripts; cycle 1's warmup dir is the corpus):

    uv run python .agents/distill/text_bridge_smoke.py \
      --episodes-root <run>/warmup-rollouts/tau2/step-0000 \
      --teacher-model Qwen/Qwen3.6-27B --max-datums 8