### PR TITLE
Same-fit-matrix reports note the excluded split instead of claiming IN-SAMPLE

### DIFF
--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -1331,12 +1331,13 @@ def report(
 def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
     """The caveat for a report measured on the very matrix the policy was fitted on.
 
-    `fit` sends the user here precisely to escape its own in-sample number, and the report labels
-    its scenarios held-out, so a report over the fit matrix is the one case where both surfaces
-    say the opposite of what happened. The digest in `fitted_from` is an identity rather than a
-    label (`load_matrix_with_digest`), so the collision is detectable even when the matrix was
-    renamed or moved after the fit, and a matrix with the same path but different bytes does not
-    trip it.
+    Since the router split (#308), `build_report` excludes the policy's recorded fit scenarios,
+    so a report over the fit matrix IS held out whenever that split is recoverable - the note
+    says so, with the count. The in-sample WARNING remains only for a policy that records no
+    split and whose evidence cannot name one: those numbers retrieve their own rows. The digest
+    in `fitted_from` is an identity rather than a label (`load_matrix_with_digest`), so the
+    collision is detectable even when the matrix was renamed or moved after the fit, and a
+    matrix with the same path but different bytes does not trip it.
     """
     # `load_matrix_with_digest` appends the marker LAST, so split from the right: a matrix under a
     # content-addressed directory (`artifacts/sha256=.../matrix.json`) carries the marker in its
@@ -1345,9 +1346,26 @@ def _in_sample_warning(policy: RoutingPolicy, matrix_source: str) -> str | None:
     stamped = policy.fitted_from or ""
     if not mark or not digest or f"{_MATRIX_DIGEST_MARK}{digest}" not in stamped:
         return None
+    fit_ids = set(policy.fit_scenario_ids)
+    if not fit_ids and policy.kind == "knn":
+        # The same recovery `build_report` uses for legacy kNN artifacts: their evidence bank
+        # names the fit scenarios even when the policy predates recording them.
+        try:
+            fit_ids = set(policy.knn_bank().scenario_ids)
+        except (FileNotFoundError, ValueError):
+            fit_ids = set()
+    if fit_ids:
+        # Same matrix as the fit, but the report excluded the fit scenarios (the split is
+        # recorded on the policy), so the numbers above ARE held out. Say what happened instead
+        # of contradicting the report's own label.
+        return (
+            f"note: same matrix as the fit ({_MATRIX_DIGEST_MARK}{digest}); the "
+            f"{len(fit_ids)} fit scenario(s) were excluded, so the numbers above are over "
+            "held-out scenarios only."
+        )
     return (
         f"[yellow]warning[/yellow] this policy was FITTED on this matrix "
-        f"({_MATRIX_DIGEST_MARK}{digest}), so these numbers are IN-SAMPLE, not held out: every "
-        "request retrieves its own row. Sweep a second matrix over scenarios the fit never saw "
-        "and report against that one."
+        f"({_MATRIX_DIGEST_MARK}{digest}) and records no fit split, so these numbers are "
+        "IN-SAMPLE, not held out: every request retrieves its own row. Sweep a second matrix "
+        "over scenarios the fit never saw and report against that one."
     )

--- a/wmo/cli/route_app_test.py
+++ b/wmo/cli/route_app_test.py
@@ -2936,37 +2936,36 @@ def test_route_report_creates_the_out_directory_like_fit_does(tmp_path: Path) ->
     assert json.loads(out.read_text(encoding="utf-8"))["headline"]
 
 
-def test_route_report_warns_when_it_measures_the_matrix_the_policy_was_fitted_on(
+def test_route_report_notes_the_excluded_fit_split_on_the_fit_matrix(
     tmp_path: Path,
 ) -> None:
-    """`fit` sends the user here to escape its in-sample number; report never checked.
-
-    The report even labels its scenarios held-out, so this is the one case where both surfaces
-    say the opposite of what happened. The matrix digest in `fitted_from` is an identity, so a
-    renamed copy of the fit matrix has to trip it too.
+    """Same matrix as the fit: since #308 the report excludes the fit split, so the surface says
+    "held-out with N fit scenarios excluded" rather than contradicting the report's own label.
+    The matrix digest in `fitted_from` is an identity, so a renamed copy has to trip it too.
     """
     matrix_file = _knn_matrix_file(tmp_path)
     policy_file = _fitted_knn_policy(tmp_path)
 
     result = _report(matrix_file, policy_file, tmp_path / "report.json")
     assert result.exit_code == 0, result.output
-    assert _says(result.output, "IN-SAMPLE")
+    assert _says(result.output, "fit scenario(s) were excluded")
+    assert "IN-SAMPLE" not in _flat(result.output)
 
     renamed = tmp_path / "renamed.json"
     renamed.write_bytes(matrix_file.read_bytes())
     moved = _report(renamed, policy_file, tmp_path / "report_renamed.json")
     assert moved.exit_code == 0, moved.output
-    assert _says(moved.output, "IN-SAMPLE")
+    assert _says(moved.output, "fit scenario(s) were excluded")
 
     # The provenance marker is appended LAST, so a matrix stored under a content-addressed
     # directory carries `sha256=` in its path too. Splitting from the left read THAT one and
-    # dropped the warning on exactly the layout most likely to keep a fit matrix around.
+    # dropped the caveat on exactly the layout most likely to keep a fit matrix around.
     addressed = tmp_path / "artifacts" / "sha256=deadbeef" / "matrix.json"
     addressed.parent.mkdir(parents=True)
     addressed.write_bytes(matrix_file.read_bytes())
     content_addressed = _report(addressed, policy_file, tmp_path / "report_addressed.json")
     assert content_addressed.exit_code == 0, content_addressed.output
-    assert _says(content_addressed.output, "IN-SAMPLE")
+    assert _says(content_addressed.output, "fit scenario(s) were excluded")
 
 
 def test_route_report_stays_quiet_on_a_matrix_the_fit_never_saw(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #339: build_report excludes the fit split, but the digest-based warning still printed 'IN-SAMPLE, not held out' on exactly the command path a reproducer runs. The warning now downgrades to an informative note (naming the excluded fit-scenario count) whenever the split is recoverable from the policy or its kNN bank, and survives only for legacy artifacts with no recoverable split. Tests updated to assert the note and the absence of the contradiction.

Gates: ruff, ty, pytest full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)