### PR TITLE
Validate `route fit`/`report` inputs at the CLI boundary instead of in the loaders

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,7 +21,7 @@ Three optimizers, named for the artifact each produces.
 | Command | Purpose | Artifact |
 |---|---|---|
 | `wmo optimize route sweep` | Measure every pool candidate closed-loop against the world model. The only paid step of routing, and the only thing that produces a matrix. | `matrix.json` (an `OutcomeMatrix`) |
-| `wmo optimize route fit` | Fit a routing policy on a matrix: `--kind knn` guarded neighbor evidence, or `--kind rank` cluster ranks. | `policy.json` + its evidence bank |
+| `wmo optimize route fit` | Fit a routing policy on a matrix: `--kind knn` guarded neighbor evidence (the default), or `--kind rank` cluster ranks. | `policy.json` + its evidence bank |
 | `wmo optimize route tune` | Set a fitted policy's cost/quality dial in place, no refit. | the policy, rewritten; `policy.base.json` snapshot |
 | `wmo optimize route report` | Build the three-objective improvement report for a policy over a matrix. | `report.json` (an `ImprovementReport`) |
 | `wmo optimize route pin` | Serve one pool model as an endpoint, with no matrix and no fit. | a `kind="static"` `policy.json` |

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -43,6 +43,7 @@ from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compression import (
     CompressingEmbedder,
     compression_signature,
+    registered_compressor_ids,
     resolve_compression,
     same_compression,
 )
@@ -63,6 +64,7 @@ from wmo.optimize.policy import (
     embedder_provenance,
     probe_embedder,
     resolve_embedder,
+    write_artifact_atomically,
 )
 from wmo.optimize.report import build_report
 from wmo.optimize.routing import evaluate_policy, fit_rank_policy, rerank_policy
@@ -100,6 +102,12 @@ _console = Console()
 
 DEFAULT_MATRIX_FILENAME = "matrix.json"
 """Default `sweep --out`: the outcome matrix `fit` takes as its argument."""
+
+COMPRESSOR_IDS_HELP = " | ".join(registered_compressor_ids())
+"""What `--compressor` accepts, rendered from the registry so the help cannot go stale."""
+
+_MATRIX_DIGEST_MARK = "sha256="
+"""How `load_matrix_with_digest` spells the digest inside a policy's `fitted_from`."""
 
 
 @route_app.command("sweep")
@@ -170,9 +178,9 @@ def sweep(
     compressor: str = typer.Option(
         None,
         "--compressor",
-        help="D-COMPRESS: measure every candidate call through this compressor (identity | "
-        "truncate), so the matrix is the compressed ARM of the grid. Default: uncompressed. "
-        "`fit` requires the matrix arm to match the policy it stamps.",
+        help="D-COMPRESS: measure every candidate call through this compressor "
+        f"({COMPRESSOR_IDS_HELP}), so the matrix is the compressed ARM of the grid. Default: "
+        "uncompressed. `fit` requires the matrix arm to match the policy it stamps.",
     ),
     aggressiveness: float = typer.Option(
         0.0,
@@ -755,14 +763,74 @@ def _confirm_replace(path: Path, name: str) -> bool:
         return False
 
 
+# ------------------------------------------------------------------ artifact loading boundary
+# `fit` and `report` are handed paths a user typed, and the loaders behind them raise pathlib and
+# pydantic errors. Both artifacts come through here so a wrong path, a truncated file, or the two
+# `report` positionals in the wrong order is a usage error naming the fix, instead of the
+# traceback every other input in this file is already careful not to produce.
+
+
+def _reads_as(model: type[OutcomeMatrix] | type[RoutingPolicy], path: Path) -> bool:
+    """Whether `path` parses as the OTHER artifact, which is what a swapped pair looks like."""
+    try:
+        model.model_validate_json(path.read_bytes())
+    except (ValidationError, OSError):
+        return False
+    return True
+
+
+def _load_matrix(matrix_file: str) -> tuple[OutcomeMatrix, str]:
+    """The outcome matrix at `matrix_file`, with the digest provenance a fit stamps."""
+    path = Path(matrix_file)
+    try:
+        return load_matrix_with_digest(path)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(
+            f"no outcome matrix at {path}; `wmo optimize route sweep <world-model>` measures the "
+            f"pool and writes one (its --out, default {DEFAULT_MATRIX_FILENAME})"
+        ) from exc
+    except OSError as exc:
+        raise typer.BadParameter(f"cannot read the outcome matrix at {path}: {exc}") from exc
+    except ValidationError as exc:
+        if _reads_as(RoutingPolicy, path):
+            raise typer.BadParameter(
+                f"{path} holds a fitted policy, not an outcome matrix. The matrix is what "
+                "`wmo optimize route sweep` writes, and it comes FIRST: "
+                "`wmo optimize route report <matrix.json> <policy.json>`"
+            ) from exc
+        raise typer.BadParameter(f"{path} is not a readable OutcomeMatrix: {exc}") from exc
+
+
+def _load_policy(policy_file: str) -> RoutingPolicy:
+    """The fitted policy at `policy_file`."""
+    path = Path(policy_file)
+    try:
+        return RoutingPolicy.load(path)
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(
+            f"no policy file at {path}; fit one with "
+            "`wmo optimize route fit <matrix.json> --kind knn`"
+        ) from exc
+    except OSError as exc:
+        raise typer.BadParameter(f"cannot read the policy at {path}: {exc}") from exc
+    except ValidationError as exc:
+        if _reads_as(OutcomeMatrix, path):
+            raise typer.BadParameter(
+                f"{path} holds an outcome matrix, not a fitted policy. The policy is what "
+                "`wmo optimize route fit` writes, and it comes SECOND: "
+                "`wmo optimize route report <matrix.json> <policy.json>`"
+            ) from exc
+        raise typer.BadParameter(f"{path} is not a readable routing policy: {exc}") from exc
+
+
 @route_app.command("fit")
 def fit(
     matrix_file: str = typer.Argument(..., help="OutcomeMatrix JSON (closed-loop eval output)."),
     kind: str = typer.Option(
-        "rank",
+        "knn",
         "--kind",
-        help="knn (guarded nearest-neighbor evidence, the validated champion) | rank "
-        "(Avengers cluster ranks).",
+        help="knn (guarded nearest-neighbor evidence, the validated champion, and what `tune`, "
+        "`sweep`'s handoff and the docs all assume) | rank (Avengers cluster ranks).",
     ),
     out: str = typer.Option(
         POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
@@ -841,8 +909,8 @@ def fit(
     compressor: str = typer.Option(
         None,
         "--compressor",
-        help="D-COMPRESS: compressor id the endpoint applies before routing (identity | "
-        "truncate). Default: compression off.",
+        help="D-COMPRESS: compressor id the endpoint applies before routing "
+        f"({COMPRESSOR_IDS_HELP}). Default: compression off.",
     ),
     aggressiveness: float = typer.Option(
         0.0,
@@ -857,7 +925,16 @@ def fit(
     """Fit a routing policy on an outcome matrix (kNN evidence or Avengers cluster ranks)."""
     if kind not in ("rank", "knn"):
         raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
-    matrix, source = load_matrix_with_digest(Path(matrix_file))
+    matrix, source = _load_matrix(matrix_file)
+    if not any(outcome.scored for outcome in matrix.outcomes):
+        # `sweep` already exits 1 saying "fitting will fail" on this matrix, so it is a state a
+        # user arrives here from: answer it the way sweep does instead of letting the fitter's
+        # own ValueError out (the rank one names no remedy at all).
+        raise typer.BadParameter(
+            f"no cell in {matrix_file} carries a reward, so there is nothing to fit: read the "
+            "`error` field of a row to see what broke, fix it, then re-run "
+            "`wmo optimize route sweep <world-model>`"
+        )
     try:
         spec, resolution = resolve_embedder(
             embedder, dim=dim, deployment=deployment, endpoint=endpoint, api_key_env=api_key_env
@@ -911,20 +988,25 @@ def fit(
                 "policy trades cost through its dial instead: fit it, then "
                 "`wmo optimize route tune <policy.json> --cost-quality <0..1>`"
             )
-        fitted = fit_knn_artifact(
-            matrix,
-            out_path=out_path,
-            matrix_source=source,
-            embedder=spec,
-            fallback=fallback,
-            z=z,
-            rag_num=rag_num,
-            rag_thres=rag_thres,
-            min_pairs=min_pairs,
-            se_floor=se_floor,
-            floor_q=floor_q,
-            compression=compression,
-        )
+        try:
+            fitted = fit_knn_artifact(
+                matrix,
+                out_path=out_path,
+                matrix_source=source,
+                embedder=spec,
+                fallback=fallback,
+                z=z,
+                rag_num=rag_num,
+                rag_thres=rag_thres,
+                min_pairs=min_pairs,
+                se_floor=se_floor,
+                floor_q=floor_q,
+                compression=compression,
+            )
+        except ValueError as exc:
+            # What the fitter can still refuse once the matrix loads: an unknown --fallback, or a
+            # fit split whose own rows are all unscored. Both are about the arguments.
+            raise typer.BadParameter(str(exc)) from exc
         print_knn_fit(_console, fitted, out=out, z=z)
         return
     built = spec.build()  # ONE embedder for fit and evaluation; azure would otherwise embed twice
@@ -933,18 +1015,21 @@ def fit(
         # text serving will embed, which is the COMPRESSED text (see `fit_knn_artifact`, which
         # applies the same rule to the bank on the knn path).
         built = CompressingEmbedder(built, compression)
-    policy = fit_rank_policy(
-        matrix,
-        embedder=spec,
-        n_clusters=clusters,
-        seed=seed,
-        top_k_clusters=top_k_clusters,
-        beta=beta,
-        fitted_from=(
-            f"{source} rank seed={seed} k={clusters} topk={top_k_clusters} beta={beta:g} "
-            f"cost_weight={cost_weight:g} {embedder_provenance(spec)}"
-        ),
-    )
+    try:
+        policy = fit_rank_policy(
+            matrix,
+            embedder=spec,
+            n_clusters=clusters,
+            seed=seed,
+            top_k_clusters=top_k_clusters,
+            beta=beta,
+            fitted_from=(
+                f"{source} rank seed={seed} k={clusters} topk={top_k_clusters} beta={beta:g} "
+                f"cost_weight={cost_weight:g} {embedder_provenance(spec)}"
+            ),
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     if cost_weight > 0.0:
         policy = rerank_policy(policy, cost_weight=cost_weight)
     if compression is not None:
@@ -1012,10 +1097,19 @@ def pin(
     say so. Replace it with `wmo optimize route fit` on a real outcome matrix to let the router
     choose per request.
     """
+    store = WorldModelStore(root)
     try:
-        model_dir = WorldModelStore(root).resolve(world_model)
-    except (FileNotFoundError, ValueError) as exc:
+        model_dir = store.resolve(world_model)
+    except FileNotFoundError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    except ValueError as exc:
+        # `resolve` says "pass --name", the option `wmo serve`/`play`/`demo` carry. This command
+        # has no --name (its --model is the POOL entry), so say what a user of it actually types.
+        names = store.list_names()
+        raise typer.BadParameter(
+            f"multiple world models built ({', '.join(names)}); name one as the WORLD_MODEL "
+            f"argument, e.g. `wmo optimize route pin {names[0]} --model {model}`"
+        ) from exc
     pool_path = Path(pool)
     try:
         roster = load_pool(pool_path)
@@ -1123,25 +1217,71 @@ def report(
     matrix_file: str = typer.Argument(..., help="OutcomeMatrix JSON with held-out scenarios."),
     policy_file: str = typer.Argument(..., help="Fitted policy JSON."),
     baseline: str = typer.Option(
-        ..., "--baseline", help="Frontier pool model the report compares against."
+        ...,
+        "--baseline",
+        # The doubled brackets are escaped for the same reason `sweep --pool`'s are: typer
+        # renders help through rich markup, which otherwise prints an empty pair.
+        help="Pool entry HANDLE to compare against: the `name` of a \\[\\[model]] table in the "
+        "matrix's pool, NOT the model id. Normally the frontier candidate.",
     ),
     endpoint: str = typer.Option("endpoint", "--endpoint", help="Endpoint id for the report."),
     out: str = typer.Option("report.json", "--out", help="Where to write the report JSON."),
 ) -> None:
     """Build the improvement report for a fitted policy over a matrix."""
-    matrix = OutcomeMatrix.load(Path(matrix_file))
-    policy = RoutingPolicy.load(Path(policy_file))
-    improvement = build_report(
-        matrix,
-        policy,
-        baseline=baseline,
-        endpoint=endpoint,
-        generated_at=datetime.now(tz=UTC).isoformat(),
-    )
-    Path(out).write_text(improvement.model_dump_json(indent=2), encoding="utf-8")
+    matrix, matrix_source = _load_matrix(matrix_file)
+    policy = _load_policy(policy_file)
+    try:
+        improvement = build_report(
+            matrix,
+            policy,
+            baseline=baseline,
+            endpoint=endpoint,
+            generated_at=datetime.now(tz=UTC).isoformat(),
+        )
+    except KeyError as exc:
+        # `--baseline` is a pool entry handle; the KeyError already lists the ones this matrix
+        # has. `str()` on a KeyError quotes its own argument, so unwrap it.
+        raise typer.BadParameter(
+            f"{exc.args[0]}. --baseline names a pool entry handle (the `name` of a [[model]] "
+            "table), not a model id."
+        ) from exc
+    except FileNotFoundError as exc:
+        # A knn policy carries its evidence in a sidecar; `knn_bank` says how to restore it.
+        raise typer.BadParameter(str(exc)) from exc
+    except ValueError as exc:
+        # Nothing scored on both sides, so there is no paired comparison to report.
+        raise typer.BadParameter(str(exc)) from exc
+    # mkdir + atomic, exactly as `fit --out` and `pin --out` write their policies: a report whose
+    # parent directory does not exist must not throw away the work that produced it.
+    write_artifact_atomically(Path(out), improvement.model_dump_json(indent=2).encode("utf-8"))
     headline = improvement.headline
     _console.print(
         f"[green]✓[/green] report -> {out}\n"
         f"  routed acc {headline.accuracy:.4f} @ ${headline.cost_per_run_usd:.5f}/run vs "
         f"{baseline} {headline.baseline_accuracy:.4f} @ ${headline.baseline_cost_per_run_usd:.5f}"
+    )
+    in_sample = _in_sample_warning(policy, matrix_source)
+    if in_sample is not None:
+        _console.print(in_sample)
+
+
+def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
+    """The caveat for a report measured on the very matrix the policy was fitted on.
+
+    `fit` sends the user here precisely to escape its own in-sample number, and the report labels
+    its scenarios held-out, so a report over the fit matrix is the one case where both surfaces
+    say the opposite of what happened. The digest in `fitted_from` is an identity rather than a
+    label (`load_matrix_with_digest`), so the collision is detectable even when the matrix was
+    renamed or moved after the fit, and a matrix with the same path but different bytes does not
+    trip it.
+    """
+    digest = matrix_source.partition(_MATRIX_DIGEST_MARK)[2]
+    stamped = policy.fitted_from or ""
+    if not digest or f"{_MATRIX_DIGEST_MARK}{digest}" not in stamped:
+        return None
+    return (
+        f"[yellow]warning[/yellow] this policy was FITTED on this matrix "
+        f"({_MATRIX_DIGEST_MARK}{digest}), so these numbers are IN-SAMPLE, not held out: every "
+        "request retrieves its own row. Sweep a second matrix over scenarios the fit never saw "
+        "and report against that one."
     )

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -811,7 +811,12 @@ def _load_policy(policy_file: str) -> RoutingPolicy:
             f"no policy file at {path}; fit one with "
             "`wmo optimize route fit <matrix.json> --kind knn`"
         ) from exc
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
+        # `RoutingPolicy.load` decodes before pydantic sees anything, so bytes that are not UTF-8
+        # (a truncated download, a `.npz` bank passed as the policy) raise UnicodeDecodeError,
+        # which is a ValueError and NOT a ValidationError. `_load_matrix` needs no such clause:
+        # `load_matrix_with_digest` hands raw bytes to pydantic, which reports undecodable input
+        # as a ValidationError.
         raise typer.BadParameter(f"cannot read the policy at {path}: {exc}") from exc
     except ValidationError as exc:
         if _reads_as(OutcomeMatrix, path):
@@ -1275,9 +1280,12 @@ def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
     renamed or moved after the fit, and a matrix with the same path but different bytes does not
     trip it.
     """
-    digest = matrix_source.partition(_MATRIX_DIGEST_MARK)[2]
+    # `load_matrix_with_digest` appends the marker LAST, so split from the right: a matrix under a
+    # content-addressed directory (`artifacts/sha256=.../matrix.json`) carries the marker in its
+    # path too, and splitting from the left would read that one and silently drop the warning.
+    _, mark, digest = matrix_source.rpartition(_MATRIX_DIGEST_MARK)
     stamped = policy.fitted_from or ""
-    if not digest or f"{_MATRIX_DIGEST_MARK}{digest}" not in stamped:
+    if not mark or not digest or f"{_MATRIX_DIGEST_MARK}{digest}" not in stamped:
         return None
     return (
         f"[yellow]warning[/yellow] this policy was FITTED on this matrix "

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -27,6 +27,7 @@ from wmo.optimize.compression import (
     Compressor,
     TruncateCompressor,
     register_compressor,
+    registered_compressor_ids,
     same_compression,
 )
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
@@ -118,6 +119,8 @@ def test_route_fit_and_report(tmp_path: Path) -> None:
             "route",
             "fit",
             str(matrix_file),
+            "--kind",
+            "rank",
             "--out",
             str(policy_file),
             "--clusters",
@@ -372,7 +375,16 @@ def test_route_tune_rejects_a_policy_kind_without_a_dial(tmp_path: Path) -> None
     policy_file = tmp_path / POLICY_FILENAME
     fit = runner.invoke(
         app,
-        ["optimize", "route", "fit", str(_matrix_file(tmp_path)), "--out", str(policy_file)],
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path)),
+            "--kind",
+            "rank",
+            "--out",
+            str(policy_file),
+        ],
     )
     assert fit.exit_code == 0, fit.output
     result = runner.invoke(
@@ -556,7 +568,16 @@ def test_route_tune_that_fails_leaves_no_base_snapshot_behind(tmp_path: Path) ->
     policy_file = tmp_path / POLICY_FILENAME
     fit = runner.invoke(
         app,
-        ["optimize", "route", "fit", str(_matrix_file(tmp_path)), "--out", str(policy_file)],
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_matrix_file(tmp_path)),
+            "--kind",
+            "rank",
+            "--out",
+            str(policy_file),
+        ],
     )
     assert fit.exit_code == 0, fit.output
     rejected = runner.invoke(
@@ -1370,6 +1391,8 @@ def test_route_sweep_writes_a_matrix_fit_can_consume(
             "route",
             "fit",
             str(out),
+            "--kind",
+            "rank",
             "--out",
             str(policy_file),
             "--clusters",
@@ -2545,3 +2568,366 @@ def test_route_fit_knn_leaves_the_stamp_null_without_the_flag(tmp_path: Path) ->
     assert result.exit_code == 0, result.output
     policy = RoutingPolicy.load(policy_file)
     assert policy.compression is None and policy.fit_compression is None
+
+
+# ------------------------------------------- input validation at the fit/report boundary
+# `fit` and `report` used to hand user-typed paths straight to the pydantic and pathlib loaders,
+# so a missing file, a swapped pair of positionals, or a matrix nothing scored came out as a
+# Python traceback. Every test below asserts the same two things the rest of this file asserts
+# for every other input: a clean usage error, and no exception escaping.
+
+
+def _no_traceback(result: Result) -> bool:
+    return result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def _unscored_matrix_file(tmp_path: Path) -> Path:
+    """What a sweep writes when every episode errored: rows on disk, not one reward.
+
+    `sweep` still saves this matrix (the cells were paid for and their `error` fields are the
+    diagnosis) and exits 1 saying "fitting will fail", so it is a state a user reaches `fit`
+    from rather than an invented one.
+    """
+    matrix = OutcomeMatrix.load(_matrix_file(tmp_path))
+    path = tmp_path / "unscored.json"
+    OutcomeMatrix(
+        pool=matrix.pool,
+        outcomes=[o.model_copy(update={"reward": None, "success": False}) for o in matrix.outcomes],
+    ).save(path)
+    return path
+
+
+def test_route_fit_names_the_producer_when_the_matrix_is_missing(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(tmp_path / "nope.json"),
+            "--embedder",
+            "hashing",
+            "--out",
+            str(tmp_path / "policy.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "no outcome matrix at")
+    assert _says(result.output, "wmo optimize route sweep")
+
+
+def test_route_fit_rejects_a_matrix_that_is_not_readable(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(bad),
+            "--embedder",
+            "hashing",
+            "--out",
+            str(tmp_path / "policy.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "is not a readable OutcomeMatrix")
+
+
+@pytest.mark.parametrize("kind", ["knn", "rank"])
+def test_route_fit_refuses_a_matrix_with_no_scored_cell(tmp_path: Path, kind: str) -> None:
+    """Both kinds, and both used to traceback.
+
+    The rank fitter's own message ("no scored outcomes; cannot pick a default model") named no
+    remedy at all, so the answer belongs at the boundary where sweep's warning can be echoed.
+    """
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_unscored_matrix_file(tmp_path)),
+            "--kind",
+            kind,
+            "--embedder",
+            "hashing",
+            "--out",
+            str(tmp_path / "policy.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "carries a reward")
+    assert _says(result.output, "wmo optimize route sweep")
+    assert not (tmp_path / "policy.json").exists()
+
+
+def test_route_fit_defaults_to_the_knn_champion(tmp_path: Path) -> None:
+    """The default kind has to be the one every other surface steers to.
+
+    `fit --help` calls knn "the validated champion", sweep's handoff prints `--kind knn`, and
+    `tune` only dials a knn policy -- but the flag defaulted to rank, so a user who omitted it
+    silently fitted the non-champion and only found out at `tune`.
+    """
+    policy_file = tmp_path / POLICY_FILENAME
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit",
+            str(_knn_matrix_file(tmp_path)),
+            "--fallback",
+            "a",
+            "--rag-num",
+            "3",
+            "--min-pairs",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert RoutingPolicy.load(policy_file).kind == "knn"
+    # And therefore dialable without a refit, which is what the old default was not.
+    tuned = runner.invoke(
+        app, ["optimize", "route", "tune", str(policy_file), "--cost-quality", "0.5"]
+    )
+    assert tuned.exit_code == 0, tuned.output
+
+
+@pytest.mark.parametrize("command", ["fit", "sweep"])
+def test_route_compressor_help_lists_every_shipped_id(command: str) -> None:
+    """Rendered from the registry: `llmlingua2-endpoint` shipped while the help said two ids.
+
+    Asserted against the ids registered at import rather than the live registry, because that is
+    when typer builds a help string (this module itself registers fakes afterwards).
+    """
+    result = runner.invoke(app, ["optimize", "route", command, "--help"])
+    assert result.exit_code == 0, result.output
+    for compressor_id in ("identity", "truncate", "llmlingua2-endpoint"):
+        assert compressor_id in registered_compressor_ids()
+        assert _says(result.output, compressor_id)
+
+
+def _report(matrix_file: Path, policy_file: Path, out: Path, *, baseline: str = "a") -> Result:
+    """`route report`, always with an explicit --out so nothing lands in the working dir."""
+    return runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "report",
+            str(matrix_file),
+            str(policy_file),
+            "--baseline",
+            baseline,
+            "--out",
+            str(out),
+        ],
+    )
+
+
+def test_route_report_names_the_swap_when_the_positionals_are_reversed(tmp_path: Path) -> None:
+    # Two same-typed positionals in a fixed order is a swap waiting to happen, and a pydantic
+    # schema dump ("outcomes / Field required") is not a diagnosis.
+    matrix_file = _knn_matrix_file(tmp_path)
+    policy_file = _fitted_knn_policy(tmp_path)
+
+    swapped = _report(policy_file, matrix_file, tmp_path / "report.json")
+    assert swapped.exit_code != 0
+    assert _no_traceback(swapped)
+    assert _says(swapped.output, "holds a fitted policy, not an outcome matrix")
+    assert _says(swapped.output, "wmo optimize route report <matrix.json> <policy.json>")
+    assert not (tmp_path / "report.json").exists()
+
+
+def test_route_report_rejects_a_policy_that_is_not_readable(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    result = _report(_knn_matrix_file(tmp_path), bad, tmp_path / "report.json")
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "is not a readable routing policy")
+
+
+def test_route_report_delivers_the_missing_sidecar_message_cleanly(tmp_path: Path) -> None:
+    """The message was already written; it arrived as the last line of a stack trace.
+
+    Copying a knn policy.json without its `.bank.npz` is the exact mistake `knn_bank` anticipates.
+    """
+    matrix_file = _knn_matrix_file(tmp_path)
+    policy_file = _fitted_knn_policy(tmp_path)
+    RoutingPolicy.load(policy_file).bank_path().unlink()
+
+    result = _report(matrix_file, policy_file, tmp_path / "report.json")
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "knn policy bank not found at")
+    assert _says(result.output, "Copy the sidecar next to the policy file")
+
+
+def test_route_report_says_baseline_is_a_pool_handle(tmp_path: Path) -> None:
+    # `--baseline` takes the [[model]] table's `name`, not the model id, and passing an id used
+    # to raise a bare KeyError.
+    result = _report(
+        _knn_matrix_file(tmp_path),
+        _fitted_knn_policy(tmp_path),
+        tmp_path / "report.json",
+        baseline="gpt-4o",
+    )
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "baseline 'gpt-4o' is not in the matrix pool")
+    assert _says(result.output, "pool entry handle")
+
+
+def test_route_report_refuses_a_matrix_with_nothing_scored_on_both_sides(tmp_path: Path) -> None:
+    matrix = OutcomeMatrix.load(_matrix_file(tmp_path))
+    half = tmp_path / "half.json"
+    OutcomeMatrix(
+        pool=matrix.pool,
+        outcomes=[
+            o.model_copy(update={"reward": None, "success": False}) if o.model == "a" else o
+            for o in matrix.outcomes
+        ],
+    ).save(half)
+    policy_file = tmp_path / "static.json"
+    RoutingPolicy(kind="static", default_model="a", pool=matrix.pool, fitted_from="handmade").save(
+        policy_file
+    )
+
+    result = _report(half, policy_file, tmp_path / "report.json", baseline="b")
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "nothing to compare")
+    assert not (tmp_path / "report.json").exists()
+
+
+def test_route_report_creates_the_out_directory_like_fit_does(tmp_path: Path) -> None:
+    """`fit --out` mkdir -p's its parents; report tracebacked AFTER computing the whole report."""
+    out = tmp_path / "missing" / "sub" / "report.json"
+    result = _report(_knn_matrix_file(tmp_path), _fitted_knn_policy(tmp_path), out)
+    assert result.exit_code == 0, result.output
+    assert json.loads(out.read_text(encoding="utf-8"))["headline"]
+
+
+def test_route_report_warns_when_it_measures_the_matrix_the_policy_was_fitted_on(
+    tmp_path: Path,
+) -> None:
+    """`fit` sends the user here to escape its in-sample number; report never checked.
+
+    The report even labels its scenarios held-out, so this is the one case where both surfaces
+    say the opposite of what happened. The matrix digest in `fitted_from` is an identity, so a
+    renamed copy of the fit matrix has to trip it too.
+    """
+    matrix_file = _knn_matrix_file(tmp_path)
+    policy_file = _fitted_knn_policy(tmp_path)
+
+    result = _report(matrix_file, policy_file, tmp_path / "report.json")
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "IN-SAMPLE")
+
+    renamed = tmp_path / "renamed.json"
+    renamed.write_bytes(matrix_file.read_bytes())
+    moved = _report(renamed, policy_file, tmp_path / "report_renamed.json")
+    assert moved.exit_code == 0, moved.output
+    assert _says(moved.output, "IN-SAMPLE")
+
+
+def test_route_report_stays_quiet_on_a_matrix_the_fit_never_saw(tmp_path: Path) -> None:
+    """The negative control: held-out numbers are what report is for, so no warning."""
+    policy_file = _fitted_knn_policy(tmp_path)
+    held_out = _knn_matrix_file(tmp_path, flip=True, name="held_out.json")
+    result = _report(held_out, policy_file, tmp_path / "report.json")
+    assert result.exit_code == 0, result.output
+    assert "IN-SAMPLE" not in _flat(result.output)
+
+
+def test_route_pin_names_the_positional_when_the_model_is_ambiguous(tmp_path: Path) -> None:
+    # `WorldModelStore.resolve` says "pass --name", which `pin` does not have: its world model is
+    # a positional and its --model is the POOL entry. Following the old advice failed outright.
+    pool_file = tmp_path / "pool.toml"
+    assert _add_student(tmp_path, pool_file).exit_code == 0
+    _built_model(tmp_path, "alpha")
+    _built_model(tmp_path, "beta")
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    flat = _flat(result.output)
+    assert "WORLD_MODEL" in flat and "alpha,beta" in flat
+    assert "--name" not in flat
+    assert "wmooptimizeroutepinalpha--modelstudent" in flat  # a command that actually works
+
+    followed = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "alpha",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+    assert followed.exit_code == 0, followed.output
+
+
+def test_route_pin_names_the_pool_writers_when_the_pool_is_empty(tmp_path: Path) -> None:
+    pool_file = tmp_path / "pool.toml"
+    pool_file.write_text("# nothing yet\n", encoding="utf-8")
+    _built_model(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "pin",
+            "support",
+            "--model",
+            "student",
+            "--pool",
+            str(pool_file),
+            "--root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, str(pool_file))
+    assert _says(result.output, "wmo optimize route student")
+    assert "too_short" not in _flat(result.output)  # was a raw pydantic dump
+
+
+def test_route_tune_names_the_fit_when_there_is_no_policy(tmp_path: Path) -> None:
+    # The sibling not-dialable error names `wmo optimize route fit --kind knn`; this branch,
+    # which is the one a first-time user hits (the argument defaults to ./policy.json), did not.
+    result = runner.invoke(
+        app, ["optimize", "route", "tune", str(tmp_path / "nope.json"), "--cost-quality", "0.5"]
+    )
+    assert result.exit_code != 0
+    assert _says(result.output, "no policy file at")
+    assert _says(result.output, "wmo optimize route fit <matrix.json> --kind knn")

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -2756,6 +2756,22 @@ def test_route_report_rejects_a_policy_that_is_not_readable(tmp_path: Path) -> N
     assert _says(result.output, "is not a readable routing policy")
 
 
+def test_route_report_rejects_a_policy_that_is_not_utf8_text(tmp_path: Path) -> None:
+    """`RoutingPolicy.load` decodes before pydantic runs, so this never reached the other clause.
+
+    UnicodeDecodeError is a ValueError but NOT a ValidationError, so undecodable bytes (a
+    truncated download, or the `.npz` evidence bank handed over as the policy) walked straight
+    past the boundary and tracebacked.
+    """
+    bad = tmp_path / "bad.json"
+    bad.write_bytes(b'{"kind": "\xff\xfeknn"}')
+    result = _report(_knn_matrix_file(tmp_path), bad, tmp_path / "report.json")
+    assert result.exit_code != 0
+    assert _no_traceback(result)
+    assert _says(result.output, "cannot read the policy at")
+    assert not (tmp_path / "report.json").exists()
+
+
 def test_route_report_delivers_the_missing_sidecar_message_cleanly(tmp_path: Path) -> None:
     """The message was already written; it arrived as the last line of a stack trace.
 
@@ -2838,6 +2854,16 @@ def test_route_report_warns_when_it_measures_the_matrix_the_policy_was_fitted_on
     moved = _report(renamed, policy_file, tmp_path / "report_renamed.json")
     assert moved.exit_code == 0, moved.output
     assert _says(moved.output, "IN-SAMPLE")
+
+    # The provenance marker is appended LAST, so a matrix stored under a content-addressed
+    # directory carries `sha256=` in its path too. Splitting from the left read THAT one and
+    # dropped the warning on exactly the layout most likely to keep a fit matrix around.
+    addressed = tmp_path / "artifacts" / "sha256=deadbeef" / "matrix.json"
+    addressed.parent.mkdir(parents=True)
+    addressed.write_bytes(matrix_file.read_bytes())
+    content_addressed = _report(addressed, policy_file, tmp_path / "report_addressed.json")
+    assert content_addressed.exit_code == 0, content_addressed.output
+    assert _says(content_addressed.output, "IN-SAMPLE")
 
 
 def test_route_report_stays_quiet_on_a_matrix_the_fit_never_saw(tmp_path: Path) -> None:

--- a/wmo/optimize/compression.py
+++ b/wmo/optimize/compression.py
@@ -456,6 +456,17 @@ def register_compressor_factory(compressor_id: str, factory: CompressorFactory) 
     _COMPRESSOR_FACTORIES[compressor_id] = factory
 
 
+def registered_compressor_ids() -> tuple[str, ...]:
+    """Every compressor id `--compressor` accepts, built and lazily-registered alike.
+
+    The one source of that list. `--compressor`'s help text renders it rather than spelling the
+    ids out, because a hand-written enumeration goes stale the moment a compressor is registered:
+    `llmlingua2-endpoint` shipped as a lazy factory and the help kept advertising two ids for
+    several releases while the flag accepted three.
+    """
+    return tuple(sorted({*_COMPRESSORS, *_COMPRESSOR_FACTORIES}))
+
+
 def get_compressor(compressor_id: str) -> Compressor:
     """Resolve a compressor by id, or raise naming the known ids (fail at mount, not mid-call)."""
     compressor = _COMPRESSORS.get(compressor_id)
@@ -481,7 +492,7 @@ def get_compressor(compressor_id: str) -> Compressor:
             )
         register_compressor(built)
         return built
-    known = ", ".join(sorted({*_COMPRESSORS, *_COMPRESSOR_FACTORIES}))
+    known = ", ".join(registered_compressor_ids())
     raise ValueError(
         f"unknown compressor '{compressor_id}'; known compressors: {known}. "
         "Register new compressors with wmo.optimize.compression.register_compressor "

--- a/wmo/optimize/compression_test.py
+++ b/wmo/optimize/compression_test.py
@@ -18,6 +18,7 @@ from wmo.optimize.compression import (
     get_compressor,
     register_compressor,
     register_compressor_factory,
+    registered_compressor_ids,
     same_compression,
     segment_batch_limit,
     servable_compressor,
@@ -87,6 +88,17 @@ def test_registry_rejects_unknown_id_with_guidance() -> None:
         get_compressor("llmzip")
     assert "identity" in str(caught.value)
     assert "truncate" in str(caught.value)
+
+
+def test_registered_ids_include_the_lazily_registered_endpoint_compressor() -> None:
+    """The list `--compressor`'s help renders, so a registered id cannot go undocumented.
+
+    `llmlingua2-endpoint` is registered as a FACTORY at import of `wmo.optimize`, which is why
+    the two hand-written help strings kept advertising only identity and truncate.
+    """
+    ids = registered_compressor_ids()
+    assert {"identity", "truncate", "llmlingua2-endpoint"} <= set(ids)
+    assert list(ids) == sorted(ids)
 
 
 def test_aggressiveness_is_bounded() -> None:

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -626,7 +626,14 @@ def tune_policy_dial(policy_path: Path, cost_quality: float) -> DialResult:
             superseded fit, or the policy has no dial (see `apply_cost_quality`).
     """
     if not policy_path.is_file():
-        raise ValueError(f"no policy file at {policy_path}")
+        # Name the producer, as the not-dialable branch of `apply_cost_quality` does: the default
+        # argument is a bare `policy.json`, so this is the first thing a new user hits.
+        raise ValueError(
+            f"no policy file at {policy_path}; fit one first with "
+            "`wmo optimize route fit <matrix.json> --kind knn`, or pass the path of an "
+            "installed policy (`wmo optimize route pin` and `wmo optimize model` write it to "
+            "<root>/models/<name>/policy.json)"
+        )
     policy = RoutingPolicy.load(policy_path)
     base_path = policy_path.with_name(f"{policy_path.stem}.base{policy_path.suffix}")
     as_fitted = RoutingPolicy.load(base_path) if base_path.is_file() else None

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -238,7 +238,12 @@ class ModelPool(BaseModel):
 
 
 def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
-    """Load and validate the pool file at `path`."""
+    """Load and validate the pool file at `path`.
+
+    A file that exists but declares no candidate is answered like a missing one: with the path and
+    the commands that write an entry. Falling through to pydantic instead named neither, and the
+    caller only ever sees `str(exc)`.
+    """
     if not path.is_file():
         raise FileNotFoundError(
             f"no model pool file at {path}; create it with one [[model]] table per candidate "
@@ -246,7 +251,23 @@ def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
             "output_per_mtok; endpoint/deployment/api_version/api_key_env as the backend needs)"
         )
     data = tomllib.loads(path.read_text(encoding="utf-8"))
-    return ModelPool.model_validate({"models": data.get("model", [])})
+    entries = data.get("model", [])
+    if not isinstance(entries, list):
+        # `[model]` declares ONE table; the roster is an array of tables, which needs the doubled
+        # brackets. Worth naming, since it is a typo on the very syntax the missing-file message
+        # above recommends.
+        raise ValueError(
+            f"{path} declares a single [model] table; the candidate pool is an array of tables, "
+            "so each candidate needs DOUBLED brackets: [[model]]"
+        )
+    if not entries:
+        raise ValueError(
+            f"no [[model]] tables in {path}, so the candidate pool is empty; register a hosted "
+            "model with `wmo providers set <provider>`, add a distilled student with "
+            "`wmo optimize route student <run-dir> --input-per-mtok <p> --output-per-mtok <p>`, "
+            "or write one [[model]] table per candidate by hand"
+        )
+    return ModelPool.model_validate({"models": entries})
 
 
 def pool_api_key(entry: PoolEntry) -> str | None:

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -97,8 +97,25 @@ def test_duplicate_names_rejected(tmp_path: Path) -> None:
 
 
 def test_empty_pool_rejected(tmp_path: Path) -> None:
-    with pytest.raises(ValueError):
-        load_pool(_write_pool(tmp_path, "# no models\n"))
+    """And it names the file and a command that writes an entry, as the missing case does.
+
+    Falling through to pydantic here printed `List should have at least 1 item ... [too_short]`
+    plus an errors.pydantic.dev URL: no path, no remedy. Every caller only ever shows `str(exc)`.
+    """
+    path = _write_pool(tmp_path, "# no models\n")
+    with pytest.raises(ValueError, match="wmo providers set") as excinfo:
+        load_pool(path)
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "wmo optimize route student" in message
+    assert "too_short" not in message
+
+
+def test_single_bracket_model_table_says_to_double_the_brackets(tmp_path: Path) -> None:
+    # `[model]` is a typo on the very syntax the missing-file message recommends, and pydantic
+    # answered it with `Input should be a valid list`.
+    with pytest.raises(ValueError, match=r"\[\[model\]\]"):
+        load_pool(_write_pool(tmp_path, '[model]\nname = "fable"\n'))
 
 
 def test_unknown_model_requires_explicit_price() -> None:


### PR DESCRIPTION
## What was broken

`wmo optimize route fit` and `wmo optimize route report` are the two commands in `wmo/cli/route_app.py` that hand user-typed paths straight to the pydantic and pathlib loaders. `fit` guards every other input it takes (`--kind`, `--embedder`, `--rag-thres`, `--compressor`, the compression-mismatch gate) and converts each failure to a `typer.BadParameter`; its `matrix_file` was the one exception. `report` had no error handling at all — not on either positional, not on `--baseline`, not on `--out`.

So every foreseeable mistake on the two commands the README quickstart ends with produced a rich-rendered Python traceback.

One repro a reviewer can paste (offline, free, no provider):

```
printf 'not json' > bad.json
wmo optimize route fit bad.json --embedder hashing
```

Before: ~40 lines of stack frames ending in `ValidationError: 1 validation error for OutcomeMatrix / Invalid JSON: expected ident at line 1 column 2` plus an `errors.pydantic.dev` URL.

After:

```
Usage: wmo optimize route fit [OPTIONS] {matrix_file}
╭─ Error ─────────────────────────────────────────────────────────────╮
│ Invalid value: bad.json is not a readable OutcomeMatrix: ...        │
╰─────────────────────────────────────────────────────────────────────╯
```

Alongside that root cause, the same commands carried messages and defaults that had drifted from the workflow they hand off to: `--kind` defaulted to `rank` while its own help calls knn "the validated champion", `pin` advised a `--name` flag it does not have, and `report` accepted the very matrix a policy was fitted on and printed in-sample numbers under a "held-out" label.

## What changed

**Input validation at the boundary** (`wmo/cli/route_app.py`)

- New `_load_matrix` / `_load_policy` helpers: both commands load through them. A missing file names its producer (`wmo optimize route sweep` / `wmo optimize route fit`), an unreadable file says so, and a file that parses as the *other* artifact says the two `report` positionals are the wrong way round.
- `build_report`'s `KeyError` (bad `--baseline`), `FileNotFoundError` (missing `.bank.npz` sidecar — the good message was already written, it just arrived at the bottom of a stack trace) and `ValueError` (nothing scored on both sides) are converted at the call site.
- `report --out` now `mkdir -p`s its parents and writes through `write_artifact_atomically`, exactly as `fit --out` and `pin --out` already did. It used to traceback *after* computing the whole report.
- `fit` refuses a matrix with zero scored cells up front, echoing sweep's own "fitting will fail" warning, instead of letting the fitters' `ValueError` out (the rank one named no remedy at all). Both fitter calls are also wrapped.

**Defaults and messages that had drifted**

- `fit --kind` now defaults to `knn` — what its own help, sweep's handoff line, README, the cookbook and `tune` all steer to. Three tests that wanted a rank policy now say `--kind rank` explicitly.
- `--compressor`'s help on `fit` and `sweep` renders `registered_compressor_ids()` (new, in `wmo/optimize/compression.py`) instead of a hand-written `identity | truncate`, so the registered-but-undocumented `llmlingua2-endpoint` shows up and the list cannot go stale again.
- `report --baseline` help says it is a pool entry **handle**, not a model id.
- `pin` splits `WorldModelStore.resolve`'s exceptions like `sweep` does and names the `WORLD_MODEL` positional with a command that actually works, instead of inheriting "pass --name" for an option it has never had.
- `tune`'s missing-policy error names `wmo optimize route fit --kind knn` (`wmo/optimize/knn.py`).
- `load_pool` answers an empty `pool.toml` like a missing one — the path plus `wmo providers set` / `wmo optimize route student` — instead of a raw `too_short` pydantic dump, and names the doubled-bracket rule for a `[model]` typo (`wmo/providers/pool.py`).
- `report` warns when the matrix digest in the policy's `fitted_from` matches the matrix it is being measured on: those numbers are in-sample, not held out. Digest-based, so a renamed copy of the fit matrix trips it too.

## Findings closed

From `/tmp/cli-audit-out/confirmed.json` (route group):

| # | Command | Finding |
|---|---|---|
| 19 | `route fit` | missing/invalid matrix JSON tracebacks; `load_matrix_with_digest` outside any try/except |
| 20 | `route report` | knn policy without its `.bank.npz` sidecar tracebacks instead of delivering the already-written error |
| 72 | `route report` | `--baseline` must be a pool entry handle; anything else raises `KeyError`, and the help never said so |
| 73 | `route fit` | zero-scored matrix tracebacks, though `sweep` warns the state exists and says "fitting will fail" |
| 74 | `route pin` | says "pass --name"; `pin` has no `--name`, the world model is positional |
| 75 | `route sweep` / `pin` | empty `.wmo/pool.toml` gives a raw pydantic dump naming neither the pool file nor a populating command |
| 76 | `route report` | no error handling on either positional: swapped arguments or a wrong-schema file dump pydantic |
| 77 | `route report` | tracebacks when no scenario has a scored episode on both sides |
| 78 | `route report` | `--out <missing dir>` tracebacks after all the work is done, while `fit --out` creates parents |
| 80 | `route fit` / `sweep` | `--compressor` help documents two ids while three are registered and accepted |
| 81 | `route tune` | "no policy file at policy.json" names no command that produces one |
| 82 | `route fit` | `--kind` defaults to `rank` while every other surface steers to `knn` |
| 84 | `route fit` / `report` | `report` accepts the fit matrix and prints in-sample numbers with no warning, despite the digest being available |

## Tests

CI runs no tests, so these were run locally: `uv run pytest wmo/ -q` → **3774 passed, 10 skipped**. `uv run ruff check wmo/`, `ruff format --check`, and `uv run ty check` all clean.

19 new/strengthened tests across `wmo/cli/route_app_test.py`, `wmo/providers/pool_test.py` and `wmo/optimize/compression_test.py`. Each was confirmed to **fail** against `origin/main`'s `route_app.py` / `pool.py` / `knn.py` before the fix and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
