### PR TITLE
tau-telecom card: mechanism-free customer copy (drop GEPA naming)

### DIFF
--- a/packages/environment-capture/tau-bench/models/tau-telecom/card.json
+++ b/packages/environment-capture/tau-bench/models/tau-telecom/card.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "name": "tau-telecom",
-  "title": "τ²-bench telecom (GEPA-optimized)",
-  "description": "The telecom slice of τ²-bench with a GEPA-evolved environment prompt (317 optimization rollouts). Same customer-service tool surface as tau-bench, tuned for the telecom domain's device and plan workflows.",
+  "title": "τ²-bench telecom",
+  "description": "The telecom slice of τ²-bench with an optimized environment prompt (317 optimization rollouts). Same customer-service tool surface as tau-bench, tuned for the telecom domain's device and plan workflows.",
   "task": "tau-bench",
   "corpus": {
     "traces": 29,
@@ -18,7 +18,6 @@
   "license": null,
   "tags": [
     "tool-calls",
-    "customer-service",
-    "gepa"
+    "customer-service"
   ]
 }

--- a/web/src/data/index.json
+++ b/web/src/data/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-26T18:58:05.842Z",
+  "generated_at": "2026-07-28T02:55:41.908Z",
   "models": [
     {
       "card": {
@@ -6146,8 +6146,8 @@
       "card": {
         "schema_version": 1,
         "name": "tau-telecom",
-        "title": "τ²-bench telecom (GEPA-optimized)",
-        "description": "The telecom slice of τ²-bench with a GEPA-evolved environment prompt (317 optimization rollouts). Same customer-service tool surface as tau-bench, tuned for the telecom domain's device and plan workflows.",
+        "title": "τ²-bench telecom",
+        "description": "The telecom slice of τ²-bench with an optimized environment prompt (317 optimization rollouts). Same customer-service tool surface as tau-bench, tuned for the telecom domain's device and plan workflows.",
         "task": "tau-bench",
         "corpus": {
           "traces": 29,
@@ -6163,8 +6163,7 @@
         "license": null,
         "tags": [
           "tool-calls",
-          "customer-service",
-          "gepa"
+          "customer-service"
         ]
       },
       "dir": "packages/environment-capture/tau-bench/models/tau-telecom",


### PR DESCRIPTION
Platform QA follow-up (Silen ruling, 2026-07-27: remove GEPA mentions from customer-visible catalog copy).

The tau-telecom card.json is the source of truth the platform vendors into its public catalog (apps/web/scripts/build-public-catalog.mjs), so its title/description/tags render verbatim on the signed-out catalog and the authed Simulations page. Per the endpoint-pivot vocabulary rules, customer copy never names mechanisms: the tile said "GEPA-optimized" / "a GEPA-evolved environment prompt" and carried a "gepa" tag.

- title: "τ²-bench telecom (GEPA-optimized)" -> "τ²-bench telecom"
- description: "a GEPA-evolved environment prompt" -> "an optimized environment prompt" (rollout count kept)
- tags: drop "gepa" (tool-calls, customer-service stay)

No other card.json carries GEPA copy (grep-verified). The platform-side regen of data/public-catalog.json rides the platform QA PR and points at this rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)