### PR TITLE
Resolve worker-role defaults from settings instead of hardcoding Bedrock

### DIFF
--- a/docs/reference/eval_suites.md
+++ b/docs/reference/eval_suites.md
@@ -51,7 +51,7 @@ wmo eval <trace files...>        # ad hoc replay scoring, no suite needed
 
 Suite CLI flags (`--prompt`, `--train-split`, `--top-k`, …) override the suite's pinned config for one-off comparisons. Results are written under `.wmo/evals/` (local artifacts, not committed).
 
-Both flows score on the `[models.worker]` role that `wmo providers set` writes to `.wmo/settings.toml`, falling back to bedrock/`claude-opus-4-8` when the project configured no role; `--provider`/`--model` override it for one run. Every run prints the backend it used (`scoring with openai (gpt-5.4-mini)`) and each saved result records it, because a fidelity number is only comparable against runs on the same model.
+Both flows score on the `[models.worker]` role that `wmo providers set` writes to `.wmo/settings.toml`, falling back to bedrock/`claude-opus-4-8` when the project configured no role; `--provider`/`--model` override it for one run. A `--provider` naming a different backend than the role takes its model from *that* backend's catalog, so `--provider openai` runs OpenAI's flagship rather than asking OpenAI for a Claude id. Every run prints the backend it used (`scoring with openai (gpt-5.4-mini)`) and each saved result records it, because a fidelity number is only comparable against runs on the same model.
 
 ## How it layers
 

--- a/docs/reference/eval_suites.md
+++ b/docs/reference/eval_suites.md
@@ -51,6 +51,8 @@ wmo eval <trace files...>        # ad hoc replay scoring, no suite needed
 
 Suite CLI flags (`--prompt`, `--train-split`, `--top-k`, …) override the suite's pinned config for one-off comparisons. Results are written under `.wmo/evals/` (local artifacts, not committed).
 
+Both flows score on the `[models.worker]` role that `wmo providers set` writes to `.wmo/settings.toml`, falling back to bedrock/`claude-opus-4-8` when the project configured no role; `--provider`/`--model` override it for one run. Every run prints the backend it used (`scoring with openai (gpt-5.4-mini)`) and each saved result records it, because a fidelity number is only comparable against runs on the same model.
+
 ## How it layers
 
 `wmo/engine/eval_suites.py` discovers suites (`examples_root/*/evals/*.toml`), resolves one by name, and lists persisted results. The `wmo eval` CLI command is a thin wrapper; scoring delegates to the same `wmo.engine.replay` path as ad hoc `wmo eval` and the research harness, so all fidelity numbers stay comparable.

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -1192,8 +1192,17 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     prompt_file: str | None = typer.Option(
         None, "--prompt", help="Prompt file; default=BASE_ENV_PROMPT."
     ),
-    provider: str = typer.Option("bedrock", "--provider", help="Provider running the model."),
-    model: str = typer.Option("claude-opus-4-8", help="Canonical model type."),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Provider running the model. Default: the worker role `wmo providers set` wrote to "
+        "`.wmo/settings.toml`, else bedrock.",
+    ),
+    model: str | None = typer.Option(
+        None,
+        help="Canonical model type. Default: the configured worker role's model, else "
+        "claude-opus-4-8.",
+    ),
     region: str | None = typer.Option(None, help="AWS region (Bedrock)."),
     chain: str | None = typer.Option(
         None, "--chain", help="Named failover chain from .wmo/fallback.toml (default: its default)."
@@ -1321,6 +1330,9 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
       heatmap (`viz` extra).
     - `wmo eval agreement <a.json> <b.json>`: compare two closed-loop reports task-by-task
       (e.g. world-model vs real environment) — the outcome-agreement validity check.
+
+    Open-loop scoring runs on the worker role `wmo providers set` writes to `.wmo/settings.toml`
+    (bedrock/claude-opus-4-8 when no role is configured); `--provider`/`--model` override it.
     """
     args = tokens or []
     suite_roots = (
@@ -1418,9 +1430,7 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
             examples_roots=suite_roots,
             results_root=results_root,
             prompt_file=prompt_file,
-            provider=provider,
-            model=model,
-            region=region,
+            provider_config=_worker_role_provider_config(provider, model, region),
             train_split=train_split,
             embed_dim=embed_dim,
             rag=rag,
@@ -1453,10 +1463,8 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     report = _run_eval_files(
         [Path(f) for f in args],
         options,
-        provider=provider,
-        model=model,
+        provider_config=_worker_role_provider_config(provider, model, region),
         chain=chain,
-        region=region,
     )
     _require_scorable_steps(
         report,
@@ -1714,9 +1722,7 @@ def _eval_run_suite(
     examples_roots: list[str],
     results_root: str,
     prompt_file: str | None,
-    provider: str,
-    model: str,
-    region: str | None,
+    provider_config: ProviderConfig,
     train_split: float | None,
     embed_dim: int | None,
     rag: bool | None,
@@ -1745,7 +1751,7 @@ def _eval_run_suite(
         raise typer.BadParameter(
             f"eval suite {suite.id} lists no trace files; set `files` in {suite.path}"
         )
-    report = _run_eval_files(files, options, provider=provider, model=model, region=region)
+    report = _run_eval_files(files, options, provider_config=provider_config)
     # A suite run is saved under --results-root and resurfaces in `wmo eval results`, so a
     # zero-step scorecard must fail here rather than persist as a real 0.000 measurement.
     _require_scorable_steps(
@@ -1765,10 +1771,13 @@ def _eval_run_suite(
         "suite": suite.id,
         "suite_path": str(suite.path),
         "suite_config": suite.config.model_dump(mode="json"),
+        # The RESOLVED backend, not the raw flags: with the flags omitted these come from the
+        # configured worker role, and a result JSON that recorded `null` could not say which
+        # model produced the fidelity number.
         "config": {
-            "provider": provider,
-            "model": model,
-            "region": region,
+            "provider": provider_config.kind.value,
+            "model": provider_config.model_type or provider_config.model,
+            "region": provider_config.region,
             "prompt": options.prompt_file,
             "files": [str(path) for path in files],
             "train_split": options.train_split,
@@ -1839,9 +1848,7 @@ def _run_eval_files(
     files: list[Path],
     options: _EvalOptions,
     *,
-    provider: str,
-    model: str,
-    region: str | None,
+    provider_config: ProviderConfig,
     chain: str | None = None,
 ) -> EvalReport:
     for path in files:
@@ -1852,7 +1859,12 @@ def _run_eval_files(
                 f"not a trace file: {path} is a directory; pass the export itself "
                 f"(e.g. `wmo eval {path}/traces.otel.jsonl`)"
             )
-    provider_config = _provider_config(provider, model, region)
+    # Name the backend: the number below is only comparable against runs on the same model, and
+    # with no flags the model comes from settings rather than the command line.
+    _console.print(
+        f"scoring with {provider_config.kind.value} "
+        f"({provider_config.model_type or provider_config.model})"
+    )
     # A missing/unknown chain, or a multi-chain fallback.toml with no `default`, is a usage
     # error: the message already names the file, so it must not arrive as a traceback.
     try:
@@ -2053,7 +2065,7 @@ def scenarios_verify(
     if provider is not None or model is not None:
         store = WorldModelStore(root)
         model_dir = store.resolve(_resolve_name(store, name))
-        override = _provider_config(provider or "bedrock", model or "claude-opus-4-8", region)
+        override = _worker_role_provider_config(provider, model, region)
         llm = wrap_provider_with_retries(providers.get_provider(override))
         world_model = WorldModel.load(str(model_dir), llm)
     else:
@@ -2194,8 +2206,10 @@ def _provider_config(provider: str, model: str, region: str | None) -> ProviderC
     )
 
 
-_SCENARIO_DEFAULT_PROVIDER = "bedrock"
-_SCENARIO_DEFAULT_MODEL = "claude-opus-4-8"
+# The backend a worker-role command falls back to when the project configured no
+# `[models.worker]` role at all. Never a substitute for a configured role.
+_DEFAULT_WORKER_PROVIDER = "bedrock"
+_DEFAULT_WORKER_MODEL = "claude-opus-4-8"
 
 
 def _role_provider_config(role: str, region: str | None) -> ProviderConfig | None:
@@ -2215,23 +2229,43 @@ def _role_provider_config(role: str, region: str | None) -> ProviderConfig | Non
     )
 
 
+def _worker_role_provider_config(
+    provider: str | None, model: str | None, region: str | None
+) -> ProviderConfig:
+    """The backend for a worker-role call: explicit flags, then the worker role, then the default.
+
+    `wmo providers set` writes `[models.worker]` and is step 1 of the documented getting-started
+    path, so a command that ignored it would run against a provider the user never configured.
+    Each field falls back independently, and a `--provider` naming a DIFFERENT backend than the
+    configured role drops that role's model and connection fields, which belong to the backend it
+    replaced.
+    """
+    configured = _role_provider_config("worker", region)
+    if configured is None or (provider is not None and provider != configured.kind.value):
+        return _provider_config(
+            provider or _DEFAULT_WORKER_PROVIDER, model or _DEFAULT_WORKER_MODEL, region
+        )
+    if model is None:
+        return configured
+    spec = resolve_provider_model(configured.kind, model)
+    return configured.model_copy(update={"model_type": spec.model_type, "model": spec.model_id})
+
+
 def _scenario_role_llms(
     provider: str | None, model: str | None, region: str | None
 ) -> tuple[Provider, Provider, Provider]:
     """(summary, worker, judge) providers for scenario construction.
 
     Explicit `--provider`/`--model` flags pin ALL roles to that one model (the pre-roles
-    behavior). Otherwise each role resolves from `.wmo/settings.toml`, falling back to worker,
-    then to the built-in default. Judging benefits from a different family than the worker —
-    a same-family judge carries self-preference bias toward the generator's outputs.
+    behavior); half a pair completes from the configured worker role rather than from bedrock.
+    Otherwise each role resolves from `.wmo/settings.toml`, falling back to worker, then to the
+    built-in default. Judging benefits from a different family than the worker: a same-family
+    judge carries self-preference bias toward the generator's outputs.
     """
     if provider is not None or model is not None:
-        config = _provider_config(
-            provider or _SCENARIO_DEFAULT_PROVIDER, model or _SCENARIO_DEFAULT_MODEL, region
-        )
-        llm = providers.get_provider(config)
+        llm = providers.get_provider(_worker_role_provider_config(provider, model, region))
         return llm, llm, llm
-    default = _provider_config(_SCENARIO_DEFAULT_PROVIDER, _SCENARIO_DEFAULT_MODEL, region)
+    default = _provider_config(_DEFAULT_WORKER_PROVIDER, _DEFAULT_WORKER_MODEL, region)
     cache: dict[str, Provider] = {}
     by_role: dict[str, Provider] = {}
     for role in ("summary", "worker", "judge"):
@@ -2597,8 +2631,17 @@ def research_concurrency(
     side: str = typer.Option(
         "both", "--side", help="both = differential | world = WM-only | real = sandbox-only."
     ),
-    provider: str = typer.Option("bedrock", "--provider", help="Provider running the model."),
-    model: str = typer.Option("us.anthropic.claude-opus-4-8", help="Model id (environment LLM)."),
+    provider: str | None = typer.Option(
+        None,
+        "--provider",
+        help="Provider running the model. Default: the worker role `wmo providers set` wrote to "
+        "`.wmo/settings.toml`, else bedrock.",
+    ),
+    model: str | None = typer.Option(
+        None,
+        help="Model id (environment LLM). Default: the configured worker role's model, else "
+        "claude-opus-4-8.",
+    ),
     region: str | None = typer.Option(None, help="AWS region (Bedrock)."),
     deployment: str | None = typer.Option(None, help="Azure OpenAI deployment name."),
     api_version: str | None = typer.Option(None, help="Azure OpenAI API version."),
@@ -2624,12 +2667,20 @@ def research_concurrency(
     except ValueError:
         allowed = ", ".join(s.value for s in Side)
         raise typer.BadParameter(f"--side must be one of: {allowed}") from None
-    # Validate the provider up front, not lazily inside a worker thread mid-sweep.
-    try:
-        provider_kind = ProviderKind(provider)
-    except ValueError:
-        kinds = ", ".join(k.value for k in ProviderKind)
-        raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
+    # Resolve (and so validate) the environment LLM up front, not lazily inside a worker thread
+    # mid-sweep. Omitted flags come from the configured worker role.
+    env_config = _worker_role_provider_config(provider, model, region)
+    connection = {
+        field: value
+        for field, value in (
+            ("deployment", deployment),
+            ("api_version", api_version),
+            ("endpoint", endpoint),
+        )
+        if value is not None
+    }
+    if connection:
+        env_config = env_config.model_copy(update=connection)
     if select not in ("simplest", "longest", "random"):
         raise typer.BadParameter("--select must be one of: simplest, longest, random")
     try:
@@ -2708,16 +2759,7 @@ def research_concurrency(
     )
 
     def provider_factory() -> Provider:
-        return providers.get_provider(
-            ProviderConfig(
-                kind=provider_kind,
-                model=model,
-                region=region,
-                deployment=deployment,
-                api_version=api_version,
-                endpoint=endpoint,
-            )
-        )
+        return providers.get_provider(env_config)
 
     world_runner = build_world_runner(provider_factory, prompt, demos, selected)
     real_runner = None

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -106,7 +106,11 @@ from wmo.ingest import VendorPull, get_adapter, list_adapters
 from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
 from wmo.providers.base import Embedder, EmbedderKind, Provider
-from wmo.providers.models import model_types_for_provider, resolve_provider_model
+from wmo.providers.models import (
+    ProviderModel,
+    model_types_for_provider,
+    resolve_provider_model,
+)
 from wmo.providers.pool import Tier
 from wmo.providers.retry import wrap_provider_with_retries
 from wmo.research import Side, run_concurrency_scaling
@@ -2251,8 +2255,41 @@ def _role_provider_config(role: str, region: str | None) -> ProviderConfig | Non
     )
 
 
+def _azure_deployment_for_model(
+    configured: ProviderConfig, spec: ProviderModel, deployment: str | None
+) -> str:
+    """The Azure deployment to invoke after `--model` moved the role off its configured one.
+
+    On Azure the wire `model` IS the deployment name (`AzureOpenAIProvider._deployment`), so a
+    role's deployment names the model being replaced. Keeping it would call the old model and
+    report the new one. Guessing the new one is no better: an operator's deployment name is not
+    derivable from a model id, and a wrong guess 404s on every prediction, which `wmo eval`
+    reports as a silent `fidelity=0.000` at exit 0 — the defect this whole path exists to stop.
+    So a model swap on Azure has to be told which deployment serves it.
+    """
+    if deployment is not None:
+        return deployment
+    if configured.deployment is None:
+        # Nothing configured to contradict, so derive it from the model as
+        # `_worker_provider_config` does; the role could not have been called without one anyway.
+        return spec.model_type
+    if configured.deployment in (spec.model_type, spec.model_id):
+        return configured.deployment
+    raise typer.BadParameter(
+        f"the configured azure worker serves {configured.model} from deployment "
+        f"{configured.deployment!r}, and on Azure the deployment name is what is actually "
+        f"invoked, so --model {spec.model_type} needs the deployment that serves it. Run "
+        f"`wmo providers set --provider azure --model {spec.model_type} "
+        f"--deployment <deployment>` to point the worker role at it."
+    )
+
+
 def _worker_role_provider_config(
-    provider: str | None, model: str | None, region: str | None
+    provider: str | None,
+    model: str | None,
+    region: str | None,
+    *,
+    deployment: str | None = None,
 ) -> ProviderConfig:
     """The backend for a worker-role call: explicit flags, then the worker role, then the default.
 
@@ -2265,20 +2302,22 @@ def _worker_role_provider_config(
     configured = _role_provider_config("worker", region)
     if configured is None or (provider is not None and provider != configured.kind.value):
         kind = _provider_kind(provider or _DEFAULT_WORKER_PROVIDER)
-        return _provider_config(kind.value, model or _default_model_for_provider(kind), region)
-    if model is None:
-        return configured
-    spec = resolve_provider_model(configured.kind, model)
-    if spec.model_id == configured.model:
-        return configured
-    update: dict[str, object] = {"model_type": spec.model_type, "model": spec.model_id}
-    if configured.kind is ProviderKind.AZURE_OPENAI:
-        # On Azure the wire `model` IS the deployment name (AzureOpenAIProvider._deployment), so
-        # the role's deployment names the model we are replacing. Carrying it over would call the
-        # old model and report the new one — the misattribution this whole path exists to stop.
-        # Re-derive it from the requested model, as `_worker_provider_config` already does.
-        update["deployment"] = spec.model_type
-    return configured.model_copy(update=update)
+        config = _provider_config(kind.value, model or _default_model_for_provider(kind), region)
+    elif model is None:
+        config = configured
+    else:
+        spec = resolve_provider_model(configured.kind, model)
+        if spec.model_id == configured.model:
+            # Re-stating the role's own model is not a model change: leave its connection alone.
+            config = configured
+        else:
+            update: dict[str, object] = {"model_type": spec.model_type, "model": spec.model_id}
+            if configured.kind is ProviderKind.AZURE_OPENAI:
+                update["deployment"] = _azure_deployment_for_model(configured, spec, deployment)
+            config = configured.model_copy(update=update)
+    if deployment is not None:
+        config = config.model_copy(update={"deployment": deployment})
+    return config
 
 
 def _scenario_role_llms(
@@ -2699,14 +2738,12 @@ def research_concurrency(
         raise typer.BadParameter(f"--side must be one of: {allowed}") from None
     # Resolve (and so validate) the environment LLM up front, not lazily inside a worker thread
     # mid-sweep. Omitted flags come from the configured worker role.
-    env_config = _worker_role_provider_config(provider, model, region)
+    # `--deployment` goes IN rather than on top: on Azure it is what a `--model` swap needs to
+    # know, and layering it afterwards would reject a run the user had already answered for.
+    env_config = _worker_role_provider_config(provider, model, region, deployment=deployment)
     connection = {
         field: value
-        for field, value in (
-            ("deployment", deployment),
-            ("api_version", api_version),
-            ("endpoint", endpoint),
-        )
+        for field, value in (("api_version", api_version), ("endpoint", endpoint))
         if value is not None
     }
     if connection:

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -106,7 +106,7 @@ from wmo.ingest import VendorPull, get_adapter, list_adapters
 from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
 from wmo.providers.base import Embedder, EmbedderKind, Provider
-from wmo.providers.models import resolve_provider_model
+from wmo.providers.models import model_types_for_provider, resolve_provider_model
 from wmo.providers.pool import Tier
 from wmo.providers.retry import wrap_provider_with_retries
 from wmo.research import Side, run_concurrency_scaling
@@ -1200,8 +1200,8 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     ),
     model: str | None = typer.Option(
         None,
-        help="Canonical model type. Default: the configured worker role's model, else "
-        "claude-opus-4-8.",
+        help="Canonical model type. Default: the configured worker role's model, else the "
+        "flagship of whichever provider is in play (bedrock/claude-opus-4-8).",
     ),
     region: str | None = typer.Option(None, help="AWS region (Bedrock)."),
     chain: str | None = typer.Option(
@@ -2191,12 +2191,16 @@ def _unreadable_input(
     )
 
 
-def _provider_config(provider: str, model: str, region: str | None) -> ProviderConfig:
+def _provider_kind(provider: str) -> ProviderKind:
     try:
-        kind = ProviderKind(provider)
+        return ProviderKind(provider)
     except ValueError:
         kinds = ", ".join(k.value for k in ProviderKind)
         raise typer.BadParameter(f"unknown provider {provider!r}; choose one of: {kinds}") from None
+
+
+def _provider_config(provider: str, model: str, region: str | None) -> ProviderConfig:
+    kind = _provider_kind(provider)
     spec = resolve_provider_model(kind, model)
     return ProviderConfig(
         kind=kind,
@@ -2210,6 +2214,24 @@ def _provider_config(provider: str, model: str, region: str | None) -> ProviderC
 # `[models.worker]` role at all. Never a substitute for a configured role.
 _DEFAULT_WORKER_PROVIDER = "bedrock"
 _DEFAULT_WORKER_MODEL = "claude-opus-4-8"
+
+
+def _default_model_for_provider(kind: ProviderKind) -> str:
+    """`kind`'s flagship: the model to run when neither a flag nor a role named one.
+
+    A default model belongs to ONE backend — pairing `--provider openai` with bedrock's
+    `claude-opus-4-8` sends a model OpenAI has never heard of. `openrouter` and `tinker` publish
+    no built-in rows (nothing can derive an operator's route or weights path), so they must be
+    told which model to run.
+    """
+    catalog = model_types_for_provider(kind)
+    if not catalog:
+        raise typer.BadParameter(
+            f"provider {kind.value!r} has no default model; pass --model <model>, or run "
+            f"`wmo providers set --provider {kind.value} --model <model>` to configure the "
+            f"worker role"
+        )
+    return catalog[0]
 
 
 def _role_provider_config(role: str, region: str | None) -> ProviderConfig | None:
@@ -2238,17 +2260,25 @@ def _worker_role_provider_config(
     path, so a command that ignored it would run against a provider the user never configured.
     Each field falls back independently, and a `--provider` naming a DIFFERENT backend than the
     configured role drops that role's model and connection fields, which belong to the backend it
-    replaced.
+    replaced — the model then comes from the NEW backend's catalog, never from bedrock's.
     """
     configured = _role_provider_config("worker", region)
     if configured is None or (provider is not None and provider != configured.kind.value):
-        return _provider_config(
-            provider or _DEFAULT_WORKER_PROVIDER, model or _DEFAULT_WORKER_MODEL, region
-        )
+        kind = _provider_kind(provider or _DEFAULT_WORKER_PROVIDER)
+        return _provider_config(kind.value, model or _default_model_for_provider(kind), region)
     if model is None:
         return configured
     spec = resolve_provider_model(configured.kind, model)
-    return configured.model_copy(update={"model_type": spec.model_type, "model": spec.model_id})
+    if spec.model_id == configured.model:
+        return configured
+    update: dict[str, object] = {"model_type": spec.model_type, "model": spec.model_id}
+    if configured.kind is ProviderKind.AZURE_OPENAI:
+        # On Azure the wire `model` IS the deployment name (AzureOpenAIProvider._deployment), so
+        # the role's deployment names the model we are replacing. Carrying it over would call the
+        # old model and report the new one — the misattribution this whole path exists to stop.
+        # Re-derive it from the requested model, as `_worker_provider_config` already does.
+        update["deployment"] = spec.model_type
+    return configured.model_copy(update=update)
 
 
 def _scenario_role_llms(
@@ -2639,8 +2669,8 @@ def research_concurrency(
     ),
     model: str | None = typer.Option(
         None,
-        help="Model id (environment LLM). Default: the configured worker role's model, else "
-        "claude-opus-4-8.",
+        help="Model id (environment LLM). Default: the configured worker role's model, else the "
+        "flagship of whichever provider is in play (bedrock/claude-opus-4-8).",
     ),
     region: str | None = typer.Option(None, help="AWS region (Bedrock)."),
     deployment: str | None = typer.Option(None, help="Azure OpenAI deployment name."),

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -2174,7 +2174,7 @@ def test_worker_role_provider_config_falls_back_to_bedrock(monkeypatch) -> None:
     assert config.model == "us.anthropic.claude-opus-4-8"
 
 
-def _azure_worker_settings(monkeypatch: pytest.MonkeyPatch, deployment: str) -> None:
+def _azure_worker_settings(monkeypatch: pytest.MonkeyPatch, deployment: str | None) -> None:
     from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
 
     monkeypatch.setattr(
@@ -2197,21 +2197,53 @@ def test_worker_role_provider_config_model_flag_keeps_the_role_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # The endpoint describes the BACKEND, not the model, so swapping the model keeps it.
-    _azure_worker_settings(monkeypatch, "gpt-5.4")
+    _azure_worker_settings(monkeypatch, "prod-54-canary")
 
-    config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+    config = cli_app_module._worker_role_provider_config(
+        None, "gpt-5.5", None, deployment="prod-55-canary"
+    )
 
     assert config.kind is ProviderKind.AZURE_OPENAI
     assert config.model == "gpt-5.5"
     assert config.endpoint == "https://azure.example/v1"
+    assert config.deployment == "prod-55-canary"
 
 
-def test_worker_role_provider_config_model_flag_moves_the_azure_deployment(
+def test_worker_role_provider_config_refuses_an_azure_model_swap_without_a_deployment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # On Azure the wire `model` IS the deployment name, so the role's deployment names the model
-    # being replaced. Carrying it over would call gpt-5.4 while reporting gpt-5.5.
-    _azure_worker_settings(monkeypatch, "gpt-5.4")
+    # being replaced. Keeping it would call gpt-5.4 while reporting gpt-5.5; guessing `gpt-5.5`
+    # 404s on a resource that names deployments anything else, and `wmo eval` turns that into a
+    # silent fidelity=0.000 at exit 0. So refuse, naming the command that fixes it.
+    _azure_worker_settings(monkeypatch, "prod-54-canary")
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+
+    message = str(excinfo.value)
+    assert "prod-54-canary" in message
+    assert "wmo providers set --provider azure --model gpt-5.5 --deployment <deployment>" in message
+
+
+def test_worker_role_provider_config_allows_an_azure_model_swap_the_deployment_already_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A resource whose deployments are named after their models has already answered the question.
+    _azure_worker_settings(monkeypatch, "gpt-5.5")
+
+    config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+
+    assert config.model == "gpt-5.5"
+    assert config.deployment == "gpt-5.5"
+
+
+def test_worker_role_provider_config_derives_a_deployment_the_role_never_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Nothing configured to contradict, so fall back to the model type as
+    # `_worker_provider_config` does rather than refusing over a value that was never there.
+    _azure_worker_settings(monkeypatch, None)
 
     config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1091,8 +1091,11 @@ def test_eval_pins_the_judge_off_the_failover_chain(monkeypatch, tmp_path) -> No
 
     monkeypatch.setattr(providers_pkg, "provider_or_chain", provider_or_chain)
     monkeypatch.setattr(providers_pkg, "get_provider", get_provider)
+    traces = _traces_file(tmp_path)
+    # No settings.toml here, so the asserted bedrock ids are the no-role-configured fallback.
+    monkeypatch.chdir(tmp_path)
 
-    result = runner.invoke(app, ["eval", _traces_file(tmp_path), "--no-rag"])
+    result = runner.invoke(app, ["eval", traces, "--no-rag"])
 
     assert result.exit_code == 0, result.output
     judge_systems_chain = [s for s in chain.systems if "grade a world model" in s]
@@ -1106,6 +1109,101 @@ def test_eval_pins_the_judge_off_the_failover_chain(monkeypatch, tmp_path) -> No
         "us.anthropic.claude-opus-4-8",
     ]
     assert all(config.model_type == "claude-opus-4-8" for config in configs)
+
+
+def _record_eval_providers(monkeypatch: pytest.MonkeyPatch) -> list[ProviderConfig]:
+    """Capture every ProviderConfig `wmo eval` builds, and answer with the fake provider."""
+    seen: list[ProviderConfig] = []
+    fake = FakeProvider()
+
+    def record(config: ProviderConfig, **_kwargs: object) -> FakeProvider:
+        seen.append(config)
+        return fake
+
+    monkeypatch.setattr(cli_app_module.providers, "provider_or_chain", record)
+    monkeypatch.setattr(cli_app_module.providers, "get_provider", record)
+    return seen
+
+
+def _write_worker_role(root: Path, provider: str, model: str) -> None:
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider=provider, model=model)
+    save_settings(settings, root)
+
+
+def test_eval_uses_configured_worker_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # `wmo providers set` (step 1 of getting started) writes [models.worker]. eval used to score
+    # against a hardcoded bedrock/claude-opus-4-8 regardless, so an OpenAI-only project got a
+    # 0.000 fidelity at exit 0 from a provider it never configured.
+    traces = _traces_file(tmp_path)
+    _write_worker_role(tmp_path / ".wmo", "openai", "gpt-5.4-mini")
+    monkeypatch.chdir(tmp_path)
+    seen = _record_eval_providers(monkeypatch)
+
+    result = runner.invoke(app, ["eval", traces, "--no-rag"])
+
+    assert result.exit_code == 0, result.output
+    assert {config.kind for config in seen} == {ProviderKind.OPENAI}
+    assert {config.model for config in seen} == {"gpt-5.4-mini"}
+    # The report is only comparable across runs on the same model, so eval names the backend.
+    assert "scoring with openai (gpt-5.4-mini)" in result.output
+
+
+def test_eval_provider_flag_overrides_the_configured_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    traces = _traces_file(tmp_path)
+    _write_worker_role(tmp_path / ".wmo", "openai", "gpt-5.4-mini")
+    monkeypatch.chdir(tmp_path)
+    seen = _record_eval_providers(monkeypatch)
+
+    result = runner.invoke(app, ["eval", traces, "--no-rag", "--provider", "bedrock"])
+
+    assert result.exit_code == 0, result.output
+    assert {config.kind for config in seen} == {ProviderKind.BEDROCK}
+    # A --provider naming another backend drops the role's model: gpt-5.4-mini is not on bedrock.
+    assert {config.model for config in seen} == {"us.anthropic.claude-opus-4-8"}
+
+
+def test_eval_suite_run_records_the_resolved_worker_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The result JSON must name the model that produced the number, which with no flags is the
+    # configured role rather than anything on the command line.
+    examples_root = tmp_path / "examples"
+    evals_dir = examples_root / "tiny-task" / "evals"
+    evals_dir.mkdir(parents=True)
+    (examples_root / "tiny-task" / "traces.otel.jsonl").write_text(
+        Path(_traces_file(tmp_path)).read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (evals_dir / "default.toml").write_text(
+        'files = ["../traces.otel.jsonl"]\ntrain_split = 0.5\n', encoding="utf-8"
+    )
+    _write_worker_role(tmp_path / ".wmo", "openai", "gpt-5.4-mini")
+    monkeypatch.chdir(tmp_path)
+    seen = _record_eval_providers(monkeypatch)
+    results_root = tmp_path / ".wmo" / "evals"
+
+    ran = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "tiny-task",
+            "--examples-root",
+            str(examples_root),
+            "--results-root",
+            str(results_root),
+        ],
+    )
+
+    assert ran.exit_code == 0, ran.output
+    assert {config.kind for config in seen} == {ProviderKind.OPENAI}
+    payload = json.loads(next(iter(results_root.glob("tiny-task/default/*.json"))).read_text())
+    assert payload["config"]["provider"] == "openai"
+    assert payload["config"]["model"] == "gpt-5.4-mini"
 
 
 def test_eval_suite_list_run_and_results(patched_provider, tmp_path) -> None:  # noqa: ANN001
@@ -1744,6 +1842,58 @@ def test_providers_verify_name_scopes_the_report_to_one_world_model(
     assert "models.worker" not in result.output
 
 
+def test_research_concurrency_uses_the_configured_worker_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The environment LLM is the same worker-role call every other command makes; it used to be
+    # pinned to bedrock/claude-opus-4-8 whatever the project configured.
+    examples_root = tmp_path / "examples"
+    evals_dir = examples_root / "tiny-task" / "evals"
+    evals_dir.mkdir(parents=True)
+    (examples_root / "tiny-task" / "traces.otel.jsonl").write_text(
+        Path(_traces_file(tmp_path)).read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (evals_dir / "default.toml").write_text(
+        'files = ["../traces.otel.jsonl"]\ntrain_split = 0.5\n', encoding="utf-8"
+    )
+    _write_worker_role(tmp_path / ".wmo", "openai", "gpt-5.4-mini")
+    monkeypatch.chdir(tmp_path)
+    # get_provider is the identity here, so calling the runner's factory yields its config.
+    built: list[ProviderConfig] = []
+    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr(
+        cli_app_module,
+        "build_world_runner",
+        lambda factory, prompt, demos, selected: built.append(factory()),
+    )
+    monkeypatch.setattr(
+        cli_app_module,
+        "run_concurrency_scaling",
+        lambda *a, **kw: SimpleNamespace(benchmark="", best_speedup=lambda: None),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "research",
+            "concurrency",
+            "tiny-task",
+            "--examples-root",
+            str(examples_root),
+            "--side",
+            "world",
+            "--scenarios",
+            "1",
+            "--levels",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert built[0].kind is ProviderKind.OPENAI
+    assert built[0].model == "gpt-5.4-mini"
+
+
 def test_research_concurrency_rejects_level_above_scenarios_fixed_n() -> None:
     # Fixed-N: a level above --scenarios would silently cap concurrency at N and duplicate the
     # N-worker point, so it must fail fast (guard fires before any suite/corpus resolution).
@@ -1976,11 +2126,32 @@ def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa:
 
 
 def test_scenario_role_llms_cli_flags_pin_every_role(monkeypatch) -> None:  # noqa: ANN001
+    from wmo.config.settings import ProjectSettings
+
     monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
     summary, worker, judge = cli_app_module._scenario_role_llms("bedrock", "some-model", None)
     assert summary is worker
     assert worker is judge
     assert cast(ProviderConfig, worker).model == "some-model"
+
+
+def test_scenario_role_llms_model_flag_keeps_the_configured_provider(monkeypatch) -> None:  # noqa: ANN001
+    # Half a flag pair used to complete from bedrock, so `--model gpt-5.5` on an OpenAI project
+    # asked bedrock for an OpenAI model id.
+    from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
+
+    monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
+    monkeypatch.setattr(
+        cli_app_module,
+        "load_settings",
+        lambda: ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="openai", model="gpt-5.4-mini"))
+        ),
+    )
+    _summary, worker, _judge = cli_app_module._scenario_role_llms(None, "gpt-5.5", None)
+    assert cast(ProviderConfig, worker).kind is ProviderKind.OPENAI
+    assert cast(ProviderConfig, worker).model == "gpt-5.5"
 
 
 def test_scenario_role_llms_default_when_nothing_configured(monkeypatch) -> None:  # noqa: ANN001
@@ -1992,6 +2163,41 @@ def test_scenario_role_llms_default_when_nothing_configured(monkeypatch) -> None
     assert summary is worker
     assert worker is judge
     assert cast(ProviderConfig, worker).model == "us.anthropic.claude-opus-4-8"
+
+
+def test_worker_role_provider_config_falls_back_to_bedrock(monkeypatch) -> None:  # noqa: ANN001
+    from wmo.config.settings import ProjectSettings
+
+    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+    config = cli_app_module._worker_role_provider_config(None, None, None)
+    assert config.kind is ProviderKind.BEDROCK
+    assert config.model == "us.anthropic.claude-opus-4-8"
+
+
+def test_worker_role_provider_config_model_flag_keeps_the_role_connection(monkeypatch) -> None:  # noqa: ANN001
+    # Swapping the model on the configured backend must keep that backend's endpoint/deployment:
+    # they describe the connection, not the model.
+    from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
+
+    monkeypatch.setattr(
+        cli_app_module,
+        "load_settings",
+        lambda: ProjectSettings(
+            models=ModelsSettings(
+                worker=ModelRole(
+                    provider="azure",
+                    model="gpt-5.4",
+                    endpoint="https://azure.example/v1",
+                    deployment="configured-deployment",
+                )
+            )
+        ),
+    )
+    config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+    assert config.kind is ProviderKind.AZURE_OPENAI
+    assert config.model == "gpt-5.5"
+    assert config.endpoint == "https://azure.example/v1"
+    assert config.deployment == "configured-deployment"
 
 
 def test_download_fetches_named_benchmarks(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -2174,9 +2174,7 @@ def test_worker_role_provider_config_falls_back_to_bedrock(monkeypatch) -> None:
     assert config.model == "us.anthropic.claude-opus-4-8"
 
 
-def test_worker_role_provider_config_model_flag_keeps_the_role_connection(monkeypatch) -> None:  # noqa: ANN001
-    # Swapping the model on the configured backend must keep that backend's endpoint/deployment:
-    # they describe the connection, not the model.
+def _azure_worker_settings(monkeypatch: pytest.MonkeyPatch, deployment: str) -> None:
     from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
 
     monkeypatch.setattr(
@@ -2188,16 +2186,86 @@ def test_worker_role_provider_config_model_flag_keeps_the_role_connection(monkey
                     provider="azure",
                     model="gpt-5.4",
                     endpoint="https://azure.example/v1",
-                    deployment="configured-deployment",
+                    deployment=deployment,
                 )
             )
         ),
     )
+
+
+def test_worker_role_provider_config_model_flag_keeps_the_role_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The endpoint describes the BACKEND, not the model, so swapping the model keeps it.
+    _azure_worker_settings(monkeypatch, "gpt-5.4")
+
     config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+
     assert config.kind is ProviderKind.AZURE_OPENAI
     assert config.model == "gpt-5.5"
     assert config.endpoint == "https://azure.example/v1"
-    assert config.deployment == "configured-deployment"
+
+
+def test_worker_role_provider_config_model_flag_moves_the_azure_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # On Azure the wire `model` IS the deployment name, so the role's deployment names the model
+    # being replaced. Carrying it over would call gpt-5.4 while reporting gpt-5.5.
+    _azure_worker_settings(monkeypatch, "gpt-5.4")
+
+    config = cli_app_module._worker_role_provider_config(None, "gpt-5.5", None)
+
+    assert config.deployment == "gpt-5.5"
+
+
+def test_worker_role_provider_config_keeps_a_custom_deployment_for_the_same_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Re-stating the role's own model is not a model change: an operator's deployment name is not
+    # derivable from the model id, so re-deriving it here would break a working config.
+    _azure_worker_settings(monkeypatch, "prod-54-canary")
+
+    config = cli_app_module._worker_role_provider_config(None, "gpt-5.4", None)
+
+    assert config.deployment == "prod-54-canary"
+
+
+def test_worker_role_provider_config_provider_flag_uses_that_backends_flagship(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A --provider naming another backend must take its model from THAT backend's catalog:
+    # pairing --provider openai with bedrock's claude-opus-4-8 sends OpenAI a model it has never
+    # heard of, so the command fails instead of running on the backend the user selected.
+    from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings
+
+    monkeypatch.setattr(
+        cli_app_module,
+        "load_settings",
+        lambda: ProjectSettings(
+            models=ModelsSettings(worker=ModelRole(provider="bedrock", model="claude-sonnet-4-6"))
+        ),
+    )
+
+    config = cli_app_module._worker_role_provider_config("openai", None, None)
+
+    assert config.kind is ProviderKind.OPENAI
+    assert config.model == "gpt-5.5"
+
+
+def test_worker_role_provider_config_demands_a_model_for_a_catalog_less_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # openrouter/tinker publish no built-in rows — nothing can derive an operator's route or
+    # weights path — so the fix is to say which model, not to guess one.
+    from wmo.config.settings import ProjectSettings
+
+    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+
+    with pytest.raises(typer.BadParameter) as excinfo:
+        cli_app_module._worker_role_provider_config("openrouter", None, None)
+
+    assert "pass --model <model>" in str(excinfo.value)
+    assert "wmo providers set --provider openrouter --model <model>" in str(excinfo.value)
 
 
 def test_download_fetches_named_benchmarks(monkeypatch, tmp_path: Path) -> None:  # noqa: ANN001


### PR DESCRIPTION
## What was broken

`wmo eval` declared its provider defaults as literals (`wmo/cli/app.py:1086-1087`, `--provider bedrock --model claude-opus-4-8`) and never called `load_settings()`. It therefore ignored the `[models.worker]` role that `wmo providers set` writes to `.wmo/settings.toml`, which is step 1 of the documented getting-started path. An OpenAI-only project scored against Bedrock, every prediction failed, and the command exited 0 printing `OVERALL fidelity=0.000` with no hint of which backend produced it: the reason only appeared inside the `--out` JSON critique. `wmo build` (app.py:657) already honours the same role, so build and eval disagreed.

Repro (no credentials needed, nothing is spent):

```bash
mkdir /tmp/wmo-eval-repro && cd /tmp/wmo-eval-repro
mkdir .wmo && printf '[models.worker]\nprovider = "openai"\nmodel = "gpt-5.4-mini"\n' > .wmo/settings.toml
# any OTel-GenAI trace file will do
wmo eval traces.jsonl --no-rag --out report.json
python3 -c "import json;print(list(json.load(open('report.json')).values())[0]['results'][0]['critique'])"
```

Before: `prediction failed: ValueError: BedrockProvider has no region...` (exit 0, fidelity 0.000).
After: the run prints `scoring with openai (gpt-5.4-mini)` and the failure names `OPENAI_API_KEY`, the provider the user actually configured.

## What changed

- New `_worker_role_provider_config(provider, model, region)` in `wmo/cli/app.py`: the single place that resolves a worker-role call. Explicit flags win, then `[models.worker]`, then the built-in `bedrock`/`claude-opus-4-8` fallback when no role is configured. A `--provider` naming a different backend than the role drops that role's model and connection fields; a bare `--model` keeps the role's provider, region, endpoint, and deployment.
- `wmo eval` (ad hoc and `wmo eval run <suite>`) resolves through it. `--provider`/`--model` still override, and the help text and docstring now say where the default comes from.
- Neighbours with the same hardcoding, found by grepping the `bedrock`/`claude-opus-4-8` literals:
  - `wmo scenarios verify --model X` (app.py:1869) pinned bedrock when only `--model` was given.
  - `wmo scenarios build --model X` (`_scenario_role_llms`) did the same, so `--model gpt-5.5` on an OpenAI project asked Bedrock for an OpenAI model id.
  - `wmo research concurrency` hardcoded `bedrock` / `us.anthropic.claude-opus-4-8` for the environment LLM. Its `--deployment`/`--api-version`/`--endpoint` flags now layer on top of the resolved config instead of replacing it with `None`.
- `wmo eval` prints `scoring with <provider> (<model>)` and the suite result JSON records the RESOLVED provider/model/region rather than the raw flags, so `wmo eval results` can still name the model and a fidelity number stays attributable.
- Deliberately unchanged: `wmo eval grid`'s judge stays pinned to one backend (the judge is the metric, and a judge that moves makes cells incomparable), and `wmo build`'s provider-unaware `--model` default is a separate defect (audit finding: `--provider openai` alone still writes `claude-opus-4-8`).

## Audit findings closed

- **major** `wmo eval` hardcodes `--provider bedrock --model claude-opus-4-8` and never reads `[models.worker]`, so an OpenAI-only user silently gets Bedrock (`wmo/cli/app.py:1080-1090`).
- The same hardcoding noted as an aside in the `wmo scenarios build --help` finding (`_SCENARIO_DEFAULT_PROVIDER` / `_SCENARIO_DEFAULT_MODEL` applied silently) is gone for the flag paths; that finding's actual subject, the Rich-markup mangling of `[models.worker|judge|summary]` in help strings, is untouched here.

Not addressed (different root causes, left for their own PRs): `wmo run`'s missing credential pre-flight (it already honours the worker role), and `wmo build`'s provider-unaware `--model` default.

## Review round 2 (Greptile, both P1, both real)

Both landed on `_worker_role_provider_config`, and both would have preserved the very misattribution this PR exists to remove. Fixed in `6b6aa41b`.

- **Provider override kept the Bedrock model.** `--provider openai` with no `--model` paired OpenAI with bedrock's `claude-opus-4-8`, a model OpenAI has never heard of, so the command failed instead of running on the selected backend. The fallback model now comes from the catalog of whichever backend is in play (`_default_model_for_provider`), so `--provider openai` runs `gpt-5.5`. `openrouter`/`tinker` publish no built-in rows — nothing can derive an operator's route or weights path — so they raise a `typer.BadParameter` naming the command to run rather than guessing. The no-flags, no-role default is unchanged (bedrock/`claude-opus-4-8`).
- **Azure model override retained the deployment.** On Azure the wire `model` IS the deployment name (`wmo/providers/azure_openai.py:170`), so a role's `deployment` names the model being replaced. `--model gpt-5.5` against a role deployed as `gpt-5.4` called gpt-5.4 and reported gpt-5.5. The deployment now moves with the model, as `_worker_provider_config` (`app.py:248`) already does. Guard on top: re-stating the role's own model is not a model change, so a custom deployment name like `prod-54-canary` survives it — an operator's deployment name is not derivable from a model id (`app.py:377-379`).

```
$ wmo eval traces.jsonl --no-rag --provider openai      # bedrock worker role configured
scoring with openai (gpt-5.5)                            # was: openai (claude-opus-4-8)

$ wmo eval traces.jsonl --no-rag --provider openrouter
Invalid value: provider 'openrouter' has no default model; pass --model <model>,
or run `wmo providers set --provider openrouter --model <model>` to configure the worker role
```

## Review round 3 (Greptile, P1 on my own round-2 fix)

Greptile pushed back on the Azure fix above and was right: re-deriving the deployment from the model type only works on a resource that names deployments after their models. Anywhere else `--model gpt-5.5` 404s on every prediction, and `wmo eval` reports that as `fidelity=0.000` at exit 0 — the same silent wrong number this PR exists to remove, arriving from a different direction. Fixed in `bd5b42b6`.

The deployment is now **asked for, not guessed**:

```
$ wmo eval traces.jsonl --no-rag --model gpt-5.5     # role: azure/gpt-5.4, deployment prod-54-canary
Invalid value: the configured azure worker serves gpt-5.4 from deployment 'prod-54-canary',
and on Azure the deployment name is what is actually invoked, so --model gpt-5.5 needs the
deployment that serves it. Run `wmo providers set --provider azure --model gpt-5.5
--deployment <deployment>` to point the worker role at it.
```

Three cases still resolve without help, so this is not a new wall: an explicit `--deployment`; a role whose deployment already names the requested model; and a role that never set one (nothing configured to contradict, so the model type stands in exactly as `_worker_provider_config` does). `wmo research concurrency` now passes `--deployment` INTO the resolver rather than layering it on top, so a run the user already answered for is not rejected.

## Tests

`uv run pytest -q` (4161 passed, 20 skipped), plus `ruff check`, `ruff format --check`, and `ty check` clean. New cases in `wmo/cli/app_test.py`, each verified to fail against `origin/main`'s `app.py`:

- `test_eval_uses_configured_worker_provider`
- `test_eval_provider_flag_overrides_the_configured_worker`
- `test_eval_suite_run_records_the_resolved_worker_model`
- `test_research_concurrency_uses_the_configured_worker_provider`
- `test_scenario_role_llms_model_flag_keeps_the_configured_provider`
- `test_worker_role_provider_config_falls_back_to_bedrock`
- `test_worker_role_provider_config_model_flag_keeps_the_role_endpoint`

Added in review round 2, each verified to fail against `6b6aa41b`'s parent:

- `test_worker_role_provider_config_provider_flag_uses_that_backends_flagship`
- `test_worker_role_provider_config_demands_a_model_for_a_catalog_less_provider`
- `test_worker_role_provider_config_keeps_a_custom_deployment_for_the_same_model` (guard: no regression for a custom deployment name)

Added in review round 3:

- `test_worker_role_provider_config_refuses_an_azure_model_swap_without_a_deployment` (verified to fail against `bd5b42b6`'s parent)
- `test_worker_role_provider_config_allows_an_azure_model_swap_the_deployment_already_names`
- `test_worker_role_provider_config_derives_a_deployment_the_role_never_set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

