### PR TITLE
Run sweep cells concurrently, persist each one as it completes, and resume the rest

### DIFF
--- a/docs/cookbook/tau-bench.md
+++ b/docs/cookbook/tau-bench.md
@@ -284,6 +284,20 @@ sweep (never completed here)
 Those per-cell dollar figures are candidate-side only. A cell can come back `reward=unscored`
 when its episode or its scoring failed, and both fitters skip unscored rows.
 
+Cells run one at a time by default. `--concurrency N` runs N of them at once, which is what turns
+a several-hour grid into a run you watch finish; it changes nothing about what a cell measures, so
+the matrix is the same evidence either way. The real ceiling is your provider's rate limits, and
+the world model's own serve and judge calls all come out of one account's bucket, so a number
+past what that bucket allows buys throttling errors rather than speed.
+
+Nothing measured is lost and nothing measured is bought twice. Each cell is appended to
+`matrix.json.partial.jsonl` the moment it completes, so a sweep killed at hour five keeps every
+cell it paid for; the next run measures only what is missing, then writes the matrix and removes
+the sidecar. Change what the sweep measures (the pool, the scenario cut, episodes, the step
+budget, the observation window, the compressor) and those rows are a different arm: the command
+says which pin moved and stops, before the spend question, rather than merging two arms into one
+matrix. Resuming at a different `--concurrency` is fine, because pace is not evidence.
+
 Fit-readiness is a coverage contract, not a nonzero count: every candidate must have the same
 number of scored episodes on the same scenarios, or the policy ends up decided by whichever cells
 each candidate happened to lose. Per-candidate scored counts always print. When the evidence
@@ -343,6 +357,9 @@ instance a cost delta against an anchor whose episodes measured $0.
     └── optimize-run.json       the resume manifest
 ```
 
+A sweep in flight (or one that died mid-flight) also leaves `matrix.json.partial.jsonl` beside the
+matrix: the cells measured so far, one JSON line each. It is removed when the matrix is written.
+
 Serving artifacts stay where serving already looks for them. `optimize/` holds only the staged
 run's own bookkeeping and is disposable: deleting it resets resume and breaks no serving path.
 
@@ -356,6 +373,9 @@ halfway resumes at the stage that stopped it.
 uv run wmo optimize model tau-bench                    # resumes; skipped stages say why
 uv run wmo optimize model tau-bench --force-from sweep  # buy fresh cells anyway
 ```
+
+Inside the sweep, resume is per CELL: a stage that never completed still keeps the cells it paid
+for, and the plan table's sweep row says how many are already measured and how many are left.
 
 `--force-from` takes `sweep | fit | tune | report` and redoes that stage and everything after it.
 

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -104,6 +104,7 @@ from wmo.optimize.sweep import (
     execute_sweep,
     plan_sweep,
     resolve_config,
+    resumable_cells,
 )
 from wmo.optimize.sweep import preflight_pool as run_preflight
 from wmo.providers.pool import DEFAULT_POOL_PATH
@@ -159,6 +160,16 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
     ),
     max_steps: int = typer.Option(
         DEFAULT_MAX_STEPS, "--max-steps", min=1, help="Step budget per episode."
+    ),
+    concurrency: int = typer.Option(
+        1,
+        "--concurrency",
+        min=1,
+        help="Cells the sweep measures at once (1 = one at a time). Changes only how long the "
+        "sweep takes, never what it measures, so it is not part of what decides whether the "
+        "sweep stage can be skipped. Your PROVIDER LIMITS are the real ceiling: every candidate "
+        "call and every world-model serve and judge call is a request, and the world model's own "
+        "calls all come out of ONE account's bucket.",
     ),
     cost_quality: float = typer.Option(
         COST_QUALITY_BALANCED,
@@ -257,6 +268,11 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         wmo optimize model support                 # resumes; unchanged stages say why they skipped
         wmo optimize model support --force-from sweep   # buy fresh cells anyway
         wmo optimize model support --yes --max-usd 25   # scripted, with a hard spend cap
+        wmo optimize model support --concurrency 6      # six cells at once, same evidence
+
+    Resume is per CELL inside the sweep, not just per stage: a sweep that died at hour five keeps
+    every cell it paid for (in `<matrix>.partial.jsonl`) and the next run measures only what is
+    missing, so an interrupted grid never gets bought twice.
 
     `--compressor` measures and fits a compressed arm end to end, which is the same thing a
     `route sweep --compressor` plus `route fit --compressor` pair does by hand:
@@ -336,7 +352,11 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             assume_input_tokens=ASSUMED_INPUT_TOKENS,
             assume_output_tokens=ASSUMED_OUTPUT_TOKENS,
             compression=compression,
+            max_concurrency=concurrency,
         )
+        # Read before the plan table so the sweep row can say how much of the grid a previous
+        # attempt already bought, and so a sidecar from a different plan is refused for free.
+        already_measured = resumable_cells(plan)
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
     print_tiny_corpus_note(_console, plan)
@@ -386,6 +406,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         compression=compression,
         projection=projection,
         paths=paths,
+        already_measured=already_measured,
     )
     # After the plan, before any consent or spend question: the whole point of a dry run is
     # reading the table above without committing to anything, so it exits here even when the
@@ -436,6 +457,7 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
             baseline=baseline,
             cost_quality=cost_quality,
             allow_uneven_coverage=allow_uneven_coverage,
+            already_measured=already_measured,
         )
     except BudgetExceeded as exc:
         _print_budget_stop(model_dir.name, exc)
@@ -784,16 +806,26 @@ def _stage_plan_text(
     cost_quality: float,
     fallback: str | None,
     anchor: str,
+    already_measured: int = 0,
 ) -> str:
     """One line saying what this stage will actually do, in the operator's terms."""
     match stage:
         case Stage.PREFLIGHT:
             return f"resolve {len(plan.pool.models)} backend(s), check prices"
         case Stage.SWEEP:
-            return (
+            grid = (
                 f"{len(plan.pool.models)} candidate(s) x {len(plan.scenarios)} scenario(s) "
                 f"x {plan.episodes} episode(s)"
             )
+            pace = f", {plan.max_concurrency} at a time" if plan.max_concurrency > 1 else ""
+            # A resumed sweep is not the grid it prints: saying so here is what stops the row
+            # from reading as a bill for cells the last attempt already paid for.
+            resumed = (
+                f"; {already_measured} already measured, {plan.cells - already_measured} to buy"
+                if already_measured
+                else ""
+            )
+            return f"{grid}{pace}{resumed}"
         case Stage.COMPACT:
             # Says what it IS rather than implying a step: the arm plus the two stages it sets up.
             return f"{escape(compression_signature(compression))}, configures sweep and fit"
@@ -839,6 +871,7 @@ def _print_plan(
     compression: CompressionConfig | None,
     projection: SweepSpendProjection,
     paths: _RunPaths,
+    already_measured: int = 0,
 ) -> None:
     """The whole run in one table, printed before anything spends.
 
@@ -877,6 +910,7 @@ def _print_plan(
                 cost_quality=cost_quality,
                 fallback=fallback,
                 anchor=anchor,
+                already_measured=already_measured,
             ),
             _estimate_text(decision.stage, plan=plan, embedder=embedder, paths=paths),
             _status_text(decision),
@@ -1038,6 +1072,7 @@ def _run_stages(
     baseline: str | None,
     cost_quality: float,
     allow_uneven_coverage: bool,
+    already_measured: int = 0,
 ) -> RunManifest:
     """Walk the plan, running what it said would run and recording each stage as it completes.
 
@@ -1059,7 +1094,12 @@ def _run_stages(
         match decision.stage:
             case Stage.SWEEP:
                 ledger.check(Stage.SWEEP, projection.total_usd, basis=projection.basis)
-                record = _stage_sweep(plan, model_dir=model_dir, pool_file=pool_file)
+                record = _stage_sweep(
+                    plan,
+                    model_dir=model_dir,
+                    pool_file=pool_file,
+                    already_measured=already_measured,
+                )
                 ledger.record(record.total_spend_usd)
             case Stage.COMPACT:
                 record = _stage_compact(compression)
@@ -1086,7 +1126,9 @@ def _now() -> str:
     return datetime.now(tz=UTC).isoformat()
 
 
-def _stage_sweep(plan: SweepPlan, *, model_dir: Path, pool_file: Path) -> StageRecord:
+def _stage_sweep(
+    plan: SweepPlan, *, model_dir: Path, pool_file: Path, already_measured: int = 0
+) -> StageRecord:
     """Measure every candidate closed-loop and record what it cost.
 
     Deliberately does NOT judge the evidence it produced. The coverage contract that withholds a
@@ -1104,7 +1146,7 @@ def _stage_sweep(plan: SweepPlan, *, model_dir: Path, pool_file: Path) -> StageR
         plan,
         world_model=world_model,
         env_factory=lambda: WorldModelEnv(world_model, score_on_close=True),
-        on_outcome=cell_progress(_console, plan.cells),
+        on_outcome=cell_progress(_console, plan.cells - already_measured),
     )
     matrix = run.matrix
     scored = sum(1 for outcome in matrix.outcomes if outcome.scored)

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -23,9 +23,10 @@ from wmo.cli.app import app
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
 from wmo.engine.world_model import WorldModel
+from wmo.env.closed_loop import scenario_id
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.compression import CompressionConfig
-from wmo.optimize.outcomes import OutcomeMatrix
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.pipeline import (
     MANIFEST_FILENAME,
     MATRIX_FILENAME,
@@ -42,6 +43,8 @@ from wmo.optimize.policy import (
 )
 from wmo.optimize.report import ImprovementReport
 from wmo.optimize.reward import EpisodeScore
+from wmo.optimize.sweep import SweepPlan, plan_sweep, resolve_config
+from wmo.optimize.sweep_partial import PartialHeader
 from wmo.providers.base import (
     Completion,
     Message,
@@ -51,6 +54,7 @@ from wmo.providers.base import (
     TokenUsage,
     VerifyResult,
 )
+from wmo.providers.pool import load_pool
 from wmo.serving.traces_source import TRACES_FILENAME
 from wmo.tracking import Phase, RunRecord, UsageTotals, load_runs
 
@@ -601,6 +605,56 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     assert _says(result.output, "cost_quality 0.25 (Balanced (default))")
     assert "aprojection" in flat and "assumedoutputtoken" in flat
     assert _says(result.output, "are NOT in that figure")
+
+
+def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two things an operator authorizing a run needs to see: how hard it will lean on the
+    provider, and how much of the grid a previous attempt already paid for."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    monkeypatch.setattr(optimize_module, "Confirm", _Answer(False))
+    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    paced = _run(tmp_path, root, "--concurrency", "6")
+    assert "2candidate(s)x3scenario(s)x1episode(s),6atatime" in _flat(paced.output)
+
+    # A sidecar from an interrupted attempt at THIS plan: the row says what is left to buy.
+    matrix_path = _paths(root)[0]
+    matrix_path.parent.mkdir(parents=True, exist_ok=True)
+    plan = _sweep_plan(tmp_path, root)
+    sidecar = matrix_path.with_name(matrix_path.name + ".partial.jsonl")
+    sidecar.write_text(
+        PartialHeader(identity=plan.identity).model_dump_json()
+        + "\n"
+        + ScenarioOutcome(
+            scenario_id=scenario_id(plan.scenarios[0]),
+            task=plan.scenarios[0].task,
+            model="cheap",
+            reward=0.5,
+        ).model_dump_json()
+        + "\n",
+        encoding="utf-8",
+    )
+    resumed = _run(tmp_path, root)
+    assert "1alreadymeasured,5tobuy" in _flat(resumed.output)
+
+
+def _sweep_plan(tmp_path: Path, root: Path) -> SweepPlan:
+    """The plan `_run` builds, so a test can stamp a sidecar with the same identity."""
+    model_dir = root / "models" / "support"
+    return plan_sweep(
+        model_dir=model_dir,
+        config=resolve_config(model_dir),
+        pool=load_pool(_pool_file(tmp_path)),
+        out_path=_paths(root)[0],
+        traces_file=None,
+        scenarios=3,
+        episodes=1,
+        max_steps=4,
+        assume_input_tokens=2000,
+        assume_output_tokens=250,
+    )
 
 
 def test_an_unscored_sweep_withholds_the_fit_and_keeps_the_matrix(

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -78,6 +78,7 @@ from wmo.optimize.sweep import (
     plan_sweep,
     preflight_pool,
     resolve_config,
+    resumable_cells,
     unevenness,
 )
 from wmo.providers.pool import (
@@ -132,6 +133,17 @@ def sweep(
     ),
     max_steps: int = typer.Option(
         20, "--max-steps", min=1, help="Step budget per episode (also the cost estimate's cap)."
+    ),
+    concurrency: int = typer.Option(
+        1,
+        "--concurrency",
+        min=1,
+        help="Cells measured at once (1 = one at a time). Changes only how long the sweep takes, "
+        "never what it measures, and a sweep interrupted at one value resumes at another. Your "
+        "PROVIDER LIMITS are the real ceiling, not this number: every candidate call and every "
+        "world-model serve and judge call is a request, and the world model's own calls all come "
+        "out of ONE account's bucket, so raising this past what that bucket allows turns cells "
+        "into throttling errors instead of results.",
     ),
     history_chars: int = typer.Option(
         DEFAULT_HISTORY_CHARS,
@@ -204,6 +216,16 @@ def sweep(
     traces can appear on both sides. The whole sweep runs the world model frozen, so no cell's
     predictions become another cell's retrieved demos and the result does not depend on sweep
     order.
+
+    Nothing measured is lost, and nothing measured is bought twice. Every cell lands in
+    `<out>.partial.jsonl` the moment it completes, so a sweep killed at hour five keeps the cells
+    it paid for; re-running the same command measures only what is missing and then writes the
+    matrix and removes the sidecar. Changing what the sweep measures (the pool, the scenario cut,
+    episodes, the step budget, the observation window, the compressor) makes those rows a
+    different arm, and the command says so and stops rather than merging two arms into one matrix.
+    `--concurrency N` runs N cells at once, which is the difference between a six-hour grid and a
+    one-hour grid; it is not part of what the sweep measures, so a run interrupted at one value
+    resumes at another.
 
     Spend is confirmed before the first episode runs (`--yes` skips, as in
     `wmo optimize harness --mode distill`). What that estimate multiplies is ASSUMED tokens per
@@ -289,13 +311,20 @@ def sweep(
             assume_output_tokens=assume_output_tokens,
             history_chars=history_chars,
             compression=sweep_compression,
+            max_concurrency=concurrency,
         )
     except SweepError as exc:
         raise typer.BadParameter(str(exc)) from exc
     print_tiny_corpus_note(_console, plan)
+    try:
+        # Before the money question, not after it: a sidecar left by a run of a DIFFERENT plan is
+        # refused here, while refusing still costs nothing.
+        already_measured = resumable_cells(plan)
+    except SweepError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     world_model, _serve_provider = load_world_model(model_dir)
 
-    print_cost_estimate(_console, plan)
+    print_cost_estimate(_console, plan, already_measured=already_measured)
     _confirm_cost(yes=yes)
 
     _console.print(
@@ -306,7 +335,7 @@ def sweep(
         plan,
         world_model=world_model,
         env_factory=lambda: WorldModelEnv(world_model, score_on_close=True),
-        on_outcome=cell_progress(_console, plan.cells),
+        on_outcome=cell_progress(_console, plan.cells - already_measured),
     )
     matrix = run.matrix
     scored = sum(1 for outcome in matrix.outcomes if outcome.scored)
@@ -519,13 +548,17 @@ def print_coverage(console: Console, rows: list[CandidateCoverage]) -> None:
             )
 
 
-def print_cost_estimate(console: Console, plan: SweepPlan) -> None:
+def print_cost_estimate(console: Console, plan: SweepPlan, *, already_measured: int = 0) -> None:
     """Render the projected spend, stating exactly which parts are assumed.
 
     Honest by construction: the CELL and CALL counts are real (the step budget is the per-episode
     cap, so calls are an upper bound), the tokens per call are an assumption the flags name, and
     the per-candidate $/Mtok is the pool entry's own price row. The world model's serve and judge
     calls are a separate meter (the D12 cost split) and are deliberately absent.
+
+    `already_measured` is the count a resume will reuse instead of buying. The table above it is
+    still the whole grid, because that is what the per-candidate arithmetic describes; the line
+    under it says how much of that grid this run is actually paying for.
     """
     table = Table(title="Route sweep cost estimate (ASSUMED tokens, not a measurement)")
     table.add_column("Candidate", no_wrap=True)
@@ -552,6 +585,17 @@ def print_cost_estimate(console: Console, plan: SweepPlan) -> None:
         f"{len(plan.scenarios)} held-out scenario(s) x {plan.episodes} episode(s); estimated "
         f"total ${plan.total_usd:.2f}"
     )
+    if already_measured:
+        console.print(
+            f"  RESUMING: {already_measured} of those cell(s) are already measured beside the "
+            f"matrix and are NOT bought again, so this run measures {plan.cells - already_measured}"
+            " and spends proportionally less than the total above."
+        )
+    if plan.max_concurrency > 1:
+        console.print(
+            f"  {plan.max_concurrency} cell(s) run at once, so the sweep finishes sooner for the "
+            "same money; it does not change what is measured."
+        )
     console.print(
         f"  ASSUMPTION: {plan.assume_input_tokens:,} input + {plan.assume_output_tokens:,} output "
         f"token(s) per policy call, and every episode running its full {plan.max_steps}-call "

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import importlib
+import itertools
 import json
 import os
 from collections import Counter
@@ -21,6 +22,7 @@ from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Session, Step, Trace
 from wmo.distill.store import DistillModelCard
 from wmo.engine.world_model import WorldModel
+from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.compression import (
     CompressionConfig,
@@ -33,6 +35,7 @@ from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
 from wmo.optimize.policy import POLICY_FILENAME, RoutingPolicy, select_model
 from wmo.optimize.reward import EpisodeScore
 from wmo.optimize.routing import evaluate_policy
+from wmo.optimize.sweep_partial import PartialHeader, PlanIdentity
 from wmo.providers import pool as pool_module
 from wmo.providers.base import (
     Completion,
@@ -1398,6 +1401,104 @@ def test_route_sweep_scores_every_episode_through_a_scoring_env(
     # Every episode ran with index enrichment suspended, so no candidate's predictions can
     # become the next candidate's retrieved demos (which would make scores sweep-order dependent).
     assert seams.world_model.opened_frozen == [True] * 4
+
+
+def test_route_sweep_at_higher_concurrency_writes_the_same_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `--concurrency` is a speed knob the operator can see in the plan, not a change of evidence:
+    # the same cells, the same rows, in the same order.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, result = _sweep(
+        tmp_path, root, "support", "--scenarios", "3", "--concurrency", "4", "--yes"
+    )
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "4 cell(s) run at once")
+    matrix = OutcomeMatrix.load(out)
+    assert [(o.model, o.scenario_id) for o in matrix.outcomes] == [
+        (model, sid) for model in ("cheap", "pricey") for sid in _HELD_OUT_IDS[:3]
+    ]
+    assert all(o.scored for o in matrix.outcomes)
+
+
+def test_route_sweep_resumes_the_cells_an_interrupted_run_already_bought(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A grid killed mid-flight is finished, not repeated: the filed gap, end to end.
+
+    The first attempt dies inside its fourth cell. The rows it completed are on disk beside the
+    matrix, so the second attempt measures only what is missing and the matrix it writes is the
+    whole grid.
+    """
+    seams = _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    real_env = route_module.WorldModelEnv
+    cells = itertools.count(1)
+
+    class _DiesOnTheFourthCell:
+        def __init__(self, world_model: object, *, score_on_close: bool = False) -> None:
+            self._inner = real_env(cast("WorldModel", world_model), score_on_close=score_on_close)
+            self._n = next(cells)
+
+        def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
+            if self._n == 4:
+                raise RuntimeError("simulated transport fault")
+            return self._inner.reset(task=task, seed_state=seed_state)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._inner, name)
+
+    monkeypatch.setattr(route_module, "WorldModelEnv", _DiesOnTheFourthCell)
+    out, first = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert first.exit_code != 0
+    assert not out.exists()  # no matrix: the sweep never finished
+    sidecar = out.with_name(out.name + ".partial.jsonl")
+    assert len(sidecar.read_text(encoding="utf-8").splitlines()) == 4  # header + 3 paid cells
+
+    monkeypatch.setattr(route_module, "WorldModelEnv", real_env)
+    scored_before = len(seams.world_model.scored)
+    _, second = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert second.exit_code == 0, second.output
+    assert _says(second.output, "RESUMING: 3 of those cell(s) are already measured")
+    assert len(seams.world_model.scored) - scored_before == 3  # only the missing cells ran
+    assert len(OutcomeMatrix.load(out).outcomes) == 6
+    assert not sidecar.exists()
+
+
+def test_route_sweep_refuses_a_sidecar_that_belongs_to_a_different_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Refused BEFORE the spend question, naming the pin that moved: two arms in one matrix is a
+    # comparison nobody measured.
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path, traces=_corpus())
+    out, _first = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    sidecar = out.with_name(out.name + ".partial.jsonl")
+    # Re-create the sidecar a killed run would have left, then change what the sweep measures.
+    sidecar.write_text(
+        "\n".join(
+            [
+                PartialHeader(
+                    identity=PlanIdentity(
+                        pool="stale",
+                        scenarios=tuple(_HELD_OUT_IDS[:3]),
+                        episodes=1,
+                        max_steps=20,
+                        history_chars=DEFAULT_HISTORY_CHARS,
+                        compression="raw text (no compression)",
+                    )
+                ).model_dump_json(),
+                *(row.model_dump_json() for row in OutcomeMatrix.load(out).outcomes[:2]),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _, blocked = _sweep(tmp_path, root, "support", "--scenarios", "3", "--yes")
+    assert blocked.exit_code != 0
+    assert _says(blocked.output, "measured under a DIFFERENT plan")
+    assert _says(blocked.output, "candidate pool changed")
 
 
 def test_route_sweep_without_a_scoring_env_produces_no_evidence(

--- a/wmo/engine/world_model_test.py
+++ b/wmo/engine/world_model_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -712,3 +713,57 @@ def test_ground_failures_degrade_and_are_never_negative_cached(tmp_path: Path) -
     session2 = wm2.new_session(task="t")
     wm2.step(session2.id, Action(kind=ActionKind.TOOL_CALL, name="f", arguments={}))
     assert kb.lookup_grounded("entity y") is None  # empty results never negative-cached
+
+
+def test_a_frozen_world_model_serves_concurrent_sessions_without_crossing_them() -> None:
+    """The property a concurrent sweep bets on, measured rather than assumed.
+
+    A sweep runs many episodes against ONE WorldModel at once, each with its own session, with
+    the model frozen for the whole run. What could go wrong is shared mutable state: the session
+    and tracker dicts, the retrieval index, and the enrichment flag. So: 16 sessions on 8 threads,
+    each stepping several times, then check that every session kept its OWN history and its OWN
+    metering, that the shared retrieval buffer did not grow, and that ending them all leaves the
+    model empty.
+
+    Frozen is load-bearing here, not incidental. Enrichment appends to the retriever's step list
+    and vstacks its matrix, which concurrent sessions would race; freezing turns the shared index
+    read-only for the duration, which is why `execute_sweep` freezes around the whole grid rather
+    than per cell.
+    """
+    sessions_per_thread, threads = 2, 8
+    provider = FakeProvider('{"output": "ok", "is_error": false}')
+    retriever = _retriever_with(
+        [
+            Step(
+                action=Action(kind=ActionKind.TOOL_CALL, name="ls", arguments={}),
+                observation=Observation(content="a.txt"),
+            )
+        ]
+    )
+    wm = WorldModel(provider, retriever, top_k=1)
+    indexed_before = len(retriever.sample(1000))
+    steps_per_session = 3
+    errors: list[BaseException] = []
+
+    def episode(index: int) -> tuple[int, int]:
+        try:
+            session = wm.new_session(task=f"task {index}")
+            for _ in range(steps_per_session):
+                wm.step(session.id, Action(kind=ActionKind.TOOL_CALL, name="ls", arguments={}))
+            history = len(wm.get_session(session.id).history)
+            record = wm.end_session(session.id)
+            return history, record.total.calls
+        except BaseException as exc:  # noqa: BLE001 - re-raised through the collected list
+            errors.append(exc)
+            raise
+
+    with wm.frozen(), ThreadPoolExecutor(max_workers=threads) as pool:
+        results = list(pool.map(episode, range(sessions_per_thread * threads)))
+
+    assert not errors
+    # Every session saw its own steps and only its own: a shared history would show 3 x N here,
+    # and a tracker read off the wrong session would show someone else's call count.
+    assert len(results) == sessions_per_thread * threads
+    assert results == [(steps_per_session, steps_per_session)] * len(results)
+    assert wm._sessions == {} and wm._trackers == {}
+    assert len(retriever.sample(1000)) == indexed_before  # no cell fed another cell's retrieval

--- a/wmo/env/closed_loop.py
+++ b/wmo/env/closed_loop.py
@@ -4,6 +4,23 @@ Each (candidate model, scenario, episode) cell runs one `run_episode` with the c
 `LLMAgent` against the env, then reads the env's episode score (VERIFY). The result is the
 `OutcomeMatrix` the routing optimizer fits on and the improvement report cites.
 
+The grid is addressable, not just iterable: `pool_cells` enumerates it in the canonical order,
+`run_cell` measures exactly one cell, and `run_cells` drives a list of them with bounded
+concurrency. That split is what lets `wmo.optimize.sweep` resume a partially measured grid (it
+runs the cells that are missing, not the whole product) while `evaluate_pool` stays the one-call
+API for measuring all of it.
+
+Concurrency notes:
+- A cell is an independent episode against its OWN env and its OWN candidate provider, so cells
+  parallelize; `max_concurrency` bounds how many are in flight. The default of 1 is the
+  sequential loop this module has always run, cell for cell.
+- The work is IO-bound (provider round trips), so the pool is threads, not processes.
+- Completion order is nondeterministic above concurrency 1, but the returned outcomes are always
+  in the canonical cell order, so the matrix (and every digest taken of it) does not depend on
+  which cell finished first.
+- `on_outcome` fires from the WORKER thread that finished the cell, serialized under one lock, so
+  a console-printing callback never interleaves two cells mid-line.
+
 Measurement notes:
 - Latency is measured per POLICY CALL (the candidate's own completions), not per episode: episode
   wall time is dominated by the world model's simulation latency, which production traffic never
@@ -24,8 +41,12 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict
 
 from wmo.env.base import Env
 from wmo.env.episode import run_episode
@@ -46,7 +67,7 @@ from wmo.providers.base import (
 from wmo.providers.pool import ModelPool, PoolEntry, pool_provider
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -160,8 +181,8 @@ _NEEDS_SCORING_ENV = (
 _SALVAGE_PREFIX = "salvage-judged despite error: "
 
 
-class _ScoringEnv(Protocol):
-    """The scoring surface `evaluate_pool` needs on top of `Env`; `WorldModelEnv` provides it."""
+class ScoringEnv(Protocol):
+    """The scoring surface a cell needs on top of `Env`; `WorldModelEnv` provides it."""
 
     @property
     def last_score(self) -> EpisodeScore: ...
@@ -176,7 +197,7 @@ def _read_episode_score(env: Env) -> tuple[EpisodeScore | None, str | None]:
     failure, e.g. a throttled judge call) is per-episode: that one cell is unscored with the
     reason recorded, and the sweep keeps its other completed cells.
     """
-    scoring = cast("_ScoringEnv", env)
+    scoring = cast("ScoringEnv", env)
     try:
         raw: object = scoring.last_score
     except AttributeError as exc:
@@ -205,6 +226,241 @@ def scenario_id(scenario: Scenario) -> str:
     return hashlib.sha256(scenario.task.encode("utf-8")).hexdigest()[:12]
 
 
+class CellKey(BaseModel):
+    """Which cell a row of the matrix is: one scenario, one candidate, one episode index.
+
+    The identity a partially measured grid is resumed against, so it is a value rather than a
+    tuple: `(scenario, model, episode)` in either order reads the same in a type signature, and
+    reading it wrong is how a resume silently re-buys or silently skips the wrong cells.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    scenario_id: str
+    model: str  # pool entry name
+    episode: int
+
+    @classmethod
+    def of(cls, outcome: ScenarioOutcome) -> CellKey:
+        """The key of a measured row."""
+        return cls(scenario_id=outcome.scenario_id, model=outcome.model, episode=outcome.episode)
+
+    def __str__(self) -> str:
+        return f"{self.model} on {self.scenario_id} ep{self.episode}"
+
+
+class PoolCell(BaseModel):
+    """One unit of closed-loop work: this candidate, on this scenario, for this episode index."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    entry: PoolEntry
+    scenario: Scenario
+    episode: int
+    # Set when this cell is being measured AGAIN after an earlier attempt (a transport fault, a
+    # throttled judge). Rides onto the row so a matrix says which of its cells are re-runs: the
+    # retry of a flaky cell and a cell that ran clean the first time are not the same evidence.
+    remeasured: bool = False
+
+    @property
+    def key(self) -> CellKey:
+        return CellKey(
+            scenario_id=scenario_id(self.scenario), model=self.entry.name, episode=self.episode
+        )
+
+
+def pool_cells(
+    pool: ModelPool, scenarios: list[Scenario], *, episodes_per_scenario: int = 1
+) -> list[PoolCell]:
+    """Every cell of the grid, in the canonical order: pool order, scenario order, episode index.
+
+    THE order, not an order: it is what a matrix's rows are sorted into whatever sequence they
+    were measured in, so two runs of the same plan at different concurrencies produce the same
+    file. Callers that measure a subset (a resume, a retry pass) filter this list rather than
+    building their own, so the subset's rows still land in the same places.
+    """
+    return [
+        PoolCell(entry=entry, scenario=scenario, episode=episode)
+        for entry in pool.models
+        for scenario in scenarios
+        for episode in range(episodes_per_scenario)
+    ]
+
+
+def run_cell(
+    cell: PoolCell,
+    env_factory: Callable[[], Env],
+    *,
+    max_steps: int = 20,
+    agent_temperature: float = 0.0,
+    tools_hint: str | None = None,
+    history_chars: int = DEFAULT_HISTORY_CHARS,
+    provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
+    compression: CompressionConfig | None = None,
+) -> ScenarioOutcome:
+    """Measure ONE cell: one episode of one candidate on one scenario, against a fresh env.
+
+    Everything the cell owns is built here rather than shared: its candidate provider (so
+    per-episode provider state stays per episode, and so concurrent cells never share a client),
+    its agent, and its env. That is what makes a cell safe to run on a worker thread.
+
+    Raises:
+        ValueError: The env produced no episode score and no error, so it does not score at all
+            and no cell of this measurement could ever be evidence.
+    """
+    timed = _TimedProvider(provider_factory(cell.entry))
+    compressing = _CompressingProvider(timed, compression) if compression is not None else None
+    agent = LLMAgent(
+        compressing if compressing is not None else timed,
+        temperature=agent_temperature,
+        tools_hint=tools_hint,
+        history_chars=history_chars,
+    )
+    env = env_factory()
+    result = run_episode(env, agent, cell.scenario.task, max_steps=max_steps)
+    score, score_error = _read_episode_score(env)
+    error = result.error
+    if score_error is not None:
+        error = f"{error}; {score_error}" if error else score_error
+    if score is None and error is None:
+        raise ValueError(_NEEDS_SCORING_ENV)
+    critique = score.critique if score else ""
+    if score is not None and result.error is not None:
+        # The episode broke mid-flight, so this verdict grades an unfinished run: keep the text,
+        # drop the reward (see the module docstring).
+        critique = f"{_SALVAGE_PREFIX}{critique}" if critique else ""
+        score = None
+    return ScenarioOutcome(
+        scenario_id=scenario_id(cell.scenario),
+        task=cell.scenario.task,
+        model=cell.entry.name,
+        episode=cell.episode,
+        reward=score.reward if score else None,
+        success=score.success if score else False,
+        critique=critique,
+        steps=len(result.steps),
+        stop_reason=str(result.stop_reason),
+        usage=timed.usage,
+        cost_usd=cell.entry.cost_usd(timed.usage),
+        call_seconds=timed.call_seconds,
+        replies=timed.replies,
+        error=error,
+        remeasured=cell.remeasured,
+        tokens_in_raw=compressing.tokens_in_raw if compressing else 0,
+        tokens_in_compressed=compressing.tokens_in_compressed if compressing else 0,
+        compressor_id=compressing.compressor.id if compressing else "",
+        compressor_version=compressing.compressor.version if compressing else "",
+        aggressiveness=compression.aggressiveness if compression else 0.0,
+        compressor_latency_s=compressing.latency_s if compressing else 0.0,
+        compressor_cost_usd=compressing.cost_usd if compressing else 0.0,
+    )
+
+
+def run_cells(
+    cells: Sequence[PoolCell],
+    env_factory: Callable[[], Env],
+    *,
+    max_steps: int = 20,
+    agent_temperature: float = 0.0,
+    tools_hint: str | None = None,
+    history_chars: int = DEFAULT_HISTORY_CHARS,
+    provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
+    on_outcome: Callable[[ScenarioOutcome], None] | None = None,
+    compression: CompressionConfig | None = None,
+    max_concurrency: int = 1,
+) -> list[ScenarioOutcome]:
+    """Measure `cells`, at most `max_concurrency` at a time, and return them IN CELL ORDER.
+
+    `max_concurrency=1` is the plain sequential loop, with no thread and no executor involved:
+    the default path is the one this module has always run. Above 1 the cells go to a thread pool
+    (the work is provider round trips, so threads are the right tool) and the returned list is
+    still indexed by input position, never by finish time.
+
+    When a cell raises, the cells already in flight are allowed to finish (they are being paid
+    for either way) and no queued cell is started; the first failure is then re-raised. A caller
+    that wants the completed rows despite the failure collects them from `on_outcome`.
+
+    `on_outcome` fires as each cell completes, from the worker thread that ran it, serialized
+    under one lock so two cells cannot interleave inside it. A callback that raises is logged and
+    ignored: a broken progress pipe (or a full disk under a persisting callback) must not throw
+    away cells that have already been paid for.
+
+    Raises:
+        ValueError: `max_concurrency` is below 1, or a cell's env does not score.
+    """
+    if max_concurrency < 1:
+        raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
+    measured: dict[int, ScenarioOutcome] = {}
+    lock = threading.Lock()
+
+    def measure(index: int, cell: PoolCell) -> None:
+        """Run one cell and bank it, with the reporting every path shares."""
+        outcome = run_cell(
+            cell,
+            env_factory,
+            max_steps=max_steps,
+            agent_temperature=agent_temperature,
+            tools_hint=tools_hint,
+            history_chars=history_chars,
+            provider_factory=provider_factory,
+            compression=compression,
+        )
+        with lock:
+            measured[index] = outcome
+            if on_outcome is not None:
+                try:
+                    on_outcome(outcome)
+                except Exception:  # noqa: BLE001 - a broken progress pipe never costs cells
+                    logger.warning(
+                        "on_outcome callback failed for %s; measurement continues",
+                        cell.key,
+                        exc_info=True,
+                    )
+            logger.info(
+                "closed-loop %s: reward=%s cost=$%.5f steps=%d",
+                cell.key,
+                "unscored" if outcome.reward is None else f"{outcome.reward:.2f}",
+                outcome.cost_usd,
+                outcome.steps,
+            )
+
+    if max_concurrency == 1:
+        for index, cell in enumerate(cells):
+            measure(index, cell)
+    else:
+        _measure_concurrently(cells, measure, max_concurrency=max_concurrency)
+    return [measured[index] for index in sorted(measured)]
+
+
+def _measure_concurrently(
+    cells: Sequence[PoolCell],
+    measure: Callable[[int, PoolCell], None],
+    *,
+    max_concurrency: int,
+) -> None:
+    """Drive `measure` over `cells` on a bounded thread pool, re-raising the first failure.
+
+    Cancelling the queue rather than the pool is the point: a cell already in flight has an open
+    world-model session and a candidate call in the air, so killing it would spend money and
+    record nothing. Queued cells have spent nothing, so they are dropped.
+    """
+    failure: BaseException | None = None
+    with ThreadPoolExecutor(max_workers=max_concurrency, thread_name_prefix="wmo-cell") as pool:
+        futures: dict[Future[None], PoolCell] = {
+            pool.submit(measure, index, cell): cell for index, cell in enumerate(cells)
+        }
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except BaseException as exc:  # noqa: BLE001 - re-raised below, once the pool drains
+                if failure is None:
+                    failure = exc
+                    for queued in futures:
+                        queued.cancel()
+    if failure is not None:
+        raise failure
+
+
 def evaluate_pool(
     env_factory: Callable[[], Env],
     pool: ModelPool,
@@ -218,6 +474,7 @@ def evaluate_pool(
     provider_factory: Callable[[PoolEntry], Provider] = pool_provider,
     on_outcome: Callable[[ScenarioOutcome], None] | None = None,
     compression: CompressionConfig | None = None,
+    max_concurrency: int = 1,
 ) -> OutcomeMatrix:
     """Run every pool candidate over `scenarios`, one fresh env per episode.
 
@@ -237,78 +494,25 @@ def evaluate_pool(
     `compression` applies the D-COMPRESS stage to every candidate call, measured through the
     same wrapper stack production serves through; each outcome then carries the compressor's
     per-episode accounting fields. None (the default) = uncompressed, today's rows exactly.
+
+    `max_concurrency` bounds how many cells are in flight at once (1 = sequential, the default).
+    It changes only how long the measurement takes, never what a cell measures or where its row
+    lands, so two matrices that differ only in this value are the same evidence. The real ceiling
+    is your provider's rate limit, and the world model's own serve and judge calls all come out of
+    ONE account's bucket.
     """
-    outcomes: list[ScenarioOutcome] = []
-    for entry in pool.models:
-        for scenario in scenarios:
-            sid = scenario_id(scenario)
-            for episode in range(episodes_per_scenario):
-                timed = _TimedProvider(provider_factory(entry))
-                compressing = (
-                    _CompressingProvider(timed, compression) if compression is not None else None
-                )
-                agent = LLMAgent(
-                    compressing if compressing is not None else timed,
-                    temperature=agent_temperature,
-                    tools_hint=tools_hint,
-                    history_chars=history_chars,
-                )
-                env = env_factory()
-                result = run_episode(env, agent, scenario.task, max_steps=max_steps)
-                score, score_error = _read_episode_score(env)
-                error = result.error
-                if score_error is not None:
-                    error = f"{error}; {score_error}" if error else score_error
-                if score is None and error is None:
-                    raise ValueError(_NEEDS_SCORING_ENV)
-                critique = score.critique if score else ""
-                if score is not None and result.error is not None:
-                    # The episode broke mid-flight, so this verdict grades an unfinished run:
-                    # keep the text, drop the reward (see the module docstring).
-                    critique = f"{_SALVAGE_PREFIX}{critique}" if critique else ""
-                    score = None
-                outcome = ScenarioOutcome(
-                    scenario_id=sid,
-                    task=scenario.task,
-                    model=entry.name,
-                    episode=episode,
-                    reward=score.reward if score else None,
-                    success=score.success if score else False,
-                    critique=critique,
-                    steps=len(result.steps),
-                    stop_reason=str(result.stop_reason),
-                    usage=timed.usage,
-                    cost_usd=entry.cost_usd(timed.usage),
-                    call_seconds=timed.call_seconds,
-                    replies=timed.replies,
-                    error=error,
-                    tokens_in_raw=compressing.tokens_in_raw if compressing else 0,
-                    tokens_in_compressed=compressing.tokens_in_compressed if compressing else 0,
-                    compressor_id=compressing.compressor.id if compressing else "",
-                    compressor_version=compressing.compressor.version if compressing else "",
-                    aggressiveness=compression.aggressiveness if compression else 0.0,
-                    compressor_latency_s=compressing.latency_s if compressing else 0.0,
-                    compressor_cost_usd=compressing.cost_usd if compressing else 0.0,
-                )
-                outcomes.append(outcome)
-                if on_outcome is not None:
-                    try:
-                        on_outcome(outcome)
-                    except Exception:  # noqa: BLE001 - a broken progress pipe never costs cells
-                        logger.warning(
-                            "on_outcome callback failed for %s on %s ep%d; sweep continues",
-                            entry.name,
-                            sid,
-                            episode,
-                            exc_info=True,
-                        )
-                logger.info(
-                    "closed-loop %s on %s ep%d: reward=%s cost=$%.5f steps=%d",
-                    entry.name,
-                    sid,
-                    episode,
-                    "unscored" if outcome.reward is None else f"{outcome.reward:.2f}",
-                    outcome.cost_usd,
-                    outcome.steps,
-                )
-    return OutcomeMatrix(pool=pool.models, outcomes=outcomes)
+    return OutcomeMatrix(
+        pool=pool.models,
+        outcomes=run_cells(
+            pool_cells(pool, scenarios, episodes_per_scenario=episodes_per_scenario),
+            env_factory,
+            max_steps=max_steps,
+            agent_temperature=agent_temperature,
+            tools_hint=tools_hint,
+            history_chars=history_chars,
+            provider_factory=provider_factory,
+            on_outcome=on_outcome,
+            compression=compression,
+            max_concurrency=max_concurrency,
+        ),
+    )

--- a/wmo/env/closed_loop_test.py
+++ b/wmo/env/closed_loop_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import cast
 
 import pytest
@@ -419,6 +421,165 @@ def test_uncompressed_rows_keep_default_compression_fields() -> None:
     assert outcome.tokens_in_raw == 0
     assert outcome.tokens_in_compressed == 0
     assert outcome.aggressiveness == 0.0
+
+
+class _SleepingProvider(_ScriptedProvider):
+    """Scripted provider whose every completion takes real wall time, like a real one does."""
+
+    delay_s = 0.05
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        time.sleep(self.delay_s)
+        return super().complete(system, messages, temperature=temperature, max_tokens=max_tokens)
+
+
+def _timed_evaluation(max_concurrency: int) -> tuple[float, list[ScenarioOutcome]]:
+    """Wall seconds to measure the 4-cell grid at `max_concurrency`, and the rows it produced."""
+    started = time.monotonic()
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_SleepingProvider,
+        max_steps=2,
+        max_concurrency=max_concurrency,
+    )
+    return time.monotonic() - started, matrix.outcomes
+
+
+def test_concurrent_cells_finish_in_a_fraction_of_the_sequential_wall_clock() -> None:
+    """The point of the whole change: cells are IO-bound, so they overlap.
+
+    4 cells x 2 completions x 50ms = 400ms of sleeping. Sequentially that is the wall clock;
+    four at a time it is one cell's worth. The assertion is deliberately coarse (the ratio, plus
+    a ceiling well above the ideal 100ms) so a loaded CI box cannot make it flap, while a
+    regression that quietly serializes the pool again cannot pass it.
+    """
+    concurrent_s, concurrent_rows = _timed_evaluation(4)
+    sequential_s, sequential_rows = _timed_evaluation(1)
+    assert concurrent_s < 0.25, f"4 cells at once took {concurrent_s:.3f}s"
+    assert sequential_s > concurrent_s * 1.8
+    # Same evidence either way: concurrency is a speed knob, not a measurement change.
+    assert [(row.model, row.scenario_id) for row in concurrent_rows] == [
+        (row.model, row.scenario_id) for row in sequential_rows
+    ]
+    assert all(row.reward == pytest.approx(0.8) for row in concurrent_rows)
+
+
+def test_the_matrix_is_in_cell_order_even_when_the_cells_finish_backwards() -> None:
+    """Row order is the grid's order, not the finish order, or every digest of it drifts.
+
+    The second candidate is made much faster than the first, so completion order is the reverse
+    of cell order. The rows must still come back candidate-major.
+    """
+    finished: list[str] = []
+
+    class _PacedProvider(_ScriptedProvider):
+        def complete(
+            self,
+            system: str,
+            messages: list[Message],
+            *,
+            temperature: float = 0.7,
+            max_tokens: int = 8192,
+        ) -> Completion:
+            time.sleep(0.08 if self.config.model == "custom-a" else 0.0)
+            return super().complete(
+                system, messages, temperature=temperature, max_tokens=max_tokens
+            )
+
+    matrix = evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_PacedProvider,
+        max_steps=2,
+        max_concurrency=4,
+        on_outcome=lambda outcome: finished.append(outcome.model),
+    )
+    assert finished[0] == "candidate-b"  # the fast candidate really did finish first
+    assert [row.model for row in matrix.outcomes] == [
+        "candidate-a",
+        "candidate-a",
+        "candidate-b",
+        "candidate-b",
+    ]
+
+
+def test_the_progress_callback_never_runs_two_cells_at_once() -> None:
+    # A console-printing callback that interleaved would corrupt the operator's progress lines,
+    # so the callback is serialized even though the cells are not.
+    inside = 0
+    overlaps = 0
+
+    def watch(outcome: ScenarioOutcome) -> None:
+        nonlocal inside, overlaps
+        inside += 1
+        if inside > 1:
+            overlaps += 1
+        time.sleep(0.01)
+        inside -= 1
+
+    evaluate_pool(
+        lambda: _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="fine")),
+        _pool(),
+        _SCENARIOS,
+        provider_factory=_ScriptedProvider,
+        max_concurrency=4,
+        on_outcome=watch,
+    )
+    assert overlaps == 0
+
+
+def test_a_cell_that_raises_under_concurrency_still_reports_the_cells_that_finished() -> None:
+    # The failure aborts the measurement (there is no matrix to return), but the cells that were
+    # already paid for reached the callback, which is what the sweep persists them from.
+    seen: list[str] = []
+
+    class _ExplodingEnv(_FakeEnv):
+        def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
+            raise RuntimeError("world model session refused")
+
+    envs = iter(
+        [
+            _FakeEnv(EpisodeScore(reward=0.8, success=True, critique="ok")),
+            _ExplodingEnv(None),
+        ]
+    )
+    lock = threading.Lock()
+
+    def next_env() -> _FakeEnv:
+        with lock:
+            return next(envs)
+
+    with pytest.raises(RuntimeError, match="session refused"):
+        evaluate_pool(
+            next_env,
+            ModelPool(models=[_pool().models[0]]),
+            _SCENARIOS,
+            provider_factory=_ScriptedProvider,
+            max_concurrency=2,
+            on_outcome=lambda outcome: seen.append(outcome.scenario_id),
+        )
+    assert len(seen) == 1
+
+
+def test_a_concurrency_below_one_is_a_usage_error() -> None:
+    with pytest.raises(ValueError, match="max_concurrency must be >= 1"):
+        evaluate_pool(
+            lambda: _FakeEnv(EpisodeScore(reward=0.1, success=False, critique="")),
+            _pool(),
+            _SCENARIOS[:1],
+            provider_factory=_ScriptedProvider,
+            max_concurrency=0,
+        )
 
 
 def test_pre_compression_outcome_json_loads_with_defaults() -> None:

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -47,6 +47,12 @@ class ScenarioOutcome(BaseModel):
     # fitting). Reasoning models that emit thought before the JSON action keep it here.
     replies: list[str] = []
     error: str | None = None
+    # Whether this row is a RE-measurement of a cell an earlier attempt already ran (a transport
+    # fault, a throttled judge). Additive with a default so pre-retry matrices load unchanged.
+    # Retries are not free evidence: a cell measured only on its second try survived a filter its
+    # neighbours never faced, and a reader comparing two matrices deserves to see how much of one
+    # of them is re-runs.
+    remeasured: bool = False
     # D-COMPRESS fields, additive with defaults so pre-compression matrices load unchanged;
     # 0/"" = the episode ran uncompressed. Token counts are the compressor's deterministic
     # proxy totals summed over the episode's calls (wmo.optimize.compression); billable truth

--- a/wmo/optimize/sweep.py
+++ b/wmo/optimize/sweep.py
@@ -17,25 +17,45 @@ constructed, and so tests can stub both at the CLI module they already patch.
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import os
+import threading
 from collections import Counter
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from wmo.config import ArtifactPaths, HarnessConfig, load_config
+from wmo.core.types import Action, EnvState, Observation
 from wmo.engine import split_holdout
-from wmo.env.closed_loop import evaluate_pool
+from wmo.env.closed_loop import (
+    CellKey,
+    PoolCell,
+    ScoringEnv,
+    pool_cells,
+    run_cells,
+    scenario_id,
+)
 from wmo.env.llm_agent import DEFAULT_HISTORY_CHARS
 from wmo.env.scenarios import Scenario, scenarios_from_traces, tools_hint_from_traces
 from wmo.ingest import get_adapter
-from wmo.optimize.compression import CompressionConfig
+from wmo.optimize.compression import CompressionConfig, compression_signature
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.reward import EpisodeScore
+from wmo.optimize.sweep_partial import (
+    PartialSweepError,
+    PartialWriter,
+    PlanIdentity,
+    partial_path,
+    read_partial,
+)
 from wmo.providers.base import ProviderKind, TokenUsage
 from wmo.providers.pool import ModelPool, load_pool, prepare_pool_provider
 from wmo.serving.traces_source import TRACES_FILENAME, local_traces_path
@@ -45,6 +65,8 @@ if TYPE_CHECKING:
     from wmo.core.types import Trace
     from wmo.engine.world_model import WorldModel
     from wmo.env.base import Env
+
+logger = logging.getLogger(__name__)
 
 
 class SweepError(ValueError):
@@ -128,6 +150,10 @@ class SweepPlan(BaseModel):
     # runs: it decides what the rewards MEAN, so two matrices swept under different compressors
     # are different evidence, and a resumed run whose compressor changed must re-measure.
     compression: CompressionConfig | None = None
+    # How many cells run at once. NOT part of the plan's identity: it changes how long the
+    # measurement takes, never what a cell measures, so a run resumed at a different value
+    # continues the same cohort rather than re-buying it. 1 is the sequential default.
+    max_concurrency: int = Field(default=1, ge=1)
     trace_count: int  # traces the corpus ingested, which is what decides `tiny_corpus`
     tiny_corpus: bool  # too small for a held-out band, so the scenarios are not leak-free
     assume_input_tokens: int
@@ -143,6 +169,25 @@ class SweepPlan(BaseModel):
     def total_usd(self) -> float:
         """The projected candidate-side spend (a projection, never a measurement)."""
         return sum(line.usd for line in self.cost_lines)
+
+    @property
+    def identity(self) -> PlanIdentity:
+        """What this plan MEASURES, as the value a resumed run is checked against.
+
+        Everything a matrix's rows depend on for comparability: which candidates at which prices,
+        which scenario cut, how many episodes of how many steps, how much of each observation the
+        agent saw, and which compression arm. Two plans that agree here produce rows that belong
+        in one matrix; two that disagree produce two arms, and merging them would be a fabricated
+        comparison. `identity.digest` is the short form for stamping into logs and artifacts.
+        """
+        return PlanIdentity(
+            pool=_pool_digest(self.pool),
+            scenarios=tuple(scenario_id(scenario) for scenario in self.scenarios),
+            episodes=self.episodes,
+            max_steps=self.max_steps,
+            history_chars=self.history_chars,
+            compression=compression_signature(self.compression),
+        )
 
 
 def resolve_config(model_dir: Path) -> HarnessConfig:
@@ -229,6 +274,7 @@ def plan_sweep(
     assume_output_tokens: int,
     history_chars: int = DEFAULT_HISTORY_CHARS,
     compression: CompressionConfig | None = None,
+    max_concurrency: int = 1,
 ) -> SweepPlan:
     """Cut the held-out scenario set and project the spend, without touching the filesystem.
 
@@ -236,10 +282,20 @@ def plan_sweep(
     and a corpus that carries no task prompt are both boundary errors, raised before a caller
     asks its operator to authorize anything.
 
+    `max_concurrency` is how many cells the sweep runs at once (1 = sequential). It is on the
+    PLAN because an operator confirms the plan, and how hard a run leans on a provider's rate
+    limit is something they should see before they say yes; it is not part of the plan's identity,
+    because it changes nothing about what a cell measures.
+
     Raises:
-        SweepError: The destination is unwritable, the corpus is missing or unreadable, or the
-            held-out band carries no task prompt to measure.
+        SweepError: The destination is unwritable, the corpus is missing or unreadable, the
+            held-out band carries no task prompt to measure, or `max_concurrency` is below 1.
     """
+    if max_concurrency < 1:
+        raise SweepError(
+            f"--concurrency must be at least 1, got {max_concurrency}: 1 runs the cells one at "
+            "a time, higher runs that many at once"
+        )
     _check_out_writable(out_path)
     traces = _corpus_traces(model_dir, config.trace_adapter, traces_file)
     train, holdout, tiny_corpus = split_holdout(
@@ -264,6 +320,7 @@ def plan_sweep(
         tools_hint=tools_hint_from_traces(train) or None,
         history_chars=history_chars,
         compression=compression,
+        max_concurrency=max_concurrency,
         trace_count=len(traces),
         tiny_corpus=tiny_corpus,
         assume_input_tokens=assume_input_tokens,
@@ -306,6 +363,12 @@ class SweepRun(BaseModel):
     episodes_metered: int  # episodes whose world-model session reported usage
     episodes_unmetered: int  # episodes whose env exposed none (see `metering_gap`)
     usage_path: Path | None  # where the kind="sweep" record was persisted, if it was
+    # Cells this attempt did NOT run because an earlier attempt already had (see the resume
+    # contract in `execute_sweep`). Zero for a sweep that measured its whole grid.
+    resumed_cells: int = 0
+    # Cells this attempt measured AGAIN on the caller's instruction, after an earlier attempt
+    # produced a row it did not want to keep.
+    remeasured_cells: int = 0
 
     @property
     def world_model_usd(self) -> float:
@@ -317,18 +380,32 @@ class SweepRun(BaseModel):
         """Why the world-model figure is not the whole sweep, or None when it covers every cell.
 
         A caller prints this INSTEAD of the number when nothing was metered: a $0.00 that means
-        "not measured" is the kind of zero the numbers-honesty rule exists to forbid.
+        "not measured" is the kind of zero the numbers-honesty rule exists to forbid. A resumed
+        run reports the same way for a different reason: its number is real, but it covers only
+        the cells THIS attempt ran, and the earlier attempt persisted its own record.
         """
         if self.episodes_unmetered == 0:
-            return None
+            return self._resume_note
         if self.episodes_metered == 0:
             return (
                 "not measured: the env this sweep ran on exposes no usage record, so the world "
                 "model's own serve and judge cost is unknown rather than zero"
             )
-        return (
+        partial = (
             f"partial: {self.episodes_metered} of "
             f"{self.episodes_metered + self.episodes_unmetered} episode(s) reported usage"
+        )
+        note = self._resume_note
+        return f"{partial}; {note}" if note else partial
+
+    @property
+    def _resume_note(self) -> str | None:
+        """How a resume narrows what the world-model figure covers, or None when it did not."""
+        if self.resumed_cells == 0:
+            return None
+        return (
+            f"this attempt only: {self.resumed_cells} cell(s) came from the earlier attempt, "
+            "whose own world-model spend is in its own run record"
         )
 
 
@@ -339,53 +416,89 @@ def execute_sweep(
     env_factory: Callable[[], Env],
     on_outcome: Callable[[ScenarioOutcome], None] | None = None,
     runs_dir: Path | None = None,
+    remeasure: frozenset[CellKey] = frozenset(),
 ) -> SweepRun:
     """Run every cell of `plan` against a FROZEN world model, write the matrix, meter both sides.
 
     Frozen for the whole sweep (the `wmo.evals.closed_loop` precedent): without it a candidate's
     PREDICTED steps enter the shared retrieval buffer and become demos for the next candidate, so
-    the comparison this matrix exists to make would depend on sweep order.
+    the comparison this matrix exists to make would depend on sweep order. Freezing is also what
+    makes concurrent cells safe: the shared retrieval index is read-only for the whole run, so
+    parallel episodes cannot race to write it (see `plan.max_concurrency`).
 
     `env_factory` must build an env that scores on close (`score_on_close=True`): a matrix
-    without verified rewards is not evidence, and `evaluate_pool` refuses one that does not score.
+    without verified rewards is not evidence, and a cell refuses an env that does not score. It
+    is called once per CELL, on the worker thread running that cell, so it must be safe to call
+    from several threads (`WorldModelEnv` is: each env owns its own world-model session).
+
+    NOTHING IS LOST TO A CRASH. Every cell is appended to `<out>.partial.jsonl` the moment it
+    completes, and a later call with the same plan measures only the cells that file does not
+    already hold. A sidecar whose rows were measured under a different plan is refused rather
+    than merged (`SweepPlan.identity`). The sidecar is removed once the matrix is written, so a
+    finished sweep leaves exactly the artifact it always left.
 
     The world model opens one metered session per episode and `WorldModelEnv.close` leaves that
     session's final `RunRecord` on the env. Those records used to die with the env: the sweep
     said the simulator's cost was "metered separately" and then nothing anywhere persisted it, so
-    the eval-infrastructure half of a sweep's bill was unaccountable. They are harvested here and
-    rolled into ONE `kind="sweep"` record under `runs_dir`, beside the build and serve records the
-    same directory already holds.
+    the eval-infrastructure half of a sweep's bill was unaccountable. They are harvested here as
+    each env closes and rolled into ONE `kind="sweep"` record under `runs_dir`, beside the build
+    and serve records the same directory already holds. A RESUMED run records only what IT spent;
+    the attempt that bought the earlier cells wrote its own record, so nothing is double counted
+    and `metering_gap` says the figure covers this attempt alone.
 
     Args:
         plan: What to measure, from `plan_sweep`.
         world_model: The model to freeze and measure against.
-        env_factory: Builds one scoring env per episode.
-        on_outcome: Per-cell progress callback.
+        env_factory: Builds one scoring env per episode; called per cell, from worker threads.
+        on_outcome: Per-cell progress callback, fired from the worker thread that finished the
+            cell and serialized so two cells never interleave inside it.
         runs_dir: Where to persist the run record. Defaults to the model's own `runs/`; pass a
             path to redirect it, and nothing is written when the sweep metered no session at all.
+        remeasure: Cells to buy again even though the sidecar already holds them, for a retry
+            pass over cells an earlier attempt lost to a transient fault. Their new rows carry
+            `remeasured=True` and replace the earlier ones.
+
+    Raises:
+        SweepError: The sidecar beside `out_path` belongs to a different plan, or is damaged.
     """
+    resumed = _resume(plan, remeasure)
     harvest = _SessionHarvest(env_factory)
     destination = runs_dir or ArtifactPaths(plan.model_dir).runs
+    measured: list[ScenarioOutcome] = []
+
+    def persist(outcome: ScenarioOutcome) -> None:
+        """Bank one measured cell durably, then let the caller's progress display have it.
+
+        Called under the one lock `run_cells` serializes its callback with, which is why the
+        writer needs no lock of its own and why the log's order is the completion order.
+        """
+        resumed.writer.append(outcome)
+        if on_outcome is not None:
+            on_outcome(outcome)
+
     try:
         with world_model.frozen():
-            matrix = evaluate_pool(
+            measured = run_cells(
+                resumed.pending,
                 harvest,
-                plan.pool,
-                list(plan.scenarios),
-                episodes_per_scenario=plan.episodes,
                 max_steps=plan.max_steps,
                 tools_hint=plan.tools_hint,
                 history_chars=plan.history_chars,
-                on_outcome=on_outcome,
+                on_outcome=persist,
                 compression=plan.compression,
+                max_concurrency=plan.max_concurrency,
             )
     finally:
-        # `evaluate_pool` can raise (a provider that fails to build, an env that does not score),
-        # and the episodes it already ran were still paid for on the world model's side. Persisting
-        # the harvest here keeps that spend accountable instead of dying with the exception; the
-        # candidate-side matrix is lost either way, because there is no matrix to save.
+        # A cell can raise (a provider that fails to build, an env that does not score), and the
+        # episodes that already ran were still paid for on the world model's side. Persisting the
+        # harvest here keeps that spend accountable instead of dying with the exception; the
+        # candidate-side rows survive in the sidecar, which is what the next run resumes from.
         usage, usage_path = _persist_harvest(harvest, destination)
+        resumed.writer.close()
+    matrix = OutcomeMatrix(pool=plan.pool.models, outcomes=_assemble(plan, resumed.rows, measured))
     matrix.save(plan.out_path)
+    # Only now: while the matrix was unwritten the sidecar was the only copy of these cells.
+    resumed.writer.discard()
     return SweepRun(
         matrix=matrix,
         candidate_usd=sum(
@@ -396,12 +509,119 @@ def execute_sweep(
         episodes_metered=len(harvest.records),
         episodes_unmetered=harvest.unmetered,
         usage_path=usage_path,
+        resumed_cells=len(resumed.rows),
+        remeasured_cells=sum(1 for cell in resumed.pending if cell.remeasured),
     )
+
+
+@dataclass(frozen=True)
+class _Resume:
+    """What an earlier attempt at this plan left behind, and what is therefore left to run.
+
+    A dataclass rather than a model because it carries an OPEN FILE: the sidecar writer is a live
+    resource with a lifetime, not validated data to persist.
+    """
+
+    rows: dict[str, ScenarioOutcome]  # surviving row per reused cell, keyed by CellKey JSON
+    pending: list[PoolCell]  # cells this attempt must measure, in canonical order
+    writer: PartialWriter
+
+
+def _resume(plan: SweepPlan, remeasure: frozenset[CellKey]) -> _Resume:
+    """Read the sidecar, decide which cells still need buying, and open the log for appending.
+
+    A row is reused when the sidecar holds it AND the caller did not ask for that cell again.
+    Unscored rows are reused too: the cell ran, the episode was paid for, and its `error` is the
+    diagnosis. Re-running it is a decision the caller makes with `remeasure`, not one a resume
+    makes silently on their behalf and their budget.
+
+    Raises:
+        SweepError: The sidecar belongs to a different plan, or cannot be read.
+    """
+    path = partial_path(plan.out_path)
+    identity = plan.identity
+    try:
+        rows = read_partial(path, identity)
+        writer = PartialWriter(path, identity)
+    except PartialSweepError as exc:
+        raise SweepError(str(exc)) from exc
+    except OSError as exc:
+        raise SweepError(f"cannot write the partial sweep log at {path}: {exc}") from exc
+    reusable: dict[str, ScenarioOutcome] = {}
+    for row in rows:  # append-only log: a later row for a cell supersedes an earlier one
+        key = CellKey.of(row)
+        if key not in remeasure:
+            reusable[key.model_dump_json()] = row
+    pending: list[PoolCell] = []
+    for cell in pool_cells(plan.pool, list(plan.scenarios), episodes_per_scenario=plan.episodes):
+        if cell.key.model_dump_json() in reusable:
+            continue
+        pending.append(cell.model_copy(update={"remeasured": cell.key in remeasure}))
+    if reusable:
+        logger.info(
+            "resuming sweep %s: %d cell(s) already measured, %d to go",
+            identity.digest,
+            len(reusable),
+            len(pending),
+        )
+    return _Resume(rows=reusable, pending=pending, writer=writer)
+
+
+def _assemble(
+    plan: SweepPlan, reused: dict[str, ScenarioOutcome], measured: list[ScenarioOutcome]
+) -> list[ScenarioOutcome]:
+    """The matrix's rows in canonical cell order, whatever order they were measured in.
+
+    Deterministic ORDER, not just deterministic content: `fit` and `tune` identify a matrix by the
+    sha256 of its bytes, so a matrix whose rows follow finish time would get a different digest
+    every run and every artifact stamped with it would look like new evidence. Sorting by cell
+    position (rather than, say, by scenario id) also means a concurrent sweep and a sequential one
+    of the same plan produce the same file, byte for byte.
+    """
+    fresh = {CellKey.of(outcome).model_dump_json(): outcome for outcome in measured}
+    ordered: list[ScenarioOutcome] = []
+    for cell in pool_cells(plan.pool, list(plan.scenarios), episodes_per_scenario=plan.episodes):
+        key = cell.key.model_dump_json()
+        # This attempt's row wins over a reused one: a remeasured cell is measured precisely to
+        # replace what the sidecar holds. A cell in neither is one no attempt has run, which the
+        # matrix simply omits (the coverage contract is what judges the hole).
+        row = fresh.get(key, reused.get(key))
+        if row is not None:
+            ordered.append(row)
+    return ordered
+
+
+def resumable_cells(plan: SweepPlan) -> int:
+    """How many of `plan`'s cells a previous attempt already measured and left in the sidecar.
+
+    Called BEFORE the spend confirmation, so a resumed run can say how much of the projected cost
+    it is not going to pay again, and so a sidecar that belongs to a different plan is refused
+    while refusing is still free. Zero when there is nothing to resume.
+
+    Raises:
+        SweepError: The sidecar beside the plan's `out_path` belongs to a different plan, or is
+            damaged. Same message the run itself would raise, delivered before the money question.
+    """
+    try:
+        rows = read_partial(partial_path(plan.out_path), plan.identity)
+    except PartialSweepError as exc:
+        raise SweepError(str(exc)) from exc
+    return len({CellKey.of(row).model_dump_json() for row in rows})
+
+
+def _pool_digest(pool: ModelPool) -> str:
+    """A digest of the candidate roster: which models, at which prices, in which order.
+
+    The whole entry, not just the name: a matrix's rows are priced by their pool entry, so an
+    edited price makes an old row's `cost_usd` a different number than the same cell would get
+    today, and resuming across that edit would mix two price regimes into one comparison.
+    """
+    payload = "\n".join(entry.model_dump_json() for entry in pool.models)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def _persist_harvest(harvest: _SessionHarvest, runs_dir: Path) -> tuple[RunRecord, Path | None]:
     """Roll the harvested sessions into one record and write it, unless nothing was metered."""
-    harvest.finish()
     usage = merge_run_records(
         harvest.records,
         run_id=f"sweep-{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}",
@@ -417,37 +637,75 @@ SWEEP_RUN_KIND = "sweep"
 class _SessionHarvest:
     """An `env_factory` wrapper that collects each episode's world-model usage as it completes.
 
-    Harvesting on the NEXT call (and once more at `finish`) rather than holding every env is
-    deliberate: `run_episode` closes its env before `evaluate_pool` asks for the next one, so the
-    previous env's record is already final by then, and a sweep of thousands of cells keeps one
-    env alive at a time instead of all of them.
+    Harvest happens at each env's OWN close, which is the only rule that survives concurrency.
+    The previous design banked the last env's record when the next env was requested, on the
+    assumption that exactly one env is alive at a time; with cells running in parallel that
+    assumption is false in both directions (several envs are open at once, and the next request
+    comes from a different thread than the one that finished), and the records would be attributed
+    to the wrong episodes or dropped entirely. Wrapping the env instead needs no bookkeeping at
+    all: the record is final exactly when `close` returns, and that is where it is taken.
 
-    An env that exposes no usage is counted, not guessed at. `evaluate_pool` accepts any `Env`,
-    and a caller who supplies a non-metering one gets a stated gap rather than a fabricated $0.
+    An env that exposes no usage is counted, not guessed at. A cell accepts any `Env`, and a
+    caller who supplies a non-metering one gets a stated gap rather than a fabricated $0.
     """
 
     def __init__(self, inner: Callable[[], Env]) -> None:
         self._inner = inner
-        self._open: Env | None = None
+        self._lock = threading.Lock()
         self.records: list[RunRecord] = []
         self.unmetered = 0
 
     def __call__(self) -> Env:
-        """Build the next episode's env, banking the previous one's record first."""
-        self.finish()
-        self._open = self._inner()
-        return self._open
+        """Build one cell's env, wrapped so its record is banked when the cell closes it."""
+        return cast("Env", _HarvestedEnv(self._inner(), self))
 
-    def finish(self) -> None:
-        """Take the record off the env that just finished, if it kept one."""
-        if self._open is None:
-            return
-        env, self._open = self._open, None
+    def bank(self, env: Env) -> None:
+        """Take the final record off a closed env, or count it as unmetered."""
         record = getattr(env, "usage", None)
-        if isinstance(record, RunRecord):
-            self.records.append(record)
-        else:
-            self.unmetered += 1
+        with self._lock:
+            if isinstance(record, RunRecord):
+                self.records.append(record)
+            else:
+                self.unmetered += 1
+
+
+class _HarvestedEnv:
+    """One cell's env, which banks its world-model usage into the harvest when it closes.
+
+    Everything delegates. `last_score` in particular must propagate its own failures verbatim,
+    since a cell reads it defensively and tells a missing attribute (a non-scoring env, fatal)
+    apart from a raised one (a throttled judge, this cell only).
+    """
+
+    def __init__(self, inner: Env, harvest: _SessionHarvest) -> None:
+        self._inner = inner
+        self._harvest = harvest
+        self._banked = False
+
+    def reset(self, task: str | None = None, seed_state: EnvState | None = None) -> EnvState:
+        return self._inner.reset(task=task, seed_state=seed_state)
+
+    def step(self, action: Action) -> Observation:
+        return self._inner.step(action)
+
+    def close(self) -> None:
+        """Close the episode, then bank its record. Idempotent, as the `Env` contract requires."""
+        try:
+            self._inner.close()
+        finally:
+            if not self._banked:
+                self._banked = True
+                self._harvest.bank(self._inner)
+
+    @property
+    def last_score(self) -> EpisodeScore:
+        scoring = cast("ScoringEnv", self._inner)
+        return scoring.last_score
+
+    @property
+    def usage(self) -> RunRecord | None:
+        record = getattr(self._inner, "usage", None)
+        return record if isinstance(record, RunRecord) else None
 
 
 class CandidateCoverage(BaseModel):

--- a/wmo/optimize/sweep_partial.py
+++ b/wmo/optimize/sweep_partial.py
@@ -1,0 +1,254 @@
+"""The sweep's crash-safe sidecar: rows on disk the moment they are measured, and the resume.
+
+A sweep used to hold every measured cell in memory and write `matrix.json` once, at the end. One
+transport fault, one Ctrl-C, one laptop lid at hour five, and a run that had already bought
+hundreds of episodes had nothing to show for them. This module is the other half of that
+contract: `<matrix>.partial.jsonl` gains one line per cell as the cell completes, and the next
+invocation of the same plan measures only the cells the file does not already have.
+
+The format is a JSON Lines log, not a document: line 1 is the plan identity these rows were
+measured under, every later line is one `ScenarioOutcome`. Append-only, flushed and fsynced per
+line, so what survives a kill is a prefix of what was measured rather than a corrupt file. The
+last line for a cell wins, which is what makes a re-measured cell (`remeasured=True`) replace its
+earlier row without rewriting anything.
+
+Identity is checked, never assumed. Resuming a sidecar whose rows were measured under a different
+pool, a different scenario cut, a different episode count, step budget, history window, or
+compressor would silently mix two arms into one matrix, so a mismatch is refused with the field
+that differs named. That check is also the answer to a gap the tau-grid runner filed against the
+library: before this, nothing on disk recorded WHICH scenario cut a matrix came from.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Self
+
+from pydantic import BaseModel, ConfigDict
+
+from wmo.optimize.outcomes import ScenarioOutcome
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+PARTIAL_SUFFIX = ".partial.jsonl"
+"""Appended to the matrix path: `matrix.json` -> `matrix.json.partial.jsonl`."""
+
+PARTIAL_FORMAT_VERSION = 1
+"""Bumped only by a change that makes an older sidecar unreadable, so the refusal can say so."""
+
+IDENTITY_DIGEST_CHARS = 16
+"""64 bits, the same width `OutcomeMatrix`'s provenance digest uses."""
+
+
+class PartialSweepError(ValueError):
+    """A sidecar cannot be used, for a reason the operator can fix.
+
+    Raised rather than worked around on purpose: every alternative (ignore the file, delete it,
+    mix its rows in) either throws away paid cells or fabricates a matrix whose rows were measured
+    under two different plans. `wmo.optimize.sweep` re-raises these as `SweepError`.
+    """
+
+
+class PlanIdentity(BaseModel):
+    """What a set of measured rows was measured UNDER: the cohort pins, as data.
+
+    Two matrices are comparable when these agree and are different evidence when they do not, so
+    this is exactly the resume check, and exactly what a sidecar records about itself. Fields are
+    the properties that change what a cell MEASURES; how fast the sweep ran (concurrency) is not
+    one of them, so raising concurrency mid-run resumes cleanly instead of re-buying the grid.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pool: str  # digest of the candidate roster, prices included
+    scenarios: tuple[str, ...]  # the scenario cut, by id, in sweep order
+    episodes: int
+    max_steps: int
+    history_chars: int
+    compression: str  # `wmo.optimize.compression.compression_signature`
+
+    @property
+    def digest(self) -> str:
+        """A short stable hash of the whole identity, for stamping into artifacts and logs."""
+        canonical = self.model_dump_json()
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:IDENTITY_DIGEST_CHARS]
+
+    def mismatch(self, other: PlanIdentity) -> str | None:
+        """How `other` differs from this identity in operator terms, or None when it does not.
+
+        Names ONE difference, the first in declaration order: an operator who changed the pool and
+        the episode count fixes them one at a time anyway, and a wall of diffs buries the field
+        that actually explains the refusal.
+        """
+        if self == other:
+            return None
+        if self.pool != other.pool:
+            return "the candidate pool changed (different models, or different prices)"
+        if self.scenarios != other.scenarios:
+            return (
+                f"the scenario cut changed ({len(other.scenarios)} scenario(s) then, "
+                f"{len(self.scenarios)} now)"
+            )
+        if self.episodes != other.episodes:
+            return f"episodes per cell changed ({other.episodes} then, {self.episodes} now)"
+        if self.max_steps != other.max_steps:
+            return f"the step budget changed ({other.max_steps} then, {self.max_steps} now)"
+        if self.history_chars != other.history_chars:
+            return (
+                f"the observation window changed ({other.history_chars} chars then, "
+                f"{self.history_chars} now)"
+            )
+        return f"the compression arm changed ({other.compression} then, {self.compression} now)"
+
+
+class PartialHeader(BaseModel):
+    """Line 1 of a sidecar: which plan the rows below it belong to."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    version: int = PARTIAL_FORMAT_VERSION
+    identity: PlanIdentity
+
+
+def partial_path(out_path: Path) -> Path:
+    """Where a matrix destination's sidecar lives: beside it, so one dir check covers both."""
+    return out_path.with_name(out_path.name + PARTIAL_SUFFIX)
+
+
+def read_partial(path: Path, identity: PlanIdentity) -> list[ScenarioOutcome]:
+    """Rows a previous attempt at THIS plan measured, oldest first; empty when there are none.
+
+    A torn final line is tolerated and dropped: the process was killed between the write and the
+    flush, so that cell is simply unmeasured and gets bought again. A malformed line anywhere
+    ELSE is refused, because a hole in the middle of the log means the file is not what this
+    module wrote and guessing which rows are real is not a thing evidence may do.
+
+    Raises:
+        PartialSweepError: The sidecar is unreadable, was written by a newer format, or its rows
+            were measured under a different plan.
+    """
+    if not path.is_file():
+        return []
+    try:
+        lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    except OSError as exc:
+        raise PartialSweepError(
+            f"cannot read the partial sweep at {path}: {exc}. Delete it to start the sweep over "
+            "(the cells it holds are then bought again), or fix the permissions to resume it"
+        ) from exc
+    if not lines:
+        return []
+    header = _parse_header(path, lines[0])
+    difference = identity.mismatch(header.identity)
+    if difference is not None:
+        raise PartialSweepError(
+            f"{path} holds {len(lines) - 1} cell(s) measured under a DIFFERENT plan: "
+            f"{difference}. Those rows and this sweep's rows are not the same evidence, so they "
+            "cannot be merged into one matrix. Re-run with the previous settings to finish that "
+            f"sweep, or delete {path} to measure this plan from scratch"
+        )
+    return _parse_rows(path, lines[1:])
+
+
+def _parse_header(path: Path, line: str) -> PartialHeader:
+    """Line 1, or a refusal naming what the file is instead."""
+    try:
+        header = PartialHeader.model_validate_json(line)
+    except ValueError as exc:
+        raise PartialSweepError(
+            f"{path} does not start with a partial-sweep header, so it was not written by this "
+            f"sweep and its contents are unknown: {exc}. Move or delete it, then re-run"
+        ) from exc
+    if header.version != PARTIAL_FORMAT_VERSION:
+        raise PartialSweepError(
+            f"{path} was written in partial-sweep format v{header.version}; this build reads "
+            f"v{PARTIAL_FORMAT_VERSION}. Finish that sweep with the build that started it, or "
+            "delete the file to measure this plan from scratch"
+        )
+    return header
+
+
+def _parse_rows(path: Path, lines: list[str]) -> list[ScenarioOutcome]:
+    """Every row after the header, dropping only a torn LAST line."""
+    rows: list[ScenarioOutcome] = []
+    for number, line in enumerate(lines, start=2):
+        try:
+            rows.append(ScenarioOutcome.model_validate_json(line))
+        except ValueError as exc:
+            if number == len(lines) + 1:
+                logger.warning(
+                    "%s ends in a partly written row (line %d); that cell is measured again",
+                    path,
+                    number,
+                )
+                break
+            raise PartialSweepError(
+                f"{path} line {number} is not a measured cell: {exc}. The log is damaged in the "
+                "middle, so which of its rows are real cannot be established; move or delete the "
+                "file and re-run"
+            ) from exc
+    return rows
+
+
+class PartialWriter:
+    """Append-only writer for the sidecar: one flushed, fsynced line per completed cell.
+
+    Not thread-safe by itself, deliberately. The sweep already serializes its per-cell callback
+    under one lock (so progress printing cannot interleave), and writing under that same lock
+    keeps the log's order the completion order instead of adding a second lock to reason about.
+    """
+
+    def __init__(self, path: Path, identity: PlanIdentity) -> None:
+        self._path = path
+        self._identity = identity
+        # The matrix's directory is created by `OutcomeMatrix.save`, which does not run until the
+        # end; the sidecar needs it at the start. Creating it here (rather than at plan time)
+        # keeps the pre-spend path pure: an operator who declines the cost question leaves no
+        # trace on disk.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = path.open("a", encoding="utf-8")
+        if path.stat().st_size == 0:
+            self._write(PartialHeader(identity=identity).model_dump_json())
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, outcome: ScenarioOutcome) -> None:
+        """Persist one measured cell, durably, before the next one starts."""
+        self._write(outcome.model_dump_json())
+
+    def _write(self, payload: str) -> None:
+        self._handle.write(payload + "\n")
+        # Flushed AND fsynced per cell: a cell is minutes of wall clock and real money, and the
+        # whole point of the sidecar is to survive a kill that a buffered write would lose. The
+        # cost is one fsync per multi-minute episode.
+        self._handle.flush()
+        os.fsync(self._handle.fileno())
+
+    def close(self) -> None:
+        """Close the handle. Idempotent; the file stays on disk."""
+        if not self._handle.closed:
+            self._handle.close()
+
+    def discard(self) -> None:
+        """Close and remove the sidecar: the matrix it was protecting is written."""
+        self.close()
+        self._path.unlink(missing_ok=True)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/wmo/optimize/sweep_partial_test.py
+++ b/wmo/optimize/sweep_partial_test.py
@@ -1,0 +1,146 @@
+"""Tests for the sweep's crash-safe sidecar: what survives a kill, and what is refused.
+
+The sweep-level behaviour (resume, remeasure, the matrix the two halves assemble into) lives in
+`sweep_test.py`; these pin the file format itself, where the failure modes are damage and
+mistaken identity rather than measurement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wmo.optimize.outcomes import ScenarioOutcome
+from wmo.optimize.sweep_partial import (
+    PARTIAL_FORMAT_VERSION,
+    PartialHeader,
+    PartialSweepError,
+    PartialWriter,
+    PlanIdentity,
+    partial_path,
+    read_partial,
+)
+
+
+def _identity(**overrides: object) -> PlanIdentity:
+    fields: dict[str, object] = {
+        "pool": "poolsha",
+        "scenarios": ("s1", "s2"),
+        "episodes": 1,
+        "max_steps": 20,
+        "history_chars": 2000,
+        "compression": "raw text (no compression)",
+    }
+    return PlanIdentity.model_validate(fields | overrides)
+
+
+def _row(scenario: str, *, model: str = "cheap", episode: int = 0) -> ScenarioOutcome:
+    return ScenarioOutcome(
+        scenario_id=scenario, task=f"task {scenario}", model=model, episode=episode, reward=0.5
+    )
+
+
+def test_the_sidecar_sits_beside_the_matrix_it_protects() -> None:
+    assert partial_path(Path("/tmp/run/matrix.json")).name == "matrix.json.partial.jsonl"
+
+
+def test_rows_written_are_rows_read_back(tmp_path: Path) -> None:
+    path = partial_path(tmp_path / "matrix.json")
+    with PartialWriter(path, _identity()) as writer:
+        writer.append(_row("s1"))
+        writer.append(_row("s2"))
+    assert [row.scenario_id for row in read_partial(path, _identity())] == ["s1", "s2"]
+
+
+def test_reopening_appends_rather_than_starting_over(tmp_path: Path) -> None:
+    # This IS the resume: the second attempt adds to what the first one paid for.
+    path = partial_path(tmp_path / "matrix.json")
+    with PartialWriter(path, _identity()) as first:
+        first.append(_row("s1"))
+    with PartialWriter(path, _identity()) as second:
+        second.append(_row("s2"))
+    assert len(read_partial(path, _identity())) == 2
+    assert path.read_text(encoding="utf-8").count("\n") == 3  # one header, two rows
+
+
+def test_a_missing_sidecar_is_simply_nothing_to_resume(tmp_path: Path) -> None:
+    assert read_partial(partial_path(tmp_path / "matrix.json"), _identity()) == []
+
+
+def test_a_torn_last_line_costs_that_cell_and_nothing_else(tmp_path: Path) -> None:
+    # A kill between the write and the flush truncates the line being written. That cell is
+    # unmeasured and gets bought again; every completed cell before it still counts.
+    path = partial_path(tmp_path / "matrix.json")
+    with PartialWriter(path, _identity()) as writer:
+        writer.append(_row("s1"))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"scenario_id": "s2", "task": "half a ro')
+    rows = read_partial(path, _identity())
+    assert [row.scenario_id for row in rows] == ["s1"]
+
+
+def test_damage_in_the_middle_is_refused_because_the_log_is_then_unknown(tmp_path: Path) -> None:
+    path = partial_path(tmp_path / "matrix.json")
+    with PartialWriter(path, _identity()) as writer:
+        writer.append(_row("s1"))
+        writer.append(_row("s2"))
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines[1] = "{not json at all"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with pytest.raises(PartialSweepError, match="damaged in the middle"):
+        read_partial(path, _identity())
+
+
+def test_a_file_this_module_did_not_write_is_refused_by_its_first_line(tmp_path: Path) -> None:
+    path = partial_path(tmp_path / "matrix.json")
+    path.write_text('{"some": "other jsonl file"}\n', encoding="utf-8")
+    with pytest.raises(PartialSweepError, match="does not start with a partial-sweep header"):
+        read_partial(path, _identity())
+
+
+def test_a_newer_format_says_which_build_can_finish_that_sweep(tmp_path: Path) -> None:
+    path = partial_path(tmp_path / "matrix.json")
+    header = PartialHeader(version=PARTIAL_FORMAT_VERSION + 1, identity=_identity())
+    path.write_text(header.model_dump_json() + "\n", encoding="utf-8")
+    with pytest.raises(PartialSweepError, match="format v"):
+        read_partial(path, _identity())
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"pool": "different"}, "candidate pool changed"),
+        ({"scenarios": ("s1",)}, "scenario cut changed"),
+        ({"episodes": 3}, "episodes per cell changed"),
+        ({"max_steps": 40}, "step budget changed"),
+        ({"history_chars": 500}, "observation window changed"),
+        ({"compression": "compressor 'truncate' version 1 at aggressiveness 0.5"}, "arm changed"),
+    ],
+)
+def test_every_cohort_pin_is_a_refusal_that_names_itself(
+    tmp_path: Path, overrides: dict[str, object], expected: str
+) -> None:
+    # Each of these makes the rows a different arm. Merging any of them into one matrix would be
+    # a comparison nobody measured, so the refusal names the pin that moved.
+    path = partial_path(tmp_path / "matrix.json")
+    with PartialWriter(path, _identity()) as writer:
+        writer.append(_row("s1"))
+    with pytest.raises(PartialSweepError, match=expected):
+        read_partial(path, _identity(**overrides))
+
+
+def test_the_identity_digest_is_stable_and_sensitive() -> None:
+    assert _identity().digest == _identity().digest
+    assert _identity().digest != _identity(episodes=2).digest
+    assert _identity().mismatch(_identity()) is None
+
+
+def test_discarding_removes_the_file_the_matrix_replaced(tmp_path: Path) -> None:
+    path = partial_path(tmp_path / "matrix.json")
+    writer = PartialWriter(path, _identity())
+    writer.append(_row("s1"))
+    assert path.is_file()
+    writer.discard()
+    assert not path.exists()
+    writer.discard()  # idempotent: a second finish must not explode

--- a/wmo/optimize/sweep_test.py
+++ b/wmo/optimize/sweep_test.py
@@ -7,6 +7,9 @@ cases are cheaper to state than to stage through a command.
 
 from __future__ import annotations
 
+import json
+import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,6 +19,7 @@ import pytest
 
 from wmo.config import HarnessConfig, save_config
 from wmo.core.types import Action, ActionKind, EnvState, Observation, Step, Trace
+from wmo.env.closed_loop import CellKey
 from wmo.ingest.otel_writer import write_traces_jsonl
 from wmo.optimize.compression import CompressionConfig
 from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
@@ -30,14 +34,25 @@ from wmo.optimize.sweep import (
     plan_sweep,
     preflight_pool,
     resolve_config,
+    resumable_cells,
     unevenness,
 )
-from wmo.providers.base import ProviderConfig, ProviderKind
+from wmo.optimize.sweep_partial import partial_path
+from wmo.providers.base import (
+    Completion,
+    Message,
+    ProviderConfig,
+    ProviderKind,
+    TokenUsage,
+    VerifyResult,
+)
 from wmo.providers.pool import PoolEntry, load_pool
 from wmo.serving.traces_source import TRACES_FILENAME
 from wmo.tracking import Phase, RunRecord, UsageTotals
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from wmo.engine.world_model import WorldModel
     from wmo.env.base import Env
 
@@ -94,13 +109,15 @@ def _plan(
     episodes: int = 1,
     max_steps: int = 4,
     compression: CompressionConfig | None = None,
+    max_concurrency: int = 1,
+    out_name: str = "matrix.json",
 ) -> SweepPlan:
     model_dir = _model_dir(tmp_path)
     return plan_sweep(
         model_dir=model_dir,
         config=resolve_config(model_dir),
         pool=load_pool(_pool_file(tmp_path)),
-        out_path=tmp_path / "matrix.json",
+        out_path=tmp_path / out_name,
         traces_file=None,
         assume_input_tokens=2000,
         assume_output_tokens=250,
@@ -108,6 +125,7 @@ def _plan(
         episodes=episodes,
         max_steps=max_steps,
         compression=compression,
+        max_concurrency=max_concurrency,
     )
 
 
@@ -392,3 +410,274 @@ def test_a_sweep_that_dies_mid_flight_still_accounts_for_what_it_already_spent(
     # session was still opened against the world model and still metered, so leaving it out
     # would under-report what the aborted sweep actually cost.
     assert salvaged.total.cost_usd == pytest.approx(0.13)
+
+
+# --------------------------------------------------------- concurrency, persistence, and resume
+# The three properties a six-hour grid needs from this library: cells overlap, a cell that
+# completed is on disk, and a run that died buys only what is missing.
+
+
+class _DoneProvider:
+    """Candidate provider that finishes the episode on its first call, deterministically."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+
+    def complete(
+        self,
+        system: str,
+        messages: list[Message],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 8192,
+    ) -> Completion:
+        return Completion(
+            text='{"done": true, "summary": "finished"}',
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def verify(self) -> VerifyResult:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def candidates(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stub candidate construction; returns the list every constructed model id lands in.
+
+    `pool_provider` resolves `get_provider` from its module at call time, which is the seam the
+    CLI tests already use. Counting constructions is how a resume test proves that a skipped cell
+    was not merely overwritten but never ran.
+    """
+    built: list[str] = []
+
+    def _get_provider(config: ProviderConfig, api_key: str | None = None) -> _DoneProvider:
+        built.append(config.model)
+        return _DoneProvider(config)
+
+    monkeypatch.setattr("wmo.providers.pool.get_provider", _get_provider)
+    return built
+
+
+class _SlowEnv(_StubEnv):
+    """A stub env whose episode takes real wall time, so overlap is measurable."""
+
+    def reset(self, task: str | None = None, seed_state: object | None = None) -> EnvState:
+        time.sleep(0.05)
+        return super().reset(task, seed_state)
+
+
+class _ExplodingEnv(_StubEnv):
+    """A stub env that refuses to start: the transport fault a long grid eventually hits."""
+
+    def reset(self, task: str | None = None, seed_state: object | None = None) -> EnvState:
+        raise RuntimeError("world model session refused")
+
+
+def _factory(envs: list[_StubEnv]) -> Callable[[], Env]:
+    """Hand out `envs` in order, safely from several threads."""
+    handed = iter(envs)
+    lock = threading.Lock()
+
+    def build() -> Env:
+        with lock:
+            return cast("Env", next(handed))
+
+    return build
+
+
+def _run_plan(
+    plan: SweepPlan,
+    envs: list[_StubEnv],
+    *,
+    runs_dir: Path,
+    remeasure: frozenset[CellKey] = frozenset(),
+    on_outcome: Callable[[ScenarioOutcome], None] | None = None,
+) -> SweepRun:
+    return execute_sweep(
+        plan,
+        world_model=cast("WorldModel", _FrozenWorldModel()),
+        env_factory=_factory(envs),
+        runs_dir=runs_dir,
+        remeasure=remeasure,
+        on_outcome=on_outcome,
+    )
+
+
+def _sidecar_rows(plan: SweepPlan) -> list[ScenarioOutcome]:
+    """Every row in the sidecar, header skipped, in the order it was written."""
+    lines = partial_path(plan.out_path).read_text(encoding="utf-8").splitlines()
+    return [ScenarioOutcome.model_validate_json(line) for line in lines[1:]]
+
+
+def _comparable(matrix: OutcomeMatrix) -> str:
+    """The matrix as JSON with per-call WALL TIMES dropped, which no two runs can share."""
+    payload = matrix.model_dump(mode="json")
+    for row in payload["outcomes"]:
+        row["call_seconds"] = len(row["call_seconds"])
+    return json.dumps(payload, sort_keys=True)
+
+
+def test_a_cell_is_on_disk_before_the_next_one_starts(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    # The whole crash-safety claim in one assertion: by the time a cell is reported, its row is
+    # already durable, so a kill one microsecond later cannot lose it.
+    plan = _plan(tmp_path, scenarios=3)
+    seen_lines: list[int] = []
+
+    def check(outcome: ScenarioOutcome) -> None:
+        rows = _sidecar_rows(plan)
+        assert rows[-1].scenario_id == outcome.scenario_id
+        seen_lines.append(len(rows))
+
+    run = _run_plan(
+        plan, [_StubEnv(0.10) for _ in range(3)], runs_dir=tmp_path / "runs", on_outcome=check
+    )
+    assert seen_lines == [1, 2, 3]
+    assert len(run.matrix.outcomes) == 3
+    # ...and the sidecar is gone once the matrix it protected exists.
+    assert not partial_path(plan.out_path).exists()
+    assert plan.out_path.is_file()
+
+
+def test_a_crash_keeps_its_paid_cells_and_the_resume_buys_only_the_rest(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    envs = [_StubEnv(0.10), _StubEnv(0.10), _ExplodingEnv(0.10)]
+    with pytest.raises(RuntimeError, match="session refused"):
+        _run_plan(plan, envs, runs_dir=tmp_path / "runs")
+    assert len(_sidecar_rows(plan)) == 2  # the two that completed, not the one that died
+    assert not plan.out_path.exists()  # no matrix: the sweep never finished
+
+    built_before = len(candidates)
+    resumed = _run_plan(_plan(tmp_path, scenarios=3), [_StubEnv(0.10)], runs_dir=tmp_path / "runs")
+    assert len(candidates) - built_before == 1  # ONE cell ran, not three
+    assert resumed.resumed_cells == 2
+    assert len(resumed.matrix.outcomes) == 3
+    assert resumed.episodes_metered == 1  # this attempt's world-model spend, not the last one's
+    assert not partial_path(plan.out_path).exists()
+
+
+def test_a_resumed_run_says_its_world_model_figure_is_this_attempt_only(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    # The earlier attempt persisted its own kind="sweep" record, so adding the two here would
+    # double count; saying which cells this number covers is the honest alternative.
+    plan = _plan(tmp_path, scenarios=2)
+    with pytest.raises(RuntimeError):
+        _run_plan(plan, [_StubEnv(0.10), _ExplodingEnv(0.0)], runs_dir=tmp_path / "runs")
+    resumed = _run_plan(_plan(tmp_path, scenarios=2), [_StubEnv(0.10)], runs_dir=tmp_path / "runs")
+    gap = resumed.metering_gap
+    assert gap is not None and "this attempt only" in gap
+    assert resumed.world_model_usd == pytest.approx(0.10)
+
+
+def test_a_sidecar_from_a_different_plan_is_refused_rather_than_merged(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    # Two arms in one matrix is a fabricated comparison, so the mismatch is fatal and names the
+    # field that changed. Refused BEFORE the spend question too, via `resumable_cells`.
+    plan = _plan(tmp_path, scenarios=3)
+    with pytest.raises(RuntimeError):
+        _run_plan(plan, [_StubEnv(0.10), _ExplodingEnv(0.0)], runs_dir=tmp_path / "runs")
+    changed = _plan(tmp_path, scenarios=3, episodes=2)
+    with pytest.raises(SweepError, match="episodes per cell changed"):
+        resumable_cells(changed)
+    with pytest.raises(SweepError, match="DIFFERENT plan"):
+        _run_plan(changed, [_StubEnv(0.10) for _ in range(6)], runs_dir=tmp_path / "runs")
+
+
+def test_a_remeasured_cell_replaces_its_row_and_the_row_says_so(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    plan = _plan(tmp_path, scenarios=3)
+    with pytest.raises(RuntimeError, match="session refused"):
+        _run_plan(
+            plan, [_StubEnv(0.10), _StubEnv(0.10), _ExplodingEnv(0.10)], runs_dir=tmp_path / "runs"
+        )
+    retry = CellKey.of(_sidecar_rows(plan)[0])
+    resumed = _run_plan(
+        _plan(tmp_path, scenarios=3),
+        [_StubEnv(0.10), _StubEnv(0.10)],
+        runs_dir=tmp_path / "runs",
+        remeasure=frozenset({retry}),
+    )
+    assert resumed.remeasured_cells == 1
+    assert resumed.resumed_cells == 1  # the other completed cell was still reused
+    rows = {CellKey.of(row).model_dump_json(): row for row in resumed.matrix.outcomes}
+    assert rows[retry.model_dump_json()].remeasured is True
+    assert sum(row.remeasured for row in resumed.matrix.outcomes) == 1
+    assert len(resumed.matrix.outcomes) == 3  # replaced, not appended
+
+
+def test_the_matrix_is_the_same_evidence_at_one_cell_at_a_time_or_four(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    """The control for the whole change: concurrency is a speed knob, not a measurement change.
+
+    Compared with per-call wall times dropped, because those are the one field two runs of
+    anything cannot share. Everything else, including row ORDER, must match exactly, or the
+    matrix digests that `fit` and `tune` identify evidence by would drift with the thread count.
+    """
+    sequential = _run_plan(
+        _plan(tmp_path, scenarios=3, out_name="one.json"),
+        [_StubEnv(0.10) for _ in range(3)],
+        runs_dir=tmp_path / "runs",
+    )
+    concurrent = _run_plan(
+        _plan(tmp_path, scenarios=3, max_concurrency=4, out_name="four.json"),
+        [_StubEnv(0.10) for _ in range(3)],
+        runs_dir=tmp_path / "runs",
+    )
+    assert _comparable(concurrent.matrix) == _comparable(sequential.matrix)
+
+
+def test_concurrent_cells_overlap_and_still_meter_every_session(
+    tmp_path: Path, candidates: list[str]
+) -> None:
+    # Four 50ms episodes: sequentially 200ms of wall clock, four at a time one episode's worth.
+    # The metering assertion rides along because the harvest is what the redesign put at risk:
+    # four envs are alive at once, and each one's record must land exactly once.
+    plan = _plan(tmp_path, scenarios=4, max_concurrency=4)
+    started = time.monotonic()
+    run = _run_plan(plan, [_SlowEnv(0.10) for _ in range(4)], runs_dir=tmp_path / "runs")
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.15, f"4 overlapping cells took {elapsed:.3f}s"
+    assert run.episodes_metered == 4 and run.episodes_unmetered == 0
+    assert run.world_model_usd == pytest.approx(0.40)
+    assert run.metering_gap is None
+    assert len(_load_records(tmp_path / "runs")) == 1
+
+
+def _load_records(runs_dir: Path) -> list[RunRecord]:
+    return [
+        RunRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        for path in sorted(runs_dir.glob("*.json"))
+    ]
+
+
+def test_a_plan_identity_changes_with_what_it_measures_and_not_with_how_fast(
+    tmp_path: Path,
+) -> None:
+    base = _plan(tmp_path, scenarios=3)
+    assert _plan(tmp_path, scenarios=3, max_concurrency=8).identity == base.identity
+    assert _plan(tmp_path, scenarios=3, episodes=2).identity != base.identity
+    assert _plan(tmp_path, scenarios=2).identity != base.identity
+    assert (
+        _plan(
+            tmp_path,
+            scenarios=3,
+            compression=CompressionConfig(compressor_id="truncate", aggressiveness=0.5),
+        ).identity
+        != base.identity
+    )
+    assert len(base.identity.digest) == 16
+
+
+def test_a_concurrency_below_one_is_refused_at_plan_time(tmp_path: Path) -> None:
+    with pytest.raises(SweepError, match="at least 1"):
+        _plan(tmp_path, max_concurrency=0)

--- a/wmo/providers/bedrock.py
+++ b/wmo/providers/bedrock.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 from wmo.core.types import JsonValue
@@ -131,6 +132,17 @@ def resolve_region(configured: str | None) -> str | None:
     return configured or os.environ.get(AWS_REGION_ENV) or None
 
 
+_CLIENT_CONSTRUCTION_LOCK = threading.Lock()
+"""Serializes boto3 client CONSTRUCTION across every Bedrock provider in the process.
+
+boto3 documents a built client as safe to call from several threads, and says nothing of the
+kind about building one: `boto3.client()` goes through the shared default session, whose service
+loader and credential cache are filled in on first use. A concurrent sweep builds one provider
+per cell and starts several cells at once, which is exactly the race. Held only while the client
+is constructed; requests never touch it.
+"""
+
+
 class BedrockProvider:
     """Claude 4.8 via the Bedrock Runtime (InvokeModel with the Anthropic Messages body)."""
 
@@ -153,6 +165,21 @@ class BedrockProvider:
         # Lazy: import boto3 and open the client only on first use. The region comes from
         # `resolve_region` (config, then AWS_REGION), and None hands the rest of the chain
         # (AWS_DEFAULT_REGION, profile, instance role) back to boto3.
+        #
+        # Lock-guarded, and the lock is MODULE-level rather than per-provider: `boto3.client()`
+        # builds from boto3's shared default session, whose loader and credential caches are
+        # populated on first use and are not thread-safe, so two providers constructing their
+        # first client at the same moment race each other, not just themselves. A concurrent
+        # sweep does exactly that (one provider per cell, several cells starting together).
+        # Only CONSTRUCTION is serialized; the built client is thread-safe to call, and requests
+        # never touch this lock.
+        if self._client is None:
+            with _CLIENT_CONSTRUCTION_LOCK:
+                return self._build_client()
+        return self._client
+
+    def _build_client(self) -> BaseClient:
+        """Build this provider's boto3 client, unless another thread built it while we waited."""
         if self._client is None:
             import boto3
             from botocore.config import Config


### PR DESCRIPTION
The sweep measured cells strictly one at a time and wrote nothing until the last one finished, so a product-scale grid took most of a day and one transport fault at hour five threw all of it away. This adds bounded concurrency, per-cell persistence, and per-cell resume to `wmo/optimize/sweep.py`, which is the library both `wmo optimize route sweep` and `wmo optimize model` measure through.

Measured on a fake 0.2s cell (15 cells, same matrix at every setting): 3.08s at concurrency 1, 0.82s at 4, 0.41s at 8. Scaling is linear because the work is provider round trips. On the canonical tau arm's own numbers (~220 cells at ~2 min) that is roughly 7h to a bit over 1h at 6 concurrent, bounded by provider limits rather than by this code.

## What's in the diff

- `wmo/env/closed_loop.py`: the cell loop split into `pool_cells` (the grid in canonical order), `run_cell` (one cell, its own env and its own provider), and `run_cells` (bounded concurrency). `evaluate_pool` keeps its signature and is now that composition, so there is no second path to drift. `max_concurrency=1` is the sequential loop, cell for cell, log line included. Rows always come back in cell order, never finish order, because `fit` and `tune` identify a matrix by the sha256 of its bytes. The progress callback fires from the worker thread that finished the cell, serialized under one lock.
- `wmo/optimize/sweep_partial.py` (new): the crash-safe sidecar. `<matrix>.partial.jsonl` gains one flushed, fsynced line per completed cell, under a header recording the plan identity. A torn last line costs that one cell; damage in the middle is refused, because guessing which rows are real is not something evidence may do.
- `wmo/optimize/sweep.py`: `SweepPlan.max_concurrency` and `SweepPlan.identity`; `execute_sweep` resumes from the sidecar, runs only the missing cells, assembles the matrix in canonical order from both halves, and removes the sidecar once the matrix exists. `resumable_cells(plan)` lets a caller read the resume count (and hit an identity mismatch) before asking anyone to authorize spend. `remeasure` takes cells to buy again despite the sidecar holding them, for a retry pass.
- `wmo/providers/bedrock.py`: a module-level lock around boto3 client CONSTRUCTION. See the thread-safety notes below.
- CLI: `--concurrency` on both faces, the pace and the resume count in the plan table and the cost estimate, and a progress counter that counts what this run is measuring rather than the whole grid. The sweep stage's skip fingerprint deliberately excludes concurrency, so raising it does not re-buy a current matrix.
- Docs: the `--concurrency` flag, the sidecar, and cell-level resume in `docs/cookbook/tau-bench.md`.

## Thread-safety, checked rather than assumed

- **WorldModel sessions are independent, and freezing is what makes them safe.** New regression test: 16 sessions on 8 threads against one frozen model, asserting each session kept its own history and its own metering, that ending them all leaves the model empty, and that the shared retrieval index did not grow. The session and tracker dicts are keyed per session and only ever touched at distinct keys. The hazard is enrichment (append plus `np.vstack` on the shared retriever), which `frozen()` disables for the whole run; that is why `execute_sweep` freezes around the grid rather than per cell.
- **boto3 client construction was racy.** boto3 documents a built client as safe to call from several threads and says nothing of the kind about building one: `boto3.client()` goes through the shared default session, whose loader and credential caches fill in on first use, and a concurrent sweep builds one provider per cell. The lock is module-level (the session is shared across instances) and held only during construction. llm-waterfall's Bedrock adapter already does exactly this. httpx-backed providers (openai, anthropic) are safe to call concurrently and their duplicate-construction race is benign.
- **Candidate providers are never shared**: `run_cell` builds its own per cell, which was already true and is now the reason a cell is safe to hand to a worker.
- **The session harvest was the one thing concurrency broke, so it is redesigned.** It banked the previous env's record when the next env was requested, which assumed one env alive at a time; with cells in parallel that is false in both directions. Each env is now wrapped and banks its own record at its own close.

## Correctness contracts held

Coverage contract, cost confirmation, consent refusal, and the `kind="sweep"` world-model record are unchanged. A resumed run persists only what IT spent (the earlier attempt wrote its own record) and `metering_gap` says so, rather than quietly reporting a figure that covers part of the matrix. An identity mismatch (pool, scenario cut, episodes, step budget, observation window, compressor) is refused with the pin that moved named, before the spend question, instead of merging two arms into one matrix.

## Tests

- Concurrency: 4 cells at once finish in a fraction of the sequential wall clock with sleeping fake providers; the matrix is in cell order even when the cells finish backwards; the callback never runs two cells at once; a cell that raises still reports the cells that finished; concurrency below 1 is a usage error at plan time.
- Persistence and resume: a cell is on disk before the next one starts; a crash keeps its paid cells and the resume buys only the rest (asserted by counting provider constructions); a sidecar from a different plan is refused; a remeasured cell replaces its row and says so; the matrix is the same evidence at 1 or 4 (byte-comparable with per-call wall times dropped, the one field no two runs share); world-model totals equal the sum of per-cell session records under concurrency.
- Sidecar format: 16 tests over torn last lines, mid-file damage, foreign files, newer formats, and every cohort pin's refusal message.
- Both CLI faces: higher concurrency writes the same matrix, an interrupted run resumes, a foreign sidecar is refused, the plan table shows the pace and what a resume will not rebuy.

Also driven end to end through the real `route sweep` command with faked providers: killed mid-sweep (4 rows on disk, no matrix), resumed at `--concurrency 4` (8 remaining cells, 12-row matrix in canonical order, sidecar removed, "this attempt only" note on the world-model spend), and refused when the plan changed underneath it.

## Justification ledger

- Named consumers: Silen's pipeline-speed directive ("the pipeline shouldn't take six hours"); the corner chats' re-renders, which re-measure the same grids; every future product run of `wmo optimize model`; and the continual-loop vision, which cannot exist on a library that forfeits a run on any fault.
- Gaps closed, by the number the tau-grid runner filed them under: (1) no concurrency; (2) no scenario slicing, now `pool_cells` plus a resume that runs an arbitrary subset; (3) no mid-sweep persistence; (4) no retry provenance on rows, now `ScenarioOutcome.remeasured`; (5) nothing recorded the scenario cut's identity, now `SweepPlan.identity`, stamped into the sidecar and checked on resume.
- Default path unchanged: `max_concurrency=1` is byte-identical, and every existing test passes without modification.

## Merge gate

`/ready-for-merge` has NOT been run. Full gate green on this branch: `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pytest -q` (4184 passed, 19 skipped).