### PR TITLE
Default `wmo build` to the free fidelity tier

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -83,10 +83,10 @@ same command with `--source <name>`, or through `wmo ingest` first.
 
 The two flags above are the free configuration: `--fidelity low` takes the estimated-best config
 with no search, and `--embed-provider hashing` indexes with an offline embedder. That is what
-produced the transcript below, at a measured `$0.0000`. The default is `--fidelity medium`, which
-adds light prompt optimization and a cheap-lever search and does cost money; `high` and `max`
-search harder. Every searching tier is floored at low's estimate, so more effort never ships a
-worse config than low.
+produced the transcript below, at a measured `$0.0000`. `low` is also the default, so a plain
+`wmo build` does not spend on search. Opt into `--fidelity medium` for light prompt optimization
+and a cheap-lever search, or `high`/`max` to search harder; those tiers cost real money. Every
+searching tier is floored at low's estimate, so more effort never ships a worse config than low.
 
 ```
 ✓ ingested 1033 traces → normalized 5289 steps

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -589,11 +589,13 @@ def build(
     ),
     region: str = typer.Option(None, help="AWS region (Bedrock)."),
     fidelity: str = typer.Option(
-        "medium",
+        "low",
         help="Build effort (all searching tiers are floored at low's estimate — more effort "
-        "never ships worse than low): low (free; the estimated-best config, no search) | "
-        "medium (+light GEPA + cheap-lever search) | high (+GEPA + config search) | max (deep "
-        "GEPA + full config search). The chosen config serves under `--max-fidelity`.",
+        "never ships worse than low): low (default; free — the estimated-best config, no "
+        "search) | medium (+light GEPA + cheap-lever search) | high (+GEPA + config search) | "
+        "max (deep GEPA + full config search). Searching tiers cost real money: one observed "
+        "medium build spent 73% of its total on GEPA. The chosen config serves under "
+        "`--max-fidelity`.",
     ),
     chain: str = typer.Option(
         None, "--chain", help="Named failover chain from .wmo/fallback.toml (default: its default)."

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -19,7 +19,15 @@ from typer.testing import CliRunner
 from wmo.cli import app, pool_registry
 from wmo.cli.app import _CONCURRENCY_ISOLATION_FLAGS
 from wmo.cli.pool_registry import read_pool_entries
-from wmo.config import HarnessConfig, ModelRole, load_config, load_settings, save_settings
+from wmo.config import (
+    FIDELITY_TIERS,
+    FidelityTier,
+    HarnessConfig,
+    ModelRole,
+    load_config,
+    load_settings,
+    save_settings,
+)
 from wmo.core.types import Trace
 from wmo.engine.build import DEFAULT_TRAIN_SPLIT, split_traces, split_traces_3way
 from wmo.engine.eval_suites import EvalSuiteConfig
@@ -1748,3 +1756,38 @@ def test_default_eval_holdout_contains_no_build_training_trace() -> None:
     assert holdout, "sanity: the corpus must actually produce a holdout"
     leaked = {t.trace_id for t in gepa_train} & {t.trace_id for t in holdout}
     assert leaked == set(), f"{len(leaked)} GEPA training traces scored as held-out"
+
+
+def test_build_defaults_to_the_free_fidelity_tier(patched_provider, tmp_path) -> None:  # noqa: ANN001
+    """A plain `wmo build` must not spend on search.
+
+    The default was `medium`, which runs GEPA plus a cheap-lever config search; in one observed
+    build that was 73% of total spend. `low` is `estimate_only` with `gepa_budget=0` and no
+    config search, so the documented quickstart no longer bills a first-time user by default.
+    `auto_fidelity.json` records the difference: the low tier writes a signature estimate with
+    no `scores`, while every searching tier writes the scores it paid for.
+    """
+    spec = FIDELITY_TIERS[FidelityTier.LOW]
+    assert spec.gepa_budget == 0 and spec.config_search is False, "low is no longer the free tier"
+
+    root = tmp_path / ".wmo"
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "defaulted",
+            "--file",
+            _traces_file(tmp_path),
+            "--root",
+            str(root),
+            "--provider",
+            "bedrock",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    auto = json.loads(
+        (root / "models" / "defaulted" / "auto_fidelity.json").read_text(encoding="utf-8")
+    )
+    assert not auto.get("scores"), f"default build paid for a config search: {auto['scores']}"


### PR DESCRIPTION
## What was wrong

`wmo build --fidelity` defaulted to `medium`, which runs a light GEPA pass **plus** a cheap-lever config search. Both spend real money, so the first command in the README quickstart bills a first-time user by default.

Measured on one end-to-end build (`tau`, 4 scenarios):

| | tokens | cost | calls |
| --- | --- | --- | --- |
| GEPA | 1,105,963 | **$1.4724** | 222 |
| judge | 407,595 | $0.5488 | 217 |
| **total** | 1,513,558 | **$2.0212** | 439 |

GEPA was 73% of spend. That build's config search then reported `base=0.523, reason=0.073` — the *base* config won, i.e. the search paid to rediscover the default.

## What changed

`--fidelity` now defaults to `low`, which is `estimate_only` with `gepa_budget=0` and `config_search=False`. The tau-bench cookbook measures that path at `$0.0000`.

GEPA is **not** removed. `--fidelity medium|high|max` are unchanged and one flag away; every searching tier is still floored at low's estimate, so opting up never ships a worse config than low. This only makes paying for search opt-in.

Also updates the `--fidelity` help text and the cookbook line that stated the old default.

## Repro

```bash
curl -sL https://huggingface.co/datasets/experiential-labs/wmh-tau-bench-traces/resolve/main/traces.otel.jsonl -o traces.otel.jsonl
wmo build --file traces.otel.jsonl --name tau     # before: spends on GEPA. after: free.
```

## Test

`test_build_defaults_to_the_free_fidelity_tier` asserts the default build writes an `auto_fidelity.json` with no `scores` — the artifact only carries scores when a search actually ran, so this fails if the default ever goes back to a paying tier.

`uv run pytest wmo/cli/ wmo/config/` → 568 passed.

## For reviewers

`wmo/config/config.py:106-110` already records that high's 8-iteration GEPA increment "measured ~noise on every benchmark" (tau -0.005, terminal +0.007, swe +0.006), and that PR #97 found the base template's iteration lift ≈0. There is no comparable measurement of **0 vs 4** iterations — which is exactly what the `medium` default was charging for. An audit of that question is running separately; this PR does not depend on its outcome, since it only changes which tier is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)