### PR TITLE
Give every durable-file writer the safeguards pool.py documents

### DIFF
--- a/wmo/cli/pool_registry.py
+++ b/wmo/cli/pool_registry.py
@@ -39,12 +39,12 @@ from rich.table import Table
 from wmo.cli.model_roles import DEFAULT_AZURE_API_VERSION
 from wmo.cli.ui import PromptReader, creds_note, ensure_credentials, has_credentials, select_option
 from wmo.config import PROVIDER_ENV_VARS
+from wmo.core.files import FileLockTimeout
 from wmo.providers.base import ProviderKind, VerifyResult
 from wmo.providers.catalog import CatalogModel, CatalogSource, ProviderCatalog, list_provider_models
 from wmo.providers.openrouter_pricing import resolve_price as resolve_openrouter_price
 from wmo.providers.pool import (
     PoolEntry,
-    PoolLockTimeout,
     Tier,
     load_pool,
     pool_provider,
@@ -550,7 +550,7 @@ def _write(console: Console, entry: PoolEntry, pool_path: Path) -> bool:
         return False
     try:
         written = upsert_pool_entry(entry, pool_path)
-    except PoolLockTimeout as exc:
+    except FileLockTimeout as exc:
         # Another writer is in the way; nothing about the entry is wrong, so say to retry rather
         # than sending the user back through the prompts.
         console.print(f"  [red]pool busy[/red] {escape(str(exc))}")

--- a/wmo/cli/route_app.py
+++ b/wmo/cli/route_app.py
@@ -37,6 +37,7 @@ from rich.table import Table
 
 from wmo.cli.consent import require_spend_consent
 from wmo.config import ARTIFACT_DIR, WorldModelStore
+from wmo.core.files import FileLockTimeout
 from wmo.distill.store import MODEL_CARD_FILE, DistillModelCard, student_pool_entry
 from wmo.engine import load_world_model
 from wmo.env import WorldModelEnv
@@ -93,7 +94,6 @@ from wmo.optimize.sweep import (
 from wmo.providers.pool import (
     DEFAULT_POOL_PATH,
     PoolEntry,
-    PoolLockTimeout,
     load_pool,
     upsert_pool_entry,
 )
@@ -776,7 +776,7 @@ def student(
         raise typer.Exit(0)
     try:
         written = upsert_pool_entry(entry, pool_path)
-    except PoolLockTimeout as exc:
+    except FileLockTimeout as exc:
         # Nothing is wrong with the flags, so this is not a BadParameter: another writer is in the
         # way. Exit non-zero (and say to retry) so a script does not read it as a registration.
         _console.print(f"[red]pool busy[/red] {escape(str(exc))}")

--- a/wmo/config/card.py
+++ b/wmo/config/card.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field, ValidationError
 
+from wmo.core.files import write_text_atomic
+
 CARD_FILENAME = "card.json"
 
 
@@ -110,7 +112,7 @@ def save_card(card: ModelCard, model_dir: str | Path) -> Path:
     """Write `card.json` into `model_dir`, returning the path written."""
     path = card_path(model_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(card.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    write_text_atomic(path, card.model_dump_json(indent=2) + "\n")
     return path
 
 

--- a/wmo/config/config.py
+++ b/wmo/config/config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import tomli_w
 from pydantic import BaseModel, Field, JsonValue, ValidationError
 
+from wmo.core.files import write_text_atomic
 from wmo.core.types import JsonObject
 from wmo.providers.base import EmbedderKind, ProviderConfig, ProviderKind
 from wmo.providers.models import resolve_provider_model
@@ -391,9 +392,5 @@ def save_config(config: HarnessConfig, root: str | Path = ARTIFACT_DIR) -> None:
     failed write never leaves a truncated `config.toml` behind.
     """
     paths = ArtifactPaths(root)
-    paths.root.mkdir(parents=True, exist_ok=True)
     data = _strip_none_object(config.model_dump(mode="json"))
-    tmp = paths.config.with_name(f"{paths.config.name}.tmp")
-    with tmp.open("wb") as fh:
-        tomli_w.dump(data, fh)
-    tmp.replace(paths.config)
+    write_text_atomic(paths.config, tomli_w.dumps(data))

--- a/wmo/config/settings.py
+++ b/wmo/config/settings.py
@@ -11,6 +11,7 @@ from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, Field, ValidationError
 
 from wmo.config.config import ARTIFACT_DIR
+from wmo.core.files import write_text_atomic
 
 SETTINGS_FILENAME = "settings.toml"
 
@@ -132,12 +133,8 @@ def load_settings(root: str | Path = ARTIFACT_DIR) -> ProjectSettings:
 
 def save_settings(settings: ProjectSettings, root: str | Path = ARTIFACT_DIR) -> None:
     path = settings_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
     data = settings.model_dump(mode="json", exclude_none=True)
-    tmp = path.with_name(f"{path.name}.tmp")
-    with tmp.open("wb") as fh:
-        tomli_w.dump(data, fh)
-    tmp.replace(path)
+    write_text_atomic(path, tomli_w.dumps(data))
 
 
 def set_telemetry_enabled(enabled: bool, root: str | Path = ARTIFACT_DIR) -> ProjectSettings:

--- a/wmo/core/files.py
+++ b/wmo/core/files.py
@@ -1,0 +1,174 @@
+"""Durable writes for the small files wmo owns: atomic replace, plus a cross-process write lock.
+
+Every file this covers is a registry or a config that a later command reads back: the candidate
+pool roster, a store's `aliases.toml`, `.wmo/config.toml`, `.wmo/settings.toml`, a distill run's
+resume state, a fitted policy, a paid sweep's outcome matrix. They share one failure mode, and it
+is not losing the file. It is leaving a TRUNCATED or EMPTY file behind an apparently successful
+write, so the next command fails to parse something nobody edited, and the recovery is hand-repair.
+
+The two helpers answer different halves of that, which is why they are separate. Rename atomicity
+means a reader never sees half a file, but two writers doing read-modify-write still overwrite
+each other with both reporting success. A file written whole from its source of truth (a config
+snapshot, a rendered document) needs `write_text_atomic` alone; a file that is read, edited, and
+written back (a roster, an alias table) needs `file_write_lock` around the whole cycle too.
+
+Not covered here: the credential and session writers (`wmo.config.dotenv`,
+`wmo.platform.credentials`, `wmo.connect.credentials`, `wmo.cli.session_state`,
+`wmo.cli.workspace_sync`). Those need 0600 from the moment of creation and refuse to follow a
+symlink, which is a different contract, not a stricter setting of this one.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import uuid4
+
+# How long a writer waits for another process to finish. These writes are a few file operations,
+# so real contention never comes close; the bound exists so a hung holder is REPORTED instead of
+# hanging the terminal forever.
+DEFAULT_LOCK_TIMEOUT_S = 10.0
+_LOCK_POLL_S = 0.01
+
+
+class FileLockTimeout(RuntimeError):
+    """Another process held a file's write lock for longer than the bounded wait."""
+
+
+def write_bytes_atomic(path: Path, payload: bytes) -> None:
+    """Write `payload` to `path` so a reader sees the previous file or the whole new one.
+
+    Four properties, each answering a failure this codebase has actually shipped:
+
+    - **Same-directory staging file plus `replace`.** A rename within a filesystem is atomic, so a
+      crash or a full disk leaves the previous file intact instead of a truncated one. Writing in
+      place does not: a half-written `aliases.toml` loses the champion pointer that
+      `resolve_version` depends on, and a half-written `checkpoints.json` breaks resume exactly
+      when the crash that caused it made resume necessary.
+    - **A staging name unique PER CALL.** A shared fixed `.tmp` lets two writers rename each
+      other's half-written file into place, which turns a lost update into a corrupt file. The
+      name is a uuid rather than the pid because two THREADS of one process collide on a pid.
+    - **fsync on the payload and then on its parent directory.** Without both, a power loss can
+      persist the rename while the data blocks are lost, leaving an empty file behind a write that
+      reported success. These files are small and written rarely: measured at 0.08 ms per write,
+      about 0.1 s across a 200-step distill run whose steps are minutes of paid rollouts.
+    - **The destination's mode is carried over.** `replace` installs a NEW inode, so without this
+      a file an operator or an installer had restricted comes back as 0644 on the first write.
+
+    Cleanup is `BaseException`, not `OSError`: a Ctrl-C between the write and the rename would
+    otherwise strand a staging file in an artifact directory that serving and the fitter scan.
+
+    Args:
+        path: The destination file. Its parent directory is created when missing.
+        payload: The complete file contents.
+
+    Raises:
+        OSError: The write, the rename, or either fsync failed. Whether `path` changed depends on
+            where it failed, and the two cases are distinguishable by the caller only if it looks:
+            BEFORE the rename (the common case: no space, no permission) `path` is untouched and
+            the staging file is cleaned up; AFTER it (the parent-directory fsync, which some FUSE
+            and NFS mounts reject) `path` already holds `payload` and only its durability against
+            a power loss is unproven. Neither case can leave a partly written `path`.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
+    try:
+        with staging.open("wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists():
+            # `replace` installs the staging inode, so the destination's mode has to be carried
+            # over explicitly or a restricted file silently widens to the umask default.
+            staging.chmod(path.stat().st_mode & 0o7777)
+        staging.replace(path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        staging.unlink(missing_ok=True)  # never leave a stray staging file beside the real one
+        raise
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    """`write_bytes_atomic` for UTF-8 text; see it for the guarantees.
+
+    Encoding happens BEFORE anything touches the filesystem, so text that cannot be encoded (a
+    lone surrogate reaching `json.dumps(..., ensure_ascii=False)`) fails without creating a
+    staging file at all.
+    """
+    write_bytes_atomic(path, text.encode("utf-8"))
+
+
+@contextmanager
+def file_write_lock(
+    path: Path, *, what: str, timeout_s: float = DEFAULT_LOCK_TIMEOUT_S
+) -> Iterator[None]:
+    """Hold the exclusive cross-process write lock for `path`, for a read-modify-write cycle.
+
+    Take this around the WHOLE cycle, not just the write. Atomic replace alone does not stop two
+    writers from each reading the same file, each applying their own edit, and the later write
+    erasing the earlier one, with both commands reporting success: a registration an operator made
+    is simply not in the file, and nothing says so.
+
+    The lock sits in a sibling `<name>.lock` file, not in the file itself: writing goes through an
+    atomic rename, which swaps the inode, so a lock taken on the file would stop protecting
+    anything the moment the first writer landed.
+
+    `flock` belongs to the open file description, so the kernel drops it when the holder exits,
+    crashes, or is killed. A leftover `.lock` FILE is therefore never a held lock and can never
+    wedge a later run (which is also why it is left in place: unlinking it would let a waiter
+    block on an inode nobody else can reach). A live holder that hangs still could, so the wait is
+    bounded and reports what to do instead of blocking forever.
+
+    NOT REENTRANT. Each `with` opens its own file description, and flock conflicts between two
+    descriptions of one file even inside a single process, so nesting this on the same path blocks
+    for the full timeout and then reports a stuck OTHER process, which would be a lie. A caller
+    that wants several edits to land together (promoting `champion` and `staging` in one step)
+    must take the lock ONCE around all of them rather than calling a locked helper per edit.
+
+    Args:
+        path: The file being written. The lock file is created beside it.
+        what: The noun for the error message ("the model pool"), naming what is being written from
+            the perspective of someone who ran a command, not the file's role in the code.
+        timeout_s: Seconds to keep retrying the lock before raising.
+
+    Yields:
+        None, with the lock held; it is released when the block exits, on any path.
+
+    Raises:
+        FileLockTimeout: The lock was still held after `timeout_s`.
+        OSError: The lock could not be taken at all, which on a filesystem with no working
+            advisory locks (NFS without lockd, some container volume drivers) is ENOLCK.
+    """
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_s
+    fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC, 0o600)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise FileLockTimeout(
+                        f"another process has been writing {what} at {path} for more than "
+                        f"{timeout_s:g}s (lock file {lock_path}); this write takes milliseconds, "
+                        "so retry, and if it keeps failing look for a stuck process holding that "
+                        "lock (the lock is released automatically when that process exits, so "
+                        "the lock file itself is never the problem)"
+                    ) from None
+                time.sleep(_LOCK_POLL_S)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)

--- a/wmo/core/files_test.py
+++ b/wmo/core/files_test.py
@@ -1,0 +1,308 @@
+"""Tests for the durable-write helpers: atomic replace and the cross-process write lock.
+
+Every assertion is about what survives a FAILURE, because that is the whole point of the module:
+the happy path of any of these writers was already correct. Torn writes are modelled by failing
+`os.fsync`, which is reached with the payload already on the temp file and the rename not yet
+done, so it is the moment where an in-place writer would have destroyed the previous contents.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from wmo.core.files import (
+    FileLockTimeout,
+    file_write_lock,
+    write_bytes_atomic,
+    write_text_atomic,
+)
+
+
+def _fail_fsync(monkeypatch: pytest.MonkeyPatch, message: str = "disk full") -> None:
+    def _boom(fd: int) -> None:
+        raise OSError(message)
+
+    monkeypatch.setattr(os, "fsync", _boom)
+
+
+def test_write_text_atomic_writes_the_file_and_creates_its_parent(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "state.json"
+
+    write_text_atomic(path, '{"run": 1}')
+
+    assert path.read_text(encoding="utf-8") == '{"run": 1}'
+
+
+def test_write_text_atomic_replaces_existing_contents_whole(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    write_text_atomic(path, "a much longer previous payload")
+
+    write_text_atomic(path, "short")
+
+    assert path.read_text(encoding="utf-8") == "short"  # not overwritten in place, so no tail
+
+
+def test_write_text_atomic_uses_a_staging_name_unique_per_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shared staging name lets two writers rename each other's half-written file into place.
+
+    That turns a lost update into a CORRUPT file, which is strictly worse: last-writer-wins at
+    least leaves something loadable. The name is a uuid rather than the pid because two THREADS
+    of one process share a pid, and the alias tables are written from threads in this suite.
+    """
+    renamed: list[str] = []
+    real_replace = Path.replace
+
+    def _record(self: Path, target: object) -> Path:
+        renamed.append(self.name)
+        return real_replace(self, target)  # ty: ignore[invalid-argument-type]
+
+    monkeypatch.setattr(Path, "replace", _record)
+    write_text_atomic(tmp_path / "state.json", "one")
+    write_text_atomic(tmp_path / "state.json", "two")
+
+    assert len(set(renamed)) == 2, f"the staging name repeated across calls: {renamed}"
+    assert all(name.startswith(".state.json.") for name in renamed)
+
+
+def test_write_text_atomic_staging_name_differs_across_threads(tmp_path: Path) -> None:
+    """The pid is not enough: same-process threads would collide on it and corrupt the file.
+
+    Each thread writes its own long distinct payload many times over; if two shared a staging
+    path they would interleave inside one file and the winner would publish a mixture. Every
+    read must see exactly one thread's whole payload.
+    """
+    path = tmp_path / "shared.txt"
+    payloads = {name: name * 5000 for name in ("a", "b", "c")}
+    torn: list[str] = []
+
+    def _hammer(name: str) -> None:
+        for _ in range(20):
+            write_text_atomic(path, payloads[name])
+            seen = path.read_text(encoding="utf-8")
+            if seen not in payloads.values():
+                torn.append(seen[:40])
+
+    writers = [threading.Thread(target=_hammer, args=(name,)) for name in payloads]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join(timeout=30)
+
+    assert torn == []
+    assert list(tmp_path.glob("*.partial")) == []
+
+
+def test_write_bytes_atomic_round_trips_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+
+    write_bytes_atomic(path, b'{"weights": [1, 2]}')
+
+    assert path.read_bytes() == b'{"weights": [1, 2]}'
+
+
+def test_write_text_atomic_rejects_unencodable_text_without_leaving_a_staging_file(
+    tmp_path: Path,
+) -> None:
+    """A lone surrogate reaches `json.dumps(..., ensure_ascii=False)` and cannot be encoded.
+
+    That raises `UnicodeEncodeError`, which is a ValueError, not an OSError. Encoding before
+    touching the filesystem means no staging file is created at all, rather than one that an
+    `except OSError` cleanup would have missed and stranded in the run directory.
+    """
+    path = tmp_path / "state.json"
+
+    with pytest.raises(UnicodeEncodeError):
+        write_text_atomic(path, '{"text": "\ud83d"}')
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_text_atomic_cleans_up_after_a_keyboard_interrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ctrl-C between the write and the rename must not strand a staging file.
+
+    `KeyboardInterrupt` is a BaseException, so an `except OSError` cleanup would let it through
+    and leave litter in an artifact directory that serving and the fitter both scan.
+    """
+    path = tmp_path / "policy.json"
+
+    def _interrupt(fd: int) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(os, "fsync", _interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        write_text_atomic(path, "payload")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_text_atomic_keeps_the_destinations_mode(tmp_path: Path) -> None:
+    """`replace` installs a NEW inode, so a restricted file would silently widen to the umask.
+
+    An operator (or an installer) who chmods a credential-adjacent config to 0600 must not have
+    it reset to 0644 by the next write.
+    """
+    path = tmp_path / "settings.toml"
+    write_text_atomic(path, "first")
+    path.chmod(0o600)
+
+    write_text_atomic(path, "second")
+
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_write_text_atomic_leaves_the_previous_file_intact_when_the_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core guarantee: a reader sees the previous file or the whole new one, never a stub."""
+    path = tmp_path / "aliases.toml"
+    write_text_atomic(path, "[aliases]\nchampion = 3\n")
+    _fail_fsync(monkeypatch)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_text_atomic(path, "[aliases]\nchampion = 4\n")
+
+    assert path.read_text(encoding="utf-8") == "[aliases]\nchampion = 3\n"
+
+
+def test_a_failure_after_the_rename_reports_the_new_contents_not_the_old(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The parent-directory fsync runs AFTER the rename, so its failure is not a no-op write.
+
+    Some FUSE, SMB and NFS mounts reject `fsync` on a directory fd. The write has landed by then,
+    and the docstring says so rather than claiming the file is untouched: a caller that reported
+    "the promotion failed" and rolled back on that basis would be acting on the opposite of the
+    truth. Only the durability of the rename against a power loss is unproven.
+    """
+    path = tmp_path / "aliases.toml"
+    write_text_atomic(path, "old")
+    real_fsync = os.fsync
+    calls: list[int] = []
+
+    def _fail_the_directory(fd: int) -> None:
+        calls.append(fd)
+        if len(calls) == 2:  # 1 is the payload, 2 is the parent directory
+            raise OSError("directory fsync unsupported")
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _fail_the_directory)
+    with pytest.raises(OSError, match="directory fsync unsupported"):
+        write_text_atomic(path, "new")
+
+    assert path.read_text(encoding="utf-8") == "new"
+    assert list(tmp_path.glob("*.partial")) == []
+
+
+def test_write_text_atomic_leaves_no_temp_behind_when_the_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "aliases.toml"
+    write_text_atomic(path, "[aliases]\nchampion = 3\n")
+    _fail_fsync(monkeypatch)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_text_atomic(path, "[aliases]\nchampion = 4\n")
+
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_write_text_atomic_fsyncs_the_payload_and_the_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both, or a power loss can persist the rename while the data blocks are lost.
+
+    The result of that is an EMPTY file behind a write that reported success, which is the
+    failure mode the whole helper exists to prevent, so it is worth pinning rather than trusting.
+    """
+    synced: list[int] = []
+    real_fsync = os.fsync
+
+    def _record(fd: int) -> None:
+        synced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _record)
+    write_text_atomic(tmp_path / "state.json", "payload")
+
+    assert len(synced) == 2  # the temp file, then the directory that now holds the rename
+
+
+def test_file_write_lock_reports_a_stuck_holder_instead_of_hanging(tmp_path: Path) -> None:
+    path = tmp_path / "roster.toml"
+    lock_path = path.with_name("roster.toml.lock")
+    holder = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+    fcntl.flock(holder, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(FileLockTimeout, match=r"writing the roster at .*roster\.toml"):
+            with file_write_lock(path, what="the roster", timeout_s=0.05):
+                pass  # pragma: no cover - the lock is held, so this is never reached
+    finally:
+        os.close(holder)
+
+    # Once the holder is gone the lock is free again: the kernel owns that release, so a leftover
+    # lock FILE is never a held lock and cannot wedge the next run.
+    with file_write_lock(path, what="the roster", timeout_s=0.05):
+        pass
+
+
+def test_file_write_lock_releases_on_an_exception_inside_the_block(tmp_path: Path) -> None:
+    """A rejected write must not leave the file locked, or one bad input wedges every later run."""
+    path = tmp_path / "roster.toml"
+
+    with pytest.raises(ValueError, match="rejected"):
+        with file_write_lock(path, what="the roster", timeout_s=0.05):
+            raise ValueError("rejected")
+
+    with file_write_lock(path, what="the roster", timeout_s=0.05):
+        pass
+
+
+def test_file_write_lock_serializes_a_read_modify_write(tmp_path: Path) -> None:
+    """The lost-update guarantee: atomic replace alone does NOT give you this.
+
+    Both threads read, edit, and write back the same file. Unlocked, each reads the same starting
+    contents and the later write erases the earlier thread's line, with neither raising. The sleep
+    inside the critical section makes that interleaving certain rather than timing-dependent.
+    """
+    path = tmp_path / "roster.toml"
+    write_text_atomic(path, "")
+
+    def _append(line: str) -> None:
+        with file_write_lock(path, what="the roster"):
+            current = path.read_text(encoding="utf-8")
+            time.sleep(0.05)  # hold the section open so an unlocked version would interleave
+            write_text_atomic(path, f"{current}{line}\n")
+
+    writers = [threading.Thread(target=_append, args=(name,)) for name in ("a", "b")]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join(timeout=30)
+        assert not writer.is_alive(), "the lock wait is not bounded"
+
+    assert sorted(path.read_text(encoding="utf-8").split()) == ["a", "b"]
+
+
+def test_file_write_lock_does_not_lock_the_file_being_written(tmp_path: Path) -> None:
+    """The lock has to live in a sibling, because an atomic write swaps the file's inode.
+
+    A lock taken on the roster itself would stop protecting anything the moment the first writer
+    renamed a new inode into place, and the failure would be silent.
+    """
+    path = tmp_path / "roster.toml"
+
+    with file_write_lock(path, what="the roster"):
+        write_text_atomic(path, "payload")
+
+    assert path.with_name("roster.toml.lock").is_file()
+    assert path.read_text(encoding="utf-8") == "payload"

--- a/wmo/distill/store.py
+++ b/wmo/distill/store.py
@@ -42,6 +42,7 @@ from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from wmo.config.store import validate_name
+from wmo.core.files import file_write_lock, write_text_atomic
 from wmo.core.types import JsonObject
 from wmo.distill.config import DistillConfig, load_distill_config, snapshot_toml
 from wmo.distill.gate import DistillGateRecord
@@ -51,24 +52,6 @@ from wmo.providers.base import ProviderKind
 from wmo.providers.pool import PoolEntry
 
 logger = logging.getLogger(__name__)
-
-
-def write_text_atomic(path: Path, text: str) -> None:
-    """Write `text` to `path` via a same-directory tmp file plus atomic replace.
-
-    Every durable file in the run dir goes through this, including the ones
-    other modules own (`wmo.distill.tracking`'s wandb run record): a torn
-    write to checkpoints.json (or the config snapshot, warmup record, gate
-    verdict, wandb run id) would otherwise corrupt the resume path exactly
-    when a crash made resume necessary.
-
-    Args:
-        path: The destination file; its parent directory must exist.
-        text: The complete file contents, written as UTF-8.
-    """
-    tmp_path = path.with_name(path.name + ".tmp")
-    tmp_path.write_text(text, encoding="utf-8")
-    tmp_path.replace(path)
 
 
 ADAPTERS_DIR = "adapters"
@@ -708,20 +691,41 @@ class AdapterStore:
     # -- aliases ---------------------------------------------------------------------------------
 
     def aliases(self, name: str) -> dict[str, int]:
+        """The alias table for `name`, empty when it has none.
+
+        Names the file on a decode error: `resolve_version(None)` reads this to find the champion,
+        so a bare `tomllib` message would reach an operator as a parse error with no path, for a
+        file they never edited.
+        """
         path = self.dir_for(name) / _ALIASES_FILE
         if not path.exists():
             return {}
-        data = tomllib.loads(path.read_text(encoding="utf-8")).get("aliases", {})
+        try:
+            parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(
+                f"adapter alias file {path} is not valid TOML ({exc}); it maps alias names to "
+                f"version numbers under [aliases]. Repair it, or delete it to fall back to the "
+                f"latest version until the next `wmo optimize distill run` promotion re-points "
+                f"{CHAMPION_ALIAS}"
+            ) from exc
+        data = parsed.get("aliases", {})
         return {k: v for k, v in data.items() if isinstance(v, int)}
 
     def set_alias(self, name: str, alias: str, version: int) -> None:
-        """Point `alias` at `version` (moving it if it exists). Rollback is re-pointing."""
+        """Point `alias` at `version` (moving it if it exists). Rollback is re-pointing.
+
+        The write was already atomic; the lock covers the rest of the read-modify-write. Two
+        promotions of DIFFERENT aliases each read the same table and the later write drops the
+        earlier one, with both reporting success.
+        """
         if version not in self.versions(name):
             raise ValueError(f"adapter {name!r} has no version v{version}")
-        current = self.aliases(name)
-        current[alias] = version
         path = self.dir_for(name) / _ALIASES_FILE
-        write_text_atomic(path, tomli_w.dumps({"aliases": current}))
+        with file_write_lock(path, what="the adapter alias table"):
+            current = self.aliases(name)
+            current[alias] = version
+            write_text_atomic(path, tomli_w.dumps({"aliases": current}))
 
     # -- load / save -----------------------------------------------------------------------------
 

--- a/wmo/distill/store_test.py
+++ b/wmo/distill/store_test.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import threading
 import tomllib
 from pathlib import Path
 
@@ -485,6 +487,67 @@ def test_rollback_is_repointing_the_alias(tmp_path: Path) -> None:
     store.save_version("a", _card("tinker://fake/sampler/final/1"))
     store.set_alias("a", CHAMPION_ALIAS, 1)
     assert store.resolve("a").version == 1
+
+
+def test_concurrent_adapter_alias_moves_both_land(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two promotions of DIFFERENT aliases must not erase each other.
+
+    The write here was already atomic, which is the wrong half for this failure: neither write is
+    torn, the second simply overwrites a table the first had already added a key to, and both
+    calls return normally. The race is forced with a barrier on every read of `aliases.toml`, so
+    both writers provably hold the same snapshot; with the lock held the second cannot reach its
+    read until the first is done, the barrier times out, and the reads happen in sequence.
+    """
+    store = AdapterStore(tmp_path)
+    store.save_version("a", _card())
+    store.save_version("a", _card("tinker://fake/sampler/final/1"))
+    read_together = threading.Barrier(2, timeout=1.0)
+    real_read = Path.read_text
+
+    def _park_on_every_alias_read(self: Path, **kwargs: object) -> str:
+        text = real_read(self, **kwargs)  # ty: ignore[invalid-argument-type]
+        if self.name == "aliases.toml":
+            with contextlib.suppress(threading.BrokenBarrierError):
+                read_together.wait()
+        return text
+
+    monkeypatch.setattr(Path, "read_text", _park_on_every_alias_read)
+    failures: list[BaseException] = []
+
+    def _promote(alias: str, version: int) -> None:
+        try:
+            store.set_alias("a", alias, version)
+        except BaseException as exc:  # noqa: BLE001 - reported by the assertions below
+            failures.append(exc)
+
+    writers = [
+        threading.Thread(target=_promote, args=args)
+        for args in ((CHAMPION_ALIAS, 2), ("staging", 1))
+    ]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join(timeout=30)
+        assert not writer.is_alive(), "the alias lock wait is not bounded"
+    monkeypatch.undo()  # the assertion below reads the table without parking on the barrier
+
+    assert failures == []
+    assert store.aliases("a") == {CHAMPION_ALIAS: 2, "staging": 1}
+
+
+def test_a_corrupt_adapter_alias_file_names_itself(tmp_path: Path) -> None:
+    """The user never edited this file, so a bare `tomllib` message gives them nowhere to start."""
+    store = AdapterStore(tmp_path)
+    store.save_version("a", _card())
+    path = store.dir_for("a") / "aliases.toml"
+    path.write_text("[aliases]\nchampion = \n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"is not valid TOML") as caught:
+        store.aliases("a")
+
+    assert str(path) in str(caught.value)
 
 
 def test_unknown_adapter_ref_and_alias_are_friendly(tmp_path: Path) -> None:

--- a/wmo/distill/tracking.py
+++ b/wmo/distill/tracking.py
@@ -26,10 +26,10 @@ from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from wmo.core.files import write_text_atomic
 from wmo.core.types import JsonObject, JsonValue
 from wmo.distill.config import DistillConfig
 from wmo.distill.samples import SampleRollout
-from wmo.distill.store import write_text_atomic
 
 if TYPE_CHECKING:
     from wmo.distill.loop import StepMetrics, WarmupMetrics

--- a/wmo/distill/tracking_test.py
+++ b/wmo/distill/tracking_test.py
@@ -348,36 +348,28 @@ def test_a_torn_run_record_write_leaves_the_previous_record_intact(
 ) -> None:
     """The persisted run id is the resume anchor, so its write must be atomic.
 
-    A crash mid-write is modelled by a `write_text` that persists half its
-    payload and then raises. The record goes through the run dir's shared
-    temp-file-then-replace helper, so the half write lands on the temp file
-    and the record a resume reads back is still the complete previous one; an
-    in-place write would have truncated it and cost the dashboard run.
+    A crash mid-write is modelled by failing the payload's `fsync`, which is
+    reached with the bytes already written to the temp file and the rename not
+    yet done. The record goes through `wmo.core.files.write_text_atomic`, so
+    what a resume reads back is still the complete previous record; an in-place
+    write would have truncated it and cost the dashboard run.
     """
     run_dir = tmp_path / "run"
     _tracker(fake_wandb, run_dir)
     first_id = fake_wandb.run.id
-    intact = Path.write_text
 
-    def _torn(
-        self: Path,
-        data: str,
-        encoding: str | None = None,
-        errors: str | None = None,
-        newline: str | None = None,
-    ) -> int:
-        intact(self, data[: len(data) // 2], encoding=encoding)
+    def _torn(fd: int) -> None:
         raise OSError("disk full halfway through the record")
 
-    monkeypatch.setattr(Path, "write_text", _torn)
+    monkeypatch.setattr(os, "fsync", _torn)
     with pytest.raises(OSError, match="disk full"):
         _tracker(fake_wandb, run_dir)
 
     assert json.loads((run_dir / WANDB_RUN_FILE).read_text(encoding="utf-8")) == {
         "run_id": first_id
     }
-    # The torn bytes went to the sibling temp file, never to the record.
-    assert (run_dir / f"{WANDB_RUN_FILE}.tmp").is_file()
+    # The partial bytes went to a sibling temp, which the failed write then cleaned up.
+    assert list(run_dir.glob(f"{WANDB_RUN_FILE}.*.tmp")) == []
 
 
 def test_missing_sdk_error_names_the_extra(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/wmo/harness/population.py
+++ b/wmo/harness/population.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -31,6 +30,7 @@ from typing import Protocol
 
 from pydantic import JsonValue
 
+from wmo.core.files import write_text_atomic
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.runtime import HarnessSearchCancelled
 from wmo.harness.scoring import Scorer, ScoreReport
@@ -148,25 +148,12 @@ class PopulationResult:
 
 
 def write_json_atomic(path: Path, value: JsonValue) -> None:
-    """Write deterministic JSON through a same-directory fsynced tmp+rename.
+    """Write deterministic JSON durably: sorted keys, trailing newline, atomic replace.
 
-    The temp file is fsynced before the rename and the directory after it: without both, a
-    power loss can persist the rename while the data blocks are lost, leaving a truncated or
-    empty state file behind an apparently successful commit.
+    Determinism is this function's own contract (a state file that reorders between writes is
+    unreadable as a diff); the durability is `wmo.core.files.write_text_atomic`.
     """
-    temporary = path.with_name(f"{path.name}.tmp")
-    temporary.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
-    with temporary.open("w", encoding="utf-8") as handle:
-        handle.write(payload)
-        handle.flush()
-        os.fsync(handle.fileno())
-    temporary.replace(path)
-    directory = os.open(path.parent, os.O_RDONLY)
-    try:
-        os.fsync(directory)
-    finally:
-        os.close(directory)
+    write_text_atomic(path, json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
 
 
 class PopulationRunState:

--- a/wmo/harness/store.py
+++ b/wmo/harness/store.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import tomli_w
 
 from wmo.config.store import validate_name
+from wmo.core.files import file_write_lock, write_text_atomic
 from wmo.harness.doc import HarnessDoc
 from wmo.harness.source_tree import SYSTEM_FILE, HarnessSourceFile, HarnessSourceTree
 
@@ -78,20 +79,43 @@ class HarnessStore:
     # -- aliases -----------------------------------------------------------------------------
 
     def aliases(self, name: str) -> dict[str, int]:
+        """The alias table for `name`, empty when it has none.
+
+        Names the file on a decode error: `resolve_version(None)` reads this to find the champion,
+        so a bare `tomllib` message would reach an operator as a parse error with no path, for a
+        file they never edited.
+        """
         path = self.dir_for(name) / _ALIASES_FILE
         if not path.exists():
             return {}
-        data = tomllib.loads(path.read_text(encoding="utf-8")).get("aliases", {})
+        try:
+            parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(
+                f"harness alias file {path} is not valid TOML ({exc}); it maps alias names to "
+                f"version numbers under [aliases]. Repair it, or delete it to fall back to the "
+                f"latest version until the next `wmo optimize harness` promotion re-points "
+                f"{CHAMPION_ALIAS} (`wmo harness list` shows the versions this name has)"
+            ) from exc
+        data = parsed.get("aliases", {})
         return {k: v for k, v in data.items() if isinstance(v, int)}
 
     def set_alias(self, name: str, alias: str, version: int) -> None:
-        """Point `alias` at `version` (moving it if it exists). Rollback is re-pointing."""
+        """Point `alias` at `version` (moving it if it exists). Rollback is re-pointing.
+
+        Locked and atomic, because this is a read-modify-write of the file that holds the champion
+        pointer. Written in place, a crash or a full disk mid-write leaves a truncated
+        `aliases.toml` and the champion is gone; done unlocked, two promotions of DIFFERENT
+        aliases each read the same table and the later write drops the earlier one, with both
+        reporting success.
+        """
         if version not in self.versions(name):
             raise ValueError(f"harness {name!r} has no version v{version}")
-        current = self.aliases(name)
-        current[alias] = version
         path = self.dir_for(name) / _ALIASES_FILE
-        path.write_text(tomli_w.dumps({"aliases": current}), encoding="utf-8")
+        with file_write_lock(path, what="the harness alias table"):
+            current = self.aliases(name)
+            current[alias] = version
+            write_text_atomic(path, tomli_w.dumps({"aliases": current}))
 
     # -- load / save ---------------------------------------------------------------------------
 

--- a/wmo/harness/store_test.py
+++ b/wmo/harness/store_test.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -40,6 +43,100 @@ def test_default_load_prefers_champion_alias_else_latest(tmp_path: Path) -> None
     # Rollback/promotion is just re-pointing.
     store.set_alias("h", CHAMPION_ALIAS, 2)
     assert store.load("h").version == 2
+
+
+def test_a_torn_alias_write_keeps_the_previous_champion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`aliases.toml` holds the champion pointer `resolve_version(None)` depends on.
+
+    Written in place, a crash or a full disk mid-write truncates it and the pointer is simply
+    gone, so `wmo` silently starts serving `latest` instead of the promoted version. The failure
+    is modelled at the payload's fsync, the point where an in-place write would already have
+    destroyed the old contents.
+    """
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    store.save_version(_variant("h", "v2 prompt"))
+    store.set_alias("h", CHAMPION_ALIAS, 1)
+
+    def _boom(fd: int) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "fsync", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        store.set_alias("h", CHAMPION_ALIAS, 2)
+    monkeypatch.undo()
+
+    assert store.aliases("h") == {CHAMPION_ALIAS: 1}
+    assert store.load("h").version == 1
+
+
+def test_concurrent_alias_moves_both_land(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two promotions of DIFFERENT aliases must not erase each other.
+
+    Unlocked, each reads the same table, adds its own key, and writes the whole thing back; the
+    later write drops the earlier alias and both calls return normally. Atomic replace does not
+    help here, because neither write is torn: the update is simply lost.
+
+    The race is forced, not hoped for: every read of `aliases.toml` parks on a barrier, so both
+    writers provably hold the SAME snapshot before either writes. With the lock held across the
+    whole cycle the second writer cannot reach its read until the first has finished, so the
+    barrier times out (its wait is far shorter than the lock's) and the reads happen in sequence.
+    """
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    store.save_version(_variant("h", "v2 prompt"))
+    # `save_version` defaults to alias=None, so aliases.toml does not exist yet and `aliases()`
+    # returns early from its `path.exists()` guard WITHOUT reading. The barrier below hooks
+    # `read_text`, so without this seeding write it is never armed and the two threads serialize
+    # by luck: measured 8 passes in 10 against the unlocked implementation.
+    store.set_alias("h", "seed", 1)
+    read_together = threading.Barrier(2, timeout=1.0)
+    real_read = Path.read_text
+
+    def _park_on_every_alias_read(self: Path, **kwargs: object) -> str:
+        text = real_read(self, **kwargs)  # ty: ignore[invalid-argument-type]
+        if self.name == "aliases.toml":
+            with contextlib.suppress(threading.BrokenBarrierError):
+                read_together.wait()
+        return text
+
+    monkeypatch.setattr(Path, "read_text", _park_on_every_alias_read)
+    failures: list[BaseException] = []
+
+    def _promote(alias: str, version: int) -> None:
+        try:
+            store.set_alias("h", alias, version)
+        except BaseException as exc:  # noqa: BLE001 - reported by the assertions below
+            failures.append(exc)
+
+    writers = [
+        threading.Thread(target=_promote, args=args)
+        for args in ((CHAMPION_ALIAS, 2), ("staging", 1))
+    ]
+    for writer in writers:
+        writer.start()
+    for writer in writers:
+        writer.join(timeout=30)
+        assert not writer.is_alive(), "the alias lock wait is not bounded"
+    monkeypatch.undo()  # the assertion below reads the table without parking on the barrier
+
+    assert failures == []
+    assert store.aliases("h") == {"seed": 1, CHAMPION_ALIAS: 2, "staging": 1}
+
+
+def test_a_corrupt_alias_file_names_itself(tmp_path: Path) -> None:
+    """The user never edited this file, so a bare `tomllib` message gives them nowhere to start."""
+    store = HarnessStore(tmp_path)
+    store.save_version(HarnessDoc.baseline("h"))
+    path = store.dir_for("h") / "aliases.toml"
+    path.write_text("[aliases]\nchampion = \n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"is not valid TOML") as caught:
+        store.aliases("h")
+
+    assert str(path) in str(caught.value)
 
 
 def test_alias_to_missing_version_rejected(tmp_path: Path) -> None:

--- a/wmo/optimize/outcomes.py
+++ b/wmo/optimize/outcomes.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, model_validator
 
+from wmo.core.files import write_text_atomic
 from wmo.optimize.compression import CompressionConfig
 from wmo.providers.base import TokenUsage
 from wmo.providers.pool import PoolEntry
@@ -195,8 +196,8 @@ class OutcomeMatrix(BaseModel):
         return sum(rewards) / len(rewards)
 
     def save(self, path: Path) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        """Write the matrix atomically: it is the measured output of a run that cost real money."""
+        write_text_atomic(path, self.model_dump_json(indent=2))
 
     @classmethod
     def load(cls, path: Path) -> OutcomeMatrix:

--- a/wmo/optimize/policy.py
+++ b/wmo/optimize/policy.py
@@ -43,6 +43,7 @@ from uuid import uuid4
 import numpy as np
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
+from wmo.core.files import write_bytes_atomic
 from wmo.optimize.compression import (
     CompressionConfig,
     Compressor,
@@ -100,20 +101,11 @@ def write_artifact_atomically(path: Path, payload: bytes) -> None:
     a command that writes several artifacts promise that a failure leaves the old ones intact.
     `KnnBank.save` stages the same way for the sidecar it streams through numpy.
 
-    The staging name is unique PER CALL. `replace` is atomic, but a staging path shared between
-    two concurrent writers is not: they would interleave on one file, so one could publish the
-    other's bytes under its own name and the loser would fail on a file already renamed away.
-    It is also hidden and cleaned up on failure, so an interrupted write cannot leave litter in
-    an artifact directory that serving and the fitter both scan.
+    The per-call staging name, the cleanup on failure, and the durability are
+    `wmo.core.files.write_bytes_atomic`'s; this wrapper is the artifact layer's name for it, kept
+    because the reason above is the artifact directory's, not a property of writing files.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    staging = path.with_name(f".{path.name}.{uuid4().hex}.partial")
-    try:
-        staging.write_bytes(payload)
-        staging.replace(path)
-    except BaseException:
-        staging.unlink(missing_ok=True)
-        raise
+    write_bytes_atomic(path, payload)
 
 
 def knn_bank_path_for(policy_path: Path) -> Path:

--- a/wmo/optimize/policy_test.py
+++ b/wmo/optimize/policy_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Literal, cast
@@ -260,15 +261,20 @@ def test_openrouter_candidate_keeps_the_price_it_was_fitted_under(
 def test_a_failed_policy_save_leaves_the_previous_artifact_intact(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Serving reads the artifact dir while the optimizer writes it: no torn policy.json."""
+    """Serving reads the artifact dir while the optimizer writes it: no torn policy.json.
+
+    The failure is injected at the payload's fsync, which `wmo.core.files.write_bytes_atomic`
+    reaches with the bytes on the staging file and the rename not yet done. That is the moment an
+    in-place write would already have destroyed the served artifact.
+    """
     path = tmp_path / "policy.json"
     _rank_policy().save(path)
     served = RoutingPolicy.load(path)
 
-    def _die(self: Path, data: bytes) -> int:
+    def _die(fd: int) -> None:
         raise OSError("disk full")
 
-    monkeypatch.setattr(Path, "write_bytes", _die)
+    monkeypatch.setattr(os, "fsync", _die)
     with pytest.raises(OSError, match="disk full"):
         _static().save(path)
     assert RoutingPolicy.load(path) == served  # the staged write never replaced it

--- a/wmo/providers/openrouter_pricing.py
+++ b/wmo/providers/openrouter_pricing.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from wmo.core.files import write_text_atomic
 from wmo.core.types import JsonValue
 from wmo.platform.credentials import wmo_home
 from wmo.providers.openrouter import OPENROUTER_MODELS_URL
@@ -202,10 +203,7 @@ def _read_cache(path: Path) -> PriceCatalog | None:
 def _write_cache(path: Path, catalog: PriceCatalog) -> None:
     """Persist the table atomically. A cache that cannot be written is a warning, not an error."""
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        staging = path.with_name(f"{path.name}.partial")
-        staging.write_text(json.dumps(catalog.model_dump(mode="json")), encoding="utf-8")
-        staging.replace(path)
+        write_text_atomic(path, json.dumps(catalog.model_dump(mode="json")))
     except OSError as exc:
         logger.warning("could not cache the OpenRouter price table at %s: %s", path, exc)
 

--- a/wmo/providers/pool.py
+++ b/wmo/providers/pool.py
@@ -25,12 +25,8 @@ back to the same "declare the prices" error, with the catalog failure named.
 
 from __future__ import annotations
 
-import fcntl
 import os
-import time
 import tomllib
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal, NamedTuple
 
@@ -39,6 +35,7 @@ from llm_waterfall import ChatMaxTokensField
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from pydantic_core import ErrorDetails
 
+from wmo.core.files import DEFAULT_LOCK_TIMEOUT_S, file_write_lock, write_text_atomic
 from wmo.core.types import JsonObject
 from wmo.providers.base import (
     PreparableProvider,
@@ -53,11 +50,9 @@ from wmo.tracking.pricing import ModelPrice, price_for
 
 DEFAULT_POOL_PATH = Path(".wmo/pool.toml")
 
-# How long an upsert waits for another process to finish its write. A write is a few file
-# operations, so two racing `wmo optimize route student` runs never come close to this; the bound
-# exists so a hung holder is REPORTED instead of hanging the terminal forever.
-POOL_LOCK_TIMEOUT_S = 10.0
-_LOCK_POLL_S = 0.01
+# Kept as a module constant, rather than defaulted at the call, so a test can shorten the wait
+# for a CLI command that exposes no timeout flag (`wmo/cli/route_app_test.py`).
+POOL_LOCK_TIMEOUT_S = DEFAULT_LOCK_TIMEOUT_S
 
 # D-REPORT ModelRef vocabulary: "frontier" anchors the improvement report's comparison; "open"
 # models carry the run-10x-more-for-the-same-budget story.
@@ -338,10 +333,6 @@ def pool_api_key(entry: PoolEntry) -> str | None:
     return api_key
 
 
-class PoolLockTimeout(RuntimeError):
-    """Another writer held the roster's lock for longer than the bounded wait."""
-
-
 class PoolWrite(NamedTuple):
     """What one `upsert_pool_entry` did to the file, for a caller that has to report it.
 
@@ -393,7 +384,7 @@ def upsert_pool_entry(
     being added.
 
     The whole read-validate-write cycle runs under an exclusive cross-process lock (see
-    `_pool_write_lock`), so two registrations racing each other both land. Without it each reads
+    `wmo.core.files.file_write_lock`), so two racing registrations both land. Without it each reads
     the same roster and the later write erases the earlier entry, while both commands report
     success: a model an operator registered is simply not in the pool, and nothing says so.
 
@@ -409,62 +400,11 @@ def upsert_pool_entry(
     Raises:
         ValueError: If `path` exists but is not a readable pool file, if it is already an invalid
             roster before this entry is added, or if adding `entry` would make it one.
-        PoolLockTimeout: If another writer holds the roster's lock for the whole wait.
+        FileLockTimeout: If another writer holds the roster's lock for the whole wait.
     """
     timeout_s = POOL_LOCK_TIMEOUT_S if lock_timeout_s is None else lock_timeout_s
-    path.parent.mkdir(parents=True, exist_ok=True)  # the lock file lives beside the roster
-    with _pool_write_lock(path, timeout_s=timeout_s):
+    with file_write_lock(path, what="the model pool", timeout_s=timeout_s):
         return _upsert_locked(entry, path)
-
-
-@contextmanager
-def _pool_write_lock(path: Path, *, timeout_s: float) -> Iterator[None]:
-    """Hold the exclusive cross-process write lock for the roster at `path`.
-
-    The lock sits in a sibling `<pool>.lock` file, not in the roster: writing goes through an
-    atomic rename, which swaps the roster's inode, so a lock taken on the file itself would stop
-    protecting anything the moment the first writer landed.
-
-    `flock` belongs to the open file description, so the kernel drops it when the holder exits,
-    crashes, or is killed. A leftover `.lock` FILE is therefore never a held lock and can never
-    wedge a later run (which is also why it is left in place: unlinking it would let a waiter
-    block on an inode nobody else can reach). A live holder that hangs still could wedge us, so
-    the wait is bounded and reports what to do instead of blocking forever.
-
-    Args:
-        path: The pool TOML being written.
-        timeout_s: Seconds to keep retrying the lock before raising.
-
-    Yields:
-        None, with the lock held; it is released when the block exits, on any path.
-
-    Raises:
-        PoolLockTimeout: If the lock is still held after `timeout_s`.
-    """
-    lock_path = path.with_name(f"{path.name}.lock")
-    deadline = time.monotonic() + timeout_s
-    fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC, 0o600)
-    try:
-        while True:
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except BlockingIOError:
-                if time.monotonic() >= deadline:
-                    raise PoolLockTimeout(
-                        f"another process has been writing the model pool at {path} for more "
-                        f"than {timeout_s:g}s (lock file {lock_path}); a registration takes "
-                        "milliseconds, so retry, and if it keeps failing look for a stuck "
-                        "process holding that lock (the lock is released automatically when "
-                        "that process exits, so the lock file itself is never the problem)"
-                    ) from None
-                time.sleep(_LOCK_POLL_S)
-        try:
-            yield
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-    finally:
-        os.close(fd)
 
 
 def _upsert_locked(entry: PoolEntry, path: Path) -> PoolWrite:
@@ -512,17 +452,7 @@ def _upsert_locked(entry: PoolEntry, path: Path) -> PoolWrite:
             f"the {len(merged)} intended entries. This is a bug in wmo, not in your file, which "
             "is untouched; the likely cause is a pool field whose value is not a plain scalar"
         )
-    # The temp name carries this process's pid. The lock already keeps writers off each other, so
-    # this is defense in depth for anything that writes the roster without taking it: a shared
-    # fixed `.tmp` path would let each writer rename the other's half-written file into place,
-    # turning a lost update into a CORRUPT roster.
-    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-    try:
-        tmp_path.write_text(body, encoding="utf-8")
-        tmp_path.replace(path)
-    except OSError:
-        tmp_path.unlink(missing_ok=True)  # never leave a stray temp beside the roster
-        raise
+    write_text_atomic(path, body)
     return PoolWrite(replaced=replaced, rewritten=rewritten)
 
 

--- a/wmo/providers/pool_test.py
+++ b/wmo/providers/pool_test.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from wmo.core.files import FileLockTimeout
 from wmo.providers import pool as pool_module
 from wmo.providers.azure_openai import AzureOpenAIProvider
 from wmo.providers.base import ProviderConfig, ProviderKind, TokenUsage
@@ -22,7 +23,6 @@ from wmo.providers.openrouter_pricing import CATALOG_PATH_ENV, PriceCatalog
 from wmo.providers.pool import (
     DEFAULT_POOL_PATH,
     PoolEntry,
-    PoolLockTimeout,
     load_pool,
     pool_api_key,
     pool_provider,
@@ -527,22 +527,27 @@ def test_upsert_pool_entry_uses_a_process_private_temp_file(
 ) -> None:
     """Two concurrent upserts must not be able to rename each other's half-written file.
 
-    A shared fixed `.tmp` path turns a lost update into a CORRUPT roster: writer A can rename
-    B's partially written file into place. Distinct temps bound the damage to last-writer-wins.
+    A shared fixed staging path turns a lost update into a CORRUPT roster: writer A can rename
+    B's partially written file into place. A name unique per call bounds the damage to
+    last-writer-wins. The property belongs to `wmo.core.files.write_bytes_atomic` and is covered
+    directly in `wmo/core/files_test.py`; this pins that the roster's write actually goes through
+    it, which is the reason it was documented on this function in the first place.
     """
-    seen: list[str] = []
-    real_write = Path.write_text
+    renamed: list[str] = []
+    real_replace = Path.replace
 
-    def _record(self: Path, data: str, **kwargs: object) -> int:
-        if self.suffix == ".tmp":
-            seen.append(self.name)
-        return real_write(self, data, **kwargs)  # ty: ignore[invalid-argument-type]
+    def _record(self: Path, target: object) -> Path:
+        renamed.append(self.name)
+        return real_replace(self, target)  # ty: ignore[invalid-argument-type]
 
-    monkeypatch.setattr(Path, "write_text", _record)
-    upsert_pool_entry(_student_entry(), tmp_path / "pool.toml")
+    monkeypatch.setattr(Path, "replace", _record)
+    path = tmp_path / "pool.toml"
+    upsert_pool_entry(_student_entry(), path)
+    upsert_pool_entry(_student_entry("other"), path)
 
-    assert seen == [f"pool.toml.{os.getpid()}.tmp"]
-    assert list(tmp_path.glob("*.tmp")) == []  # the temp is gone once renamed
+    assert len(set(renamed)) == 2, f"the staging name repeated across calls: {renamed}"
+    assert all(name.startswith(".pool.toml.") for name in renamed)
+    assert list(tmp_path.glob("*.partial")) == []  # the staging file is gone once renamed
 
 
 def test_upsert_pool_entry_leaves_no_temp_behind_when_the_write_fails(
@@ -553,7 +558,7 @@ def test_upsert_pool_entry_leaves_no_temp_behind_when_the_write_fails(
     real_replace = Path.replace
 
     def _boom(self: Path, target: object) -> Path:
-        if self.suffix == ".tmp":
+        if self.suffix == ".partial":
             raise OSError("disk full")
         return real_replace(self, target)  # ty: ignore[invalid-argument-type]
 
@@ -561,7 +566,7 @@ def test_upsert_pool_entry_leaves_no_temp_behind_when_the_write_fails(
     with pytest.raises(OSError, match="disk full"):
         upsert_pool_entry(_student_entry(), path)
 
-    assert list(tmp_path.glob("*.tmp")) == []
+    assert list(tmp_path.glob("*.partial")) == []
     assert load_pool(path).models  # the roster is untouched and still loadable
 
 
@@ -785,7 +790,7 @@ def test_upsert_pool_entry_refuses_to_write_a_roster_that_does_not_read_back(
         upsert_pool_entry(_short_openai("gpt-5.5"), path)
 
     assert not path.exists()  # nothing was committed
-    assert list(tmp_path.glob("*.tmp")) == []
+    assert list(tmp_path.glob("*.partial")) == []
 
 
 def test_load_pool_names_the_file_when_it_is_not_valid_toml(tmp_path: Path) -> None:
@@ -972,7 +977,7 @@ def test_upsert_pool_entry_reports_a_stuck_writer_instead_of_hanging(tmp_path: P
     holder = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
     fcntl.flock(holder, fcntl.LOCK_EX)
     try:
-        with pytest.raises(PoolLockTimeout, match=r"writing the model pool at .*pool\.toml"):
+        with pytest.raises(FileLockTimeout, match=r"writing the model pool at .*pool\.toml"):
             upsert_pool_entry(_student_entry(), path, lock_timeout_s=0.05)
     finally:
         os.close(holder)

--- a/wmo/providers/waterfall.py
+++ b/wmo/providers/waterfall.py
@@ -283,8 +283,20 @@ def _parse_rungs(path: Path, name: str, entries: list[dict[str, object]]) -> Cha
 
 
 def _parse_fallback_config(path: Path) -> tuple[dict[str, Chain], str | None]:
-    """Parse the named chains and the optional `default` selector."""
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    """Parse the named chains and the optional `default` selector.
+
+    Every other failure here is prefixed with `path`, and a decode error has to be too: it reaches
+    the user through a CLI error that renders `str(exc)` alone, so a bare "Cannot overwrite a
+    value (at line 7, column 2)" reads as a bad command argument rather than as a broken file.
+    """
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(
+            f"{path} is not valid TOML ({exc}); it holds the provider fallback chains as "
+            '[[chain.<name>]] rung entries plus an optional `default = "<name>"`, so fix the '
+            "file or move it aside to fall back to the configured provider"
+        ) from exc
     unknown_top = set(data) - {"chain", "default"}
     if unknown_top:
         raise ValueError(

--- a/wmo/providers/waterfall_test.py
+++ b/wmo/providers/waterfall_test.py
@@ -311,6 +311,22 @@ def test_fallback_config_rejects_unknown_keys_and_kinds(tmp_path: Path) -> None:
         provider_or_chain(ProviderConfig(kind=ProviderKind.BEDROCK, model="m"), path=path)
 
 
+def test_fallback_config_names_the_file_when_it_is_not_valid_toml(tmp_path: Path) -> None:
+    """Every other failure here is prefixed with the path, and a decode error has to be too.
+
+    `.wmo/fallback.toml` is operator-edited and its errors render as `str(exc)` alone, so a bare
+    "Cannot overwrite a value (at line 4, column 1)" reads as a bad command argument rather than
+    as a broken file the user can go and fix.
+    """
+    path = tmp_path / "fallback.toml"
+    path.write_text('default = "a"\n\ndefault = "b"\n')
+
+    with pytest.raises(ValueError, match=r"is not valid TOML") as caught:
+        provider_or_chain(ProviderConfig(kind=ProviderKind.BEDROCK, model="m"), path=path)
+
+    assert str(path) in str(caught.value)
+
+
 def test_fallback_config_preserves_custom_token_field(tmp_path: Path) -> None:
     path = tmp_path / "fallback.toml"
     path.write_text(

--- a/wmo/serving/endpoint_config.py
+++ b/wmo/serving/endpoint_config.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import tomli_w
 from pydantic import BaseModel, ConfigDict, Field
 
+from wmo.core.files import write_text_atomic
+
 ENDPOINT_CONFIG_FILENAME = "endpoint.toml"
 
 
@@ -66,8 +68,4 @@ class EndpointConfig(BaseModel):
 
     def save(self, path: Path) -> None:
         """Write the config atomically (a half-written dial must not be loadable)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        staging = path.with_name(f"{path.name}.partial")
-        with staging.open("wb") as handle:
-            tomli_w.dump(self.model_dump(exclude_none=True), handle)
-        staging.replace(path)
+        write_text_atomic(path, tomli_w.dumps(self.model_dump(exclude_none=True)))


### PR DESCRIPTION
Stacked on #341 (base is `fix/pool-duplicate-model-key`; retarget to main once that merges).

## Why

`wmo/providers/pool.py` was the only writer in the package with the full set: an atomic write
through a per-call staging file, under a bounded cross-process `flock`. Its comments argue why
each safeguard matters. None of that reasoning had reached its siblings, which write the same kind
of file: a registry or a config a later command reads back, where a torn write leaves something
unloadable that nobody edited.

Three of these were reported; the sweep for siblings found the rest.

## What was broken

- **`HarnessStore.set_alias` wrote `aliases.toml` in place.** Its distill twin is
  character-identical except the noun and got the atomic fix; this copy did not even import a
  helper. A crash mid-write loses the champion pointer `resolve_version(None)` depends on, and wmo
  silently serves `latest` instead.
- **Neither `set_alias` took a lock.** Two promotions of *different* aliases each read the same
  table and the later write dropped the earlier one, both reporting success. Atomicity does not
  help: neither write is torn, the update is simply lost.
- **Fixed `.tmp` names** in `write_text_atomic` (distill), `write_json_atomic` (population), and
  the inline writers in `config/settings.py` and `config/config.py` — the exact hazard pool.py's
  comment names.
- **`OutcomeMatrix.save` was not atomic at all**, and it writes the measured output of a sweep
  that costs real money.
- **Five competing answers to "write this file durably."** `EndpointConfig.save` and the OpenRouter
  price cache hand-rolled a fixed `.partial` with no cleanup and no fsync;
  `write_artifact_atomically` was a second general-purpose atomic writer with five call sites.
  Each was strongest on a different axis, so a fix to one never reached the others.
- **`_parse_fallback_config` called `tomllib.loads` bare** while prefixing every other error with
  the path, so a malformed `.wmo/fallback.toml` gave a filename-less "Cannot overwrite a value"
  under typer's `Invalid value:`. Both `aliases.toml` readers had the same gap.

## The consolidated writer keeps the strongest of each

Nothing regresses, because every property came from one of the versions being replaced:

| property | inherited from | why |
|---|---|---|
| fsync payload + parent dir | `write_json_atomic` | without both, a power loss persists the rename and loses the data blocks |
| cleanup on `BaseException` | `write_artifact_atomically` | `OSError` misses Ctrl-C and an unencodable payload |
| staging name unique per call | `write_artifact_atomically` | uuid not pid: two *threads* share a pid |
| destination mode carried over | the in-place `write_text` | `replace` installs a new inode, so 0600 would widen to 0644 |

Measured cost of the added fsync: **0.08 ms per write, ~0.1 s across a 200-step distill run**
whose individual steps are minutes of paid rollouts.

Deliberately left alone: the mkstemp/0600 credential and session writers. They refuse symlinks and
need owner-only permissions from creation, which is a different contract, not a stricter setting
of this one.

## Tests

Six fail on the parent commit. Both concurrency tests force the interleaving with a barrier on
every read — written the obvious way the harness one **passed 8 runs in 10 unfixed**, because
`save_version` defaults to no alias, so `aliases.toml` did not exist and `aliases()` returned from
its `path.exists()` guard before reaching the patched read. It now seeds an alias first and fails
10 out of 10.

Also pinned in `wmo/core/files_test.py`: threads never publish a torn payload, an unencodable
string leaves no staging file, Ctrl-C cleans up, the mode survives, and a failure *after* the
rename reports the new contents rather than claiming the file is untouched (the parent-directory
fsync runs post-rename and some FUSE/NFS mounts reject it — the docstring says so instead of
promising otherwise).

Verified end to end: a corrupt `aliases.toml` names itself, and deleting it does fall back to the
latest version as the message claims.

## Follow-ups, not in this PR

- `HarnessStore.save_version` hardens the pointer but not the artifact: `doc.json` and the
  rendered surfaces are still plain `write_text`, and the version-dir `mkdir` races between two
  concurrent optimize runs.
- Five `tomllib.loads` sites still raise bare (`config/store.py`, `harness/source_tree.py`,
  `platform/transfer.py`, both `credentials.py`); they want one shared `load_toml_file(path, what)`.
- `HarnessStore` and `AdapterStore` are ~78% line-identical and this PR made that worse by copying
  the lock+atomic body into both; they want an `AliasTable` or a shared base.
- `tomlkit` would round-trip comments and delete `_render_sections`, `_appended_body`, the
  append/re-render branch, the legacy path, and four "your comments are gone" warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
