### PR TITLE
Fix README router policy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ wmo optimize route sweep my-model --traces traces.otel.jsonl
 
 # Turn those measurements into a routing policy
 wmo optimize route fit matrix.json --kind knn \
-  --out .wmo/models/my-endpoint/policy.json
+  --out .wmo/models/my-model/policy.json
 ```
 
 **3. Serve it.**


### PR DESCRIPTION
## Summary

Unify the router quickstart on `my-model` so the fitted policy is written where the subsequent `serve` and `route report` commands read it.

## Root cause

The primary README recipe built, served, and reported `my-model`, but wrote the policy under `my-endpoint`. That orphaned the policy and left the served endpoint unrouted.

## Validation

- Parsed the README recipe and verified build, fit output, serve, and report use `.wmo/models/my-model/policy.json`
- `uv run --extra dev wmo optimize route fit --help`
- `uv run --extra dev wmo serve --help`
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check`