### PR TITLE
Per-cluster compaction fitter: measured-arm gates, A/A kill bar, fit-compaction CLI (C2 round 2)

### DIFF
--- a/.agents/scripts/c2_decision_surface.py
+++ b/.agents/scripts/c2_decision_surface.py
@@ -1,0 +1,123 @@
+"""C2 overnight menu A: the corrected-gate decision surface on the financebench arms.
+
+Sweeps z x margin x min_pairs over the five financebench-s80 arm matrices under the RULED
+non-inferiority gate (mean - z*se >= -margin AND effective-cost win AND no control quality
+dominance), reporting per setting: which (cluster, arm) cells pass, what the fitted map
+would stamp, whether the A/A bar is clean at that (z, margin), and which control flags
+fire. EVERY quality-side number here is PENDING-RESCORE (the matrices' accuracy axis is
+ruled unmeasurable until the master's rescore); the object of study is the MACHINERY's
+behavior across its knob space, not the corpus verdict.
+
+Run from the c2-r2 worktree:
+
+    uv run python .agents/scripts/c2_decision_surface.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from wmo.optimize.compaction_fit import (
+    ArmMatrices,
+    EvidenceProvenance,
+    aa_report,
+    assign_to_clusters,
+    fit_compaction,
+)
+from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.policy import EmbedderSpec
+from wmo.optimize.routing import fit_rank_policy
+
+logging.basicConfig(level=logging.WARNING)
+
+MATRICES = Path.home() / "Desktop/Projects/wmh-compression-data/matrices"
+OUT = Path.home() / "Desktop/Projects/wmh-compression-data/fits/c2-r2/decision-surface.json"
+ARMS = ["llmlingua2-endpoint", "truncate-protect-task"]
+CONTROLS = ["control-random", "control-truncate"]
+Z_GRID = [0.5, 0.75, 1.0, 1.5, 2.0, 2.5]
+MARGIN_GRID = [0.0, 0.01, 0.02, 0.03]
+MIN_PAIRS_GRID = [8, 16, 30]
+
+
+def main() -> None:
+    off = OutcomeMatrix.load(MATRICES / "financebench-s80-off_matrix.json")
+    arms = []
+    for name in ARMS + CONTROLS:
+        matrix = OutcomeMatrix.load(MATRICES / f"financebench-s80-{name}_matrix.json")
+        arms.append(
+            ArmMatrices(
+                matrix=matrix,
+                config=matrix.measured_compression(),
+                control=name in CONTROLS,
+            )
+        )
+    spec = EmbedderSpec()
+    policy = fit_rank_policy(off, embedder=spec, n_clusters=8, seed=42)
+    assignment = assign_to_clusters(policy.clusters, off, embed_with=spec.build())
+    provenance = EvidenceProvenance.build(
+        off_source="financebench-s80-off_matrix.json",
+        arm_sources={},
+        scorer_era="pre-rescore-broken-wm-scorer",
+    )
+
+    rows = []
+    for z in Z_GRID:
+        for margin in MARGIN_GRID:
+            aa = aa_report(assignment, off, z=z, margin=margin)
+            for min_pairs in MIN_PAIRS_GRID:
+                fit = fit_compaction(
+                    assignment,
+                    off,
+                    arms,
+                    z=z,
+                    margin=margin,
+                    min_pairs=min_pairs,
+                    allow_uneven=True,
+                    provenance=provenance,
+                )
+                passing = [
+                    {
+                        "cluster": r.cluster_id,
+                        "arm": r.signature,
+                        "control": r.control,
+                        "mean_diff": round(r.mean_diff, 4),
+                        "se": round(r.se, 4),
+                        "n": r.n_pairs,
+                    }
+                    for r in fit.evidence
+                    if r.quality_pass and r.cost_pass
+                ]
+                rows.append(
+                    {
+                        "z": z,
+                        "margin": margin,
+                        "min_pairs": min_pairs,
+                        "aa_clean": not aa,
+                        "aa_deviations": [
+                            {"cluster": d.cluster_id, "mean_diff": round(d.mean_diff, 4)}
+                            for d in aa
+                        ],
+                        "clusters_compressed": fit.compressed_clusters(),
+                        "stamped": {
+                            str(cid): (cfg.compressor_id if cfg else None)
+                            for cid, cfg in fit.per_cluster.items()
+                        },
+                        "gate_passing_cells": passing,
+                        "control_flags": fit.control_flags,
+                    }
+                )
+                print(
+                    f"z={z:<4} margin={margin:<5} min_pairs={min_pairs:<3} "
+                    f"aa={'CLEAN' if not aa else 'FIRES'} "
+                    f"compressed={fit.compressed_clusters()} "
+                    f"passing_cells={len(passing)} flags={len(fit.control_flags)}"
+                )
+
+    OUT.write_text(json.dumps({"label": "PENDING-RESCORE", "rows": rows}, indent=1))
+    print(f"\nwrote {len(rows)} settings -> {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c2_features_and_anchors.py
+++ b/.agents/scripts/c2_features_and_anchors.py
@@ -1,0 +1,287 @@
+"""C2 overnight menus D+E: verbatim-critical features round 2, plus D-DIAL anchor emission.
+
+D: cheap cluster-level predictors (numeric density, capitalized-entity density, code/JSON
+char share, mean task words) against the corrected-gate outcome variable (the better REAL
+arm's paired quality delta per cluster), across both cohorts (financebench k=8 rank-path
+clusters, tau k=4). n = 12 clusters total: candidate-labeled, Spearman only. Plus an
+opus-5 exemplar labeling leg (Silen's overnight credit authorization): one call per
+cluster asking whether compressing these prompts risks breaking exact-match-critical
+content; metered per call, cumulative total printed and ledgered.
+
+E: joint anchors in the D-DIAL v2 ruled shape from the corrected fits. On BOTH cohorts
+the fitted map is compression=None everywhere, so the three corners coincide; the anchors
+STATE that as the measured verdict (per the routing master's note they must never imply a
+live knob) and carry the measured per-arm deltas as the evidence behind the None.
+
+Run from the c2-r2 worktree with ANTHROPIC_API_KEY exported:
+
+    uv run python .agents/scripts/c2_features_and_anchors.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from pathlib import Path
+
+from wmo.optimize.compaction_fit import (
+    ArmMatrices,
+    assign_to_clusters,
+    fit_compaction,
+)
+from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.policy import EmbedderSpec
+from wmo.optimize.routing import fit_rank_policy
+from wmo.optimize.scorecard import RowOverhead, effective_cost_per_completed_task
+
+DATA = Path.home() / "Desktop/Projects/wmh-compression-data"
+FB = DATA / "matrices"
+TAU = Path.home() / "Desktop/Projects/world-model-harness/.wmo/jt/grid-c2"
+OUT_FEATURES = DATA / "fits/c2-r2/features-r2.json"
+OUT_ANCHORS = DATA / "fits/c2-r2/anchors.json"
+
+OPUS_IN_PER_MTOK = 5.0
+OPUS_OUT_PER_MTOK = 25.0
+
+
+def cluster_features(tasks: list[str]) -> dict[str, float]:
+    text = " ".join(tasks)
+    words = text.split()
+    return {
+        "numeric_density": round(sum(1 for w in words if re.search(r"\d", w)) / len(words), 4),
+        "entity_density": round(sum(1 for w in words if w[:1].isupper()) / len(words), 4),
+        "codejson_share": round(
+            len(re.findall(r"[{}\[\]`$%()=<>_]", text)) / max(1, len(text)), 5
+        ),
+        "mean_words": round(statistics.mean(len(t.split()) for t in tasks), 1),
+    }
+
+
+def load_cohort(name: str):  # noqa: ANN202
+    if name == "financebench":
+        off = OutcomeMatrix.load(FB / "financebench-s80-off_matrix.json")
+        arm_names = ["llmlingua2-endpoint", "truncate-protect-task"]
+        arms = [
+            OutcomeMatrix.load(FB / f"financebench-s80-{a}_matrix.json") for a in arm_names
+        ]
+        k, allow_uneven = 8, True
+    else:
+        off = OutcomeMatrix.load(TAU / "identity/matrix.json")
+        arm_names = ["truncate", "llmlingua2-endpoint"]
+        arms = [OutcomeMatrix.load(TAU / a / "matrix.json") for a in arm_names]
+        k, allow_uneven = 4, False
+    spec = EmbedderSpec()
+    policy = fit_rank_policy(off, embedder=spec, n_clusters=k, seed=42)
+    assignment = assign_to_clusters(policy.clusters, off, embed_with=spec.build())
+    fit = fit_compaction(
+        assignment,
+        off,
+        [ArmMatrices(matrix=m, config=m.measured_compression()) for m in arms],
+        allow_uneven=allow_uneven,
+    )
+    return off, arms, assignment, fit
+
+
+def spearman(xs: list[float], ys: list[float]) -> float:
+    def ranks(vals: list[float]) -> list[float]:
+        order = sorted(range(len(vals)), key=lambda i: vals[i])
+        out = [0.0] * len(vals)
+        for rank, index in enumerate(order):
+            out[index] = float(rank)
+        return out
+
+    rx, ry = ranks(xs), ranks(ys)
+    mx, my = statistics.mean(rx), statistics.mean(ry)
+    num = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    den = (
+        sum((a - mx) ** 2 for a in rx) ** 0.5 * sum((b - my) ** 2 for b in ry) ** 0.5
+    )
+    return num / den if den else 0.0
+
+
+def opus_label(exemplars: list[str]) -> tuple[str, str, float]:
+    """One metered opus-5 call: verbatim-critical YES/NO + reason. Returns (label, reason, usd)."""
+    from anthropic import Anthropic
+
+    client = Anthropic()
+    prompt = (
+        "These are task prompts from one workload cluster:\n\n"
+        + "\n---\n".join(exemplars[:3])
+        + "\n\nIf a compressor removed low-information tokens from prompts like these "
+        "before an LLM answered them, would it risk deleting exact-match-critical content "
+        "(identifiers, numbers, code, exact names the answer must reproduce)? "
+        "Answer with YES or NO on the first line, then one sentence of reasoning."
+    )
+    response = client.messages.create(
+        model="claude-opus-5",
+        max_tokens=100,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = next(
+        block.text for block in response.content if getattr(block, "type", "") == "text"
+    ).strip()
+    usd = (
+        response.usage.input_tokens * OPUS_IN_PER_MTOK
+        + response.usage.output_tokens * OPUS_OUT_PER_MTOK
+    ) / 1e6
+    label = "YES" if text.upper().startswith("YES") else "NO"
+    return label, text.splitlines()[-1][:200], usd
+
+
+def arm_deltas(off: OutcomeMatrix, arm: OutcomeMatrix) -> dict[str, float]:
+    """Pooled per-arm deltas vs off on shared scored cells: the evidence behind the anchors."""
+
+    def cells(matrix: OutcomeMatrix):  # noqa: ANN202
+        by = {}
+        for row in matrix.outcomes:
+            if row.scored:
+                by.setdefault((row.scenario_id, row.model), []).append(row)
+        return by
+
+    off_cells, arm_cells = cells(off), cells(arm)
+    shared = sorted(set(off_cells) & set(arm_cells))
+    off_rows = [r for key in shared for r in off_cells[key]]
+    arm_rows = [r for key in shared for r in arm_cells[key]]
+
+    def quality(rows) -> float:  # noqa: ANN001
+        return statistics.mean(r.reward for r in rows)
+
+    def eff(rows) -> float | None:  # noqa: ANN001
+        overheads = [
+            RowOverhead(
+                scenario_id=r.scenario_id,
+                model=r.model,
+                episode=r.episode,
+                component="compressor",
+                cost_usd=r.compressor_cost_usd,
+                latency_s=r.compressor_latency_s,
+            )
+            for r in rows
+            if r.compressor_cost_usd > 0 or r.compressor_latency_s > 0
+        ]
+        return effective_cost_per_completed_task(
+            rows, overheads=overheads
+        ).cost_per_completed_task_usd
+
+    def p50_latency(rows) -> float:  # noqa: ANN001
+        totals = sorted(sum(r.call_seconds) + r.compressor_latency_s for r in rows)
+        return totals[len(totals) // 2] if totals else 0.0
+
+    off_eff, arm_eff = eff(off_rows), eff(arm_rows)
+    return {
+        "quality_delta_pt": round((quality(arm_rows) - quality(off_rows)) * 100, 2),
+        "cost_delta_pct": round((arm_eff / off_eff - 1) * 100, 1) if off_eff and arm_eff else None,
+        "latency_delta_ms": round((p50_latency(arm_rows) - p50_latency(off_rows)) * 1000, 0),
+        "n_cells": len(shared),
+    }
+
+
+def main() -> None:
+    feature_rows = []
+    anchor_blocks = {}
+    spend = 0.0
+    for cohort in ("financebench", "tau"):
+        off, arms, assignment, fit = load_cohort(cohort)
+        tasks_by_sid = {}
+        for outcome in off.outcomes:
+            tasks_by_sid.setdefault(outcome.scenario_id, outcome.task)
+        for cluster_id in sorted(set(assignment.values())):
+            member_tasks = [
+                tasks_by_sid[sid] for sid, c in assignment.items() if c == cluster_id
+            ]
+            real_rows = [
+                r
+                for r in fit.evidence
+                if r.cluster_id == cluster_id and not r.control and r.n_pairs > 0
+            ]
+            best = max(real_rows, key=lambda r: r.mean_diff) if real_rows else None
+            label, reason, usd = opus_label(member_tasks)
+            spend += usd
+            feature_rows.append(
+                {
+                    "cohort": cohort,
+                    "cluster": cluster_id,
+                    "n_scenarios": len(member_tasks),
+                    **cluster_features(member_tasks),
+                    "best_real_quality_delta": round(best.mean_diff, 4) if best else None,
+                    "opus5_verbatim_critical": label,
+                    "opus5_reason": reason,
+                    "opus5_call_usd": round(usd, 5),
+                }
+            )
+        anchor_blocks[cohort] = {
+            "corners": {
+                name: {
+                    "compression": None,
+                    "note": "measured verdict: no cluster passed the corrected gate; the "
+                    "corners coincide at uncompressed (this is a statement, not a knob)",
+                }
+                for name in ("quality-max", "balanced", "max-savings")
+            },
+            "per_cluster_map": {
+                str(c): None for c in sorted({r["cluster"] for r in feature_rows if r["cohort"] == cohort})
+            },
+            "evidence_deltas_if_compressed": {
+                str(arm.measured_compression().compressor_id): arm_deltas(off, arm)
+                for arm in arms
+            },
+            "provenance": (
+                "pre-rescore-broken-wm-scorer (PENDING-RESCORE)"
+                if cohort == "financebench"
+                else "tau-wm-simulated-judge-uncondemned-2026-07-28"
+            ),
+            "gate": "non-inferiority z=0.5 margin=0.02 min_pairs=8 + control-dominance",
+        }
+
+    deltas = [r["best_real_quality_delta"] for r in feature_rows]
+    correlations = {
+        feature: round(
+            spearman([r[feature] for r in feature_rows], deltas), 3
+        )
+        for feature in ("numeric_density", "entity_density", "codejson_share", "mean_words")
+    }
+    yes_deltas = [
+        r["best_real_quality_delta"]
+        for r in feature_rows
+        if r["opus5_verbatim_critical"] == "YES"
+    ]
+    no_deltas = [
+        r["best_real_quality_delta"]
+        for r in feature_rows
+        if r["opus5_verbatim_critical"] == "NO"
+    ]
+
+    OUT_FEATURES.write_text(
+        json.dumps(
+            {
+                "label": "CANDIDATE (n=12 clusters, two cohorts, mixed provenance)",
+                "clusters": feature_rows,
+                "spearman_vs_quality_delta": correlations,
+                "opus5": {
+                    "yes_mean_delta": round(statistics.mean(yes_deltas), 4) if yes_deltas else None,
+                    "no_mean_delta": round(statistics.mean(no_deltas), 4) if no_deltas else None,
+                    "n_yes": len(yes_deltas),
+                    "n_no": len(no_deltas),
+                    "total_usd": round(spend, 4),
+                },
+            },
+            indent=1,
+        )
+    )
+    OUT_ANCHORS.write_text(json.dumps(anchor_blocks, indent=1))
+    print(json.dumps(correlations, indent=1))
+    print(f"opus5: YES clusters mean delta "
+          f"{statistics.mean(yes_deltas) if yes_deltas else float('nan'):+.4f} (n={len(yes_deltas)}), "
+          f"NO {statistics.mean(no_deltas) if no_deltas else float('nan'):+.4f} (n={len(no_deltas)}); "
+          f"spend ${spend:.4f}")
+    for row in feature_rows:
+        print(f"  {row['cohort']:<13} c{row['cluster']} num={row['numeric_density']:.3f} "
+              f"ent={row['entity_density']:.3f} code={row['codejson_share']:.4f} "
+              f"words={row['mean_words']:>6} delta={row['best_real_quality_delta']} "
+              f"opus5={row['opus5_verbatim_critical']}")
+    print(f"wrote {OUT_FEATURES}\nwrote {OUT_ANCHORS}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c2_r3_analysis.py
+++ b/.agents/scripts/c2_r3_analysis.py
@@ -1,0 +1,222 @@
+"""C2 round 3 analysis: the deliverable table + corrected-gate fits per corpus.
+
+Per arm x corpus, corpus-level PAIRED metrics vs the off arm on shared (scenario, model)
+cells: quality delta (wm_simulated, labeled), cache-adjusted effective cost per completed
+task (compressor bill folded, #294 conventions), p50 episode wall latency (call_seconds
+plus compressor latency), steps per episode, achieved keep
+(tokens_in_compressed / tokens_in_raw). Then the corrected non-inferiority gate at k=4
+clusters (scoped-truncate as the matched-dial control for scoped-llmlingua2-endpoint),
+the calibrator-v1 selection over both arms, and the A/A bar on the off arm.
+
+Tau: the scoped arm matrices are UNIONED from chunk files here (the runner's own merge
+refuses because chunk 0 ran the 3-model pool and later chunks the 2-model restriction;
+rows are rows, and this analysis pairs per cell). Kimi-k3's chunk-0 rows are reported
+separately as a labeled partial. The off arm is the jt grid-c2 identity matrix filtered
+to the same models (comparability ruling in findings/c2.md). Cohort caveat carried on
+every output: cells bought under working tree at tip 4ffc23f0 plus the then-uncommitted
+scoped module, which equals aedade4d minus a non-behavioral lint fix.
+
+Usage: uv run python .agents/scripts/c2_r3_analysis.py [tau|terminal]
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+from wmo.optimize.compaction_fit import (
+    ArmMatrices,
+    EvidenceProvenance,
+    aa_report,
+    assign_to_clusters,
+    fit_compaction,
+)
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.policy import EmbedderSpec
+from wmo.optimize.routing import fit_rank_policy
+from wmo.optimize.scorecard import RowOverhead, effective_cost_per_completed_task
+
+R3 = Path.home() / "Desktop/Projects/wmh-compression-data/fits/c2-r3"
+JT = Path.home() / "Desktop/Projects/world-model-harness/.wmo/jt/grid-c2"
+MODELS = ("gpt-5.4-mini", "sonnet-5")
+
+
+def union_chunks(arm_dir: Path, models: tuple[str, ...]) -> OutcomeMatrix:
+    outcomes: list[ScenarioOutcome] = []
+    pool = None
+    for chunk in sorted(arm_dir.glob("chunk-*.json")):
+        matrix = OutcomeMatrix.load(chunk)
+        keep = [entry for entry in matrix.pool if entry.name in models]
+        if pool is None or len(keep) < len(pool):
+            pool = keep
+        outcomes.extend(o for o in matrix.outcomes if o.model in models)
+    # Retry results live under retry/ as single-cell OutcomeMatrix files; retried-*.json
+    # is just the list of retried cell keys. Fresh scored rows replace their stale cells.
+    for retried in sorted((arm_dir / "retry").glob("*.json")) if (arm_dir / "retry").exists() else []:
+        matrix = OutcomeMatrix.load(retried)
+        fresh = {(o.scenario_id, o.model, o.episode) for o in matrix.outcomes if o.scored}
+        outcomes = [
+            o for o in outcomes if (o.scenario_id, o.model, o.episode) not in fresh
+        ] + [o for o in matrix.outcomes if o.model in models and o.scored]
+    return OutcomeMatrix(pool=pool, outcomes=outcomes)
+
+
+def cells(matrix: OutcomeMatrix) -> dict[tuple[str, str], list[ScenarioOutcome]]:
+    by: dict[tuple[str, str], list[ScenarioOutcome]] = {}
+    for row in matrix.outcomes:
+        if row.scored:
+            by.setdefault((row.scenario_id, row.model), []).append(row)
+    return by
+
+
+def paired_metrics(off: OutcomeMatrix, arm: OutcomeMatrix) -> dict[str, object]:
+    off_cells, arm_cells = cells(off), cells(arm)
+    shared = sorted(set(off_cells) & set(arm_cells))
+    off_rows = [r for k in shared for r in off_cells[k]]
+    arm_rows = [r for k in shared for r in arm_cells[k]]
+
+    def eff(rows):  # noqa: ANN001, ANN202
+        overheads = [
+            RowOverhead(
+                scenario_id=r.scenario_id, model=r.model, episode=r.episode,
+                component="compressor", cost_usd=r.compressor_cost_usd,
+                latency_s=r.compressor_latency_s,
+            )
+            for r in rows if r.compressor_cost_usd > 0 or r.compressor_latency_s > 0
+        ]
+        return effective_cost_per_completed_task(rows, overheads=overheads)
+
+    def p50_wall(rows):  # noqa: ANN001, ANN202
+        walls = sorted(sum(r.call_seconds) + r.compressor_latency_s for r in rows)
+        return walls[len(walls) // 2] if walls else 0.0
+
+    diffs = [
+        statistics.mean(x.reward for x in arm_cells[k])
+        - statistics.mean(x.reward for x in off_cells[k])
+        for k in shared
+    ]
+    n = len(diffs)
+    mean = statistics.mean(diffs) if diffs else 0.0
+    se = statistics.stdev(diffs) / n**0.5 if n > 1 else 0.0
+    off_eff, arm_eff = eff(off_rows), eff(arm_rows)
+    keeps = [
+        r.tokens_in_compressed / r.tokens_in_raw for r in arm_rows if r.tokens_in_raw > 0
+    ]
+    return {
+        "n_paired_cells": n,
+        "quality_delta": round(mean, 4),
+        "quality_se": round(se, 4),
+        "off_cost_per_completed": off_eff.cost_per_completed_task_usd,
+        "arm_cost_per_completed": arm_eff.cost_per_completed_task_usd,
+        "cost_delta_pct": round(
+            (arm_eff.cost_per_completed_task_usd / off_eff.cost_per_completed_task_usd - 1) * 100, 1
+        )
+        if off_eff.cost_per_completed_task_usd and arm_eff.cost_per_completed_task_usd
+        else None,
+        "p50_wall_s_off": round(p50_wall(off_rows), 2),
+        "p50_wall_s_arm": round(p50_wall(arm_rows), 2),
+        "latency_delta_pct": round((p50_wall(arm_rows) / p50_wall(off_rows) - 1) * 100, 1)
+        if p50_wall(off_rows)
+        else None,
+        "steps_off": round(statistics.mean(r.steps for r in off_rows), 2),
+        "steps_arm": round(statistics.mean(r.steps for r in arm_rows), 2),
+        "achieved_keep": round(statistics.mean(keeps), 4) if keeps else None,
+    }
+
+
+def main() -> None:
+    corpus = sys.argv[1] if len(sys.argv) > 1 else "tau"
+    if corpus == "tau":
+        off = union_chunks(JT / "identity", MODELS)
+        grid = R3 / "grid-tau"
+        contrast = {
+            "whole-truncate": union_chunks(JT / "truncate", MODELS),
+            "whole-llmlingua2": union_chunks(JT / "llmlingua2-endpoint", MODELS),
+        }
+        era = "tau-wm-simulated-judge-uncondemned-2026-07-28"
+    else:
+        off = union_chunks(R3 / "grid-terminal/identity", MODELS)
+        grid = R3 / "grid-terminal"
+        contrast = {}
+        era = "terminal-wm-simulated-unaudited-2026-07-28"
+
+    arms = {
+        "scoped-llmlingua2-endpoint": union_chunks(grid / "scoped-llmlingua2-endpoint", MODELS),
+        "scoped-truncate": union_chunks(grid / "scoped-truncate", MODELS),
+    }
+
+    table = {}
+    for name, matrix in {**arms, **contrast}.items():
+        table[name] = paired_metrics(off, matrix)
+        print(f"{corpus} {name}: {json.dumps(table[name])}")
+
+    spec = EmbedderSpec()
+    policy = fit_rank_policy(off, embedder=spec, n_clusters=4, seed=42)
+    assignment = assign_to_clusters(policy.clusters, off, embed_with=spec.build())
+    aa = aa_report(assignment, off)
+    provenance = EvidenceProvenance.build(
+        off_source=f"{corpus} off arm", arm_sources={}, scorer_era=era
+    )
+    gated = fit_compaction(
+        assignment,
+        off,
+        [
+            ArmMatrices(
+                matrix=arms["scoped-llmlingua2-endpoint"],
+                config=arms["scoped-llmlingua2-endpoint"].measured_compression(),
+            ),
+            ArmMatrices(
+                matrix=arms["scoped-truncate"],
+                config=arms["scoped-truncate"].measured_compression(),
+                control=True,
+            ),
+        ],
+        allow_uneven=True,
+        provenance=provenance,
+    )
+    calibrated = fit_compaction(
+        assignment,
+        off,
+        [
+            ArmMatrices(matrix=m, config=m.measured_compression())
+            for m in arms.values()
+        ],
+        allow_uneven=True,
+        provenance=provenance,
+        selection="aggressiveness",
+    )
+    result = {
+        "corpus": corpus,
+        "scorer_era": era,
+        "cohort_caveat": "cells bought at working-tree 4ffc23f0 + scoped module (= aedade4d minus a non-behavioral lint fix)",
+        "table": table,
+        "aa_clean_at_ruled_gate": not aa,
+        "gated_fit": {
+            "clusters_compressed": gated.compressed_clusters(),
+            "per_cluster": {str(k): (v.compressor_id if v else None) for k, v in gated.per_cluster.items()},
+            "control_flags": gated.control_flags,
+        },
+        "calibrator_v1_fit": {
+            "clusters_compressed": calibrated.compressed_clusters(),
+            "per_cluster": {
+                str(k): (f"{v.compressor_id}@{v.aggressiveness:g}" if v else None)
+                for k, v in calibrated.per_cluster.items()
+            },
+            "control_flags": calibrated.control_flags,
+        },
+        "gate_evidence": [
+            {k: getattr(r, k) for k in ("cluster_id", "signature", "n_pairs", "mean_diff", "se", "quality_pass", "cost_pass", "chosen", "control_dominated")}
+            for r in gated.evidence
+        ],
+    }
+    out = R3 / f"analysis-{corpus}.json"
+    out.write_text(json.dumps(result, indent=1))
+    print(f"\nAA {'CLEAN' if not aa else 'FIRES'}; gated {gated.compressed_clusters()} compressed, "
+          f"flags {gated.control_flags}; calibrator {calibrated.compressed_clusters()} compressed")
+    print("wrote", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/c2_real_tau2_leg.py
+++ b/.agents/scripts/c2_real_tau2_leg.py
@@ -138,6 +138,11 @@ class ToolRoleScoped:
 
     def complete_chat(self, request: ChatRequest) -> ChatResponse:
         self.calls += 1
+        if self._model_id.startswith("us.anthropic."):
+            # Bedrock Converse rejects `temperature` for sonnet-5 ("deprecated for this
+            # model"); stripped uniformly for this model across ALL arms, so the arms stay
+            # comparable within the model.
+            request = request.model_copy(update={"temperature": None})
         if self._compressor is not None:
             tool_indices = [
                 i
@@ -180,8 +185,14 @@ async def run_episode(
     episode_dir = OUT / arm / entry.name / f"{task_id.replace(':', '_')}-e{episode}"
     results_copy = episode_dir / "results.json"
     if results_copy.exists():
-        log.info("resume: %s already has results", alias)
-        return
+        payload = json.loads(results_copy.read_text())
+        sims = payload.get("simulations") or []
+        prior = (sims[0].get("reward_info") or {}).get("reward") if sims else None
+        if prior is not None:
+            log.info("resume: %s already has verifier evidence", alias)
+            return
+        # A results file without a reward is an errored simulation, not evidence: re-run.
+        shutil.rmtree(episode_dir)
     async with semaphore:
         if state["spend"] >= BUDGET_GUARD_USD:
             state["skipped"] += 1

--- a/.agents/scripts/c2_real_tau2_leg.py
+++ b/.agents/scripts/c2_real_tau2_leg.py
@@ -1,0 +1,305 @@
+"""C2 real tau2 leg: scoped compression validated on the REAL benchmark (round 3, GO'd).
+
+Pre-registered pass bar (findings/c2.md 2026-07-28 evening): the wm_simulated
+corpus-grain result (+4.4 +- 4.3 quality at -29.4% effective cost) must REPRODUCE IN
+SIGN on real tau2 episodes, scored by tau2's own deterministic evaluator (judge-free).
+
+Arms, both scoped configs because aggressiveness is identity-grained (D-DIAL ruling):
+off (uncompressed), scoped@0.48 (the C1-amended handoff threshold), scoped@0.5 (the
+wm-evidence match). 25 tasks (13 retail + 12 airline, sorted prefix of the 720-episode
+study's 40 known-good ids) x {gpt-5.4-mini via azure, sonnet-5 via bedrock} x 2
+episodes = 300 episodes, ~$57 at the measured $0.19/ep, hard budget guard at $75
+(cap $80 all-in). Protocol pins per the training-chat entry: max_turns 100, timeout
+1800, user simulator azure/gpt-5.4-mini with {} args; any deviation is a new cohort
+label.
+
+Wiring: every arm's agent traffic goes through ONE loopback `EpisodeProxy`
+(wmo.distill.tau2_proxy) with a per-episode alias, uniformly (the off arm too, so the
+provider stack is identical across arms). The scoped arms wrap the pool provider in
+`ToolRoleScoped`, which compresses TOOL-ROLE message content only, through the live
+llmlingua2 endpoint; system, user (dialogue in both directions), and assistant
+messages pass through byte-exact. Deterministic per message content, so the growing
+transcript stays append-stable; live keep is ENDOGENOUS (C1) and reported per episode
+as (achieved keep, accuracy) points, never a nominal claim.
+
+Run from the c2-r2 worktree with the compressor + azure + aws env exported:
+
+    uv run python .agents/scripts/c2_real_tau2_leg.py [--smoke]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+
+from llm_waterfall.types import ChatRequest, ChatResponse
+
+from wmo.optimize.compression import CompressionConfig, estimate_tokens, get_compressor
+from wmo.providers.base import ProviderKind, TokenUsage, ToolCallingProvider
+from wmo.providers.pool import PoolEntry, pool_provider
+from wmo.tracking.pricing import cost_usd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)-7s %(message)s")
+log = logging.getLogger("c2_real_tau2")
+
+TAU2_BIN = Path.home() / "Desktop/Projects/tau2-bench/.venv/bin/tau2"
+TAU2_DATA = Path.home() / "Desktop/Projects/tau2-bench/data"  # tasks under data/tau2/, sims under data/simulations/
+OUT = Path.home() / "Desktop/Projects/wmh-compression-data/fits/c2-r3/real-tau2"
+ROWS = OUT / "rows.jsonl"
+
+MAX_TURNS = 100
+TIMEOUT_S = 1800
+USER_LLM = "azure/gpt-5.4-mini"
+KILL_MARGIN_S = 120
+BUDGET_GUARD_USD = 75.0
+EPISODES = 2
+CONCURRENCY = 4
+
+ENTRIES = [
+    PoolEntry(
+        name="gpt-5.4-mini",
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.4-mini",
+        deployment="gpt-5.4-mini",
+        endpoint="https://google-sheets.openai.azure.com",
+        api_version="2024-10-21",
+        api_key_env="AZURE_GOOGLE_SHEETS_API_KEY",
+        input_per_mtok=0.75,
+        output_per_mtok=4.5,
+    ),
+    # Same weights as the wm arms' sonnet-5, served via Bedrock (the anthropic-direct
+    # provider has no complete_chat); the provider difference is ledgered.
+    PoolEntry(
+        name="sonnet-5",
+        kind=ProviderKind.BEDROCK,
+        model="us.anthropic.claude-sonnet-5",
+        region="us-west-2",
+        input_per_mtok=3.0,
+        output_per_mtok=15.0,
+    ),
+]
+
+ARMS = {
+    "off": None,
+    "scoped048": 0.48,
+    "scoped05": 0.5,
+}
+
+
+def task_ids() -> list[str]:
+    matrix = json.loads(
+        (Path.home() / "Desktop/Projects/wmh-routing-data/matrices/tau-bench-real_matrix.json")
+        .read_text()
+    )
+    ids = sorted({o["scenario_id"] for o in matrix["outcomes"]})
+    retail = [i for i in ids if i.startswith("retail:")][:13]
+    airline = [i for i in ids if i.startswith("airline:")][:12]
+    return retail + airline
+
+
+class ToolRoleScoped:
+    """Tool-role-only compression at tau2's real message boundary.
+
+    Compresses the content of role == "tool" messages through the live endpoint
+    compressor; every other message passes through byte-exact. Accounts achieved keep
+    (proxy-token estimates), compressor cost/latency, and the provider's own usage
+    cost per episode.
+    """
+
+    def __init__(self, inner: ToolCallingProvider, model_id: str, aggressiveness: float | None):
+        self._inner = inner
+        self._model_id = model_id
+        self._compressor = get_compressor("llmlingua2-endpoint") if aggressiveness else None
+        self._config = (
+            CompressionConfig(
+                compressor_id="llmlingua2-endpoint",
+                compressor_version=self._compressor.version,
+                aggressiveness=aggressiveness,
+            )
+            if aggressiveness
+            else None
+        )
+        self.tokens_raw = 0
+        self.tokens_kept = 0
+        self.compressor_usd = 0.0
+        self.compressor_s = 0.0
+        self.provider_usd = 0.0
+        self.calls = 0
+
+    @property
+    def config(self):  # noqa: ANN201 - Provider protocol surface
+        return self._inner.config
+
+    def complete_chat(self, request: ChatRequest) -> ChatResponse:
+        self.calls += 1
+        if self._compressor is not None:
+            tool_indices = [
+                i
+                for i, m in enumerate(request.messages)
+                if m.role == "tool" and isinstance(m.content, str) and m.content.strip()
+            ]
+            if tool_indices:
+                started = time.monotonic()
+                result = self._compressor.compress(
+                    [request.messages[i].content for i in tool_indices], self._config
+                )
+                self.compressor_s += time.monotonic() - started
+                self.compressor_usd += result.cost_usd
+                messages = list(request.messages)
+                for index, compressed in zip(tool_indices, result.segments, strict=True):
+                    self.tokens_raw += estimate_tokens(messages[index].content)
+                    self.tokens_kept += estimate_tokens(compressed)
+                    messages[index] = messages[index].model_copy(update={"content": compressed})
+                request = request.model_copy(update={"messages": messages})
+        response = self._inner.complete_chat(request)
+        if response.usage is not None:
+            usage = response.usage
+            details = getattr(usage, "prompt_tokens_details", None) or {}
+            cached = details.get("cached_tokens", 0) if isinstance(details, dict) else 0
+            self.provider_usd += cost_usd(
+                self._model_id,
+                TokenUsage(
+                    input_tokens=usage.prompt_tokens or 0,
+                    output_tokens=usage.completion_tokens or 0,
+                    cached_input_tokens=cached or 0,
+                ),
+            )
+        return response
+
+
+async def run_episode(
+    proxy, semaphore, arm: str, entry: PoolEntry, task_id: str, episode: int, state: dict
+) -> None:  # noqa: ANN001
+    alias = f"{arm}-{entry.name}-{task_id.replace(':', '_')}-e{episode}"
+    episode_dir = OUT / arm / entry.name / f"{task_id.replace(':', '_')}-e{episode}"
+    results_copy = episode_dir / "results.json"
+    if results_copy.exists():
+        log.info("resume: %s already has results", alias)
+        return
+    async with semaphore:
+        if state["spend"] >= BUDGET_GUARD_USD:
+            state["skipped"] += 1
+            return
+        episode_dir.mkdir(parents=True, exist_ok=True)
+        provider = ToolRoleScoped(
+            pool_provider(entry), entry.model, ARMS[arm]
+        )
+        proxy.register(alias, provider)
+        domain, tau2_task = task_id.split(":", 1)
+        save_name = f"c2r3-{alias}"
+        sim_dir = TAU2_DATA / "simulations" / save_name
+        shutil.rmtree(sim_dir, ignore_errors=True)
+        agent_args = {
+            "api_base": proxy.base_url,
+            "api_key": "wmo-local-proxy",
+            "temperature": 0.7,
+            "max_tokens": 1024,
+            "num_retries": 0,
+            "timeout": TIMEOUT_S,
+        }
+        command = [
+            str(TAU2_BIN), "run", "--domain", domain,
+            "--task-ids", tau2_task, "--num-trials", "1",
+            "--max-steps", str(MAX_TURNS), "--max-errors", "10",
+            "--timeout", str(TIMEOUT_S),
+            "--agent-llm", f"openai/{alias}",
+            "--agent-llm-args", json.dumps(agent_args),
+            "--user-llm", USER_LLM, "--user-llm-args", json.dumps({}),
+            "--save-to", save_name, "--max-retries", "0", "--auto-resume",
+        ]
+        env = os.environ | {
+            "TAU2_DATA_DIR": str(TAU2_DATA),
+            "AZURE_API_KEY": os.environ.get("AZURE_GOOGLE_SHEETS_API_KEY", ""),
+            "AZURE_API_BASE": "https://google-sheets.openai.azure.com",
+            "AZURE_API_VERSION": "2024-10-21",
+        }
+        started = time.monotonic()
+        log_path = episode_dir / "runner.log"
+        with log_path.open("wb") as log_file:
+            process = await asyncio.create_subprocess_exec(
+                *command, stdout=log_file, stderr=asyncio.subprocess.STDOUT, env=env
+            )
+            try:
+                await asyncio.wait_for(process.wait(), timeout=TIMEOUT_S + KILL_MARGIN_S)
+            except (TimeoutError, asyncio.CancelledError):
+                process.kill()
+                await process.wait()
+                raise
+        wall = time.monotonic() - started
+        reward = None
+        results_path = sim_dir / "results.json"
+        if results_path.exists():
+            shutil.copyfile(results_path, results_copy)
+            payload = json.loads(results_copy.read_text())
+            sims = payload.get("simulations") or []
+            if sims and isinstance(sims[0], dict):
+                info = sims[0].get("reward_info") or {}
+                reward = info.get("reward")
+        row = {
+            "arm": arm, "model": entry.name, "task": task_id, "episode": episode,
+            "reward": reward, "infra_failed": reward is None,
+            "provider_usd": round(provider.provider_usd, 5),
+            "compressor_usd": round(provider.compressor_usd, 5),
+            "compressor_s": round(provider.compressor_s, 2),
+            "achieved_keep": round(provider.tokens_kept / provider.tokens_raw, 4)
+            if provider.tokens_raw else None,
+            "agent_calls": provider.calls, "wall_s": round(wall, 1),
+            "cohort": "real-tau2 maxturns100 timeout1800 usersim-gpt-5.4-mini "
+                      "sonnet-5-via-bedrock",
+        }
+        state["spend"] += provider.provider_usd + provider.compressor_usd
+        with ROWS.open("a") as handle:
+            handle.write(json.dumps(row) + "\n")
+        log.info(
+            "%s: reward=%s $%.3f keep=%s wall=%.0fs (cumulative $%.2f)",
+            alias, reward, provider.provider_usd, row["achieved_keep"], wall, state["spend"],
+        )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--smoke", action="store_true", help="2 episodes only")
+    args = parser.parse_args()
+
+    from wmo.distill.tau2_proxy import EpisodeProxy
+
+    OUT.mkdir(parents=True, exist_ok=True)
+    spend0 = 0.0
+    if ROWS.exists():
+        for line in ROWS.read_text().splitlines():
+            row = json.loads(line)
+            spend0 += row.get("provider_usd", 0.0) + row.get("compressor_usd", 0.0)
+    state = {"spend": spend0, "skipped": 0}
+    proxy = EpisodeProxy()
+    proxy.start()
+    tasks = task_ids()
+    log.info("tasks (%d): %s", len(tasks), tasks)
+    jobs = []
+    if args.smoke:
+        jobs = [("off", ENTRIES[0], tasks[0], 0), ("scoped048", ENTRIES[0], tasks[0], 0)]
+    else:
+        for arm in ARMS:
+            for entry in ENTRIES:
+                for task_id in tasks:
+                    for episode in range(EPISODES):
+                        jobs.append((arm, entry, task_id, episode))
+    semaphore = asyncio.Semaphore(CONCURRENCY)
+    try:
+        await asyncio.gather(
+            *(run_episode(proxy, semaphore, *job, state) for job in jobs)
+        )
+    finally:
+        proxy.stop()
+    log.info(
+        "leg done: cumulative $%.2f, %d skipped by budget guard", state["spend"], state["skipped"]
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.agents/scripts/run_tau_grid.py
+++ b/.agents/scripts/run_tau_grid.py
@@ -135,7 +135,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 IDENTITY_ARM = "identity"
 TRUNCATE_ARM = "truncate"
 ENDPOINT_ARM = "llmlingua2-endpoint"
-ALL_ARMS = (IDENTITY_ARM, TRUNCATE_ARM, ENDPOINT_ARM)
+# C2 round 3: segment-SCOPED arms (compress tool observations only, never dialogue or the
+# task; wmo.optimize.compression_scoped). The scoped truncate control shares the whole-context
+# calibration's dial: both scoped arms compress the SAME observation spans, so matching inner
+# dials matches their achieved ratios on those spans; the per-episode ACHIEVED keep is recorded
+# either way and the match is verified post-hoc at the compression track's 0.05 tolerance.
+SCOPED_ENDPOINT_ARM = "scoped-llmlingua2-endpoint"
+SCOPED_TRUNCATE_ARM = "scoped-truncate"
+ALL_ARMS = (IDENTITY_ARM, TRUNCATE_ARM, ENDPOINT_ARM, SCOPED_ENDPOINT_ARM, SCOPED_TRUNCATE_ARM)
 
 DEFAULT_MODEL_DIR = REPO_ROOT / ".wmo" / "models" / "tau-bench"
 DEFAULT_POOL = REPO_ROOT / ".wmo" / "pool.toml"
@@ -700,6 +707,13 @@ def arm_compression(
         return None
     if arm == ENDPOINT_ARM:
         return endpoint_compression()
+    if arm == SCOPED_ENDPOINT_ARM:
+        inner = endpoint_compression()  # the reachability check applies to the scoped arm too
+        return CompressionConfig(
+            compressor_id=SCOPED_ENDPOINT_ARM,
+            compressor_version=get_compressor(SCOPED_ENDPOINT_ARM).version,
+            aggressiveness=inner.aggressiveness,
+        )
     existing = state.calibration()
     if existing is None:
         sample = calibration_sample(config, train_split, adapter)
@@ -731,9 +745,10 @@ def arm_compression(
             existing.chosen_achieved_ratio,
             existing.endpoint_achieved_ratio,
         )
+    chosen_arm = SCOPED_TRUNCATE_ARM if arm == SCOPED_TRUNCATE_ARM else TRUNCATE_ARM
     return CompressionConfig(
-        compressor_id=TRUNCATE_ARM,
-        compressor_version=get_compressor(TRUNCATE_ARM).version,
+        compressor_id=chosen_arm,
+        compressor_version=get_compressor(chosen_arm).version,
         aggressiveness=existing.chosen_aggressiveness,
     )
 

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -61,6 +61,7 @@ from wmo.optimize.knn import (
     COST_QUALITY_ANCHORS,
     DialResult,
     KnnFitOutcome,
+    best_single_on_fit,
     fit_knn_artifact,
     tune_policy_dial,
 )
@@ -1113,13 +1114,13 @@ def fit_compaction_cmd(
     off_matrix: str = typer.Argument(
         ..., help="The uncompressed OFF arm's OutcomeMatrix JSON (the grid's baseline)."
     ),
-    arm: list[str] = typer.Option(
+    arm: list[str] = typer.Option(  # noqa: B008 - typer reads option defaults at definition time
         [],
         "--arm",
         help="A compressed arm's OutcomeMatrix JSON, repeatable; the arm's compression config "
         "is read from the matrix itself (one matrix per arm, same scenario cohort as off).",
     ),
-    control: list[str] = typer.Option(
+    control: list[str] = typer.Option(  # noqa: B008 - typer reads option defaults at definition time
         [],
         "--control",
         help="Like --arm but a CONTROL (random removal, matched-ratio truncation): evaluated "
@@ -1222,23 +1223,20 @@ def fit_compaction_cmd(
     out_path = Path(out)
     built = spec.build()  # ONE embedder: base fit, overlay, and assignment share it
 
+    # EVERY gate runs before ANY artifact is written: a rejected fit must not leave a
+    # mountable policy or sidecar behind (a command that exits 1 and also produces the thing
+    # it rejected would hand the investigation result to whatever consumes the directory
+    # next). The knn base fit is therefore deferred until the gates pass; only the evidence
+    # file, which IS the investigation record, is written on the failure paths.
     if kind == "knn":
-        fitted = fit_knn_artifact(
-            off,
-            out_path=out_path,
-            matrix_source=off_source,
-            embedder=spec,
-            fallback=fallback,
-            floor_q=floor_q,
-            compression=None,  # per-cluster mode routes on raw text (exclusivity rule)
-        )
-        policy = fitted.policy
+        policy = None
+        default_model = fallback or best_single_on_fit(off, off.scenario_ids())
         policy_clusters, assignment = overlay_clusters(
             off,
             embed_with=built,
             n_clusters=clusters,
             seed=seed,
-            default_model=policy.default_model,
+            default_model=default_model,
         )
     else:
         policy = fit_rank_policy(
@@ -1276,15 +1274,6 @@ def fit_compaction_cmd(
     evidence_path = out_path.with_suffix(".compaction-evidence.json")
     evidence_path.write_text(fit.model_dump_json(indent=2))
 
-    if kind == "knn":
-        sidecar = out_path.parent / COMPACTION_SIDECAR_FILENAME
-        save_compaction_sidecar(policy_clusters, fit, sidecar, fitted_from=off_source)
-        target = f"sidecar {sidecar}"
-    else:
-        policy = apply_compaction(policy, fit)
-        policy.save(out_path)
-        target = out
-
     for note in fit.coverage:
         _console.print(f"[yellow]coverage[/yellow] {note}")
     for row in sorted(fit.evidence, key=lambda r: (r.cluster_id, r.signature)):
@@ -1295,18 +1284,39 @@ def fit_compaction_cmd(
             f"quality {'pass' if row.quality_pass else 'fail'} "
             f"cost {'pass' if row.cost_pass else 'fail'} {verdict}"
         )
+    if fit.controls_would_win:
+        _console.print(
+            f"[red]INVESTIGATION GATE[/red]: control arms would have won clusters: "
+            f"{fit.controls_would_win}. A control beating the learned arms through the full "
+            "gate is a finding to investigate, not a policy to ship. No policy or sidecar "
+            f"was written; the evidence is in {evidence_path}."
+        )
+        raise typer.Exit(1)
+
+    if kind == "knn":
+        fitted = fit_knn_artifact(
+            off,
+            out_path=out_path,
+            matrix_source=off_source,
+            embedder=spec,
+            fallback=fallback,
+            floor_q=floor_q,
+            compression=None,  # per-cluster mode routes on raw text (exclusivity rule)
+        )
+        del fitted
+        sidecar = out_path.parent / COMPACTION_SIDECAR_FILENAME
+        save_compaction_sidecar(policy_clusters, fit, sidecar, fitted_from=off_source)
+        target = f"sidecar {sidecar}"
+    else:
+        policy = apply_compaction(policy, fit)
+        policy.save(out_path)
+        target = out
+
     label = " [CANDIDATE: uneven coverage]" if fit.coverage else ""
     _console.print(
         f"[green]✓[/green] {fit.compressed_clusters()}/{len(fit.per_cluster)} clusters "
         f"compressed -> {target}{label}\n  evidence: {evidence_path}"
     )
-    if fit.controls_would_win:
-        _console.print(
-            f"[red]INVESTIGATION GATE[/red]: control arms would have won clusters: "
-            f"{fit.controls_would_win}. A control beating the learned arms through the full "
-            "gate is a finding to investigate, not a policy to ship."
-        )
-        raise typer.Exit(1)
 
 
 def print_knn_fit(console: Console, fitted: KnnFitOutcome, *, out: str, z: float) -> None:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -41,11 +41,13 @@ from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.optimize.compaction_fit import (
-    COMPACTION_SIDECAR_FILENAME,
+    DEFAULT_NONINFERIORITY_MARGIN,
     ArmMatrices,
+    EvidenceProvenance,
     aa_report,
     apply_compaction,
     assign_to_clusters,
+    compaction_path_for,
     fit_compaction,
     overlay_clusters,
     save_compaction_sidecar,
@@ -1149,11 +1151,32 @@ def fit_compaction_cmd(
         "--z",
         min=0.0,
         help="Quality-gate confidence bar: a cluster deviates from uncompressed only when the "
-        "paired per-cell reward delta clears mean - z*SE >= 0 (small-sample SE floor applied). "
-        "Raise it if the A/A bar reports deviations.",
+        "paired per-cell delta clears mean - z*SE >= -margin (small-sample SE floor applied). "
+        "This is a BACKSTOP floor, not a tuning knob: raise it when the A/A bar reports "
+        "deviations, never lower it after seeing results.",
+    ),
+    margin: float = typer.Option(
+        DEFAULT_NONINFERIORITY_MARGIN,
+        "--margin",
+        min=0.0,
+        help="Non-inferiority margin in absolute reward (the 2026-07-28 ruling: 0.02, the "
+        "fleet's noise-floor bar). An arm that PRESERVES quality at lower cost passes; 0.0 "
+        "recovers the stricter superiority form for comparison sweeps.",
     ),
     min_pairs: int = typer.Option(
-        8, "--min-pairs", min=1, help="Paired cells a cluster needs before it may deviate."
+        8,
+        "--min-pairs",
+        min=1,
+        help="Paired cells a cluster needs before it may deviate. A BACKSTOP floor like --z: "
+        "with the SE floor active below 30 pairs, thin clusters cannot clear the margin "
+        "anyway; this bound refuses them explicitly rather than numerically.",
+    ),
+    scorer_era: str = typer.Option(
+        "",
+        "--scorer-era",
+        help="Provenance label for the judge/scorer state the matrices' rewards were produced "
+        "under (e.g. post-rescore-2026-07-28). Empty or containing 'broken' marks every "
+        "quality-side number PENDING-RESCORE on the fit output and sidecar.",
     ),
     fallback: str = typer.Option(
         None, "--fallback", help="(knn) Baseline model, as in `route fit`."
@@ -1249,7 +1272,7 @@ def fit_compaction_cmd(
         policy_clusters = policy.clusters
         assignment = assign_to_clusters(policy_clusters, off, embed_with=built)
 
-    deviations = aa_report(assignment, off, z=z, min_pairs=min_pairs)
+    deviations = aa_report(assignment, off, z=z, min_pairs=min_pairs, margin=margin)
     if deviations:
         for row in deviations:
             _console.print(
@@ -1263,13 +1286,30 @@ def fit_compaction_cmd(
         raise typer.Exit(1)
     _console.print(f"[green]✓[/green] A/A bar clean at z={z:g} (no cluster deviates on noise)")
 
+    provenance = EvidenceProvenance.build(
+        off_source=off_source,
+        arm_sources={
+            compression_signature(a.config): str(path)
+            for a, path in zip(arms, [*arm, *control], strict=True)
+        },
+        scorer_era=scorer_era,
+    )
+    if provenance.quality_label:
+        _console.print(
+            f"[yellow]PENDING-RESCORE[/yellow]: scorer era is "
+            f"{'unlabeled' if not scorer_era else repr(scorer_era)}; every quality-side number "
+            "below carries that label until the master's rescore (pass --scorer-era once the "
+            "matrices are rescored)."
+        )
     fit = fit_compaction(
         assignment,
         off,
         arms,
         z=z,
         min_pairs=min_pairs,
+        margin=margin,
         allow_uneven=allow_uneven_coverage,
+        provenance=provenance,
     )
     evidence_path = out_path.with_suffix(".compaction-evidence.json")
     evidence_path.write_text(fit.model_dump_json(indent=2))
@@ -1284,12 +1324,13 @@ def fit_compaction_cmd(
             f"quality {'pass' if row.quality_pass else 'fail'} "
             f"cost {'pass' if row.cost_pass else 'fail'} {verdict}"
         )
-    if fit.controls_would_win:
+    if fit.control_flags:
         _console.print(
-            f"[red]INVESTIGATION GATE[/red]: control arms would have won clusters: "
-            f"{fit.controls_would_win}. A control beating the learned arms through the full "
-            "gate is a finding to investigate, not a policy to ship. No policy or sidecar "
-            f"was written; the evidence is in {evidence_path}."
+            f"[red]INVESTIGATION GATE[/red]: {len(fit.control_flags)} control flag(s): "
+            f"{fit.control_flags}. A control matching or beating the learned arms' quality "
+            "signal (at any cost rank) means the signal is not compression-specific: a finding "
+            "to investigate, not a policy to ship. No policy or sidecar was written; the "
+            f"evidence is in {evidence_path}."
         )
         raise typer.Exit(1)
 
@@ -1303,10 +1344,10 @@ def fit_compaction_cmd(
             floor_q=floor_q,
             compression=None,  # per-cluster mode routes on raw text (exclusivity rule)
         )
-        del fitted
-        sidecar = out_path.parent / COMPACTION_SIDECAR_FILENAME
-        save_compaction_sidecar(policy_clusters, fit, sidecar, fitted_from=off_source)
-        target = f"sidecar {sidecar}"
+        save_compaction_sidecar(
+            out_path, fitted.policy, policy_clusters, fit, fitted_from=off_source
+        )
+        target = f"sidecar {compaction_path_for(out_path)}"
     else:
         policy = apply_compaction(policy, fit)
         policy.save(out_path)

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -40,6 +40,16 @@ from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_en
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
+from wmo.optimize.compaction_fit import (
+    COMPACTION_SIDECAR_FILENAME,
+    ArmMatrices,
+    aa_report,
+    apply_compaction,
+    assign_to_clusters,
+    fit_compaction,
+    overlay_clusters,
+    save_compaction_sidecar,
+)
 from wmo.optimize.compression import (
     CompressingEmbedder,
     compression_signature,
@@ -1096,6 +1106,207 @@ def fit(
         f"{result.scenarios} scenarios -> {out}\n"
         f"  fit-set accuracy {result.accuracy:.4f}, cost/scenario ${result.cost_per_scenario:.5f}"
     )
+
+
+@route_app.command("fit-compaction")
+def fit_compaction_cmd(
+    off_matrix: str = typer.Argument(
+        ..., help="The uncompressed OFF arm's OutcomeMatrix JSON (the grid's baseline)."
+    ),
+    arm: list[str] = typer.Option(
+        [],
+        "--arm",
+        help="A compressed arm's OutcomeMatrix JSON, repeatable; the arm's compression config "
+        "is read from the matrix itself (one matrix per arm, same scenario cohort as off).",
+    ),
+    control: list[str] = typer.Option(
+        [],
+        "--control",
+        help="Like --arm but a CONTROL (random removal, matched-ratio truncation): evaluated "
+        "and reported, never chosen. A control that would have won a cluster fails the run.",
+    ),
+    kind: str = typer.Option(
+        "rank",
+        "--kind",
+        help="rank (gates run on the policy's own routing clusters) | knn (routing untouched; "
+        "the map is written as a policy_compaction.json sidecar overlay).",
+    ),
+    out: str = typer.Option(
+        POLICY_FILENAME, "--out", help="Where to write the fitted policy JSON."
+    ),
+    clusters: int = typer.Option(
+        8,
+        "--clusters",
+        min=1,
+        help="Compaction cluster count (also the rank kind's routing cluster count, so the "
+        "gates run on THE clusters the policy routes with). Pre-registered default for s80 "
+        "cohorts: 8 (about 30 paired cells per cluster with 3 models).",
+    ),
+    seed: int = typer.Option(42, "--seed", help="Clustering seed."),
+    z: float = typer.Option(
+        0.5,
+        "--z",
+        min=0.0,
+        help="Quality-gate confidence bar: a cluster deviates from uncompressed only when the "
+        "paired per-cell reward delta clears mean - z*SE >= 0 (small-sample SE floor applied). "
+        "Raise it if the A/A bar reports deviations.",
+    ),
+    min_pairs: int = typer.Option(
+        8, "--min-pairs", min=1, help="Paired cells a cluster needs before it may deviate."
+    ),
+    fallback: str = typer.Option(
+        None, "--fallback", help="(knn) Baseline model, as in `route fit`."
+    ),
+    floor_q: float = typer.Option(0.05, "--floor-q", min=0.0, max=1.0),
+    embedder: str = typer.Option(
+        "auto",
+        "--embedder",
+        help="As in `route fit`. The base policy is fitted RAW (per-cluster mode routes on "
+        "uncompressed text; DECISIONS 2026-07-27), so no --compressor exists here.",
+    ),
+    dim: int = typer.Option(None, "--dim", min=1),
+    deployment: str = typer.Option(None, "--deployment"),
+    endpoint: str = typer.Option(None, "--endpoint"),
+    api_key_env: str = typer.Option(None, "--api-key-env"),
+    allow_uneven_coverage: bool = typer.Option(
+        False,
+        "--allow-uneven-coverage",
+        help="Pair on the cell intersection when an arm does not cover the off cohort (an "
+        "interim fit on a mid-flight grid); the result is a CANDIDATE, labeled in the "
+        "evidence file.",
+    ),
+) -> None:
+    """Fit per-cluster compression from measured per-arm matrices (C2 round 2).
+
+    UNCOMPRESSED IS THE FALLBACK: a cluster receives a compressed config only on paired
+    statistical evidence it does not lose quality (mean - z*SE >= 0 on >= min-pairs cells,
+    the routing guard's shape) AND a measured effective-cost-per-completed-task win on the
+    same cells, choosing among MEASURED arms only. The A/A kill bar (off arm split by episode
+    parity fed through the same gates) runs first and must be clean at the shipped z; a
+    deviation there means the gates would compress on noise, and the command refuses to fit.
+
+    The base policy is fitted RAW and the exclusivity rule is enforced (per-cluster mode
+    never mixes with an endpoint-level --compressor config). Evidence behind every decision
+    lands next to the policy as <out>.compaction-evidence.json.
+    """
+    if kind not in ("rank", "knn"):
+        raise typer.BadParameter(f"unknown kind '{kind}'; use knn or rank")
+    if not arm and not control:
+        raise typer.BadParameter("nothing to fit: pass at least one --arm or --control matrix")
+    off, off_source = load_matrix_with_digest(Path(off_matrix))
+    if off.measured_compression() is not None:
+        raise typer.BadParameter(
+            f"{off_matrix} is a compressed arm, not the off arm; pass it via --arm"
+        )
+    arms: list[ArmMatrices] = []
+    for path, is_control in [(p, False) for p in arm] + [(p, True) for p in control]:
+        matrix, _source = load_matrix_with_digest(Path(path))
+        config = matrix.measured_compression()
+        if config is None:
+            raise typer.BadParameter(
+                f"{path} carries no compression arm (its rows ran uncompressed); an arm "
+                "matrix must have been measured through a compressor"
+            )
+        arms.append(ArmMatrices(matrix=matrix, config=config, control=is_control))
+    try:
+        spec, resolution = resolve_embedder(
+            embedder, dim=dim, deployment=deployment, endpoint=endpoint, api_key_env=api_key_env
+        )
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    _console.print(resolution)
+    try:
+        probe_embedder(spec)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    out_path = Path(out)
+    built = spec.build()  # ONE embedder: base fit, overlay, and assignment share it
+
+    if kind == "knn":
+        fitted = fit_knn_artifact(
+            off,
+            out_path=out_path,
+            matrix_source=off_source,
+            embedder=spec,
+            fallback=fallback,
+            floor_q=floor_q,
+            compression=None,  # per-cluster mode routes on raw text (exclusivity rule)
+        )
+        policy = fitted.policy
+        policy_clusters, assignment = overlay_clusters(
+            off,
+            embed_with=built,
+            n_clusters=clusters,
+            seed=seed,
+            default_model=policy.default_model,
+        )
+    else:
+        policy = fit_rank_policy(
+            off,
+            embedder=spec,
+            n_clusters=clusters,
+            seed=seed,
+            fitted_from=f"{off_source} rank seed={seed} k={clusters} {embedder_provenance(spec)}",
+        )
+        policy_clusters = policy.clusters
+        assignment = assign_to_clusters(policy_clusters, off, embed_with=built)
+
+    deviations = aa_report(assignment, off, z=z, min_pairs=min_pairs)
+    if deviations:
+        for row in deviations:
+            _console.print(
+                f"[red]A/A deviation[/red] cluster {row.cluster_id}: mean_diff "
+                f"{row.mean_diff:+.4f}, se {row.se:.4f}, n_pairs {row.n_pairs}"
+            )
+        _console.print(
+            "[red]A/A kill bar failed[/red]: the gates deviate on pure episode noise at "
+            f"z={z:g}. Raise --z until this bar is clean; do not weaken it after results."
+        )
+        raise typer.Exit(1)
+    _console.print(f"[green]✓[/green] A/A bar clean at z={z:g} (no cluster deviates on noise)")
+
+    fit = fit_compaction(
+        assignment,
+        off,
+        arms,
+        z=z,
+        min_pairs=min_pairs,
+        allow_uneven=allow_uneven_coverage,
+    )
+    evidence_path = out_path.with_suffix(".compaction-evidence.json")
+    evidence_path.write_text(fit.model_dump_json(indent=2))
+
+    if kind == "knn":
+        sidecar = out_path.parent / COMPACTION_SIDECAR_FILENAME
+        save_compaction_sidecar(policy_clusters, fit, sidecar, fitted_from=off_source)
+        target = f"sidecar {sidecar}"
+    else:
+        policy = apply_compaction(policy, fit)
+        policy.save(out_path)
+        target = out
+
+    for note in fit.coverage:
+        _console.print(f"[yellow]coverage[/yellow] {note}")
+    for row in sorted(fit.evidence, key=lambda r: (r.cluster_id, r.signature)):
+        verdict = "CHOSEN" if row.chosen else ("would win" if row.would_win else "")
+        _console.print(
+            f"  cluster {row.cluster_id} {row.signature}: n={row.n_pairs} "
+            f"delta {row.mean_diff:+.4f}+-{row.se:.4f} "
+            f"quality {'pass' if row.quality_pass else 'fail'} "
+            f"cost {'pass' if row.cost_pass else 'fail'} {verdict}"
+        )
+    label = " [CANDIDATE: uneven coverage]" if fit.coverage else ""
+    _console.print(
+        f"[green]✓[/green] {fit.compressed_clusters()}/{len(fit.per_cluster)} clusters "
+        f"compressed -> {target}{label}\n  evidence: {evidence_path}"
+    )
+    if fit.controls_would_win:
+        _console.print(
+            f"[red]INVESTIGATION GATE[/red]: control arms would have won clusters: "
+            f"{fit.controls_would_win}. A control beating the learned arms through the full "
+            "gate is a finding to investigate, not a policy to ship."
+        )
+        raise typer.Exit(1)
 
 
 def print_knn_fit(console: Console, fitted: KnnFitOutcome, *, out: str, z: float) -> None:

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3072,3 +3072,155 @@ def test_route_student_help_keeps_the_pool_table_name() -> None:
     result = runner.invoke(app, ["optimize", "route", "student", "--help"])
     assert result.exit_code == 0, result.output
     assert "[[model]]" in _flat(result.output)
+
+
+# ---------------------------------------------------------------------------
+# fit-compaction (C2 round 2: per-cluster compression from measured arms).
+# ---------------------------------------------------------------------------
+
+_COMPACTION_TRUNCATE = CompressionConfig(
+    compressor_id="truncate", compressor_version="1", aggressiveness=0.2
+)
+
+
+def _compaction_grid(
+    tmp_path: Path, *, arm_cost: float = 0.005
+) -> tuple[Path, Path]:
+    """An off matrix with headroom in its SQL half, and an arm that claims it.
+
+    Two lexically distant scenario groups (so the hashing embedder clusters them apart),
+    2 models x 2 episodes: 12 paired cells per cluster, clearing the min-pairs default. The
+    arm lifts the SQL group at lower cost (a genuine per-cluster win under the registered
+    gate, which demands POSITIVE paired evidence) and wrecks the prose group (the quality
+    gate must hold that cluster at None).
+    """
+    pool = [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+        PoolEntry(
+            name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+    ]
+    groups = {
+        "sql": "SELECT revenue balance sheet fiscal audit dividend capital table",
+        "prose": "write a warm poem about rivers meadows sunsets and quiet mornings",
+    }
+    arm_id, arm_version, arm_aggressiveness = _arm(_COMPACTION_TRUNCATE)
+
+    def rows(*, arm: bool) -> list[ScenarioOutcome]:
+        out = []
+        for group, text in groups.items():
+            for index in range(6):
+                for model in ("a", "b"):
+                    for episode in range(2):
+                        if arm:
+                            reward = 1.0 if group == "sql" else 0.0
+                        else:
+                            reward = 1.0 if (group == "prose" or index < 3) else 0.0
+                        out.append(
+                            ScenarioOutcome(
+                                scenario_id=f"{group}-{index}",
+                                task=f"{text} variant {index}",
+                                model=model,
+                                episode=episode,
+                                reward=reward,
+                                success=reward >= 1.0,
+                                cost_usd=arm_cost if arm else 0.01,
+                                compressor_id=arm_id if arm else "",
+                                compressor_version=arm_version if arm else "",
+                                aggressiveness=arm_aggressiveness if arm else 0.0,
+                            )
+                        )
+        return out
+
+    off_path = tmp_path / "off.json"
+    arm_path = tmp_path / "arm.json"
+    OutcomeMatrix(pool=pool, outcomes=rows(arm=False)).save(off_path)
+    OutcomeMatrix(pool=pool, outcomes=rows(arm=True)).save(arm_path)
+    return off_path, arm_path
+
+
+def test_fit_compaction_stamps_the_winning_cluster_only(tmp_path: Path) -> None:
+    off_path, arm_path = _compaction_grid(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit-compaction",
+            str(off_path),
+            "--arm",
+            str(arm_path),
+            "--kind",
+            "rank",
+            "--clusters",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "A/A bar clean" in result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.compression is None and policy.fit_compression is None  # raw-routed
+    configs = [c.compression for c in policy.clusters]
+    assert sum(1 for c in configs if c is not None) == 1
+    stamped = next(c for c in configs if c is not None)
+    assert same_compression(stamped, _COMPACTION_TRUNCATE)
+    assert policy_file.with_suffix(".compaction-evidence.json").exists()
+
+
+def test_fit_compaction_control_win_is_an_investigation_gate(tmp_path: Path) -> None:
+    off_path, arm_path = _compaction_grid(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit-compaction",
+            str(off_path),
+            "--control",
+            str(arm_path),
+            "--kind",
+            "rank",
+            "--clusters",
+            "2",
+            "--out",
+            str(tmp_path / "policy.json"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "INVESTIGATION GATE" in result.output
+
+
+def test_fit_compaction_knn_writes_a_sidecar_overlay(tmp_path: Path) -> None:
+    from wmo.optimize.compaction_fit import COMPACTION_SIDECAR_FILENAME, CompactionArtifact
+
+    off_path, arm_path = _compaction_grid(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit-compaction",
+            str(off_path),
+            "--arm",
+            str(arm_path),
+            "--kind",
+            "knn",
+            "--clusters",
+            "2",
+            "--out",
+            str(policy_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    policy = RoutingPolicy.load(policy_file)
+    assert policy.kind == "knn" and not policy.clusters  # routing untouched
+    sidecar = CompactionArtifact.model_validate_json(
+        (tmp_path / COMPACTION_SIDECAR_FILENAME).read_text()
+    )
+    assert sum(1 for c in sidecar.clusters if c.compression is not None) == 1

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3196,7 +3196,7 @@ def test_fit_compaction_control_win_is_an_investigation_gate(tmp_path: Path) -> 
 
 
 def test_fit_compaction_knn_writes_a_sidecar_overlay(tmp_path: Path) -> None:
-    from wmo.optimize.compaction_fit import COMPACTION_SIDECAR_FILENAME, CompactionArtifact
+    from wmo.optimize.compaction_fit import CompactionArtifact, compaction_path_for
 
     off_path, arm_path = _compaction_grid(tmp_path)
     policy_file = tmp_path / "policy.json"
@@ -3221,7 +3221,7 @@ def test_fit_compaction_knn_writes_a_sidecar_overlay(tmp_path: Path) -> None:
     policy = RoutingPolicy.load(policy_file)
     assert policy.kind == "knn" and not policy.clusters  # routing untouched
     sidecar = CompactionArtifact.model_validate_json(
-        (tmp_path / COMPACTION_SIDECAR_FILENAME).read_text()
+        compaction_path_for(policy_file).read_text()
     )
     assert sum(1 for c in sidecar.clusters if c.compression is not None) == 1
 
@@ -3230,7 +3230,7 @@ def test_fit_compaction_rejected_run_leaves_no_mountable_artifact(tmp_path: Path
     # The investigation gate must not leave a policy or sidecar behind (a rejected fit that
     # still writes its outputs hands the rejected result to whatever consumes the directory
     # next); only the evidence file, which IS the investigation record, may exist.
-    from wmo.optimize.compaction_fit import COMPACTION_SIDECAR_FILENAME
+    from wmo.optimize.compaction_fit import compaction_path_for
 
     off_path, arm_path = _compaction_grid(tmp_path)
     for kind in ("rank", "knn"):
@@ -3256,5 +3256,69 @@ def test_fit_compaction_rejected_run_leaves_no_mountable_artifact(tmp_path: Path
         )
         assert result.exit_code == 1
         assert not policy_file.exists()
-        assert not (out_dir / COMPACTION_SIDECAR_FILENAME).exists()
+        assert not compaction_path_for(policy_file).exists()
         assert policy_file.with_suffix(".compaction-evidence.json").exists()
+
+
+def test_fit_compaction_aa_kill_bar_fires_and_writes_nothing(tmp_path: Path) -> None:
+    # M5: the A/A bar's FIRING path. An off arm with a systematic episode-parity effect
+    # (episode 1 wins where episode 0 fails, in one lexical group) must trip the bar, exit
+    # nonzero, and leave NO artifact of any kind behind, evidence included: the fit never ran.
+    from wmo.optimize.compaction_fit import compaction_path_for
+
+    pool = [
+        PoolEntry(
+            name="a", kind=ProviderKind.OPENAI, model="a", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+        PoolEntry(
+            name="b", kind=ProviderKind.OPENAI, model="b", input_per_mtok=1.0, output_per_mtok=1.0
+        ),
+    ]
+    groups = {
+        "sql": "SELECT revenue balance sheet fiscal audit dividend capital table",
+        "prose": "write a warm poem about rivers meadows sunsets and quiet mornings",
+    }
+    rows = []
+    for group, text_ in groups.items():
+        for index in range(6):
+            for model in ("a", "b"):
+                for episode in range(2):
+                    reward = 1.0 if (group == "prose" or episode == 1 or index < 2) else 0.0
+                    rows.append(
+                        ScenarioOutcome(
+                            scenario_id=f"{group}-{index}",
+                            task=f"{text_} variant {index}",
+                            model=model,
+                            episode=episode,
+                            reward=reward,
+                            success=reward >= 1.0,
+                            cost_usd=0.01,
+                        )
+                    )
+    off_path = tmp_path / "off-aa.json"  # its own name: _compaction_grid writes off.json
+    OutcomeMatrix(pool=pool, outcomes=rows).save(off_path)
+    _dummy, arm_path = _compaction_grid(tmp_path)
+    policy_file = tmp_path / "policy.json"
+    result = runner.invoke(
+        app,
+        [
+            "optimize",
+            "route",
+            "fit-compaction",
+            str(off_path),
+            "--arm",
+            str(arm_path),
+            "--kind",
+            "rank",
+            "--clusters",
+            "2",
+            "--out",
+            str(policy_file),
+            "--allow-uneven-coverage",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "A/A kill bar failed" in result.output
+    assert not policy_file.exists()
+    assert not compaction_path_for(policy_file).exists()
+    assert not policy_file.with_suffix(".compaction-evidence.json").exists()

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -3224,3 +3224,37 @@ def test_fit_compaction_knn_writes_a_sidecar_overlay(tmp_path: Path) -> None:
         (tmp_path / COMPACTION_SIDECAR_FILENAME).read_text()
     )
     assert sum(1 for c in sidecar.clusters if c.compression is not None) == 1
+
+
+def test_fit_compaction_rejected_run_leaves_no_mountable_artifact(tmp_path: Path) -> None:
+    # The investigation gate must not leave a policy or sidecar behind (a rejected fit that
+    # still writes its outputs hands the rejected result to whatever consumes the directory
+    # next); only the evidence file, which IS the investigation record, may exist.
+    from wmo.optimize.compaction_fit import COMPACTION_SIDECAR_FILENAME
+
+    off_path, arm_path = _compaction_grid(tmp_path)
+    for kind in ("rank", "knn"):
+        out_dir = tmp_path / kind
+        out_dir.mkdir()
+        policy_file = out_dir / "policy.json"
+        result = runner.invoke(
+            app,
+            [
+                "optimize",
+                "route",
+                "fit-compaction",
+                str(off_path),
+                "--control",
+                str(arm_path),
+                "--kind",
+                kind,
+                "--clusters",
+                "2",
+                "--out",
+                str(policy_file),
+            ],
+        )
+        assert result.exit_code == 1
+        assert not policy_file.exists()
+        assert not (out_dir / COMPACTION_SIDECAR_FILENAME).exists()
+        assert policy_file.with_suffix(".compaction-evidence.json").exists()

--- a/wmo/optimize/__init__.py
+++ b/wmo/optimize/__init__.py
@@ -10,6 +10,7 @@ its `Optimizer` protocol and return `OptimizeResult`s whose `ArtifactRef`s say w
 # the serving runtime, reach this package, so a policy naming that id resolves on either path
 # without the caller registering anything by hand.
 from wmo.optimize import compression_endpoint as compression_endpoint  # noqa: F401
+from wmo.optimize import compression_scoped as compression_scoped  # noqa: F401
 from wmo.optimize.base import ArtifactRef, OptimizeMetrics, Optimizer, OptimizeResult
 from wmo.optimize.gepa import GEPAOptimizer
 from wmo.optimize.judge import Judge, JudgeResult, RubricJudge

--- a/wmo/optimize/compaction_fit.py
+++ b/wmo/optimize/compaction_fit.py
@@ -7,39 +7,55 @@ config, all on the SAME scenario cohort, each self-describing via
 `OutcomeMatrix.measured_compression()`. Its output is a per-cluster
 `CompressionConfig | None` map plus the paired evidence behind every decision.
 
-The choice rule is conservative by design, mirroring the routing guard's shape: UNCOMPRESSED
-IS THE FALLBACK, and a cluster receives a compressed config only on statistical evidence it
-does not lose quality AND a measured effective-cost win. Concretely, an arm passes in a
-cluster iff
+The choice rule is conservative by design: UNCOMPRESSED IS THE FALLBACK, and a cluster
+receives a compressed config only on statistical evidence it does not lose quality AND a
+measured effective-cost win. Concretely, an arm passes in a cluster iff
 
-- quality: the paired per-cell reward delta (arm minus off, cells = (scenario, model) means
-  over scored episodes) satisfies mean - z * SE >= 0 on at least `min_pairs` paired cells,
-  with the same small-sample SE floor the knn guard uses (`SE_FLOOR_MAX_PAIRS`), and
+- quality (NON-INFERIORITY, the 2026-07-28 gate ruling): the paired per-cell reward delta
+  (arm minus off, cells = (scenario, model) means over scored episodes) satisfies
+  mean - z * SE >= -margin on at least `min_pairs` paired cells, with margin = 0.02 absolute
+  reward (the fleet's noise-floor bar) and the knn guard's small-sample SE floor
+  (`SE_FLOOR_MAX_PAIRS`). An arm that PRESERVES quality at lower cost passes, which is the
+  product case; the earlier zero-margin superiority form structurally refused it, and that
+  miscalibration was most of round 2's "0/8" headline. Note the floor's interaction: below
+  30 pairs the floored SE (sqrt(0.25/n)) exceeds the margin at any practical z, so thin
+  clusters still cannot deviate, by construction rather than by accident.
 - cost: the arm's effective cost per COMPLETED task on those cells, compressor bill folded
   as a `RowOverhead`, beats the off arm's on the same cells. Input-token accounting alone is
   banned here: the grid measured dumb deletion RAISING effective cost by lengthening
   episodes, so only the completed-task metric can gate.
+- control dominance (the 2026-07-28 HIGH-1 ruling): no control arm in the cluster may pass
+  its own quality gate with a delta at or above the winner's, REGARDLESS of cost rank. A
+  matched-ratio control matching the winner's quality signal means the signal is not
+  compression-specific; the cluster is refused and flagged, never silently stamped.
 
 Among passing arms the tie-break is lowest effective cost, then lower aggressiveness. Arms
 are MEASURED points only: the fitter never interpolates an aggressiveness the grid did not
 run, matching the D-DIAL v2 ruling that aggressiveness is a step function over mounted
-artifacts.
+artifacts. Every arm's config is verified against its matrix's own
+`measured_compression()`, so a caller cannot stamp an arm that was never measured.
 
 Two mandatory validations ride along. The A/A bar (`aa_report`) splits the off arm by episode
 parity and runs the same gates: a guard loose enough to compress on noise fails there before
-it can ship. Control arms (`control=True`) are evaluated and reported but never chosen; a
-control that WOULD have won a cluster is an investigation flag, not a result.
+it can ship. Control arms (`control=True`) are evaluated and reported but never chosen.
 
-Representation rule (proposed in DECISIONS 2026-07-27, C2 round 2): a policy carrying
-per-cluster configs routes on RAW text (policy-level `compression` and `fit_compression`
-both None) and compresses after cluster assignment. `apply_compaction` enforces that
-exclusivity; the serving-side delta lands separately behind the co-signed contract.
+Evidence provenance (the 2026-07-28 MEDIUM-3 ruling): every fit records where its matrices
+came from and which scorer era produced their rewards; a fit whose era is unlabeled or
+known-broken carries a pending-rescore quality label that consumers must surface.
+
+Representation rule (proposed in DECISIONS 2026-07-27, co-signed 2026-07-28 with
+conditions): a policy carrying per-cluster configs routes on RAW text (policy-level
+`compression` and `fit_compression` both None) and compresses after cluster assignment.
+`apply_compaction` enforces that exclusivity; the serving-side delta lands separately
+behind the routing-lane co-sign.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from collections import defaultdict
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -48,9 +64,16 @@ from pydantic import BaseModel, Field
 from wmo.optimize.compression import (
     CompressionConfig,
     compression_signature,
+    same_compression,
     servable_compressor,
 )
-from wmo.optimize.policy import SE_FLOOR_MAX_PAIRS, ClusterRanking, RoutingPolicy
+from wmo.optimize.policy import (
+    SE_FLOOR_MAX_PAIRS,
+    ClusterRanking,
+    EmbedderSpec,
+    RoutingPolicy,
+    write_artifact_atomically,
+)
 from wmo.optimize.scorecard import (
     DEFAULT_COMPLETION,
     CompletionRule,
@@ -66,10 +89,41 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_COMPACTION_Z = 0.5  # the routing guard's confidence bar, reused deliberately
 DEFAULT_COMPACTION_MIN_PAIRS = 8  # below this a cluster never deviates from uncompressed
+# The ruled non-inferiority margin: 0.02 absolute reward, the fleet's established noise-floor
+# bar (ladder verdict rule), adopted by the 2026-07-28 gate ruling. 0.0 recovers the
+# superiority form for comparison sweeps; serving fits use the ruled default.
+DEFAULT_NONINFERIORITY_MARGIN = 0.02
 
 # The A/A pseudo-arm's placeholder identity. It exists only inside `aa_report` evidence rows;
 # it is marked control, is never eligible, and never reaches an artifact.
 AA_SIGNATURE = "aa-episode-split"
+
+
+class EvidenceProvenance(BaseModel):
+    """Where a fit's evidence came from, carried on every output (MEDIUM-3 ruling).
+
+    `scorer_era` names the judge/scorer state the matrices' rewards were produced under
+    (e.g. "post-rescore-2026-07-28"); empty or containing "broken" means the quality axis is
+    not currently trustworthy and `quality_label` says so. Consumers surface the label; they
+    do not get to average a pending-rescore number into a headline silently.
+    """
+
+    off_source: str = ""
+    arm_sources: dict[str, str] = Field(default_factory=dict)  # signature -> matrix source
+    scorer_era: str = ""
+    quality_label: str = ""  # "" = trusted; "pending-rescore" = quality side not yet believable
+
+    @classmethod
+    def build(
+        cls, *, off_source: str, arm_sources: dict[str, str], scorer_era: str
+    ) -> EvidenceProvenance:
+        broken = not scorer_era or "broken" in scorer_era.lower()
+        return cls(
+            off_source=off_source,
+            arm_sources=arm_sources,
+            scorer_era=scorer_era,
+            quality_label="pending-rescore" if broken else "",
+        )
 
 
 class ClusterArmEvidence(BaseModel):
@@ -77,7 +131,9 @@ class ClusterArmEvidence(BaseModel):
 
     `would_win` is true when the arm passed both gates and led the tie-break regardless of
     eligibility, so a control or unservable arm that would have taken the cluster is visible
-    instead of silently skipped. `chosen` additionally requires eligible and not control.
+    instead of silently skipped. `chosen` additionally requires eligible, not control, and
+    not control-dominated. `control_dominated` marks a winner refused because a control
+    matched or beat its quality delta (HIGH-1).
     """
 
     cluster_id: int
@@ -93,6 +149,7 @@ class ClusterArmEvidence(BaseModel):
     arm_cost_per_completed: float | None = None
     cost_pass: bool = False
     would_win: bool = False
+    control_dominated: bool = False
     chosen: bool = False
 
 
@@ -103,21 +160,31 @@ class CompactionFit(BaseModel):
     evidence: list[ClusterArmEvidence]
     z: float
     min_pairs: int
+    margin: float = DEFAULT_NONINFERIORITY_MARGIN
     coverage: list[str] = Field(default_factory=list)  # human-readable coverage notes
-    controls_would_win: list[str] = Field(default_factory=list)  # "cluster=3 truncate/1/0.2"
+    # Investigation flags, one string per event: a control led the tie-break, or a control
+    # quality-dominated the winner. Any entry means the fit must not ship without a human read.
+    control_flags: list[str] = Field(default_factory=list)
+    provenance: EvidenceProvenance = Field(default_factory=EvidenceProvenance)
 
     def compressed_clusters(self) -> int:
         return sum(1 for config in self.per_cluster.values() if config is not None)
 
 
 class ArmMatrices(BaseModel):
-    """One measured arm: its matrix and how the fitter should treat it."""
+    """One measured arm: its matrix and how the fitter should treat it.
+
+    `pseudo` is reserved for `aa_report`'s episode-split arm, whose placeholder config
+    deliberately does not match its matrix; every real arm is verified against
+    `measured_compression()`.
+    """
 
     model_config = {"arbitrary_types_allowed": True}
 
     matrix: object  # OutcomeMatrix; typed loosely to avoid a runtime import cycle
     config: CompressionConfig
     control: bool = False
+    pseudo: bool = False
 
 
 def _cells(matrix: OutcomeMatrix) -> dict[tuple[str, str], list[ScenarioOutcome]]:
@@ -278,8 +345,10 @@ def fit_compaction(
     *,
     z: float = DEFAULT_COMPACTION_Z,
     min_pairs: int = DEFAULT_COMPACTION_MIN_PAIRS,
+    margin: float = DEFAULT_NONINFERIORITY_MARGIN,
     completion: CompletionRule = DEFAULT_COMPLETION,
     allow_uneven: bool = False,
+    provenance: EvidenceProvenance | None = None,
 ) -> CompactionFit:
     """The gates: per cluster, choose among measured arms or stay uncompressed.
 
@@ -292,13 +361,24 @@ def fit_compaction(
     signatures = [compression_signature(arm.config) for arm in arms]
     if len(set(signatures)) != len(signatures):
         raise ValueError(f"duplicate arm signatures: {sorted(signatures)}")
+    for arm in arms:
+        # Measured arms only, verified: a config that disagrees with what the matrix's episodes
+        # actually ran under would stamp an arm that was never measured. The CLI reads configs
+        # FROM the matrices so it cannot hit this; named future consumers calling the module
+        # directly can, which is why it is asserted here and not only at the boundary.
+        if not arm.pseudo and not same_compression(arm.config, arm.matrix.measured_compression()):
+            raise ValueError(
+                f"arm config {compression_signature(arm.config)} does not match its matrix's "
+                f"measured arm {compression_signature(arm.matrix.measured_compression())}; "
+                "the fitter only stamps configs whose episodes were actually measured"
+            )
     coverage = check_cohort(off, arms, allow_uneven=allow_uneven)
 
     off_cells = _cells(off)
     cluster_ids = sorted(set(assignment.values()))
     evidence: list[ClusterArmEvidence] = []
     per_cluster: dict[int, CompressionConfig | None] = {}
-    controls_would_win: list[str] = []
+    control_flags: list[str] = []
 
     for cluster_id in cluster_ids:
         member_cells = [key for key in off_cells if assignment.get(key[0]) == cluster_id]
@@ -315,7 +395,10 @@ def fit_compaction(
             se = float(diffs.std(ddof=1)) / n_pairs**0.5 if n_pairs > 1 else 0.0
             if 0 < n_pairs < SE_FLOOR_MAX_PAIRS:
                 se = max(se, (0.25 / n_pairs) ** 0.5)
-            quality_pass = n_pairs >= min_pairs and mean_diff - z * se >= 0.0
+            # NON-INFERIORITY (the ruled gate): the lower confidence bound at z must clear
+            # -margin, not 0. Quality preservation at lower cost passes; quality loss beyond
+            # the fleet's noise-floor bar cannot.
+            quality_pass = n_pairs >= min_pairs and mean_diff - z * se >= -margin
 
             arm_rows = [row for key in paired for row in arm_cells[key]]
             off_rows = [row for key in paired for row in off_cells[key]]
@@ -346,6 +429,7 @@ def fit_compaction(
             )
 
         passing = [c for c in candidates if c.quality_pass and c.cost_pass]
+        per_cluster[cluster_id] = None
         if passing:
             # Tie-break lowest effective cost, then lower aggressiveness (conservative).
             ranked = sorted(
@@ -353,17 +437,33 @@ def fit_compaction(
                 key=lambda c: (c.arm_cost_per_completed, c.config.aggressiveness),
             )
             ranked[0].would_win = True
-            winner = next((c for c in ranked if c.eligible and not c.control), None)
-            if winner is not None:
-                winner.chosen = True
-                per_cluster[cluster_id] = winner.config
-            else:
-                per_cluster[cluster_id] = None
-            for candidate in ranked:
-                if candidate.control and candidate.would_win:
-                    controls_would_win.append(f"cluster={cluster_id} {candidate.signature}")
-        else:
-            per_cluster[cluster_id] = None
+            if ranked[0].control:
+                control_flags.append(
+                    f"cluster={cluster_id} {ranked[0].signature} led the tie-break"
+                )
+            # CONTROL DOMINANCE (HIGH-1): a control passing its own quality gate with a
+            # delta at or above the leading real arm's means the cluster's signal is not
+            # compression-specific, REGARDLESS of which arm is cheaper. The flag fires even
+            # when the leading arm is ineligible (a surface sweep must see the dominance,
+            # not have eligibility hide it); the refusal applies to whatever would be chosen.
+            leader = next((c for c in ranked if not c.control), None)
+            if leader is not None:
+                dominating = [
+                    c
+                    for c in candidates
+                    if c.control and c.quality_pass and c.mean_diff >= leader.mean_diff
+                ]
+                if dominating:
+                    leader.control_dominated = True
+                    for control in dominating:
+                        control_flags.append(
+                            f"cluster={cluster_id} control {control.signature} quality-dominates "
+                            f"{leader.signature} ({control.mean_diff:+.4f} >= "
+                            f"{leader.mean_diff:+.4f})"
+                        )
+                elif leader.eligible:
+                    leader.chosen = True
+                    per_cluster[cluster_id] = leader.config
         evidence.extend(candidates)
 
     fit = CompactionFit(
@@ -371,16 +471,20 @@ def fit_compaction(
         evidence=evidence,
         z=z,
         min_pairs=min_pairs,
+        margin=margin,
         coverage=coverage,
-        controls_would_win=controls_would_win,
+        control_flags=control_flags,
+        provenance=provenance or EvidenceProvenance(),
     )
     logger.info(
-        "compaction fit: %d/%d clusters compressed (z=%g, min_pairs=%d)%s",
+        "compaction fit: %d/%d clusters compressed (z=%g, margin=%g, min_pairs=%d)%s%s",
         fit.compressed_clusters(),
         len(cluster_ids),
         z,
+        margin,
         min_pairs,
-        f"; CONTROLS WOULD WIN: {controls_would_win}" if controls_would_win else "",
+        f"; CONTROL FLAGS: {control_flags}" if control_flags else "",
+        f" [{fit.provenance.quality_label}]" if fit.provenance.quality_label else "",
     )
     return fit
 
@@ -415,13 +519,16 @@ def aa_report(
     *,
     z: float = DEFAULT_COMPACTION_Z,
     min_pairs: int = DEFAULT_COMPACTION_MIN_PAIRS,
+    margin: float = DEFAULT_NONINFERIORITY_MARGIN,
     completion: CompletionRule = DEFAULT_COMPLETION,
 ) -> list[ClusterArmEvidence]:
     """The A/A kill bar: run the gates on the episode-parity pseudo-arms.
 
     Returns the evidence rows whose gates BOTH passed (the deviations); an empty list is the
     bar passing. The pseudo-arm is marked control and carries a placeholder config, so nothing
-    from this report can reach an artifact even if a caller mishandles it.
+    from this report can reach an artifact even if a caller mishandles it. Runs at the SAME
+    margin as the real fit: the margin loosens the quality gate, so an A/A bar run without it
+    would certify a z the real gate then betrays.
     """
     pseudo_off, pseudo_arm = aa_pseudo_arms(off)
     placeholder = CompressionConfig(compressor_id=AA_SIGNATURE, compressor_version="0")
@@ -429,9 +536,10 @@ def aa_report(
     fit = fit_compaction(
         assignment,
         pseudo_off,
-        [ArmMatrices(matrix=pseudo_arm, config=placeholder, control=True)],
+        [ArmMatrices(matrix=pseudo_arm, config=placeholder, control=True, pseudo=True)],
         z=z,
         min_pairs=min_pairs,
+        margin=margin,
         completion=completion,
         allow_uneven=True,  # single-episode cells exist on one side only; pairing drops them
     )
@@ -443,36 +551,77 @@ def aa_report(
     return rows
 
 
+# `models/policy.json` -> `models/policy.json.compaction.json`: same derivation shape as
+# `knn_bank_path_for`, same reason (distinct policy filenames always give distinct sidecar
+# filenames, and one owner for the derivation means nothing can disagree about which map
+# belongs to which policy).
+COMPACTION_SUFFIX = ".compaction.json"
+
+
+def compaction_path_for(policy_path: Path) -> Path:
+    """The compaction sidecar that belongs to one policy file (mirrors `knn_bank_path_for`)."""
+    return policy_path.with_name(f"{policy_path.name}{COMPACTION_SUFFIX}")
+
+
 class CompactionArtifact(BaseModel):
     """The per-cluster compaction map as a policy SIDECAR (knn policies, v1).
 
     The merged `RoutingPolicy` validator forbids clusters on a knn policy, so the overlay
     cannot ride on the policy model without the co-signed contract delta. Until that lands,
-    the map ships beside the policy the way the knn bank itself does (`knn_bank_path`): the
-    clusters here carry centroids in the SAME raw embedding geometry the policy routes in,
-    plus their fitted compression configs. Nothing serves this yet; the serving delta is
-    gated on the DECISIONS co-sign.
+    the map ships beside the policy the way the knn bank itself does: the clusters here carry
+    centroids in the SAME raw embedding geometry the policy routes in, plus their fitted
+    compression configs.
+
+    Identity binding (MEDIUM-4 ruling): `policy_digest` is the sha256 of the policy file the
+    map was fitted beside, and `embedder` is that policy's embedding spec. A consumer loads
+    the sidecar through `load_compaction_sidecar`, which refuses both mismatches: mounting a
+    foreign policy's centroids is the C2 floor-failure class (geometry that looks valid and
+    silently routes wrong), so it must fail closed, not load. Nothing serves this yet; the
+    serving delta is gated on the routing-lane co-sign.
     """
 
     clusters: list[ClusterRanking]
     z: float
     min_pairs: int
+    margin: float = DEFAULT_NONINFERIORITY_MARGIN
+    policy_digest: str = ""
+    embedder: EmbedderSpec = Field(default_factory=EmbedderSpec)
+    provenance: EvidenceProvenance = Field(default_factory=EvidenceProvenance)
     fitted_from: str | None = None
 
 
-COMPACTION_SIDECAR_FILENAME = "policy_compaction.json"
+def _policy_digest(policy_path: Path) -> str:
+    return hashlib.sha256(policy_path.read_bytes()).hexdigest()
 
 
 def save_compaction_sidecar(
+    policy_path: Path,
+    policy: RoutingPolicy,
     clusters: list[ClusterRanking],
     fit: CompactionFit,
-    path,  # noqa: ANN001 - Path-like
     *,
     fitted_from: str | None = None,
 ) -> CompactionArtifact:
-    """Write the stamped overlay next to a knn policy (see `CompactionArtifact`)."""
-    from pathlib import Path
+    """Write the stamped overlay beside `policy_path` (see `CompactionArtifact`).
 
+    The policy must already be SAVED at `policy_path` (the digest binds to the bytes on
+    disk), must be raw-routed (the exclusivity rule applies to the sidecar exactly as it
+    applies to `apply_compaction`: a per-cluster map beside an endpoint-level compression
+    config is two representations in one artifact directory), and every stamped config must
+    be servable. The write is atomic, so a failure leaves any previous sidecar intact.
+    """
+    if policy.compression is not None or policy.fit_compression is not None:
+        raise ValueError(
+            "per-cluster compaction requires a raw-routed policy: policy-level compression "
+            f"is {compression_signature(policy.compression)} and fit_compression is "
+            f"{compression_signature(policy.fit_compression)}; per-cluster mode and "
+            "endpoint-level mode never mix, on the sidecar exactly as on the policy"
+        )
+    if not policy_path.exists():
+        raise ValueError(
+            f"policy file {policy_path} does not exist; save the policy first, the sidecar's "
+            "digest binds to its bytes"
+        )
     stamped = [
         cluster.model_copy(update={"compression": fit.per_cluster.get(cluster.cluster_id)})
         for cluster in clusters
@@ -481,20 +630,55 @@ def save_compaction_sidecar(
         if cluster.compression is not None:
             servable_compressor(cluster.compression)
     artifact = CompactionArtifact(
-        clusters=stamped, z=fit.z, min_pairs=fit.min_pairs, fitted_from=fitted_from
+        clusters=stamped,
+        z=fit.z,
+        min_pairs=fit.min_pairs,
+        margin=fit.margin,
+        policy_digest=_policy_digest(policy_path),
+        embedder=policy.embedder,
+        provenance=fit.provenance,
+        fitted_from=fitted_from,
     )
-    Path(path).write_text(artifact.model_dump_json(indent=2))
+    write_artifact_atomically(
+        compaction_path_for(policy_path), artifact.model_dump_json(indent=2).encode()
+    )
+    return artifact
+
+
+def load_compaction_sidecar(policy_path: Path, policy: RoutingPolicy) -> CompactionArtifact:
+    """Load and VERIFY the compaction sidecar belonging to `policy_path`.
+
+    Refuses a digest mismatch (the policy file changed since the map was fitted beside it)
+    and an embedder mismatch (the centroids live in a different geometry than the one the
+    policy routes in). Either would mount foreign-geometry centroids, which is the measured
+    C2 floor-failure class; the consumer contract is fail-closed.
+    """
+    path = compaction_path_for(policy_path)
+    artifact = CompactionArtifact.model_validate_json(path.read_text())
+    digest = _policy_digest(policy_path)
+    if artifact.policy_digest != digest:
+        raise ValueError(
+            f"compaction sidecar {path.name} was fitted beside a different policy file "
+            f"(digest {artifact.policy_digest[:12]}.. != {digest[:12]}..); refit the map for "
+            "this policy rather than mounting another policy's centroids"
+        )
+    if artifact.embedder != policy.embedder:
+        raise ValueError(
+            f"compaction sidecar {path.name} carries centroids in a different embedding "
+            "geometry than this policy routes in; a nearest-centroid assignment across "
+            "geometries is the measured floor-failure class, so it does not load"
+        )
     return artifact
 
 
 def apply_compaction(policy: RoutingPolicy, fit: CompactionFit) -> RoutingPolicy:
     """Stamp the fitted per-cluster map onto `policy` under the exclusivity rule.
 
-    The proposed representation rule (DECISIONS 2026-07-27): a policy carrying per-cluster
-    configs routes on RAW text, so policy-level `compression` and `fit_compression` must both
-    be None; mixing modes in one artifact is refused here, not discovered at mount. Every
-    stamped config is checked servable, so a control or churny arm that leaked into the map
-    fails closed at stamp time.
+    The co-signed representation rule (DECISIONS 2026-07-27/28): a policy carrying
+    per-cluster configs routes on RAW text, so policy-level `compression` and
+    `fit_compression` must both be None; mixing modes in one artifact is refused here, not
+    discovered at mount. Every stamped config is checked servable, so a control or churny
+    arm that leaked into the map fails closed at stamp time.
 
     Cluster-carrying kinds only (`rank`): a knn policy cannot carry clusters under the merged
     validator, so its map goes through `save_compaction_sidecar` instead.

--- a/wmo/optimize/compaction_fit.py
+++ b/wmo/optimize/compaction_fit.py
@@ -1,0 +1,528 @@
+"""Per-cluster compaction fitter: populate `ClusterRanking.compression` from measured arms.
+
+#265 merged the artifact field ("this cluster's compression choice, fitted jointly with the
+model ranking") with nothing fitting it. This module is the fitter. Its inputs are the grid's
+per-arm outcome matrices: one OFF arm (uncompressed) plus one matrix per measured compression
+config, all on the SAME scenario cohort, each self-describing via
+`OutcomeMatrix.measured_compression()`. Its output is a per-cluster
+`CompressionConfig | None` map plus the paired evidence behind every decision.
+
+The choice rule is conservative by design, mirroring the routing guard's shape: UNCOMPRESSED
+IS THE FALLBACK, and a cluster receives a compressed config only on statistical evidence it
+does not lose quality AND a measured effective-cost win. Concretely, an arm passes in a
+cluster iff
+
+- quality: the paired per-cell reward delta (arm minus off, cells = (scenario, model) means
+  over scored episodes) satisfies mean - z * SE >= 0 on at least `min_pairs` paired cells,
+  with the same small-sample SE floor the knn guard uses (`SE_FLOOR_MAX_PAIRS`), and
+- cost: the arm's effective cost per COMPLETED task on those cells, compressor bill folded
+  as a `RowOverhead`, beats the off arm's on the same cells. Input-token accounting alone is
+  banned here: the grid measured dumb deletion RAISING effective cost by lengthening
+  episodes, so only the completed-task metric can gate.
+
+Among passing arms the tie-break is lowest effective cost, then lower aggressiveness. Arms
+are MEASURED points only: the fitter never interpolates an aggressiveness the grid did not
+run, matching the D-DIAL v2 ruling that aggressiveness is a step function over mounted
+artifacts.
+
+Two mandatory validations ride along. The A/A bar (`aa_report`) splits the off arm by episode
+parity and runs the same gates: a guard loose enough to compress on noise fails there before
+it can ship. Control arms (`control=True`) are evaluated and reported but never chosen; a
+control that WOULD have won a cluster is an investigation flag, not a result.
+
+Representation rule (proposed in DECISIONS 2026-07-27, C2 round 2): a policy carrying
+per-cluster configs routes on RAW text (policy-level `compression` and `fit_compression`
+both None) and compresses after cluster assignment. `apply_compaction` enforces that
+exclusivity; the serving-side delta lands separately behind the co-signed contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from wmo.optimize.compression import (
+    CompressionConfig,
+    compression_signature,
+    servable_compressor,
+)
+from wmo.optimize.policy import SE_FLOOR_MAX_PAIRS, ClusterRanking, RoutingPolicy
+from wmo.optimize.scorecard import (
+    DEFAULT_COMPLETION,
+    CompletionRule,
+    RowOverhead,
+    effective_cost_per_completed_task,
+)
+
+if TYPE_CHECKING:
+    from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+    from wmo.providers.base import Embedder
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMPACTION_Z = 0.5  # the routing guard's confidence bar, reused deliberately
+DEFAULT_COMPACTION_MIN_PAIRS = 8  # below this a cluster never deviates from uncompressed
+
+# The A/A pseudo-arm's placeholder identity. It exists only inside `aa_report` evidence rows;
+# it is marked control, is never eligible, and never reaches an artifact.
+AA_SIGNATURE = "aa-episode-split"
+
+
+class ClusterArmEvidence(BaseModel):
+    """The paired statistics behind one (cluster, arm) decision, kept auditable.
+
+    `would_win` is true when the arm passed both gates and led the tie-break regardless of
+    eligibility, so a control or unservable arm that would have taken the cluster is visible
+    instead of silently skipped. `chosen` additionally requires eligible and not control.
+    """
+
+    cluster_id: int
+    signature: str  # compression_signature of the arm
+    config: CompressionConfig | None = None  # None only for the A/A pseudo-arm
+    control: bool = False
+    eligible: bool = True  # servable_compressor accepted the config
+    n_pairs: int = 0
+    mean_diff: float = 0.0
+    se: float = 0.0
+    quality_pass: bool = False
+    off_cost_per_completed: float | None = None
+    arm_cost_per_completed: float | None = None
+    cost_pass: bool = False
+    would_win: bool = False
+    chosen: bool = False
+
+
+class CompactionFit(BaseModel):
+    """The fitter's output: the per-cluster map plus everything needed to audit it."""
+
+    per_cluster: dict[int, CompressionConfig | None]
+    evidence: list[ClusterArmEvidence]
+    z: float
+    min_pairs: int
+    coverage: list[str] = Field(default_factory=list)  # human-readable coverage notes
+    controls_would_win: list[str] = Field(default_factory=list)  # "cluster=3 truncate/1/0.2"
+
+    def compressed_clusters(self) -> int:
+        return sum(1 for config in self.per_cluster.values() if config is not None)
+
+
+class ArmMatrices(BaseModel):
+    """One measured arm: its matrix and how the fitter should treat it."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    matrix: object  # OutcomeMatrix; typed loosely to avoid a runtime import cycle
+    config: CompressionConfig
+    control: bool = False
+
+
+def _cells(matrix: OutcomeMatrix) -> dict[tuple[str, str], list[ScenarioOutcome]]:
+    """Scored rows grouped by (scenario_id, model): the unit quality is paired on."""
+    cells: dict[tuple[str, str], list[ScenarioOutcome]] = defaultdict(list)
+    for row in matrix.outcomes:
+        if row.scored:
+            cells[(row.scenario_id, row.model)].append(row)
+    return cells
+
+
+def _cell_reward(rows: list[ScenarioOutcome]) -> float:
+    return float(np.mean([row.reward for row in rows]))
+
+
+def _compressor_overheads(rows: list[ScenarioOutcome]) -> list[RowOverhead]:
+    """The rows' own compressor bill as scorecard overheads (the #294 convention)."""
+    return [
+        RowOverhead(
+            scenario_id=row.scenario_id,
+            model=row.model,
+            episode=row.episode,
+            component="compressor",
+            cost_usd=row.compressor_cost_usd,
+            latency_s=row.compressor_latency_s,
+        )
+        for row in rows
+        if row.compressor_cost_usd > 0.0 or row.compressor_latency_s > 0.0
+    ]
+
+
+def _effective_cost(rows: list[ScenarioOutcome], completion: CompletionRule) -> float | None:
+    if not rows:
+        return None
+    result = effective_cost_per_completed_task(
+        rows, overheads=_compressor_overheads(rows), completion=completion
+    )
+    return result.cost_per_completed_task_usd
+
+
+def check_cohort(
+    off: OutcomeMatrix, arms: list[ArmMatrices], *, allow_uneven: bool = False
+) -> list[str]:
+    """Enforce that every arm was measured on the off arm's cohort, both directions.
+
+    Strict mode (the default) requires identical scored (scenario, model) cell sets: a grid arm
+    measured on a subset ranks its clusters on DIFFERENT evidence, which is the bias the route
+    sweep's coverage gate exists to block. `allow_uneven` downgrades the mismatch to printed
+    notes; pairing then happens on the intersection per cluster, and the caller labels the fit
+    accordingly (the grid mid-flight is the intended use).
+    """
+    notes: list[str] = []
+    off_cells = set(_cells(off))
+    for arm in arms:
+        arm_cells = set(_cells(arm.matrix))
+        missing = len(off_cells - arm_cells)
+        extra = len(arm_cells - off_cells)
+        if missing or extra:
+            notes.append(
+                f"{compression_signature(arm.config)}: {missing} off cells unmeasured on this "
+                f"arm, {extra} arm cells absent from off ({len(arm_cells & off_cells)} shared)"
+            )
+    if notes and not allow_uneven:
+        raise ValueError(
+            "arm matrices do not cover the off arm's cohort; pairing on a subset biases the "
+            "per-cluster ranking toward whichever cells each arm happened to keep:\n  "
+            + "\n  ".join(notes)
+            + "\nRe-run the missing cells, or pass allow_uneven for an interim, "
+            "candidate-labeled fit."
+        )
+    return notes
+
+
+def overlay_clusters(
+    matrix: OutcomeMatrix,
+    *,
+    embed_with: Embedder,
+    n_clusters: int = 8,
+    seed: int = 42,
+    default_model: str,
+) -> tuple[list[ClusterRanking], dict[str, int]]:
+    """K-means compression-overlay clusters on the off arm's raw task embeddings.
+
+    For `kind="rank"` policies the fitted clusters already exist and the caller uses
+    `assign_to_clusters` against them instead. This overlay is for `kind="knn"` policies, which
+    route without clusters: the overlay rides on the artifact solely so the compress stage has
+    an assignment surface, fitted on the SAME raw geometry the router embeds queries in (the
+    proposed serving delta reuses the decision's own query embedding, so overlay centroids in
+    any other space would be meaningless).
+
+    The `ranking` field is stamped `[default_model]`: it satisfies the model's shape and makes
+    plain that routing never reads these clusters. Conventions mirror `fit_rank_policy`
+    (L2-normalized embeddings, k-means++ with the reference seed).
+    """
+    from sklearn.cluster import KMeans
+    from sklearn.preprocessing import Normalizer
+
+    tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        tasks.setdefault(outcome.scenario_id, outcome.task)
+    scenario_ids = list(tasks)
+    if not scenario_ids:
+        raise ValueError("no scenarios to cluster")
+    embeddings = np.asarray(embed_with.embed([tasks[sid] for sid in scenario_ids]))
+    embeddings = Normalizer(norm="l2").fit_transform(embeddings)
+    k = min(n_clusters, len(scenario_ids))
+    kmeans = KMeans(
+        n_clusters=k,
+        random_state=seed,
+        init="k-means++",
+        n_init="auto",
+        max_iter=1000,
+        algorithm="elkan",
+    )
+    labels = kmeans.fit_predict(embeddings)
+    assignment = {sid: int(label) for sid, label in zip(scenario_ids, labels, strict=True)}
+    counts = defaultdict(int)
+    for cluster in assignment.values():
+        counts[cluster] += 1
+    clusters = [
+        ClusterRanking(
+            cluster_id=cluster_id,
+            label=f"compaction-{cluster_id}",
+            centroid=kmeans.cluster_centers_[cluster_id].tolist(),
+            ranking=[default_model],
+            total=counts[cluster_id],
+        )
+        for cluster_id in range(k)
+    ]
+    return clusters, assignment
+
+
+def assign_to_clusters(
+    clusters: list[ClusterRanking], matrix: OutcomeMatrix, *, embed_with: Embedder
+) -> dict[str, int]:
+    """Nearest-centroid assignment of the matrix's scenarios to existing policy clusters.
+
+    Used on `kind="rank"` policies so the compaction gates run on THE clusters the policy
+    routes with, not a parallel clustering that would drift from it.
+    """
+    tasks: dict[str, str] = {}
+    for outcome in matrix.outcomes:
+        tasks.setdefault(outcome.scenario_id, outcome.task)
+    scenario_ids = list(tasks)
+    embeddings = np.asarray(embed_with.embed([tasks[sid] for sid in scenario_ids]))
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings = embeddings / np.where(norms == 0.0, 1.0, norms)
+    centroids = np.asarray([c.centroid for c in clusters])
+    cluster_ids = [c.cluster_id for c in clusters]
+    sims = embeddings @ centroids.T
+    return {
+        sid: cluster_ids[int(np.argmax(sims[index]))]
+        for index, sid in enumerate(scenario_ids)
+    }
+
+
+def fit_compaction(
+    assignment: dict[str, int],
+    off: OutcomeMatrix,
+    arms: list[ArmMatrices],
+    *,
+    z: float = DEFAULT_COMPACTION_Z,
+    min_pairs: int = DEFAULT_COMPACTION_MIN_PAIRS,
+    completion: CompletionRule = DEFAULT_COMPLETION,
+    allow_uneven: bool = False,
+) -> CompactionFit:
+    """The gates: per cluster, choose among measured arms or stay uncompressed.
+
+    `assignment` maps scenario_id to cluster_id (from the policy's own clusters via
+    `assign_to_clusters`, or from `overlay_clusters`). See the module docstring for the rule;
+    every decision's paired statistics are returned as evidence rows.
+    """
+    if off.measured_compression() is not None:
+        raise ValueError("the off arm must be uncompressed; got a matrix with a compression arm")
+    signatures = [compression_signature(arm.config) for arm in arms]
+    if len(set(signatures)) != len(signatures):
+        raise ValueError(f"duplicate arm signatures: {sorted(signatures)}")
+    coverage = check_cohort(off, arms, allow_uneven=allow_uneven)
+
+    off_cells = _cells(off)
+    cluster_ids = sorted(set(assignment.values()))
+    evidence: list[ClusterArmEvidence] = []
+    per_cluster: dict[int, CompressionConfig | None] = {}
+    controls_would_win: list[str] = []
+
+    for cluster_id in cluster_ids:
+        member_cells = [key for key in off_cells if assignment.get(key[0]) == cluster_id]
+        candidates: list[ClusterArmEvidence] = []
+        for arm in arms:
+            signature = compression_signature(arm.config)
+            arm_cells = _cells(arm.matrix)
+            paired = [key for key in member_cells if key in arm_cells]
+            diffs = np.asarray(
+                [_cell_reward(arm_cells[key]) - _cell_reward(off_cells[key]) for key in paired]
+            )
+            n_pairs = int(diffs.size)
+            mean_diff = float(diffs.mean()) if n_pairs else 0.0
+            se = float(diffs.std(ddof=1)) / n_pairs**0.5 if n_pairs > 1 else 0.0
+            if 0 < n_pairs < SE_FLOOR_MAX_PAIRS:
+                se = max(se, (0.25 / n_pairs) ** 0.5)
+            quality_pass = n_pairs >= min_pairs and mean_diff - z * se >= 0.0
+
+            arm_rows = [row for key in paired for row in arm_cells[key]]
+            off_rows = [row for key in paired for row in off_cells[key]]
+            arm_cost = _effective_cost(arm_rows, completion)
+            off_cost = _effective_cost(off_rows, completion)
+            cost_pass = arm_cost is not None and off_cost is not None and arm_cost < off_cost
+
+            try:
+                servable_compressor(arm.config)
+                eligible = True
+            except ValueError:
+                eligible = False
+            candidates.append(
+                ClusterArmEvidence(
+                    cluster_id=cluster_id,
+                    signature=signature,
+                    config=arm.config,
+                    control=arm.control,
+                    eligible=eligible,
+                    n_pairs=n_pairs,
+                    mean_diff=mean_diff,
+                    se=se,
+                    quality_pass=quality_pass,
+                    off_cost_per_completed=off_cost,
+                    arm_cost_per_completed=arm_cost,
+                    cost_pass=cost_pass,
+                )
+            )
+
+        passing = [c for c in candidates if c.quality_pass and c.cost_pass]
+        if passing:
+            # Tie-break lowest effective cost, then lower aggressiveness (conservative).
+            ranked = sorted(
+                passing,
+                key=lambda c: (c.arm_cost_per_completed, c.config.aggressiveness),
+            )
+            ranked[0].would_win = True
+            winner = next((c for c in ranked if c.eligible and not c.control), None)
+            if winner is not None:
+                winner.chosen = True
+                per_cluster[cluster_id] = winner.config
+            else:
+                per_cluster[cluster_id] = None
+            for candidate in ranked:
+                if candidate.control and candidate.would_win:
+                    controls_would_win.append(f"cluster={cluster_id} {candidate.signature}")
+        else:
+            per_cluster[cluster_id] = None
+        evidence.extend(candidates)
+
+    fit = CompactionFit(
+        per_cluster=per_cluster,
+        evidence=evidence,
+        z=z,
+        min_pairs=min_pairs,
+        coverage=coverage,
+        controls_would_win=controls_would_win,
+    )
+    logger.info(
+        "compaction fit: %d/%d clusters compressed (z=%g, min_pairs=%d)%s",
+        fit.compressed_clusters(),
+        len(cluster_ids),
+        z,
+        min_pairs,
+        f"; CONTROLS WOULD WIN: {controls_would_win}" if controls_would_win else "",
+    )
+    return fit
+
+
+def aa_pseudo_arms(off: OutcomeMatrix) -> tuple[OutcomeMatrix, OutcomeMatrix]:
+    """Split the off arm by episode parity into two pseudo-arms measuring NOTHING.
+
+    Any per-cluster difference between the two sides is noise by construction, which is what
+    makes them the fitter's A/A control: gates loose enough to deviate here would compress on
+    noise in production. Episode indices are renumbered per side so each pseudo-matrix is
+    well-formed on its own.
+    """
+    from wmo.optimize.outcomes import OutcomeMatrix
+
+    even: list[ScenarioOutcome] = []
+    odd: list[ScenarioOutcome] = []
+    counters: dict[tuple[str, str, int], int] = defaultdict(int)
+    for row in off.outcomes:
+        side = even if row.episode % 2 == 0 else odd
+        key = (row.scenario_id, row.model, row.episode % 2)
+        side.append(row.model_copy(update={"episode": counters[key]}))
+        counters[key] += 1
+    return (
+        OutcomeMatrix(pool=off.pool, outcomes=even),
+        OutcomeMatrix(pool=off.pool, outcomes=odd),
+    )
+
+
+def aa_report(
+    assignment: dict[str, int],
+    off: OutcomeMatrix,
+    *,
+    z: float = DEFAULT_COMPACTION_Z,
+    min_pairs: int = DEFAULT_COMPACTION_MIN_PAIRS,
+    completion: CompletionRule = DEFAULT_COMPLETION,
+) -> list[ClusterArmEvidence]:
+    """The A/A kill bar: run the gates on the episode-parity pseudo-arms.
+
+    Returns the evidence rows whose gates BOTH passed (the deviations); an empty list is the
+    bar passing. The pseudo-arm is marked control and carries a placeholder config, so nothing
+    from this report can reach an artifact even if a caller mishandles it.
+    """
+    pseudo_off, pseudo_arm = aa_pseudo_arms(off)
+    placeholder = CompressionConfig(compressor_id=AA_SIGNATURE, compressor_version="0")
+    rows: list[ClusterArmEvidence] = []
+    fit = fit_compaction(
+        assignment,
+        pseudo_off,
+        [ArmMatrices(matrix=pseudo_arm, config=placeholder, control=True)],
+        z=z,
+        min_pairs=min_pairs,
+        completion=completion,
+        allow_uneven=True,  # single-episode cells exist on one side only; pairing drops them
+    )
+    for row in fit.evidence:
+        row.signature = AA_SIGNATURE
+        row.config = None
+        if row.quality_pass and row.cost_pass:
+            rows.append(row)
+    return rows
+
+
+class CompactionArtifact(BaseModel):
+    """The per-cluster compaction map as a policy SIDECAR (knn policies, v1).
+
+    The merged `RoutingPolicy` validator forbids clusters on a knn policy, so the overlay
+    cannot ride on the policy model without the co-signed contract delta. Until that lands,
+    the map ships beside the policy the way the knn bank itself does (`knn_bank_path`): the
+    clusters here carry centroids in the SAME raw embedding geometry the policy routes in,
+    plus their fitted compression configs. Nothing serves this yet; the serving delta is
+    gated on the DECISIONS co-sign.
+    """
+
+    clusters: list[ClusterRanking]
+    z: float
+    min_pairs: int
+    fitted_from: str | None = None
+
+
+COMPACTION_SIDECAR_FILENAME = "policy_compaction.json"
+
+
+def save_compaction_sidecar(
+    clusters: list[ClusterRanking],
+    fit: CompactionFit,
+    path,  # noqa: ANN001 - Path-like
+    *,
+    fitted_from: str | None = None,
+) -> CompactionArtifact:
+    """Write the stamped overlay next to a knn policy (see `CompactionArtifact`)."""
+    from pathlib import Path
+
+    stamped = [
+        cluster.model_copy(update={"compression": fit.per_cluster.get(cluster.cluster_id)})
+        for cluster in clusters
+    ]
+    for cluster in stamped:
+        if cluster.compression is not None:
+            servable_compressor(cluster.compression)
+    artifact = CompactionArtifact(
+        clusters=stamped, z=fit.z, min_pairs=fit.min_pairs, fitted_from=fitted_from
+    )
+    Path(path).write_text(artifact.model_dump_json(indent=2))
+    return artifact
+
+
+def apply_compaction(policy: RoutingPolicy, fit: CompactionFit) -> RoutingPolicy:
+    """Stamp the fitted per-cluster map onto `policy` under the exclusivity rule.
+
+    The proposed representation rule (DECISIONS 2026-07-27): a policy carrying per-cluster
+    configs routes on RAW text, so policy-level `compression` and `fit_compression` must both
+    be None; mixing modes in one artifact is refused here, not discovered at mount. Every
+    stamped config is checked servable, so a control or churny arm that leaked into the map
+    fails closed at stamp time.
+
+    Cluster-carrying kinds only (`rank`): a knn policy cannot carry clusters under the merged
+    validator, so its map goes through `save_compaction_sidecar` instead.
+    """
+    if policy.compression is not None or policy.fit_compression is not None:
+        raise ValueError(
+            "per-cluster compaction requires a raw-routed policy: policy-level compression "
+            f"is {compression_signature(policy.compression)} and fit_compression is "
+            f"{compression_signature(policy.fit_compression)}. Fit the base policy without "
+            "--compressor; per-cluster mode and endpoint-level mode never mix."
+        )
+    if not policy.clusters:
+        raise ValueError(
+            "policy has no clusters to stamp; fit a rank policy or attach overlay_clusters first"
+        )
+    known = {cluster.cluster_id for cluster in policy.clusters}
+    unknown = sorted(set(fit.per_cluster) - known)
+    if unknown:
+        raise ValueError(f"fit names cluster ids absent from the policy: {unknown[:5]}")
+    for cluster_id, config in fit.per_cluster.items():
+        if config is not None:
+            servable_compressor(config)
+        del cluster_id
+    clusters = [
+        cluster.model_copy(update={"compression": fit.per_cluster.get(cluster.cluster_id)})
+        for cluster in policy.clusters
+    ]
+    return policy.model_copy(update={"clusters": clusters})

--- a/wmo/optimize/compaction_fit.py
+++ b/wmo/optimize/compaction_fit.py
@@ -161,6 +161,9 @@ class CompactionFit(BaseModel):
     z: float
     min_pairs: int
     margin: float = DEFAULT_NONINFERIORITY_MARGIN
+    # Which selection rule chose among passing arms: "cost" (default) or "aggressiveness"
+    # (calibrator-v1). Part of the fit's identity; consumers must not mix maps across rules.
+    selection: str = "cost"
     coverage: list[str] = Field(default_factory=list)  # human-readable coverage notes
     # Investigation flags, one string per event: a control led the tie-break, or a control
     # quality-dominated the winner. Any entry means the fit must not ship without a human read.
@@ -338,6 +341,17 @@ def assign_to_clusters(
     return {sid: cluster_ids[int(np.argmax(sims[index]))] for index, sid in enumerate(scenario_ids)}
 
 
+# Selection rules among gate-passing arms. "cost" is the conservative default (cheapest,
+# then least aggressive). "aggressiveness" is calibrator-v1 (the learned-calibration-ratio
+# directive): the HIGHEST aggressiveness whose arm passes BOTH gates, so the learned
+# operating point inherits the corrected gate's guarantee instead of a point estimate.
+# Either way the choice is made at cluster/artifact grain from MEASURED arms only, and the
+# rule is part of the fit's identity (recorded on the output; a different rule = a
+# different artifact, exactly like a compressor version).
+SELECTION_RULES = ("cost", "aggressiveness")
+CALIBRATOR_VERSION = "calibrator-v1"
+
+
 def fit_compaction(
     assignment: dict[str, int],
     off: OutcomeMatrix,
@@ -349,6 +363,7 @@ def fit_compaction(
     completion: CompletionRule = DEFAULT_COMPLETION,
     allow_uneven: bool = False,
     provenance: EvidenceProvenance | None = None,
+    selection: str = "cost",
 ) -> CompactionFit:
     """The gates: per cluster, choose among measured arms or stay uncompressed.
 
@@ -356,6 +371,8 @@ def fit_compaction(
     `assign_to_clusters`, or from `overlay_clusters`). See the module docstring for the rule;
     every decision's paired statistics are returned as evidence rows.
     """
+    if selection not in SELECTION_RULES:
+        raise ValueError(f"unknown selection rule '{selection}'; use one of {SELECTION_RULES}")
     if off.measured_compression() is not None:
         raise ValueError("the off arm must be uncompressed; got a matrix with a compression arm")
     signatures = [compression_signature(arm.config) for arm in arms]
@@ -431,11 +448,18 @@ def fit_compaction(
         passing = [c for c in candidates if c.quality_pass and c.cost_pass]
         per_cluster[cluster_id] = None
         if passing:
-            # Tie-break lowest effective cost, then lower aggressiveness (conservative).
-            ranked = sorted(
-                passing,
-                key=lambda c: (c.arm_cost_per_completed, c.config.aggressiveness),
-            )
+            if selection == "aggressiveness":
+                # calibrator-v1: most aggressive passing arm, cheaper first on ties.
+                ranked = sorted(
+                    passing,
+                    key=lambda c: (-c.config.aggressiveness, c.arm_cost_per_completed),
+                )
+            else:
+                # Conservative default: lowest effective cost, then lower aggressiveness.
+                ranked = sorted(
+                    passing,
+                    key=lambda c: (c.arm_cost_per_completed, c.config.aggressiveness),
+                )
             ranked[0].would_win = True
             if ranked[0].control:
                 control_flags.append(
@@ -472,6 +496,7 @@ def fit_compaction(
         z=z,
         min_pairs=min_pairs,
         margin=margin,
+        selection=selection,
         coverage=coverage,
         control_flags=control_flags,
         provenance=provenance or EvidenceProvenance(),

--- a/wmo/optimize/compaction_fit.py
+++ b/wmo/optimize/compaction_fit.py
@@ -268,10 +268,7 @@ def assign_to_clusters(
     centroids = np.asarray([c.centroid for c in clusters])
     cluster_ids = [c.cluster_id for c in clusters]
     sims = embeddings @ centroids.T
-    return {
-        sid: cluster_ids[int(np.argmax(sims[index]))]
-        for index, sid in enumerate(scenario_ids)
-    }
+    return {sid: cluster_ids[int(np.argmax(sims[index]))] for index, sid in enumerate(scenario_ids)}
 
 
 def fit_compaction(

--- a/wmo/optimize/compaction_fit_synthetic_test.py
+++ b/wmo/optimize/compaction_fit_synthetic_test.py
@@ -1,0 +1,191 @@
+"""Ground-truth robustness harness for the compaction gates (C2 overnight, menu C).
+
+Four constructed cluster types with KNOWN correct verdicts, in one synthetic grid. The
+corrected non-inferiority gate must:
+
+- ACCEPT the genuinely-compressible cluster (quality preserved exactly, cost halved):
+  this is the product case the zero-margin superiority gate structurally refused, and the
+  reason HIGH-2 exists.
+- REFUSE the verbatim-critical cluster (quality drops far beyond the margin).
+- REFUSE the lottery cluster (mean delta ~0 with huge cell variance: the SE term, not the
+  margin, must do the refusing).
+- REFUSE AND FLAG the control-dominant cluster (the real arm passes both gates, but a
+  matched-ratio control passes quality with a larger delta at a WORSE cost rank: HIGH-1's
+  exact blind spot).
+
+Every cluster carries 40 paired cells (20 scenarios x 2 models), deliberately above
+SE_FLOOR_MAX_PAIRS so the small-sample floor is off and the verdicts test the gate's own
+arithmetic rather than the floor's backstop. This file is the permanent regression suite
+that retires the "gate calibration vs corpus fact" ambiguity: any future gate change must
+keep all four verdicts.
+"""
+
+from __future__ import annotations
+
+from wmo.optimize.compaction_fit import (
+    ArmMatrices,
+    aa_report,
+    fit_compaction,
+    overlay_clusters,
+)
+from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry
+from wmo.retrieval.embedders import HashingEmbedder
+
+MODELS = ["worker-a", "worker-b"]
+SCENARIOS_PER_GROUP = 20  # 40 paired cells per cluster: the SE floor is OFF (>= 30)
+
+# Lexically distant vocabularies so the hashing embedder separates the four ground-truth
+# groups into four clusters.
+GROUPS = {
+    "compressible": "quarterly revenue ledger fiscal audit dividend margin balance capital",
+    "verbatim": "order identifier exact serial number code reference token digits precise",
+    "lottery": "random draw shuffle coin flip chance dice spin gamble outcome luck",
+    "controlled": "python traceback compile refactor merge repository branch commit test",
+}
+
+REAL = CompressionConfig(compressor_id="truncate", compressor_version="1", aggressiveness=0.2)
+CONTROL = CompressionConfig(compressor_id="identity", compressor_version="1")
+
+
+def _off_reward(group: str, index: int) -> float:
+    if group == "lottery":
+        return float(index % 2)  # half succeed: room to swing both ways
+    return 1.0 if index % 10 else 0.0  # 90% completion: headroom without degeneracy
+
+
+def _real_arm_reward(group: str, index: int) -> float:
+    off = _off_reward(group, index)
+    if group == "compressible":
+        return off  # EXACT quality preservation: the product case
+    if group == "verbatim":
+        return max(0.0, off - 1.0)  # completed tasks now fail: far beyond the margin
+    if group == "lottery":
+        return 1.0 - off  # every cell flips: mean delta ~0, cell variance ~1
+    return min(1.0, off + 0.1) if index % 10 else 0.0  # controlled: a modest real lift
+
+
+def _control_arm_reward(group: str, index: int) -> float:
+    off = _off_reward(group, index)
+    if group == "controlled":
+        # Dominates the real arm's quality delta (+0.2 vs +0.1 per lifted cell).
+        return min(1.0, off + 0.2) if index % 10 else 0.0
+    return max(0.0, off - 1.0)  # elsewhere: clearly fails its own quality gate
+
+
+def _matrix(reward_fn, cost: float, config: CompressionConfig | None) -> OutcomeMatrix:  # noqa: ANN001
+    pool = [
+        PoolEntry(name=name, kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5")
+        for name in MODELS
+    ]
+    rows = []
+    for group, text in GROUPS.items():
+        for index in range(SCENARIOS_PER_GROUP):
+            for model in MODELS:
+                for episode in range(2):
+                    reward = reward_fn(group, index)
+                    rows.append(
+                        ScenarioOutcome(
+                            scenario_id=f"{group}-{index}",
+                            task=f"{text} case {index}",
+                            model=model,
+                            episode=episode,
+                            reward=reward,
+                            success=reward >= 1.0,
+                            usage=TokenUsage(input_tokens=100, output_tokens=10),
+                            cost_usd=cost,
+                            compressor_id=config.compressor_id if config else "",
+                            compressor_version=config.compressor_version if config else "",
+                            aggressiveness=config.aggressiveness if config else 0.0,
+                        )
+                    )
+    return OutcomeMatrix(pool=pool, outcomes=rows)
+
+
+def _ground_truth_fit():  # noqa: ANN202 - shared across assertions below
+    off = _matrix(_off_reward, 0.010, None)
+    real = _matrix(_real_arm_reward, 0.005, REAL)
+    # The control sits BETWEEN the real arm and off on cost, so it never leads the
+    # tie-break: the dominance check has to catch it on quality alone (HIGH-1's blind spot).
+    control = _matrix(_control_arm_reward, 0.008, CONTROL)
+    clusters, assignment = overlay_clusters(
+        off, embed_with=HashingEmbedder(dim=512), n_clusters=4, default_model="worker-a"
+    )
+    groups_seen = {sid.rsplit("-", 1)[0] for sid in assignment}
+    by_group = {
+        group: {assignment[sid] for sid in assignment if sid.startswith(f"{group}-")}
+        for group in groups_seen
+    }
+    # Each ground-truth group must land in exactly one cluster, all distinct, or the
+    # verdicts below would test the clustering rather than the gates.
+    assert all(len(ids) == 1 for ids in by_group.values()), by_group
+    cluster_of = {group: next(iter(ids)) for group, ids in by_group.items()}
+    assert len(set(cluster_of.values())) == 4, cluster_of
+    fit = fit_compaction(
+        assignment,
+        off,
+        [
+            ArmMatrices(matrix=real, config=REAL),
+            ArmMatrices(matrix=control, config=CONTROL, control=True),
+        ],
+    )
+    return off, assignment, cluster_of, fit
+
+
+def test_compressible_cluster_is_accepted() -> None:
+    _off, _assignment, cluster_of, fit = _ground_truth_fit()
+    assert fit.per_cluster[cluster_of["compressible"]] == REAL
+
+
+def test_verbatim_critical_cluster_is_refused() -> None:
+    _off, _assignment, cluster_of, fit = _ground_truth_fit()
+    assert fit.per_cluster[cluster_of["verbatim"]] is None
+    row = next(
+        r
+        for r in fit.evidence
+        if r.cluster_id == cluster_of["verbatim"] and r.signature.startswith("compressor 'trunc")
+    )
+    assert not row.quality_pass  # refused on quality, not on cost or eligibility
+
+
+def test_lottery_cluster_is_refused_by_the_se_term() -> None:
+    _off, _assignment, cluster_of, fit = _ground_truth_fit()
+    assert fit.per_cluster[cluster_of["lottery"]] is None
+    row = next(
+        r
+        for r in fit.evidence
+        if r.cluster_id == cluster_of["lottery"] and r.signature.startswith("compressor 'trunc")
+    )
+    # Mean inside the margin but the confidence bound far outside it: the SE term refuses.
+    assert abs(row.mean_diff) <= 0.02
+    assert row.se > 0.1
+    assert not row.quality_pass
+
+
+def test_control_dominant_cluster_is_refused_and_flagged() -> None:
+    _off, _assignment, cluster_of, fit = _ground_truth_fit()
+    cluster_id = cluster_of["controlled"]
+    assert fit.per_cluster[cluster_id] is None
+    assert any(
+        "quality-dominates" in flag and f"cluster={cluster_id}" in flag
+        for flag in fit.control_flags
+    )
+    winner = next(
+        r
+        for r in fit.evidence
+        if r.cluster_id == cluster_id and r.signature.startswith("compressor 'trunc")
+    )
+    # The real arm PASSED both gates and was cheaper; only the dominance check stops it.
+    assert winner.quality_pass and winner.cost_pass and winner.control_dominated
+
+
+def test_only_the_compressible_cluster_is_compressed() -> None:
+    _off, _assignment, _cluster_of, fit = _ground_truth_fit()
+    assert fit.compressed_clusters() == 1
+
+
+def test_aa_bar_is_clean_on_the_synthetic_off_arm() -> None:
+    off, assignment, _cluster_of, _fit = _ground_truth_fit()
+    assert aa_report(assignment, off) == []

--- a/wmo/optimize/compaction_fit_test.py
+++ b/wmo/optimize/compaction_fit_test.py
@@ -192,7 +192,7 @@ def test_controls_are_reported_but_never_chosen(
     arm = _winning_arm(config=TRUNCATE)
     fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE, control=True)])
     assert fit.compressed_clusters() == 0
-    assert fit.controls_would_win  # it would have won, and that is loud, not silent
+    assert fit.control_flags  # it would have won, and that is loud, not silent
 
 
 def test_unservable_arm_is_evaluated_but_ineligible(
@@ -264,24 +264,112 @@ def test_apply_compaction_stamps_and_enforces_exclusivity(
         apply_compaction(endpoint_level, fit)
 
 
-def test_knn_map_ships_as_a_sidecar(
+def _knn_policy_on_disk(tmp_path: Path, clusters: list) -> tuple[Path, RoutingPolicy]:
+    policy = RoutingPolicy(
+        kind="rank",  # any savable kind works for sidecar identity tests
+        default_model="worker-a",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=256),
+        clusters=clusters,
+    )
+    path = tmp_path / "policy.json"
+    path.write_text(policy.model_dump_json())
+    return path, policy
+
+
+def test_knn_map_ships_as_an_identity_bound_sidecar(
     off: OutcomeMatrix, assignment: dict[str, int], tmp_path: Path
 ) -> None:
     # The merged RoutingPolicy validator forbids clusters on a knn policy, so the overlay
-    # cannot ride on the policy model until the co-signed contract delta lands; the map goes
-    # beside the policy the way the knn bank does.
-    from wmo.optimize.compaction_fit import CompactionArtifact, save_compaction_sidecar
+    # goes beside the policy the way the knn bank does, BOUND to it: policy digest and
+    # embedder spec ride in the artifact and load_compaction_sidecar refuses mismatches
+    # (mounting foreign-geometry centroids is the measured floor-failure class).
+    from wmo.optimize.compaction_fit import (
+        compaction_path_for,
+        load_compaction_sidecar,
+        save_compaction_sidecar,
+    )
 
     clusters, _ = overlay_clusters(
         off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
     )
+    policy_path, policy = _knn_policy_on_disk(tmp_path, clusters)
     arm = _winning_arm(config=TRUNCATE)
     fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
-    path = tmp_path / "policy_compaction.json"
-    save_compaction_sidecar(clusters, fit, path, fitted_from="test cohort")
-    loaded = CompactionArtifact.model_validate_json(path.read_text())
+    save_compaction_sidecar(policy_path, policy, clusters, fit, fitted_from="test cohort")
+
+    loaded = load_compaction_sidecar(policy_path, policy)
     assert {c.cluster_id: c.compression for c in loaded.clusters} == fit.per_cluster
     assert loaded.z == fit.z
+    assert compaction_path_for(policy_path).name == "policy.json.compaction.json"
+
+    # Digest mismatch: the policy file changed after the map was fitted beside it.
+    policy_path.write_text(
+        policy.model_copy(update={"default_model": "worker-b"}).model_dump_json()
+    )
+    with pytest.raises(ValueError, match="different policy file"):
+        load_compaction_sidecar(policy_path, policy)
+
+    # Embedder mismatch: same bytes, different geometry claimed by the caller.
+    policy_path.write_text(policy.model_dump_json())
+    foreign = policy.model_copy(update={"embedder": EmbedderSpec(dim=512)})
+    with pytest.raises(ValueError, match="different embedding geometry"):
+        load_compaction_sidecar(policy_path, foreign)
+
+
+def test_sidecar_refuses_an_endpoint_level_policy(
+    off: OutcomeMatrix, assignment: dict[str, int], tmp_path: Path
+) -> None:
+    from wmo.optimize.compaction_fit import save_compaction_sidecar
+
+    clusters, _ = overlay_clusters(
+        off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
+    )
+    policy_path, policy = _knn_policy_on_disk(tmp_path, clusters)
+    mixed = policy.model_copy(update={"compression": TRUNCATE, "fit_compression": TRUNCATE})
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    with pytest.raises(ValueError, match="never mix"):
+        save_compaction_sidecar(policy_path, mixed, clusters, fit)
+
+
+def test_module_fitter_refuses_an_unmeasured_arm_config(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
+    # Named future consumers bypass the CLI (which reads configs FROM matrices); the module
+    # itself must refuse a config the matrix's episodes never ran under.
+    arm = _winning_arm(config=TRUNCATE)
+    lied = CompressionConfig(compressor_id="truncate", compressor_version="1", aggressiveness=0.9)
+    with pytest.raises(ValueError, match="never .* measured|actually measured"):
+        fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=lied)])
+
+
+def test_control_dominance_refuses_a_winner_regardless_of_cost_rank(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
+    # HIGH-1: the real arm is CHEAPER (so it leads the tie-break) but a control passes its
+    # own quality gate with a LARGER delta. The cluster must be refused and flagged; the
+    # old gate stayed silent here because the control was not ranked[0].
+    real = _winning_arm(cost=0.001, config=TRUNCATE)
+    control_cfg = CompressionConfig(
+        compressor_id="identity", compressor_version="1", aggressiveness=0.0
+    )
+    control = _matrix(
+        lambda group, index: 1.0,  # beats the real arm's fin delta (larger mean_diff)
+        lambda group, index: 0.009,  # cheaper than off, but pricier than the real arm
+        config=control_cfg,
+    )
+    fit = fit_compaction(
+        assignment,
+        off,
+        [
+            ArmMatrices(matrix=real, config=TRUNCATE),
+            ArmMatrices(matrix=control, config=control_cfg, control=True),
+        ],
+    )
+    assert fit.compressed_clusters() == 0
+    assert any("quality-dominates" in flag for flag in fit.control_flags)
+    assert any(row.control_dominated for row in fit.evidence)
 
 
 def test_assign_to_clusters_matches_overlay_assignment(off: OutcomeMatrix) -> None:

--- a/wmo/optimize/compaction_fit_test.py
+++ b/wmo/optimize/compaction_fit_test.py
@@ -1,0 +1,278 @@
+"""Tests for the per-cluster compaction fitter.
+
+Pure offline stats over synthetic outcome matrices: no provider, no judge, no spend. The
+synthetic grid has two well-separated scenario groups (financey vs codey task texts, so the
+hashing embedder clusters them apart) and arms constructed so exactly one cluster carries a
+genuine compression win, which is what the gates must find and the only thing they may find.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from wmo.optimize.compaction_fit import (
+    ArmMatrices,
+    aa_report,
+    apply_compaction,
+    assign_to_clusters,
+    fit_compaction,
+    overlay_clusters,
+)
+from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.policy import EmbedderSpec, RoutingPolicy
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry
+from wmo.retrieval.embedders import HashingEmbedder
+
+MODELS = ["worker-a", "worker-b"]
+# Two lexically distant scenario groups so the hashing embedder separates them cleanly.
+GROUP_TEXTS = {
+    "fin": "quarterly revenue balance sheet capital expenditure fiscal audit dividend",
+    "code": "python traceback refactor unit test compile stack trace repository merge",
+}
+
+
+def _pool() -> list[PoolEntry]:
+    return [
+        PoolEntry(name=name, kind=ProviderKind.ANTHROPIC, model="claude-haiku-4-5")
+        for name in MODELS
+    ]
+
+
+def _row(
+    sid: str,
+    task: str,
+    model: str,
+    episode: int,
+    reward: float,
+    *,
+    cost: float = 0.01,
+    config: CompressionConfig | None = None,
+) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=sid,
+        task=task,
+        model=model,
+        episode=episode,
+        reward=reward,
+        success=reward >= 1.0,
+        usage=TokenUsage(input_tokens=100, output_tokens=10),
+        cost_usd=cost,
+        compressor_id=config.compressor_id if config else "",
+        compressor_version=config.compressor_version if config else "",
+        aggressiveness=config.aggressiveness if config else 0.0,
+    )
+
+
+def _scenarios() -> list[tuple[str, str, str, int]]:
+    """(sid, task, group, index) for 12 scenarios, 6 per group."""
+    out = []
+    for group, text in GROUP_TEXTS.items():
+        for index in range(6):
+            out.append((f"{group}-{index}", f"{text} variant {index}", group, index))
+    return out
+
+
+def _matrix(
+    reward_fn,
+    cost_fn,
+    config: CompressionConfig | None = None,
+    episodes: int = 2,
+) -> OutcomeMatrix:
+    """reward_fn/cost_fn take (group, scenario_index)."""
+    rows = []
+    for sid, task, group, index in _scenarios():
+        for model in MODELS:
+            for episode in range(episodes):
+                rows.append(
+                    _row(
+                        sid,
+                        task,
+                        model,
+                        episode,
+                        reward_fn(group, index),
+                        cost=cost_fn(group, index),
+                        config=config,
+                    )
+                )
+    return OutcomeMatrix(pool=_pool(), outcomes=rows)
+
+
+def _off_rewards(group: str, index: int) -> float:
+    """The off arm leaves headroom on fin (half its scenarios fail) and is perfect on code.
+
+    The registered quality gate demands POSITIVE paired evidence (mean - z*SE >= 0 under the
+    small-sample SE floor), so a winning arm must genuinely lift fin, not merely match it.
+    """
+    if group == "fin":
+        return 1.0 if index < 3 else 0.0
+    return 1.0
+
+
+def _winning_arm(*, cost: float = 0.005, config: CompressionConfig) -> OutcomeMatrix:
+    """Lifts fin to perfect at lower cost; wrecks code (quality gate must block it there)."""
+    return _matrix(
+        lambda group, index: 1.0 if group == "fin" else 0.0,
+        lambda group, index: cost,
+        config=config,
+    )
+
+
+TRUNCATE = CompressionConfig(compressor_id="truncate", compressor_version="1", aggressiveness=0.2)
+UNKNOWN = CompressionConfig(compressor_id="not-registered", compressor_version="1")
+
+
+@pytest.fixture
+def off() -> OutcomeMatrix:
+    return _matrix(_off_rewards, lambda group, index: 0.01)
+
+
+@pytest.fixture
+def assignment(off: OutcomeMatrix) -> dict[str, int]:
+    clusters, assignment = overlay_clusters(
+        off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
+    )
+    # The two lexical groups must land in different clusters or every test below is vacuous.
+    fin = {assignment[sid] for sid, _, group, _i in _scenarios() if group == "fin"}
+    code = {assignment[sid] for sid, _, group, _i in _scenarios() if group == "code"}
+    assert len(fin) == 1 and len(code) == 1 and fin != code
+    return assignment
+
+
+def test_win_cluster_gets_the_config_and_loss_cluster_stays_none(off, assignment) -> None:
+    # The arm lifts fin (positive paired evidence) at lower cost, and wrecks code.
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    fin_cluster = assignment["fin-0"]
+    code_cluster = assignment["code-0"]
+    assert fit.per_cluster[fin_cluster] == TRUNCATE
+    assert fit.per_cluster[code_cluster] is None
+
+
+def test_matching_quality_is_not_positive_evidence(off, assignment) -> None:
+    # An arm identical to off on quality: mean paired delta is 0, and the floored SE makes
+    # the registered gate (mean - z*SE >= 0) fail. Preserving quality is not evidence; this
+    # is the strictness the A/A bar depends on.
+    arm = _matrix(_off_rewards, lambda group, index: 0.001, config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    assert fit.compressed_clusters() == 0
+    assert all(not row.quality_pass for row in fit.evidence)
+
+
+def test_quality_pass_alone_is_not_enough_without_a_cost_win(off, assignment) -> None:
+    # The arm lifts fin but costs MORE per completed task (the dumb-deletion failure the
+    # grid measured): the cost gate must hold every cluster at None.
+    arm = _winning_arm(cost=0.05, config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    assert fit.compressed_clusters() == 0
+    fin_rows = [r for r in fit.evidence if r.cluster_id == assignment["fin-0"]]
+    assert all(row.quality_pass and not row.cost_pass for row in fin_rows)
+
+
+def test_thin_clusters_never_deviate(off, assignment) -> None:
+    # min_pairs above the cluster size: no deviation regardless of how good the arm looks.
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(
+        assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)], min_pairs=99
+    )
+    assert fit.compressed_clusters() == 0
+
+
+def test_controls_are_reported_but_never_chosen(off, assignment) -> None:
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(
+        assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE, control=True)]
+    )
+    assert fit.compressed_clusters() == 0
+    assert fit.controls_would_win  # it would have won, and that is loud, not silent
+
+
+def test_unservable_arm_is_evaluated_but_ineligible(off, assignment) -> None:
+    arm = _winning_arm(config=UNKNOWN)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=UNKNOWN)])
+    assert fit.compressed_clusters() == 0
+    assert any(row.would_win and not row.eligible for row in fit.evidence)
+
+
+def test_uneven_coverage_is_refused_unless_opted_in(off, assignment) -> None:
+    arm = _winning_arm(config=TRUNCATE)
+    arm = OutcomeMatrix(pool=arm.pool, outcomes=arm.outcomes[: len(arm.outcomes) // 2])
+    with pytest.raises(ValueError, match="cohort"):
+        fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    fit = fit_compaction(
+        assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)], allow_uneven=True
+    )
+    assert fit.coverage  # the mismatch is printed, not swallowed
+
+
+def test_off_arm_must_be_uncompressed(assignment) -> None:
+    compressed = _matrix(_off_rewards, lambda group, index: 0.01, config=TRUNCATE)
+    with pytest.raises(ValueError, match="off arm"):
+        fit_compaction(assignment, compressed, [])
+
+
+def test_aa_bar_passes_on_pure_noise(assignment) -> None:
+    # Episode 1 rewards differ from episode 0 by symmetric noise; the A/A gates must not
+    # deviate anywhere (the SE floor keeps even zero-variance clusters honest).
+    import random
+
+    rng = random.Random(7)
+    rows = []
+    for sid, task, _group, _index in _scenarios():
+        for model in MODELS:
+            for episode in range(2):
+                rows.append(_row(sid, task, model, episode, rng.choice([0.0, 1.0]), cost=0.01))
+    off = OutcomeMatrix(pool=_pool(), outcomes=rows)
+    assert aa_report(assignment, off) == []
+
+
+def test_apply_compaction_stamps_and_enforces_exclusivity(off, assignment) -> None:
+    clusters, _ = overlay_clusters(
+        off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
+    )
+    policy = RoutingPolicy(
+        kind="rank",
+        default_model="worker-a",
+        pool=_pool(),
+        embedder=EmbedderSpec(dim=256),
+        clusters=clusters,
+    )
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    stamped = apply_compaction(policy, fit)
+    stamped_configs = {c.cluster_id: c.compression for c in stamped.clusters}
+    assert stamped_configs == fit.per_cluster
+
+    endpoint_level = policy.model_copy(
+        update={"compression": TRUNCATE, "fit_compression": TRUNCATE}
+    )
+    with pytest.raises(ValueError, match="never mix"):
+        apply_compaction(endpoint_level, fit)
+
+
+def test_knn_map_ships_as_a_sidecar(off, assignment, tmp_path) -> None:
+    # The merged RoutingPolicy validator forbids clusters on a knn policy, so the overlay
+    # cannot ride on the policy model until the co-signed contract delta lands; the map goes
+    # beside the policy the way the knn bank does.
+    from wmo.optimize.compaction_fit import CompactionArtifact, save_compaction_sidecar
+
+    clusters, _ = overlay_clusters(
+        off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
+    )
+    arm = _winning_arm(config=TRUNCATE)
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
+    path = tmp_path / "policy_compaction.json"
+    save_compaction_sidecar(clusters, fit, path, fitted_from="test cohort")
+    loaded = CompactionArtifact.model_validate_json(path.read_text())
+    assert {c.cluster_id: c.compression for c in loaded.clusters} == fit.per_cluster
+    assert loaded.z == fit.z
+
+
+def test_assign_to_clusters_matches_overlay_assignment(off) -> None:
+    embedder = HashingEmbedder(dim=256)
+    clusters, assignment = overlay_clusters(
+        off, embed_with=embedder, n_clusters=2, default_model="worker-a"
+    )
+    reassigned = assign_to_clusters(clusters, off, embed_with=embedder)
+    assert reassigned == assignment

--- a/wmo/optimize/compaction_fit_test.py
+++ b/wmo/optimize/compaction_fit_test.py
@@ -8,6 +8,9 @@ genuine compression win, which is what the gates must find and the only thing th
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from pathlib import Path
+
 import pytest
 
 from wmo.optimize.compaction_fit import (
@@ -75,8 +78,8 @@ def _scenarios() -> list[tuple[str, str, str, int]]:
 
 
 def _matrix(
-    reward_fn,
-    cost_fn,
+    reward_fn: Callable[[str, int], float],
+    cost_fn: Callable[[str, int], float],
     config: CompressionConfig | None = None,
     episodes: int = 2,
 ) -> OutcomeMatrix:
@@ -140,7 +143,9 @@ def assignment(off: OutcomeMatrix) -> dict[str, int]:
     return assignment
 
 
-def test_win_cluster_gets_the_config_and_loss_cluster_stays_none(off, assignment) -> None:
+def test_win_cluster_gets_the_config_and_loss_cluster_stays_none(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     # The arm lifts fin (positive paired evidence) at lower cost, and wrecks code.
     arm = _winning_arm(config=TRUNCATE)
     fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)])
@@ -150,7 +155,9 @@ def test_win_cluster_gets_the_config_and_loss_cluster_stays_none(off, assignment
     assert fit.per_cluster[code_cluster] is None
 
 
-def test_matching_quality_is_not_positive_evidence(off, assignment) -> None:
+def test_matching_quality_is_not_positive_evidence(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     # An arm identical to off on quality: mean paired delta is 0, and the floored SE makes
     # the registered gate (mean - z*SE >= 0) fail. Preserving quality is not evidence; this
     # is the strictness the A/A bar depends on.
@@ -160,7 +167,9 @@ def test_matching_quality_is_not_positive_evidence(off, assignment) -> None:
     assert all(not row.quality_pass for row in fit.evidence)
 
 
-def test_quality_pass_alone_is_not_enough_without_a_cost_win(off, assignment) -> None:
+def test_quality_pass_alone_is_not_enough_without_a_cost_win(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     # The arm lifts fin but costs MORE per completed task (the dumb-deletion failure the
     # grid measured): the cost gate must hold every cluster at None.
     arm = _winning_arm(cost=0.05, config=TRUNCATE)
@@ -170,32 +179,34 @@ def test_quality_pass_alone_is_not_enough_without_a_cost_win(off, assignment) ->
     assert all(row.quality_pass and not row.cost_pass for row in fin_rows)
 
 
-def test_thin_clusters_never_deviate(off, assignment) -> None:
+def test_thin_clusters_never_deviate(off: OutcomeMatrix, assignment: dict[str, int]) -> None:
     # min_pairs above the cluster size: no deviation regardless of how good the arm looks.
     arm = _winning_arm(config=TRUNCATE)
-    fit = fit_compaction(
-        assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)], min_pairs=99
-    )
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE)], min_pairs=99)
     assert fit.compressed_clusters() == 0
 
 
-def test_controls_are_reported_but_never_chosen(off, assignment) -> None:
+def test_controls_are_reported_but_never_chosen(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     arm = _winning_arm(config=TRUNCATE)
-    fit = fit_compaction(
-        assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE, control=True)]
-    )
+    fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=TRUNCATE, control=True)])
     assert fit.compressed_clusters() == 0
     assert fit.controls_would_win  # it would have won, and that is loud, not silent
 
 
-def test_unservable_arm_is_evaluated_but_ineligible(off, assignment) -> None:
+def test_unservable_arm_is_evaluated_but_ineligible(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     arm = _winning_arm(config=UNKNOWN)
     fit = fit_compaction(assignment, off, [ArmMatrices(matrix=arm, config=UNKNOWN)])
     assert fit.compressed_clusters() == 0
     assert any(row.would_win and not row.eligible for row in fit.evidence)
 
 
-def test_uneven_coverage_is_refused_unless_opted_in(off, assignment) -> None:
+def test_uneven_coverage_is_refused_unless_opted_in(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     arm = _winning_arm(config=TRUNCATE)
     arm = OutcomeMatrix(pool=arm.pool, outcomes=arm.outcomes[: len(arm.outcomes) // 2])
     with pytest.raises(ValueError, match="cohort"):
@@ -206,13 +217,13 @@ def test_uneven_coverage_is_refused_unless_opted_in(off, assignment) -> None:
     assert fit.coverage  # the mismatch is printed, not swallowed
 
 
-def test_off_arm_must_be_uncompressed(assignment) -> None:
+def test_off_arm_must_be_uncompressed(assignment: dict[str, int]) -> None:
     compressed = _matrix(_off_rewards, lambda group, index: 0.01, config=TRUNCATE)
     with pytest.raises(ValueError, match="off arm"):
         fit_compaction(assignment, compressed, [])
 
 
-def test_aa_bar_passes_on_pure_noise(assignment) -> None:
+def test_aa_bar_passes_on_pure_noise(assignment: dict[str, int]) -> None:
     # Episode 1 rewards differ from episode 0 by symmetric noise; the A/A gates must not
     # deviate anywhere (the SE floor keeps even zero-variance clusters honest).
     import random
@@ -227,7 +238,9 @@ def test_aa_bar_passes_on_pure_noise(assignment) -> None:
     assert aa_report(assignment, off) == []
 
 
-def test_apply_compaction_stamps_and_enforces_exclusivity(off, assignment) -> None:
+def test_apply_compaction_stamps_and_enforces_exclusivity(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
     clusters, _ = overlay_clusters(
         off, embed_with=HashingEmbedder(dim=256), n_clusters=2, default_model="worker-a"
     )
@@ -251,7 +264,9 @@ def test_apply_compaction_stamps_and_enforces_exclusivity(off, assignment) -> No
         apply_compaction(endpoint_level, fit)
 
 
-def test_knn_map_ships_as_a_sidecar(off, assignment, tmp_path) -> None:
+def test_knn_map_ships_as_a_sidecar(
+    off: OutcomeMatrix, assignment: dict[str, int], tmp_path: Path
+) -> None:
     # The merged RoutingPolicy validator forbids clusters on a knn policy, so the overlay
     # cannot ride on the policy model until the co-signed contract delta lands; the map goes
     # beside the policy the way the knn bank does.
@@ -269,7 +284,7 @@ def test_knn_map_ships_as_a_sidecar(off, assignment, tmp_path) -> None:
     assert loaded.z == fit.z
 
 
-def test_assign_to_clusters_matches_overlay_assignment(off) -> None:
+def test_assign_to_clusters_matches_overlay_assignment(off: OutcomeMatrix) -> None:
     embedder = HashingEmbedder(dim=256)
     clusters, assignment = overlay_clusters(
         off, embed_with=embedder, n_clusters=2, default_model="worker-a"

--- a/wmo/optimize/compaction_fit_test.py
+++ b/wmo/optimize/compaction_fit_test.py
@@ -379,3 +379,31 @@ def test_assign_to_clusters_matches_overlay_assignment(off: OutcomeMatrix) -> No
     )
     reassigned = assign_to_clusters(clusters, off, embed_with=embedder)
     assert reassigned == assignment
+
+
+def test_calibrator_selection_picks_the_most_aggressive_passing_arm(
+    off: OutcomeMatrix, assignment: dict[str, int]
+) -> None:
+    # calibrator-v1 (the learned-calibration-ratio directive): among arms passing BOTH
+    # gates, take the highest aggressiveness, so the learned operating point inherits the
+    # corrected gate's guarantee. The rule is recorded on the fit (identity-grained).
+    gentle = _winning_arm(cost=0.004, config=TRUNCATE)  # aggressiveness 0.2, cheaper
+    bold_cfg = CompressionConfig(
+        compressor_id="truncate", compressor_version="1", aggressiveness=0.6
+    )
+    bold = _winning_arm(cost=0.005, config=bold_cfg)  # more aggressive, still passing
+    arms = [
+        ArmMatrices(matrix=gentle, config=TRUNCATE),
+        ArmMatrices(matrix=bold, config=bold_cfg),
+    ]
+    conservative = fit_compaction(assignment, off, arms)
+    calibrated = fit_compaction(assignment, off, arms, selection="aggressiveness")
+    fin = assignment["fin-0"]
+    assert conservative.per_cluster[fin].aggressiveness == 0.2  # cheapest wins by default
+    assert calibrated.per_cluster[fin].aggressiveness == 0.6  # calibrator takes the ceiling
+    assert calibrated.selection == "aggressiveness" and conservative.selection == "cost"
+
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError, match="selection rule"):
+        fit_compaction(assignment, off, arms, selection="vibes")

--- a/wmo/optimize/compression_scoped.py
+++ b/wmo/optimize/compression_scoped.py
@@ -1,0 +1,174 @@
+"""Segment-SCOPED compression: compress tool observations only, never dialogue or the task.
+
+C2's rounds measured why whole-context compression is the wrong shape for agent episodes:
+on tau dialogue it lost 6.4 to 16.8 points of quality per cluster and INVERTED cost
+(derailed episodes run longer than the tokens saved), while round 0 measured the same
+mechanism on the routing channel. The compressible mass in an agent episode is the tool
+observations (the literature puts them at ~84% of agent-turn tokens); the task statement
+and the dialogue are where the meaning lives. This module scopes any registered compressor
+to exactly that split.
+
+A `ScopedCompressor` wraps an inner compressor and applies it ONLY to the observation span
+of TOOL_CALL history entries in the eval path's rendered turn (`wmo.env.llm_agent's`
+`TASK: / EPISODE SO FAR: / N. call -> observation` format, which `_CompressingProvider`
+hands over as the user segment). Everything else passes through byte-exact:
+
+- the TASK line and ENVIRONMENT NOTES (the ruled seam protection: the task/question
+  segment is never compressed),
+- `message:` entries and their observations (dialogue turns, both directions),
+- the action text of tool calls (verbatim tool syntax),
+- the trailing instruction line.
+
+Append-stability is inherited per entry: each observation is compressed in isolation with
+a deterministic inner compressor, and a history entry already rendered is re-rendered
+byte-identically on later turns, so the compressed transcript grows append-only exactly
+like the unscoped stage. The parse is pinned to `_render_turn`'s format by a test that
+renders through the real function; if the format changes, the test breaks loudly instead
+of the scope silently protecting nothing.
+
+Scoped ids are `scoped-<inner>` (e.g. `scoped-truncate`, `scoped-llmlingua2-endpoint`),
+registered as factories so the inner compressor's own construction rules (env-gated for
+the endpoint) keep applying. A segment that does not parse as a rendered turn passes
+through UNCOMPRESSED: outside the eval path's format the scope cannot tell observations
+from dialogue, and the fail-safe direction is compressing nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+from wmo.optimize.compression import (
+    CompressionConfig,
+    CompressionResult,
+    Compressor,
+    estimate_tokens,
+    get_compressor,
+    register_compressor_factory,
+)
+
+# One history entry in the rendered turn: "N. <call> -> <observation>[ [ERROR]]". Entries are
+# located by their index prefix at line start; an entry runs to the next entry or the final
+# instruction line. Observations may span lines (history_chars truncation preserves newlines).
+_ENTRY_START = re.compile(r"(?m)^\d+\. ")
+_INSTRUCTION_LINE = "Your next move (JSON only):"
+_SEPARATOR = " -> "
+_DIALOGUE_PREFIX = "message: "
+_ERROR_SUFFIX = " [ERROR]"
+
+SCOPE_PREFIX = "scoped-"
+
+
+def _split_rendered_turn(segment: str) -> tuple[str, list[str], str] | None:
+    """(head, entries, tail) of a rendered turn, or None when it is not one.
+
+    `head` is everything through the `EPISODE SO FAR:` line; `entries` are the history
+    entries; `tail` is the trailing instruction line. A turn with no history section returns
+    None (nothing in scope to compress).
+    """
+    if _INSTRUCTION_LINE not in segment:
+        return None
+    body, _, _ = segment.rpartition(_INSTRUCTION_LINE)
+    starts = [match.start() for match in _ENTRY_START.finditer(body)]
+    if not starts:
+        return None
+    head = body[: starts[0]]
+    entries = [body[start:end] for start, end in zip(starts, [*starts[1:], len(body)], strict=True)]
+    return head, entries, _INSTRUCTION_LINE + segment.rpartition(_INSTRUCTION_LINE)[2]
+
+
+def _observation_span(entry: str) -> tuple[str, str, str] | None:
+    """(prefix, observation, suffix) of a TOOL entry, or None when the entry is protected.
+
+    The prefix keeps the index and the verbatim call text plus the separator; the suffix
+    keeps the error mark and the entry's trailing newline. Dialogue entries (`message:`
+    actions) return None: their observations are the other party's words, not tool output.
+    """
+    marker = entry.find(_SEPARATOR)
+    if marker < 0:
+        return None
+    call = entry[:marker]
+    call_text = call.split(". ", 1)[1] if ". " in call else call
+    if call_text.startswith(_DIALOGUE_PREFIX):
+        return None
+    observation = entry[marker + len(_SEPARATOR) :]
+    suffix = ""
+    stripped = observation.rstrip("\n")
+    trailing_newlines = observation[len(stripped) :]
+    if stripped.endswith(_ERROR_SUFFIX):
+        stripped = stripped[: -len(_ERROR_SUFFIX)]
+        suffix = _ERROR_SUFFIX
+    return entry[: marker + len(_SEPARATOR)], stripped, suffix + trailing_newlines
+
+
+class ScopedCompressor:
+    """The scope wrapper: inner compression on tool observations, byte-exact everything else."""
+
+    def __init__(self, inner: Compressor) -> None:
+        self._inner = inner
+        self.id = f"{SCOPE_PREFIX}{inner.id}"
+        # The scope rule is part of the bytes-out identity, exactly like the inner version:
+        # the same inner compressor under a different scope emits different bytes.
+        self.version = f"{inner.version}-scope1"
+        self.append_stable = inner.append_stable
+
+    def compress(self, segments: list[str], config: CompressionConfig) -> CompressionResult:
+        started = time.monotonic()
+        inner_config = config.model_copy(update={"compressor_id": self._inner.id})
+
+        parsed: list[tuple[str, list[str], str] | None] = [
+            _split_rendered_turn(segment) for segment in segments
+        ]
+        spans: list[tuple[int, int, str, str, str]] = []  # (segment, entry, prefix, obs, suffix)
+        for segment_index, split in enumerate(parsed):
+            if split is None:
+                continue
+            for entry_index, entry in enumerate(split[1]):
+                span = _observation_span(entry)
+                if span is not None and span[1].strip():
+                    spans.append((segment_index, entry_index, *span))
+
+        inner_cost = 0.0
+        replacements: dict[tuple[int, int], str] = {}
+        if spans:
+            result = self._inner.compress([span[3] for span in spans], inner_config)
+            inner_cost = result.cost_usd
+            for (segment_index, entry_index, prefix, _obs, suffix), compressed in zip(
+                spans, result.segments, strict=True
+            ):
+                replacements[(segment_index, entry_index)] = prefix + compressed + suffix
+
+        out: list[str] = []
+        for segment_index, (segment, split) in enumerate(zip(segments, parsed, strict=True)):
+            if split is None:
+                out.append(segment)  # not a rendered turn: fail safe, compress nothing
+                continue
+            head, entries, tail = split
+            rebuilt = [
+                replacements.get((segment_index, entry_index), entry)
+                for entry_index, entry in enumerate(entries)
+            ]
+            out.append(head + "".join(rebuilt) + tail)
+
+        return CompressionResult(
+            segments=out,
+            tokens_in_raw=sum(estimate_tokens(segment) for segment in segments),
+            tokens_in_compressed=sum(estimate_tokens(segment) for segment in out),
+            latency_s=time.monotonic() - started,  # inner ran inline, so wall time covers it
+            cost_usd=inner_cost,
+        )
+
+
+def _scoped_factory(inner_id: str):  # noqa: ANN202 - CompressorFactory
+    def build() -> Compressor:
+        return ScopedCompressor(get_compressor(inner_id))
+
+    return build
+
+
+# The round-3 arms. Factories, so the endpoint compressor's env-gated construction (and its
+# fail-closed behavior without WMO_COMPRESSOR_* config) applies unchanged behind the scope.
+register_compressor_factory(f"{SCOPE_PREFIX}truncate", _scoped_factory("truncate"))
+register_compressor_factory(
+    f"{SCOPE_PREFIX}llmlingua2-endpoint", _scoped_factory("llmlingua2-endpoint")
+)

--- a/wmo/optimize/compression_scoped_test.py
+++ b/wmo/optimize/compression_scoped_test.py
@@ -1,0 +1,105 @@
+"""Tests for segment-scoped compression (C2 round 3).
+
+The protection guarantees are tested against the REAL rendered-turn format
+(`wmo.env.llm_agent._render_turn`), so a format change breaks these tests loudly instead
+of the scope silently protecting nothing.
+"""
+
+from __future__ import annotations
+
+import wmo.optimize  # noqa: F401 - registers the scoped factories
+from wmo.core.types import Action, ActionKind, EnvState, Observation, Step
+from wmo.env.llm_agent import _render_turn
+from wmo.optimize.compression import CompressionConfig, get_compressor
+from wmo.optimize.compression_scoped import ScopedCompressor
+
+CONFIG = CompressionConfig(
+    compressor_id="scoped-truncate", compressor_version="1-scope1", aggressiveness=0.5
+)
+
+LONG_OBS = "line one of tool output\nline two with many words " + "filler " * 40
+DIALOGUE_REPLY = "customer says: my order id is X-9931-B and I want a refund please"
+
+
+def _step(kind: ActionKind, observation: str, *, error: bool = False) -> Step:
+    action = (
+        Action(kind=kind, name="search", arguments={"query": "orders"})
+        if kind is ActionKind.TOOL_CALL
+        else Action(kind=kind, content="what is your order id?")
+    )
+    return Step(
+        action=action,
+        observation=Observation(content=observation, is_error=error),
+    )
+
+
+def _turn(history: list[Step]) -> str:
+    return _render_turn(
+        "Refund order X-9931-B for the customer",
+        EnvState(scratchpad="be polite"),
+        history,
+    )
+
+
+def test_task_dialogue_and_actions_pass_through_byte_exact() -> None:
+    turn = _turn(
+        [
+            _step(ActionKind.TOOL_CALL, LONG_OBS),
+            _step(ActionKind.MESSAGE, DIALOGUE_REPLY),
+            _step(ActionKind.TOOL_CALL, "short", error=True),
+        ]
+    )
+    compressor = get_compressor("scoped-truncate")
+    out = compressor.compress([turn], CONFIG).segments[0]
+
+    assert out.startswith("TASK: Refund order X-9931-B for the customer")
+    assert "ENVIRONMENT NOTES: be polite" in out
+    assert DIALOGUE_REPLY in out  # dialogue observation untouched
+    assert 'search({"query": "orders"})' in out  # tool syntax untouched
+    assert out.rstrip().endswith("Your next move (JSON only):")
+    assert " [ERROR]" in out  # error mark survives on the compressed entry
+    assert "line one of tool output" in out  # head of the tool observation kept
+    assert out.count("filler") < LONG_OBS.count("filler")  # the tail was compressed
+
+
+def test_only_tool_observations_shrink() -> None:
+    tool_turn = _turn([_step(ActionKind.TOOL_CALL, LONG_OBS)])
+    dialogue_turn = _turn([_step(ActionKind.MESSAGE, LONG_OBS)])
+    compressor = get_compressor("scoped-truncate")
+    assert compressor.compress([tool_turn], CONFIG).segments[0] != tool_turn
+    assert compressor.compress([dialogue_turn], CONFIG).segments[0] == dialogue_turn
+
+
+def test_append_stability_across_growing_history() -> None:
+    # Turn k+1 re-renders turn k's entries verbatim; the compressed bytes of the shared
+    # entries must be identical (the cache-safety property the whole track rides on).
+    history = [_step(ActionKind.TOOL_CALL, LONG_OBS), _step(ActionKind.MESSAGE, DIALOGUE_REPLY)]
+    grown = [*history, _step(ActionKind.TOOL_CALL, "another tool result " + "word " * 30)]
+    compressor = get_compressor("scoped-truncate")
+    short = compressor.compress([_turn(history)], CONFIG).segments[0]
+    longer = compressor.compress([_turn(grown)], CONFIG).segments[0]
+    shared_prefix = short.rpartition("Your next move")[0]
+    assert longer.startswith(shared_prefix)
+
+
+def test_non_rendered_segments_pass_through_uncompressed() -> None:
+    # Outside the eval path's format the scope cannot tell observations from dialogue;
+    # the fail-safe direction is compressing nothing.
+    raw = "just some text " * 50
+    compressor = get_compressor("scoped-truncate")
+    assert compressor.compress([raw], CONFIG).segments[0] == raw
+
+
+def test_scope_rides_the_version_identity() -> None:
+    compressor = get_compressor("scoped-truncate")
+    assert compressor.id == "scoped-truncate"
+    assert compressor.version == "1-scope1"  # a different scope rule = different bytes
+    assert compressor.append_stable is True
+
+
+def test_accounting_reflects_only_what_changed() -> None:
+    turn = _turn([_step(ActionKind.TOOL_CALL, LONG_OBS)])
+    compressor = ScopedCompressor(get_compressor("truncate"))
+    result = compressor.compress([turn], CONFIG)
+    assert result.tokens_in_compressed < result.tokens_in_raw
+    assert result.segments[0].startswith("TASK:")


### PR DESCRIPTION
C2 round 2: the fitter that populates the per-cluster compression #265 merged the field for. Through the compaction master's gate; the SERVING delta is deliberately absent (gated on the D-COMPRESS-PER-CLUSTER co-sign filed in DECISIONS 2026-07-27, amended same day with the knn-validator constraint discovered here).

## What's in the diff

- `wmo/optimize/compaction_fit.py`: the gates and their harness. A cluster receives a compressed config ONLY on paired NON-INFERIORITY evidence (the 2026-07-28 gate ruling: mean - z*SE >= -0.02, the fleet's noise-floor margin, on >= min-pairs (scenario, model) cells, the knn guard's SE floor; an arm that PRESERVES quality at lower cost passes, which is the product case the earlier zero-margin superiority form structurally refused) AND a measured effective-cost-per-completed-task win on the same cells (#294 conventions, compressor bill folded as RowOverhead). Measured arms only, both directions (arm configs are read from each matrix's own `measured_compression()`; nothing interpolates). Tie-break lowest effective cost then lower aggressiveness. The A/A bar (`aa_report`: off arm split by episode parity through the same gates) must be clean or nothing fits. Controls are evaluated, reported, and never chosen; a control that leads the tie-break OR quality-dominates the winner at ANY cost rank (HIGH-1) is an investigation flag that refuses the cluster. `apply_compaction` stamps rank policies under the exclusivity rule (per-cluster mode = raw-routed: policy-level compression and fit_compression both None); knn maps ship as an identity-bound sidecar (policy.json.compaction.json mirroring knn_bank_path_for, policy sha256 digest + embedder spec inside, load refused on mismatch) because the merged validator forbids clusters on knn policies (DECISIONS amendment). Every fit and sidecar carries EvidenceProvenance (matrix sources + scorer era); unlabeled or broken eras stamp PENDING-RESCORE.
- `wmo/cli/route_app.py`: `wmo optimize route fit-compaction OFF --arm M... --control M... --kind rank|knn`, which fits the base policy RAW, runs the A/A bar first (refuses to fit on a deviation), writes `<out>.compaction-evidence.json`, and exits non-zero on the investigation gate.
- Tests: 15 module + 6 synthetic ground-truth harness + 5 CLI, including the A/A property AND its firing path (exits 1, writes nothing), control dominance at a non-leading cost rank, sidecar identity refusal, unmeasured-arm refusal, cohort refusal, and exclusivity enforcement. Full wmo/optimize + wmo/cli suite: 1158 passed, 1 skipped.

## First real fit (financebench-s80, all 5 arms, ~$0; CANDIDATE: one corpus, hashing embedder)

- The A/A kill bar FIRED at the pre-registered z=0.5 (episode-parity noise +0.10 on 32 pairs cleared the gate). Shipped z=1.5, the smallest A/A-clean setting; the shift is reported per the pre-registration.
- THE GUARD HELD: 0/8 clusters compressed. All three D-DIAL v2 corners collapse to compression=None on this corpus.
- The one would-win (cluster 7: truncate-protect-task +7.0pt at -36% effective cost) is disbelieved on three measured grounds: the matched-ratio RANDOM control passes the same cluster at larger magnitude (+9.4pt), the arm is nearly a no-op on 12-word first-turn tasks (rows show tokens_in_raw == tokens_in_compressed), and the same grid's A/A produced a +0.10 cluster. The fitter refused it anyway on servability, which is fail-closed working.
- FLAG: `truncate-protect-task` and `random-removal` are not in main's compressor registry, so the grid's best-looking arm cannot be stamped by this build even where it passes; registering it is the gate if tau confirms a real win.
- Z-sweep risk-coverage recorded (6 passing cells at z=0.25 down to 1 at z=2.0; the random control co-passes wherever an arm passes, at every z; control-truncate, completed after the first run, adds no passing cells, and its absence from cluster 7 while random passes there further marks that cluster as lottery).

Full round entry with all numbers: `wmh-compression-data/findings/c2.md` (2026-07-27); evidence and sweep artifacts in `wmh-compression-data/fits/c2-r2/`; 26 run records in `runs/c2.jsonl`.

## Fix round (2026-07-28, overnight autonomy ruling)

All gate findings closed at 4ffc23f0: HIGH-2 ruled non-inferiority gate (--margin, 0.0 recovers superiority for sweeps), HIGH-1 control quality-dominance regardless of cost rank (flag fires even for ineligible leaders so surface sweeps see it), M3 EvidenceProvenance + pending-rescore labels, M4 per-policy sidecar path + digest + embedder binding + atomic writes, M5 A/A firing test, LOWs (measured-arm assert, sidecar exclusivity, backstop help text, these body counts). New permanent regression suite (compaction_fit_synthetic_test.py): four ground-truth cluster types (compressible / verbatim-critical / lottery / control-dominant); the corrected gate accepts, refuses, refuses, and refuses+flags respectively.

Overnight results (full ledger in findings/c2.md, artifacts in wmh-compression-data/fits/c2-r2/): the fb decision surface (72 settings, PENDING-RESCORE) stamps zero clusters everywhere with the refusal now coherent (A/A-clean needs z=2.0 under the ruled margin; cluster 7 control-dominated at most clean settings); the TAU fits (all 3 arms final, 440/440) give the track's first real per-cluster verdict: compression None everywhere AS CORPUS FACT (A/A clean at the ruled gate, quality -3.1 to -16.8pt with floor-off SEs, cost inversion to 2.3x, llmlingua2 never beats truncate); D-DIAL anchors emitted for both cohorts (corners coincide at None, stated as measured verdict). Overnight spend $0.0587.

## Review round (2026-07-27, later)

Rebased onto main (both-appended test-section conflict resolved, tree scanned for markers). Greptile P1 fixed in 42683c71: all gates run before any artifact write, so a rejected fit leaves only the evidence file; regression test added for both kinds. Fit reran with ALL FIVE arms (control-truncate completed): identical verdict, A/A clean at z=1.5, 0/8 clusters compressed, cluster-7 would-win persists and stays refused on servability.

## Justification ledger

- `compaction_fit.py` consumers: the `fit-compaction` CLI (this PR), the joint-tau ladder's anchor emission (per-cluster corners), and C3's serving delta once co-signed. Every gate exists because of a measured failure it prevents: the SE floor and A/A bar (this grid's episode lottery passed z=0.5 on noise), the cost gate (the grid measured dumb deletion RAISING effective cost 21-36%), servability-at-stamp (churny configs, C2 round 0's 2.65x), exclusivity (C2 round 0's floor-abstention failure).
- No serving changes, no validator changes, no new registry entries: all deliberately deferred to the co-signed contract delta.

## How Silen tests

`cd ~/Desktop/Projects/wmo-c2-r2 && R=~/Desktop/Projects/wmh-compression-data && uv run wmo optimize route fit-compaction $R/matrices/financebench-s80-off_matrix.json --arm $R/matrices/financebench-s80-llmlingua2-endpoint_matrix.json --arm $R/matrices/financebench-s80-truncate-protect-task_matrix.json --control $R/matrices/financebench-s80-control-random_matrix.json --kind rank --clusters 8 --z 1.5 --out /tmp/policy.json --allow-uneven-coverage`

Look for "A/A bar clean at z=1.5", the cluster-7 rows (both gates pass, would win, not chosen), "0/8 clusters compressed". Then re-run with `--z 0.5` and watch the A/A kill bar refuse to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)