### PR TITLE
Keep optimize plans readable on narrow terminals

### DIFF
--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -130,6 +130,11 @@ _KNN_KNOBS = (
 )
 """The knn fit this command performs. Fixed: the validated champion, dialed after the fact."""
 
+# Four columns leave too little room for the sweep's authorization details at the usual 80-column
+# redirected terminal width. Keep those details in one readable stream there instead of interleaving
+# wrapped plan and status cells line by line.
+_PLAN_TABLE_MIN_WIDTH = 120
+
 
 def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (see the help text)
     world_model: str = typer.Argument(
@@ -934,40 +939,28 @@ def _print_plan(
         f"\n[bold]optimize model: {escape(name)}[/bold]    "
         f"pool: {pool_size} candidate(s) ({escape(str(pool_file))})\n"
     )
-    table = Table(show_header=True, box=None, pad_edge=False, padding=(0, 2))
-    table.add_column("stage", no_wrap=True)
-    table.add_column("plan")
-    table.add_column("est. cost", justify="right")
-    table.add_column("status")
-    table.add_row(
-        Stage.PREFLIGHT.value,
-        _stage_plan_text(
-            Stage.PREFLIGHT,
-            plan=plan,
-            compression=compression,
-            cost_quality=cost_quality,
-            fallback=fallback,
-            anchor=anchor,
-        ),
-        "free",
-        "[green]ok[/green]",
+    rows = _plan_rows(
+        plan=plan,
+        decisions=decisions,
+        cost_quality=cost_quality,
+        fallback=fallback,
+        anchor=anchor,
+        embedder=embedder,
+        compression=compression,
+        paths=paths,
+        already_measured=already_measured,
     )
-    for decision in decisions:
-        table.add_row(
-            decision.stage.value,
-            _stage_plan_text(
-                decision.stage,
-                plan=plan,
-                compression=compression,
-                cost_quality=cost_quality,
-                fallback=fallback,
-                anchor=anchor,
-                already_measured=already_measured,
-            ),
-            _estimate_text(decision.stage, plan=plan, embedder=embedder, paths=paths),
-            _status_text(decision),
-        )
-    console.print(table)
+    if console.width < _PLAN_TABLE_MIN_WIDTH:
+        _print_compact_plan(console, rows)
+    else:
+        table = Table(show_header=True, box=None, pad_edge=False, padding=(0, 2))
+        table.add_column("stage", no_wrap=True)
+        table.add_column("plan")
+        table.add_column("est. cost", justify="right")
+        table.add_column("status")
+        for stage, stage_plan, estimate, status in rows:
+            table.add_row(stage, stage_plan, estimate, status)
+        console.print(table)
     running = [decision for decision in decisions if decision.will_run]
     total = _projected_total(decisions, plan)
     if not running:
@@ -989,6 +982,62 @@ def _print_plan(
         f"and call counts, at each candidate's own pool price)"
     )
     console.print(_world_model_forecast(projection, compressed=plan.compression is not None))
+
+
+def _plan_rows(
+    *,
+    plan: SweepPlan,
+    decisions: list[StageDecision],
+    cost_quality: float,
+    fallback: str | None,
+    anchor: str,
+    embedder: EmbedderSpec,
+    compression: CompressionConfig | None,
+    paths: _RunPaths,
+    already_measured: int,
+) -> list[tuple[str, str, str, str]]:
+    """Build the stage rows once for the wide table and the narrow readable layout."""
+    rows = [
+        (
+            Stage.PREFLIGHT.value,
+            _stage_plan_text(
+                Stage.PREFLIGHT,
+                plan=plan,
+                compression=compression,
+                cost_quality=cost_quality,
+                fallback=fallback,
+                anchor=anchor,
+            ),
+            "free",
+            "[green]ok[/green]",
+        )
+    ]
+    rows.extend(
+        (
+            decision.stage.value,
+            _stage_plan_text(
+                decision.stage,
+                plan=plan,
+                compression=compression,
+                cost_quality=cost_quality,
+                fallback=fallback,
+                anchor=anchor,
+                already_measured=already_measured,
+            ),
+            _estimate_text(decision.stage, plan=plan, embedder=embedder, paths=paths),
+            _status_text(decision),
+        )
+        for decision in decisions
+    )
+    return rows
+
+
+def _print_compact_plan(console: Console, rows: list[tuple[str, str, str, str]]) -> None:
+    """Print plan details linearly when a four-column table would interleave them."""
+    for stage, stage_plan, estimate, status in rows:
+        console.print(
+            f"[bold]{stage}[/bold]: {stage_plan}\n  est. cost: {estimate}; status: {status}"
+        )
 
 
 def _print_budget_stop(name: str, exc: BudgetExceeded) -> None:

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -92,7 +92,7 @@ def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
     three and spliced through the plan column, and every assertion on a printed sentence becomes
     an assertion about where the wrap landed. Width is presentation, not behavior.
     """
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240))
+    monkeypatch.setattr(optimize_module, "_console", Console(width=240, height=25))
 
 
 @pytest.fixture(autouse=True)
@@ -606,7 +606,9 @@ def test_declining_the_confirmation_spends_nothing(
     root = _project(tmp_path)
     answer = _Answer(False)
     monkeypatch.setattr(optimize_module, "Confirm", answer)
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     result = _run(tmp_path, root)
     assert result.exit_code == 0, result.output
     assert answer.asked  # exactly one question, and it was asked before any episode
@@ -622,7 +624,9 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     root = _project(tmp_path)
     answer = _Answer(False)
     monkeypatch.setattr(optimize_module, "Confirm", answer)
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     result = _run(tmp_path, root)
     flat = _flat(result.output)
     # 3 scenarios x 1 episode x 4 calls = 12 calls; cheap = 12 x (2000 + 250x2)/1e6 = $0.03,
@@ -645,7 +649,9 @@ def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
     _patch_seams(monkeypatch)
     root = _project(tmp_path)
     monkeypatch.setattr(optimize_module, "Confirm", _Answer(False))
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     paced = _run(tmp_path, root, "--concurrency", "6")
     assert "2candidate(s)x3scenario(s)x1episode(s),6atatime" in _flat(paced.output)
 
@@ -668,6 +674,24 @@ def test_the_plan_table_shows_the_pace_and_what_a_resume_will_not_rebuy(
     )
     resumed = _run(tmp_path, root)
     assert "1alreadymeasured,5tobuy" in _flat(resumed.output)
+
+
+def test_the_plan_stays_linear_in_a_narrow_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A redirected 80-column run keeps the authorization facts out of interleaved table cells."""
+    _patch_seams(monkeypatch)
+    root = _project(tmp_path)
+    monkeypatch.setattr(optimize_module, "Confirm", _Answer(False))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=80, height=25, force_terminal=True)
+    )
+
+    result = _run(tmp_path, root, "--concurrency", "6")
+
+    assert result.exit_code == 0, result.output
+    assert _says(result.output, "sweep: 2 candidate(s) x 3 scenario(s) x 1 episode(s), 6 at a time")
+    assert _says(result.output, "est. cost: ~$0.33; status: will run")
 
 
 def _sweep_plan(tmp_path: Path, root: Path) -> SweepPlan:
@@ -1014,7 +1038,9 @@ def test_the_first_sweep_says_the_world_model_side_is_not_projectable(
     root = _project(tmp_path)
     answer = _Answer(False)
     monkeypatch.setattr(optimize_module, "Confirm", answer)
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     result = _run(tmp_path, root)
     assert result.exit_code == 0, result.output
     assert _says(result.output, "not projectable before this model's first sweep")
@@ -1175,7 +1201,9 @@ def test_the_cap_refuses_before_asking_rather_than_after(
     root = _project(tmp_path)
     answer = _Answer(True)
     monkeypatch.setattr(optimize_module, "Confirm", answer)
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     result = _run(tmp_path, root, "--max-usd", "0.01")
     assert result.exit_code == 1, result.output
     assert answer.asked == []  # never asked
@@ -1206,7 +1234,9 @@ def test_a_zero_priced_pool_is_still_confirmed_because_the_simulator_is_not_free
     )
     answer = _Answer(False)
     monkeypatch.setattr(optimize_module, "Confirm", answer)
-    monkeypatch.setattr(optimize_module, "_console", Console(width=240, force_terminal=True))
+    monkeypatch.setattr(
+        optimize_module, "_console", Console(width=240, height=25, force_terminal=True)
+    )
     result = _run(tmp_path, root, pool=free_pool)
     assert result.exit_code == 0, result.output
     assert len(answer.asked) == 1  # asked, despite a $0.00 candidate projection


### PR DESCRIPTION
## What changed

- Render `wmo optimize model`'s pre-spend plan as linear stage records below 120 columns.
- Preserve the existing four-column table on wider terminals.
- Stabilize the wide-console test fixture and add an 80-column regression test.

## Why

At the normal 80-column redirected width, Rich wrapped and interleaved the plan and status columns. That hid the sweep grid, concurrency, resume cells, and cost authorization details even though optimization behavior was unchanged.

## Validation

- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ty check`
- `uv run --extra dev pytest -q wmo/cli/optimize_model_app_test.py` (59 passed)
- `uv run --extra dev pytest -q` (4396 passed, 20 skipped)