### PR TITLE
Resolve the model, its corpus and its credentials once for demo/play/knowledge

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -144,8 +144,12 @@ Look at the thing before optimizing it:
 
 ```bash
 uv run wmo play --name tau-bench      # step in yourself
-uv run wmo demo --name tau-bench      # replay a recorded scenario, open loop
+uv run wmo demo --name tau-bench \
+  --traces packages/environment-capture/tau-bench/traces.otel.jsonl   # replay one, open loop
 ```
+
+`wmo demo` needs the corpus because a build keeps no copy of the traces it read, only the prompts,
+the metrics and the retrieval index. Pass the same file step 1's `wmo build --file` was given.
 
 ## Step 2: register the routing candidates
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,9 +39,9 @@ functions they do, so you can drop to any stage and the next run resumes around 
 | Command | Purpose | Artifact |
 |---|---|---|
 | `wmo play` | Step into the environment yourself: type actions, get observations back. | nothing (a session) |
-| `wmo demo` | Replay a randomly sampled recorded scenario against the world model, open loop. | nothing (prints) |
+| `wmo demo` | Replay a randomly sampled recorded scenario against the world model, open loop. Needs the corpus (`--traces`) unless the model ships one, since a build keeps no copy of what it read. | nothing (prints) |
 | `wmo eval` | Score reconstruction fidelity (open-loop, teacher-forced) or run a live agent against the model (`--mode closed-loop`), or run a named example-local suite. | results under `.wmo/evals/` |
-| `wmo knowledge` | Print the model's knowledge base directory: editable markdown that is the env's canonical facts. | nothing (the directory it names is the editing interface) |
+| `wmo knowledge` | Print the model's knowledge base directory: editable markdown that is the env's canonical facts. Says so when the model was built without `--knowledge`, which makes those files inert. | nothing (the directory it names is the editing interface) |
 | `wmo list` | List every world model built under the project dir. | nothing (prints) |
 
 ## Traces and data

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -20,7 +20,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import NoReturn, cast
 from uuid import uuid4
 
 import typer
@@ -2493,23 +2493,20 @@ def demo(
                     _NARRATOR.detach()
             break
         except Exception as exc:  # noqa: BLE001 - classified below
-            if not is_capacity_error(exc) or not _console.is_terminal:
+            out_of_capacity = is_capacity_error(exc)
+            if not out_of_capacity or not _console.is_terminal:
                 # A backend that refused the request (missing/expired credentials, a model id it
                 # does not serve) is a user-fixable setup error, not a wmo bug: render it with the
                 # same hint `wmo providers verify` prints. Anything else keeps its traceback.
                 if not _is_provider_sdk_error(exc):
                     raise
-                serve_config = config.serve_provider_config()
-                _console.print(
-                    f"\n[red]✗ the serve provider for {resolved_name!r} "
-                    f"({serve_config.kind.value}, {serve_config.model}) failed[/red]: "
-                    f"{escape(_short_error(exc))}"
+                _exit_serve_provider_failure(
+                    resolved_name,
+                    config.serve_provider_config(),
+                    exc,
+                    out_of_capacity=out_of_capacity,
+                    retry=f"`wmo demo --name {resolved_name}`",
                 )
-                _console.print(
-                    f"  [yellow]{escape(_credential_hint(serve_config.kind, str(exc)))}[/yellow]"
-                )
-                _console.print("  [yellow]then re-check with `wmo providers verify`[/yellow]")
-                raise typer.Exit(1) from exc
             # Retries are exhausted and the backend is still down: offer to re-point the model
             # at a different provider (same picker as the build wizard) and RESUME from the
             # failed step — completed steps stay done.
@@ -3159,6 +3156,42 @@ def _prepare_serve_provider_or_exit(provider: Provider, config: ProviderConfig) 
         _console.print(f"  [yellow]{escape(_credential_hint(config.kind, str(exc)))}[/yellow]")
         _console.print("  [yellow]then re-check with `wmo providers verify`[/yellow]")
         raise typer.Exit(1) from exc
+
+
+def _exit_serve_provider_failure(
+    resolved_name: str,
+    config: ProviderConfig,
+    exc: Exception,
+    *,
+    out_of_capacity: bool,
+    retry: str,
+) -> NoReturn:
+    """Render a serve-provider failure as the setup error or the outage it actually is, then exit.
+
+    The two need opposite next steps, and printing the wrong one costs the user the debugging
+    session: a 429/503/timeout has already survived `RetryingProvider`'s backoff, so the
+    credentials it took to get that far are demonstrably fine and `wmo providers verify` will
+    just report the same outage. Only a refusal (bad key, unserved model id) earns the
+    credential hint.
+    """
+    verb = "is out of capacity" if out_of_capacity else "failed"
+    _console.print(
+        f"\n[red]✗ the serve provider for {resolved_name!r} "
+        f"({config.kind.value}, {config.model}) {verb}[/red]: {escape(_short_error(exc))}"
+    )
+    if out_of_capacity:
+        _console.print(
+            "  [yellow]retries are exhausted and the backend is still refusing; this is an "
+            "outage or a rate limit, not a credentials problem[/yellow]"
+        )
+        _console.print(
+            f"  [yellow]re-run {retry} once it recovers, or run it on a terminal to switch "
+            "provider and resume from the failed step[/yellow]"
+        )
+    else:
+        _console.print(f"  [yellow]{escape(_credential_hint(config.kind, str(exc)))}[/yellow]")
+        _console.print("  [yellow]then re-check with `wmo providers verify`[/yellow]")
+    raise typer.Exit(1) from exc
 
 
 # Top-level modules whose exceptions mean "the backend refused", not "wmo has a bug": the provider

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -105,7 +105,7 @@ from wmo.evals.open_loop import EvalReport, OpenLoopEval
 from wmo.ingest import VendorPull, get_adapter, list_adapters
 from wmo.optimize.judge import JUDGE_VERSION, RubricJudge
 from wmo.providers import ProviderConfig, ProviderKind, VerifyResult, verify_all, verify_embedder
-from wmo.providers.base import Embedder, EmbedderKind, Provider
+from wmo.providers.base import Embedder, EmbedderKind, PreparableProvider, Provider
 from wmo.providers.models import (
     ProviderModel,
     model_types_for_provider,
@@ -127,6 +127,7 @@ from wmo.scenarios import (
     verify_scenarios,
 )
 from wmo.serving.server import create_app
+from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
 from wmo.telemetry import (
     BuildTelemetryStats,
     TelemetryBuildReporter,
@@ -1958,24 +1959,41 @@ def _eval_report_payload(report: EvalReport) -> JsonObject:
 @app.command("knowledge")
 def knowledge_(
     name: str = typer.Option(None, "--name", help="World model (default: the only one)."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Project dir."),
+    root: str = typer.Option(
+        ARTIFACT_DIR,
+        help="Project dir. Shipped example models are found too while this is the default "
+        "project dir; point it elsewhere to search that root alone.",
+    ),
 ) -> None:
     """Show a model's knowledge base: the env's canonical facts, a folder of editable markdown.
 
-    The printed directory IS the editing interface — open it in any editor. `rules.md`/
+    The printed directory IS the editing interface, open it in any editor. `rules.md`/
     `entities.md`/`schemas.md` are seeded at build (with knowledge enabled); `learned.md` collects
-    the env's own cross-session notes; `grounded.md` caches web-search groundings.
+    the env's own cross-session notes; `grounded.md` caches web-search groundings. Models are
+    resolved exactly as `wmo demo`/`wmo play` resolve them, so a shipped example needs no `--root`.
     """
-    store = WorldModelStore(root)
-    resolved = _resolve_name(store, name)
-    kb = KnowledgeBase(ArtifactPaths(store.resolve(resolved)).knowledge)
+    store_root, resolved = _resolve_model_any(name, root)
+    model_dir = WorldModelStore(str(store_root)).resolve(resolved)
+    kb = KnowledgeBase(ArtifactPaths(model_dir).knowledge)
     _console.print(f"[bold]{escape(str(kb.directory))}[/bold]")
+    build_with_knowledge = f"`wmo build --name {resolved} --file <traces> --knowledge`"
     if kb.is_empty:
+        state = "is empty" if kb.directory.is_dir() else "does not exist yet"
         _console.print(
-            "(empty — enable knowledge at build, drop *.md files in this folder, "
-            "or PUT files via the serving API)"
+            f"(that directory {state}) seed one with {build_with_knowledge}, which extracts "
+            "rules.md / entities.md / schemas.md from the train traces"
         )
         return
+    if not load_config(model_dir).knowledge:
+        # The files are on disk but `WorldModel.load` gates the KB on config.knowledge, so at the
+        # default fidelity nothing here reaches the env prompt. Say so instead of printing them
+        # back as if they were live.
+        _console.print(
+            f"[yellow]inert[/yellow]: {resolved!r} was built without a knowledge base, so "
+            "`wmo demo` / `wmo play` / `wmo serve` never render these files into the env "
+            f"prompt. Activate them by rebuilding with {build_with_knowledge}, or by setting "
+            f"`knowledge = true` in {escape(str(ArtifactPaths(model_dir).config))}."
+        )
     # Knowledge is hand-edited markdown: `[/items]`, `list[str]` and `[text](url)` are ordinary
     # content, so it is escaped rather than parsed as rich markup (which would crash on the
     # first, and silently delete the other two).
@@ -2380,10 +2398,18 @@ def _resolve_scenario_embedder(
 @app.command("demo")
 def demo(
     name: str = typer.Option(None, "--name", help="World model to demo (default: pick one)."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (example models are found too)."),
-    steps: int = typer.Option(5, help="Max scenario steps to replay."),
+    root: str = typer.Option(
+        ARTIFACT_DIR,
+        help="Project dir. Shipped example models are found too while this is the default "
+        "project dir; point it elsewhere to search that root alone.",
+    ),
+    steps: int = typer.Option(5, min=1, help="Max scenario steps to replay."),
     traces: str = typer.Option(
-        None, "--traces", help="Trace file to sample the scenario from (default: the model's)."
+        None,
+        "--traces",
+        help="Trace file to sample the scenario from. Default: the model's own "
+        "traces.otel.jsonl, which only a Hub-downloaded model or a shipped example has, since a "
+        "build keeps no copy of the corpus it read.",
     ),
     seed: int = typer.Option(None, help="Seed for the scenario sample (default: random)."),
     show_prompt: bool = typer.Option(
@@ -2399,12 +2425,8 @@ def demo(
     wm, resolved_name, _provider, model_root = _load_model_any(
         name, root, max_fidelity=max_fidelity
     )
-    traces_file = Path(traces) if traces else _traces_for_root(model_root)
-    if traces_file is None or not traces_file.exists():
-        raise typer.BadParameter(
-            f"no trace file found for {resolved_name!r} under {model_root}; pass --traces"
-        )
     model_dir = WorldModelStore(str(model_root)).resolve(resolved_name)
+    traces_file = _demo_traces(model_dir, resolved_name, traces)
     config = load_config(model_dir)  # the model dir holds its own HarnessConfig
     candidates = [t for t in ingest(config, file=str(traces_file)) if t.steps]
     if not candidates:
@@ -2472,7 +2494,22 @@ def demo(
             break
         except Exception as exc:  # noqa: BLE001 - classified below
             if not is_capacity_error(exc) or not _console.is_terminal:
-                raise
+                # A backend that refused the request (missing/expired credentials, a model id it
+                # does not serve) is a user-fixable setup error, not a wmo bug: render it with the
+                # same hint `wmo providers verify` prints. Anything else keeps its traceback.
+                if not _is_provider_sdk_error(exc):
+                    raise
+                serve_config = config.serve_provider_config()
+                _console.print(
+                    f"\n[red]✗ the serve provider for {resolved_name!r} "
+                    f"({serve_config.kind.value}, {serve_config.model}) failed[/red]: "
+                    f"{escape(_short_error(exc))}"
+                )
+                _console.print(
+                    f"  [yellow]{escape(_credential_hint(serve_config.kind, str(exc)))}[/yellow]"
+                )
+                _console.print("  [yellow]then re-check with `wmo providers verify`[/yellow]")
+                raise typer.Exit(1) from exc
             # Retries are exhausted and the backend is still down: offer to re-point the model
             # at a different provider (same picker as the build wizard) and RESUME from the
             # failed step — completed steps stay done.
@@ -2514,7 +2551,11 @@ def _first_prompt(wm: WorldModel, trace) -> str:  # noqa: ANN001 - core Trace
 def play(
     name: str = typer.Option(None, "--name", help="World model to play (default: pick one)."),
     task: str = typer.Option(None, "--task", help="Task to seed the session with."),
-    root: str = typer.Option(ARTIFACT_DIR, help="Project dir (example models are found too)."),
+    root: str = typer.Option(
+        ARTIFACT_DIR,
+        help="Project dir. Shipped example models are found too while this is the default "
+        "project dir; point it elsewhere to search that root alone.",
+    ),
     max_fidelity: bool = typer.Option(
         False, "--max-fidelity", help="Run with the online extras on (default: pure RAG)."
     ),
@@ -2527,10 +2568,28 @@ def play(
     run_play_repl(_console, wm, resolved_name, task, suggestions=suggestions)
 
 
-def _traces_for_root(model_root: Path) -> Path | None:
-    """The trace corpus that built the models under `model_root`, when it ships alongside."""
-    candidate = model_root / "traces.otel.jsonl"
-    return candidate if candidate.exists() else None
+def _demo_traces(model_dir: Path, resolved_name: str, explicit: str | None) -> Path:
+    """The corpus `wmo demo` samples its scenario from: explicit `--traces`, else the model's own.
+
+    Default resolution is `local_traces_path`, the same one `wmo serve` and `wmo optimize route
+    sweep` use: a Hub-downloaded copy inside the artifact, else the sibling corpus of the shipped
+    example layout. A build keeps NO copy of the corpus it read, so a plain `wmo build` leaves
+    neither, and the failure has to name the file to pass rather than the directory it searched.
+    """
+    if explicit is not None:
+        path = Path(explicit)
+        if not path.is_file():
+            raise typer.BadParameter(f"no trace file at {path} (--traces)")
+        return path
+    found = local_traces_path(model_dir)
+    if found is not None:
+        return found
+    raise typer.BadParameter(
+        f"no trace corpus for world model {resolved_name!r}: looked for "
+        f"{model_dir / TRACES_FILENAME} and {model_dir.parent.parent / TRACES_FILENAME}. "
+        "A build keeps no copy of the corpus it read, so pass the file `wmo build --file` was "
+        f"given: `wmo demo --name {resolved_name} --traces <that file>`"
+    )
 
 
 def _action_suggestions(wm: WorldModel, n: int = 3) -> list[str]:
@@ -2553,49 +2612,90 @@ def _action_suggestions(wm: WorldModel, n: int = 3) -> list[str]:
 
 
 def _load_model_any(name: str | None, root: str, *, max_fidelity: bool = False):  # noqa: ANN202
-    """Resolve a model across the project dir AND shipped examples, then load it.
+    """Resolve a model across the project dir AND shipped examples, then load it."""
+    store_root, resolved = _resolve_model_any(name, root)
+    wm, resolved, provider = _load_model(resolved, str(store_root), max_fidelity=max_fidelity)
+    return wm, resolved, provider, store_root
 
-    An explicit non-default `--root` keeps the old single-root behavior. Otherwise the picker
-    spans `<root>/models/*` plus `examples/*/models/*`, labeling each with its source.
+
+def _model_candidates(root: str) -> list[tuple[str, Path, str]]:
+    """Every reachable artifact as `(label, store_root, name)`, local builds first.
+
+    The label disambiguates same-named artifacts (`tau-bench (local)` vs `tau-bench (tau-bench
+    example)`), so every message that enumerates choices must print labels, not bare names.
     """
-    if root != ARTIFACT_DIR:
-        wm, resolved, provider = _load_model(name, root, max_fidelity=max_fidelity)
-        return wm, resolved, provider, Path(root)
-
-    candidates: list[tuple[str, Path, str]] = []  # (label, store_root, name)
-    local = WorldModelStore(root)
-    candidates.extend((f"{n} (local)", Path(root), n) for n in local.list_names())
+    candidates: list[tuple[str, Path, str]] = []
+    candidates.extend((f"{n} (local)", Path(root), n) for n in WorldModelStore(root).list_names())
     for example_dir in _discover_examples():
         example_store = WorldModelStore(example_dir)
         candidates.extend(
             (f"{n} ({example_dir.name} example)", example_dir, n)
             for n in example_store.list_names()
         )
+    return candidates
 
+
+def _is_default_project_dir(root: str) -> bool:
+    """Whether `--root` still points at the default project dir, however it was spelled.
+
+    Comparing the raw string against `.wmo` made `--root ./.wmo` and `--root .wmo/` (what shell
+    tab-completion types) silently mean something different from `--root .wmo`, so resolve both.
+    """
+    return Path(root).resolve() == Path(ARTIFACT_DIR).resolve()
+
+
+def _resolve_model_any(name: str | None, root: str) -> tuple[Path, str]:
+    """Which artifact a read command should open, as `(store_root, resolved_name)`.
+
+    A `--root` pointing somewhere other than the default project dir keeps single-root behavior.
+    Otherwise the search spans `<root>/models/*` plus the shipped `examples/*/models/*` and
+    `packages/environment-capture/*/models/*`, so `demo`, `play` and `knowledge` all agree on
+    which models exist.
+    """
+    if not _is_default_project_dir(root):
+        return Path(root), _resolve_name(WorldModelStore(root), name)
+
+    candidates = _model_candidates(root)
     if name is not None:
         matched = [c for c in candidates if c[2] == name]
         if not matched:
-            have = ", ".join(c[2] for c in candidates) or "none built"
+            have = ", ".join(c[0] for c in candidates) or "none built"
             raise typer.BadParameter(f"no world model named {name!r} (have: {have})")
         # Prefer the local build over a same-named example artifact.
-        label, store_root, resolved = matched[0]
+        _label, store_root, resolved = matched[0]
     elif not candidates:
         raise typer.BadParameter(
-            "no world models found; run `wmo build` or try an example "
-            "(packages/environment-capture/tau-bench)"
+            "no world models found; build one with `wmo build --file <traces> --name <name>`, "
+            "or fetch a published benchmark corpus first with `wmo download tau-bench`"
         )
     elif len(candidates) == 1:
-        label, store_root, resolved = candidates[0]
+        _label, store_root, resolved = candidates[0]
     elif _console.is_terminal:
         labels = [c[0] for c in candidates]
         chosen = _select_from(labels)
-        label, store_root, resolved = candidates[labels.index(chosen)]
+        _label, store_root, resolved = candidates[labels.index(chosen)]
     else:
-        have = ", ".join(c[2] for c in candidates)
-        raise typer.BadParameter(f"multiple world models ({have}); pass --name")
+        have = ", ".join(c[0] for c in candidates)
+        raise typer.BadParameter(
+            f"multiple world models ({have}); pass --name{_shadow_hint(candidates)}"
+        )
+    return store_root, resolved
 
-    wm, resolved, provider = _load_model(resolved, str(store_root), max_fidelity=max_fidelity)
-    return wm, resolved, provider, store_root
+
+def _shadow_hint(candidates: list[tuple[str, Path, str]]) -> str:
+    """Name the flag that reaches a shipped example a same-named local build shadows.
+
+    `--name` cannot separate the two (the local build always wins), so a listing that shows the
+    name twice has to say which flag can: `--root <the example dir>`.
+    """
+    names = [c[2] for c in candidates]
+    shadowed = [c for c in candidates if names.count(c[2]) > 1 and not c[0].endswith("(local)")]
+    if not shadowed:
+        return ""
+    label, store_root, shadowed_name = shadowed[0]
+    return (
+        f" (--name {shadowed_name} takes the local build; for '{label}' pass --root {store_root})"
+    )
 
 
 def _select_from(labels: list[str]) -> str:
@@ -3024,8 +3124,11 @@ def _load_model(name: str | None, root: str, *, max_fidelity: bool = False):  # 
     resolved_name = _resolve_name(store, name)
     model_dir = store.resolve(resolved_name)
     config = load_config(model_dir)
+    serve_config = config.serve_provider_config()
+    backend = providers.get_provider(serve_config)
+    _prepare_serve_provider_or_exit(backend, serve_config)
     provider = wrap_provider_with_retries(
-        providers.get_provider(config.serve_provider_config()),
+        backend,
         on_retry=_NARRATOR.on_retry,
         sleep=_NARRATOR.sleep,
     )
@@ -3033,6 +3136,50 @@ def _load_model(name: str | None, root: str, *, max_fidelity: bool = False):  # 
         str(model_dir), provider, telemetry_root=store.root, max_fidelity=max_fidelity
     )
     return world_model, resolved_name, provider
+
+
+def _prepare_serve_provider_or_exit(provider: Provider, config: ProviderConfig) -> None:
+    """Resolve the serve backend's local prerequisites before the first step, or exit cleanly.
+
+    Every backend builds its SDK client lazily, so a missing SDK or an unset credential otherwise
+    surfaces as the SDK's own exception mid-rollout, which Typer renders as a traceback.
+    `PreparableProvider.prepare` is the free, offline seam `wmo optimize route sweep` already
+    pre-flights with (no backend's `prepare` touches the network), so the interactive commands
+    fail here with the same hint `wmo providers verify` prints. Bedrock and tinker document a
+    residual gap they cannot close locally; those still fail on the first call.
+    """
+    if not isinstance(provider, PreparableProvider):
+        return
+    try:
+        provider.prepare()
+    except Exception as exc:  # noqa: BLE001 - every backend raises its own SDK's type here
+        _console.print(
+            f"[red]✗ {config.kind.value} ({config.model}) unusable[/red]: {escape(str(exc))}"
+        )
+        _console.print(f"  [yellow]{escape(_credential_hint(config.kind, str(exc)))}[/yellow]")
+        _console.print("  [yellow]then re-check with `wmo providers verify`[/yellow]")
+        raise typer.Exit(1) from exc
+
+
+# Top-level modules whose exceptions mean "the backend refused", not "wmo has a bug": the provider
+# SDKs plus the HTTP transports they raise through. llm-waterfall gates its capacity/client
+# classification on the same set; this one answers a different question (is a credential hint the
+# right thing to print?), so it stays a local literal rather than importing a private name.
+_PROVIDER_SDK_MODULES = frozenset(
+    {"anthropic", "boto3", "botocore", "httpcore", "httpx", "openai", "tinker"}
+)
+
+
+def _is_provider_sdk_error(exc: Exception) -> bool:
+    """Whether `exc` was DEFINED by a provider SDK (bad creds, bad model id, refused request).
+
+    Deliberately narrow: wmo's own bugs must keep their traceback, so only exceptions whose class
+    (or a base of it) comes from a backend SDK are re-rendered as a setup error.
+    """
+    return any(
+        (getattr(klass, "__module__", "") or "").split(".")[0] in _PROVIDER_SDK_MODULES
+        for klass in type(exc).__mro__
+    )
 
 
 if __name__ == "__main__":

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -774,6 +774,60 @@ def test_demo_provider_failure_is_a_clean_error_not_a_traceback(
     assert _squashed("wmo providers verify") in flat
 
 
+def test_demo_off_a_terminal_calls_an_outage_an_outage(
+    patched_provider: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 429 that outlived the retries is not a credentials problem, and must not claim to be.
+
+    CliRunner is never a terminal, so this is exactly the CI/redirected path: the interactive
+    branch (offer a different provider) is unreachable and the capacity error falls through to
+    the setup-error renderer, which used to print `check ... your credentials`.
+    """
+    import httpx
+    import openai
+
+    import wmo.providers as providers_pkg
+
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+    class _RateLimited(FakeProvider):
+        def complete(self, system, messages, *, temperature=0.7, max_tokens=8192):  # noqa: ANN001, ANN202
+            raise openai.RateLimitError(
+                "Rate limit reached for gpt-4o",
+                response=httpx.Response(429, request=request),
+                body=None,
+            )
+
+    monkeypatch.setattr(providers_pkg, "get_provider", lambda config: _RateLimited())
+
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--steps",
+            "1",
+            "--no-prompt",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert not isinstance(result.exception, openai.RateLimitError)  # still no traceback
+    flat = _squashed(result.output)
+    assert _squashed("is out of capacity") in flat
+    assert _squashed("not a credentials problem") in flat
+    assert _squashed("re-run `wmo demo --name demo-model`") in flat  # the exact next command
+    assert "credentialsareset" not in flat  # the setup hint, squashed; wrong diagnosis here
+    assert "wmoprovidersverify" not in flat  # it would only re-report the same outage
+
+
 def test_demo_keeps_the_traceback_for_a_wmo_bug(patched_provider, tmp_path, monkeypatch) -> None:  # noqa: ANN001
     """Only backend SDK failures are re-rendered; our own bugs must not be dressed up as setup."""
     root = tmp_path / ".wmo"

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -94,6 +94,16 @@ class FakeProvider:
         return verify_via_ping(self)
 
 
+def _squashed(text: str) -> str:
+    """Whitespace-free view of rich output, so a boxed+wrapped message still matches a substring.
+
+    Typer renders usage errors inside a panel that hard-wraps at the terminal width, which splits
+    long paths and command hints across lines; dropping whitespace and the box rules puts them
+    back together. Callers squash the expected string the same way.
+    """
+    return "".join(ch for ch in text if not ch.isspace() and ch not in "│┃")
+
+
 def _traces_file(tmp_path) -> str:  # noqa: ANN001 - pytest fixture path
     span_llm = {
         "traceId": "a" * 32,
@@ -371,6 +381,8 @@ def test_knowledge_command_prints_bracketed_markdown_verbatim(tmp_path) -> None:
 
 
 def test_knowledge_command_without_kb_says_how_to_enable(tmp_path) -> None:  # noqa: ANN001
+    # The empty state used to print a directory that does not exist and say "drop *.md files in
+    # this folder" without naming the flag that seeds one, so this now pins both halves.
     from wmo.config import save_config
     from wmo.config.config import HarnessConfig
 
@@ -378,7 +390,67 @@ def test_knowledge_command_without_kb_says_how_to_enable(tmp_path) -> None:  # n
     save_config(HarnessConfig(), root=root / "models" / "airline")
     result = runner.invoke(app, ["knowledge", "--name", "airline", "--root", str(root)])
     assert result.exit_code == 0, result.output
-    assert "empty" in result.output.lower()
+    flat = _squashed(result.output)
+    assert _squashed("does not exist yet") in flat  # the printed dir is absent, and it says so
+    assert "--knowledge" in flat  # the exact build flag that creates one
+
+
+def test_knowledge_command_flags_a_kb_the_model_ignores(tmp_path) -> None:  # noqa: ANN001
+    """Files under `knowledge/` are inert unless the model was built with `--knowledge`."""
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+    from wmo.engine.knowledge import KnowledgeBase
+
+    root = tmp_path / ".wmo"
+    model_dir = root / "models" / "airline"
+    save_config(HarnessConfig(), root=model_dir)  # knowledge=False, the build default
+    KnowledgeBase(model_dir / "knowledge").write_file("rules.md", "- gate: auth required")
+
+    result = runner.invoke(app, ["knowledge", "--name", "airline", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    flat = _squashed(result.output)
+    assert "inert" in flat
+    assert "--knowledge" in flat  # names the flag that activates them
+    assert _squashed("gate: auth required") in flat  # the files are still shown
+
+
+def test_knowledge_command_stays_quiet_when_the_kb_is_live(tmp_path) -> None:  # noqa: ANN001
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+    from wmo.engine.knowledge import KnowledgeBase
+
+    root = tmp_path / ".wmo"
+    model_dir = root / "models" / "airline"
+    save_config(HarnessConfig(knowledge=True), root=model_dir)
+    KnowledgeBase(model_dir / "knowledge").write_file("rules.md", "- gate: auth required")
+
+    result = runner.invoke(app, ["knowledge", "--name", "airline", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert "inert" not in result.output
+
+
+def test_knowledge_resolves_a_shipped_example_like_demo_and_play(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    """`wmo knowledge` must see the same models `wmo demo`/`wmo play` resolve, examples included."""
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+    from wmo.engine.knowledge import KnowledgeBase
+
+    example = tmp_path / "airline-bench"
+    model_dir = example / "models" / "airline"
+    save_config(HarnessConfig(knowledge=True), root=model_dir)
+    (example / "traces.otel.jsonl").write_text("", encoding="utf-8")
+    KnowledgeBase(model_dir / "knowledge").write_file("rules.md", "- gate: auth required")
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["knowledge", "--name", "airline"])
+
+    assert result.exit_code == 0, result.output
+    assert "gate: auth required" in result.output
 
 
 @pytest.mark.parametrize(
@@ -595,6 +667,233 @@ def test_demo_replays_a_sampled_scenario_open_loop(patched_provider, tmp_path) -
     assert "predicted" in result.output
     assert "actual" in result.output
     assert "exact matches" in result.output
+
+
+@pytest.mark.parametrize("steps", ["0", "-1"])
+def test_demo_rejects_a_non_positive_step_budget(patched_provider, tmp_path, steps) -> None:  # noqa: ANN001
+    # `--steps 0` used to slice the trace to [] and index [-1] on it: an IndexError traceback.
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--steps",
+            steps,
+            "--no-prompt",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert not isinstance(result.exception, IndexError)
+    assert "--steps" in result.output
+
+
+def test_demo_missing_explicit_traces_names_the_path_given(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    # The old message blamed the model's default location and told you to pass the flag you just
+    # passed; an explicit path that does not exist must name that path.
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    typo = tmp_path / "does-not-exist.jsonl"
+    result = runner.invoke(
+        app, ["demo", "--name", "demo-model", "--root", str(root), "--traces", str(typo)]
+    )
+    assert result.exit_code == 2, result.output
+    assert _squashed(str(typo)) in _squashed(result.output)
+
+
+def test_demo_without_a_corpus_names_the_file_to_pass(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    """A build keeps no copy of its corpus, so the default can never resolve after `wmo build`."""
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    result = runner.invoke(app, ["demo", "--name", "demo-model", "--root", str(root)])
+    assert result.exit_code == 2, result.output
+    flat = _squashed(result.output)
+    assert _squashed("keeps no copy of the corpus it read") in flat
+    assert _squashed("--traces <that file>") in flat
+    assert _squashed(str(root / "models" / "demo-model" / "traces.otel.jsonl")) in flat
+
+
+def test_demo_finds_a_corpus_stored_beside_the_artifact(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    """serve and `optimize route sweep` read <model_dir>/traces.otel.jsonl; demo must too."""
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    corpus = Path(_traces_file(tmp_path)).read_text(encoding="utf-8")
+    (root / "models" / "demo-model" / "traces.otel.jsonl").write_text(corpus, encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["demo", "--name", "demo-model", "--root", str(root), "--seed", "0", "--steps", "1"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "replaying scenario" in result.output
+
+
+def test_demo_provider_failure_is_a_clean_error_not_a_traceback(
+    patched_provider: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The likeliest first-run failure: the serve provider has no credentials."""
+    import openai
+
+    import wmo.providers as providers_pkg
+
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+
+    class _NoCredentials(FakeProvider):
+        def complete(self, system, messages, *, temperature=0.7, max_tokens=8192):  # noqa: ANN001, ANN202
+            raise openai.OpenAIError("Missing credentials. Please pass an `api_key`")
+
+    monkeypatch.setattr(providers_pkg, "get_provider", lambda config: _NoCredentials())
+
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--steps",
+            "1",
+            "--no-prompt",
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert not isinstance(result.exception, openai.OpenAIError)
+    flat = _squashed(result.output)
+    assert _squashed("Missing credentials") in flat
+    assert _squashed("wmo providers verify") in flat
+
+
+def test_demo_keeps_the_traceback_for_a_wmo_bug(patched_provider, tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    """Only backend SDK failures are re-rendered; our own bugs must not be dressed up as setup."""
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+    monkeypatch.setattr(
+        cli_app_module,
+        "run_demo",
+        lambda *a, **kw: (_ for _ in ()).throw(KeyError("internal")),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "demo",
+            "--name",
+            "demo-model",
+            "--root",
+            str(root),
+            "--traces",
+            _traces_file(tmp_path),
+            "--steps",
+            "1",
+            "--no-prompt",
+        ],
+    )
+
+    assert isinstance(result.exception, KeyError)
+
+
+def test_play_refuses_a_serve_provider_it_cannot_prepare(
+    patched_provider: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`prepare()` is free and offline, so a missing credential fails before the first step."""
+    import wmo.providers as providers_pkg
+
+    root = tmp_path / ".wmo"
+    _build(root, "demo-model", tmp_path)
+
+    class _Unpreparable(FakeProvider):
+        def prepare(self) -> None:
+            raise RuntimeError("Missing credentials. Set OPENAI_API_KEY")
+
+    monkeypatch.setattr(providers_pkg, "get_provider", lambda config: _Unpreparable())
+
+    result = runner.invoke(app, ["play", "--name", "demo-model", "--root", str(root)])
+
+    assert result.exit_code == 1, result.output
+    flat = _squashed(result.output)
+    assert _squashed("Missing credentials") in flat
+    assert _squashed("wmo providers verify") in flat
+
+
+def _example_model(root: Path, example: str, name: str) -> Path:
+    """A shipped-example artifact: <root>/<example>/models/<name>/ plus the example's corpus."""
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+
+    example_dir = root / example
+    (example_dir / "traces.otel.jsonl").parent.mkdir(parents=True, exist_ok=True)
+    (example_dir / "traces.otel.jsonl").write_text("", encoding="utf-8")
+    model_dir = example_dir / "models" / name
+    save_config(HarnessConfig(), root=model_dir)
+    return model_dir
+
+
+def test_demo_root_spelling_does_not_change_what_is_discovered(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # Discovery used to be gated on `root != ".wmo"` string equality, so `./.wmo` (or the `.wmo/`
+    # shell tab-completion types) silently searched a different set than the identical `.wmo`.
+    _example_model(tmp_path, "airline-bench", "airline")
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+    monkeypatch.chdir(project)
+
+    outputs = [
+        _squashed(runner.invoke(app, ["demo", "--name", "ghost", "--root", spelling]).output)
+        for spelling in (".wmo", "./.wmo", ".wmo/")
+    ]
+
+    assert all(_squashed("airline (airline-bench example)") in out for out in outputs), outputs
+
+
+def test_demo_lists_a_shadowed_example_distinguishably(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # A local build of the same name used to appear twice in the list, and --name could not say
+    # which one was meant.
+    from wmo.config import save_config
+    from wmo.config.config import HarnessConfig
+
+    _example_model(tmp_path, "airline-bench", "airline")
+    project = tmp_path / "project"
+    save_config(HarnessConfig(), root=project / ".wmo" / "models" / "airline")
+    _example_model(tmp_path, "retail-bench", "retail")
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (tmp_path,))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["demo"])
+
+    assert result.exit_code == 2, result.output
+    flat = _squashed(result.output)
+    assert _squashed("airline (local)") in flat
+    assert _squashed("airline (airline-bench example)") in flat
+    assert _squashed(f"--root {tmp_path / 'airline-bench'}") in flat
+
+
+def test_demo_with_nothing_built_points_at_a_command_that_exists(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    # The old hint named `examples/tau-bench`, a path that ships in neither the wheel nor the repo.
+    empty_root = tmp_path / "no-examples"
+    empty_root.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(cli_app_module, "_benchmark_roots", lambda: (empty_root,))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["demo"])
+
+    assert result.exit_code == 2, result.output
+    flat = _squashed(result.output)
+    assert "examples/tau-bench" not in flat
+    assert "wmodownload" in flat
+    assert _squashed("wmo build --file <traces> --name <name>") in flat
 
 
 def test_retry_narrator_dedupes_identical_failures_and_counts_down(monkeypatch) -> None:  # noqa: ANN001


### PR DESCRIPTION
## What was broken

`wmo demo`, `wmo play` and `wmo knowledge` each answered the same three questions their own way:
which model, which trace corpus, and can the serve provider even be called. Every finding below
falls out of that, including the single most likely first-run failure of the whole CLI.

One repro a reviewer can paste (a repo checkout, no AWS credentials in the environment):

```bash
mkdir -p /tmp/wmoproj/.wmo/models && cd /tmp/wmoproj
cp -R "$(git -C <repo> rev-parse --show-toplevel)/packages/environment-capture/tau-bench/models/tau-bench" .wmo/models/
wmo demo --name tau-bench          # documented in docs/cookbook/tau-bench.md
```

Before: `Invalid value: no trace file found for 'tau-bench' under .wmo; pass --traces`, which
blames a directory the CLI does not build corpora into and names the flag as if it were optional.
Pass a corpus and it gets further, into a ~60 line rich `Traceback` panel ending in
`botocore ... Unable to locate credentials` (or `OpenAIError: Missing credentials`), because
`demo` only handled *capacity* errors and re-raised everything else bare.

After:

```
Invalid value: no trace corpus for world model 'tau-bench': looked for
.wmo/models/tau-bench/traces.otel.jsonl and .wmo/traces.otel.jsonl. A build keeps no copy of the
corpus it read, so pass the file `wmo build --file` was given:
`wmo demo --name tau-bench --traces <that file>`
```

```
✗ the serve provider for 'tau-bench' (bedrock, us.anthropic.claude-opus-4-8) failed: Unable to locate credentials
  check the model id and that your credentials are set (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
  then re-check with `wmo providers verify`
```

## What changed

All in `wmo/cli/app.py`.

- **One model resolver.** `_resolve_model_any` (project dir + shipped examples) now backs `demo`,
  `play` **and** `knowledge`, so the three agree on which models exist. It keys on the RESOLVED
  project dir, so `--root ./.wmo` and `--root .wmo/` (what shell tab-completion types) no longer
  silently search a different set than `--root .wmo`. Every message that enumerates choices prints
  the disambiguating labels the picker already builds (`tau-bench (local)` vs
  `tau-bench (tau-bench example)`) instead of the same bare name twice, and when a local build
  shadows an example it names the flag that reaches the example: `--root <the example dir>`.
- **One corpus resolver.** Demo's private one-path lookup is replaced by `local_traces_path`, the
  resolver `wmo serve` and `wmo optimize route sweep` already use, so a Hub-downloaded corpus in the
  artifact is found. When nothing resolves, the error names both paths searched, states that a
  build keeps no copy of the corpus it read, and prints the command to run. An explicit `--traces`
  that does not exist is now its own error naming the path you gave.
- **One credential pre-flight.** `_load_model` runs the free, offline `PreparableProvider.prepare`
  (the same seam `optimize route sweep` pre-flights with, no network, no spend) and exits with the
  `_credential_hint` + `wmo providers verify` message. For backends that document a residual gap
  they cannot close locally (bedrock, tinker), demo's runtime handler re-renders a backend SDK
  error the same way. It is deliberately narrow: `_is_provider_sdk_error` matches only exceptions
  DEFINED by a provider SDK or its HTTP transport, so wmo's own bugs keep their traceback (pinned
  by a test). That renderer also splits the two diagnoses a failed backend can have: a capacity
  error (429/503/timeout) has already outlived `RetryingProvider`'s backoff, so the credentials are
  demonstrably fine and it is named as the outage it is, with the command to re-run; only a refusal
  earns the credential hint.
- **Knowledge is honest about being inert.** `wmo knowledge` says so when the model was built
  without `--knowledge`, since `WorldModel.load` gates the KB on `config.knowledge` and demo / play
  / serve then never render those files into the env prompt. It names the exact flag and the config
  line that activate them. The empty-state message no longer tells you to drop files into a
  directory that does not exist, and names `--knowledge` instead of "enable knowledge at build".
  (`packages/environment-capture/swe-bench` ships a populated `knowledge/` with `knowledge = false`,
  so this is not hypothetical.)
- **`--steps` gets `min=1`.** `--steps 0` sliced the trace to `[]` and then indexed `[-1]`.
- The "nothing built" hint pointed at `examples/tau-bench`, which exists in neither the wheel nor
  the repo (benchmarks live under `packages/environment-capture/`); it now names `wmo build` and
  `wmo download`.

Behaviour change worth a reviewer's eye: `wmo knowledge` now spans the shipped examples like
`demo`/`play` do, so in a repo checkout with one local model it can ask for `--name` where it used
to auto-pick. That is the consistency the finding asks for, and `--root <dir>` still scopes to one
root.

Docs: `docs/cookbook/tau-bench.md`'s demo line passes `--traces` (it could not work as written),
and `docs/usage.md` records both caveats.

## Tests

`uv run pytest wmo/cli wmo/engine wmo/serving wmo/config -q` -> 970 passed, 1 skipped. Full suite:
4139 passed, with 4 pre-existing `wmo/harness/pi_runtime_test.py` order-dependent failures that
reproduce identically on the baseline files (verified by copying my files aside and restoring
`HEAD:wmo/cli/app.py`). 13 new/updated tests in `wmo/cli/app_test.py`, one per behaviour changed.

## Review

Greptile raised one P1 (`wmo/cli/app.py:2129`): off a terminal, `not _console.is_terminal` routed
capacity failures into the setup-error branch, so a rate limit was reported as a credentials
problem. Fixed in ffd1509f, with a regression test that pins the outage wording and asserts the
credential hint is absent. Greptile's re-review is 5/5 with no remaining comments.

## Findings closed

- `wmo demo` dumps a raw traceback when the serve provider has no credentials (major)
- `wmo demo` cannot run after a normal `wmo build` because a build keeps no copy of its corpus (major)
- Files in the folder `wmo knowledge` tells you to edit are silently ignored unless built with `--knowledge` (major)
- `wmo demo --steps 0` (and negatives) crashes with `IndexError` (minor)
- An explicitly passed `--traces` that does not exist blames the model's default location (minor)
- `wmo knowledge` does not resolve the shipped example models demo/play resolve, and misdirects to `wmo build` (minor)
- The "multiple world models" error lists the same name twice and `--name` cannot disambiguate (minor)
- Example discovery toggled by exact string equality with `.wmo`, so `--root ./.wmo` disables it (minor)
- The empty-knowledge-base message prints a directory that does not exist and never names `--knowledge` (minor)
- The "no world models found" hint points at `examples/tau-bench`, which does not exist (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

