### PR TITLE
Activate the compaction stage in `wmo optimize model`, and let it choose its embedder

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -15,7 +15,7 @@ the name and the same six commands apply.
 | 2 | `wmo providers set --pool-model ...` | `.wmo/pool.toml`, the routing candidate roster |
 | 3 | `wmo optimize model tau-bench` | `optimize/matrix.json`, `policy.json` + bank, `optimize/report.json` |
 | 4 (optional) | `wmo optimize distill run --config run.toml` | a run dir, a gate verdict, an adapter |
-| 5 (optional) | `wmo optimize route sweep --compressor ...` | per-arm matrices, a policy stamped with its fit geometry |
+| 5 (optional) | `wmo optimize model --compressor ...` (or the `route sweep`/`route fit` pair) | per-arm matrices, a policy stamped with its fit geometry |
 | 6 | `wmo serve --name tau-bench` | a live endpoint, plus its savings and dial routes |
 
 ## How to read the numbers in this walk
@@ -461,6 +461,10 @@ uv run wmo optimize route fit matrix-c04.json --kind knn \
   --compressor llmlingua2-endpoint --aggressiveness 0.4 \
   --out .wmo/models/tau-bench/policy.json
 ```
+
+`wmo optimize model tau-bench --compressor llmlingua2-endpoint --aggressiveness 0.4` runs that same
+pair end to end (the arm configures its sweep and its fit, and the compact row in the plan table
+names it), which is the one-command way to measure an arm once you know which one you want.
 
 One sweep per arm, one matrix per arm. `--aggressiveness` is a dial in `[0, 1]` where 0.0 is a
 no-op and higher never removes less, but it is not an exact removal fraction: the achieved ratio

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ Run `wmo <command> --help` for the full option list; each one documents its own 
 |---|---|---|
 | `wmo build` | Ingest traces and build a named world model: normalize, split, index, optimize prompts, write. | `.wmo/models/<name>/` (`config.toml`, `card.json`, `index/`, `prompts/`, `metrics.json`) |
 | `wmo providers set` | Choose the local worker model, and register the models the router may choose between. | `.wmo/settings.toml` (worker role) and `.wmo/pool.toml` (candidate roster) |
-| `wmo optimize model` | The staged one-command routing workflow: preflight, sweep, fit, tune, report, with one plan table and one confirmation. `--dry-run` previews the plan and spends nothing; a non-interactive spending run needs `--yes`; `--max-usd` caps. | `policy.json` + `policy.json.bank.npz` in the model dir; `matrix.json`, `report.json`, `optimize-run.json` under `<model>/optimize/` |
+| `wmo optimize model` | The staged one-command routing workflow: preflight, sweep, fit, tune, report, with one plan table and one confirmation. `--dry-run` previews the plan and spends nothing; a non-interactive spending run needs `--yes`; `--max-usd` caps. `--compressor`/`--aggressiveness` measure and fit a compressed arm end to end; `--embedder` picks what the policy routes on. | `policy.json` + `policy.json.bank.npz` in the model dir; `matrix.json`, `report.json`, `optimize-run.json` under `<model>/optimize/` |
 | `wmo serve` | Run the local backend: the OpenAI-compatible endpoint plus the world-model step API. | a live server (`/v1/chat/completions`, `/v1/endpoints/<name>/config`, `/v1/endpoints/<name>/savings`) |
 
 ## The optimizers

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -7,14 +7,20 @@ manual command calls (`wmo.optimize.sweep`, `knn.fit_knn_artifact`, `knn.tune_po
 `report.build_report`), so consent, metering, and artifacts stay single-sourced and a user can
 drop to any manual command mid-flow. The only artifact format this command adds is its manifest.
 
-Not in this build: the `--distill` stage (train a student, gate it, add it to the pool, re-sweep)
-and the compaction slot reserved between sweep and fit. Both are named in
-`wmo.optimize.pipeline.STAGE_ORDER` so their arrival is additive; passing `--distill` today is a
-usage error that names the manual command instead.
+`--compressor` activates the compaction slot between sweep and fit. It is not a paid step of its
+own: it configures the sweep (which then measures that D-COMPRESS arm) and the fit (which embeds
+its bank through the compressor, the representation-consistency rule), so the plan table shows it
+as a row that spends nothing while the compressor's own per-call bill lands folded into the sweep's
+candidate spend.
+
+Not in this build: the `--distill` stage (train a student, gate it, add it to the pool, re-sweep).
+It is named in `wmo.optimize.pipeline.STAGE_ORDER` so its arrival is additive; passing `--distill`
+today is a usage error that names the manual command instead.
 """
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -40,7 +46,11 @@ from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.closed_loop import scenario_id
-from wmo.optimize.compression import compression_signature
+from wmo.optimize.compression import (
+    CompressionConfig,
+    compression_signature,
+    resolve_compression,
+)
 from wmo.optimize.knn import (
     COST_QUALITY_BALANCED,
     DEFAULT_KNN_MIN_PAIRS,
@@ -54,6 +64,7 @@ from wmo.optimize.knn import (
 from wmo.optimize.outcomes import OutcomeMatrix, load_matrix_with_digest
 from wmo.optimize.pipeline import (
     BUILT_STAGES,
+    CONFIGURED_STAGES,
     MANIFEST_DIRNAME,
     MANIFEST_FILENAME,
     MATRIX_FILENAME,
@@ -71,14 +82,19 @@ from wmo.optimize.pipeline import (
     file_sha256,
     forced_stages,
     load_manifest,
+    planned_stages,
     project_sweep_spend,
 )
 from wmo.optimize.policy import (
+    AZURE_EMBEDDER_DEPLOYMENT,
+    AZURE_EMBEDDER_ENV,
     DEFAULT_KNN_Z,
     POLICY_FILENAME,
     EmbedderSpec,
     RoutingPolicy,
     embedder_provenance,
+    probe_embedder,
+    resolve_embedder,
 )
 from wmo.optimize.report import ImprovementReport, build_report
 from wmo.optimize.sweep import (
@@ -163,6 +179,31 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         "--baseline",
         help="Compare the final numbers against this pool model instead of the fallback.",
     ),
+    compressor: str = typer.Option(
+        None,
+        "--compressor",
+        help="Compress every request through this compressor before routing it (identity | "
+        "truncate | llmlingua2-endpoint). The sweep then measures that arm and the fit embeds "
+        "its bank through the same compressor, so the endpoint serves what was measured. "
+        "Default: no compression.",
+    ),
+    aggressiveness: float = typer.Option(
+        0.0,
+        "--aggressiveness",
+        min=0.0,
+        max=1.0,
+        help="Compressor-defined dial in [0, 1] for --compressor: 0.0 is a no-op and higher never "
+        "removes less, but it is not an exact removal fraction (the achieved ratio is measured per "
+        "episode).",
+    ),
+    embedder: str = typer.Option(
+        "auto",
+        "--embedder",
+        help="What the fitted policy routes on: auto | hashing | azure. `auto` uses "
+        "text-embedding-3-large when AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT are set "
+        "(semantic features, billed to that resource) and hashing-512 otherwise; the resolution "
+        "is always printed.",
+    ),
     distill: str = typer.Option(
         None,
         "--distill",
@@ -217,6 +258,11 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         wmo optimize model support --force-from sweep   # buy fresh cells anyway
         wmo optimize model support --yes --max-usd 25   # scripted, with a hard spend cap
 
+    `--compressor` measures and fits a compressed arm end to end, which is the same thing a
+    `route sweep --compressor` plus `route fit --compressor` pair does by hand:
+
+        wmo optimize model support --compressor llmlingua2-endpoint --aggressiveness 0.4
+
     Artifacts land exactly where the manual commands put them, so you can drop to any of them
     mid-flow and this command resumes around it: `policy.json` (plus its evidence bank) in the
     model's own directory where `wmo serve` reads it, and the outcome matrix, report, and run
@@ -230,7 +276,23 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             "`wmo optimize route student <run-dir> --input-per-mtok ... --output-per-mtok ...` "
             "to put the student in the pool, then re-run this command without --distill."
         )
-    redo = _parse_force_from(force_from)
+    if compressor is None and aggressiveness > 0.0:
+        raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
+    compression: CompressionConfig | None = None
+    if compressor is not None:
+        try:
+            # Resolved at PLAN time, before the table: an unknown id, or an implementation that
+            # could never be mounted, is a usage error. Discovering it after the sweep this arm
+            # configured has been paid for would be discovering it too late to matter.
+            compression = resolve_compression(compressor, aggressiveness)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+    try:
+        embedder_spec, resolution = _resolve_embedder_choice(embedder)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    redo = _parse_force_from(force_from, compacting=compression is not None)
+    stages = planned_stages(compacting=compression is not None)
     store = WorldModelStore(root)
     try:
         model_dir = store.resolve(world_model)
@@ -273,6 +335,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             max_steps=max_steps,
             assume_input_tokens=ASSUMED_INPUT_TOKENS,
             assume_output_tokens=ASSUMED_OUTPUT_TOKENS,
+            compression=compression,
         )
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -287,17 +350,22 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
                 f"anchor on a candidate the sweep measures. Available: {', '.join(known)}"
             )
 
-    embedder = EmbedderSpec()
+    # Printed before the plan table, the way `route fit` prints it before the fit: the embedder
+    # decides what the policy can route on, and an operator who meant to fit on semantic vectors
+    # should see that it resolved to hashed features before authorizing any spend.
+    _console.print(resolution)
     # The world-model side of a sweep is not projectable from arithmetic, but once this model has
     # been swept once its OWN measured ratio is, and it is far too big to leave out of a cap
     # (7.0x the candidate side on a real tau corpus).
     projection = project_sweep_spend(plan.total_usd, manifest.record_for(Stage.SWEEP))
     decisions = _plan_stages(
+        stages,
         manifest=manifest,
         paths=paths,
         plan=plan,
         pool_file=Path(pool_file),
-        embedder=embedder,
+        embedder=embedder_spec,
+        compression=compression,
         fallback=fallback,
         baseline=baseline,
         cost_quality=cost_quality,
@@ -314,7 +382,8 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         cost_quality=cost_quality,
         fallback=fallback,
         anchor=_report_anchor(paths.policy, baseline=baseline, fallback=fallback),
-        embedder=embedder,
+        embedder=embedder_spec,
+        compression=compression,
         projection=projection,
         paths=paths,
     )
@@ -324,6 +393,17 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     if dry_run:
         _console.print("\ndry run: nothing was run and nothing was spent")
         raise typer.Exit(0)
+
+    # One throwaway embedding before anything is bought, and only when a fit will actually happen:
+    # `--embedder auto` turns the mere presence of AZURE_OPENAI_* into a network dependency, and
+    # those variables routinely point at a resource that serves chat but hosts no embedding
+    # deployment. Without this the failure lands after the sweep has been paid for. After the dry
+    # run exits, because a dry run promises to reach nothing.
+    if any(decision.stage is Stage.FIT and decision.will_run for decision in decisions):
+        try:
+            probe_embedder(embedder_spec)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
 
     # Seeded from every dollar this model's optimization has already spent, both sides:
     # --max-usd bounds the optimization, not one invocation of it (see `SpendLedger`).
@@ -350,7 +430,8 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             projection=projection,
             model_dir=model_dir,
             pool_file=Path(pool_file),
-            embedder=embedder,
+            embedder=embedder_spec,
+            compression=compression,
             fallback=fallback,
             baseline=baseline,
             cost_quality=cost_quality,
@@ -375,7 +456,39 @@ class _RunPaths(BaseModel):
     report: Path
 
 
-def _parse_force_from(force_from: str | None) -> frozenset[Stage]:
+def _resolve_embedder_choice(choice: str) -> tuple[EmbedderSpec, str]:
+    """`--embedder` as the spec to fit with, plus the one line explaining the choice.
+
+    The resolution itself is `wmo.optimize.policy.resolve_embedder`, shared with
+    `wmo optimize route fit` so the two commands cannot disagree about what `auto` means. What is
+    decided here is the narrower surface: this command takes no `--deployment`, `--endpoint`, or
+    `--dim`, because its whole promise is one command with no routing knobs in it. So `azure` reads
+    the same standard environment pair `auto` looks for rather than flags that do not exist, and
+    the operator who needs to name a specific deployment is pointed at the manual fit that has
+    those flags.
+
+    Raises:
+        ValueError: An unknown choice, or `azure` with nothing in the environment to point it at.
+    """
+    endpoint = os.environ.get(AZURE_EMBEDDER_ENV[1])
+    if choice == "azure" and not endpoint:
+        raise ValueError(
+            f"--embedder azure needs {' and '.join(AZURE_EMBEDDER_ENV)} in the environment: this "
+            "command resolves the azure deployment from that standard pair rather than taking "
+            "--deployment/--endpoint flags. Export them, or fit by hand with `wmo optimize route "
+            "fit <matrix.json> --kind knn --embedder azure --deployment <name> --endpoint <url>`."
+        )
+    explicit_azure = choice == "azure"
+    return resolve_embedder(
+        choice,
+        dim=None,
+        deployment=AZURE_EMBEDDER_DEPLOYMENT if explicit_azure else None,
+        endpoint=endpoint if explicit_azure else None,
+        api_key_env=AZURE_EMBEDDER_ENV[0] if explicit_azure else None,
+    )
+
+
+def _parse_force_from(force_from: str | None, *, compacting: bool) -> frozenset[Stage]:
     """`--force-from` as the set of stages it invalidates, or a usage error naming the choices."""
     if force_from is None:
         return frozenset()
@@ -387,6 +500,20 @@ def _parse_force_from(force_from: str | None) -> frozenset[Stage]:
             f"unknown stage '{force_from}' for --force-from; use "
             f"{' | '.join(item.value for item in redoable)}"
         ) from exc
+    if stage in CONFIGURED_STAGES:
+        # Forcing a configuration is a category error, whether or not it is active on this run:
+        # the compaction stage does no work to redo. What changes its outcome is the arm itself,
+        # and changing that already re-measures the sweep (the arm is in its fingerprint).
+        instead = (
+            "Change --compressor/--aggressiveness to measure a different arm"
+            if compacting
+            else "This run named no compressor for it to configure anything with"
+        )
+        raise typer.BadParameter(
+            f"stage '{stage.value}' configures the sweep and the fit rather than running on its "
+            f"own, so there is nothing to force. {instead}, or force one of "
+            f"{' | '.join(item.value for item in redoable)}"
+        )
     if stage in RESERVED_STAGES:
         raise typer.BadParameter(
             f"stage '{stage.value}' is a reserved slot that this build does not run, so there is "
@@ -401,12 +528,14 @@ def _parse_force_from(force_from: str | None) -> frozenset[Stage]:
 
 
 def _plan_stages(
+    stages: tuple[Stage, ...],
     *,
     manifest: RunManifest,
     paths: _RunPaths,
     plan: SweepPlan,
     pool_file: Path,
     embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
     fallback: str | None,
     baseline: str | None,
     cost_quality: float,
@@ -420,13 +549,19 @@ def _plan_stages(
     about to replace, so any verdict taken now would describe a state that no longer exists by the
     time the stage is reached. Saying "sweep reruns first" is both true and what the plan table
     then honors.
+
+    COMPACT is the exception, decided on its own fingerprint however dirty the run above it is. Its
+    only input is the arm the operator named, which no other stage writes, so borrowing the "runs
+    after sweep, which will change its input" line for it would print something false. It still
+    dirties what follows: the fit embeds its bank through the compressor, so a changed arm is a
+    changed fit.
     """
     decisions: list[StageDecision] = []
     running: Stage | None = None
-    for stage in BUILT_STAGES:
+    for stage in stages:
         if stage is Stage.PREFLIGHT:
             continue
-        if running is not None:
+        if running is not None and stage not in CONFIGURED_STAGES:
             decisions.append(
                 StageDecision(
                     stage=stage,
@@ -441,6 +576,7 @@ def _plan_stages(
             plan=plan,
             pool_file=pool_file,
             embedder=embedder,
+            compression=compression,
             fallback=fallback,
             baseline=baseline,
             cost_quality=cost_quality,
@@ -462,14 +598,65 @@ def _plan_stages(
 
 
 class _StageInputs(BaseModel):
-    """What one stage consumes and produces right now: everything `decide_stage` compares."""
+    """What one stage consumes and produces right now: everything `decide_stage` compares.
+
+    `artifact` is None for a stage that writes no file (compaction configures the two stages
+    around it), which leaves its fingerprint the whole of its verdict.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     fingerprint: dict[str, str]
-    artifact: Path
-    artifact_identity: str
+    artifact: Path | None = None
+    artifact_identity: str | None = None
     skip_summary: str
+
+
+def _compact_fingerprint(compression: CompressionConfig | None) -> dict[str, str]:
+    """The arm the compaction stage configured, rendered once for both the plan and the record.
+
+    Deliberately the same string `compression_signature` puts in the SWEEP fingerprint, and
+    deliberately recorded twice: the sweep's copy is the one that forces cells to be re-measured
+    when the arm moves, since that is what makes its rewards mean something different. This copy
+    only decides whether the compact ROW reads as run or skipped, and sharing the rendering is what
+    keeps the two from ever describing different arms.
+    """
+    return {"compression": compression_signature(compression)}
+
+
+def _fit_fingerprint(
+    *,
+    matrix: Path,
+    embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
+    fallback: str | None,
+    allow_uneven: bool,
+) -> dict[str, str]:
+    """Everything that decides what the fit produces, for both the plan and the record.
+
+    One function so the planned and recorded fingerprints cannot drift, which matters most for the
+    conditional key: `compression` is present only when a compressor is named. Adding it
+    unconditionally would refit every model whose manifest predates the flag in order to record a
+    value meaning "no compression", which is exactly what the key's absence already says. Both
+    directions still rerun the fit, since an added key and a removed one are each a difference.
+    """
+    fingerprint = {
+        "matrix": file_sha256(matrix),
+        "kind": "knn",
+        "fallback": fallback or "auto",
+        "knobs": _KNN_KNOBS,
+        "embedder": embedder_provenance(embedder),
+        # Whether the operator accepted biased evidence is part of what produced this fit. Without
+        # it here, consent given once would stick silently: a later run WITHOUT the flag would skip
+        # the fit, never reach the coverage gate, and leave a policy fitted on knowingly-uneven
+        # evidence with nothing saying so.
+        "allow_uneven": str(allow_uneven),
+    }
+    if compression is not None:
+        # The fit embeds its bank through the compressor and stamps the arm on the policy, so the
+        # arm is an input to the fit in its own right, not only through the matrix it reads.
+        fingerprint["compression"] = compression_signature(compression)
+    return fingerprint
 
 
 def _live_inputs(
@@ -479,6 +666,7 @@ def _live_inputs(
     plan: SweepPlan,
     pool_file: Path,
     embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
     fallback: str | None,
     baseline: str | None,
     cost_quality: float,
@@ -494,30 +682,29 @@ def _live_inputs(
                     "episodes": str(plan.episodes),
                     "max_steps": str(plan.max_steps),
                     # A matrix's rewards belong to ONE D-COMPRESS arm, so a changed compressor
-                    # means different evidence and the cells have to be bought again. The
-                    # orchestrator exposes no compression flag yet, so this reads "raw text"
-                    # today; recording it now means the reserved COMPACT stage cannot arrive
-                    # and silently reuse a matrix measured under a different arm.
+                    # means different evidence and the cells have to be bought again. This is the
+                    # fingerprint that makes `--compressor` re-measure rather than reuse cells
+                    # that ran under a different arm.
                     "compression": compression_signature(plan.compression),
                 },
                 artifact=paths.matrix,
                 artifact_identity=file_sha256(paths.matrix),
                 skip_summary="same pool, same scenarios, same episodes",
             )
+        case Stage.COMPACT:
+            return _StageInputs(
+                fingerprint=_compact_fingerprint(compression),
+                skip_summary="same compressor, same aggressiveness",
+            )
         case Stage.FIT:
             return _StageInputs(
-                fingerprint={
-                    "matrix": file_sha256(paths.matrix),
-                    "kind": "knn",
-                    "fallback": fallback or "auto",
-                    "knobs": _KNN_KNOBS,
-                    "embedder": embedder_provenance(embedder),
-                    # Whether the operator accepted biased evidence is part of what produced this
-                    # fit. Without it here, consent given once would stick silently: a later run
-                    # WITHOUT the flag would skip the fit, never reach the coverage gate, and
-                    # leave a policy fitted on knowingly-uneven evidence with nothing saying so.
-                    "allow_uneven": str(allow_uneven),
-                },
+                fingerprint=_fit_fingerprint(
+                    matrix=paths.matrix,
+                    embedder=embedder,
+                    compression=compression,
+                    fallback=fallback,
+                    allow_uneven=allow_uneven,
+                ),
                 artifact=paths.policy,
                 artifact_identity=_policy_fit_identity(paths.policy),
                 skip_summary="same matrix, same knn knobs",
@@ -590,7 +777,13 @@ def _policy_fit_identity(policy_path: Path) -> str:
 
 
 def _stage_plan_text(
-    stage: Stage, *, plan: SweepPlan, cost_quality: float, fallback: str | None, anchor: str
+    stage: Stage,
+    *,
+    plan: SweepPlan,
+    compression: CompressionConfig | None,
+    cost_quality: float,
+    fallback: str | None,
+    anchor: str,
 ) -> str:
     """One line saying what this stage will actually do, in the operator's terms."""
     match stage:
@@ -601,6 +794,9 @@ def _stage_plan_text(
                 f"{len(plan.pool.models)} candidate(s) x {len(plan.scenarios)} scenario(s) "
                 f"x {plan.episodes} episode(s)"
             )
+        case Stage.COMPACT:
+            # Says what it IS rather than implying a step: the arm plus the two stages it sets up.
+            return f"{escape(compression_signature(compression))}, configures sweep and fit"
         case Stage.FIT:
             return f"knn (guarded, fallback {escape(fallback or 'best single on the sweep')})"
         case Stage.TUNE:
@@ -640,6 +836,7 @@ def _print_plan(
     fallback: str | None,
     anchor: str,
     embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
     projection: SweepSpendProjection,
     paths: _RunPaths,
 ) -> None:
@@ -662,6 +859,7 @@ def _print_plan(
         _stage_plan_text(
             Stage.PREFLIGHT,
             plan=plan,
+            compression=compression,
             cost_quality=cost_quality,
             fallback=fallback,
             anchor=anchor,
@@ -675,6 +873,7 @@ def _print_plan(
             _stage_plan_text(
                 decision.stage,
                 plan=plan,
+                compression=compression,
                 cost_quality=cost_quality,
                 fallback=fallback,
                 anchor=anchor,
@@ -761,6 +960,12 @@ def _estimate_text(
     match stage:
         case Stage.SWEEP:
             return f"~${plan.total_usd:.2f}"
+        case Stage.COMPACT:
+            # Not free and not its own line: the compressor bills per call, and every one of those
+            # calls happens inside the sweep, so its cost arrives folded into the sweep's measured
+            # candidate spend (the D-COMPRESS accounting rule). Saying "free" here would promise
+            # the operator a compressor that costs nothing.
+            return "included in sweep"
         case Stage.REPORT:
             return _report_estimate(paths.policy, embedder)
         case _:
@@ -828,6 +1033,7 @@ def _run_stages(
     model_dir: Path,
     pool_file: Path,
     embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
     fallback: str | None,
     baseline: str | None,
     cost_quality: float,
@@ -855,11 +1061,14 @@ def _run_stages(
                 ledger.check(Stage.SWEEP, projection.total_usd, basis=projection.basis)
                 record = _stage_sweep(plan, model_dir=model_dir, pool_file=pool_file)
                 ledger.record(record.total_spend_usd)
+            case Stage.COMPACT:
+                record = _stage_compact(compression)
             case Stage.FIT:
                 _enforce_coverage(paths.matrix, allow_uneven=allow_uneven_coverage)
                 record = _stage_fit(
                     paths,
                     embedder=embedder,
+                    compression=compression,
                     fallback=fallback,
                     allow_uneven=allow_uneven_coverage,
                 )
@@ -926,6 +1135,35 @@ def _stage_sweep(plan: SweepPlan, *, model_dir: Path, pool_file: Path) -> StageR
     return record
 
 
+def _stage_compact(compression: CompressionConfig | None) -> StageRecord:
+    """Record the D-COMPRESS arm this run configured into the sweep and the fit.
+
+    The compaction slot as it actually turned out. The design reserved it as a step between sweep
+    and fit, and the seam that landed made it a configuration instead: one arm, applied by the sweep
+    to every candidate call it measures and by the fit to every text it embeds into the bank. So
+    this stage runs nothing and buys nothing, and it writes no artifact of its own. What it does own
+    is the record that the arm was applied, which is what lets a later run say the compact row is
+    current instead of silently assuming it.
+
+    The compressor's own per-call bill is real and is NOT lost by having no line here: it is
+    metered inside the sweep and reported as the compressor's share of that stage's candidate
+    spend (`StageRecord.compressor_spend_usd`).
+    """
+    signature = compression_signature(compression)
+    _console.print(
+        f"  [green]✓[/green] configured {escape(signature)}\n"
+        "  no separate step and no separate bill: this arm is what the sweep measures every "
+        "candidate through and what the fit embeds its bank through, so the endpoint routes on "
+        "the representation it will serve",
+        soft_wrap=True,
+    )
+    return StageRecord(
+        stage=Stage.COMPACT,
+        fingerprint=_compact_fingerprint(compression),
+        completed_at=_now(),
+    )
+
+
 def _enforce_coverage(matrix_path: Path, *, allow_uneven: bool) -> None:
     """Show what the fit would be weighed on, and withhold it when that is not a comparison.
 
@@ -963,9 +1201,22 @@ def _enforce_coverage(matrix_path: Path, *, allow_uneven: bool) -> None:
 
 
 def _stage_fit(
-    paths: _RunPaths, *, embedder: EmbedderSpec, fallback: str | None, allow_uneven: bool
+    paths: _RunPaths,
+    *,
+    embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
+    fallback: str | None,
+    allow_uneven: bool,
 ) -> StageRecord:
-    """Fit the guarded kNN policy on the swept matrix, into the path `wmo serve` reads."""
+    """Fit the guarded kNN policy on the swept matrix, into the path `wmo serve` reads.
+
+    `compression` is the compaction stage's arm, and passing it here is the fit half of
+    representation consistency: `fit_knn_artifact` embeds the bank through the compressor and stamps
+    both `compression` and `fit_compression` on the policy, which is what the mount gate re-checks.
+    The arm cannot disagree with the one the matrix was measured under, because the same flag
+    configured the sweep and the sweep re-measures whenever it moves (the arm is in its
+    fingerprint).
+    """
     matrix, source = load_matrix_with_digest(paths.matrix)
     try:
         fitted = fit_knn_artifact(
@@ -974,6 +1225,7 @@ def _stage_fit(
             matrix_source=source,
             embedder=embedder,
             fallback=fallback,
+            compression=compression,
         )
     except ValueError as exc:
         # Nothing is wrong with the flags: the matrix this run measured cannot be fitted. Exit 1
@@ -991,14 +1243,13 @@ def _stage_fit(
     )
     return StageRecord(
         stage=Stage.FIT,
-        fingerprint={
-            "matrix": file_sha256(paths.matrix),
-            "kind": "knn",
-            "fallback": fallback or "auto",
-            "knobs": _KNN_KNOBS,
-            "embedder": embedder_provenance(embedder),
-            "allow_uneven": str(allow_uneven),
-        },
+        fingerprint=_fit_fingerprint(
+            matrix=paths.matrix,
+            embedder=embedder,
+            compression=compression,
+            fallback=fallback,
+            allow_uneven=allow_uneven,
+        ),
         artifact_path=str(paths.policy),
         artifact_identity=fit_provenance(fitted.policy),
         completed_at=_now(),

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -24,6 +24,7 @@ from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
 from wmo.engine.world_model import WorldModel
 from wmo.ingest.otel_writer import write_traces_jsonl
+from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import OutcomeMatrix
 from wmo.optimize.pipeline import (
     MANIFEST_FILENAME,
@@ -32,7 +33,13 @@ from wmo.optimize.pipeline import (
     RunManifest,
     Stage,
 )
-from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy
+from wmo.optimize.policy import (
+    AZURE_EMBEDDER_DEPLOYMENT,
+    AZURE_EMBEDDER_ENV,
+    POLICY_FILENAME,
+    EmbedderSpec,
+    RoutingPolicy,
+)
 from wmo.optimize.report import ImprovementReport
 from wmo.optimize.reward import EpisodeScore
 from wmo.providers.base import (
@@ -82,6 +89,19 @@ def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
     an assertion about where the wrap landed. Width is presentation, not behavior.
     """
     monkeypatch.setattr(optimize_module, "_console", Console(width=240))
+
+
+@pytest.fixture(autouse=True)
+def _no_azure_embedder_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset the pair `--embedder auto` looks for, so these runs never reach a real resource.
+
+    Without this the suite's behavior depends on the developer's shell: a machine with
+    `AZURE_OPENAI_*` exported would resolve auto to text-embedding-3-large and fit against a
+    billed embedding API, which is exactly the spend these tests promise not to make. The
+    env-present branch is tested by setting them deliberately, on the pure resolver.
+    """
+    for name in AZURE_EMBEDDER_ENV:
+        monkeypatch.delenv(name, raising=False)
 
 
 def _corpus(count: int = 30) -> list[Trace]:
@@ -485,10 +505,27 @@ def test_force_from_a_reserved_stage_says_it_is_not_built(
 ) -> None:
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
-    result = _run(tmp_path, root, "--yes", "--force-from", "compact")
+    result = _run(tmp_path, root, "--yes", "--force-from", "distill")
     assert result.exit_code != 0
     flat = _flat(result.output)
     assert "reservedslot" in flat and "sweep|fit|tune|report" in flat
+
+
+def test_force_from_compact_says_it_configures_rather_than_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compaction is a configuration, so there is no work to redo: refuse either way it is asked."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    off = _run(tmp_path, root, "--yes", "--force-from", "compact")
+    assert off.exit_code != 0
+    assert _says(off.output, "named no compressor for it to configure anything with")
+    assert _says(off.output, "force one of sweep | fit | tune | report")
+
+    on = _run(tmp_path, root, "--yes", "--force-from", "compact", "--compressor", "truncate")
+    assert on.exit_code != 0
+    assert _says(on.output, "configures the sweep and the fit rather than running on its own")
+    assert _says(on.output, "Change --compressor/--aggressiveness to measure a different arm")
 
 
 def test_force_from_an_unknown_stage_lists_the_real_ones(
@@ -1116,3 +1153,289 @@ def test_dry_run_prints_the_plan_and_spends_nothing(
     matrix_path, manifest_path = _paths(root)[0], _paths(root)[1]
     assert not matrix_path.exists()
     assert not manifest_path.exists()  # a dry run leaves no resume state behind
+
+
+# ------------------------------------------------------- the compaction stage and the embedder
+
+_ARM = ("--compressor", "truncate", "--aggressiveness", "0.3")
+"""A local, free, append-stable compressor at a dial that actually removes words."""
+
+_ARM_LINE = "compressor 'truncate' version 1 at aggressiveness 0.3"
+
+
+def _stage_rows(output: str) -> list[str]:
+    """The plan table's stage column, in order: which stages the run advertised."""
+    flat = _flat(output)
+    return [stage for stage in (item.value for item in Stage) if stage in flat]
+
+
+def test_a_compressed_run_shows_the_compact_row_and_charges_it_to_the_sweep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compaction is represented honestly: an arm, the two stages it configures, no second bill."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", *_ARM)
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, f"{_ARM_LINE}, configures sweep and fit")
+    assert _says(result.output, "included in sweep")
+    # The compact row sits between sweep and fit, as STAGE_ORDER promised.
+    assert (
+        _stage_rows(result.output).index("compact") == _stage_rows(result.output).index("sweep") + 1
+    )
+    # The candidate projection is now an over-estimate AND misses the compressor: both said.
+    assert _says(result.output, "that candidate figure is an OVER-estimate")
+
+    _, _, _, manifest_path = _paths(root)
+    manifest = RunManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+    assert [record.stage.value for record in manifest.stages] == [
+        "sweep",
+        "compact",
+        "fit",
+        "tune",
+        "report",
+    ]
+    compact = manifest.record_for(Stage.COMPACT)
+    assert compact is not None
+    # No artifact of its own, no bill of its own: the arm's fingerprint is the whole record.
+    assert compact.artifact_path is None
+    assert compact.spend_usd == 0.0 and compact.world_model_spend_usd == 0.0
+    assert compact.fingerprint == {"compression": _ARM_LINE}
+
+
+def test_a_compressed_run_fits_the_policy_in_the_geometry_it_will_serve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Representation consistency end to end: the served arm and the fitted arm are stamped equal.
+
+    This is what the mount gate re-checks, and why the orchestrator cannot fit a compressed
+    endpoint on a raw bank: one flag configures the sweep and the fit, so both halves agree by
+    construction rather than by the operator remembering to pass it twice.
+    """
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes", *_ARM).exit_code == 0
+
+    policy = RoutingPolicy.load(_paths(root)[1])
+    assert policy.fit_compression is not None
+    assert policy.compression is not None
+    assert policy.fit_compression.compressor_id == "truncate"
+    assert policy.fit_compression.aggressiveness == pytest.approx(0.3)
+    assert policy.fit_compression.compressor_version == "1"
+    assert policy.compression == policy.fit_compression
+    # The matrix's episodes really ran that arm, which is what the fit is allowed to stamp.
+    measured = OutcomeMatrix.load(_paths(root)[0]).measured_compression()
+    assert measured is not None and measured == policy.fit_compression
+
+
+def test_the_uncompressed_plan_table_is_untouched_by_the_new_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control: without --compressor this is byte-for-byte the command it was before.
+
+    Same stage rows, same projected spend string, no compact row advertising a stage with nothing
+    to do, and no compression key in the fit's fingerprint (its absence is what says "raw", so
+    adding one would re-fit every model whose manifest predates the flag).
+    """
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--dry-run")
+    assert result.exit_code == 0, result.output
+    assert _stage_rows(result.output) == ["preflight", "sweep", "fit", "tune", "report"]
+    assert "compact" not in _flat(result.output)
+    assert "includedinsweep" not in _flat(result.output)
+    assert "~$0.33" in _flat(result.output)  # the same projection as before this change
+    assert "OVER-estimate" not in result.output
+
+    assert _run(tmp_path, root, "--yes").exit_code == 0
+    manifest = RunManifest.model_validate_json(_paths(root)[3].read_text(encoding="utf-8"))
+    fit = manifest.record_for(Stage.FIT)
+    assert fit is not None and "compression" not in fit.fingerprint
+    assert RoutingPolicy.load(_paths(root)[1]).fit_compression is None
+
+
+def test_an_unchanged_arm_skips_the_whole_run_compaction_included(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes", *_ARM).exit_code == 0
+    again = _run(tmp_path, root, "--yes", *_ARM)
+    assert again.exit_code == 0, again.output
+    # Nothing runs at all, so the whole verdict is the plan table's: compaction reads as done
+    # rather than as a stage that quietly did nothing.
+    assert _says(again.output, "SKIP (already done: same compressor, same aggressiveness)")
+    assert _says(again.output, "matrix.json is current")
+    assert _says(again.output, "policy.json is current")
+    assert _says(again.output, "every stage is current")
+
+
+def test_moving_the_dial_re_measures_the_arm_and_refits_on_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A different aggressiveness is different evidence, so the cells are bought again."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes", *_ARM).exit_code == 0
+    moved = _run(tmp_path, root, "--yes", "--compressor", "truncate", "--aggressiveness", "0.6")
+    assert moved.exit_code == 0, moved.output
+    assert _says(moved.output, "compression changed")
+    # The fit is dirtied BY the compaction row, not by the sweep above it: the arm it embeds
+    # through is what changed, and the reason printed says which stage owns that.
+    assert _says(moved.output, "runs after compact, which will change its input")
+    assert RoutingPolicy.load(_paths(root)[1]).fit_compression is not None
+    assert (
+        OutcomeMatrix.load(_paths(root)[0]).measured_compression()
+        == RoutingPolicy.load(_paths(root)[1]).fit_compression
+    )
+
+
+def test_dropping_the_compressor_re_measures_the_raw_arm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Turning compression off is a change of arm like any other, in the other direction."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes", *_ARM).exit_code == 0
+    raw = _run(tmp_path, root, "--yes")
+    assert raw.exit_code == 0, raw.output
+    assert _says(raw.output, "compression changed")
+    assert "compact" not in _flat(raw.output)  # the row is gone with the flag
+    policy = RoutingPolicy.load(_paths(root)[1])
+    assert policy.fit_compression is None and policy.compression is None
+    manifest = RunManifest.model_validate_json(_paths(root)[3].read_text(encoding="utf-8"))
+    # The compact record from the compressed run is stale, and the fit no longer claims an arm.
+    fit = manifest.record_for(Stage.FIT)
+    assert fit is not None and "compression" not in fit.fingerprint
+
+
+def test_an_unknown_compressor_is_refused_before_the_plan_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    world_model = _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", "--compressor", "gzip-but-for-prompts")
+    assert result.exit_code != 0
+    assert _says(result.output, "unknown compressor 'gzip-but-for-prompts'")
+    assert _says(result.output, "known compressors:")
+    assert not _says(result.output, "optimize model: support")  # no plan table was printed
+    assert world_model.tasks == [] and not _paths(root)[0].exists()
+
+
+def test_aggressiveness_without_a_compressor_says_what_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", "--aggressiveness", "0.4")
+    assert result.exit_code != 0
+    assert _says(result.output, "--aggressiveness needs --compressor to apply it")
+    assert not _paths(root)[0].exists()
+
+
+def test_the_embedder_resolution_is_printed_and_lands_in_the_fit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto with no azure resource resolves to hashing, says so, and quotes what that costs."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes")
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "embedder: hashing-512 (auto;")
+    assert _says(result.output, "AZURE_OPENAI_API_KEY")
+    assert _says(result.output, "measured +0.60pt")
+    manifest = RunManifest.model_validate_json(_paths(root)[3].read_text(encoding="utf-8"))
+    fit = manifest.record_for(Stage.FIT)
+    assert fit is not None and fit.fingerprint["embedder"] == "hashing-512"
+    assert RoutingPolicy.load(_paths(root)[1]).embedder.kind == "hashing"
+
+
+def test_an_explicit_hashing_embedder_is_the_same_fit_auto_already_produced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The fingerprint records the RESOLVED embedder, not the word the operator typed, so naming
+    # the backend auto had already chosen is not a refit.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes").exit_code == 0
+    again = _run(tmp_path, root, "--yes", "--embedder", "hashing")
+    assert again.exit_code == 0, again.output
+    assert _says(again.output, "embedder: hashing-512 (explicit)")
+    assert _says(again.output, "policy.json is current")
+
+
+def test_embedder_azure_without_the_env_pair_names_the_pair_and_the_manual_fit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """This command has no --deployment/--endpoint, so its refusal must not name them as the fix."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", "--embedder", "azure")
+    assert result.exit_code != 0
+    assert _says(result.output, "needs AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT")
+    assert _says(result.output, "wmo optimize route fit")
+    assert not _paths(root)[0].exists()
+
+
+def test_an_unknown_embedder_lists_the_real_ones(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", "--embedder", "word2vec")
+    assert result.exit_code != 0
+    assert _says(result.output, "unknown embedder 'word2vec'; use auto, hashing or azure")
+
+
+def test_auto_takes_the_semantic_embedder_when_the_resource_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of auto, on the pure resolver so no test ever bills an embedding API."""
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "k")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    spec, line = optimize_module._resolve_embedder_choice("auto")
+    assert spec.kind == "azure"
+    assert spec.deployment == AZURE_EMBEDDER_DEPLOYMENT
+    assert spec.dim == 3072  # the deployment's native width, not the hashing default
+    assert spec.endpoint == "https://example.openai.azure.com"
+    assert "auto; AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT present" in line
+    # Spend nobody typed a flag for is stated, because `auto` chose it.
+    assert "billed to that resource" in line
+
+    explicit, explicit_line = optimize_module._resolve_embedder_choice("azure")
+    assert explicit == spec  # same resource, same deployment, same width
+    assert "(explicit)" in explicit_line
+
+
+def test_the_fit_fingerprint_moves_with_the_embedder_and_with_the_arm(tmp_path: Path) -> None:
+    """What makes a resume re-fit: a different embedder or a different arm, each on its own."""
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text("{}", encoding="utf-8")
+
+    def fingerprint(
+        *, embedder: EmbedderSpec, compression: CompressionConfig | None
+    ) -> dict[str, str]:
+        return optimize_module._fit_fingerprint(
+            matrix=matrix,
+            embedder=embedder,
+            compression=compression,
+            fallback=None,
+            allow_uneven=False,
+        )
+
+    hashing = fingerprint(embedder=EmbedderSpec(), compression=None)
+    azure = fingerprint(
+        embedder=EmbedderSpec(
+            kind="azure", dim=3072, deployment="text-embedding-3-large", endpoint="https://r/"
+        ),
+        compression=None,
+    )
+    assert hashing["embedder"] != azure["embedder"]
+    assert "compression" not in hashing  # absence is how raw is spelled
+
+    arm = CompressionConfig(compressor_id="truncate", aggressiveness=0.3)
+    keener = CompressionConfig(compressor_id="truncate", aggressiveness=0.6)
+    assert fingerprint(embedder=EmbedderSpec(), compression=arm) != hashing
+    assert fingerprint(embedder=EmbedderSpec(), compression=arm) != fingerprint(
+        embedder=EmbedderSpec(), compression=keener
+    )

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -42,11 +42,9 @@ from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compression import (
     CompressingEmbedder,
-    CompressionConfig,
     compression_signature,
-    get_compressor,
+    resolve_compression,
     same_compression,
-    servable_compressor,
 )
 from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
@@ -102,26 +100,6 @@ _console = Console()
 
 DEFAULT_MATRIX_FILENAME = "matrix.json"
 """Default `sweep --out`: the outcome matrix `fit` takes as its argument."""
-
-
-def _compression_for(compressor: str, aggressiveness: float) -> CompressionConfig:
-    """The compression config `--compressor` names, stamped with the version that will RUN.
-
-    The version is read off the resolved implementation rather than defaulted, because that is
-    what the field means: the version this config was fitted against. Defaulting it to "1" made
-    every fit against a version-bumped compressor stamp a lie, which the mount gate would then
-    correctly refuse with a remedy the CLI has no flag to carry out.
-
-    Raises (naming the compressor) when the id is unknown or the implementation is not servable.
-    """
-    resolved = get_compressor(compressor)
-    config = CompressionConfig(
-        compressor_id=compressor,
-        compressor_version=resolved.version,
-        aggressiveness=aggressiveness,
-    )
-    servable_compressor(config)
-    return config
 
 
 @route_app.command("sweep")
@@ -272,7 +250,7 @@ def sweep(
         try:
             # Checked before a single episode is paid for, and against the SERVING rule: there
             # is no point measuring an arm whose compressor could never be mounted.
-            sweep_compression = _compression_for(compressor, aggressiveness)
+            sweep_compression = resolve_compression(compressor, aggressiveness)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     store = WorldModelStore(root)
@@ -908,7 +886,7 @@ def fit(
         try:
             # Fail before the fit spends anything: model_copy below skips validators, and an
             # unservable compressor would otherwise only surface when serving mounts the result.
-            compression = _compression_for(compressor, aggressiveness)
+            compression = resolve_compression(compressor, aggressiveness)
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
     # The rewards in this matrix were produced under SOME compression config, and a joint fit is

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -395,6 +395,31 @@ def servable_compressor(config: CompressionConfig | None) -> Compressor | None:
     return compressor
 
 
+def resolve_compression(compressor_id: str, aggressiveness: float) -> CompressionConfig:
+    """The config a `--compressor` flag names, stamped with the version that will actually RUN.
+
+    Every command that turns a compressor id into a config comes through here (`route sweep`,
+    `route fit`, `optimize model`), because two things have to happen that the config's own shape
+    does not do. The version is read off the resolved implementation rather than defaulted, since
+    that is what the field means: the version this config was fitted against. Defaulting it to "1"
+    made every fit against a version-bumped compressor stamp a lie, which the mount gate would
+    then correctly refuse with a remedy no CLI has a flag to carry out. And the result is checked
+    against the v1 serving rule right here, so an arm that could never be mounted fails at the
+    boundary instead of after a sweep has been paid for.
+
+    Raises:
+        ValueError: The id is unknown, or the implementation cannot be served, naming which.
+    """
+    resolved = get_compressor(compressor_id)
+    config = CompressionConfig(
+        compressor_id=compressor_id,
+        compressor_version=resolved.version,
+        aggressiveness=aggressiveness,
+    )
+    servable_compressor(config)
+    return config
+
+
 def register_compressor_factory(compressor_id: str, factory: CompressorFactory) -> None:
     """Register a compressor to be CONSTRUCTED on first use, not at import.
 

--- a/wmo/optimize/pipeline.py
+++ b/wmo/optimize/pipeline.py
@@ -13,11 +13,16 @@ command would have put it, so deleting `optimize/` resets resume without breakin
 serving path, and dropping to a manual command mid-flow just changes a fingerprint the next run
 notices.
 
-Two stages are NAMED here and not implemented in this build: `DISTILL` (train a student, gate it,
-add it to the pool, re-sweep it) and `COMPACT` (the compaction slot reserved between sweep and
-fit, which activates when the representation-consistency seam lands). They sit in `STAGE_ORDER`
-now so their arrival is additive: ordering, force-from arithmetic, and downstream invalidation
-already account for them.
+`COMPACT` is the compaction slot between sweep and fit, and it is not a paid step of its own: with
+the representation-consistency seam landed, naming a compressor CONFIGURES the sweep (which
+measures that arm) and the fit (which embeds its bank through the compressor), so the stage's whole
+job is to hold the arm's fingerprint and say so in the plan table. It is therefore in a run's
+stages only when a compressor is named (`planned_stages`), and its cost is the compressor's share
+of the sweep's own bill, never a second line item.
+
+`DISTILL` is still NAMED here and not implemented (train a student, gate it, add it to the pool,
+re-sweep it). It sits in `STAGE_ORDER` now so its arrival is additive: ordering, force-from
+arithmetic, and downstream invalidation already account for it.
 """
 
 from __future__ import annotations
@@ -61,11 +66,31 @@ BUILT_STAGES: tuple[Stage, ...] = (
     Stage.TUNE,
     Stage.REPORT,
 )
-"""The stages this build actually runs; the rest are reserved slots (see the module docstring)."""
+"""The stages EVERY run walks. `COMPACT` joins them only when a compressor is named."""
+
+CONFIGURED_STAGES: tuple[Stage, ...] = (Stage.COMPACT,)
+"""Built, but absent from a run that did not ask for them (see `planned_stages`).
+
+A configured stage is one whose work is a choice the operator makes rather than a step the
+workflow always takes: `COMPACT` does nothing at all unless `--compressor` names an arm, and
+printing a row for it on every run would advertise a stage that has nothing to do.
+"""
 
 RESERVED_STAGES: tuple[Stage, ...] = tuple(
-    stage for stage in STAGE_ORDER if stage not in BUILT_STAGES
+    stage for stage in STAGE_ORDER if stage not in BUILT_STAGES and stage not in CONFIGURED_STAGES
 )
+"""Named in the ordering, not implemented: naming one is an error pointing at the real command."""
+
+
+def planned_stages(*, compacting: bool) -> tuple[Stage, ...]:
+    """Every stage this run walks, in `STAGE_ORDER`.
+
+    Args:
+        compacting: A compressor was named, so the compaction slot is part of this run.
+    """
+    active = set(BUILT_STAGES) | ({Stage.COMPACT} if compacting else set())
+    return tuple(stage for stage in STAGE_ORDER if stage in active)
+
 
 MANIFEST_DIRNAME = "optimize"
 """Where a run's own artifacts live, under the world model's dir."""

--- a/wmo/optimize/pipeline_test.py
+++ b/wmo/optimize/pipeline_test.py
@@ -8,6 +8,7 @@ import pytest
 
 from wmo.optimize.pipeline import (
     BUILT_STAGES,
+    CONFIGURED_STAGES,
     MANIFEST_VERSION,
     RESERVED_STAGES,
     STAGE_ORDER,
@@ -22,6 +23,7 @@ from wmo.optimize.pipeline import (
     file_sha256,
     forced_stages,
     load_manifest,
+    planned_stages,
     project_sweep_spend,
 )
 
@@ -222,15 +224,28 @@ def test_file_sha256_of_a_missing_file_is_empty(tmp_path: Path) -> None:
     assert file_sha256(tmp_path / "nope") == ""
 
 
-def test_the_reserved_slots_are_named_but_not_built() -> None:
-    """The distill and compaction stages exist in the ordering so their arrival is additive."""
-    assert set(RESERVED_STAGES) == {Stage.DISTILL, Stage.COMPACT}
+def test_the_reserved_slot_is_named_but_not_built() -> None:
+    """Distill exists in the ordering so its arrival is additive; compaction has arrived."""
+    assert set(RESERVED_STAGES) == {Stage.DISTILL}
     assert set(BUILT_STAGES).isdisjoint(RESERVED_STAGES)
-    assert set(BUILT_STAGES) | set(RESERVED_STAGES) == set(STAGE_ORDER)
+    assert set(BUILT_STAGES) | set(RESERVED_STAGES) | set(CONFIGURED_STAGES) == set(STAGE_ORDER)
     # Compaction sits between sweep and fit, distill after sweep: the slots the design reserved.
     order = list(STAGE_ORDER)
     assert order.index(Stage.SWEEP) < order.index(Stage.COMPACT) < order.index(Stage.FIT)
     assert order.index(Stage.SWEEP) < order.index(Stage.DISTILL)
+
+
+def test_compaction_is_in_a_run_only_when_a_compressor_is_named() -> None:
+    # The row would otherwise advertise a stage with nothing to do, on every uncompressed run.
+    assert planned_stages(compacting=False) == BUILT_STAGES
+    assert planned_stages(compacting=True) == (
+        Stage.PREFLIGHT,
+        Stage.SWEEP,
+        Stage.COMPACT,
+        Stage.FIT,
+        Stage.TUNE,
+        Stage.REPORT,
+    )
 
 
 def _sweep_record(*, candidate: float, world_model: float, compressor: float = 0.0) -> StageRecord:

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -27,6 +27,7 @@ from statistics import median, quantiles
 
 from pydantic import BaseModel, Field
 
+from wmo.optimize.compression import CompressingEmbedder
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import RoutingPolicy, select_model
 from wmo.providers.pool import Tier
@@ -174,6 +175,15 @@ def build_report(
     # One embedder for the whole report: an azure spec builds an HTTP client per `build()`, and
     # a report routes every held-out scenario.
     embedder = policy.embedder.build() if policy.kind != "static" else None
+    if embedder is not None and policy.compression is not None:
+        # Representation consistency, on the reporting side. A compressed endpoint's bank lives in
+        # the geometry of compressed text, and serving compresses each request before the router
+        # embeds it. Replaying the selection on RAW task text would therefore measure a policy
+        # nobody serves: every query lands farther from every bank row, the novelty floor trips,
+        # and the report would show routing collapsing to the fallback (C2 measured the floor
+        # tripping 10-13x more often under exactly this mismatch). So the replay embeds through the
+        # same compressor the fit did.
+        embedder = CompressingEmbedder(embedder, policy.compression)
 
     routed_rows: dict[str, list[ScenarioOutcome]] = {}
     baseline_rows: dict[str, list[ScenarioOutcome]] = {}

--- a/wmo/optimize/report_test.py
+++ b/wmo/optimize/report_test.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import pytest
 
+from wmo.optimize.compression import (
+    CompressionConfig,
+    CompressionResult,
+    estimate_tokens,
+    register_compressor,
+)
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import ClusterRanking, EmbedderSpec, RoutingPolicy
 from wmo.optimize.report import build_report
@@ -243,3 +249,64 @@ def test_latency_counts_every_call_when_replies_are_not_call_aligned() -> None:
         replies=["only one reply"],
     )
     assert _productive_call_seconds([outcome]) == [1.0, 2.0, 3.0]
+
+
+class _RecordingCompressor:
+    """Records every segment it is handed and returns it unchanged (a pass-through spy)."""
+
+    id = "report-test-recorder"
+    version = "1"
+    append_stable = True
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        del config
+        self.seen.extend(segments)
+        tokens = sum(estimate_tokens(segment) for segment in segments)
+        return CompressionResult(
+            segments=list(segments),
+            tokens_in_raw=tokens,
+            tokens_in_compressed=tokens,
+            latency_s=0.0,
+        )
+
+
+_RECORDER = _RecordingCompressor()
+register_compressor(_RECORDER)
+
+
+def test_a_compressed_policys_report_replays_in_the_geometry_it_was_fitted_in() -> None:
+    """The reporting half of representation consistency (C2's Q2 rule).
+
+    A compressed endpoint's bank lives in the geometry of compressed text, and serving compresses
+    each request before the router embeds it. A report that embedded RAW task text against that
+    bank would measure a policy nobody serves: the queries land farther from every row, the novelty
+    floor trips, and routing reads as collapsed to the fallback.
+    """
+    _RECORDER.seen.clear()
+    arm = CompressionConfig(compressor_id=_RecordingCompressor.id, aggressiveness=0.5)
+    policy = _cluster_policy().model_copy(update={"compression": arm, "fit_compression": arm})
+    report = build_report(
+        _matrix(),
+        policy,
+        baseline="fable-5",
+        endpoint="tau-bench",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    assert report.scenario_count == 2
+    # Every routed scenario's task text went through the compressor on its way to the embedder.
+    assert sorted(_RECORDER.seen) == sorted([_SQL_TASK, _PROSE_TASK])
+
+
+def test_an_uncompressed_policys_report_embeds_the_task_text_as_it_is() -> None:
+    _RECORDER.seen.clear()
+    build_report(
+        _matrix(),
+        _cluster_policy(),
+        baseline="fable-5",
+        endpoint="tau-bench",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+    assert _RECORDER.seen == []


### PR DESCRIPTION
Closes the two follow-ups `wmo optimize model` shipped with: the compaction slot reserved between sweep and fit, and the hardcoded `EmbedderSpec()` in its fit stage.

```bash
wmo optimize model tau-bench --compressor llmlingua2-endpoint --aggressiveness 0.4
wmo optimize model tau-bench --embedder auto          # the default; resolution always printed
```

## What the compaction stage turned out to be

The design reserved COMPACT as a paid step (compress-aware sweep + bank refit). The seam that landed in #265 made it something else: naming a compressor CONFIGURES the sweep (which measures that arm) and the fit (which embeds its bank through the compressor). So the stage runs nothing, buys nothing, and writes no artifact. It is represented that way rather than dressed up as work:

```
  stage        plan                                                             est. cost    status
  preflight    resolve 2 backend(s), check prices                                    free    ok
  sweep        2 candidate(s) x 3 scenario(s) x 1 episode(s)                       ~$0.33    will run (never completed here)
  compact      compressor 'truncate' version 1 at aggressiveness 0.3,   included in sweep    will run (never completed here)
               configures sweep and fit
  fit          knn (guarded, fallback best single on the sweep)                      free    will run (runs after compact, ...)
```

`included in sweep`, not `free`: the compressor bills per call and every one of those calls happens inside the sweep, so its cost arrives folded into that stage's measured candidate spend (the D-COMPRESS accounting rule, `StageRecord.compressor_spend_usd`). Calling it free would promise a compressor that costs nothing.

The row exists only when a compressor is named (`planned_stages(compacting=...)`), so an uncompressed run does not advertise a stage with nothing to do.

## Resume, and how it composes with what #265 already recorded

- The arm is in the SWEEP fingerprint (it already was: a matrix's rewards belong to one arm, so a changed compressor means the cells are bought again). That is the fingerprint that forces re-measurement.
- The compact stage records the SAME `compression_signature` string, through one shared renderer, so the two can never describe different arms. Its own copy decides only whether the compact row reads as run or skipped.
- The FIT fingerprint gains a `compression` key **only when a compressor is named**. Absence is how raw is spelled, so adding it unconditionally would refit every model whose manifest predates the flag to record a value meaning "no compression". Both directions still rerun (an added key and a removed key are each a difference).
- The compact row is decided on its own fingerprint however dirty the run above it is: its only input is the arm the operator named, which no other stage writes, so borrowing "runs after sweep, which will change its input" would print something false. It still dirties the fit below it, and the fit's reason then names compact.
- `--force-from compact` is refused with what to do instead. A configuration has no work to redo; changing the arm already re-measures the sweep.

## `--embedder auto | hashing | azure`

Replaces the hardcoded hashing-512, reusing the pure `resolve_embedder` that #298 put beside `EmbedderSpec` so this command and `route fit` cannot disagree about what `auto` means. The resolution always prints. The RESOLVED spec (not the word typed) is what lands in the fit fingerprint, so naming the backend auto already chose is not a refit. `azure` reads the standard `AZURE_OPENAI_*` pair rather than `--deployment`/`--endpoint` flags this command deliberately does not have, and its refusal names the manual fit that does. The embedder is probed once before any spend and only when a fit will run, after the dry-run exit so a dry run still reaches nothing.

## A correctness fix this exposed

`build_report` replays the policy's selection over each held-out scenario's task text, and for a compressed policy it was embedding RAW text against a bank fitted on compressed text. That is exactly the mismatch C2 measured: the novelty floor trips 10-13x more often and routing reads as collapsed to the fallback, so the closing numbers would understate a policy nobody serves. Pre-existing in `route report`, but this PR makes it run automatically after every compressed fit, so it is fixed here (wrap the report's one embedder, same rule `fit_knn_artifact` applies to the bank). Pinned with a spy compressor: a compressed policy's report routes through it, an uncompressed one never touches it, and the test fails without the fix.

## Justification ledger

- **The cookbook's one-command story** (`docs/cookbook/tau-bench.md` step 5): it documented the `route sweep --compressor` + `route fit --compressor` pair as the only compressed path. That stays true and stays the way to walk a grid of arms; one sentence now names the end-to-end equivalent.
- **The compaction lane's green-light contract** (DECISIONS.md 2026-07-27, "compaction green light ACK"): the reserved slot activates additively once the representation-consistency seam lands. It did, and this is the activation: no new artifact format, no second way to set the same arm.
- **The `--embedder` follow-up owner note from #298's PR body**: #298 put the resolution logic in `wmo/optimize/policy.py` explicitly because a second command would fit a policy. This is that command.
- **`resolve_compression`** (first commit): `route sweep`, `route fit`, and now `optimize model` all turn an id into a stamped, servable config. The version stamp and the servable check are library concerns, so they moved out of `route_app`'s private helper to sit beside the registry they read. No behavior change.

## What was verified by driving

`--dry-run` driven for real in a terminal on both paths against a stubbed project (free, no LLM calls): the uncompressed table is unchanged row for row and still projects `~$0.33`; the compressed table renders the compact row above, plus the "on a compressed arm that candidate figure is an OVER-estimate" caveat. Also drove the three boundary errors (unknown compressor, `--embedder azure` with no env pair, `--force-from compact`) and read each message. The full compressed run (sweep -> compact -> fit -> tune -> report) was driven through the stubbed CLI test harness and its output read end to end.

## Gates

`uv run ruff check .` clean · `ruff format --check` clean (537 files) · `uv run ty check` clean · `uv run pytest -q`: **4149 passed, 19 skipped** (includes `wmo/cli`, `wmo/optimize`, and the layout/docs tests).

Zero LLM spend: every new test stubs the world model and every pool candidate, and an autouse fixture unsets `AZURE_OPENAI_*` so `--embedder auto` can never reach a billed embedding API from the suite.

This PR has not been merged. `/ready-for-merge` still owes it a run.
