### PR TITLE
Validate scenarios/research CLI inputs instead of letting library exceptions escape

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -1937,7 +1937,10 @@ def _ingest_scenario_corpus(file: str) -> list[Trace]:
             f"--file {file} does not exist; pass an exported OTel-GenAI corpus, or fetch a "
             "benchmark one with `wmo download <benchmark>`"
         )
-    return get_adapter("otel-genai").from_file(file)
+    try:
+        return get_adapter("otel-genai").from_file(file)
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _unreadable_input(f"--file {file}", path, exc) from exc
 
 
 def _load_scenario_set(scenarios_file: str) -> ScenarioSet:
@@ -1966,6 +1969,26 @@ def _load_scenario_set(scenarios_file: str) -> ScenarioSet:
             f"({exc.error_count()} validation error(s), first: {exc.errors()[0]['msg']}); "
             f"{build_hint}"
         ) from exc
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _unreadable_input(f"scenario set {scenarios_file}", path, exc) from exc
+
+
+def _unreadable_input(label: str, path: Path, exc: OSError | UnicodeDecodeError) -> Exception:
+    """Report the two read failures an exists/is-dir check cannot predict as a usage error.
+
+    A path that passes the shape checks can still fail inside the read: no permission on it, or
+    bytes that are not UTF-8 (a compressed or binary export). Both otherwise reach the user as a
+    stdlib traceback, which is the thing these guards exist to prevent.
+    """
+    if isinstance(exc, UnicodeDecodeError):
+        return typer.BadParameter(
+            f"{label} is not UTF-8 text; pass the decompressed JSON/JSONL export "
+            f"(`file {path}` says what it actually is)"
+        )
+    return typer.BadParameter(
+        f"{label} could not be read ({exc.strerror or exc}); "
+        f"`ls -l {path}` shows its owner and mode"
+    )
 
 
 def _provider_config(provider: str, model: str, region: str | None) -> ProviderConfig:
@@ -2443,11 +2466,16 @@ def research_concurrency(
         [str(root) for root in _benchmark_roots()] if examples_root is None else [examples_root]
     )
     # An unresolvable suite is a bad argument, like every other input validated above; the
-    # ValueError carries the available names, so only the next command has to be added.
+    # ValueError carries the available names, so only the next command has to be added. A direct
+    # `.toml` selector that exists resolves past name lookup and fails on its own contents, so
+    # listing the discoverable suites there would point away from the file that needs repairing.
+    direct_suite_file = Path(suite)
     try:
         resolved = resolve_eval_suite(suite, suite_roots)
     except ValueError as exc:
-        raise typer.BadParameter(f"{exc}; `wmo eval list` prints the suites") from exc
+        by_name = not (direct_suite_file.suffix == ".toml" and direct_suite_file.exists())
+        hint = "; `wmo eval list` prints the suites" if by_name else ""
+        raise typer.BadParameter(f"{exc}{hint}") from exc
     files = resolved.resolve_files()
     missing = [f for f in files if not f.exists()]
     if not files or missing:

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -1973,7 +1973,9 @@ def _load_scenario_set(scenarios_file: str) -> ScenarioSet:
         raise _unreadable_input(f"scenario set {scenarios_file}", path, exc) from exc
 
 
-def _unreadable_input(label: str, path: Path, exc: OSError | UnicodeDecodeError) -> Exception:
+def _unreadable_input(
+    label: str, path: Path, exc: OSError | UnicodeDecodeError
+) -> typer.BadParameter:
     """Report the two read failures an exists/is-dir check cannot predict as a usage error.
 
     A path that passes the shape checks can still fail inside the read: no permission on it, or
@@ -2469,12 +2471,12 @@ def research_concurrency(
     # ValueError carries the available names, so only the next command has to be added. A direct
     # `.toml` selector that exists resolves past name lookup and fails on its own contents, so
     # listing the discoverable suites there would point away from the file that needs repairing.
-    direct_suite_file = Path(suite)
     try:
         resolved = resolve_eval_suite(suite, suite_roots)
     except ValueError as exc:
-        by_name = not (direct_suite_file.suffix == ".toml" and direct_suite_file.exists())
-        hint = "; `wmo eval list` prints the suites" if by_name else ""
+        direct = Path(suite)
+        resolved_by_name = not (direct.suffix == ".toml" and direct.exists())
+        hint = "; `wmo eval list` prints the suites" if resolved_by_name else ""
         raise typer.BadParameter(f"{exc}{hint}") from exc
     files = resolved.resolve_files()
     missing = [f for f in files if not f.exists()]

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -30,6 +30,7 @@ from environment_capture.hub import (
     published_corpora,
 )
 from llm_waterfall import is_capacity_error
+from pydantic import ValidationError
 from rich.console import Console
 from rich.markup import escape
 from rich.panel import Panel
@@ -77,7 +78,7 @@ from wmo.config import (
     validate_name,
 )
 from wmo.config.card import make_build_card, save_card
-from wmo.core.types import JsonObject
+from wmo.core.types import JsonObject, Trace
 from wmo.engine.build import DEFAULT_TRAIN_SPLIT, ingest, split_traces
 from wmo.engine.build import build as run_build
 from wmo.engine.demo import run_demo
@@ -1800,7 +1801,7 @@ def scenarios_build(
         help=(
             "Facet embedder: hashing (offline but lexical-only — clusters by wording, not "
             "meaning; prefer a semantic embedder for real corpora) | bedrock | openai | "
-            "azure_openai."
+            "azure."
         ),
     ),
     embed_model: str = typer.Option(None, help="Embeddings model id / Azure deployment."),
@@ -1812,7 +1813,7 @@ def scenarios_build(
     Writes a `ScenarioSet` JSON: scenarios (task, seed state, checklist, weight, provenance),
     the named clusters they came from, and the corpus-coverage number that justifies them.
     """
-    traces = get_adapter("otel-genai").from_file(file)
+    traces = _ingest_scenario_corpus(file)
     if limit is not None:
         traces = traces[:limit]
     if not traces:
@@ -1861,8 +1862,8 @@ def scenarios_verify(
     baseline LLM agent on every scenario, and grades episodes against each scenario's checklist.
     With `--drop`, unverified scenarios are removed from the set in place.
     """
-    scenario_set = ScenarioSet.load(scenarios_file)
-    traces = get_adapter("otel-genai").from_file(file)
+    scenario_set = _load_scenario_set(scenarios_file)
+    traces = _ingest_scenario_corpus(file)
     if provider is not None or model is not None:
         store = WorldModelStore(root)
         model_dir = store.resolve(_resolve_name(store, name))
@@ -1916,6 +1917,55 @@ def scenarios_verify(
             f"kept {len(scenario_set.scenarios)} verified scenarios "
             f"(weights renormalized, coverage reset) -> {scenarios_file}"
         )
+
+
+def _ingest_scenario_corpus(file: str) -> list[Trace]:
+    """Ingest a `--file` trace corpus for the scenarios commands as a validated CLI input.
+
+    `--file` is the only required option on `wmo scenarios build`, so a mistyped path is the
+    likeliest first-run mistake. Guard it here rather than letting `Path.read_text` raise, which
+    reaches the user as a stdlib FileNotFoundError/IsADirectoryError traceback.
+    """
+    path = Path(file)
+    if path.is_dir():
+        raise typer.BadParameter(
+            f"--file {file} is a directory; point it at the trace file itself, "
+            f"e.g. `--file {Path(file) / 'traces.otel.jsonl'}`"
+        )
+    if not path.exists():
+        raise typer.BadParameter(
+            f"--file {file} does not exist; pass an exported OTel-GenAI corpus, or fetch a "
+            "benchmark one with `wmo download <benchmark>`"
+        )
+    return get_adapter("otel-genai").from_file(file)
+
+
+def _load_scenario_set(scenarios_file: str) -> ScenarioSet:
+    """Load a `ScenarioSet` argument, reporting a missing or malformed file as a usage error.
+
+    The raw failures are a stdlib FileNotFoundError/IsADirectoryError and a pydantic
+    ValidationError that sends the user to pydantic's docs; neither says the file is supposed to
+    be the output of `wmo scenarios build`.
+    """
+    path = Path(scenarios_file)
+    build_hint = (
+        f"build one with `wmo scenarios build --file <traces.jsonl> --out {scenarios_file}`"
+    )
+    if path.is_dir():
+        raise typer.BadParameter(
+            f"scenario set {scenarios_file} is a directory; pass the JSON file written by "
+            "`wmo scenarios build --out <scenarios.json>`"
+        )
+    if not path.exists():
+        raise typer.BadParameter(f"scenario set {scenarios_file} does not exist; {build_hint}")
+    try:
+        return ScenarioSet.load(path)
+    except ValidationError as exc:
+        raise typer.BadParameter(
+            f"{scenarios_file} is not a scenario set written by `wmo scenarios build` "
+            f"({exc.error_count()} validation error(s), first: {exc.errors()[0]['msg']}); "
+            f"{build_hint}"
+        ) from exc
 
 
 def _provider_config(provider: str, model: str, region: str | None) -> ProviderConfig:
@@ -2392,7 +2442,12 @@ def research_concurrency(
     suite_roots = (
         [str(root) for root in _benchmark_roots()] if examples_root is None else [examples_root]
     )
-    resolved = resolve_eval_suite(suite, suite_roots)
+    # An unresolvable suite is a bad argument, like every other input validated above; the
+    # ValueError carries the available names, so only the next command has to be added.
+    try:
+        resolved = resolve_eval_suite(suite, suite_roots)
+    except ValueError as exc:
+        raise typer.BadParameter(f"{exc}; `wmo eval list` prints the suites") from exc
     files = resolved.resolve_files()
     missing = [f for f in files if not f.exists()]
     if not files or missing:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1591,6 +1591,59 @@ def test_scenarios_verify_malformed_scenario_set_is_clean_error(tmp_path) -> Non
     assert "errors.pydantic.dev" not in flat
 
 
+def test_scenarios_verify_non_utf8_scenario_set_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # Regression (Greptile P1): `ScenarioSet.load` reads with encoding="utf-8", so binary bytes
+    # raise UnicodeDecodeError *before* pydantic and slipped past the ValidationError handler.
+    scenarios_file = tmp_path / "scenarios.json"
+    scenarios_file.write_bytes(b"\xff\xfe\x00binary")
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    result = runner.invoke(app, ["scenarios", "verify", str(scenarios_file), "--file", str(corpus)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, UnicodeDecodeError)
+    assert "is not UTF-8 text" in _framed(result.output)
+
+
+def test_scenarios_build_non_utf8_corpus_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # Regression (Greptile P1): a path that exists still fails inside the adapter's read.
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_bytes(b"\xff\xfe\x00binary")
+    result = runner.invoke(app, ["scenarios", "build", "--file", str(corpus)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, UnicodeDecodeError)
+    flat = _framed(result.output)
+    assert "--file" in flat and "is not UTF-8 text" in flat
+
+
+def test_scenarios_build_unreadable_corpus_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # Regression (Greptile P1): chmod-000 raised PermissionError out of Path.read_text.
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    corpus.chmod(0)
+    try:
+        result = runner.invoke(app, ["scenarios", "build", "--file", str(corpus)])
+    finally:
+        corpus.chmod(0o644)
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, PermissionError)
+    flat = _framed(result.output)
+    assert "could not be read" in flat
+    assert "shows its owner and mode" in flat
+
+
+def test_research_concurrency_malformed_suite_file_omits_the_listing_hint(tmp_path) -> None:  # noqa: ANN001
+    # Regression (Greptile P2): a direct `.toml` selector that exists resolves past name lookup
+    # and fails on its own contents, so `wmo eval list` would point away from the broken file.
+    suite_file = tmp_path / "broken.toml"
+    suite_file.write_text("this is not = toml [[[\n", encoding="utf-8")
+    result = runner.invoke(app, ["research", "concurrency", str(suite_file)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ValueError)
+    flat = _framed(result.output)
+    assert "is not valid TOML" in flat
+    assert "wmo eval list" not in flat
+
+
 def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa: ANN001
     from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import pytest
 import typer
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from wmo.cli import app, pool_registry
@@ -25,6 +26,7 @@ from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3wa
 from wmo.engine.eval_suites import EvalSuiteConfig
 from wmo.providers.base import (
     Completion,
+    EmbedderKind,
     Message,
     ProviderConfig,
     ProviderKind,
@@ -1498,6 +1500,95 @@ def test_research_concurrency_rejects_bad_select() -> None:
     )
     assert result.exit_code != 0
     assert "--select must be one of" in result.output
+
+
+def _framed(output: str) -> str:
+    """One flat line of a rich-framed message: the box wraps and pads what it renders."""
+    return " ".join(output.replace("│", " ").split())
+
+
+def test_research_concurrency_unknown_suite_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # The suite argument must fail like every other argument on this command: a framed usage
+    # error naming the next command, not the raw ValueError traceback out of resolve_eval_suite.
+    result = runner.invoke(
+        app,
+        ["research", "concurrency", "nosuchsuite", "--examples-root", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ValueError)
+    flat = _framed(result.output)
+    assert "unknown eval suite 'nosuchsuite'" in flat
+    assert "`wmo eval list` prints the suites" in flat
+
+
+def test_scenarios_build_missing_file_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # A typo in --file is the likeliest first-run mistake; it must not be a FileNotFoundError.
+    result = runner.invoke(app, ["scenarios", "build", "--file", str(tmp_path / "nope.jsonl")])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, FileNotFoundError)
+    flat = _framed(result.output)
+    assert "does not exist" in flat
+    assert "`wmo download <benchmark>`" in flat
+
+
+def test_scenarios_build_directory_file_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(app, ["scenarios", "build", "--file", str(tmp_path)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, IsADirectoryError)
+    assert "is a directory" in _framed(result.output)
+
+
+def test_scenarios_build_help_documents_the_accepted_embed_provider() -> None:
+    # The help must name values the command accepts: EmbedderKind spells Azure "azure".
+    result = runner.invoke(app, ["scenarios", "build", "--help"])
+    assert result.exit_code == 0
+    flat = _framed(result.output)
+    documented = flat[flat.index("Facet embedder") : flat.index("--embed-model")]
+    for kind in EmbedderKind:
+        assert kind.value in documented, kind
+    assert "azure_openai" not in documented
+
+
+def test_scenarios_verify_missing_scenario_set_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["scenarios", "verify", str(tmp_path / "nope.json"), "--file", str(corpus)],
+    )
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, FileNotFoundError)
+    flat = _framed(result.output)
+    assert "does not exist" in flat
+    assert "`wmo scenarios build --file <traces.jsonl> --out" in flat
+
+
+def test_scenarios_verify_missing_corpus_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    scenarios_file = tmp_path / "scenarios.json"
+    scenarios_file.write_text('{"scenarios": []}', encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["scenarios", "verify", str(scenarios_file), "--file", str(tmp_path / "nope.jsonl")],
+    )
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, FileNotFoundError)
+    flat = _framed(result.output)
+    assert "--file" in flat and "does not exist" in flat
+
+
+def test_scenarios_verify_malformed_scenario_set_is_clean_error(tmp_path) -> None:  # noqa: ANN001
+    # Pydantic's ValidationError points at pydantic's docs; the user needs the command that
+    # writes this artifact instead.
+    scenarios_file = tmp_path / "scenarios.json"
+    scenarios_file.write_text("not json\n", encoding="utf-8")
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    result = runner.invoke(app, ["scenarios", "verify", str(scenarios_file), "--file", str(corpus)])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ValidationError)
+    flat = _framed(result.output)
+    assert "is not a scenario set written by `wmo scenarios build`" in flat
+    assert "errors.pydantic.dev" not in flat
 
 
 def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa: ANN001


### PR DESCRIPTION
## What was broken

`wmo scenarios build`, `wmo scenarios verify` and `wmo research concurrency` fed user-supplied paths and suite names straight into the library layer. Every path mistake surfaced as a Python traceback instead of the framed usage error the same commands already produce for every other bad input, and one help string documented a value the command rejects.

Repro (no provider calls, nothing spent):

```bash
cd $(mktemp -d)
wmo scenarios verify /tmp/nope.json --file /tmp/nope.jsonl
```

Before: a rich-rendered traceback ending in `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/nope.json'`.

After:

```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid value: scenario set /tmp/nope.json does not exist; build one with    │
│ `wmo scenarios build --file <traces.jsonl> --out /tmp/nope.json`             │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## What changed

All in `wmo/cli/app.py`, at the CLI boundary only. No catch-all handler was added; each specific path is guarded.

- `_ingest_scenario_corpus(file)` is the new front door for the `--file` trace corpus shared by `scenarios build` and `scenarios verify`. A missing path or a directory becomes a `typer.BadParameter` that names `wmo download <benchmark>` (a directory gets the `--file <dir>/traces.otel.jsonl` form back). Previously `Path.read_text` raised `FileNotFoundError` / `IsADirectoryError`.
- `_load_scenario_set(scenarios_file)` guards the `scenarios verify` positional argument and catches pydantic's `ValidationError`. A missing, directory, or malformed set now points at `wmo scenarios build` and quotes the first validation message, instead of sending the user to `errors.pydantic.dev`.
- `research concurrency <suite>` wraps `resolve_eval_suite`'s `ValueError` into `typer.BadParameter` and appends `` `wmo eval list` prints the suites ``. This is the same `except ValueError -> BadParameter` idiom the five other arguments on that command already use; only the `research concurrency` call site is touched, so it does not collide with the `wmo eval run/grid` call sites.
- `scenarios build --help`: `--embed-provider` documented `azure_openai`, which `EmbedderKind` rejects (`EmbedderKind.AZURE_OPENAI.value == "azure"`, and the sibling `wmo build --help` already spells it `azure`). The help now lists `azure`, and a new test asserts the help names exactly the values `EmbedderKind` accepts, so the two cannot drift again.

Deliberately untouched, since they belong to sibling PRs: the `suite {suite!r} has no trace corpus` message (wheel-vs-checkout) and the `viz` extra `ModuleNotFoundError` in the plot commands (eval-robustness).

## Findings closed

- (a) `scenarios verify` tracebacks on a missing scenario-set file, a missing `--file` corpus, and a malformed scenario-set JSON (audit `wmo scenarios verify /tmp/nope.json --file /tmp/nope.jsonl`, major, `wmo/cli/app.py:1866`)
- (b) `scenarios build --file <missing or directory>` raises raw `FileNotFoundError` / `IsADirectoryError` (audit `wmo scenarios build --file /tmp/nope.jsonl`, minor, `wmo/cli/app.py:1816`)
- (c) `research concurrency nosuchsuite` raises a raw `ValueError` traceback instead of `typer.BadParameter` (audit `wmo research concurrency nosuchsuite`, minor, `wmo/engine/eval_suites.py:181`)
- (d) `scenarios build --embed-provider` help documents `azure_openai`, which the command rejects (audit `wmo scenarios build --help`, minor, `wmo/cli/app.py:1802`)

## Verification

- Every repro re-run through the real console entry point (`.venv/bin/wmo`), before and after: all four now exit 2 with a framed `Invalid value:` message and no traceback. The happy paths still work: a valid corpus ingests, `--embed-provider azure` is accepted, an existing-but-empty corpus still hits the pre-existing `no traces ingested from ...` error, and a valid scenario set still reaches the pre-existing `no world models built under .wmo/models` error.
- 12 new tests in `wmo/cli/app_test.py` covering each repro plus the help/`EmbedderKind` agreement.
- `uv run pytest -q`: 4159 passed, 20 skipped. `uv run ruff check .` and `uv run ty check` clean.

## Greptile review (3 comments, all fixed in 63359a7e)

- **P1, scenario-set decoding** — `ScenarioSet.load` reads with `encoding="utf-8"`, so non-UTF-8 bytes raise `UnicodeDecodeError` *before* pydantic and bypassed the `ValidationError` handler.
- **P1, corpus read errors** — the same miss one layer down: `from_file` -> `spans_from_file` -> `Path.read_text` (`wmo/ingest/base.py:99`), so an existing-but-unreadable (`PermissionError`) or non-UTF-8 corpus escaped the exists/is-dir guards.
  Both now route through a new `_unreadable_input`, which names the next command: `` `file <path>` `` for a decode failure, `` `ls -l <path>` `` for a permission one.
- **P2, suite advice obscured config errors** — `resolve_eval_suite` short-circuits on a direct `.toml` selector that exists, so those `ValueError`s are config errors in a suite the user already has; `` `wmo eval list` `` pointed away from the file that needs repairing. The hint is now appended only when the selector went through name lookup.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
