### PR TITLE
Stop `wmo providers set` corrupting the pool when a short entry is added

### DIFF
--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -549,7 +549,7 @@ def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
         console.print(f"  {_CHECK} {summary} [dim]already registered, unchanged[/dim]")
         return False
     try:
-        replaced = upsert_pool_entry(entry, pool_path)
+        written = upsert_pool_entry(entry, pool_path)
     except PoolLockTimeout as exc:
         # Another writer is in the way; nothing about the entry is wrong, so say to retry rather
         # than sending the user back through the prompts.
@@ -558,8 +558,14 @@ def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
     except ValueError as exc:
         console.print(f"  [red]skipped {escape(entry.name)}[/red]: {escape(str(exc))}")
         return False
-    note = " [dim](the roster was rewritten, so its comments are gone)[/dim]" if replaced else ""
-    console.print(f"  {_CHECK} {'replaced' if replaced else 'added'} {summary}{note}")
+    # `rewritten`, not `replaced`: normalizing a legacy inline-form roster drops the comments on
+    # an ADD too, and reporting that as a plain "added" would delete them silently.
+    note = (
+        " [dim](the roster was rewritten, so its comments are gone)[/dim]"
+        if written.rewritten
+        else ""
+    )
+    console.print(f"  {_CHECK} {'replaced' if written.replaced else 'added'} {summary}{note}")
     return True
 
 

--- a/wmo/cli/pool_registry_test.py
+++ b/wmo/cli/pool_registry_test.py
@@ -32,7 +32,7 @@ from wmo.config import PROVIDER_ENV_VARS
 from wmo.providers.base import ProviderKind, VerifyResult
 from wmo.providers.catalog import list_provider_models
 from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
-from wmo.providers.pool import PoolEntry
+from wmo.providers.pool import PoolEntry, load_pool
 from wmo.tracking.pricing import ModelPrice
 
 _SONNET = "anthropic/claude-sonnet-4.5"
@@ -488,6 +488,33 @@ def test_register_model_ids_writes_without_prompting(tmp_path: Path) -> None:
     entries = read_pool_entries(pool)
     assert [entry.name for entry in entries] == ["claude-sonnet-4.5", "deepseek-v3.2"]
     assert all(entry.tier == "open" for entry in entries)
+
+
+def test_register_model_ids_writes_a_loadable_roster_for_two_built_in_priced_ids(
+    tmp_path: Path,
+) -> None:
+    """Two ids in one pass must leave a pool `load_pool` can read.
+
+    `--pool-model` writes one entry per id through `upsert_pool_entry`, so it is not a workaround
+    for the duplicate-key corruption: entry #2 takes the same append path. The ids here are
+    deliberately built-in priced ones, whose entries carry no price fields and so render short.
+    The OpenRouter batch above cannot catch this: its entries are stamped with resolved prices,
+    which pushes them past the length heuristic that decided the rendering.
+    """
+    pool = tmp_path / "pool.toml"
+    console = Console(file=StringIO(), width=120, no_color=True)
+
+    written = register_model_ids(
+        console,
+        pool_path=pool,
+        kind=ProviderKind.OPENAI,
+        model_ids=["gpt-5.5", "gpt-5.4-mini"],
+        options=EntryOptions(),
+        verify=_ok,
+    )
+
+    assert written == 2
+    assert [entry.name for entry in load_pool(pool).models] == ["gpt-5.5", "gpt-5.4-mini"]
 
 
 def test_register_model_ids_is_idempotent(tmp_path: Path) -> None:

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -775,7 +775,7 @@ def student(
         )
         raise typer.Exit(0)
     try:
-        replaced = upsert_pool_entry(entry, pool_path)
+        written = upsert_pool_entry(entry, pool_path)
     except PoolLockTimeout as exc:
         # Nothing is wrong with the flags, so this is not a BadParameter: another writer is in the
         # way. Exit non-zero (and say to retry) so a script does not read it as a registration.
@@ -783,9 +783,12 @@ def student(
         raise typer.Exit(1) from exc
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
-    verb = "replaced" if replaced else "added"
+    verb = "replaced" if written.replaced else "added"
+    rewrite_note = (
+        "\n  the roster was rewritten, so its comments are gone" if written.rewritten else ""
+    )
     _console.print(
-        f"[green]✓[/green] {verb} pool candidate [bold]{name}[/bold] -> {pool_path}\n"
+        f"[green]✓[/green] {verb} pool candidate [bold]{name}[/bold]{rewrite_note} -> {pool_path}\n"
         f"  {card.base_model} adapter at {entry.model}\n"
         f"  ${input_per_mtok:g}/${output_per_mtok:g} per 1M in/out tokens, "
         f"{_credential_note(entry)}\n"

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -32,7 +32,7 @@ import tomllib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NamedTuple
 
 import tomli_w
 from llm_waterfall import ChatMaxTokensField
@@ -342,12 +342,26 @@ class PoolLockTimeout(RuntimeError):
     """Another writer held the roster's lock for longer than the bounded wait."""
 
 
+class PoolWrite(NamedTuple):
+    """What one `upsert_pool_entry` did to the file, for a caller that has to report it.
+
+    Two independent facts, because the CLI says a different thing for each and a bool cannot
+    carry both. `replaced` answers "was an entry of this name already there", which is the
+    question `wmo optimize route student` prompts about BEFORE writing. `rewritten` answers
+    "were the operator's comments dropped", which a replacement always does and an ADD can now
+    also do, when the roster had to be normalized out of the legacy inline form.
+    """
+
+    replaced: bool
+    rewritten: bool
+
+
 def upsert_pool_entry(
     entry: PoolEntry,
     path: Path = DEFAULT_POOL_PATH,
     *,
     lock_timeout_s: float | None = None,
-) -> bool:
+) -> PoolWrite:
     """Add `entry` to the pool roster at `path`, replacing any entry with the same name.
 
     The one write path for the roster, so a trained model becomes routable without hand-editing
@@ -355,11 +369,22 @@ def upsert_pool_entry(
     as: re-serializing them through `PoolEntry` would stamp every default (`tier`,
     `chat_max_tokens_field`) into a file an operator maintains by hand.
 
-    Adding a NEW entry appends its one table and touches nothing else, so comments, key order,
-    and spacing all survive byte for byte. REPLACING an entry has to remove the old table, which
-    means re-rendering the file through `tomllib` -> `tomli_w`: that keeps every entry's fields
-    but DROPS comments, because neither library round-trips them. Callers that can prompt should
-    say so before replacing (`wmo optimize route student` does).
+    Adding a NEW entry appends its one `[[model]]` section and touches nothing else, so comments,
+    key order, and spacing all survive byte for byte. REPLACING an entry has to remove the old
+    table, which means re-rendering the file through `tomllib` -> `tomli_w`: that keeps every
+    entry's fields but DROPS comments, because neither library round-trips them. Callers that can
+    prompt should say so before replacing (`wmo optimize route student` does).
+
+    One kind of ADD re-renders too, and so also drops comments: a roster written as the inline
+    array `model = [ {...} ]` rather than as `[[model]]` sections cannot be appended to (the
+    section header would be a second top-level `model` key), so it is normalized on the next
+    write. Releases up to 0.2.1 could write that form; a file this command has written since is
+    always in section form and always takes the append path. That case is why the return value
+    reports `rewritten` separately from `replaced`: an add that silently deleted the comments
+    recording which account each row bills to, while printing a plain "added", is not acceptable.
+
+    Whichever body is produced, it is parsed back and required to read as exactly the intended
+    roster before it is committed (`_parses_back`), so no write can leave the pool unloadable.
 
     The merged roster is validated as a whole `ModelPool` BEFORE anything is written, and the
     write itself goes through a temp file, so a rejected entry can never leave the pool
@@ -379,7 +404,7 @@ def upsert_pool_entry(
             is `POOL_LOCK_TIMEOUT_S`.
 
     Returns:
-        True when an entry of the same name was replaced, False when `entry` was appended.
+        What the write did: see `PoolWrite`.
 
     Raises:
         ValueError: If `path` exists but is not a readable pool file, if it is already an invalid
@@ -442,7 +467,7 @@ def _pool_write_lock(path: Path, *, timeout_s: float) -> Iterator[None]:
         os.close(fd)
 
 
-def _upsert_locked(entry: PoolEntry, path: Path) -> bool:
+def _upsert_locked(entry: PoolEntry, path: Path) -> PoolWrite:
     """The read-validate-write cycle of `upsert_pool_entry`, with the roster's lock held."""
     tables = _raw_tables(path)
     if tables:
@@ -467,21 +492,26 @@ def _upsert_locked(entry: PoolEntry, path: Path) -> bool:
         ModelPool.model_validate({"models": merged})
     except ValidationError as exc:
         raise ValueError(f"adding '{entry.name}' would make {path} an invalid pool: {exc}") from exc
-    rendered = tomli_w.dumps({"model": [table]})
-    if replaced or not path.is_file():
-        # A replacement has to remove the old table, which means re-rendering the whole file.
-        body = tomli_w.dumps({"model": merged})
-    else:
-        # The common case is a first registration, and appending the one new table byte-preserves
-        # everything already in the file: an operator's comments, key order, and spacing. Rewriting
-        # would silently destroy the comments that say which account a row bills to, and nothing
-        # would tell them it happened.
-        existing = path.read_text(encoding="utf-8")
-        if existing.endswith("\n\n"):
-            separator = ""
-        else:
-            separator = "\n" if existing.endswith("\n") else "\n\n"
-        body = f"{existing}{separator}{rendered}"
+    # The common case is a first registration, and appending the one new section byte-preserves
+    # everything already in the file: an operator's comments, key order, and spacing. Rewriting
+    # would silently destroy the comments that say which account a row bills to. A replacement
+    # cannot append (removing the old table means re-rendering), and neither can a file whose
+    # roster is not in section form, so both of those fall through to the re-render below.
+    existed = path.is_file()
+    body = None
+    if not replaced and existed:
+        body = _parses_back(_appended_body(path.read_text(encoding="utf-8"), table), merged)
+    # Creating the file is not a rewrite: there was nothing in it to lose, and reporting one
+    # would put "its comments are gone" on a first registration.
+    rewritten = body is None and existed
+    if body is None:
+        body = _parses_back(_render_sections(merged), merged)
+    if body is None:  # the re-render is what every other path falls back TO; it has no fallback
+        raise ValueError(
+            f"refusing to write {path}: the roster rendered to TOML that does not read back as "
+            f"the {len(merged)} intended entries. This is a bug in wmo, not in your file, which "
+            "is untouched; the likely cause is a pool field whose value is not a plain scalar"
+        )
     # The temp name carries this process's pid. The lock already keeps writers off each other, so
     # this is defense in depth for anything that writes the roster without taking it: a shared
     # fixed `.tmp` path would let each writer rename the other's half-written file into place,
@@ -493,7 +523,83 @@ def _upsert_locked(entry: PoolEntry, path: Path) -> bool:
     except OSError:
         tmp_path.unlink(missing_ok=True)  # never leave a stray temp beside the roster
         raise
-    return replaced
+    return PoolWrite(replaced=replaced, rewritten=rewritten)
+
+
+def _parses_back(body: str, merged: list[JsonObject]) -> str | None:
+    """`body` if it reads back as exactly the roster `merged`, else None.
+
+    The commit gate, checked on EVERY write rather than only on the append path, because the two
+    ways to render this file fail differently and both fail silently. Appending to a roster
+    written as the inline array `model = [ {...} ]` (the form releases up to 0.2.1 could produce)
+    is a duplicate top-level key, so the file stops loading. And `tomli_w.dumps` on a table with a
+    non-scalar value emits a `[key]` header, which under a hand-written `[[model]]` parses as a
+    SIBLING top-level table: the field silently vanishes from the entry with no error at all,
+    which is worse. `PoolEntry`'s all-scalar schema is what rules the second one out today, and
+    this is what keeps it ruled out if that ever changes.
+
+    Cheap enough to be unconditional: one `tomllib` parse of a file that holds a handful of
+    entries, once per registration, under a lock that is already held.
+    """
+    try:
+        parsed = tomllib.loads(body)
+    except tomllib.TOMLDecodeError:
+        return None
+    return body if parsed.get("model") == merged else None
+
+
+def _render_sections(tables: list[JsonObject]) -> str:
+    """`tables` as one `[[model]]` section each, blank-line separated.
+
+    The section headers are written HERE rather than left to `tomli_w.dumps({"model": tables})`,
+    which does not reliably produce them. `tomli_w` picks the rendering per value: an array of
+    tables comes out as `[[model]]` sections only when at least one of them fails
+    `is_suitable_inline_table`, which is a LINE-LENGTH heuristic (100 characters). A roster of
+    short entries (`{name, kind, model}` for an OpenAI model) renders instead as the inline array
+    `model = [ {...} ]`. That form is valid TOML and still loads, but it cannot be APPENDED to:
+    adding a second `model = [...]` (or a `[[model]]` section) is a duplicate top-level key, so
+    every later `load_pool` fails with `Cannot overwrite a value` and the roster has to be
+    repaired by hand. Verbose entries (an Azure row carrying deployment/api_version/api_key_env)
+    cross 100 characters and come out as sections, which is what made the corruption look
+    intermittent rather than what it was: data-dependent, and reliably hit by the smallest entry
+    anyone registers.
+
+    Writing the header ourselves takes that heuristic out of the write path entirely, in both
+    directions: the file this command creates is one an append can extend, so the byte-preserving
+    add path in `_appended_body` stays reachable no matter how short the entries are.
+
+    Correct only while every table is a flat dict of scalars, which `PoolEntry` is: `tomli_w.dumps`
+    on a table holding a nested value emits a `[key]` header for it, and under a hand-written
+    `[[model]]` that header reads as a SIBLING top-level table, so the field leaves the entry with
+    no error raised. Nothing here enforces that; `_parses_back` is what catches it at the commit
+    point, for this and for the whole-roster render alike.
+    """
+    return "\n".join(f"[[model]]\n{tomli_w.dumps(table)}" for table in tables)
+
+
+def _appended_body(existing: str, table: JsonObject) -> str:
+    """`existing` plus one `[[model]]` section for `table`, separated by a blank line.
+
+    A pure string builder: whether the result is SAFE to write is `_parses_back`'s question, asked
+    at the commit point for every render rather than only for this one. Appending is what
+    byte-preserves an operator's comments, and it works against any roster already in section
+    form, which `_render_sections` guarantees for every file this command has written. A roster
+    still in the inline `model = [ {...} ]` form from 0.2.1 or earlier is the case that fails: a
+    section header appended to one is a duplicate top-level `model` key, the caller falls back to
+    a full re-render, and the file is normalized to section form so the next add can append again.
+
+    Args:
+        existing: The current file contents, already known to parse (`_raw_tables` read it).
+        table: The new entry's table, as rendered into the file.
+
+    Returns:
+        The full file contents to write, unverified.
+    """
+    if existing.endswith("\n\n"):
+        separator = ""
+    else:
+        separator = "\n" if existing.endswith("\n") else "\n\n"
+    return f"{existing}{separator}{_render_sections([table])}"
 
 
 def _raw_tables(path: Path) -> list[JsonObject]:

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from wmo.providers import pool as pool_module
 from wmo.providers.azure_openai import AzureOpenAIProvider
 from wmo.providers.base import ProviderConfig, ProviderKind, TokenUsage
 from wmo.providers.openrouter import OPENROUTER_API_KEY_ENV, OpenRouterProvider
@@ -465,7 +466,7 @@ def test_pool_entry_defaults_keep_the_built_in_contract() -> None:
 def test_upsert_pool_entry_creates_the_file_and_appends(tmp_path: Path) -> None:
     path = tmp_path / "nested" / "pool.toml"
 
-    assert upsert_pool_entry(_student_entry(), path) is False
+    assert upsert_pool_entry(_student_entry(), path).replaced is False
 
     assert [m.name for m in load_pool(path).models] == ["student"]
     entry = load_pool(path).entry("student")
@@ -479,8 +480,8 @@ def test_upsert_pool_entry_replaces_by_name_and_keeps_the_others(tmp_path: Path)
     path.write_text(_POOL_TOML, encoding="utf-8")
     before = [m.name for m in load_pool(path).models]
 
-    assert upsert_pool_entry(_student_entry(), path) is False
-    assert upsert_pool_entry(_student_entry(), path) is True
+    assert upsert_pool_entry(_student_entry(), path).replaced is False
+    assert upsert_pool_entry(_student_entry(), path).replaced is True
 
     after = [m.name for m in load_pool(path).models]
     assert after == [*before, "student"]  # replaced in place, nothing duplicated or dropped
@@ -588,7 +589,7 @@ def test_upsert_pool_entry_appends_without_touching_a_byte_of_the_existing_file(
     path = tmp_path / "pool.toml"
     path.write_text(_COMMENTED_POOL, encoding="utf-8")
 
-    assert upsert_pool_entry(_student_entry(), path) is False
+    assert upsert_pool_entry(_student_entry(), path).replaced is False
 
     written = path.read_text(encoding="utf-8")
     assert written.startswith(_COMMENTED_POOL)  # byte-identical prefix, comments included
@@ -609,6 +610,197 @@ def test_upsert_pool_entry_append_round_trips_when_the_file_has_no_trailing_newl
     upsert_pool_entry(_student_entry(), path)
 
     assert [m.name for m in load_pool(path).models] == ["haiku", "student"]
+
+
+def _short_openai(name: str) -> PoolEntry:
+    """The smallest entry anyone registers: three fields, well under 100 rendered characters."""
+    return PoolEntry(name=name, kind=ProviderKind.OPENAI, model="gpt-5.5")
+
+
+def test_upsert_pool_entry_keeps_the_roster_loadable_across_two_short_registrations(
+    tmp_path: Path,
+) -> None:
+    """The direct regression: two minimal OpenAI rows used to write a duplicate top-level key.
+
+    `tomli_w` emits `[[model]]` sections only when a table is too long to inline (a 100-character
+    heuristic), so `model = [ {...} ]` came out for short entries and appending a second one
+    produced invalid TOML. Every later `load_pool` then failed, which takes serving and the
+    routing optimizer down, not just the candidate being added. This fixture must stay MINIMAL: a
+    verbose Azure row crosses the heuristic and passes with or without the fix.
+    """
+    path = tmp_path / "pool.toml"
+
+    assert upsert_pool_entry(_short_openai("gpt-5.5"), path).replaced is False
+    assert upsert_pool_entry(_short_openai("gpt-5.4-mini"), path).replaced is False
+
+    assert [m.name for m in load_pool(path).models] == ["gpt-5.5", "gpt-5.4-mini"]
+
+
+@pytest.mark.parametrize(
+    "second",
+    [
+        pytest.param(_short_openai("gpt-5.4-mini"), id="short-openai"),
+        pytest.param(
+            PoolEntry(
+                name="azure-gpt",
+                kind=ProviderKind.AZURE_OPENAI,
+                model="gpt-5.5",
+                deployment="gpt-5.5",
+                endpoint="https://example.openai.azure.com",
+                api_version="2024-10-21",
+                api_key_env="AZURE_EXAMPLE_KEY",
+            ),
+            id="long-azure",
+        ),
+    ],
+)
+def test_upsert_pool_entry_round_trips_whatever_shape_the_entry_renders_to(
+    tmp_path: Path, second: PoolEntry
+) -> None:
+    """Parametrized over both sides of the length heuristic so it cannot silently come back."""
+    path = tmp_path / "pool.toml"
+
+    upsert_pool_entry(_short_openai("gpt-5.5"), path)
+    upsert_pool_entry(second, path)
+
+    assert [m.name for m in load_pool(path).models] == ["gpt-5.5", second.name]
+
+
+def test_upsert_pool_entry_appends_short_entries_indefinitely(tmp_path: Path) -> None:
+    """Three-plus sequential adds: the roster stays loadable and keeps every entry, in order."""
+    path = tmp_path / "pool.toml"
+    names = ["gpt-5.5", "gpt-5.4-mini", "haiku", "sonnet"]
+
+    for name in names:
+        assert upsert_pool_entry(_short_openai(name), path).replaced is False
+
+    assert [m.name for m in load_pool(path).models] == names
+
+
+def test_upsert_pool_entry_writes_a_file_a_later_append_can_preserve(tmp_path: Path) -> None:
+    """Creating the file must not cost the NEXT add its comment preservation.
+
+    The inline array form loads fine, so the corruption is only half the story: a file in that
+    form cannot be appended to at all, and every later add has to re-render it and drop the
+    operator's comments. Writing sections from the first entry on is what keeps the byte-preserving
+    path reachable for a roster of short entries.
+    """
+    path = tmp_path / "pool.toml"
+    upsert_pool_entry(_short_openai("gpt-5.5"), path)
+    annotated = path.read_text(encoding="utf-8") + "\n# billed to the research account\n"
+    path.write_text(annotated, encoding="utf-8")
+
+    upsert_pool_entry(_short_openai("gpt-5.4-mini"), path)
+
+    written = path.read_text(encoding="utf-8")
+    assert written.startswith(annotated)  # byte-identical prefix, comment included
+    assert [m.name for m in load_pool(path).models] == ["gpt-5.5", "gpt-5.4-mini"]
+
+
+_LEGACY_INLINE_POOL = """model = [
+    { name = "gpt-5.5", kind = "openai", model = "gpt-5.5" },
+]
+"""
+
+
+def test_upsert_pool_entry_normalizes_a_legacy_inline_pool_file(tmp_path: Path) -> None:
+    """Rosters written by releases up to 0.2.1 are one inline array, which cannot be appended to.
+
+    Adding a `[[model]]` section to one is the same duplicate-key corruption in the other
+    direction, so the upgrade path is a full re-render. It costs that file its comments once, and
+    leaves it in the section form every later add can extend.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text(_LEGACY_INLINE_POOL, encoding="utf-8")
+
+    assert upsert_pool_entry(_short_openai("haiku"), path).replaced is False
+
+    assert [m.name for m in load_pool(path).models] == ["gpt-5.5", "haiku"]
+    assert "[[model]]" in path.read_text(encoding="utf-8")  # normalized, so the next add appends
+
+
+def test_upsert_pool_entry_reports_the_rewrite_that_normalizing_a_legacy_pool_costs(
+    tmp_path: Path,
+) -> None:
+    """An ADD that drops the operator's comments must SAY so; the CLI prints the note from this.
+
+    Normalizing an inline-form roster is a re-render, so the comments recording which account
+    each row bills to are gone. Reporting that as a plain "added" (which is what keying the
+    note off `replaced` alone does) deletes them silently and unrecoverably.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text(f"# bills to research\n{_LEGACY_INLINE_POOL}", encoding="utf-8")
+
+    written = upsert_pool_entry(_short_openai("haiku"), path)
+
+    assert written.replaced is False  # nothing of that name was there
+    assert written.rewritten is True  # but the file was re-rendered anyway, so say so
+    assert "bills to research" not in path.read_text(encoding="utf-8")
+
+
+def test_upsert_pool_entry_reports_no_rewrite_for_a_plain_append(tmp_path: Path) -> None:
+    """The common case must not print the comment warning, or it stops meaning anything."""
+    path = tmp_path / "pool.toml"
+    upsert_pool_entry(_short_openai("gpt-5.5"), path)
+
+    written = upsert_pool_entry(_short_openai("gpt-5.4-mini"), path)
+
+    assert (written.replaced, written.rewritten) == (False, False)
+
+
+def test_upsert_pool_entry_does_not_call_creating_the_file_a_rewrite(tmp_path: Path) -> None:
+    """A first registration has no comments to lose, so it must not claim any were dropped."""
+    written = upsert_pool_entry(_short_openai("gpt-5.5"), tmp_path / "pool.toml")
+
+    assert (written.replaced, written.rewritten) == (False, False)
+
+
+def test_upsert_pool_entry_refuses_to_write_a_roster_that_does_not_read_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The commit gate, on the re-render path that has no fallback.
+
+    `_render_sections` hand-writes the `[[model]]` header, which is only correct while every
+    table is a flat dict of scalars. A nested value makes `tomli_w` emit a `[key]` header that
+    TOML reads as a SIBLING top-level table, so the field leaves the entry with no error raised:
+    silent data loss, not a parse failure.
+
+    `PoolEntry`'s `extra="forbid"` is the first line of defence and rejects such a field before
+    the renderer ever sees it, so the renderer is stubbed here to produce what tomli_w would
+    produce if that schema were ever relaxed. What is under test is the commit gate on the
+    RE-RENDER path, which is the one with no fallback: the append path could still fall back to
+    re-rendering, but a bad re-render used to be written straight out.
+    """
+    path = tmp_path / "pool.toml"
+
+    def _hoists_a_sub_table(tables: list[dict[str, object]]) -> str:
+        # Exactly what tomli_w does with a nested value today: the sub-table gets its own header,
+        # which under the [[model]] above it parses as a SIBLING, not as a field of the entry.
+        return "".join(
+            f"[[model]]\nname = {table['name']!r}\n\n[rate_limits]\nrpm = 60\n" for table in tables
+        )
+
+    monkeypatch.setattr(pool_module, "_render_sections", _hoists_a_sub_table)
+    with pytest.raises(ValueError, match="does not read back as"):
+        upsert_pool_entry(_short_openai("gpt-5.5"), path)
+
+    assert not path.exists()  # nothing was committed
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_load_pool_names_the_file_when_it_is_not_valid_toml(tmp_path: Path) -> None:
+    """A decode error reaches the user through `SweepError(str(exc))`, so it must carry the path.
+
+    Bare, `tomllib`'s "Cannot overwrite a value (at line 7, column 2)" surfaces under typer's
+    `Invalid value:`, which reads as a bad CLI argument rather than a corrupt pool file.
+    """
+    path = tmp_path / "pool.toml"
+    path.write_text('model = [ { name = "a" } ]\n\nmodel = [ { name = "b" } ]\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"is not valid TOML") as caught:
+        load_pool(path)
+
+    assert str(path) in str(caught.value)
 
 
 def test_upsert_pool_entry_blames_a_pre_existing_bad_row_on_the_file_not_the_new_entry(
@@ -789,7 +981,7 @@ def test_upsert_pool_entry_reports_a_stuck_writer_instead_of_hanging(tmp_path: P
     assert list(tmp_path.glob("*.tmp")) == []
     # Once the holder is gone the lock is free again: the kernel owns that release, so a leftover
     # lock FILE is never a held lock and cannot wedge the next run.
-    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05) is False
+    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05).replaced is False
 
 
 def test_upsert_pool_entry_releases_the_lock_when_it_rejects_the_roster(tmp_path: Path) -> None:
@@ -804,7 +996,7 @@ def test_upsert_pool_entry_releases_the_lock_when_it_rejects_the_roster(tmp_path
         upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05)
 
     path.write_text(_COMMENTED_POOL, encoding="utf-8")  # the operator fixes the row
-    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05) is False
+    assert upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05).replaced is False
 
 
 # --- OpenRouter entries: priced from the published catalog, not by hand -----------------------


### PR DESCRIPTION
## The bug

Register two models in one `wmo providers set` pass. Both report success. Every subsequent
command that reads the pool then dies:

```
$ wmo optimize route sweep tau --traces traces.otel.jsonl
╭─ Error ─────────────────────────────────────────────────────╮
│ Invalid value: Cannot overwrite a value (at line 7, column 2)│
╰─────────────────────────────────────────────────────────────╯
```

`load_pool` is what serving and the routing optimizer both call, so this takes every endpoint
down, not just the candidate being added. The pool has to be hand-repaired.

## Root cause

The append fast-path exists to byte-preserve an operator's comments, and it is only valid if
`rendered` is a `[[model]]` section header. It took that from `tomli_w.dumps({"model": [table]})`,
which does not reliably produce one: `tomli_w` picks the style per value with
`is_suitable_inline_table`, a **line-length heuristic** (100 characters).

| entry | rendered as | append result |
|---|---|---|
| `{name, kind, model}` openai (~85 chars) | `model = [ {...} ]` | **duplicate key, corrupt** |
| azure with `deployment`/`api_version`/`api_key_env` (>100) | `[[model]]` | valid |

Verbose Azure-shaped fixtures append fine and the minimal OpenAI entry in the demo path is the one
that breaks, which is why this reads as flaky rather than as what it is: data-dependent.
`--pool-model` was not a workaround either, since `register_model_ids` calls `upsert_pool_entry`
once per id.

## The fix

`_render_sections` writes the section headers itself, taking the heuristic out of the write path.
It does that for the **whole-file** render too, not just the append. That second half matters and
was not in the original report: without it a short-entry pool is written in inline form at
creation, so the byte-preserving append path is never reachable and every later add re-renders and
drops the operator's comments.

Hand-rendering is only correct while every table is a flat dict of scalars. It is today, but a
nested value makes `tomli_w` emit a `[key]` header that TOML reads as a **sibling** top-level
table, so the field would leave the entry with nothing raised:

```
'[[model]]\nname = "a"\n\n[rate_limits]\nrpm = 60\n'  ->  {'model': [{'name': 'a'}], 'rate_limits': {...}}
```

So the written body is parsed back and required to read as exactly the intended roster before it
is committed, **on every path** rather than only the append. A legacy inline roster from 0.2.1
fails that check and is normalized by a full re-render; a render that loses a field is refused.

Normalizing costs that file its comments, so `upsert_pool_entry` returns
`PoolWrite(replaced, rewritten)` rather than a bare bool. Both CLIs keyed their "the roster was
rewritten, so its comments are gone" note off `replaced`, so an add that silently deleted the
comments recording which account each row bills to still printed a plain green "added". This is a
deliberate deviation from the issue's "preserve the `replaced` return-value semantics" constraint:
`.replaced` still means exactly what it did, but the bool could not carry both facts, and its
documented meaning ("False when `entry` was appended") was already wrong once a non-replacing add
could re-render.

The lock and the atomic write are untouched. They were already correct here, and #342 is what
gives them to the siblings that lack them; keeping that out of this PR is what makes it 372 lines
rather than 884.

## Root cause 2 was already fixed

`load_pool`'s bare `tomllib.loads` landed in #323. A regression test now pins that the message
names the path.

## Tests

Ten fail on the parent commit, verified by copying the file aside rather than stashing:

- two short openai entries round-trip (the direct regression; must stay minimal, a verbose Azure
  fixture passes either way)
- parametrized over both sides of the length heuristic
- four sequential short appends
- creating the file leaves one a later append can byte-preserve
- legacy inline file upgrades and normalizes
- `register_model_ids` with two built-in-priced ids
- the commit gate refuses a render that does not read back
- `rewritten` is reported for the legacy upgrade and not for a plain append or a create
- `load_pool` names the file on a decode error

Verified end to end: `wmo optimize route sweep` now gets past the pool load and fails on the
genuinely missing world model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
