### PR TITLE
Route every spend gate through one consent boundary, and pre-flight `wmo run`'s worker

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -407,10 +407,10 @@ uv run wmo optimize route report matrix.json .wmo/models/tau-bench/policy.json \
   --baseline claude-opus-4-8 --endpoint tau-bench --out report.json
 ```
 
-One difference worth knowing before scripting these: `route sweep` does **not** share the staged
-command's consent refusal. On a non-interactive session it prints that it is proceeding without
-confirmation and buys the sweep. So pass `--yes` there because you mean it, and treat an unattended
-`route sweep` as spending by default; `--dry-run` is the staged command's flag, not this one's.
+One thing worth knowing before scripting these: `route sweep` shares the staged command's consent
+refusal. Consent is said, never inferred, so on a non-interactive session (CI, cron, piped output,
+`| tee`) it prints what it would have spent and exits 2 instead of buying the sweep. Pass `--yes`
+there because you mean it. `--dry-run` is the staged command's flag, not this one's.
 
 Reach for these when you want a knob the staged command does not expose: `--kind rank` for
 Avengers cluster ranks instead of kNN evidence, `--z` for a stricter or looser confidence bar,

--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -262,9 +262,10 @@ episode, and written no artifact, not even resume state. It is the honest way to
 would cost, in a script or at a terminal, and it prints the table even when `--max-usd` would have
 refused the real run.
 
-**`--yes` consents.** Consent has to be said, never inferred from the absence of a terminal: a
-non-interactive session (a pipe, a CI job) that would buy a sweep and was not told `--yes` exits 2
-with `cannot ask for spend consent`, naming both honest ways forward. Nothing is bought. A run
+**`--yes` consents.** Consent has to be said, never inferred from the absence of someone to ask: a
+non-interactive session (a pipe, a CI job, or a redirected stdin, which is not a person even when
+stdout is a terminal) that would buy a sweep and was not told `--yes` exits 2 with `cannot ask for
+spend consent`, naming both honest ways forward. Nothing is bought. A run
 with no sweep left to buy needs no consent at all, so a resume down to fit, tune, and report
 proceeds unattended.
 
@@ -409,8 +410,8 @@ uv run wmo optimize route report matrix.json .wmo/models/tau-bench/policy.json \
 
 One thing worth knowing before scripting these: `route sweep` shares the staged command's consent
 refusal. Consent is said, never inferred, so on a non-interactive session (CI, cron, piped output,
-`| tee`) it prints what it would have spent and exits 2 instead of buying the sweep. Pass `--yes`
-there because you mean it. `--dry-run` is the staged command's flag, not this one's.
+`| tee`, a redirected stdin) it prints what it would have spent and exits 2 instead of buying the
+sweep. Pass `--yes` there because you mean it. `--dry-run` is the staged command's flag, not this one's.
 
 Reach for these when you want a knob the staged command does not expose: `--kind rank` for
 Avengers cluster ranks instead of kNN evidence, `--z` for a stricter or looser confidence bar,

--- a/docs/reference/distill.md
+++ b/docs/reference/distill.md
@@ -199,6 +199,11 @@ than the unique context size. The CLI prints the per-meter projection and asks f
 confirmation before anything is spent; unpriced meters print as `unknown`, and a run with
 unpriced meters and no `budget.max_usd` refuses to start non-interactively.
 
+Consent is said, never inferred. There is nobody to ask on a non-interactive session (CI, cron,
+piped output), so the run refuses there with exit code 2 unless `--yes` was passed, printing what
+it would have spent and the flag that authorizes it. A bounded `budget.max_usd` caps the damage
+but is not permission, so it does not change that.
+
 ## Running it
 
 ```bash
@@ -217,9 +222,9 @@ not the executing agent: the rollout knobs (`sampling.temperature`, `rollout.max
 surfaces, and its hash keys every harbor job so a config change cannot resume another config's
 trials. The agent harbor runs is always `terminus-2`.
 
-`--backend local|e2b` overrides the config's `harbor.backend`. `--yes` skips the cost
-confirmation when the spend is accountable. Add `--promote` to be offered a `[models.agent]`
-settings write after an accepted gate.
+`--backend local|e2b` overrides the config's `harbor.backend`. `--yes` consents to the cost
+when the spend is accountable, and is required on a non-interactive session. Add `--promote` to
+be offered a `[models.agent]` settings write after an accepted gate.
 
 Before spending anything the run preflights: renderer resolution, a student/teacher tokenizer
 fingerprint check, one-token pings, and a tokens-in-tokens-out (TITO) recompute proof that the

--- a/docs/reference/distill.md
+++ b/docs/reference/distill.md
@@ -200,8 +200,9 @@ confirmation before anything is spent; unpriced meters print as `unknown`, and a
 unpriced meters and no `budget.max_usd` refuses to start non-interactively.
 
 Consent is said, never inferred. There is nobody to ask on a non-interactive session (CI, cron,
-piped output), so the run refuses there with exit code 2 unless `--yes` was passed, printing what
-it would have spent and the flag that authorizes it. A bounded `budget.max_usd` caps the damage
+piped output, or a redirected stdin, which is not a person even when stdout is a terminal), so the
+run refuses there with exit code 2 unless `--yes` was passed, printing what it would have spent
+and the flag that authorizes it. A bounded `budget.max_usd` caps the damage
 but is not permission, so it does not change that.
 
 ## Running it

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,15 +20,15 @@ Three optimizers, named for the artifact each produces.
 
 | Command | Purpose | Artifact |
 |---|---|---|
-| `wmo optimize route sweep` | Measure every pool candidate closed-loop against the world model. The only paid step of routing, and the only thing that produces a matrix. | `matrix.json` (an `OutcomeMatrix`) |
+| `wmo optimize route sweep` | Measure every pool candidate closed-loop against the world model. The only paid step of routing, and the only thing that produces a matrix. A non-interactive run needs `--yes`, or it prints the projected spend and exits 2. | `matrix.json` (an `OutcomeMatrix`) |
 | `wmo optimize route fit` | Fit a routing policy on a matrix: `--kind knn` guarded neighbor evidence (the default), or `--kind rank` cluster ranks. | `policy.json` + its evidence bank |
 | `wmo optimize route tune` | Set a fitted policy's cost/quality dial in place, no refit. | the policy, rewritten; `policy.base.json` snapshot |
 | `wmo optimize route report` | Build the three-objective improvement report for a policy over a matrix. | `report.json` (an `ImprovementReport`) |
 | `wmo optimize route pin` | Serve one pool model as an endpoint, with no matrix and no fit. | a `kind="static"` `policy.json` |
 | `wmo optimize route student` | Add a distilled student to the candidate pool as a priced entry. | a `[[model]]` entry in `pool.toml` |
-| `wmo optimize harness` | Search the agent scaffold (prompts, skills, tool policy, loop params) against a world model or on harbor tasks. | an immutable `vN` `HarnessDoc` in the store, `champion` alias moved, plus a delta archive |
+| `wmo optimize harness` | Search the agent scaffold (prompts, skills, tool policy, loop params) against a world model or on harbor tasks. A non-interactive run needs `--yes` in either environment. | an immutable `vN` `HarnessDoc` in the store, `champion` alias moved, plus a delta archive |
 | `wmo optimize distill probe` | Ask a measured outcome matrix whether this workload has a teacher gap worth distilling at all, and which model is the cheapest sufficient teacher. Free. Exits 0 (distill), 3 (no gap), 4 (too thin to say). | nothing (prints) |
-| `wmo optimize distill run` | Train the agent model itself: on-policy distillation of a Tinker LoRA student from harbor rollouts, gated on held-out solve rates. | a run dir (config snapshot, metrics, checkpoints, evals, `gate.json`) and, on an accepted gate, an adapter version |
+| `wmo optimize distill run` | Train the agent model itself: on-policy distillation of a Tinker LoRA student from harbor rollouts, gated on held-out solve rates. A non-interactive run needs `--yes`. | a run dir (config snapshot, metrics, checkpoints, evals, `gate.json`) and, on an accepted gate, an adapter version |
 | `wmo optimize distill report` | Read a finished or aborted run back: gate verdict and held-out before/after table. Free. | nothing (prints) |
 
 `wmo optimize model` is the staged path over the four `route` commands and calls the same library

--- a/wmo/cli/agent_session.py
+++ b/wmo/cli/agent_session.py
@@ -64,7 +64,12 @@ from wmo.harness.tools import READ_SKILL, resolve_tools
 from wmo.harness.workspace_patch import WorkspacePatchError
 from wmo.platform.client import PlatformClient, PlatformError, RemoteAgentSession
 from wmo.platform.credentials import PlatformCredentials, load_credentials
-from wmo.providers.base import ProviderConfig, ProviderKind, ToolCallingProvider
+from wmo.providers.base import (
+    PreparableProvider,
+    ProviderConfig,
+    ProviderKind,
+    ToolCallingProvider,
+)
 from wmo.providers.models import resolve_provider_model
 from wmo.providers.registry import get_provider
 
@@ -788,7 +793,22 @@ class RemoteWorldModelDriver:
 
 
 def _local_worker_provider(provider: str | None, model: str | None) -> ToolCallingProvider:
-    """Build the logged-out worker provider from local environment credentials."""
+    """Build the logged-out worker provider from local environment credentials, and pre-flight it.
+
+    The pre-flight is the point. Constructing a provider proves almost nothing (every backend
+    builds its SDK client lazily), so a bare `wmo run` with nothing configured used to say
+    nothing about the model it picked, download the ~130MB pi Node runtime, reach "session
+    ready", and only THEN fail mid-session on a Bedrock configuration the user never chose. The
+    chosen provider/model is now named up front and `PreparableProvider.prepare` runs before the
+    harness boots, the same free, request-free check `wmo optimize route sweep` does over its
+    roster (`wmo.providers.pool.prepare_pool_provider`). Backends keep their documented residual
+    gaps: bedrock's AWS credentials and tinker's reachability are not locally knowable and stay
+    first-call failures.
+
+    Raises:
+        typer.BadParameter: The provider name is unknown, the model cannot do tool calling, or
+            the backend cannot be prepared. Every message names `wmo providers set`.
+    """
     configured = load_settings().models.resolve("worker")
     provider_name = provider or (
         configured.provider if configured is not None else _DEFAULT_PROVIDER
@@ -814,8 +834,25 @@ def _local_worker_provider(provider: str | None, model: str | None) -> ToolCalli
         )
     )
     if not isinstance(built, ToolCallingProvider):
-        msg = f"provider {kind.value}/{spec.model_id} does not support structured tool calling"
+        msg = (
+            f"provider {kind.value}/{spec.model_id} does not support structured tool calling; "
+            "pick a tool-calling model with "
+            f"`wmo providers set --provider {kind.value} --model <model>`"
+        )
         raise typer.BadParameter(msg)
+    source = "settings models.worker" if configured is not None else "built-in default"
+    if provider is not None or model is not None:
+        source = "--provider/--model"
+    _console.print(f"[dim]worker: {kind.value}/{spec.model_id} ({source})[/dim]")
+    if isinstance(built, PreparableProvider):
+        try:
+            built.prepare()
+        except Exception as exc:  # noqa: BLE001 - every backend raises its own SDK's type here
+            raise typer.BadParameter(
+                f"worker provider {kind.value}/{spec.model_id} ({source}) cannot be used: {exc}\n"
+                f"Fix that, or choose another worker with "
+                f"`wmo providers set --provider <provider> --model <model>`"
+            ) from exc
     return built
 
 

--- a/wmo/cli/agent_session_test.py
+++ b/wmo/cli/agent_session_test.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 import typer
 from llm_waterfall.types import ChatChoice, ChatMessage, ChatRequest, ChatResponse, ChatUsage
+from rich.console import Console
 from typer.testing import CliRunner
 
 import wmo.cli.agent_session as mod
@@ -205,6 +206,52 @@ def test_build_driver_uses_configured_local_worker(
     [config] = configs
     assert config.kind is ProviderKind.OPENAI
     assert config.model == "gpt-5.4-mini"
+
+
+class _UnpreparedProvider(_FakeProvider):
+    """A `PreparableProvider` whose backend cannot be resolved locally."""
+
+    def prepare(self) -> None:
+        raise ValueError("no AWS region configured (set AWS_REGION)")
+
+
+def test_build_driver_names_the_worker_it_picked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare `wmo run` with nothing configured says which model it silently defaulted to."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    _patch_local_provider(monkeypatch)
+    console = Console(file=io.StringIO(), width=200)
+    monkeypatch.setattr(mod, "_console", console)
+
+    mod._build_driver(target=None, jail_root=tmp_path, provider=None, model=None, task=None)
+
+    printed = cast(io.StringIO, console.file).getvalue()
+    assert f"worker: {mod._DEFAULT_PROVIDER}/" in printed
+    assert "built-in default" in printed
+
+
+def test_build_driver_preflights_the_worker_before_the_harness_boots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker that cannot be prepared is a boundary error, not a mid-session failure.
+
+    Without this the run downloads the pi Node runtime, reaches "session ready", and only then
+    fails on a provider the user never chose, with nothing pointing at `wmo providers set`.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "load_credentials", PlatformCredentials)
+    monkeypatch.setattr(mod, "get_provider", lambda _config: _UnpreparedProvider())
+    monkeypatch.setattr(mod, "_console", Console(file=io.StringIO(), width=200))
+
+    with pytest.raises(typer.BadParameter) as caught:
+        mod._build_driver(target=None, jail_root=tmp_path, provider=None, model=None, task=None)
+
+    message = " ".join(str(caught.value).split())
+    assert "no AWS region configured" in message
+    assert f"worker provider {mod._DEFAULT_PROVIDER}/" in message
+    assert "wmo providers set --provider <provider> --model <model>" in message
 
 
 def test_build_driver_logged_in_agent_uses_hosted_e2b_without_local_workspace(

--- a/wmo/cli/consent.py
+++ b/wmo/cli/consent.py
@@ -1,8 +1,14 @@
 """The one spend boundary every `wmo` command that can cost money passes through.
 
 The rule: consent to spend is SAID, never inferred. It is said by `--yes`, or by answering the
-prompt at a terminal. The absence of a terminal (CI, cron, a pipe, `| tee`) is not consent, it
-is the absence of anyone to ask, so a spending run refuses there instead of starting.
+prompt at a terminal. The absence of an interactive session (CI, cron, a pipe, `| tee`, a
+redirected `< /dev/null` or heredoc stdin) is not consent, it is the absence of anyone to ask,
+so a spending run refuses there instead of starting. Nor is a blank line or an EOF an answer:
+the safe direction is refusal, so neither can authorize spend.
+
+"Interactive" means BOTH streams. Prompting reads stdin while the console reports on stdout, so
+a terminal stdout with a redirected stdin was a real hole: the gate saw a terminal, the prompt
+read whatever the redirect supplied, and a blank line was taken as approval.
 
 This lives in one place because the rule kept being re-implemented per command and a site kept
 being missed: `wmo optimize model` shipped proceed-and-note and spent a scripted caller's real
@@ -14,6 +20,9 @@ one behaviour to read and one place a future spend surface has to reach for.
 
 from __future__ import annotations
 
+import sys
+from typing import NoReturn
+
 import typer
 from rich.console import Console
 from rich.prompt import Confirm
@@ -22,6 +31,50 @@ from rich.prompt import Confirm
 # (0, the user said no and nothing happened) and from a run failure (1), so a CI job can tell
 # "you forgot --yes" apart from "the run broke".
 NO_CONSENT_EXIT_CODE = 2
+
+# The two ways there turns out to be nobody to ask. Both open the same refusal, so a caller
+# reads one shape of message and always learns the flag that authorizes the spend.
+_NO_ONE_TO_ASK = (
+    "non-interactive session: cannot ask for spend consent, and consent is never inferred "
+    "from the absence of someone to ask. A prompt needs a terminal on stdin as well as "
+    "stdout, so a redirected or piped input refuses here too."
+)
+_NO_ANSWER = (
+    "input ended before the spend question was answered: cannot ask for spend consent, and "
+    "consent is never inferred from an unanswered prompt."
+)
+
+
+def _stdin_is_terminal() -> bool:
+    """Whether the INPUT stream is a terminal.
+
+    Its own function so a test can force the input side the way rich's `force_terminal` forces
+    the output side: `click.testing.CliRunner` installs its own non-terminal `sys.stdin` for the
+    duration of an `invoke`, so a CLI test cannot fake this by replacing `sys.stdin` itself.
+    """
+    stdin = sys.stdin
+    try:
+        return stdin is not None and stdin.isatty()
+    except ValueError:
+        # A closed stdin. Nobody to ask, which is the same answer as a redirected one.
+        return False
+
+
+def can_prompt(console: Console) -> bool:
+    """Whether there is an interactive human to ask, on BOTH ends of this session.
+
+    `console.is_terminal` answers only for the OUTPUT stream. A prompt reads the INPUT one, so
+    checking the console alone let `wmo ... < /dev/null`, a heredoc, or `printf y | wmo ...`
+    through with a terminal stdout and no human behind stdin. A prompt is only honest when both
+    streams belong to the same person, so both have to be a TTY.
+
+    Args:
+        console: The console the command prints to, owned by the calling CLI module.
+
+    Returns:
+        True only when stdout and stdin are both a terminal.
+    """
+    return console.is_terminal and _stdin_is_terminal()
 
 
 def require_spend_consent(
@@ -35,9 +88,10 @@ def require_spend_consent(
     """Get explicit consent before the first paid call, or refuse to start.
 
     Args:
-        console: The console the command prints to. Its `is_terminal` decides whether there is
-            anyone to ask, which is why it is passed in rather than imported: each CLI module
-            owns its own `Console`, and tests drive this through a non-terminal one.
+        console: The console the command prints to. It is passed in rather than imported
+            because each CLI module owns its own `Console`, and tests drive this through a
+            non-terminal one. Whether there is anyone to ask is `can_prompt`'s decision, which
+            reads this console's stdout state AND stdin.
         yes: The command's `--yes` flag. Consent, already said.
         spend: What this run would spend, in whatever unit the command can honestly quote (a
             projected dollar figure, or the rollout/episode counts when the work is unpriced).
@@ -53,17 +107,37 @@ def require_spend_consent(
         on False rather than treating it as an error: nothing was run and nothing was spent.
 
     Raises:
-        typer.Exit: Code 2 when there is no terminal to ask at and `--yes` was not passed.
+        typer.Exit: Code 2 when `--yes` was not passed and either there was no interactive
+            session to ask at, or the prompt reached EOF instead of an answer.
     """
     if yes:
         return True
-    if not console.is_terminal:
-        tail = f", or with {alternative}" if alternative else ""
-        console.print(
-            f"\nnon-interactive session: cannot ask for spend consent, and consent is never "
-            f"inferred from the absence of a terminal.\n"
-            f"  [bold]{command}[/bold] would spend {spend} here.\n"
-            f"Re-run the same command with --yes to consent explicitly{tail}."
-        )
-        raise typer.Exit(NO_CONSENT_EXIT_CODE)
-    return Confirm.ask("\nProceed?", default=True)
+    if not can_prompt(console):
+        _refuse(console, _NO_ONE_TO_ASK, spend=spend, command=command, alternative=alternative)
+    try:
+        # `default=False`: pressing Enter, and anything else that arrives as a blank line, is a
+        # refusal. Defaulting to True made the cheapest possible input authorize the spend.
+        return Confirm.ask("\nProceed?", default=False)
+    except EOFError:
+        # Both streams claimed to be a terminal and then the input ended anyway (Ctrl-D, or a
+        # pty that closed under us). Nobody answered, so this is the "could not ask" refusal
+        # rather than a considered no, and it exits 2 instead of leaking a traceback.
+        _refuse(console, _NO_ANSWER, spend=spend, command=command, alternative=alternative)
+
+
+def _refuse(
+    console: Console,
+    lead: str,
+    *,
+    spend: str,
+    command: str,
+    alternative: str | None,
+) -> NoReturn:
+    """Print what would have been spent, what would have spent it, and the flag that allows it."""
+    tail = f", or with {alternative}" if alternative else ""
+    console.print(
+        f"\n{lead}\n"
+        f"  [bold]{command}[/bold] would spend {spend} here.\n"
+        f"Re-run the same command with --yes to consent explicitly{tail}."
+    )
+    raise typer.Exit(NO_CONSENT_EXIT_CODE)

--- a/wmo/cli/consent.py
+++ b/wmo/cli/consent.py
@@ -1,0 +1,69 @@
+"""The one spend boundary every `wmo` command that can cost money passes through.
+
+The rule: consent to spend is SAID, never inferred. It is said by `--yes`, or by answering the
+prompt at a terminal. The absence of a terminal (CI, cron, a pipe, `| tee`) is not consent, it
+is the absence of anyone to ask, so a spending run refuses there instead of starting.
+
+This lives in one place because the rule kept being re-implemented per command and a site kept
+being missed: `wmo optimize model` shipped proceed-and-note and spent a scripted caller's real
+money (#305), `route sweep`, `optimize distill run` and the harbor population search were fixed
+next (#307), and the world-model mode of `wmo optimize harness` was still falling through with
+no prompt and no notice after both. Every gate now calls `require_spend_consent`, so there is
+one behaviour to read and one place a future spend surface has to reach for.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.prompt import Confirm
+
+# Exit code for "a spending run could not ask for consent". Distinct from the decline path
+# (0, the user said no and nothing happened) and from a run failure (1), so a CI job can tell
+# "you forgot --yes" apart from "the run broke".
+NO_CONSENT_EXIT_CODE = 2
+
+
+def require_spend_consent(
+    console: Console,
+    *,
+    yes: bool,
+    spend: str,
+    command: str,
+    alternative: str | None = None,
+) -> bool:
+    """Get explicit consent before the first paid call, or refuse to start.
+
+    Args:
+        console: The console the command prints to. Its `is_terminal` decides whether there is
+            anyone to ask, which is why it is passed in rather than imported: each CLI module
+            owns its own `Console`, and tests drive this through a non-terminal one.
+        yes: The command's `--yes` flag. Consent, already said.
+        spend: What this run would spend, in whatever unit the command can honestly quote (a
+            projected dollar figure, or the rollout/episode counts when the work is unpriced).
+            Printed in the refusal, so a scripted caller learns the size of what it just
+            declined to authorize instead of only that something was skipped.
+        command: The command being run, e.g. `wmo optimize route sweep`, named in the refusal
+            so the message says what to re-run.
+        alternative: An optional second way out, phrased as a flag plus what it does, e.g.
+            "--dry-run to see the plan without spending".
+
+    Returns:
+        True when consent was given, False when the user declined at a terminal. Callers exit
+        on False rather than treating it as an error: nothing was run and nothing was spent.
+
+    Raises:
+        typer.Exit: Code 2 when there is no terminal to ask at and `--yes` was not passed.
+    """
+    if yes:
+        return True
+    if not console.is_terminal:
+        tail = f", or with {alternative}" if alternative else ""
+        console.print(
+            f"\nnon-interactive session: cannot ask for spend consent, and consent is never "
+            f"inferred from the absence of a terminal.\n"
+            f"  [bold]{command}[/bold] would spend {spend} here.\n"
+            f"Re-run the same command with --yes to consent explicitly{tail}."
+        )
+        raise typer.Exit(NO_CONSENT_EXIT_CODE)
+    return Confirm.ask("\nProceed?", default=True)

--- a/wmo/cli/consent_test.py
+++ b/wmo/cli/consent_test.py
@@ -1,26 +1,37 @@
-"""The shared spend boundary: consent is said, never inferred from the absence of a terminal."""
+"""The shared spend boundary: consent is said, never inferred from the absence of someone to ask."""
 
 from __future__ import annotations
 
 import io
+import re
+import sys
 
 import pytest
 import typer
 from rich.console import Console
 
 from wmo.cli import consent as consent_module
-from wmo.cli.consent import NO_CONSENT_EXIT_CODE, require_spend_consent
+from wmo.cli.consent import NO_CONSENT_EXIT_CODE, can_prompt, require_spend_consent
+
+
+class _TerminalStdin(io.StringIO):
+    """A stdin that claims to be a terminal, with `keystrokes` already queued for the prompt."""
+
+    def isatty(self) -> bool:
+        return True
 
 
 class _Answer:
-    """A `rich.prompt.Confirm` stand-in recording what it was asked."""
+    """A `rich.prompt.Confirm` stand-in recording what it was asked, and with what default."""
 
     def __init__(self, answer: bool) -> None:
         self._answer = answer
         self.asked: list[str] = []
+        self.defaults: list[bool] = []
 
     def ask(self, prompt: str, *, default: bool = True) -> bool:
         self.asked.append(prompt)
+        self.defaults.append(default)
         return self._answer
 
 
@@ -30,7 +41,11 @@ def _console(*, terminal: bool) -> tuple[Console, io.StringIO]:
 
 
 def _flat(buffer: io.StringIO) -> str:
-    return " ".join(buffer.getvalue().split())
+    """The buffer as one line of plain text: a forced-terminal console also emits ANSI."""
+    return " ".join(_ANSI.sub("", buffer.getvalue()).split())
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
 
 def test_yes_consents_without_asking_even_at_a_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -45,7 +60,9 @@ def test_yes_consents_without_asking_even_at_a_terminal(monkeypatch: pytest.Monk
     assert buffer.getvalue() == ""
 
 
-def test_a_terminal_is_asked_and_a_no_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_terminal_is_asked_and_a_no_declines(
+    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
+) -> None:
     answer = _Answer(False)
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, _buffer = _console(terminal=True)
@@ -56,7 +73,9 @@ def test_a_terminal_is_asked_and_a_no_declines(monkeypatch: pytest.MonkeyPatch) 
     assert len(answer.asked) == 1
 
 
-def test_a_terminal_is_asked_and_a_yes_consents(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_terminal_is_asked_and_a_yes_consents(
+    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
+) -> None:
     answer = _Answer(True)
     monkeypatch.setattr(consent_module, "Confirm", answer)
     console, _buffer = _console(terminal=True)
@@ -108,3 +127,109 @@ def test_the_refusal_names_a_second_way_out_when_the_command_has_one() -> None:
         )
 
     assert "or with --dry-run to see the plan without spending" in _flat(buffer)
+
+
+# -- the input stream is half of "interactive" --------------------------------------------------
+# Checking only the console asked the wrong stream: the console reports on stdout while the
+# prompt reads stdin, so `wmo optimize route sweep < /dev/null` at a terminal passed the gate
+# and then had a redirect answer the money question for the absent human.
+
+
+def test_a_terminal_stdout_with_redirected_stdin_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hole: a TTY stdout is not a human if stdin comes from a file, a pipe, or a heredoc.
+
+    Under pytest `sys.stdin` is already a non-terminal stub, which is exactly the redirected
+    case, so only the console is forced here.
+    """
+    answer = _Answer(True)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=True)
+
+    with pytest.raises(typer.Exit) as caught:
+        require_spend_consent(
+            console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+        )
+
+    assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
+    assert answer.asked == []  # never offered, so a redirect could not answer it
+    flat = _flat(buffer)
+    assert "cannot ask for spend consent" in flat
+    # The reader IS at a terminal, so the refusal has to name the stream that is not one.
+    assert "needs a terminal on stdin as well as stdout" in flat
+
+
+def test_can_prompt_needs_both_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Either stream alone is not an interactive session."""
+    terminal, _ = _console(terminal=True)
+    piped, _ = _console(terminal=False)
+
+    monkeypatch.setattr(sys, "stdin", _TerminalStdin())
+    assert can_prompt(terminal)
+    assert not can_prompt(piped)  # terminal stdin, redirected stdout
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO("y\n"))
+    assert not can_prompt(terminal)  # terminal stdout, redirected stdin
+    assert not can_prompt(piped)
+
+
+def test_a_closed_stdin_is_not_an_interactive_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`isatty()` raises on a closed stream; that is nobody to ask, not a crash."""
+    closed = io.StringIO()
+    closed.close()  # a later isatty() raises ValueError
+    monkeypatch.setattr(sys, "stdin", closed)
+    console, _buffer = _console(terminal=True)
+
+    assert not can_prompt(console)
+
+
+def test_a_blank_answer_refuses_instead_of_authorizing_the_spend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real `Confirm`, a real blank line: the cheapest possible input must not buy anything.
+
+    `default=True` made pressing Enter (and every blank line a redirect can supply) an approval.
+    The default is the answer given when nothing was said, so it has to be the refusal.
+    """
+    monkeypatch.setattr(sys, "stdin", _TerminalStdin("\n"))
+    console, _buffer = _console(terminal=True)
+
+    assert not require_spend_consent(
+        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+    )
+
+
+def test_eof_at_the_prompt_is_the_documented_refusal_not_a_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An input that ends without answering exits 2 with the refusal, not an `EOFError`."""
+    monkeypatch.setattr(sys, "stdin", _TerminalStdin(""))  # readline() -> "" -> EOFError
+    console, buffer = _console(terminal=True)
+
+    with pytest.raises(typer.Exit) as caught:
+        require_spend_consent(
+            console,
+            yes=False,
+            spend="~$12.00 across 240 cell(s)",
+            command="wmo optimize route sweep",
+        )
+
+    assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
+    flat = _flat(buffer)
+    assert "cannot ask for spend consent" in flat
+    assert "wmo optimize route sweep would spend ~$12.00 across 240 cell(s) here" in flat
+    assert "Re-run the same command with --yes to consent explicitly." in flat
+
+
+def test_the_prompt_defaults_to_refusing(
+    monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
+) -> None:
+    """Belt and braces on the default itself, in the units the stand-in tests are written in."""
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    require_spend_consent(console, yes=False, spend="~$12.00", command="wmo optimize route sweep")
+
+    assert answer.defaults == [False]

--- a/wmo/cli/consent_test.py
+++ b/wmo/cli/consent_test.py
@@ -1,0 +1,110 @@
+"""The shared spend boundary: consent is said, never inferred from the absence of a terminal."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+import typer
+from rich.console import Console
+
+from wmo.cli import consent as consent_module
+from wmo.cli.consent import NO_CONSENT_EXIT_CODE, require_spend_consent
+
+
+class _Answer:
+    """A `rich.prompt.Confirm` stand-in recording what it was asked."""
+
+    def __init__(self, answer: bool) -> None:
+        self._answer = answer
+        self.asked: list[str] = []
+
+    def ask(self, prompt: str, *, default: bool = True) -> bool:
+        self.asked.append(prompt)
+        return self._answer
+
+
+def _console(*, terminal: bool) -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    return Console(file=buffer, force_terminal=terminal, width=200), buffer
+
+
+def _flat(buffer: io.StringIO) -> str:
+    return " ".join(buffer.getvalue().split())
+
+
+def test_yes_consents_without_asking_even_at_a_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=True)
+
+    assert require_spend_consent(
+        console, yes=True, spend="~$12.00", command="wmo optimize route sweep"
+    )
+    assert answer.asked == []
+    assert buffer.getvalue() == ""
+
+
+def test_a_terminal_is_asked_and_a_no_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+    answer = _Answer(False)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    assert not require_spend_consent(
+        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+    )
+    assert len(answer.asked) == 1
+
+
+def test_a_terminal_is_asked_and_a_yes_consents(monkeypatch: pytest.MonkeyPatch) -> None:
+    answer = _Answer(True)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, _buffer = _console(terminal=True)
+
+    assert require_spend_consent(
+        console, yes=False, spend="~$12.00", command="wmo optimize route sweep"
+    )
+    assert len(answer.asked) == 1
+
+
+def test_no_terminal_and_no_yes_refuses_naming_the_spend_and_the_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The money bug: a pipe, CI, or cron used to be read as consent. It now exits 2.
+
+    The refusal has to be actionable on its own, so it carries what would have been spent, the
+    command that would have spent it, and the flag that authorizes it.
+    """
+    answer = _Answer(True)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
+    console, buffer = _console(terminal=False)
+
+    with pytest.raises(typer.Exit) as caught:
+        require_spend_consent(
+            console,
+            yes=False,
+            spend="~$12.00 across 240 cell(s)",
+            command="wmo optimize route sweep",
+        )
+
+    assert caught.value.exit_code == NO_CONSENT_EXIT_CODE
+    assert answer.asked == []  # nothing was asked, because there was nobody to ask
+    flat = _flat(buffer)
+    assert "cannot ask for spend consent" in flat
+    assert "wmo optimize route sweep would spend ~$12.00 across 240 cell(s) here" in flat
+    assert "Re-run the same command with --yes to consent explicitly." in flat
+
+
+def test_the_refusal_names_a_second_way_out_when_the_command_has_one() -> None:
+    console, buffer = _console(terminal=False)
+
+    with pytest.raises(typer.Exit):
+        require_spend_consent(
+            console,
+            yes=False,
+            spend="~$1.65",
+            command="wmo optimize model",
+            alternative="--dry-run to see the plan without spending",
+        )
+
+    assert "or with --dry-run to see the plan without spending" in _flat(buffer)

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -22,12 +22,13 @@ import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
 from rich.console import Console
 from rich.markup import escape
-from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.prompt import IntPrompt, Prompt
 from rich.table import Table
 
 from wmo.agents.default import default_agent
 from wmo.agents.optimizer import optimizer_agent
 from wmo.agents.project import AgentProject
+from wmo.cli.consent import require_spend_consent
 from wmo.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
 from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.config.store import validate_name
@@ -227,7 +228,12 @@ def optimize(
     archive_out: str = typer.Option(
         None, "--archive", help="Also write the full delta archive JSON here."
     ),
-    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation prompt."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Consent to the projected spend up front. Required in a non-interactive "
+        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+    ),
     harbor_config: str = typer.Option(
         None,
         "--harbor-config",
@@ -429,7 +435,15 @@ def optimize(
         f"-> up to ~{rollouts} rollouts{holdout_note} + {candidate_count} proposals"
         f"{meta_note}{agent_note}{backend_note}"
     )
-    if interactive and not yes and not Confirm.ask("Proceed?", default=True):
+    if not require_spend_consent(
+        _console,
+        yes=yes,
+        spend=(
+            f"up to ~{rollouts} rollout(s){holdout_note} + {candidate_count} proposal(s) "
+            f"against world model {model_name}"
+        ),
+        command="wmo optimize harness",
+    ):
         raise typer.Exit(0)
 
     def _progress(iteration: int, variant: str, score: float, changed: bool) -> None:
@@ -709,16 +723,16 @@ def _optimize_harbor(
         f"{config.attempts} attempt(s), reward mode {config.reward_mode}, "
         f"worker backend {config.backend} (proposer project: E2B) -> {run_dir}"
     )
-    if not yes:
-        if not _console.is_terminal:
-            # Consent is said, never inferred (the shared spend-surface rule).
-            _console.print(
-                "non-interactive session: cannot ask for spend consent; re-run with --yes to "
-                "consent explicitly"
-            )
-            raise typer.Exit(2)
-        if not Confirm.ask("Proceed?", default=True):
-            raise typer.Exit(0)
+    if not require_spend_consent(
+        _console,
+        yes=yes,
+        spend=(
+            f"1 seed + {config.iterations} proposal slot(s) over {len(config.task_ids)} task(s) "
+            f"x {config.attempts} attempt(s) on backend {config.backend}"
+        ),
+        command="wmo optimize harness",
+    ):
+        raise typer.Exit(0)
 
     scorer, task_pins = _build_harbor_scorer(config, run_dir=run_dir, provider_config=agent_config)
     if resume:

--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -28,7 +28,7 @@ from rich.table import Table
 from wmo.agents.default import default_agent
 from wmo.agents.optimizer import optimizer_agent
 from wmo.agents.project import AgentProject
-from wmo.cli.consent import require_spend_consent
+from wmo.cli.consent import can_prompt, require_spend_consent
 from wmo.cli.model_roles import resolve_opt_in_model_provider, resolve_required_model_config
 from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.config.store import validate_name
@@ -232,7 +232,8 @@ def optimize(
         False,
         "--yes",
         help="Consent to the projected spend up front. Required in a non-interactive "
-        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+        "session (CI, cron, piped output, redirected input), where the run otherwise "
+        "refuses to start.",
     ),
     harbor_config: str = typer.Option(
         None,
@@ -375,14 +376,17 @@ def optimize(
             "--iterations 0 (score-only) applies only to the harbor environment; "
             "world-model optimization needs at least one search iteration"
         )
-    interactive = _console.is_terminal
+    # The same both-streams test the spend gate below uses: a terminal stdout with a redirected
+    # stdin has nobody to answer the wizard, and asking anyway raised EOFError at the first
+    # `Prompt.ask` instead of the usage error that names the missing option.
+    interactive = can_prompt(_console)
     if name is None:
         if not interactive:
-            raise typer.BadParameter("provide a harness NAME (or run at a TTY for the wizard)")
+            raise typer.BadParameter("provide a harness NAME (or run interactively for the wizard)")
         name = Prompt.ask("Name for the created harness", default="evolved")
     if tasks_file is None:
         if not interactive:
-            raise typer.BadParameter("provide --tasks (or run at a TTY for the wizard)")
+            raise typer.BadParameter("provide --tasks (or run interactively for the wizard)")
         tasks_file = Prompt.ask("Task file (JSONL of task_id/instruction/gold)")
     if iterations is None:
         iterations = (

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -104,9 +104,51 @@ def _invoke(tmp_path: Path, *extra: str) -> Result:
             "2",
             "--root",
             str(tmp_path / ".wmo"),
+            # Consent is explicit on every spend surface: a non-TTY search without --yes
+            # refuses (exit 2), and CliRunner is never a TTY. Consent semantics have their own
+            # test below; every other world-model test consents up front.
+            "--yes",
             *extra,
         ],
     )
+
+
+def test_world_model_search_non_interactive_without_yes_refuses_to_spend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No TTY and no --yes: the search refuses before `create_harness` is ever called.
+
+    The harbor mode of this same command grew the refusal first; this branch kept inferring
+    consent from `interactive`, so a piped or CI run started a paid propose-and-gate search
+    with no prompt and no notice.
+    """
+    recorder = _CreateRecorder()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    _patch_load(monkeypatch, object(), _Provider())
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "harness",
+            "made",
+            "--tasks",
+            _tasks_file(tmp_path),
+            "--iterations",
+            "2",
+            "--root",
+            str(tmp_path / ".wmo"),
+        ],
+    )
+
+    flat = " ".join(result.output.split())  # rich wraps to the console width
+    assert result.exit_code == 2, result.output
+    assert "cannot ask for spend consent" in flat
+    # The refusal quotes the size of what it declined to authorize and the flag that authorizes
+    # it, so a scripted caller can act on the message alone.
+    assert "up to ~9 rollout(s) + 2 proposal(s)" in flat
+    assert "--yes" in flat
+    assert recorder.calls == []  # no paid search started
 
 
 def _patch_load(
@@ -246,6 +288,7 @@ def test_optimize_accepts_world_model_as_second_argument(
             "1",
             "--root",
             str(tmp_path / ".wmo"),
+            "--yes",
         ],
     )
 

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 from typer.testing import CliRunner, Result
 
 from wmo.cli import app
@@ -149,6 +150,58 @@ def test_world_model_search_non_interactive_without_yes_refuses_to_spend(
     assert "up to ~9 rollout(s) + 2 proposal(s)" in flat
     assert "--yes" in flat
     assert recorder.calls == []  # no paid search started
+
+
+def test_world_model_search_at_a_terminal_with_redirected_stdin_refuses_to_spend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A terminal stdout with a redirected stdin is not an interactive session either.
+
+    Same refusal as the fully non-interactive case: the console reports on stdout while the
+    prompt reads stdin, so keying the gate on the console alone let `wmo optimize harness ... <
+    /dev/null` at a terminal have its money question answered by the redirect.
+    """
+    recorder = _CreateRecorder()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    monkeypatch.setattr(harness_app_module, "_console", Console(width=240, force_terminal=True))
+    _patch_load(monkeypatch, object(), _Provider())
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "harness",
+            "made",
+            "--tasks",
+            _tasks_file(tmp_path),
+            "--iterations",
+            "2",
+            "--root",
+            str(tmp_path / ".wmo"),
+        ],
+        input="y\n",  # what a heredoc or a `yes |` would supply
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "cannot ask for spend consent" in " ".join(result.output.split())
+    assert recorder.calls == []  # the piped "y" started nothing
+
+
+def test_the_wizard_needs_a_terminal_stdin_and_says_so_instead_of_raising_eoferror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wizard reads stdin, so a terminal stdout alone must not open it.
+
+    Opening it anyway meant the first `Prompt.ask` hit an exhausted stdin and the command died
+    with an `EOFError` traceback rather than the usage error that names the missing option.
+    """
+    monkeypatch.setattr(harness_app_module, "_console", Console(width=240, force_terminal=True))
+
+    result = runner.invoke(app, ["optimize", "harness", "made", "--root", str(tmp_path / ".wmo")])
+
+    assert result.exit_code == 2, result.output
+    assert not isinstance(result.exception, EOFError)
+    assert "provide --tasks" in " ".join(result.output.replace("│", " ").split())
 
 
 def _patch_load(
@@ -1006,6 +1059,10 @@ def test_a_world_model_search_without_iterations_buys_the_documented_five(
             _tasks_file(tmp_path),
             "--root",
             str(tmp_path / ".wmo"),
+            # What the default buys is the question here, not consent: CliRunner is never a
+            # TTY, so without this the search refuses (exit 2) before it picks an iteration
+            # count. Same reason `_invoke` passes it.
+            "--yes",
         ],
     )
 

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -43,6 +43,7 @@ from rich.prompt import Confirm
 from rich.table import Table
 
 from wmo.agents.default import default_agent
+from wmo.cli.consent import require_spend_consent
 from wmo.cli.model_roles import load_settings_or_abort
 from wmo.config import ARTIFACT_DIR
 from wmo.config.settings import ModelRole, save_settings, settings_path
@@ -163,7 +164,12 @@ def run(
         help="After an accepted gate, offer to point the models.agent role in settings.toml "
         "at the distilled adapter (always asks for confirmation).",
     ),
-    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation prompt."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Consent to the projected spend up front. Required in a non-interactive "
+        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+    ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir."),
 ) -> None:
     """Train (or resume) an agent model by distillation on real benchmark tasks.
@@ -920,9 +926,13 @@ def _confirm_cost(
     with `--yes`; a non-interactive invocation in that state is rejected with
     instructions (price the meters or set the cap).
 
+    Everything else goes through the shared spend boundary
+    (`wmo.cli.consent.require_spend_consent`), so consent is said, never inferred.
+
     Raises:
         typer.BadParameter: Unbounded spend in a non-interactive session.
-        typer.Exit: The user declined (exit code 0).
+        typer.Exit: The user declined (exit code 0), or a non-interactive session was not
+            told `--yes` (exit code 2).
     """
     if estimate.unpriced_meters and max_usd is None:
         meters = ", ".join(estimate.unpriced_meters)
@@ -941,17 +951,21 @@ def _confirm_cost(
         if not Confirm.ask("Proceed with unbounded spend?", default=False):
             raise typer.Exit(0)
         return
-    if yes:
-        return
-    if not console.is_terminal:
-        # Consent is said, never inferred: a bounded budget caps the damage but does not
-        # grant permission, and this used to start six-figure-token training runs silently.
-        console.print(
-            "non-interactive session: cannot ask for spend consent; re-run with --yes to "
-            "consent explicitly"
-        )
-        raise typer.Exit(2)
-    if not Confirm.ask("Proceed?", default=True):
+    # Consent is said, never inferred: a bounded budget caps the damage but does not grant
+    # permission, and this used to start six-figure-token training runs silently.
+    cap = f" under the ${max_usd:.2f} budget.max_usd cap" if max_usd is not None else ""
+    episodes = (
+        estimate.train_episodes
+        + estimate.warmup_episodes
+        + estimate.eval_episodes
+        + estimate.baseline_episodes
+    )
+    if not require_spend_consent(
+        console,
+        yes=yes,
+        spend=f"~${estimate.priced_usd:.2f} over {episodes} episode(s){cap}",
+        command="wmo optimize distill run",
+    ):
         raise typer.Exit(0)
 
 

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -431,8 +431,10 @@ def run_distill(
         backend: An explicit `--backend` override for the rollout source's
             backend (harbor or tau2), or None when the flag was not given.
         resume: Continue the run recorded in `run_dir`.
-        yes: Skip the cost confirmation (see `_confirm_cost` for the one
-            case where confirmation is forced anyway).
+        yes: Consent to the projected spend up front, and required on a
+            non-interactive session where there is nobody to ask (see
+            `_confirm_cost` for the one case where confirmation is forced
+            anyway).
         promote: After an accepted gate, offer to write `[models.agent]`
             pointing at the distilled adapter (explicit confirmation).
         root: The project dir (harness store, adapter store, settings).

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -43,7 +43,7 @@ from rich.prompt import Confirm
 from rich.table import Table
 
 from wmo.agents.default import default_agent
-from wmo.cli.consent import require_spend_consent
+from wmo.cli.consent import can_prompt, require_spend_consent
 from wmo.cli.model_roles import load_settings_or_abort
 from wmo.config import ARTIFACT_DIR
 from wmo.config.settings import ModelRole, save_settings, settings_path
@@ -168,7 +168,8 @@ def run(
         False,
         "--yes",
         help="Consent to the projected spend up front. Required in a non-interactive "
-        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+        "session (CI, cron, piped output, redirected input), where the run otherwise "
+        "refuses to start.",
     ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir."),
 ) -> None:
@@ -943,14 +944,20 @@ def _confirm_cost(
             "budget.max_usd is unset: the run's spend is unbounded and unaccounted, "
             "so --yes does not apply here"
         )
-        if not console.is_terminal:
+        # `can_prompt`, not `console.is_terminal`: the question below reads stdin, so a terminal
+        # stdout with a redirected stdin has nobody behind it to answer for unbounded spend.
+        if not can_prompt(console):
             raise typer.BadParameter(
                 f"cannot start with unbounded spend non-interactively: meter(s) "
                 f"{meters} are unpriced and budget.max_usd is unset; add [pricing] "
                 "entries for them or set [budget] max_usd in the distill config, "
-                "or run at a TTY to confirm explicitly"
+                "or run it interactively to confirm explicitly"
             )
-        if not Confirm.ask("Proceed with unbounded spend?", default=False):
+        try:
+            confirmed = Confirm.ask("Proceed with unbounded spend?", default=False)
+        except EOFError:
+            confirmed = False  # an ended input is not an answer, and never authorizes spend
+        if not confirmed:
             raise typer.Exit(0)
         return
     # Consent is said, never inferred: a bounded budget caps the damage but does not grant

--- a/wmo/cli/model_app_test.py
+++ b/wmo/cli/model_app_test.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from rich.console import Console
 from typer.testing import CliRunner, Result
 
 from wmo.agents.default import default_agent
@@ -392,6 +393,29 @@ def test_distill_unpriced_meters_without_budget_reject_yes_non_interactively(
     assert "unbounded" in flat
     assert "budget.max_usd" in flat
     assert recorder.calls == []
+
+
+def test_distill_unbounded_spend_refuses_a_terminal_stdout_with_redirected_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A terminal stdout is not a human when stdin is a redirect.
+
+    This is the one branch `--yes` cannot answer, so it is also the one that most needs the
+    question to reach a person. Keying it on the console alone meant `wmo optimize distill run
+    --yes < /dev/null` at a terminal fell through to the prompt, where a redirect answered for
+    the absent human or the read died with an `EOFError` traceback.
+    """
+    _write_inputs(tmp_path, extra_toml="")  # no pricing, no budget cap
+    recorder = _RunRecorder()
+    _patch_run(monkeypatch, recorder)
+    monkeypatch.setattr(model_app_module, "_console", Console(width=240, force_terminal=True))
+
+    result = _invoke(tmp_path, "--yes", input="y\n")
+
+    assert result.exit_code == 2, result.output
+    flat = _flat(result)
+    assert "cannot start with unbounded spend non-interactively" in flat
+    assert recorder.calls == []  # the piped "y" bought nothing
 
 
 def test_distill_unpriced_meters_with_a_budget_cap_honor_yes(

--- a/wmo/cli/model_app_test.py
+++ b/wmo/cli/model_app_test.py
@@ -358,6 +358,25 @@ def test_distill_runtime_error_exits_nonzero_with_the_message(
 # -- cost confirmation -------------------------------------------------------------------------
 
 
+def test_distill_non_interactive_without_yes_refuses_and_prices_the_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No TTY and no --yes: exit 2, naming the projected spend and the flag that authorizes it."""
+    _write_inputs(tmp_path, extra_toml=_PRICING_TOML + _BUDGET_TOML)
+    recorder = _RunRecorder()
+    _patch_run(monkeypatch, recorder)
+
+    result = _invoke(tmp_path)
+
+    assert result.exit_code == 2, result.output
+    flat = _flat(result)
+    assert "cannot ask for spend consent" in flat
+    assert "wmo optimize distill run would spend ~$" in flat
+    assert "budget.max_usd cap" in flat
+    assert "--yes" in flat
+    assert recorder.calls == []  # no training started
+
+
 def test_distill_unpriced_meters_without_budget_reject_yes_non_interactively(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -253,7 +253,8 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         False,
         "--yes",
         help="Consent to the projected spend up front. Required in a non-interactive "
-        "session (CI, cron, piped output), where a spending run otherwise refuses to start.",
+        "session (CI, cron, piped output, redirected input), where a spending run "
+        "otherwise refuses to start.",
     ),
     dry_run: bool = typer.Option(
         False,
@@ -1089,7 +1090,8 @@ def _confirm(decisions: list[StageDecision], plan: SweepPlan, *, yes: bool) -> b
     run of only those does not need permission to happen.
 
     A non-interactive session cannot answer, so a spending run REFUSES rather than proceeding:
-    consent must be said (`--yes`), never inferred from the absence of a terminal. Every spend
+    consent must be said (`--yes`), never inferred from the absence of an interactive session on
+    BOTH streams (a redirected stdin is not a person, even under a terminal stdout). Every spend
     surface (`route sweep`, `optimize distill`, both harness environments) shares the one
     implementation in `wmo.cli.consent`; all of them originally shipped
     proceed-silently-or-note, and the proceed branch here cost a scripted caller real money it

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -31,9 +31,9 @@ import typer
 from pydantic import BaseModel, ConfigDict, ValidationError
 from rich.console import Console
 from rich.markup import escape
-from rich.prompt import Confirm
 from rich.table import Table
 
+from wmo.cli.consent import require_spend_consent
 from wmo.cli.route_app import (
     BIAS_ACCEPTED_NOTE,
     NO_EVIDENCE_WARNING,
@@ -249,7 +249,12 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         "biased; the coverage table prints either way.",
     ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir holding the built models."),
-    yes: bool = typer.Option(False, "--yes", help="Skip the one spend confirmation."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Consent to the projected spend up front. Required in a non-interactive "
+        "session (CI, cron, piped output), where a spending run otherwise refuses to start.",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -442,7 +447,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     except BudgetExceeded as exc:
         _print_budget_stop(model_dir.name, exc)
         raise typer.Exit(1) from exc
-    if not _confirm(decisions, yes=yes):
+    if not _confirm(decisions, plan, yes=yes):
         _console.print("nothing was run and nothing was spent")
         raise typer.Exit(0)
 
@@ -1074,7 +1079,7 @@ def _status_text(decision: StageDecision) -> str:
     return f"will run [dim]({escape(decision.reason)})[/dim]"
 
 
-def _confirm(decisions: list[StageDecision], *, yes: bool) -> bool:
+def _confirm(decisions: list[StageDecision], plan: SweepPlan, *, yes: bool) -> bool:
     """The run's single spend confirmation. One question, before the first paid call.
 
     Asked whenever the SWEEP will run, rather than whenever the candidate projection is nonzero.
@@ -1085,9 +1090,10 @@ def _confirm(decisions: list[StageDecision], *, yes: bool) -> bool:
 
     A non-interactive session cannot answer, so a spending run REFUSES rather than proceeding:
     consent must be said (`--yes`), never inferred from the absence of a terminal. Every spend
-    surface (`route sweep`, `optimize distill`, the harbor search) shares this rule; all of
-    them originally shipped proceed-silently-or-note, and the proceed branch here cost a
-    scripted caller real money it never agreed to.
+    surface (`route sweep`, `optimize distill`, both harness environments) shares the one
+    implementation in `wmo.cli.consent`; all of them originally shipped
+    proceed-silently-or-note, and the proceed branch here cost a scripted caller real money it
+    never agreed to.
 
     Raises:
         typer.Exit: code 2 when a spending run cannot ask and was not told `--yes`.
@@ -1096,13 +1102,13 @@ def _confirm(decisions: list[StageDecision], *, yes: bool) -> bool:
         return False
     if yes or not _will_sweep(decisions):
         return True
-    if not _console.is_terminal:
-        _console.print(
-            "\nnon-interactive session: cannot ask for spend consent. Re-run with --yes to "
-            "consent explicitly, or --dry-run to see the plan without spending."
-        )
-        raise typer.Exit(2)
-    return Confirm.ask("\nProceed?", default=True)
+    return require_spend_consent(
+        _console,
+        yes=yes,
+        spend=f"~${_projected_total(decisions, plan):.2f} across {plan.cells} sweep cell(s)",
+        command="wmo optimize model",
+        alternative="--dry-run to see the plan without spending",
+    )
 
 
 # ------------------------------------------------------------------------------ stage execution

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -19,6 +19,7 @@ import pytest
 from rich.console import Console
 from typer.testing import CliRunner, Result
 
+from wmo.cli import consent as consent_module
 from wmo.cli.app import app
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
@@ -605,7 +606,7 @@ def test_declining_the_confirmation_spends_nothing(
     world_model = _patch_seams(monkeypatch)
     root = _project(tmp_path)
     answer = _Answer(False)
-    monkeypatch.setattr(optimize_module, "Confirm", answer)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     result = _run(tmp_path, root)
     assert result.exit_code == 0, result.output
@@ -621,7 +622,7 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
     answer = _Answer(False)
-    monkeypatch.setattr(optimize_module, "Confirm", answer)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     result = _run(tmp_path, root)
     flat = _flat(result.output)
@@ -644,7 +645,7 @@ def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
     provider, and how much of the grid a previous attempt already paid for."""
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
-    monkeypatch.setattr(optimize_module, "Confirm", _Answer(False))
+    monkeypatch.setattr(consent_module, "Confirm", _Answer(False))
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     paced = _run(tmp_path, root, "--concurrency", "6")
     assert "2candidate(s)x3scenario(s)x1episode(s),6atatime" in _flat(paced.output)
@@ -1013,7 +1014,7 @@ def test_the_first_sweep_says_the_world_model_side_is_not_projectable(
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
     answer = _Answer(False)
-    monkeypatch.setattr(optimize_module, "Confirm", answer)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     result = _run(tmp_path, root)
     assert result.exit_code == 0, result.output
@@ -1174,7 +1175,7 @@ def test_the_cap_refuses_before_asking_rather_than_after(
     world_model = _patch_seams(monkeypatch)
     root = _project(tmp_path)
     answer = _Answer(True)
-    monkeypatch.setattr(optimize_module, "Confirm", answer)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     result = _run(tmp_path, root, "--max-usd", "0.01")
     assert result.exit_code == 1, result.output
@@ -1205,7 +1206,7 @@ def test_a_zero_priced_pool_is_still_confirmed_because_the_simulator_is_not_free
         encoding="utf-8",
     )
     answer = _Answer(False)
-    monkeypatch.setattr(optimize_module, "Confirm", answer)
+    monkeypatch.setattr(consent_module, "Confirm", answer)
     monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
     result = _run(tmp_path, root, pool=free_pool)
     assert result.exit_code == 0, result.output

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -601,7 +601,7 @@ def test_a_cap_that_covers_the_run_lets_it_finish(
 
 
 def test_declining_the_confirmation_spends_nothing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     world_model = _patch_seams(monkeypatch)
     root = _project(tmp_path)
@@ -617,7 +617,7 @@ def test_declining_the_confirmation_spends_nothing(
 
 
 def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
@@ -639,7 +639,7 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
 
 
 def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     """Two things an operator authorizing a run needs to see: how hard it will lean on the
     provider, and how much of the grid a previous attempt already paid for."""
@@ -1003,7 +1003,7 @@ def test_a_candidate_only_cap_would_have_let_that_second_sweep_through(
 
 
 def test_the_first_sweep_says_the_world_model_side_is_not_projectable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     """Before a model's first sweep there is nothing to forecast from, and silence would mislead.
 
@@ -1169,7 +1169,7 @@ def test_accepting_biased_evidence_does_not_stick_silently(
 
 
 def test_the_cap_refuses_before_asking_rather_than_after(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     """Being asked to approve a run and then told it cannot start is the wrong order."""
     world_model = _patch_seams(monkeypatch)
@@ -1185,7 +1185,7 @@ def test_the_cap_refuses_before_asking_rather_than_after(
 
 
 def test_a_zero_priced_pool_is_still_confirmed_because_the_simulator_is_not_free(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     """Keying the question on the candidate projection skips it exactly when it matters most.
 

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -35,6 +35,7 @@ from rich.markup import escape
 from rich.prompt import Confirm
 from rich.table import Table
 
+from wmo.cli.consent import require_spend_consent
 from wmo.config import ARTIFACT_DIR, WorldModelStore
 from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_entry
 from wmo.engine import load_world_model
@@ -178,7 +179,12 @@ def sweep(
         DEFAULT_MATRIX_FILENAME, "--out", help="Where to write the OutcomeMatrix JSON."
     ),
     root: str = typer.Option(ARTIFACT_DIR, "--root", help="Project dir."),
-    yes: bool = typer.Option(False, "--yes", help="Skip the cost confirmation."),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Consent to the projected spend up front. Required in a non-interactive "
+        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+    ),
     allow_uneven_coverage: bool = typer.Option(
         False,
         "--allow-uneven-coverage",
@@ -235,11 +241,13 @@ def sweep(
     one-hour grid; it is not part of what the sweep measures, so a run interrupted at one value
     resumes at another.
 
-    Spend is confirmed before the first episode runs (`--yes` skips, as in
-    `wmo optimize harness --mode distill`). What that estimate multiplies is ASSUMED tokens per
-    policy call by the real cell and call counts, so it is a projection, never a measurement;
-    the measured candidate spend is printed when the sweep finishes. Before that question is asked,
-    every candidate's backend is resolved as far as it goes without a request: its kind's static
+    Spend is confirmed before the first episode runs, and consent is said, never inferred: at a
+    terminal the projected cost is a question, and with no terminal to ask at (CI, cron, piped
+    output, `| tee`) the run REFUSES with exit code 2 unless `--yes` was passed, naming what it
+    would have spent. What that estimate multiplies is ASSUMED tokens per policy call by the real
+    cell and call counts, so it is a projection, never a measurement; the measured candidate spend
+    is printed when the sweep finishes. Before that question is asked, every candidate's backend
+    is resolved as far as it goes without a request: its kind's static
     requirements from the entry alone, then its lazy SDK client forced to BUILD, which imports the
     SDK and resolves credentials locally. So a candidate that could never be called is a usage
     error at the boundary, not a mid-sweep abort with earlier candidates already paid for. Two
@@ -333,7 +341,7 @@ def sweep(
     world_model, _serve_provider = load_world_model(model_dir)
 
     print_cost_estimate(_console, plan, already_measured=already_measured)
-    _confirm_cost(yes=yes)
+    _confirm_cost(plan, yes=yes)
 
     _console.print(
         f"sweeping {len(plan.pool.models)} candidate(s) over {len(plan.scenarios)} held-out "
@@ -617,27 +625,25 @@ def print_cost_estimate(console: Console, plan: SweepPlan, *, already_measured: 
     )
 
 
-def _confirm_cost(*, yes: bool) -> None:
+def _confirm_cost(plan: SweepPlan, *, yes: bool) -> None:
     """Confirm the projected spend before any episode runs.
 
     Consent is said, never inferred: a non-interactive session cannot answer a prompt, so a
     spending run REFUSES unless `--yes` was passed. This command shipped proceed-and-note for
     its first day, and the equivalent branch in `wmo optimize model` spent a scripted caller's
-    real money it never agreed to; every spend surface now shares the refusal.
+    real money it never agreed to; every spend surface now shares one refusal
+    (`wmo.cli.consent.require_spend_consent`).
 
     Raises:
         typer.Exit: The user declined (exit code 0), or a non-interactive session was not told
             `--yes` (exit code 2).
     """
-    if yes:
-        return
-    if not _console.is_terminal:
-        _console.print(
-            "non-interactive session: cannot ask for spend consent; re-run with --yes to "
-            "consent explicitly"
-        )
-        raise typer.Exit(2)
-    if not Confirm.ask("Proceed?", default=True):
+    if not require_spend_consent(
+        _console,
+        yes=yes,
+        spend=f"~${plan.total_usd:.2f} across {plan.cells} cell(s)",
+        command="wmo optimize route sweep",
+    ):
         raise typer.Exit(0)
 
 

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -183,7 +183,8 @@ def sweep(
         False,
         "--yes",
         help="Consent to the projected spend up front. Required in a non-interactive "
-        "session (CI, cron, piped output), where the run otherwise refuses to start.",
+        "session (CI, cron, piped output, redirected input), where the run otherwise "
+        "refuses to start.",
     ),
     allow_uneven_coverage: bool = typer.Option(
         False,
@@ -242,9 +243,10 @@ def sweep(
     resumes at another.
 
     Spend is confirmed before the first episode runs, and consent is said, never inferred: at a
-    terminal the projected cost is a question, and with no terminal to ask at (CI, cron, piped
-    output, `| tee`) the run REFUSES with exit code 2 unless `--yes` was passed, naming what it
-    would have spent. What that estimate multiplies is ASSUMED tokens per policy call by the real
+    terminal the projected cost is a question, and with nobody to ask (CI, cron, piped output,
+    `| tee`, or a redirected stdin, which is not a person even when stdout is a terminal) the run
+    REFUSES with exit code 2 unless `--yes` was passed, naming what it would have spent.
+    What that estimate multiplies is ASSUMED tokens per policy call by the real
     cell and call counts, so it is a projection, never a measurement; the measured candidate spend
     is printed when the sweep finishes. Before that question is asked, every candidate's backend
     is resolved as far as it goes without a request: its kind's static

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -1703,7 +1703,7 @@ def test_route_sweep_hands_off_when_every_candidate_lost_the_same_scenario(
 
 
 def test_route_sweep_declining_the_confirmation_spends_nothing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     seams = _patch_seams(monkeypatch)
     root = _project(tmp_path, traces=_corpus())
@@ -1721,7 +1721,7 @@ def test_route_sweep_declining_the_confirmation_spends_nothing(
 
 
 def test_route_sweep_confirming_at_a_tty_runs_the_sweep(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interactive_stdin: None
 ) -> None:
     seams = _patch_seams(monkeypatch)
     root = _project(tmp_path, traces=_corpus())

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -17,6 +17,7 @@ import pytest
 from rich.console import Console
 from typer.testing import CliRunner, Result
 
+from wmo.cli import consent as consent_module
 from wmo.cli.app import app
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
@@ -1707,7 +1708,7 @@ def test_route_sweep_declining_the_confirmation_spends_nothing(
     seams = _patch_seams(monkeypatch)
     root = _project(tmp_path, traces=_corpus())
     monkeypatch.setattr(route_module, "_console", Console(force_terminal=True))
-    monkeypatch.setattr(route_module, "Confirm", _Answer(False))
+    monkeypatch.setattr(consent_module, "Confirm", _Answer(False))
     out, result = _sweep(tmp_path, root, "support", "--scenarios", "3")
     assert result.exit_code == 0, result.output
     assert not out.exists()  # nothing written
@@ -1725,7 +1726,7 @@ def test_route_sweep_confirming_at_a_tty_runs_the_sweep(
     seams = _patch_seams(monkeypatch)
     root = _project(tmp_path, traces=_corpus())
     monkeypatch.setattr(route_module, "_console", Console(force_terminal=True))
-    monkeypatch.setattr(route_module, "Confirm", _Answer(True))
+    monkeypatch.setattr(consent_module, "Confirm", _Answer(True))
     out, result = _sweep(tmp_path, root, "support", "--scenarios", "1")
     assert result.exit_code == 0, result.output
     assert len(OutcomeMatrix.load(out).outcomes) == 2

--- a/wmo/conftest.py
+++ b/wmo/conftest.py
@@ -1,8 +1,9 @@
 """Suite-wide fixtures.
 
-Both fixtures here enforce the same rule: a test must behave identically on a machine that has
-developer state (a failover chain, a fetched OpenRouter price catalog) and one that does not,
-and no test may reach the network.
+The two autouse fixtures enforce the same rule: a test must behave identically on a machine
+that has developer state (a failover chain, a fetched OpenRouter price catalog) and one that
+does not, and no test may reach the network. `interactive_stdin` is opt-in and does the
+opposite job: it supplies the interactive session a prompt test needs.
 """
 
 from __future__ import annotations
@@ -44,3 +45,19 @@ def _offline_openrouter_catalog(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
 def _refuse_network() -> openrouter_pricing.PriceCatalog:
     """Stand-in for the live catalog fetch: tests never reach openrouter.ai."""
     raise RuntimeError("the test suite does not fetch the OpenRouter catalog")
+
+
+@pytest.fixture
+def interactive_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Present a terminal stdin, for a test that has to reach an interactive prompt.
+
+    `wmo.cli.consent.can_prompt` requires a TTY on BOTH streams, so forcing a terminal `Console`
+    (stdout) is not enough on its own: a spend gate refuses before any prompt is offered. This
+    is the input-side counterpart of rich's `force_terminal`, and it patches the seam rather
+    than `sys.stdin` because pytest's capture stub and `click.testing.CliRunner` both install a
+    non-terminal `sys.stdin` of their own. Tests that need to control what the prompt READS
+    replace `sys.stdin` directly instead.
+    """
+    from wmo.cli import consent
+
+    monkeypatch.setattr(consent, "_stdin_is_terminal", lambda: True)


### PR DESCRIPTION
## What was broken

The spend-consent rule (`--yes`, or a "yes" at a terminal) was re-implemented at every gate
instead of living in one place, so a site kept being missed. `wmo optimize model` shipped
proceed-and-note and spent a scripted caller's real money (#305); `route sweep`,
`optimize distill run` and the harbor population search were fixed next (#307). **The
world-model mode of `wmo optimize harness` was still falling through** after both: on a non-TTY
it asked nothing, printed nothing, and started a paid propose-and-gate search.

Repro (no money spent, the paid entry point raises instead):

```python
# /tmp/repro.py  -- run with `python /tmp/repro.py`
from pathlib import Path
from typer.testing import CliRunner
import wmo.cli.harness_app as harness_app, wmo.cli.consent as consent
from wmo.cli.app import app

tmp = Path("/tmp/wmo-consent-repro"); tmp.mkdir(exist_ok=True)
(tmp / "tasks.jsonl").write_text('{"task_id":"t1","instruction":"do it","gold":["done"]}\n')

harness_app._load_world_model = lambda m, r: (object(), type("P", (), {"name": "fake"})(), "wm-alpha")
harness_app.create_harness = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("SPEND-REACHED"))
harness_app.resolve_opt_in_model_provider = lambda root, role, p: (None, None)
asked = []; consent.Confirm.ask = lambda *a, **k: asked.append(a) or True

res = CliRunner().invoke(app, ["optimize", "harness", "made", "--tasks", str(tmp / "tasks.jsonl"),
                               "--iterations", "2", "--root", str(tmp / ".wmo")])
print("exit:", res.exit_code, "| prompts asked:", asked, "|", repr(res.exception))
```

Before: `exit: 1 | prompts asked: [] | RuntimeError('SPEND-REACHED')` -- the search started with
no prompt and no notice.
After: `exit: 2 | prompts asked: [] | SystemExit(2)`, and the output says

```
non-interactive session: cannot ask for spend consent, and consent is never inferred from the
absence of a terminal.
  wmo optimize harness would spend up to ~9 rollout(s) + 2 proposal(s) against world model wm-alpha here.
Re-run the same command with --yes to consent explicitly.
```

Separately, `wmo run` did no worker-provider pre-flight. With nothing configured it hard-selected
`bedrock/claude-opus-4-8` without ever naming it, downloaded the ~130MB pi Node runtime, reached
"session ready", and only then failed with `worker LLM error: BedrockProvider has no region...`,
with nothing pointing at `wmo providers set`.

## What changed

- **New `wmo/cli/consent.py`**: `require_spend_consent(console, *, yes, spend, command,
  alternative=None)` is the one implementation of the rule. `--yes` consents; an INTERACTIVE
  SESSION is asked; anything else exits 2 after printing what would have been spent, the
  command that would have spent it, and the flag that authorizes it.
  "Interactive" means both streams (`can_prompt`): the console reports on stdout while the
  prompt reads stdin, so a terminal stdout with a redirected stdin is not a person. The prompt
  is `default=False`, so a blank line refuses rather than approves, and an `EOFError` (Ctrl-D,
  or a pty that closed) becomes the same exit-2 refusal instead of a traceback. The first cut
  of this file got all three wrong and Greptile caught it as a P1; see the
  [thread](https://github.com/experientiallabs/world-model-optimizer/pull/321#discussion_r3662139998).
- **All five spend gates route through it**: `wmo optimize harness` (world-model mode, the one
  still broken, and harbor mode), `wmo optimize distill run`, `wmo optimize route sweep`, and
  `wmo optimize model`. Behaviour at a real terminal and under `--yes` is unchanged; the refusals
  now carry a priced/sized projection they did not have before. `optimize model` keeps its
  `--dry-run` second way out. `distill run`'s stricter unpriced-and-uncapped refusal keeps its own
  message and its "`--yes` does not apply here" rule, but it now uses the same both-streams test:
  it is the one branch `--yes` cannot answer, so it is the last line of defence, and keying it on
  the console alone let `--yes < /dev/null` at a terminal have a piped `y` authorize an uncapped,
  unpriced training run. `wmo optimize harness`'s argument wizard uses the same test, so a
  redirected stdin gets the usage error naming `--tasks` instead of an `EOFError` traceback.
- **`wmo optimize route sweep --help` no longer promises what it does not do.** It said "Spend is
  confirmed before the first episode runs" with no caveat; it now states the non-TTY refusal and
  its exit code. Same correction in `docs/cookbook/tau-bench.md` (which claimed sweep does *not*
  share the refusal), `docs/reference/distill.md`, `docs/usage.md`, and every `--yes` help string.
- **`wmo run` pre-flights its worker.** It prints the provider/model it picked and where that came
  from (`--provider/--model`, `settings models.worker`, or `built-in default`), then runs
  `PreparableProvider.prepare()` -- the same free, request-free check `route sweep` does over its
  roster -- before the harness boots. A backend that cannot be prepared is a `typer.BadParameter`
  naming `wmo providers set`, not a mid-session failure after a 130MB download. Backends keep
  their documented residual gaps (bedrock's AWS credentials, tinker's reachability are not
  locally knowable and stay first-call failures).

## Tests

New `wmo/cli/consent_test.py` (11 cases: `--yes`, TTY yes/no, the non-interactive refusal and
its contents, the `alternative` line, plus the boundary's harder half: a terminal stdout with a
redirected stdin, the both-streams `can_prompt` matrix, a closed stdin, and blank-line and EOF
answers driven through the REAL `rich.prompt.Confirm` rather than a stand-in). New refusal tests
for the world-model harness search
(`harness_app_test.py`) and for `distill run` (`model_app_test.py`), which had none. New
`wmo run` tests for the worker line and the pre-flight refusal (`agent_session_test.py`). The
existing `Confirm` monkeypatches in `route_app_test.py` and `optimize_model_app_test.py` now
patch the shared module, and the world-model harness test helper consents with `--yes` the way
`_invoke_harbor` already did. A new `interactive_stdin` fixture in `wmo/conftest.py` gives the
tests that have to reach a prompt the input-side counterpart of rich's `force_terminal`, which
they need because `click.testing.CliRunner` installs its own non-TTY `sys.stdin` for the
duration of an `invoke`.

Beyond the suite, the boundary was exercised against a REAL pty (so `is_terminal` and `isatty()`
are genuine, not forced): pty stdout with `< /dev/null` refuses with exit 2 where it used to
raise `EOFError`; a blank Enter at a real terminal returns False where it used to return True and
authorize the spend; typing `y` still consents; Ctrl-D refuses with exit 2 instead of a traceback.

`uv run pytest -q` : 4413 passed, 20 skipped. `ruff check .`, `ruff format --check .` and
`ty check` all clean over the whole project. Rebased onto current main (#325 and this branch both
touched `wmo/cli/model_app.py`'s imports).

## Audit findings closed

- `[model/major]` `wmo optimize harness` (both modes) and `wmo optimize distill run` skip the
  cost confirmation entirely on a non-TTY and start spending with no prompt and no notice.
  (The harbor and distill halves landed in #307; the world-model half is fixed here, and both
  refusals now name the spend.)
- `[route/minor]` `wmo optimize route sweep --help` promises a spend confirmation before the
  first episode but never asks in a non-TTY -- the help, `docs/usage.md`, and the cookbook are
  all corrected.
- `[session/minor]` Bare `wmo run` performs no worker-provider pre-flight: it silently defaults
  to `bedrock/claude-opus-4-8` and a missing-credential failure only surfaces mid-session after
  an npm install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

