### PR TITLE
Record GEPA's base-vs-winner delta on selection-disjoint data

### DIFF
--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -265,13 +265,16 @@ def build(
         # (never test: the build's data boundary keeps test untouched for `wmo eval`), so its
         # leftover traces past the cap are a genuinely disjoint, still leak-free sample. Capping
         # that remainder at the same `gepa_val_size` keeps the re-check's cost the same order of
-        # magnitude as before: the two fresh eval passes already happened every GEPA build
-        # (`recheck_rollouts = 2 * len(recheck_steps)`), just against the selection data; this
-        # only repoints them. Empty (never None, falsy either way) exactly when `val` was too
-        # small to leave anything past the cap; `GEPAOptimizer.optimize` then falls back to the
-        # selection valset itself, so `metrics.base_fresh`/`best_fresh` stay populated (not a
-        # leak-free comparison in that corner case, but never silently mislabeled as one).
-        recheck = _cap_gepa_valset(val[len(gepa_val) :], gepa_val_size)
+        # magnitude as before in the common case: the two fresh eval passes already happened
+        # every GEPA build (`recheck_rollouts = 2 * len(recheck_steps)`), just against the
+        # selection data; this only repoints them. `allow_oversized_first=False`: unlike
+        # `gepa_val` (which must never come back empty - GEPA needs SOME valset), an empty
+        # `recheck` has a graceful, already-tested fallback inside `optimize()` (re-scores the
+        # selection valset itself), so a single oversized trace landing first in the leftover
+        # must not be let through alone - that would blow the re-check's cost past the selection
+        # pass it is supposed to match, for no benefit over falling back. `metrics.json` records
+        # which of the two happened via `fresh_recheck_disjoint` - never silently indistinguishable.
+        recheck = _cap_gepa_valset(val[len(gepa_val) :], gepa_val_size, allow_oversized_first=False)
         result = optimizer.optimize(
             train, gepa_val, BASE_ENV_PROMPT, config.gepa_budget, recheck=recheck
         )
@@ -364,16 +367,28 @@ def build(
 _GEPA_VAL_STEP_CAP = 16
 
 
-def _cap_gepa_valset(traces: list[Trace], max_steps: int = _GEPA_VAL_STEP_CAP) -> list[Trace]:
-    """A prefix of `traces` totalling at most `max_steps` steps (always at least one trace).
+def _cap_gepa_valset(
+    traces: list[Trace], max_steps: int = _GEPA_VAL_STEP_CAP, *, allow_oversized_first: bool = True
+) -> list[Trace]:
+    """A prefix of `traces` totalling at most `max_steps` steps.
 
     `split_traces` already shuffles deterministically, so the prefix is an unbiased, stable
     sample of the held-out split.
+
+    `allow_oversized_first` (default True, GEPA's own selection valset): a single trace bigger
+    than `max_steps` still passes through alone when it is the very first candidate, so GEPA is
+    never starved of a valset entirely. Pass False for a caller where an EMPTY result has an
+    acceptable fallback and the cost ceiling matters more than always returning something (e.g.
+    the acceptance re-check's disjoint sample in `wmo.engine.build.build`: if the leftover
+    validation traces happen to start with one unusually long trace, letting it through alone
+    would blow the re-check's cost past what the selection valset itself pays - `optimize()`
+    already falls back gracefully to the selection valset on an empty `recheck`, so returning
+    `[]` here is strictly safer than an oversized pass).
     """
     capped: list[Trace] = []
     steps = 0
     for trace in traces:
-        if capped and steps + len(trace.steps) > max_steps:
+        if (capped or not allow_oversized_first) and steps + len(trace.steps) > max_steps:
             break
         capped.append(trace)
         steps += len(trace.steps)

--- a/wmo/engine/build.py
+++ b/wmo/engine/build.py
@@ -256,8 +256,25 @@ def build(
         # the whole valset, and steps (not traces) are what bound cost — a long-trace corpus once
         # turned a 4-iteration tier into $131. The default ceiling applies always; a fidelity
         # tier may widen it (`gepa_val_cap`, in steps).
-        gepa_val = _cap_gepa_valset(val or train, gepa_val_cap or _GEPA_VAL_STEP_CAP)
-        result = optimizer.optimize(train, gepa_val, BASE_ENV_PROMPT, config.gepa_budget)
+        gepa_val_size = gepa_val_cap or _GEPA_VAL_STEP_CAP
+        gepa_val = _cap_gepa_valset(val or train, gepa_val_size)
+        # The acceptance re-check (inside `optimizer.optimize`) must not grade base-vs-winner on
+        # the very steps GEPA selected candidates against: that would test selection, not
+        # generalization, and is exactly what made `metrics.held_out_accuracy` unable to answer
+        # whether GEPA helps. `val` is the SAME validation split `gepa_val` was capped from
+        # (never test: the build's data boundary keeps test untouched for `wmo eval`), so its
+        # leftover traces past the cap are a genuinely disjoint, still leak-free sample. Capping
+        # that remainder at the same `gepa_val_size` keeps the re-check's cost the same order of
+        # magnitude as before: the two fresh eval passes already happened every GEPA build
+        # (`recheck_rollouts = 2 * len(recheck_steps)`), just against the selection data; this
+        # only repoints them. Empty (never None, falsy either way) exactly when `val` was too
+        # small to leave anything past the cap; `GEPAOptimizer.optimize` then falls back to the
+        # selection valset itself, so `metrics.base_fresh`/`best_fresh` stay populated (not a
+        # leak-free comparison in that corner case, but never silently mislabeled as one).
+        recheck = _cap_gepa_valset(val[len(gepa_val) :], gepa_val_size)
+        result = optimizer.optimize(
+            train, gepa_val, BASE_ENV_PROMPT, config.gepa_budget, recheck=recheck
+        )
         # A GEPA candidate can be empty - a weak reflection LM (e.g. a self-reflecting open model)
         # sometimes proposes a blank env prompt that still scores acceptably on easy steps and
         # gets selected. An empty env prompt is never a valid artifact, so fall back to base.

--- a/wmo/engine/build_test.py
+++ b/wmo/engine/build_test.py
@@ -591,3 +591,88 @@ def test_build_default_runs_no_search(tmp_path) -> None:  # noqa: ANN001
         embedder=HashingEmbedder(dim=64),
     )
     assert not (root / "auto_fidelity.json").exists()  # default stays plain RAG, no search
+
+
+def test_build_low_tier_records_no_gepa_sentinel_not_zero(tmp_path) -> None:  # noqa: ANN001
+    """`--fidelity low` (gepa_budget<=0) never runs the acceptance re-check, so `metrics.json`
+    must record base_fresh/best_fresh/fresh_delta as `null`, never a `0.0` a reader could mistake
+    for "GEPA ran and measured a tie". Without `OptimizeMetrics` carrying these fields at all,
+    this key lookup fails outright."""
+    root = tmp_path / ".wmo"
+    config = HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="m")],
+        serve_provider=ProviderKind.BEDROCK,
+        embed_dim=64,
+        gepa_budget=0,  # the low fidelity tier: RAG only, GEPA never runs
+        train_split=0.5,
+    )
+    build(
+        config,
+        file=_tiny_trace_file(tmp_path),
+        root=str(root),
+        serve_provider=FakeProvider(),
+        embedder=HashingEmbedder(dim=64),
+    )
+    metrics = json.loads(ArtifactPaths(root).metrics.read_text(encoding="utf-8"))
+    assert metrics["base_fresh"] is None
+    assert metrics["best_fresh"] is None
+    assert metrics["fresh_delta"] is None
+
+
+def test_build_gepa_recheck_is_disjoint_from_the_selection_valset(tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    """The build must not re-check GEPA's winner on the same steps it was selected on: that
+    would test selection, not generalization, and is exactly why `held_out_accuracy` could not
+    answer whether GEPA helps. Regression for `optimize()` being called without `recheck=` at
+    all, which silently fell back to the selection valset itself."""
+    import sys
+
+    from wmo.optimize import OptimizeResult
+
+    build_mod = sys.modules["wmo.engine.build"]
+    # Plenty of one-step traces so the val split comfortably exceeds the GEPA valset step cap
+    # (16 by default), leaving a real disjoint remainder to recheck against.
+    traces_file = _multi_trace_file(tmp_path, 150)
+
+    captured: dict[str, list[Trace] | None] = {}
+
+    class _RecordingOptimizer:
+        def __init__(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+            pass
+
+        def optimize(  # noqa: ANN202
+            self,
+            train,  # noqa: ANN001
+            test,  # noqa: ANN001
+            base_prompt,  # noqa: ANN001
+            budget,  # noqa: ANN001
+            *,
+            recheck=None,  # noqa: ANN001
+            **kwargs,  # noqa: ANN003
+        ):
+            captured["gepa_val"] = test
+            captured["recheck"] = recheck
+            return OptimizeResult(prompt=base_prompt, frontier=[base_prompt])
+
+    monkeypatch.setattr(build_mod, "GEPAOptimizer", _RecordingOptimizer)
+    config = HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="m")],
+        serve_provider=ProviderKind.BEDROCK,
+        embed_dim=64,
+        gepa_budget=2,
+        train_split=0.5,
+    )
+    build(
+        config,
+        file=traces_file,
+        root=str(tmp_path / ".wmo"),
+        serve_provider=FakeProvider(),
+        embedder=HashingEmbedder(dim=64),
+    )
+
+    gepa_val = captured["gepa_val"]
+    recheck = captured["recheck"]
+    assert gepa_val  # the selection valset itself was non-empty
+    assert recheck  # a real disjoint sample was found, not an empty no-op fallback
+    gepa_val_ids = {t.trace_id for t in gepa_val}
+    recheck_ids = {t.trace_id for t in recheck}
+    assert not (gepa_val_ids & recheck_ids)

--- a/wmo/engine/build_test.py
+++ b/wmo/engine/build_test.py
@@ -152,6 +152,28 @@ def test_cap_gepa_valset_bounds_steps_and_keeps_at_least_one_trace() -> None:
     assert _cap_gepa_valset([huge]) == [huge]
 
 
+def test_cap_gepa_valset_can_refuse_an_oversized_first_trace() -> None:
+    """`allow_oversized_first=False` (used for the acceptance re-check's disjoint sample, which
+    has a safe empty-result fallback) must return `[]` rather than let one oversized trace
+    through - letting it through would make that one re-check pass cost far more than the
+    selection valset it is supposed to match, for no benefit over falling back."""
+    from wmo.engine.build import _GEPA_VAL_STEP_CAP, _cap_gepa_valset
+
+    def trace_with_steps(tid: str, n: int) -> Trace:
+        step = Step(
+            action=Action(kind=ActionKind.TOOL_CALL, name="get", arguments={}),
+            observation=Observation(content="ok"),
+        )
+        return Trace(trace_id=tid, steps=[step.model_copy() for _ in range(n)])
+
+    huge = trace_with_steps("huge", _GEPA_VAL_STEP_CAP + 10)
+    small = trace_with_steps("small", 2)
+    assert _cap_gepa_valset([huge, small], allow_oversized_first=False) == []
+    # A normal-sized leading trace is unaffected: the strict mode only refuses an OVERSIZED
+    # first trace, it does not change behavior when nothing would overflow.
+    assert _cap_gepa_valset([small, small], allow_oversized_first=False) == [small, small]
+
+
 def _multi_trace_file(tmp_path, n: int) -> str:  # noqa: ANN001 - pytest fixture
     """Write `n` one-step OTel traces with distinct 32-char trace ids."""
     lines: list[str] = []
@@ -617,6 +639,7 @@ def test_build_low_tier_records_no_gepa_sentinel_not_zero(tmp_path) -> None:  # 
     assert metrics["base_fresh"] is None
     assert metrics["best_fresh"] is None
     assert metrics["fresh_delta"] is None
+    assert metrics["fresh_recheck_disjoint"] is None
 
 
 def test_build_gepa_recheck_is_disjoint_from_the_selection_valset(tmp_path, monkeypatch) -> None:  # noqa: ANN001
@@ -676,3 +699,61 @@ def test_build_gepa_recheck_is_disjoint_from_the_selection_valset(tmp_path, monk
     gepa_val_ids = {t.trace_id for t in gepa_val}
     recheck_ids = {t.trace_id for t in recheck}
     assert not (gepa_val_ids & recheck_ids)
+
+
+def test_build_records_disjoint_false_when_recheck_falls_back_to_selection(tmp_path) -> None:  # noqa: ANN001
+    """When the validation split is too small to leave anything past the GEPA selection cap,
+    `recheck` comes back empty and the acceptance re-check falls back to re-scoring the
+    selection valset itself (pre-existing behavior). That fallback is NOT a held-out
+    measurement: `metrics.json` must say so via `fresh_recheck_disjoint: false`, not persist
+    `base_fresh`/`best_fresh` in the same shape as a genuinely disjoint comparison (Greptile
+    flagged this: a selection-biased delta would be indistinguishable from generalization
+    evidence in artifact audits)."""
+    MARKER = "Environment-specific notes"
+
+    class _PromptSensitiveBuildProvider(FakeProvider):
+        """Predicts (and is judged) differently depending on which candidate is serving, so the
+        real (unmocked) `gepa` engine has an actual signal to prefer the evolved candidate."""
+
+        def complete(self, system, messages, *, temperature=0.7, max_tokens=8192):  # noqa: ANN001, ANN202
+            self.systems.append(system)
+            if "improve the system prompt" in system:
+                return Completion(text=f"BASE ENV PROMPT\n\n{MARKER}:\n- always succeed")
+            if "grade a world model" in system:
+                good = '"predicted-good"' in "".join(m.content for m in messages)
+                score = 0.9 if good else 0.2
+                return Completion(
+                    text=(
+                        f'{{"format": {score}, "factuality": {score}, "consistency": {score}, '
+                        f'"realism": {score}, "quality": {score}, "critique": "ok"}}'
+                    )
+                )
+            if MARKER in system:
+                return Completion(text='{"output": "predicted-good", "is_error": false}')
+            return Completion(text='{"output": "predicted-bad", "is_error": false}')
+
+    root = tmp_path / ".wmo"
+    config = HarnessConfig(
+        providers=[ProviderConfig(kind=ProviderKind.BEDROCK, model="m")],
+        serve_provider=ProviderKind.BEDROCK,
+        embed_dim=64,
+        gepa_budget=3,
+        train_split=0.5,
+    )
+    # Few one-step traces: however the hash split lands, the validation split's total steps
+    # cannot exceed the default 16-step selection cap, so `gepa_val` consumes all of it and
+    # `recheck` is guaranteed empty - the exact corner case under test.
+    build(
+        config,
+        file=_multi_trace_file(tmp_path, 6),
+        root=str(root),
+        serve_provider=_PromptSensitiveBuildProvider(),
+        embedder=HashingEmbedder(dim=64),
+    )
+    metrics = json.loads(ArtifactPaths(root).metrics.read_text(encoding="utf-8"))
+    # The search found and kept a real winner over base (base_fresh/best_fresh are populated,
+    # not the "GEPA never ran"/"nothing to re-check" None), but on the selection sample - the
+    # artifact must label it as such.
+    assert metrics["base_fresh"] is not None
+    assert metrics["best_fresh"] is not None
+    assert metrics["fresh_recheck_disjoint"] is False

--- a/wmo/optimize/base.py
+++ b/wmo/optimize/base.py
@@ -115,6 +115,16 @@ class OptimizeMetrics(BaseModel):
     # `best_fresh - base_fresh`: positive means the accepted/rejected winner beat base on the
     # fresh sample; `None` exactly when `base_fresh`/`best_fresh` are `None`.
     fresh_delta: float | None = None
+    # Whether the fresh comparison above actually ran on data disjoint from GEPA's selection
+    # valset (a caller-supplied `recheck` set that yielded real steps), or fell back to re-scoring
+    # the selection valset itself (no `recheck` given, or it flattened to zero steps - e.g. the
+    # validation split was too small to leave anything past the selection cap). A selection-set
+    # comparison tests selection, not generalization: without this flag, a build whose corpus
+    # forced the fallback would persist `base_fresh`/`best_fresh`/`fresh_delta` in the exact same
+    # shape as a genuinely held-out measurement, so a reader auditing the artifact could not tell
+    # the two apart. `None` exactly when `base_fresh`/`best_fresh` are `None` (no fresh comparison
+    # happened at all); `True`/`False` whenever the acceptance re-check ran.
+    fresh_recheck_disjoint: bool | None = None
     # Reserved: judge self-consistency / human-agreement proxy. Populating it needs repeated or
     # independent judging (not yet implemented); `None` until then so it never reads as a real 0.0.
     judge_agreement: float | None = None

--- a/wmo/optimize/base.py
+++ b/wmo/optimize/base.py
@@ -99,6 +99,22 @@ class OptimizeMetrics(BaseModel):
     # and the base prompt was restored (see `GEPAOptimizer.optimize`). Surfaced so research runs
     # can report how often GEPA's search wins fail to survive an independent evaluation.
     reverted_to_base: bool = False
+    # The base-vs-winner acceptance re-check's fresh paired scores (see `GEPAOptimizer.optimize`):
+    # `base_fresh` is the base prompt's mean judge score and `best_fresh` the search's winning
+    # candidate's mean judge score, both measured in the SAME pass over the SAME (ideally
+    # selection-disjoint) sample - the exact comparison the revert decision is made from. This is
+    # the answer to "did GEPA actually help", which the boolean `reverted_to_base` alone cannot
+    # give: `reverted_to_base=False` is ambiguous between "the winner beat base and was kept" and
+    # "GEPA's own search already picked base, nothing to re-check" and "GEPA never ran at all"
+    # (`--fidelity low`, budget<=0). `base_fresh`/`best_fresh` stay `None` (never a misleading 0.0)
+    # in the two cases where no fresh comparison happened - a `--fidelity low` build and a GEPA
+    # pass whose search-time winner was already the base prompt - and are both populated (even
+    # when they tie, `fresh_delta == 0.0`) whenever the acceptance re-check actually ran.
+    base_fresh: float | None = None
+    best_fresh: float | None = None
+    # `best_fresh - base_fresh`: positive means the accepted/rejected winner beat base on the
+    # fresh sample; `None` exactly when `base_fresh`/`best_fresh` are `None`.
+    fresh_delta: float | None = None
     # Reserved: judge self-consistency / human-agreement proxy. Populating it needs repeated or
     # independent judging (not yet implemented); `None` until then so it never reads as a real 0.0.
     judge_agreement: float | None = None

--- a/wmo/optimize/base_test.py
+++ b/wmo/optimize/base_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -27,6 +28,21 @@ def test_optimize_result_defaults_are_prompt_only() -> None:
     assert result.prompt == "serve this"
     assert result.artifacts == []
     assert result.metrics == OptimizeMetrics()
+
+
+def test_optimize_metrics_fresh_recheck_fields_default_to_none_not_zero() -> None:
+    # A "no fresh comparison happened" build (GEPA never ran, or its search-time winner was
+    # already base) must be distinguishable from a real measured tie: None, never a 0.0 that a
+    # reader could mistake for "GEPA ran and found no difference".
+    metrics = OptimizeMetrics()
+    assert metrics.base_fresh is None
+    assert metrics.best_fresh is None
+    assert metrics.fresh_delta is None
+    # Round-trips through JSON as `null`, not omitted or coerced to 0.0.
+    dumped = json.loads(metrics.model_dump_json())
+    assert dumped["base_fresh"] is None
+    assert dumped["best_fresh"] is None
+    assert dumped["fresh_delta"] is None
 
 
 def test_artifact_refs_cover_every_optimizer_family() -> None:

--- a/wmo/optimize/base_test.py
+++ b/wmo/optimize/base_test.py
@@ -38,11 +38,13 @@ def test_optimize_metrics_fresh_recheck_fields_default_to_none_not_zero() -> Non
     assert metrics.base_fresh is None
     assert metrics.best_fresh is None
     assert metrics.fresh_delta is None
+    assert metrics.fresh_recheck_disjoint is None
     # Round-trips through JSON as `null`, not omitted or coerced to 0.0.
     dumped = json.loads(metrics.model_dump_json())
     assert dumped["base_fresh"] is None
     assert dumped["best_fresh"] is None
     assert dumped["fresh_delta"] is None
+    assert dumped["fresh_recheck_disjoint"] is None
 
 
 def test_artifact_refs_cover_every_optimizer_family() -> None:

--- a/wmo/optimize/gepa.py
+++ b/wmo/optimize/gepa.py
@@ -692,6 +692,7 @@ class GEPAOptimizer:
         # comparison happened" from a real measured tie (see `OptimizeMetrics` docstring).
         base_fresh: float | None = None
         best_fresh: float | None = None
+        disjoint: bool | None = None
         if best != base_prompt:
             # Stagnant-or-improve acceptance re-check. GEPA promotes by argmax over SINGLE-sample
             # valset evaluations, and rollout+judge scores are noisy run-to-run even at T=0 (the
@@ -705,10 +706,13 @@ class GEPAOptimizer:
             # instead, which also catches winners whose valset win is real but biased (e.g. a
             # step-capped valset over-representing short traces). Always falls back to the FULL
             # valset - never the hard-filtered selection subset - and to the full valset again if
-            # the recheck traces carry no steps (0.0-vs-0.0 would silently keep any winner).
-            recheck_steps = _eval_steps(recheck, demos) if recheck else full_valset
-            if not recheck_steps:
-                recheck_steps = full_valset
+            # the recheck traces carry no steps (0.0-vs-0.0 would silently keep any winner). This
+            # fallback tests selection, not generalization, so `disjoint` records which one
+            # actually happened - a reader auditing `metrics.json` must not mistake a
+            # selection-sample fallback for a held-out measurement.
+            disjoint_steps = _eval_steps(recheck, demos) if recheck else []
+            disjoint = bool(disjoint_steps)
+            recheck_steps = disjoint_steps if disjoint else full_valset
             base_fresh = _mean_valset_score(adapter, recheck_steps, base_prompt)
             best_fresh = _mean_valset_score(adapter, recheck_steps, best)
             recheck_rollouts = 2 * len(recheck_steps)
@@ -737,6 +741,7 @@ class GEPAOptimizer:
                 base_fresh=base_fresh,
                 best_fresh=best_fresh,
                 fresh_delta=fresh_delta,
+                fresh_recheck_disjoint=disjoint,
             ),
         )
 

--- a/wmo/optimize/gepa.py
+++ b/wmo/optimize/gepa.py
@@ -687,6 +687,11 @@ class GEPAOptimizer:
         held_out = float(result.val_aggregate_scores[result.best_idx])
         reverted = False
         recheck_rollouts = 0
+        # Populated only when the acceptance re-check below actually runs (`best != base_prompt`);
+        # stay `None` otherwise so `OptimizeMetrics.base_fresh`/`best_fresh` distinguish "no fresh
+        # comparison happened" from a real measured tie (see `OptimizeMetrics` docstring).
+        base_fresh: float | None = None
+        best_fresh: float | None = None
         if best != base_prompt:
             # Stagnant-or-improve acceptance re-check. GEPA promotes by argmax over SINGLE-sample
             # valset evaluations, and rollout+judge scores are noisy run-to-run even at T=0 (the
@@ -717,6 +722,9 @@ class GEPAOptimizer:
                 frontier = [base_prompt] + [p for p in frontier if p != base_prompt]
             else:
                 held_out = best_fresh
+        fresh_delta = (
+            best_fresh - base_fresh if base_fresh is not None and best_fresh is not None else None
+        )
         return OptimizeResult(
             prompt=best,
             frontier=frontier,
@@ -726,6 +734,9 @@ class GEPAOptimizer:
                 held_out_accuracy=held_out,
                 rollouts_used=int(result.total_metric_calls or 0) + recheck_rollouts,
                 reverted_to_base=reverted,
+                base_fresh=base_fresh,
+                best_fresh=best_fresh,
+                fresh_delta=fresh_delta,
             ),
         )
 

--- a/wmo/optimize/gepa_test.py
+++ b/wmo/optimize/gepa_test.py
@@ -247,6 +247,7 @@ def test_optimize_with_zero_budget_returns_base_prompt() -> None:
     assert result.metrics.base_fresh is None
     assert result.metrics.best_fresh is None
     assert result.metrics.fresh_delta is None
+    assert result.metrics.fresh_recheck_disjoint is None
 
 
 def test_optimize_with_no_traces_returns_base_prompt() -> None:
@@ -333,6 +334,9 @@ def test_optimize_reverts_to_base_when_fresh_recheck_contradicts(monkeypatch) ->
     assert abs(result.metrics.base_fresh - 0.9) < 1e-9
     assert abs(result.metrics.best_fresh - 0.1) < 1e-9
     assert abs(result.metrics.fresh_delta - (-0.8)) < 1e-9
+    # No `recheck` traces were supplied: the comparison fell back to re-scoring the selection
+    # valset itself, which the artifact must not mislabel as a held-out measurement.
+    assert result.metrics.fresh_recheck_disjoint is False
     # The returned prompt leads the frontier - the rejected winner must not be presented as the
     # top validated candidate (frontier.json consumers pick from the front).
     assert result.frontier[0] == "BASE"
@@ -385,6 +389,8 @@ def test_optimize_keeps_winner_when_fresh_recheck_confirms(monkeypatch) -> None:
     assert abs(result.metrics.base_fresh - 0.2) < 1e-9
     assert abs(result.metrics.best_fresh - 0.8) < 1e-9
     assert abs(result.metrics.fresh_delta - 0.6) < 1e-9
+    # No `recheck` traces were supplied here either: same fallback, same "not disjoint" label.
+    assert result.metrics.fresh_recheck_disjoint is False
 
 
 def test_optimize_recheck_raises_on_total_judge_outage(monkeypatch) -> None:  # noqa: ANN001
@@ -420,6 +426,9 @@ def test_optimize_recheck_with_empty_step_traces_falls_back_to_valset(monkeypatc
     assert result.prompt == "BASE"
     assert result.metrics.reverted_to_base is True
     assert result.metrics.held_out_accuracy > 0.0
+    # A `recheck` that flattened to zero steps is a fallback, not a disjoint measurement - the
+    # artifact must say so, or a selection-sample comparison reads as held-out evidence.
+    assert result.metrics.fresh_recheck_disjoint is False
 
 
 def test_optimize_recheck_can_use_disjoint_traces(monkeypatch) -> None:  # noqa: ANN001
@@ -448,6 +457,9 @@ def test_optimize_recheck_can_use_disjoint_traces(monkeypatch) -> None:  # noqa:
     assert result.metrics.reverted_to_base is True
     # The re-check scored the DISJOINT recheck steps, not the valset's.
     assert set(seen_contexts) == {"recheck-obs"}
+    # A genuinely disjoint `recheck` sample was used and yielded real steps: the artifact must
+    # say so, distinguishing this from a selection-sample fallback.
+    assert result.metrics.fresh_recheck_disjoint is True
 
 
 def test_optimize_minibatch_size_is_configurable(monkeypatch) -> None:  # noqa: ANN001
@@ -491,6 +503,7 @@ def test_optimize_skips_recheck_when_base_wins_the_search(monkeypatch) -> None: 
     assert result.metrics.base_fresh is None
     assert result.metrics.best_fresh is None
     assert result.metrics.fresh_delta is None
+    assert result.metrics.fresh_recheck_disjoint is None
 
 
 def _eval_batch(trace: Trace) -> list[_EvalStep]:

--- a/wmo/optimize/gepa_test.py
+++ b/wmo/optimize/gepa_test.py
@@ -242,6 +242,11 @@ def test_optimize_with_zero_budget_returns_base_prompt() -> None:
     )
     assert result.prompt == "BASE"
     assert result.frontier == ["BASE"]
+    # GEPA never ran (zero budget): the fresh base-vs-winner comparison must read as "did not
+    # run" (None), never a misleading 0.0 that would look like a measured tie.
+    assert result.metrics.base_fresh is None
+    assert result.metrics.best_fresh is None
+    assert result.metrics.fresh_delta is None
 
 
 def test_optimize_with_no_traces_returns_base_prompt() -> None:
@@ -320,6 +325,14 @@ def test_optimize_reverts_to_base_when_fresh_recheck_contradicts(monkeypatch) ->
     assert result.metrics.reverted_to_base is True
     # held-out accuracy reflects the fresh base score, not the discarded winner's search score.
     assert abs(result.metrics.held_out_accuracy - 0.9) < 1e-9
+    # The comparison that DROVE the revert decision survives on the result: base beat the
+    # winner by 0.8 on the fresh paired sample, not just a bare "it was reverted" boolean.
+    assert result.metrics.base_fresh is not None
+    assert result.metrics.best_fresh is not None
+    assert result.metrics.fresh_delta is not None
+    assert abs(result.metrics.base_fresh - 0.9) < 1e-9
+    assert abs(result.metrics.best_fresh - 0.1) < 1e-9
+    assert abs(result.metrics.fresh_delta - (-0.8)) < 1e-9
     # The returned prompt leads the frontier - the rejected winner must not be presented as the
     # top validated candidate (frontier.json consumers pick from the front).
     assert result.frontier[0] == "BASE"
@@ -364,6 +377,14 @@ def test_optimize_keeps_winner_when_fresh_recheck_confirms(monkeypatch) -> None:
     assert result.prompt == "EVOLVED"
     assert result.metrics.reverted_to_base is False
     assert abs(result.metrics.held_out_accuracy - 0.8) < 1e-9
+    # The kept winner's margin over base on the fresh paired sample is recorded, not discarded:
+    # this is the "did GEPA actually help" number the boolean alone cannot give.
+    assert result.metrics.base_fresh is not None
+    assert result.metrics.best_fresh is not None
+    assert result.metrics.fresh_delta is not None
+    assert abs(result.metrics.base_fresh - 0.2) < 1e-9
+    assert abs(result.metrics.best_fresh - 0.8) < 1e-9
+    assert abs(result.metrics.fresh_delta - 0.6) < 1e-9
 
 
 def test_optimize_recheck_raises_on_total_judge_outage(monkeypatch) -> None:  # noqa: ANN001
@@ -465,6 +486,11 @@ def test_optimize_skips_recheck_when_base_wins_the_search(monkeypatch) -> None: 
     assert result.prompt == "BASE"
     assert result.metrics.reverted_to_base is False
     assert provider.rollout_calls == 0  # no fresh eval spent when there is nothing to re-check
+    # No acceptance re-check ran (the search's own winner was already base): the fresh
+    # comparison fields must stay None, not a fabricated 0.0-vs-0.0 "tie".
+    assert result.metrics.base_fresh is None
+    assert result.metrics.best_fresh is None
+    assert result.metrics.fresh_delta is None
 
 
 def _eval_batch(trace: Trace) -> list[_EvalStep]:


### PR DESCRIPTION
## What was discarded

`GEPAOptimizer.optimize` (`wmo/optimize/gepa.py`, ~line 707-719) already runs a fresh paired
acceptance re-check that computes `base_fresh` and `best_fresh` (mean judge score of the base
prompt and the search's winning candidate, on the same held-out steps) to decide whether to keep
GEPA's winner or revert to base. Both numbers were local variables, thrown away once the decision
was made. Only `reverted_to_base: bool` survived, and that boolean is ambiguous three ways:
`false` means "winner kept", "the search's own winner was already base (nothing to re-check)", or
"GEPA never ran at all" (`--fidelity low` writes `false` too, having made zero GEPA calls). The
codebase had no artifact-level way to answer "did GEPA actually help over `--fidelity low`" - an
audit needed this and could not get it from a build's own output.

## What is now recorded

Added `base_fresh: float | None`, `best_fresh: float | None`, `fresh_delta: float | None`
(`best_fresh - base_fresh`), and `fresh_recheck_disjoint: bool | None` to `OptimizeMetrics`
(`wmo/optimize/base.py`), populated at the exact point `base_fresh`/`best_fresh` were already
computed in `gepa.py`, and persisted into every build's `metrics.json` (`wmo/engine/build.py`
already serializes the whole `OptimizeMetrics` model, so no separate persistence code was needed).
They stay `None` - never a misleading `0.0` - in the two cases where no fresh comparison happened:
a `--fidelity low` build (`gepa_budget<=0`), and a GEPA pass whose search-time winner was already
the base prompt. Whenever the re-check actually runs, both fields are populated, including a
genuine tie (`fresh_delta == 0.0`), so "GEPA ran and found no difference" is now distinguishable
from "GEPA never ran". `fresh_recheck_disjoint` additionally says whether that comparison ran on a
genuinely disjoint sample (`true`) or fell back to re-scoring the selection valset itself
(`false`) - see the Greptile fix below.

This costs **zero extra provider spend** for `base_fresh`/`best_fresh`/`fresh_delta`: they are the
same two eval passes the acceptance re-check already pays for every GEPA build; this PR only stops
throwing the numbers away.

## Change 2: making the recorded number honest

`wmo build` (`wmo/engine/build.py`, ~line 260) called `optimizer.optimize(train, gepa_val,
BASE_ENV_PROMPT, config.gepa_budget)` without a `recheck=` argument, so `recheck_steps` fell back
to `full_valset` - the exact same steps GEPA capped and selected candidates against
(`gepa_val`). A delta measured on the selection data tests selection, not generalization.

The build already carves a 3-way `train`/`val`/`test` split (`split_traces_3way`); `gepa_val` is
only a small step-capped prefix of `val` (`_cap_gepa_valset(val, ...)`, default cap 16 steps).
The remainder of `val` past that cap is a genuinely disjoint, still leak-free sample (same
validation split, never `test` - the build's documented data boundary keeps `test` untouched
until `wmo eval`). `build()` now passes `recheck=` that remainder, capped at the same size so the
re-check's cost stays the same order of magnitude as before in the common case (the two fresh
passes were already being paid for on `gepa_val`-sized data; this only repoints them at different
data). When a corpus is too small to leave anything past the cap, `recheck` comes back empty and
`GEPAOptimizer.optimize` falls back to the selection valset itself (pre-existing behavior).

## Follow-up fixes from review

**Greptile (P1, addressed):** the empty-remainder fallback above persisted `base_fresh`/
`best_fresh`/`fresh_delta` in the exact same shape as a genuinely disjoint measurement, so a
selection-biased delta was indistinguishable from generalization evidence in the artifact. Fixed
by adding `fresh_recheck_disjoint` (see above): `false` whenever the fallback fires, so a reader
auditing `metrics.json` can no longer mistake it for held-out evidence. Reply on the thread with
the commit.

**Self-caught while verifying the "no extra spend" claim (raised by the human reviewer):**
`_cap_gepa_valset`'s existing "never starve GEPA of a valset" rule always lets the first trace of
its input through even if that one trace alone exceeds the step cap. Reusing it unchanged for the
disjoint `recheck` remainder meant a single unusually long trace landing right after the selection
cutoff could make that ONE re-check pass cost far more than the selection valset it is supposed to
match - the opposite of "same cost as before." Fixed by adding `allow_oversized_first` (default
`True`, preserving `gepa_val`'s existing contract and its test exactly) and passing `False` for
the `recheck` computation: an empty result there already has a safe, pre-existing fallback (re-use
the selection valset), so there is no reason to ever let an oversized trace through alone.
Verified with a synthetic worst case (short trace, then a 50-step trace, cap 16): before the fix
the disjoint recheck would have cost 50 steps against a 2-step selection pass; after, it correctly
returns empty and falls back.

## Before / after `metrics.json`

Before:
```json
{"held_out_accuracy": 0.9, "rollouts_used": 106, "reverted_to_base": false}
```

After (a real GEPA pass with a genuinely disjoint recheck sample, verified end-to-end through
`build()` with the real `gepa` engine, no mocking):
```json
{
  "held_out_accuracy": 0.9,
  "rollouts_used": 106,
  "reverted_to_base": false,
  "base_fresh": 0.2,
  "best_fresh": 0.9,
  "fresh_delta": 0.7,
  "fresh_recheck_disjoint": true,
  "judge_agreement": null
}
```

After (a `--fidelity low` build, `gepa_budget=0`, verified end-to-end):
```json
{
  "held_out_accuracy": 0.0,
  "rollouts_used": 0,
  "reverted_to_base": false,
  "base_fresh": null,
  "best_fresh": null,
  "fresh_delta": null,
  "fresh_recheck_disjoint": null,
  "judge_agreement": null
}
```

After (a real GEPA pass where the validation split was too small to leave a disjoint remainder,
verified end-to-end - the exact case Greptile flagged):
```json
{
  "held_out_accuracy": 0.9,
  "rollouts_used": 16,
  "reverted_to_base": false,
  "base_fresh": 0.2,
  "best_fresh": 0.9,
  "fresh_delta": 0.7,
  "fresh_recheck_disjoint": false,
  "judge_agreement": null
}
```

This makes "does GEPA improve over `--fidelity low`" answerable from a build's own artifacts for
the first time, and makes it possible to tell a real held-out lift apart from a selection-sample
artifact.

## Testing

- `uv run pytest wmo/optimize/ wmo/engine/ wmo/cli/ -q` - 1146 passed, 2 skipped
- `uv run pytest -q` (whole repo) - 4214 passed, 20 skipped
- `uv run ruff check .` and `uv run ruff format --check .` - clean
- `uv run ty check` - clean
- Confirmed every new/changed test fails on `origin/main` (reverted the three source files
  temporarily, reran, restored) - all fail without this change.
- Manually verified end-to-end through `build()` with the real (unmocked) `gepa` engine for the
  "GEPA finds a real winner with a disjoint recheck", "`--fidelity low`, GEPA never runs", and
  "GEPA finds a real winner but the recheck falls back to the selection sample" cases (outputs
  above).

## Scope

No default changed, GEPA not touched structurally, `--fidelity` untouched (PR #326 owns that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
