### PR TITLE
Warmup gets its own learning rate, and a warmup-only run gets a degeneration reading

### DIFF
--- a/.agents/distill/k3_headroom_probe.py
+++ b/.agents/distill/k3_headroom_probe.py
@@ -1,0 +1,187 @@
+"""Measure a hosted model's own tau2 solve rate on TRAIN tasks, under the canonical pins.
+
+The question cycle 1 left: is there a teacher with real headroom over the
+Qwen3.5-9B student (71.7% on the holdout)? Cycle 1's teacher was a peer (73.3%),
+which is why warmup-only distillation had nothing to teach. This measures a
+candidate teacher's capability cheaply, before anyone pays for a training leg.
+
+TRAIN TASKS ONLY, deliberately. Measuring a candidate on the holdout and then
+deciding whether to train would select on the same data the gate reads, which
+breaks the one-gate-read-per-cycle pre-registration. The train split answers
+the capability question just as well.
+
+No span recording: capability is a reward question, so the model is reached
+through tau2's own litellm route rather than the span-recording proxy. That
+also means this probe works for ANY hosted model, including ones with no
+logprob surface (which is the whole point of the text-bridge teacher path).
+
+    uv run python .agents/distill/k3_headroom_probe.py \
+        --model fireworks_ai/accounts/fireworks/models/kimi-k3 \
+        --tasks /tmp/k3-probe-tasks.json --label kimi-k3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s: %(message)s")
+logger = logging.getLogger("k3_headroom_probe")
+
+_TAU_ROOT = Path(__file__).resolve().parents[2] / "packages/environment-capture/tau-bench"
+_TAU2_BIN = _TAU_ROOT / ".venv/bin/tau2"
+_DATA_DIR = _TAU_ROOT / "tau2-bench/data"
+
+# The canonical real-tau2 protocol (adopted 2026-07-27). Changing any of these
+# makes a new capture cohort, so they are constants here, not flags.
+MAX_STEPS = 100
+EPISODE_TIMEOUT_S = 1800
+MAX_TOKENS = 8192
+TEMPERATURE = 1.0
+USER_SIM = "azure/gpt-5.4-mini"
+TASK_SPLIT_OVERRIDES = {"telecom": "full"}
+
+
+def run_episode(model: str, task_id: str, label: str, out_root: Path) -> dict[str, object]:
+    """Run one tau2 episode against a hosted model; return its graded row."""
+    domain, _, tau2_task = task_id.partition("/")
+    save_name = f"probe-{label}-{domain}-{tau2_task}".replace("/", "-")
+    episode_dir = out_root / save_name
+    episode_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(_TAU2_BIN),
+        "run",
+        "--domain",
+        domain,
+        *(
+            ["--task-split-name", TASK_SPLIT_OVERRIDES[domain]]
+            if domain in TASK_SPLIT_OVERRIDES
+            else []
+        ),
+        "--task-ids",
+        tau2_task,
+        "--num-trials",
+        "1",
+        "--max-steps",
+        str(MAX_STEPS),
+        "--timeout",
+        str(EPISODE_TIMEOUT_S),
+        "--max-retries",
+        "0",
+        "--agent-llm",
+        model,
+        "--agent-llm-args",
+        json.dumps(
+            {
+                "temperature": TEMPERATURE,
+                "max_tokens": MAX_TOKENS,
+                # Retries off for the same reason the collector pins them off:
+                # a retried episode is a different episode, not a repair.
+                "num_retries": 0,
+                "timeout": EPISODE_TIMEOUT_S,
+            }
+        ),
+        "--user-llm",
+        USER_SIM,
+        "--user-llm-args",
+        "{}",
+        "--save-to",
+        save_name,
+        "--auto-resume",
+    ]
+    env = os.environ | {"TAU2_DATA_DIR": str(_DATA_DIR)}
+    log_path = episode_dir / "tau2.log"
+    with log_path.open("wb") as log_file:
+        subprocess.run(command, stdout=log_file, stderr=subprocess.STDOUT, env=env, check=False)
+    results = _DATA_DIR / "simulations" / save_name / "results.json"
+    row: dict[str, object] = {"task_id": task_id, "reward": None, "passed": False, "note": ""}
+    if not results.exists():
+        row["note"] = f"no results.json (see {log_path})"
+        return row
+    payload = json.loads(results.read_text(encoding="utf-8"))
+    simulations = payload.get("simulations") or []
+    if not simulations:
+        row["note"] = "no simulation recorded"
+        return row
+    simulation = simulations[0]
+    reward = (simulation.get("reward_info") or {}).get("reward")
+    row["termination_reason"] = simulation.get("termination_reason")
+    row["messages"] = len(simulation.get("messages") or [])
+    row["duration_s"] = simulation.get("duration")
+    if isinstance(reward, int | float):
+        row["reward"] = float(reward)
+        row["passed"] = float(reward) >= 1.0 - 1e-9
+    else:
+        row["note"] = f"ungraded ({row['termination_reason']})"
+    (episode_dir / "results.json").write_bytes(results.read_bytes())
+    return row
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="litellm model spec for the candidate")
+    parser.add_argument("--tasks", required=True, help="JSON array of composite train task ids")
+    parser.add_argument("--label", required=True, help="short name for artifacts, e.g. kimi-k3")
+    parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument("--out-root", default=".wmo/probes")
+    args = parser.parse_args()
+
+    task_ids = json.loads(Path(args.tasks).read_text(encoding="utf-8"))
+    out_root = Path(args.out_root) / args.label
+    out_root.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "probing %s on %d TRAIN task(s) (holdout untouched), canonical pins, concurrency %d",
+        args.model,
+        len(task_ids),
+        args.concurrency,
+    )
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        rows = list(
+            pool.map(lambda t: run_episode(args.model, t, args.label, out_root), task_ids)
+        )
+
+    graded = [r for r in rows if r["reward"] is not None]
+    by_domain: dict[str, list[bool]] = defaultdict(list)
+    for row in graded:
+        by_domain[str(row["task_id"]).split("/")[0]].append(bool(row["passed"]))
+    solve = sum(bool(r["passed"]) for r in graded) / len(graded) if graded else 0.0
+    summary = {
+        "model": args.model,
+        "label": args.label,
+        "tasks": len(task_ids),
+        "graded": len(graded),
+        "solve_rate": solve,
+        "by_domain": {d: sum(v) / len(v) for d, v in sorted(by_domain.items())},
+        "rows": rows,
+    }
+    (out_root / "probe.json").write_text(json.dumps(summary, indent=1), encoding="utf-8")
+    for row in rows:
+        logger.info(
+            "  %-14s reward=%s stop=%s msgs=%s %s",
+            row["task_id"],
+            row["reward"],
+            row.get("termination_reason"),
+            row.get("messages"),
+            row["note"],
+        )
+    logger.info(
+        "PROBE %s: solve %.3f over %d graded of %d task(s); by domain %s -> %s",
+        args.label,
+        solve,
+        len(graded),
+        len(task_ids),
+        summary["by_domain"],
+        out_root / "probe.json",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/docs/research/tau2-cycle1-result-note.md
+++ b/.agents/docs/research/tau2-cycle1-result-note.md
@@ -1,0 +1,77 @@
+# Cycle 1 result note: warmup-only distillation on real tau2 (REJECTED, no effect)
+
+**Capture cohort**: own tau2 harness (wmo `[tau2]` rollout source, PR #297 as merged 7e163298),
+post tool-argument-realignment fix, canonical real-tau2 protocol pins (max_turns=100,
+episode_timeout_s=1800, max_tokens=8192, user simulator azure/gpt-5.4-mini, tau2
+`--max-retries 0` plus one episode-level retry). Never pool these rows with pre-fix or
+different-pin cohorts.
+
+**Verdict**: gate REJECTED, adapter NOT promoted, no pool entry created. Total spend $34.94 of
+the approved $120 cap.
+
+## The three measured arms (one pre-registered gate read, k=3, 20 pinned holdout tasks)
+
+| arm | model | solve rate | executed | infra failures |
+|---|---|---|---|---|
+| teacher | Qwen/Qwen3.6-27B | 73.3% | 60/60 | 0 |
+| student-before | Qwen/Qwen3.5-9B (base) | 71.7% | 60/60 | 0 |
+| student-after | the warmed LoRA (r32) | 65.0% | 60/60 | 0 |
+
+Scoring is tau2's own reward. Note honestly that 7 of the 20 holdout tasks include tau2's
+NL-assertion judge in their reward basis, so this is "tau2 reward", not a purely deterministic
+check. Per-task per-arm episode rows: `episode-rows.jsonl` in the run dir (180 rows).
+
+## What happened: no measurable effect, not degeneration
+
+The regression is 4 episodes out of 60. A paired sign test over the 7 tasks that moved at all
+(5 down, 2 up) gives a two-sided p of 0.45, so before-vs-after is indistinguishable from noise;
+13 of 20 tasks did not move at all.
+
+Degeneration is ruled out by the behavioral metrics, which are flat:
+
+| | student-before | student-after |
+|---|---|---|
+| episodes ending on a clean protocol stop | 60/60 | 60/60 |
+| mean messages per episode | 29.5 | 30.4 |
+| mean episode duration | 94s | 93s |
+
+No collapse, no length runaway, no scaffold loss, no truncation. The warmed student behaves like
+the base student and scores within noise of it.
+
+## Why there was nothing to measure
+
+1. **The teacher had almost no headroom over the student: 73.3% vs 71.7%, a 1.6-point gap.**
+   Warmup-only distillation copies the teacher's trajectories; when the teacher is effectively a
+   peer, there is nothing to copy that the student does not already do.
+2. **The holdout cannot resolve a small effect.** 9 of 20 tasks sit at the student's own ceiling
+   (pinned before this cycle, in the power check), so the measurable surface is the 10 interior
+   tasks and 60 episodes total. A ~2-point true effect is far below what this pin can detect.
+3. **Data yield was NOT the problem.** The teacher's 194 episodes produced 133 kept (68.6% pass
+   rate on the train split) and 133 datums with zero overflow or overlong drops, 918,869 loss
+   tokens per pass over 1,066,513 context tokens. The supply side worked exactly as designed.
+
+## Follow-ups this cycle earned
+
+- **Warmup has no degeneration-tripwire coverage.** Tripwires are computed per training step, and
+  a warmup-only run takes no training steps, so entropy and length guards never ran. Here the
+  behavioral metrics happened to be flat, but a warmup-only run currently trains with no
+  automated collapse detector. Owner: the distill lane (#268 territory).
+- **The learning rate was the OPD default (1e-4) applied to ~1.8M loss tokens across two full
+  passes.** No damage is visible in this run's behavior, but the anchor config uses 5e-5 for
+  warmup specifically, and a warmup-only cycle should probably not inherit the on-policy default.
+- **The escalation premise now has evidence behind it.** The failure mode is "teacher too close to
+  the student", which is exactly what a stronger teacher fixes. Before spending on a K3 leg, the
+  cheap decisive measurement is K3's own solve rate on TRAIN tasks (never the holdout, which would
+  select on gate data): roughly 10 episodes, a few dollars.
+
+## Artifacts
+
+`.wmo/distill-runs/tau2-cycle1/`: config snapshot, `metrics.jsonl`, `spend.json` ($34.94),
+`checkpoints.json`, `gate.json`, `model_card.json`, `warmup-trials.json` (the 194-episode teacher
+manifest, reusable by any future run via `warmup.trajectories_from`), `evals/` (three arm
+reports), `episode-rows.jsonl` (per-task per-arm rows), plus the raw episode dirs with every
+transcript. W&B run `tau2-cycle1-warmup` in project `wmo-distill`.
+
+The trained weights and resumable state exist and are recorded in the model card, but the adapter
+was NOT versioned into `.wmo/adapters` and NOT priced into the routing pool, because the gate
+rejected it. An unpromoted student must never enter the pool.

--- a/.agents/docs/research/tau2-k3-headroom-probe.json
+++ b/.agents/docs/research/tau2-k3-headroom-probe.json
@@ -1,0 +1,103 @@
+{
+ "model": "fireworks_ai/accounts/fireworks/models/kimi-k3",
+ "label": "kimi-k3",
+ "tasks": 10,
+ "graded": 10,
+ "solve_rate": 0.6,
+ "by_domain": {
+  "airline": 0.6,
+  "retail": 0.6
+ },
+ "rows": [
+  {
+   "task_id": "airline/10",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 24,
+   "duration_s": 95.4830316669977
+  },
+  {
+   "task_id": "airline/14",
+   "reward": 0.0,
+   "passed": false,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 14,
+   "duration_s": 31.375248084004852
+  },
+  {
+   "task_id": "airline/15",
+   "reward": 0.0,
+   "passed": false,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 20,
+   "duration_s": 378.7883498339943
+  },
+  {
+   "task_id": "airline/16",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 19,
+   "duration_s": 55.582724167004926
+  },
+  {
+   "task_id": "airline/17",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 34,
+   "duration_s": 69.83979645800719
+  },
+  {
+   "task_id": "retail/0",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 22,
+   "duration_s": 173.768400749992
+  },
+  {
+   "task_id": "retail/1",
+   "reward": 0.0,
+   "passed": false,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 16,
+   "duration_s": 39.535189832997276
+  },
+  {
+   "task_id": "retail/10",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 14,
+   "duration_s": 34.133110000009765
+  },
+  {
+   "task_id": "retail/11",
+   "reward": 1.0,
+   "passed": true,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 20,
+   "duration_s": 44.02226625000185
+  },
+  {
+   "task_id": "retail/112",
+   "reward": 0.0,
+   "passed": false,
+   "note": "",
+   "termination_reason": "user_stop",
+   "messages": 32,
+   "duration_s": 62.22025900000881
+  }
+ ]
+}

--- a/wmo/distill/config.py
+++ b/wmo/distill/config.py
@@ -558,6 +558,13 @@ class SamplingConfig(BaseModel):
     """Per-completion output cap for every rollout request."""
 
 
+DEFAULT_WARMUP_LEARNING_RATE = 5e-5
+"""The supervised phase's own learning rate, independent of the OPD rate.
+
+The value the reference anchor config pins for warmup while running 1e-4 for
+its on-policy steps (`wmo/distill/configs/distill-qwen-anchor.toml`)."""
+
+
 class WarmupConfig(BaseModel):
     """Supervised warmup on the teacher's own pi trajectories before OPD steps.
 
@@ -580,8 +587,18 @@ class WarmupConfig(BaseModel):
     keep: Literal["passed", "all"] = "passed"
     """Which teacher trials feed the SFT set: reward-passing only, or all."""
 
-    learning_rate: Annotated[float, Field(gt=0)] | None = None
-    """Warmup optimizer LR; None uses `train.learning_rate`."""
+    learning_rate: Annotated[float, Field(gt=0)] | None = DEFAULT_WARMUP_LEARNING_RATE
+    """Warmup optimizer LR; None falls back to `train.learning_rate`.
+
+    Defaults to `DEFAULT_WARMUP_LEARNING_RATE` rather than to the on-policy
+    rate, because the two phases are not the same optimization. An OPD step
+    trains a small batch of freshly sampled tokens; a warmup pass trains the
+    whole kept corpus at once (measured on the tau cycle: 918,869 loss tokens
+    per pass, twice), and the reference anchor config deliberately pins 5e-5
+    there while running 1e-4 for its OPD steps. Inheriting the OPD rate was
+    silent, so a warmup-only run trained an entire corpus at double the rate
+    its own reference config uses. Set this explicitly (or to None, to opt
+    back into `train.learning_rate`) when a run wants the coupling."""
 
     trajectories_from: str | None = None
     """Path to another run dir whose warmup COLLECTION completed: the warmup

--- a/wmo/distill/config_test.py
+++ b/wmo/distill/config_test.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from wmo.distill.config import (
+    DEFAULT_WARMUP_LEARNING_RATE,
     PROBE_BASELINE_ENTROPY_NATS,
     PROBE_BASELINE_EPISODE_TOKENS,
     DistillConfig,
@@ -86,7 +87,11 @@ def test_load_minimal_applies_defaults(tmp_path: Path) -> None:
     assert cfg.warmup.steps == 0
     assert cfg.warmup.rollouts_per_task == 1
     assert cfg.warmup.keep == "passed"
-    assert cfg.warmup.learning_rate is None
+    # The supervised phase owns its LR: inheriting the OPD default silently
+    # trained an entire kept corpus at 1e-4 where the reference anchor config
+    # deliberately pins 5e-5 for warmup (cycle 1, 918,869 loss tokens x2).
+    assert cfg.warmup.learning_rate == pytest.approx(DEFAULT_WARMUP_LEARNING_RATE)
+    assert DEFAULT_WARMUP_LEARNING_RATE == pytest.approx(5e-5)
     # Interim evals default OFF: the holdout gate is the run's measurement.
     assert cfg.eval.every == 0
     assert cfg.eval.tasks == 12
@@ -1000,3 +1005,14 @@ def test_snapshot_round_trips_the_tau2_source(tmp_path: Path) -> None:
     snap_path = tmp_path / "snapshot.toml"
     snap_path.write_text(snapshot_toml(cfg), encoding="utf-8")
     assert load_distill_config(snap_path) == cfg
+
+
+def test_warmup_can_still_opt_into_the_training_learning_rate(tmp_path: Path) -> None:
+    """Explicit None restores the old coupling for a run that wants it."""
+    text = MINIMAL_TOML + "\n[train]\nlearning_rate = 2e-4\n\n[warmup]\nsteps = 1\n"
+    cfg = load_distill_config(_write(tmp_path, text))
+    assert cfg.warmup.learning_rate == pytest.approx(DEFAULT_WARMUP_LEARNING_RATE)
+    explicit = load_distill_config(
+        _write(tmp_path, MINIMAL_TOML + "\n[warmup]\nsteps = 1\nlearning_rate = 3e-5\n")
+    )
+    assert explicit.warmup.learning_rate == pytest.approx(3e-5)

--- a/wmo/distill/loop.py
+++ b/wmo/distill/loop.py
@@ -396,6 +396,19 @@ class DistillEvalReport(BaseModel):
     measurement, not a score. See `RolloutStats.graded_solve_rate`. 0.0 on reports from before this
     field."""
 
+    health: PolicyHealth | None = None
+    """The sampling policy's pooled entropy and generation length over this batch.
+
+    Free degeneration evidence: the eval arms already sample a policy under a
+    fixed temperature and k, so the student-before and student-after arms are a
+    controlled reading of the SAME two statistics the training-step tripwire
+    bounds. That matters most for a warmup-only run (`train.steps = 0`), which
+    takes no training steps and therefore arms no per-step tripwire at all; the
+    warmup batch cannot substitute, because those spans are the TEACHER's and
+    say nothing about whether the student collapsed. Carries its own
+    denominators (episodes, sampled tokens), so a reader can tell a real
+    measurement from a thin one. None on reports written before this field."""
+
     graded_trials: int = Field(default=0, ge=0)
     """Gradeable trials that carried a readable test report: the `graded_solve_rate`
     denominator."""
@@ -1665,6 +1678,11 @@ def _teacher_rows(
     return rows, _batch_reverse_kl(datums, rows)
 
 
+def _ratio_phrase(ratio: float | None) -> str:
+    """A ratio rendered for a log line, or an honest 'unmeasured'."""
+    return "unmeasured" if ratio is None else f"{ratio:.2f}x"
+
+
 def _graded_phrase(graded_solve_rate: float, graded_trials: int) -> str:
     """One progress-line clause for the graded rate, saying so when there is none.
 
@@ -2268,9 +2286,14 @@ class _DistillRun:
                 "verifier.override_timeout_sec in the harbor job template. Writing 0.0% here "
                 "would put a null baseline behind gate.require_no_regression"
             )
+        # Free degeneration evidence: this batch already sampled a policy, so
+        # pool its spans now. For the student arms the before/after pair is the
+        # only collapse detector a warmup-only run has (see the report fields).
+        health = policy_health(records)
         report = DistillEvalReport(
             name=key,
             provider_model=provider.model,
+            health=health,
             base_model=provider.model_type,
             task_ids=list(task_ids),
             attempts=attempts,
@@ -3331,6 +3354,68 @@ class _DistillRun:
 
         return self._finalize(teacher_report, before_report)
 
+    def _check_trained_policy_health(
+        self, before_report: DistillEvalReport | None, after_report: DistillEvalReport
+    ) -> None:
+        """Compare the student's sampled health across the gate's own two arms.
+
+        The per-step tripwire never sees a warmup-only run: it arms on the
+        first TRAINING step, and `train.steps = 0` takes none. The warmup batch
+        cannot stand in either, because those spans are the TEACHER's, so their
+        entropy says nothing about whether the STUDENT collapsed. What does
+        exist, already paid for, is the gate's own before/after student arms:
+        same tasks, same k, same temperature, both sampled by the student. That
+        is a controlled reading of exactly the two statistics the tripwire
+        bounds, so it is checked here against the same configured fractions.
+
+        Post hoc by nature: the training is already done, so this reports
+        rather than aborts. It runs for every gated run (an OPD run gets it as
+        a second, independent check on top of its per-step tripwire), and stays
+        silent when either arm sampled nothing to measure.
+
+        Args:
+            before_report: The student-before arm, used as the baseline.
+            after_report: The student-after arm, the reading.
+        """
+        cfg = self._cfg
+        if before_report is None or before_report.health is None or after_report.health is None:
+            logger.info(
+                "no post-training health check: one of the student arms recorded no sampled "
+                "tokens to measure (a reused or imported baseline carries none)"
+            )
+            return
+        baseline = capture_baseline(0, before_report.health)
+        if baseline is None:
+            logger.info(
+                "no post-training health check: the student-before arm recorded no usable "
+                "entropy or length baseline"
+            )
+            return
+        after_health = after_report.health
+        entropy_ratio = metric_ratio(after_health.entropy_per_token, baseline.entropy_per_token)
+        length_ratio = metric_ratio(
+            after_health.mean_generation_tokens, baseline.mean_generation_tokens
+        )
+        breaches = evaluate_breaches(cfg.tripwire, baseline, after_health)
+        summary = (
+            f"post-training health (student-after vs student-before, the gate's own arms): "
+            f"entropy {_ratio_phrase(entropy_ratio)}, "
+            f"sampled tokens/episode {_ratio_phrase(length_ratio)}"
+        )
+        if breaches:
+            detail = "; ".join(breach.describe() for breach in breaches)
+            logger.warning(
+                "%s. DEGENERATION SIGNAL on the trained policy: %s. The training already "
+                "finished, so this is a report, not an abort: read the sampled episodes in "
+                "the student-after eval rollouts before promoting anything downstream",
+                summary,
+                detail,
+            )
+            self._emit("gate", f"{summary} -- degeneration signal: {detail}")
+        else:
+            logger.info("%s: within the configured tripwire bounds", summary)
+            self._emit("gate", summary)
+
     def _finalize(
         self,
         teacher_report: DistillEvalReport | None,
@@ -3376,6 +3461,7 @@ class _DistillRun:
             cfg.gate,
         )
         self._store.write_gate(record)
+        self._check_trained_policy_health(before_report, after_report)
         card = DistillModelCard(
             base_model=cfg.student.base_model,
             lora_rank=cfg.student.lora_rank,

--- a/wmo/distill/loop_test.py
+++ b/wmo/distill/loop_test.py
@@ -3671,3 +3671,30 @@ def test_deferred_baselines_still_run_the_warmup_phase(
     (warmup_call,) = _warmup_calls(env)
     assert warmup_call.provider_model == _TEACHER
     assert "cross_entropy" in _loss_fns(env), "the supervised passes must have trained"
+
+
+def test_a_warmup_only_run_still_gets_a_degeneration_reading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """train.steps = 0 arms no per-step tripwire, so the gate's own arms must report.
+
+    The warmup batch cannot substitute: those spans are the TEACHER's, and the
+    question is whether the STUDENT collapsed. The student-before and
+    student-after eval arms sample the student under the same k and
+    temperature, so they are the controlled reading this check uses.
+    """
+    env = _setup(tmp_path, monkeypatch)
+    base = _warmup_cfg()
+    cfg = base.model_copy(update={"train": base.train.model_copy(update={"steps": 0})})
+
+    with caplog.at_level(logging.INFO, logger="wmo.distill.loop"):
+        result = _run(env, cfg)
+
+    assert result.steps_completed == 0, "this is the warmup-only shape"
+    assert any("post-training health" in record.message for record in caplog.records), (
+        "a warmup-only run must still report a student before/after health reading"
+    )
+    # And the reading is persisted beside the arms it came from.
+    payload = json.loads((env.run_dir / "evals" / f"{STUDENT_AFTER_EVAL}.json").read_text())
+    assert payload["health"] is not None
+    assert payload["health"]["entropy_per_token"] is not None


### PR DESCRIPTION
The two follow-ups cycle 1 earned, both filed in DECISIONS.md at the time. Small and independent; either can be dropped without the other.

## (a) Warmup's learning rate was silently the on-policy one

`warmup.learning_rate` defaulted to `None`, meaning "inherit `train.learning_rate`", which is the OPD default `1e-4`. Those are not the same optimization: an OPD step trains a small batch of freshly sampled tokens, while a warmup pass trains the **whole kept corpus at once** (cycle 1: 918,869 loss tokens per pass, twice), and the reference anchor config deliberately pins `5e-5` for warmup while running `1e-4` for its steps. So a warmup-only run trained an entire corpus at double the rate its own reference config uses, and nothing said so.

`warmup.learning_rate` now defaults to `DEFAULT_WARMUP_LEARNING_RATE` (5e-5). Explicit `None` still opts back into the training rate for a run that wants the coupling, and that path has a test.

## (b) A warmup-only run had no degeneration detector at all

Tripwires arm on the first **training** step, so `train.steps = 0` arms none. The warmup batch cannot substitute: those spans are the **teacher's**, and the question is whether the **student** collapsed.

What can substitute costs nothing extra. The gate already samples the student twice, before and after, on the same tasks at the same `k` and temperature: a controlled reading of exactly the two statistics the tripwire bounds. So each `DistillEvalReport` now carries its batch's `PolicyHealth` (including its own denominators, so a thin measurement is visible as one), and `_finalize` compares the two student arms against the **same configured tripwire fractions** through the same `capture_baseline` / `evaluate_breaches` path rather than a parallel copy of the bounds logic.

Post hoc by nature, so it reports rather than aborts, and it runs for **every** gated run: an OPD run gets it as a second independent check on top of its per-step tripwire. It stays quiet and says why when either arm has nothing to measure (an imported or reused baseline carries no health).

Had this existed for cycle 1, it would have printed the reassuring version: that run's behavioral metrics were flat (60/60 clean stops both arms, 29.5 -> 30.4 messages, 94s -> 93s), which is what let me diagnose "no effect" rather than "collapse".

## Justification ledger

- `DEFAULT_WARMUP_LEARNING_RATE` as a named constant, not a literal: the anchor config's value is the rationale, and the constant is where that rationale is written down.
- `DistillEvalReport.health` carries the whole `PolicyHealth` rather than two loose floats, deliberately: my first cut passed `sampled_tokens=0` into a fabricated `PolicyHealth` to reuse the baseline helper, which the model's own `ge=1` validator rejected. It was right to: those denominators are what separate a real reading from a thin one, so the report carries the true object.
- Non-removals: the per-step tripwire path is untouched; this adds a second, independent check rather than replacing it.
- All new fields default to `None`/absent, so every previously written eval report loads unchanged.

## Checks

`ruff` and `ty` clean; full suite **4151 passed, 19 skipped**. New coverage: warmup-LR default plus the opt-in-to-training-rate path, and a warmup-only run asserting the health reading is both logged and persisted beside the arm it came from.