### PR TITLE
Report a malformed config or settings file, instead of raising through it

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -49,7 +49,7 @@ from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
 # mode-inapplicable flags exactly the way `wmo optimize harness` already does.
 from wmo.cli.harness_app import _explicit, harness_app, optimize_app
 from wmo.cli.ingest_cmd import ingest as _ingest_command
-from wmo.cli.model_roles import configured_role_configs
+from wmo.cli.model_roles import configured_role_configs, load_settings_or_abort
 from wmo.cli.platform_cmds import register as register_platform_commands
 from wmo.cli.ui import (
     BuildParams,
@@ -76,7 +76,6 @@ from wmo.config import (
     WorldModelStore,
     load_config,
     load_env_file,
-    load_settings,
     normalize_name,
     save_settings,
     set_telemetry_enabled,
@@ -239,14 +238,14 @@ def config_telemetry(
 ) -> None:
     """View or change project-local usage telemetry settings."""
     normalized = action.lower()
-    if normalized == "status":
-        settings = load_settings(root)
-    elif normalized == "enable":
-        settings = set_telemetry_enabled(True, root)
-    elif normalized == "disable":
-        settings = set_telemetry_enabled(False, root)
-    else:
+    if normalized not in ("status", "enable", "disable"):
         raise typer.BadParameter("action must be one of: status, enable, disable")
+    # Read through the guarded loader first: `set_telemetry_enabled` reads the same file to
+    # preserve the rest of it, so a corrupt settings.toml must fail here as a usage error naming
+    # the file rather than as a tomllib traceback from inside the write.
+    settings = load_settings_or_abort(root)
+    if normalized != "status":
+        settings = set_telemetry_enabled(normalized == "enable", root)
     state = "enabled" if settings.telemetry.enabled else "disabled"
     _console.print(f"telemetry {state} ({settings_path(root)})")
 
@@ -331,7 +330,11 @@ def providers_set(
             "set both --input-per-mtok and --output-per-mtok, or neither; a pool entry prices "
             "prompt and completion tokens together"
         )
-    existing = load_settings(root).models.worker
+    if provider is not None:
+        # Reject a bad --provider before reading the project's settings, so the argument the
+        # caller typed is what the error is about even in a project whose settings.toml is broken.
+        _provider_kind(provider)
+    existing = load_settings_or_abort(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:
         provider, model, region = select_provider_and_model(
@@ -374,7 +377,7 @@ def providers_set(
             _console.print(f"[red]provider verification failed[/red]: {detail}")
             raise typer.Exit(1)
 
-    settings = load_settings(root)
+    settings = load_settings_or_abort(root)
     settings.models.worker = ModelRole(
         provider=config.kind.value,
         model=config.model_type or model,
@@ -464,10 +467,11 @@ def providers_verify(
     configs: list[HarnessConfig] = []
     for model_name in names:
         try:
-            model_dir = str(store.resolve(model_name))
+            # Reading the artifact is inside the guard too: a model dir that exists but whose
+            # config.toml is corrupt or unreadable is a bad artifact, not an internal error.
+            configs.append(load_config(str(store.resolve(model_name))))
         except (FileNotFoundError, ValueError) as exc:
             raise typer.BadParameter(str(exc)) from exc
-        configs.append(load_config(model_dir))
 
     # Dedup identical completion calls across all selected models, then across the settings
     # roles. World models come FIRST so a config present in both is pinged with the built
@@ -541,16 +545,17 @@ def _print_verify_result(result: VerifyResult, sources: list[str], *, prefix: st
     """Print one `providers verify` line, plus the next step to take when the ping failed.
 
     `sources` names what asked for this provider (world model names, `models.<role>` settings
-    roles) so a failure points at the thing to fix. The detail is escaped: it carries raw
-    provider error text, and an unescaped `[...]` in it would be read as rich markup and crash
-    the report.
+    roles) so a failure points at the thing to fix. The detail and the hint are escaped: they
+    carry raw provider error text and pip extras (`...[distill]`), and an unescaped `[...]` in
+    either would be read as rich markup and silently dropped from the report.
     """
     mark = "[green]ok[/green]" if result.ok else "[red]fail[/red]"
     origin = f" [dim]({', '.join(sources)})[/dim]" if sources else ""
     detail = f" {escape(result.detail)}" if result.detail else ""
     _console.print(f"{mark} {prefix}{result.kind.value} ({result.model}){origin}{detail}")
     if not result.ok:
-        _console.print(f"  [yellow]{_credential_hint(result.kind, result.detail)}[/yellow]")
+        hint = escape(_credential_hint(result.kind, result.detail))
+        _console.print(f"  [yellow]{hint}[/yellow]")
 
 
 @examples_app.command("list")
@@ -790,7 +795,7 @@ def build(
     needs_input = name is None or (file is None and not pull)
     use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
 
-    configured_worker = load_settings(root).models.resolve("worker")
+    configured_worker = load_settings_or_abort(root).models.resolve("worker")
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider
     )
@@ -1081,9 +1086,28 @@ def _verify_or_abort(config: HarnessConfig, chain: str | None = None) -> None:
             continue
         failed = True
         _console.print(f"  [red]✗ {label} ({result.model}) failed[/red]: {result.detail}")
-        _console.print(f"    [yellow]{_credential_hint(cfg.kind, result.detail)}[/yellow]")
+        hint = escape(_credential_hint(cfg.kind, result.detail))
+        _console.print(f"    [yellow]{hint}[/yellow]")
     if failed:
         raise typer.Exit(1)
+
+
+_PROVIDER_EXTRAS: dict[ProviderKind, str] = {ProviderKind.TINKER: "distill"}
+"""Providers whose SDK ships in an optional extra, keyed by kind so the hint can name the extra.
+
+Every other provider's SDK is a core dependency, so "the module is missing" means something
+different for them (a stale env) than it does here (an install step the user has not run yet).
+"""
+
+
+def _missing_sdk(detail: str) -> bool:
+    """Does a failed ping's detail mean "the SDK is absent" rather than "the creds are wrong"?
+
+    Two shapes reach here: the raw ImportError text of a core SDK ("No module named 'boto3'"), and
+    an optional extra's own message, which replaces that text with its install hint (see
+    `wmo.providers.tinker.check_tinker_prerequisites`) and so never contains the module wording.
+    """
+    return "No module named" in detail or "SDK is not installed" in detail
 
 
 def _credential_hint(kind: ProviderKind, detail: str) -> str:
@@ -1091,8 +1115,14 @@ def _credential_hint(kind: ProviderKind, detail: str) -> str:
 
     Shared by the pre-build guard and `wmo providers verify` so both name the same env vars.
     """
-    if "No module named" in detail:
-        # SDKs are core deps; a missing module means the env is stale or hand-rolled.
+    if _missing_sdk(detail):
+        extra = _PROVIDER_EXTRAS.get(kind)
+        if extra is not None:
+            return (
+                f"run `pip install 'world-model-optimizer[{extra}]'` (or `uv sync --extra {extra}` "
+                "in a checkout), then re-run `wmo providers verify`"
+            )
+        # The rest are core deps; a missing module means the env is stale or hand-rolled.
         return "run `uv sync` to install the provider SDKs"
     envs = ", ".join(PROVIDER_ENV_VARS.get(kind, []))
     hint = f" ({envs})" if envs else ""
@@ -1101,16 +1131,31 @@ def _credential_hint(kind: ProviderKind, detail: str) -> str:
 
 @app.command("list")
 def list_models(root: str = typer.Option(ARTIFACT_DIR, help="Project dir to list.")) -> None:
-    """List every world model built under the project dir."""
-    infos = WorldModelStore(root).list_info()
+    """List every world model built under the project dir.
+
+    An empty listing names the directory it searched, because `--root` defaults to a
+    cwd-relative `.wmo` and "nothing here" and "wrong directory" look identical otherwise.
+    An artifact that cannot be read is listed as `unreadable` with its reason, so one broken
+    `config.toml` costs you that one row instead of the whole listing.
+    """
+    if Path(root).is_file():
+        raise typer.BadParameter(
+            f"--root {root} is a file, not a project dir; pass the dir holding models/ "
+            f"(the default is `{ARTIFACT_DIR}`)"
+        )
+    store = WorldModelStore(root)
+    infos = store.list_info()
     if not infos:
         # Name the trace export too: `wmo build --name <name>` alone has no corpus to build from.
         _console.print(
-            "[yellow]no world models built yet[/yellow]; run "
+            f"[yellow]no world models built under {store.models_dir}[/yellow]; run "
             "`wmo build --name <name> --file <traces export>`"
         )
         return
     _console.print(models_table(infos))
+    for info in infos:
+        if info.error is not None:
+            _console.print(f"  [red]✗ {info.name}[/red]: {escape(info.error)}")
 
 
 @app.command("download")
@@ -2339,6 +2384,7 @@ def _unreadable_input(
 
 
 def _provider_kind(provider: str) -> ProviderKind:
+    """The `ProviderKind` a `--provider` flag names, as a usage error when it names none."""
     try:
         return ProviderKind(provider)
     except ValueError:
@@ -2389,7 +2435,7 @@ def _role_provider_config(role: str, region: str | None) -> ProviderConfig | Non
     generic `--region` flag — the flag also feeds the embedder, and e.g. a judge pinned to the
     one region where its model is enabled must not follow it.
     """
-    configured = load_settings().models.resolve(role)
+    configured = load_settings_or_abort().models.resolve(role)
     if configured is None:
         return None
     config = _provider_config(configured.provider, configured.model, configured.region or region)
@@ -2846,7 +2892,15 @@ def _resolve_name(store: WorldModelStore, name: str | None) -> str:
         # Only enumerate full model summaries when we actually need the picker (>1 model on a TTY).
         # `list_names` is cheap (a dir scan); `list_info` reads every config/metrics/frontier file.
         if _console.is_terminal and len(store.list_names()) > 1:
-            return select_model(_console, store.list_info())
+            # An artifact `list_info` reports as unreadable cannot be run, so keep it off the
+            # menu; `wmo list` is where its reason is printed.
+            readable = [info for info in store.list_info() if info.error is None]
+            if not readable:
+                raise ValueError(
+                    f"no readable world model under {store.models_dir}; "
+                    "run `wmo list` to see what is wrong with each one"
+                )
+            return select_model(_console, readable)
         return store.resolve(None).name
     except (FileNotFoundError, ValueError) as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -3094,7 +3094,7 @@ def test_scenario_role_llms_cli_flags_pin_every_role(monkeypatch) -> None:  # no
     from wmo.config.settings import ProjectSettings
 
     monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
-    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+    monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
     summary, worker, judge = cli_app_module._scenario_role_llms("bedrock", "some-model", None)
     assert summary is worker
     assert worker is judge
@@ -3109,7 +3109,7 @@ def test_scenario_role_llms_model_flag_keeps_the_configured_provider(monkeypatch
     monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
     monkeypatch.setattr(
         cli_app_module,
-        "load_settings",
+        "load_settings_or_abort",
         lambda: ProjectSettings(
             models=ModelsSettings(worker=ModelRole(provider="openai", model="gpt-5.4-mini"))
         ),
@@ -3133,7 +3133,7 @@ def test_scenario_role_llms_default_when_nothing_configured(monkeypatch) -> None
 def test_worker_role_provider_config_falls_back_to_bedrock(monkeypatch) -> None:  # noqa: ANN001
     from wmo.config.settings import ProjectSettings
 
-    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+    monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
     config = cli_app_module._worker_role_provider_config(None, None, None)
     assert config.kind is ProviderKind.BEDROCK
     assert config.model == "us.anthropic.claude-opus-4-8"
@@ -3144,7 +3144,7 @@ def _azure_worker_settings(monkeypatch: pytest.MonkeyPatch, deployment: str | No
 
     monkeypatch.setattr(
         cli_app_module,
-        "load_settings",
+        "load_settings_or_abort",
         lambda: ProjectSettings(
             models=ModelsSettings(
                 worker=ModelRole(
@@ -3237,7 +3237,7 @@ def test_worker_role_provider_config_provider_flag_uses_that_backends_flagship(
 
     monkeypatch.setattr(
         cli_app_module,
-        "load_settings",
+        "load_settings_or_abort",
         lambda: ProjectSettings(
             models=ModelsSettings(worker=ModelRole(provider="bedrock", model="claude-sonnet-4-6"))
         ),
@@ -3256,7 +3256,7 @@ def test_worker_role_provider_config_demands_a_model_for_a_catalog_less_provider
     # weights path — so the fix is to say which model, not to guess one.
     from wmo.config.settings import ProjectSettings
 
-    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+    monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
 
     with pytest.raises(typer.BadParameter) as excinfo:
         cli_app_module._worker_role_provider_config("openrouter", None, None)

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -26,7 +26,9 @@ from wmo.config import (
     FIDELITY_TIERS,
     FidelityTier,
     HarnessConfig,
+    ModelInfo,
     ModelRole,
+    WorldModelStore,
     load_config,
     load_settings,
     save_settings,
@@ -45,6 +47,10 @@ from wmo.providers.base import (
     verify_via_ping,
 )
 from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
+
+# The exact text the tinker provider raises: the CLI hint has to recognise THAT
+# message, not a paraphrase of it.
+from wmo.providers.tinker import _MISSING_TINKER_EXTRA
 from wmo.tracking.pricing import ModelPrice
 
 # `wmo.cli`'s `app` attribute (the Typer object) shadows the `wmo.cli.app` submodule on
@@ -1883,6 +1889,79 @@ def test_list_empty_project_is_friendly(tmp_path) -> None:  # noqa: ANN001
     result = runner.invoke(app, ["list", "--root", str(tmp_path / ".wmo")])
     assert result.exit_code == 0
     assert "no world models" in result.output
+    # --root defaults to a cwd-relative `.wmo`, so "nothing built" and "wrong directory" read
+    # the same unless the empty listing says where it looked. Asserted on the tail of the path
+    # only: rich wraps a long tmp_path across lines.
+    flat = _flat(result.output)
+    assert "no world models built under" in flat
+    assert str(Path(".wmo") / "models") in flat
+
+
+def test_list_rejects_a_file_as_root(tmp_path) -> None:  # noqa: ANN001
+    # `--root traces.jsonl` used to report a healthy empty project; a file can never hold models/.
+    corpus = tmp_path / "traces.jsonl"
+    corpus.write_text("{}\n", encoding="utf-8")
+    result = runner.invoke(app, ["list", "--root", str(corpus)])
+    assert result.exit_code == 2
+    assert "is a file, not a project dir" in _flat(result.output)
+
+
+def test_list_shows_an_unreadable_artifact_as_a_row(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    # One artifact this CLI cannot parse (a bundle from a newer CLI, a hand edit) used to
+    # traceback the whole listing; the healthy models beside it must still be listed.
+    root = tmp_path / ".wmo"
+    _build(root, "alpha-healthy", tmp_path)
+    broken = root / "models" / "zz-broken"
+    broken.mkdir(parents=True)
+    (broken / "config.toml").write_text("this is not toml =", encoding="utf-8")
+
+    result = runner.invoke(app, ["list", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None  # a bad row, not an escaped TOMLDecodeError
+    assert "alpha-healthy" in result.output
+    assert "unreadable" in result.output
+    assert "zz-broken" in result.output
+    assert "is not valid TOML" in _flat(result.output)
+
+
+def _write_broken_model(root: Path, name: str) -> None:
+    (root / "models" / name).mkdir(parents=True)
+    (root / "models" / name / "config.toml").write_text("this is not toml =", encoding="utf-8")
+
+
+def test_the_model_picker_offers_only_readable_artifacts(
+    patched_provider: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `list_info` now hands back a row for an artifact it could not read, so the picker has to
+    # drop those rather than offer a choice that dead-ends the moment it is picked.
+    root = tmp_path / ".wmo"
+    _build(root, "alpha-healthy", tmp_path)
+    _build(root, "beta-healthy", tmp_path)
+    _write_broken_model(root, "zz-broken")
+    offered: list[str] = []
+
+    def fake_select_model(console: object, infos: list[ModelInfo]) -> str:
+        offered.extend(info.name for info in infos)
+        return infos[0].name
+
+    monkeypatch.setattr(cli_app_module, "_console", SimpleNamespace(is_terminal=True))
+    monkeypatch.setattr(cli_app_module, "select_model", fake_select_model)
+
+    assert cli_app_module._resolve_name(WorldModelStore(root), None) == "alpha-healthy"
+    assert offered == ["alpha-healthy", "beta-healthy"]
+
+
+def test_the_model_picker_reports_when_nothing_is_readable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / ".wmo"
+    for name in ("one-broken", "two-broken"):
+        _write_broken_model(root, name)
+    monkeypatch.setattr(cli_app_module, "_console", SimpleNamespace(is_terminal=True))
+
+    with pytest.raises(typer.BadParameter, match="no readable world model"):
+        cli_app_module._resolve_name(WorldModelStore(root), None)
 
 
 def test_play_repl_steps_and_quits(patched_provider, tmp_path) -> None:  # noqa: ANN001
@@ -2368,6 +2447,85 @@ def test_providers_verify_unknown_model_is_clean_error(tmp_path) -> None:  # noq
     assert not isinstance(result.exception, FileNotFoundError)
 
 
+# Hand-editing `.wmo/settings.toml` is documented (docs/reference/closed_loop.md), and a file
+# written by an older CLI outlives an upgrade, so every command that reads it has to fail as a
+# usage error naming the file — never as a tomllib/pydantic traceback.
+_BROKEN_SETTINGS = pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ('[models.worker\nprovider = "openai"\n', "is not valid TOML"),
+        ('[models]\nworker = "openai"\n', "does not match the current settings schema"),
+    ],
+    ids=["malformed-toml", "schema-invalid"],
+)
+
+
+def _write_settings(tmp_path: Path, payload: str) -> Path:
+    root = tmp_path / ".wmo"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "settings.toml").write_text(payload, encoding="utf-8")
+    return root
+
+
+@_BROKEN_SETTINGS
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["providers", "verify"],
+        ["config", "telemetry", "status"],
+        ["config", "telemetry", "enable"],
+        ["providers", "set", "--provider", "openai", "--model", "gpt-5.4"],
+    ],
+    ids=["verify", "telemetry-status", "telemetry-enable", "providers-set"],
+)
+def test_broken_settings_is_a_usage_error_not_a_traceback(
+    tmp_path: Path, payload: str, expected: str, argv: list[str]
+) -> None:
+    root = _write_settings(tmp_path, payload)
+
+    result = runner.invoke(app, [*argv, "--root", str(root)])
+
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)  # BadParameter, not a leaked loader raise
+    flat = _flat(result.output)
+    assert expected in flat
+    assert "settings.toml" in flat
+    assert "delete it and re-run `wmo providers set`" in flat
+
+
+@_BROKEN_SETTINGS
+def test_providers_set_rejects_a_bad_provider_before_reading_settings(
+    tmp_path: Path, payload: str, expected: str
+) -> None:
+    # The caller's own argument is wrong too; the error must be about the argument they typed.
+    root = _write_settings(tmp_path, payload)
+
+    result = runner.invoke(
+        app, ["providers", "set", "--provider", "bogus", "--model", "x", "--root", str(root)]
+    )
+
+    assert result.exit_code == 2
+    assert "unknown provider 'bogus'" in _flat(result.output)
+    assert expected not in _flat(result.output)
+
+
+def test_providers_verify_unreadable_model_config_is_clean_error(tmp_path: Path) -> None:
+    # An artifact copied in by hand (or extracted from a bundle a newer CLI wrote) can hold a
+    # config.toml this CLI cannot parse; the command whose job is reporting configuration
+    # problems must report that one too.
+    broken = tmp_path / ".wmo" / "models" / "foo"
+    broken.mkdir(parents=True)
+    (broken / "config.toml").write_text("this is not toml [[[\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(tmp_path / ".wmo")])
+
+    assert result.exit_code == 2
+    assert not isinstance(result.exception, ValueError)
+    flat = _flat(result.output)
+    assert "foo/config.toml is not valid TOML" in flat
+    assert "re-run `wmo build`" in flat
+
+
 def _record_verify_all(monkeypatch: pytest.MonkeyPatch, pinged: list[ProviderConfig]) -> None:
     """Record exactly which providers `providers verify` decided to ping, and report them ok."""
 
@@ -2444,6 +2602,34 @@ def test_providers_verify_reports_a_role_failure_with_its_credentials(
     assert "fail bedrock" in result.output
     assert "[foo]" in result.output
     assert "AWS_ACCESS_KEY_ID" in result.output
+
+
+def test_providers_verify_missing_optional_sdk_points_at_the_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # tinker's SDK is an optional extra, and its ImportError text replaces the "No module named"
+    # wording the hint used to key on — so the hint said "check your credentials" on a failure
+    # that has nothing to do with credentials.
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="tinker", model="Qwen/Qwen3-8B")
+    save_settings(settings, root)
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: [
+            VerifyResult(ok=False, kind=c.kind, model=c.model, detail=_MISSING_TINKER_EXTRA)
+            for c in configs
+        ],
+    )
+
+    result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
+
+    flat = _flat(result.output)
+    # pip is the documented install path, so the extra must be reachable without a checkout —
+    # and the `[distill]` must survive rich markup rather than being read as a style tag.
+    assert "pip install 'world-model-optimizer[distill]'" in flat
+    assert "credentials are set" not in flat
 
 
 def test_providers_verify_reports_built_model_provider(patched_provider, tmp_path) -> None:  # noqa: ANN001
@@ -2885,7 +3071,7 @@ def test_scenario_role_llms_resolve_from_settings(monkeypatch) -> None:  # noqa:
     monkeypatch.setattr(cli_app_module.providers, "get_provider", fake_get_provider)
     monkeypatch.setattr(
         cli_app_module,
-        "load_settings",
+        "load_settings_or_abort",
         lambda: ProjectSettings(
             models=ModelsSettings(
                 worker=ModelRole(provider="azure", model="gpt-5.4", endpoint="https://x/v1"),
@@ -2937,7 +3123,7 @@ def test_scenario_role_llms_default_when_nothing_configured(monkeypatch) -> None
     from wmo.config.settings import ProjectSettings
 
     monkeypatch.setattr(cli_app_module.providers, "get_provider", lambda config: config)
-    monkeypatch.setattr(cli_app_module, "load_settings", lambda: ProjectSettings())
+    monkeypatch.setattr(cli_app_module, "load_settings_or_abort", lambda: ProjectSettings())
     summary, worker, judge = cli_app_module._scenario_role_llms(None, None, None)
     assert summary is worker
     assert worker is judge

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -2449,7 +2449,7 @@ def test_providers_verify_unknown_model_is_clean_error(tmp_path) -> None:  # noq
 
 # Hand-editing `.wmo/settings.toml` is documented (docs/reference/closed_loop.md), and a file
 # written by an older CLI outlives an upgrade, so every command that reads it has to fail as a
-# usage error naming the file — never as a tomllib/pydantic traceback.
+# usage error naming the file, never as a tomllib/pydantic traceback.
 _BROKEN_SETTINGS = pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -2608,7 +2608,7 @@ def test_providers_verify_missing_optional_sdk_points_at_the_install(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     # tinker's SDK is an optional extra, and its ImportError text replaces the "No module named"
-    # wording the hint used to key on — so the hint said "check your credentials" on a failure
+    # wording the hint used to key on, so the hint said "check your credentials" on a failure
     # that has nothing to do with credentials.
     root = tmp_path / ".wmo"
     settings = load_settings(root)
@@ -2626,7 +2626,7 @@ def test_providers_verify_missing_optional_sdk_points_at_the_install(
     result = runner.invoke(app, ["providers", "verify", "--root", str(root)])
 
     flat = _flat(result.output)
-    # pip is the documented install path, so the extra must be reachable without a checkout —
+    # pip is the documented install path, so the extra must be reachable without a checkout,
     # and the `[distill]` must survive rich markup rather than being read as a style tag.
     assert "pip install 'world-model-optimizer[distill]'" in flat
     assert "credentials are set" not in flat

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -43,8 +43,9 @@ from rich.prompt import Confirm
 from rich.table import Table
 
 from wmo.agents.default import default_agent
+from wmo.cli.model_roles import load_settings_or_abort
 from wmo.config import ARTIFACT_DIR
-from wmo.config.settings import ModelRole, load_settings, save_settings, settings_path
+from wmo.config.settings import ModelRole, save_settings, settings_path
 from wmo.config.store import validate_name
 from wmo.core.types import JsonObject
 from wmo.distill.config import DistillConfig, load_distill_config
@@ -1026,10 +1027,7 @@ def _maybe_promote(console: Console, result: DistillResult, cfg: DistillConfig, 
             f"skipped writing \\[models.agent]; paste the handoff snippet into {path} when ready"
         )
         return
-    try:
-        settings = load_settings(root)
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
+    settings = load_settings_or_abort(root)
     settings.models.agent = ModelRole(
         provider="openai",
         model=result.final_sampler_path,

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -1,12 +1,14 @@
-"""Provider resolution for opt-in model roles shared by CLI workflows."""
+"""Reading project settings, and resolving the opt-in model roles, for CLI workflows."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal
 
 import typer
 
-from wmo.config.settings import ModelRole, load_settings
+from wmo.config.config import ARTIFACT_DIR
+from wmo.config.settings import ModelRole, ProjectSettings, load_settings
 from wmo.providers.base import Provider, ProviderConfig, ProviderKind
 from wmo.providers.models import resolve_provider_model
 from wmo.providers.registry import get_provider
@@ -21,6 +23,24 @@ MODEL_ROLE_NAMES: tuple[ModelRoleName, ...] = ("worker", "judge", "summary", "me
 # pool entry, or the local worker role) does not pin one, this shared default applies. Imported
 # by `wmo.cli.app` and `wmo.cli.pool_registry` so the three surfaces cannot drift apart.
 DEFAULT_AZURE_API_VERSION = "2024-05-01-preview"
+
+
+def load_settings_or_abort(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
+    """`load_settings`, with an unreadable settings file as a usage error, not a traceback.
+
+    The one path every CLI command uses to read `<root>/settings.toml`. Hand-editing that file is
+    a documented workflow, and a file written by an older CLI outlives an upgrade, so "the file is
+    broken" is an ordinary user state: it has to print as an error naming the file and the repair,
+    the way an unknown provider inside the file already does.
+
+    Raises:
+        typer.BadParameter: The settings file is unreadable, is not valid TOML, or does not match
+            the current schema.
+    """
+    try:
+        return load_settings(root)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def resolve_opt_in_model_provider(
@@ -39,9 +59,10 @@ def resolve_opt_in_model_provider(
         The resolved provider and configured model name, or the fallback and ``None``.
 
     Raises:
-        typer.BadParameter: The configured provider kind is unknown.
+        typer.BadParameter: The settings file is unreadable, or the configured provider kind is
+            unknown.
     """
-    configured = load_settings(root).models.resolve(role)
+    configured = load_settings_or_abort(root).models.resolve(role)
     if configured is None:
         return fallback, None
     config = _model_config(configured, role=role)
@@ -54,7 +75,7 @@ def resolve_required_model_config(root: str, role: OptInModelRole) -> ProviderCo
     The harbor optimize flow has no world model whose provider could stand in, so its
     ``agent`` (worker) and ``meta`` (proposer) roles must be configured explicitly.
     """
-    configured = load_settings(root).models.resolve(role)
+    configured = load_settings_or_abort(root).models.resolve(role)
     if configured is None:
         raise typer.BadParameter(
             f"settings [models.{role}] must be configured in <root>/settings.toml for this "
@@ -84,9 +105,10 @@ def configured_role_configs(root: str) -> list[tuple[ModelRoleName, ProviderConf
         One ``(role, config)`` pair per configured role; empty when nothing is configured.
 
     Raises:
-        typer.BadParameter: A configured role names an unknown provider kind.
+        typer.BadParameter: The settings file is unreadable, or a configured role names an
+            unknown provider kind.
     """
-    models = load_settings(root).models
+    models = load_settings_or_abort(root).models
     resolved: list[tuple[ModelRoleName, ProviderConfig]] = []
     for role in MODEL_ROLE_NAMES:
         configured: ModelRole | None = getattr(models, role)

--- a/wmo/cli/model_roles_test.py
+++ b/wmo/cli/model_roles_test.py
@@ -13,6 +13,7 @@ from wmo.cli.model_roles import (
     OptInModelRole,
     _model_config,
     configured_role_configs,
+    load_settings_or_abort,
     resolve_opt_in_model_provider,
 )
 from wmo.config.settings import ModelRole, ModelsSettings, ProjectSettings, save_settings
@@ -232,6 +233,24 @@ def test_model_role_names_covers_every_settings_role() -> None:
 
 def test_configured_role_configs_is_empty_for_a_project_with_no_settings(tmp_path: Path) -> None:
     assert configured_role_configs(str(tmp_path / ".wmo")) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ['[models.worker\nprovider = "openai"\n', '[models]\nworker = "openai"\n'],
+    ids=["malformed-toml", "schema-invalid"],
+)
+def test_a_settings_file_this_cli_cannot_read_is_a_usage_error(
+    tmp_path: Path, payload: str
+) -> None:
+    # Every CLI read of settings.toml goes through this one loader, so a broken file has to come
+    # back as the same clean usage error an unknown provider inside the file already does.
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    (root / "settings.toml").write_text(payload, encoding="utf-8")
+    for read in (load_settings_or_abort, configured_role_configs):
+        with pytest.raises(typer.BadParameter, match="settings.toml"):
+            read(str(root))
 
 
 def test_configured_role_configs_reports_only_roles_the_file_sets(tmp_path: Path) -> None:

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -990,7 +990,12 @@ def build_summary_panel(info: ModelInfo, root: str) -> Panel:
 
 
 def models_table(infos: list[ModelInfo]) -> Table:
-    """A table of every built world model (for `wmo list`)."""
+    """A table of every built world model (for `wmo list`).
+
+    An artifact the store could not read still gets a row, marked `unreadable` — it exists on
+    disk, so hiding it would be a lie, and dropping the whole table would hide the healthy models
+    beside it. `wmo list` prints the reason under the table.
+    """
     table = Table(title="world models")
     table.add_column("name", style="bold")
     table.add_column("serve provider")
@@ -1000,7 +1005,9 @@ def models_table(infos: list[ModelInfo]) -> Table:
     for info in infos:
         table.add_row(
             info.name,
-            f"{info.serve_provider} ({info.serve_model})",
+            "[red]unreadable[/red]"
+            if info.error is not None
+            else f"{info.serve_provider} ({info.serve_model})",
             "-" if info.held_out_accuracy is None else f"{info.held_out_accuracy:.3f}",
             "-" if info.rollouts_used is None else str(info.rollouts_used),
             "-" if info.frontier_size is None else str(info.frontier_size),

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -992,7 +992,7 @@ def build_summary_panel(info: ModelInfo, root: str) -> Panel:
 def models_table(infos: list[ModelInfo]) -> Table:
     """A table of every built world model (for `wmo list`).
 
-    An artifact the store could not read still gets a row, marked `unreadable` — it exists on
+    An artifact the store could not read still gets a row, marked `unreadable`: it exists on
     disk, so hiding it would be a lie, and dropping the whole table would hide the healthy models
     beside it. `wmo list` prints the reason under the table.
     """

--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -361,7 +361,10 @@ def load_config(root: str | Path = ARTIFACT_DIR) -> HarnessConfig:
     try:
         with paths.config.open("rb") as fh:
             data = tomllib.load(fh)
-    except tomllib.TOMLDecodeError as exc:
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        # A TOML document is UTF-8 by definition, so bytes that do not decode are the same
+        # "not valid TOML" answer; `tomllib.load` decodes before it parses, and the raw
+        # UnicodeDecodeError names neither the file nor the way out.
         raise ValueError(
             f"{paths.config} is not valid TOML ({exc}); re-run `wmo build` to regenerate it"
         ) from exc

--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -342,7 +342,13 @@ def _strip_none_object(obj: dict[str, JsonValue]) -> JsonObject:
 
 
 def load_config(root: str | Path = ARTIFACT_DIR) -> HarnessConfig:
-    """Read `.wmo/config.toml`. Raises a friendly error if the project hasn't been built yet."""
+    """Read `.wmo/config.toml`. Raises a friendly error if the project hasn't been built yet.
+
+    Raises:
+        FileNotFoundError: The root or its `config.toml` does not exist yet.
+        ValueError: The config exists but cannot be read, is not valid TOML, or does not match
+            the current schema. The message names the path and the repair.
+    """
     paths = ArtifactPaths(root)
     if not paths.root.exists():
         raise FileNotFoundError(
@@ -358,6 +364,13 @@ def load_config(root: str | Path = ARTIFACT_DIR) -> HarnessConfig:
     except tomllib.TOMLDecodeError as exc:
         raise ValueError(
             f"{paths.config} is not valid TOML ({exc}); re-run `wmo build` to regenerate it"
+        ) from exc
+    except OSError as exc:
+        # An unreadable (root-owned, chmod 000, half-copied) artifact is the same user problem as
+        # a corrupt one, so it gets the same named-path error rather than a bare PermissionError.
+        raise ValueError(
+            f"{paths.config} could not be read ({exc}); fix the file's permissions, or re-run "
+            "`wmo build` to regenerate it"
         ) from exc
     try:
         return HarnessConfig.model_validate(data)

--- a/wmo/config/config_test.py
+++ b/wmo/config/config_test.py
@@ -142,6 +142,19 @@ def test_load_unreadable_config_raises_friendly_error(tmp_path: Path) -> None:
         config.chmod(0o644)
 
 
+def test_load_non_utf8_config_raises_friendly_error(tmp_path: Path) -> None:
+    # `tomllib.load` decodes before it parses, and UnicodeDecodeError is a ValueError rather than
+    # a TOMLDecodeError, so a non-UTF-8 artifact used to surface a bare codec error naming no file.
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    (root / "config.toml").write_bytes(b'system_prompt = "\x93hi\x94"\n')
+    with pytest.raises(ValueError) as excinfo:
+        load_config(root=root)
+    message = str(excinfo.value)
+    assert "not valid TOML" in message
+    assert str(root / "config.toml") in message
+
+
 def test_save_does_not_leave_temp_file(tmp_path: Path) -> None:
     root = tmp_path / ".wmo"
     save_config(HarnessConfig(), root=root)

--- a/wmo/config/config_test.py
+++ b/wmo/config/config_test.py
@@ -127,6 +127,21 @@ def test_load_schema_invalid_toml_raises_friendly_error(tmp_path: Path) -> None:
         load_config(root=root)
 
 
+def test_load_unreadable_config_raises_friendly_error(tmp_path: Path) -> None:
+    # A root-owned or chmod-000 artifact used to escape as a bare PermissionError with no path
+    # and no next step; it is the same user problem as a corrupt one.
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    config = root / "config.toml"
+    config.write_text("top_k = 3", encoding="utf-8")
+    config.chmod(0o000)
+    try:
+        with pytest.raises(ValueError, match="could not be read"):
+            load_config(root=root)
+    finally:
+        config.chmod(0o644)
+
+
 def test_save_does_not_leave_temp_file(tmp_path: Path) -> None:
     root = tmp_path / ".wmo"
     save_config(HarnessConfig(), root=root)

--- a/wmo/config/settings.py
+++ b/wmo/config/settings.py
@@ -98,7 +98,7 @@ _SETTINGS_REPAIR = "fix the file, or delete it and re-run `wmo providers set` to
 """How to recover a settings file this loader refuses. Every raise below names it.
 
 `wmo providers set` reads the file before it rewrites it, so "just re-run it" is only true once
-the broken file is out of the way — hence "delete it and re-run", not "re-run".
+the broken file is out of the way, hence "delete it and re-run", not "re-run".
 """
 
 

--- a/wmo/config/settings.py
+++ b/wmo/config/settings.py
@@ -115,7 +115,10 @@ def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
     try:
         with path.open("rb") as fh:
             data = tomllib.load(fh)
-    except tomllib.TOMLDecodeError as exc:
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        # A TOML document is UTF-8 by definition, so bytes that do not decode are the same
+        # "not valid TOML" answer; `tomllib.load` decodes before it parses, and the raw
+        # UnicodeDecodeError names neither the file nor the way out.
         raise ValueError(f"{path} is not valid TOML ({exc}); {_SETTINGS_REPAIR}") from exc
     except OSError as exc:
         raise ValueError(f"{path} could not be read ({exc}); {_SETTINGS_REPAIR}") from exc

--- a/wmo/config/settings.py
+++ b/wmo/config/settings.py
@@ -94,7 +94,21 @@ def settings_path(root: str | Path = ARTIFACT_DIR) -> Path:
     return Path(root) / SETTINGS_FILENAME
 
 
+_SETTINGS_REPAIR = "fix the file, or delete it and re-run `wmo providers set` to write a fresh one"
+"""How to recover a settings file this loader refuses. Every raise below names it.
+
+`wmo providers set` reads the file before it rewrites it, so "just re-run it" is only true once
+the broken file is out of the way — hence "delete it and re-run", not "re-run".
+"""
+
+
 def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
+    """Read `<root>/settings.toml`, defaulting when it does not exist.
+
+    Raises:
+        ValueError: The file exists but cannot be read, is not valid TOML, or does not match the
+            current settings schema. The message names the path and the repair.
+    """
     path = settings_path(root)
     if not path.exists():
         return ProjectSettings()
@@ -102,11 +116,15 @@ def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
         with path.open("rb") as fh:
             data = tomllib.load(fh)
     except tomllib.TOMLDecodeError as exc:
-        raise ValueError(f"{path} is not valid TOML ({exc})") from exc
+        raise ValueError(f"{path} is not valid TOML ({exc}); {_SETTINGS_REPAIR}") from exc
+    except OSError as exc:
+        raise ValueError(f"{path} could not be read ({exc}); {_SETTINGS_REPAIR}") from exc
     try:
         return ProjectSettings.model_validate(data)
     except ValidationError as exc:
-        raise ValueError(f"{path} does not match the current settings schema ({exc})") from exc
+        raise ValueError(
+            f"{path} does not match the current settings schema ({exc}); {_SETTINGS_REPAIR}"
+        ) from exc
 
 
 def save_settings(settings: ProjectSettings, root: str | Path = ARTIFACT_DIR) -> None:

--- a/wmo/config/settings_test.py
+++ b/wmo/config/settings_test.py
@@ -77,6 +77,21 @@ def test_refused_settings_name_the_path_and_the_repair(
     assert "delete it and re-run `wmo providers set`" in message
 
 
+def test_non_utf8_settings_name_the_path_and_the_repair(tmp_path: Path) -> None:
+    # TOML is UTF-8 by definition, and `tomllib.load` decodes before it parses, so a file saved
+    # in another encoding raises UnicodeDecodeError — a ValueError that is not a TOMLDecodeError
+    # and so used to escape the guard as a bare codec error naming no file.
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    settings_path(root).write_bytes(b'[models.worker]\nprovider = "\x93openai\x94"\n')
+    with pytest.raises(ValueError) as excinfo:
+        load_settings(root)
+    message = str(excinfo.value)
+    assert "not valid TOML" in message
+    assert str(settings_path(root)) in message
+    assert "delete it and re-run `wmo providers set`" in message
+
+
 def test_model_roles_round_trip_through_toml(tmp_path: Path) -> None:
     root = tmp_path / ".wmo"
     settings = ProjectSettings(

--- a/wmo/config/settings_test.py
+++ b/wmo/config/settings_test.py
@@ -79,7 +79,7 @@ def test_refused_settings_name_the_path_and_the_repair(
 
 def test_non_utf8_settings_name_the_path_and_the_repair(tmp_path: Path) -> None:
     # TOML is UTF-8 by definition, and `tomllib.load` decodes before it parses, so a file saved
-    # in another encoding raises UnicodeDecodeError — a ValueError that is not a TOMLDecodeError
+    # in another encoding raises UnicodeDecodeError, a ValueError that is not a TOMLDecodeError
     # and so used to escape the guard as a bare codec error naming no file.
     root = tmp_path / ".wmo"
     root.mkdir()

--- a/wmo/config/settings_test.py
+++ b/wmo/config/settings_test.py
@@ -54,6 +54,29 @@ def test_load_corrupt_settings_raises_friendly_error(tmp_path: Path) -> None:
         load_settings(root)
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("not = = toml", "not valid TOML"),
+        ('[models]\nworker = "openai"', "does not match the current settings schema"),
+    ],
+)
+def test_refused_settings_name_the_path_and_the_repair(
+    tmp_path: Path, payload: str, expected: str
+) -> None:
+    # Editing settings.toml by hand is documented, and a file written by an older CLI outlives an
+    # upgrade, so both refusals have to say which file and what to do about it.
+    root = tmp_path / ".wmo"
+    root.mkdir()
+    settings_path(root).write_text(payload, encoding="utf-8")
+    with pytest.raises(ValueError) as excinfo:
+        load_settings(root)
+    message = str(excinfo.value)
+    assert expected in message
+    assert str(settings_path(root)) in message
+    assert "delete it and re-run `wmo providers set`" in message
+
+
 def test_model_roles_round_trip_through_toml(tmp_path: Path) -> None:
     root = tmp_path / ".wmo"
     settings = ProjectSettings(

--- a/wmo/config/store.py
+++ b/wmo/config/store.py
@@ -19,13 +19,12 @@ from __future__ import annotations
 
 import json
 import re
-import tomllib
 from pathlib import Path
 
 from pydantic import BaseModel, JsonValue
 
 from wmo.config.card import ModelCard, load_card
-from wmo.config.config import ARTIFACT_DIR, ArtifactPaths, HarnessConfig
+from wmo.config.config import ARTIFACT_DIR, ArtifactPaths, load_config
 from wmo.providers.models import resolve_provider_model
 
 # The implicit model name used when the user does not pass `--name`.
@@ -64,6 +63,13 @@ class ModelInfo(BaseModel):
     held_out_accuracy: float | None = None
     rollouts_used: int | None = None
     frontier_size: int | None = None
+    error: str | None = None
+    """Why this artifact could not be read, on a row where the summary fields are unknown."""
+
+    @classmethod
+    def unreadable(cls, name: str, error: str) -> ModelInfo:
+        """A `wmo list` row standing in for an artifact that could not be summarized."""
+        return cls(name=name, serve_provider="-", serve_model="-", error=error)
 
 
 class WorldModelStore:
@@ -140,22 +146,28 @@ class WorldModelStore:
         return load_card(model_dir)
 
     def info(self, name: str) -> ModelInfo:
-        """Read a model's config + metrics into a summary (for `wmo list`)."""
+        """Read a model's config + metrics into a summary (for `wmo list`).
+
+        Raises:
+            FileNotFoundError: No artifact named `name` under this root.
+            ValueError: One of the artifact's files could not be read or parsed. Goes through
+                `load_config` / `_read_json` so the message names the offending file.
+        """
         model_dir = self.dir_for(name)
         if model_dir is None:
             raise FileNotFoundError(f"no world model named {name!r}")
         paths = ArtifactPaths(model_dir)
-        with paths.config.open("rb") as fh:
-            config = HarnessConfig.model_validate(tomllib.load(fh))
+        config = load_config(model_dir)
         accuracy: float | None = None
         rollouts: int | None = None
         if paths.metrics.exists():
-            metrics = json.loads(paths.metrics.read_text(encoding="utf-8"))
-            accuracy = _as_float(metrics.get("held_out_accuracy"))
-            rollouts = _as_int(metrics.get("rollouts_used"))
+            metrics = _read_json(paths.metrics)
+            if isinstance(metrics, dict):
+                accuracy = _as_float(metrics.get("held_out_accuracy"))
+                rollouts = _as_int(metrics.get("rollouts_used"))
         frontier_size: int | None = None
         if paths.frontier.exists():
-            frontier = json.loads(paths.frontier.read_text(encoding="utf-8"))
+            frontier = _read_json(paths.frontier)
             if isinstance(frontier, list):
                 frontier_size = len(frontier)
         serve = config.serve_provider_config()
@@ -170,7 +182,27 @@ class WorldModelStore:
         )
 
     def list_info(self) -> list[ModelInfo]:
-        return [self.info(name) for name in self.list_names()]
+        """One row per built model; an artifact that cannot be read becomes a row, not a raise.
+
+        `wmo list` is how you find out what a project holds, so one hand-edited or half-copied
+        `models/<name>/config.toml` must not hide every healthy model beside it. The failure
+        rides along in `ModelInfo.error` for the caller to render next to the good rows.
+        """
+        infos: list[ModelInfo] = []
+        for name in self.list_names():
+            try:
+                infos.append(self.info(name))
+            except (OSError, ValueError) as exc:
+                infos.append(ModelInfo.unreadable(name, str(exc)))
+        return infos
+
+
+def _read_json(path: Path) -> JsonValue:
+    """Parse `path`, naming it in the error so a bad row can say which file is bad."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path} could not be read ({exc}); re-run `wmo build`") from exc
 
 
 def _as_float(value: JsonValue) -> float | None:

--- a/wmo/config/store.py
+++ b/wmo/config/store.py
@@ -161,15 +161,12 @@ class WorldModelStore:
         accuracy: float | None = None
         rollouts: int | None = None
         if paths.metrics.exists():
-            metrics = _read_json(paths.metrics)
-            if isinstance(metrics, dict):
-                accuracy = _as_float(metrics.get("held_out_accuracy"))
-                rollouts = _as_int(metrics.get("rollouts_used"))
+            metrics = _read_json(paths.metrics, dict)
+            accuracy = _as_float(metrics.get("held_out_accuracy"))
+            rollouts = _as_int(metrics.get("rollouts_used"))
         frontier_size: int | None = None
         if paths.frontier.exists():
-            frontier = _read_json(paths.frontier)
-            if isinstance(frontier, list):
-                frontier_size = len(frontier)
+            frontier_size = len(_read_json(paths.frontier, list))
         serve = config.serve_provider_config()
         model_type = serve.model_type or resolve_provider_model(serve.kind, serve.model).model_type
         return ModelInfo(
@@ -197,12 +194,27 @@ class WorldModelStore:
         return infos
 
 
-def _read_json(path: Path) -> JsonValue:
-    """Parse `path`, naming it in the error so a bad row can say which file is bad."""
+_JSON_SHAPE_NAMES: dict[type, str] = {dict: "object", list: "array"}
+
+
+def _read_json[T: dict | list](path: Path, shape: type[T]) -> T:
+    """Parse `path` as a JSON `shape`, naming it so a bad row can say which file is bad.
+
+    The shape is checked here rather than skipped past at the call site: an artifact whose
+    `metrics.json` holds an array is corrupt, and reading it as "this model has no metrics"
+    would print a row indistinguishable from a healthy model that was never evaluated.
+    """
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        # UnicodeDecodeError is a ValueError, not an OSError, so it needs naming here or a
+        # non-UTF-8 artifact reports a bare codec error with no path and no next step.
         raise ValueError(f"{path} could not be read ({exc}); re-run `wmo build`") from exc
+    if not isinstance(value, shape):
+        raise ValueError(
+            f"{path} is not a JSON {_JSON_SHAPE_NAMES[shape]}; re-run `wmo build` to regenerate it"
+        )
+    return value
 
 
 def _as_float(value: JsonValue) -> float | None:

--- a/wmo/config/store_test.py
+++ b/wmo/config/store_test.py
@@ -82,3 +82,34 @@ def test_resolve_unknown_name_lists_available(tmp_path) -> None:  # noqa: ANN001
     _build_fake_model(store, "alpha")
     with pytest.raises(FileNotFoundError, match="alpha"):
         store.resolve("nope")
+
+
+def test_one_unreadable_artifact_does_not_hide_the_healthy_ones(tmp_path) -> None:  # noqa: ANN001
+    # A model dir arrives from `wmo pull` or a hand copy, so a config.toml this CLI cannot parse
+    # is an ordinary state. It must cost its own row, not the whole listing.
+    store = WorldModelStore(tmp_path / ".wmo")
+    _build_fake_model(store, "alpha-healthy")
+    for name, payload in (("zz-bad-toml", "this is not toml ="), ("zz-bad-schema", 'top_k = "x"')):
+        bad = store.model_dir(name)
+        bad.mkdir(parents=True)
+        (bad / "config.toml").write_text(payload, encoding="utf-8")
+
+    infos = {info.name: info for info in store.list_info()}
+
+    assert infos["alpha-healthy"].error is None
+    assert infos["alpha-healthy"].serve_provider == "bedrock"
+    # Each bad row names its own file and the way out.
+    assert "zz-bad-toml/config.toml is not valid TOML" in str(infos["zz-bad-toml"].error)
+    assert "re-run `wmo build`" in str(infos["zz-bad-toml"].error)
+    assert "does not match the current config schema" in str(infos["zz-bad-schema"].error)
+
+
+def test_unreadable_metrics_names_the_file_it_could_not_read(tmp_path) -> None:  # noqa: ANN001
+    # metrics.json is written after config.toml, so a half-written artifact fails here; the row
+    # has to say which file rather than a bare json decode position.
+    store = WorldModelStore(tmp_path / ".wmo")
+    _build_fake_model(store, "alpha")
+    ArtifactPaths(store.model_dir("alpha")).metrics.write_text("{not json", encoding="utf-8")
+
+    (info,) = store.list_info()
+    assert "metrics.json could not be read" in str(info.error)

--- a/wmo/config/store_test.py
+++ b/wmo/config/store_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -113,3 +114,38 @@ def test_unreadable_metrics_names_the_file_it_could_not_read(tmp_path) -> None: 
 
     (info,) = store.list_info()
     assert "metrics.json could not be read" in str(info.error)
+
+
+def test_non_utf8_artifact_json_names_the_file(tmp_path) -> None:  # noqa: ANN001
+    # UnicodeDecodeError is a ValueError, not an OSError, so it slips past a read/parse guard
+    # that only names those two and arrives as a bare codec error with no path.
+    store = WorldModelStore(tmp_path / ".wmo")
+    _build_fake_model(store, "alpha")
+    ArtifactPaths(store.model_dir("alpha")).metrics.write_bytes(b'{"held_out_accuracy": "\x80"}')
+
+    (info,) = store.list_info()
+    assert "metrics.json could not be read" in str(info.error)
+    assert "codec can't decode" in str(info.error)
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload", "expected"),
+    [
+        ("metrics", "[0.5, 7]", "metrics.json is not a JSON object"),
+        ("frontier", '{"a": 1}', "frontier.json is not a JSON array"),
+    ],
+    ids=["metrics-array", "frontier-object"],
+)
+def test_a_wrongly_shaped_summary_file_is_an_unreadable_row(
+    tmp_path: Path, filename: str, payload: str, expected: str
+) -> None:
+    # Valid JSON of the wrong top-level type is still a corrupt artifact. Skipping past it would
+    # print a row identical to a healthy model that was simply never evaluated.
+    store = WorldModelStore(tmp_path / ".wmo")
+    _build_fake_model(store, "alpha")
+    path = getattr(ArtifactPaths(store.model_dir("alpha")), filename)
+    path.write_text(payload, encoding="utf-8")
+
+    (info,) = store.list_info()
+    assert expected in str(info.error)
+    assert "re-run `wmo build`" in str(info.error)

--- a/wmo/providers/tinker.py
+++ b/wmo/providers/tinker.py
@@ -84,6 +84,8 @@ _MISSING_TINKER_EXTRA = (
     "the tinker SDK is not installed; run `uv sync --extra distill` (or "
     "`pip install 'world-model-optimizer[distill]'`) to use the tinker provider"
 )
+"""Both install forms, because `pip install world-model-optimizer` is the documented entry point
+and `uv sync` needs a checkout of this repo to have anything to sync."""
 
 # The tinker SamplingParams default; used when a structured request carries no
 # temperature (pi normally stamps one on every request).


### PR DESCRIPTION
## What was broken

Six commands ended in a user-visible Python traceback whenever one TOML file on
disk was malformed, schema-stale, or unreadable. In every case the loader had
already produced an accurate, actionable message, but nothing routed it to the
user, so it arrived wrapped in 90 lines of `tomllib`/pydantic stack frames.

Paste this to see the old behaviour (no network, no spend):

```sh
mkdir -p /tmp/wmo-badtoml/.wmo/models/foo
printf '[models.worker\nprovider = "openai"\n' > /tmp/wmo-badtoml/.wmo/settings.toml
printf 'this is not toml [[[\n'                > /tmp/wmo-badtoml/.wmo/models/foo/config.toml
cd /tmp/wmo-badtoml
wmo providers verify        # rich traceback -> ValueError, exit 1
wmo config telemetry status # rich traceback -> ValueError, exit 1
wmo list                    # rich traceback -> TOMLDecodeError, and every healthy model vanishes
```

`wmo list` was the worst of them: `WorldModelStore.info` parsed every
`models/*/config.toml` with no handling, so one bad artifact (a bundle pushed
by a newer CLI, a half-finished `cp`) removed the entire discovery command for
the whole project, naming neither the file nor the model.

Two smaller things in the same area: `wmo list` reported the empty state
identically for "no models", a typo'd `--root`, and `--root <a regular file>`,
and never echoed the directory it searched; and `providers verify`'s hint for a
missing tinker SDK told a pip user to run `uv sync --extra distill` (which needs
a git checkout) and then advised them to check their credentials on what is a
missing-SDK failure.

## What changed

One robust load path per file kind, each naming the offending file and the fix.

- **`wmo/config/store.py`**: `list_info` catches per artifact and returns a row
  carrying the reason, so a bad artifact costs its own row (`unreadable`, with
  the reason printed under the table) instead of the listing. `info` now reads
  through `load_config` and a path-naming JSON helper rather than a bare
  `tomllib.load`. The interactive model picker drops unreadable rows so it never
  offers a choice that dead-ends.
- **`wmo/cli/model_roles.py`**: a single `load_settings_or_abort`, which every
  CLI read of `settings.toml` now goes through (`providers verify`,
  `providers set`, `config telemetry`, `build`, the scenario roles, the distill
  promote path). It mirrors the `typer.BadParameter` conversion the same file
  already does for an unknown provider inside that file.
- **`wmo/config/settings.py` / `config.py`**: both loaders append the repair to
  their messages, and both turn an unreadable file into a named-path error
  instead of a bare `PermissionError`.
- **`wmo providers verify`**: `load_config` moved inside the existing
  `except (FileNotFoundError, ValueError)` guard, so a built model with a
  corrupt `config.toml` reports as a bad artifact.
- **`wmo providers set`**: validates `--provider` before it reads the project's
  settings, so a bad argument reads as a bad argument even in a broken project.
- **`wmo list`**: names the directory it searched on an empty listing, and
  rejects a regular file as `--root`.
- **`wmo providers verify` messages**: the tinker SDK error names
  `pip install 'world-model-optimizer[distill]'` alongside `uv sync --extra
  distill` (matching `wmo/distill/rollouts.py`), and `_credential_hint` now
  recognises an optional extra's own "SDK is not installed" wording, so it points
  at the install rather than at credentials. Both print sites escape the hint, or
  rich would eat the `[distill]`.

After the change, the repro above gives three clean usage errors, and `wmo list`
lists the healthy models with the broken one marked `unreadable` and its reason
underneath.

No blanket handler was added at the CLI entry point; each path is fixed where it
raises.

## Audit findings closed

- `wmo list` tracebacks for the whole project when any one `models/*/config.toml`
  is malformed (`wmo/config/store.py:143`): major
- `wmo config telemetry` tracebacks on a malformed or schema-invalid
  `.wmo/settings.toml`: major
- `wmo providers verify` tracebacks on the same file: minor
- `wmo providers set` tracebacks on the same file, before it validates its own
  arguments: minor
- `wmo providers verify` tracebacks when a built model has an unreadable
  `config.toml`: minor
- `wmo list` reports the empty state identically for "no models", a typo'd
  `--root` and a file `--root`, and never echoes the directory it searched: minor
- The tinker SDK-missing error tells a pip user to run `uv sync --extra distill`: minor
- `providers verify`'s next-step hint points at credentials on a missing-SDK
  failure: minor

## Tests

`uv run pytest wmo packages`: 4174 passed, 20 skipped. New coverage: an
unreadable artifact becomes a row without hiding healthy ones; a bad row and an
unreadable `metrics.json` name their own file; `load_config` on a chmod-000
config; both settings refusals name the path and the repair; a parametrized
CLI check that `providers verify`, `providers set` and both `config telemetry`
actions exit 2 with a named file on malformed *and* schema-invalid settings;
`providers set` preferring its own bad `--provider`; the empty-listing path and
the file-as-`--root` rejection; the picker skipping unreadable artifacts; and the
missing-optional-SDK hint naming the pip install and not mentioning credentials.

## Review follow-ups (Greptile)

- **Non-UTF-8 files lost their path.** `tomllib.load` decodes before it parses and
  `UnicodeDecodeError` is a `ValueError`, not a `TOMLDecodeError` or an `OSError`, so a
  `config.toml`/`settings.toml` saved in another encoding slipped past both new guards as a bare
  codec error. Both loaders now catch it alongside `TOMLDecodeError` and report "is not valid
  TOML" (a TOML document is UTF-8 by definition). `_read_json` had the same hole.
- **Valid JSON of the wrong shape looked readable.** The `isinstance(metrics, dict)` guard was new
  in this PR and turned a traceback into a silent `-`, i.e. a row indistinguishable from a healthy
  model that was never evaluated. The shape is now checked inside `_read_json`, which names the
  file; applied to `frontier.json` too, so the two adjacent reads agree.

- **Invalid metric field *values*** (a string `held_out_accuracy`, a null `rollouts_used`)
  reported as `-` rather than as a bad artifact. Declined as out of scope: `_as_float`/`_as_int`
  are byte-identical to `main`, so this is not a regression this PR introduced, and `null` is the
  ordinary spelling of "not measured" (`wmo/serving/builds.py:86` declares
  `held_out_accuracy: float | None = None`), so refusing it would reject legitimate artifacts.
  Giving `metrics.json` a pydantic model the way `config.toml` has one is the right fix, in its
  own PR. Reasoning left on the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


