### PR TITLE
Validate `wmo build`'s trace-source arguments at the CLI boundary

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -699,8 +699,9 @@ def build(
     limit: int = typer.Option(
         None,
         "--limit",
-        help="Only use the first N traces (caps a --file export too, not just "
-        "--pull); cost control for a first build over a large corpus.",
+        help="Only use the first N traces (caps a --file export too, not just --pull); cost "
+        "control for a first build over a large corpus. A --pull is capped at fetch time, so "
+        "with --drop-degenerate it can yield fewer than N; a --file export yields N usable.",
     ),
     vendor: str = typer.Option(
         None, "--vendor", help="\\[deprecated] alias for --source <name> --pull."
@@ -975,7 +976,11 @@ def build(
                 estimate_only=spec.estimate_only,
                 drop_degenerate=drop_degenerate,
                 gepa_val_cap=spec.gepa_val_cap or None,
-                limit=params.limit,
+                # One cap per build, never both: a pull is already sliced to `--limit` inside
+                # `from_vendor`, so repeating it post-filter cannot restore what
+                # `--drop-degenerate` removed and would only read as a promise of N usable
+                # traces that the pull transport cannot keep.
+                limit=None if params.pull else params.limit,
             )
         except EmptyCorpusError:
             # The one ingest outcome a user causes and can fix: the export does not parse under

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -62,6 +62,7 @@ from wmo.cli.ui import (
     select_model,
     select_option,
     select_provider_and_model,
+    serve_model_default,
 )
 from wmo.config import (
     ARTIFACT_DIR,
@@ -84,7 +85,7 @@ from wmo.config import (
 )
 from wmo.config.card import make_build_card, save_card
 from wmo.core.types import JsonObject, Trace
-from wmo.engine.build import DEFAULT_TRAIN_SPLIT, ingest, split_traces
+from wmo.engine.build import DEFAULT_TRAIN_SPLIT, EmptyCorpusError, ingest, split_traces
 from wmo.engine.build import build as run_build
 from wmo.engine.demo import run_demo
 from wmo.engine.eval_suites import (
@@ -103,12 +104,15 @@ from wmo.evals.grid import GridResult, ModelSpec, merge_results, run_grid
 from wmo.evals.grid_plot import plot_grid, plot_grid_heatmap
 from wmo.evals.open_loop import EvalReport, OpenLoopEval
 from wmo.ingest import VendorPull, get_adapter, list_adapters
+from wmo.ingest.base import load_payloads
+from wmo.ingest.detect import detect_format
 from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
 from wmo.providers.base import Embedder, EmbedderKind, Provider
 from wmo.providers.models import resolve_provider_model
 from wmo.providers.pool import Tier
 from wmo.providers.retry import wrap_provider_with_retries
+from wmo.providers.waterfall import FALLBACK_CONFIG_PATH
 from wmo.research import Side, run_concurrency_scaling
 from wmo.research.concurrency_run import build_real_runner, build_world_runner
 from wmo.research.concurrency_scaling import ConcurrencyPoint
@@ -597,14 +601,93 @@ def examples_run(
     raise typer.Exit(result.returncode)
 
 
+# The serve provider `wmo build` falls back to when neither `--provider` nor a configured worker
+# role names one.
+_BUILD_PROVIDER = "bedrock"
+# Sources that read a live database rather than an export. `wmo build` has no transport flags for
+# them (`VendorPull.dsn/table` are only reachable from `wmo ingest`), so it rejects them up front
+# instead of failing inside the adapter with advice about flags it does not define.
+_DB_SOURCES = ("postgres",)
+
+
+def _check_build_source(source: str) -> None:
+    """Reject a `--source` that `wmo build` cannot drive, naming the `wmo ingest` two-step."""
+    if source not in list_adapters():
+        raise typer.BadParameter(
+            f"unknown --source {source!r}; choose one of: {', '.join(list_adapters())}"
+        )
+    if source in _DB_SOURCES:
+        raise typer.BadParameter(
+            f"--source {source} reads a live database, which `wmo build` has no connection flags "
+            f"for: normalize first with `wmo ingest --source {source} --dsn <dsn> --table <table> "
+            "--out traces.otel.jsonl`, then `wmo build --file traces.otel.jsonl`"
+        )
+
+
+def _check_build_file(file: str) -> None:
+    """Reject a missing/unreadable `--file` before the provider ping, not inside the adapter."""
+    path = Path(file)
+    if not path.exists():
+        raise typer.BadParameter(
+            f"trace file not found: {file} (export one with `wmo ingest --file <export> --out "
+            f"{file}`, or pass an existing path)"
+        )
+    if path.is_dir():
+        raise typer.BadParameter(f"--file must be a trace export, not a directory: {file}")
+
+
+def _empty_corpus_error(file: str | None, source: str) -> typer.BadParameter:
+    """Explain an empty ingest: usually `--source` does not match the export's real format."""
+    if file is None:
+        return typer.BadParameter(
+            f"the --source {source} pull returned no traces; widen --since/--limit or check the "
+            "--project"
+        )
+    detected: str | None = None
+    try:
+        detected = detect_format(load_payloads(Path(file).read_text(encoding="utf-8")))
+    except (ValueError, OSError):
+        detected = None
+    if detected is not None and detected != source:
+        return typer.BadParameter(
+            f"no traces ingested from {file} with --source {source}: it looks like {detected}. "
+            f"Retry with `--source {detected}`, or let `wmo ingest --file {file} --out "
+            "traces.otel.jsonl` auto-detect the format and build from its output."
+        )
+    return typer.BadParameter(
+        f"no traces ingested from {file} with --source {source} (build never auto-detects): "
+        f"check that the export carries agent steps and that --source names its format, or run "
+        f"`wmo ingest --file {file} --out traces.otel.jsonl` to auto-detect and normalize it "
+        "first"
+    )
+
+
+def _chain_bad_parameter(err: ValueError) -> typer.BadParameter:
+    """Render a failover-chain resolution failure as a usage error naming the file to write."""
+    return typer.BadParameter(
+        f"{err}. Write {FALLBACK_CONFIG_PATH} as [[chain.<name>]] rung tables (one table per "
+        "fallback rung, keys kind/model/profile/region; format in docs/reference/failover.md), "
+        "or drop --chain to serve from --provider alone"
+    )
+
+
+def _provider_or_chain_or_abort(config: ProviderConfig, chain: str | None) -> Provider:
+    """`providers.provider_or_chain`, with chain-resolution errors as clean usage errors."""
+    try:
+        return providers.provider_or_chain(config, chain=chain)
+    except ValueError as err:
+        raise _chain_bad_parameter(err) from None
+
+
 @app.command("build")
 def build(
     name: str = typer.Option(None, "--name", help="Name for this world model."),
     source: str = typer.Option(
         "otel-genai",
         "--source",
-        help="Trace source adapter: otel-genai, chat-json, braintrust, phoenix, langfuse, "
-        "langsmith, posthog, mastra.",
+        help="Trace source adapter, pinned (build never auto-detects): otel-genai, chat-json, "
+        "braintrust, phoenix, langfuse, langsmith, posthog, mastra. To auto-detect an export's "
+        "format, normalize it first with `wmo ingest --file <export>`.",
     ),
     file: str = typer.Option(None, "--file", help="Path to an exported traces file for --source."),
     pull: bool = typer.Option(
@@ -613,15 +696,22 @@ def build(
     project: str = typer.Option(None, "--project", help="Vendor project/workspace id (--pull)."),
     api_key: str = typer.Option(None, "--api-key", help="Vendor API key (else env var)."),
     since: str = typer.Option(None, "--since", help="Only pull traces since this ISO timestamp."),
-    limit: int = typer.Option(None, "--limit", help="Max number of traces to pull."),
+    limit: int = typer.Option(
+        None,
+        "--limit",
+        help="Only use the first N traces (caps a --file export too, not just "
+        "--pull); cost control for a first build over a large corpus.",
+    ),
     vendor: str = typer.Option(
         None, "--vendor", help="\\[deprecated] alias for --source <name> --pull."
     ),
     root: str = typer.Option(ARTIFACT_DIR, help="Project dir holding all world models."),
     provider: str = typer.Option(
-        None, "--provider", help="Provider that serves the model (default: bedrock)."
+        None, "--provider", help=f"Provider that serves the model (default: {_BUILD_PROVIDER})."
     ),
-    model: str = typer.Option(None, help="Canonical serve model type."),
+    model: str = typer.Option(
+        None, help="Canonical serve model type (default: the provider's suggested model)."
+    ),
     judge_model: str = typer.Option(
         None, "--judge-model", help="Canonical GEPA judge model type (default: cheap per provider)."
     ),
@@ -698,6 +788,21 @@ def build(
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider
     )
+    # Settle the serve provider here so the model default can follow it. A single hard-coded
+    # Anthropic default wrote artifacts configured to call e.g. OpenAI with `claude-opus-4-8`.
+    resolved_provider = (
+        provider or (configured_worker.provider if configured_worker else None) or _BUILD_PROVIDER
+    )
+    resolved_model = (
+        model
+        or (configured_worker.model if use_configured_worker and configured_worker else None)
+        or serve_model_default(resolved_provider)
+    )
+    if resolved_model is None and not use_wizard:
+        raise typer.BadParameter(
+            f"--provider {resolved_provider} has no default serve model: pass `--model <id>` "
+            f"(`wmo build --provider {resolved_provider} --model <id> --file <export>`)"
+        )
     params = BuildParams(
         name=name or DEFAULT_MODEL_NAME,
         source=source,
@@ -708,11 +813,9 @@ def build(
         since=since,
         limit=limit,
         provider=provider or (configured_worker.provider if configured_worker else None),
-        model=(
-            model
-            or (configured_worker.model if use_configured_worker and configured_worker else None)
-            or "claude-opus-4-8"
-        ),
+        # A wizard run re-picks provider and model from its own per-provider lists, so an
+        # unresolved default here is only an unused suggestion; the flag path errored above.
+        model=resolved_model or "",
         region=(
             region
             or (configured_worker.region if use_configured_worker and configured_worker else None)
@@ -726,18 +829,22 @@ def build(
     )
     if use_wizard:
         params = run_build_wizard(_console, params)
-    elif name is None and file is None and not pull:
+    elif params.file is None and not params.pull:
+        # This guard also required `name is None`, so `wmo build --name x` (verbatim the
+        # empty-state hint `wmo list` prints) fell through to a raw ValueError from the ingest
+        # seam instead. A name is not a corpus: what is missing is the trace source.
         raise typer.BadParameter(
             "provide --file <export> or --pull (with --source), or run `wmo build` interactively"
         )
     if params.file and params.pull:
         raise typer.BadParameter("pass either --file or --pull, not both")
-    if params.source not in list_adapters():
-        raise typer.BadParameter(
-            f"unknown --source {params.source!r}; choose one of: {', '.join(list_adapters())}"
-        )
+    _check_build_source(params.source)
+    if params.file is not None:
+        _check_build_file(params.file)
+    if params.limit is not None and params.limit < 1:
+        raise typer.BadParameter(f"--limit must be at least 1, got {params.limit}")
     # The wizard always resolves a provider; the flag path keeps its historical default.
-    params.provider = params.provider or "bedrock"
+    params.provider = params.provider or _BUILD_PROVIDER
     # The wizard may replace the configured worker's provider. Re-evaluate the match before
     # carrying provider-specific connection fields into the build config.
     use_configured_worker = (
@@ -830,7 +937,7 @@ def build(
     # so cost/tokens still land in a single run record.
     tracker = RunTracker(run_id=uuid.uuid4().hex, kind="build")
     metered = MeteredProvider(
-        providers.provider_or_chain(config.serve_provider_config(), chain=chain),
+        _provider_or_chain_or_abort(config.serve_provider_config(), chain),
         tracker,
         classify=classify_build_call,
     )
@@ -842,32 +949,38 @@ def build(
         )
     build_stats = BuildTelemetryStats()
     with tracker.timed(), RichBuildReporter(_console, params.name) as reporter:
-        result = run_build(
-            config,
-            file=None if params.pull else params.file,
-            vendor=(
-                VendorPull(
-                    api_key=params.api_key,
-                    project=params.project,
-                    since=params.since,
-                    limit=params.limit,
-                )
-                if params.pull
-                else None
-            ),
-            root=model_dir,
-            serve_provider=metered,
-            judge_provider=metered_judge,
-            embedder=get_embedder(config),
-            reporter=TelemetryBuildReporter(reporter, build_stats),
-            max_fidelity=spec.config_search,
-            fidelity_budget=spec.search_budget,
-            full_search=spec.full_ladder,
-            cheap_search=spec.cheap_frontier_only,
-            estimate_only=spec.estimate_only,
-            drop_degenerate=drop_degenerate,
-            gepa_val_cap=spec.gepa_val_cap or None,
-        )
+        try:
+            result = run_build(
+                config,
+                file=None if params.pull else params.file,
+                vendor=(
+                    VendorPull(
+                        api_key=params.api_key,
+                        project=params.project,
+                        since=params.since,
+                        limit=params.limit,
+                    )
+                    if params.pull
+                    else None
+                ),
+                root=model_dir,
+                serve_provider=metered,
+                judge_provider=metered_judge,
+                embedder=get_embedder(config),
+                reporter=TelemetryBuildReporter(reporter, build_stats),
+                max_fidelity=spec.config_search,
+                fidelity_budget=spec.search_budget,
+                full_search=spec.full_ladder,
+                cheap_search=spec.cheap_frontier_only,
+                estimate_only=spec.estimate_only,
+                drop_degenerate=drop_degenerate,
+                gepa_val_cap=spec.gepa_val_cap or None,
+                limit=params.limit,
+            )
+        except EmptyCorpusError:
+            # The one ingest outcome a user causes and can fix: the export does not parse under
+            # the pinned --source. Only this type is caught, so real build bugs still surface.
+            raise _empty_corpus_error(None if params.pull else params.file, params.source) from None
     record = tracker.record_summary()
     save_run(record, ArtifactPaths(model_dir).runs)
     # The card is additive metadata; a write failure (disk full, permissions) must not make an
@@ -940,7 +1053,7 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
     failed = False
     for cfg, is_embed in checks:
         label = f"embed:{cfg.kind.value}" if is_embed else cfg.kind.value
-        serve_provider = None if is_embed else providers.provider_or_chain(cfg, chain=chain)
+        serve_provider = None if is_embed else _provider_or_chain_or_abort(cfg, chain)
         if is_embed:
             _console.print(f"verifying {label}…")
             result = verify_embedder(cfg)
@@ -981,7 +1094,11 @@ def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list
     """List every world model built under the project dir."""
     infos = WorldModelStore(root).list_info()
     if not infos:
-        _console.print("[yellow]no world models built yet[/yellow]; run `wmo build --name <name>`")
+        # Name the trace export too: `wmo build --name <name>` alone has no corpus to build from.
+        _console.print(
+            "[yellow]no world models built yet[/yellow]; run "
+            "`wmo build --name <name> --file <traces export>`"
+        )
         return
     _console.print(models_table(infos))
 

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -31,9 +31,10 @@ from wmo.config import (
     load_settings,
     save_settings,
 )
-from wmo.core.types import Trace
+from wmo.core.types import Action, ActionKind, Observation, Step, Trace
 from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3way
 from wmo.engine.eval_suites import EvalSuiteConfig
+from wmo.ingest import VendorPull
 from wmo.providers.base import (
     Completion,
     EmbedderKind,
@@ -1490,6 +1491,20 @@ def _flat(output: str) -> str:
     return " ".join(output.replace("│", " ").split())
 
 
+def _pull_trace(trace_id: str, *, usable: bool) -> Trace:
+    """One single-step trace. `usable=False` makes it degenerate (empty observation)."""
+    return Trace(
+        trace_id=trace_id,
+        source="otel-genai:vendor",
+        steps=[
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="get_user", arguments={"id": "u1"}),
+                observation=Observation(content="found u1" if usable else ""),
+            )
+        ],
+    )
+
+
 def _many_traces_file(tmp_path, count: int) -> str:  # noqa: ANN001 - pytest fixture path
     """`count` copies of the single-trace export, each under its own trace id."""
     base = Path(_traces_file(tmp_path)).read_text(encoding="utf-8").splitlines()
@@ -1674,6 +1689,72 @@ def test_build_limit_caps_a_file_corpus(patched_provider, tmp_path) -> None:  # 
     card = load_card(root / "models" / "capped")
     assert card is not None
     assert card.corpus.traces == 2
+
+
+def test_build_pull_limit_is_a_fetch_cap_applied_once(
+    patched_provider,  # noqa: ANN001 - pytest fixture
+    monkeypatch,  # noqa: ANN001 - pytest fixture
+    tmp_path,  # noqa: ANN001 - pytest fixture path
+) -> None:
+    """A pull spends `--limit` vendor-side, so `--drop-degenerate` can leave fewer than N.
+
+    `wmo.ingest.base.from_vendor` slices to `pull.limit` before `build` ever sees the corpus,
+    so re-applying the same cap after the degenerate filter cannot restore the dropped traces —
+    it would only read as a promise of N usable traces that this transport cannot keep. Pinning
+    both halves: the adapter receives the cap, and `build` is not handed it a second time.
+    """
+    import sys
+
+    from wmo.config.card import load_card
+
+    seen: list[VendorPull] = []
+    passed_to_build: dict[str, object] = {}
+
+    class _CappingAdapter:
+        """Mimics `base.from_vendor`: alternating junk/usable traces, sliced at `pull.limit`."""
+
+        name = "otel-genai"
+
+        def from_vendor(self, pull: VendorPull) -> list[Trace]:
+            seen.append(pull)
+            traces = [_pull_trace(f"{i:032d}", usable=bool(i % 2)) for i in range(6)]
+            return traces if pull.limit is None else traces[: pull.limit]
+
+    real_run_build = cli_app_module.run_build
+
+    def _spy(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202 - passthrough spy
+        passed_to_build.update(kwargs)
+        return real_run_build(*args, **kwargs)
+
+    monkeypatch.setattr(
+        sys.modules["wmo.engine.build"], "get_adapter", lambda name: _CappingAdapter()
+    )
+    monkeypatch.setattr(cli_app_module, "run_build", _spy)
+    root = tmp_path / ".wmo"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "pulled",
+            "--pull",
+            "--limit",
+            "4",
+            "--drop-degenerate",
+            "--root",
+            str(root),
+            "--provider",
+            "bedrock",
+            "--fidelity",
+            "low",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert [p.limit for p in seen] == [4]  # spent at fetch…
+    assert passed_to_build["limit"] is None  # …and not a second time after the filter
+    card = load_card(root / "models" / "pulled")
+    assert card is not None
+    assert card.corpus.traces == 2  # 4 fetched, 2 of them degenerate; the cap cannot refill
 
 
 def test_build_rejects_a_limit_below_one(tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -1485,6 +1485,299 @@ def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa:
     assert result.exit_code != 0
 
 
+def _flat(output: str) -> str:
+    """CliRunner output with rich's panel borders and line wrapping removed, for substrings."""
+    return " ".join(output.replace("│", " ").split())
+
+
+def _many_traces_file(tmp_path, count: int) -> str:  # noqa: ANN001 - pytest fixture path
+    """`count` copies of the single-trace export, each under its own trace id."""
+    base = Path(_traces_file(tmp_path)).read_text(encoding="utf-8").splitlines()
+    lines: list[str] = []
+    for i in range(count):
+        for line in base:
+            lines.append(json.dumps({**json.loads(line), "traceId": f"{i:032d}"}))
+    path = tmp_path / "many.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def test_build_with_a_name_but_no_trace_source_is_a_usage_error(tmp_path) -> None:  # noqa: ANN001
+    # `wmo list` prints `wmo build --name <name>` as its empty-state hint, and every non-TTY
+    # (CI, piped output) takes the scriptable path. It used to reach the ingest seam and raise
+    # a raw ValueError; the guard only fired when --name was ALSO omitted.
+    result = runner.invoke(
+        app, ["build", "--name", "x", "--root", str(tmp_path / ".wmo"), "--no-interactive"]
+    )
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "provide --file <export> or --pull" in _flat(result.output)
+
+
+def test_list_empty_state_names_a_trace_export(tmp_path) -> None:  # noqa: ANN001
+    # The hint must be a runnable command: --name alone is a usage error (test above).
+    result = runner.invoke(app, ["list", "--root", str(tmp_path / ".wmo")])
+    assert result.exit_code == 0
+    assert "--file" in result.output
+
+
+def test_build_missing_trace_file_is_a_usage_error(tmp_path) -> None:  # noqa: ANN001
+    # A typo'd --file used to die with a raw FileNotFoundError from the adapter, and only after
+    # the provider ping had already run.
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            str(tmp_path / "nope.jsonl"),
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, FileNotFoundError)
+    assert "trace file not found" in _flat(result.output)
+    # Rejected at the argument boundary: no provider was pinged.
+    assert "verifying" not in result.output
+
+
+def test_build_rejects_a_directory_as_the_trace_file(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            str(tmp_path),
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, IsADirectoryError)
+    assert "not a directory" in _flat(result.output)
+
+
+def test_build_rejects_the_postgres_source_and_names_wmo_ingest(tmp_path) -> None:  # noqa: ANN001
+    # `postgres` passes the adapter-name validator but can never work here: build has no
+    # --dsn/--table (those live on `wmo ingest`), so it must be rejected at the boundary.
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            _traces_file(tmp_path),
+            "--source",
+            "postgres",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)
+    flat = _flat(result.output)
+    assert "wmo ingest --source postgres --dsn <dsn> --table <table>" in flat
+    assert "--dsn" not in _flat(runner.invoke(app, ["build", "--help"]).output)
+
+
+def test_build_wrong_source_names_the_detected_format(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    # A chat-json export under the silent `--source otel-genai` default ingested nothing and
+    # raised ValueError('no traces ingested; nothing to build') as a traceback.
+    chat = tmp_path / "chat.json"
+    chat.write_text(json.dumps({"messages": [{"role": "user", "content": "hi"}]}), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            str(chat),
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--provider",
+            "bedrock",
+            "--fidelity",
+            "low",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)
+    flat = _flat(result.output)
+    assert "--source otel-genai" in flat
+    assert "it looks like chat-json" in flat
+    # The path itself is wrapped by rich, so assert on the command, not the rendered path.
+    assert "wmo ingest --file" in flat
+
+
+def test_build_empty_trace_file_names_source_and_ingest(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            str(empty),
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--provider",
+            "bedrock",
+            "--fidelity",
+            "low",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)
+    flat = _flat(result.output)
+    assert "--source otel-genai" in flat
+    assert "wmo ingest --file" in flat
+
+
+def test_build_limit_caps_a_file_corpus(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    # --limit was wired only into the VendorPull branch, so it was silently ignored for --file
+    # builds while `wmo ingest --limit` capped both transports.
+    from wmo.config.card import load_card
+
+    root = tmp_path / ".wmo"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "capped",
+            "--file",
+            _many_traces_file(tmp_path, 6),
+            "--limit",
+            "2",
+            "--root",
+            str(root),
+            "--provider",
+            "bedrock",
+            "--fidelity",
+            "low",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    card = load_card(root / "models" / "capped")
+    assert card is not None
+    assert card.corpus.traces == 2
+
+
+def test_build_rejects_a_limit_below_one(tmp_path) -> None:  # noqa: ANN001
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            _traces_file(tmp_path),
+            "--limit",
+            "0",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "--limit must be at least 1" in _flat(result.output)
+
+
+def test_build_unknown_chain_is_a_usage_error(tmp_path) -> None:  # noqa: ANN001
+    """`--chain` with no `.wmo/fallback.toml` must say how to create the file, not traceback.
+
+    Deliberately no `patched_provider`: that fixture stubs `providers.provider_or_chain`, which
+    is the seam under test. Chain resolution runs before the provider ping, so nothing here
+    reaches the network (`wmo/conftest.py` points the chain path at an empty tmp dir).
+    """
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            _traces_file(tmp_path),
+            "--chain",
+            "fast",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--provider",
+            "bedrock",
+            "--fidelity",
+            "low",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)
+    flat = _flat(result.output)
+    assert "chain 'fast' requested but" in flat
+    assert "fallback.toml" in flat
+    assert "[[chain.<name>]] rung tables" in flat
+    assert "docs/reference/failover.md" in flat
+
+
+def test_build_model_default_follows_the_provider(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    # --provider openai with no --model used to persist the Anthropic id `claude-opus-4-8`.
+    root = tmp_path / ".wmo"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "oa",
+            "--file",
+            _traces_file(tmp_path),
+            "--provider",
+            "openai",
+            "--fidelity",
+            "low",
+            "--root",
+            str(root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    config = load_config(root / "models" / "oa")
+    assert config.serve_provider is ProviderKind.OPENAI
+    assert config.serve_provider_config().model_type == "gpt-5.5"
+
+
+def test_build_requires_a_model_for_a_provider_without_a_default(tmp_path) -> None:  # noqa: ANN001
+    # openrouter/tinker/openai_responses have no curated model list: ask rather than guess,
+    # matching `wmo providers set`'s scriptable contract.
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "x",
+            "--file",
+            _traces_file(tmp_path),
+            "--provider",
+            "openrouter",
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "--provider openrouter has no default serve model" in _flat(result.output)
+
+
 def test_build_aborts_when_provider_sdk_missing(monkeypatch, tmp_path) -> None:  # noqa: ANN001
     """A missing SDK must abort the build before any rollouts, with the `uv sync` extra hint.
 

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -99,6 +99,17 @@ def judge_model_default(provider: str | None, serve_model: str) -> str:
     return _JUDGE_MODEL_DEFAULTS.get(provider or "", serve_model)
 
 
+def serve_model_default(provider: str | None) -> str | None:
+    """The serve model when none was chosen: the provider's suggested (first) model id.
+
+    Mirrors what the wizard offers, so the scriptable flag path and the interactive path agree.
+    Returns None for a provider with no curated list (openai_responses, openrouter, tinker):
+    there is no id worth guessing, so the caller must ask for `--model`.
+    """
+    models = _PROVIDER_MODELS.get(provider or "")
+    return models[0] if models else None
+
+
 # Embedders offered in the wizard, with the embeddings-model ids each provider-backed one supports
 # (None = the offline hashing embedder, no model). First entry is the suggested default.
 _EMBEDDERS: dict[str, list[str] | None] = {

--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -180,10 +180,14 @@ def build(
     the serve DEFAULTS (plain RAG unless flags were set explicitly): the winner activates at
     runtime via `--max-fidelity`.
 
-    `limit` caps the corpus at the first N normalized traces for BOTH transports, matching
-    `wmo ingest --limit` (`wmo.ingest.stream`) rather than only bounding a vendor pull: a first
-    cheap build over a large export is the whole point of the flag. The cap runs after the
-    degenerate-trace filter, so `--limit N --drop-degenerate` yields N usable traces.
+    `limit` caps the corpus at the first N normalized traces, so a first cheap build over a large
+    file export does not have to read the whole thing into GEPA. It is applied AFTER the
+    degenerate-trace filter, so `limit=N` with `drop_degenerate` yields N *usable* traces — which
+    is why it is not the same knob as `VendorPull.limit`. A pull is bounded vendor-side at fetch
+    time (`wmo.ingest.base.from_vendor` slices to `pull.limit`), before this function can see
+    which traces are degenerate; combining the two therefore yields *at most* N. Callers that
+    want exactly N usable traces from a pull must over-fetch: pass a larger `VendorPull.limit`
+    than `limit`.
     """
     report = reporter or NullReporter()
     paths = ArtifactPaths(root)

--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -40,6 +40,15 @@ from wmo.retrieval import EmbeddingRetriever, HashingEmbedder
 DEFAULT_TRAIN_SPLIT = 0.8
 
 
+class EmptyCorpusError(ValueError):
+    """Ingest produced no traces, so there is nothing to build.
+
+    A `ValueError` subclass so existing library callers keep working, but a distinct type so the
+    CLI can turn the most common cause (an export the pinned `--source` adapter cannot read) into
+    a usage error naming `--source` instead of letting a traceback escape.
+    """
+
+
 def _count_steps(traces: list[Trace]) -> int:
     return sum(len(trace.steps) for trace in traces)
 
@@ -151,6 +160,7 @@ def build(
     estimate_only: bool = False,
     drop_degenerate: bool = False,
     gepa_val_cap: int | None = None,
+    limit: int | None = None,
 ) -> OptimizeResult:
     """Ingest traces and run the full build, creating + persisting the artifact under `root`.
 
@@ -169,6 +179,11 @@ def build(
     artifact will serve, and the result lands in `auto_fidelity.json`. The search never changes
     the serve DEFAULTS (plain RAG unless flags were set explicitly): the winner activates at
     runtime via `--max-fidelity`.
+
+    `limit` caps the corpus at the first N normalized traces for BOTH transports, matching
+    `wmo ingest --limit` (`wmo.ingest.stream`) rather than only bounding a vendor pull: a first
+    cheap build over a large export is the whole point of the flag. The cap runs after the
+    degenerate-trace filter, so `--limit N --drop-degenerate` yields N usable traces.
     """
     report = reporter or NullReporter()
     paths = ArtifactPaths(root)
@@ -180,8 +195,10 @@ def build(
         # (run_trace_scaling / run_fidelity_tiers, via their own --drop-degenerate) apply.
         traces, dropped = drop_degenerate_traces(traces)
         report.activity(f"dropped {dropped} degenerate (all-empty-observation) traces")
+    if limit is not None:
+        traces = traces[:limit]
     if not traces:
-        raise ValueError("no traces ingested; nothing to build")
+        raise EmptyCorpusError("no traces ingested; nothing to build")
     report.ingest_done(len(traces), _count_steps(traces))
 
     # Three disjoint sets: train seeds GEPA's reflection minibatches, val (capped) selects

--- a/wmo/engine/build_test.py
+++ b/wmo/engine/build_test.py
@@ -8,7 +8,13 @@ import pytest
 
 from wmo.config import ArtifactPaths, HarnessConfig
 from wmo.core.types import Action, ActionKind, Observation, Step, Trace
-from wmo.engine.build import build, split_holdout, split_traces, split_traces_3way
+from wmo.engine.build import (
+    EmptyCorpusError,
+    build,
+    split_holdout,
+    split_traces,
+    split_traces_3way,
+)
 from wmo.providers.base import Completion, Message, ProviderConfig, ProviderKind
 from wmo.retrieval import HashingEmbedder
 
@@ -757,3 +763,50 @@ def test_build_records_disjoint_false_when_recheck_falls_back_to_selection(tmp_p
     assert metrics["base_fresh"] is not None
     assert metrics["best_fresh"] is not None
     assert metrics["fresh_recheck_disjoint"] is False
+
+
+def _low_tier_config() -> HarnessConfig:
+    return HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="m")],
+        serve_provider=ProviderKind.BEDROCK,
+        embed_dim=64,
+        gepa_budget=0,
+        train_split=0.5,
+    )
+
+
+def test_build_limit_caps_a_file_corpus(tmp_path) -> None:  # noqa: ANN001
+    # `limit` is cost control for a first build over a large export, so it must cap a FILE
+    # ingest and not only a vendor pull (the same contract as `wmo ingest --limit`).
+    seen: dict[str, int] = {}
+
+    class _CountingEmbedder(HashingEmbedder):
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            seen["steps"] = seen.get("steps", 0) + len(texts)
+            return super().embed(texts)
+
+    build(
+        _low_tier_config(),
+        file=_multi_trace_file(tmp_path, 6),
+        root=str(tmp_path / ".wmo"),
+        serve_provider=FakeProvider(),
+        embedder=_CountingEmbedder(dim=64),
+        limit=2,
+    )
+    assert seen["steps"] == 2  # one step per trace, capped at 2 of 6
+
+
+def test_build_empty_corpus_raises_the_typed_error(tmp_path) -> None:  # noqa: ANN001
+    # `EmptyCorpusError` is the seam the CLI catches to turn "your --source does not match this
+    # export" into a usage error; it stays a ValueError for existing library callers.
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    with pytest.raises(EmptyCorpusError) as excinfo:
+        build(
+            _low_tier_config(),
+            file=str(empty),
+            root=str(tmp_path / ".wmo"),
+            serve_provider=FakeProvider(),
+            embedder=HashingEmbedder(dim=64),
+        )
+    assert isinstance(excinfo.value, ValueError)


### PR DESCRIPTION
## What was broken

`wmo build` validates `--name`, `--fidelity`, `--provider`, `--embed-provider` and the
`--file`-vs-`--pull` pair, but it never validated the trace source itself. Everything that
could go wrong with the corpus went straight through to `wmo/engine/build.py`'s ingest seam and
escaped `main()` (which has no exception handling) as a user-visible Python traceback, in most
cases *after* the live provider verification ping had already run.

One repro a reviewer can paste (no credentials needed for the argument errors):

```bash
cd $(mktemp -d)
wmo list                      # prints: run `wmo build --name <name>`
wmo build --name x --no-interactive
# before: ValueError: ingest needs either a file path or a vendor pull  (rich traceback, exit 1)
# after:  Invalid value: provide --file <export> or --pull (with --source), or run
#         `wmo build` interactively                                     (exit 2)
```

And the one from the README quickstart, with any non-OTel export:

```bash
echo '{"messages": [{"role": "user", "content": "hi"}]}' > chat.json
wmo build --name x --file chat.json --no-interactive
# before: ValueError: no traces ingested; nothing to build              (rich traceback, exit 1)
# after:  Invalid value: no traces ingested from chat.json with --source otel-genai: it looks
#         like chat-json. Retry with `--source chat-json`, or let `wmo ingest --file chat.json
#         --out traces.otel.jsonl` auto-detect the format and build from its output.
```

## What changed

All of it is boundary validation in `wmo/cli/app.py`; no blanket `try/except` was added at the
entry point.

- **Wrong `--source` for the export, or an empty file.** `wmo/engine/build.py` now raises a typed
  `EmptyCorpusError(ValueError)` instead of a bare `ValueError`, and the CLI catches that one type
  around `run_build`. On the failure path only (zero cost when the build succeeds) it runs the
  ingest layer's own `detect_format` to name the real format, and always names `--source` plus the
  `wmo ingest --file <f>` auto-detect route. Copies the `typer.BadParameter` pattern the sibling
  `wmo scenarios build` already uses at `app.py:1819`. `--source`'s help now says build never
  auto-detects.
- **`--name` with no trace source.** The guard read
  `elif name is None and file is None and not pull:`; the `name is None` conjunct meant the exact
  command `wmo list` prints as its empty-state hint crashed in every non-TTY (CI, piped output),
  not just under `--no-interactive`. The conjunct is gone, and the `wmo list` hint now reads
  ``wmo build --name <name> --file <traces export>`` so it is a runnable command.
- **Missing or wrong-type `--file`.** Checked before the provider ping, so a typo no longer costs a
  provider round-trip: `trace file not found: <path>` / `--file must be a trace export, not a
  directory`. Follows the existing convention at `_run_eval_files` (`app.py:1694`).
- **`--source postgres`.** Rejected at the boundary rather than wired through. Justification: the
  postgres adapter is the only one that reads a live database, `build`'s pull path constructs a
  `VendorPull` with no `dsn`/`table` fields, and `wmo build --help` advertises neither flag, so
  wiring them would duplicate `wmo ingest`'s whole database transport surface on a second command
  for a path that already has a documented two-step. The error names that two-step:
  `wmo ingest --source postgres --dsn <dsn> --table <table> --out traces.otel.jsonl`, then
  `wmo build --file traces.otel.jsonl`. Build's hand-written `--source` list (8 adapters, no
  postgres) is now honest again.
- **`--limit` for `--file` builds.** Honoured rather than rejected: `wmo ingest --limit` and
  `wmo scenarios build --limit` both cap file ingests (`wmo/ingest/stream_test.py:162` pins that
  contract as cost control), and two identically named flags on the two ingestion doors should not
  disagree. `build()` takes a `limit` that caps the corpus after the degenerate-trace filter, so
  `--limit N --drop-degenerate` yields N usable traces. `--limit 0` is now a usage error. The cap
  is spent exactly once per build: post-filter for `--file`, and at fetch time for `--pull`
  (`wmo/ingest/base.py:112` already slices to `VendorPull.limit`, so a pull yields *at most* N and
  re-applying the cap after the filter could not refill it). Both the `build()` docstring and
  `--limit`'s help name that boundary.
- **`--chain`.** `provider_or_chain`'s `ValueError`s (missing file, unknown chain, malformed file)
  are converted to usage errors at build's two call sites, adding the file to write and its
  `[[chain.<name>]]` rung format plus the doc that describes it.
- **`--model`.** `app.py:674` hard-defaulted every provider to the Anthropic id
  `claude-opus-4-8`, so `--provider openai` alone persisted an artifact configured to call OpenAI
  with a Claude model id. The default now follows the resolved provider through the same
  per-provider list the wizard offers (`serve_model_default` in `wmo/cli/ui.py`, alongside the
  existing `judge_model_default`). Providers with no curated list (openai_responses, openrouter,
  tinker) ask for `--model` rather than guessing, matching `wmo providers set`'s scriptable
  contract.

## Audit findings closed

| # | Finding |
| --- | --- |
| core/major | `wmo build` on a non-OTel export or an empty file raises `ValueError('no traces ingested; nothing to build')` as a traceback, never naming `--source` |
| core/major | `wmo build --name x` with no `--file`/`--pull` raises `ValueError('ingest needs either a file path or a vendor pull')`, and that is verbatim what `wmo list` tells a new user to run |
| core/major | `--source postgres` passes the validator, always crashes, and its error names `--dsn`/`--table`, flags that exist only on `wmo ingest` |
| core/minor | A typo'd or absent `--file` dies with a raw `FileNotFoundError` (a directory gives `IsADirectoryError`), after the provider ping |
| core/minor | `--chain <name>` with no `.wmo/fallback.toml` raises an unhandled `ValueError` from `wmo/providers/waterfall.py:323` |
| core/minor | `--limit N` is silently ignored for `--file` builds; it was only wired into the `VendorPull` branch |
| core/minor | `--model` hard-defaults every provider to `claude-opus-4-8`, which is wrong for `--provider openai` |

## Tests

Twelve new tests (`wmo/cli/app_test.py`, `wmo/engine/build_test.py`), one per behaviour changed,
including that the file checks happen before any provider ping and that the chain test runs
against the real `provider_or_chain` seam rather than the stub. Local run: `uv run pytest -q`,
4143 passed / 20 skipped; `uv run ruff check .`, `uv run ruff format --check .` and
`uv run ty check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

