### PR TITLE
Make `optimize model` and `optimize distill` own their input-boundary failures

### DIFF
--- a/wmo/cli/harness_app.py
+++ b/wmo/cli/harness_app.py
@@ -61,6 +61,9 @@ from wmo.providers.registry import get_provider
 # The default agent seed's literal CLI name: `wmo optimize harness pi harbor ...` starts from the
 # built-in pi agent and publishes new versions under the store name "pi".
 DEFAULT_SEED_AGENT = "pi"
+# The search budget each environment falls back to when --iterations is not given. They differ
+# (harbor buys more, cheaper, steps), which is exactly why --iterations' help states both.
+_DEFAULT_WORLD_MODEL_ITERATIONS = 5
 _DEFAULT_HARBOR_ITERATIONS = 10
 _HARBOR_ENVIRONMENT = "harbor"
 _HARBOR_EXTRA_HINT = (
@@ -180,7 +183,9 @@ def optimize(
         "local",
         "--backend",
         help="Where the harness PROCESS runs: local (in/from this process) or e2b (the real "
-        "pi agent inside pooled E2B sandboxes). The environment is always the world model.",
+        "pi agent inside pooled E2B sandboxes). With a world-model ENVIRONMENT that is all it "
+        "moves: the environment stays the world model. With `harbor` it also selects the task "
+        "environment (local = docker tasks, e2b = E2B tasks).",
     ),
     eval_concurrency: int | None = typer.Option(
         None,
@@ -204,7 +209,9 @@ def optimize(
     iterations: int = typer.Option(
         None,
         min=0,
-        help="Propose-and-gate steps (the search budget). 0 scores the seed only (harbor env), "
+        help=f"Propose-and-gate steps (the search budget). Default: "
+        f"{_DEFAULT_WORLD_MODEL_ITERATIONS} for a world-model environment, "
+        f"{_DEFAULT_HARBOR_ITERATIONS} for harbor. 0 scores the seed only (harbor env), "
         "the way a baseline or a frozen champion is scored on a task set.",
     ),
     proposal_batch_size: int = typer.Option(
@@ -371,9 +378,12 @@ def optimize(
         tasks_file = Prompt.ask("Task file (JSONL of task_id/instruction/gold)")
     if iterations is None:
         iterations = (
-            IntPrompt.ask("Search iterations (each = 1 delta + 1 gated eval)", default=5)
+            IntPrompt.ask(
+                "Search iterations (each = 1 delta + 1 gated eval)",
+                default=_DEFAULT_WORLD_MODEL_ITERATIONS,
+            )
             if interactive
-            else 5
+            else _DEFAULT_WORLD_MODEL_ITERATIONS
         )
 
     if backend not in ("local", "e2b"):

--- a/wmo/cli/harness_app_test.py
+++ b/wmo/cli/harness_app_test.py
@@ -920,6 +920,88 @@ def test_harbor_scorer_receives_the_local_backend_episode_timeout(
     assert scorer.kwargs["episode_timeout_s"] == pytest.approx(1800.0)
 
 
+# -- what --help promises ----------------------------------------------------------------------
+
+
+def _help_text() -> str:
+    return " ".join(
+        runner.invoke(app, ["optimize", "harness", "--help"]).output.replace("│", " ").split()
+    )
+
+
+def test_backend_help_does_not_deny_that_harbor_moves_the_environment() -> None:
+    """On the harbor path --backend picks the TASK environment (docker vs E2B), and there is
+    no world model at all, so the option table must not claim otherwise: the same --help says
+    the opposite three paragraphs above."""
+    help_text = _help_text()
+    assert "The environment is always the world model." not in help_text
+    assert "the environment stays the world model" in help_text
+    assert "docker tasks" in help_text and "E2B tasks" in help_text
+
+
+def test_iterations_help_states_both_environment_defaults() -> None:
+    """Each iteration is a paid propose-and-gate step, and the fallback is not the same on both
+    paths, so --help states both numbers (Click can render no static default: the None sentinel
+    is what --resume's conflict check reads)."""
+    assert "Default: 5 for a world-model environment, 10 for harbor." in _help_text()
+
+
+def test_a_world_model_search_without_iterations_buys_the_documented_five(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _CreateRecorder()
+    monkeypatch.setattr(harness_app_module, "create_harness", recorder)
+    _patch_load(monkeypatch, object(), _Provider())
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "harness",
+            "made",
+            "--tasks",
+            _tasks_file(tmp_path),
+            "--root",
+            str(tmp_path / ".wmo"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    [call] = recorder.calls
+    assert call["iterations"] == 5
+    assert "5 iteration(s)" in " ".join(result.output.split())
+
+
+def test_a_harbor_search_without_iterations_buys_the_documented_ten(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _harbor_project(tmp_path, monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "harness",
+            "pi",
+            "harbor",
+            "--harbor-config",
+            str(tmp_path / "job.yaml"),
+            "--task-ids",
+            str(tmp_path / "tasks.json"),
+            "--run-dir",
+            str(tmp_path / "run"),
+            "--root",
+            str(tmp_path / ".wmo"),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = captured["config"]
+    assert isinstance(config, _HarborRunConfig)
+    assert config.iterations == 10
+
+
 # -- the retired distill mode ------------------------------------------------------------------
 
 

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -646,10 +646,15 @@ def _preflight_tau2(cfg: DistillConfig, task_ids: Sequence[str]) -> None:
         )
     tau2_bin = Path(cfg.tau2.tau2_bin)
     if not tau2_bin.is_file():
+        # Self-contained on purpose: tau2-bench is an external clone no wheel can ship, so a
+        # pip-installed user has no repo file to be pointed at. The one-time setup is three
+        # commands, so the message carries them instead of a path that may not exist.
         raise typer.BadParameter(
-            f"tau2.tau2_bin {tau2_bin} does not exist; point it at the tau2 CLI inside "
-            "its own venv (see packages/environment-capture/tau-bench/README.md for the "
-            "one-time setup)"
+            f"tau2.tau2_bin {tau2_bin} does not exist; tau2-bench runs from its own Python 3.13 "
+            "venv, so set it up once (`git clone --depth 1 "
+            "https://github.com/sierra-research/tau2-bench && uv venv --python 3.13 .venv && "
+            "uv pip install --python .venv ./tau2-bench audioop-lts boto3`) and point "
+            "tau2.tau2_bin at that venv's CLI, <where-you-ran-it>/.venv/bin/tau2"
         )
     data_dir = Path(cfg.tau2.data_dir)
     if not data_dir.is_dir():
@@ -686,6 +691,13 @@ def _load_config(path: Path) -> DistillConfig:
         ) from exc
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    except ImportError as exc:
+        # Some sections can only be VALIDATED with the distill extra installed:
+        # `[rollout.renderers]` resolves its names through tinker-cookbook. pydantic re-raises a
+        # non-ValueError out of a field validator untouched, so without this a missing extra
+        # (the state every shipped reference config lands in on a plain `pip install`) escapes
+        # as a traceback instead of the install command the user needs.
+        raise typer.BadParameter(f"cannot load {path}: {exc}") from exc
 
 
 def _load_record(path: Path) -> DistillCliRunRecord:
@@ -1157,6 +1169,41 @@ def _print_paired_delta(console: Console, store: DistillRunStore, gate: DistillG
     )
 
 
+def _read_metrics(console: Console, store: DistillRunStore) -> list[JsonObject]:
+    """Every metrics row, surviving the half-written last line an aborted run leaves.
+
+    `report` advertises itself as safe on a live or aborted run dir, so a torn final row (all a
+    run killed mid-append can leave behind) must not end the command: drop it, say so, and
+    report what is complete. Damage above the last line means the file lost content, so it stays
+    an error; it is just a usage error now, the way `_load_gate` and `_load_eval_report` already
+    treat the same class of damage, rather than a traceback.
+
+    Args:
+        console: Where to print the note about a dropped final line.
+        store: The run store to read `metrics.jsonl` from.
+
+    Returns:
+        Every complete row, in append order.
+
+    Raises:
+        typer.BadParameter: If a row above the last one is not a JSON object.
+    """
+    try:
+        return store.read_metrics()
+    except ValueError:
+        pass  # the tolerant read below decides whether the damage is only the torn tail
+    try:
+        rows = store.read_metrics(tolerate_partial_tail=True)
+    except ValueError as fatal:
+        raise typer.BadParameter(str(fatal)) from fatal
+    console.print(
+        f"[yellow]note[/yellow] ignoring a half-written last line in "
+        f"{escape(str(store.metrics_path))} (a run killed mid-append leaves one); "
+        f"reporting the {len(rows)} complete row(s)"
+    )
+    return rows
+
+
 def _print_training_summary(console: Console, store: DistillRunStore) -> None:
     """Print the last training row's health metrics, or say the run trained nothing.
 
@@ -1164,7 +1211,7 @@ def _print_training_summary(console: Console, store: DistillRunStore) -> None:
     it. `mean_generation_tokens` is the per-episode series the loop does
     measure (sampled tokens, pooled over the batch's span-bearing episodes).
     """
-    rows = [row for row in store.read_metrics() if row.get("phase") is None]
+    rows = [row for row in _read_metrics(console, store) if row.get("phase") is None]
     if not rows:
         console.print("no training step recorded in metrics.jsonl")
         return

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -1174,9 +1174,11 @@ def _read_metrics(console: Console, store: DistillRunStore) -> list[JsonObject]:
 
     `report` advertises itself as safe on a live or aborted run dir, so a torn final row (all a
     run killed mid-append can leave behind) must not end the command: drop it, say so, and
-    report what is complete. Damage above the last line means the file lost content, so it stays
-    an error; it is just a usage error now, the way `_load_gate` and `_load_eval_report` already
-    treat the same class of damage, rather than a traceback.
+    report what is complete. Every other shape of damage -- a broken row above the last one, or
+    a last line that parses into something other than a JSON object, which no truncated append
+    can produce -- means the file lost or gained content, so it stays an error; it is just a
+    usage error now, the way `_load_gate` and `_load_eval_report` already treat the same class
+    of damage, rather than a traceback.
 
     Args:
         console: Where to print the note about a dropped final line.
@@ -1186,7 +1188,7 @@ def _read_metrics(console: Console, store: DistillRunStore) -> list[JsonObject]:
         Every complete row, in append order.
 
     Raises:
-        typer.BadParameter: If a row above the last one is not a JSON object.
+        typer.BadParameter: If the damage is anything but a half-written last line.
     """
     try:
         return store.read_metrics()

--- a/wmo/cli/model_app_test.py
+++ b/wmo/cli/model_app_test.py
@@ -1258,6 +1258,28 @@ def test_report_on_metrics_damaged_above_the_last_line_is_a_usage_error(tmp_path
     assert "Traceback" not in result.output
 
 
+def test_report_refuses_a_last_metrics_line_that_parses_into_a_non_object(tmp_path: Path) -> None:
+    """The tail excuse is for a line that fails to parse, which is all a torn append leaves.
+
+    A whole `[]`/`null` at the end was written intact, so skipping it would report the previous
+    step as the run's latest state while hiding that the file had been damaged.
+    """
+    run_dir = _finished_run(tmp_path)
+    store = DistillRunStore(run_dir)
+    store.append_metrics(0, _step_metrics())
+    with store.metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write("[]\n")
+
+    result = _report(run_dir)
+
+    assert result.exit_code == 2
+    flat = _flat(result)
+    assert "corrupt metrics row on line 2" in flat
+    assert "expected a JSON object" in flat
+    assert "ignoring a half-written last line" not in flat
+    assert "Traceback" not in result.output
+
+
 # -- `probe`: the teacher-search gate over a measured matrix ------------------------------------
 
 

--- a/wmo/cli/model_app_test.py
+++ b/wmo/cli/model_app_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -215,6 +216,11 @@ def _invoke(
 def _flat(result: Result) -> str:
     """Collapse rich wrapping (and typer's error-box borders) for substring asserts."""
     return " ".join(result.output.replace("│", " ").split())
+
+
+def _unwrapped(result: Result) -> str:
+    """Every space dropped, so an assert survives rich breaking a long command mid-token."""
+    return "".join(result.output.replace("│", " ").split())
 
 
 # -- routing and the happy path ---------------------------------------------------------------
@@ -512,6 +518,52 @@ def test_distill_names_the_failing_config_field(
 
     assert result.exit_code == 2
     assert "harbor" in _flat(result)  # the missing required section is named
+
+
+def test_distill_names_the_install_command_when_the_distill_extra_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every shipped reference config has [rollout.renderers], which only VALIDATES with the extra.
+
+    pydantic re-raises a non-ValueError out of a field validator untouched, so a plain
+    `pip install world-model-optimizer` used to meet a traceback here instead of the install
+    command that fixes it.
+    """
+    _write_inputs(tmp_path, extra_toml='[rollout.renderers]\n"test/student" = "qwen3"\n')
+    # A deterministic stand-in for a no-extras install, whether or not this venv has the extra.
+    monkeypatch.setitem(sys.modules, "wmo.distill.renderers", None)
+    _patch_run(monkeypatch, _RunRecorder())
+
+    result = _invoke(tmp_path, "--yes")
+
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    unwrapped = _unwrapped(result)
+    assert "uvsync--extradistill" in unwrapped
+    assert "pipinstall'world-model-optimizer[distill]'" in unwrapped
+
+
+def test_a_missing_tau2_binary_names_a_setup_a_pip_installed_user_can_follow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fix must not be a repo path: no wheel ships packages/environment-capture/."""
+    _write_inputs(tmp_path)
+    (tmp_path / "distill.toml").write_text(
+        '[student]\nbase_model = "test/student"\n'
+        '[teacher]\nmodel = "test/teacher"\n'
+        f'[tau2]\ntau2_bin = "{tmp_path / "nope" / "tau2"}"\ndata_dir = "{tmp_path}"\n'
+        "[train]\nsteps = 2\ntasks_per_batch = 1\ngroup_size = 1\n",
+        encoding="utf-8",
+    )
+    _patch_run(monkeypatch, _RunRecorder())
+
+    result = _invoke(tmp_path, "--yes")
+
+    assert result.exit_code == 2
+    flat = _flat(result)
+    assert "does not exist" in flat
+    assert "packages/environment-capture" not in flat
+    assert "github.com/sierra-research/tau2-bench" in _unwrapped(result)
 
 
 def test_distill_rejects_overlapping_splits(
@@ -1166,6 +1218,44 @@ def test_report_on_a_run_that_never_gated_says_how_to_finish_it(tmp_path: Path) 
     flat = _flat(result)
     assert "has not reached its gate yet" in flat
     assert "wmo optimize distill run --run-dir <dir> --resume" in flat
+
+
+def test_report_survives_the_half_written_last_metrics_line_of_an_aborted_run(
+    tmp_path: Path,
+) -> None:
+    """`report` advertises itself as safe on an aborted run dir, so it must read one.
+
+    A run that died mid-append leaves a torn final line. That used to end the command in a
+    traceback, after the gate verdict and the solve-rate table had already printed.
+    """
+    run_dir = _finished_run(tmp_path)
+    store = DistillRunStore(run_dir)
+    store.append_metrics(0, _step_metrics())
+    with store.metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"step": 1, "reverse_')
+
+    result = _report(run_dir)
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "ignoring a half-written last line" in flat
+    assert "reporting the 1 complete row(s)" in flat
+    assert "1 training step(s) recorded" in flat  # the complete row is still reported
+    assert "Traceback" not in result.output
+
+
+def test_report_on_metrics_damaged_above_the_last_line_is_a_usage_error(tmp_path: Path) -> None:
+    """Only the final line is excusable: a broken row above it means content was lost."""
+    run_dir = _finished_run(tmp_path)
+    store = DistillRunStore(run_dir)
+    store.metrics_path.write_text('{"step": 0}\n[1, 2, 3]\n{"step": 2}\n', encoding="utf-8")
+
+    result = _report(run_dir)
+
+    assert result.exit_code == 2
+    flat = _flat(result)
+    assert "corrupt metrics row on line 2" in flat
+    assert "Traceback" not in result.output
 
 
 # -- `probe`: the teacher-search gate over a measured matrix ------------------------------------

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -360,14 +360,19 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
     print_tiny_corpus_note(_console, plan)
-    if baseline is not None:
-        # Knowable from the pool the pre-flight already loaded, so it is a boundary error rather
-        # than a surprise after the sweep has been paid for and the fit written.
-        known = [entry.name for entry in preflight.pool.models]
-        if baseline not in known:
+    # Both flags name a pool candidate, and the pool is loaded by the pre-flight above, so a typo
+    # is knowable here for free: a boundary error rather than a surprise after the sweep has been
+    # paid for and the fit written. --fallback used to survive this far and then be printed in the
+    # plan table as if it were a real model, only failing inside the fit stage.
+    known = [entry.name for entry in preflight.pool.models]
+    for flag, value, why in (
+        ("--fallback", fallback, "the fit can only guard a candidate the sweep measures"),
+        ("--baseline", baseline, "the report can only anchor on a candidate the sweep measures"),
+    ):
+        if value is not None and value not in known:
             raise typer.BadParameter(
-                f"--baseline '{baseline}' is not a model in {pool_file}; the report can only "
-                f"anchor on a candidate the sweep measures. Available: {', '.join(known)}"
+                f"{flag} '{value}' is not a model in {pool_file}; {why}. "
+                f"Available: {', '.join(known)}"
             )
 
     # Printed before the plan table, the way `route fit` prints it before the fit: the embedder

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -808,6 +808,36 @@ def test_an_anchor_outside_the_pool_is_refused_before_anything_is_spent(
     assert not _paths(root)[0].exists()
 
 
+def test_a_fallback_outside_the_pool_is_refused_before_anything_is_spent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--fallback names a pool candidate too, so it is checked at --baseline's boundary.
+
+    A typo used to render in the plan table as if it were a real model, pass the spend
+    confirmation, and only fail inside the fit stage, after the sweep had been bought.
+    """
+    world_model = _patch_seams(monkeypatch, rewards={"cheap-1": 0.4, "pricey-1": 0.9})
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--yes", "--fallback", "ghost")
+    assert result.exit_code != 0
+    assert _says(result.output, "--fallback 'ghost' is not a model in")
+    assert _says(result.output, "Available: cheap, pricey")
+    assert world_model.tasks == []  # not one cell bought
+    assert not _paths(root)[0].exists()
+
+
+def test_a_fallback_typo_is_refused_by_a_dry_run_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The plan table is the thing a --dry-run reader trusts; it must not print a typo as real."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    result = _run(tmp_path, root, "--dry-run", "--fallback", "ghost")
+    assert result.exit_code != 0
+    assert _says(result.output, "--fallback 'ghost' is not a model in")
+    assert not _says(result.output, "knn (guarded, fallback ghost)")
+
+
 def test_a_missing_world_model_names_the_command_a_user_types(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmo/distill/config.py
+++ b/wmo/distill/config.py
@@ -1083,6 +1083,9 @@ def load_distill_config(path: Path) -> DistillConfig:
         FileNotFoundError: If the file does not exist.
         ValueError: If the file is not valid TOML or fails validation; the
             message names the file and each failing field.
+        ImportError: If a section can only be validated with the distill extra
+            installed (`[rollout.renderers]` resolves names through
+            tinker-cookbook) and the extra is missing.
     """
     try:
         text = path.read_text(encoding="utf-8")

--- a/wmo/distill/data.py
+++ b/wmo/distill/data.py
@@ -49,8 +49,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MISSING_TINKER_EXTRA = (
-    "the tinker SDK is not installed; run `uv sync --extra distill` to convert "
-    "training datums for a real Tinker training client"
+    "the tinker SDK is not installed; run `uv sync --extra distill` (or "
+    "`pip install 'world-model-optimizer[distill]'`) to convert training datums "
+    "for a real Tinker training client"
 )
 
 TopkCandidates = list[tuple[int, float]]

--- a/wmo/distill/rendering.py
+++ b/wmo/distill/rendering.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 MISSING_DISTILL_EXTRA = (
     "the tinker-cookbook SDK is not installed; run `uv sync --extra distill` "
-    "to use the Tinker distillation provider"
+    "(or `pip install 'world-model-optimizer[distill]'`) to use the Tinker "
+    "distillation provider"
 )
 
 

--- a/wmo/distill/store.py
+++ b/wmo/distill/store.py
@@ -320,7 +320,11 @@ class DistillRunStore:
                 and a read-only reader of an aborted run has to survive it. Off by default:
                 everything that writes or resumes a run wants the damage reported, and only
                 the last line is ever excusable (a broken row anywhere above it means the
-                file lost content, which no reader may quietly skip).
+                file lost content, which no reader may quietly skip). Narrow on purpose: it
+                excuses only a line that fails to PARSE. `append_metrics` writes one JSON
+                object per line, and no truncation of one parses (every strict prefix of
+                `{...}` is invalid JSON), so a last line that parses into a non-object is
+                something a torn append cannot produce -- real corruption, and still an error.
 
         Returns:
             One JSON object per non-empty line; an empty list when no metrics
@@ -350,8 +354,9 @@ class DistillRunStore:
                     "remove the broken line (each line must be one JSON object) and retry"
                 ) from exc
             if not isinstance(parsed, dict):
-                if tolerate_partial_tail and is_tail:
-                    continue
+                # Not excused even at the tail, and even under tolerate_partial_tail: a line
+                # that parses is a line that was written whole, so this is content damage, not
+                # the torn append that flag exists for.
                 raise ValueError(
                     f"corrupt metrics row on line {line_number} of {self.metrics_path}: "
                     "expected a JSON object; remove the broken line and retry"

--- a/wmo/distill/store.py
+++ b/wmo/distill/store.py
@@ -311,8 +311,16 @@ class DistillRunStore:
         with self.metrics_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(payload) + "\n")
 
-    def read_metrics(self) -> list[JsonObject]:
+    def read_metrics(self, *, tolerate_partial_tail: bool = False) -> list[JsonObject]:
         """Read every metrics row back, in append order.
+
+        Args:
+            tolerate_partial_tail: Drop a half-written FINAL line instead of raising. A run
+                that died mid-append (ENOSPC, a run dir copied while it was live) leaves one,
+                and a read-only reader of an aborted run has to survive it. Off by default:
+                everything that writes or resumes a run wants the damage reported, and only
+                the last line is ever excusable (a broken row anywhere above it means the
+                file lost content, which no reader may quietly skip).
 
         Returns:
             One JSON object per non-empty line; an empty list when no metrics
@@ -326,18 +334,24 @@ class DistillRunStore:
             text = self.metrics_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             return []
+        lines = text.splitlines()
         rows: list[JsonObject] = []
-        for line_number, line in enumerate(text.splitlines(), 1):
+        for line_number, line in enumerate(lines, 1):
             if not line.strip():
                 continue
+            is_tail = line_number == len(lines)
             try:
                 parsed = json.loads(line)
             except json.JSONDecodeError as exc:
+                if tolerate_partial_tail and is_tail:
+                    continue
                 raise ValueError(
                     f"corrupt metrics row on line {line_number} of {self.metrics_path}: {exc}; "
                     "remove the broken line (each line must be one JSON object) and retry"
                 ) from exc
             if not isinstance(parsed, dict):
+                if tolerate_partial_tail and is_tail:
+                    continue
                 raise ValueError(
                     f"corrupt metrics row on line {line_number} of {self.metrics_path}: "
                     "expected a JSON object; remove the broken line and retry"

--- a/wmo/distill/store_test.py
+++ b/wmo/distill/store_test.py
@@ -188,6 +188,30 @@ def test_corrupt_metrics_line_names_the_line(tmp_path: Path) -> None:
         store.read_metrics()
 
 
+def test_a_tolerant_read_drops_only_a_half_written_last_line(tmp_path: Path) -> None:
+    """What a run killed mid-append leaves: a torn tail a read-only reader must survive."""
+    store = DistillRunStore(tmp_path / "run")
+    store.append_metrics(0, _MetricsRow(solve_rate=0.1, reverse_kl_per_token=2.0, usd=1.0))
+    with store.metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write('{"step": 1, "solve_')
+
+    rows = store.read_metrics(tolerate_partial_tail=True)
+
+    assert [row["step"] for row in rows] == [0]
+    with pytest.raises(ValueError, match="line 2"):
+        store.read_metrics()  # strict is still the default, for everything that resumes a run
+
+
+def test_a_tolerant_read_still_refuses_damage_above_the_last_line(tmp_path: Path) -> None:
+    """A broken row with complete rows after it means content was lost, not a torn write."""
+    store = DistillRunStore(tmp_path / "run")
+    store.metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    store.metrics_path.write_text('{"step": 0}\n[1, 2, 3]\n{"step": 2}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="line 2"):
+        store.read_metrics(tolerate_partial_tail=True)
+
+
 def test_spend_ledger_round_trips_and_updates(tmp_path: Path) -> None:
     store = DistillRunStore(tmp_path / "run")
     assert store.read_spend() is None  # fresh dir: no ledger yet

--- a/wmo/distill/store_test.py
+++ b/wmo/distill/store_test.py
@@ -212,6 +212,22 @@ def test_a_tolerant_read_still_refuses_damage_above_the_last_line(tmp_path: Path
         store.read_metrics(tolerate_partial_tail=True)
 
 
+@pytest.mark.parametrize("tail", ["[]", "null", '"step 1"', "[1, 2, 3]"])
+def test_a_tolerant_read_still_refuses_a_last_line_that_parses(tmp_path: Path, tail: str) -> None:
+    """A whole non-object value is not a torn append: every prefix of `{...}` fails to PARSE.
+
+    So a final line json.loads accepts was written whole, and dropping it would hide real
+    corruption while reporting an older step as the run's latest state.
+    """
+    store = DistillRunStore(tmp_path / "run")
+    store.append_metrics(0, _MetricsRow(solve_rate=0.1, reverse_kl_per_token=2.0, usd=1.0))
+    with store.metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{tail}\n")
+
+    with pytest.raises(ValueError, match="line 2.*expected a JSON object"):
+        store.read_metrics(tolerate_partial_tail=True)
+
+
 def test_spend_ledger_round_trips_and_updates(tmp_path: Path) -> None:
     store = DistillRunStore(tmp_path / "run")
     assert store.read_spend() is None  # fresh dir: no ledger yet

--- a/wmo/distill/tracking.py
+++ b/wmo/distill/tracking.py
@@ -43,8 +43,9 @@ WANDB_RUN_FILE = "wandb-run.json"
 """Run-dir file persisting the wandb run id so a restart resumes the same run."""
 
 _MISSING_WANDB_EXTRA = (
-    "the wandb SDK is not installed; run `uv sync --extra distill` to enable "
-    "[wandb] run tracking, or set wandb.enabled = false in the distill config"
+    "the wandb SDK is not installed; run `uv sync --extra distill` (or "
+    "`pip install 'world-model-optimizer[distill]'`) to enable [wandb] run tracking, "
+    "or set wandb.enabled = false in the distill config"
 )
 
 

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -37,6 +37,7 @@ from typing import Literal
 import tomli_w
 from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic_core import ErrorDetails
 
 from wmo.core.types import JsonObject
 from wmo.providers.base import (
@@ -240,17 +241,39 @@ class ModelPool(BaseModel):
 def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
     """Load and validate the pool file at `path`.
 
-    A file that exists but declares no candidate is answered like a missing one: with the path and
-    the commands that write an entry. Falling through to pydantic instead named neither, and the
-    caller only ever sees `str(exc)`.
+    Every failure names the file and the command that writes it. Callers turn what this raises
+    straight into the user's error (`wmo optimize model`, `wmo optimize route sweep`), so a bare
+    `tomllib`/pydantic message would reach an operator as a schema dump with a pydantic.dev URL,
+    no path, and nothing to type next. The roster is an operator-edited file, and the whole
+    point of the message is to say which file and how to repair it. A file that exists but
+    declares no candidate is answered like a missing one: with the path and the commands that
+    write an entry.
+
+    Args:
+        path: The pool TOML to read.
+
+    Returns:
+        The validated roster.
+
+    Raises:
+        FileNotFoundError: No file at `path`.
+        ValueError: The file is not valid TOML, declares no `[[model]]` table, or has an entry
+            that fails validation; the message names the path and each failing field.
     """
     if not path.is_file():
         raise FileNotFoundError(
-            f"no model pool file at {path}; create it with one [[model]] table per candidate "
-            "(fields: name, kind, model, and for non-built-in models input_per_mtok/"
-            "output_per_mtok; endpoint/deployment/api_version/api_key_env as the backend needs)"
+            f"no model pool file at {path}; register candidates with `wmo providers set` (or "
+            "write the file by hand: one [[model]] table per candidate, fields: name, kind, "
+            "model, and for non-built-in models input_per_mtok/output_per_mtok; "
+            "endpoint/deployment/api_version/api_key_env as the backend needs)"
         )
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(
+            f"pool file {path} is not valid TOML ({exc}); fix the file, or move it aside and "
+            "re-register the candidates with `wmo providers set`"
+        ) from exc
     entries = data.get("model", [])
     if not isinstance(entries, list):
         # `[model]` declares ONE table; the roster is an array of tables, which needs the doubled
@@ -267,7 +290,29 @@ def load_pool(path: Path = DEFAULT_POOL_PATH) -> ModelPool:
             "`wmo optimize route student <run-dir> --input-per-mtok <p> --output-per-mtok <p>`, "
             "or write one [[model]] table per candidate by hand"
         )
-    return ModelPool.model_validate({"models": entries})
+    try:
+        return ModelPool.model_validate({"models": entries})
+    except ValidationError as exc:
+        # `loc` is ("models", <table index>, <field>); the leading "models" is this function's
+        # own wrapper key and means nothing to someone reading their TOML, so drop it and name
+        # the [[model]] table by the position they can count to in the file.
+        details = "; ".join(_entry_error(err) for err in exc.errors())
+        raise ValueError(
+            f"pool file {path} is not a valid model pool ({details}); fix the entry, or "
+            "re-register the candidate with `wmo providers set`"
+        ) from exc
+
+
+def _entry_error(error: ErrorDetails) -> str:
+    """One pydantic pool error as `[[model]] N field: message`, for a TOML-file reader."""
+    # A whole-pool failure (the duplicate-name rule) carries no entry position at all.
+    location = list(error["loc"][1:])
+    index = location[0] if location else None
+    if not isinstance(index, int):
+        return error["msg"]
+    field = ".".join(str(part) for part in location[1:])
+    table = f"[[model]] {index + 1}"
+    return f"{table} {field}: {error['msg']}" if field else f"{table}: {error['msg']}"
 
 
 def pool_api_key(entry: PoolEntry) -> str | None:

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -84,8 +84,9 @@ def test_load_pool_parses_entries(tmp_path: Path) -> None:
 
 def test_load_pool_missing_file_says_what_to_create(tmp_path: Path) -> None:
     missing = tmp_path / "nope.toml"
-    with pytest.raises(FileNotFoundError, match=r"\[\[model\]\]"):
+    with pytest.raises(FileNotFoundError, match=r"\[\[model\]\]") as excinfo:
         load_pool(missing)
+    assert "wmo providers set" in str(excinfo.value), "the command that writes the file"
     assert DEFAULT_POOL_PATH == Path(".wmo/pool.toml")
 
 
@@ -116,6 +117,25 @@ def test_single_bracket_model_table_says_to_double_the_brackets(tmp_path: Path) 
     # answered it with `Input should be a valid list`.
     with pytest.raises(ValueError, match=r"\[\[model\]\]"):
         load_pool(_write_pool(tmp_path, '[model]\nname = "fable"\n'))
+
+
+def test_a_pool_that_is_not_valid_toml_names_the_file(tmp_path: Path) -> None:
+    path = _write_pool(tmp_path, "model = \n")
+    with pytest.raises(ValueError) as excinfo:
+        load_pool(path)
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "not valid TOML" in message
+
+
+def test_an_invalid_entry_names_the_file_the_table_and_the_field(tmp_path: Path) -> None:
+    path = _write_pool(tmp_path, _POOL_TOML + '\n[[model]]\nname = "half"\nkind = "openai"\n')
+    with pytest.raises(ValueError) as excinfo:
+        load_pool(path)
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "[[model]] 4 model" in message, "the table's position in the file, and the field"
+    assert "errors.pydantic.dev" not in message
 
 
 def test_unknown_model_requires_explicit_price() -> None:
@@ -853,7 +873,10 @@ def test_openrouter_entry_needs_only_a_model_id(
 def test_openrouter_entry_offline_falls_back_to_the_explicit_price_error(tmp_path: Path) -> None:
     # No cache and no network (the conftest fetch stub refuses): the entry must fail with the
     # ordinary "declare the prices" instruction, and say WHY the automatic route did not apply.
-    with pytest.raises(ValidationError) as excinfo:
+    # `load_pool` re-raises pydantic's ValidationError as a plain ValueError (still what every
+    # caller catches) so the message can carry the file path and a next command instead of a
+    # schema dump; the entry's own instruction has to survive that rewrap intact.
+    with pytest.raises(ValueError) as excinfo:
         load_pool(_write_pool(tmp_path, _OPENROUTER_POOL))
     message = str(excinfo.value)
     assert "OpenRouter price catalog" in message

--- a/wmo/providers/tinker.py
+++ b/wmo/providers/tinker.py
@@ -81,7 +81,8 @@ logger = logging.getLogger(__name__)
 TINKER_API_KEY_ENV = "TINKER_API_KEY"
 
 _MISSING_TINKER_EXTRA = (
-    "the tinker SDK is not installed; run `uv sync --extra distill` to use the tinker provider"
+    "the tinker SDK is not installed; run `uv sync --extra distill` (or "
+    "`pip install 'world-model-optimizer[distill]'`) to use the tinker provider"
 )
 
 # The tinker SamplingParams default; used when a structured request carries no


### PR DESCRIPTION
## What was broken

Seven user-visible failures on `wmo optimize model` / `wmo optimize distill` / `wmo optimize
harness`, all the same root cause: a failure that is knowable at the command's input boundary
either escapes it unconverted (a Python traceback, a raw pydantic dump) or is never checked
there at all.

The worst one is the first thing a pip-installed user hits, because all three shipped reference
configs carry a `[rollout.renderers]` table:

```bash
pip install world-model-optimizer            # no extras
cp "$(python -c 'import wmo,os;print(os.path.dirname(wmo.__file__))')/distill/configs/distill-smoke-dev.toml" cfg.toml
printf '["t1"]' > tr.json ; printf '["t2"]' > ho.json
wmo optimize distill run --config cfg.toml --run-dir ./r1 --task-ids tr.json --holdout-task-ids ho.json
```

Before: a two-panel rich traceback dumping `wmo/distill/config.py`, `wmo/cli/model_app.py` and
`pydantic/main.py`, ending in `ImportError: the tinker-cookbook SDK is not installed`.
`_load_config` caught only `FileNotFoundError`/`ValueError`, and pydantic re-raises a
non-`ValueError` out of a field validator untouched.

After:

```
Invalid value: cannot load cfg.toml: the tinker-cookbook SDK is not installed; run
`uv sync --extra distill` (or `pip install 'world-model-optimizer[distill]'`) to use the
Tinker distillation provider
```

## What changed

- **`distill run` missing extra** (`wmo/cli/model_app.py`): `_load_config` converts `ImportError`
  to `typer.BadParameter`, naming the file. All four distill-extra hints (`rendering.py`,
  `data.py`, `tracking.py`, `providers/tinker.py`) gained the pip spelling beside the uv one, the
  way the harbor hints already do, since `uv sync` is not a command a pip user has.
- **`distill report` on a torn `metrics.jsonl`** (`wmo/distill/store.py`, `wmo/cli/model_app.py`):
  `read_metrics` gains `tolerate_partial_tail` (off by default, so everything that resumes a run
  still sees the damage). `report`, which advertises itself as safe on an aborted run dir, drops a
  half-written FINAL line with a note and reports the complete rows. The excuse is scoped to a
  line that fails to PARSE, which is all a torn append can leave: `append_metrics` writes one
  JSON object per line and every strict prefix of `{...}` is invalid JSON, so a last line
  `json.loads` accepts was written whole. Anything else -- a broken row above the last one, or a
  final line that parses into a non-object -- means the file lost or gained content, so it stays
  an error, now a clean usage error matching `_load_gate` / `_load_eval_report` rather than a
  traceback.
- **Pool-file failures** (`wmo/providers/pool.py`): `load_pool` wraps `TOMLDecodeError` and
  `ValidationError`. Missing, empty, malformed, and invalid-entry rosters all name the file and
  `wmo providers set`; an invalid entry is reported as `[[model]] N field: message` instead of a
  pydantic dump with an `errors.pydantic.dev` URL. This also improves `optimize route sweep`,
  `route pin` and `providers set`, which share the loader.
- **`optimize model --fallback`** (`wmo/cli/optimize_model_app.py`): validated against the
  preflighted pool at exactly `--baseline`'s boundary, so a typo can no longer render in the plan
  table as a real model, pass the spend confirmation, and fail inside `_stage_fit` after the sweep
  has been paid for.
- **tau2 preflight** (`wmo/cli/model_app.py`): the message carries the clone-and-venv commands
  instead of pointing at `packages/environment-capture/tau-bench/README.md`, which exists only in
  a source checkout (the wheel ships `wmo` and `llm_waterfall` only).
- **`optimize harness --help`** (`wmo/cli/harness_app.py`): `--backend` no longer asserts "The
  environment is always the world model", which the same command's own docstring contradicts for
  `harbor` (there `--backend` selects the task environment, docker vs E2B). `--iterations` states
  both defaults, and the world-model literal `5` is now a named constant beside
  `_DEFAULT_HARBOR_ITERATIONS` so the help and the code cannot drift.

## Audit findings closed

- `optimize distill run`: unhandled `ImportError` traceback when a config has `[rollout.renderers]`
  and the distill extra is missing (every shipped reference config)
- `optimize distill run`: `uv sync --extra distill` is the only install spelling offered, on a
  documented `pip install` path
- `optimize distill report`: traceback on a torn/partial last line of `metrics.jsonl`
- `optimize model`: pool-file failures return a raw pydantic dump with no path and no next command
- `optimize model`: `--fallback` is not validated against the pool the way `--baseline` is
- `optimize distill run`: tau2 preflight points at a source-checkout-only README
- `optimize harness --help`: `--backend` help is false for the harbor environment
- `optimize harness --help`: `--iterations` documents no default and silently differs by environment

## Tests

Every behaviour change has coverage, and each new CLI test was confirmed to fail without its fix.
`uv run pytest` (4162 passed), `uv run ruff check .`, `uv run ruff format --check`, `uv run ty
check` all green. Each repro was also driven through the real console entry point before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

