### PR TITLE
Release 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "world-model-optimizer"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run agents, build world models from traces, and optimize agent harnesses."
 readme = "README.md"
 # harbor 0.20.0 requires Python >=3.12; the harbor evaluator is a first-class optimize

--- a/uv.lock
+++ b/uv.lock
@@ -3913,7 +3913,7 @@ wheels = [
 
 [[package]]
 name = "world-model-optimizer"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why now

v0.2.0 was tagged in #276; **31 commits** have landed since. Six of them add CLI commands, and the released wheel has none of them:

```
wmo optimize route sweep
wmo optimize route pin
wmo optimize route student
wmo optimize model
wmo optimize distill run
wmo optimize distill report
```

That is the whole router-tuning and distillation surface. `sweep` is the OutcomeMatrix producer added in #277, so `fit` has no input without it — **step 2 of the README quickstart cannot run on 0.2.0 at all**. OpenRouter (#284, #287) is likewise missing from the released provider list.

Nothing was removed between the tag and now; this is pure release lag.

## Verified against the built wheel

```
uv build --package world-model-optimizer --no-sources
uv pip install --python /tmp/rel-smoke/bin/python dist/*.whl
```

| command | 0.2.0 | 0.2.1 |
| --- | --- | --- |
| `optimize route sweep` | rc=2 no such command | rc=0 |
| `optimize route pin` | rc=2 | rc=0 |
| `optimize route student` | rc=2 | rc=0 |
| `optimize model` | rc=2 | rc=0 |
| `optimize distill run` | rc=2 | rc=0 |
| `optimize distill report` | rc=2 | rc=0 |

Provider list in the 0.2.1 wheel: `anthropic, bedrock, azure, openai, openai_responses, openrouter, tinker`. `import llm_waterfall, wmo` OK.

## Scope

Root `pyproject.toml` version + `uv.lock` only, mirroring #276.

## Known gap, deliberately not in this release

`wmo download` stays broken for pip users. It resolves `environment-capture` from PyPI, which is still 0.1.0; the `wmh-`/`wmo-` dataset-name fix (#291) is in the repo at 0.1.1 but unpublished, and AGENTS.md forbids adding a member publishing workflow. Workaround for anyone testing:

```bash
curl -sL https://huggingface.co/datasets/experiential-labs/wmh-tau-bench-traces/resolve/main/traces.otel.jsonl -o traces.otel.jsonl
```

The 104 CLI defects from the pathway audit are also not in this release; those are in a separate 13-PR stack and would land in 0.2.2.

## Release steps after merge

1. Tag and create the GitHub Release `v0.2.1` — the publish job in `python-package.yml` runs only on `release: published` and uses the `pypi` trusted-publisher environment.
2. Confirm the wheel on PyPI exposes `wmo optimize route sweep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)