### PR TITLE
Fix build wizard custom endpoint verification

### DIFF
--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -51,6 +51,7 @@ from wmo.cli.harness_app import _explicit, harness_app, optimize_app
 from wmo.cli.ingest_cmd import ingest as _ingest_command
 from wmo.cli.model_roles import (
     configured_role_configs,
+    configured_role_provider_config,
     inherit_provider_connection,
     load_settings_or_abort,
 )
@@ -800,9 +801,10 @@ def build(
     use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
 
     configured_worker = load_settings_or_abort(root).models.resolve("worker")
-    configured_worker_config = next(
-        (config for role, config in configured_role_configs(root) if role == "worker"),
-        None,
+    configured_worker_config = (
+        configured_role_provider_config(configured_worker, role="worker")
+        if configured_worker is not None
+        else None
     )
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -801,13 +801,13 @@ def build(
     use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
 
     configured_worker = load_settings_or_abort(root).models.resolve("worker")
-    configured_worker_config = (
-        configured_role_provider_config(configured_worker, role="worker")
-        if configured_worker is not None
-        else None
-    )
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider
+    )
+    configured_worker_config = (
+        configured_role_provider_config(configured_worker, role="worker")
+        if use_configured_worker
+        else None
     )
     # Settle the serve provider here so the model default can follow it. A single hard-coded
     # Anthropic default wrote artifacts configured to call e.g. OpenAI with `claude-opus-4-8`.

--- a/wmo/cli/app.py
+++ b/wmo/cli/app.py
@@ -49,7 +49,11 @@ from wmo.cli.eval_closed_loop import run_agreement, run_closed_loop
 # mode-inapplicable flags exactly the way `wmo optimize harness` already does.
 from wmo.cli.harness_app import _explicit, harness_app, optimize_app
 from wmo.cli.ingest_cmd import ingest as _ingest_command
-from wmo.cli.model_roles import configured_role_configs, load_settings_or_abort
+from wmo.cli.model_roles import (
+    configured_role_configs,
+    inherit_provider_connection,
+    load_settings_or_abort,
+)
 from wmo.cli.platform_cmds import register as register_platform_commands
 from wmo.cli.ui import (
     BuildParams,
@@ -796,6 +800,10 @@ def build(
     use_wizard = interactive if interactive is not None else (_console.is_terminal and needs_input)
 
     configured_worker = load_settings_or_abort(root).models.resolve("worker")
+    configured_worker_config = next(
+        (config for role, config in configured_role_configs(root) if role == "worker"),
+        None,
+    )
     use_configured_worker = configured_worker is not None and (
         provider is None or provider == configured_worker.provider
     )
@@ -839,7 +847,11 @@ def build(
         embed_dim=embed_dim,
     )
     if use_wizard:
-        params = run_build_wizard(_console, params)
+        params = run_build_wizard(
+            _console,
+            params,
+            configured_provider=configured_worker_config if use_configured_worker else None,
+        )
     elif params.file is None and not params.pull:
         # This guard also required `name is None`, so `wmo build --name x` (verbatim the
         # empty-state hint `wmo list` prints) fell through to a raw ValueError from the ingest
@@ -917,13 +929,10 @@ def build(
         judge_model=params.judge_model or judge_model_default(params.provider, params.model),
         trace_adapter=params.source,
     )
-    if use_configured_worker and configured_worker is not None:
-        config.providers[0] = config.providers[0].model_copy(
-            update={
-                "endpoint": configured_worker.endpoint,
-                "deployment": configured_worker.deployment,
-                "api_version": configured_worker.api_version,
-            }
+    if use_configured_worker:
+        config.providers[0] = inherit_provider_connection(
+            config.providers[0],
+            configured_worker_config,
         )
     if grounder not in GROUNDER_KINDS:
         raise typer.BadParameter(

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -56,6 +56,7 @@ from wmo.tracking.pricing import ModelPrice
 # `wmo.cli`'s `app` attribute (the Typer object) shadows the `wmo.cli.app` submodule on
 # plain `import wmo.cli.app as ...`; go through importlib to monkeypatch module globals.
 cli_app_module = importlib.import_module("wmo.cli.app")
+ui_module = importlib.import_module("wmo.cli.ui")
 
 runner = CliRunner()
 
@@ -274,7 +275,8 @@ def test_build_wizard_does_not_reuse_connection_for_changed_provider(
     )
     save_settings(settings, root)
 
-    def switch_provider(_console, params):  # noqa: ANN001, ANN202
+    def switch_provider(_console, params, *, configured_provider):  # noqa: ANN001, ANN202
+        assert configured_provider is not None
         return params.model_copy(
             update={
                 "name": "wizard-switch",
@@ -2008,6 +2010,56 @@ def test_build_interactive_wizard_creates_model(
     )
     assert result.exit_code == 0, result.output
     assert (root / "models" / "wizard-built" / "config.toml").exists()
+
+
+def test_build_wizard_verifies_the_configured_custom_endpoint(
+    patched_provider: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The wizard must ping the same endpoint it writes into the built model."""
+    root = tmp_path / ".wmo"
+    endpoint = "https://models.example/v1"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(
+        provider="openai",
+        model="gpt-5.5",
+        endpoint=endpoint,
+    )
+    save_settings(settings, root)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("WMO_ENDPOINT_API_KEY", "endpoint-key")
+    verified: list[ProviderConfig] = []
+
+    def verify(configs: list[ProviderConfig]) -> list[VerifyResult]:
+        verified.extend(configs)
+        return [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
+
+    monkeypatch.setattr(ui_module, "verify_all", verify)
+    answers = "\n".join(
+        [
+            "wizard-custom",
+            "",
+            _traces_file(tmp_path),
+            "",
+            "",
+            "",
+            "1",
+            "1",
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        ["build", "--interactive", "--root", str(root)],
+        input=answers + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "OPENAI_API_KEY" not in result.output
+    assert len(verified) == 2
+    assert all(config.kind is ProviderKind.OPENAI for config in verified)
+    assert all(config.endpoint == endpoint for config in verified)
+    config = load_config(root / "models" / "wizard-custom")
+    assert config.serve_provider_config().endpoint == endpoint
 
 
 def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -218,6 +218,35 @@ def test_build_uses_configured_worker_provider(patched_provider, tmp_path) -> No
     assert config.serve_provider_config().model_type == "gpt-5.4-mini"
 
 
+def test_build_does_not_validate_an_unrelated_model_role(
+    patched_provider: None, tmp_path: Path
+) -> None:
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="openai", model="gpt-5.4-mini")
+    settings.models.judge = ModelRole(provider="bogus", model="unused")
+    save_settings(settings, root)
+
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "valid-worker",
+            "--file",
+            _traces_file(tmp_path),
+            "--fidelity",
+            "low",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = load_config(root / "models" / "valid-worker")
+    assert config.serve_provider is ProviderKind.OPENAI
+
+
 def test_build_explicit_model_keeps_configured_azure_connection(
     patched_provider: None, tmp_path: Path
 ) -> None:

--- a/wmo/cli/app_test.py
+++ b/wmo/cli/app_test.py
@@ -247,6 +247,38 @@ def test_build_does_not_validate_an_unrelated_model_role(
     assert config.serve_provider is ProviderKind.OPENAI
 
 
+def test_explicit_build_provider_ignores_an_invalid_configured_worker(
+    patched_provider: None, tmp_path: Path
+) -> None:
+    root = tmp_path / ".wmo"
+    settings = load_settings(root)
+    settings.models.worker = ModelRole(provider="bogus", model="stale")
+    save_settings(settings, root)
+
+    result = runner.invoke(
+        app,
+        [
+            "build",
+            "--name",
+            "explicit-provider",
+            "--file",
+            _traces_file(tmp_path),
+            "--provider",
+            "bedrock",
+            "--model",
+            "claude-haiku-4-5",
+            "--fidelity",
+            "low",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = load_config(root / "models" / "explicit-provider")
+    assert config.serve_provider is ProviderKind.BEDROCK
+
+
 def test_build_explicit_model_keeps_configured_azure_connection(
     patched_provider: None, tmp_path: Path
 ) -> None:
@@ -2057,12 +2089,18 @@ def test_build_wizard_verifies_the_configured_custom_endpoint(
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("WMO_ENDPOINT_API_KEY", "endpoint-key")
     verified: list[ProviderConfig] = []
+    verified_embedders: list[ProviderConfig] = []
 
     def verify(configs: list[ProviderConfig]) -> list[VerifyResult]:
         verified.extend(configs)
         return [VerifyResult(ok=True, kind=config.kind, model=config.model) for config in configs]
 
+    def verify_embedder(config: ProviderConfig) -> VerifyResult:
+        verified_embedders.append(config)
+        return VerifyResult(ok=True, kind=config.kind, model=config.model)
+
     monkeypatch.setattr(ui_module, "verify_all", verify)
+    monkeypatch.setattr(ui_module, "verify_embedder", verify_embedder)
     answers = "\n".join(
         [
             "wizard-custom",
@@ -2072,7 +2110,8 @@ def test_build_wizard_verifies_the_configured_custom_endpoint(
             "",
             "",
             "1",
-            "1",
+            "2",
+            "",
         ]
     )
 
@@ -2087,8 +2126,12 @@ def test_build_wizard_verifies_the_configured_custom_endpoint(
     assert len(verified) == 2
     assert all(config.kind is ProviderKind.OPENAI for config in verified)
     assert all(config.endpoint == endpoint for config in verified)
+    [embedder] = verified_embedders
+    assert embedder.kind is ProviderKind.OPENAI
+    assert embedder.endpoint == endpoint
     config = load_config(root / "models" / "wizard-custom")
     assert config.serve_provider_config().endpoint == endpoint
+    assert config.embed_provider_config().endpoint == endpoint
 
 
 def test_build_non_interactive_without_source_errors(tmp_path) -> None:  # noqa: ANN001

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -114,20 +114,24 @@ def configured_role_configs(root: str) -> list[tuple[ModelRoleName, ProviderConf
         configured: ModelRole | None = getattr(models, role)
         if configured is None:
             continue
-        config = _model_config(configured, role=role)
-        spec = resolve_provider_model(config.kind, config.model)
-        resolved.append(
-            (
-                role,
-                config.model_copy(
-                    update={
-                        "model": spec.model_id,
-                        "model_type": config.model_type or spec.model_type,
-                    }
-                ),
-            )
-        )
+        resolved.append((role, configured_role_provider_config(configured, role=role)))
     return resolved
+
+
+def configured_role_provider_config(
+    configured: ModelRole,
+    *,
+    role: ModelRoleName,
+) -> ProviderConfig:
+    """Resolve one stored model role without inspecting unrelated role settings."""
+    config = _model_config(configured, role=role)
+    spec = resolve_provider_model(config.kind, config.model)
+    return config.model_copy(
+        update={
+            "model": spec.model_id,
+            "model_type": config.model_type or spec.model_type,
+        }
+    )
 
 
 def inherit_provider_connection(
@@ -150,14 +154,16 @@ def inherit_provider_connection(
     }
     selected_model = selected.model_type or selected.model
     configured_model = configured.model_type or configured.model
-    if selected_model == configured_model:
+    if selected_model.casefold() == configured_model.casefold():
         updates.update(
             {
                 field: value
-                for field in ("deployment", "reasoning_effort", "chat_max_tokens_field")
+                for field in ("deployment", "reasoning_effort")
                 if (value := getattr(configured, field)) is not None
             }
         )
+        if "chat_max_tokens_field" in configured.model_fields_set:
+            updates["chat_max_tokens_field"] = configured.chat_max_tokens_field
     return selected.model_copy(update=updates) if updates else selected
 
 

--- a/wmo/cli/model_roles.py
+++ b/wmo/cli/model_roles.py
@@ -130,6 +130,37 @@ def configured_role_configs(root: str) -> list[tuple[ModelRoleName, ProviderConf
     return resolved
 
 
+def inherit_provider_connection(
+    selected: ProviderConfig,
+    configured: ProviderConfig | None,
+) -> ProviderConfig:
+    """Carry the configured provider connection into a newly selected model.
+
+    Endpoints and API versions describe the provider connection, so they remain valid when the
+    wizard selects another model on the same provider. Deployment names and model-specific
+    request knobs only remain valid when the canonical model identity is unchanged.
+    """
+    if configured is None or selected.kind is not configured.kind:
+        return selected
+
+    updates = {
+        field: value
+        for field in ("endpoint", "api_version")
+        if (value := getattr(configured, field)) is not None
+    }
+    selected_model = selected.model_type or selected.model
+    configured_model = configured.model_type or configured.model
+    if selected_model == configured_model:
+        updates.update(
+            {
+                field: value
+                for field in ("deployment", "reasoning_effort", "chat_max_tokens_field")
+                if (value := getattr(configured, field)) is not None
+            }
+        )
+    return selected.model_copy(update=updates) if updates else selected
+
+
 def _model_config(configured: ModelRole, *, role: ModelRoleName) -> ProviderConfig:
     """Turn one configured role into provider-neutral config with the Azure default."""
     try:

--- a/wmo/cli/model_roles_test.py
+++ b/wmo/cli/model_roles_test.py
@@ -13,6 +13,7 @@ from wmo.cli.model_roles import (
     OptInModelRole,
     _model_config,
     configured_role_configs,
+    inherit_provider_connection,
     load_settings_or_abort,
     resolve_opt_in_model_provider,
 )
@@ -342,3 +343,58 @@ def test_configured_role_configs_names_the_role_with_the_bad_provider(tmp_path: 
         typer.BadParameter, match=r"settings \[models\.summary\] has unknown provider 'bogus'"
     ):
         configured_role_configs(str(root))
+
+
+def test_provider_connection_endpoint_applies_to_another_model() -> None:
+    selected = ProviderConfig(
+        kind=ProviderKind.OPENAI,
+        model="gpt-5.4-mini",
+        model_type="gpt-5.4-mini",
+    )
+    configured = ProviderConfig(
+        kind=ProviderKind.OPENAI,
+        model="gpt-5.5",
+        model_type="gpt-5.5",
+        endpoint="https://models.example/v1",
+        reasoning_effort="high",
+        chat_max_tokens_field="max_tokens",
+    )
+
+    resolved = inherit_provider_connection(selected, configured)
+
+    assert resolved.endpoint == "https://models.example/v1"
+    assert resolved.reasoning_effort is None
+    assert resolved.chat_max_tokens_field == "max_completion_tokens"
+
+
+def test_provider_connection_deployment_only_applies_to_the_same_model() -> None:
+    configured = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="gpt-5.5",
+        model_type="gpt-5.5",
+        endpoint="https://azure.example",
+        deployment="gpt-5-5-prod",
+        api_version="2026-01-01",
+    )
+
+    same_model = inherit_provider_connection(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.5",
+            model_type="gpt-5.5",
+        ),
+        configured,
+    )
+    another_model = inherit_provider_connection(
+        ProviderConfig(
+            kind=ProviderKind.AZURE_OPENAI,
+            model="gpt-5.4-mini",
+            model_type="gpt-5.4-mini",
+        ),
+        configured,
+    )
+
+    assert same_model.deployment == "gpt-5-5-prod"
+    assert another_model.deployment is None
+    assert another_model.endpoint == "https://azure.example"
+    assert another_model.api_version == "2026-01-01"

--- a/wmo/cli/model_roles_test.py
+++ b/wmo/cli/model_roles_test.py
@@ -13,6 +13,7 @@ from wmo.cli.model_roles import (
     OptInModelRole,
     _model_config,
     configured_role_configs,
+    configured_role_provider_config,
     inherit_provider_connection,
     load_settings_or_abort,
     resolve_opt_in_model_provider,
@@ -398,3 +399,39 @@ def test_provider_connection_deployment_only_applies_to_the_same_model() -> None
     assert another_model.deployment is None
     assert another_model.endpoint == "https://azure.example"
     assert another_model.api_version == "2026-01-01"
+
+
+def test_provider_connection_does_not_inherit_an_implicit_token_field() -> None:
+    configured = configured_role_provider_config(
+        ModelRole(provider="azure", model="kimi-k2.6"),
+        role="worker",
+    )
+    assert "chat_max_tokens_field" not in configured.model_fields_set
+    selected = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="kimi-k2.6",
+        model_type="kimi-k2.6",
+        chat_max_tokens_field="max_tokens",
+    )
+
+    resolved = inherit_provider_connection(selected, configured)
+
+    assert resolved.chat_max_tokens_field == "max_tokens"
+
+
+def test_provider_connection_matches_canonical_model_identity_without_case() -> None:
+    configured = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="Kimi-K2.6",
+        model_type="Kimi-K2.6",
+        deployment="Kimi-Production",
+    )
+    selected = ProviderConfig(
+        kind=ProviderKind.AZURE_OPENAI,
+        model="kimi-k2.6",
+        model_type="kimi-k2.6",
+    )
+
+    resolved = inherit_provider_connection(selected, configured)
+
+    assert resolved.deployment == "Kimi-Production"

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -507,12 +507,15 @@ def run_build_wizard(
         # stamped on (mirrors HarnessConfig.embed_provider_config).
         console.print(f"verifying embed:{embed_provider}…")
         ping = check_embed(
-            ProviderConfig(
-                kind=ProviderKind(embed_provider),
-                model=embed_model,
-                embed_model=embed_model,
-                embed_dim=defaults.embed_dim,
-                region=region if embed_provider == "bedrock" else None,
+            inherit_provider_connection(
+                ProviderConfig(
+                    kind=ProviderKind(embed_provider),
+                    model=embed_model,
+                    embed_model=embed_model,
+                    embed_dim=defaults.embed_dim,
+                    region=region if embed_provider == "bedrock" else None,
+                ),
+                configured_provider,
             )
         )
         if ping.ok:

--- a/wmo/cli/ui.py
+++ b/wmo/cli/ui.py
@@ -42,6 +42,7 @@ from rich.segment import ControlType
 from rich.table import Table
 from rich.text import Text
 
+from wmo.cli.model_roles import inherit_provider_connection
 from wmo.config import (
     PROVIDER_ENV_VARS,
     ModelInfo,
@@ -240,6 +241,7 @@ def select_provider_and_model(
     default_region: str | None,
     interactive: bool,
     check: Callable[[ProviderConfig], VerifyResult],
+    configured_provider: ProviderConfig | None = None,
 ) -> tuple[str, str, str | None]:
     """The wizard's serve-provider block: pick provider + model (+ region), creds, live verify.
 
@@ -249,10 +251,23 @@ def select_provider_and_model(
     (provider, model, region).
     """
     providers = list(_PROVIDER_MODELS)
-    with_creds = [p for p in providers if has_credentials(p)]
+
+    def configured_endpoint(provider: str) -> str | None:
+        if configured_provider is None or configured_provider.kind.value != provider:
+            return None
+        return configured_provider.endpoint
+
+    with_creds = [
+        provider
+        for provider in providers
+        if has_credentials(provider, endpoint=configured_endpoint(provider))
+    ]
     # Name the actual variable so a key inherited from the shell (e.g. exported in ~/.zshrc)
     # is traceable — "api key exists" alone reads as a mystery when .env doesn't have it.
-    notes = {p: creds_note(p) for p in with_creds}
+    notes = {
+        provider: creds_note(provider, endpoint=configured_endpoint(provider))
+        for provider in with_creds
+    }
     provider_default = default_provider or (with_creds[0] if with_creds else None)
     while True:
         provider = _select(
@@ -264,7 +279,12 @@ def select_provider_and_model(
             interactive=interactive,
             notes=notes,
         )
-        ensure_credentials(console, ask_secret, provider)
+        ensure_credentials(
+            console,
+            ask_secret,
+            provider,
+            endpoint=configured_endpoint(provider),
+        )
         model = _select(
             console,
             ask,
@@ -283,11 +303,14 @@ def select_provider_and_model(
         console.print(f"verifying {provider}…")
         model_spec = resolve_provider_model(ProviderKind(provider), model)
         ping = check(
-            ProviderConfig(
-                kind=ProviderKind(provider),
-                model_type=model_spec.model_type,
-                model=model_spec.model_id,
-                region=region,
+            inherit_provider_connection(
+                ProviderConfig(
+                    kind=ProviderKind(provider),
+                    model_type=model_spec.model_type,
+                    model=model_spec.model_id,
+                    region=region,
+                ),
+                configured_provider,
             )
         )
         if ping.ok:
@@ -306,6 +329,7 @@ def run_build_wizard(
     reader: PromptReader | None = None,
     verify: Callable[[ProviderConfig], VerifyResult] | None = None,
     verify_embed: Callable[[ProviderConfig], VerifyResult] | None = None,
+    configured_provider: ProviderConfig | None = None,
 ) -> BuildParams:
     """Guided creation flow: prompt for each build input, pre-filled with `defaults`.
 
@@ -381,6 +405,7 @@ def run_build_wizard(
         default_region=defaults.region,
         interactive=interactive,
         check=check,
+        configured_provider=configured_provider,
     )
 
     # GEPA judge model: defaults to a cheap model of the same provider (haiku / gpt-5.4-mini);
@@ -404,11 +429,14 @@ def run_build_wizard(
         console.print(f"verifying {provider} (judge)…")
         judge_spec = resolve_provider_model(ProviderKind(provider), judge_model)
         ping = check(
-            ProviderConfig(
-                kind=ProviderKind(provider),
-                model_type=judge_spec.model_type,
-                model=judge_spec.model_id,
-                region=region,
+            inherit_provider_connection(
+                ProviderConfig(
+                    kind=ProviderKind(provider),
+                    model_type=judge_spec.model_type,
+                    model=judge_spec.model_id,
+                    region=region,
+                ),
+                configured_provider,
             )
         )
         if ping.ok:
@@ -695,33 +723,41 @@ def _select(
         console.print(f"[red]pick 1-{len(options)} or an option name[/red]")
 
 
-def _provider_env_vars(provider: str) -> list[str]:
+def _provider_env_vars(provider: str, *, endpoint: str | None = None) -> list[str]:
     """The env vars `provider` reads its credentials from ([] for unknown/offline kinds)."""
+    if provider == ProviderKind.OPENAI.value and endpoint is not None:
+        return ["WMO_ENDPOINT_API_KEY"]
     try:
         return PROVIDER_ENV_VARS[ProviderKind(provider)]
     except (ValueError, KeyError):
         return []
 
 
-def creds_note(provider: str) -> str:
+def creds_note(provider: str, *, endpoint: str | None = None) -> str:
     """Picker annotation for a provider whose credentials are present, naming what was found."""
-    env_vars = _provider_env_vars(provider)
+    env_vars = _provider_env_vars(provider, endpoint=endpoint)
     return f"{env_vars[0]} set" if len(env_vars) == 1 else "creds set"
 
 
-def has_credentials(provider: str) -> bool:
+def has_credentials(provider: str, *, endpoint: str | None = None) -> bool:
     """Offline presence check: every credential env var for `provider` is set (not validated)."""
-    env_vars = _provider_env_vars(provider)
+    env_vars = _provider_env_vars(provider, endpoint=endpoint)
     return bool(env_vars) and all(os.environ.get(var) for var in env_vars)
 
 
-def ensure_credentials(console: Console, ask_secret: PromptReader, provider: str) -> None:
+def ensure_credentials(
+    console: Console,
+    ask_secret: PromptReader,
+    provider: str,
+    *,
+    endpoint: str | None = None,
+) -> None:
     """Prompt for any missing credential env vars and persist entered values to `.env`.
 
     Presence only — the live ping that confirms the creds actually work happens once before
     the build (see `wmo build`). Enter skips a var, leaving it to the shell environment.
     """
-    for var in _provider_env_vars(provider):
+    for var in _provider_env_vars(provider, endpoint=endpoint):
         if os.environ.get(var):
             console.print(f"  {_CHECK} {var} is set")
             continue


### PR DESCRIPTION
## Summary

- preserve the configured provider endpoint through interactive model selection
- use endpoint-specific credentials for OpenAI-compatible custom endpoints
- verify the exact effective serve, judge, and same-provider embed configurations that the build persists
- carry model-specific deployment and request fields only when canonical model identity still matches
- resolve only a configured worker that the build actually uses, so an explicit provider override ignores stale unrelated settings

Fixes audit finding QA-005.

## Verification

- rebased onto `31da9251`
- branch full suite: 4482 passed, 20 skipped
- affected CLI suites: 236 passed
- whole-repo `ruff check .`: passed
- whole-repo `ty check`: passed
- GitHub build and CodeQL: passed
- Greptile exact-head review: 5/5, no unresolved threads

## Review feedback

All initial Greptile threads were fixed and automatically resolved. Independent cross-PR review then found and this branch fixed two more mismatches:

- semantic embedding verification now uses the same custom endpoint as the persisted artifact
- an explicit different provider no longer resolves an unused invalid worker role

## Integration

The local-only combined tree with current provider, sweep, and harness fixes passed 4,520 tests
with 20 skips, plus whole-repo Ruff and ty. PR #352 touches the same picker interface. Land this
PR first, then rebase #352 while preserving its exact verified `ProviderConfig` flow.
