### PR TITLE
Teacher search: decide distillation from the sweep's own matrix

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -407,7 +407,14 @@ step 4's keystone.
 
 ## Step 4 (optional): train the agent model
 
-The first three optimizers change the harness around a model. This one changes the model.
+The first three optimizers change the harness around a model. This one changes the model. Before
+spending on it, ask the matrix step 3 already bought whether there is anything to learn: the
+pipeline refuses to distill when the measured matrix shows no teacher gap, and
+`wmo optimize distill probe .wmo/models/tau-bench/optimize/matrix.json` prints that verdict (with
+the cheapest sufficient teacher when there is one) for free. On this corpus the answer is no: the
+27B scored +1.6 points over the 9B and Kimi K3 scored below both, so the cheap model already
+serves the workload.
+
 `wmo optimize distill run` does on-policy distillation of a Tinker LoRA student from rollouts of
 harbor's own `terminus_2` agent on harbor tasks: the student samples, a larger teacher scores the
 exact tokens the student sampled, and each step nudges the student toward the teacher under a

--- a/docs/reference/distill.md
+++ b/docs/reference/distill.md
@@ -12,6 +12,29 @@ student-after solve rates, and only an adapter that closes enough of the gap to 
 promoted. The result is a small model that behaves like the big one inside your agent, plus a
 ready-to-paste serving snippet.
 
+## First: is there a teacher at all? (`wmo optimize distill probe`)
+
+Distillation is the most expensive thing the optimizer can do, and most workloads do not need it.
+The routing sweep has already measured every pool model on your own held-out scenarios, so that
+matrix answers the question for free:
+
+```bash
+wmo optimize distill probe .wmo/models/<model>/optimize/matrix.json
+```
+
+It compares each candidate with the cheapest measured model, paired per scenario (unscored
+episodes excluded, an interval that has to exclude zero), and prints one verdict: `distill` with
+the cheapest sufficient teacher named, `do_not_distill` when no model clears the gap, or
+`insufficient_evidence` when the matrix is too thin to say. Exit codes 0, 3 and 4 match those
+three, so a script can branch on them. `--student NAME` probes a model other than the cheapest
+one, and `--min-gap` moves the bar (default 0.10, i.e. 10 reward points).
+
+Two rules worth knowing before reading a verdict. A gain whose confidence interval includes zero
+is not a gap, however large the point estimate. And among the models that do clear the gap, the
+teacher is the cheapest one that keeps 80% of the best measured gain, preferring open weights: a
+frontier model can prove the gap exists, but the model you train on should be one you are
+permitted to train on.
+
 ## Rollout sources
 
 Where episodes come from is config-selected: exactly one of `[harbor]` or `[tau2]`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,7 @@ Three optimizers, named for the artifact each produces.
 | `wmo optimize route pin` | Serve one pool model as an endpoint, with no matrix and no fit. | a `kind="static"` `policy.json` |
 | `wmo optimize route student` | Add a distilled student to the candidate pool as a priced entry. | a `[[model]]` entry in `pool.toml` |
 | `wmo optimize harness` | Search the agent scaffold (prompts, skills, tool policy, loop params) against a world model or on harbor tasks. | an immutable `vN` `HarnessDoc` in the store, `champion` alias moved, plus a delta archive |
+| `wmo optimize distill probe` | Ask a measured outcome matrix whether this workload has a teacher gap worth distilling at all, and which model is the cheapest sufficient teacher. Free. Exits 0 (distill), 3 (no gap), 4 (too thin to say). | nothing (prints) |
 | `wmo optimize distill run` | Train the agent model itself: on-policy distillation of a Tinker LoRA student from harbor rollouts, gated on held-out solve rates. | a run dir (config snapshot, metrics, checkpoints, evals, `gate.json`) and, on an accepted gate, an adapter version |
 | `wmo optimize distill report` | Read a finished or aborted run back: gate verdict and held-out before/after table. Free. | nothing (prints) |
 

--- a/wmo/cli/model_app.py
+++ b/wmo/cli/model_app.py
@@ -8,6 +8,11 @@ benchmark rollouts (the config selects the source: harbor's own terminus-2
 agent, or tau2-bench's own harness), and `report` reads a finished run dir
 back.
 
+`probe` comes BEFORE either of those and costs nothing: it reads the routing
+sweep's outcome matrix and answers whether this workload has a teacher gap at
+all (`wmo.optimize.teacher`). Most workloads do not, and the cheapest run is
+the one the evidence says to skip.
+
 `run` owns the run's CLI lifecycle: load and pin the inputs (config, task
 splits, the harness document supplying the rollout params), project the run
 cost into a confirmation table, drive `run_distillation` with progress
@@ -76,9 +81,22 @@ from wmo.harness.e2b_reap import (
 )
 from wmo.harness.population import write_json_atomic
 from wmo.harness.store import HarnessStore
+from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.teacher import DEFAULT_MIN_GAP, TeacherSearchVerdict, select_teacher
 
 DISTILL_RUN_RECORD = "distill-run.json"
 """The CLI-level pin file inside the run dir (see `DistillCliRunRecord`)."""
+
+PROBE_EXIT_NO_GAP = 3
+"""`probe` exit code: the matrix shows no teacher gap, so training is refused."""
+
+PROBE_EXIT_INSUFFICIENT = 4
+"""`probe` exit code: the matrix is too thin to decide either way.
+
+Distinct from `PROBE_EXIT_NO_GAP` because the two call for opposite actions (ship the cheap model
+against sweep more scenarios), and distinct from 1 and 2 so a script can tell a verdict from a
+crash or a usage error.
+"""
 
 _PI_NODE_RUNTIME = "pi-node"
 
@@ -200,6 +218,134 @@ def report(
     _print_trained_artifact(_console, store)
     _print_paired_delta(_console, store, gate)
     _print_training_summary(_console, store)
+
+
+@model_app.command("probe")
+def probe(
+    matrix_file: str = typer.Argument(
+        ...,
+        help="The outcome matrix to read: `<model>/optimize/matrix.json`, or wherever "
+        "`wmo optimize route sweep --out` put one.",
+    ),
+    student: str = typer.Option(
+        None,
+        "--student",
+        help="Pool model the distillation would train. Default: the cheapest measured model, "
+        "which is the one whose price makes distillation worth doing at all.",
+    ),
+    min_gap: float = typer.Option(
+        DEFAULT_MIN_GAP,
+        "--min-gap",
+        min=0.0,
+        max=1.0,
+        help="Reward points (as a fraction of 1.0) a teacher must beat the student by. The "
+        "default 0.10 is 10 points.",
+    ),
+) -> None:
+    """Ask a measured matrix whether this workload has a teacher worth distilling from.
+
+    Free and read-only: the sweep already bought this evidence, so the gate is arithmetic over
+    the file.
+
+        wmo optimize distill probe .wmo/models/tau-bench/optimize/matrix.json
+
+    It prints every candidate's paired gain over the student, with a 95% interval and the price
+    it would teach at, then one verdict line to act on. Exit codes, so a script can branch
+    without parsing the text: 0 = distill (the gap is real; the named teacher is the cheapest
+    sufficient one), 3 = do not distill (no gap, so training has nothing to teach), 4 =
+    insufficient evidence (this matrix is too thin to say either way; sweep more scenarios).
+    Anything else is the usual usage or IO failure.
+    """
+    path = Path(matrix_file)
+    if not path.is_file():
+        raise typer.BadParameter(
+            f"no outcome matrix at {path}; a sweep writes one to "
+            f"`<model>/optimize/matrix.json`, so run `wmo optimize model <world-model>` (or "
+            f"`wmo optimize route sweep`) before probing it"
+        )
+    try:
+        matrix = OutcomeMatrix.load(path)
+    except ValidationError as exc:
+        raise typer.BadParameter(f"{path} is not a readable outcome matrix: {exc}") from exc
+    try:
+        verdict = select_teacher(matrix, student=student, min_gap=min_gap)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    _console.print(_teacher_gain_table(verdict, path))
+    color = "green" if verdict.should_distill else "yellow"
+    _console.print(f"[{color}]{verdict.decision}[/{color}] {escape(verdict.reason)}")
+    if verdict.unmeasured_models:
+        _console.print(
+            f"[dim]not compared (no scenario scored alongside '{escape(verdict.student)}'): "
+            f"{escape(', '.join(verdict.unmeasured_models))}[/dim]"
+        )
+    if verdict.decision == "do_not_distill":
+        raise typer.Exit(code=PROBE_EXIT_NO_GAP)
+    if verdict.decision == "insufficient_evidence":
+        raise typer.Exit(code=PROBE_EXIT_INSUFFICIENT)
+
+
+def _teacher_gain_table(verdict: TeacherSearchVerdict, matrix_file: Path) -> Table:
+    """Every candidate's paired gain over the student, best first.
+
+    Six columns, not nine: a gain and its interval belong in one cell (they are one measurement),
+    and the student's own reward is the same on every row, so it goes in the title. At an
+    80-column terminal the wider layout truncated every cell to an ellipsis, which is worse than
+    omitting the columns outright.
+
+    The price column carries its unit in its header, because the ladder is measured dollars per
+    completed task when the matrix recorded spend and list dollars per Mtok when it did not, and
+    a bare number would be read as the wrong one.
+    """
+    unit = "$/task" if verdict.price_basis == "measured" else "$/Mtok"
+    measured = verdict.price_basis == "measured"
+    unit_note = (
+        "this matrix's own cost per completed task"
+        if measured
+        else "list price per 1M tokens, input + output, which is the fallback whenever some "
+        "model has no measured cost per completed task (an unpriced entry, or a model that "
+        "completed nothing)"
+    )
+    table = Table(
+        title=f"Teacher search against '{verdict.student}' "
+        f"({verdict.n_scenarios} scored scenarios, {matrix_file})",
+        caption=f"n = scenarios shared with the student; gains are paired over those. "
+        f"{unit} is {unit_note}. Bar: {verdict.min_gap * 100:.1f} points over "
+        f"{verdict.min_scenarios}+ shared scenarios, interval excluding zero. "
+        f"A teacher (*) keeps {verdict.sufficiency * 100:.0f}% of the best gain.",
+        caption_justify="left",
+    )
+    table.add_column("Model", overflow="fold")
+    table.add_column("Tier")
+    table.add_column("n", justify="right")
+    table.add_column("Reward", justify="right")
+    table.add_column("Gain in points (95% CI)", justify="right")
+    table.add_column(unit, justify="right")
+    table.add_column("Gap?")
+    for row in verdict.gains:
+        interval = (
+            f"({row.ci_low * 100:+.1f} to {row.ci_high * 100:+.1f})"
+            if row.ci_low is not None and row.ci_high is not None
+            else "(no interval: one scenario)"
+        )
+        table.add_row(
+            f"{row.model} *" if row.model == verdict.teacher else row.model,
+            row.tier,
+            str(row.n_scenarios),
+            f"{row.mean_reward:.3f}",
+            f"{row.mean_gain * 100:+.1f} {interval}",
+            _probe_price(row.price, measured=measured),
+            "yes" if row.clears_gap else "no",
+        )
+    return table
+
+
+def _probe_price(price: float | None, *, measured: bool) -> str:
+    """A ladder key at the precision its unit deserves: fractions of a cent, or dollars a Mtok."""
+    if price is None:
+        return "unpriced"
+    return f"{price:.4f}" if measured else f"{price:.2f}"
 
 
 def _explicit(ctx: typer.Context, param: str) -> bool:

--- a/wmo/cli/model_app_test.py
+++ b/wmo/cli/model_app_test.py
@@ -19,6 +19,7 @@ from typer.testing import CliRunner, Result
 
 from wmo.agents.default import default_agent
 from wmo.cli import app
+from wmo.cli.model_app import PROBE_EXIT_INSUFFICIENT, PROBE_EXIT_NO_GAP
 from wmo.config.settings import load_settings
 from wmo.distill.config import DistillConfig
 from wmo.distill.gate import DistillGateRecord
@@ -40,6 +41,9 @@ from wmo.distill.store import DEFAULT_TINKER_OPENAI_ENDPOINT, AdapterStore, Dist
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.e2b_reap import CapacityCheck, ReapOutcome
 from wmo.harness.store import HarnessStore
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -1162,3 +1166,98 @@ def test_report_on_a_run_that_never_gated_says_how_to_finish_it(tmp_path: Path) 
     flat = _flat(result)
     assert "has not reached its gate yet" in flat
     assert "wmo optimize distill run --run-dir <dir> --resume" in flat
+
+
+# -- `probe`: the teacher-search gate over a measured matrix ------------------------------------
+
+
+def _probe(matrix_file: Path, *extra: str) -> Result:
+    return runner.invoke(app, ["optimize", "distill", "probe", str(matrix_file), *extra])
+
+
+def _matrix_file(tmp_path: Path, *, gain: float, scenarios: int = 12) -> Path:
+    """A two-candidate matrix where the dearer model is `gain` reward points better."""
+    pool = [
+        PoolEntry(
+            name=name,
+            kind=ProviderKind.OPENAI,
+            model=f"{name}-runtime",
+            tier="open",
+            input_per_mtok=rate,
+            output_per_mtok=rate,
+        )
+        for name, rate in (("small", 0.10), ("big", 1.15))
+    ]
+    outcomes = [
+        ScenarioOutcome(
+            scenario_id=f"s{i:02d}",
+            task=f"task {i}",
+            model=name,
+            reward=0.30 + (gain + (0.02 if i % 2 else -0.02) if name == "big" else 0.0),
+            success=True,
+            usage=TokenUsage(input_tokens=100, output_tokens=50),
+            # Distinct per-episode spend, so the measured ladder has a cheapest model to pick
+            # the student from rather than a tie.
+            cost_usd=0.002 if name == "small" else 0.020,
+        )
+        for name in ("small", "big")
+        for i in range(scenarios)
+    ]
+    path = tmp_path / "matrix.json"
+    OutcomeMatrix(pool=pool, outcomes=outcomes).save(path)
+    return path
+
+
+def test_probe_exits_zero_and_names_the_teacher_when_the_gap_is_real(tmp_path: Path) -> None:
+    result = _probe(_matrix_file(tmp_path, gain=0.30))
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "distill" in flat
+    assert "big *" in flat  # the gain table stars the chosen teacher
+    assert "+30.0" in flat
+
+
+def test_probe_exits_three_when_the_matrix_shows_no_gap(tmp_path: Path) -> None:
+    """The documented no-gap code: a script branches on it without parsing the sentence."""
+    result = _probe(_matrix_file(tmp_path, gain=0.02))
+
+    assert result.exit_code == PROBE_EXIT_NO_GAP
+    assert "DO NOT DISTILL" in _flat(result)
+
+
+def test_probe_exits_four_when_the_matrix_is_too_thin_to_decide(tmp_path: Path) -> None:
+    result = _probe(_matrix_file(tmp_path, gain=0.30, scenarios=3))
+
+    assert result.exit_code == PROBE_EXIT_INSUFFICIENT
+    assert "INSUFFICIENT EVIDENCE" in _flat(result)
+
+
+def test_probe_takes_the_bar_and_the_student_from_the_caller(tmp_path: Path) -> None:
+    matrix_file = _matrix_file(tmp_path, gain=0.30)
+
+    lowered = _probe(matrix_file, "--min-gap", "0.5")
+    assert lowered.exit_code == PROBE_EXIT_NO_GAP  # +30 points no longer clears a 50-point bar
+
+    inverted = _probe(matrix_file, "--student", "big")
+    assert inverted.exit_code == PROBE_EXIT_NO_GAP  # the small model is 30 points WORSE
+    assert "against 'big'" in _flat(inverted)
+
+
+def test_probe_on_a_missing_matrix_says_which_command_writes_one(tmp_path: Path) -> None:
+    result = _probe(tmp_path / "nope.json")
+
+    assert result.exit_code == 2
+    flat = _flat(result)
+    assert "no outcome matrix at" in flat
+    assert "wmo optimize route sweep" in flat
+
+
+def test_probe_on_a_file_that_is_not_a_matrix_says_so(tmp_path: Path) -> None:
+    path = tmp_path / "matrix.json"
+    path.write_text('{"pool": []}', encoding="utf-8")
+
+    result = _probe(path)
+
+    assert result.exit_code == 2
+    assert "is not a readable outcome matrix" in _flat(result)

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -15,7 +15,10 @@ candidate spend.
 
 Not in this build: the `--distill` stage (train a student, gate it, add it to the pool, re-sweep).
 It is named in `wmo.optimize.pipeline.STAGE_ORDER` so its arrival is additive; passing `--distill`
-today is a usage error that names the manual command instead.
+today is a usage error that names the manual command instead. Its PREFLIGHT already exists,
+though (`wmo.optimize.teacher`), and that refusal carries the teacher-search verdict on whatever
+matrix this model has: usually there is no teacher gap, and the cheapest run is the one the
+evidence says to skip.
 """
 
 from __future__ import annotations
@@ -25,7 +28,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 from rich.console import Console
 from rich.markup import escape
 from rich.prompt import Confirm
@@ -106,6 +109,7 @@ from wmo.optimize.sweep import (
     resolve_config,
 )
 from wmo.optimize.sweep import preflight_pool as run_preflight
+from wmo.optimize.teacher import TeacherSearchVerdict, select_teacher
 from wmo.providers.pool import DEFAULT_POOL_PATH
 
 _console = Console()
@@ -208,7 +212,9 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         None,
         "--distill",
         help="NOT IN THIS BUILD. Reserved for the distillation stage (train a student, gate it, "
-        "add it to the pool, re-sweep it). Use `wmo optimize distill run` for now.",
+        "add it to the pool, re-sweep it). Use `wmo optimize distill run` for now, and "
+        "`wmo optimize distill probe <matrix.json>` to find out whether you should at all: "
+        "passing this flag prints that verdict for this model's own matrix.",
     ),
     force_from: str = typer.Option(
         None,
@@ -269,13 +275,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     manifest under `<model>/optimize/`. Deleting that directory resets resume and breaks nothing.
     """
     if distill is not None:
-        raise typer.BadParameter(
-            "--distill is reserved and not implemented in this build: the distillation stage "
-            "(train a student, gate it, add it to the pool, re-sweep it, merge the matrix) is "
-            "still a separate workflow. Run `wmo optimize distill run --config <toml>`, then "
-            "`wmo optimize route student <run-dir> --input-per-mtok ... --output-per-mtok ...` "
-            "to put the student in the pool, then re-run this command without --distill."
-        )
+        raise typer.BadParameter(_distill_reserved_message(world_model=world_model, root=root))
     if compressor is None and aggressiveness > 0.0:
         raise typer.BadParameter("--aggressiveness needs --compressor to apply it")
     compression: CompressionConfig | None = None
@@ -454,6 +454,53 @@ class _RunPaths(BaseModel):
     matrix: Path
     policy: Path
     report: Path
+
+
+def _distill_reserved_message(*, world_model: str | None, root: str) -> str:
+    """Why `--distill` is refused, plus this model's teacher-search verdict when one is readable.
+
+    The stage is not wired, but its PREFLIGHT is (`wmo.optimize.teacher`), and the preflight is
+    the half that decides whether the stage should run at all. Printing the verdict here means
+    the product surface already answers the real question ("should I distill?") in the same place
+    an operator asked for it, and usually answers no, which is the cheapest possible outcome.
+
+    Everything about the lookup is best effort: an unresolvable model, an absent matrix, or a
+    matrix too small to compare adds nothing to the message rather than replacing a usage error
+    with an unrelated one.
+    """
+    base = (
+        "--distill is reserved and not implemented in this build: the distillation stage "
+        "(train a student, gate it, add it to the pool, re-sweep it, merge the matrix) is "
+        "still a separate workflow. Run `wmo optimize distill run --config <toml>`, then "
+        "`wmo optimize route student <run-dir> --input-per-mtok ... --output-per-mtok ...` "
+        "to put the student in the pool, then re-run this command without --distill."
+    )
+    found = _teacher_verdict(world_model=world_model, root=root)
+    if found is None:
+        return base
+    matrix_path, verdict = found
+    return (
+        f"{base} Worth knowing before you spend anything, the teacher-search verdict on this "
+        f"model's current matrix: {verdict.reason} "
+        f"(`wmo optimize distill probe {matrix_path}` prints the full table.)"
+    )
+
+
+def _teacher_verdict(
+    *, world_model: str | None, root: str
+) -> tuple[Path, TeacherSearchVerdict] | None:
+    """This model's teacher search over the matrix already on disk, or None when unavailable."""
+    try:
+        model_dir = WorldModelStore(root).resolve(world_model)
+    except (FileNotFoundError, ValueError):
+        return None
+    matrix_path = model_dir / MANIFEST_DIRNAME / MATRIX_FILENAME
+    if not matrix_path.is_file():
+        return None
+    try:
+        return matrix_path, select_teacher(OutcomeMatrix.load(matrix_path))
+    except (ValidationError, ValueError, OSError):
+        return None
 
 
 def _resolve_embedder_choice(choice: str) -> tuple[EmbedderSpec, str]:

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -500,6 +500,36 @@ def test_distill_is_rejected_with_the_command_that_does_work(
     assert not _paths(root)[0].exists()  # nothing ran
 
 
+def test_distill_refusal_carries_the_teacher_verdict_on_the_matrix_it_finds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stage is unwired, but its preflight is not: the refusal answers "should I?" anyway."""
+    _patch_seams(monkeypatch, rewards={"cheap-1": 0.4, "pricey-1": 0.42})
+    root = _project(tmp_path)
+    assert _run(tmp_path, root, "--yes", "--scenarios", "4").exit_code == 0
+
+    result = _run(tmp_path, root, "--yes", "--distill", "distill.toml")
+
+    assert result.exit_code != 0
+    assert _says(result.output, "the teacher-search verdict on this model's current matrix")
+    # Four scenarios is under the gate's evidence bar, and it says so rather than guessing.
+    assert _says(result.output, "INSUFFICIENT EVIDENCE")
+    assert _says(result.output, "wmo optimize distill probe")
+
+
+def test_distill_refusal_without_a_matrix_is_just_the_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing has been measured yet, so there is no verdict to quote and none is invented."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+
+    result = _run(tmp_path, root, "--yes", "--distill", "distill.toml")
+
+    assert result.exit_code != 0
+    assert not _says(result.output, "teacher-search verdict")
+
+
 def test_force_from_a_reserved_stage_says_it_is_not_built(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wmo/optimize/teacher.py
+++ b/wmo/optimize/teacher.py
@@ -1,0 +1,555 @@
+"""Teacher search: the distillation go/no-go, computed from evidence the sweep already bought.
+
+Distillation is the most expensive thing this optimizer can do, and most workloads do not need
+it. The decision is not a research judgement call, it is a function over data the pipeline pays
+for anyway: `wmo optimize route sweep` measures EVERY pool model on the customer's own held-out
+scenarios, so the resulting `OutcomeMatrix` already answers "is there a bigger model that is
+materially better here, and what does it cost". This module reads that answer.
+
+Two steps, in the order the money is at stake:
+
+1. EXISTENCE. Take the cheapest measured model as the candidate STUDENT and ask whether any other
+   model in the matrix beats it by at least `min_gap`, paired per scenario. No gap means no
+   teacher: the cheap model already serves this workload and earns its traffic on price, so
+   training would buy nothing and the stage skips with zero spend.
+2. CHEAPEST SUFFICIENT TEACHER. When the gap exists, walk the price ladder upward and take the
+   cheapest model that still keeps `sufficiency` of the best measured gain, preferring an
+   open-weights candidate. A frontier model is usually the existence proof, rarely the economic
+   teacher.
+
+Measured evidence this reproduces, and the reason the two steps are separate:
+
+- tau-bench: Qwen3.6-27B scored +1.6 points over the 9B student and Kimi K3 scored BELOW both.
+  No gap, so no distillation, and the several hundred dollars a training run costs stayed unspent.
+- TerminalBench-2: the same 27B scored +27 points over the same 9B. A gap, and the teacher is the
+  27B at $0.30/$2.00 per Mtok rather than K3 at $3/$15, because K3's extra gain (if any) is not
+  worth ten times the data cost.
+
+Honest-stats rules, inherited from `wmo.optimize.scorecard` and non-negotiable here because the
+output authorizes spending:
+
+- PAIRED, same scenarios. A model is compared with the student only over scenarios BOTH have a
+  scored episode on, per-scenario means first, so an easy subset cannot manufacture a gap.
+- `reward is None` is an infrastructure failure, never a judge verdict of 0 (`outcomes.py`), so
+  unscored rows are excluded from both sides.
+- A gain whose confidence interval includes zero is NOT a gap. A thin matrix returns
+  `insufficient_evidence`, never a false yes: the failure mode this gate exists to prevent is
+  authorizing a training run on noise.
+
+Call site:
+
+    from wmo.optimize.outcomes import OutcomeMatrix
+    from wmo.optimize.teacher import select_teacher
+
+    verdict = select_teacher(OutcomeMatrix.load(matrix_path))
+    if verdict.decision == "distill":
+        train(student=verdict.student, teacher=verdict.teacher)
+    else:
+        print(verdict.reason)
+"""
+
+from __future__ import annotations
+
+from math import sqrt
+from statistics import fmean, stdev
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.scorecard import effective_cost_per_completed_task, rows_for_model
+from wmo.providers.pool import PoolEntry, Tier
+
+DEFAULT_MIN_GAP = 0.10
+"""Reward points (as a fraction of 1.0) a teacher must beat the student by. 0.10 = 10 points.
+
+The bar is deliberately coarse. A 2-point gap is inside the noise of any ablation-sized scenario
+set, and closing it does not repay a training run; the two measured cases this gate was written
+against (+1.6 points and +27 points) sit far on either side of it.
+"""
+
+DEFAULT_MIN_SCENARIOS = 8
+"""Shared scored scenarios a comparison needs before this gate calls it either way."""
+
+DEFAULT_SUFFICIENCY = 0.8
+"""Fraction of the BEST measured gain a cheaper model must keep to be a sufficient teacher."""
+
+CI_Z = 1.96
+"""Normal quantile for the 95% interval reported on every gain row."""
+
+Decision = Literal["distill", "do_not_distill", "insufficient_evidence"]
+"""What the matrix supports. `insufficient_evidence` is a real answer, not an error."""
+
+PriceBasis = Literal["measured", "list"]
+"""Which ladder ordered the candidates: this matrix's own spend, or the pool's list prices."""
+
+
+class ModelGain(BaseModel):
+    """One candidate model's paired comparison against the student, with its price.
+
+    Every number is measured over `n_scenarios`, the scenarios this model AND the student both
+    have a scored episode on, so `mean_gain` is exactly `mean_reward - student_mean_reward` on
+    one common set. Comparing two rows of this table against each other is not paired, however:
+    two candidates may share different scenario subsets with the student.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    model: str
+    tier: Tier
+    n_scenarios: int
+    mean_reward: float  # this model, over the shared scenarios only
+    student_mean_reward: float  # the student, over those same scenarios
+    mean_gain: float
+    # None below n=2: one scenario has no spread to estimate from, and quoting a zero-width
+    # interval would read as certainty. Such a row can never clear the gap.
+    standard_error: float | None
+    ci_low: float | None
+    ci_high: float | None
+    # The ladder key, in whatever unit `TeacherSearchVerdict.price_basis` names. None when this
+    # model has no usable price at all, which sorts it last rather than first.
+    price: float | None
+    clears_gap: bool
+    """Gain at or above `min_gap` AND an interval that excludes zero, on enough scenarios."""
+
+
+class TeacherSearchVerdict(BaseModel):
+    """The gate's answer: what to do, who with, and the reason to print verbatim."""
+
+    model_config = ConfigDict(frozen=True)
+
+    decision: Decision
+    student: str
+    teacher: str | None  # set only on `distill`
+    n_scenarios: int  # scenarios the student itself was scored on: the ceiling on any pairing
+    gains: list[ModelGain]  # every measured candidate, best gain first
+    unmeasured_models: list[str] = []  # pool models sharing no scored scenario with the student
+    price_basis: PriceBasis
+    min_gap: float
+    min_scenarios: int
+    sufficiency: float
+    reason: str = Field(min_length=1)
+
+    @property
+    def should_distill(self) -> bool:
+        """Whether the matrix authorizes spending on a training run."""
+        return self.decision == "distill"
+
+
+def select_teacher(
+    matrix: OutcomeMatrix,
+    *,
+    student: str | None = None,
+    min_gap: float = DEFAULT_MIN_GAP,
+    min_scenarios: int = DEFAULT_MIN_SCENARIOS,
+    sufficiency: float = DEFAULT_SUFFICIENCY,
+) -> TeacherSearchVerdict:
+    """Decide whether this workload has a teacher worth distilling from, and which one.
+
+    Pure function over the matrix: no network, no spend, no artifact written.
+
+    Args:
+        matrix: an `OutcomeMatrix` from `wmo optimize route sweep`, carrying its own pool.
+        student: the model distillation would train. Defaults to the cheapest measured model,
+            which is the one whose price makes distillation worth doing at all.
+        min_gap: reward points (as a fraction of 1.0) a teacher must beat the student by.
+        min_scenarios: shared scored scenarios a comparison needs to count as evidence.
+        sufficiency: fraction of the best measured gain a cheaper teacher must keep.
+
+    Returns:
+        A `TeacherSearchVerdict` whose `reason` is written to be printed verbatim to an operator.
+
+    Raises:
+        ValueError: the thresholds are out of range, the matrix has fewer than two models with
+            scored episodes, or a named `student` is absent or unscored there.
+    """
+    _validate_thresholds(min_gap=min_gap, min_scenarios=min_scenarios, sufficiency=sufficiency)
+
+    means = {
+        entry.name: _scenario_means(rows_for_model(matrix, entry.name)) for entry in matrix.pool
+    }
+    measured = sorted(name for name, scores in means.items() if scores)
+    if len(measured) < 2:
+        raise ValueError(
+            f"teacher search needs at least two models with scored episodes in the matrix, and "
+            f"this one has {len(measured)} ({', '.join(measured) or 'none'}); a gap is a "
+            f"comparison, so sweep the pool you want compared before probing it"
+        )
+
+    prices, basis = _price_ladder(matrix, measured)
+    student_name = _resolve_student(student, measured=measured, prices=prices, means=means)
+    student_scores = means[student_name]
+
+    gains = sorted(
+        (
+            _gain_row(
+                entry=_entry(matrix, name),
+                scores=means[name],
+                student_scores=student_scores,
+                price=prices[name],
+                min_gap=min_gap,
+                min_scenarios=min_scenarios,
+            )
+            for name in measured
+            if name != student_name and _shared(means[name], student_scores)
+        ),
+        key=lambda row: (-row.mean_gain, row.model),
+    )
+    unmeasured = sorted(
+        name for name in means if name != student_name and not _shared(means[name], student_scores)
+    )
+
+    decision, teacher, reason = _decide(
+        student=student_name,
+        gains=gains,
+        min_gap=min_gap,
+        min_scenarios=min_scenarios,
+        sufficiency=sufficiency,
+        basis=basis,
+    )
+    return TeacherSearchVerdict(
+        decision=decision,
+        student=student_name,
+        teacher=teacher,
+        n_scenarios=len(student_scores),
+        gains=gains,
+        unmeasured_models=unmeasured,
+        price_basis=basis,
+        min_gap=min_gap,
+        min_scenarios=min_scenarios,
+        sufficiency=sufficiency,
+        reason=reason,
+    )
+
+
+def _validate_thresholds(*, min_gap: float, min_scenarios: int, sufficiency: float) -> None:
+    """Reject thresholds whose verdict would be meaningless rather than merely strict."""
+    if min_gap <= 0.0:
+        raise ValueError(
+            f"min_gap must be a positive fraction of a reward point (got {min_gap}); a "
+            "non-positive bar would call every scoring difference a teacher gap"
+        )
+    if min_scenarios < 2:
+        raise ValueError(
+            f"min_scenarios must be at least 2 (got {min_scenarios}); one shared scenario has no "
+            "spread to estimate an interval from, so it can never establish a gap"
+        )
+    if not 0.0 < sufficiency <= 1.0:
+        raise ValueError(
+            f"sufficiency must be in (0, 1] (got {sufficiency}); it is the fraction of the best "
+            "measured gain a cheaper teacher has to keep"
+        )
+
+
+def _entry(matrix: OutcomeMatrix, name: str) -> PoolEntry:
+    """The pool entry behind a measured model name (present by the matrix's own validator)."""
+    return next(entry for entry in matrix.pool if entry.name == name)
+
+
+def _scenario_means(rows: list[ScenarioOutcome]) -> dict[str, float]:
+    """Mean reward per scenario over SCORED episodes only; scenarios with none are absent.
+
+    Per scenario before anything else, as in `scorecard._quality`: a model that ran three
+    episodes on an easy scenario and one on a hard one would otherwise weight the easy scenario
+    three times against a student that ran one of each.
+    """
+    grouped: dict[str, list[float]] = {}
+    for row in rows:
+        if row.reward is not None:
+            grouped.setdefault(row.scenario_id, []).append(row.reward)
+    return {sid: fmean(rewards) for sid, rewards in grouped.items()}
+
+
+def _shared(scores: dict[str, float], student_scores: dict[str, float]) -> list[str]:
+    """The scenarios both sides scored, in the student's own order (deterministic output)."""
+    return [sid for sid in student_scores if sid in scores]
+
+
+def _price_ladder(
+    matrix: OutcomeMatrix, measured: list[str]
+) -> tuple[dict[str, float | None], PriceBasis]:
+    """Every measured model's ladder key, and which unit the whole ladder is in.
+
+    Prefers what the matrix itself recorded: `scorecard.effective_cost_per_completed_task` over a
+    model's own rows is cache-adjusted spend divided by tasks it actually completed, which is the
+    price an operator would really pay to serve this workload on it. That figure is unavailable
+    for a model whose entries carried no price, and undefined for one that completed no task at
+    all, so the ladder falls back to LIST prices (a pool entry's own published input + output
+    rate per Mtok) whenever any measured model is missing a figure. A measured $0.0000 counts as
+    missing rather than as free: the rows recorded no spend, which is an absent price, and taking
+    it literally would seat that model at the bottom of the ladder ahead of models that were
+    priced.
+
+    One basis for the whole ladder, never a mix: ordering some models by dollars per completed
+    task and others by dollars per Mtok would compare two different quantities and could rank a
+    genuinely cheaper model above a genuinely dearer one.
+    """
+    effective: dict[str, float | None] = {}
+    for name in measured:
+        cost = effective_cost_per_completed_task(rows_for_model(matrix, name))
+        per_task = cost.cost_per_completed_task_usd
+        effective[name] = None if cost.cost_is_unpriced or not per_task else per_task
+    if all(value is not None for value in effective.values()):
+        return effective, "measured"
+    return {name: _list_price(_entry(matrix, name)) for name in measured}, "list"
+
+
+def _list_price(entry: PoolEntry) -> float | None:
+    """A pool entry's published input + output rate per Mtok: an ORDERING KEY, not a cost.
+
+    The sum is not what anything will be billed (that depends on the token mix); it is monotone
+    in both published rates, which is all a ladder needs, and it matches how these models are
+    quoted to operators ("$0.30/$2.00 against $3/$15"). None when the entry has no price row at
+    all, which sorts the model last rather than free.
+    """
+    try:
+        price = entry.price()
+    except ValueError:
+        return None
+    return price.input_per_mtok + price.output_per_mtok
+
+
+def _ladder_key(name: str, prices: dict[str, float | None]) -> tuple[bool, float, str]:
+    """Ascending price, unpriced models last, name as the deterministic tie-break."""
+    price = prices.get(name)
+    return (price is None, price if price is not None else 0.0, name)
+
+
+def _resolve_student(
+    student: str | None,
+    *,
+    measured: list[str],
+    prices: dict[str, float | None],
+    means: dict[str, dict[str, float]],
+) -> str:
+    """The model distillation would train: the named one, else the cheapest measured one.
+
+    A price tie is broken toward the BETTER model (then the name). That is the conservative
+    direction: the better of two equally cheap students makes the gap harder to prove, so a tie
+    can never be resolved into a training run that a different tie-break would have refused.
+    """
+    if student is not None:
+        if student not in means:
+            raise ValueError(
+                f"no pool model named '{student}' in this matrix; measured models are "
+                f"{', '.join(measured)}"
+            )
+        if not means[student]:
+            raise ValueError(
+                f"'{student}' has no scored episode in this matrix, so nothing can be compared "
+                f"against it; measured models are {', '.join(measured)}"
+            )
+        return student
+    priced = [price for name in measured if (price := prices[name]) is not None]
+    if not priced:
+        # Nothing in this matrix carries a price, so there is no ladder to be cheapest on. Name
+        # the choice deterministically rather than picking whichever model the pool listed first.
+        return sorted(measured)[0]
+    cheapest = min(priced)
+    tied = [name for name in measured if prices[name] == cheapest]
+    return sorted(tied, key=lambda name: (-fmean(means[name].values()), name))[0]
+
+
+def _gain_row(
+    *,
+    entry: PoolEntry,
+    scores: dict[str, float],
+    student_scores: dict[str, float],
+    price: float | None,
+    min_gap: float,
+    min_scenarios: int,
+) -> ModelGain:
+    """One candidate's paired gain over the student, with its 95% interval.
+
+    The interval is over per-scenario DIFFERENCES, which is what makes it paired: scenario
+    difficulty cancels, so the width reflects how consistently this model beats the student
+    rather than how varied the scenarios were.
+    """
+    shared = _shared(scores, student_scores)
+    diffs = [scores[sid] - student_scores[sid] for sid in shared]
+    mean_gain = fmean(diffs)
+    standard_error: float | None = None
+    ci_low: float | None = None
+    ci_high: float | None = None
+    if len(diffs) > 1:
+        standard_error = stdev(diffs) / sqrt(len(diffs))
+        ci_low = mean_gain - CI_Z * standard_error
+        ci_high = mean_gain + CI_Z * standard_error
+    return ModelGain(
+        model=entry.name,
+        tier=entry.tier,
+        n_scenarios=len(shared),
+        mean_reward=fmean(scores[sid] for sid in shared),
+        student_mean_reward=fmean(student_scores[sid] for sid in shared),
+        mean_gain=mean_gain,
+        standard_error=standard_error,
+        ci_low=ci_low,
+        ci_high=ci_high,
+        price=price,
+        clears_gap=(
+            len(shared) >= min_scenarios
+            and mean_gain >= min_gap
+            and ci_low is not None
+            and ci_low > 0.0
+        ),
+    )
+
+
+def _decide(
+    *,
+    student: str,
+    gains: list[ModelGain],
+    min_gap: float,
+    min_scenarios: int,
+    sufficiency: float,
+    basis: PriceBasis,
+) -> tuple[Decision, str | None, str]:
+    """The three-way verdict and the sentence that explains it.
+
+    Order matters. `insufficient_evidence` is checked in the two places a "no" would be dishonest
+    (nothing was measured against the student, or the leading candidate was measured too thinly
+    to test), so a thin matrix never reads as "no teacher exists" and never as "train now".
+    """
+    if not gains:
+        return (
+            "insufficient_evidence",
+            None,
+            f"INSUFFICIENT EVIDENCE: no other model in this matrix shares a scored scenario with "
+            f"'{student}', so nothing can be compared against it. Sweep the candidates over the "
+            f"same scenarios, then probe again.",
+        )
+
+    clearing = [row for row in gains if row.clears_gap]
+    if clearing:
+        teacher = _cheapest_sufficient(clearing, sufficiency=sufficiency)
+        best = clearing[0]  # gains are sorted by gain, and every clearing row is in that order
+        return (
+            "distill",
+            teacher.model,
+            _distill_reason(
+                student=student,
+                teacher=teacher,
+                best=best,
+                min_gap=min_gap,
+                sufficiency=sufficiency,
+                basis=basis,
+            ),
+        )
+
+    leader = gains[0]
+    if leader.n_scenarios < min_scenarios:
+        return (
+            "insufficient_evidence",
+            None,
+            _thin_reason(student, leader, min_gap, min_scenarios),
+        )
+    return ("do_not_distill", None, _no_gap_reason(student, leader, min_gap))
+
+
+def _cheapest_sufficient(clearing: list[ModelGain], *, sufficiency: float) -> ModelGain:
+    """The teacher: cheapest model keeping `sufficiency` of the best gain, open weights first.
+
+    Open tier outranks price, rather than merely breaking its ties. The existence proof may come
+    from a frontier model, but a data teacher is trained ON, and an open-weights model is the one
+    whose outputs you are reliably permitted to train on (the directive's open-source teacher
+    preference). A frontier teacher is therefore chosen only when no open candidate is sufficient,
+    and the reason says so, so the licensing question lands in front of the operator before the
+    training spend does.
+    """
+    best_gain = max(row.mean_gain for row in clearing)
+    sufficient = [row for row in clearing if row.mean_gain >= sufficiency * best_gain]
+    return min(
+        sufficient,
+        key=lambda row: (
+            row.tier != "open",
+            row.price is None,
+            row.price if row.price is not None else 0.0,
+            row.model,
+        ),
+    )
+
+
+def _distill_reason(
+    *,
+    student: str,
+    teacher: ModelGain,
+    best: ModelGain,
+    min_gap: float,
+    sufficiency: float,
+    basis: PriceBasis,
+) -> str:
+    """The printed reason behind a `distill` verdict, teacher choice included."""
+    kept = teacher.mean_gain / best.mean_gain * 100.0
+    if teacher.tier == "open":
+        tier_clause = (
+            "It is open weights, which is the tier this gate prefers for a data teacher: a "
+            "frontier model can prove the gap exists, but you have to be allowed to train on "
+            "what the teacher writes."
+        )
+    else:
+        tier_clause = (
+            "No open-weights candidate kept enough of the gain, so this teacher is frontier "
+            "tier: check that provider's terms before training on its outputs."
+        )
+    return (
+        f"DISTILL: '{best.model}' beats '{student}' by {_points(best.mean_gain)} points on "
+        f"{best.n_scenarios} shared scenarios ({_interval(best)}), clearing the "
+        f"{_bar(min_gap)}-point bar this gate requires, so there is something to teach. "
+        f"The cheapest sufficient teacher is '{teacher.model}' at {_price(teacher.price, basis)}, "
+        f"keeping {kept:.0f}% of the best measured gain (the bar is "
+        f"{sufficiency * 100:.0f}%). {tier_clause}"
+    )
+
+
+def _no_gap_reason(student: str, leader: ModelGain, min_gap: float) -> str:
+    """The printed reason behind a `do_not_distill` verdict."""
+    caveat = ""
+    if leader.mean_gain >= min_gap:
+        caveat = (
+            " Its point gain clears the bar, but the interval includes zero, which is not a gap; "
+            "more scenarios would settle it."
+        )
+    return (
+        f"DO NOT DISTILL: no model in this matrix beats '{student}' by the {_bar(min_gap)} points "
+        f"this gate requires. The best is '{leader.model}' at {_points(leader.mean_gain)} points "
+        f"on {leader.n_scenarios} shared scenarios ({_interval(leader)}).{caveat} '{student}' "
+        f"already serves this workload and earns its traffic on price, so training has no teacher "
+        f"to learn from and this stage skips with zero spend."
+    )
+
+
+def _thin_reason(student: str, leader: ModelGain, min_gap: float, min_scenarios: int) -> str:
+    """The printed reason when the leading candidate was measured too thinly to test."""
+    return (
+        f"INSUFFICIENT EVIDENCE: the leading candidate '{leader.model}' is "
+        f"{_points(leader.mean_gain)} points over '{student}' but shares only "
+        f"{leader.n_scenarios} scored scenario(s) with it, below the {min_scenarios} this gate "
+        f"requires before it calls a {_bar(min_gap)}-point gap real or absent. Sweep more "
+        f"scenarios, then probe again."
+    )
+
+
+def _points(gain: float) -> str:
+    """A paired gain in signed reward points, the unit these results are quoted in."""
+    return f"{gain * 100:+.1f}"
+
+
+def _bar(threshold: float) -> str:
+    """A threshold in unsigned reward points."""
+    return f"{threshold * 100:.1f}"
+
+
+def _interval(row: ModelGain) -> str:
+    """A gain row's 95% interval, or why it has none."""
+    if row.ci_low is None or row.ci_high is None:
+        return "no interval: one shared scenario"
+    return f"95% CI {_points(row.ci_low)} to {_points(row.ci_high)} points"
+
+
+def _price(price: float | None, basis: PriceBasis) -> str:
+    """A ladder key rendered in the unit its basis actually means."""
+    if price is None:
+        return "no price on its pool entry"
+    if basis == "measured":
+        return f"${price:.4f} per completed task on this matrix"
+    return f"${price:.2f} per 1M tokens (list, input + output)"

--- a/wmo/optimize/teacher_test.py
+++ b/wmo/optimize/teacher_test.py
@@ -1,0 +1,397 @@
+"""Tests for the teacher-search gate.
+
+Pure offline arithmetic over synthetic outcome matrices: no provider, no judge, no spend. The two
+shapes that matter are the ones this gate was written from, tau-bench's (peer models, no gap) and
+TerminalBench-2's (+27 points, a real gap), so both are reproduced here as fixtures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.teacher import select_teacher
+from wmo.providers.base import ProviderKind, TokenUsage
+from wmo.providers.pool import PoolEntry, Tier
+
+
+def _entry(name: str, *, per_mtok: float, tier: Tier = "open") -> PoolEntry:
+    """A priced pool entry. `per_mtok` sets both rates, so the list ladder is just that number."""
+    return PoolEntry(
+        name=name,
+        kind=ProviderKind.OPENAI,
+        model=f"{name}-runtime",
+        tier=tier,
+        input_per_mtok=per_mtok,
+        output_per_mtok=per_mtok,
+    )
+
+
+def _rows(
+    model: str, rewards: Mapping[str, float | None], *, cost: float = 0.01, tokens: int = 100
+) -> list[ScenarioOutcome]:
+    """One episode per scenario for `model`; a None reward is an unscored (failed) episode."""
+    return [
+        ScenarioOutcome(
+            scenario_id=sid,
+            task=f"task for {sid}",
+            model=model,
+            reward=reward,
+            success=reward is not None and reward >= 0.5,
+            usage=TokenUsage(input_tokens=tokens, output_tokens=tokens // 2),
+            cost_usd=cost,
+            error=None if reward is not None else "sandbox timeout",
+        )
+        for sid, reward in rewards.items()
+    ]
+
+
+def _scenarios(n: int) -> list[str]:
+    return [f"s{i:02d}" for i in range(n)]
+
+
+def _flat(rewards: float, n: int) -> dict[str, float | None]:
+    return dict.fromkeys(_scenarios(n), rewards)
+
+
+def _tau_matrix() -> OutcomeMatrix:
+    """tau-bench's measured shape: the 27B is +1.6 points and K3 is well BELOW the 9B student.
+
+    (The measured K3 row was -11.7 points; this fixture puts it at -12.5, which is the same
+    verdict for the same reason and keeps the rewards to two decimals.)
+
+    Rewards alternate around each model's mean so the paired differences carry real spread, which
+    is what a matrix from a live sweep looks like and what the interval is estimated from.
+    """
+    ids = _scenarios(20)
+    student = {sid: 0.60 if i % 2 else 0.50 for i, sid in enumerate(ids)}
+    peer = {sid: student[sid] + (-0.18 if i < 6 else 0.10) for i, sid in enumerate(ids)}
+    weak = {sid: student[sid] - (0.20 if i % 2 else 0.05) for i, sid in enumerate(ids)}
+    return OutcomeMatrix(
+        pool=[
+            _entry("qwen3-9b", per_mtok=0.10),
+            _entry("qwen3.6-27b", per_mtok=1.15),
+            _entry("kimi-k3", per_mtok=9.00),
+        ],
+        outcomes=[
+            *_rows("qwen3-9b", student, cost=0.002),
+            *_rows("qwen3.6-27b", peer, cost=0.020),
+            *_rows("kimi-k3", weak, cost=0.200),
+        ],
+    )
+
+
+def _tb2_matrix(*, n: int = 12) -> OutcomeMatrix:
+    """TerminalBench-2's measured shape: a real gap over the 9B, and two models that clear it.
+
+    The 27B is +27 points at $1.15/Mtok list; K3 is +30 points at $9.00. K3 has the bigger gain
+    and the 27B keeps 90% of it, so at the default 0.8 sufficiency the cheap model is the teacher.
+    """
+    ids = _scenarios(n)
+    student = {sid: 0.20 if i % 2 else 0.24 for i, sid in enumerate(ids)}
+    teacher = {
+        sid: value + (0.30 if i % 2 else 0.24) for i, (sid, value) in enumerate(student.items())
+    }
+    frontier = {
+        sid: value + (0.34 if i % 2 else 0.26) for i, (sid, value) in enumerate(student.items())
+    }
+    return OutcomeMatrix(
+        pool=[
+            _entry("qwen3-9b", per_mtok=0.10),
+            _entry("qwen3.6-27b", per_mtok=1.15),
+            _entry("kimi-k3", per_mtok=9.00),
+        ],
+        outcomes=[
+            *_rows("qwen3-9b", student, cost=0.002),
+            *_rows("qwen3.6-27b", teacher, cost=0.020),
+            *_rows("kimi-k3", frontier, cost=0.200),
+        ],
+    )
+
+
+def test_tau_shape_finds_no_teacher_and_refuses_to_distill() -> None:
+    """The measured tau verdict: peers, not teachers, so the training run is never authorized."""
+    verdict = select_teacher(_tau_matrix())
+
+    assert verdict.decision == "do_not_distill"
+    assert verdict.student == "qwen3-9b"  # the cheapest measured model, unnamed by the caller
+    assert verdict.teacher is None
+    assert not verdict.should_distill
+    leader = verdict.gains[0]
+    assert leader.model == "qwen3.6-27b"
+    assert leader.mean_gain == pytest.approx(0.016, abs=5e-4)  # the measured +1.6 points
+    assert not leader.clears_gap
+    # K3 below the student is a NEGATIVE gain, not a missing row: the table has to show it.
+    assert verdict.gains[-1].model == "kimi-k3"
+    assert verdict.gains[-1].mean_gain < 0.0
+
+
+def test_tb2_shape_distills_and_picks_the_cheapest_sufficient_teacher() -> None:
+    """The measured TB2 verdict: a gap exists, and the $1.15 model teaches it, not the $9.00 one."""
+    verdict = select_teacher(_tb2_matrix())
+
+    assert verdict.decision == "distill"
+    assert verdict.student == "qwen3-9b"
+    assert verdict.teacher == "qwen3.6-27b"
+    assert [row.model for row in verdict.gains] == ["kimi-k3", "qwen3.6-27b"]
+    best, chosen = verdict.gains[0], verdict.gains[1]
+    assert best.model == "kimi-k3"  # the biggest gain is NOT the teacher
+    assert best.clears_gap and chosen.clears_gap
+    assert chosen.mean_gain == pytest.approx(0.27)
+
+
+def test_a_bigger_gain_wins_when_the_cheap_model_falls_below_sufficiency() -> None:
+    """Sufficiency is a real bar: a cheap model that keeps too little of the gain is not enough."""
+    verdict = select_teacher(_tb2_matrix(), sufficiency=0.95)
+
+    assert verdict.decision == "distill"
+    assert verdict.teacher == "kimi-k3"  # 0.27 / 0.30 = 90%, under the 95% asked for
+
+
+def test_a_gain_whose_interval_includes_zero_is_not_a_gap() -> None:
+    """A large point gain over wildly inconsistent scenarios does not authorize spending."""
+    ids = _scenarios(10)
+    student = _flat(0.40, 10)
+    noisy = {sid: (1.00 if i % 2 else 0.10) for i, sid in enumerate(ids)}
+    matrix = OutcomeMatrix(
+        pool=[_entry("small", per_mtok=0.10), _entry("erratic", per_mtok=1.15)],
+        outcomes=[*_rows("small", student), *_rows("erratic", noisy)],
+    )
+
+    verdict = select_teacher(matrix)
+
+    row = verdict.gains[0]
+    assert row.mean_gain == pytest.approx(0.15)  # a point gain half again over the bar
+    assert row.ci_low is not None and row.ci_high is not None
+    assert row.ci_low < 0.0 < row.ci_high
+    assert not row.clears_gap
+    assert verdict.decision == "do_not_distill"
+    assert "interval includes zero" in verdict.reason
+
+
+def test_a_thin_matrix_says_insufficient_rather_than_yes() -> None:
+    """Three scenarios cannot authorize a training run, however large the apparent gain."""
+    verdict = select_teacher(_tb2_matrix(n=3))
+
+    assert verdict.decision == "insufficient_evidence"
+    assert verdict.teacher is None
+    assert "below the 8 this gate requires" in verdict.reason
+    assert verdict.gains[0].n_scenarios == 3
+
+
+def test_a_thin_matrix_is_still_decidable_when_the_caller_lowers_the_bar() -> None:
+    """`min_scenarios` is the caller's, so a deliberately small probe can still return a verdict."""
+    verdict = select_teacher(_tb2_matrix(n=3), min_scenarios=3)
+
+    assert verdict.decision == "distill"
+    assert verdict.teacher == "qwen3.6-27b"
+
+
+def test_no_shared_scenario_is_insufficient_evidence() -> None:
+    """Two models measured on disjoint scenarios were never compared, whatever their means say."""
+    matrix = OutcomeMatrix(
+        pool=[_entry("small", per_mtok=0.10), _entry("big", per_mtok=1.15)],
+        outcomes=[
+            *_rows("small", dict.fromkeys(_scenarios(4), 0.2)),
+            *_rows("big", {f"other-{i}": 0.9 for i in range(4)}),
+        ],
+    )
+
+    verdict = select_teacher(matrix)
+
+    assert verdict.decision == "insufficient_evidence"
+    assert verdict.gains == []
+    assert verdict.unmeasured_models == ["big"]
+    assert "shares a scored scenario" in verdict.reason
+
+
+def test_unscored_episodes_are_excluded_from_both_sides() -> None:
+    """An infrastructure failure is not a reward of 0, so it narrows the pairing instead."""
+    ids = _scenarios(10)
+    student = _flat(0.30, 10)
+    teacher: dict[str, float | None] = {sid: (None if i < 3 else 0.90) for i, sid in enumerate(ids)}
+    matrix = OutcomeMatrix(
+        pool=[_entry("small", per_mtok=0.10), _entry("big", per_mtok=1.15)],
+        outcomes=[*_rows("small", student), *_rows("big", teacher)],
+    )
+
+    verdict = select_teacher(matrix)
+
+    row = verdict.gains[0]
+    assert row.n_scenarios == 7  # the three unscored episodes are not zeros
+    assert row.mean_gain == pytest.approx(0.60)
+    assert row.student_mean_reward == pytest.approx(0.30)
+    assert verdict.n_scenarios == 10  # the student itself was scored on all ten
+
+
+def test_unpriced_rows_fall_back_to_the_list_price_ladder() -> None:
+    """A matrix whose episodes recorded $0 still has a ladder: the pool's published prices."""
+    ids = _scenarios(10)
+    student = _flat(0.20, 10)
+    cheap = {sid: 0.60 for sid in ids}
+    dear = {sid: 0.62 for sid in ids}
+    matrix = OutcomeMatrix(
+        pool=[
+            _entry("self-hosted-small", per_mtok=0.10),
+            _entry("cheap-teacher", per_mtok=1.15),
+            _entry("dear-teacher", per_mtok=9.00),
+        ],
+        outcomes=[
+            *_rows("self-hosted-small", student, cost=0.0),
+            *_rows("cheap-teacher", cheap, cost=0.0),
+            *_rows("dear-teacher", dear, cost=0.0),
+        ],
+    )
+
+    verdict = select_teacher(matrix)
+
+    assert verdict.price_basis == "list"
+    assert verdict.student == "self-hosted-small"
+    assert verdict.teacher == "cheap-teacher"  # 0.40 keeps 97% of the 0.42 best gain
+    assert verdict.gains[0].price == pytest.approx(18.0)  # the $9.00/$9.00 entry, summed
+
+
+def test_the_measured_ladder_is_used_when_every_model_completed_paid_tasks() -> None:
+    """With real spend and real completions on the rows, the ladder is dollars per completed task.
+
+    Note what that requires, and why the TB2 fixture above does NOT get there: cost per completed
+    task is undefined for a model that completed nothing, so a workload the student fails outright
+    is priced from the pool's list rates instead.
+    """
+    ids = _scenarios(10)
+    matrix = OutcomeMatrix(
+        pool=[
+            # List order would put `dear-per-mtok` last; its measured cost per completed task
+            # puts it second, so this also pins WHICH ladder decided the teacher.
+            _entry("small", per_mtok=0.10),
+            _entry("dear-per-mtok", per_mtok=9.00),
+            _entry("cheap-per-mtok", per_mtok=1.15),
+        ],
+        outcomes=[
+            *_rows("small", dict.fromkeys(ids, 0.55), cost=0.002),
+            *_rows("dear-per-mtok", dict.fromkeys(ids, 0.95), cost=0.010),
+            *_rows("cheap-per-mtok", dict.fromkeys(ids, 0.94), cost=0.050),
+        ],
+    )
+
+    verdict = select_teacher(matrix)
+
+    assert verdict.price_basis == "measured"
+    assert verdict.student == "small"
+    assert verdict.teacher == "dear-per-mtok"  # $0.010 a completed task against $0.050
+    chosen = next(row for row in verdict.gains if row.model == verdict.teacher)
+    assert chosen.price == pytest.approx(0.010)
+
+
+def test_an_open_teacher_is_preferred_over_a_cheaper_frontier_one() -> None:
+    """The existence proof may be frontier; the model trained ON should be one you may train on."""
+    ids = _scenarios(10)
+    student = _flat(0.20, 10)
+    matrix = OutcomeMatrix(
+        pool=[
+            _entry("small", per_mtok=0.10),
+            _entry("frontier-cheap", per_mtok=1.00, tier="frontier"),
+            _entry("open-dearer", per_mtok=2.00, tier="open"),
+        ],
+        outcomes=[
+            *_rows("small", student, cost=0.002),
+            *_rows("frontier-cheap", dict.fromkeys(ids, 0.60), cost=0.010),
+            *_rows("open-dearer", dict.fromkeys(ids, 0.58), cost=0.020),
+        ],
+    )
+
+    verdict = select_teacher(matrix)
+
+    assert verdict.decision == "distill"
+    assert verdict.teacher == "open-dearer"  # dearer, but 0.38 keeps 95% of the 0.40 best gain
+    assert "open weights" in verdict.reason
+
+
+def test_a_frontier_teacher_is_chosen_when_no_open_model_is_sufficient() -> None:
+    """And the reason says so, so the licensing question lands before the training spend."""
+    ids = _scenarios(10)
+    student = _flat(0.20, 10)
+    matrix = OutcomeMatrix(
+        pool=[
+            _entry("small", per_mtok=0.10),
+            _entry("frontier-strong", per_mtok=9.00, tier="frontier"),
+            _entry("open-weak", per_mtok=1.00, tier="open"),
+        ],
+        outcomes=[
+            *_rows("small", student, cost=0.002),
+            *_rows("frontier-strong", dict.fromkeys(ids, 0.90), cost=0.200),
+            *_rows("open-weak", dict.fromkeys(ids, 0.35), cost=0.010),
+        ],
+    )
+
+    verdict = select_teacher(matrix)
+
+    assert verdict.teacher == "frontier-strong"  # open-weak keeps 21% of the gain, under 80%
+    assert "check that provider's terms" in verdict.reason
+
+
+def test_the_student_can_be_named_when_the_cheapest_model_is_not_the_one_being_trained() -> None:
+    """A distillation trains a specific model; the default is a convenience, not a constraint."""
+    verdict = select_teacher(_tb2_matrix(), student="qwen3.6-27b")
+
+    assert verdict.student == "qwen3.6-27b"
+    assert verdict.decision == "do_not_distill"  # K3 is only +3 points over the 27B
+    assert [row.model for row in verdict.gains] == ["kimi-k3", "qwen3-9b"]
+
+
+def test_naming_a_model_the_matrix_never_scored_says_which_ones_it_did() -> None:
+    matrix = _tb2_matrix()
+    with pytest.raises(ValueError, match="no pool model named 'ghost'"):
+        select_teacher(matrix, student="ghost")
+
+
+def test_a_matrix_with_one_measured_model_cannot_be_probed() -> None:
+    """A gap is a comparison: refuse rather than report 'no teacher' from a pool of one."""
+    matrix = OutcomeMatrix(
+        pool=[_entry("small", per_mtok=0.10), _entry("big", per_mtok=1.15)],
+        outcomes=[
+            *_rows("small", _flat(0.3, 4)),
+            *_rows("big", dict.fromkeys(_scenarios(4), None)),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="at least two models with scored episodes"):
+        select_teacher(matrix)
+
+
+def test_thresholds_that_would_make_the_verdict_meaningless_are_rejected() -> None:
+    matrix = _tb2_matrix()
+    with pytest.raises(ValueError, match="min_gap must be a positive fraction"):
+        select_teacher(matrix, min_gap=0.0)
+    with pytest.raises(ValueError, match="min_scenarios must be at least 2"):
+        select_teacher(matrix, min_scenarios=1)
+    with pytest.raises(ValueError, match="sufficiency must be in"):
+        select_teacher(matrix, sufficiency=1.5)
+
+
+def test_the_do_not_distill_reason_reads_as_product_copy() -> None:
+    """The reason string is printed verbatim by the CLI and by the orchestrator, so pin it."""
+    verdict = select_teacher(_tau_matrix())
+
+    assert verdict.reason == (
+        "DO NOT DISTILL: no model in this matrix beats 'qwen3-9b' by the 10.0 points this gate "
+        "requires. The best is 'qwen3.6-27b' at +1.6 points on 20 shared scenarios (95% CI -4.2 "
+        "to +7.4 points). 'qwen3-9b' already serves this workload and earns its traffic on "
+        "price, so training has no teacher to learn from and this stage skips with zero spend."
+    )
+
+
+def test_the_distill_reason_names_the_gap_the_teacher_and_the_price() -> None:
+    verdict = select_teacher(_tb2_matrix())
+
+    assert verdict.reason == (
+        "DISTILL: 'kimi-k3' beats 'qwen3-9b' by +30.0 points on 12 shared scenarios (95% CI "
+        "+27.6 to +32.4 points), clearing the 10.0-point bar this gate requires, so there is "
+        "something to teach. The cheapest sufficient teacher is 'qwen3.6-27b' at $2.30 per 1M "
+        "tokens (list, input + output), keeping 90% of the best measured gain (the bar is 80%). "
+        "It is open weights, which is the tier this gate prefers for a data teacher: a frontier "
+        "model can prove the gap exists, but you have to be allowed to train on what the teacher "
+        "writes."
+    )


### PR DESCRIPTION
The distillation go/no-go stops being a judgement call and becomes a function over data the
pipeline already buys. The routing sweep measures every pool model on the customer's own held-out
scenarios, so its `OutcomeMatrix` already contains the answer to "is there a bigger model that is
materially better here, and what would it cost to teach with". `wmo.optimize.teacher` reads it.

```bash
wmo optimize distill probe .wmo/models/tau-bench/optimize/matrix.json
```

```
   Teacher search against 'qwen3-9b' (20 scored scenarios, /tmp/tg/tau.json)
┏━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━┓
┃ Model       ┃ Tier     ┃  n ┃ Reward ┃   Gain in points (95% ┃ $/Mtok ┃ Gap? ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━┩
│ qwen3.6-27b │ open     │ 20 │  0.584 │   +1.6 (+1.6 to +1.6) │   2.30 │ no   │
│ kimi-k3     │ frontier │ 20 │  0.451 │       -11.7 (-11.7 to │  18.00 │ no   │
│             │          │    │        │                -11.7) │        │      │
└─────────────┴──────────┴────┴────────┴───────────────────────┴────────┴──────┘
do_not_distill DO NOT DISTILL: no model in this matrix beats 'qwen3-9b' by the
10.0 points this gate requires. ... 'qwen3-9b' already serves this workload and
earns its traffic on price, so training has no teacher to learn from and this
stage skips with zero spend.
```

Exit 3. That is tau's real verdict, and it is the one that saves the money.

## The two steps

1. **Existence.** Take the cheapest measured model as the candidate student; ask whether any
   other model beats it by `min_gap` (default 10 reward points), paired per scenario. No gap
   means no teacher, and the cheap model keeps earning its traffic on price.
2. **Cheapest sufficient teacher.** When the gap exists, walk the price ladder upward and take
   the cheapest model that still keeps `sufficiency` (default 80%) of the best measured gain.

Both measured shapes reproduce as tests. tau: the 27B is +1.6 points over the 9B and K3 is below
both, so `do_not_distill`. TB2: +27 points, so `distill`, and the teacher is the $1.15/Mtok 27B
rather than the $9.00 K3 that gained three points more.

## Semantics chosen where the spec was silent

- **Open tier outranks price, not merely ties.** A frontier model may be the existence proof, but
  a data teacher is trained ON, so a sufficient open-weights candidate wins even when a frontier
  one is cheaper. When none is sufficient the teacher is frontier and the reason says to check
  that provider's terms.
- **One price ladder, one unit.** Measured cost per completed task when every model has one;
  otherwise the pool's list price (input + output per Mtok) for the whole ladder. Mixing dollars
  per completed task with dollars per Mtok could rank a genuinely cheaper model above a dearer
  one. A measured $0.0000 counts as missing, not free. Note the consequence: a TB2-shaped
  workload the student fails outright has no cost per completed task, so it prices from the list.
- **`insufficient_evidence` has two triggers**, both places where "no" would be dishonest:
  nothing shares a scored scenario with the student, or the LEADING candidate was measured on
  fewer than `min_scenarios`. A matrix cannot say "no gap" about a model it barely measured.
- **A CI that includes zero is `do_not_distill`, with the caveat printed** rather than a fourth
  decision state: the reason says the point gain clears the bar but the interval does not, so
  more scenarios would settle it.
- **Student price ties break toward the BETTER model.** That is the conservative direction: the
  better of two equally cheap students makes the gap harder to prove, so a tie can never resolve
  into a training run a different tie-break would have refused.
- **n < 2 shared scenarios has no interval at all** (`None`, not a zero-width one) and can never
  clear the gap.

## Justification ledger

| Change | Named consumer |
| --- | --- |
| `wmo/optimize/teacher.py` | Silen's directive, DECISIONS 2026-07-27 "THE TEACHER-SEARCH GATE IS REPO CODE": "DISPATCHED: wmo.optimize.teacher (new module): select_teacher(matrix, pool) -> TeacherSearchVerdict ... Every lane: consume this function when it lands; never reimplement the gate." |
| `wmo optimize distill probe` | The same directive's "exposed standalone (`wmo optimize distill probe <matrix>`) so any consumer - product or chat - reads the same function"; the tb2-cost corner chat and the training chat's ladder probe, which this replaces for every model the matrix already covers |
| The `--distill` refusal carrying the verdict | The orchestrator distill stage's future wiring: the directive's "the plan table's distill row shows the verdict BEFORE consent". The stage stays unwired; only its preflight speaks today |
| Docs rows | `docs/usage.md` command table, cookbook step 4, and the distill reference's new "is there a teacher at all?" section |

## Verification

Driven live on real matrices on disk, not only through tests: the tau shape exits 3 with the
no-gap reason, the TB2 shape exits 0 naming the 27B as teacher, and the `--distill` refusal
quotes the verdict for a matrix under `<model>/optimize/`. Zero LLM spend anywhere (every fixture
is synthetic).

The table lost three columns during that drive: at nine columns an 80-column terminal truncated
every cell to an ellipsis, so the gain and its interval now share one cell and the student's own
reward moved into the title.

## Merge gate

`uv run ruff check .` clean, `uv run ruff format --check .` clean (539 files), `uv run ty check`
clean, `uv run pytest -q` 4175 passed / 19 skipped. `/ready-for-merge` has NOT been run yet; not
merging.
