### PR TITLE
Require explicit Azure deployment for providers set

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -250,6 +250,42 @@ def config_telemetry(
     _console.print(f"telemetry {state} ({settings_path(root)})")
 
 
+def _azure_worker_deployment(
+    kind: ProviderKind, model: str, deployment: str | None, *, interactive: bool
+) -> str | None:
+    """Return Azure's explicitly named worker deployment, prompting only in the picker.
+
+    Azure sends a deployment name as the request model. The base model type is catalog metadata,
+    not a route an Azure resource necessarily exposes, so a command must never turn it into a
+    deployment name on the user's behalf.
+    """
+    if kind is not ProviderKind.AZURE_OPENAI:
+        return deployment
+    if deployment is not None:
+        chosen = deployment.strip()
+        if chosen:
+            return chosen
+    if not interactive:
+        raise typer.BadParameter(
+            "Azure deployment names are chosen by the resource owner and cannot be inferred "
+            f"from model {escape(model)}; pass --deployment <deployment>, for example "
+            f"`wmo providers set --provider azure --model {escape(model)} "
+            "--deployment <deployment>`"
+        )
+    while True:
+        try:
+            chosen = _console.input(
+                f"[bold]Azure deployment serving {escape(model)}[/bold]: "
+            ).strip()
+        except EOFError:
+            raise typer.Abort() from None
+        if chosen:
+            return chosen
+        _console.print(
+            "[red]an Azure deployment is required; it cannot be inferred from the model type[/red]"
+        )
+
+
 def _worker_provider_config(
     provider: str,
     model: str,
@@ -266,7 +302,9 @@ def _worker_provider_config(
     if config.kind is ProviderKind.AZURE_OPENAI:
         config = config.model_copy(
             update={
-                "deployment": deployment or config.model_type or config.model,
+                "deployment": _azure_worker_deployment(
+                    config.kind, config.model_type or config.model, deployment, interactive=False
+                ),
                 "api_version": api_version or "2024-05-01-preview",
             }
         )
@@ -279,7 +317,11 @@ def providers_set(
     model: str = typer.Option(None, "--model", help="Canonical model type for the worker."),
     region: str = typer.Option(None, "--region", help="AWS region for Bedrock."),
     endpoint: str = typer.Option(None, "--endpoint", help="OpenAI-compatible API endpoint."),
-    deployment: str = typer.Option(None, "--deployment", help="Azure deployment name."),
+    deployment: str = typer.Option(
+        None,
+        "--deployment",
+        help="Azure deployment name (required when --provider azure).",
+    ),
     api_version: str = typer.Option(None, "--api-version", help="Azure API version."),
     pool: str = typer.Option(
         None,
@@ -318,8 +360,10 @@ def providers_set(
     ones already registered.
 
     Scripts keep the old contract: with `--provider` and `--model` both given, nothing is
-    prompted. Registering non-interactively is `--pool-model <id>`, repeated per model, with
-    `--input-per-mtok`/`--output-per-mtok` when the model has no published price.
+    prompted. Azure scripts must also name `--deployment`, because Azure resources choose that
+    route name independently of the base model type. Registering non-interactively is
+    `--pool-model <id>`, repeated per model, with `--input-per-mtok`/`--output-per-mtok` when the
+    model has no published price.
     """
     if tier is not None and tier not in pool_registry.TIERS:
         raise typer.BadParameter(f"--tier must be one of: {', '.join(pool_registry.TIERS)}")
@@ -337,6 +381,31 @@ def providers_set(
     existing = load_settings_or_abort(root).models.worker
     used_picker = _console.is_terminal and (provider is None or model is None)
     if used_picker:
+        deployment_was_flagged = deployment is not None and bool(deployment.strip())
+
+        def verify_selected_worker(selected: ProviderConfig) -> VerifyResult:
+            """Verify the picker choice after Azure's operator-owned route is known."""
+            nonlocal deployment
+            if selected.kind is ProviderKind.AZURE_OPENAI:
+                deployment = _azure_worker_deployment(
+                    selected.kind,
+                    selected.model_type or selected.model,
+                    deployment if deployment_was_flagged else None,
+                    interactive=True,
+                )
+            return verify_all(
+                [
+                    _worker_provider_config(
+                        selected.kind.value,
+                        selected.model_type or selected.model,
+                        selected.region,
+                        endpoint=endpoint,
+                        deployment=deployment,
+                        api_version=api_version,
+                    )
+                ]
+            )[0]
+
         provider, model, region = select_provider_and_model(
             _console,
             lambda text: _console.input(text),
@@ -345,18 +414,7 @@ def providers_set(
             default_model=model or (existing.model if existing else None),
             default_region=region or (existing.region if existing else None),
             interactive=True,
-            check=lambda cfg: verify_all(
-                [
-                    _worker_provider_config(
-                        cfg.kind.value,
-                        cfg.model_type or cfg.model,
-                        cfg.region,
-                        endpoint=endpoint,
-                        deployment=deployment,
-                        api_version=api_version,
-                    )
-                ]
-            )[0],
+            check=verify_selected_worker,
         )
     if provider is None or model is None:
         raise typer.BadParameter(

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -9,6 +9,7 @@ import json
 import os
 import subprocess
 import time
+from collections.abc import Callable
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from typing import cast
 import pytest
 import typer
 from pydantic import ValidationError
+from rich.console import Console
 from typer.testing import CliRunner
 
 from wmo.cli import app, pool_registry
@@ -1247,13 +1249,17 @@ def test_providers_set_rejects_an_unknown_tier(
     assert "frontier, open" in result.output
 
 
-def test_providers_set_never_guesses_an_azure_deployment_for_the_pool(
+def test_providers_set_requires_an_explicit_azure_worker_deployment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    # The worker config fills an Azure deployment in from the model id when none was given; a
-    # pool entry must not inherit that guess, because Azure sends the deployment as the request
-    # model and a guessed name addresses a route that does not exist.
-    _accept_every_provider(monkeypatch)
+    # Azure sends the deployment as the request model. A script cannot discover the operator's
+    # deployment name, so fail before it pings a guessed route or writes a broken worker role.
+    checked: list[ProviderConfig] = []
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: checked.extend(configs) or [],
+    )
     root = tmp_path / ".wmo"
 
     result = runner.invoke(
@@ -1265,19 +1271,68 @@ def test_providers_set_never_guesses_an_azure_deployment_for_the_pool(
             "azure",
             "--model",
             "gpt-5.5",
-            "--pool-model",
-            "gpt-5.5",
             "--root",
             str(root),
         ],
     )
 
     assert result.exit_code != 0
-    assert "azure needs --deployment" in result.output
+    assert "cannot be inferred" in result.output
+    assert _squashed(
+        "wmo providers set --provider azure --model gpt-5.5 --deployment <deployment>"
+    ) in _squashed(result.output)
+    assert checked == []
+    assert not (root / "settings.toml").exists()
     assert not (root / "pool.toml").exists()
-    # The worker role is still saved with its derived deployment: only the pool is strict.
+
+
+def test_providers_set_prompts_for_an_azure_deployment_before_it_verifies(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The terminal picker asks for a route before its first Azure request."""
+    prompts: list[str] = []
+    answers = iter(["", "chat-prod"])
+    console = SimpleNamespace(
+        is_terminal=True,
+        input=lambda prompt: prompts.append(prompt) or next(answers),
+        print=lambda *args, **kwargs: None,
+    )
+    checked: list[ProviderConfig] = []
+    monkeypatch.setattr(cli_app_module, "_console", console)
+    monkeypatch.setattr(
+        cli_app_module,
+        "verify_all",
+        lambda configs: (
+            checked.extend(configs)
+            or [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
+        ),
+    )
+
+    def choose_provider(
+        _console: Console,
+        _ask: Callable[[str], str],
+        _ask_secret: Callable[[str], str],
+        **kwargs: object,
+    ) -> tuple[str, str, str | None]:
+        selected = ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI, model_type="gpt-5.5", model="gpt-5.5"
+        )
+        check = cast(Callable[[ProviderConfig], VerifyResult], kwargs["check"])
+        assert check(selected).ok
+        return "azure", "gpt-5.5", None
+
+    monkeypatch.setattr(cli_app_module, "select_provider_and_model", choose_provider)
+    monkeypatch.setattr(cli_app_module, "_register_pool_models", lambda **kwargs: None)
+    root = tmp_path / ".wmo"
+
+    result = runner.invoke(app, ["providers", "set", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert len(prompts) == 2
+    assert all("Azure deployment serving gpt-5.5" in prompt for prompt in prompts)
+    assert checked[0].deployment == "chat-prod"
     worker = load_settings(root).models.worker
-    assert worker is not None and worker.deployment == "gpt-5.5"
+    assert worker is not None and worker.deployment == "chat-prod"
 
 
 def test_providers_set_registers_a_named_azure_deployment(


### PR DESCRIPTION
## What changed

- Require `--deployment` for scripted Azure worker setup.
- Prompt for an Azure deployment before terminal-picker verification.
- Preserve non-Azure setup and explicit Azure deployment flows.

## Why

Azure sends an operator-chosen deployment name as the request model. Treating a canonical model type such as `gpt-5.5` as that route produced a raw 404 on ordinary Azure resources.

## Validation

- `pytest -q -p no:cacheprovider wmo/cli/app_test.py` (171 passed)
- `ruff check .`
- `ty check`
- Loopback Azure stub: omitted deployment gives a usage error before any request; explicit `qa-deployment` verifies and saves it.