### PR TITLE
Escape rich markup in CLI help, error codes, and user content

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -302,7 +302,7 @@ def providers_set(
     """Choose the local worker's provider, and register the models the router can choose from.
 
     Two things a project needs, in one command. The worker provider lands in
-    `<root>/settings.toml` as `[models.worker]`, exactly as before. Then, on a terminal, this
+    `<root>/settings.toml` as `\\[models.worker]`, exactly as before. Then, on a terminal, this
     offers to register models as ROUTING CANDIDATES in `<root>/pool.toml`, the roster
     `wmo optimize route` selects over: pick a backend, search its catalog, and answer only what
     that backend needs (an Azure deployment; a price for a model with no published one, never
@@ -441,7 +441,7 @@ def providers_verify(
     """Ping every configured provider (completion + embed path) and report status.
 
     Two sources count as "configured", because checking that credentials work is what you do
-    BEFORE spending anything on `wmo build`: the `[models.<role>]` roles in
+    BEFORE spending anything on `wmo build`: the `\\[models.<role>]` roles in
     `<root>/settings.toml` (what `wmo providers set` writes), and the providers persisted inside
     every built world model. Completion providers are deduped by kind+model across both, so a
     role naming the same backend as a built model costs one ping, not two. The phi embed path
@@ -615,7 +615,7 @@ def build(
     since: str = typer.Option(None, "--since", help="Only pull traces since this ISO timestamp."),
     limit: int = typer.Option(None, "--limit", help="Max number of traces to pull."),
     vendor: str = typer.Option(
-        None, "--vendor", help="[deprecated] alias for --source <name> --pull."
+        None, "--vendor", help="\\[deprecated] alias for --source <name> --pull."
     ),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
     provider: str = typer.Option(
@@ -1306,7 +1306,7 @@ def eval_(  # noqa: A001 - `eval` is the user-facing command name; the builtin i
     - `wmo eval <trace files...>`: ad hoc replay scoring (open-loop, teacher-forced — the
       default mode).
     - `wmo eval <tasks.jsonl> --mode closed-loop`: a live agent runs tasks WITH the world model
-      as its environment. `[models.agent]` selects a distinct agent provider when configured;
+      as its environment. `\\[models.agent]` selects a distinct agent provider when configured;
       otherwise the agent shares the world model's provider. `--harness-backend e2b` moves the
       pi-node harness process into pooled E2B sandboxes while the environment stays the world
       model. Score task success against gold assertions (see docs/reference/closed_loop.md).
@@ -1953,16 +1953,19 @@ def knowledge_(
     store = WorldModelStore(root)
     resolved = _resolve_name(store, name)
     kb = KnowledgeBase(ArtifactPaths(store.resolve(resolved)).knowledge)
-    _console.print(f"[bold]{kb.directory}[/bold]")
+    _console.print(f"[bold]{escape(str(kb.directory))}[/bold]")
     if kb.is_empty:
         _console.print(
             "(empty — enable knowledge at build, drop *.md files in this folder, "
             "or PUT files via the serving API)"
         )
         return
+    # Knowledge is hand-edited markdown: `[/items]`, `list[str]` and `[text](url)` are ordinary
+    # content, so it is escaped rather than parsed as rich markup (which would crash on the
+    # first, and silently delete the other two).
     for file_name, content in kb.files().items():
-        _console.print(f"\n[bold]## {file_name}[/bold]")
-        _console.print(content.strip())
+        _console.print(f"\n[bold]## {escape(file_name)}[/bold]")
+        _console.print(escape(content.strip()))
 
 
 @scenarios_app.command("build")
@@ -1977,7 +1980,7 @@ def scenarios_build(
         "--provider",
         help=(
             "Pin ONE LLM for every role (facets/naming/synthesis/validation). When omitted, "
-            "roles resolve from .wmo/settings.toml [models.worker|judge|summary]."
+            "roles resolve from .wmo/settings.toml \\[models.worker|judge|summary]."
         ),
     ),
     model: str = typer.Option(None, help="Model id (pins all roles, like --provider)."),

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -343,6 +343,33 @@ def test_knowledge_command_prints_path_and_files(tmp_path) -> None:  # noqa: ANN
     assert "gate: auth required" in result.output
 
 
+def test_knowledge_command_prints_bracketed_markdown_verbatim(tmp_path) -> None:  # noqa: ANN001
+    """Knowledge is hand-edited markdown, so rich must not read its brackets as style tags.
+
+    Unescaped, `[/items]` raised MarkupError (the command died on ordinary content) and both
+    `list[str]` and the link text were silently deleted from the rendered output.
+    """
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+    from wmo.engine.knowledge import KnowledgeBase
+
+    root = tmp_path / ".wmo"
+    model_dir = root / "models" / "airline"
+    save_config(HarnessConfig(), root=model_dir)
+    KnowledgeBase(model_dir / "knowledge").write_file(
+        "schemas.md",
+        "Use the XML close marker [/items] to end a list.\n"
+        "reservations: list[str]\n"
+        "See [the docs](https://example.com) for details.",
+    )
+
+    result = runner.invoke(app, ["knowledge", "--name", "airline", "--root", str(root)])
+    assert result.exit_code == 0, result.exception
+    assert "[/items]" in result.output
+    assert "list[str]" in result.output
+    assert "[the docs](https://example.com)" in result.output
+
+
 def test_knowledge_command_without_kb_says_how_to_enable(tmp_path) -> None:  # noqa: ANN001
     from wmo.config import save_config
     from wmo.config.config import HarnessConfig
@@ -352,6 +379,31 @@ def test_knowledge_command_without_kb_says_how_to_enable(tmp_path) -> None:  # n
     result = runner.invoke(app, ["knowledge", "--name", "airline", "--root", str(root)])
     assert result.exit_code == 0, result.output
     assert "empty" in result.output.lower()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["build", "--help"], "[deprecated] alias for --source"),
+        (["eval", "--help"], "`[models.agent]` selects a distinct agent provider"),
+        (["providers", "set", "--help"], "settings.toml` as `[models.worker]`"),
+        (["providers", "verify", "--help"], "the `[models.<role>]` roles in"),
+        (["scenarios", "build", "--help"], "settings.toml [models.worker|judge|summary]."),
+    ],
+)
+def test_help_keeps_the_bracketed_pointer_it_exists_to_teach(
+    argv: list[str], expected: str
+) -> None:
+    """Typer renders help through rich markup, which swallows an unescaped `[...]` whole.
+
+    Each of these is the only pointer in that help text to where the setting lives (or, for
+    `--vendor`, the only sign that the option is deprecated), so a swallowed pair is silent
+    misinformation.
+    """
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 0, result.output
+    rendered = " ".join(result.output.replace("│", " ").split())
+    assert expected in rendered
 
 
 @pytest.mark.parametrize("args", [[], ["providers"], ["examples"], ["config"]])

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -105,7 +105,7 @@ def list_harnesses(root: str = typer.Option(ARTIFACT_DIR, help="Project dir.")) 
             broken.append((name, str(exc)))
     _console.print(table)
     for name, reason in broken:
-        _console.print(f"[red]broken[/red] {name}: {reason}")
+        _console.print(f"[red]broken[/red] {escape(name)}: {escape(reason)}")
 
 
 @harness_app.command("show")
@@ -127,14 +127,16 @@ def show_harness(
         raise typer.BadParameter(
             f"{exc}; run `wmo harness list` to see its versions and aliases"
         ) from exc
-    _console.print(f"[bold]{doc.name}[/bold] v{doc.version}  doc_hash={doc.doc_hash[:12]}")
+    _console.print(f"[bold]{escape(doc.name)}[/bold] v{doc.version}  doc_hash={doc.doc_hash[:12]}")
+    # Surface bodies are prompts, skills and code: brackets are ordinary content, so they are
+    # escaped rather than read as rich markup (which crashes on an unmatched closing tag).
     for surface in doc.surfaces:
         budget = f"  budget={surface.budget}" if surface.budget is not None else ""
         _console.print(
-            f"\n[bold]{surface.id}[/bold]  ({surface.kind.value}, "
+            f"\n[bold]{escape(surface.id)}[/bold]  ({surface.kind.value}, "
             f"hash={surface.content_hash[:12]}{budget})"
         )
-        _console.print(surface.content)
+        _console.print(escape(surface.content))
 
 
 optimize_app = typer.Typer(
@@ -429,7 +431,7 @@ def optimize(
             if changed
             else "[yellow]unchanged[/yellow]"
         )
-        _console.print(f"  [{tag}] {variant}: success_rate={score:.3f} {state}")
+        _console.print(f"  \\[{tag}] {escape(variant)}: success_rate={score:.3f} {state}")
 
     def _note(message: str) -> None:
         # Dead proposals narrate here; scored proposals use the structured callback below.
@@ -447,8 +449,8 @@ def optimize(
             else "[yellow]rejected by gate[/yellow]"
         )
         _console.print(
-            f"  [iteration {record.iteration} proposal {record.proposal_index}] "
-            f"{record.candidate}: success_rate={record.score:.3f} {state}"
+            f"  \\[iteration {record.iteration} proposal {record.proposal_index}] "
+            f"{escape(record.candidate)}: success_rate={record.score:.3f} {state}"
         )
 
     result = create_harness(
@@ -729,12 +731,14 @@ def _optimize_harbor(
     def _on_boundary(outcome: SlotOutcome) -> None:
         if outcome.evaluated is None:
             _console.print(
-                f"  [slot {outcome.slot}] {outcome.candidate_id}: "
+                f"  \\[slot {outcome.slot}] {escape(outcome.candidate_id)}: "
                 f"[yellow]invalid[/yellow] ({escape(outcome.reason)})"
             )
         else:
             tag = "seed" if outcome.slot == 0 else f"slot {outcome.slot}"
-            _console.print(f"  [{tag}] {outcome.candidate_id}: score={outcome.evaluated.score:.3f}")
+            _console.print(
+                f"  \\[{tag}] {escape(outcome.candidate_id)}: score={outcome.evaluated.score:.3f}"
+            )
 
     result = optimize_population(
         seed_tree,

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -1051,3 +1051,54 @@ def test_harness_show_unknown_ref_names_list(tmp_path: Path, ref: str) -> None:
 
     assert result.exit_code == 2, result.output
     assert "wmo harness list" in _flat(result.output)
+
+
+# --- rich markup: brackets in surface bodies and progress lines are content, not style tags ---
+
+
+def test_harness_list_keeps_the_bracketed_half_of_a_broken_dir_reason(tmp_path: Path) -> None:
+    """Pydantic puts its diagnosis in `[type=..., input_value=...]`, which rich ate whole."""
+    version_dir = tmp_path / ".wmo" / "harnesses" / "x" / "v1"
+    version_dir.mkdir(parents=True)
+    (version_dir / "doc.json").write_text("not json", encoding="utf-8")
+
+    result = runner.invoke(app, ["harness", "list", "--root", str(tmp_path / ".wmo")])
+    assert result.exit_code == 0, result.exception
+    assert "[type=json_invalid" in " ".join(result.output.split())
+
+
+def test_harness_show_prints_bracketed_surface_content_verbatim(tmp_path: Path) -> None:
+    """Surface bodies are prompts and code: rich must print their brackets, not parse them.
+
+    Unescaped, an unmatched `[/tool]` raised MarkupError and `list[str]` lost its type argument.
+    """
+    from wmo.harness.doc import Surface, SurfaceKind
+
+    body = "Close every block with [/tool].\nReturn list[str] from `plan`."
+    doc = HarnessDoc(
+        name="pi", surfaces=[Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content=body)]
+    )
+    HarnessStore(str(tmp_path / ".wmo")).save_version(doc)
+
+    result = runner.invoke(app, ["harness", "show", "pi", "--root", str(tmp_path / ".wmo")])
+    assert result.exit_code == 0, result.exception
+    assert "[/tool]" in result.output
+    assert "list[str]" in result.output
+
+
+def test_harbor_progress_lines_show_which_slot_scored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`[seed]` / `[slot 1]` is the only thing identifying a progress line's candidate.
+
+    Rich reads a lowercase bracketed word as a style tag, so unescaped these rendered as an
+    empty string and every line started with a bare candidate id.
+    """
+    _harbor_project(tmp_path, monkeypatch)
+
+    result = _invoke_harbor(tmp_path)
+
+    assert result.exit_code == 0, result.output
+    flat = " ".join(result.output.split())
+    assert "[seed] candidate-0000" in flat
+    assert "[slot 1] candidate-0001" in flat

--- a/wmo/cli/ingest_cmd.py
+++ b/wmo/cli/ingest_cmd.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.progress import BarColumn, Progress, TextColumn
 
 from wmo.ingest import VendorPull, list_adapters
@@ -52,7 +53,9 @@ def _render_rich(stream: Iterator[IngestEvent]) -> bool:
         task_id = None
         for event in stream:
             if isinstance(event, DetectedEvent):
-                _console.print(f"detected [bold]{event.format}[/bold] · {event.traces} traces")
+                _console.print(
+                    f"detected [bold]{escape(event.format)}[/bold] · {event.traces} traces"
+                )
                 task_id = progress.add_task("normalizing", total=event.traces)
             elif isinstance(event, ProgressEvent) and task_id is not None:
                 progress.update(task_id, completed=event.normalized)
@@ -63,16 +66,18 @@ def _render_rich(stream: Iterator[IngestEvent]) -> bool:
                 progress.stop()
                 _console.print(
                     f"[green]done[/green] · {event.traces} traces / {event.steps} steps "
-                    f"→ [bold]{event.otel_object}[/bold]"
+                    f"→ [bold]{escape(event.otel_object)}[/bold]"
                 )
                 _console.print(
                     f"build from it: wmo build --name <name> --source otel-genai "
-                    f"--file {event.otel_object}"
+                    f"--file {escape(event.otel_object)}"
                 )
             elif isinstance(event, ErrorEvent):
                 progress.stop()
-                code = f" [{event.code}]" if event.code else ""
-                _console.print(f"[red]error{code}[/red] {event.message}")
+                # `\[` keeps rich from reading the code (and any bracket in the message, which
+                # comes from an adapter/driver exception or a user path) as a style tag.
+                code = f" \\[{escape(event.code)}]" if event.code else ""
+                _console.print(f"[red]error{code}[/red] {escape(event.message)}")
     return ok
 
 

--- a/wmo/cli/ingest_cmd_test.py
+++ b/wmo/cli/ingest_cmd_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from rich.errors import MarkupError
 from typer.testing import CliRunner
 
 from wmo.cli.app import app
@@ -63,6 +64,28 @@ def test_ingest_error_exits_nonzero(tmp_path: Path) -> None:
     events = [json.loads(line) for line in result.output.strip().splitlines()]
     assert events[-1]["type"] == "error"
     assert events[-1]["code"] == "bad_format"
+
+
+def test_ingest_rich_error_shows_the_code_it_classified(tmp_path: Path) -> None:
+    """The human-readable mode must report the same code `--json` does.
+
+    Unescaped, rich read `[bad_format]` as a style tag and dropped it, so the only classification
+    a non-`--json` user ever sees vanished.
+    """
+    src = tmp_path / "junk.json"
+    src.write_text('{"nothing": true}', encoding="utf-8")
+    result = runner.invoke(app, ["ingest", "--file", str(src)])
+    assert result.exit_code == 1
+    assert "[bad_format]" in result.output
+
+
+def test_ingest_rich_error_survives_markup_in_the_failing_path(tmp_path: Path) -> None:
+    """A bracket in the path (or in an adapter's exception text) must not crash the renderer."""
+    missing = tmp_path / "[/bold]missing.jsonl"
+    result = runner.invoke(app, ["ingest", "--file", str(missing)])
+    assert result.exit_code == 1
+    assert not isinstance(result.exception, MarkupError), result.exception
+    assert "[bad_format]" in result.output
 
 
 def test_ingest_requires_a_transport() -> None:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -692,7 +692,7 @@ def student(
     """Add a distilled student to the candidate pool, so the router can select it.
 
     The keystone step between training and serving: a run produces a `tinker://` adapter, and this
-    turns it into a `[[model]]` entry the sweep measures, the fitter routes to, and the endpoint
+    turns it into a `\\[\\[model]]` entry the sweep measures, the fitter routes to, and the endpoint
     calls, with no hand-edited TOML in between:
 
         wmo optimize route student .wmo/distill/support --input-per-mtok 0.1 --output-per-mtok 0.4

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3058,3 +3058,17 @@ def test_route_tune_names_the_fit_when_there_is_no_policy(tmp_path: Path) -> Non
     assert result.exit_code != 0
     assert _says(result.output, "no policy file at")
     assert _says(result.output, "wmo optimize route fit <matrix.json> --kind knn")
+
+
+# ------------------------------------------- rich markup in help text
+
+
+def test_route_student_help_keeps_the_pool_table_name() -> None:
+    """The paragraph exists to name the TOML table `student` writes, so it must survive rich.
+
+    Typer renders help through rich markup, which swallowed the unescaped `[[model]]` and left
+    an empty pair of backticks where the identifier should be.
+    """
+    result = runner.invoke(app, ["optimize", "route", "student", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "[[model]]" in _flat(result.output)


### PR DESCRIPTION
## What was broken

Typer renders every help string through Rich markup, and every `console.print` parses markup by
default. Rich reads `[` followed by a lowercase letter, `#`, `/` or `@` as a style tag, so an
unescaped `[...]` that is *content* is either resolved to an unknown style and silently deleted,
or (for an unmatched closing tag) raises `MarkupError` and takes the command down. One root cause,
three symptoms:

**Crash + silent corruption on user content.** `wmo knowledge` printed hand-edited markdown
straight through Rich, so `[/items]` killed the command and `list[str]` / `[the docs](url)` lost
text. `wmo harness show` printed surface bodies (prompts, skills, code) the same way, and
`wmo harness list` printed a pydantic reason whose entire `[type=..., input_value=...]` diagnosis
vanished.

```bash
mkdir -p /tmp/kb/.wmo/models/demo/knowledge && cd /tmp/kb
printf 'provider = "bedrock"\nmodel = "claude-opus-4-8"\n' > .wmo/models/demo/config.toml
printf 'Use the XML close marker [/items] to end a list.\n' > .wmo/models/demo/knowledge/schemas.md
wmo knowledge
# before: rich Traceback panel, MarkupError: closing tag '[/items]' ... doesn't match any open tag
# after:  Use the XML close marker [/items] to end a list.
```

**Swallowed error code.** `wmo ingest --file /tmp/nope.jsonl` printed
`error  [Errno 2] No such file...` with a doubled space where `[bad_format]` should be, so the
classification `--json` reports never reached a human. A bracket in the failing path
(`wmo ingest --file '/tmp/[/bold]missing.jsonl'`) raised `MarkupError` from the same line.

**Swallowed help text**, six places where the deleted token is the only pointer the sentence
exists to give: `[models.worker]` in `providers set --help`, `[models.<role>]` in
`providers verify --help`, `[models.agent]` in `eval --help`, `[[model]]` in
`optimize route student --help`, `[models.worker|judge|summary]` in `scenarios build --provider`
(which left a dangling period), and `[deprecated]` on `build --vendor`, which made a deprecated
alias read as a current, supported option.

Also swallowed at runtime: the `[seed]` / `[iter N]` / `[slot N]` / `[iteration N proposal N]`
tags that are the only thing identifying which candidate a harness-search progress line is about.

## What changed

- User-authored content is escaped before printing (`rich.markup.escape`): knowledge files,
  harness surface bodies, ingest error messages, and the exception text in `harness list`.
- Literal brackets that must render are escaped as `\[`, matching the convention already
  documented in `route_app.py` and `optimize_model_app.py`
  (`help="... one \[\[model]] table per candidate."`).
- Six help strings/docstrings escaped so the TOML table names and the `[deprecated]` marker
  survive.
- No behaviour outside rendering changed; no catch-all handler was added.

The whole `wmo/` tree was swept with an AST scan that renders every literal `console.print`
template through `rich.markup.render` and flags spans whose style name is not resolvable. The only
remaining hits are `f"[{color}]gate[/{color}]"` in `model_app.py`, where the interpolated value
really is a style name.

## Verified

`uv run pytest wmo` -> 3766 passed, 10 skipped. `uv run ruff check .` clean. Every new test was
confirmed to fail against `origin/main`'s version of the source (11 failures) before the fix.

New tests: `wmo/cli/app_test.py` (parametrized over the five help sites in `app.py`, plus
markup-bearing knowledge content), `wmo/cli/ingest_cmd_test.py` (rich-mode error code, and a
bracketed path that used to raise `MarkupError`), `wmo/cli/route_app_test.py`
(`route student --help`), `wmo/cli/harness_app_test.py` (`harness show`, `harness list`, and the
harbor `[seed]`/`[slot 1]` progress lines).

## Audit findings closed

- #4 `wmo ingest` never shows its error code in rich mode
- #15 `wmo knowledge` crashes with `MarkupError` on ordinary user-edited content
- #32 `[deprecated]` on `wmo build --vendor` renders as nothing
- #45 `[models.agent]` eaten from `wmo eval --help`
- #63 TOML table names eaten from `providers set --help` and `providers verify --help`
- #79 `[[model]]` renders as `[]` in `wmo optimize route student --help`
- #98 `[models.worker|judge|summary]` eaten from `wmo scenarios build --provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
