### PR TITLE
Turn unusable roots and unrunnable examples into usage errors that name the next command

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -60,9 +60,10 @@ a wrong key surfaces there rather than inside a paid sweep. Step 3's preflight t
 every candidate's backend as far as it can without making a request, before it asks you to confirm
 any spend.
 
-(`wmo providers verify` is worth knowing about from step 1 onward: it reads the providers a
-**built** world model recorded and pings them on both the completion and the embedding path. On a
-fresh project it has nothing to read, so run it after a build, not before one.)
+(`wmo providers verify` is worth running from step 0 onward: it pings the `[models.<role>]` roles
+in `.wmo/settings.toml` as well as the providers a **built** world model recorded. On a fresh
+project it still checks the roles and skips the embedding half with a note, so it is the cheapest
+credential preflight there is — run it before a build, not only after one.)
 
 ## Step 1: build the world model
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,7 +60,7 @@ JSONL. The two formats are not interchangeable.
 
 | Command | Purpose | Artifact |
 |---|---|---|
-| `wmo providers verify` | Ping the providers that **built** world models recorded, on the completion and embedding paths (deduped by kind and model). A project with nothing built has nothing to verify. | nothing (prints a row per provider) |
+| `wmo providers verify` | Ping every configured provider on the completion and embedding paths (deduped by kind and model): the `[models.<role>]` roles in `.wmo/settings.toml` **and** the providers each built world model recorded. Run it before `wmo build` — with nothing built yet it still checks the roles, and just skips the embed half. | nothing (prints a row per provider) |
 | `wmo harness list` / `show` / `init` | Inspect stored harness versions and aliases, or write the baseline as `v1` with `champion` pointed at it. | a `HarnessDoc` version in the store |
 | `wmo config telemetry` | View or change project-local usage telemetry settings. | `.wmo/settings.toml` |
 | `wmo e2b` | Inspect and reclaim E2B sandbox capacity. | nothing (prints, or reclaims) |

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import subprocess
 import time
@@ -135,7 +136,8 @@ providers_app = typer.Typer(help="Manage and verify LLM providers.", no_args_is_
 examples_app = typer.Typer(
     help="List and launch self-contained task examples.", no_args_is_help=True
 )
-config_app = typer.Typer(help="Manage local harness config.", no_args_is_help=True)
+# "harness" here would collide with the `wmo harness` group, which manages a different object.
+config_app = typer.Typer(help="Manage project-local wmo settings.", no_args_is_help=True)
 research_app = typer.Typer(
     help="Research experiments over the harness (scaling laws, ablations).", no_args_is_help=True
 )
@@ -539,7 +541,10 @@ def examples_list() -> None:
         _console.print("[yellow]no examples found[/yellow]")
         return
     for example in examples:
-        _console.print(example.name)
+        # Data-only bundles (what `wmo download` fetches) have no launcher, so say so here
+        # rather than letting `wmo examples run` be the only way to find out.
+        note = "" if (example / "run.sh").exists() else "  [dim](data only — no run.sh)[/dim]"
+        _console.print(f"{example.name}{note}")
 
 
 @examples_app.command(
@@ -554,7 +559,19 @@ def examples_run(
     example_dir = _resolve_example(name)
     runner = example_dir / "run.sh"
     if not runner.exists():
-        raise typer.BadParameter(f"example {name!r} has no run.sh launcher")
+        # A data-only bundle (`wmo download`) is listed but not runnable; name what it IS for.
+        traces = example_dir / "traces.otel.jsonl"
+        hint = (
+            "; it is a data-only bundle — build a world model from it with "
+            f"`wmo build --file {traces} --name {name}`"
+            if traces.exists()
+            else ""
+        )
+        raise typer.BadParameter(f"example {name!r} has no run.sh launcher{hint}")
+    if not os.access(runner, os.X_OK):
+        raise typer.BadParameter(
+            f"example {name!r} has a run.sh that is not executable; run `chmod +x {runner}`"
+        )
     result = subprocess.run([str(runner), *ctx.args], cwd=example_dir, check=False)
     raise typer.Exit(result.returncode)
 
@@ -1058,8 +1075,11 @@ def serve(
     """Run the local FastAPI backend so agents can step against world models over HTTP.
 
     Serves every built model by default, or just the `--name` ones, from one or more roots
-    (e.g. `--root .wmo --root examples/tau-bench`). Routes are namespaced:
-    `/world_models/{name}/sessions` and `.../step`.
+    (e.g. `--root .wmo --root packages/environment-capture/tau-bench`). Two surfaces are
+    exposed: the world-model step API, namespaced `/world_models/{name}/sessions` and
+    `.../step`; and, for every served model whose dir carries a `policy.json` (written by
+    `wmo optimize route fit --out` or `wmo optimize model`), the OpenAI-compatible endpoint
+    `POST /v1/chat/completions` with `model="<name>"`, listed by `GET /v1/models`.
     """
     names = list(name) if name else None
     # Bad --name input (unsafe segment, unknown model, nothing built) is a usage error,
@@ -2214,7 +2234,8 @@ def _load_model_any(name: str | None, root: str, *, max_fidelity: bool = False):
         label, store_root, resolved = matched[0]
     elif not candidates:
         raise typer.BadParameter(
-            "no world models found; run `wmo build` or try an example (examples/tau-bench)"
+            "no world models found; run `wmo build` or try an example "
+            "(packages/environment-capture/tau-bench)"
         )
     elif len(candidates) == 1:
         label, store_root, resolved = candidates[0]

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -572,7 +572,17 @@ def examples_run(
         raise typer.BadParameter(
             f"example {name!r} has a run.sh that is not executable; run `chmod +x {runner}`"
         )
-    result = subprocess.run([str(runner), *ctx.args], cwd=example_dir, check=False)
+    try:
+        result = subprocess.run([str(runner), *ctx.args], cwd=example_dir, check=False)
+    except OSError as exc:
+        # The exec itself failed, so there is no exit code to forward: the launcher has no
+        # shebang (ENOEXEC), or names an interpreter that is not installed (ENOENT, whose
+        # "No such file or directory" reads as a lie about a run.sh we just stat'd). Say which
+        # line to look at instead of letting the errno out as a traceback.
+        raise typer.BadParameter(
+            f"example {name!r} could not start {runner} ({exc.strerror or exc}); "
+            f"check its interpreter line with `head -1 {runner}`"
+        ) from exc
     raise typer.Exit(result.returncode)
 
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -398,6 +398,69 @@ def test_examples_discovery_skips_unresolvable_names(tmp_path, monkeypatch) -> N
     assert "available: good-example" in unknown.output
 
 
+def _flat(output: str) -> str:
+    """Rich wraps error panels; flatten box drawing and newlines before matching a message."""
+    return " ".join(output.replace("│", " ").split())
+
+
+def test_examples_data_only_bundle_is_marked_and_points_at_wmo_build(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # What `wmo download` fetches: a corpus with no launcher. `list` must say so, and `run` must
+    # name what the bundle IS for instead of dead-ending on "no run.sh launcher".
+    bundle = tmp_path / "demo-corpus"
+    bundle.mkdir()
+    (bundle / "traces.otel.jsonl").write_text("", encoding="utf-8")
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+
+    listed = runner.invoke(app, ["examples", "list"])
+    assert listed.exit_code == 0, listed.output
+    assert "demo-corpus" in listed.output
+    assert "data only" in listed.output
+
+    result = runner.invoke(app, ["examples", "run", "demo-corpus"])
+    assert result.exit_code == 2, result.output
+    output = _flat(result.output)
+    assert "data-only bundle" in output
+    assert "wmo build --file" in output
+    assert "--name demo-corpus" in output
+
+
+def test_examples_run_rejects_a_non_executable_launcher(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # A run.sh that lost its exec bit (archive, checkout) must be a usage error naming chmod,
+    # not a PermissionError traceback out of subprocess.
+    example = tmp_path / "noexec"
+    example.mkdir()
+    launcher = example / "run.sh"
+    launcher.write_text("#!/bin/sh\n", encoding="utf-8")
+    launcher.chmod(0o644)
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+
+    result = runner.invoke(app, ["examples", "run", "noexec"])
+
+    assert result.exit_code == 2, result.output  # usage error, not a traceback
+    assert "chmod +x" in _flat(result.output)
+
+
+def test_config_help_does_not_reuse_the_harness_group_name() -> None:
+    # `wmo harness` is a different group managing a different object; `wmo config` manages the
+    # project's own settings file.
+    result = runner.invoke(app, ["config", "--help"])
+    assert result.exit_code == 0, result.output
+    output = _flat(result.output)
+    assert "project-local wmo settings" in output
+    assert "harness" not in output
+
+
+def test_serve_help_names_the_openai_endpoint_and_a_real_example_root() -> None:
+    # The OpenAI-compatible surface is what README step 3 exists for, and examples/tau-bench
+    # moved to packages/environment-capture/ — the help must name both correctly.
+    result = runner.invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0, result.output
+    output = _flat(result.output)
+    assert "/v1/chat/completions" in output
+    assert "examples/tau-bench" not in output
+    assert "packages/environment-capture/tau-bench" in output
+
+
 def test_main_entry_loads_dotenv_before_dispatch(tmp_path, monkeypatch) -> None:  # noqa: ANN001
     # The persistence half of the wizard's credential flow: keys saved to .env must be back in
     # os.environ on the next `wmo` invocation (main), and importing the module must NOT load.

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -440,6 +440,36 @@ def test_examples_run_rejects_a_non_executable_launcher(tmp_path, monkeypatch) -
     assert "chmod +x" in _flat(result.output)
 
 
+@pytest.mark.parametrize(
+    "script",
+    [
+        pytest.param("echo hi\n", id="no-shebang"),  # execve -> ENOEXEC
+        pytest.param("#!/nonexistent/interp\n", id="missing-interpreter"),  # execve -> ENOENT
+    ],
+)
+def test_examples_run_reports_a_launcher_that_cannot_be_started(
+    tmp_path,  # noqa: ANN001
+    monkeypatch,  # noqa: ANN001
+    script: str,
+) -> None:
+    # X_OK passes but the kernel still refuses to exec, so `subprocess.run` raises before there
+    # is any exit code to forward. That must not surface as an OSError traceback either.
+    example = tmp_path / "unstartable"
+    example.mkdir()
+    launcher = example / "run.sh"
+    launcher.write_text(script, encoding="utf-8")
+    launcher.chmod(0o755)
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+
+    result = runner.invoke(app, ["examples", "run", "unstartable"])
+
+    assert result.exit_code == 2, result.output  # usage error, not a traceback
+    assert not isinstance(result.exception, OSError), result.exception
+    output = _flat(result.output)
+    assert "could not start" in output
+    assert "head -1" in output
+
+
 def test_config_help_does_not_reuse_the_harness_group_name() -> None:
     # `wmo harness` is a different group managing a different object; `wmo config` manages the
     # project's own settings file.

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -116,9 +116,17 @@ def show_harness(
     """Print one harness version's surfaces."""
     base, _, ref = name.partition("@")
     try:
-        doc = HarnessStore(root).load(base, ref or None)
-    except (FileNotFoundError, ValueError) as exc:
+        validate_name(base, kind="harness")  # a bad name is a name error, not a missing ref
+    except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    try:
+        doc = HarnessStore(root).load(base, ref or None)
+    except FileNotFoundError as exc:  # no such harness: nothing to list, so offer to create it
+        raise typer.BadParameter(f"{exc}; `wmo harness init {base}` creates the baseline") from exc
+    except ValueError as exc:  # the harness exists, the ref does not
+        raise typer.BadParameter(
+            f"{exc}; run `wmo harness list` to see its versions and aliases"
+        ) from exc
     _console.print(f"[bold]{doc.name}[/bold] v{doc.version}  doc_hash={doc.doc_hash[:12]}")
     for surface in doc.surfaces:
         budget = f"  budget={surface.budget}" if surface.budget is not None else ""
@@ -372,7 +380,7 @@ def optimize(
         raise typer.BadParameter(f"unknown --backend {backend!r}; choose local or e2b")
     # Fail on a bad name NOW, not after the search has spent its eval budget on the save.
     try:
-        validate_name(name)
+        validate_name(name, kind="harness")
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
     tasks = _load_task_file(tasks_file)
@@ -909,7 +917,7 @@ def _resolve_harbor_seed(root: str, agent_ref: str) -> tuple[str, HarnessSourceT
     """
     base, _, ref = agent_ref.partition("@")
     try:
-        validate_name(base)
+        validate_name(base, kind="harness")
     except ValueError as error:
         raise typer.BadParameter(str(error)) from error
     if base == DEFAULT_SEED_AGENT and not ref:
@@ -1050,13 +1058,21 @@ def init_harness(
     store = HarnessStore(root)
     try:
         if store.exists(name):
+            # Only name commands that exist: there is no CLI surface for moving an alias by
+            # hand, so point at the command that appends a version and moves `champion` itself.
             raise typer.BadParameter(
-                f"harness {name!r} already exists; new versions are appended by "
-                "`wmo optimize harness`, and aliases move with `set_alias`"
+                f"harness {name!r} already exists; run `wmo harness show {name}` to inspect it, "
+                f"or `wmo optimize harness {name} <world-model>` to append a new version and "
+                "move `champion` to it"
             )
         doc = store.save_version(HarnessDoc.baseline(name), alias=CHAMPION_ALIAS)
     except ValueError as exc:  # invalid name -> usage error, not a traceback
         raise typer.BadParameter(str(exc)) from exc
+    except OSError as exc:  # unusable --root -> usage error, not a traceback
+        raise typer.BadParameter(
+            f"cannot write the harness store under {root!r} ({exc.strerror or exc}); "
+            "pass a writable project dir with --root"
+        ) from exc
     _console.print(
         f"[green]wrote[/green] {name} v{doc.version} (champion) -> {store.dir_for(name)}"
     )

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -984,3 +984,70 @@ def test_model_identity_pins_model_type_and_endpoint() -> None:
     identity = _model_identity(config)
     assert identity["model_type"] == "Qwen/Qwen3-8B"
     assert identity["endpoint"] == "https://serve.example/v1"
+
+
+# -- `wmo harness init` / `wmo harness show`: unusable roots and errors that name a next step ---
+
+
+def _flat(output: str) -> str:
+    """Rich wraps error panels; flatten box drawing and newlines before matching a message."""
+    return " ".join(output.replace("│", " ").split())
+
+
+def test_harness_init_rejects_an_unusable_root_with_a_usage_error(tmp_path: Path) -> None:
+    """A --root that is a file (or otherwise unwritable) is a usage error naming --root, not a
+    NotADirectoryError traceback out of `mkdir(parents=True)`."""
+    not_a_dir = tmp_path / "root.txt"
+    not_a_dir.write_text("x", encoding="utf-8")
+
+    result = runner.invoke(app, ["harness", "init", "demo", "--root", str(not_a_dir)])
+
+    assert result.exit_code == 2, result.output  # usage error, not a traceback
+    output = _flat(result.output)
+    assert "cannot write the harness store" in output
+    assert "--root" in output
+
+
+def test_harness_init_twice_names_commands_that_exist(tmp_path: Path) -> None:
+    """`set_alias` is a HarnessStore method, not a CLI command; the error must not send a user
+    looking for it."""
+    root = str(tmp_path / ".wmo")
+    first = runner.invoke(app, ["harness", "init", "--root", root])
+    assert first.exit_code == 0, first.output
+
+    result = runner.invoke(app, ["harness", "init", "--root", root])
+
+    assert result.exit_code == 2, result.output
+    output = _flat(result.output)
+    assert "already exists" in output
+    assert "wmo optimize harness baseline" in output
+    assert "set_alias" not in output
+
+
+def test_harness_init_bad_name_names_the_object_it_creates(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["harness", "init", "bad/name", "--root", str(tmp_path / ".wmo")])
+
+    assert result.exit_code == 2, result.output
+    output = _flat(result.output)
+    assert "invalid harness name 'bad/name'" in output
+    assert "world model" not in output
+
+
+def test_harness_show_missing_harness_names_init(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["harness", "show", "baseline", "--root", str(tmp_path / ".wmo")])
+
+    assert result.exit_code == 2, result.output
+    output = _flat(result.output)
+    assert "no harness named 'baseline'" in output
+    assert "wmo harness init baseline" in output
+
+
+@pytest.mark.parametrize("ref", ["baseline@v9", "baseline@prod"])
+def test_harness_show_unknown_ref_names_list(tmp_path: Path, ref: str) -> None:
+    root = str(tmp_path / ".wmo")
+    assert runner.invoke(app, ["harness", "init", "--root", root]).exit_code == 0
+
+    result = runner.invoke(app, ["harness", "show", ref, "--root", root])
+
+    assert result.exit_code == 2, result.output
+    assert "wmo harness list" in _flat(result.output)

--- a/wmo/config/store.py
+++ b/wmo/config/store.py
@@ -35,11 +35,16 @@ DEFAULT_MODEL_NAME = "default"
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
-def validate_name(name: str) -> str:
-    """Return `name` if it is a safe single path segment, else raise a friendly ValueError."""
+def validate_name(name: str, *, kind: str = "world model") -> str:
+    """Return `name` if it is a safe single path segment, else raise a friendly ValueError.
+
+    `kind` names the object being named, because this validator guards several stores and the
+    error is read by a user who typed one command: a bad `wmo harness init` name must say
+    "harness", not "world model".
+    """
     if not _NAME_RE.match(name) or name in {".", ".."} or "/" in name or "\\" in name:
         raise ValueError(
-            f"invalid world model name {name!r}: use letters, digits, '.', '_', '-' "
+            f"invalid {kind} name {name!r}: use letters, digits, '.', '_', '-' "
             "(must start with a letter or digit, no path separators)"
         )
     return name

--- a/wmo/harness/store.py
+++ b/wmo/harness/store.py
@@ -51,7 +51,7 @@ class HarnessStore:
         return self.root / HARNESSES_DIR
 
     def dir_for(self, name: str) -> Path:
-        return self.harnesses_dir / validate_name(name)
+        return self.harnesses_dir / validate_name(name, kind="harness")
 
     # -- enumeration -------------------------------------------------------------------------
 
@@ -131,7 +131,7 @@ class HarnessStore:
 
         Versions are append-only: this never touches an existing version directory.
         """
-        validate_name(doc.name)
+        validate_name(doc.name, kind="harness")
         version = (self.versions(doc.name)[-1] + 1) if self.exists(doc.name) else 1
         stamped = doc.model_copy(update={"version": version})
         directory = self.dir_for(doc.name) / f"v{version}"

--- a/wmo/serving/server.py
+++ b/wmo/serving/server.py
@@ -126,9 +126,11 @@ def resolve_model_dirs(artifact_dirs: Sequence[str], names: list[str] | None) ->
         for name in names:
             validate_name(name)  # friendly ValueError on an unsafe name, before any disk lookup
     wanted = set(names) if names is not None else None
+    built: set[str] = set()  # every name on disk, so a typo can be told what IS there
     for root in artifact_dirs:
         store = WorldModelStore(root)
         for name in store.list_names():
+            built.add(name)
             if wanted is not None and name not in wanted:
                 continue  # only names we'll actually serve can collide
             if name in resolved:
@@ -141,10 +143,11 @@ def resolve_model_dirs(artifact_dirs: Sequence[str], names: list[str] | None) ->
     if names is not None:
         missing = [name for name in names if name not in resolved]
         if missing:
-            available = ", ".join(sorted(resolved)) or "(none)"
+            available = ", ".join(sorted(built)) or "(none)"
+            remedy = "`wmo list` shows what is built" if built else "run `wmo build --name <name>`"
             raise FileNotFoundError(
                 f"no world model named {', '.join(missing)} under "
-                f"{', '.join(map(str, artifact_dirs))}; have: {available}"
+                f"{', '.join(map(str, artifact_dirs))}; have: {available}; {remedy}"
             )
         resolved = {name: resolved[name] for name in names}
     if not resolved:

--- a/wmo/serving/server_test.py
+++ b/wmo/serving/server_test.py
@@ -122,6 +122,26 @@ def test_resolve_model_dirs_rejects_name_collision(tmp_path: Path) -> None:
         resolve_model_dirs([str(tmp_path / "a"), str(tmp_path / "b")], None)
 
 
+def test_resolve_model_dirs_unknown_name_lists_what_is_built_and_names_wmo_list(
+    tmp_path: Path,
+) -> None:
+    """The typo case must show the models that DO exist (they are filtered out of `resolved`,
+    so the enumeration cannot come from there) and name the command that shows them."""
+    _fake_artifact(tmp_path / "a", "airline")
+    with pytest.raises(FileNotFoundError) as excinfo:
+        resolve_model_dirs([str(tmp_path / "a")], ["nope"])
+    message = str(excinfo.value)
+    assert "have: airline" in message
+    assert "`wmo list`" in message
+
+
+def test_resolve_model_dirs_unknown_name_with_nothing_built_names_wmo_build(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(FileNotFoundError, match=r"wmo build --name <name>"):
+        resolve_model_dirs([str(tmp_path / "a")], ["nope"])
+
+
 def test_resolve_model_dirs_ignores_collision_outside_requested_names(tmp_path: Path) -> None:
     _fake_artifact(tmp_path / "a", "dup")
     _fake_artifact(tmp_path / "b", "dup")


### PR DESCRIPTION
## What was broken

The harness and examples paths validated only the happy path. When the filesystem
disagreed, the exception escaped as a user-visible Python traceback; when a usage
error *was* raised, it frequently named the wrong thing — an internal Python method,
the wrong noun, a path that no longer exists, or no next command at all.

One repro a reviewer can paste:

```
printf 'x' > /tmp/notadir.txt
wmo harness init demo --root /tmp/notadir.txt
```

Before: a full rich traceback ending in
`NotADirectoryError: [Errno 20] Not a directory: '/tmp/notadir.txt/harnesses/demo/v1'`
(`wmo/harness/store.py` `mkdir(parents=True)`; the caller caught only `ValueError`).

After:

```
Invalid value: cannot write the harness store under '/tmp/notadir.txt' (Not a
directory); pass a writable project dir with --root
```

The same shape appears in `wmo examples run` on an example whose `run.sh` lost its
exec bit:

```
mkdir -p examples/noexec && printf '#!/bin/sh\n' > examples/noexec/run.sh
chmod 644 examples/noexec/run.sh
wmo examples run noexec
```

Before: `PermissionError: [Errno 13] Permission denied: .../run.sh`, exit 1.
After: `Invalid value: example 'noexec' has a run.sh that is not executable; run
`chmod +x .../run.sh``, exit 2 — the same check `wmo/research/concurrency_run.py`
already does with `os.access(..., os.X_OK)`.

## What changed

`wmo/cli/harness_app.py`
- `harness init` catches `OSError` (unusable `--root`: a file, an unwritable dir,
  a read-only cwd) and raises a usage error naming `--root`.
- The "already exists" error now names `wmo harness show <name>` and
  `wmo optimize harness <name> <world-model>`. It used to say aliases move with
  `set_alias`, a `HarnessStore` method with no CLI surface at all — nothing for a
  user to type. Rather than add an alias command nobody asked for, the message only
  names commands that exist (`wmo optimize harness` moves `champion` itself).
- `harness show` validates the name first, then names `wmo harness init <name>` for
  a missing harness and `wmo harness list` for an unknown version/alias — matching
  its sibling `wmo harness list`, which already does this.

`wmo/config/store.py`, `wmo/harness/store.py`
- `validate_name` takes `kind` (default `"world model"`), and the harness store and
  harness commands pass `kind="harness"`. `wmo harness init 'bad/name'` no longer
  reports "invalid world model name" for an object that is not a world model.

`wmo/cli/app.py`
- `examples list` marks data-only bundles (`(data only — no run.sh)`), and
  `examples run` on one names what it *is* for:
  `wmo build --file <bundle>/traces.otel.jsonl --name <bundle>`. 7 of the 10
  corpora `wmo download` fetches have no launcher, so the list/run disagreement was
  reachable straight off the documented download path.
- `examples run` checks `os.access(run.sh, os.X_OK)`, not just `exists()`, and wraps the
  `subprocess.run` call itself in `except OSError`: the exec bit being set does not mean the
  kernel will start the script (no shebang -> ENOEXEC; a shebang naming an uninstalled
  interpreter -> ENOENT, whose "No such file or directory" names a `run.sh` that plainly
  exists). Both now read `could not start <run.sh> (<strerror>); check its interpreter line
  with `head -1 <run.sh>``, exit 2. (Raised by Greptile.)
- `serve --help` documents the OpenAI-compatible surface
  (`POST /v1/chat/completions`, `GET /v1/models`) that README getting-started step 3
  exists for, and its worked example now points at
  `packages/environment-capture/tau-bench`, which exists (`examples/tau-bench` does
  not, and ships in no wheel). The same stale path in the `wmo demo` / `wmo play`
  "no world models found" hint is fixed too.
- `wmo config`'s group help is "Manage project-local wmo settings"; "harness"
  collided with the separate `wmo harness` group four lines away in `wmo --help`.

`wmo/serving/server.py`
- `serve --name <typo>` names `wmo list`, and its `have:` enumeration is built from
  every model on disk. It was built from the already-`--name`-filtered dict, so in
  the single-typo case it could only ever print `(none)`.

`docs/usage.md`, `docs/cookbook/tau-bench.md`
- `wmo providers verify` also pings the `[models.<role>]` roles in
  `.wmo/settings.toml`, so it is the cheap preflight to run *before* `wmo build`.
  Both docs still described the pre-#292 behaviour and told the user to run it only
  after a build — the inverse of what it does (pinned by
  `test_providers_verify_without_a_world_model_checks_settings_roles`).

## Tests

New regression coverage beside each module (`uv run pytest`, 4162 passed):
`wmo/cli/harness_app_test.py` (unusable root, init-twice wording, harness noun,
show's two next-command hints), `wmo/cli/app_test.py` (data-only bundle marked and
redirected, non-executable launcher, unstartable launcher over both errnos, config
help, serve help), and
`wmo/serving/server_test.py` (the `have:` enumeration and both remedies).

## Audit findings closed

- `wmo harness init demo --root <file>` / `<unwritable dir>` raises NotADirectoryError / PermissionError
- `wmo examples run <data-only bundle>` — listed by `examples list`, refused by `run`, no alternative named
- `wmo examples run` checks run.sh exists but not that it is executable, and not that it can
  be exec'd at all (Greptile P1)
- `wmo harness init` run twice points at `set_alias`, a Python method with no CLI surface
- `wmo harness show` errors name no next command, unlike `wmo harness list`
- `wmo harness init 'bad/name'` reports "invalid world model name"
- `wmo config` is "Manage local harness config" and collides with `wmo harness`
- `wmo serve --help` never mentions `/v1/chat/completions`
- `wmo serve --help` worked example points at `examples/tau-bench`, which does not exist
- `wmo serve --name nope` names no next command (and its `have:` list is always `(none)`)
- docs/usage.md:63 describes `wmo providers verify` with its pre-roles behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

