### PR TITLE
Reserve held-out scenarios for policy reports (rebase of #308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ wmo build --file traces.jsonl --name my-model
 # Score every registered model on held-out tasks from your traces
 wmo optimize route sweep my-model --traces traces.otel.jsonl
 
-# Turn those measurements into a routing policy
+# Deterministically reserve 30% for reporting and fit on the other 70%
 wmo optimize route fit matrix.json --kind knn \
   --out .wmo/models/my-model/policy.json
 ```
@@ -43,7 +43,8 @@ wmo optimize route fit matrix.json --kind knn \
 wmo serve --name my-model
 ```
 
-See what it bought you against the model you were using before:
+See what it bought you against the model you were using before. The report automatically excludes
+the router-fit scenarios recorded in the policy:
 
 ```bash
 wmo optimize route report matrix.json .wmo/models/my-model/policy.json \

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -870,9 +870,7 @@ def _stage_plan_text(
     already_measured: int = 0,
 ) -> str:
     """One line saying what this stage will actually do, in the operator's terms."""
-    router_split = split_router_scenarios(
-        [scenario_id(scenario) for scenario in plan.scenarios]
-    )
+    router_split = split_router_scenarios([scenario_id(scenario) for scenario in plan.scenarios])
     match stage:
         case Stage.PREFLIGHT:
             return f"resolve {len(plan.pool.models)} backend(s), check prices"

--- a/wmo/cli/optimize_model_app.py
+++ b/wmo/cli/optimize_model_app.py
@@ -64,7 +64,12 @@ from wmo.optimize.knn import (
     fit_provenance,
     tune_policy_dial,
 )
-from wmo.optimize.outcomes import OutcomeMatrix, load_matrix_with_digest
+from wmo.optimize.outcomes import (
+    ROUTER_SPLIT_VERSION,
+    OutcomeMatrix,
+    load_matrix_with_digest,
+    split_router_scenarios,
+)
 from wmo.optimize.pipeline import (
     BUILT_STAGES,
     CONFIGURED_STAGES,
@@ -126,7 +131,7 @@ ASSUMED_OUTPUT_TOKENS = 250
 
 _KNN_KNOBS = (
     f"z={DEFAULT_KNN_Z:g} k={DEFAULT_RAG_NUM} thres={DEFAULT_RAG_THRES:g} "
-    f"pairs={DEFAULT_KNN_MIN_PAIRS} se_floor=True q=0.05"
+    f"pairs={DEFAULT_KNN_MIN_PAIRS} se_floor=True q=0.05 split={ROUTER_SPLIT_VERSION}"
 )
 """The knn fit this command performs. Fixed: the validated champion, dialed after the fact."""
 
@@ -358,6 +363,10 @@ def optimize_model(  # noqa: PLR0913 - each flag is one decision a user owns (se
         # attempt already bought, and so a sidecar from a different plan is refused for free.
         already_measured = resumable_cells(plan)
     except SweepError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    try:
+        split_router_scenarios([scenario_id(scenario) for scenario in plan.scenarios])
+    except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
     print_tiny_corpus_note(_console, plan)
     # Both flags name a pool candidate, and the pool is loaded by the pre-flight above, so a typo
@@ -861,6 +870,9 @@ def _stage_plan_text(
     already_measured: int = 0,
 ) -> str:
     """One line saying what this stage will actually do, in the operator's terms."""
+    router_split = split_router_scenarios(
+        [scenario_id(scenario) for scenario in plan.scenarios]
+    )
     match stage:
         case Stage.PREFLIGHT:
             return f"resolve {len(plan.pool.models)} backend(s), check prices"
@@ -882,11 +894,17 @@ def _stage_plan_text(
             # Says what it IS rather than implying a step: the arm plus the two stages it sets up.
             return f"{escape(compression_signature(compression))}, configures sweep and fit"
         case Stage.FIT:
-            return f"knn (guarded, fallback {escape(fallback or 'best single on the sweep')})"
+            return (
+                f"knn over {len(router_split.fit_ids)} fit scenario(s) "
+                f"(guarded, fallback {escape(fallback or 'best single on the fit split')})"
+            )
         case Stage.TUNE:
             return f"cost_quality {cost_quality:g} ({cost_quality_named_point(cost_quality)})"
         case _:
-            return f"3-objective headline vs {escape(anchor)}"
+            return (
+                f"3-objective headline vs {escape(anchor)} over "
+                f"{len(router_split.report_ids)} router-held-out scenario(s)"
+            )
 
 
 def _report_estimate(policy_path: Path, fitting_with: EmbedderSpec) -> str:
@@ -1313,11 +1331,17 @@ def _stage_fit(
     """
     matrix, source = load_matrix_with_digest(paths.matrix)
     try:
+        router_split = split_router_scenarios(matrix.scenario_ids())
+    except ValueError as exc:
+        _console.print(f"[red]fit failed[/red] {escape(str(exc))}")
+        raise typer.Exit(1) from exc
+    try:
         fitted = fit_knn_artifact(
             matrix,
             out_path=paths.policy,
             matrix_source=source,
             embedder=embedder,
+            fit_ids=list(router_split.fit_ids),
             fallback=fallback,
             compression=compression,
         )

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -633,7 +633,7 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     assert "2candidate(s)x3scenario(s)x1episode(s)" in flat
     # The free stages say free rather than showing a fabricated number, and the estimate names
     # itself a projection with its assumption spelled out.
-    assert _says(result.output, "knn (guarded, fallback best single on the sweep)")
+    assert _says(result.output, "knn (guarded, fallback best single on the fit split)")
     assert _says(result.output, "cost_quality 0.25 (Balanced (default))")
     assert "aprojection" in flat and "assumedoutputtoken" in flat
     assert _says(result.output, "are NOT in that figure")

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -633,7 +633,10 @@ def test_the_plan_table_prices_the_sweep_and_labels_the_rest(
     assert "2candidate(s)x3scenario(s)x1episode(s)" in flat
     # The free stages say free rather than showing a fabricated number, and the estimate names
     # itself a projection with its assumption spelled out.
-    assert _says(result.output, "knn (guarded, fallback best single on the fit split)")
+    # 3 scenarios split 70/30 for router fit vs report: 2 fit, 1 reserved (PR #308).
+    assert _says(
+        result.output, "knn over 2 fit scenario(s) (guarded, fallback best single on the fit split)"
+    )
     assert _says(result.output, "cost_quality 0.25 (Balanced (default))")
     assert "aprojection" in flat and "assumedoutputtoken" in flat
     assert _says(result.output, "are NOT in that figure")

--- a/wmo/cli/optimize_model_app_test.py
+++ b/wmo/cli/optimize_model_app_test.py
@@ -363,7 +363,9 @@ def test_one_command_lands_every_artifact_where_serving_reads_it(
     assert RoutingPolicy.load(policy_path.parent / "policy.base.json").cost_quality is None
     report = ImprovementReport.model_validate_json(report_path.read_text(encoding="utf-8"))
     assert report.endpoint_id == "support"
-    assert report.headline.scenarios_compared == 3
+    assert report.headline.scenarios_compared == 1
+    assert set(policy.fit_scenario_ids).isdisjoint(report.scenario_ids)
+    assert len(policy.fit_scenario_ids) + report.scenario_count == 3
 
     manifest = RunManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
     assert [record.stage.value for record in manifest.stages] == ["sweep", "fit", "tune", "report"]

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -54,7 +54,13 @@ from wmo.optimize.knn import (
     fit_knn_artifact,
     tune_policy_dial,
 )
-from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome, load_matrix_with_digest
+from wmo.optimize.outcomes import (
+    ROUTER_SPLIT_VERSION,
+    OutcomeMatrix,
+    ScenarioOutcome,
+    load_matrix_with_digest,
+    split_router_scenarios,
+)
 from wmo.optimize.policy import (
     AZURE_EMBEDDER_DIM,
     AZURE_EMBEDDER_ENV,
@@ -1030,6 +1036,11 @@ def fit(
             "`wmo optimize route sweep <model> --compressor <id> --aggressiveness <a>` writes a "
             "matrix whose episodes actually ran that way (one matrix per arm)."
         )
+    try:
+        router_split = split_router_scenarios(matrix.scenario_ids())
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    fit_ids = list(router_split.fit_ids)
     if kind == "knn":
         if cost_weight > 0.0:
             raise typer.BadParameter(
@@ -1043,6 +1054,7 @@ def fit(
                 out_path=out_path,
                 matrix_source=source,
                 embedder=spec,
+                fit_ids=fit_ids,
                 fallback=fallback,
                 z=z,
                 rag_num=rag_num,
@@ -1067,13 +1079,15 @@ def fit(
     try:
         policy = fit_rank_policy(
             matrix,
+            fit_ids=fit_ids,
             embedder=spec,
             n_clusters=clusters,
             seed=seed,
             top_k_clusters=top_k_clusters,
             beta=beta,
             fitted_from=(
-                f"{source} rank seed={seed} k={clusters} topk={top_k_clusters} beta={beta:g} "
+                f"{source} split={ROUTER_SPLIT_VERSION} "
+                f"rank seed={seed} k={clusters} topk={top_k_clusters} beta={beta:g} "
                 f"cost_weight={cost_weight:g} {embedder_provenance(spec)}"
             ),
         )
@@ -1090,7 +1104,7 @@ def fit(
             update={"compression": compression, "fit_compression": compression}
         )
     policy.save(out_path)
-    result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
+    result = evaluate_policy(policy, matrix, fit_ids, embedder=built)
     _console.print(
         f"[green]✓[/green] fitted {len(policy.clusters)} clusters over "
         f"{result.scenarios} scenarios -> {out}\n"

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -155,7 +155,8 @@ def test_route_fit_and_report(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     report = json.loads(report_file.read_text())
     assert report["baseline"]["model_id"] == "a"
-    assert report["headline"]["baseline_accuracy"] == 0.5
+    assert set(policy.fit_scenario_ids).isdisjoint(report["scenario_ids"])
+    assert len(policy.fit_scenario_ids) + report["scenario_count"] == 4
     assert report["cost_assumptions"]
 
 
@@ -261,7 +262,8 @@ def test_route_fit_knn_writes_policy_and_sidecar(tmp_path: Path) -> None:
     assert policy.knn_bank_path == "policy.json.bank.npz"
     assert policy.bank_path() == tmp_path / "policy.json.bank.npz"
     assert policy.bank_path().is_file()  # sidecar beside the policy
-    assert len(policy.knn_bank().scenario_ids) == 12
+    assert len(policy.knn_bank().scenario_ids) == 8
+    assert policy.fit_scenario_ids == policy.knn_bank().scenario_ids
     assert "routed away from the fallback" in result.output
     # The prose neighborhoods carry unanimous evidence for b, so that traffic leaves the
     # fallback while the SQL half stays on it.

--- a/wmo/optimize/knn.py
+++ b/wmo/optimize/knn.py
@@ -28,6 +28,7 @@ Operators do not set those knobs. They set `cost_quality`, one number in [0, 1] 
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import re
@@ -252,6 +253,7 @@ def fit_knn_policy(
         # setting mean different things on different processes.
         cost_scale=bank_cost_scale(bank),
         fitted_from=fitted_from,
+        fit_scenario_ids=list(scenario_ids),
     )
     policy.attach_bank(bank)
     logger.info(
@@ -286,6 +288,7 @@ def fit_knn_artifact(
     out_path: Path,
     matrix_source: str,
     embedder: EmbedderSpec,
+    fit_ids: list[str] | None = None,
     fallback: str | None = None,
     z: float = DEFAULT_KNN_Z,
     rag_num: int = DEFAULT_RAG_NUM,
@@ -314,6 +317,8 @@ def fit_knn_artifact(
     """
     if rag_thres <= 0.0:
         raise ValueError("rag_thres must be greater than 0")
+    selected_ids = fit_ids if fit_ids is not None else matrix.scenario_ids()
+    fit_digest = hashlib.sha256("\0".join(selected_ids).encode("utf-8")).hexdigest()[:16]
     built = embedder.build()
     if compression is not None:
         # Representation consistency, the C2 rule that makes or breaks a compressed arm: the
@@ -327,6 +332,7 @@ def fit_knn_artifact(
     policy = fit_knn_policy(
         matrix,
         bank_path=knn_bank_path_for(out_path),
+        fit_ids=selected_ids,
         embedder=embedder,
         embed_with=built,
         guard_model=fallback,
@@ -337,7 +343,8 @@ def fit_knn_artifact(
         se_floor=se_floor,
         floor_q=floor_q,
         fitted_from=(
-            f"{matrix_source} knn fallback={fallback or 'auto'} z={z:g} k={rag_num} "
+            f"{matrix_source} fit_ids_sha256={fit_digest} "
+            f"knn fallback={fallback or 'auto'} z={z:g} k={rag_num} "
             f"thres={rag_thres:g} pairs={min_pairs} se_floor={se_floor} q={floor_q:g} "
             f"{embed_tag}"
         ),
@@ -353,7 +360,7 @@ def fit_knn_artifact(
             update={"compression": compression, "fit_compression": compression}
         )
     policy.save(out_path)
-    result = evaluate_policy(policy, matrix, matrix.scenario_ids(), embedder=built)
+    result = evaluate_policy(policy, matrix, selected_ids, embedder=built)
     return KnnFitOutcome(
         policy=policy,
         bank_path=policy.bank_path(),

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -22,6 +22,47 @@ from wmo.providers.pool import PoolEntry
 # is 64 bits, far past collision risk for the handful of matrices one artifact directory sees.
 MATRIX_DIGEST_CHARS = 16
 
+# Router fitting and reporting share one paid outcome matrix, but they must not share scenarios.
+# Hash ordering makes the partition stable across machines and independent of matrix row order.
+ROUTER_FIT_FRACTION = 0.7
+ROUTER_SPLIT_VERSION = "scenario-hash-70-30-v1"
+
+
+class RouterScenarioSplit(BaseModel):
+    """Disjoint scenario ids used to fit a router and report its generalization."""
+
+    fit_ids: tuple[str, ...]
+    report_ids: tuple[str, ...]
+
+
+def split_router_scenarios(scenario_ids: list[str]) -> RouterScenarioSplit:
+    """Deterministically reserve 30% of scenarios for router evaluation.
+
+    At least two scenarios are required because a router trained and evaluated on one scenario
+    cannot produce a held-out claim. Returned ids retain the matrix's original order; hashing is
+    used only to assign membership.
+    """
+    if len(scenario_ids) != len(set(scenario_ids)):
+        raise ValueError("router split requires unique scenario ids")
+    if len(scenario_ids) < 2:
+        raise ValueError(
+            "router fitting needs at least 2 scenarios so one can remain held out for reporting"
+        )
+    ranked = sorted(
+        scenario_ids,
+        key=lambda scenario_id: (
+            hashlib.sha256(scenario_id.encode("utf-8")).digest(),
+            scenario_id,
+        ),
+    )
+    fit_count = round(len(ranked) * ROUTER_FIT_FRACTION)
+    fit_count = min(len(ranked) - 1, max(1, fit_count))
+    fit_set = set(ranked[:fit_count])
+    return RouterScenarioSplit(
+        fit_ids=tuple(sid for sid in scenario_ids if sid in fit_set),
+        report_ids=tuple(sid for sid in scenario_ids if sid not in fit_set),
+    )
+
 
 class ScenarioOutcome(BaseModel):
     """One episode of one candidate model on one scenario.

--- a/wmo/optimize/outcomes_test.py
+++ b/wmo/optimize/outcomes_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome
+from wmo.optimize.outcomes import OutcomeMatrix, ScenarioOutcome, split_router_scenarios
 from wmo.providers.base import ProviderKind, TokenUsage
 from wmo.providers.pool import PoolEntry
 
@@ -52,6 +52,25 @@ def test_matrix_accessors() -> None:
     assert matrix.mean_reward("fable-5") == pytest.approx(0.8)
     assert matrix.mean_reward("haiku-4-5") == pytest.approx(0.6)
     assert [o.model for o in matrix.for_scenario("s1")] == ["fable-5", "haiku-4-5"]
+
+
+def test_router_split_is_deterministic_disjoint_and_order_preserving() -> None:
+    ids = [f"scenario-{index}" for index in range(10)]
+    split = split_router_scenarios(ids)
+
+    assert len(split.fit_ids) == 7
+    assert len(split.report_ids) == 3
+    assert set(split.fit_ids).isdisjoint(split.report_ids)
+    assert [sid for sid in ids if sid in split.fit_ids] == list(split.fit_ids)
+    reordered = list(reversed(ids))
+    rerun = split_router_scenarios(reordered)
+    assert set(rerun.fit_ids) == set(split.fit_ids)
+    assert set(rerun.report_ids) == set(split.report_ids)
+
+
+def test_router_split_refuses_a_claim_with_no_holdout() -> None:
+    with pytest.raises(ValueError, match="at least 2 scenarios"):
+        split_router_scenarios(["only-one"])
 
 
 def test_matrix_round_trips_through_json(tmp_path: Path) -> None:

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -390,6 +390,10 @@ class RoutingPolicy(BaseModel):
     min_support: int | None = None  # scored episodes a challenger needs to lead its cluster
     guard_margin: float | None = None  # reward the challenger must beat the guard by
     fitted_from: str | None = None  # provenance: the outcome matrix the fitter used
+    # Scenario-level provenance for evaluation integrity. Reports exclude these ids when they
+    # appear in the supplied matrix; an entirely separate matrix has no overlap and is all held
+    # out. Empty is retained for static and legacy artifacts that learned no recorded split.
+    fit_scenario_ids: list[str] = Field(default_factory=list)
     # D-COMPRESS: the endpoint-level compression choice, applied by the serving compress stage
     # BEFORE routing (the router embeds what the model will see), so it cannot vary by cluster
     # at serve time; per-cluster overrides live on ClusterRanking for the joint fit and eval

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -1,7 +1,7 @@
 """The improvement report (D-REPORT): the endpoint's evidence artifact.
 
 Pure aggregation over an `OutcomeMatrix` given a `RoutingPolicy`: what the policy's routed mix
-scores on the held-out scenarios versus one frontier baseline model, at what cost and latency,
+scores on router-held-out scenarios versus one frontier baseline model, at what cost and latency,
 and which models the mix uses. No fitting happens here; any policy (hand-written, static, or a
 future fitted one) reports through the same function, so the artifact shape is stable before
 the optimizer exists.
@@ -87,6 +87,7 @@ class ImprovementReport(BaseModel):
     endpoint_id: str
     generated_at: str
     scenario_count: int
+    scenario_ids: list[str] = Field(default_factory=list)
     scenario_label: str  # e.g. "on 90 held-out scenarios reconstructed from your traces"
     baseline: ModelRef
     headline: Headline
@@ -155,22 +156,42 @@ def build_report(
 ) -> ImprovementReport:
     """Aggregate `matrix` into the endpoint's improvement report under `policy`.
 
-    The routed side replays the policy's serve-time selection over each held-out scenario's
+    The routed side replays the policy's serve-time selection over each router-held-out scenario's
     task text and takes THAT model's measured outcomes for the scenario; the baseline side is
     `baseline`'s own rows on the same scenarios. Both sides therefore quote real, per-scenario
     measurements from the identical matrix, over the identical scenarios (module docstring:
     the headline is a PAIRED comparison over commonly-scored scenarios).
 
-    Raises ValueError when no scenario was scored on both sides: a matrix that measured nothing
-    comparable has no honest report in it.
+    Fit scenarios recorded by the policy are excluded. An entirely separate evaluation matrix
+    has no overlapping ids, so all of its scenarios remain eligible. Raises ValueError when no
+    eligible scenario was scored on both sides: a matrix that measured nothing comparable has no
+    honest report in it.
     """
     names = {entry.name: entry for entry in matrix.pool}
     if baseline not in names:
         raise KeyError(f"baseline '{baseline}' is not in the matrix pool; have: {sorted(names)}")
 
-    scenario_tasks: dict[str, str] = {}
+    all_scenario_tasks: dict[str, str] = {}
     for outcome in matrix.outcomes:
-        scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+        all_scenario_tasks.setdefault(outcome.scenario_id, outcome.task)
+
+    fit_ids = set(policy.fit_scenario_ids)
+    if not fit_ids and policy.kind == "knn":
+        # Legacy kNN artifacts did not serialize fit ids on the policy, but their evidence bank
+        # does. Recover the boundary rather than silently calling those rows held out.
+        fit_ids = set(policy.knn_bank().scenario_ids)
+    if policy.kind == "rank" and not fit_ids:
+        raise ValueError(
+            "the fitted rank policy does not record its fit scenario ids, so held-out reporting "
+            "cannot be proved; refit the policy with this version"
+        )
+    report_ids = [sid for sid in all_scenario_tasks if sid not in fit_ids]
+    if not report_ids:
+        raise ValueError(
+            "the report matrix contains no scenario outside the router fit set; use a matrix "
+            "with the reserved report partition or a separate evaluation matrix"
+        )
+    scenario_tasks = {sid: all_scenario_tasks[sid] for sid in report_ids}
 
     # One embedder for the whole report: an azure spec builds an HTTP client per `build()`, and
     # a report routes every held-out scenario.
@@ -221,7 +242,11 @@ def build_report(
 
     candidates: list[CandidateResult] = []
     for entry in matrix.pool:
-        rows = [o for o in matrix.outcomes if o.model == entry.name]
+        rows = [
+            o
+            for o in matrix.outcomes
+            if o.model == entry.name and o.scenario_id in scenario_tasks
+        ]
         accuracy, success, cost, p50, p95 = _aggregate(rows)
         candidates.append(
             CandidateResult(
@@ -241,6 +266,7 @@ def build_report(
         endpoint_id=endpoint,
         generated_at=generated_at,
         scenario_count=total,
+        scenario_ids=list(scenario_tasks),
         scenario_label=f"on {total} held-out scenarios reconstructed from your traces",
         baseline=_ref(baseline),
         headline=Headline(

--- a/wmo/optimize/report.py
+++ b/wmo/optimize/report.py
@@ -243,9 +243,7 @@ def build_report(
     candidates: list[CandidateResult] = []
     for entry in matrix.pool:
         rows = [
-            o
-            for o in matrix.outcomes
-            if o.model == entry.name and o.scenario_id in scenario_tasks
+            o for o in matrix.outcomes if o.model == entry.name and o.scenario_id in scenario_tasks
         ]
         accuracy, success, cost, p50, p95 = _aggregate(rows)
         candidates.append(

--- a/wmo/optimize/report_test.py
+++ b/wmo/optimize/report_test.py
@@ -71,6 +71,9 @@ def _cluster_policy() -> RoutingPolicy:
         kind="rank",
         default_model="cheap",
         pool=_entries(),
+        # This policy represents one fitted on a separate matrix. None of these report rows
+        # overlap its recorded fit evidence, so all are legitimately held out.
+        fit_scenario_ids=["external-fit-scenario"],
         embedder=EmbedderSpec(dim=64),
         top_k_clusters=1,
         clusters=[
@@ -118,6 +121,36 @@ def test_report_model_mix_and_candidates() -> None:
     assert by_name["cheap"].cost_per_run_usd == pytest.approx(0.001)
     assert by_name["cheap"].model.tier == "open"
     assert by_name["fable-5"].latency_p50_ms == pytest.approx(300.0)
+
+
+def test_report_excludes_rows_recorded_as_router_fit_evidence() -> None:
+    policy = _cluster_policy().model_copy(update={"fit_scenario_ids": ["s1"]})
+
+    report = build_report(
+        _matrix(),
+        policy,
+        baseline="fable-5",
+        endpoint="tau-bench",
+        generated_at="2026-07-24T00:00:00Z",
+    )
+
+    assert report.scenario_ids == ["s2"]
+    assert report.scenario_count == report.headline.scenarios_compared == 1
+    assert report.headline.accuracy == pytest.approx(0.8)
+    assert all(candidate.scored_episodes == 1 for candidate in report.candidates)
+
+
+def test_report_refuses_when_every_scenario_was_used_for_router_fit() -> None:
+    policy = _cluster_policy().model_copy(update={"fit_scenario_ids": ["s1", "s2"]})
+
+    with pytest.raises(ValueError, match="no scenario outside the router fit set"):
+        build_report(
+            _matrix(),
+            policy,
+            baseline="fable-5",
+            endpoint="tau-bench",
+            generated_at="2026-07-24T00:00:00Z",
+        )
 
 
 def test_report_static_policy_and_unscored_rows() -> None:

--- a/wmo/optimize/routing.py
+++ b/wmo/optimize/routing.py
@@ -242,6 +242,7 @@ def fit_rank_policy(
         min_support=min_support if guard_model is not None else None,
         guard_margin=guard_margin if guard_model is not None else None,
         fitted_from=fitted_from,
+        fit_scenario_ids=list(scenario_ids),
     )
 
 


### PR DESCRIPTION
Rebase of #308 by @yashwardhanchaudhuri onto current main (post #310/#323/#329/#330/#331), conflicts resolved as unions (main's typer.BadParameter wrapping + the PR's fit_ids/split provenance), plus one rebase-seam test fix (the plan table now says "fit split").

All credit to the original author: deterministic sha256 70/30 scenario split, fit_scenario_ids on the policy, reports exclude fit ids, legacy kNN bank recovery, rank policies refuse unproveable held-out claims.

Gates: ruff, ty, pytest 4400 passed / 19 skipped.

Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)