### PR TITLE
Report every platform failure as a PlatformError, not an httpx traceback

### DIFF
--- a/wmo/cli/platform_cmds.py
+++ b/wmo/cli/platform_cmds.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import socket
 import tempfile
 import webbrowser
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Annotated
 
@@ -22,7 +24,13 @@ from wmo.config.store import WorldModelStore
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.store import CHAMPION_ALIAS, HarnessStore
 from wmo.platform.auth import BrowserLogin
-from wmo.platform.client import PlatformClient, PlatformError, WhoAmI, fetch_cli_config
+from wmo.platform.client import (
+    PlatformClient,
+    PlatformError,
+    PlatformUnreachable,
+    WhoAmI,
+    fetch_cli_config,
+)
 from wmo.platform.credentials import (
     DEFAULT_WEB_URL,
     PlatformCredentials,
@@ -74,20 +82,28 @@ def login(
 ) -> None:
     """Connect this machine to a platform account."""
     credentials = load_credentials()
-    web_url = (url or credentials.web_url or DEFAULT_WEB_URL).rstrip("/")
+    web_url: str | None
 
     if api_url is None:
+        web_url = (url or credentials.web_url or DEFAULT_WEB_URL).rstrip("/")
         try:
             api_url = fetch_cli_config(web_url)
+        except PlatformUnreachable as error:
+            raise typer.BadParameter(str(error)) from error
         except PlatformError as error:
             raise typer.BadParameter(f"{web_url} does not look like a platform: {error}") from error
         if api_url is None:
             raise typer.BadParameter(f"{web_url} did not advertise a backend URL; is it deployed?")
     else:
         api_url = api_url.rstrip("/")
+        # --api-url names a backend directly; only --url can say which web app
+        # fronts it. Recording the hosted default here would misreport every
+        # later "connected to ..." line, so leave it unset — the API URL is
+        # what gets displayed then.
+        web_url = url.rstrip("/") if url else None
 
     if token is None:
-        token = _browser_login(web_url, open_browser=not no_browser)
+        token = _browser_login(web_url or DEFAULT_WEB_URL, open_browser=not no_browser)
     if token is None or not token.strip():
         _console.print("[red]No key received; nothing saved.[/red]")
         raise typer.Exit(code=1)
@@ -96,9 +112,14 @@ def login(
     with PlatformClient(api_url, token) as client:
         try:
             identity = client.whoami()
+        except PlatformUnreachable as error:
+            raise _platform_failure(error, "Connection failed") from error
         except PlatformError as error:
-            _console.print(f"[red]The key was rejected:[/red] {error}")
-            raise typer.Exit(code=1) from error
+            # Only an auth status means the key itself is bad; a login wall or a
+            # deploy that is not a platform must not be blamed on the key.
+            rejected = error.status_code in (401, 403)
+            headline = "The key was rejected" if rejected else "Login failed"
+            raise _platform_failure(error, headline) from error
 
     # A relogin may land on a different account: keep the saved default
     # organization only if the new identity can still see it.
@@ -144,9 +165,11 @@ def status() -> None:
         try:
             identity = client.whoami()
         except PlatformError as error:
-            _console.print(f"[red]Connection check failed:[/red] {error}")
-            raise typer.Exit(code=1) from error
-    _console.print(f"{_CHECK} Connected to [bold]{credentials.web_url}[/bold]")
+            raise _platform_failure(error, "Connection check failed") from error
+    # Env-var credentials (the headless path) carry no web_url; show the host
+    # requests actually went to rather than "None".
+    home = credentials.web_url or credentials.api_url
+    _console.print(f"{_CHECK} Connected to [bold]{home}[/bold]")
     _console.print(f"  acting as: {identity.actor.kind} {identity.actor.id}")
     _print_orgs(identity, credentials.default_org)
 
@@ -162,11 +185,13 @@ def push(
     """Publish a local world model or harness to the platform registry."""
     model_dir = WorldModelStore(root).dir_for(name)
     harness_exists = HarnessStore(root).exists(name)
-    resolved_kind = _resolve_kind(kind, model=model_dir is not None, harness=harness_exists)
+    resolved_kind = _resolve_kind(
+        kind, name=name, root=root, model=model_dir is not None, harness=harness_exists
+    )
     remote_name = push_as or name
 
     credentials, org_id = _require_connection(org)
-    with _client(credentials) as client:
+    with _connected(credentials, "Push failed") as client:
         if resolved_kind == "model" and model_dir is not None:
             _push_model(client, org_id, remote_name, model_dir)
         else:
@@ -185,7 +210,7 @@ def pull(
     if kind is not None and kind not in ("model", "harness"):
         raise typer.BadParameter("--kind must be 'model' or 'harness'")
     credentials, org_id = _require_connection(org)
-    with _client(credentials) as client:
+    with _connected(credentials, "Pull failed") as client:
         resolved_kind = kind or _detect_remote_kind(client, org_id, name)
         if resolved_kind == "model":
             _pull_model(client, org_id, name, root, force=force)
@@ -221,6 +246,26 @@ def _client(credentials: PlatformCredentials) -> PlatformClient:
     return PlatformClient(credentials.api_url, credentials.token)
 
 
+@contextmanager
+def _connected(credentials: PlatformCredentials, headline: str) -> Iterator[PlatformClient]:
+    """Open a client whose request failures end the command without a traceback.
+
+    `PlatformClient` reports every failure as a `PlatformError` (unreachable
+    hosts included), so this one handler covers every request the body makes.
+    """
+    with _client(credentials) as client:
+        try:
+            yield client
+        except PlatformError as error:
+            raise _platform_failure(error, headline) from error
+
+
+def _platform_failure(error: PlatformError, headline: str) -> typer.Exit:
+    """Render a failed platform request as a clean error; the message carries the next step."""
+    _console.print(f"[red]{headline}:[/red] {error}")
+    return typer.Exit(code=1)
+
+
 def _require_connection(org: str | None) -> tuple[PlatformCredentials, str]:
     credentials = load_credentials()
     if not credentials.is_complete():
@@ -233,14 +278,14 @@ def _require_connection(org: str | None) -> tuple[PlatformCredentials, str]:
     return credentials, org_id
 
 
-def _resolve_kind(kind: str | None, *, model: bool, harness: bool) -> str:
+def _resolve_kind(kind: str | None, *, name: str, root: str, model: bool, harness: bool) -> str:
     if kind is not None:
         if kind not in ("model", "harness"):
             raise typer.BadParameter("--kind must be 'model' or 'harness'")
         if kind == "model" and not model:
-            raise typer.BadParameter("no local world model has this name")
+            raise typer.BadParameter(_nothing_local(name, root, kind="model"))
         if kind == "harness" and not harness:
-            raise typer.BadParameter("no local harness has this name")
+            raise typer.BadParameter(_nothing_local(name, root, kind="harness"))
         return kind
     if model and harness:
         raise typer.BadParameter("both a model and a harness have this name locally; pass --kind")
@@ -248,7 +293,23 @@ def _resolve_kind(kind: str | None, *, model: bool, harness: bool) -> str:
         return "model"
     if harness:
         return "harness"
-    raise typer.BadParameter("no local world model or harness has this name")
+    raise typer.BadParameter(_nothing_local(name, root, kind=None))
+
+
+def _nothing_local(name: str, root: str, *, kind: str | None) -> str:
+    """Say what was looked for, where, what is actually there, and what to run next."""
+    if kind == "model":
+        label, have = "world model", WorldModelStore(root).list_names()
+        hint = f"`wmo build --name {name}` builds one"
+    elif kind == "harness":
+        label, have = "harness", HarnessStore(root).list_names()
+        hint = f"`wmo harness init {name}` creates one"
+    else:
+        label = "world model or harness"
+        have = [*WorldModelStore(root).list_names(), *HarnessStore(root).list_names()]
+        hint = "`wmo list` and `wmo harness list` show what is here"
+    found = f"have: {', '.join(have)}" if have else "nothing is built there"
+    return f"no local {label} named {name!r} under {root} ({found}); {hint}, or pass --root <dir>"
 
 
 def _detect_remote_kind(client: PlatformClient, org_id: str, name: str) -> str:
@@ -296,7 +357,14 @@ def _push_harness(
     ref: str | None,
     root: str,
 ) -> None:
-    doc = HarnessStore(root).load(local_name, ref)
+    try:
+        doc = HarnessStore(root).load(local_name, ref)
+    except (FileNotFoundError, ValueError) as error:
+        # A typo'd --ref is user input, not a bug: same treatment as
+        # `wmo harness show <name>@<ref>`.
+        raise typer.BadParameter(
+            f"{error}; `wmo harness list --root {root}` shows the versions and aliases"
+        ) from error
     if remote_name != local_name:
         doc = doc.model_copy(update={"name": remote_name})
     pushed = client.push_harness_version(

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -2,18 +2,25 @@
 
 from __future__ import annotations
 
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
 import typer
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from wmo.cli.app import app
 from wmo.cli.platform_cmds import _pull_harness, _resolve_kind
 from wmo.harness.doc import HarnessDoc, Surface, SurfaceKind
 from wmo.harness.store import HarnessStore
-from wmo.platform.client import HarnessVersionDoc, PlatformError, WhoAmI
+from wmo.platform.client import (
+    HarnessVersionDoc,
+    PlatformError,
+    PlatformUnreachable,
+    RemoteWorldModel,
+    WhoAmI,
+)
 from wmo.platform.credentials import ENV_HOME, PlatformCredentials, save_credentials
 
 if TYPE_CHECKING:
@@ -57,6 +64,28 @@ class _StubClient:
         return _WHOAMI
 
 
+def _unreachable() -> PlatformUnreachable:
+    return PlatformUnreachable(
+        "cannot reach https://api.test/api/whoami: [Errno 61] Connection refused; "
+        "check your connection, or re-run `wmo login --url <platform url>`"
+    )
+
+
+def _flatten(output: str) -> str:
+    """Rejoin a rich-wrapped message so assertions can match it as one string."""
+    return " ".join(output.replace("│", " ").split())
+
+
+def _assert_clean_failure(result: Result) -> None:
+    """The command failed through the CLI instead of letting an exception escape.
+
+    A `PlatformError`/`ConnectError` reaching here is what a user sees as a
+    Python traceback, so the exception type is the assertion that matters.
+    """
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit), result.exception
+
+
 def test_platform_commands_are_registered() -> None:
     result = runner.invoke(app, ["--help"])
     for command in ("login", "logout", "status", "push", "pull"):
@@ -97,6 +126,35 @@ def test_status_surfaces_rejected_credentials(monkeypatch: pytest.MonkeyPatch) -
 
     assert result.exit_code == 1
     assert "Unauthorized" in result.output
+
+
+def test_status_reports_an_unreachable_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command that answers "is my connection healthy?" must survive "no"."""
+    save_credentials(PlatformCredentials(api_url="http://127.0.0.1:9", token="xpl_x"))
+
+    class _UnreachableClient(_StubClient):
+        def whoami(self) -> WhoAmI:
+            raise _unreachable()
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _UnreachableClient)
+
+    result = runner.invoke(app, ["status"])
+
+    _assert_clean_failure(result)
+    assert "Connection check failed" in result.output
+    assert "cannot reach" in result.output
+
+
+def test_status_falls_back_to_the_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env-var credentials carry no web_url; the host still has to be named."""
+    save_credentials(PlatformCredentials(api_url="https://api.test", token="xpl_x"))
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "https://api.test" in result.output
+    assert "None" not in result.output
 
 
 def test_pull_rejects_unknown_kind() -> None:
@@ -222,10 +280,199 @@ def test_login_with_explicit_api_url_skips_web_discovery(
     assert saved.token == "xpl_new"
 
 
+def test_login_with_api_url_only_records_no_web_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--api-url alone cannot know the web app, so it must not claim the hosted one."""
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(
+        app, ["login", "--api-url", "https://api-preview.test/", "--token", "xpl_new"]
+    )
+
+    assert result.exit_code == 0, result.output
+    from wmo.platform.credentials import load_credentials
+
+    saved = load_credentials()
+    assert saved.api_url == "https://api-preview.test"
+    assert saved.web_url is None
+
+
+def test_login_reports_an_unreachable_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    def refuse(_url: str) -> str:
+        raise _unreachable()
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.fetch_cli_config", refuse)
+
+    result = runner.invoke(app, ["login", "--url", "http://127.0.0.1:9"])
+
+    _assert_clean_failure(result)
+    assert "cannot reach" in result.output
+    assert "wmo login --url" in result.output
+
+
+def test_login_reports_a_url_that_is_not_a_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 of HTML (login wall, SPA rewrite) is a verdict, not a decode crash."""
+
+    def not_json(_url: str) -> str:
+        raise PlatformError("answered HTTP 200 with text/html, not JSON", status_code=200)
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.fetch_cli_config", not_json)
+
+    result = runner.invoke(app, ["login", "--url", "https://preview.test"])
+
+    _assert_clean_failure(result)
+    assert "does not look like a platform" in result.output
+    assert "not JSON" in result.output
+
+
+def test_login_does_not_blame_the_key_for_an_unreachable_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _UnreachableClient(_StubClient):
+        def whoami(self) -> WhoAmI:
+            raise _unreachable()
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _UnreachableClient)
+
+    result = runner.invoke(app, ["login", "--api-url", "http://127.0.0.1:9", "--token", "xpl_new"])
+
+    _assert_clean_failure(result)
+    assert "Connection failed" in result.output
+    assert "rejected" not in result.output
+
+
 def test_push_requires_login_first(tmp_path: Path) -> None:
     result = runner.invoke(app, ["push", "anything", "--root", str(tmp_path)])
     assert result.exit_code != 0
     assert "no local world model or harness" in result.output
+
+
+def _connected() -> None:
+    save_credentials(
+        PlatformCredentials(
+            web_url="https://platform.test",
+            api_url="https://api.test",
+            token="xpl_x",
+            default_org="org-1",
+        )
+    )
+
+
+def _write_harness(root: str, name: str = "demo") -> None:
+    doc = HarnessDoc(
+        name=name, surfaces=[Surface(id="prompt:core", kind=SurfaceKind.PROMPT, content="p")]
+    )
+    HarnessStore(root).save_version(doc)
+
+
+def test_push_reports_an_unreachable_platform(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = str(tmp_path / ".wmo")
+    _write_harness(root)
+    _connected()
+
+    class _UnreachableClient(_StubClient):
+        def push_harness_version(self, *_args: object, **_kwargs: object) -> object:
+            raise _unreachable()
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _UnreachableClient)
+
+    result = runner.invoke(app, ["push", "demo", "--root", root])
+
+    _assert_clean_failure(result)
+    assert "Push failed" in result.output
+    assert "cannot reach" in result.output
+
+
+def test_push_reports_a_platform_http_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = str(tmp_path / ".wmo")
+    _write_harness(root)
+    _connected()
+
+    class _MissingOrgClient(_StubClient):
+        def push_harness_version(self, *_args: object, **_kwargs: object) -> object:
+            raise PlatformError("not found", status_code=404)
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _MissingOrgClient)
+
+    result = runner.invoke(app, ["push", "demo", "--root", root])
+
+    _assert_clean_failure(result)
+    assert "Push failed: not found" in _flatten(result.output)
+
+
+def test_pull_surfaces_the_hint_inside_a_platform_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A revoked key already carries the remedy; it must not be buried in a traceback."""
+    _connected()
+
+    class _RevokedKeyClient(_StubClient):
+        def list_world_models(self, _org_id: str) -> list[RemoteWorldModel]:
+            raise PlatformError(
+                "invalid API key — run `wmo login` (or check WMO_PLATFORM_TOKEN)", status_code=401
+            )
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _RevokedKeyClient)
+
+    result = runner.invoke(app, ["pull", "demo", "--root", str(tmp_path / ".wmo")])
+
+    _assert_clean_failure(result)
+    normalized = _flatten(result.output)
+    assert "Pull failed: invalid API key" in normalized
+    assert "run `wmo login`" in normalized
+
+
+def test_pull_reports_an_unreachable_platform(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _connected()
+
+    class _UnreachableClient(_StubClient):
+        def list_world_models(self, _org_id: str) -> list[RemoteWorldModel]:
+            raise _unreachable()
+
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _UnreachableClient)
+
+    result = runner.invoke(app, ["pull", "demo", "--root", str(tmp_path / ".wmo")])
+
+    _assert_clean_failure(result)
+    assert "Pull failed" in result.output
+    assert "cannot reach" in result.output
+
+
+def test_push_rejects_an_unknown_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo'd --ref is a usage error naming where the versions are listed."""
+    root = str(tmp_path / ".wmo")
+    _write_harness(root)
+    _connected()
+    monkeypatch.setattr("wmo.cli.platform_cmds.PlatformClient", _StubClient)
+
+    result = runner.invoke(app, ["push", "demo", "--ref", "v99", "--root", root])
+
+    _assert_clean_failure(result)
+    normalized = _flatten(result.output)
+    assert "no version v99" in normalized
+    assert "wmo harness list" in normalized
+
+
+def test_push_unknown_name_names_the_root_and_the_next_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Run against the default relative --root so the message's root is readable
+    # in the wrapped error box, exactly as a user in the wrong directory sees it.
+    monkeypatch.chdir(tmp_path)
+    _write_harness(".wmo")
+
+    result = runner.invoke(app, ["push", "nosuchmodel"])
+
+    _assert_clean_failure(result)
+    normalized = _flatten(result.output)
+    assert "no local world model or harness named 'nosuchmodel' under .wmo" in normalized
+    assert "have: demo" in normalized
+    assert "wmo list" in normalized
 
 
 def test_logout_when_not_logged_in() -> None:
@@ -234,18 +481,20 @@ def test_logout_when_not_logged_in() -> None:
     assert "nothing to remove" in result.output.lower()
 
 
-def test_resolve_kind_disambiguates() -> None:
-    assert _resolve_kind(None, model=True, harness=False) == "model"
-    assert _resolve_kind(None, model=False, harness=True) == "harness"
-    assert _resolve_kind("model", model=True, harness=True) == "model"
+def test_resolve_kind_disambiguates(tmp_path: Path) -> None:
+    root = str(tmp_path / ".wmo")
+    resolve = partial(_resolve_kind, name="x", root=root)
+    assert resolve(None, model=True, harness=False) == "model"
+    assert resolve(None, model=False, harness=True) == "harness"
+    assert resolve("model", model=True, harness=True) == "model"
     with pytest.raises(typer.BadParameter, match="pass --kind"):
-        _resolve_kind(None, model=True, harness=True)
+        resolve(None, model=True, harness=True)
     with pytest.raises(typer.BadParameter, match="no local world model or harness"):
-        _resolve_kind(None, model=False, harness=False)
+        resolve(None, model=False, harness=False)
     with pytest.raises(typer.BadParameter, match="no local world model"):
-        _resolve_kind("model", model=False, harness=True)
+        resolve("model", model=False, harness=True)
     with pytest.raises(typer.BadParameter, match="must be"):
-        _resolve_kind("bundle", model=True, harness=False)
+        resolve("bundle", model=True, harness=False)
 
 
 def test_bare_login_targets_the_hosted_platform(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/wmo/cli/platform_cmds_test.py
+++ b/wmo/cli/platform_cmds_test.py
@@ -153,8 +153,10 @@ def test_status_falls_back_to_the_api_url(monkeypatch: pytest.MonkeyPatch) -> No
     result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0, result.output
-    assert "https://api.test" in result.output
-    assert "None" not in result.output
+    # Equality on the host, not a substring: the bug printed "None" here, so
+    # what matters is exactly which host got named.
+    connected = next(line for line in result.output.splitlines() if "Connected to" in line)
+    assert connected.split("Connected to ", 1)[1].strip() == "https://api.test"
 
 
 def test_pull_rejects_unknown_kind() -> None:

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -4,6 +4,13 @@ Every call carries the org API key as a bearer credential; the platform scopes
 reads and writes to that key's organization at member strength. Error payloads
 are the platform's uniform ``{"error": message}`` shape, surfaced as
 :class:`PlatformError` with the HTTP status attached.
+
+Every failure leaves this module as a :class:`PlatformError`: a host that
+answers nothing becomes :class:`PlatformUnreachable`, and a host that answers
+something other than JSON becomes a plain :class:`PlatformError`. Callers
+therefore handle one exception type instead of httpx internals, which is what
+keeps ``wmo login``/``status``/``run``/``push``/``pull`` from printing
+tracebacks when the platform is down or the URL is not a platform at all.
 """
 
 from __future__ import annotations
@@ -18,7 +25,7 @@ import httpx
 from llm_waterfall import ChatRequest, ChatResponse
 from pydantic import BaseModel
 
-from wmo.core.types import Action, JsonValue, Observation
+from wmo.core.types import Action, JsonObject, JsonValue, Observation
 
 _TIMEOUT_SECONDS = 120.0
 _WORKSPACE_TIMEOUT_SECONDS = 300.0
@@ -30,6 +37,68 @@ class PlatformError(RuntimeError):
     def __init__(self, message: str, *, status_code: int | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
+
+
+class PlatformUnreachable(PlatformError):
+    """No response at all: DNS failure, refused connection, timeout, bad scheme.
+
+    Distinct from an HTTP error because the remedy is different — the host or
+    the network is wrong, not the credential — and `status_code` is None.
+    """
+
+
+class _GuardedTransport(httpx.BaseTransport):
+    """Maps httpx transport failures to :class:`PlatformUnreachable`.
+
+    Every request in this module goes through one transport, so this is the
+    single place a connection failure has to be translated; wrapping here also
+    covers the injected test transports unchanged.
+    """
+
+    def __init__(self, inner: httpx.BaseTransport) -> None:
+        self._inner = inner
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        try:
+            return self._inner.handle_request(request)
+        except httpx.RequestError as error:
+            # Connect timeouts stringify to "", so name the class instead. The
+            # remedy is the same wherever this surfaces, so it travels with the
+            # message: every caller re-raises it as its own clean CLI error.
+            detail = str(error) or type(error).__name__
+            raise PlatformUnreachable(
+                f"cannot reach {request.url}: {detail}; check your connection, "
+                "or re-run `wmo login --url <platform url>`"
+            ) from error
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+def _guarded(transport: httpx.BaseTransport | None) -> _GuardedTransport:
+    """Wrap an injected transport, or the default one, in the failure mapping."""
+    return _GuardedTransport(transport if transport is not None else httpx.HTTPTransport())
+
+
+def _decode_json(response: httpx.Response) -> JsonObject:
+    """Read a JSON object body, reporting anything else as a platform error.
+
+    A 200 carrying HTML is how a marketing site, a login-walled preview, or a
+    captive portal answers: "this is not a platform", not a crash.
+    """
+    try:
+        payload = response.json()
+    except ValueError as error:
+        content_type = response.headers.get("content-type", "no content type").split(";")[0]
+        msg = (
+            f"{response.request.url} answered HTTP {response.status_code} "
+            f"with {content_type}, not JSON"
+        )
+        raise PlatformError(msg, status_code=response.status_code) from error
+    if not isinstance(payload, dict):
+        msg = f"{response.request.url} answered with a JSON {type(payload).__name__}, not an object"
+        raise PlatformError(msg, status_code=response.status_code)
+    return payload
 
 
 class ActorInfo(BaseModel):
@@ -181,12 +250,12 @@ def fetch_cli_config(web_url: str, *, transport: httpx.BaseTransport | None = No
     secret (every Endpoints page shows it) and everything behind it is
     bearer-gated.
     """
-    with httpx.Client(timeout=30.0, transport=transport) as client:
+    with httpx.Client(timeout=30.0, transport=_guarded(transport)) as client:
         response = client.get(f"{web_url.rstrip('/')}/api/cli/config")
         if response.status_code != 200:
             msg = f"platform discovery failed with HTTP {response.status_code} at {web_url}"
             raise PlatformError(msg, status_code=response.status_code)
-        api_url = response.json().get("apiUrl")
+        api_url = _decode_json(response).get("apiUrl")
         return str(api_url).rstrip("/") if api_url else None
 
 
@@ -211,14 +280,14 @@ class PlatformClient:
                 "User-Agent": f"wmo/{version}",
             },
             timeout=_TIMEOUT_SECONDS,
-            transport=transport,
+            transport=_guarded(transport),
         )
         # Bundle bytes move directly against storage's signed URLs; that
         # client carries no platform credential.
         self._transfer = httpx.Client(
             headers={"User-Agent": f"wmo/{version}"},
             timeout=_TIMEOUT_SECONDS,
-            transport=transport,
+            transport=_guarded(transport),
         )
 
     def __enter__(self) -> PlatformClient:
@@ -236,7 +305,10 @@ class PlatformClient:
     def whoami(self) -> WhoAmI:
         response = self._client.get("/api/whoami")
         self._raise_for_error(response)
-        return WhoAmI.model_validate(response.json())
+        # The identity call doubles as "is this host a platform?": `login
+        # --api-url` and `status` reach it before anything else, so a non-JSON
+        # 200 has to read as a verdict rather than a decoder traceback.
+        return WhoAmI.model_validate(_decode_json(response))
 
     # -- unified runs --------------------------------------------------------------------------
 

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -571,7 +571,8 @@ class PlatformClient:
         self._raise_for_error(response)
         payload = _decode_json(response)
         harness = RemoteHarness.model_validate(payload["harness"])
-        versions = [RemoteHarnessVersion.model_validate(r) for r in _rows(payload, "versions")]
+        rows = _rows(payload, "versions")
+        versions = [RemoteHarnessVersion.model_validate(row) for row in rows]
         return harness, versions
 
     def get_harness_version(self, org_id: str, name: str, version: int) -> HarnessVersionDoc:

--- a/wmo/platform/client.py
+++ b/wmo/platform/client.py
@@ -67,7 +67,7 @@ class _GuardedTransport(httpx.BaseTransport):
             # message: every caller re-raises it as its own clean CLI error.
             detail = str(error) or type(error).__name__
             raise PlatformUnreachable(
-                f"cannot reach {request.url}: {detail}; check your connection, "
+                f"cannot reach {_shown(request.url)}: {detail}; check your connection, "
                 "or re-run `wmo login --url <platform url>`"
             ) from error
 
@@ -80,25 +80,44 @@ def _guarded(transport: httpx.BaseTransport | None) -> _GuardedTransport:
     return _GuardedTransport(transport if transport is not None else httpx.HTTPTransport())
 
 
+def _shown(url: httpx.URL) -> str:
+    """The part of a URL safe to print: bundle transfers sign with query parameters.
+
+    Storage hands back capability URLs whose token lives in the query string, and
+    these messages land in terminals and CI logs. The host and path are what tell
+    the user which hop failed; the signature never is.
+    """
+    return str(url.copy_with(query=None, fragment=None))
+
+
 def _decode_json(response: httpx.Response) -> JsonObject:
     """Read a JSON object body, reporting anything else as a platform error.
 
     A 200 carrying HTML is how a marketing site, a login-walled preview, or a
-    captive portal answers: "this is not a platform", not a crash.
+    captive portal answers: "this is not a platform", not a crash. Every
+    successful response in this module is decoded here so that answer can never
+    reach the user as a `JSONDecodeError`.
     """
+    where = _shown(response.request.url)
     try:
         payload = response.json()
     except ValueError as error:
         content_type = response.headers.get("content-type", "no content type").split(";")[0]
-        msg = (
-            f"{response.request.url} answered HTTP {response.status_code} "
-            f"with {content_type}, not JSON"
-        )
+        msg = f"{where} answered HTTP {response.status_code} with {content_type}, not JSON"
         raise PlatformError(msg, status_code=response.status_code) from error
     if not isinstance(payload, dict):
-        msg = f"{response.request.url} answered with a JSON {type(payload).__name__}, not an object"
+        msg = f"{where} answered with a JSON {type(payload).__name__}, not an object"
         raise PlatformError(msg, status_code=response.status_code)
     return payload
+
+
+def _rows(payload: JsonObject, key: str) -> list[JsonValue]:
+    """Read a list of rows out of a decoded payload, or report the wrong shape."""
+    rows = payload.get(key, [])
+    if not isinstance(rows, list):
+        msg = f"platform answered with {key!r} as a JSON {type(rows).__name__}, not a list"
+        raise PlatformError(msg)
+    return rows
 
 
 class ActorInfo(BaseModel):
@@ -316,7 +335,7 @@ class PlatformClient:
         """Resolve an opaque platform id without guessing from failed requests."""
         response = self._client.get(f"/api/run-targets/{target_id}")
         self._raise_for_error(response)
-        return RunTarget.model_validate(response.json())
+        return RunTarget.model_validate(_decode_json(response))
 
     def create_world_model_session(
         self, world_model_id: str, *, task: str | None = None
@@ -326,7 +345,7 @@ class PlatformClient:
             f"/api/world-models/{world_model_id}/sessions", json={"task": task}
         )
         self._raise_for_error(response)
-        return RemoteWorldModelSession.model_validate(response.json())
+        return RemoteWorldModelSession.model_validate(_decode_json(response))
 
     def step_world_model_session(self, session_id: str, action: Action) -> Observation:
         """Advance a hosted world-model session by one action."""
@@ -335,7 +354,7 @@ class PlatformClient:
             json={"action": action.model_dump(mode="json")},
         )
         self._raise_for_error(response)
-        return Observation.model_validate(response.json()["observation"])
+        return Observation.model_validate(_decode_json(response)["observation"])
 
     def create_agent_session(
         self,
@@ -353,31 +372,31 @@ class PlatformClient:
                 timeout=_WORKSPACE_TIMEOUT_SECONDS,
             )
             self._raise_for_error(upload)
-            payload["workspace_upload_id"] = str(upload.json()["id"])
+            payload["workspace_upload_id"] = str(_decode_json(upload)["id"])
         response = self._client.post(
             f"/api/agents/{agent_id}/sessions",
             json=payload,
         )
         self._raise_for_error(response)
-        return RemoteAgentSession.model_validate(response.json())
+        return RemoteAgentSession.model_validate(_decode_json(response))
 
     def get_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
         """Read current hosted agent session state."""
         response = self._client.get(f"/api/agents/{agent_id}/sessions/{session_id}")
         self._raise_for_error(response)
-        return RemoteAgentSession.model_validate(response.json())
+        return RemoteAgentSession.model_validate(_decode_json(response))
 
     def resolve_agent_session(self, session_id: str) -> RemoteAgentSession:
         """Resolve a bare session id to its owning agent and current state."""
         response = self._client.get(f"/api/agent-sessions/{session_id}")
         self._raise_for_error(response)
-        return RemoteAgentSession.model_validate(response.json())
+        return RemoteAgentSession.model_validate(_decode_json(response))
 
     def end_agent_session(self, agent_id: str, session_id: str) -> RemoteAgentSession:
         """Request an end, reconciling directly when the hosted driver is gone."""
         response = self._client.post(f"/api/agents/{agent_id}/sessions/{session_id}/end")
         self._raise_for_error(response)
-        return RemoteAgentSession.model_validate(response.json())
+        return RemoteAgentSession.model_validate(_decode_json(response))
 
     def list_agent_session_events(
         self, agent_id: str, session_id: str, *, after: int
@@ -388,7 +407,7 @@ class PlatformClient:
             params={"after": after},
         )
         self._raise_for_error(response)
-        return RemoteAgentEventPage.model_validate(response.json())
+        return RemoteAgentEventPage.model_validate(_decode_json(response))
 
     def post_agent_session_command(
         self, agent_id: str, session_id: str, kind: str, *, text: str | None = None
@@ -410,7 +429,7 @@ class PlatformClient:
             timeout=_WORKSPACE_TIMEOUT_SECONDS,
         )
         self._raise_for_error(response)
-        return WorkspacePatchResult.model_validate(response.json())
+        return WorkspacePatchResult.model_validate(_decode_json(response))
 
     def download_agent_workspace_patch(
         self, agent_id: str, session_id: str, revision: str
@@ -451,7 +470,7 @@ class PlatformClient:
     def list_world_models(self, org_id: str) -> list[RemoteWorldModel]:
         response = self._client.get(f"/api/orgs/{org_id}/world-models")
         self._raise_for_error(response)
-        rows = response.json().get("world_models", [])
+        rows = _rows(_decode_json(response), "world_models")
         return [RemoteWorldModel.model_validate(row) for row in rows]
 
     def push_model_bundle(
@@ -473,7 +492,7 @@ class PlatformClient:
             f"/api/orgs/{org_id}/world-models/{name}/bundle/uploads"
         )
         self._raise_for_error(ticket_response)
-        ticket = ticket_response.json()
+        ticket = _decode_json(ticket_response)
         upload_url = str(ticket["upload_url"])
         with bundle_path.open("rb") as fh:
             upload_response = self._transfer.put(
@@ -502,7 +521,7 @@ class PlatformClient:
             },
         )
         self._raise_for_error(finalize)
-        return RemoteWorldModel.model_validate(finalize.json())
+        return RemoteWorldModel.model_validate(_decode_json(finalize))
 
     def download_model_bundle(self, org_id: str, name: str, dest: Path) -> str:
         """Stream a model's bundle from storage to ``dest``, verifying its digest.
@@ -516,7 +535,7 @@ class PlatformClient:
         """
         response = self._client.get(f"/api/orgs/{org_id}/world-models/{name}/bundle")
         self._raise_for_error(response)
-        payload = response.json()
+        payload = _decode_json(response)
         declared = str(payload["sha256"])
 
         digest = hashlib.sha256()
@@ -542,7 +561,7 @@ class PlatformClient:
     def list_harnesses(self, org_id: str) -> list[RemoteHarness]:
         response = self._client.get(f"/api/orgs/{org_id}/harnesses")
         self._raise_for_error(response)
-        rows = response.json().get("harnesses", [])
+        rows = _rows(_decode_json(response), "harnesses")
         return [RemoteHarness.model_validate(row) for row in rows]
 
     def get_harness(
@@ -550,15 +569,15 @@ class PlatformClient:
     ) -> tuple[RemoteHarness, list[RemoteHarnessVersion]]:
         response = self._client.get(f"/api/orgs/{org_id}/harnesses/{name}")
         self._raise_for_error(response)
-        payload = response.json()
+        payload = _decode_json(response)
         harness = RemoteHarness.model_validate(payload["harness"])
-        versions = [RemoteHarnessVersion.model_validate(row) for row in payload["versions"]]
+        versions = [RemoteHarnessVersion.model_validate(r) for r in _rows(payload, "versions")]
         return harness, versions
 
     def get_harness_version(self, org_id: str, name: str, version: int) -> HarnessVersionDoc:
         response = self._client.get(f"/api/orgs/{org_id}/harnesses/{name}/versions/{version}")
         self._raise_for_error(response)
-        return HarnessVersionDoc.model_validate(response.json())
+        return HarnessVersionDoc.model_validate(_decode_json(response))
 
     def push_harness_version(
         self,
@@ -572,7 +591,7 @@ class PlatformClient:
             json={"doc": doc, "doc_hash": doc_hash},
         )
         self._raise_for_error(response)
-        return PushedHarnessVersion.model_validate(response.json())
+        return PushedHarnessVersion.model_validate(_decode_json(response))
 
     # -- built-in local pi runs ---------------------------------------------------------------
 
@@ -580,7 +599,7 @@ class PlatformClient:
         """Open a metered platform run for WMO's built-in local pi harness."""
         response = self._client.post(f"/api/orgs/{org_id}/local-pi-runs")
         self._raise_for_error(response)
-        return LocalPiRunInfo.model_validate(response.json())
+        return LocalPiRunInfo.model_validate(_decode_json(response))
 
     def complete_local_pi_worker(
         self, org_id: str, run_id: str, request: ChatRequest
@@ -591,7 +610,7 @@ class PlatformClient:
             json=request.model_dump(mode="json", exclude_none=True),
         )
         self._raise_for_error(response)
-        return ChatResponse.model_validate(response.json())
+        return ChatResponse.model_validate(_decode_json(response))
 
     def finish_local_pi_run(
         self,

--- a/wmo/platform/client_test.py
+++ b/wmo/platform/client_test.py
@@ -15,6 +15,7 @@ from wmo.core.types import Action, ActionKind
 from wmo.platform.client import (
     PlatformClient,
     PlatformError,
+    PlatformUnreachable,
     RemoteAgentSession,
     fetch_cli_config,
 )
@@ -494,3 +495,54 @@ def test_fetch_cli_config_maps_failures() -> None:
 
     with pytest.raises(PlatformError, match="discovery failed"):
         fetch_cli_config("https://platform.test", transport=httpx.MockTransport(handler))
+
+
+def test_fetch_cli_config_maps_an_unreachable_host() -> None:
+    """A refused connection is a platform verdict, not an httpx traceback."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("[Errno 61] Connection refused", request=request)
+
+    with pytest.raises(PlatformUnreachable, match="cannot reach") as info:
+        fetch_cli_config("https://platform.test", transport=httpx.MockTransport(handler))
+    assert "wmo login --url" in str(info.value)
+    assert info.value.status_code is None
+
+
+def test_fetch_cli_config_maps_a_non_json_200() -> None:
+    """A login-walled preview answers 200 with HTML; that is 'not a platform'."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, html="<html>Authentication Required</html>")
+
+    with pytest.raises(PlatformError, match="not JSON") as info:
+        fetch_cli_config("https://platform.test", transport=httpx.MockTransport(handler))
+    assert not isinstance(info.value, PlatformUnreachable)
+    assert "text/html" in str(info.value)
+
+
+def test_requests_map_an_unreachable_host() -> None:
+    """Every request goes through the guarded transport, whichever endpoint it hits."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("", request=request)
+
+    with _client(handler) as client:
+        with pytest.raises(PlatformUnreachable, match="cannot reach") as info:
+            client.whoami()
+        # An empty-message timeout must still name what happened.
+        assert "ConnectTimeout" in str(info.value)
+        with pytest.raises(PlatformUnreachable):
+            client.resolve_run_target("wm_1")
+        with pytest.raises(PlatformUnreachable):
+            client.list_harnesses("org-1")
+
+
+def test_whoami_maps_a_non_json_200() -> None:
+    """`login --api-url`/`status` reach whoami first: a captive portal is not a crash."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, html="<html>Sign in</html>")
+
+    with _client(handler) as client, pytest.raises(PlatformError, match="not JSON"):
+        client.whoami()

--- a/wmo/platform/client_test.py
+++ b/wmo/platform/client_test.py
@@ -546,3 +546,58 @@ def test_whoami_maps_a_non_json_200() -> None:
 
     with _client(handler) as client, pytest.raises(PlatformError, match="not JSON"):
         client.whoami()
+
+
+def test_every_endpoint_maps_a_non_json_200() -> None:
+    """A proxy that answers 200 HTML everywhere must not reach any caller as a decoder error."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, html="<html>Sign in</html>")
+
+    with _client(handler) as client:
+        for call in (
+            lambda: client.resolve_run_target("wm_1"),
+            lambda: client.list_world_models("org-1"),
+            lambda: client.list_harnesses("org-1"),
+            lambda: client.get_harness_version("org-1", "pi", 1),
+            lambda: client.create_agent_session("agent-1", workspace=None),
+        ):
+            with pytest.raises(PlatformError, match="not JSON"):
+                call()
+
+
+def test_a_json_array_body_is_a_platform_error() -> None:
+    """Valid JSON that is not an object would crash `.get`/`model_validate` the same way."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    with _client(handler) as client, pytest.raises(PlatformError, match="not an object"):
+        client.list_world_models("org-1")
+
+
+def test_an_unreachable_storage_host_hides_the_signed_url(tmp_path: Path) -> None:
+    """Signed upload URLs carry their capability in the query; errors land in CI logs."""
+    bundle_path = tmp_path / "tau-bench.tar.gz"
+    bundle_path.write_bytes(b"bundle-bytes")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "storage.test":
+            raise httpx.ConnectError("[Errno 61] Connection refused", request=request)
+        return httpx.Response(
+            201,
+            json={
+                "upload_url": "https://storage.test/upload/x?token=SIGNATURE",
+                "token": "SIGNATURE",
+                "staging_path": "staging/cli/x.tar.gz",
+            },
+        )
+
+    with _client(handler) as client, pytest.raises(PlatformUnreachable) as info:
+        client.push_model_bundle("org-1", "tau-bench", bundle_path, "0" * 64, 12, {})
+
+    message = str(info.value)
+    assert "SIGNATURE" not in message
+    # The hop that failed still has to be named, host and path intact.
+    reached = message.removeprefix("cannot reach ").split(": ", 1)[0]
+    assert reached == "https://storage.test/upload/x"


### PR DESCRIPTION
## What was broken

Every platform-backed command dumped a raw Python traceback when the platform was unreachable or was not a platform at all. One root cause: `PlatformError` was only ever raised by `PlatformClient._raise_for_error`, which inspects an HTTP **response**. Two failure classes never produce one — a host that answers nothing (refused / DNS / timeout / missing scheme) and a host that answers `200` with HTML — so httpx's `ConnectError` and json's `JSONDecodeError` escaped to the user. `grep 'except httpx' wmo/platform/` returned zero hits.

Paste this to see it on `main` (nothing listening on port 9, no network, no spend):

```
cd /tmp && WMO_HOME=/tmp/h wmo login --url http://127.0.0.1:9
```

`main`: ~255 lines of Rich traceback through `httpx/_transports/default.py` ending in `ConnectError: [Errno 61] Connection refused`.

This branch:

```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid value: cannot reach http://127.0.0.1:9/api/cli/config: [Errno 61]    │
│ Connection refused; check your connection, or re-run `wmo login --url        │
│ <platform url>`                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## What changed

Fixed once at the client layer, not at each of the six commands:

- **`wmo/platform/client.py`** — `_GuardedTransport` wraps the one transport every request goes through and maps `httpx.RequestError` (connect, DNS, timeout, unsupported scheme) to a new `PlatformUnreachable(PlatformError)` whose message names the next command. `_decode_json` turns a non-JSON body into a plain `PlatformError`, and every success-path decode in the module goes through it — a login wall answers 200 HTML on every path, not just the two "is this host a platform?" probes. Transport errors name the host and path only: bundle transfers run against storage URLs signed in the query string, which must not land in a terminal or a CI log. The module's contract is now: every failure leaves it as a `PlatformError`.
- Callers that already caught `PlatformError` — `wmo run <id>`, `--send/--attach/--end`, `login`, `status` — are fixed by that alone.
- **`wmo/cli/platform_cmds.py`** — `push`/`pull` get one `_connected` context manager (`Push failed: …` / `Pull failed: …`) instead of a handler per request, which also surfaces the `— run \`wmo login\`` hint a 401 already carries. `login` no longer blames the key for a host that is unreachable or is not a platform. `wmo push --ref <bad ref>` is a usage error pointing at `wmo harness list`, matching `wmo harness show <name>@<ref>`. `wmo push <unknown>` names the artifact, the directory searched, what is in it, and `wmo list` / `wmo harness list`.
- Two display bugs: `wmo status` falls back to `api_url` when env-var credentials carry no `web_url` (it printed `Connected to None`), and `wmo login --api-url X` without `--url` stops recording the hosted platform as a `web_url` it is not talking to.

No catch-all at the CLI entry point; each path is handled where it is known.

## Verified

Each repro run before and after against local stub servers (refused port, a 200-HTML "Authentication Required" page, a 404 stub, a 401 stub) — all now exit 1 or 2 with a rendered message and no traceback.

`uv run pytest wmo/cli wmo/platform -q` → 563 passed. `ruff check .`, `ruff format --check`, `ty check` clean. 14 new tests in `wmo/platform/client_test.py` and `wmo/cli/platform_cmds_test.py`, each asserting the exception did not escape the CLI rather than only the exit code.

## Audit findings closed

| # | Finding |
|---|---|
| session/25 | `wmo login --url <unreachable>` — raw httpx `ConnectError` traceback |
| session/26 | `wmo login` against a 200 non-JSON URL — raw `JSONDecodeError` (the "protected preview" case its own `--api-url` help calls out) |
| session/27 | `wmo status` — raw `ConnectError` when the saved/env host is unreachable |
| session/28 | `wmo run <id>` (and `--send`/`--attach`/`--end`) — raw `ConnectError` |
| data/5 | `wmo push` / `wmo pull` — raw `ConnectError` |
| data/6 | `wmo push` / `wmo pull` — unhandled `PlatformError`, burying the one helpful hint it carries |
| data/38 | `wmo push --ref <bad version/alias>` — unhandled `ValueError` traceback |
| data/40 | `wmo push nosuchmodel` — no next step, no directory named |
| session/102 | `wmo status` prints `Connected to None` with env-var credentials |
| session/103 | `wmo login --api-url X` without `--url` records the hosted platform as `web_url` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

